### PR TITLE
[core] Adding better error message for worker startup errors

### DIFF
--- a/src/ray/raylet/scheduling/local_lease_manager.cc
+++ b/src/ray/raylet/scheduling/local_lease_manager.cc
@@ -654,6 +654,10 @@ bool LocalLeaseManager::PoppedWorkerHandler(
 
       auto max_retries = RayConfig::instance().pop_worker_max_retries();
       if (max_retries >= 0 && work->GetPopWorkerRetries() > max_retries) {
+        // In case of too many retries, we cancel this task
+        // directly and raise a `RaySystemError` exception to user
+        // eventually. The task will be removed from dispatch queue in
+        // `CancelTask`.
         CancelLeases(
             [lease_id](const auto &w) {
               return lease_id == w->lease_.GetLeaseSpecification().LeaseId();
@@ -662,9 +666,9 @@ bool LocalLeaseManager::PoppedWorkerHandler(
             absl::StrCat("Failed to startup worker after retrying ",
                          RayConfig::instance().pop_worker_max_retries(),
                          " times. This is most often caused by errors in the worker's "
-                         "Python environment setup -- for example, pip / uv install "
-                         "failures, a broken py_executable, or a missing dependency in "
-                         "the cluster image. The underlying error is logged in "
+                         "Python environment setup. For example, pip / uv install "
+                         "failures, a broken py_executable, or a dependency conflict in "
+                         "the cluster image. For additional context, please look at the "
                          "raylet.err on node ",
                          self_node_id_.Hex(),
                          "."));

--- a/src/ray/raylet/scheduling/local_lease_manager.cc
+++ b/src/ray/raylet/scheduling/local_lease_manager.cc
@@ -654,10 +654,6 @@ bool LocalLeaseManager::PoppedWorkerHandler(
 
       auto max_retries = RayConfig::instance().pop_worker_max_retries();
       if (max_retries >= 0 && work->GetPopWorkerRetries() > max_retries) {
-        // In case of too many retries, we cancel this task
-        // directly and raise a `RaySystemError` exception to user
-        // eventually. The task will be removed from dispatch queue in
-        // `CancelTask`.
         CancelLeases(
             [lease_id](const auto &w) {
               return lease_id == w->lease_.GetLeaseSpecification().LeaseId();
@@ -665,7 +661,13 @@ bool LocalLeaseManager::PoppedWorkerHandler(
             rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_WORKER_STARTUP_FAILED,
             absl::StrCat("Failed to startup worker after retrying ",
                          RayConfig::instance().pop_worker_max_retries(),
-                         " times."));
+                         " times. This is most often caused by errors in the worker's "
+                         "Python environment setup -- for example, pip / uv install "
+                         "failures, a broken py_executable, or a missing dependency in "
+                         "the cluster image. The underlying error is logged in "
+                         "raylet.err on node ",
+                         self_node_id_.Hex(),
+                         "."));
       } else {
         work->SetStateWaiting(cause);
       }


### PR DESCRIPTION
Following up on https://github.com/ray-project/ray/pull/60104

Currently in cases where the worker process fails to start up due to pip/uv issues, the user gets a generic ray system error:
```
2026-03-27 19:19:22,544 INFO job_manager.py:587 -- Runtime env is setting up.
Job supervisor actor could not be scheduled: The actor is not schedulable: Could not create the actor because worker startup repeatedly failed.
Failed to startup worker after retrying 5 times.
```
and the specific uv/pip errors are stored in the corresponding raylet.err file for that node. This is usually fine as error logs get streamed to the driver and are visible from the user's terminal, however there's an edge case when using the ray jobs API. The ray jobs API creates a job submission actor before the driver is started for the job. If the job submission actor fails to get created due to a uv/pip dependency issue, then all the user will see is this generic error message without the raylet.err logs as they won't be streamed due to the driver not yet being created. 

Ideally we'd extract the specific uv/pip errors from raylet.err and include them in the RaySystemError, but this is non-trivial since raylet.err is shared across all workers on the node and the raylet would need per-worker IPC to isolate the relevant lines.  For example, we'd need the worker process to do something like write the startup errors to a new specific file, read them from the raylet, and clean up the file. 

Hence I think a simpler solution is just to point the user to the raylet.err logs when this error propagates.
