### PR TITLE
[Data][Release] pyspy: enable --native by dropping --nonblocking

### DIFF
--- a/release/nightly_tests/dataset/profiling/pyspy.py
+++ b/release/nightly_tests/dataset/profiling/pyspy.py
@@ -80,8 +80,15 @@ def start(outdir):
         PYSPY_FORMAT,
         "-r",
         str(PYSPY_RATE),
-        "--nonblocking",
         "--subprocesses",
+        # --native walks C/C++/Cython frames so the speedscope surfaces
+        # raylet RPC / cloudpickle / arrow leaves alongside Python.
+        # py-spy hard-rejects --native + --nonblocking ("Can't get native
+        # stack traces with the --nonblocking option."), so we run in
+        # the blocking mode: a brief ptrace-stop per sample. At
+        # PYSPY_RATE=100 the overhead is small but measurable; if a
+        # release-test run shows throughput regression, halve PYSPY_RATE.
+        "--native",
     ]
 
     _log_file = open(log_path, "w")
@@ -247,7 +254,11 @@ def _attach_worker_pyspy(pid, name, outdir, name_counts):
         PYSPY_FORMAT,
         "-r",
         str(PYSPY_RATE),
-        "--nonblocking",
+        # --native walks C/C++/Cython frames; py-spy hard-rejects
+        # --native + --nonblocking, so we run in blocking mode (one
+        # brief ptrace-stop per sample). See the matching note on the
+        # driver-side cmd.
+        "--native",
     ]
 
     log_file = open(log_path, "w")


### PR DESCRIPTION
## Summary

In `release/nightly_tests/dataset/profiling/pyspy.py`, both the driver and per-worker `py-spy record` invocations now pass `--native` (and no longer pass `--nonblocking`).

Without `--native`, the release-test speedscopes can't walk past the Cython boundary — in our 5000_tasks worker_scaling traces, ~80 s of `auto_init_wrapper` / `_invocation_remote_span` / `invocation` collapses into a single opaque frame, hiding cloudpickle / msgpack / raylet-RPC leaves.

py-spy 0.4.2 (the version in the Anyscale base image) hard-rejects `--native --nonblocking` with `Can't get native stack traces with the --nonblocking option.` Verified by running py-spy directly on the image: `--native` alone and `--native --subprocesses` both produce a valid native-frames speedscope; any combo with `--nonblocking` exits 1 immediately and produces no file.

## Trade-off

Dropping `--nonblocking` means py-spy ptrace-stops the target briefly per sample. At `PYSPY_RATE=100` the cost is small but measurable on Ray UDF workers doing arrow / serialization work. If the next worker_scaling release-test run shows throughput regression, halve `PYSPY_RATE` to 50 in the same file — cost scales linearly with sample rate, and 50 Hz still surfaces arrow / cloudpickle leaves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)