### PR TITLE
[core] Deflake `test_stop_job_timeout` by stopping the job only after its SIGTERM handler is installed

### DIFF
--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1310,20 +1310,20 @@ while True:
     "use_env_var,stop_timeout",
     [(True, 10), (False, JobSupervisor.DEFAULT_RAY_JOB_STOP_WAIT_TIME_S)],
 )
-async def test_stop_job_timeout(job_manager, use_env_var, stop_timeout):
+async def test_stop_job_timeout(job_manager, tmp_path, use_env_var, stop_timeout):
     """
     Stop job should send SIGTERM first, then if timeout occurs, send SIGKILL.
     """
-    entrypoint = """python -c \"
-import sys
+    ready_file = tmp_path / "handler_installed"
+    handled_file = tmp_path / "sigterm_handled"
+    entrypoint = f"""python -c \"
 import signal
 import time
 def handler(*args):
-    print('SIGTERM signal handled!');
+    open({str(handled_file)!r}, 'w').close()
 signal.signal(signal.SIGTERM, handler)
-
+open({str(ready_file)!r}, 'w').close()
 while True:
-    print('Waiting...')
     time.sleep(1)\"
 """
     if use_env_var:
@@ -1334,9 +1334,7 @@ while True:
     else:
         job_id = await job_manager.submit_job(entrypoint=entrypoint)
 
-    await async_wait_for_condition(
-        lambda: "Waiting..." in job_manager.get_job_logs(job_id)
-    )
+    await async_wait_for_condition(lambda: ready_file.exists())
 
     assert job_manager.stop_job(job_id) is True
 
@@ -1348,9 +1346,7 @@ while True:
             timeout=stop_timeout / 2,
         )
 
-    await async_wait_for_condition(
-        lambda: "SIGTERM signal handled!" in job_manager.get_job_logs(job_id)
-    )
+    await async_wait_for_condition(lambda: handled_file.exists())
 
     await async_wait_for_condition(
         check_job_stopped,

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1320,9 +1320,9 @@ async def test_stop_job_timeout(job_manager, tmp_path, use_env_var, stop_timeout
 import signal
 import time
 def handler(*args):
-    open({str(handled_file)!r}, 'w').close()
+    open({handled_file.as_posix()!r}, 'w').close()
 signal.signal(signal.SIGTERM, handler)
-open({str(ready_file)!r}, 'w').close()
+open({ready_file.as_posix()!r}, 'w').close()
 while True:
     time.sleep(1)\"
 """


### PR DESCRIPTION
## Description

`test_stop_job_timeout` basically wants to do the following:
- The driver installs a SIGTERM handler and, once installed, prints log A.
- We grep for log A to make sure the SIGTERM handler is installed.
- We then stop the job with SIGTERM, and the driver should not exit on it.
- The handler also prints log B, which we check to confirm the handler actually ran.

The problem is that grepping the log isn't reliable. Before launching the driver, the supervisor writes the entrypoint command into the log, and it includes the whole script source, including those two print A and B:
https://github.com/ray-project/ray/blob/13e1bd138a209c0d1a5c50843c4a6d45b198eb6b/python/ray/dashboard/modules/job/job_supervisor.py#L179

So A and B are already in the log before the driver runs a single line. So we might end up sending SIGTERM before the driver installs the handler.

So we use files instead: the driver creates one file after the handler is installed, and the handler creates another when it runs. 

This flaky test also reproduces on my local Mac, and I verified it is stable after the fix.
