### PR TITLE
[core] Fix `subprocesses/tests/test_e2e`

### DIFF
--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -1,7 +1,9 @@
 import asyncio
 import pathlib
 import re
+import shutil
 import sys
+import tempfile
 from typing import List
 
 import pytest
@@ -27,20 +29,28 @@ def default_module_config(tmp_path) -> SubprocessModuleConfig:
     """
     Creates a tmpdir to hold the logs.
     """
-    yield SubprocessModuleConfig(
-        cluster_id_hex="test_cluster_id",
-        gcs_address="",
-        session_name="test_session",
-        temp_dir=str(tmp_path),
-        session_dir=str(tmp_path),
-        logging_level=ray_constants.LOGGER_LEVEL,
-        logging_format=ray_constants.LOGGER_FORMAT,
-        log_dir=str(tmp_path),
-        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
-        logging_rotate_bytes=LOGGING_ROTATE_BYTES,
-        logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
-        socket_dir=str(tmp_path),
-    )
+    # macOS caps AF_UNIX sun_path at 104 bytes. pytest's tmp_path on macOS is
+    # rooted at /private/var/folders/... which is already long enough that
+    # appending the socket filename exceeds the limit, so use a short directory
+    # under /tmp for the socket files specifically.
+    socket_dir = tempfile.mkdtemp(prefix="ray_e2e_", dir="/tmp")
+    try:
+        yield SubprocessModuleConfig(
+            cluster_id_hex="test_cluster_id",
+            gcs_address="",
+            session_name="test_session",
+            temp_dir=str(tmp_path),
+            session_dir=str(tmp_path),
+            logging_level=ray_constants.LOGGER_LEVEL,
+            logging_format=ray_constants.LOGGER_FORMAT,
+            log_dir=str(tmp_path),
+            logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+            logging_rotate_bytes=LOGGING_ROTATE_BYTES,
+            logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
+            socket_dir=socket_dir,
+        )
+    finally:
+        shutil.rmtree(socket_dir, ignore_errors=True)
 
 
 class _DummyConn:

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -33,7 +33,7 @@ def default_module_config(tmp_path) -> SubprocessModuleConfig:
     # rooted at /private/var/folders/... which is already long enough that
     # appending the socket filename exceeds the limit, so use a short directory
     # under /tmp for the socket files specifically.
-    socket_dir = tempfile.mkdtemp(prefix="ray_e2e_", dir="/tmp")
+    socket_dir = tempfile.mkdtemp(prefix="ray_e2e_", dir="/tmp" if sys.platform != "win32" else None)
     try:
         yield SubprocessModuleConfig(
             cluster_id_hex="test_cluster_id",

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -33,7 +33,9 @@ def default_module_config(tmp_path) -> SubprocessModuleConfig:
     # rooted at /private/var/folders/... which is already long enough that
     # appending the socket filename exceeds the limit, so use a short directory
     # under /tmp for the socket files specifically.
-    socket_dir = tempfile.mkdtemp(prefix="ray_e2e_", dir="/tmp" if sys.platform != "win32" else None)
+    socket_dir = tempfile.mkdtemp(
+        prefix="ray_e2e_", dir="/tmp" if sys.platform != "win32" else None
+    )
     try:
         yield SubprocessModuleConfig(
             cluster_id_hex="test_cluster_id",


### PR DESCRIPTION
Test is failing in CI due to subprocess module failing to start.

Thanks to claude, identified that this is due to the socket name being too long in the temp dir. Fixed by using shorter prefix. Verified that the tests pass locally now.