### PR TITLE
[train] Add debug prints to rec_sys tutorial test

### DIFF
--- a/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
@@ -39,6 +39,9 @@ from ray.train.torch import TorchTrainer, prepare_model
 # Other
 
 import subprocess
+
+print("Imports complete", flush=True)
+
 # 02. Load MovieLens 100K Dataset and store in /mnt/cluster_storage/ as CSV + Parquet
 
 # Define clean working paths
@@ -53,20 +56,20 @@ os.makedirs("/mnt/cluster_storage/rec_sys_tutorial/raw", exist_ok=True)
 
 # Download only if not already done
 if not os.path.exists(LOCAL_ZIP):
-    print(f"[debug] downloading {DATA_URL}", flush=True)
+    print(f"Downloading {DATA_URL}", flush=True)
     subprocess.run(
         ["wget", "-q", DATA_URL, "-O", LOCAL_ZIP],
         check=True,
     )
-    print(f"[debug] download complete: {LOCAL_ZIP}", flush=True)
+    print(f"✅ Download complete: {LOCAL_ZIP}", flush=True)
 
 # Extract cleanly
 if not os.path.exists(EXTRACT_DIR):
-    print(f"[debug] extracting {LOCAL_ZIP}", flush=True)
+    print(f"Extracting {LOCAL_ZIP}", flush=True)
     import zipfile
     with zipfile.ZipFile(LOCAL_ZIP, 'r') as zip_ref:
         zip_ref.extractall("/mnt/cluster_storage/rec_sys_tutorial")
-    print(f"[debug] extraction complete: {EXTRACT_DIR}", flush=True)
+    print(f"✅ Extraction complete: {EXTRACT_DIR}", flush=True)
 
 # Load raw file
 raw_path = os.path.join(EXTRACT_DIR, "u.data")

--- a/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
@@ -40,7 +40,7 @@ from ray.train.torch import TorchTrainer, prepare_model
 
 import subprocess
 
-print("Imports complete.", flush=True)
+print("✅ Imports complete.", flush=True)
 
 # 02. Load MovieLens 100K Dataset and store in /mnt/cluster_storage/ as CSV + Parquet
 

--- a/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
@@ -53,16 +53,20 @@ os.makedirs("/mnt/cluster_storage/rec_sys_tutorial/raw", exist_ok=True)
 
 # Download only if not already done
 if not os.path.exists(LOCAL_ZIP):
+    print(f"[debug] downloading {DATA_URL}", flush=True)
     subprocess.run(
         ["wget", "-q", DATA_URL, "-O", LOCAL_ZIP],
         check=True,
     )
+    print(f"[debug] download complete: {LOCAL_ZIP}", flush=True)
 
 # Extract cleanly
 if not os.path.exists(EXTRACT_DIR):
+    print(f"[debug] extracting {LOCAL_ZIP}", flush=True)
     import zipfile
     with zipfile.ZipFile(LOCAL_ZIP, 'r') as zip_ref:
         zip_ref.extractall("/mnt/cluster_storage/rec_sys_tutorial")
+    print(f"[debug] extraction complete: {EXTRACT_DIR}", flush=True)
 
 # Load raw file
 raw_path = os.path.join(EXTRACT_DIR, "u.data")

--- a/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
@@ -40,7 +40,7 @@ from ray.train.torch import TorchTrainer, prepare_model
 
 import subprocess
 
-print("Imports complete", flush=True)
+print("Imports complete.", flush=True)
 
 # 02. Load MovieLens 100K Dataset and store in /mnt/cluster_storage/ as CSV + Parquet
 


### PR DESCRIPTION
`ray_train_workloads.aws` has been an intermittently flaky release test — leading suspect is the `wget` against `files.grouplens.org` in `04e_rec_sys_workload_pattern.py`. This PR adds a few flushed `print()` lines around the imports, download, and extract steps so the next failure tells us where it hangs.

### Testing
Passing [release test](https://buildkite.com/ray-project/release/builds/94554#019e6c00-998e-4c46-b219-7fe62fa8effd) with new prints