### PR TITLE
Remove return in finally block (Python 3.14 SyntaxWarning)

### DIFF
--- a/python/ray/_common/usage/usage_lib.py
+++ b/python/ray/_common/usage/usage_lib.py
@@ -656,8 +656,8 @@ def _get_cluster_status_to_report_v2(gcs_client: GcsClient) -> ClusterStatusToRe
         )
     except Exception as e:
         logger.info(f"Failed to get cluster status to report {e}")
-    finally:
-        return result
+
+    return result
 
 
 def get_cluster_status_to_report(gcs_client: GcsClient) -> ClusterStatusToReport:


### PR DESCRIPTION
## Description
Running anything ray-related (e.g `ray --help`) on Python 3.14+ results in:

```
/.venv/lib/python3.14/site-packages/ray/_common/usage/usage_lib.py:660: SyntaxWarning: 'return' in a 'finally' block
  return result
```

this should fix that whilst preserving the same behaviour.