### PR TITLE
[train][tests] Async checkpointing/validation release test now uses subcluster labels

### DIFF
--- a/release/train_tests/async_checkpointing_validation_benchmark/compute_aws.yaml
+++ b/release/train_tests/async_checkpointing_validation_benchmark/compute_aws.yaml
@@ -11,7 +11,17 @@ head_node:
     instance_type: m5.4xlarge
 
 worker_nodes:
-    - instance_type: g4dn.xlarge
+    - name: train-worker-node
+      instance_type: g4dn.xlarge
       min_nodes: 2
-      max_nodes: 4
+      max_nodes: 2
       market_type: ON_DEMAND
+      labels:
+        subcluster: train
+    - name: validation-worker-node
+      instance_type: g4dn.xlarge
+      min_nodes: 0
+      max_nodes: 2
+      market_type: ON_DEMAND
+      labels:
+        subcluster: validation

--- a/release/train_tests/async_checkpointing_validation_benchmark/compute_aws.yaml
+++ b/release/train_tests/async_checkpointing_validation_benchmark/compute_aws.yaml
@@ -17,11 +17,11 @@ worker_nodes:
       max_nodes: 2
       market_type: ON_DEMAND
       labels:
-        subcluster: train
+        ray-subcluster: train
     - name: validation-worker-node
       instance_type: g4dn.xlarge
       min_nodes: 0
       max_nodes: 2
       market_type: ON_DEMAND
       labels:
-        subcluster: validation
+        ray-subcluster: validation

--- a/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
+++ b/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
@@ -109,6 +109,7 @@ class Predictor:
 
 
 def validate_with_map_batches(checkpoint):
+    validation_dataset.set_name("async_val_map_batches")
     validation_dataset.context.execution_options.label_selector = {
         "ray-subcluster": "validation"
     }
@@ -152,7 +153,7 @@ def eval_only_train_func(config_dict):
     model.cuda().eval()
 
     # Get the data
-    test_data_shard = ray.train.get_dataset_shard("test")
+    test_data_shard = ray.train.get_dataset_shard("async_val_torch_trainer")
     test_dataloader = test_data_shard.iter_torch_batches(batch_size=128)
 
     # Report metrics
@@ -171,13 +172,13 @@ def validate_with_torch_trainer(checkpoint, parent_run_name, epoch, batch_idx):
         eval_only_train_func,
         train_loop_config={"checkpoint": checkpoint},
         scaling_config=ray.train.ScalingConfig(num_workers=2, use_gpu=True),
-        datasets={"test": validation_dataset},
+        datasets={"async_val_torch_trainer": validation_dataset},
         run_config=ray.train.RunConfig(
             name=f"{parent_run_name}-validation_epoch={epoch}_batch_idx={batch_idx}"
         ),
         dataset_config=ray.train.DataConfig(
             execution_options={
-                "test": ExecutionOptions(
+                "async_val_torch_trainer": ExecutionOptions(
                     label_selector={"ray-subcluster": "validation"}
                 ),
             },
@@ -208,7 +209,7 @@ def validate_and_report(
     checkpoint_save_mode = config["checkpoint_save_mode"]
 
     if validate_within_trainer:
-        test_dataloader = ray.train.get_dataset_shard("test").iter_torch_batches(
+        test_dataloader = ray.train.get_dataset_shard("inline_val").iter_torch_batches(
             batch_size=128
         )
 
@@ -406,14 +407,14 @@ def run_training_with_validation(
         "checkpoint_save_mode": checkpoint_save_mode,
     }
     if validate_within_trainer:
-        datasets["test"] = validation_dataset
+        datasets["inline_val"] = validation_dataset
         # Sync validation: train workers iterate both datasets, so split each
         # across the train subcluster and the validation subcluster respectively.
         dataset_config = ray.train.DataConfig(
-            datasets_to_split=["train", "test"],
+            datasets_to_split=["train", "inline_val"],
             execution_options={
                 "train": ExecutionOptions(label_selector={"ray-subcluster": "train"}),
-                "test": ExecutionOptions(
+                "inline_val": ExecutionOptions(
                     label_selector={"ray-subcluster": "validation"}
                 ),
             },

--- a/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
+++ b/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
@@ -17,6 +17,7 @@ from torchvision.transforms import ToTensor, Normalize
 import ray
 import ray.train
 import ray.train.torch
+from ray.data import ExecutionOptions
 from ray.train import CheckpointUploadMode, ValidationConfig, ValidationTaskConfig
 from ray._private.test_utils import safe_write_to_results_json
 
@@ -108,6 +109,9 @@ class Predictor:
 
 
 def validate_with_map_batches(checkpoint):
+    validation_dataset.context.execution_options.label_selector = {
+        "subcluster": "validation"
+    }
     start_time = time.time()
     eval_res = validation_dataset.map_batches(
         Predictor,
@@ -170,6 +174,11 @@ def validate_with_torch_trainer(checkpoint, parent_run_name, epoch, batch_idx):
         datasets={"test": validation_dataset},
         run_config=ray.train.RunConfig(
             name=f"{parent_run_name}-validation_epoch={epoch}_batch_idx={batch_idx}"
+        ),
+        data_config=ray.train.DataConfig(
+            execution_options={
+                "test": ExecutionOptions(label_selector={"subcluster": "validation"}),
+            },
         ),
     )
     result = trainer.fit()
@@ -396,6 +405,25 @@ def run_training_with_validation(
     }
     if validate_within_trainer:
         datasets["test"] = validation_dataset
+        # Sync validation: train workers iterate both datasets, so split each
+        # across the train subcluster and the validation subcluster respectively.
+        data_config = ray.train.DataConfig(
+            datasets_to_split=["train", "test"],
+            execution_options={
+                "train": ExecutionOptions(label_selector={"subcluster": "train"}),
+                "test": ExecutionOptions(label_selector={"subcluster": "validation"}),
+            },
+        )
+    else:
+        # Async validation: the validation dataset is consumed by a separate
+        # driver (validate_with_torch_trainer / validate_with_map_batches),
+        # which sets its own subcluster label.
+        data_config = ray.train.DataConfig(
+            datasets_to_split=["train"],
+            execution_options={
+                "train": ExecutionOptions(label_selector={"subcluster": "train"}),
+            },
+        )
 
     # async_save additionally requires a CPU process group alongside the GPU one
     #   because it runs collectives in a background thread.
@@ -412,6 +440,7 @@ def run_training_with_validation(
         datasets=datasets,
         torch_config=torch_config,
         run_config=ray.train.RunConfig(storage_path="/mnt/cluster_storage"),
+        data_config=data_config,
     )
     result = trainer.fit()
     end_time = time.time()

--- a/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
+++ b/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
@@ -110,7 +110,7 @@ class Predictor:
 
 def validate_with_map_batches(checkpoint):
     validation_dataset.context.execution_options.label_selector = {
-        "subcluster": "validation"
+        "ray-subcluster": "validation"
     }
     start_time = time.time()
     eval_res = validation_dataset.map_batches(
@@ -177,7 +177,9 @@ def validate_with_torch_trainer(checkpoint, parent_run_name, epoch, batch_idx):
         ),
         dataset_config=ray.train.DataConfig(
             execution_options={
-                "test": ExecutionOptions(label_selector={"subcluster": "validation"}),
+                "test": ExecutionOptions(
+                    label_selector={"ray-subcluster": "validation"}
+                ),
             },
         ),
     )
@@ -410,8 +412,10 @@ def run_training_with_validation(
         dataset_config = ray.train.DataConfig(
             datasets_to_split=["train", "test"],
             execution_options={
-                "train": ExecutionOptions(label_selector={"subcluster": "train"}),
-                "test": ExecutionOptions(label_selector={"subcluster": "validation"}),
+                "train": ExecutionOptions(label_selector={"ray-subcluster": "train"}),
+                "test": ExecutionOptions(
+                    label_selector={"ray-subcluster": "validation"}
+                ),
             },
         )
     else:
@@ -421,7 +425,7 @@ def run_training_with_validation(
         dataset_config = ray.train.DataConfig(
             datasets_to_split=["train"],
             execution_options={
-                "train": ExecutionOptions(label_selector={"subcluster": "train"}),
+                "train": ExecutionOptions(label_selector={"ray-subcluster": "train"}),
             },
         )
 

--- a/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
+++ b/release/train_tests/async_checkpointing_validation_benchmark/test_async_checkpointing_validation_benchmark.py
@@ -175,7 +175,7 @@ def validate_with_torch_trainer(checkpoint, parent_run_name, epoch, batch_idx):
         run_config=ray.train.RunConfig(
             name=f"{parent_run_name}-validation_epoch={epoch}_batch_idx={batch_idx}"
         ),
-        data_config=ray.train.DataConfig(
+        dataset_config=ray.train.DataConfig(
             execution_options={
                 "test": ExecutionOptions(label_selector={"subcluster": "validation"}),
             },
@@ -407,7 +407,7 @@ def run_training_with_validation(
         datasets["test"] = validation_dataset
         # Sync validation: train workers iterate both datasets, so split each
         # across the train subcluster and the validation subcluster respectively.
-        data_config = ray.train.DataConfig(
+        dataset_config = ray.train.DataConfig(
             datasets_to_split=["train", "test"],
             execution_options={
                 "train": ExecutionOptions(label_selector={"subcluster": "train"}),
@@ -418,7 +418,7 @@ def run_training_with_validation(
         # Async validation: the validation dataset is consumed by a separate
         # driver (validate_with_torch_trainer / validate_with_map_batches),
         # which sets its own subcluster label.
-        data_config = ray.train.DataConfig(
+        dataset_config = ray.train.DataConfig(
             datasets_to_split=["train"],
             execution_options={
                 "train": ExecutionOptions(label_selector={"subcluster": "train"}),
@@ -440,7 +440,7 @@ def run_training_with_validation(
         datasets=datasets,
         torch_config=torch_config,
         run_config=ray.train.RunConfig(storage_path="/mnt/cluster_storage"),
-        data_config=data_config,
+        dataset_config=dataset_config,
     )
     result = trainer.fit()
     end_time = time.time()


### PR DESCRIPTION
# Summary

Update the async checkpointing/validation release test to use the newly added subcluster labels feature.

# Testing

Release test run: https://console.anyscale-staging.com/o/anyscale-internal/jobs/prodjob_rw7irfdawcn2lnkn1jwb3wygyp

Evidence that resource splitting is working as intended:
* `train_.*` datasets ran tasks that only landed on nodes in the `train` `ray-subcluster`
* `inline_val_.*`,  `async_val_torch_trainer_.*`, and `async_val_map_batches` datasets ran tasks that only landed on nodes in the validation `ray-subcluster`