### PR TITLE
[Core] Add HDFS backend for object spilling via PyArrow

### DIFF
--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -598,6 +598,8 @@ class ExternalStorageHDFSImpl(ExternalStorage):
             uri = [uri]
         if not isinstance(uri, list):
             raise TypeError("uri must be a string or list of strings.")
+        if not uri:
+            raise ValueError("uri must contain at least one HDFS URI.")
         for u in uri:
             if not u.startswith("hdfs://"):
                 raise ValueError(f"HDFS URI must start with 'hdfs://', got: {u}")

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -3,6 +3,7 @@ import logging
 import os
 import random
 import shutil
+import threading
 import time
 import urllib
 import uuid
@@ -537,6 +538,217 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
 _external_storage = NullStorage()
 
 
+class ExternalStorageHDFSImpl(ExternalStorage):
+    """The external storage class for HDFS-backed spilling.
+
+    Uses PyArrow's HadoopFileSystem (libhdfs via JNI). Spilled files are
+    visible cluster-wide, so any node can restore objects spilled by other
+    nodes without cross-node RPC, similar to S3/GCS backends.
+
+    Requirements (on every Ray node):
+        - pyarrow >= 17.0.0 (already required by Ray)
+        - Hadoop client installed (libhdfs and jars)
+        - HADOOP_HOME and JAVA_HOME exported
+        - CLASSPATH includes Hadoop jars (e.g. via
+          ``hadoop classpath --glob``)
+        - RAY_DISABLE_FAILURE_SIGNAL_HANDLER=1 may be required because
+          Ray's C++ failure signal handler conflicts with the JVM.
+
+    Args:
+        node_id: Node id used as prefix for the spill directory to avoid
+            collisions between nodes sharing the same HDFS path.
+        uri: HDFS URI (single string or list of strings for round-robin),
+            e.g. "hdfs://nameservice/user/ray/spill".
+        user: Optional HDFS user. Defaults to the current OS user.
+        kerb_ticket: Optional path to Kerberos ticket cache.
+        extra_conf: Optional dict of Hadoop conf overrides, e.g.
+            ``{"dfs.replication": "3"}`` to reduce replication for ephemeral
+            spill data.
+        buffer_size: Buffer size in bytes for HDFS I/O. At least 1 MB is
+            recommended for remote storage.
+
+    Raises:
+        ImportError: If pyarrow is not installed.
+        ValueError: If the given URI is invalid or the spill directory
+            cannot be created.
+    """
+
+    def __init__(
+        self,
+        node_id: str,
+        uri: Union[str, List[str]],
+        user: Optional[str] = None,
+        kerb_ticket: Optional[str] = None,
+        extra_conf: Optional[dict] = None,
+        buffer_size: int = 1024 * 1024,
+    ):
+        super().__init__()
+
+        try:
+            import pyarrow.fs as pa_fs
+        except ImportError as e:
+            raise ImportError(
+                "HDFS object spilling requires pyarrow. "
+                f"Original error: {e}"
+            )
+
+        if uri is None:
+            raise ValueError("uri must be provided for HDFS spilling.")
+        if isinstance(uri, str):
+            uri = [uri]
+        if not isinstance(uri, list):
+            raise TypeError("uri must be a string or list of strings.")
+        for u in uri:
+            if not u.startswith("hdfs://"):
+                raise ValueError(f"HDFS URI must start with 'hdfs://', got: {u}")
+        if not isinstance(buffer_size, int) or buffer_size <= 0:
+            raise ValueError("buffer_size must be a positive integer.")
+
+        # All URIs are assumed to point to the same logical HDFS cluster.
+        # Use the first URI to derive the host/port for the HDFS client.
+        # For HA clusters, host is typically a nameservice (port defaults to 0).
+        parsed = urllib.parse.urlparse(uri[0])
+        self._pa_fs = pa_fs
+        self._host = parsed.hostname or parsed.netloc or "default"
+        self._port = parsed.port or 0
+        self._user = user
+        self._kerb_ticket = kerb_ticket
+        self._extra_conf = extra_conf
+
+        # Lazily initialized after CoreWorker connects (see _ensure_fs).
+        self._fs = None
+        self._fs_lock = threading.Lock()
+
+        self._buffer_size = buffer_size
+        self._uris = [u.rstrip("/") for u in uri]
+        self._base_paths = [
+            urllib.parse.urlparse(u).path.rstrip("/") or "/" for u in self._uris
+        ]
+        self._current_uri_index = random.randrange(0, len(self._uris))
+
+        # Per-node directory to isolate spill files across nodes.
+        self._node_prefix = f"{DEFAULT_OBJECT_PREFIX}_{node_id}"
+        self._spill_dirs: List[str] = []
+        for base_path in self._base_paths:
+            spill_dir = f"{base_path.rstrip('/')}/{self._node_prefix}"
+            self._spill_dirs.append(spill_dir)
+
+    def _ensure_fs(self):
+        """Create the HDFS client and spill dirs for this node."""
+        if self._fs is not None:
+            return
+        with self._fs_lock:
+            if self._fs is not None:
+                return
+            fs = self._pa_fs.HadoopFileSystem(
+                host=self._host,
+                port=self._port,
+                user=self._user,
+                kerb_ticket=self._kerb_ticket,
+                extra_conf=self._extra_conf,
+            )
+            for spill_dir in self._spill_dirs:
+                try:
+                    fs.create_dir(spill_dir, recursive=True)
+                except OSError as e:
+                    raise ValueError(
+                        f"Failed to create HDFS spill directory {spill_dir}: {e}"
+                    )
+            self._fs = fs
+
+    def ensure_initialized(self):
+        """Eagerly initialize the HDFS client (starts the JVM via libhdfs)."""
+        self._ensure_fs()
+
+    def spill_objects(self, object_refs, owner_addresses) -> List[str]:
+        if not object_refs:
+            return []
+
+        self._ensure_fs()
+        self._current_uri_index = (self._current_uri_index + 1) % len(self._uris)
+        uri = self._uris[self._current_uri_index]
+        spill_dir = self._spill_dirs[self._current_uri_index]
+
+        filename = _get_unique_spill_filename(object_refs)
+        write_path = f"{spill_dir}/{filename}"
+        # Keep hdfs:// scheme so the URL is resolvable across nodes.
+        url = f"{uri}/{self._node_prefix}/{filename}"
+
+        with self._fs.open_output_stream(
+            write_path, buffer_size=self._buffer_size
+        ) as f:
+            return self._write_multiple_objects(f, object_refs, owner_addresses, url)
+
+    def restore_spilled_objects(
+        self, object_refs: List[ObjectRef], url_with_offset_list: List[str]
+    ):
+        self._ensure_fs()
+        total = 0
+        for object_ref, url_with_offset_item in zip(object_refs, url_with_offset_list):
+            url_with_offset = (
+                url_with_offset_item.decode()
+                if isinstance(url_with_offset_item, bytes)
+                else url_with_offset_item
+            )
+            logger.info(
+                "Restoring spilled object %s from %s",
+                object_ref,
+                url_with_offset,
+            )
+            parsed_result = parse_url_with_offset(url_with_offset)
+            base_url = parsed_result.base_url
+            offset = parsed_result.offset
+
+            # PyArrow's HDFS API takes bare paths, not URIs.
+            read_path = urllib.parse.urlparse(base_url).path
+
+            # open_input_file (not open_input_stream) supports random-access seek().
+            with self._fs.open_input_file(read_path) as f:
+                f.seek(offset)
+                address_len = int.from_bytes(f.read(8), byteorder="little")
+                metadata_len = int.from_bytes(f.read(8), byteorder="little")
+                buf_len = int.from_bytes(f.read(8), byteorder="little")
+                self._size_check(address_len, metadata_len, buf_len, parsed_result.size)
+                owner_address = f.read(address_len)
+                total += buf_len
+                metadata = f.read(metadata_len)
+                self._put_object_to_store(
+                    metadata, buf_len, f, object_ref, owner_address
+                )
+        return total
+
+    def delete_spilled_objects(self, urls: List[str]):
+        if not urls:
+            return
+        self._ensure_fs()
+        for url in urls:
+            url_str = url.decode() if isinstance(url, bytes) else url
+            base_url = parse_url_with_offset(url_str).base_url
+            path = urllib.parse.urlparse(base_url).path
+            try:
+                self._fs.delete_file(path)
+            except FileNotFoundError:
+                # Occurs when the urls are retried during worker crash/failure.
+                pass
+            except OSError as e:
+                # Best-effort deletion: log but don't raise.
+                logger.debug(f"Failed to delete spilled object {path}: {e}")
+
+    def destroy_external_storage(self):
+        self._ensure_fs()
+        for spill_dir in self._spill_dirs:
+            try:
+                self._fs.delete_dir(spill_dir)
+                logger.info(f"Deleted HDFS spill directory {spill_dir}")
+            except FileNotFoundError:
+                pass
+            except OSError:
+                logger.exception(
+                    f"Error cleaning up HDFS spill directory {spill_dir}. "
+                    "You might still have remaining spilled objects there."
+                )
+
+
 class UnstableFileStorage(FileSystemStorage):
     """This class is for testing with writing failure."""
 
@@ -584,6 +796,8 @@ def setup_external_storage(config, node_id, session_name):
             _external_storage = ExternalStorageSmartOpenImpl(
                 node_id, **config["params"]
             )
+        elif storage_type == "hdfs":
+            _external_storage = ExternalStorageHDFSImpl(node_id, **config["params"])
         elif storage_type == "mock_distributed_fs":
             # This storage is used to unit test distributed external storages.
             # TODO(sang): Delete it after introducing the mock S3 test.

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -564,8 +564,8 @@ class ExternalStorageHDFSImpl(ExternalStorage):
         extra_conf: Optional dict of Hadoop conf overrides, e.g.
             ``{"dfs.replication": "3"}`` to reduce replication for ephemeral
             spill data.
-        buffer_size: Buffer size in bytes for HDFS I/O. At least 1 MB is
-            recommended for remote storage.
+        buffer_size: Buffer size in bytes for PyArrow ``HadoopFileSystem``
+            read/write I/O. At least 1 MB is recommended for remote storage.
 
     Raises:
         ImportError: If pyarrow is not installed.
@@ -646,6 +646,7 @@ class ExternalStorageHDFSImpl(ExternalStorage):
                 user=self._user,
                 kerb_ticket=self._kerb_ticket,
                 extra_conf=self._extra_conf,
+                buffer_size=self._buffer_size,
             )
             for spill_dir in self._spill_dirs:
                 try:
@@ -675,9 +676,7 @@ class ExternalStorageHDFSImpl(ExternalStorage):
         # Keep hdfs:// scheme so the URL is resolvable across nodes.
         url = f"{uri}/{self._node_prefix}/{filename}"
 
-        with self._fs.open_output_stream(
-            write_path, buffer_size=self._buffer_size
-        ) as f:
+        with self._fs.open_output_stream(write_path) as f:
             return self._write_multiple_objects(f, object_refs, owner_addresses, url)
 
     def restore_spilled_objects(

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -737,7 +737,6 @@ class ExternalStorageHDFSImpl(ExternalStorage):
                 logger.debug(f"Failed to delete spilled object {path}: {e}")
 
     def destroy_external_storage(self):
-        self._ensure_fs()
         for spill_dir in self._spill_dirs:
             try:
                 self._fs.delete_dir(spill_dir)

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -665,9 +665,10 @@ class ExternalStorageHDFSImpl(ExternalStorage):
             return []
 
         self._ensure_fs()
-        self._current_uri_index = (self._current_uri_index + 1) % len(self._uris)
-        uri = self._uris[self._current_uri_index]
-        spill_dir = self._spill_dirs[self._current_uri_index]
+        current_uri_index = (self._current_uri_index + 1) % len(self._uris)
+        self._current_uri_index = current_uri_index
+        uri = self._uris[current_uri_index]
+        spill_dir = self._spill_dirs[current_uri_index]
 
         filename = _get_unique_spill_filename(object_refs)
         write_path = f"{spill_dir}/{filename}"

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -623,7 +623,7 @@ class ExternalStorageHDFSImpl(ExternalStorage):
 
         self._buffer_size = buffer_size
         self._uris = [u.rstrip("/") for u in uri]
-        self._base_paths = [
+        base_paths = [
             urllib.parse.urlparse(u).path.rstrip("/") or "/" for u in self._uris
         ]
         self._current_uri_index = random.randrange(0, len(self._uris))
@@ -631,7 +631,7 @@ class ExternalStorageHDFSImpl(ExternalStorage):
         # Per-node directory to isolate spill files across nodes.
         self._node_prefix = f"{DEFAULT_OBJECT_PREFIX}_{node_id}"
         self._spill_dirs: List[str] = []
-        for base_path in self._base_paths:
+        for base_path in base_paths:
             spill_dir = f"{base_path.rstrip('/')}/{self._node_prefix}"
             self._spill_dirs.append(spill_dir)
 

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -588,8 +588,7 @@ class ExternalStorageHDFSImpl(ExternalStorage):
             import pyarrow.fs as pa_fs
         except ImportError as e:
             raise ImportError(
-                "HDFS object spilling requires pyarrow. "
-                f"Original error: {e}"
+                "HDFS object spilling requires pyarrow. " f"Original error: {e}"
             )
 
         if uri is None:

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1818,16 +1818,19 @@ class Node:
                         env=env,
                         timeout=60,
                     )
-                except subprocess.TimeoutExpired:
-                    logger.warning(
-                        "Timed out destroying HDFS external storage during shutdown."
-                    )
-                else:
                     if result.returncode != 0:
                         logger.warning(
                             f"Failed to destroy HDFS external storage. "
                             f"Exit code: {result.returncode}"
                         )
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "Timed out destroying HDFS external storage during shutdown."
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to destroy HDFS external storage during shutdown."
+                    )
                 return
 
             from ray._private import external_storage

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1787,7 +1787,7 @@ class Node:
         if object_spilling_config:
             object_spilling_config = json.loads(object_spilling_config)
             if object_spilling_config.get("type") == "hdfs":
-                # Destroy HDFS spill dirs in a child process to avoid JVM crash 
+                # Destroy HDFS spill dirs in a child process to avoid JVM crash
                 # in head when pyarrow jvm already started.
                 hdfs_destroy_script = textwrap.dedent(
                     """

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -11,6 +11,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
 import time
 import traceback
@@ -1785,6 +1786,50 @@ class Node:
         object_spilling_config = self._config.get("object_spilling_config", {})
         if object_spilling_config:
             object_spilling_config = json.loads(object_spilling_config)
+            if object_spilling_config.get("type") == "hdfs":
+                # Destroy HDFS spill dirs in a child process to avoid JVM crash 
+                # in head when pyarrow jvm already started.
+                hdfs_destroy_script = textwrap.dedent(
+                    """
+                    import json
+                    import os
+
+                    from ray._private import external_storage
+
+                    config = json.loads(os.environ["RAY_HDFS_DESTROY_CONFIG"])
+                    storage = external_storage.setup_external_storage(
+                        config,
+                        os.environ["RAY_HDFS_DESTROY_NODE_ID"],
+                        "",
+                    )
+                    if hasattr(storage, "ensure_initialized"):
+                        storage.ensure_initialized()
+                    storage.destroy_external_storage()
+                    """
+                )
+                env = os.environ.copy()
+                env["RAY_HDFS_DESTROY_CONFIG"] = json.dumps(
+                    object_spilling_config
+                )
+                env["RAY_HDFS_DESTROY_NODE_ID"] = self._node_id
+                try:
+                    result = subprocess.run(
+                        [sys.executable, "-c", hdfs_destroy_script],
+                        env=env,
+                        timeout=60,
+                    )
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "Timed out destroying HDFS external storage during shutdown."
+                    )
+                else:
+                    if result.returncode != 0:
+                        logger.warning(
+                            f"Failed to destroy HDFS external storage. "
+                            f"Exit code: {result.returncode}"
+                        )
+                return
+
             from ray._private import external_storage
 
             storage = external_storage.setup_external_storage(
@@ -1832,6 +1877,8 @@ class Node:
         storage = external_storage.setup_external_storage(
             deserialized_config, dummy_node_id, self._session_name
         )
+        if hasattr(storage, "ensure_initialized"):
+            storage.ensure_initialized()
         storage.destroy_external_storage()
         external_storage.reset_external_storage()
 

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1808,9 +1808,7 @@ class Node:
                     """
                 )
                 env = os.environ.copy()
-                env["RAY_HDFS_DESTROY_CONFIG"] = json.dumps(
-                    object_spilling_config
-                )
+                env["RAY_HDFS_DESTROY_CONFIG"] = json.dumps(object_spilling_config)
                 env["RAY_HDFS_DESTROY_NODE_ID"] = self._node_id
                 try:
                     result = subprocess.run(

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -250,6 +250,7 @@ if __name__ == "__main__":
     # NOTE(suquark): We must initialize the external storage before we
     # connect to raylet. Otherwise we may receive requests before the
     # external storage is initialized.
+    # HDFS uses lazy init: the JVM starts on first spill/restore via _ensure_fs().
     if mode == ray.RESTORE_WORKER_MODE or mode == ray.SPILL_WORKER_MODE:
         from ray._private import external_storage
 

--- a/python/ray/tests/unit/test_external_storage_hdfs.py
+++ b/python/ray/tests/unit/test_external_storage_hdfs.py
@@ -1,0 +1,271 @@
+import sys
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ray._private.external_storage import (
+    ExternalStorageHDFSImpl,
+    create_url_with_offset,
+    reset_external_storage,
+    setup_external_storage,
+)
+from ray._private.ray_constants import DEFAULT_OBJECT_PREFIX
+
+HDFS_NAMESERVICE = "nameservice"
+HDFS_URI = f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill"
+
+HDFS_OBJECT_SPILLING_CONFIG = {
+    "type": "hdfs",
+    "params": {"uri": HDFS_URI},
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_pyarrow_fs():
+    mock_pa_fs = MagicMock()
+    mock_pyarrow = MagicMock()
+    mock_pyarrow.fs = mock_pa_fs
+    with patch.dict(sys.modules, {"pyarrow": mock_pyarrow, "pyarrow.fs": mock_pa_fs}):
+        yield mock_pa_fs
+
+
+def _make_storage(node_id="test-node-id", uri=None, **kwargs):
+    if uri is None:
+        uri = HDFS_OBJECT_SPILLING_CONFIG["params"]["uri"]
+    return ExternalStorageHDFSImpl(node_id, uri=uri, **kwargs)
+
+
+def _init_storage_with_mock_fs(storage):
+    mock_fs = MagicMock()
+    with patch.object(storage._pa_fs, "HadoopFileSystem", return_value=mock_fs):
+        storage.ensure_initialized()
+    return mock_fs
+
+
+def test_setup_external_storage_hdfs():
+    storage = setup_external_storage(
+        HDFS_OBJECT_SPILLING_CONFIG, "node-id", "session-name"
+    )
+    assert isinstance(storage, ExternalStorageHDFSImpl)
+    reset_external_storage()
+
+
+def test_hdfs_lazy_init():
+    storage = _make_storage()
+    assert storage._fs is None
+
+
+def test_hdfs_invalid_uri():
+    with pytest.raises(ValueError, match="HDFS URI must start with 'hdfs://'"):
+        _make_storage(uri="s3://bucket/path")
+
+
+def test_hdfs_invalid_buffer_size():
+    with pytest.raises(ValueError, match="buffer_size must be a positive integer"):
+        _make_storage(buffer_size=0)
+
+
+def test_hdfs_ensure_fs_creates_client_and_spill_dirs():
+    node_id = "node-abc"
+    storage = _make_storage(node_id=node_id)
+    mock_fs = MagicMock()
+
+    with patch.object(storage._pa_fs, "HadoopFileSystem", return_value=mock_fs) as ctor:
+        storage.ensure_initialized()
+
+    ctor.assert_called_once_with(
+        host=HDFS_NAMESERVICE,
+        port=0,
+        user=None,
+        kerb_ticket=None,
+        extra_conf=None,
+    )
+    expected_spill_dir = f"/user/ray/spill/{DEFAULT_OBJECT_PREFIX}_{node_id}"
+    mock_fs.create_dir.assert_called_once_with(expected_spill_dir, recursive=True)
+    assert storage._fs is mock_fs
+
+
+def test_hdfs_create_spill_dir_failure():
+    storage = _make_storage()
+    mock_fs = MagicMock()
+    mock_fs.create_dir.side_effect = OSError("permission denied")
+
+    with patch.object(storage._pa_fs, "HadoopFileSystem", return_value=mock_fs):
+        with pytest.raises(ValueError, match="Failed to create HDFS spill directory"):
+            storage.ensure_initialized()
+
+
+def test_hdfs_node_id_in_spill_dirs():
+    node_id = "unique-node-id"
+    storage = _make_storage(
+        node_id=node_id,
+        uri=[
+            f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill-a",
+            f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill-b",
+        ],
+    )
+    node_prefix = f"{DEFAULT_OBJECT_PREFIX}_{node_id}"
+    assert storage._spill_dirs == [
+        f"/user/ray/spill-a/{node_prefix}",
+        f"/user/ray/spill-b/{node_prefix}",
+    ]
+
+
+def test_hdfs_spill_objects_writes_to_hdfs():
+    storage = _make_storage()
+    mock_fs = _init_storage_with_mock_fs(storage)
+    mock_file = MagicMock()
+    mock_file.write.side_effect = lambda data: len(data)
+    mock_fs.open_output_stream.return_value.__enter__.return_value = mock_file
+
+    object_refs = [MagicMock(), MagicMock()]
+    owner_addresses = [b"owner-a", b"owner-b"]
+    with patch.object(
+        storage, "_get_objects_from_store"
+    ) as mock_get_objects_from_store:
+        mock_get_objects_from_store.return_value = [
+            (b"buf-a", b"meta-a", None),
+            (b"buf-b", b"meta-b", None),
+        ]
+        urls = storage.spill_objects(object_refs, owner_addresses)
+
+    assert len(urls) == 2
+    mock_fs.open_output_stream.assert_called_once()
+    write_path = mock_fs.open_output_stream.call_args[0][0]
+    assert write_path.startswith(
+        f"/user/ray/spill/{DEFAULT_OBJECT_PREFIX}_test-node-id/"
+    )
+    assert urls[0].decode().startswith(f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill/")
+
+
+def test_hdfs_spill_objects_round_robin():
+    storage = _make_storage(
+        uri=[
+            f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill-a",
+            f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill-b",
+        ],
+    )
+    mock_fs = _init_storage_with_mock_fs(storage)
+    mock_file = MagicMock()
+    mock_file.write.side_effect = lambda data: len(data)
+    mock_fs.open_output_stream.return_value.__enter__.return_value = mock_file
+
+    object_refs = [MagicMock()]
+    with patch.object(
+        storage, "_get_objects_from_store", return_value=[(b"buf", b"meta", None)]
+    ):
+        first_url = storage.spill_objects(object_refs, [b"owner"])[0].decode()
+        second_url = storage.spill_objects(object_refs, [b"owner"])[0].decode()
+
+    assert "/user/ray/spill-a/" in first_url or "/user/ray/spill-b/" in first_url
+    assert first_url != second_url
+
+
+def test_hdfs_restore_spilled_objects():
+    storage = _make_storage()
+    mock_fs = _init_storage_with_mock_fs(storage)
+
+    owner_address = b"owner-address"
+    metadata = b"metadata"
+    payload = b"0123456789"
+    address_len = len(owner_address)
+    metadata_len = len(metadata)
+    buf_len = len(payload)
+    mock_file = MagicMock()
+    mock_file.read.side_effect = [
+        address_len.to_bytes(8, byteorder="little"),
+        metadata_len.to_bytes(8, byteorder="little"),
+        buf_len.to_bytes(8, byteorder="little"),
+        owner_address,
+        metadata,
+    ]
+    mock_fs.open_input_file.return_value.__enter__.return_value = mock_file
+
+    base_url = (
+        f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill/"
+        f"{DEFAULT_OBJECT_PREFIX}_test-node-id/spill-file"
+    )
+    url_with_offset = create_url_with_offset(
+        url=base_url,
+        offset=0,
+        size=storage.HEADER_LENGTH + address_len + metadata_len + buf_len,
+    )
+    object_ref = MagicMock()
+
+    with patch.object(storage, "_put_object_to_store") as mock_put:
+        restored = storage.restore_spilled_objects(
+            [object_ref], [url_with_offset.encode()]
+        )
+
+    read_path = mock_fs.open_input_file.call_args[0][0]
+    assert read_path == urllib.parse.urlparse(base_url).path
+    mock_put.assert_called_once_with(
+        metadata, buf_len, mock_file, object_ref, owner_address
+    )
+    assert restored == buf_len
+
+
+def test_hdfs_restore_spilled_objects_accepts_str_url():
+    storage = _make_storage()
+    mock_fs = _init_storage_with_mock_fs(storage)
+
+    owner_address = b"owner-address"
+    metadata = b"metadata"
+    payload = b"x"
+    address_len = len(owner_address)
+    metadata_len = len(metadata)
+    buf_len = len(payload)
+    mock_file = MagicMock()
+    mock_file.read.side_effect = [
+        address_len.to_bytes(8, byteorder="little"),
+        metadata_len.to_bytes(8, byteorder="little"),
+        buf_len.to_bytes(8, byteorder="little"),
+        owner_address,
+        metadata,
+    ]
+    mock_fs.open_input_file.return_value.__enter__.return_value = mock_file
+
+    base_url = (
+        f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill/"
+        f"{DEFAULT_OBJECT_PREFIX}_test-node-id/spill-file"
+    )
+    url_with_offset = create_url_with_offset(
+        url=base_url,
+        offset=0,
+        size=storage.HEADER_LENGTH + address_len + metadata_len + buf_len,
+    )
+    object_ref = MagicMock()
+
+    with patch.object(storage, "_put_object_to_store"):
+        restored = storage.restore_spilled_objects([object_ref], [url_with_offset])
+
+    assert restored == buf_len
+
+
+def test_hdfs_delete_spilled_objects():
+    storage = _make_storage()
+    mock_fs = _init_storage_with_mock_fs(storage)
+
+    base_url = (
+        f"hdfs://{HDFS_NAMESERVICE}/user/ray/spill/"
+        f"{DEFAULT_OBJECT_PREFIX}_test-node-id/spill-file"
+    )
+    url_with_offset = create_url_with_offset(url=base_url, offset=0, size=10)
+    storage.delete_spilled_objects([url_with_offset.encode()])
+
+    mock_fs.delete_file.assert_called_once_with(urllib.parse.urlparse(base_url).path)
+
+    mock_fs.reset_mock()
+    storage.delete_spilled_objects([url_with_offset])
+    mock_fs.delete_file.assert_called_once_with(urllib.parse.urlparse(base_url).path)
+
+
+def test_hdfs_destroy_external_storage():
+    storage = _make_storage()
+    mock_fs = _init_storage_with_mock_fs(storage)
+
+    storage.destroy_external_storage()
+
+    expected_spill_dir = f"/user/ray/spill/{DEFAULT_OBJECT_PREFIX}_test-node-id"
+    mock_fs.delete_dir.assert_called_once_with(expected_spill_dir)

--- a/python/ray/tests/unit/test_external_storage_hdfs.py
+++ b/python/ray/tests/unit/test_external_storage_hdfs.py
@@ -80,10 +80,21 @@ def test_hdfs_ensure_fs_creates_client_and_spill_dirs():
         user=None,
         kerb_ticket=None,
         extra_conf=None,
+        buffer_size=1024 * 1024,
     )
     expected_spill_dir = f"/user/ray/spill/{DEFAULT_OBJECT_PREFIX}_{node_id}"
     mock_fs.create_dir.assert_called_once_with(expected_spill_dir, recursive=True)
     assert storage._fs is mock_fs
+
+
+def test_hdfs_ensure_fs_passes_custom_buffer_size_to_client():
+    storage = _make_storage(buffer_size=2 * 1024 * 1024)
+    mock_fs = MagicMock()
+
+    with patch.object(storage._pa_fs, "HadoopFileSystem", return_value=mock_fs) as ctor:
+        storage.ensure_initialized()
+
+    assert ctor.call_args.kwargs["buffer_size"] == 2 * 1024 * 1024
 
 
 def test_hdfs_create_spill_dir_failure():
@@ -132,6 +143,7 @@ def test_hdfs_spill_objects_writes_to_hdfs():
 
     assert len(urls) == 2
     mock_fs.open_output_stream.assert_called_once()
+    assert mock_fs.open_output_stream.call_args.kwargs == {}
     write_path = mock_fs.open_output_stream.call_args[0][0]
     assert write_path.startswith(
         f"/user/ray/spill/{DEFAULT_OBJECT_PREFIX}_test-node-id/"

--- a/python/ray/tests/unit/test_external_storage_hdfs.py
+++ b/python/ray/tests/unit/test_external_storage_hdfs.py
@@ -286,3 +286,9 @@ def test_hdfs_destroy_external_storage():
 
     expected_spill_dir = f"/user/ray/spill/{DEFAULT_OBJECT_PREFIX}_test-node-id"
     mock_fs.delete_dir.assert_called_once_with(expected_spill_dir)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/unit/test_external_storage_hdfs.py
+++ b/python/ray/tests/unit/test_external_storage_hdfs.py
@@ -61,6 +61,11 @@ def test_hdfs_invalid_uri():
         _make_storage(uri="s3://bucket/path")
 
 
+def test_hdfs_empty_uri_list():
+    with pytest.raises(ValueError, match="uri must contain at least one HDFS URI"):
+        _make_storage(uri=[])
+
+
 def test_hdfs_invalid_buffer_size():
     with pytest.raises(ValueError, match="buffer_size must be a positive integer"):
         _make_storage(buffer_size=0)


### PR DESCRIPTION
## Summary
- Add `ExternalStorageHDFSImpl` for Ray object spilling to HDFS using PyArrow's `HadoopFileSystem` (libhdfs)
- Support single or round-robin HDFS URIs, lazy JVM initialization, and node-scoped spill directories
- Add HDFS cleanup on node shutdown via a child process to avoid JVM conflicts with Ray's signal handler
- Add 13 unit tests with mocked PyArrow HDFS client

## Why PyArrow instead of smart_open?

Ray already uses `smart_open` for S3/GCS object spilling (`ExternalStorageSmartOpenImpl`), but HDFS spilling is implemented with PyArrow instead for a functional reason:

**Object restore requires random access reads.** When Ray restores spilled objects, it seeks to specific byte offsets within a fused spill file to read individual object metadata and payloads. The HDFS implementation in `smart_open` does not support random reads (seek-based access), so it cannot satisfy Ray's restore path.

PyArrow's `HadoopFileSystem.open_input_file()` supports `seek()`, which matches the restore logic already used by the filesystem and smart_open backends. This is why HDFS spilling uses PyArrow directly rather than reusing the existing `smart_open` integration.

## Motivation
HDFS-backed spilling allows spilled objects to be visible cluster-wide, enabling any node to restore objects spilled by other nodes without cross-node RPC, similar to S3/GCS backends.

## Configuration example
```python
import json
import ray

ray.init(
    _system_config={
        "object_spilling_config": json.dumps({
            "type": "hdfs",
            "params": {
                "uri": "hdfs://nameservice/user/ray/spill",
            },
        })
    }
)
```

## Requirements
- pyarrow >= 17.0.0
- Hadoop client (libhdfs), `HADOOP_HOME`, `JAVA_HOME`, and Hadoop jars on `CLASSPATH`
- `RAY_DISABLE_FAILURE_SIGNAL_HANDLER=1` may be required due to JVM / Ray signal handler conflict

## Test plan
- [x] `pytest python/ray/tests/unit/test_external_storage_hdfs.py -v` (13 passed in local `3.0.0.dev` conda env)
- [x] Manual validation on a cluster with HDFS (if applicable)


Made with [Cursor](https://cursor.com)