### PR TITLE
Leverage concurrency settings in actor pools

### DIFF
--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -11,7 +11,7 @@ from ray.util import ActorPool
 
 @pytest.fixture
 def init():
-    ray.init(num_cpus=4)
+    ray.init(num_cpus=4, include_dashboard=False)
     yield
     ray.shutdown()
 
@@ -271,6 +271,28 @@ def test_push(init):
     pool.push(a3)
     assert pool.has_free() is False  # a3 is used for pending submit
     assert len(pool._pending_submits) == 0
+
+
+# DO NOT SUBMIT: time based tests are fragile, although used in above tests as well. Update?
+def test_concurrency(init):
+    _wait_time = 5
+    _concurrency = 2
+    _n_actors = 3
+    _n_tasks = _n_actors * _concurrency
+
+    @ray.remote(max_concurrency=_concurrency)
+    class MyActor:
+        def process(self, x):
+            time.sleep(_wait_time)
+            return x
+
+    pool = ActorPool([MyActor.remote() for _ in range(_n_actors)])
+
+    start_time = time.time()
+    results = pool.map(lambda a, x: a.process.remote(x), range(_n_tasks))
+    list(results)
+    end_time = time.time()
+    assert end_time - start_time < 1.5 * _wait_time
 
 
 if __name__ == "__main__":

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -42,6 +42,8 @@ class ActorPool:
 
         record_library_usage("util.ActorPool")
 
+        actors = _maybe_optimize_actor_list(actors)
+
         # actors to be used
         self._idle_actors = list(actors)
 
@@ -486,3 +488,33 @@ class ActorPool:
             raise ValueError("Actor already belongs to current ActorPool")
         else:
             self._return_actor(actor)
+
+
+def _maybe_optimize_actor_list(actors: list["ray.actor.ActorHandle"]):
+    """Optimize the actor list by repeating actors according to their
+    concurrency.
+
+    This allows parallel submissions in `ActorPool` to be scheduled on
+    the same actor, which otherwise is blocked by the return calls.
+
+    Arguments:
+        actors: List of Ray actor handles to use in this pool.
+
+    Returns:
+        A list of the same actors as the input, but each actor repeated according to its concurrency
+    """
+
+    # DO NOT SUBMIT: This requires more robustness:
+    # - concurrency may be set per class method, which is not known at this point. Fallback to lowest?
+    # - This introduces blocking ray.get calls on ActorPool init, which may be undesirable, or at the least require a timeout?
+    def _read_max_concurrency(_actor_self):
+        return (
+            ray._private.worker.global_worker.core_worker.current_actor_max_concurrency()
+        )
+
+    unique_actors = list(set(actors))
+    concurrencies = ray.get(
+        [a.__ray_call__.remote(_read_max_concurrency) for a in unique_actors]
+    )
+
+    return [act for act, conc in zip(unique_actors, concurrencies) for _ in range(conc)]


### PR DESCRIPTION
## Description
Instantiating actor pools from a list of actors adds every actor once to the internal pool (dynamically tracked via `self._idle_actors` and `self._future_to_actor`.)
This does not leverage the fact that some actors have concurrency set up, and can handle multiple calls at the same time.

This PR leverages the concurrency settings to speed up actor pool processing, by simply adding each actor as many times to the internal pool as its concurrency allows for.

See the test for an easy example of when this speeds things up.

## OPEN QUESTION:
It seems trivial that having these extra entries in the `ActorPool`'s internal pool is beneficial to leverage concurrency.
It seems nontrivial however to obtain the required concurrency settings information to unlock the benefit, see below.

**Barring a couple of todos called out in code (+ related good review comments from Gemini), a blocking decision should first be made whether the current approach is worth pursuing**, as it
- requires a ray.get remote call on every individual actor being passed to an `ActorPool` during instantiation, OR
- requires a refactor to make the concurrency settings wider available, AND
- might still have limitations to timeouts or non typical actors that cannot accept the `_read_max_concurrency` python function etc 

## Details

### Obtaining the concurrency numbers

Although any actor class has its concurrency info attached (I believe), obtaining it from instances (handles) is less trivial:
```
def _read_max_concurrency(_actor_self):
    return (
        ray._private.worker.global_worker.core_worker.current_actor_max_concurrency()
    )
    concurrency_for_my_actor = ray.get(my_actor.__ray_call__.remote(_read_max_concurrency))
```

### Interesting note on concurrency leveraging before this PR
The order of the next function already allowed for leveraging a single concurrency instance:
with e.g.
```
@ray.remote(max_concurrency=2)
class MyActor:
    def process(self, x):
        time.sleep(5)
        return x

pool = ActorPool([MyActor.remote(), MyActor.remote()])

results = pool.map(lambda a, x: a.process.remote(x), range(N_TASKS))
list(results)
```
with N_TASKS = 3 would still return in 5+eps, as the first next is immediately called, which _before_ blocking on ray.get to return the first task, already releases the internal actor handle to the available pool and imm. schedules the the pending 3rd task (which due to the concurrency starts executing immediately)

with N_TASKS = 4, the results take 10+eps  seconds without this branch, and 5+eps with this branch