### PR TITLE
[serve][llm] Deflake test_openai_compatibility_direct_streaming

### DIFF
--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -201,9 +201,6 @@ def get_rayllm_testing_model(
     router_app = build_openai_app(args)
     serve._run(router_app, name="router", _blocking=False)
 
-    # Gate on all replicas RUNNING before serving traffic, otherwise the HAProxy
-    # ingress router 503s with "unknown_replica_id" when it routes to a replica
-    # not yet in the reloaded replica map while the fleet scales up (#63731).
     wait_for_condition(
         lambda: serve.status().applications["router"].status
         == ApplicationStatus.RUNNING,

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -11,6 +11,7 @@ import yaml
 
 import ray
 from ray import serve
+from ray._common.test_utils import wait_for_condition
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
     CompletionRequest,
@@ -29,6 +30,7 @@ from ray.serve.llm import (
     ModelLoadingConfig,
     build_openai_app,
 )
+from ray.serve.schema import ApplicationStatus
 
 MOCK_MODEL_ID = "mock-model"
 
@@ -198,6 +200,16 @@ def get_rayllm_testing_model(
     args = LLMServingArgs(llm_configs=[str(test_model_path.absolute())])
     router_app = build_openai_app(args)
     serve._run(router_app, name="router", _blocking=False)
+
+    # Gate on all replicas RUNNING before serving traffic, otherwise the HAProxy
+    # ingress router 503s with "unknown_replica_id" when it routes to a replica
+    # not yet in the reloaded replica map while the fleet scales up (#63731).
+    wait_for_condition(
+        lambda: serve.status().applications["router"].status
+        == ApplicationStatus.RUNNING,
+        timeout=200,
+        retry_interval_ms=2000,
+    )
 
     # Block until the deployment is ready
     # Wait at most 200s [3 min]


### PR DESCRIPTION
## Why are these changes needed?

`test_openai_compatibility_direct_streaming` is flaky on master (#63731). The failure is a `503: Ingress request router failed: unknown_replica_id` (seen e.g. on `test_chat_without_model_parameter`).

The direct-streaming variant runs the `LLMServer` replicas as the ASGI ingress behind HAProxy, with `min_replicas`/`initial_replicas` = 4. The shared `get_rayllm_testing_model` fixture returned as soon as a single `/v1/models` request succeeded, so the test suite started before the whole fleet was up. While replicas were still scaling, the HAProxy ingress request router could return a `replica_id` not yet present in the reloaded HAProxy replica map (`ingress_request_router.lua.tmpl`), which produces the 503.

This gates the fixture on the app reaching `RUNNING` (all deployments at their target replica count) before serving traffic, matching the readiness invariant the Serve direct-ingress tests rely on. The existing per-request retry loop is kept to absorb any brief HAProxy reload lag.

## Related issue number

Fixes #63731

## Checks

- [x] I've signed off every commit (DCO).
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] Testing Strategy
   - [x] Unit tests