### PR TITLE
[core] Remove PG resource deduction from GCS and rely on resource broadcast instead

### DIFF
--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -33,7 +33,6 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     ClusterResourceScheduler &cluster_resource_scheduler,
     rpc::RayletClientPool &raylet_client_pool)
     : io_context_(io_context),
-      return_timer_(io_context),
       gcs_table_storage_(gcs_table_storage),
       gcs_node_manager_(gcs_node_manager),
       cluster_resource_scheduler_(cluster_resource_scheduler),

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -179,9 +179,9 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupBundleResourcesIfExists(
     // bundles at the same time.
     DestroyPlacementGroupPreparedBundleResources(placement_group_id);
     DestroyPlacementGroupCommittedBundleResources(placement_group_id);
-
-    // Return destroyed bundles resources to the cluster resource.
-    ReturnBundleResources(bundle_locations.value());
+    // GCS no longer locally restores the freed resources here; the next
+    // ray-syncer broadcast from each raylet whose bundles were cancelled will
+    // bring GCS's view back in line with the actual cluster state.
   }
 }
 
@@ -346,7 +346,8 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(
         lease_status_tracker->GetPlacementGroup()->GetPlacementGroupID());
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
+    // The next ray-syncer broadcast from each raylet whose bundles were
+    // cancelled will reconcile GCS's view.
     schedule_failure_handler(lease_status_tracker->GetPlacementGroup(),
                              /*is_feasible=*/true);
     return;
@@ -384,8 +385,8 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
 
       if (status.ok()) {
         // Commit the bundle resources on the remote node to the cluster resources.
-        // If status is not OK, no need to call ReturnBundleResources because the
-        // OnAllBundleCommitRequestReturned function calls it.
+        // On Commit failure we leave the optimistic state alone; the next
+        // ray-syncer broadcast from the raylet will reconcile it.
         CommitBundleResources(commited_bundle_locations);
       }
 
@@ -426,7 +427,9 @@ void GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned(
     auto it = placement_group_leasing_in_progress_.find(placement_group_id);
     RAY_CHECK(it != placement_group_leasing_in_progress_.end());
     placement_group_leasing_in_progress_.erase(it);
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
+    // The rejecting raylet (and any raylets we Cancel above for partially-
+    // prepared bundles) will broadcast their post-state via ray-syncer, which
+    // reconciles GCS's optimistic subtraction.
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -480,7 +483,8 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
   // to destroy them separately.
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(placement_group_id);
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
+    // Cancel RPCs above release the bundle resources on each raylet; their
+    // post-cancel ray-syncer broadcasts will reconcile GCS's view.
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -494,7 +498,8 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
       placement_group->GetMutableBundle(bundle.first.second)->clear_node_id();
     }
     placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
-    ReturnBundleResources(uncommitted_bundle_locations);
+    // Uncommitted bundles' resources stay subtracted in GCS's view until the
+    // next ray-syncer message from each raylet brings the actual state back.
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
   } else {
     schedule_success_handler(placement_group);
@@ -773,81 +778,6 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
         cluster_resource_manager.UpdateResourceCapacity(
             node_id, resource_id, capacity.Double());
       }
-    }
-  }
-}
-
-void GcsPlacementGroupScheduler::ReturnBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  // Return bundle resources to gcs resources manager should contains the following steps.
-  // 1. Remove related bundle resources from nodes.
-  // 2. Add resources allocated for bundles back to nodes.
-  for (auto &bundle : *bundle_locations) {
-    if (!TryReleasingBundleResources(bundle.second)) {
-      waiting_removed_bundles_.push_back(bundle.second);
-    }
-  }
-}
-
-bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
-    const std::pair<NodeID, std::shared_ptr<const BundleSpecification>> &bundle) {
-  auto &cluster_resource_manager =
-      cluster_resource_scheduler_.GetClusterResourceManager();
-  auto node_id = scheduling::NodeID(bundle.first.Binary());
-  const auto &bundle_spec = bundle.second;
-  std::vector<scheduling::ResourceID> bundle_resource_ids;
-  absl::flat_hash_map<std::string, FixedPoint> wildcard_resources;
-
-  if (!cluster_resource_manager.HasNode(node_id)) {
-    // If the node is dead, we do not need to release the bundle resources.
-    // The bundle resources will be released when the node is removed by
-    // the cluster resource manager.
-    return true;
-  }
-
-  // Subtract wildcard resources and delete bundle resources.
-  for (const auto &entry : bundle_spec->GetFormattedResources()) {
-    auto resource_id = scheduling::ResourceID(entry.first);
-    auto capacity =
-        cluster_resource_manager.GetNodeResources(node_id).total.Get(resource_id);
-    if (IsPlacementGroupWildcardResource(entry.first)) {
-      wildcard_resources[entry.first] = capacity - entry.second;
-    } else {
-      bundle_resource_ids.emplace_back(resource_id);
-    }
-  }
-
-  // This bundle is not ready for returning.
-  if (bundle_resource_ids.empty()) {
-    return false;
-  }
-
-  for (const auto &[resource_name, capacity] : wildcard_resources) {
-    if (capacity == 0) {
-      bundle_resource_ids.emplace_back(scheduling::ResourceID(resource_name));
-    } else {
-      cluster_resource_manager.UpdateResourceCapacity(
-          node_id, scheduling::ResourceID(resource_name), capacity.Double());
-    }
-  }
-
-  // It will affect nothing if the resource_id to be deleted does not exist in the
-  // cluster_resource_manager_.
-  cluster_resource_manager.DeleteResources(node_id, bundle_resource_ids);
-  // Add reserved bundle resources back to the node.
-  cluster_resource_manager.AddNodeAvailableResources(
-      node_id, bundle_spec->GetRequiredResources().GetResourceSet());
-  return true;
-}
-
-void GcsPlacementGroupScheduler::HandleWaitingRemovedBundles() {
-  for (auto iter = waiting_removed_bundles_.begin();
-       iter != waiting_removed_bundles_.end();) {
-    auto current = iter++;
-    auto bundle = *current;
-    if (TryReleasingBundleResources(bundle)) {
-      // Release bundle successfully.
-      waiting_removed_bundles_.erase(current);
     }
   }
 }

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 #pragma once
 
-#include <list>
 #include <memory>
 #include <string>
 #include <utility>
@@ -357,8 +356,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
           &group_to_bundles,
       const std::vector<SchedulePgRequest> &prepared_pgs) override;
 
-  void HandleWaitingRemovedBundles();
-
  protected:
   /// Send bundles PREPARE requests to a node. The PREPARE requests will lock resources
   /// on a node until COMMIT or CANCEL requests are sent to a node.
@@ -443,15 +440,14 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   void DestroyPlacementGroupCommittedBundleResources(
       const PlacementGroupID &placement_group_id);
 
-  /// Acquire the bundle resources from the cluster resources.
+  /// Acquire the bundle resources from the cluster resources. The matching
+  /// release is no longer mirrored here -- when bundles are cancelled or a
+  /// scheduling attempt fails, GCS waits for the raylet's next ray-syncer
+  /// broadcast to reconcile its view of the affected nodes' resources.
   void AcquireBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
 
   /// Commit the bundle resources to the cluster resources.
   void CommitBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
-
-  /// Return the bundle resources to the cluster resources.
-  /// It will remove bundle resources AND also add original resources back.
-  void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
 
   /// Create scheduling context.
   std::unique_ptr<BundleSchedulingContext> CreateSchedulingContext(
@@ -460,14 +456,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// Create scheduling options.
   SchedulingOptions CreateSchedulingOptions(const GcsPlacementGroup &placement_group,
                                             rpc::PlacementStrategy strategy);
-
-  /// Try to release bundle resource to cluster resource manager.
-  ///
-  /// \param bundle The node to which the bundle is scheduled and the bundle's
-  /// specification.
-  /// \return True if the bundle is successfully released. False otherwise.
-  bool TryReleasingBundleResources(
-      const std::pair<NodeID, std::shared_ptr<const BundleSpecification>> &bundle);
 
   /// Help function to check if the resource_name has the pattern
   /// {original_resource_name}_group_{placement_group_id}, which means
@@ -501,14 +489,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// The nodes which are releasing unused bundles.
   absl::flat_hash_set<NodeID> nodes_of_releasing_unused_bundles_;
 
-  /// The bundles that waiting to be destroyed and release resources.
-  std::list<std::pair<NodeID, std::shared_ptr<const BundleSpecification>>>
-      waiting_removed_bundles_;
-
   friend class GcsPlacementGroupSchedulerTest;
   FRIEND_TEST(GcsPlacementGroupSchedulerTest, TestCheckingWildcardResource);
-  FRIEND_TEST(GcsPlacementGroupSchedulerTest, TestWaitingRemovedBundles);
-  FRIEND_TEST(GcsPlacementGroupSchedulerTest, TestBundlesRemovedWhenNodeDead);
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -464,9 +464,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
 
   instrumented_io_context &io_context_;
 
-  /// A timer that ticks every cancel resource failure milliseconds.
-  boost::asio::deadline_timer return_timer_;
-
   /// Used to update placement group information upon creation, deletion, etc.
   gcs::GcsTableStorage &gcs_table_storage_;
 

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -930,7 +930,6 @@ void GcsServer::InstallEventListeners() {
                                          worker_failure_data->exit_type(),
                                          worker_failure_data->exit_detail(),
                                          creation_task_exception);
-        gcs_placement_group_scheduler_->HandleWaitingRemovedBundles();
         pubsub_handler_->AsyncRemoveSubscriberFrom(worker_id.Binary());
         observability_pubsub_handler_->AsyncRemoveSubscriberFrom(worker_id.Binary());
         gcs_task_manager_->OnWorkerDead(worker_id, worker_failure_data);

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -1,4 +1,3 @@
-
 // Copyright 2017 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -247,13 +246,6 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
   }
 
-  void AddTwoNodes() {
-    auto node0 = GenNodeInfo(0);
-    auto node1 = GenNodeInfo(1);
-    AddNode(node0);
-    AddNode(node1);
-  }
-
   bool EnsureClusterResourcesAreNotInUse() {
     const auto &cluster_resource_manager =
         cluster_resource_scheduler_->GetClusterResourceManager();
@@ -300,6 +292,33 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
     // node1 is dead and the callback of status is Status::IOError
     ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources(grant1));
+  }
+
+  // Apply a raylet ray-syncer ResourceView broadcast through the same entrypoint
+  // ConsumeSyncMessage uses, updating GCS's view of the node to match the
+  // raylet's reported state.
+  void ApplyRayletResourceView(const NodeID &node_id,
+                               double available_cpu,
+                               double total_cpu) {
+    rpc::syncer::ResourceViewSyncMessage msg;
+    (*msg.mutable_resources_available())["CPU"] = available_cpu;
+    (*msg.mutable_resources_total())["CPU"] = total_cpu;
+    gcs_resource_manager_->UpdateFromResourceView(node_id, msg);
+  }
+
+  double GcsAvailableCpu(const NodeID &node_id) {
+    auto resources = cluster_resource_scheduler_->GetClusterResourceManager()
+                         .GetNodeResources(scheduling::NodeID(node_id.Binary()))
+                         .available.GetResourceMap();
+    auto it = resources.find("CPU");
+    return it != resources.end() ? it->second : 0.0;
+  }
+
+  std::shared_ptr<GcsPlacementGroup> MakeStrictPackPlacementGroup(int bundles_count,
+                                                                  double cpu_per_bundle) {
+    auto request = GenCreatePlacementGroupRequest(
+        /*name=*/"", rpc::PlacementStrategy::STRICT_PACK, bundles_count, cpu_per_bundle);
+    return std::make_shared<GcsPlacementGroup>(request, "", counter_, clock_);
   }
 
  protected:
@@ -1302,8 +1321,10 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestInitialize) {
 }
 
 TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromDeadNodes) {
-  // Add two nodes to the cluster.
-  AddTwoNodes();
+  auto node0 = GenNodeInfo(0);
+  auto node1 = GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
 
   // Make sure the cluster resources are not in use.
   ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
@@ -1324,42 +1345,16 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromDeadNodes) {
   GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
                               /*grant1=*/{false, Status::IOError("")});
 
-  // Make sure the resources are returned to the cluster_resource_manager at the GCS
-  // side.
-  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
-}
-
-TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromNodeWithInsufficientResources) {
-  // Add two nodes to the cluster.
-  AddTwoNodes();
-
-  // Make sure the cluster resources are not in use.
-  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
-
-  // Create a placement group.
-  auto placement_group = std::make_shared<GcsPlacementGroup>(
-      GenCreatePlacementGroupRequest(), "", counter_, clock_);
-
-  // Schedule the unplaced bundles of the placement_group.
-  ScheduleUnplacedBundles(placement_group);
-
-  // Make sure the cluster resources are acquired at the GCS side.
-  ASSERT_FALSE(EnsureClusterResourcesAreNotInUse());
-
-  // Grant the prepare of bundle resources.
-  // node0 grants the schedule request with success=true and status=Status::OK()
-  // node1 grants the schedule request with success=false and status=Status::OK()
-  GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
-                              /*grant1=*/{false, Status::OK()});
-
-  // Make sure the resources are returned to the cluster_resource_manager at the GCS
-  // side.
-  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
+  // Mark the IO-error node dead and verify the placement group is failed.
+  RemoveNode(node1);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
 }
 
 TEST_F(GcsPlacementGroupSchedulerTest, TestCommitToDeadNodes) {
-  // Add two nodes to the cluster.
-  AddTwoNodes();
+  auto node0 = GenNodeInfo(0);
+  auto node1 = GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
 
   // Make sure the cluster resources are not in use.
   ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
@@ -1385,9 +1380,10 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestCommitToDeadNodes) {
   // node1 grants the schedule request status=Status::IOError("")
   GrantCommitBundleResources(Status::IOError(""), Status::IOError(""));
 
-  // Make sure the resources are returned to the cluster_resource_manager at the GCS
-  // side.
-  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
+  // Mark both IO-error nodes dead and verify the placement group is failed.
+  RemoveNode(node0);
+  RemoveNode(node1);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
 }
 
 TEST_F(GcsPlacementGroupSchedulerTest, TestCheckingWildcardResource) {
@@ -1438,13 +1434,95 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundlesRemovedWhenNodeDead) {
   // Remove the node.
   RemoveNode(node);
 
-  // Remove the placement group.
+  // Remove the placement group. With the node already dead, the Cancel RPCs are
+  // no-ops (CancelResourceReserve short-circuits when the node isn't alive).
   const auto &placement_group_id = placement_group->GetPlacementGroupID();
   scheduler_->DestroyPlacementGroupBundleResourcesIfExists(placement_group_id);
+  ASSERT_EQ(raylet_clients_[0]->num_remove_pg_bundles_requested, 0);
+}
 
-  // There shouldn't be any remaining bundles to be removed since the node is
-  // already removed. The bundles are already removed when the node is removed.
-  ASSERT_EQ(scheduler_->waiting_removed_bundles_.size(), 0);
+// When a placement group's Prepare RPC fails, GCS leaves the optimistic
+// subtraction it applied during scheduling in place. The view stays divergent
+// from the raylets' actual state until each raylet's next ResourceView sync
+// reconciles it.
+TEST_F(GcsPlacementGroupSchedulerTest, FailedPrepareDueToStaleResourceViewTest) {
+  auto node0 = GenNodeInfo(0);
+  auto node1 = GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
+  const NodeID node0_id = NodeID::FromBinary(node0->node_id());
+  const NodeID node1_id = NodeID::FromBinary(node1->node_id());
+
+  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
+
+  // 1. Schedule a placement group across both nodes.
+  auto placement_group = std::make_shared<GcsPlacementGroup>(
+      GenCreatePlacementGroupRequest(), "", counter_, clock_);
+  ScheduleUnplacedBundles(placement_group);
+
+  // 2. GCS subtracts the bundle resources locally before sending Prepare.
+  ASSERT_FALSE(EnsureClusterResourcesAreNotInUse());
+
+  // 3. Prepare RPC fails on node1.
+  GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
+                              /*grant1=*/{false, Status::OK()});
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+
+  // 4. GCS keeps the optimistic subtraction; the view is still divergent from
+  //    the raylets' actual state.
+  ASSERT_FALSE(EnsureClusterResourcesAreNotInUse());
+
+  // 5. Each raylet's next ResourceView sync reports the actual state (no
+  //    bundles were committed on either node).
+  ApplyRayletResourceView(node0_id, /*available_cpu=*/10, /*total_cpu=*/10);
+  ApplyRayletResourceView(node1_id, /*available_cpu=*/10, /*total_cpu=*/10);
+
+  // 6. GCS's view now matches the raylets' reported state.
+  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
+}
+
+// Upon removing a committed placement group, the GCS should receive an updated
+// ResourceView sync from the Raylet and then be able to reschedule to that node.
+TEST_F(GcsPlacementGroupSchedulerTest,
+       PendingPlacementGroupScheduledAfterRemovalAndResourceViewUpdate) {
+  auto node_a = GenNodeInfo(0);
+  AddNode(node_a, /*cpu_num=*/8);
+  const NodeID node_a_id = NodeID::FromBinary(node_a->node_id());
+
+  // 1. PG_1 commits on A.
+  auto pg_1 = MakeStrictPackPlacementGroup(/*bundles_count=*/1, /*cpu_per_bundle=*/8);
+  ScheduleUnplacedBundles(pg_1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+  ASSERT_EQ(GcsAvailableCpu(node_a_id), 0);
+
+  // 2. PG_2 (same shape) is submitted while A is fully occupied -> infeasible.
+  auto pg_2 = MakeStrictPackPlacementGroup(1, 8);
+  ScheduleUnplacedBundles(pg_2);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+
+  // 3. Remove PG_1.
+  scheduler_->DestroyPlacementGroupBundleResourcesIfExists(pg_1->GetPlacementGroupID());
+  ASSERT_TRUE(raylet_clients_[0]->GrantRemovePlacementGroupBundles());
+  ASSERT_EQ(GcsAvailableCpu(node_a_id), 0);
+
+  // 4. Retry PG_2 before any syncer message arrives -> still infeasible.
+  ScheduleUnplacedBundles(pg_2);
+  WaitPlacementGroupPendingDone(2, GcsPlacementGroupStatus::FAILURE);
+  ASSERT_EQ(GcsAvailableCpu(node_a_id), 0);
+
+  // 5. Raylet broadcasts the post-removal view: available = 8.
+  ApplyRayletResourceView(node_a_id, /*available_cpu=*/8, /*total_cpu=*/8);
+  ASSERT_EQ(GcsAvailableCpu(node_a_id), 8);
+
+  // 6. Retry PG_2 -> now schedules onto A successfully.
+  ScheduleUnplacedBundles(pg_2);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(2, GcsPlacementGroupStatus::SUCCESS);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/tests/gcs_server_test_util.h
+++ b/src/ray/gcs/tests/gcs_server_test_util.h
@@ -342,8 +342,6 @@ struct GcsServerMocker {
    public:
     using gcs::GcsPlacementGroupScheduler::GcsPlacementGroupScheduler;
 
-    size_t GetWaitingRemovedBundlesSize() { return waiting_removed_bundles_.size(); }
-
     using gcs::GcsPlacementGroupScheduler::ScheduleUnplacedBundles;
     // Extra conveinence overload for the mock tests to keep using the old interface.
     void ScheduleUnplacedBundles(


### PR DESCRIPTION
We continue to optimistically deduct resources when scheduling placement groups in the GCS, but no longer deduct those resources on placement group scheduling failure. Instead, we rely on the regular resource view broadcast to reconcile the resource view between the GCS and Raylet(s).

Closes: https://github.com/ray-project/ray/issues/62858