### PR TITLE
fix: Prevent tarfile path traversal in Tune and Prometheus installer

### DIFF
--- a/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
+++ b/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
@@ -67,7 +67,45 @@ def download_file(url, filename):
 def install_prometheus(file_path):
     try:
         with tarfile.open(file_path) as tar:
-            tar.extractall()
+            if hasattr(tarfile, "data_filter"):
+                tar.extractall(filter="data")
+            else:
+                # Python < 3.12 fallback: manual member validation
+                import os
+
+                abs_target = os.path.abspath(os.getcwd())
+                safe_members = []
+                for member in tar.getmembers():
+                    # Reject device files and FIFOs (matches data_filter)
+                    if member.isdev() or member.isfifo():
+                        raise RuntimeError(
+                            f"Tarfile member {member.name} is a special file"
+                        )
+                    member_path = os.path.abspath(
+                        os.path.join(abs_target, member.name)
+                    )
+                    if os.path.commonpath([abs_target, member_path]) != abs_target:
+                        raise RuntimeError(
+                            f"Tarfile member {member.name} attempts path traversal"
+                        )
+                    # Validate symlinks and hardlinks resolve within target
+                    if member.issym() or member.islnk():
+                        link_target = os.path.join(
+                            abs_target, member.linkname
+                        )
+                        if (
+                            os.path.commonpath(
+                                [abs_target, os.path.abspath(link_target)]
+                            )
+                            != abs_target
+                        ):
+                            raise RuntimeError(
+                                f"Tarfile member {member.name} link attempts path traversal"
+                        )
+                        safe_members.append(member)
+                        continue
+                    safe_members.append(member)
+                tar.extractall(members=safe_members)
         logging.info("Prometheus installed successfully.")
         return True
     except Exception as e:

--- a/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
+++ b/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
@@ -71,8 +71,6 @@ def install_prometheus(file_path):
                 tar.extractall(filter="data")
             else:
                 # Python < 3.12 fallback: manual member validation
-                import os
-
                 abs_target = os.path.abspath(os.getcwd())
                 safe_members = []
                 for member in tar.getmembers():
@@ -84,24 +82,38 @@ def install_prometheus(file_path):
                     member_path = os.path.abspath(
                         os.path.join(abs_target, member.name)
                     )
-                    if os.path.commonpath([abs_target, member_path]) != abs_target:
+                    try:
+                        is_unsafe = (
+                            os.path.commonpath([abs_target, member_path])
+                            != abs_target
+                        )
+                    except ValueError:
+                        is_unsafe = True
+                    if is_unsafe:
                         raise RuntimeError(
                             f"Tarfile member {member.name} attempts path traversal"
                         )
                     # Validate symlinks and hardlinks resolve within target
                     if member.issym() or member.islnk():
-                        link_target = os.path.join(
-                            abs_target, member.linkname
+                        link_base = (
+                            os.path.dirname(member_path)
+                            if member.issym()
+                            else abs_target
                         )
-                        if (
-                            os.path.commonpath(
-                                [abs_target, os.path.abspath(link_target)]
+                        link_target = os.path.abspath(
+                            os.path.join(link_base, member.linkname)
+                        )
+                        try:
+                            is_link_unsafe = (
+                                os.path.commonpath([abs_target, link_target])
+                                != abs_target
                             )
-                            != abs_target
-                        ):
+                        except ValueError:
+                            is_link_unsafe = True
+                        if is_link_unsafe:
                             raise RuntimeError(
                                 f"Tarfile member {member.name} link attempts path traversal"
-                        )
+                            )
                         safe_members.append(member)
                         continue
                     safe_members.append(member)

--- a/python/ray/tune/tests/test_util_file_transfer.py
+++ b/python/ray/tune/tests/test_util_file_transfer.py
@@ -145,9 +145,38 @@ def test_unpack_dir_rejects_symlink_member_path_traversal(tmp_path, monkeypatch)
         info.type = tarfile.SYMTYPE
         info.linkname = "safe-target"
         tar.addfile(info)
+    stream.seek(0)
 
     with pytest.raises(RuntimeError, match="attempts path traversal"):
         _unpack_dir(stream, str(tmp_path))
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="symlink extraction can require elevated permissions on Windows",
+)
+def test_unpack_dir_allows_symlink_target_relative_to_member_dir(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as tar:
+        file_info = tarfile.TarInfo(name="file")
+        data = b"safe"
+        file_info.size = len(data)
+        tar.addfile(file_info, io.BytesIO(data))
+
+        dir_info = tarfile.TarInfo(name="subdir")
+        dir_info.type = tarfile.DIRTYPE
+        tar.addfile(dir_info)
+
+        link_info = tarfile.TarInfo(name="subdir/link")
+        link_info.type = tarfile.SYMTYPE
+        link_info.linkname = "../file"
+        tar.addfile(link_info)
+    stream.seek(0)
+
+    _unpack_dir(stream, str(tmp_path))
 
 
 @pytest.mark.parametrize("exclude", [["subdir/*"], ["*/level1.txt"]])

--- a/python/ray/tune/tests/test_util_file_transfer.py
+++ b/python/ray/tune/tests/test_util_file_transfer.py
@@ -11,6 +11,7 @@ from ray.exceptions import RayTaskError
 from ray.tune.utils.file_transfer import (
     _sync_dir_between_different_nodes,
     _sync_dir_on_same_node,
+    _unpack_dir,
 )
 
 
@@ -134,6 +135,19 @@ def test_sync_nodes_only_diff(ray_start_2_cpus, temp_data_dirs):
         assert len(files_in_tar) == 7  # 3 files, 4 dirs (including root)
 
     ray.get(unpack)  # Wait until finished for teardown
+
+
+def test_unpack_dir_rejects_symlink_member_path_traversal(tmp_path, monkeypatch):
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as tar:
+        info = tarfile.TarInfo(name="../escaped")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "safe-target"
+        tar.addfile(info)
+
+    with pytest.raises(RuntimeError, match="attempts path traversal"):
+        _unpack_dir(stream, str(tmp_path))
 
 
 @pytest.mark.parametrize("exclude", [["subdir/*"], ["*/level1.txt"]])

--- a/python/ray/tune/utils/file_transfer.py
+++ b/python/ray/tune/utils/file_transfer.py
@@ -402,21 +402,35 @@ def _unpack_dir(stream: io.BytesIO, target_dir: str, *, _retry: bool = True) -> 
                         member_path = os.path.abspath(
                             os.path.join(abs_target, member.name)
                         )
-                        if os.path.commonpath([abs_target, member_path]) != abs_target:
+                        try:
+                            is_unsafe = (
+                                os.path.commonpath([abs_target, member_path])
+                                != abs_target
+                            )
+                        except ValueError:
+                            is_unsafe = True
+                        if is_unsafe:
                             raise RuntimeError(
                                 f"Tarfile member {member.name} attempts path traversal"
                             )
                         # Validate symlinks and hardlinks resolve within target
                         if member.issym() or member.islnk():
-                            link_target = os.path.join(
-                                abs_target, member.linkname
+                            link_base = (
+                                os.path.dirname(member_path)
+                                if member.issym()
+                                else abs_target
                             )
-                            if (
-                                os.path.commonpath(
-                                    [abs_target, os.path.abspath(link_target)]
+                            link_target = os.path.abspath(
+                                os.path.join(link_base, member.linkname)
+                            )
+                            try:
+                                is_link_unsafe = (
+                                    os.path.commonpath([abs_target, link_target])
+                                    != abs_target
                                 )
-                                != abs_target
-                            ):
+                            except ValueError:
+                                is_link_unsafe = True
+                            if is_link_unsafe:
                                 raise RuntimeError(
                                     f"Tarfile member {member.name} link attempts path traversal"
                                 )

--- a/python/ray/tune/utils/file_transfer.py
+++ b/python/ray/tune/utils/file_transfer.py
@@ -387,7 +387,43 @@ def _unpack_dir(stream: io.BytesIO, target_dir: str, *, _retry: bool = True) -> 
         # will be thrown.
         with TempFileLock(f"{target_dir}.lock", timeout=0):
             with tarfile.open(fileobj=stream) as tar:
-                tar.extractall(target_dir)
+                if hasattr(tarfile, "data_filter"):
+                    tar.extractall(target_dir, filter="data")
+                else:
+                    # Python < 3.12 fallback: manual member validation
+                    abs_target = os.path.abspath(target_dir)
+                    safe_members = []
+                    for member in tar.getmembers():
+                        # Reject device files and FIFOs (matches data_filter)
+                        if member.isdev() or member.isfifo():
+                            raise RuntimeError(
+                                f"Tarfile member {member.name} is a special file"
+                            )
+                        member_path = os.path.abspath(
+                            os.path.join(abs_target, member.name)
+                        )
+                        if os.path.commonpath([abs_target, member_path]) != abs_target:
+                            raise RuntimeError(
+                                f"Tarfile member {member.name} attempts path traversal"
+                            )
+                        # Validate symlinks and hardlinks resolve within target
+                        if member.issym() or member.islnk():
+                            link_target = os.path.join(
+                                abs_target, member.linkname
+                            )
+                            if (
+                                os.path.commonpath(
+                                    [abs_target, os.path.abspath(link_target)]
+                                )
+                                != abs_target
+                            ):
+                                raise RuntimeError(
+                                    f"Tarfile member {member.name} link attempts path traversal"
+                                )
+                            safe_members.append(member)
+                            continue
+                        safe_members.append(member)
+                    tar.extractall(target_dir, members=safe_members)
     except TimeoutError:
         # wait, but do not do anything
         with TempFileLock(f"{target_dir}.lock"):


### PR DESCRIPTION
## Why

This replaces and supersedes #63696 from a branch I can update with the current GitHub account. It keeps the same focused tar extraction hardening while addressing the bot feedback on the original PR.

## What changed

- Use `filter="data"` where available.
- Add a Python < 3.12 fallback that rejects path-traversing member names, device files, FIFOs, and unsafe symlink/hardlink targets before extraction.
- Validate `member.name` before link-specific checks so symlink/hardlink entries cannot skip the member path boundary check.
- Resolve symlink `linkname` relative to the symlink member's containing directory, while keeping hardlink resolution rooted at the extraction target.
- Add focused regression coverage for a symlink entry whose member name attempts to escape and for a valid subdirectory symlink target.

## Verification

- `python -m ruff check python\ray\dashboard\modules\metrics\install_and_start_prometheus.py python\ray\tune\utils\file_transfer.py python\ray\tune\tests\test_util_file_transfer.py`
- `python -m py_compile python\ray\dashboard\modules\metrics\install_and_start_prometheus.py python\ray\tune\utils\file_transfer.py python\ray\tune\tests\test_util_file_transfer.py`
- `git diff --check`
- standalone fallback validation script for safe subdirectory symlink, escaping member name, and escaping symlink target cases

I could not run the full Ray pytest target locally because this checkout is missing the compiled `ray._raylet` extension.