### PR TITLE
[data] Make RoundRobinPartitioner min/max bucket size configurable via DataContext

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -83,6 +83,11 @@ DEFAULT_USE_DATASOURCE_V2 = True
 # uses its built-in default (currently 1 GiB).
 DEFAULT_PARQUET_CHUNKER_TARGET_CHUNK_SIZE: Optional[int] = None
 
+# Default min/max bucket size in bytes for ``RoundRobinPartitioner`` (V2 reads).
+# ``None`` means fall back to ``target_min_block_size`` / ``target_max_block_size``.
+DEFAULT_PARTITIONER_MIN_BUCKET_SIZE: Optional[int] = None
+DEFAULT_PARTITIONER_MAX_BUCKET_SIZE: Optional[int] = None
+
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
 
 DEFAULT_USE_PUSH_BASED_SHUFFLE = bool(
@@ -523,6 +528,14 @@ class DataContext:
             ``ParquetFileChunker`` when splitting large Parquet files into
             multiple read tasks. When ``None``, the chunker's built-in default
             (currently 1 GiB) is used.
+        partitioner_min_bucket_size: Minimum bucket size in bytes for the V2
+            ``RoundRobinPartitioner``. The partitioner avoids emitting blocks
+            smaller than this. When ``None``, falls back to
+            ``target_min_block_size``.
+        partitioner_max_bucket_size: Maximum bucket size in bytes for the V2
+            ``RoundRobinPartitioner``. The partitioner emits a block once a
+            bucket reaches this size. When ``None``, falls back to
+            ``target_max_block_size`` (or unbounded if that is also ``None``).
         enable_tensor_extension_casting: Whether to automatically cast NumPy ndarray
             columns in Pandas DataFrames to tensor extension columns.
         arrow_fixed_shape_tensor_format: The tensor format to use for fixed-shape tensors.
@@ -760,6 +773,8 @@ class DataContext:
     parquet_chunker_target_chunk_size: Optional[
         int
     ] = DEFAULT_PARQUET_CHUNKER_TARGET_CHUNK_SIZE
+    partitioner_min_bucket_size: Optional[int] = DEFAULT_PARTITIONER_MIN_BUCKET_SIZE
+    partitioner_max_bucket_size: Optional[int] = DEFAULT_PARTITIONER_MAX_BUCKET_SIZE
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
     arrow_fixed_shape_tensor_format: "FixedShapeTensorFormat" = field(
         default_factory=_default_fixed_shape_tensor_format

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -520,17 +520,23 @@ def _read_datasource_v2(
     # encoding-ratio multiplier). ``num_buckets`` is a hint;
     # ``RoundRobinPartitioner`` honors ``[min, max]`` block-size limits
     # first, so the actual bucket count scales with total data size.
-    # ``target_*_block_size`` can be ``None`` (block sizing disabled); fall
-    # back to sentinel bounds so the partitioner just rolls every file
-    # into a single bucket.
+    # Bucket bounds default to ``partitioner_{min,max}_bucket_size`` when set,
+    # otherwise fall back to the read block-size targets. ``target_*_block_size``
+    # can be ``None`` (block sizing disabled); fall back to sentinel bounds so the
+    # partitioner just rolls every file into a single bucket.
     import sys
 
-    min_bucket_size = ctx.target_min_block_size or 0
-    max_bucket_size = (
-        ctx.target_max_block_size
-        if ctx.target_max_block_size is not None
-        else sys.maxsize
-    )
+    min_bucket_size = ctx.partitioner_min_bucket_size
+    if min_bucket_size is None:
+        min_bucket_size = ctx.target_min_block_size or 0
+
+    max_bucket_size = ctx.partitioner_max_bucket_size
+    if max_bucket_size is None:
+        max_bucket_size = (
+            ctx.target_max_block_size
+            if ctx.target_max_block_size is not None
+            else sys.maxsize
+        )
     # ``parallelism`` is the caller-resolved ``override_num_blocks`` value
     # (``-1`` when unset). Honoring it here per-read avoids mutating the
     # process-global ``DataContext.read_op_min_num_blocks``.

--- a/release/nightly_tests/dataset/text_embeddings_benchmark.py
+++ b/release/nightly_tests/dataset/text_embeddings_benchmark.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 from numpy import ndarray
 
 import ray
+from ray.data._internal.util import KiB, MiB
 import torch
 from sentence_transformers import SentenceTransformer
 from langchain_text_splitters import (
@@ -132,6 +133,11 @@ class Embedder:
 
 
 def main(args):
+    ctx = ray.data.DataContext.get_current()
+    ctx.partitioner_max_bucket_size = 1 * MiB
+    ctx.partitioner_min_bucket_size = 1 * KiB
+    ctx.read_op_min_num_blocks = 1200
+
     start_time = time.time()
     ds = ray.data.read_parquet(
         args.source_directory,

--- a/release/nightly_tests/dataset/text_embeddings_benchmark.py
+++ b/release/nightly_tests/dataset/text_embeddings_benchmark.py
@@ -9,7 +9,6 @@ from typing import Dict, List
 from numpy import ndarray
 
 import ray
-from ray.data._internal.util import KiB, MiB
 import torch
 from sentence_transformers import SentenceTransformer
 from langchain_text_splitters import (
@@ -70,16 +69,6 @@ def parse_args():
         type=int,
         default=15,
         help="Number of Embedder replicas",
-    )
-    parser.add_argument(
-        "--chunker-target-chunk-size",
-        type=int,
-        default=16 * MiB,
-        help=(
-            "Target chunk size (bytes) for splitting a Parquet file into read "
-            "tasks. Lower values produce more, smaller read blocks (bounded by "
-            "the file's row-group count)."
-        ),
     )
     parser.add_argument(
         "--num-gpus", type=int, default=1, help="Number of GPUs per Embedder"
@@ -144,14 +133,6 @@ class Embedder:
 
 def main(args):
     ctx = ray.data.DataContext.get_current()
-    ctx.partitioner_max_bucket_size = 1 * MiB
-    ctx.partitioner_min_bucket_size = 1 * KiB
-    ctx.read_op_min_num_blocks = 1200
-    # The partitioner only groups whole file-chunks into blocks; it can't split
-    # a file finer than the chunker does. Lower the chunker target so a single
-    # large Parquet file is split into many chunks (and therefore many small
-    # read blocks), instead of the default 1 GiB chunks.
-    ctx.parquet_chunker_target_chunk_size = args.chunker_target_chunk_size
 
     start_time = time.time()
     ds = ray.data.read_parquet(
@@ -162,6 +143,14 @@ def main(args):
     metadata_fetching_s = metadata_fetch_end - start_time
     if args.smoke_test:
         ds = ds.limit(100)
+
+    # A single Parquet file can't be read into more blocks than it has row
+    # groups, so the DataSourceV2 read caps out well below the parallelism we
+    # want for the downstream chunk + embed stages. Repartition to spread the
+    # data across more, smaller blocks. Gated on V2 since the V1 reader sizes
+    # its own read blocks.
+    if ctx.use_datasource_v2:
+        ds = ds.repartition(1200, shuffle=False)
 
     ds = ds.flat_map(
         Chunker(

--- a/release/nightly_tests/dataset/text_embeddings_benchmark.py
+++ b/release/nightly_tests/dataset/text_embeddings_benchmark.py
@@ -72,6 +72,16 @@ def parse_args():
         help="Number of Embedder replicas",
     )
     parser.add_argument(
+        "--chunker-target-chunk-size",
+        type=int,
+        default=16 * MiB,
+        help=(
+            "Target chunk size (bytes) for splitting a Parquet file into read "
+            "tasks. Lower values produce more, smaller read blocks (bounded by "
+            "the file's row-group count)."
+        ),
+    )
+    parser.add_argument(
         "--num-gpus", type=int, default=1, help="Number of GPUs per Embedder"
     )
     parser.add_argument(
@@ -137,6 +147,11 @@ def main(args):
     ctx.partitioner_max_bucket_size = 1 * MiB
     ctx.partitioner_min_bucket_size = 1 * KiB
     ctx.read_op_min_num_blocks = 1200
+    # The partitioner only groups whole file-chunks into blocks; it can't split
+    # a file finer than the chunker does. Lower the chunker target so a single
+    # large Parquet file is split into many chunks (and therefore many small
+    # read blocks), instead of the default 1 GiB chunks.
+    ctx.parquet_chunker_target_chunk_size = args.chunker_target_chunk_size
 
     start_time = time.time()
     ds = ray.data.read_parquet(


### PR DESCRIPTION
## Why are these changes needed?

Two related changes for tuning DataSourceV2 (`use_datasource_v2`) read parallelism:

**1. Configurable `RoundRobinPartitioner` bucket bounds (`context.py`, `read_api.py`)**

Adds `partitioner_min_bucket_size` and `partitioner_max_bucket_size` to
`DataContext`. When set, these override the V2 `RoundRobinPartitioner`'s
bucket bounds; when `None` (the default), they fall back to the existing
`target_min_block_size` / `target_max_block_size` behavior, so nothing
changes unless explicitly configured.

**2. Repartition in the text embeddings benchmark**

The partitioner only *groups* whole file-chunks into blocks, and the chunker
splits a Parquet file at row-group granularity — a single file can't be read
into more blocks than it has row groups. For the benchmark's single-file
source this caps read parallelism well below what the downstream chunk +
embed stages want, and no partitioner/chunker bucket setting can cross that
floor (you can't subdivide a row group at read time).

Instead, the benchmark now `repartition`s the dataset into more, smaller
blocks after the read. This is gated on `use_datasource_v2` since the V1
reader sizes its own read blocks.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit (`git commit -s`)
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] Testing done

🤖 Generated with [Claude Code](https://claude.com/claude-code)