### PR TITLE
[data] Show external consumer bytes in verbose operator progress log

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -384,8 +384,18 @@ class ResourceManager:
         if verbose:
             usage_str += (
                 f" (in={memory_string(self.get_mem_op_internal(op))},"
-                f"out={memory_string(self.get_mem_op_outputs(op))})"
+                f"out={memory_string(self.get_mem_op_outputs(op))}"
             )
+            # External-consumer bytes (iterator / streaming_split prefetch) are
+            # only attached to the output operator. Surface them in its line so
+            # users can see how much of `out` is held by the downstream iterator
+            # vs. the operator's own output queues.
+            if op is self._output_operator and self._has_external_consumer:
+                usage_str += (
+                    f",external_consumer="
+                    f"{memory_string(self._external_consumer_bytes)}"
+                )
+            usage_str += ")"
             if self._op_resource_allocator is not None:
                 allocation = self._op_resource_allocator.get_allocation(op)
                 if allocation:

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -629,6 +629,56 @@ class TestResourceManager:
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(buf).object_store_memory == 150
 
+    def test_external_consumer_bytes_surfaced_in_op_usage_str(
+        self, restore_data_context
+    ):
+        """The terminal operator's verbose usage string should include
+        external_consumer=... when an external consumer is registered, so users
+        can see how much of the operator's object-store memory is held by a
+        downstream iterator vs. the operator's own queues."""
+        cluster_resources = ExecutionResources(cpu=10, gpu=0, object_store_memory=1000)
+
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1)
+        o3 = mock_map_op(o2)
+
+        topo = build_streaming_topology(o3, ExecutionOptions())
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            lambda: cluster_resources,
+            DataContext.get_current(),
+        )
+
+        for op in [o1, o2, o3]:
+            op.current_logical_usage = MagicMock(return_value=ExecutionResources.zero())
+            op.running_logical_usage = MagicMock(return_value=ExecutionResources.zero())
+            op.pending_logical_usage = MagicMock(return_value=ExecutionResources.zero())
+
+        resource_manager.update_usages()
+
+        # No external consumer yet: nothing extra in the usage string.
+        terminal_str = resource_manager.get_op_usage_str(o3, verbose=True)
+        upstream_str = resource_manager.get_op_usage_str(o2, verbose=True)
+        assert "external_consumer=" not in terminal_str
+        assert "external_consumer=" not in upstream_str
+
+        # Register an external consumer. Only the terminal operator's string
+        # should pick up `external_consumer=...`.
+        resource_manager.set_external_consumer_bytes(200)
+        resource_manager.update_usages()
+        terminal_str = resource_manager.get_op_usage_str(o3, verbose=True)
+        upstream_str = resource_manager.get_op_usage_str(o2, verbose=True)
+        assert "external_consumer=200.0B" in terminal_str
+        assert "external_consumer=" not in upstream_str
+
+        # The field is inside the existing `(in=...,out=...)` parenthetical.
+        assert ",external_consumer=" in terminal_str
+
+        # Non-verbose output omits the field (existing format unchanged).
+        terminal_str_brief = resource_manager.get_op_usage_str(o3, verbose=False)
+        assert "external_consumer=" not in terminal_str_brief
+
     def test_topology_rejects_multiple_terminal_operators(self, restore_data_context):
         ctx = DataContext.get_current()
         a = PhysicalOperator("a", [], ctx)


### PR DESCRIPTION
## Description

When iterating with `ds.iter_batches()` or consuming a `streaming_split()` shard, the consumer's prefetched bytes are charged to the terminal operator's `out` memory (via `set_external_consumer_bytes`). Today the progress log shows the combined number without distinguishing the operator's own queues from what the downstream iterator is holding, which makes it hard to tell how much memory the iterator's prefetch is using.

This adds `external_consumer=...` to the verbose `(in=..., out=...)` field on the terminal operator's progress line whenever an external consumer is registered:
  
Before:
```
split(4, equal=True): Tasks: 0; Actors: 0; Queued blocks: 2 (256.1MiB); Resources: 0.0 CPU, 17.9GiB object store (in=0.0B,out=17.9GiB);
```

After:
```
split(4, equal=True): Tasks: 0; Actors: 0; Queued blocks: 2 (256.1MiB); Resources: 0.0 CPU, 17.9GiB object store (in=0.0B,out=17.9GiB,external_consumer=15.2GiB);
```

The field only appears on the terminal operator (since external consumers attach there) and only when a consumer is registered, so existing logs for pipelines without external consumers are unchanged.

## Additional details

We're going to eventually remove this "external consumer tracking" logic in Ray Data, but for now this log is useful for debugging at least internally.