### PR TITLE
[autoscaler] Fix floating-point formatting in resource usage display

### DIFF
--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -614,6 +614,16 @@ def format_memory(mem_bytes: Number) -> str:
     return f"{int(mem_bytes)}B"
 
 
+def format_resource(value: Number) -> str:
+    """Formats a resource value to be more human readable.
+    It removes trailing zeros and limits precision to avoid floating point
+    artifacts.
+    """
+    if isinstance(value, Real):
+        return f"{value:g}"
+    return str(value)
+
+
 def parse_usage(usage: Usage, verbose: bool) -> List[str]:
     # first collect resources used in placement groups
     placement_group_resource_usage = {}
@@ -667,10 +677,15 @@ def parse_usage(usage: Usage, verbose: bool) -> List[str]:
             # https://github.com/ray-project/ray/issues/33272
             pass
         else:
-            line = f"{used}/{total} {resource}"
+            formatted_used = format_resource(used)
+            formatted_total = format_resource(total)
+            line = f"{formatted_used}/{formatted_total} {resource}"
             if used_in_pg:
+                formatted_pg_used = format_resource(pg_used)
+                formatted_pg_total = format_resource(pg_total)
                 line += (
-                    f" ({pg_used} used of " f"{pg_total} reserved in placement groups)"
+                    f" ({formatted_pg_used} used of "
+                    f"{formatted_pg_total} reserved in placement groups)"
                 )
             usage_lines.append(line)
     return usage_lines
@@ -1003,10 +1018,12 @@ def format_no_node_type_string(node_type: dict):
 
     output_lines = [""]
     for resource, total in regular_resource_usage.items():
-        output_line = f"{resource}: {total}"
+        formatted_total = format_resource(total)
+        output_line = f"{resource}: {formatted_total}"
         if resource in placement_group_resource_usage:
             pg_resource = placement_group_resource_usage[resource]
-            output_line += f" ({pg_resource} reserved in placement groups)"
+            formatted_pg_resource = format_resource(pg_resource)
+            output_line += f" ({formatted_pg_resource} reserved in placement groups)"
         output_lines.append(output_line)
 
     return "\n  ".join(output_lines)

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -614,12 +614,17 @@ def format_memory(mem_bytes: Number) -> str:
     return f"{int(mem_bytes)}B"
 
 
-def format_resource(value: Number) -> str:
-    """Formats a resource value to be more human readable.
-    It removes trailing zeros and limits precision to avoid floating point
-    artifacts.
-    """
+def format_resource(value):
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int):
+        return str(value)
     if isinstance(value, Real):
+        try:
+            if float(value).is_integer():
+                return str(int(value))
+        except (ValueError, OverflowError):
+            pass
         return f"{value:g}"
     return str(value)
 

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -41,6 +41,7 @@ def test_parse_usage_formatting():
     assert "1.00MiB/2.00MiB memory" in lines
     assert "0.01/1 special_hardware" in lines
 
+
 def test_with_envs():
     assert with_envs(
         ["echo $RAY_HEAD_IP", "ray start"], {"RAY_HEAD_IP": "127.0.0.0"}

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -18,6 +18,10 @@ def test_format_resource():
     assert format_resource(123.456) == "123.456"
     assert format_resource(123.0) == "123"
     assert format_resource(0) == "0"
+    assert format_resource(123456789) == "123456789"
+    assert format_resource(123456789.0) == "123456789"
+    assert format_resource(1000000.0) == "1000000"
+    assert format_resource(1000000) == "1000000"
 
 
 def test_parse_usage_formatting():

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -2,8 +2,40 @@ import sys
 
 import pytest
 
-from ray.autoscaler._private.util import with_envs, with_head_node_ip
+from ray.autoscaler._private.util import (
+    format_resource,
+    parse_usage,
+    with_envs,
+    with_head_node_ip,
+)
 
+
+def test_format_resource():
+    assert format_resource(1.0) == "1"
+    assert format_resource(0.010000000000000009) == "0.01"
+    assert format_resource(0.0001) == "0.0001"
+    assert format_resource(0.00999999999) == "0.01"
+    assert format_resource(123.456) == "123.456"
+    assert format_resource(123.0) == "123"
+    assert format_resource(0) == "0"
+
+
+def test_parse_usage_formatting():
+    usage = {
+        "CPU": (0.010000000000000009, 1.0),
+        "special_hardware": (0.010000000000000009, 1.0),
+        "memory": (1024 * 1024, 1024 * 1024 * 2),
+    }
+
+    lines = parse_usage(usage, verbose=False)
+    # Expected lines (sorted by resource name):
+    # 0.01/1 CPU
+    # 1.00MiB/2.00MiB memory
+    # 0.01/1 special_hardware
+
+    assert "0.01/1 CPU" in lines
+    assert "1.00MiB/2.00MiB memory" in lines
+    assert "0.01/1 special_hardware" in lines
 
 def test_with_envs():
     assert with_envs(


### PR DESCRIPTION
Fixes #42491

## Description

This PR improves the formatting of resource usage values displayed in Ray autoscaler output (`ray status` and related utilities).

Previously, floating-point precision artifacts (e.g. `0.010000000000000009`) could appear in resource usage output. This change introduces a `format_resource()` helper to normalize numeric values into human-readable strings by removing floating-point noise while preserving precision where needed.

The updated formatting is applied consistently across:

- `parse_usage()` (resource usage display)
- placement group resource reporting
- node type resource summaries

Additionally, tests were added to validate correct formatting behavior and ensure consistent output across edge cases.

## Key changes

- Added `format_resource()` utility using Python’s `g` format specifier
- Updated `parse_usage()` to format:
  - used / total resource values
  - placement group resource values
- Updated node type formatting output for consistency

---

## Test coverage

Added tests:

- `test_format_resource()` → validates float formatting edge cases  
- `test_parse_usage_formatting()` → ensures consistent formatted output across CPU, memory, and custom resources  


## Example improvement

Before:
0.010000000000000009/1 special_hardware


After:
0.01/1 special_hardware

## Impact

This change improves readability of `ray status` output without affecting functionality or resource accounting logic.