### PR TITLE
[core] Remove dead `AddResourcesChangedListener` codepaths

### DIFF
--- a/src/ray/common/BUILD.bazel
+++ b/src/ray/common/BUILD.bazel
@@ -45,6 +45,7 @@ ray_cc_library(
         "//src/ray/util:process",
         "//src/ray/util:time",
         "@boost//:optional",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/src/ray/common/test_utils.cc
+++ b/src/ray/common/test_utils.cc
@@ -24,6 +24,8 @@
 #endif
 
 #include "absl/strings/escaping.h"
+#include "gtest/gtest.h"
+
 #include "ray/common/buffer.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task_util.h"

--- a/src/ray/common/test_utils.cc
+++ b/src/ray/common/test_utils.cc
@@ -25,7 +25,6 @@
 
 #include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
-
 #include "ray/common/buffer.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task_util.h"

--- a/src/ray/common/test_utils.h
+++ b/src/ray/common/test_utils.h
@@ -18,7 +18,6 @@
 #include <future>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "ray/asio/asio_util.h"
 #include "ray/common/id.h"
 #include "ray/common/placement_group.h"

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -736,10 +736,6 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
       }
     }
   }
-
-  for (const auto &listener : resources_changed_listeners_) {
-    listener();
-  }
 }
 
 void GcsPlacementGroupScheduler::ReturnBundleResources(
@@ -752,16 +748,6 @@ void GcsPlacementGroupScheduler::ReturnBundleResources(
       waiting_removed_bundles_.push_back(bundle.second);
     }
   }
-
-  for (const auto &listener : resources_changed_listeners_) {
-    listener();
-  }
-}
-
-void GcsPlacementGroupScheduler::AddResourcesChangedListener(
-    std::function<void()> listener) {
-  RAY_CHECK(listener != nullptr);
-  resources_changed_listeners_.emplace_back(std::move(listener));
 }
 
 bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
@@ -824,9 +810,6 @@ void GcsPlacementGroupScheduler::HandleWaitingRemovedBundles() {
       // Release bundle successfully.
       waiting_removed_bundles_.erase(current);
     }
-  }
-  for (const auto &listener : resources_changed_listeners_) {
-    listener();
   }
 }
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -357,9 +357,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
           &group_to_bundles,
       const std::vector<SchedulePgRequest> &prepared_pgs) override;
 
-  /// Add resources changed listener.
-  void AddResourcesChangedListener(std::function<void()> listener);
-
   void HandleWaitingRemovedBundles();
 
  protected:
@@ -501,9 +498,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
 
   /// The nodes which are releasing unused bundles.
   absl::flat_hash_set<NodeID> nodes_of_releasing_unused_bundles_;
-
-  /// The resources changed listeners.
-  std::vector<std::function<void()>> resources_changed_listeners_;
 
   /// The bundles that waiting to be destroyed and release resources.
   std::list<std::pair<NodeID, std::shared_ptr<const BundleSpecification>>>

--- a/src/ray/gcs/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_resource_manager.cc
@@ -290,11 +290,6 @@ std::string GcsResourceManager::DebugString() const {
   return stream.str();
 }
 
-void GcsResourceManager::AddResourcesChangedListener(std::function<void()> &&listener) {
-  RAY_CHECK(listener != nullptr);
-  resources_changed_listeners_.emplace_back(std::move(listener));
-}
-
 std::string GcsResourceManager::ToString() const {
   std::ostringstream ostr;
   const int indent = 0;

--- a/src/ray/gcs/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_resource_manager.h
@@ -120,9 +120,6 @@ class GcsResourceManager : public rpc::NodeResourceInfoGcsServiceHandler,
 
   std::string DebugString() const;
 
-  /// Add resources changed listener.
-  void AddResourcesChangedListener(std::function<void()> &&listener);
-
   /// Update resource usage of given node.
   ///
   /// \param node_id Node id.
@@ -175,8 +172,6 @@ class GcsResourceManager : public rpc::NodeResourceInfoGcsServiceHandler,
 
   /// Placement group load information that is used for autoscaler.
   std::optional<std::shared_ptr<rpc::PlacementGroupLoad>> placement_group_load_;
-  /// The resources changed listeners.
-  std::vector<std::function<void()>> resources_changed_listeners_;
 
   /// Debug info.
   enum CountType {

--- a/src/ray/gcs/store_client/tests/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/in_memory_store_client_test.cc
@@ -17,7 +17,6 @@
 #include <memory>
 
 #include "gtest/gtest.h"
-
 #include "ray/gcs/store_client/tests/store_client_test_base.h"
 
 namespace ray {

--- a/src/ray/gcs/store_client/tests/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/in_memory_store_client_test.cc
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include "gtest/gtest.h"
+
 #include "ray/gcs/store_client/tests/store_client_test_base.h"
 
 namespace ray {

--- a/src/ray/gcs/store_client/tests/observable_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/observable_store_client_test.cc
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include "gtest/gtest.h"
+
 #include "ray/gcs/store_client/in_memory_store_client.h"
 #include "ray/gcs/store_client/tests/store_client_test_base.h"
 #include "ray/util/clock.h"

--- a/src/ray/gcs/store_client/tests/observable_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/observable_store_client_test.cc
@@ -17,7 +17,6 @@
 #include <memory>
 
 #include "gtest/gtest.h"
-
 #include "ray/gcs/store_client/in_memory_store_client.h"
 #include "ray/gcs/store_client/tests/store_client_test_base.h"
 #include "ray/util/clock.h"

--- a/src/ray/gcs/store_client/tests/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_store_client_test.cc
@@ -14,13 +14,15 @@
 
 #include "ray/gcs/store_client/redis_store_client.h"
 
-#include <boost/optional/optional_io.hpp>
 #include <chrono>
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
+
+#include <boost/optional/optional_io.hpp>
+#include "gtest/gtest.h"
 
 #include "ray/common/test_utils.h"
 #include "ray/gcs/store_client/tests/store_client_test_base.h"

--- a/src/ray/gcs/store_client/tests/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_store_client_test.cc
@@ -14,6 +14,7 @@
 
 #include "ray/gcs/store_client/redis_store_client.h"
 
+#include <boost/optional/optional_io.hpp>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -21,9 +22,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <boost/optional/optional_io.hpp>
 #include "gtest/gtest.h"
-
 #include "ray/common/test_utils.h"
 #include "ray/gcs/store_client/tests/store_client_test_base.h"
 #include "ray/util/clock.h"


### PR DESCRIPTION
Discovered when working on: https://github.com/ray-project/ray/issues/62858