### PR TITLE
[Core] Stop spawning idle worker when OOM kill threshold reached

### DIFF
--- a/src/ray/common/event_memory_monitor.cc
+++ b/src/ray/common/event_memory_monitor.cc
@@ -119,6 +119,10 @@ void EventMemoryMonitor::Disable() { worker_killing_in_progress_.store(true); }
 
 bool EventMemoryMonitor::IsEnabled() const { return !worker_killing_in_progress_.load(); }
 
+bool EventMemoryMonitor::IsUsageAboveThreshold() const {
+  return worker_killing_in_progress_.load();
+}
+
 void EventMemoryMonitor::MonitoringThreadMain() {
   struct pollfd fds[2];
   fds[0].fd = inotify_fd_;

--- a/src/ray/common/event_memory_monitor.h
+++ b/src/ray/common/event_memory_monitor.h
@@ -72,6 +72,13 @@ class EventMemoryMonitor : public MemoryMonitorInterface {
    */
   bool IsEnabled() const override;
 
+  /**
+   * cgroup memory events are edge-triggered with no continuous "above"
+   * state, so this reports pressure only while a kill triggered by this
+   * monitor is in flight.
+   */
+  bool IsUsageAboveThreshold() const override;
+
  private:
   enum class DrainResult { kDrained, kInterrupted, kError };
 

--- a/src/ray/common/memory_monitor_interface.h
+++ b/src/ray/common/memory_monitor_interface.h
@@ -102,6 +102,20 @@ class MemoryMonitorInterface {
    */
   virtual bool IsEnabled() const = 0;
 
+  /**
+   * @return True if the monitor's most recent observation indicates memory
+   *         usage is above its trigger threshold. Used by callers (e.g. the
+   *         worker prestart path) to back off from allocating more memory
+   *         while the node is under pressure.
+   *
+   * Threshold-style monitors return the cached result of their last
+   * periodic check (at most one monitor interval stale). Event-driven
+   * monitors (PSI, cgroup events) have no continuous "above" state and
+   * fall back to reporting pressure only while a kill they triggered is
+   * in flight.
+   */
+  virtual bool IsUsageAboveThreshold() const = 0;
+
   static constexpr char kDefaultCgroupPath[] = "/sys/fs/cgroup";
   static constexpr int64_t kNull = -1;
   /// The logging frequency. Decoupled from how often the monitor runs.

--- a/src/ray/common/noop_memory_monitor.h
+++ b/src/ray/common/noop_memory_monitor.h
@@ -34,6 +34,7 @@ class NoopMemoryMonitor : public MemoryMonitorInterface {
   void Enable() override {}
   void Disable() override {}
   bool IsEnabled() const override { return true; }
+  bool IsUsageAboveThreshold() const override { return false; }
 };
 
 }  // namespace ray

--- a/src/ray/common/pressure_memory_monitor.cc
+++ b/src/ray/common/pressure_memory_monitor.cc
@@ -132,6 +132,10 @@ bool PressureMemoryMonitor::IsEnabled() const {
   return !worker_killing_in_progress_.load();
 }
 
+bool PressureMemoryMonitor::IsUsageAboveThreshold() const {
+  return worker_killing_in_progress_.load();
+}
+
 void PressureMemoryMonitor::MonitoringThreadMain() {
   struct pollfd fds[2];
   fds[0].fd = pressure_fd_;

--- a/src/ray/common/pressure_memory_monitor.h
+++ b/src/ray/common/pressure_memory_monitor.h
@@ -128,6 +128,13 @@ class PressureMemoryMonitor : public MemoryMonitorInterface {
    */
   bool IsEnabled() const override;
 
+  /**
+   * PSI is event-driven and has no continuous "above" state, so this
+   * reports pressure only while a kill triggered by this monitor is in
+   * flight.
+   */
+  bool IsUsageAboveThreshold() const override;
+
   /// The default monitoring mode for cgroup pressure monitor trigger.
   /// Possible values are:
   /// - some: At least one task is stalled for a specified duration

--- a/src/ray/common/tests/threshold_memory_monitor_test.cc
+++ b/src/ray/common/tests/threshold_memory_monitor_test.cc
@@ -265,4 +265,43 @@ TEST_F(ThresholdMemoryMonitorTest,
          "threshold.";
 }
 
+// Verifies that IsUsageAboveThreshold() reflects the cached result of the
+// last periodic check: true after the monitor observes memory above the
+// threshold. The kill callback is set up so its fire indicates the periodic
+// helper has already updated the cache.
+TEST_F(ThresholdMemoryMonitorTest, TestIsUsageAboveThresholdReflectsCachedAboveResult) {
+  int64_t cgroup_total_bytes = 1024 * 1024 * 1024;   // 1 GB
+  int64_t cgroup_current_bytes = 850 * 1024 * 1024;  // 850 MB current usage
+  int64_t anon_memory_bytes = 200 * 1024 * 1024;
+  int64_t shmem_memory_bytes = 100 * 1024 * 1024;
+  int64_t inactive_file_bytes = 30 * 1024 * 1024;
+  int64_t active_file_bytes = 20 * 1024 * 1024;
+  // Working set = 850 - 30 - 20 = 800 MB (80% of 1GB, above 70% threshold)
+
+  std::string cgroup_dir = MockCgroupv2MemoryUsage(cgroup_total_bytes,
+                                                   cgroup_current_bytes,
+                                                   anon_memory_bytes,
+                                                   shmem_memory_bytes,
+                                                   inactive_file_bytes,
+                                                   active_file_bytes);
+
+  std::shared_ptr<boost::latch> has_checked_once = std::make_shared<boost::latch>(1);
+
+  NoopCgroupManager noop_cgroup_manager;
+  int64_t memory_usage_threshold_bytes = MemoryMonitorUtils::GetMemoryThreshold(
+      cgroup_total_bytes, 0.7f, -1, false, noop_cgroup_manager);
+  auto &monitor = MakeThresholdMemoryMonitor(
+      memory_usage_threshold_bytes,  // (70%)
+      1 /*refresh_interval_ms*/,
+      [has_checked_once](std::string) { has_checked_once->count_down(); },
+      cgroup_dir /*root_cgroup_path*/);
+
+  has_checked_once->wait();
+  // Cache is written inside the helper before the kill callback fires, so the
+  // latch returning here guarantees IsUsageAboveThreshold() has been updated.
+  ASSERT_TRUE(monitor.IsUsageAboveThreshold())
+      << "Expected the cached above-threshold flag to be true after the "
+         "monitor observed memory above the threshold.";
+}
+
 }  // namespace ray

--- a/src/ray/common/threshold_memory_monitor.cc
+++ b/src/ray/common/threshold_memory_monitor.cc
@@ -30,6 +30,7 @@ ThresholdMemoryMonitor::ThresholdMemoryMonitor(KillWorkersCallback kill_workers_
                                                const std::string &system_cgroup_path)
     : kill_workers_callback_(std::move(kill_workers_callback)),
       worker_killing_in_progress_(false),
+      usage_above_threshold_(false),
       memory_usage_threshold_bytes_(memory_usage_threshold_bytes),
       resource_isolation_enabled_(resource_isolation_enabled),
       root_cgroup_path_(root_cgroup_path),
@@ -104,6 +105,10 @@ bool ThresholdMemoryMonitor::IsEnabled() const {
   return !worker_killing_in_progress_.load();
 }
 
+bool ThresholdMemoryMonitor::IsUsageAboveThreshold() const {
+  return usage_above_threshold_.load();
+}
+
 std::optional<MemoryUsageSnapshot>
 ThresholdMemoryMonitor::IsHostMemoryThresholdExceeded() {
   MemoryUsageSnapshot cur_memory_snapshot =
@@ -115,9 +120,11 @@ ThresholdMemoryMonitor::IsHostMemoryThresholdExceeded() {
     RAY_LOG_EVERY_MS(WARNING, MemoryMonitorInterface::kLogIntervalMs)
         << "Unable to capture node memory. Monitor will not be able "
         << "to detect memory usage above threshold.";
+    usage_above_threshold_.store(false);
     return std::nullopt;
   }
   bool is_usage_above_threshold = used_memory_bytes > memory_usage_threshold_bytes_;
+  usage_above_threshold_.store(is_usage_above_threshold);
   if (is_usage_above_threshold) {
     RAY_LOG_EVERY_MS(INFO, MemoryMonitorInterface::kLogIntervalMs) << absl::StrFormat(
         "Node memory usage above threshold, used: %d, threshold_bytes: %d, "
@@ -144,11 +151,13 @@ ThresholdMemoryMonitor::IsResourceIsolationThresholdExceeded() {
         "The threshold memory monitor will not be able to provide resource isolation "
         "protection.",
         user_slice_memory_snapshot_or.message());
+    usage_above_threshold_.store(false);
     return std::nullopt;
   }
   MemoryUsageSnapshot user_slice_memory_snapshot = user_slice_memory_snapshot_or.value();
   bool is_usage_above_threshold =
       user_slice_memory_snapshot.used_bytes > memory_usage_threshold_bytes_;
+  usage_above_threshold_.store(is_usage_above_threshold);
   if (is_usage_above_threshold) {
     RAY_LOG_EVERY_MS(INFO, MemoryMonitorInterface::kLogIntervalMs) << absl::StrFormat(
         "User slice memory usage above threshold, used: %d, threshold_bytes: %d, "

--- a/src/ray/common/threshold_memory_monitor.h
+++ b/src/ray/common/threshold_memory_monitor.h
@@ -78,6 +78,13 @@ class ThresholdMemoryMonitor : public MemoryMonitorInterface {
    */
   bool IsEnabled() const override;
 
+  /**
+   * @return True if the most recent periodic check observed memory usage
+   *         above the configured threshold. At most one monitor interval
+   *         stale.
+   */
+  bool IsUsageAboveThreshold() const override;
+
  private:
   /**
    * @brief Checks if the memory usage on the host exceeds the threshold.
@@ -103,6 +110,11 @@ class ThresholdMemoryMonitor : public MemoryMonitorInterface {
 
   /// Flag to indicate that the worker killing event is in progress.
   std::atomic<bool> worker_killing_in_progress_;
+
+  /// Result of the most recent periodic check. Read by callers via
+  /// IsUsageAboveThreshold() to back off from allocating more memory while
+  /// usage is over the threshold.
+  std::atomic<bool> usage_above_threshold_;
 
   /// The threshold in bytes that triggers the callback.
   int64_t memory_usage_threshold_bytes_;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1885,7 +1885,13 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
   }
 
   const auto &lease_spec = lease.GetLeaseSpecification();
-  worker_pool_.PrestartWorkers(lease_spec, request.backlog_size());
+  if (!IsAnyMemoryMonitorAboveThreshold()) {
+    worker_pool_.PrestartWorkers(lease_spec, request.backlog_size());
+  } else {
+    RAY_LOG(DEBUG) << "Skipping speculative PrestartWorkers; memory usage is "
+                      "above a monitor threshold. backlog_size="
+                   << request.backlog_size();
+  }
 
   cluster_lease_manager_.QueueAndScheduleLease(
       std::move(lease),
@@ -1897,6 +1903,14 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
 void NodeManager::HandlePrestartWorkers(rpc::PrestartWorkersRequest request,
                                         rpc::PrestartWorkersReply *reply,
                                         rpc::SendReplyCallback send_reply_callback) {
+  if (IsAnyMemoryMonitorAboveThreshold()) {
+    RAY_LOG(DEBUG) << "Skipping PrestartWorkers RPC; memory usage is above a "
+                      "monitor threshold. num_workers="
+                   << request.num_workers();
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+    return;
+  }
+
   auto pop_worker_request = std::make_shared<PopWorkerRequest>(
       request.language(),
       rpc::WorkerType::WORKER,
@@ -3072,6 +3086,15 @@ bool NodeManager::MarkKillWorkerInProgress() {
     monitor->Disable();
   }
   return true;
+}
+
+bool NodeManager::IsAnyMemoryMonitorAboveThreshold() const {
+  for (const auto &monitor : memory_monitors_) {
+    if (monitor->IsUsageAboveThreshold()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void NodeManager::ReleaseKillWorkerInProgress() {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -782,6 +782,13 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   void ReleaseKillWorkerInProgress();
 
   /**
+   * @return True if any memory monitor reports usage above its threshold.
+   *         Used to gate speculative worker prestart while the node is
+   *         under memory pressure.
+   */
+  bool IsAnyMemoryMonitorAboveThreshold() const;
+
+  /**
    * @param process_memory_snapshot The snapshot of per-process memory usage
    * for fetching the memory usage of the worker.
    * @param worker The worker to create the kill details for.


### PR DESCRIPTION
## Description
The raylet's worker prestart paths currently allocate
workers without consulting memory pressure. While the memory monitor is
firing OOM kills, the worker pool can simultaneously spawn fresh idle
workers, immediately refilling memory we just freed (kill-then-spawn
stampede).

This PR gates both prestart paths on a new
`MemoryMonitorInterface::IsUsageAboveThreshold()` query. When any installed
monitor reports pressure, the worker prestart is skipped.


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
