### PR TITLE
[Core] Add log in HandleKillLocalActor to diagnose orphan replicas

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3504,15 +3504,19 @@ int NodeManager::WaitForRuntimeEnvAgentPort(const NodeID &self_node_id,
 void NodeManager::HandleKillLocalActor(rpc::KillLocalActorRequest request,
                                        rpc::KillLocalActorReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {
-  auto worker =
-      worker_pool_.GetRegisteredWorker(WorkerID::FromBinary(request.worker_id()));
+  const auto worker_id = WorkerID::FromBinary(request.worker_id());
+  const auto actor_id = ActorID::FromBinary(request.intended_actor_id());
+  RAY_LOG(INFO).WithField(worker_id).WithField(actor_id) << "Received KillLocalActor RPC";
+
+  auto worker = worker_pool_.GetRegisteredWorker(worker_id);
   // If the worker is not registered, then it must have already been killed
   if (!worker || worker->IsDead()) {
+    RAY_LOG(WARNING).WithField(worker_id)
+        << "HandleKillLocalActor: worker not registered or already dead, "
+           "returning OK without dispatching kill";
     send_reply_callback(Status::OK(), nullptr, nullptr);
     return;
   }
-
-  auto worker_id = worker->WorkerId();
 
   rpc::KillActorRequest kill_actor_request;
   kill_actor_request.set_intended_actor_id(request.intended_actor_id());
@@ -3547,10 +3551,8 @@ void NodeManager::HandleKillLocalActor(rpc::KillLocalActorRequest request,
 
   worker->rpc_client()->KillActor(
       kill_actor_request,
-      [actor_id = ActorID::FromBinary(request.intended_actor_id()),
-       timer,
-       send_reply_callback,
-       replied](const ray::Status &status, const rpc::KillActorReply &) {
+      [actor_id, timer, send_reply_callback, replied](const ray::Status &status,
+                                                      const rpc::KillActorReply &) {
         if (*replied) {
           return;
         }


### PR DESCRIPTION
## Description
The same orphan-replica pattern occurred on two clusters within a single week in production(Ray 2.55.0). `serve status` on the head reported the replica gone, while `ps -ef` on the worker showed the `ServeReplica` process still alive (one case for 31 hours, another for 37 minutes).


<img width="1418" height="229" alt="image" src="https://github.com/user-attachments/assets/89bd9863-e59c-4d91-b690-9358b2146262" />

> head(eks) serve status vs worker(edge device) ps -ef:  replica absent on head, ServeReplica PID alive on worker


The same raylet processed 322 `KillLocalActor` RPCs for other workers in the same window, and a manual `kill -9` immediately produced `Disconnecting worker, graceful=false`, so the raylet itself is healthy. The network topology fits the same direction: head runs in EKS while workers are deployed on edge devices outside that Kubernetes cluster, so head <-> worker RPCs are more exposed to drops and partitions than they would be in a co-located cluster.

We suspect the kill RPC was lost somewhere in transit between head and worker. The raylet log contains no signal for that worker_id, so this hypothesis cannot be verified from a dump. There is no way to tell whether the RPC never reached the raylet or whether it arrived and was silently OK'd because the worker had already been unregistered.

This PR only adds logging at two points in the raylet's actor-kill RPC handler: one INFO at entry, and one WARNING in the branch where the worker is absent from the registered-worker pool or already marked dead and the handler returns OK without dispatching the kill.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information

### Kill delivery path from head to worker

```mermaid
flowchart LR
    U([User: stop actor])

    subgraph HEAD["Head node"]
        SC["ray.serve<br/>ServeController"]
        CORE_DRIVER["ray.core<br/>CoreWorker (driver)<br/>ray.kill"]
        GCS["ray.gcs<br/>GcsActorManager"]
    end

    subgraph WORKER["Worker node"]
        RAYLET["ray.raylet<br/>HandleKillLocalActor"]
        CORE_WORKER["ray.core<br/>CoreWorker (worker)<br/>HandleKillActor"]
        PROC([ServeReplica process])
    end

    U ==> SC
    SC ==> CORE_DRIVER
    CORE_DRIVER ==> GCS
    GCS ==> RAYLET
    RAYLET ==> CORE_WORKER
    CORE_WORKER ==> PROC
```

### Cases this makes diagnosable

The two new raylet signals plus two existing GCS / raylet signals let an operator partition the next dump as follows.

| Mechanism | raylet receive INFO | silent-OK WARNING | GCS `Destroying actor` | raylet `Disconnecting worker` |
|---|---|---|---|---|
| normal teardown | present | absent | present | present |
| GCS -> raylet RPC drop / timeout | absent | absent | present | delayed |
| `LocalRayletAddress` empty | absent | absent | present + `Not sending KillLocalActor` | absent |
| `worker_pool_` not-found silent OK | present | present | present | absent |
| controller never reached `ray.kill` | absent | absent | absent | absent |

The last row (chain broken before reaching the raylet) requires controller-side logging to subdivide further, which is the scope of a followup PR.

### Reproducer

Reproduces one form of the silent failure (user code's `Graceful shutdown complete; replica exiting.` is emitted but the worker stays alive). Runs on Ray 2.55.0.

```python
import os, threading, time
import ray
from ray import serve


@serve.deployment(graceful_shutdown_wait_loop_s=0.2, graceful_shutdown_timeout_s=60)
class HangShutdown:
    def __call__(self):
        return {"pid": os.getpid()}

    def __del__(self):
        threading.Thread(
            target=lambda: time.sleep(3600), daemon=False, name="hang-thread"
        ).start()
        time.sleep(3600)


if __name__ == "__main__":
    serve.start()
    handle = serve.run(HangShutdown.bind(), name="hang_app")
    pid = ray.get(handle.remote())["pid"]
    serve.delete("hang_app", _blocking=False)
    time.sleep(10)
    try:
        os.kill(pid, 0)
        print(f"replica pid={pid} STILL ALIVE 10s after serve.delete")
    except OSError:
        print(f"replica pid={pid} dead")
```

Comparison of the worker's raylet log after running the reproducer:

- **Before this PR**: zero entries for the orphan worker_id. There is no way to tell where the kill RPC was lost.
- **After this PR**: one of the following appears for the same worker_id.
    - `[INFO] Received KillLocalActor RPC worker_id=... actor_id=...` -> the RPC reached the raylet (further processing then takes the normal or silent-OK branch).
    - Neither line present -> the RPC never reached the raylet. The break is upstream of the raylet, in the GCS dispatch layer.
    - The INFO above plus `[WARNING] HandleKillLocalActor: worker not registered or already dead, returning OK without dispatching kill` -> the RPC arrived but the worker had already been unregistered (silent OK branch fired).
