### PR TITLE
[AIR] Fix MLflow artifact logging path

### DIFF
--- a/python/ray/air/integrations/mlflow.py
+++ b/python/ray/air/integrations/mlflow.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import shutil
+import tempfile
 from types import ModuleType
 from typing import Dict, Optional, Union
 
@@ -6,6 +9,7 @@ import ray
 from ray.air._internal import usage as air_usage
 from ray.air._internal.mlflow import _MLflowLoggerUtil
 from ray.air.constants import TRAINING_ITERATION
+from ray.train._internal.storage import _download_from_fs_path
 from ray.tune.experiment import Trial
 from ray.tune.logger import LoggerCallback
 from ray.tune.result import TIMESTEPS_TOTAL
@@ -226,7 +230,7 @@ class MLflowLoggerCallback(LoggerCallback):
             as tags on the run
         tracking_token: Tracking token used to authenticate with MLflow.
         save_artifact: If set to True, automatically save the entire
-            contents of the Tune local_dir as an artifact to the
+            contents of the Tune trial directory as an artifact to the
             corresponding run in MlFlow.
         log_params_on_trial_end: If set to True, log parameters to MLflow
             at the end of the trial instead of at the beginning
@@ -330,7 +334,7 @@ class MLflowLoggerCallback(LoggerCallback):
 
         # Log the artifact if set_artifact is set to True.
         if self.should_save_artifact:
-            self.mlflow_util.save_artifacts(run_id=run_id, dir=trial.local_path)
+            self._save_trial_artifacts(run_id=run_id, trial=trial)
 
         # Stop the run once trial finishes.
         status = "FINISHED" if not failed else "FAILED"
@@ -341,3 +345,31 @@ class MLflowLoggerCallback(LoggerCallback):
             self.mlflow_util.log_params(run_id=run_id, params_to_log=config)
 
         self.mlflow_util.end_run(run_id=run_id, status=status)
+
+    def _save_trial_artifacts(self, run_id: str, trial: "Trial"):
+        artifact_path = trial.path or trial.local_path
+        local_path = trial.local_path
+        fs = getattr(trial.storage, "storage_filesystem", None)
+
+        if local_path and local_path != artifact_path:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                self._copy_artifacts_to_local_dir(artifact_path, fs, tmpdir)
+                self._copy_artifacts_to_local_dir(local_path, None, tmpdir)
+                self.mlflow_util.save_artifacts(run_id=run_id, dir=tmpdir)
+            return
+
+        self.mlflow_util.save_artifacts(run_id=run_id, dir=artifact_path)
+
+    def _copy_artifacts_to_local_dir(self, path: str, fs, local_dir: str):
+        if fs and fs.type_name != "local":
+            try:
+                _download_from_fs_path(
+                    fs=fs,
+                    fs_path=path,
+                    local_path=local_dir,
+                    filelock=False,
+                )
+            except FileNotFoundError:
+                logger.debug("Trial artifact path %s does not exist.", path)
+        elif os.path.isdir(path):
+            shutil.copytree(path, local_dir, dirs_exist_ok=True)

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from mlflow.tracking import MlflowClient
+from pyarrow.fs import LocalFileSystem
 
 import ray
 from ray._private.dict import flatten_dict
@@ -17,8 +18,16 @@ from ray.train.torch import TorchTrainer
 from ray.tune import Tuner
 
 
+class MockStorage:
+    def __init__(self, storage_filesystem=None):
+        self.storage_filesystem = storage_filesystem or LocalFileSystem()
+
+
 class MockTrial(
-    namedtuple("MockTrial", ["config", "trial_name", "trial_id", "local_path"])
+    namedtuple(
+        "MockTrial",
+        ["config", "trial_name", "trial_id", "local_path", "path", "storage"],
+    )
 ):
     def __hash__(self):
         return hash(self.trial_id)
@@ -27,10 +36,35 @@ class MockTrial(
         return self.trial_name
 
 
+def make_mock_trial(
+    config,
+    trial_name="trial1",
+    trial_id=0,
+    local_path="local_artifact",
+    path="persistent_artifact",
+    storage=None,
+):
+    return MockTrial(
+        config,
+        trial_name,
+        trial_id,
+        local_path,
+        path,
+        storage or MockStorage(),
+    )
+
+
 class Mock_MLflowLoggerUtil(_MLflowLoggerUtil):
     def save_artifacts(self, dir, run_id):
         self.artifact_saved = True
         self.artifact_info = {"dir": dir, "run_id": run_id}
+        self.artifact_files = []
+        if os.path.isdir(dir):
+            for root, _, files in os.walk(dir):
+                self.artifact_files.extend(
+                    os.path.relpath(os.path.join(root, file), dir) for file in files
+                )
+            self.artifact_files.sort()
 
 
 def clear_env_vars():
@@ -181,7 +215,20 @@ class MLflowTest(unittest.TestCase):
     def testMlFlowLoggerLogging(self):
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
-        trial = MockTrial(trial_config, "trial1", 0, "artifact")
+        local_artifact_dir = tempfile.mkdtemp()
+        persistent_artifact_dir = tempfile.mkdtemp()
+        with open(os.path.join(local_artifact_dir, "result.json"), "w") as f:
+            f.write("{}")
+        os.makedirs(os.path.join(persistent_artifact_dir, "checkpoint_000001"))
+        with open(
+            os.path.join(persistent_artifact_dir, "checkpoint_000001", "data.pkl"), "w"
+        ) as f:
+            f.write("checkpoint")
+        trial = make_mock_trial(
+            trial_config,
+            local_path=local_artifact_dir,
+            path=persistent_artifact_dir,
+        )
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -229,9 +276,14 @@ class MLflowTest(unittest.TestCase):
         # Check that artifact is logged on termination.
         logger.on_trial_complete(0, [], trial)
         self.assertTrue(logger.mlflow_util.artifact_saved)
-        self.assertDictEqual(
-            logger.mlflow_util.artifact_info,
-            {"dir": "artifact", "run_id": run.info.run_id},
+        self.assertEqual(logger.mlflow_util.artifact_info["run_id"], run.info.run_id)
+        self.assertNotEqual(logger.mlflow_util.artifact_info["dir"], local_artifact_dir)
+        self.assertNotEqual(
+            logger.mlflow_util.artifact_info["dir"], persistent_artifact_dir
+        )
+        self.assertEqual(
+            logger.mlflow_util.artifact_files,
+            ["checkpoint_000001/data.pkl", "result.json"],
         )
 
         # Check if params are logged at the end.
@@ -242,7 +294,7 @@ class MLflowTest(unittest.TestCase):
     def testMlFlowLoggerLogging_logAtEnd(self):
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
-        trial = MockTrial(trial_config, "trial1", 0, "artifact")
+        trial = make_mock_trial(trial_config)
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -268,6 +320,119 @@ class MLflowTest(unittest.TestCase):
         logger.on_trial_complete(0, [], trial)
         run = logger.mlflow_util._mlflow.get_run(run_id=run.info.run_id)
         self.assertDictEqual(run.data.params, trial_config)
+
+    @patch("ray.air.integrations.mlflow._download_from_fs_path")
+    @patch("ray.air.integrations.mlflow._MLflowLoggerUtil", Mock_MLflowLoggerUtil)
+    def testMlFlowLoggerDownloadsRemoteArtifacts(self, mock_download):
+        clear_env_vars()
+
+        def fake_download(local_path, **kwargs):
+            del kwargs
+            os.makedirs(os.path.join(local_path, "checkpoint_000001"))
+            with open(
+                os.path.join(local_path, "checkpoint_000001", "data.pkl"), "w"
+            ) as f:
+                f.write("checkpoint")
+
+        mock_download.side_effect = fake_download
+        trial_config = {"par1": "a", "par2": "b"}
+        remote_fs = MagicMock()
+        remote_fs.type_name = "mock_remote"
+        local_artifact_dir = tempfile.mkdtemp()
+        with open(os.path.join(local_artifact_dir, "result.json"), "w") as f:
+            f.write("{}")
+        trial = make_mock_trial(
+            trial_config,
+            local_path=local_artifact_dir,
+            path="remote/trial",
+            storage=MockStorage(remote_fs),
+        )
+
+        logger = MLflowLoggerCallback(
+            tracking_uri=self.tracking_uri,
+            registry_uri=self.registry_uri,
+            experiment_name="test_remote_artifacts",
+            save_artifact=True,
+        )
+        logger.setup()
+        logger.on_trial_start(iteration=0, trials=[], trial=trial)
+        run_id = logger._trial_runs[trial]
+
+        logger.on_trial_complete(0, [], trial)
+
+        mock_download.assert_called_once()
+        _, kwargs = mock_download.call_args
+        self.assertEqual(kwargs["fs"], remote_fs)
+        self.assertEqual(kwargs["fs_path"], "remote/trial")
+        self.assertFalse(kwargs["filelock"])
+        self.assertTrue(logger.mlflow_util.artifact_saved)
+        self.assertEqual(logger.mlflow_util.artifact_info["run_id"], run_id)
+        self.assertNotEqual(logger.mlflow_util.artifact_info["dir"], local_artifact_dir)
+        self.assertNotEqual(logger.mlflow_util.artifact_info["dir"], "remote/trial")
+        self.assertEqual(
+            logger.mlflow_util.artifact_files,
+            ["checkpoint_000001/data.pkl", "result.json"],
+        )
+
+    @patch("ray.air.integrations.mlflow._download_from_fs_path")
+    @patch("ray.air.integrations.mlflow._MLflowLoggerUtil", Mock_MLflowLoggerUtil)
+    def testMlFlowLoggerHandlesMissingRemoteArtifacts(self, mock_download):
+        clear_env_vars()
+        mock_download.side_effect = FileNotFoundError
+        trial_config = {"par1": "a", "par2": "b"}
+        remote_fs = MagicMock()
+        remote_fs.type_name = "mock_remote"
+        local_artifact_dir = tempfile.mkdtemp()
+        with open(os.path.join(local_artifact_dir, "result.json"), "w") as f:
+            f.write("{}")
+        trial = make_mock_trial(
+            trial_config,
+            local_path=local_artifact_dir,
+            path="remote/trial",
+            storage=MockStorage(remote_fs),
+        )
+
+        logger = MLflowLoggerCallback(
+            tracking_uri=self.tracking_uri,
+            registry_uri=self.registry_uri,
+            experiment_name="test_missing_remote_artifacts",
+            save_artifact=True,
+        )
+        logger.setup()
+        logger.on_trial_start(iteration=0, trials=[], trial=trial)
+        logger.on_trial_complete(0, [], trial)
+
+        mock_download.assert_called_once()
+        self.assertTrue(logger.mlflow_util.artifact_saved)
+        self.assertEqual(logger.mlflow_util.artifact_files, ["result.json"])
+
+    @patch("ray.air.integrations.mlflow._MLflowLoggerUtil", Mock_MLflowLoggerUtil)
+    def testMlFlowLoggerSkipsLocalArtifactFile(self):
+        clear_env_vars()
+        trial_config = {"par1": "a", "par2": "b"}
+        local_artifact_dir = tempfile.mkdtemp()
+        with open(os.path.join(local_artifact_dir, "result.json"), "w") as f:
+            f.write("{}")
+        local_artifact_file = tempfile.NamedTemporaryFile(delete=False)
+        local_artifact_file.close()
+        trial = make_mock_trial(
+            trial_config,
+            local_path=local_artifact_file.name,
+            path=local_artifact_dir,
+        )
+
+        logger = MLflowLoggerCallback(
+            tracking_uri=self.tracking_uri,
+            registry_uri=self.registry_uri,
+            experiment_name="test_local_artifact_file",
+            save_artifact=True,
+        )
+        logger.setup()
+        logger.on_trial_start(iteration=0, trials=[], trial=trial)
+        logger.on_trial_complete(0, [], trial)
+
+        self.assertTrue(logger.mlflow_util.artifact_saved)
+        self.assertEqual(logger.mlflow_util.artifact_files, ["result.json"])
 
     def testMlFlowSetupExplicit(self):
         clear_env_vars()


### PR DESCRIPTION
## Description
Fixes #46569.

`MLflowLoggerCallback(save_artifact=True)` currently logs `trial.local_path`, which points to the driver staging directory and can omit checkpoints written to persistent trial storage. This changes artifact logging to merge the persistent trial directory (`trial.path`) with the fresh local staging directory (`trial.local_path`) before uploading to MLflow.

For remote storage, the callback downloads persistent trial artifacts into a temporary directory, overlays local staged artifacts, and tolerates a missing remote trial directory so short trials can still log local artifacts and close the MLflow run.

## Related issues
Fixes #46569

## Additional information
Validation run locally:

- `python3 -m py_compile python/ray/air/integrations/mlflow.py python/ray/air/tests/test_integration_mlflow.py`
- `git diff --check`
- `uvx ruff check python/ray/air/integrations/mlflow.py python/ray/air/tests/test_integration_mlflow.py`
- `uvx black --check python/ray/air/integrations/mlflow.py python/ray/air/tests/test_integration_mlflow.py`
- Isolated Python behavior check with Ray module stubs for merged local/persistent artifact paths, remote storage download plus local staging overlay, and missing remote path fallback to local staged artifacts.

I could not run the focused pytest in this sparse source worktree because it does not include a built `ray._raylet`, and the default Python environment does not have `pytest` installed.
