### PR TITLE
[core] Marking child tasks failed on worker death

### DIFF
--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1513,5 +1513,73 @@ def test_completed_task_not_marked_failed_on_worker_death(shutdown_only):
     wait_for_condition(verify, timeout=15, retry_interval_ms=500)
 
 
+def test_owner_death_skips_detached_actor_but_marks_non_detached(shutdown_only):
+    """
+    Owner spawns both a detached and a non-detached actor before crashing.
+
+    Expected after owner's ungraceful death:
+      - Non-detached actor's running method should be marked FAILED (the owner-side
+        DFS no longer skips non-detached actor subtrees).
+      - Detached actor's running method should stay RUNNING (the DFS skips detached
+        actor subtrees; the actor outlives its owner by design).
+    """
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    @ray.remote(max_retries=0)
+    def parent_starts_actors():
+        @ray.remote
+        class _Actor:
+            def __init__(self):
+                self.started = False
+
+            async def is_running(self):
+                return self.started
+
+            async def run(self):
+                self.started = True
+                await asyncio.sleep(999)
+
+        detached = _Actor.options(
+            name="mixed-detached", lifetime="detached", namespace="test"
+        ).remote()
+        detached.run.options(name="mixed-detached-run").remote()
+
+        non_detached = _Actor.remote()
+        non_detached.run.options(name="mixed-non-detached-run").remote()
+
+        # Wait until both actor methods are actually running before crashing.
+        wait_for_condition(lambda: ray.get(detached.is_running.remote()), timeout=15)
+        wait_for_condition(
+            lambda: ray.get(non_detached.is_running.remote()), timeout=15
+        )
+
+        # Give the task event buffer a chance to flush before the crash.
+        time.sleep(1)
+        os._exit(1)
+
+    with pytest.raises(ray.exceptions.WorkerCrashedError):
+        ray.get(parent_starts_actors.remote())
+
+    # Non-detached actor's task should end up FAILED (owner DFS doesn't skip it).
+    wait_for_task_states({"mixed-non-detached-run": "FAILED"})
+
+    # Detached actor's task should remain RUNNING — its subtree was skipped.
+    wait_for_task_states({"mixed-detached-run": "RUNNING"})
+
+    # Sanity check: state still RUNNING after a brief wait (no delayed marking).
+    time.sleep(2)
+    tasks = list_tasks(filters=[("name", "=", "mixed-detached-run")], detail=True)
+    assert len(tasks) == 1
+    assert tasks[0]["state"] == "RUNNING", (
+        f"detached actor task should still be RUNNING after owner death, "
+        f"got {tasks[0]['state']}"
+    )
+
+    # Clean up the detached actor explicitly.
+    detached = ray.get_actor("mixed-detached", namespace="test")
+    ray.kill(detached)
+    wait_for_task_states({"mixed-detached-run": "FAILED"})
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1332,5 +1332,186 @@ class TestIsActorTaskRunning:
         wait_for_condition(lambda: not _is_actor_task_running(pid, task_name))
 
 
+def test_owner_ungraceful_death_marks_child_tree_failed(shutdown_only):
+    """
+    Test that when an owner worker dies ungracefully (os._exit), the entire tree of
+    child tasks is marked FAILED with error_type OWNER_DIED.
+
+    Task tree:
+        owner_task -> child_task_1 (sleeping)
+                   -> child_task_2 -> grandchild_task (sleeping)
+
+    owner_task crashes via os._exit(1). All descendants should be marked FAILED.
+    """
+    ray.init(num_cpus=8, _system_config=_SYSTEM_CONFIG)
+
+    @ray.remote(max_retries=0)
+    def grandchild_task():
+        time.sleep(999)
+
+    @ray.remote(max_retries=0)
+    def child_task_1():
+        time.sleep(999)
+
+    @ray.remote(max_retries=0)
+    def child_task_2():
+        ray.get(grandchild_task.remote())
+
+    @ray.remote(max_retries=0)
+    def owner_task():
+        child_task_1.remote()
+        child_task_2.remote()
+        # Wait until all children are running before crashing.
+        def children_running():
+            tasks = list_tasks(filters=[("name", "!=", "owner_task")], detail=True)
+            running = [t for t in tasks if t["state"] == "RUNNING"]
+            # child_task_1, child_task_2, grandchild_task
+            return len(running) >= 3
+
+        wait_for_condition(children_running, timeout=15)
+        os._exit(1)
+
+    with pytest.raises(ray.exceptions.WorkerCrashedError):
+        ray.get(owner_task.remote())
+
+    def verify():
+        for name in ["child_task_1", "child_task_2", "grandchild_task"]:
+            tasks = list_tasks(filters=[("name", "=", name)], detail=True)
+            assert len(tasks) == 1, f"Expected 1 task for {name}, got {len(tasks)}"
+            t = tasks[0]
+            assert t["state"] == "FAILED", f"{name} should be FAILED, got {t['state']}"
+            assert (
+                t["error_type"] == "OWNER_DIED"
+            ), f"{name} error_type should be OWNER_DIED, got {t['error_type']}"
+        return True
+
+    wait_for_condition(verify, timeout=30, retry_interval_ms=1000)
+
+
+@pytest.mark.parametrize("worker_dead_delay_ms", [30000, 0])
+def test_owner_graceful_death_waited_does_not_fail_children(
+    shutdown_only, worker_dead_delay_ms
+):
+    """
+    Test that when an owner exits gracefully after waiting for all children
+    (via ray.get), the children are NOT incorrectly marked as FAILED.
+
+    Parametrized with delay=30000 (task events will be reported) and delay=0 (worst-case race where
+    OnWorkerDead fires before task events arrive — should still not mark children
+    failed because the death is graceful).
+    """
+    sys_config = _SYSTEM_CONFIG.copy()
+    sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = worker_dead_delay_ms
+    ray.init(num_cpus=8, _system_config=sys_config)
+
+    @ray.remote
+    def child_task():
+        return 1
+
+    @ray.remote
+    def owner_task():
+        refs = [child_task.remote() for _ in range(3)]
+        ray.get(refs)  # Wait for all children.
+        return "done"
+
+    ray.get(owner_task.remote())
+
+    def verify():
+        tasks = list_tasks(filters=[("name", "=", "child_task")], detail=True)
+        assert len(tasks) == 3, f"Expected 3 child tasks, got {len(tasks)}"
+        for t in tasks:
+            assert (
+                t["state"] == "FINISHED"
+            ), f"child_task should be FINISHED, got {t['state']}"
+        return True
+
+    wait_for_condition(verify, timeout=15, retry_interval_ms=500)
+
+
+@pytest.mark.parametrize("worker_dead_delay_ms", [30000, 0])
+def test_owner_graceful_death_no_wait_does_not_fail_children(
+    shutdown_only, worker_dead_delay_ms
+):
+    """
+    Test that when an owner exits gracefully WITHOUT waiting for children,
+    the children are NOT incorrectly marked as FAILED. The worker process stays
+    alive in the pool and remains the owner, so it will relay the statuses.
+
+    Parametrized with delay=30000 (task events will be reported) and delay=0 (worst-case race — should
+    still not mark children failed because the death is graceful).
+    """
+    sys_config = _SYSTEM_CONFIG.copy()
+    sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = worker_dead_delay_ms
+    ray.init(num_cpus=8, _system_config=sys_config)
+
+    @ray.remote
+    def short_child():
+        return 1
+
+    @ray.remote
+    def owner_no_wait():
+        # Spawn children but don't ray.get them.
+        refs = [short_child.remote() for _ in range(3)]  # noqa: F841
+        return "done"
+
+    ray.get(owner_no_wait.remote())
+
+    # Give time for children to finish and events to be reported.
+    time.sleep(3)
+
+    def verify():
+        tasks = list_tasks(filters=[("name", "=", "short_child")], detail=True)
+        assert len(tasks) == 3, f"Expected 3 child tasks, got {len(tasks)}"
+        for t in tasks:
+            assert (
+                t["state"] == "FINISHED"
+            ), f"short_child should be FINISHED, got {t['state']}"
+        return True
+
+    wait_for_condition(verify, timeout=15, retry_interval_ms=500)
+
+
+def test_completed_task_not_marked_failed_on_worker_death(shutdown_only):
+    """
+    Repro test for: https://github.com/ray-project/ray/issues/56427.
+    Workers with max_calls=1 die (INTENDED_SYSTEM_EXIT) after each task completes.
+    The worker death notification races with the task event buffer flush from the
+    owner. Completed tasks should NOT be incorrectly marked as FAILED.
+
+    With delay=0, OnWorkerDead fires immediately — maximizing the chance of the
+    race. Since we don't mark tasks on the dead worker as failed, this prevents marking
+    it as failed.
+    """
+    sys_config = _SYSTEM_CONFIG.copy()
+    # Zero delay to maximize the race between OnWorkerDead and task events.
+    sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = 0
+    ray.init(num_cpus=8, _system_config=sys_config)
+
+    @ray.remote(max_calls=1)
+    def one_shot(i):
+        return 42 + i
+
+    num_tasks = 50
+    refs = [one_shot.remote(i) for i in range(num_tasks)]
+    results = ray.get(refs)
+    assert results == list(range(42, 42 + num_tasks))
+
+    # Give time for worker death notifications and task events to be processed.
+    time.sleep(3)
+
+    def verify():
+        tasks = list_tasks(filters=[("name", "=", "one_shot")], detail=True)
+        assert len(tasks) == num_tasks, f"Expected {num_tasks} tasks, got {len(tasks)}"
+        for t in tasks:
+            assert t["state"] == "FINISHED", (
+                f"one_shot task should be FINISHED, got {t['state']}. "
+                f"error_type={t.get('error_type')}, "
+                f"error_message={t.get('error_message')}"
+            )
+        return True
+
+    wait_for_condition(verify, timeout=15, retry_interval_ms=500)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -104,7 +104,7 @@ std::vector<rpc::TaskEvents> GcsTaskManager::GcsTaskManagerStorage::GetTaskEvent
   return result;
 }
 
-void GcsTaskManager::GcsTaskManagerStorage::MarkTasksFailedOnWorkerDead(
+void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
     const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data) {
   auto task_attempts_itr = worker_index_.find(worker_id);
   if (task_attempts_itr == worker_index_.end()) {
@@ -113,16 +113,38 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTasksFailedOnWorkerDead(
   }
 
   rpc::RayErrorInfo error_info;
-  error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
-  std::stringstream error_message;
-  error_message << "Worker running the task (" << worker_id.Hex()
-                << ") died with exit_type: " << worker_failure_data.exit_type()
-                << " with error_message: " << worker_failure_data.exit_detail();
-  error_info.set_error_message(error_message.str());
+  error_info.set_error_type(rpc::ErrorType::OWNER_DIED);
+  int64_t failed_ts_ns = worker_failure_data.end_time_ms() * 1000 * 1000;
 
-  for (const auto &task_locator : task_attempts_itr->second) {
-    MarkTaskAttemptFailedIfNeeded(
-        task_locator, worker_failure_data.end_time_ms() * 1000 * 1000, error_info);
+  // DFS over the subtree rooted at a given task, marking all descendants failed.
+  // The root task itself is skipped — its owner is responsible for marking it failed.
+  std::function<void(const TaskID &)> dfs_mark_failed = [&](const TaskID &task_id) {
+    auto children_itr = parent_to_child_index_.find(task_id);
+    if (children_itr == parent_to_child_index_.end()) {
+      return;
+    }
+    for (const auto &child_locator : children_itr->second) {
+      TaskID child_task_id =
+          TaskID::FromBinary(child_locator->GetTaskEventsMutable().task_id());
+      std::stringstream error_message;
+      error_message << "Task (" << child_task_id.Hex() << ") failed because owner ("
+                    << worker_id.Hex()
+                    << ") died with exit_type: " << worker_failure_data.exit_type()
+                    << " with error_message: " << worker_failure_data.exit_detail();
+      error_info.set_error_message(error_message.str());
+      // This marking failure could be overwritten if a task event for the task comes up.
+      // But currently, final state is determined by the highest numbered state present in
+      // the state_ts map. Therefore, FAILED will persist over FINISHED.
+      MarkTaskAttemptFailedIfNeeded(child_locator, failed_ts_ns, error_info);
+      dfs_mark_failed(child_task_id);
+    }
+  };
+
+  for (const auto &parent_task_locator : task_attempts_itr->second) {
+    TaskID parent_task_id =
+        TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
+    RAY_CHECK(!parent_task_id.IsNil());
+    dfs_mark_failed(parent_task_id);
   }
 }
 
@@ -248,6 +270,19 @@ void GcsTaskManager::GcsTaskManagerStorage::UpdateIndex(
   if (!worker_id.IsNil()) {
     worker_index_[worker_id].insert(loc);
   }
+
+  // build parent->child index.
+  if (task_events.has_task_info()) {
+    const auto &task_info = task_events.task_info();
+    TaskID parent_task_id = TaskID::FromBinary(task_info.parent_task_id());
+
+    if (!parent_task_id.IsNil()) {
+      // inserting here would mean that we might, at some point, have two entries for two
+      // attempts of the same child task. Shouldn't be a problem though, since its fine to
+      // mark both attempts of the child task failed.
+      parent_to_child_index_[parent_task_id].insert(loc);
+    }
+  }
 }
 
 void GcsTaskManager::GcsTaskManagerStorage::RemoveFromIndex(
@@ -281,6 +316,19 @@ void GcsTaskManager::GcsTaskManagerStorage::RemoveFromIndex(
     RAY_CHECK(worker_attempts_iter->second.erase(loc) == 1);
     if (worker_attempts_iter->second.empty()) {
       worker_index_.erase(worker_attempts_iter);
+    }
+  }
+
+  if (task_events.has_task_info()) {
+    const auto &task_info = task_events.task_info();
+    TaskID parent_task_id = TaskID::FromBinary(task_info.parent_task_id());
+    if (!parent_task_id.IsNil()) {
+      auto child_tasks_itr = parent_to_child_index_.find(parent_task_id);
+      RAY_CHECK(child_tasks_itr != parent_to_child_index_.end());
+      RAY_CHECK(child_tasks_itr->second.erase(loc) == 1);
+      if (child_tasks_itr->second.empty()) {
+        parent_to_child_index_.erase(child_tasks_itr);
+      }
     }
   }
 
@@ -728,7 +776,20 @@ void GcsTaskManager::SetUsageStatsClient(UsageStatsClient *usage_stats_client) {
 
 void GcsTaskManager::OnWorkerDead(
     const WorkerID &worker_id, const std::shared_ptr<rpc::WorkerTableData> &worker_data) {
-  RAY_LOG(DEBUG) << "Marking all running tasks of worker " << worker_id << " as failed.";
+  // Only mark child tasks as failed on ungraceful death. On graceful death, the owner
+  // will flush the task buffer and the events would receive GCS eventually. If owner dies
+  // ungracefully, the events for child tasks will never reach GCS, so mark them
+  // explicitly.
+  if (worker_data->exit_type() == rpc::WorkerExitType::INTENDED_USER_EXIT ||
+      worker_data->exit_type() == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT) {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " died gracefully (exit_type=" << worker_data->exit_type()
+                   << "), not marking child tasks as failed.";
+    return;
+  }
+
+  RAY_LOG(DEBUG) << "Marking all running tasks owned by the worker " << worker_id
+                 << " as failed (exit_type=" << worker_data->exit_type() << ").";
 
   auto timer = std::make_shared<boost::asio::deadline_timer>(
       io_service_,
@@ -741,9 +802,8 @@ void GcsTaskManager::OnWorkerDead(
           // timer canceled or aborted.
           return;
         }
-        // If there are any non-terminated tasks from the worker, mark them failed since
-        // all workers associated with the worker will be failed.
-        task_event_storage_->MarkTasksFailedOnWorkerDead(worker_id, *worker_data);
+        // Mark the entire tree of child tasks for each task on the dead worker as FAILED.
+        task_event_storage_->MarkChildTasksFailedOnWorkerDead(worker_id, *worker_data);
       });
 }
 

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -113,9 +113,14 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
     return;
   }
 
+  // INTENDED_SYSTEM_EXIT is NOT always graceful. For eg: ray.kill(actor) calls
+  // ForceExit(INTENDED_SYSTEM_EXIT) which immediately kills the worker without
+  // flushing the buffer. INTENDED_USER_EXIT is graceful exit.
+  // Note that this means when INTENDED_SYSTEM_EXIT IS graceful, we might mark
+  // a child FINISHED as FAILED if the child's FINISHED event hasn't reached GCS
+  // yet. This is acceptable since the owner has died and the child is orphaned
   bool is_graceful =
-      worker_failure_data.exit_type() == rpc::WorkerExitType::INTENDED_USER_EXIT ||
-      worker_failure_data.exit_type() == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT;
+      worker_failure_data.exit_type() == rpc::WorkerExitType::INTENDED_USER_EXIT;
 
   // A worker is either dedicated to running a single actor, or it runs normal tasks —
   // never both. So any task on this worker carrying is_detached_actor identifies it as

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -133,6 +133,11 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
   // its task event buffer on graceful exit, so the actual states of the task will arrive
   // at GCS.
   if (!is_detached_actor_worker && is_graceful) {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " is a non-detached actor worker and exited gracefully ("
+                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
+                   << "); not marking any child tasks failed, since graceful exit "
+                      "ensures child task status to be flushed to GCS";
     return;
   }
 
@@ -150,6 +155,11 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
   // for a detached actor and This can be fixed for detached actors if we see these
   // instances happening for customers in future.
   if (is_detached_actor_worker && is_graceful) {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " is a detached actor worker and exited gracefully ("
+                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
+                   << "); marking only root tasks on this worker failed. Graceful exit "
+                      "ensures child task status wil be flushed to GCS.";
     error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
     for (const auto &task_locator : task_attempts_itr->second) {
       TaskID task_id = TaskID::FromBinary(task_locator->GetTaskEventsMutable().task_id());
@@ -169,6 +179,19 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
   // detached actor (or a method call on one) must not be marked FAILED when the owner
   // dies. The detached actor's own worker death is handled by its own OnWorkerDead
   // invocation.
+  if (is_detached_actor_worker) {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " is a detached actor worker and exited ungracefully ("
+                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
+                   << "); marking root tasks failed and DFS-marking child tasks failed.";
+  } else {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " is a non-detached actor worker and exited ungracefully ("
+                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
+                   << "); DFS-marking child tasks failed. Reporting status of tasks "
+                      "running on this worker"
+                      "is their owner's responsibility";
+  }
   std::function<void(const TaskID &)> dfs_mark_failed = [&](const TaskID &task_id) {
     absl::flat_hash_map<TaskID,
                         absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>::iterator
@@ -178,6 +201,8 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
     }
     for (const auto &child_locator : children_itr->second) {
       const auto &child_events = child_locator->GetTaskEventsMutable();
+      // At this point, child events should have task_info because when
+      // parent_to_child_index_ was populated, has_task_info() is checked.
       RAY_CHECK(child_events.has_task_info());
       if (child_events.task_info().is_detached_actor()) {
         continue;

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -112,35 +112,104 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
     return;
   }
 
+  bool is_graceful =
+      worker_failure_data.exit_type() == rpc::WorkerExitType::INTENDED_USER_EXIT ||
+      worker_failure_data.exit_type() == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT;
+
+  // A worker is either dedicated to running a single actor, or it runs normal tasks —
+  // never both. So any task on this worker carrying is_detached_actor identifies it as
+  // a detached actor worker.
+  bool is_detached_actor_worker = false;
+  for (const auto &loc : task_attempts_itr->second) {
+    const auto &events = loc->GetTaskEventsMutable();
+    if (events.has_task_info() && events.task_info().is_detached_actor()) {
+      is_detached_actor_worker = true;
+      break;
+    }
+  }
+
+  // Normal workers/non-detached actors + graceful exit -- do nothing. The worker flushes
+  // its task event buffer on graceful exit, so the actual states of the task will arrive
+  // at GCS.
+  if (!is_detached_actor_worker && is_graceful) {
+    return;
+  }
+
   rpc::RayErrorInfo error_info;
-  error_info.set_error_type(rpc::ErrorType::OWNER_DIED);
   int64_t failed_ts_ns = worker_failure_data.end_time_ms() * 1000 * 1000;
 
-  // DFS over the subtree rooted at a given task, marking all descendants failed.
-  // The root task itself is skipped — its owner is responsible for marking it failed.
+  // Detached actor worker + graceful exit — mark only the root tasks on this worker
+  // (the ACTOR_CREATION_TASK and any running ACTOR_TASKs) as FAILED. Don't DFS into
+  // children since the graceful exit flushes the task event buffer for them. For detached
+  // actors, we skip marking them in DFS of its parent, so we mark them now.
+
+  // TODO(karticam): there is an edge case here - if the detached actor task was
+  // successful, but the parent hasn't relayed it back to the GCS yet, we might mark a
+  // finished task as failed. Fixing this would require maintaining the owner death data
+  // for a detached actor and This can be fixed for detached actors if we see these
+  // instances happening for customers in future.
+  if (is_detached_actor_worker && is_graceful) {
+    error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
+    for (const auto &task_locator : task_attempts_itr->second) {
+      TaskID task_id = TaskID::FromBinary(task_locator->GetTaskEventsMutable().task_id());
+      std::stringstream error_message;
+      error_message << "Worker running the task (" << task_id.Hex()
+                    << ") died with exit_type: " << worker_failure_data.exit_type()
+                    << " with error_message: " << worker_failure_data.exit_detail();
+      error_info.set_error_message(error_message.str());
+      MarkTaskAttemptFailedIfNeeded(task_locator, failed_ts_ns, error_info);
+    }
+    return;
+  }
+
+  // Ungraceful exit — DFS the subtree, skipping any task on a detached actor along
+  // with their subtrees. Detached actors outlive their owners by design, so a child
+  // detached actor (or a method call on one) must not be marked FAILED when the owner
+  // dies. The detached actor's own worker death is handled by its own OnWorkerDead
+  // invocation.
   std::function<void(const TaskID &)> dfs_mark_failed = [&](const TaskID &task_id) {
     auto children_itr = parent_to_child_index_.find(task_id);
     if (children_itr == parent_to_child_index_.end()) {
       return;
     }
     for (const auto &child_locator : children_itr->second) {
-      TaskID child_task_id =
-          TaskID::FromBinary(child_locator->GetTaskEventsMutable().task_id());
+      const auto &child_events = child_locator->GetTaskEventsMutable();
+      if (child_events.has_task_info() && child_events.task_info().is_detached_actor()) {
+        continue;
+      }
+      TaskID child_task_id = TaskID::FromBinary(child_events.task_id());
+      error_info.set_error_type(rpc::ErrorType::OWNER_DIED);
       std::stringstream error_message;
       error_message << "Task (" << child_task_id.Hex() << ") failed because owner ("
                     << worker_id.Hex()
                     << ") died with exit_type: " << worker_failure_data.exit_type()
                     << " with error_message: " << worker_failure_data.exit_detail();
       error_info.set_error_message(error_message.str());
-      // This marking failure could be overwritten if a task event for the task comes up.
-      // But currently, final state is determined by the highest numbered state present in
-      // the state_ts map. Therefore, FAILED will persist over FINISHED.
       MarkTaskAttemptFailedIfNeeded(child_locator, failed_ts_ns, error_info);
       dfs_mark_failed(child_task_id);
     }
   };
 
   for (const auto &parent_task_locator : task_attempts_itr->second) {
+    // For detached actor workers with ungraceful exit, also mark the root tasks as
+    // FAILED. Unlike normal tasks where the root's owner reports its status, a
+    // detached actor might have no surviving owner. Also since we skip marking detached
+    // actors failed when any of its parents died, we should mark them dead now.
+
+    // TODO(karticam): Same edge as mentioned above in the detached actor + graceful case.
+    if (is_detached_actor_worker) {
+      TaskID task_id =
+          TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
+      error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
+      std::stringstream error_message;
+      error_message << "Task (" << task_id.Hex()
+                    << ") failed because detached actor worker (" << worker_id.Hex()
+                    << ") died with exit_type: " << worker_failure_data.exit_type()
+                    << " with error_message: " << worker_failure_data.exit_detail();
+      error_info.set_error_message(error_message.str());
+      MarkTaskAttemptFailedIfNeeded(parent_task_locator, failed_ts_ns, error_info);
+    }
+
     TaskID parent_task_id =
         TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
     RAY_CHECK(!parent_task_id.IsNil());
@@ -776,20 +845,9 @@ void GcsTaskManager::SetUsageStatsClient(UsageStatsClient *usage_stats_client) {
 
 void GcsTaskManager::OnWorkerDead(
     const WorkerID &worker_id, const std::shared_ptr<rpc::WorkerTableData> &worker_data) {
-  // Only mark child tasks as failed on ungraceful death. On graceful death, the owner
-  // will flush the task buffer and the events would receive GCS eventually. If owner dies
-  // ungracefully, the events for child tasks will never reach GCS, so mark them
-  // explicitly.
-  if (worker_data->exit_type() == rpc::WorkerExitType::INTENDED_USER_EXIT ||
-      worker_data->exit_type() == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT) {
-    RAY_LOG(DEBUG) << "Worker " << worker_id
-                   << " died gracefully (exit_type=" << worker_data->exit_type()
-                   << "), not marking child tasks as failed.";
-    return;
-  }
-
-  RAY_LOG(DEBUG) << "Marking all running tasks owned by the worker " << worker_id
-                 << " as failed (exit_type=" << worker_data->exit_type() << ").";
+  RAY_LOG(DEBUG) << "Worker " << worker_id
+                 << " died (exit_type=" << worker_data->exit_type()
+                 << "), scheduling task failure marking.";
 
   auto timer = std::make_shared<boost::asio::deadline_timer>(
       io_service_,

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "absl/strings/match.h"
+#include "absl/strings/str_format.h"
 #include "ray/asio/periodical_runner.h"
 #include "ray/common/id.h"
 #include "ray/common/ray_config.h"
@@ -104,7 +105,7 @@ std::vector<rpc::TaskEvents> GcsTaskManager::GcsTaskManagerStorage::GetTaskEvent
   return result;
 }
 
-void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
+void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
     const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data) {
   auto task_attempts_itr = worker_index_.find(worker_id);
   if (task_attempts_itr == worker_index_.end()) {
@@ -152,11 +153,12 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
     error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
     for (const auto &task_locator : task_attempts_itr->second) {
       TaskID task_id = TaskID::FromBinary(task_locator->GetTaskEventsMutable().task_id());
-      std::stringstream error_message;
-      error_message << "Worker running the task (" << task_id.Hex()
-                    << ") died with exit_type: " << worker_failure_data.exit_type()
-                    << " with error_message: " << worker_failure_data.exit_detail();
-      error_info.set_error_message(error_message.str());
+      error_info.set_error_message(
+          absl::StrFormat("Worker running the task (%s) died with exit_type: %s "
+                          "with error_message: %s",
+                          task_id.Hex(),
+                          rpc::WorkerExitType_Name(worker_failure_data.exit_type()),
+                          worker_failure_data.exit_detail()));
       MarkTaskAttemptFailedIfNeeded(task_locator, failed_ts_ns, error_info);
     }
     return;
@@ -168,23 +170,27 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
   // dies. The detached actor's own worker death is handled by its own OnWorkerDead
   // invocation.
   std::function<void(const TaskID &)> dfs_mark_failed = [&](const TaskID &task_id) {
-    auto children_itr = parent_to_child_index_.find(task_id);
+    absl::flat_hash_map<TaskID,
+                        absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>::iterator
+        children_itr = parent_to_child_index_.find(task_id);
     if (children_itr == parent_to_child_index_.end()) {
       return;
     }
     for (const auto &child_locator : children_itr->second) {
       const auto &child_events = child_locator->GetTaskEventsMutable();
-      if (child_events.has_task_info() && child_events.task_info().is_detached_actor()) {
+      RAY_CHECK(child_events.has_task_info());
+      if (child_events.task_info().is_detached_actor()) {
         continue;
       }
       TaskID child_task_id = TaskID::FromBinary(child_events.task_id());
       error_info.set_error_type(rpc::ErrorType::OWNER_DIED);
-      std::stringstream error_message;
-      error_message << "Task (" << child_task_id.Hex() << ") failed because owner ("
-                    << worker_id.Hex()
-                    << ") died with exit_type: " << worker_failure_data.exit_type()
-                    << " with error_message: " << worker_failure_data.exit_detail();
-      error_info.set_error_message(error_message.str());
+      error_info.set_error_message(
+          absl::StrFormat("Task (%s) failed because owner (%s) died with exit_type: %s "
+                          "with error_message: %s",
+                          child_task_id.Hex(),
+                          worker_id.Hex(),
+                          rpc::WorkerExitType_Name(worker_failure_data.exit_type()),
+                          worker_failure_data.exit_detail()));
       MarkTaskAttemptFailedIfNeeded(child_locator, failed_ts_ns, error_info);
       dfs_mark_failed(child_task_id);
     }
@@ -201,12 +207,13 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
       TaskID task_id =
           TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
       error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
-      std::stringstream error_message;
-      error_message << "Task (" << task_id.Hex()
-                    << ") failed because detached actor worker (" << worker_id.Hex()
-                    << ") died with exit_type: " << worker_failure_data.exit_type()
-                    << " with error_message: " << worker_failure_data.exit_detail();
-      error_info.set_error_message(error_message.str());
+      error_info.set_error_message(
+          absl::StrFormat("Task (%s) failed because detached actor worker (%s) died with "
+                          "exit_type: %s with error_message: %s",
+                          task_id.Hex(),
+                          worker_id.Hex(),
+                          rpc::WorkerExitType_Name(worker_failure_data.exit_type()),
+                          worker_failure_data.exit_detail()));
       MarkTaskAttemptFailedIfNeeded(parent_task_locator, failed_ts_ns, error_info);
     }
 
@@ -861,7 +868,7 @@ void GcsTaskManager::OnWorkerDead(
           return;
         }
         // Mark the entire tree of child tasks for each task on the dead worker as FAILED.
-        task_event_storage_->MarkChildTasksFailedOnWorkerDead(worker_id, *worker_data);
+        task_event_storage_->MarkTaskLineageFailedOnWorkerDead(worker_id, *worker_data);
       });
 }
 

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -158,7 +158,7 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
   // successful, but the parent hasn't relayed it back to the GCS yet, we might mark a
   // finished task as failed. Fixing this would require maintaining the owner death data
   // for a detached actor and This can be fixed for detached actors if we see these
-  // instances happening for customers in future.
+  // instances happening frequently in the future.
   if (is_detached_actor_worker && is_graceful) {
     RAY_LOG(DEBUG) << "Worker " << worker_id
                    << " is a detached actor worker and exited gracefully ("
@@ -184,19 +184,6 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
   // detached actor (or a method call on one) must not be marked FAILED when the owner
   // dies. The detached actor's own worker death is handled by its own OnWorkerDead
   // invocation.
-  if (is_detached_actor_worker) {
-    RAY_LOG(DEBUG) << "Worker " << worker_id
-                   << " is a detached actor worker and exited ungracefully ("
-                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
-                   << "); marking root tasks failed and DFS-marking child tasks failed.";
-  } else {
-    RAY_LOG(DEBUG) << "Worker " << worker_id
-                   << " is a non-detached actor worker and exited ungracefully ("
-                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
-                   << "); DFS-marking child tasks failed. Reporting status of tasks "
-                      "running on this worker"
-                      "is their owner's responsibility";
-  }
   std::function<void(const TaskID &)> dfs_mark_failed = [&](const TaskID &task_id) {
     absl::flat_hash_map<TaskID,
                         absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>::iterator
@@ -226,14 +213,17 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
     }
   };
 
-  for (const auto &parent_task_locator : task_attempts_itr->second) {
+  if (is_detached_actor_worker) {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " is a detached actor worker and exited ungracefully ("
+                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
+                   << "); marking root tasks failed and DFS-marking child tasks failed.";
     // For detached actor workers with ungraceful exit, also mark the root tasks as
     // FAILED. Unlike normal tasks where the root's owner reports its status, a
     // detached actor might have no surviving owner. Also since we skip marking detached
     // actors failed when any of its parents died, we should mark them dead now.
-
     // TODO(karticam): Same edge as mentioned above in the detached actor + graceful case.
-    if (is_detached_actor_worker) {
+    for (const auto &parent_task_locator : task_attempts_itr->second) {
       TaskID task_id =
           TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
       error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
@@ -246,7 +236,18 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskLineageFailedOnWorkerDead(
                           worker_failure_data.exit_detail()));
       MarkTaskAttemptFailedIfNeeded(parent_task_locator, failed_ts_ns, error_info);
     }
+  } else {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " is a non-detached actor worker and exited ungracefully ("
+                   << rpc::WorkerExitType_Name(worker_failure_data.exit_type())
+                   << "); DFS-marking child tasks failed. Reporting status of tasks "
+                      "running on this worker "
+                      "is their owner's responsibility";
+  }
 
+  // DFS-mark children of every root task on this worker, for both detached and
+  // non-detached cases.
+  for (const auto &parent_task_locator : task_attempts_itr->second) {
     TaskID parent_task_id =
         TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
     RAY_CHECK(!parent_task_id.IsNil());
@@ -379,7 +380,7 @@ void GcsTaskManager::GcsTaskManagerStorage::UpdateIndex(
 
   // build parent->child index.
   if (task_events.has_task_info()) {
-    const auto &task_info = task_events.task_info();
+    const rpc::TaskInfoEntry &task_info = task_events.task_info();
     TaskID parent_task_id = TaskID::FromBinary(task_info.parent_task_id());
 
     if (!parent_task_id.IsNil()) {
@@ -426,7 +427,7 @@ void GcsTaskManager::GcsTaskManagerStorage::RemoveFromIndex(
   }
 
   if (task_events.has_task_info()) {
-    const auto &task_info = task_events.task_info();
+    const rpc::TaskInfoEntry &task_info = task_events.task_info();
     TaskID parent_task_id = TaskID::FromBinary(task_info.parent_task_id());
     if (!parent_task_id.IsNil()) {
       auto child_tasks_itr = parent_to_child_index_.find(parent_task_id);

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -234,12 +234,12 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     /// failed time.
     void MarkTasksFailedOnJobEnds(const JobID &job_id, int64_t job_finish_time_ns);
 
-    /// Mark tasks from a worker as failed as worker dies.
+    /// Mark the whole tree of child tasks FAILED for each task on the dead worker.
     ///
     /// \param worker_id Worker ID
     /// \param worker_failure_data Worker failure data.
-    void MarkTasksFailedOnWorkerDead(const WorkerID &worker_id,
-                                     const rpc::WorkerTableData &worker_failure_data);
+    void MarkChildTasksFailedOnWorkerDead(
+        const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data);
 
     /// Get the job task summary given a job id.
     ///
@@ -465,6 +465,21 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
         job_index_;
     absl::flat_hash_map<WorkerID, absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>
         worker_index_;
+
+    // Tracks a TaskId to its child tasks. Used by MarkChildTasksFailedOnWorkerDead to
+    // mark the task tree of owner FAILED on worker death. The should ideally be
+    // TaskAttempt instead of TaskId, to mark only the child tasks that are created for
+    // that attempt as FAILED. But task events dont store parent task's attempt number
+    // currently.
+    //
+    // TODO(karticam): Keying by TaskId rather than TaskAttempt can mark wrong tasks as
+    // failed. Consider this race - attempt 0's worker dies, attempt 1's worker starts and
+    // spawns new children before GCS processes the death notification. The map would
+    // contain children from both attempts under the same TaskId. The DFS triggered by
+    // attempt 0's death would then incorrectly mark attempt 1's live children as FAILED.
+    // Fix can be take in a separate PR.
+    absl::flat_hash_map<TaskID, absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>
+        parent_to_child_index_;
 
     // A summary for per job stats.
     absl::flat_hash_map<JobID, JobTaskSummary> job_task_summary_;

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -234,11 +234,13 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     /// failed time.
     void MarkTasksFailedOnJobEnds(const JobID &job_id, int64_t job_finish_time_ns);
 
-    /// Mark tasks FAILED when a worker dies. Behavior depends on worker and exit type.
-    /// More explanations in the function definition.
-    ///
-    /// \param worker_id Worker ID
-    /// \param worker_failure_data Worker failure data.
+    /**
+     * Mark tasks FAILED when a worker dies. Behavior depends on worker and exit type.
+     * More explanations in the function definition.
+     *
+     * \param worker_id Worker ID
+     * \param worker_failure_data Worker failure data.
+     **/
     void MarkTaskLineageFailedOnWorkerDead(
         const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data);
 
@@ -467,10 +469,10 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     absl::flat_hash_map<WorkerID, absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>
         worker_index_;
 
-    // Tracks a TaskId to its child tasks. Used by MarkChildTasksFailedOnWorkerDead to
-    // mark the task tree of owner FAILED on worker death. The should ideally be
+    // Tracks a TaskId to its child tasks. Used by MarkTaskLineageFailedOnWorkerDead to
+    // mark the task tree of owner FAILED on worker death. This should ideally be
     // TaskAttempt instead of TaskId, to mark only the child tasks that are created for
-    // that attempt as FAILED. But task events dont store parent task's attempt number
+    // that attempt as FAILED. But task events don't store parent task's attempt number
     // currently.
     //
     // TODO(karticam): Keying by TaskId rather than TaskAttempt can mark wrong tasks as
@@ -478,7 +480,7 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     // spawns new children before GCS processes the death notification. The map would
     // contain children from both attempts under the same TaskId. The DFS triggered by
     // attempt 0's death would then incorrectly mark attempt 1's live children as FAILED.
-    // Fix can be take in a separate PR.
+    // Fix can be taken in a separate PR.
     absl::flat_hash_map<TaskID, absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>
         parent_to_child_index_;
 

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -234,7 +234,8 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     /// failed time.
     void MarkTasksFailedOnJobEnds(const JobID &job_id, int64_t job_finish_time_ns);
 
-    /// Mark the whole tree of child tasks FAILED for each task on the dead worker.
+    /// Mark tasks FAILED when a worker dies. Behavior depends on worker and exit type.
+    /// More explanations in the function definition.
     ///
     /// \param worker_id Worker ID
     /// \param worker_failure_data Worker failure data.

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -239,7 +239,7 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     ///
     /// \param worker_id Worker ID
     /// \param worker_failure_data Worker failure data.
-    void MarkChildTasksFailedOnWorkerDead(
+    void MarkTaskLineageFailedOnWorkerDead(
         const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data);
 
     /// Get the job task summary given a job id.

--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -161,7 +161,7 @@ ray_cc_test(
 
 ray_cc_test(
     name = "gcs_task_manager_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "gcs_task_manager_test.cc",
     ],

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -40,7 +40,8 @@ class GcsTaskManagerTest : public ::testing::Test {
         R"(
 {
   "task_events_max_num_task_in_gcs": 1000,
-  "gcs_mark_task_failed_on_job_done_delay_ms": 100
+  "gcs_mark_task_failed_on_job_done_delay_ms": 100,
+  "gcs_mark_task_failed_on_worker_dead_delay_ms": 100
 }
   )");
   }
@@ -1811,6 +1812,389 @@ TEST_F(GcsTaskManagerMemoryLimitedTest, TestLimitGcPriorityBased) {
     reply = SyncGetTaskEvents({});
     EXPECT_EQ(reply.events_by_task_size(), num_limit);
     EXPECT_EQ(reply.num_status_task_events_dropped(), 3);
+  }
+}
+
+// Helper to build WorkerTableData for OnWorkerDead tests.
+static std::shared_ptr<rpc::WorkerTableData> GenWorkerFailureData(
+    rpc::WorkerExitType exit_type,
+    int64_t end_time_ms = 10,
+    const std::string &exit_detail = "test worker death") {
+  auto data = std::make_shared<rpc::WorkerTableData>();
+  data->set_exit_type(exit_type);
+  data->set_end_time_ms(end_time_ms);
+  data->set_exit_detail(exit_detail);
+  return data;
+}
+
+// Test that when a worker dies ungracefully, the entire tree of child tasks owned by that
+// worker is marked FAILED.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksChildTaskTreeFailed) {
+  // Setup: owner_worker runs parent_task, which spawned child_task_1 and child_task_2.
+  // child_task_1 in turn spawned grandchild_task.
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_tasks = GenTaskIDs(2);
+  auto grandchild_task = GenTaskIDs(1)[0];
+
+  // Add parent task (running on owner_worker).
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child tasks (parent_task_id = parent_task).
+  auto child_events = GenTaskEvents(child_tasks,
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Add grandchild task (parent_task_id = child_tasks[0]).
+  auto grandchild_events = GenTaskEvents({grandchild_task},
+                                         0,
+                                         0,
+                                         absl::nullopt,
+                                         GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
+                                         GenTaskInfo(JobID::FromInt(0), child_tasks[0]));
+  SyncAddTaskEventData(GenTaskEventsData(grandchild_events));
+
+  // Owner worker dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Parent task should NOT be marked failed (its own owner is responsible).
+  {
+    auto reply = SyncGetTaskEvents({parent_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+
+  // Child tasks should be marked FAILED with OWNER_DIED error.
+  for (const auto &child_id : child_tasks) {
+    auto reply = SyncGetTaskEvents({child_id});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    auto &task_event = reply.events_by_task(0);
+    EXPECT_TRUE(
+        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
+              10 * 1000 * 1000);
+    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+
+  // Grandchild task should also be marked FAILED (DFS walks the full tree).
+  {
+    auto reply = SyncGetTaskEvents({grandchild_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    auto &task_event = reply.events_by_task(0);
+    EXPECT_TRUE(
+        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+}
+
+// Test that graceful worker death (INTENDED_USER_EXIT) does NOT mark child tasks as
+// failed.
+TEST_F(GcsTaskManagerTest, TestGracefulWorkerDeadDoesNotMarkChildTasksFailed) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  auto child_events = GenTaskEvents({child_task},
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Owner worker dies gracefully (INTENDED_USER_EXIT).
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_USER_EXIT, 10));
+
+  // Wait for the delay timer (even though it should return early).
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Child task should NOT be marked failed.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that graceful worker death (INTENDED_SYSTEM_EXIT) does NOT mark child tasks as
+// failed.
+TEST_F(GcsTaskManagerTest, TestIntendedSystemExitDoesNotMarkChildTasksFailed) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  auto child_events = GenTaskEvents({child_task},
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Owner worker dies with INTENDED_SYSTEM_EXIT (e.g., job teardown).
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_SYSTEM_EXIT, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Child task should NOT be marked failed.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that already-terminated child tasks are not overwritten when owner dies.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadDoesNotOverrideTerminatedChildTasks) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_finished = GenTaskIDs(1)[0];
+  auto child_failed = GenTaskIDs(1)[0];
+  auto child_running = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child that already finished.
+  auto finished_events = GenTaskEvents({child_finished},
+                                       0,
+                                       0,
+                                       absl::nullopt,
+                                       GenStateUpdate({{rpc::TaskStatus::FINISHED, 2}}),
+                                       GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(finished_events));
+
+  // Add child that already failed.
+  auto failed_events = GenTaskEvents({child_failed},
+                                     0,
+                                     0,
+                                     absl::nullopt,
+                                     GenStateUpdate({{rpc::TaskStatus::FAILED, 3}}),
+                                     GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(failed_events));
+
+  // Add child that is still running.
+  auto running_events = GenTaskEvents({child_running},
+                                      0,
+                                      0,
+                                      absl::nullopt,
+                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 4}}),
+                                      GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(running_events));
+
+  // Owner dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Finished child should not be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({child_finished});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().state_ts_ns().at(
+                  rpc::TaskStatus::FINISHED),
+              2);
+  }
+
+  // Already failed child should keep its original failure timestamp.
+  {
+    auto reply = SyncGetTaskEvents({child_failed});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_EQ(
+        reply.events_by_task(0).state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
+        3);
+  }
+
+  // Running child should now be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({child_running});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(
+        reply.events_by_task(0).state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
+        10 * 1000 * 1000);
+  }
+}
+
+// Test that OnWorkerDead with no tasks for the worker doesn't crash.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadNoTasks) {
+  auto unknown_worker = WorkerID::FromRandom();
+  task_manager->OnWorkerDead(unknown_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Should not crash, no events to check.
+  auto reply = SyncGetTaskEvents({});
+  EXPECT_EQ(reply.events_by_task_size(), 0);
+}
+
+// Test that when a worker dies ungracefully but has no child tasks (leaf executor),
+// nothing extra is marked failed.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadLeafTaskNoChildren) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto leaf_task = GenTaskIDs(1)[0];
+
+  // Add a leaf task running on owner_worker (no children).
+  auto events =
+      GenTaskEvents({leaf_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(events));
+
+  // Worker dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Leaf task itself should NOT be marked failed (no children to mark, and the task
+  // itself is the responsibility of its own owner).
+  {
+    auto reply = SyncGetTaskEvents({leaf_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that NODE_OUT_OF_MEMORY exit type (ungraceful) marks child tasks as failed.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadOOMMarksChildTasksFailed) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  auto child_events = GenTaskEvents({child_task},
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Worker dies from OOM.
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::NODE_OUT_OF_MEMORY, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Child task should be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
   }
 }
 

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -296,13 +296,15 @@ class GcsTaskManagerTest : public ::testing::Test {
       TaskID parent_task_id = TaskID::Nil(),
       rpc::TaskType task_type = rpc::TaskType::NORMAL_TASK,
       const ActorID actor_id = ActorID::Nil(),
-      const std::string name = "") {
+      const std::string name = "",
+      bool is_detached_actor = false) {
     rpc::TaskInfoEntry task_info;
     task_info.set_job_id(job_id.Binary());
     task_info.set_parent_task_id(parent_task_id.Binary());
     task_info.set_type(task_type);
     task_info.set_actor_id(actor_id.Binary());
     task_info.set_name(name);
+    task_info.set_is_detached_actor(is_detached_actor);
     return task_info;
   }
 
@@ -2195,6 +2197,353 @@ TEST_F(GcsTaskManagerTest, TestWorkerDeadOOMMarksChildTasksFailed) {
         rpc::TaskStatus::FAILED));
     EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
               rpc::ErrorType::OWNER_DIED);
+  }
+}
+
+// Helper: block this thread until the OnWorkerDead delay timer fires.
+static void WaitForWorkerDeadDelay() {
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+}
+
+// Test that a non-detached ACTOR_CREATION_TASK child is marked FAILED on owner death
+TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksNonDetachedActorChild) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto actor_creation_task = GenTaskIDs(1)[0];
+  auto actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
+  auto grandchild_task = GenTaskIDs(1)[0];
+
+  // Parent task running on owner_worker.
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)))));
+
+  // Non-detached ACTOR_CREATION_TASK as a child of parent_task.
+  SyncAddTaskEventData(
+      GenTaskEventsData(GenTaskEvents({actor_creation_task},
+                                      0,
+                                      0,
+                                      absl::nullopt,
+                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                      GenTaskInfo(JobID::FromInt(0),
+                                                  parent_task,
+                                                  rpc::TaskType::ACTOR_CREATION_TASK,
+                                                  actor_id,
+                                                  /*name=*/"",
+                                                  /*is_detached_actor=*/false))));
+
+  // Grandchild task spawned by the actor (parent = actor_creation_task).
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({grandchild_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
+                    GenTaskInfo(JobID::FromInt(0), actor_creation_task))));
+
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Non-detached actor creation task should be marked FAILED with OWNER_DIED.
+  {
+    auto reply = SyncGetTaskEvents({actor_creation_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+  // DFS should have recursed into the non-detached actor's subtree.
+  {
+    auto reply = SyncGetTaskEvents({grandchild_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+}
+
+// Test that a detached ACTOR_CREATION_TASK child (and its subtree) is skipped on
+// owner death.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadSkipsDetachedActorChild) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto detached_creation_task = GenTaskIDs(1)[0];
+  auto actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
+  auto descendant_task = GenTaskIDs(1)[0];
+
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)))));
+
+  // Detached ACTOR_CREATION_TASK as a child of parent_task.
+  SyncAddTaskEventData(
+      GenTaskEventsData(GenTaskEvents({detached_creation_task},
+                                      0,
+                                      0,
+                                      absl::nullopt,
+                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                      GenTaskInfo(JobID::FromInt(0),
+                                                  parent_task,
+                                                  rpc::TaskType::ACTOR_CREATION_TASK,
+                                                  actor_id,
+                                                  /*name=*/"",
+                                                  /*is_detached_actor=*/true))));
+
+  // Descendant task spawned by the detached actor.
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({descendant_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
+                    GenTaskInfo(JobID::FromInt(0), detached_creation_task))));
+
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Detached actor creation task should NOT be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({detached_creation_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+  // Descendant under detached actor should also not be marked (subtree skipped).
+  {
+    auto reply = SyncGetTaskEvents({descendant_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that a detached ACTOR_TASK child (and its subtree) is skipped on owner death.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadSkipsDetachedActorTaskChild) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto detached_actor_task = GenTaskIDs(1)[0];
+  auto actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
+  auto descendant_task = GenTaskIDs(1)[0];
+
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)))));
+
+  // Detached ACTOR_TASK as a child of parent_task.
+  SyncAddTaskEventData(
+      GenTaskEventsData(GenTaskEvents({detached_actor_task},
+                                      0,
+                                      0,
+                                      absl::nullopt,
+                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                      GenTaskInfo(JobID::FromInt(0),
+                                                  parent_task,
+                                                  rpc::TaskType::ACTOR_TASK,
+                                                  actor_id,
+                                                  /*name=*/"",
+                                                  /*is_detached_actor=*/true))));
+
+  // Descendant task spawned by the detached actor task.
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({descendant_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
+                    GenTaskInfo(JobID::FromInt(0), detached_actor_task))));
+
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  {
+    auto reply = SyncGetTaskEvents({detached_actor_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+  {
+    auto reply = SyncGetTaskEvents({descendant_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that an ungraceful death of a detached actor worker marks both the root tasks
+// (with WORKER_DIED) and descendants of those roots (with OWNER_DIED).
+TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerUngracefulMarksRootsAndChildren) {
+  auto detached_actor_worker = WorkerID::FromRandom();
+  auto detached_creation_task = GenTaskIDs(1)[0];
+  auto actor_id = ActorID::Of(JobID::FromInt(0), detached_creation_task, 1);
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Detached ACTOR_CREATION_TASK running on detached_actor_worker.
+  SyncAddTaskEventData(GenTaskEventsData(GenTaskEvents(
+      {detached_creation_task},
+      0,
+      0,
+      absl::nullopt,
+      GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, detached_actor_worker),
+      GenTaskInfo(JobID::FromInt(0),
+                  /*parent_task_id=*/TaskID::Nil(),
+                  rpc::TaskType::ACTOR_CREATION_TASK,
+                  actor_id,
+                  /*name=*/"",
+                  /*is_detached_actor=*/true))));
+
+  // Child task spawned by the detached actor (parent = creation task).
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({child_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                    GenTaskInfo(JobID::FromInt(0), detached_creation_task))));
+
+  task_manager->OnWorkerDead(detached_actor_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Root (detached creation task) should be marked WORKER_DIED.
+  {
+    auto reply = SyncGetTaskEvents({detached_creation_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::WORKER_DIED);
+  }
+  // Child of the detached actor should be marked OWNER_DIED via the DFS.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+}
+
+// Test that a graceful death of a detached actor worker marks the root tasks
+// (with WORKER_DIED) but does NOT mark children — buffer flush handles them.
+TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerGracefulMarksRootsOnly) {
+  auto detached_actor_worker = WorkerID::FromRandom();
+  auto detached_creation_task = GenTaskIDs(1)[0];
+  auto actor_id = ActorID::Of(JobID::FromInt(0), detached_creation_task, 1);
+  auto child_task = GenTaskIDs(1)[0];
+
+  SyncAddTaskEventData(GenTaskEventsData(GenTaskEvents(
+      {detached_creation_task},
+      0,
+      0,
+      absl::nullopt,
+      GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, detached_actor_worker),
+      GenTaskInfo(JobID::FromInt(0),
+                  /*parent_task_id=*/TaskID::Nil(),
+                  rpc::TaskType::ACTOR_CREATION_TASK,
+                  actor_id,
+                  /*name=*/"",
+                  /*is_detached_actor=*/true))));
+
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({child_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                    GenTaskInfo(JobID::FromInt(0), detached_creation_task))));
+
+  task_manager->OnWorkerDead(
+      detached_actor_worker,
+      GenWorkerFailureData(rpc::WorkerExitType::INTENDED_SYSTEM_EXIT, 10));
+  WaitForWorkerDeadDelay();
+
+  // Root should be marked WORKER_DIED.
+  {
+    auto reply = SyncGetTaskEvents({detached_creation_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::WORKER_DIED);
+  }
+  // Child should NOT be marked FAILED — graceful exit means no DFS.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that a graceful death of a non-detached actor worker is a no-op (the actor's
+// owner is responsible for reporting status).
+TEST_F(GcsTaskManagerTest, TestNonDetachedActorWorkerGracefulIsNoOp) {
+  auto actor_worker = WorkerID::FromRandom();
+  auto creation_task = GenTaskIDs(1)[0];
+  auto actor_id = ActorID::Of(JobID::FromInt(0), creation_task, 1);
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Non-detached ACTOR_CREATION_TASK running on actor_worker.
+  SyncAddTaskEventData(GenTaskEventsData(
+      GenTaskEvents({creation_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, actor_worker),
+                    GenTaskInfo(JobID::FromInt(0),
+                                /*parent_task_id=*/TaskID::Nil(),
+                                rpc::TaskType::ACTOR_CREATION_TASK,
+                                actor_id,
+                                /*name=*/"",
+                                /*is_detached_actor=*/false))));
+
+  SyncAddTaskEventData(
+      GenTaskEventsData(GenTaskEvents({child_task},
+                                      0,
+                                      0,
+                                      absl::nullopt,
+                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                      GenTaskInfo(JobID::FromInt(0), creation_task))));
+
+  task_manager->OnWorkerDead(
+      actor_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_USER_EXIT, 10));
+  WaitForWorkerDeadDelay();
+
+  // Neither the root nor the child should be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({creation_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
   }
 }
 

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -1911,17 +1911,9 @@ TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksChildTaskTreeFailed) {
             rpc::ErrorType::OWNER_DIED);
 }
 
-// Parameterized fixture exercising both graceful worker exit types
-// (INTENDED_USER_EXIT and INTENDED_SYSTEM_EXIT).
-class GcsTaskManagerGracefulWorkerDeadTest
-    : public GcsTaskManagerTest,
-      public ::testing::WithParamInterface<rpc::WorkerExitType> {};
-
-// Test that graceful worker death does NOT mark child tasks as failed, for both
-// graceful exit types.
-TEST_P(GcsTaskManagerGracefulWorkerDeadTest, DoesNotMarkChildTasksFailed) {
-  rpc::WorkerExitType exit_type = GetParam();
-
+// Test that graceful worker death (INTENDED_USER_EXIT) does NOT mark child tasks as
+// failed.
+TEST_F(GcsTaskManagerTest, TestGracefulWorkerDeadDoesNotMarkChildTasksFailed) {
   WorkerID owner_worker = WorkerID::FromRandom();
   TaskID parent_task = GenTaskIDs(1)[0];
   TaskID child_task = GenTaskIDs(1)[0];
@@ -1946,8 +1938,9 @@ TEST_P(GcsTaskManagerGracefulWorkerDeadTest, DoesNotMarkChildTasksFailed) {
                     GenTaskInfo(JobID::FromInt(0), parent_task));
   SyncAddTaskEventData(GenTaskEventsData(child_events));
 
-  // Owner worker dies gracefully with the parameterized exit type.
-  task_manager->OnWorkerDead(owner_worker, GenWorkerFailureData(exit_type, 10));
+  // Owner worker dies gracefully via INTENDED_USER_EXIT.
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_USER_EXIT, 10));
   WaitForWorkerDeadDelay();
 
   // Child task should NOT be marked failed.
@@ -1956,14 +1949,6 @@ TEST_P(GcsTaskManagerGracefulWorkerDeadTest, DoesNotMarkChildTasksFailed) {
   EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
       rpc::TaskStatus::FAILED));
 }
-
-INSTANTIATE_TEST_SUITE_P(GracefulExitTypes,
-                         GcsTaskManagerGracefulWorkerDeadTest,
-                         ::testing::Values(rpc::WorkerExitType::INTENDED_USER_EXIT,
-                                           rpc::WorkerExitType::INTENDED_SYSTEM_EXIT),
-                         [](const ::testing::TestParamInfo<rpc::WorkerExitType> &info) {
-                           return rpc::WorkerExitType_Name(info.param);
-                         });
 
 // Test that already-terminated child tasks are not overwritten when owner dies.
 TEST_F(GcsTaskManagerTest, TestWorkerDeadDoesNotOverrideTerminatedChildTasks) {
@@ -2337,7 +2322,7 @@ TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerGracefulMarksRootsOnly) {
 
   task_manager->OnWorkerDead(
       detached_actor_worker,
-      GenWorkerFailureData(rpc::WorkerExitType::INTENDED_SYSTEM_EXIT, 10));
+      GenWorkerFailureData(rpc::WorkerExitType::INTENDED_USER_EXIT, 10));
   WaitForWorkerDeadDelay();
 
   // Root should be marked WORKER_DIED.

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -1822,382 +1822,11 @@ static std::shared_ptr<rpc::WorkerTableData> GenWorkerFailureData(
     rpc::WorkerExitType exit_type,
     int64_t end_time_ms = 10,
     const std::string &exit_detail = "test worker death") {
-  auto data = std::make_shared<rpc::WorkerTableData>();
+  std::shared_ptr<rpc::WorkerTableData> data = std::make_shared<rpc::WorkerTableData>();
   data->set_exit_type(exit_type);
   data->set_end_time_ms(end_time_ms);
   data->set_exit_detail(exit_detail);
   return data;
-}
-
-// Test that when a worker dies ungracefully, the entire tree of child tasks owned by that
-// worker is marked FAILED.
-TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksChildTaskTreeFailed) {
-  // Setup: owner_worker runs parent_task, which spawned child_task_1 and child_task_2.
-  // child_task_1 in turn spawned grandchild_task.
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto child_tasks = GenTaskIDs(2);
-  auto grandchild_task = GenTaskIDs(1)[0];
-
-  // Add parent task (running on owner_worker).
-  auto parent_events =
-      GenTaskEvents({parent_task},
-                    0,
-                    0,
-                    absl::nullopt,
-                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
-                    GenTaskInfo(JobID::FromInt(0)));
-  SyncAddTaskEventData(GenTaskEventsData(parent_events));
-
-  // Add child tasks (parent_task_id = parent_task).
-  auto child_events = GenTaskEvents(child_tasks,
-                                    0,
-                                    0,
-                                    absl::nullopt,
-                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
-                                    GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(child_events));
-
-  // Add grandchild task (parent_task_id = child_tasks[0]).
-  auto grandchild_events = GenTaskEvents({grandchild_task},
-                                         0,
-                                         0,
-                                         absl::nullopt,
-                                         GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
-                                         GenTaskInfo(JobID::FromInt(0), child_tasks[0]));
-  SyncAddTaskEventData(GenTaskEventsData(grandchild_events));
-
-  // Owner worker dies ungracefully.
-  task_manager->OnWorkerDead(owner_worker,
-                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
-
-  // Wait for the delay timer.
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Parent task should NOT be marked failed (its own owner is responsible).
-  {
-    auto reply = SyncGetTaskEvents({parent_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
-
-  // Child tasks should be marked FAILED with OWNER_DIED error.
-  for (const auto &child_id : child_tasks) {
-    auto reply = SyncGetTaskEvents({child_id});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    auto &task_event = reply.events_by_task(0);
-    EXPECT_TRUE(
-        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
-    EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
-              10 * 1000 * 1000);
-    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
-              rpc::ErrorType::OWNER_DIED);
-  }
-
-  // Grandchild task should also be marked FAILED (DFS walks the full tree).
-  {
-    auto reply = SyncGetTaskEvents({grandchild_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    auto &task_event = reply.events_by_task(0);
-    EXPECT_TRUE(
-        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
-    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
-              rpc::ErrorType::OWNER_DIED);
-  }
-}
-
-// Test that graceful worker death (INTENDED_USER_EXIT) does NOT mark child tasks as
-// failed.
-TEST_F(GcsTaskManagerTest, TestGracefulWorkerDeadDoesNotMarkChildTasksFailed) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto child_task = GenTaskIDs(1)[0];
-
-  // Add parent task running on owner_worker.
-  auto parent_events =
-      GenTaskEvents({parent_task},
-                    0,
-                    0,
-                    absl::nullopt,
-                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
-                    GenTaskInfo(JobID::FromInt(0)));
-  SyncAddTaskEventData(GenTaskEventsData(parent_events));
-
-  // Add child task.
-  auto child_events = GenTaskEvents({child_task},
-                                    0,
-                                    0,
-                                    absl::nullopt,
-                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
-                                    GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(child_events));
-
-  // Owner worker dies gracefully (INTENDED_USER_EXIT).
-  task_manager->OnWorkerDead(
-      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_USER_EXIT, 10));
-
-  // Wait for the delay timer (even though it should return early).
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Child task should NOT be marked failed.
-  {
-    auto reply = SyncGetTaskEvents({child_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
-}
-
-// Test that graceful worker death (INTENDED_SYSTEM_EXIT) does NOT mark child tasks as
-// failed.
-TEST_F(GcsTaskManagerTest, TestIntendedSystemExitDoesNotMarkChildTasksFailed) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto child_task = GenTaskIDs(1)[0];
-
-  // Add parent task running on owner_worker.
-  auto parent_events =
-      GenTaskEvents({parent_task},
-                    0,
-                    0,
-                    absl::nullopt,
-                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
-                    GenTaskInfo(JobID::FromInt(0)));
-  SyncAddTaskEventData(GenTaskEventsData(parent_events));
-
-  // Add child task.
-  auto child_events = GenTaskEvents({child_task},
-                                    0,
-                                    0,
-                                    absl::nullopt,
-                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
-                                    GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(child_events));
-
-  // Owner worker dies with INTENDED_SYSTEM_EXIT (e.g., job teardown).
-  task_manager->OnWorkerDead(
-      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_SYSTEM_EXIT, 10));
-
-  // Wait for the delay timer.
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Child task should NOT be marked failed.
-  {
-    auto reply = SyncGetTaskEvents({child_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
-}
-
-// Test that already-terminated child tasks are not overwritten when owner dies.
-TEST_F(GcsTaskManagerTest, TestWorkerDeadDoesNotOverrideTerminatedChildTasks) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto child_finished = GenTaskIDs(1)[0];
-  auto child_failed = GenTaskIDs(1)[0];
-  auto child_running = GenTaskIDs(1)[0];
-
-  // Add parent task running on owner_worker.
-  auto parent_events =
-      GenTaskEvents({parent_task},
-                    0,
-                    0,
-                    absl::nullopt,
-                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
-                    GenTaskInfo(JobID::FromInt(0)));
-  SyncAddTaskEventData(GenTaskEventsData(parent_events));
-
-  // Add child that already finished.
-  auto finished_events = GenTaskEvents({child_finished},
-                                       0,
-                                       0,
-                                       absl::nullopt,
-                                       GenStateUpdate({{rpc::TaskStatus::FINISHED, 2}}),
-                                       GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(finished_events));
-
-  // Add child that already failed.
-  auto failed_events = GenTaskEvents({child_failed},
-                                     0,
-                                     0,
-                                     absl::nullopt,
-                                     GenStateUpdate({{rpc::TaskStatus::FAILED, 3}}),
-                                     GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(failed_events));
-
-  // Add child that is still running.
-  auto running_events = GenTaskEvents({child_running},
-                                      0,
-                                      0,
-                                      absl::nullopt,
-                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 4}}),
-                                      GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(running_events));
-
-  // Owner dies ungracefully.
-  task_manager->OnWorkerDead(owner_worker,
-                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
-
-  // Wait for the delay timer.
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Finished child should not be marked FAILED.
-  {
-    auto reply = SyncGetTaskEvents({child_finished});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().state_ts_ns().at(
-                  rpc::TaskStatus::FINISHED),
-              2);
-  }
-
-  // Already failed child should keep its original failure timestamp.
-  {
-    auto reply = SyncGetTaskEvents({child_failed});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_EQ(
-        reply.events_by_task(0).state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
-        3);
-  }
-
-  // Running child should now be marked FAILED.
-  {
-    auto reply = SyncGetTaskEvents({child_running});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(
-        reply.events_by_task(0).state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
-        10 * 1000 * 1000);
-  }
-}
-
-// Test that OnWorkerDead with no tasks for the worker doesn't crash.
-TEST_F(GcsTaskManagerTest, TestWorkerDeadNoTasks) {
-  auto unknown_worker = WorkerID::FromRandom();
-  task_manager->OnWorkerDead(unknown_worker,
-                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
-
-  // Wait for the delay timer.
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Should not crash, no events to check.
-  auto reply = SyncGetTaskEvents({});
-  EXPECT_EQ(reply.events_by_task_size(), 0);
-}
-
-// Test that when a worker dies ungracefully but has no child tasks (leaf executor),
-// nothing extra is marked failed.
-TEST_F(GcsTaskManagerTest, TestWorkerDeadLeafTaskNoChildren) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto leaf_task = GenTaskIDs(1)[0];
-
-  // Add a leaf task running on owner_worker (no children).
-  auto events =
-      GenTaskEvents({leaf_task},
-                    0,
-                    0,
-                    absl::nullopt,
-                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
-                    GenTaskInfo(JobID::FromInt(0)));
-  SyncAddTaskEventData(GenTaskEventsData(events));
-
-  // Worker dies ungracefully.
-  task_manager->OnWorkerDead(owner_worker,
-                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
-
-  // Wait for the delay timer.
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Leaf task itself should NOT be marked failed (no children to mark, and the task
-  // itself is the responsibility of its own owner).
-  {
-    auto reply = SyncGetTaskEvents({leaf_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
-}
-
-// Test that NODE_OUT_OF_MEMORY exit type (ungraceful) marks child tasks as failed.
-TEST_F(GcsTaskManagerTest, TestWorkerDeadOOMMarksChildTasksFailed) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto child_task = GenTaskIDs(1)[0];
-
-  // Add parent task running on owner_worker.
-  auto parent_events =
-      GenTaskEvents({parent_task},
-                    0,
-                    0,
-                    absl::nullopt,
-                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
-                    GenTaskInfo(JobID::FromInt(0)));
-  SyncAddTaskEventData(GenTaskEventsData(parent_events));
-
-  // Add child task.
-  auto child_events = GenTaskEvents({child_task},
-                                    0,
-                                    0,
-                                    absl::nullopt,
-                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
-                                    GenTaskInfo(JobID::FromInt(0), parent_task));
-  SyncAddTaskEventData(GenTaskEventsData(child_events));
-
-  // Worker dies from OOM.
-  task_manager->OnWorkerDead(
-      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::NODE_OUT_OF_MEMORY, 10));
-
-  // Wait for the delay timer.
-  boost::asio::io_context io;
-  boost::asio::deadline_timer timer(
-      io,
-      boost::posix_time::milliseconds(
-          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
-  timer.wait();
-
-  // Child task should be marked FAILED.
-  {
-    auto reply = SyncGetTaskEvents({child_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
-              rpc::ErrorType::OWNER_DIED);
-  }
 }
 
 // Helper: block this thread until the OnWorkerDead delay timer fires.
@@ -2210,13 +1839,256 @@ static void WaitForWorkerDeadDelay() {
   timer.wait();
 }
 
+// Test that when a worker dies ungracefully, the entire tree of child tasks owned by that
+// worker is marked FAILED.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksChildTaskTreeFailed) {
+  // Setup: owner_worker runs parent_task, which spawned child_task_1 and child_task_2.
+  // child_task_1 in turn spawned grandchild_task.
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID parent_task = GenTaskIDs(1)[0];
+  std::vector<TaskID> child_tasks = GenTaskIDs(2);
+  TaskID grandchild_task = GenTaskIDs(1)[0];
+
+  // Add parent task (running on owner_worker).
+  std::vector<rpc::TaskEvents> parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child tasks (parent_task_id = parent_task).
+  std::vector<rpc::TaskEvents> child_events =
+      GenTaskEvents(child_tasks,
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Add grandchild task (parent_task_id = child_tasks[0]).
+  std::vector<rpc::TaskEvents> grandchild_events =
+      GenTaskEvents({grandchild_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
+                    GenTaskInfo(JobID::FromInt(0), child_tasks[0]));
+  SyncAddTaskEventData(GenTaskEventsData(grandchild_events));
+
+  // Owner worker dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Parent task should NOT be marked failed (its own owner is responsible).
+  rpc::GetTaskEventsReply parent_reply = SyncGetTaskEvents({parent_task});
+  ASSERT_EQ(parent_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(parent_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+
+  // Child tasks should be marked FAILED with OWNER_DIED error.
+  for (const TaskID &child_id : child_tasks) {
+    rpc::GetTaskEventsReply child_reply = SyncGetTaskEvents({child_id});
+    ASSERT_EQ(child_reply.events_by_task_size(), 1);
+    const rpc::TaskEvents &task_event = child_reply.events_by_task(0);
+    EXPECT_TRUE(
+        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+
+  // Grandchild task should also be marked FAILED (DFS walks the full tree).
+  rpc::GetTaskEventsReply grandchild_reply = SyncGetTaskEvents({grandchild_task});
+  ASSERT_EQ(grandchild_reply.events_by_task_size(), 1);
+  const rpc::TaskEvents &grandchild_event = grandchild_reply.events_by_task(0);
+  EXPECT_TRUE(
+      grandchild_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+  EXPECT_EQ(grandchild_event.state_updates().error_info().error_type(),
+            rpc::ErrorType::OWNER_DIED);
+}
+
+// Parameterized fixture exercising both graceful worker exit types
+// (INTENDED_USER_EXIT and INTENDED_SYSTEM_EXIT).
+class GcsTaskManagerGracefulWorkerDeadTest
+    : public GcsTaskManagerTest,
+      public ::testing::WithParamInterface<rpc::WorkerExitType> {};
+
+// Test that graceful worker death does NOT mark child tasks as failed, for both
+// graceful exit types.
+TEST_P(GcsTaskManagerGracefulWorkerDeadTest, DoesNotMarkChildTasksFailed) {
+  rpc::WorkerExitType exit_type = GetParam();
+
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID parent_task = GenTaskIDs(1)[0];
+  TaskID child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  std::vector<rpc::TaskEvents> parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  std::vector<rpc::TaskEvents> child_events =
+      GenTaskEvents({child_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Owner worker dies gracefully with the parameterized exit type.
+  task_manager->OnWorkerDead(owner_worker, GenWorkerFailureData(exit_type, 10));
+  WaitForWorkerDeadDelay();
+
+  // Child task should NOT be marked failed.
+  rpc::GetTaskEventsReply reply = SyncGetTaskEvents({child_task});
+  ASSERT_EQ(reply.events_by_task_size(), 1);
+  EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+}
+
+INSTANTIATE_TEST_SUITE_P(GracefulExitTypes,
+                         GcsTaskManagerGracefulWorkerDeadTest,
+                         ::testing::Values(rpc::WorkerExitType::INTENDED_USER_EXIT,
+                                           rpc::WorkerExitType::INTENDED_SYSTEM_EXIT),
+                         [](const ::testing::TestParamInfo<rpc::WorkerExitType> &info) {
+                           return rpc::WorkerExitType_Name(info.param);
+                         });
+
+// Test that already-terminated child tasks are not overwritten when owner dies.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadDoesNotOverrideTerminatedChildTasks) {
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID parent_task = GenTaskIDs(1)[0];
+  TaskID child_finished = GenTaskIDs(1)[0];
+  TaskID child_failed = GenTaskIDs(1)[0];
+  TaskID child_running = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  std::vector<rpc::TaskEvents> parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child that already finished.
+  std::vector<rpc::TaskEvents> finished_events =
+      GenTaskEvents({child_finished},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::FINISHED, 2}}),
+                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(finished_events));
+
+  // Add child that already failed.
+  std::vector<rpc::TaskEvents> failed_events =
+      GenTaskEvents({child_failed},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::FAILED, 3}}),
+                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(failed_events));
+
+  // Add child that is still running.
+  std::vector<rpc::TaskEvents> running_events =
+      GenTaskEvents({child_running},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 4}}),
+                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(running_events));
+
+  // Owner dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Finished child should not be marked FAILED; its FINISHED timestamp is preserved.
+  rpc::GetTaskEventsReply finished_reply = SyncGetTaskEvents({child_finished});
+  ASSERT_EQ(finished_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(finished_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+  EXPECT_EQ(finished_reply.events_by_task(0).state_updates().state_ts_ns().at(
+                rpc::TaskStatus::FINISHED),
+            2);
+
+  // Already failed child should keep its original failure timestamp.
+  rpc::GetTaskEventsReply failed_reply = SyncGetTaskEvents({child_failed});
+  ASSERT_EQ(failed_reply.events_by_task_size(), 1);
+  EXPECT_EQ(failed_reply.events_by_task(0).state_updates().state_ts_ns().at(
+                rpc::TaskStatus::FAILED),
+            3);
+
+  // Running child should now be marked FAILED.
+  rpc::GetTaskEventsReply running_reply = SyncGetTaskEvents({child_running});
+  ASSERT_EQ(running_reply.events_by_task_size(), 1);
+  EXPECT_TRUE(running_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+}
+
+// Test that OnWorkerDead with no tasks for the worker doesn't crash.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadNoTasks) {
+  WorkerID unknown_worker = WorkerID::FromRandom();
+  task_manager->OnWorkerDead(unknown_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Should not crash, no events to check.
+  rpc::GetTaskEventsReply reply = SyncGetTaskEvents({});
+  EXPECT_EQ(reply.events_by_task_size(), 0);
+}
+
+// Test that when a worker dies ungracefully but has no child tasks (leaf executor),
+// nothing extra is marked failed.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadWithNoChildTask) {
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID leaf_task = GenTaskIDs(1)[0];
+
+  // Add a leaf task running on owner_worker (no children).
+  std::vector<rpc::TaskEvents> events =
+      GenTaskEvents({leaf_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(events));
+
+  // Worker dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+  WaitForWorkerDeadDelay();
+
+  // Leaf task itself should NOT be marked failed (no children to mark, and the task
+  // itself is the responsibility of its own owner).
+  rpc::GetTaskEventsReply reply = SyncGetTaskEvents({leaf_task});
+  ASSERT_EQ(reply.events_by_task_size(), 1);
+  EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+}
+
 // Test that a non-detached ACTOR_CREATION_TASK child is marked FAILED on owner death
 TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksNonDetachedActorChild) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto actor_creation_task = GenTaskIDs(1)[0];
-  auto actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
-  auto grandchild_task = GenTaskIDs(1)[0];
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID parent_task = GenTaskIDs(1)[0];
+  TaskID actor_creation_task = GenTaskIDs(1)[0];
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
+  TaskID grandchild_task = GenTaskIDs(1)[0];
 
   // Parent task running on owner_worker.
   SyncAddTaskEventData(GenTaskEventsData(
@@ -2255,33 +2127,30 @@ TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksNonDetachedActorChild) {
   WaitForWorkerDeadDelay();
 
   // Non-detached actor creation task should be marked FAILED with OWNER_DIED.
-  {
-    auto reply = SyncGetTaskEvents({actor_creation_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
-              rpc::ErrorType::OWNER_DIED);
-  }
+  rpc::GetTaskEventsReply creation_reply = SyncGetTaskEvents({actor_creation_task});
+  ASSERT_EQ(creation_reply.events_by_task_size(), 1);
+  EXPECT_TRUE(creation_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+  EXPECT_EQ(creation_reply.events_by_task(0).state_updates().error_info().error_type(),
+            rpc::ErrorType::OWNER_DIED);
+
   // DFS should have recursed into the non-detached actor's subtree.
-  {
-    auto reply = SyncGetTaskEvents({grandchild_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
-              rpc::ErrorType::OWNER_DIED);
-  }
+  rpc::GetTaskEventsReply grandchild_reply = SyncGetTaskEvents({grandchild_task});
+  ASSERT_EQ(grandchild_reply.events_by_task_size(), 1);
+  EXPECT_TRUE(grandchild_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+  EXPECT_EQ(grandchild_reply.events_by_task(0).state_updates().error_info().error_type(),
+            rpc::ErrorType::OWNER_DIED);
 }
 
 // Test that a detached ACTOR_CREATION_TASK child (and its subtree) is skipped on
 // owner death.
 TEST_F(GcsTaskManagerTest, TestWorkerDeadSkipsDetachedActorChild) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto detached_creation_task = GenTaskIDs(1)[0];
-  auto actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
-  auto descendant_task = GenTaskIDs(1)[0];
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID parent_task = GenTaskIDs(1)[0];
+  TaskID detached_creation_task = GenTaskIDs(1)[0];
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
+  TaskID descendant_task = GenTaskIDs(1)[0];
 
   SyncAddTaskEventData(GenTaskEventsData(
       GenTaskEvents({parent_task},
@@ -2319,28 +2188,25 @@ TEST_F(GcsTaskManagerTest, TestWorkerDeadSkipsDetachedActorChild) {
   WaitForWorkerDeadDelay();
 
   // Detached actor creation task should NOT be marked FAILED.
-  {
-    auto reply = SyncGetTaskEvents({detached_creation_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
+  rpc::GetTaskEventsReply creation_reply = SyncGetTaskEvents({detached_creation_task});
+  ASSERT_EQ(creation_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(creation_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+
   // Descendant under detached actor should also not be marked (subtree skipped).
-  {
-    auto reply = SyncGetTaskEvents({descendant_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
+  rpc::GetTaskEventsReply descendant_reply = SyncGetTaskEvents({descendant_task});
+  ASSERT_EQ(descendant_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(descendant_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
 }
 
 // Test that a detached ACTOR_TASK child (and its subtree) is skipped on owner death.
 TEST_F(GcsTaskManagerTest, TestWorkerDeadSkipsDetachedActorTaskChild) {
-  auto owner_worker = WorkerID::FromRandom();
-  auto parent_task = GenTaskIDs(1)[0];
-  auto detached_actor_task = GenTaskIDs(1)[0];
-  auto actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
-  auto descendant_task = GenTaskIDs(1)[0];
+  WorkerID owner_worker = WorkerID::FromRandom();
+  TaskID parent_task = GenTaskIDs(1)[0];
+  TaskID detached_actor_task = GenTaskIDs(1)[0];
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), parent_task, 1);
+  TaskID descendant_task = GenTaskIDs(1)[0];
 
   SyncAddTaskEventData(GenTaskEventsData(
       GenTaskEvents({parent_task},
@@ -2377,27 +2243,24 @@ TEST_F(GcsTaskManagerTest, TestWorkerDeadSkipsDetachedActorTaskChild) {
                              GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
   WaitForWorkerDeadDelay();
 
-  {
-    auto reply = SyncGetTaskEvents({detached_actor_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
-  {
-    auto reply = SyncGetTaskEvents({descendant_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
+  rpc::GetTaskEventsReply actor_task_reply = SyncGetTaskEvents({detached_actor_task});
+  ASSERT_EQ(actor_task_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(actor_task_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+
+  rpc::GetTaskEventsReply descendant_reply = SyncGetTaskEvents({descendant_task});
+  ASSERT_EQ(descendant_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(descendant_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
 }
 
 // Test that an ungraceful death of a detached actor worker marks both the root tasks
 // (with WORKER_DIED) and descendants of those roots (with OWNER_DIED).
 TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerUngracefulMarksRootsAndChildren) {
-  auto detached_actor_worker = WorkerID::FromRandom();
-  auto detached_creation_task = GenTaskIDs(1)[0];
-  auto actor_id = ActorID::Of(JobID::FromInt(0), detached_creation_task, 1);
-  auto child_task = GenTaskIDs(1)[0];
+  WorkerID detached_actor_worker = WorkerID::FromRandom();
+  TaskID detached_creation_task = GenTaskIDs(1)[0];
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), detached_creation_task, 1);
+  TaskID child_task = GenTaskIDs(1)[0];
 
   // Detached ACTOR_CREATION_TASK running on detached_actor_worker.
   SyncAddTaskEventData(GenTaskEventsData(GenTaskEvents(
@@ -2427,32 +2290,29 @@ TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerUngracefulMarksRootsAndChildre
   WaitForWorkerDeadDelay();
 
   // Root (detached creation task) should be marked WORKER_DIED.
-  {
-    auto reply = SyncGetTaskEvents({detached_creation_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
-              rpc::ErrorType::WORKER_DIED);
-  }
+  rpc::GetTaskEventsReply creation_reply = SyncGetTaskEvents({detached_creation_task});
+  ASSERT_EQ(creation_reply.events_by_task_size(), 1);
+  EXPECT_TRUE(creation_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+  EXPECT_EQ(creation_reply.events_by_task(0).state_updates().error_info().error_type(),
+            rpc::ErrorType::WORKER_DIED);
+
   // Child of the detached actor should be marked OWNER_DIED via the DFS.
-  {
-    auto reply = SyncGetTaskEvents({child_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
-              rpc::ErrorType::OWNER_DIED);
-  }
+  rpc::GetTaskEventsReply child_reply = SyncGetTaskEvents({child_task});
+  ASSERT_EQ(child_reply.events_by_task_size(), 1);
+  EXPECT_TRUE(child_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+  EXPECT_EQ(child_reply.events_by_task(0).state_updates().error_info().error_type(),
+            rpc::ErrorType::OWNER_DIED);
 }
 
 // Test that a graceful death of a detached actor worker marks the root tasks
 // (with WORKER_DIED) but does NOT mark children — buffer flush handles them.
 TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerGracefulMarksRootsOnly) {
-  auto detached_actor_worker = WorkerID::FromRandom();
-  auto detached_creation_task = GenTaskIDs(1)[0];
-  auto actor_id = ActorID::Of(JobID::FromInt(0), detached_creation_task, 1);
-  auto child_task = GenTaskIDs(1)[0];
+  WorkerID detached_actor_worker = WorkerID::FromRandom();
+  TaskID detached_creation_task = GenTaskIDs(1)[0];
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), detached_creation_task, 1);
+  TaskID child_task = GenTaskIDs(1)[0];
 
   SyncAddTaskEventData(GenTaskEventsData(GenTaskEvents(
       {detached_creation_task},
@@ -2481,30 +2341,27 @@ TEST_F(GcsTaskManagerTest, TestDetachedActorWorkerGracefulMarksRootsOnly) {
   WaitForWorkerDeadDelay();
 
   // Root should be marked WORKER_DIED.
-  {
-    auto reply = SyncGetTaskEvents({detached_creation_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
-              rpc::ErrorType::WORKER_DIED);
-  }
+  rpc::GetTaskEventsReply creation_reply = SyncGetTaskEvents({detached_creation_task});
+  ASSERT_EQ(creation_reply.events_by_task_size(), 1);
+  EXPECT_TRUE(creation_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+  EXPECT_EQ(creation_reply.events_by_task(0).state_updates().error_info().error_type(),
+            rpc::ErrorType::WORKER_DIED);
+
   // Child should NOT be marked FAILED — graceful exit means no DFS.
-  {
-    auto reply = SyncGetTaskEvents({child_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
+  rpc::GetTaskEventsReply child_reply = SyncGetTaskEvents({child_task});
+  ASSERT_EQ(child_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(child_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
 }
 
 // Test that a graceful death of a non-detached actor worker is a no-op (the actor's
 // owner is responsible for reporting status).
 TEST_F(GcsTaskManagerTest, TestNonDetachedActorWorkerGracefulIsNoOp) {
-  auto actor_worker = WorkerID::FromRandom();
-  auto creation_task = GenTaskIDs(1)[0];
-  auto actor_id = ActorID::Of(JobID::FromInt(0), creation_task, 1);
-  auto child_task = GenTaskIDs(1)[0];
+  WorkerID actor_worker = WorkerID::FromRandom();
+  TaskID creation_task = GenTaskIDs(1)[0];
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), creation_task, 1);
+  TaskID child_task = GenTaskIDs(1)[0];
 
   // Non-detached ACTOR_CREATION_TASK running on actor_worker.
   SyncAddTaskEventData(GenTaskEventsData(
@@ -2533,18 +2390,15 @@ TEST_F(GcsTaskManagerTest, TestNonDetachedActorWorkerGracefulIsNoOp) {
   WaitForWorkerDeadDelay();
 
   // Neither the root nor the child should be marked FAILED.
-  {
-    auto reply = SyncGetTaskEvents({creation_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
-  {
-    auto reply = SyncGetTaskEvents({child_task});
-    ASSERT_EQ(reply.events_by_task_size(), 1);
-    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
-        rpc::TaskStatus::FAILED));
-  }
+  rpc::GetTaskEventsReply creation_reply = SyncGetTaskEvents({creation_task});
+  ASSERT_EQ(creation_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(creation_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
+
+  rpc::GetTaskEventsReply child_reply = SyncGetTaskEvents({child_task});
+  ASSERT_EQ(child_reply.events_by_task_size(), 1);
+  EXPECT_FALSE(child_reply.events_by_task(0).state_updates().state_ts_ns().contains(
+      rpc::TaskStatus::FAILED));
 }
 
 }  // namespace gcs


### PR DESCRIPTION
In this https://github.com/ray-project/ray/issues/56427, some tasks with max_calls = 1 are marked failed even when actually completed.

Reason: When a worker dies (say, due to max_calls = 1 for a task), GCS receives an OnWorkerDead notification, which marks tasks as FAILED for which it has not yet received a terminal status (FINISHED/FAILED). The terminal status of a task is usually sent by the task owner via a periodic flush of the task_event_buffer. If the FINISHED task event emitted by the task owner doesn't reach the GCS before OnWorkerDead notification, the task is wrongly marked as FAILED.

Fix: One approach to fix this could be to skip marking tasks FAILED on worker death notifications if the worker exit is intended (INTENDED_USER_EXIT), and instead rely on the owner to transmit the task's final state. However, this approach doesn't work if the owner also dies before emitting the task_event_buffer. Since the owner holds the responsibility of relaying child tasks' state, if the owner dies we should mark all child tasks (immediate children + the whole tree of tasks) as FAILED. Moreover, this should be done only when the owner worker death is ungraceful because for a graceful death, the owner emits the task_event_buffer and hence the GCS can rely upon them to get the final task states.

Changes: Added parent_to_child_index_ in gcs_task_manager to track child tasks for each task. Use this index to mark the task tree of owner tasks as FAILED. It also consumes changes done in https://github.com/ray-project/ray/pull/63262 to identify whether an actor task is on a detached actor or not

There are a some cases related to detached actors. Details can be found here: https://docs.google.com/document/d/1Ythr_3aTjcEzZpWCr4Guqq_5NayZpHdfSWd-661XOqU/edit?tab=t.0

Also other approaches that were considered but not chosen are also documented in the above doc.

NOTE: 
1. I was working on this issue as a part of this PR: https://github.com/ray-project/ray/pull/61791. But I was unable to reopen the PR again and therefore decided to create a new one. All comments on the previous PR are answered there itself. 
2. Also this PR has commits that are cherry-picked from this PR: https://github.com/ray-project/ray/pull/63262. This is since changes from the other PR are needed to build and test changes in this PR. Once https://github.com/ray-project/ray/pull/63262 is merged to master, I will remove those commits from this PR. 
EDIT: https://github.com/ray-project/ray/pull/63262 is merged. Removed commits from that PR in this one
