### PR TITLE
[llm] Fix P/D direct streaming OpenAI routing

### DIFF
--- a/doc/source/llm/doc_code/serve/multi_gpu/dp_pd_example.py
+++ b/doc/source/llm/doc_code/serve/multi_gpu/dp_pd_example.py
@@ -66,7 +66,6 @@ prefill_config = LLMConfig(
         "max_model_len": 1024,
         "max_num_seqs": 32,
     },
-    experimental_configs={"NIXL_SIDE_CHANNEL_PORT_BASE": 15000},
 )
 
 # Configure decode with data parallel attention
@@ -85,7 +84,6 @@ decode_config = LLMConfig(
         "max_model_len": 1024,
         "max_num_seqs": 32,
     },
-    experimental_configs={"NIXL_SIDE_CHANNEL_PORT_BASE": 16000},
 )
 
 # Build and deploy the PD application (3-tier: ingress -> decode -> prefill)

--- a/doc/source/llm/doc_code/serve/multi_gpu/dp_pd_example.py
+++ b/doc/source/llm/doc_code/serve/multi_gpu/dp_pd_example.py
@@ -66,6 +66,7 @@ prefill_config = LLMConfig(
         "max_model_len": 1024,
         "max_num_seqs": 32,
     },
+    experimental_configs={"NIXL_SIDE_CHANNEL_PORT_BASE": 15000},
 )
 
 # Configure decode with data parallel attention
@@ -84,6 +85,7 @@ decode_config = LLMConfig(
         "max_model_len": 1024,
         "max_num_seqs": 32,
     },
+    experimental_configs={"NIXL_SIDE_CHANNEL_PORT_BASE": 16000},
 )
 
 # Build and deploy the PD application (3-tier: ingress -> decode -> prefill)

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -1,6 +1,5 @@
 import asyncio
 import copy
-import json
 import sys
 from contextlib import asynccontextmanager
 from enum import Enum
@@ -13,9 +12,7 @@ from typing import (
     Dict,
     List,
     Optional,
-    Tuple,
     Type,
-    TypeVar,
     Union,
 )
 
@@ -36,11 +33,7 @@ from ray.llm._internal.serve.constants import (
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
-    ChatCompletionResponse,
-    ChatCompletionStreamResponse,
     CompletionRequest,
-    CompletionResponse,
-    CompletionStreamResponse,
     DetokenizeRequest,
     DetokenizeResponse,
     EmbeddingRequest,
@@ -59,12 +52,16 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     TokenizeCompletionRequest,
     TokenizeResponse,
     TranscriptionRequest,
-    TranscriptionResponse,
-    TranscriptionStreamResponse,
 )
 from ray.llm._internal.serve.core.ingress.middleware import (
     SetRequestIdMiddleware,
     add_exception_handling_middleware,
+)
+from ray.llm._internal.serve.core.ingress.utils import (
+    NON_STREAMING_RESPONSE_TYPES,
+    _openai_json_wrapper,
+    _peek_at_generator,
+    _sanitize_chat_completion_request,
 )
 from ray.llm._internal.serve.core.protocol import DeploymentProtocol, RawRequestInfo
 from ray.llm._internal.serve.observability.logging import get_logger
@@ -86,8 +83,6 @@ else:
     from async_timeout import timeout
 
 logger = get_logger(__name__)
-
-T = TypeVar("T")
 
 
 DEFAULT_INGRESS_OPTIONS = {
@@ -119,72 +114,6 @@ class CallMethod(Enum):
     CHAT = "chat"
     COMPLETIONS = "completions"
     TRANSCRIPTIONS = "transcriptions"
-
-
-NON_STREAMING_RESPONSE_TYPES = (
-    ChatCompletionResponse,
-    CompletionResponse,
-    TranscriptionResponse,
-)
-
-
-def _sanitize_chat_completion_request(
-    request: ChatCompletionRequest,
-) -> ChatCompletionRequest:
-    """Sanitize ChatCompletionRequest to fix Pydantic ValidatorIterator serialization issue.
-
-    This addresses a known Pydantic bug where fields typed as ``Iterable[...]``
-    on OpenAI message TypedDicts (notably ``content`` on every message variant
-    and ``tool_calls`` on assistant messages) become ValidatorIterator objects
-    that cannot be pickled for Ray remote calls.
-
-    Workaround logic adapted from vLLM (credits: @gcalmettes):
-    - vLLM PR: https://github.com/vllm-project/vllm/pull/9951
-    - Pydantic Issue: https://github.com/pydantic/pydantic/issues/9467
-    - Related Issue: https://github.com/pydantic/pydantic/issues/9541
-    - Official Workaround: https://github.com/pydantic/pydantic/issues/9467#issuecomment-2442097291
-
-    Note: still reproducible on Pydantic 2.12 for the ``Iterable[...]`` arm of
-    a ``Union``, so this sanitizer is required regardless of Pydantic version.
-    """
-    for i, message in enumerate(request.messages):
-        # SGLang messages are Pydantic BaseModels (no .get()); convert to dicts
-        # so the same logic works for both vLLM (TypedDict) and SGLang.
-        if not isinstance(message, dict):
-            request.messages[i] = message = message.model_dump()
-
-        # `content` is typed `Union[str, Iterable[ContentPart], None]` on every
-        # OpenAI message variant. When the iterable arm matches, Pydantic stores
-        # a non-picklable ValidatorIterator. Materialize it for any role.
-        content_val = message.get("content")
-        if content_val is not None and not isinstance(content_val, str):
-            try:
-                message["content"] = list(content_val)
-            except (TypeError, ValueError) as e:
-                raise ValueError(
-                    "Validating message `content` raised an error. Please "
-                    "ensure `content` is a string, None, or an iterable of "
-                    "content parts."
-                ) from e
-
-        if message.get("role") == "assistant":
-            tool_calls_val = message.get("tool_calls")
-            if tool_calls_val is not None:
-                try:
-                    message["tool_calls"] = list(tool_calls_val)
-                except (TypeError, ValueError) as e:
-                    raise ValueError(
-                        "Validating messages' `tool_calls` raised an error. "
-                        "Please ensure `tool_calls` are iterable of tool calls."
-                    ) from e
-
-    return request
-
-
-StreamResponseType = Union[
-    ChatCompletionStreamResponse, CompletionStreamResponse, TranscriptionStreamResponse
-]
-BatchedStreamResponseType = List[StreamResponseType]
 
 
 DEFAULT_ENDPOINTS = {
@@ -301,79 +230,6 @@ def make_fastapi_ingress(
 
     # Apply the serve.ingress decorator to the new class
     return serve.ingress(app)(new_cls)
-
-
-def _apply_openai_json_format(
-    response: Union[StreamResponseType, BatchedStreamResponseType],
-) -> str:
-    """Converts the stream response to OpenAI format.
-
-    Each model response is converted to the string:
-        data: <response-json1>\n\n
-
-    The converted strings are concatenated and returned:
-        data: <response-json1>\n\ndata: <response-json2>\n\n...
-    """
-    if isinstance(response, list):
-        first_response = next(iter(response))
-        if isinstance(first_response, str):
-            return "".join(response)
-        if isinstance(first_response, dict):
-            return "".join(f"data: {json.dumps(r)}\n\n" for r in response)
-        if hasattr(first_response, "model_dump_json"):
-            return "".join(f"data: {r.model_dump_json()}\n\n" for r in response)
-        raise ValueError(
-            f"Unexpected response type: {type(first_response)}, {first_response=}"
-        )
-    if hasattr(response, "model_dump_json"):
-        return f"data: {response.model_dump_json()}\n\n"
-    if isinstance(response, str):
-        return response
-    raise ValueError(f"Unexpected response type: {type(response)}, {response=}")
-
-
-async def _peek_at_generator(
-    gen: AsyncGenerator[T, None],
-) -> Tuple[T, AsyncGenerator[T, None]]:
-    # Peek at the first element
-    first_item = await gen.__anext__()
-
-    # Create a new generator that yields the peeked item first
-    async def new_generator() -> AsyncGenerator[T, None]:
-        yield first_item
-        async for item in gen:
-            yield item
-
-    return first_item, new_generator()
-
-
-async def _openai_json_wrapper(
-    generator: AsyncGenerator[
-        Union[StreamResponseType, BatchedStreamResponseType], None
-    ],
-) -> AsyncGenerator[str, None]:
-    """Wrapper that converts stream responses into OpenAI JSON strings.
-
-    Args:
-        generator: an async generator that yields either individual stream responses
-            (StreamResponseType) or batches of stream responses (BatchedStreamResponseType).
-            Each response is converted into OpenAI JSON format and streamed to the client.
-            For batched responses, the items are concatenated together as a single string.
-
-    Yields:
-        String chunks in OpenAI SSE format: "data: {json}\n\n", with a final
-        "data: [DONE]\n\n" to indicate completion. If the upstream generator
-        already yields a "data: [DONE]" sentinel, it is not duplicated.
-    """
-    done_sent = False
-    async for response in generator:
-        packet = _apply_openai_json_format(response)
-        if packet.strip().endswith("data: [DONE]"):
-            done_sent = True
-        yield packet
-
-    if not done_sent:
-        yield "data: [DONE]\n\n"
 
 
 @asynccontextmanager

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -76,7 +76,7 @@ from ray.llm._internal.serve.utils.lora_serve_utils import (
     get_lora_model_metadata,
 )
 from ray.llm._internal.serve.utils.server_utils import replace_prefix
-from ray.serve._private.http_util import _matches_session_id_header
+from ray.serve._private.http_util import session_id_from_headers
 from ray.serve.handle import DeploymentHandle
 
 # Import asyncio timeout depends on python version
@@ -528,14 +528,7 @@ class OpenAiIngress(DeploymentProtocol):
         # proxy.py so a `-`/`_` rewrite by an intermediate proxy doesn't
         # silently drop session affinity on this second hop.
         if raw_request is not None:
-            session_id = next(
-                (
-                    v
-                    for k, v in raw_request.headers.items()
-                    if _matches_session_id_header(k)
-                ),
-                None,
-            )
+            session_id = session_id_from_headers(raw_request.headers)
             if session_id:
                 model_handle = model_handle.options(session_id=session_id)
 

--- a/python/ray/llm/_internal/serve/core/ingress/utils.py
+++ b/python/ray/llm/_internal/serve/core/ingress/utils.py
@@ -1,0 +1,153 @@
+"""Shared helpers for OpenAI ingress, reused by the P/D direct-streaming path."""
+
+import json
+from typing import AsyncGenerator, List, Tuple, TypeVar, Union
+
+from ray.llm._internal.serve.core.configs.openai_api_models import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionStreamResponse,
+    CompletionResponse,
+    CompletionStreamResponse,
+    TranscriptionResponse,
+    TranscriptionStreamResponse,
+)
+
+T = TypeVar("T")
+
+NON_STREAMING_RESPONSE_TYPES = (
+    ChatCompletionResponse,
+    CompletionResponse,
+    TranscriptionResponse,
+)
+
+StreamResponseType = Union[
+    ChatCompletionStreamResponse, CompletionStreamResponse, TranscriptionStreamResponse
+]
+BatchedStreamResponseType = List[StreamResponseType]
+
+
+def _sanitize_chat_completion_request(
+    request: ChatCompletionRequest,
+) -> ChatCompletionRequest:
+    """Sanitize ChatCompletionRequest to fix Pydantic ValidatorIterator serialization issue.
+
+    This addresses a known Pydantic bug where fields typed as ``Iterable[...]``
+    on OpenAI message TypedDicts (notably ``content`` on every message variant
+    and ``tool_calls`` on assistant messages) become ValidatorIterator objects
+    that cannot be pickled for Ray remote calls.
+
+    Workaround logic adapted from vLLM (credits: @gcalmettes):
+    - vLLM PR: https://github.com/vllm-project/vllm/pull/9951
+    - Pydantic Issue: https://github.com/pydantic/pydantic/issues/9467
+    - Related Issue: https://github.com/pydantic/pydantic/issues/9541
+    - Official Workaround: https://github.com/pydantic/pydantic/issues/9467#issuecomment-2442097291
+
+    Note: still reproducible on Pydantic 2.12 for the ``Iterable[...]`` arm of
+    a ``Union``, so this sanitizer is required regardless of Pydantic version.
+    """
+    for i, message in enumerate(request.messages):
+        # SGLang messages are Pydantic BaseModels (no .get()); convert to dicts
+        # so the same logic works for both vLLM (TypedDict) and SGLang.
+        if not isinstance(message, dict):
+            request.messages[i] = message = message.model_dump()
+
+        # `content` is typed `Union[str, Iterable[ContentPart], None]` on every
+        # OpenAI message variant. When the iterable arm matches, Pydantic stores
+        # a non-picklable ValidatorIterator. Materialize it for any role.
+        content_val = message.get("content")
+        if content_val is not None and not isinstance(content_val, str):
+            try:
+                message["content"] = list(content_val)
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    "Validating message `content` raised an error. Please "
+                    "ensure `content` is a string, None, or an iterable of "
+                    "content parts."
+                ) from e
+
+        if message.get("role") == "assistant":
+            tool_calls_val = message.get("tool_calls")
+            if tool_calls_val is not None:
+                try:
+                    message["tool_calls"] = list(tool_calls_val)
+                except (TypeError, ValueError) as e:
+                    raise ValueError(
+                        "Validating messages' `tool_calls` raised an error. "
+                        "Please ensure `tool_calls` are iterable of tool calls."
+                    ) from e
+
+    return request
+
+
+def _apply_openai_json_format(
+    response: Union[StreamResponseType, BatchedStreamResponseType],
+) -> str:
+    """Converts the stream response to OpenAI format.
+
+    Each model response is converted to the string:
+        data: <response-json1>\n\n
+
+    The converted strings are concatenated and returned:
+        data: <response-json1>\n\ndata: <response-json2>\n\n...
+    """
+    if isinstance(response, list):
+        first_response = next(iter(response))
+        if isinstance(first_response, str):
+            return "".join(response)
+        if isinstance(first_response, dict):
+            return "".join(f"data: {json.dumps(r)}\n\n" for r in response)
+        if hasattr(first_response, "model_dump_json"):
+            return "".join(f"data: {r.model_dump_json()}\n\n" for r in response)
+        raise ValueError(
+            f"Unexpected response type: {type(first_response)}, {first_response=}"
+        )
+    if hasattr(response, "model_dump_json"):
+        return f"data: {response.model_dump_json()}\n\n"
+    if isinstance(response, str):
+        return response
+    raise ValueError(f"Unexpected response type: {type(response)}, {response=}")
+
+
+async def _peek_at_generator(
+    gen: AsyncGenerator[T, None],
+) -> Tuple[T, AsyncGenerator[T, None]]:
+    # Peek at the first element
+    first_item = await gen.__anext__()
+
+    # Create a new generator that yields the peeked item first
+    async def new_generator() -> AsyncGenerator[T, None]:
+        yield first_item
+        async for item in gen:
+            yield item
+
+    return first_item, new_generator()
+
+
+async def _openai_json_wrapper(
+    generator: AsyncGenerator[
+        Union[StreamResponseType, BatchedStreamResponseType], None
+    ],
+) -> AsyncGenerator[str, None]:
+    """Wrapper that converts stream responses into OpenAI JSON strings.
+
+    Args:
+        generator: an async generator that yields either individual stream responses
+            (StreamResponseType) or batches of stream responses (BatchedStreamResponseType).
+            Each response is converted into OpenAI JSON format and streamed to the client.
+            For batched responses, the items are concatenated together as a single string.
+
+    Yields:
+        String chunks in OpenAI SSE format: "data: {json}\n\n", with a final
+        "data: [DONE]\n\n" to indicate completion. If the upstream generator
+        already yields a "data: [DONE]" sentinel, it is not duplicated.
+    """
+    done_sent = False
+    async for response in generator:
+        packet = _apply_openai_json_format(response)
+        if packet.strip().endswith("data: [DONE]"):
+            done_sent = True
+        yield packet
+
+    if not done_sent:
+        yield "data: [DONE]\n\n"

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
@@ -5,21 +5,28 @@ from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
 )
 
+_DEFAULT_SIDE_CHANNEL_PORT_START = 20000
+
 
 class NixlConnectorBackend(BaseConnectorBackend):
     def _set_side_channel_port(self):
         from vllm import envs as vllm_envs
-        from vllm.utils.network_utils import get_open_port
 
-        if not vllm_envs.is_set("VLLM_NIXL_SIDE_CHANNEL_PORT"):
-            base_port: int = int(
-                self.llm_config.experimental_configs.get(
-                    "NIXL_SIDE_CHANNEL_PORT_BASE", get_open_port()
-                )
+        if vllm_envs.is_set("VLLM_NIXL_SIDE_CHANNEL_PORT"):
+            return
+
+        # _compute_port_offset() is deterministic per replica (DP rank if set,
+        # else Serve replica rank * num_devices), so replicas within one
+        # deployment land on non-colliding ports. Operators running multiple
+        # PD deployments on a single node should set NIXL_SIDE_CHANNEL_PORT_BASE
+        # to non-overlapping ranges per deployment.
+        base_port = int(
+            self.llm_config.experimental_configs.get(
+                "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_SIDE_CHANNEL_PORT_START
             )
-            # Use a deterministic rank-based offset (DP rank if set; else replica hash)
-            port = base_port + self._compute_port_offset()
-            os.environ["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(port)
+        )
+        port = base_port + self._compute_port_offset()
+        os.environ["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(port)
 
     def _set_side_channel_host(self):
         from vllm import envs as vllm_envs
@@ -56,8 +63,8 @@ class NixlConnectorBackend(BaseConnectorBackend):
                 "that you are using an older version of vLLM."
             )
 
-        self._set_side_channel_port()
         self._set_side_channel_host()
+        self._set_side_channel_port()
 
         # We need to overwrite the engine_id to make it unique across replicas.
         engine_id = self.kv_transfer_config.get("engine_id", self._get_unique_suffix())

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
@@ -5,8 +5,6 @@ from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
 )
 
-_DEFAULT_SIDE_CHANNEL_PORT_START = 20000
-
 
 class NixlConnectorBackend(BaseConnectorBackend):
     def _set_side_channel_port(self):
@@ -17,7 +15,7 @@ class NixlConnectorBackend(BaseConnectorBackend):
 
         base_port = int(
             self.llm_config.experimental_configs.get(
-                "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_SIDE_CHANNEL_PORT_START
+                "NIXL_SIDE_CHANNEL_PORT_BASE", 20000
             )
         )
         port = base_port + self._compute_port_offset()

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
@@ -15,11 +15,6 @@ class NixlConnectorBackend(BaseConnectorBackend):
         if vllm_envs.is_set("VLLM_NIXL_SIDE_CHANNEL_PORT"):
             return
 
-        # _compute_port_offset() is deterministic per replica (DP rank if set,
-        # else Serve replica rank * num_devices), so replicas within one
-        # deployment land on non-colliding ports. Operators running multiple
-        # PD deployments on a single node should set NIXL_SIDE_CHANNEL_PORT_BASE
-        # to non-overlapping ranges per deployment.
         base_port = int(
             self.llm_config.experimental_configs.get(
                 "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_SIDE_CHANNEL_PORT_START

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
@@ -58,8 +58,8 @@ class NixlConnectorBackend(BaseConnectorBackend):
                 "that you are using an older version of vLLM."
             )
 
-        self._set_side_channel_host()
         self._set_side_channel_port()
+        self._set_side_channel_host()
 
         # We need to overwrite the engine_id to make it unique across replicas.
         engine_id = self.kv_transfer_config.get("engine_id", self._get_unique_suffix())

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
@@ -42,6 +42,10 @@ from ray.serve.deployment import Application
 
 logger = get_logger(__name__)
 
+# Disjoint default NIXL side-channel port bases so colocated prefill/decode replicas don't collide.
+_DEFAULT_NIXL_PORT_BASE_PREFILL = 20000
+_DEFAULT_NIXL_PORT_BASE_DECODE = 22000
+
 # ---------------------------------------------------------------------------
 # Deprecated: ProxyClsConfig
 # TODO(Kourosh): Deprecate, remove in Ray 2.58.
@@ -173,6 +177,17 @@ class PDServingArgs(BaseModelExtended):
                 raise ValueError(
                     "kv_transfer_config is required for P/D disaggregation"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def _default_nixl_port_bases(self):
+        """Default prefill and decode to disjoint NIXL port bases unless set."""
+        self.prefill_config.experimental_configs.setdefault(
+            "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_NIXL_PORT_BASE_PREFILL
+        )
+        self.decode_config.experimental_configs.setdefault(
+            "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_NIXL_PORT_BASE_DECODE
+        )
         return self
 
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
@@ -42,10 +42,6 @@ from ray.serve.deployment import Application
 
 logger = get_logger(__name__)
 
-# Disjoint default NIXL side-channel port bases so colocated prefill/decode replicas don't collide.
-_DEFAULT_NIXL_PORT_BASE_PREFILL = 20000
-_DEFAULT_NIXL_PORT_BASE_DECODE = 22000
-
 # ---------------------------------------------------------------------------
 # Deprecated: ProxyClsConfig
 # TODO(Kourosh): Deprecate, remove in Ray 2.58.
@@ -180,13 +176,10 @@ class PDServingArgs(BaseModelExtended):
         return self
 
     @model_validator(mode="after")
-    def _default_nixl_port_bases(self):
-        """Default prefill and decode to disjoint NIXL port bases unless set."""
-        self.prefill_config.experimental_configs.setdefault(
-            "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_NIXL_PORT_BASE_PREFILL
-        )
+    def _default_decode_nixl_port_base(self):
+        """Shift decode's NIXL base off prefill's default (20000) so colocated replicas don't collide."""
         self.decode_config.experimental_configs.setdefault(
-            "NIXL_SIDE_CHANNEL_PORT_BASE", _DEFAULT_NIXL_PORT_BASE_DECODE
+            "NIXL_SIDE_CHANNEL_PORT_BASE", 22000
         )
         return self
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -28,7 +28,7 @@ from ray.llm._internal.serve.utils.broadcast import broadcast
 from ray.llm._internal.serve.utils.server_utils import (
     get_serve_request_id,
 )
-from ray.serve._private.http_util import _matches_session_id_header
+from ray.serve._private.http_util import session_id_from_headers
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 from ray.serve.llm import LLMConfig
@@ -53,14 +53,7 @@ def _session_id_from_raw_request(
     if raw_request_info is None:
         return None
 
-    return next(
-        (
-            value
-            for key, value in raw_request_info.headers.items()
-            if _matches_session_id_header(key)
-        ),
-        None,
-    )
+    return session_id_from_headers(raw_request_info.headers)
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +188,7 @@ class PDOrchestratorMixin:
                 call_method: str,
                 raw_request: Optional[Request] = None,
             ) -> AsyncGenerator[Any, None]:
-                await self._get_model_id(body.model)
+                body.model = await self._get_model_id(body.model)
 
                 if isinstance(body, ChatCompletionRequest):
                     body = _sanitize_chat_completion_request(body)

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -19,7 +19,6 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     EmbeddingRequest,
     EmbeddingResponse,
     ErrorResponse,
-    to_model_metadata,
 )
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
@@ -48,70 +47,53 @@ _PREWARM_MAX_RETRIES = 60
 
 
 # ---------------------------------------------------------------------------
-# Direct-streaming ingress shim
+# Direct-streaming route helpers
 # ---------------------------------------------------------------------------
 #
-# HTTP direct streaming on a PDDecodeServer must route through PD
-# orchestration. ``LLMServer.__serve_build_asgi_app__`` returns the engine's
-# native ASGI app, which sends chat/completions straight to the local engine
-# and bypasses ``PDDecodeServer.chat`` / ``.completions``. To keep PD
-# orchestration on the HTTP path, ``PDOrchestratorMixin`` overrides
-# ``__serve_build_asgi_app__`` to build an ``OpenAiIngress`` whose
-# ``_get_response`` calls back into the local server instead of a remote
-# handle. Non-PD ``LLMServer`` deployments continue to use vLLM's native ASGI
-# app unchanged.
+# Direct streaming exposes the engine-native ASGI app directly on the LLM
+# server replica (see ``LLMServer.__serve_build_asgi_app__``), eliminating the
+# separate ``OpenAiIngress`` deployment. For P/D, the engine-native
+# chat/completions routes would send traffic straight to the local decode
+# engine and bypass remote prefill, so ``PDOrchestratorMixin`` re-points just
+# those two routes at its own ``chat`` / ``completions`` (which orchestrate
+# prefill then decode). Every other route stays engine-native, identical to
+# non-P/D direct streaming.
 
 
-def _build_pd_lora_paths(llm_config) -> Dict[str, str]:
-    lora_config = llm_config.lora_config
-    if lora_config is None:
-        return {}
-    return {llm_config.model_id: lora_config.dynamic_lora_loading_path}
+def _strip_routes(app, path: str) -> None:
+    """Remove the engine-native APIRoute(s) registered at ``path``."""
+    from fastapi.routing import APIRoute
+
+    app.routes[:] = [
+        r for r in app.routes if not (isinstance(r, APIRoute) and r.path == path)
+    ]
 
 
-def _make_pd_direct_streaming_ingress_cls():
-    """Build the ``_PDDirectStreamingIngress`` class lazily to keep
-    ``OpenAiIngress`` (and its FastAPI deps) out of module import time."""
+async def _pd_http_response(gen):
+    """Shape a P/D orchestration generator into an OpenAI HTTP response.
+
+    Returns a JSON response when the first chunk is an error or a complete
+    (non-streaming) response, otherwise an SSE stream. Uses the same response
+    helpers as ``OpenAiIngress`` so the wire format matches the standard path.
+    """
+    from starlette.responses import JSONResponse, StreamingResponse
+
     from ray.llm._internal.serve.core.ingress.ingress import (
-        OpenAiIngress,
-        _sanitize_chat_completion_request,
+        NON_STREAMING_RESPONSE_TYPES,
+        _openai_json_wrapper,
+        _peek_at_generator,
     )
 
-    class _PDDirectStreamingIngress(OpenAiIngress):
-        """``OpenAiIngress`` whose ``_get_response`` calls a local server's
-        ``chat`` / ``completions`` directly instead of dispatching through a
-        Ray Serve handle. Used by PDDecodeServer's direct-streaming app so
-        PD orchestration runs on the HTTP path."""
-
-        def __init__(self, server: "PDOrchestratorMixin"):
-            model_id = server._llm_config.model_id
-            super().__init__(
-                llm_deployments={model_id: None},
-                model_cards={model_id: to_model_metadata(model_id, server._llm_config)},
-                lora_paths=_build_pd_lora_paths(server._llm_config),
-            )
-            self._server = server
-
-        async def _get_response(
-            self,
-            *,
-            body,
-            call_method: str,
-            raw_request=None,
-        ):
-            body.model = await self._get_model_id(body.model)
-            if isinstance(body, ChatCompletionRequest):
-                body = _sanitize_chat_completion_request(body)
-            raw_request_info = (
-                RawRequestInfo.from_starlette_request(raw_request)
-                if raw_request is not None
-                else None
-            )
-            gen = await getattr(self._server, call_method)(body, raw_request_info)
-            async for response in gen:
-                yield response
-
-    return _PDDirectStreamingIngress
+    first, gen = await _peek_at_generator(gen)
+    if isinstance(first, list):
+        first = first[0]
+    if isinstance(first, ErrorResponse):
+        return JSONResponse(
+            content=first.model_dump(), status_code=first.error.code or 400
+        )
+    if isinstance(first, NON_STREAMING_RESPONSE_TYPES):
+        return JSONResponse(content=first.model_dump())
+    return StreamingResponse(_openai_json_wrapper(gen), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------
@@ -212,27 +194,33 @@ class PDOrchestratorMixin:
     # ---- Direct-streaming ASGI app ----
 
     async def __serve_build_asgi_app__(self):
-        """Build an OpenAI ASGI app that routes HTTP through PD orchestration.
+        """Serve direct-streaming HTTP through P/D orchestration.
 
-        See module-level note on ``_PDDirectStreamingIngress`` for why this
-        override exists. The ingress's ``chat`` / ``completions`` route
-        handlers call this server's ``chat`` / ``completions``, which run
-        through ``_pd_handle_request`` (remote prefill, then local decode).
+        Start from the engine-native app (same as non-P/D direct streaming)
+        and re-point only ``/v1/chat/completions`` and ``/v1/completions`` at
+        this server's ``chat`` / ``completions``, which run remote prefill
+        then local decode. All other routes stay engine-native.
         """
+        from starlette.requests import Request
+
         from ray.llm._internal.serve.core.ingress.ingress import (
-            DEFAULT_ENDPOINTS,
-            init,
+            _sanitize_chat_completion_request,
         )
 
-        app = init()
-        ingress = _make_pd_direct_streaming_ingress_cls()(self)
-        for method_name, route_factory in DEFAULT_ENDPOINTS.items():
-            route_factory(app)(getattr(ingress, method_name))
+        app = await super().__serve_build_asgi_app__()
+        _strip_routes(app, "/v1/chat/completions")
+        _strip_routes(app, "/v1/completions")
 
-        @app.get("/health")
-        async def _health():
-            await self.check_health()
-            return {"status": "ok"}
+        @app.post("/v1/chat/completions")
+        async def _pd_chat(body: ChatCompletionRequest, request: Request):
+            body = _sanitize_chat_completion_request(body)
+            raw_info = RawRequestInfo.from_starlette_request(request)
+            return await _pd_http_response(await self.chat(body, raw_info))
+
+        @app.post("/v1/completions")
+        async def _pd_completions(body: CompletionRequest, request: Request):
+            raw_info = RawRequestInfo.from_starlette_request(request)
+            return await _pd_http_response(await self.completions(body, raw_info))
 
         return app
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -10,6 +10,10 @@ import uuid
 import warnings
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
+from fastapi.routing import APIRoute
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
 from ray.llm._internal.serve.constants import DEFAULT_MAX_ONGOING_REQUESTS
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
@@ -19,6 +23,12 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     EmbeddingRequest,
     EmbeddingResponse,
     ErrorResponse,
+)
+from ray.llm._internal.serve.core.ingress.utils import (
+    NON_STREAMING_RESPONSE_TYPES,
+    _openai_json_wrapper,
+    _peek_at_generator,
+    _sanitize_chat_completion_request,
 )
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
@@ -62,28 +72,18 @@ _PREWARM_MAX_RETRIES = 60
 
 def _strip_routes(app, path: str) -> None:
     """Remove the engine-native APIRoute(s) registered at ``path``."""
-    from fastapi.routing import APIRoute
-
     app.routes[:] = [
         r for r in app.routes if not (isinstance(r, APIRoute) and r.path == path)
     ]
 
 
-async def _pd_http_response(gen):
+async def _pd_http_response(gen) -> Response:
     """Shape a P/D orchestration generator into an OpenAI HTTP response.
 
     Returns a JSON response when the first chunk is an error or a complete
     (non-streaming) response, otherwise an SSE stream. Uses the same response
     helpers as ``OpenAiIngress`` so the wire format matches the standard path.
     """
-    from starlette.responses import JSONResponse, StreamingResponse
-
-    from ray.llm._internal.serve.core.ingress.ingress import (
-        NON_STREAMING_RESPONSE_TYPES,
-        _openai_json_wrapper,
-        _peek_at_generator,
-    )
-
     first, gen = await _peek_at_generator(gen)
     if isinstance(first, list):
         first = first[0]
@@ -201,12 +201,6 @@ class PDOrchestratorMixin:
         this server's ``chat`` / ``completions``, which run remote prefill
         then local decode. All other routes stay engine-native.
         """
-        from starlette.requests import Request
-
-        from ray.llm._internal.serve.core.ingress.ingress import (
-            _sanitize_chat_completion_request,
-        )
-
         app = await super().__serve_build_asgi_app__()
         _strip_routes(app, "/v1/chat/completions")
         _strip_routes(app, "/v1/completions")

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -47,13 +47,71 @@ _PREWARM_RETRY_INTERVAL_S = 5.0
 _PREWARM_MAX_RETRIES = 60
 
 
-def _session_id_from_raw_request(
-    raw_request_info: Optional[RawRequestInfo],
-) -> Optional[str]:
-    if raw_request_info is None:
-        return None
+# ---------------------------------------------------------------------------
+# Direct-streaming ingress shim
+# ---------------------------------------------------------------------------
+#
+# HTTP direct streaming on a PDDecodeServer must route through PD
+# orchestration. ``LLMServer.__serve_build_asgi_app__`` returns the engine's
+# native ASGI app, which sends chat/completions straight to the local engine
+# and bypasses ``PDDecodeServer.chat`` / ``.completions``. To keep PD
+# orchestration on the HTTP path, ``PDOrchestratorMixin`` overrides
+# ``__serve_build_asgi_app__`` to build an ``OpenAiIngress`` whose
+# ``_get_response`` calls back into the local server instead of a remote
+# handle. Non-PD ``LLMServer`` deployments continue to use vLLM's native ASGI
+# app unchanged.
 
-    return session_id_from_headers(raw_request_info.headers)
+
+def _build_pd_lora_paths(llm_config) -> Dict[str, str]:
+    lora_config = llm_config.lora_config
+    if lora_config is None:
+        return {}
+    return {llm_config.model_id: lora_config.dynamic_lora_loading_path}
+
+
+def _make_pd_direct_streaming_ingress_cls():
+    """Build the ``_PDDirectStreamingIngress`` class lazily to keep
+    ``OpenAiIngress`` (and its FastAPI deps) out of module import time."""
+    from ray.llm._internal.serve.core.ingress.ingress import (
+        OpenAiIngress,
+        _sanitize_chat_completion_request,
+    )
+
+    class _PDDirectStreamingIngress(OpenAiIngress):
+        """``OpenAiIngress`` whose ``_get_response`` calls a local server's
+        ``chat`` / ``completions`` directly instead of dispatching through a
+        Ray Serve handle. Used by PDDecodeServer's direct-streaming app so
+        PD orchestration runs on the HTTP path."""
+
+        def __init__(self, server: "PDOrchestratorMixin"):
+            model_id = server._llm_config.model_id
+            super().__init__(
+                llm_deployments={model_id: None},
+                model_cards={model_id: to_model_metadata(model_id, server._llm_config)},
+                lora_paths=_build_pd_lora_paths(server._llm_config),
+            )
+            self._server = server
+
+        async def _get_response(
+            self,
+            *,
+            body,
+            call_method: str,
+            raw_request=None,
+        ):
+            body.model = await self._get_model_id(body.model)
+            if isinstance(body, ChatCompletionRequest):
+                body = _sanitize_chat_completion_request(body)
+            raw_request_info = (
+                RawRequestInfo.from_starlette_request(raw_request)
+                if raw_request is not None
+                else None
+            )
+            gen = await getattr(self._server, call_method)(body, raw_request_info)
+            async for response in gen:
+                yield response
+
+    return _PDDirectStreamingIngress
 
 
 # ---------------------------------------------------------------------------
@@ -128,9 +186,10 @@ class PDOrchestratorMixin:
         # 1. Remote prefill
         prefill_request = self._prepare_prefill_request(request)
         prefill_handle = self._prefill_handle
-        session_id = _session_id_from_raw_request(raw_request_info)
-        if session_id:
-            prefill_handle = prefill_handle.options(session_id=session_id)
+        if raw_request_info is not None:
+            session_id = session_id_from_headers(raw_request_info.headers)
+            if session_id:
+                prefill_handle = prefill_handle.options(session_id=session_id)
 
         prefill_gen = getattr(prefill_handle, method).remote(
             prefill_request, raw_request_info
@@ -142,75 +201,31 @@ class PDOrchestratorMixin:
             yield prefill_chunk
             return
 
-        # 2. Local decode via own engine
+        # 2. Local decode via super().chat / super().completions so the
+        # standard LLMServer request pipeline (request_id, LoRA multiplex,
+        # batch_output_stream) runs on the decode side.
         decode_request = self._prepare_decode_request(request, prefill_chunk)
-
-        await self._maybe_add_request_id_to_request(decode_request)
-        await self._maybe_resolve_lora_from_multiplex()
-        local_gen = getattr(self.engine, method)(decode_request, raw_request_info)
+        local_gen = await getattr(super(), method)(decode_request, raw_request_info)
         async for chunk in local_gen:
             yield chunk
 
+    # ---- Direct-streaming ASGI app ----
+
     async def __serve_build_asgi_app__(self):
-        """Build an OpenAI ASGI app that routes HTTP through P/D orchestration.
+        """Build an OpenAI ASGI app that routes HTTP through PD orchestration.
 
-        Direct streaming normally exposes the engine-native ASGI app from
-        ``LLMServer``.  For P/D, that would bypass ``PDDecodeServer.chat`` and
-        ``PDDecodeServer.completions`` and send HTTP traffic straight to the
-        decode engine.  Reuse the standard OpenAI ingress handlers, but have
-        them call this local decode-orchestrator instance directly.
+        See module-level note on ``_PDDirectStreamingIngress`` for why this
+        override exists. The ingress's ``chat`` / ``completions`` route
+        handlers call this server's ``chat`` / ``completions``, which run
+        through ``_pd_handle_request`` (remote prefill, then local decode).
         """
-        from fastapi import FastAPI
-        from starlette.requests import Request
-
         from ray.llm._internal.serve.core.ingress.ingress import (
             DEFAULT_ENDPOINTS,
-            OpenAiIngress,
-            _sanitize_chat_completion_request,
             init,
         )
 
-        model_id = self._llm_config.model_id
-        model_cards = {model_id: to_model_metadata(model_id, self._llm_config)}
-        lora_config = self._llm_config.lora_config
-        lora_paths = (
-            {model_id: lora_config.dynamic_lora_loading_path}
-            if lora_config is not None
-            else {}
-        )
-
-        class _PDDirectStreamingIngress(OpenAiIngress):
-            def __init__(self, server: PDOrchestratorMixin):
-                super().__init__(
-                    llm_deployments={model_id: None},
-                    model_cards=model_cards,
-                    lora_paths=lora_paths,
-                )
-                self._server = server
-
-            async def _get_response(
-                self,
-                *,
-                body: Any,
-                call_method: str,
-                raw_request: Optional[Request] = None,
-            ) -> AsyncGenerator[Any, None]:
-                body.model = await self._get_model_id(body.model)
-
-                if isinstance(body, ChatCompletionRequest):
-                    body = _sanitize_chat_completion_request(body)
-
-                raw_request_info = (
-                    RawRequestInfo.from_starlette_request(raw_request)
-                    if raw_request is not None
-                    else None
-                )
-                gen = await getattr(self._server, call_method)(body, raw_request_info)
-                async for response in gen:
-                    yield response
-
-        app: FastAPI = init()
-        ingress = _PDDirectStreamingIngress(self)
+        app = init()
+        ingress = _make_pd_direct_streaming_ingress_cls()(self)
         for method_name, route_factory in DEFAULT_ENDPOINTS.items():
             route_factory(app)(getattr(ingress, method_name))
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -19,6 +19,7 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     EmbeddingRequest,
     EmbeddingResponse,
     ErrorResponse,
+    to_model_metadata,
 )
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
@@ -27,6 +28,7 @@ from ray.llm._internal.serve.utils.broadcast import broadcast
 from ray.llm._internal.serve.utils.server_utils import (
     get_serve_request_id,
 )
+from ray.serve._private.http_util import _matches_session_id_header
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 from ray.serve.llm import LLMConfig
@@ -43,6 +45,22 @@ _PREWARM_PROMPT = " x"
 _PREWARM_MAX_TOKENS = 1
 _PREWARM_RETRY_INTERVAL_S = 5.0
 _PREWARM_MAX_RETRIES = 60
+
+
+def _session_id_from_raw_request(
+    raw_request_info: Optional[RawRequestInfo],
+) -> Optional[str]:
+    if raw_request_info is None:
+        return None
+
+    return next(
+        (
+            value
+            for key, value in raw_request_info.headers.items()
+            if _matches_session_id_header(key)
+        ),
+        None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -79,7 +97,11 @@ class PDOrchestratorMixin:
             "remote_port": None,
         }
         prefill_request.max_tokens = 1
+        if hasattr(prefill_request, "max_completion_tokens"):
+            prefill_request.max_completion_tokens = 1
         prefill_request.stream = False
+        if hasattr(prefill_request, "stream_options"):
+            prefill_request.stream_options = None
         return prefill_request
 
     @staticmethod
@@ -112,7 +134,12 @@ class PDOrchestratorMixin:
 
         # 1. Remote prefill
         prefill_request = self._prepare_prefill_request(request)
-        prefill_gen = getattr(self._prefill_handle, method).remote(
+        prefill_handle = self._prefill_handle
+        session_id = _session_id_from_raw_request(raw_request_info)
+        if session_id:
+            prefill_handle = prefill_handle.options(session_id=session_id)
+
+        prefill_gen = getattr(prefill_handle, method).remote(
             prefill_request, raw_request_info
         )
         prefill_chunk = await prefill_gen.__anext__()
@@ -125,10 +152,74 @@ class PDOrchestratorMixin:
         # 2. Local decode via own engine
         decode_request = self._prepare_decode_request(request, prefill_chunk)
 
-        # Use parent LLMServer's chat/completions which goes through the local engine
-        local_gen = await getattr(super(), method)(decode_request, raw_request_info)
+        await self._maybe_add_request_id_to_request(decode_request)
+        await self._maybe_resolve_lora_from_multiplex()
+        local_gen = getattr(self.engine, method)(decode_request, raw_request_info)
         async for chunk in local_gen:
             yield chunk
+
+    async def __serve_build_asgi_app__(self):
+        """Build an OpenAI ASGI app that routes HTTP through P/D orchestration.
+
+        Direct streaming normally exposes the engine-native ASGI app from
+        ``LLMServer``.  For P/D, that would bypass ``PDDecodeServer.chat`` and
+        ``PDDecodeServer.completions`` and send HTTP traffic straight to the
+        decode engine.  Reuse the standard OpenAI ingress handlers, but have
+        them call this local decode-orchestrator instance directly.
+        """
+        from fastapi import FastAPI
+        from starlette.requests import Request
+
+        from ray.llm._internal.serve.core.ingress.ingress import (
+            DEFAULT_ENDPOINTS,
+            OpenAiIngress,
+            _sanitize_chat_completion_request,
+            init,
+        )
+
+        model_id = self._llm_config.model_id
+        model_cards = {model_id: to_model_metadata(model_id, self._llm_config)}
+
+        class _PDDirectStreamingIngress(OpenAiIngress):
+            def __init__(self, server: PDOrchestratorMixin):
+                super().__init__(
+                    llm_deployments={model_id: None},
+                    model_cards=model_cards,
+                )
+                self._server = server
+
+            async def _get_response(
+                self,
+                *,
+                body: Any,
+                call_method: str,
+                raw_request: Optional[Request] = None,
+            ) -> AsyncGenerator[Any, None]:
+                await self._get_model_id(body.model)
+
+                if isinstance(body, ChatCompletionRequest):
+                    body = _sanitize_chat_completion_request(body)
+
+                raw_request_info = (
+                    RawRequestInfo.from_starlette_request(raw_request)
+                    if raw_request is not None
+                    else None
+                )
+                gen = await getattr(self._server, call_method)(body, raw_request_info)
+                async for response in gen:
+                    yield response
+
+        app: FastAPI = init()
+        ingress = _PDDirectStreamingIngress(self)
+        for method_name, route_factory in DEFAULT_ENDPOINTS.items():
+            route_factory(app)(getattr(ingress, method_name))
+
+        @app.get("/health")
+        async def _health():
+            await self.check_health()
+            return {"status": "ok"}
+
+        return app
 
     # ---- Pre-warm ----
     #

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -172,12 +172,19 @@ class PDOrchestratorMixin:
 
         model_id = self._llm_config.model_id
         model_cards = {model_id: to_model_metadata(model_id, self._llm_config)}
+        lora_config = self._llm_config.lora_config
+        lora_paths = (
+            {model_id: lora_config.dynamic_lora_loading_path}
+            if lora_config is not None
+            else {}
+        )
 
         class _PDDirectStreamingIngress(OpenAiIngress):
             def __init__(self, server: PDOrchestratorMixin):
                 super().__init__(
                     llm_deployments={model_id: None},
                     model_cards=model_cards,
+                    lora_paths=lora_paths,
                 )
                 self._server = server
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_nixl_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_nixl_connector.py
@@ -56,6 +56,26 @@ class TestNixlConnectorBackend:
             assert "VLLM_NIXL_SIDE_CHANNEL_HOST" in os.environ
             assert engine_id in nixl_backend.kv_transfer_config["engine_id"]
 
+    def test_default_side_channel_port_uses_configured_base(self):
+        """When VLLM_NIXL_SIDE_CHANNEL_PORT is not set, the port is the
+        configured base plus _compute_port_offset(). Outside a Serve
+        replica context (e.g. unit tests) the offset is 0."""
+        backend = NixlConnectorBackend(
+            llm_config=LLMConfig(
+                model_loading_config=dict(model_id="Qwen/Qwen3-0.6B"),
+                engine_kwargs=dict(
+                    kv_transfer_config=dict(
+                        kv_connector="NixlConnector",
+                        kv_role="kv_both",
+                    )
+                ),
+                experimental_configs={"NIXL_SIDE_CHANNEL_PORT_BASE": 30000},
+            ),
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            backend.setup()
+            assert os.environ["VLLM_NIXL_SIDE_CHANNEL_PORT"] == "30000"
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -1,6 +1,7 @@
 import sys
 import warnings
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -10,13 +11,12 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 )
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
-    CompletionRequest,
 )
 from ray.llm._internal.serve.core.ingress.builder import (
     IngressClsConfig,
 )
 from ray.llm._internal.serve.core.ingress.ingress import OpenAiIngress
-from ray.llm._internal.serve.core.protocol import RawRequestInfo
+from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.serving_patterns.prefill_decode.builder import (
     PDServingArgs,
     build_pd_openai_app,
@@ -43,26 +43,11 @@ class _AsyncIterator:
             raise StopAsyncIteration from exc
 
 
-class _FakeHandleMethod:
-    def __init__(self, handle, method_name):
-        self._handle = handle
-        self._method_name = method_name
-
-    def remote(self, request, raw_request_info):
-        self._handle.calls.append(
-            {
-                "method": self._method_name,
-                "request": request,
-                "raw_request_info": raw_request_info,
-                "session_id": self._handle.session_id,
-            }
-        )
-        return _AsyncIterator(
-            [SimpleNamespace(kv_transfer_params={"remote_engine_id": "prefill-1"})]
-        )
-
-
 class _FakePrefillHandle:
+    """Fake prefill DeploymentHandle. Records each .chat/.completions remote
+    call with the session_id from any preceding ``.options(session_id=...)``,
+    and yields one chunk with kv_transfer_params back to the orchestrator."""
+
     def __init__(self, calls=None, session_id=None):
         self.calls = calls if calls is not None else []
         self.session_id = session_id
@@ -73,38 +58,35 @@ class _FakePrefillHandle:
             session_id=kwargs.get("session_id", self.session_id),
         )
 
-    @property
-    def completions(self):
-        return _FakeHandleMethod(self, "completions")
+    def _method(self, name):
+        handle = self
+
+        class _M:
+            def remote(self, request, raw_request_info):
+                handle.calls.append(
+                    {
+                        "method": name,
+                        "request": request,
+                        "session_id": handle.session_id,
+                    }
+                )
+                return _AsyncIterator(
+                    [
+                        SimpleNamespace(
+                            kv_transfer_params={"remote_engine_id": "prefill-1"}
+                        )
+                    ]
+                )
+
+        return _M()
 
     @property
     def chat(self):
-        return _FakeHandleMethod(self, "chat")
+        return self._method("chat")
 
-
-class _FakeEngine:
-    def __init__(self):
-        self.calls = []
-
-    def completions(self, request, raw_request_info):
-        self.calls.append(
-            {
-                "method": "completions",
-                "request": request,
-                "raw_request_info": raw_request_info,
-            }
-        )
-        return _AsyncIterator(["decode-chunk"])
-
-    def chat(self, request, raw_request_info):
-        self.calls.append(
-            {
-                "method": "chat",
-                "request": request,
-                "raw_request_info": raw_request_info,
-            }
-        )
-        return _AsyncIterator(["decode-chunk"])
+    @property
+    def completions(self):
+        return self._method("completions")
 
 
 class TestPDServingArgs:
@@ -343,63 +325,53 @@ class TestPDOrchestratorMixin:
         assert request.stream is True
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("method", ["completions", "chat"])
-    async def test_decode_to_prefill_hop_preserves_session_id(self, method):
+    @pytest.mark.parametrize(
+        "method,path,body",
+        [
+            (
+                "chat",
+                "/v1/chat/completions",
+                {"messages": [{"role": "user", "content": "hi"}]},
+            ),
+            ("completions", "/v1/completions", {"prompt": "hi"}),
+        ],
+    )
+    async def test_direct_streaming_http_runs_pd_orchestration(
+        self, method, path, body
+    ):
+        """HTTP traffic to PDDecodeServer's direct-streaming ASGI app must
+        flow through PD orchestration (remote prefill, then local decode),
+        propagate the session-id header to the prefill handle, and pass
+        the prefill's kv_transfer_params to the local decode call.
+        Regression for https://github.com/ray-project/ray/pull/63679.
+        """
+        from fastapi.testclient import TestClient
+
         server = PDDecodeServer.__new__(PDDecodeServer)
         server._prefill_handle = _FakePrefillHandle()
-        server.engine = _FakeEngine()
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model")
         )
-        if method == "chat":
-            request = ChatCompletionRequest(
-                model="test-model",
-                messages=[{"role": "user", "content": "hello"}],
-                max_completion_tokens=16,
-                stream=True,
-            )
-        else:
-            request = CompletionRequest(
-                model="test-model",
-                prompt="hello",
-                max_tokens=16,
-                stream=True,
-            )
-        raw_request_info = RawRequestInfo(headers={SERVE_SESSION_ID: "session-a"})
 
-        chunks = [
-            chunk
-            async for chunk in server._pd_handle_request(request, raw_request_info)
-        ]
+        decode_calls = []
 
-        assert chunks == ["decode-chunk"]
-        assert server._prefill_handle.calls[0]["method"] == method
-        assert server._prefill_handle.calls[0]["session_id"] == "session-a"
-        assert (
-            server._prefill_handle.calls[0]["request"].kv_transfer_params[
-                "do_remote_decode"
-            ]
-            is True
-        )
-        assert server.engine.calls[0]["request"].kv_transfer_params == {
-            "remote_engine_id": "prefill-1"
-        }
-
-    @pytest.mark.asyncio
-    async def test_direct_streaming_asgi_routes_are_pd_orchestrator_routes(self):
-        server = PDDecodeServer.__new__(PDDecodeServer)
-        server._llm_config = LLMConfig(
-            model_loading_config=ModelLoadingConfig(model_id="test-model")
-        )
+        async def _fake_decode(self, req, raw_info):
+            decode_calls.append(req)
+            return _AsyncIterator([['data: {"ok":true}\n\n']])
 
         app = await server.__serve_build_asgi_app__()
+        with patch.object(LLMServer, method, _fake_decode):
+            with TestClient(app) as client:
+                resp = client.post(
+                    path,
+                    json={"model": "test-model", "stream": True, **body},
+                    headers={SERVE_SESSION_ID: "session-a"},
+                )
 
-        route_paths = {getattr(route, "path", None) for route in app.routes}
-        assert "/v1/chat/completions" in route_paths
-        assert "/v1/completions" in route_paths
-        assert "/v1/models" in route_paths
-        assert "/v1/models/{model:path}" in route_paths
-        assert "/health" in route_paths
+        assert resp.status_code == 200, resp.text
+        assert server._prefill_handle.calls[0]["method"] == method
+        assert server._prefill_handle.calls[0]["session_id"] == "session-a"
+        assert decode_calls[0].kv_transfer_params == {"remote_engine_id": "prefill-1"}
 
 
 class TestBuildPDOpenaiApp:

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -347,11 +347,18 @@ class TestPDOrchestratorMixin:
         """
         from fastapi.testclient import TestClient
 
+        from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
+
         server = PDDecodeServer.__new__(PDDecodeServer)
         server._prefill_handle = _FakePrefillHandle()
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model")
         )
+        # The direct-streaming app starts from the engine-native ASGI app, so
+        # the decode server needs a (mock) engine. PD only re-points the
+        # chat/completions routes at the orchestrator, patched below.
+        server.engine = MockVLLMEngine(server._llm_config)
+        await server.engine.start()
 
         decode_calls = []
 

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -29,18 +29,9 @@ from ray.llm._internal.serve.serving_patterns.prefill_decode.pd_server import (
 from ray.serve._private.http_util import SERVE_SESSION_ID
 
 
-class _AsyncIterator:
-    def __init__(self, items):
-        self._items = iter(items)
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        try:
-            return next(self._items)
-        except StopIteration as exc:
-            raise StopAsyncIteration from exc
+async def _aiter(items):
+    for item in items:
+        yield item
 
 
 class _FakePrefillHandle:
@@ -59,26 +50,15 @@ class _FakePrefillHandle:
         )
 
     def _method(self, name):
-        handle = self
+        def remote(request, raw_request_info):
+            self.calls.append(
+                {"method": name, "request": request, "session_id": self.session_id}
+            )
+            return _aiter(
+                [SimpleNamespace(kv_transfer_params={"remote_engine_id": "prefill-1"})]
+            )
 
-        class _M:
-            def remote(self, request, raw_request_info):
-                handle.calls.append(
-                    {
-                        "method": name,
-                        "request": request,
-                        "session_id": handle.session_id,
-                    }
-                )
-                return _AsyncIterator(
-                    [
-                        SimpleNamespace(
-                            kv_transfer_params={"remote_engine_id": "prefill-1"}
-                        )
-                    ]
-                )
-
-        return _M()
+        return SimpleNamespace(remote=remote)
 
     @property
     def chat(self):
@@ -364,7 +344,7 @@ class TestPDOrchestratorMixin:
 
         async def _fake_decode(self, req, raw_info):
             decode_calls.append(req)
-            return _AsyncIterator([['data: {"ok":true}\n\n']])
+            return _aiter([['data: {"ok":true}\n\n']])
 
         app = await server.__serve_build_asgi_app__()
         with patch.object(LLMServer, method, _fake_decode):

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -4,13 +4,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from ray.llm._internal.serve.core.configs.openai_api_models import (
-    ChatCompletionRequest,
-    CompletionRequest,
-)
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
+)
+from ray.llm._internal.serve.core.configs.openai_api_models import (
+    ChatCompletionRequest,
+    CompletionRequest,
 )
 from ray.llm._internal.serve.core.ingress.builder import (
     IngressClsConfig,
@@ -334,9 +334,8 @@ class TestPDOrchestratorMixin:
         )
 
         prefill_request = PDOrchestratorMixin._prepare_prefill_request(request)
-        prefill_request_dict = prefill_request.model_dump()
 
-        assert prefill_request_dict["max_tokens"] == 1
+        assert prefill_request.max_tokens == 1
         assert prefill_request.max_completion_tokens == 1
         assert prefill_request.stream is False
         assert prefill_request.stream_options is None
@@ -344,19 +343,28 @@ class TestPDOrchestratorMixin:
         assert request.stream is True
 
     @pytest.mark.asyncio
-    async def test_decode_to_prefill_hop_preserves_session_id(self):
+    @pytest.mark.parametrize("method", ["completions", "chat"])
+    async def test_decode_to_prefill_hop_preserves_session_id(self, method):
         server = PDDecodeServer.__new__(PDDecodeServer)
-        server._prefill_handle = _FakePrefillHandle().options(stream=True)
+        server._prefill_handle = _FakePrefillHandle()
         server.engine = _FakeEngine()
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model")
         )
-        request = CompletionRequest(
-            model="test-model",
-            prompt="hello",
-            max_tokens=16,
-            stream=True,
-        )
+        if method == "chat":
+            request = ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "hello"}],
+                max_completion_tokens=16,
+                stream=True,
+            )
+        else:
+            request = CompletionRequest(
+                model="test-model",
+                prompt="hello",
+                max_tokens=16,
+                stream=True,
+            )
         raw_request_info = RawRequestInfo(headers={SERVE_SESSION_ID: "session-a"})
 
         chunks = [
@@ -365,6 +373,7 @@ class TestPDOrchestratorMixin:
         ]
 
         assert chunks == ["decode-chunk"]
+        assert server._prefill_handle.calls[0]["method"] == method
         assert server._prefill_handle.calls[0]["session_id"] == "session-a"
         assert (
             server._prefill_handle.calls[0]["request"].kv_transfer_params[
@@ -389,6 +398,7 @@ class TestPDOrchestratorMixin:
         assert "/v1/chat/completions" in route_paths
         assert "/v1/completions" in route_paths
         assert "/v1/models" in route_paths
+        assert "/v1/models/{model:path}" in route_paths
         assert "/health" in route_paths
 
 

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -1,8 +1,13 @@
 import sys
 import warnings
+from types import SimpleNamespace
 
 import pytest
 
+from ray.llm._internal.serve.core.configs.openai_api_models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+)
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
@@ -11,14 +16,95 @@ from ray.llm._internal.serve.core.ingress.builder import (
     IngressClsConfig,
 )
 from ray.llm._internal.serve.core.ingress.ingress import OpenAiIngress
+from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.serving_patterns.prefill_decode.builder import (
     PDServingArgs,
     build_pd_openai_app,
 )
 from ray.llm._internal.serve.serving_patterns.prefill_decode.pd_server import (
     PDDecodeServer,
+    PDOrchestratorMixin,
     PDPrefillServer,
 )
+from ray.serve._private.http_util import SERVE_SESSION_ID
+
+
+class _AsyncIterator:
+    def __init__(self, items):
+        self._items = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._items)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeHandleMethod:
+    def __init__(self, handle, method_name):
+        self._handle = handle
+        self._method_name = method_name
+
+    def remote(self, request, raw_request_info):
+        self._handle.calls.append(
+            {
+                "method": self._method_name,
+                "request": request,
+                "raw_request_info": raw_request_info,
+                "session_id": self._handle.session_id,
+            }
+        )
+        return _AsyncIterator(
+            [SimpleNamespace(kv_transfer_params={"remote_engine_id": "prefill-1"})]
+        )
+
+
+class _FakePrefillHandle:
+    def __init__(self, calls=None, session_id=None):
+        self.calls = calls if calls is not None else []
+        self.session_id = session_id
+
+    def options(self, **kwargs):
+        return _FakePrefillHandle(
+            calls=self.calls,
+            session_id=kwargs.get("session_id", self.session_id),
+        )
+
+    @property
+    def completions(self):
+        return _FakeHandleMethod(self, "completions")
+
+    @property
+    def chat(self):
+        return _FakeHandleMethod(self, "chat")
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.calls = []
+
+    def completions(self, request, raw_request_info):
+        self.calls.append(
+            {
+                "method": "completions",
+                "request": request,
+                "raw_request_info": raw_request_info,
+            }
+        )
+        return _AsyncIterator(["decode-chunk"])
+
+    def chat(self, request, raw_request_info):
+        self.calls.append(
+            {
+                "method": "chat",
+                "request": request,
+                "raw_request_info": raw_request_info,
+            }
+        )
+        return _AsyncIterator(["decode-chunk"])
 
 
 class TestPDServingArgs:
@@ -235,6 +321,75 @@ class TestServingArgsParsing:
 
         app = build_pd_openai_app(pd_config)
         assert app is not None
+
+
+class TestPDOrchestratorMixin:
+    def test_prepare_prefill_request_limits_chat_to_one_token(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            max_completion_tokens=32,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+
+        prefill_request = PDOrchestratorMixin._prepare_prefill_request(request)
+        prefill_request_dict = prefill_request.model_dump()
+
+        assert prefill_request_dict["max_tokens"] == 1
+        assert prefill_request.max_completion_tokens == 1
+        assert prefill_request.stream is False
+        assert prefill_request.stream_options is None
+        assert request.max_completion_tokens == 32
+        assert request.stream is True
+
+    @pytest.mark.asyncio
+    async def test_decode_to_prefill_hop_preserves_session_id(self):
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._prefill_handle = _FakePrefillHandle().options(stream=True)
+        server.engine = _FakeEngine()
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model")
+        )
+        request = CompletionRequest(
+            model="test-model",
+            prompt="hello",
+            max_tokens=16,
+            stream=True,
+        )
+        raw_request_info = RawRequestInfo(headers={SERVE_SESSION_ID: "session-a"})
+
+        chunks = [
+            chunk
+            async for chunk in server._pd_handle_request(request, raw_request_info)
+        ]
+
+        assert chunks == ["decode-chunk"]
+        assert server._prefill_handle.calls[0]["session_id"] == "session-a"
+        assert (
+            server._prefill_handle.calls[0]["request"].kv_transfer_params[
+                "do_remote_decode"
+            ]
+            is True
+        )
+        assert server.engine.calls[0]["request"].kv_transfer_params == {
+            "remote_engine_id": "prefill-1"
+        }
+
+    @pytest.mark.asyncio
+    async def test_direct_streaming_asgi_routes_are_pd_orchestrator_routes(self):
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model")
+        )
+
+        app = await server.__serve_build_asgi_app__()
+
+        route_paths = {getattr(route, "path", None) for route in app.routes}
+        assert "/v1/chat/completions" in route_paths
+        assert "/v1/completions" in route_paths
+        assert "/v1/models" in route_paths
+        assert "/health" in route_paths
 
 
 class TestBuildPDOpenaiApp:

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -827,6 +827,19 @@ def _matches_session_id_header(header_key: str) -> bool:
     )
 
 
+def session_id_from_headers(headers: Dict[str, str]) -> Optional[str]:
+    """Return the session-id header value from str-keyed headers, or None.
+
+    Same matching rule as ``parse_session_id_header`` (which takes bytes
+    keys); use this for already-decoded ``Dict[str, str]`` headers such as
+    Starlette ``request.headers`` or ``RawRequestInfo.headers``.
+    """
+    return next(
+        (value for key, value in headers.items() if _matches_session_id_header(key)),
+        None,
+    )
+
+
 def parse_session_id_header(headers: Dict[bytes, bytes]) -> str:
     """Return the configured session-id header value, or '' if absent.
 


### PR DESCRIPTION
## Description

With direct streaming, the engine-native ASGI app is served straight from the LLM replica and the separate `OpenAiIngress` deployment is dropped. For prefill/decode (P/D) this broke routing: the engine-native `/v1/chat/completions` and `/v1/completions` routes hit the local decode engine and skipped remote prefill.

This PR routes direct-streaming HTTP on the decode server through P/D orchestration:

- `PDOrchestratorMixin.__serve_build_asgi_app__` starts from the engine-native app and re-points only `/v1/chat/completions` and `/v1/completions` at the orchestrator (remote prefill -> local decode). Other routes stay engine-native.
- Local decode goes through `super().chat` / `super().completions`, so the standard `LLMServer` pipeline (request id, LoRA multiplex, `batch_output_stream`) runs.
- The session-id header is propagated to the prefill handle via `.options(session_id=...)` so a proxy's `-`/`_` rewrite cannot silently drop affinity. New `session_id_from_headers` helper replaces the inlined matcher.
- `_prepare_prefill_request` also pins `max_completion_tokens=1` and clears `stream_options` so the one-token prefill request is well-formed for chat.

### NIXL side-channel port

The side-channel port must be predictable to the remote peer that starts the handshake. The old default (`get_open_port()`) picked a random ephemeral port the peer can't know. The default is now a fixed base (`20000`) plus the existing `_compute_port_offset()`, so replicas land on reproducible, non-colliding ports. `NIXL_SIDE_CHANNEL_PORT_BASE` stays as the override.

## Test plan
- [x] `test_prepare_prefill_request_limits_chat_to_one_token`
- [x] `test_direct_streaming_http_runs_pd_orchestration` (chat/completions)
- [x] `test_default_side_channel_port_uses_configured_base`
