### PR TITLE
[core] [2/2] Topology aware scheduling public API docs change

### DIFF
--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -737,8 +737,8 @@ Ray reschedules Actors and tasks that use the bundle (reserved resources) based 
 .. warning::
 
   Topology aware scheduling is an **alpha** feature. It's actively being iterated on and
-  the API surface may change. Ray currently supports only ``STRICT_PACK`` for topology labels, 
-  and one topology label. Support for additional strategies and multi-level topologies is planned.
+  the API surface may change. Ray currently supports only a single topology label with the
+  ``STRICT_PACK`` strategy. Support for additional strategies and multi-level topologies is planned.
 
 Why topology aware scheduling?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -763,10 +763,10 @@ fault tolerance. If all nodes in ``rack-1`` go down, the placement group can't a
 to a different rack. Furthermore, you have to manually specify a domain when you really just want
 any domain and this becomes cumbersome if you have many GPU domains.
 
-Topology aware scheduling solves this by letting you express the cluster topology as a list of
-levels and choose a placement strategy at each level. Ray picks a value for the topology label
-that can satisfy all bundles (for example, a specific rack) and then applies your node-level
-strategy within that value.
+Topology aware scheduling currently solves this by letting you express a topology strategy for the placement 
+group, which allows specifying a topology label within the cluster. Ray picks a value for this topology label
+that can satisfy all bundles (for example, a specific rack) and then applies your node-level strategy 
+within that value.
 
 How it works
 ~~~~~~~~~~~~

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -773,10 +773,10 @@ How it works
 ~~~~~~~~~~~~
 
 Pass ``topology_strategy=`` to :func:`ray.util.placement_group` to enable topology-aware
-placement. The argument is a list of topology levels (currently only support for one element), 
-where each level is a dict that maps a label key to the placement strategy used at that level.
+placement. The argument is a list of topology levels, where each level is a dict that maps a
+label key to the placement strategy used at that level.
 
-Currently, ``topology_strategy`` is at most a list with one dictionary that may contain up 
+Currently, ``topology_strategy`` is at most a list with one dictionrary that may contain up 
 to two keys:
 
 - The special key ``ray.io/node-id`` sets the **node-level** strategy and accepts any value

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -772,11 +772,9 @@ How it works
 ~~~~~~~~~~~~
 
 Pass ``topology_strategy=`` to :func:`ray.util.placement_group` to enable topology-aware
-placement. The argument is a list of topology levels, where each level is a dict that maps a
-label key to the placement strategy used at that level.
+placement. The argument is a dict that maps a label key to the placement strategy used at that level.
 
-Currently, ``topology_strategy`` is at most a list with one dictionary that may contain up 
-to two keys:
+Currently, ``topology_strategy`` is a dictionary that may contain up to two keys:
 
 - The special key ``ray.io/node-id`` sets the **node-level** strategy and accepts any value
   in ``{"PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"}``. If you omit it, the node-level

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -794,7 +794,7 @@ With this, Ray accomplishes the following:
 2. Selects a value for that label that can satisfy all bundles.
 3. Applies the node-level scheduling strategy within the selected value.
 
-Currently, ``topology_strategy`` is at most a singleton list that may contain up to two keys:
+Currently, ``topology_strategy`` must be a list containing at most one dictionary, which can have up to two keys:
 
 - The special key ``ray.io/node-id`` sets the **node-level** strategy and accepts any value
   in ``{"PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"}``. If you omit it, the node-level

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -729,20 +729,19 @@ Fault Tolerance of Actors and Tasks that Use the Bundle
 
 Ray reschedules Actors and tasks that use the bundle (reserved resources) based on their :ref:`fault tolerant policy <fault-tolerance>` once Ray recovers the bundle.
 
-.. _pgroup-label-locality:
+.. _pgroup-topology-strategy:
 
-[Alpha] Label locality scheduling
+[Alpha] Topology aware scheduling
 ---------------------------------
 
 .. warning::
 
-  Label locality scheduling is an **alpha** feature. It's actively being iterated on and
-  the API surface may change. It only supports GB200 or GB300 accelerator types with
-  STRICT_PACK at the domain level. We plan to relax these constraints in the future 
-  and support more scheduling strategies at the domain level and abitrary label domains.
+  Topology aware scheduling is an **alpha** feature. It's actively being iterated on and
+  the API surface may change. Ray currently supports only ``STRICT_PACK`` for topology labels, 
+  and one topology label. Support for additional strategies and multi-level topologies is planned.
 
-Why label locality?
-~~~~~~~~~~~~~~~~~~~
+Why topology aware scheduling?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The placement strategies above (PACK, STRICT_PACK, SPREAD, STRICT_SPREAD) operate purely on a
 per-node basis. For multi-node GPU domains such as GB200 or GB300 NVL racks where nodes share
@@ -761,40 +760,69 @@ You could work around this with static :ref:`label selectors <labels>` (such as
 ``bundle_label_selector=[{"my_custom_gpu_domain_label": "rack-1"}] * 18``), but that approach doesn't support
 fault tolerance. If all nodes in ``rack-1`` go down, the placement group can't automatically move
 to a different rack. Furthermore, you have to manually specify a domain when you really just want
-any domain and this becomes cumbersome if you have many GPU domains. 
+any domain and this becomes cumbersome if you have many GPU domains.
 
-Label locality scheduling solves this by adding a **domain-level** scheduling layer on top of
-node-level strategies. It STRICT_PACKs all bundles within a single domain (a group of nodes
-sharing the same ``ray.io/gpu-domain`` label value), while the node-level strategy you specify
-still applies within that domain.
+Topology aware scheduling solves this by letting you express the cluster topology as a list of
+levels and choose a placement strategy at each level. Ray picks a value for the topology label
+that can satisfy all bundles (for example, a specific rack) and then applies your node-level
+strategy within that value.
 
 How it works
 ~~~~~~~~~~~~
 
-When **all** bundles in a placement group have ``bundle_label_selector`` containing
-``ray.io/accelerator-type`` set to ``GB200`` or ``GB300``, Ray automatically enables
-label-domain scheduling. Ray:
-
-1. Groups candidate nodes by their ``ray.io/gpu-domain`` label value.
-2. Selects a domain that can satisfy all bundles.
-3. Applies the node-level scheduling strategy within the selected domain.
+Pass ``topology_strategy=`` to :func:`ray.util.placement_group` to enable topology-aware
+placement. The argument is a list of topology levels, where each level is a dict that maps a
+label key to the placement strategy used at that level.
 
 .. code-block:: python
 
+  from ray.util.placement_group import placement_group
+
   bundles = [{"GPU": 4, "CPU": 2}] * 18
-  label_selector = [{"ray.io/accelerator-type": "GB300"}] * 18
 
   pg = placement_group(
       bundles=bundles,
-      bundle_label_selector=label_selector
+      topology_strategy=[{"ray.io/gpu-domain": "STRICT_PACK"}],
   )
 
   ray.get(pg.ready())
 
+With this, Ray accomplishes the following:
+
+1. Groups candidate nodes by the value of the topology label you named
+   (``ray.io/gpu-domain`` in the example above).
+2. Selects a value for that label that can satisfy all bundles.
+3. Applies the node-level scheduling strategy within the selected value.
+
+Currently, ``topology_strategy`` is at most a singleton list that may contain up to two keys:
+
+- The special key ``ray.io/node-id`` sets the **node-level** strategy and accepts any value
+  in ``{"PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"}``. If you omit it, the node-level
+  strategy defaults to ``PACK``.
+- Any other key is a **topology label** that nodes have set (via ``ray start --labels`` or
+  your cluster configuration). Only ``STRICT_PACK`` is supported for these labels today.
+
+For example, to STRICT_SPREAD bundles across distinct nodes while still STRICT_PACKing them
+onto a single rack (``ray.io/gpu-domain`` is each rack's **topology label**):
+
+.. code-block:: python
+
+  pg = placement_group(
+      bundles=[{"CPU": 1}] * 4,
+      topology_strategy=[{
+          "ray.io/node-id": "STRICT_SPREAD",
+          "ray.io/gpu-domain": "STRICT_PACK",
+      }],
+  )
+
+``topology_strategy`` is mutually exclusive with the ``strategy=`` parameter, and passing both
+raises ``ValueError``. To override the default node-level strategy alongside a topology label,
+put the node-level strategy under ``ray.io/node-id`` in the same dict, as shown above.
+
 .. note::
 
-  Ray doesn't automatically set the ``ray.io/gpu-domain`` label on nodes.
-  Configure this label through ``ray start --labels`` or your cluster configuration.
+  Ray doesn't automatically set topology labels such as ``ray.io/gpu-domain`` on nodes.
+  Configure these labels through ``ray start --labels`` or your cluster configuration.
   For example:
 
   .. code-block:: bash
@@ -804,35 +832,36 @@ label-domain scheduling. Ray:
 Fault tolerance
 ~~~~~~~~~~~~~~~
 
-Label locality scheduling improves on static label selectors by providing automatic
-domain-level fault tolerance:
+Topology aware scheduling improves on static label selectors by providing automatic
+fault tolerance at the topology-label level:
 
-- **Partial failure** (some nodes in the domain die): Ray reschedules the lost bundles
-  onto surviving nodes **within the same domain**. Actors and tasks on the remaining
-  bundles keep running. If the domain doesn't have enough resources to reschedule the
-  lost bundles, those bundles stay infeasible and queued until resources free up in
-  the same domain. To force the placement group onto a different domain, call
-  :func:`ray.util.remove_placement_group <ray.util.remove_placement_group>` and
-  create a new one. Removing the placement group forcefully kills every actor and
-  task still using its bundles and doesn't restart them, so you must re-create them
-  yourself on the new placement group.
-- **Total failure** (all nodes in the domain die): Ray clears the domain assignment
-  and reschedules the entire placement group onto a different domain.
+- **Partial failure** (some nodes within the selected value of the topology label die):
+  Ray reschedules the lost bundles onto surviving nodes **within the same value** (for
+  example, the same rack). Actors and tasks on the remaining bundles keep running. If
+  the selected value doesn't have enough resources to reschedule the lost bundles,
+  those bundles stay infeasible and queued until resources free up in the same value.
+  To force the placement group onto a different value, call
+  :func:`ray.util.remove_placement_group <ray.util.remove_placement_group>` and create
+  a new one. Removing the placement group forcefully kills every actor and task still
+  using its bundles and doesn't restart them, so you must re-create them yourself on
+  the new placement group.
+- **Total failure** (all nodes with the selected value die): Ray clears the topology
+  assignment and reschedules the entire placement group onto a different value.
 
 Observability
 ~~~~~~~~~~~~~
 
-You can inspect label locality placement groups using the existing placement group
+You can inspect topology-aware placement groups using the existing placement group
 observability tools:
 
-- **Dashboard**: The placement group table shows a ``Label Domain`` column, which displays the
-  selected label key and domain for the placement group (for example, ``ray.io/gpu-domain: rack-1``).
-- **State API**: ``ray list placement-groups --detail`` returns the selected label key and the
-  domain assignment for each placement group.
+- **Dashboard**: The placement group table shows a ``Topology`` column, which displays the
+  strategy you requested and the value Ray selected for each topology label.
+- **State API**: ``ray list placement-groups --detail`` returns the requested strategy in
+  ``topology_strategy`` and the value Ray selected in ``topology_assignments``.
 
-The following ``ray list placement-groups --detail`` output shows the two label-locality
-fields, ``label_domain_key`` and ``label_domain_assignments``, populated for a placement
-group that requests ``ray.io/accelerator-type: GB200``:
+The following ``ray list placement-groups --detail`` output shows the two topology fields,
+``topology_strategy`` and ``topology_assignments``, populated for a placement group that
+packs onto a single ``ray.io/gpu-domain``:
 
 .. code-block:: yaml
 
@@ -846,25 +875,24 @@ group that requests ``ray.io/accelerator-type: GB200``:
       unit_resources:
         CPU: 1.0
       node_id: 0fd7eecf6335633ba39ab66f5a26b18eeb35c70c15a9563a29ee2bce
-      label_selector:
-        ray.io/accelerator-type: GB200
     - bundle_id:
         placement_group_id: 237f47c3235ac1a96ad423c3f74501000000
         bundle_index: 1
       unit_resources:
         CPU: 1.0
       node_id: 0fd7eecf6335633ba39ab66f5a26b18eeb35c70c15a9563a29ee2bce
-      label_selector:
-        ray.io/accelerator-type: GB200
     is_detached: false
     stats: ...
-    label_domain_key: ray.io/gpu-domain
-    label_domain_assignments:
-      ray.io/gpu-domain: rack-2
+    topology_strategy:
+    - entries:
+        ray.io/gpu-domain: STRICT_PACK
+    topology_assignments:
+    - assignments:
+        ray.io/gpu-domain: rack-2
 
-For placement groups that don't use label-locality scheduling, ``label_domain_key`` is
-an empty string and ``label_domain_assignments`` is an empty map. Both fields appear only
-when you pass ``--detail``.
+For placement groups that don't use topology-aware scheduling, ``topology_strategy`` and
+``topology_assignments`` are both empty lists. Both fields appear only when you pass
+``--detail``.
 
 API Reference
 -------------

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -792,7 +792,7 @@ to two keys:
 
   pg = placement_group(
       bundles=bundles,
-      topology_strategy=[{"ray.io/gpu-domain": "STRICT_PACK"}],
+      topology_strategy={"ray.io/gpu-domain": "STRICT_PACK"},
   )
 
   ray.get(pg.ready())
@@ -811,10 +811,10 @@ STRICT_PACKing them onto a single rack (``ray.io/gpu-domain`` is each rack's **t
 
   pg = placement_group(
       bundles=[{"CPU": 1}] * 4,
-      topology_strategy=[{
+      topology_strategy={
           "ray.io/node-id": "STRICT_SPREAD",
           "ray.io/gpu-domain": "STRICT_PACK",
-      }],
+      },
   )
 
 ``topology_strategy`` is mutually exclusive with the ``strategy=`` parameter, and passing both

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -737,8 +737,10 @@ Ray reschedules Actors and tasks that use the bundle (reserved resources) based 
 .. warning::
 
   Topology aware scheduling is an **alpha** feature. It's actively being iterated on and
-  the API surface may change. Ray currently supports only ``STRICT_PACK`` for topology labels, 
-  and one topology label. Support for additional strategies and multi-level topologies is planned.
+  the API surface may change. Ray currently only supports defining one topology label and 
+  one node level strategy (same as current strategy= implementation). For topology labels, 
+  Ray currently supports only ``STRICT_PACK``. Support for additional strategies and 
+  multi-level topologies is planned.
 
 Why topology aware scheduling?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -771,8 +773,17 @@ How it works
 ~~~~~~~~~~~~
 
 Pass ``topology_strategy=`` to :func:`ray.util.placement_group` to enable topology-aware
-placement. The argument is a list of topology levels, where each level is a dict that maps a
-label key to the placement strategy used at that level.
+placement. The argument is a list of topology levels (currently only support for one element), 
+where each level is a dict that maps a label key to the placement strategy used at that level.
+
+Currently, ``topology_strategy`` is at most a list with one dictionary that may contain up 
+to two keys:
+
+- The special key ``ray.io/node-id`` sets the **node-level** strategy and accepts any value
+  in ``{"PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"}``. If you omit it, the node-level
+  strategy defaults to ``PACK``.
+- Any other key is a **topology label** that nodes have set (via ``ray start --labels`` or
+  your cluster configuration). Only ``STRICT_PACK`` is supported for these labels today.
 
 .. code-block:: python
 
@@ -794,16 +805,8 @@ With this, Ray accomplishes the following:
 2. Selects a value for that label that can satisfy all bundles.
 3. Applies the node-level scheduling strategy within the selected value.
 
-Currently, ``topology_strategy`` is at most a singleton list that may contain up to two keys:
-
-- The special key ``ray.io/node-id`` sets the **node-level** strategy and accepts any value
-  in ``{"PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"}``. If you omit it, the node-level
-  strategy defaults to ``PACK``.
-- Any other key is a **topology label** that nodes have set (via ``ray start --labels`` or
-  your cluster configuration). Only ``STRICT_PACK`` is supported for these labels today.
-
-For example, to STRICT_SPREAD bundles across distinct nodes while still STRICT_PACKing them
-onto a single rack (``ray.io/gpu-domain`` is each rack's **topology label**):
+Here is a following example to STRICT_SPREAD bundles across distinct nodes while still 
+STRICT_PACKing them onto a single rack (``ray.io/gpu-domain`` is each rack's **topology label**):
 
 .. code-block:: python
 


### PR DESCRIPTION
## Description
This is directly related to #63479. This is the necessary docs change for the change in the previous PR. This describes how the topology aware scheduling alpha feature works.