### PR TITLE
[Dashboard] Fix invalid PromQL when global_filters is empty in Grafana dashboard generation

### DIFF
--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -190,12 +190,17 @@ def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:
     for variable in variables:
         if "definition" not in variable:
             continue
-        variable["definition"] = variable["definition"].format(
-            global_filters=global_filters_str
-        )
-        variable["query"]["query"] = variable["query"]["query"].format(
-            global_filters=global_filters_str
-        )
+        definition = variable["definition"].format(global_filters=global_filters_str)
+        query = variable["query"]["query"].format(global_filters=global_filters_str)
+        if not global_filters_str:
+            definition = re.sub(r",\s*,", ",", definition)
+            definition = re.sub(r",\s*}", "}", definition)
+            definition = re.sub(r"{\s*,", "{", definition)
+            query = re.sub(r",\s*,", ",", query)
+            query = re.sub(r",\s*}", "}", query)
+            query = re.sub(r"{\s*,", "{", query)
+        variable["definition"] = definition
+        variable["query"]["query"] = query
 
     tags = base_json.get("tags", []) or []
     tags.append(f"rayVersion:{ray.__version__}")
@@ -505,10 +510,11 @@ def _generate_targets(panel: Panel, panel_global_filters: List[str]) -> List[dic
         template = copy.deepcopy(target.template.value)
         global_filters_str = ",".join(panel_global_filters)
         expr = target.expr.format(global_filters=global_filters_str)
-        # Clean up empty global_filters: ", ," → "," and ", }" → "}"
-        expr = re.sub(r",\s*,", ",", expr)
-        expr = re.sub(r",\s*}", "}", expr)
-        expr = re.sub(r"{\s*,", "{", expr)
+        if not global_filters_str:
+            # Clean up empty global_filters: ", ," → "," and ", }" → "}"
+            expr = re.sub(r",\s*,", ",", expr)
+            expr = re.sub(r",\s*}", "}", expr)
+            expr = re.sub(r"{\s*,", "{", expr)
         template.update(
             {
                 "expr": expr,

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -193,12 +193,8 @@ def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:
         definition = variable["definition"].format(global_filters=global_filters_str)
         query = variable["query"]["query"].format(global_filters=global_filters_str)
         if not global_filters_str:
-            definition = re.sub(r",\s*,", ",", definition)
-            definition = re.sub(r",\s*}", "}", definition)
-            definition = re.sub(r"{\s*,", "{", definition)
-            query = re.sub(r",\s*,", ",", query)
-            query = re.sub(r",\s*}", "}", query)
-            query = re.sub(r"{\s*,", "{", query)
+            definition = _clean_empty_filters(definition)
+            query = _clean_empty_filters(query)
         variable["definition"] = definition
         variable["query"]["query"] = query
 
@@ -496,6 +492,20 @@ def _generate_grafana_panels(
     return panels
 
 
+def _clean_empty_filters(expr: str) -> str:
+    """Clean up malformed PromQL when global_filters is empty.
+
+    Removes artifacts like trailing/leading commas in label matchers:
+      ", ," → ","
+      ", }" → "}"
+      "{ ," → "{"
+    """
+    expr = re.sub(r",\s*,", ",", expr)
+    expr = re.sub(r",\s*}", "}", expr)
+    expr = re.sub(r"{\s*,", "{", expr)
+    return expr
+
+
 def gen_incrementing_alphabets(length):
     assert 65 + length < 96, "we only support up to 26 targets at a time."
     # 65: ascii code of 'A'.
@@ -511,10 +521,7 @@ def _generate_targets(panel: Panel, panel_global_filters: List[str]) -> List[dic
         global_filters_str = ",".join(panel_global_filters)
         expr = target.expr.format(global_filters=global_filters_str)
         if not global_filters_str:
-            # Clean up empty global_filters: ", ," → "," and ", }" → "}"
-            expr = re.sub(r",\s*,", ",", expr)
-            expr = re.sub(r",\s*}", "}", expr)
-            expr = re.sub(r"{\s*,", "{", expr)
+            expr = _clean_empty_filters(expr)
         template.update(
             {
                 "expr": expr,

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -2,6 +2,7 @@ import copy
 import json
 import math
 import os
+import re
 from dataclasses import asdict
 from typing import List, Tuple
 
@@ -502,11 +503,15 @@ def _generate_targets(panel: Panel, panel_global_filters: List[str]) -> List[dic
         panel.targets, gen_incrementing_alphabets(len(panel.targets))
     ):
         template = copy.deepcopy(target.template.value)
+        global_filters_str = ",".join(panel_global_filters)
+        expr = target.expr.format(global_filters=global_filters_str)
+        # Clean up empty global_filters: ", ," → "," and ", }" → "}"
+        expr = re.sub(r",\s*,", ",", expr)
+        expr = re.sub(r",\s*}", "}", expr)
+        expr = re.sub(r"{\s*,", "{", expr)
         template.update(
             {
-                "expr": target.expr.format(
-                    global_filters=",".join(panel_global_filters)
-                ),
+                "expr": expr,
                 "legendFormat": target.legend,
                 "refId": ref_id,
             }


### PR DESCRIPTION
  Description

  Fix Serve LLM Grafana dashboard failing to load due to invalid PromQL syntax.

  The Serve LLM dashboard (serve_llm_dashboard_panels.py) sets standard_global_filters=[]. When the environment variable RAY_GRAFANA_SERVE_LLM_DASHBOARD_GLOBAL_FILTERS is also not set, {global_filters} in panel expressions is replaced with an empty string, producing invalid PromQL with double commas:

<img width="1785" height="414" alt="Clipboard_Screenshot_1779942646" src="https://github.com/user-attachments/assets/9038d10e-fe51-4759-8df4-c505ac3ad2df" />

  # Generated invalid expression - Grafana fails to load
  ray_serve_deployment_request_counter_total{model_name=~"$vllm_model_name", , deployment=~"$deployment"}

  This PR adds post-format regex cleanup in _generate_targets() to remove empty filter artifacts:
  - , , → ,
  - , } → }
  - { , → {

  These patterns are never valid in PromQL, so other dashboards with non-empty filters are unaffected.
