### PR TITLE
[core] Fix ray.get hanging forever when an object's owner dies during pull

### DIFF
--- a/src/mock/ray/object_manager/object_manager.h
+++ b/src/mock/ray/object_manager/object_manager.h
@@ -28,6 +28,10 @@ class MockObjectManager : public ObjectManagerInterface {
                const TaskMetricsKey &task_key),
               (override));
   MOCK_METHOD(void, CancelPull, (uint64_t request_id), (override));
+  MOCK_METHOD(void,
+              MarkObjectFailed,
+              (const ObjectID &object_id, rpc::ErrorType error_type),
+              (override));
   MOCK_METHOD(bool,
               PullRequestActiveOrWaitingForMetadata,
               (uint64_t request_id),

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -23,11 +23,14 @@
 #include <utility>
 #include <vector>
 
+#include "absl/time/clock.h"
 #include "ray/asio/asio_util.h"
+#include "ray/common/protobuf_utils.h"
 #include "ray/object_manager/plasma/store_runner.h"
 #include "ray/object_manager/spilled_object_reader.h"
 #include "ray/util/exponential_backoff.h"
 #include "ray/util/network_util.h"
+#include "ray/util/time.h"
 
 namespace ray {
 
@@ -69,7 +72,6 @@ ObjectManager::ObjectManager(
     RestoreSpilledObjectCallback restore_spilled_object,
     std::function<std::string(const ObjectID &)> get_spilled_object_url,
     std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-    std::function<void(const ObjectID &, rpc::ErrorType)> fail_pull_request,
     const std::shared_ptr<plasma::PlasmaClientInterface> &buffer_pool_store_client,
     std::unique_ptr<ObjectStoreRunner> object_store_internal,
     std::function<std::shared_ptr<rpc::ObjectManagerClientInterface>(
@@ -119,6 +121,9 @@ ObjectManager::ObjectManager(
     // created and will cause a leak if we never receive the rest of the
     // object. This is a no-op if the object is already sealed or evicted.
     buffer_pool_.AbortCreate(object_id);
+  };
+  auto fail_pull_request = [this](const ObjectID &object_id, rpc::ErrorType error_type) {
+    MarkObjectFailed(object_id, error_type);
   };
   auto get_time = []() { return absl::GetCurrentTimeNanos() / 1e9; };
   const int64_t available_memory = std::max<int64_t>(config.object_store_memory, 0);
@@ -250,6 +255,43 @@ void ObjectManager::CancelPull(uint64_t request_id) {
   for (const auto &object_id : objects_to_cancel) {
     object_directory_->UnsubscribeObjectLocations(object_directory_pull_callback_id_,
                                                   object_id);
+  }
+}
+
+void ObjectManager::MarkObjectFailed(const ObjectID &object_id,
+                                     rpc::ErrorType error_type) {
+  // TODO(swang): Ideally we should return the error directly to the client
+  // that needs this object instead of storing the object in plasma, which is
+  // not guaranteed to succeed. This avoids hanging the client if plasma is not
+  // reachable.
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Mark the object as failed due to " << error_type;
+  // Release any in flight pull placeholder first, otherwise the error
+  // sentinel write below would silently collide with it.
+  buffer_pool_.AbortCreate(object_id);
+  const std::string meta = std::to_string(static_cast<int>(error_type));
+  std::shared_ptr<Buffer> data;
+  Status status = buffer_pool_store_client_->TryCreateImmediately(
+      object_id,
+      rpc::Address{},
+      0,
+      reinterpret_cast<const uint8_t *>(meta.c_str()),
+      meta.length(),
+      &data,
+      plasma::flatbuf::ObjectSource::ErrorStoredByRaylet);
+  if (status.ok()) {
+    status = buffer_pool_store_client_->Seal(object_id);
+  }
+  if (!status.ok() && !status.IsObjectExists()) {
+    std::ostringstream stream;
+    stream << "A plasma error (" << status.ToString()
+           << ") occurred while saving error code to object " << object_id
+           << ". Anyone who's getting this object may hang forever.";
+    std::string error_message = stream.str();
+    RAY_LOG(ERROR) << error_message;
+    auto error_data = gcs::CreateErrorTableData(
+        "task", error_message, absl::FromUnixMillis(current_time_ms()));
+    gcs_client_.Errors().AsyncReportJobError(std::move(error_data));
   }
 }
 

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -103,6 +103,11 @@ class ObjectManagerInterface {
                         BundlePriority prio,
                         const TaskMetricsKey &task_key) = 0;
   virtual void CancelPull(uint64_t request_id) = 0;
+  /// Mark the specified object as failed with the given error type.
+  ///
+  /// \param object_id The object id to store error message into.
+  /// \param error_type The type of the error that caused this task to fail.
+  virtual void MarkObjectFailed(const ObjectID &object_id, rpc::ErrorType error_type) = 0;
   virtual bool PullRequestActiveOrWaitingForMetadata(uint64_t request_id) const = 0;
   virtual int64_t PullManagerNumInactivePullsByTaskName(
       const TaskMetricsKey &task_key) const = 0;
@@ -188,7 +193,6 @@ class ObjectManager : public ObjectManagerInterface,
       RestoreSpilledObjectCallback restore_spilled_object,
       std::function<std::string(const ObjectID &)> get_spilled_object_url,
       std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-      std::function<void(const ObjectID &, rpc::ErrorType)> fail_pull_request,
       const std::shared_ptr<plasma::PlasmaClientInterface> &buffer_pool_store_client,
       std::unique_ptr<ObjectStoreRunner> object_store_internal,
       std::function<std::shared_ptr<rpc::ObjectManagerClientInterface>(
@@ -235,6 +239,8 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param pull_request_id The request to cancel.
   void CancelPull(uint64_t pull_request_id) override;
 
+  void MarkObjectFailed(const ObjectID &object_id, rpc::ErrorType error_type) override;
+
   /// Free a list of objects from object store.
   ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
@@ -277,7 +283,7 @@ class ObjectManager : public ObjectManagerInterface,
   }
 
  private:
-  friend class TestObjectManager;
+  friend class ObjectManagerTest;
   friend uint32_t NumRemoteFreeObjectsRequests(const ObjectManager &object_manager);
 
   /// Spread the Free request to all objects managers.

--- a/src/ray/object_manager/plasma/fake_plasma_client.h
+++ b/src/ray/object_manager/plasma/fake_plasma_client.h
@@ -44,6 +44,16 @@ class FakePlasmaClient : public PlasmaClientInterface {
                                 std::shared_ptr<Buffer> *data,
                                 plasma::flatbuf::ObjectSource source,
                                 int device_num = 0) override {
+    auto [it, inserted] =
+        objects_in_plasma_.emplace(object_id,
+                                   std::make_pair(std::vector<uint8_t>(data_size),
+                                                  std::vector<uint8_t>(metadata_size)));
+    if (!inserted) {
+      return Status::ObjectExists("Object already exists in plasma");
+    }
+    if (data != nullptr) {
+      *data = std::make_shared<SharedMemoryBuffer>(it->second.first.data(), data_size);
+    }
     return Status::OK();
   }
 
@@ -63,8 +73,11 @@ class FakePlasmaClient : public PlasmaClientInterface {
     if (metadata != nullptr && metadata_size > 0) {
       metadata_vec.assign(metadata, metadata + metadata_size);
     }
-    objects_in_plasma_.emplace(
+    auto [it, inserted] = objects_in_plasma_.emplace(
         object_id, std::make_pair(std::move(data_vec), std::move(metadata_vec)));
+    if (!inserted) {
+      return Status::ObjectExists("Object already exists in plasma");
+    }
     return Status::OK();
   }
 

--- a/src/ray/object_manager/tests/object_manager_test.cc
+++ b/src/ray/object_manager/tests/object_manager_test.cc
@@ -76,8 +76,6 @@ class ObjectManagerTest : public ::testing::Test {
         [](const ObjectID &object_id) -> std::string { return ""; },
         // pin_object
         [](const ObjectID &object_id) -> std::unique_ptr<RayObject> { return nullptr; },
-        // fail_pull_request
-        [](const ObjectID &object_id, rpc::ErrorType error_type) {},
         fake_plasma_client_,
         nullptr,
         [](const std::string &address,
@@ -87,6 +85,12 @@ class ObjectManagerTest : public ::testing::Test {
               address, port, client_call_manager);
         },
         rpc_context_);
+  }
+
+  void InstallPullPlaceholder(const ObjectID &object_id, int64_t size) {
+    rpc::Address owner;
+    ASSERT_TRUE(
+        object_manager_->buffer_pool_.CreateChunk(object_id, owner, size, 0, 0).ok());
   }
 
   NodeID local_node_id_;
@@ -113,6 +117,26 @@ uint32_t NumRemoteFreeObjectsRequests(const ObjectManager &object_manager) {
     num_free_objects_requests += fake_rpc_client->num_free_objects_requests;
   }
   return num_free_objects_requests;
+}
+
+TEST_F(ObjectManagerTest, MarkObjectFailedReleasesPlaceholderAndWritesSentinel) {
+  // While a pull is in flight, we put an unsealed buffer at that
+  // ObjectID slot in plasma (so we can stream chunks into it). If the
+  // pull fails (e.g., the owner dies or it times out), we must release
+  // the slot before writing the error sentinel; otherwise the write
+  // collides with the slot and we pull forever.
+  ObjectID id = ObjectID::FromRandom();
+  InstallPullPlaceholder(id, 100);
+  ASSERT_TRUE(fake_plasma_client_->objects_in_plasma_.contains(id));
+  ASSERT_TRUE(fake_plasma_client_->objects_in_plasma_[id].second.empty());
+
+  object_manager_->MarkObjectFailed(id, rpc::ErrorType::OWNER_DIED);
+
+  ASSERT_TRUE(fake_plasma_client_->objects_in_plasma_.contains(id));
+  std::string expected_meta =
+      std::to_string(static_cast<int>(rpc::ErrorType::OWNER_DIED));
+  const auto &actual_meta = fake_plasma_client_->objects_in_plasma_[id].second;
+  EXPECT_EQ(std::string(actual_meta.begin(), actual_meta.end()), expected_meta);
 }
 
 TEST_F(ObjectManagerTest, TestFreeObjectsLocalOnlyFalse) {

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -778,9 +778,7 @@ int main(int argc, char *argv[]) {
         core_worker_subscriber.get(),
         worker_rpc_pool.get(),
         [&](const ray::ObjectID &obj_id, const ray::rpc::ErrorType &error_type) {
-          ray::rpc::ObjectReference ref;
-          ref.set_object_id(obj_id.Binary());
-          node_manager->MarkObjectsAsFailed(error_type, {ref}, ray::JobID::Nil());
+          object_manager->MarkObjectFailed(obj_id, error_type);
         });
 
     auto object_store_runner = std::make_unique<ray::ObjectStoreRunner>(
@@ -857,12 +855,6 @@ int main(int argc, char *argv[]) {
             result = std::move(results[0]);
           }
           return result;
-        },
-        /*fail_pull_request=*/
-        [&](const ray::ObjectID &object_id, ray::rpc::ErrorType error_type) {
-          ray::rpc::ObjectReference ref;
-          ref.set_object_id(object_id.Binary());
-          node_manager->MarkObjectsAsFailed(error_type, {ref}, ray::JobID::Nil());
         },
         std::make_shared<plasma::PlasmaClient>(),
         std::move(object_store_runner),

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2283,49 +2283,6 @@ void NodeManager::HandleCancelWorkerLease(rpc::CancelWorkerLeaseRequest request,
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
-void NodeManager::MarkObjectsAsFailed(
-    const ErrorType &error_type,
-    const std::vector<rpc::ObjectReference> &objects_to_fail,
-    const JobID &job_id) {
-  // TODO(swang): Ideally we should return the error directly to the client
-  // that needs this object instead of storing the object in plasma, which is
-  // not guaranteed to succeed. This avoids hanging the client if plasma is not
-  // reachable.
-  const std::string meta = std::to_string(static_cast<int>(error_type));
-  for (const auto &ref : objects_to_fail) {
-    ObjectID object_id = ObjectID::FromBinary(ref.object_id());
-    RAY_LOG(DEBUG).WithField(object_id)
-        << "Mark the object as failed due to " << error_type;
-    std::shared_ptr<Buffer> data;
-    Status status;
-    status = store_client_->TryCreateImmediately(
-        object_id,
-        ref.owner_address(),
-        0,
-        reinterpret_cast<const uint8_t *>(meta.c_str()),
-        meta.length(),
-        &data,
-        plasma::flatbuf::ObjectSource::ErrorStoredByRaylet);
-    if (status.ok()) {
-      status = store_client_->Seal(object_id);
-    }
-    if (!status.ok() && !status.IsObjectExists()) {
-      RAY_LOG(DEBUG).WithField(object_id) << "Marking plasma object failed.";
-      // If we failed to save the error code, log a warning and push an error message
-      // to the driver.
-      std::ostringstream stream;
-      stream << "A plasma error (" << status.ToString() << ") occurred while saving"
-             << " error code to object " << object_id << ". Anyone who's getting this"
-             << " object may hang forever.";
-      std::string error_message = stream.str();
-      RAY_LOG(ERROR) << error_message;
-      auto error_data = gcs::CreateErrorTableData(
-          "task", error_message, absl::FromUnixMillis(current_time_ms()), job_id);
-      gcs_client_.Errors().AsyncReportJobError(std::move(error_data));
-    }
-  }
-}
-
 void NodeManager::HandleNotifyWorkerBlocked(
     const std::shared_ptr<WorkerInterface> &worker) {
   if (!worker || worker->IsBlocked() || worker->GetGrantedLeaseId().IsNil()) {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -245,15 +245,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// or object ids can be freed up across the cluster.
   void SetShouldGlobalGC();
 
-  /// Mark the specified objects as failed with the given error type.
-  ///
-  /// \param error_type The type of the error that caused this task to fail.
-  /// \param object_ids The object ids to store error messages into.
-  /// \param job_id The optional job to push errors to if the writes fail.
-  void MarkObjectsAsFailed(const ErrorType &error_type,
-                           const std::vector<rpc::ObjectReference> &object_ids,
-                           const JobID &job_id);
-
   /// Stop this node manager.
   void Stop();
 


### PR DESCRIPTION

## Description
oncall and here is the user facing issue. Basically the scenario is:
- The driver creates actor A and actor B.
- Actor A calls `ray.put` creating an object and returns the ref back to the driver.
- The driver then passes the ref to actor B.
- Actor B tries to `ray.get` that object.
- Actor B's raylet pubsubs to the object owner (actor A) for the object location and gets it.
- Actor B then starts pulling.
- During pulling, actor A dies.
- Actor B waits forever.

Now, we all know this ref passing pattern is completely an anti pattern, but this is the scenario and this is what the user is doing.

The thing is, although this is an anti pattern, when actor A (the object owner) dies, we should be able to surface an error instead of waiting forever.

When actor A's worker dies, GCS will be notified and propagate the notification to actor B's raylet. In this case, actor B's raylet should put an `OWNER_DIED` error sentinel object into the local plasma store, and the actor B process should fetch that error object and surface the owner died error to the user.

Even if this does not work, we have a last resort : the 10 minute timeout. Pulling for longer than 10 minutes should also raise an error if you look at the code.

But all of these failed.

The bug is that, regardless of whether it's the owner death notification or the 10 minute timeout, both rely on writing an  error sentinel object into the local plasma store, but writes to the object store can fail!

In our case, when actor B gets the object location and starts pulling, it actually first puts an unsealed buffer at that `ObjectID` slot in plasma (so it can stream chunks into it) with exactly the object's size. Then, when we try to put the `OWNER_DIED` error sentinel object in, we get an "object already exists" error and just silently move on. As a result, actor B never sees the error object and hangs forever.


Debating whether writing the error object into plasma is the right design is out of scope for this PR. We definitely can and maybe should surface the error directly instead, but that would require a larger refactor.


## repro

```python
import time
import ray
from ray.cluster_utils import Cluster


cluster = Cluster()
cluster.add_node(num_cpus=4, resources={"head": 1}, _system_config={
    # make sure pull object is slow enough to enlarge the race window.
    "object_manager_default_chunk_size":  64 * 1024,
    "object_manager_max_bytes_in_flight": 64 * 1024,
})
ray.init(address=cluster.address, log_to_driver=False)
worker = cluster.add_node(num_cpus=2, resources={"worker": 1})
cluster.wait_for_nodes()


@ray.remote(resources={"worker": 0.01})
class Owner:
    def make(self):
        return [ray.put(b"x" * 50 * 1024 * 1024)]


@ray.remote(resources={"head": 0.01})
class Consumer:
    def consume(self, refs):
        return sum(len(d) for d in ray.get(refs))


consumer = Consumer.remote()
owner_calib = Owner.remote()
owner_race  = Owner.remote()

# Measure baseline pull time on this machine.
refs = ray.get(owner_calib.make.remote())
t = time.time()
ray.get(consumer.consume.remote(refs))
pull_time = time.time() - t

# Kill the Owner during object pulling.
refs = ray.get(owner_race.make.remote())
task = consumer.consume.remote(refs)
time.sleep(pull_time / 2)
cluster.remove_node(worker)

# before this pr: GetTimeoutError raised after 30 s.
# after this pr: RayTaskError(OwnerDiedError) raised in 1.98s.
ray.get(task, timeout=30)
```



## The fix

The fix is simple: whenever we try to put an error sentinel object in and get an "object exists" error, we check if the exists one is actually a placeholder for an in progress pull. If so, we abort the placeholder and write the error sentinel object in plasma.


This PR also:
- move both the sentinel write and the placeholder abort into ObjectManager. Previously the sentinel write was in NodeManager, which doesn't make sense considering the responsibility, and plasma requires the abort to come from the same client that created the placeholder, so the abort and the sentinel write have to live in the same place.


