### PR TITLE
[Data] Preserve right-side join keys for asymmetric Dataset.join

### DIFF
--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -107,10 +107,13 @@ class JoiningAggregation(ShuffleAggregation):
         left_on = list(self._left_key_col_names)
         right_on = list(self._right_key_col_names)
 
+        # Preserve right-side keys when asymmetric so downstream ops can
+        # reference either name; symmetric joins keep the default coalesce.
+        coalesce_keys = left_on == right_on
+
         # Eagerly validate suffix conflicts so callers get a clear error instead
         # of the opaque PyArrow schema-merge error ('Field X exists 2 times').
-        # Skip for semi/anti joins: only one side's columns appear in the result,
-        # so overlapping non-key names between left and right are harmless.
+        # Skip for semi/anti joins: only one side's columns appear in the result.
         if self._join_type not in (
             JoinType.LEFT_SEMI,
             JoinType.LEFT_ANTI,
@@ -118,11 +121,9 @@ class JoiningAggregation(ShuffleAggregation):
             JoinType.RIGHT_ANTI,
         ):
             left_cols = set(left_table.schema.names)
-            # PyArrow drops right key columns from output (coalescing them into
-            # the left keys), so only right non-key columns can collide with
-            # left columns. Subtracting only right_on (not left_on) correctly
-            # handles asymmetric key names (left_on != right_on).
-            right_output_cols = set(right_table.schema.names) - set(right_on)
+            right_output_cols = set(right_table.schema.names)
+            if coalesce_keys:
+                right_output_cols -= set(right_on)
             collisions = left_cols & right_output_cols
             if (
                 self._left_columns_suffix is None
@@ -149,6 +150,7 @@ class JoiningAggregation(ShuffleAggregation):
             right_keys=right_on,
             left_suffix=self._left_columns_suffix,
             right_suffix=self._right_columns_suffix,
+            coalesce_keys=coalesce_keys,
         )
 
         # Add back unsupported columns

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -858,6 +858,49 @@ def test_join_cross_side_column_comparison_no_pushdown(ray_start_regular_shared_
     )
 
 
+def test_asymmetric_join_keys_preserved_in_output(ray_start_regular_shared_2_cpus):
+    """Asymmetric join keys (``left_on != right_on``) must both appear in the
+    output so downstream operators can reference either name."""
+    left = ray.data.range(5).map(lambda r: {"left_id": r["id"], "left_val": 0})
+    right = ray.data.range(5).map(lambda r: {"right_id": r["id"], "right_val": 0})
+
+    joined = left.join(
+        right,
+        join_type="inner",
+        num_partitions=4,
+        on=("left_id",),
+        right_on=("right_id",),
+    )
+
+    schema_names = set(joined.schema().names)
+    assert {"left_id", "right_id", "left_val", "right_val"} == schema_names
+    assert len(joined.select_columns(["right_id"]).take_all()) == 5
+
+
+def test_partial_symmetric_join_requires_suffixes(ray_start_regular_shared_2_cpus):
+    """Multi-key join where one pair is symmetric and another is not: without
+    suffixes the duplicate name must raise; with suffixes it is disambiguated."""
+    left = ray.data.from_items([{"id": i, "country": "US"} for i in range(3)])
+    right = ray.data.from_items([{"user_id": i, "country": "US"} for i in range(3)])
+    join_kwargs = dict(
+        join_type="inner",
+        num_partitions=2,
+        on=("id", "country"),
+        right_on=("user_id", "country"),
+    )
+
+    with pytest.raises(RayTaskError) as exc_info:
+        left.join(right, **join_kwargs).count()
+    assert "Left and right columns suffixes cannot be both None" in str(
+        exc_info.value.cause
+    )
+
+    joined = left.join(right, left_suffix="_l", right_suffix="_r", **join_kwargs)
+    assert {"id", "country_l", "user_id", "country_r"}.issubset(
+        set(joined.schema().names)
+    )
+
+
 def test_chained_left_outer_join_with_empty_blocks(ray_start_regular_shared_2_cpus):
     """Regression test for https://github.com/ray-project/ray/issues/60013.
 


### PR DESCRIPTION
## Description

`Dataset.join` with asymmetric keys (`on != right_on`) silently dropped the right-side key from the output because PyArrow's `Table.join` defaults to `coalesce_keys=True`. Downstream operators referencing the right key (filters, projections, TPC-H Q5) failed with `KeyError`.

This PR sets `coalesce_keys=False` exactly when keys are asymmetric, so both key columns are preserved. Symmetric joins keep the original coalesce semantics (backward compatible). The suffix collision check is extended so partial-symmetric multi-key joins without user-provided suffixes raise the existing clear error rather than producing a duplicate-name schema.

## Related issues

Closes #62846

## Additional information

Behavior matrix:

| `on` vs `right_on` | Before | After |
|---|---|---|
| Symmetric (`("id",) == ("id",)`) | 1 `id` column | 1 `id` column (unchanged) |
| Fully asymmetric (`("a",) vs ("b",)`) | right key dropped, downstream `KeyError` | both `a` and `b` in output |
| Partial symmetric without suffix | silently drops one side | raises existing "suffixes cannot be both None" |
| Partial symmetric with suffix | silently drops one side | columns disambiguated via suffix |
| Semi/anti joins | unchanged | unchanged (`coalesce_keys` is no-op for these) |

Two regression tests added to `test_join.py` covering the asymmetric and partial-symmetric paths.