### PR TITLE
[Data] Release permanently dead actors from ActorPool

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -869,7 +869,8 @@ class _ActorPool(AutoscalingActorPool):
     @override
     def refresh_actor_state(self):
         self._alive_node_to_actor_heap.clear()
-        for actor in self._running_actors:
+        # Copy: dead actors may be released mid-iteration.
+        for actor in list(self._running_actors):
             self._update_running_actor_state(actor)
 
     @override
@@ -1004,6 +1005,9 @@ class _ActorPool(AutoscalingActorPool):
     @override
     def on_task_completed(self, actor: ActorHandle):
         """Called when a task completes. Returns the provided actor to the pool."""
+        if actor not in self._running_actors:
+            # Actor was already released (e.g. dead-actor cleanup ran first).
+            return
         state = self._running_actors[actor]
         assert state.num_tasks_in_flight > 0
         state.num_tasks_in_flight -= 1
@@ -1063,7 +1067,7 @@ class _ActorPool(AutoscalingActorPool):
         self._actor_to_logical_id[actor] = logical_actor_id
         return actor, ready_ref, resource_usage
 
-    def _update_running_actor_state(self, actor: ActorHandle):
+    def _update_running_actor_state(self, actor: ActorHandle) -> None:
         """Update running actor state. This is called for every actor
         in `refresh_actor_state`.
 
@@ -1075,10 +1079,13 @@ class _ActorPool(AutoscalingActorPool):
         # 1) Check if actor is restarting
         running_actor_state = self._running_actors[actor]
         died: bool = False
-        if actor_state in (None, _ACTOR_STATE_DEAD):
-            # actor._get_local_state can return None if the state is Unknown
-            # If actor_state is None or dead, there is nothing to do.
+        if actor_state is None:
+            # Unknown state (transient); leave the actor tracked.
             died = True
+        elif actor_state == _ACTOR_STATE_DEAD:
+            # Permanently dead -- autoscaler will replace it.
+            self._release_dead_actor(actor)
+            return
         elif actor_state != _ACTOR_STATE_ALIVE:
             # The actors can be either ALIVE or RESTARTING here because they will
             # be restarted indefinitely until execution finishes.
@@ -1124,6 +1131,15 @@ class _ActorPool(AutoscalingActorPool):
             node_heap = self._alive_node_to_actor_heap.get(node_id)
             if node_heap is not None and actor in node_heap:
                 del node_heap[actor]
+
+    def _release_dead_actor(self, actor: ActorHandle) -> None:
+        """Release a permanently dead actor so the autoscaler can replace it."""
+        if actor not in self._running_actors:
+            return
+        self._release_running_actor(actor)
+        logger.info(
+            f"Removed dead actor from pool (pool_size={len(self._running_actors)})"
+        )
 
     def _add_pending_actor(
         self,

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -1370,6 +1370,7 @@ def test_dead_actor_replaced_in_fixed_size_pool(shutdown_only, restore_data_cont
     """Test that a fixed-size actor pool replaces a permanently dead actor."""
     import concurrent.futures
 
+    ray.shutdown()
     ray.init(num_cpus=2)
     ray.data.DataContext.get_current().max_errored_blocks = -1
 

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -356,6 +356,67 @@ class TestActorPool(unittest.TestCase):
             tasks_in_flight=0,
         )
 
+    def test_dead_actor_released_from_pool(self):
+        # Test that a permanently DEAD actor is removed from the pool.
+        pool = self._create_actor_pool(min_size=1, max_size=1, max_tasks_in_flight=1)
+        actor = self._add_ready_actor(pool)
+        assert self._assign_actor(pool) == actor
+        assert pool.num_running_actors() == 1
+        assert pool.num_active_actors() == 1
+
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.DEAD,
+        ):
+            pool.refresh_actor_state()
+
+        assert pool.current_size() == 0
+        assert pool.num_running_actors() == 0
+        assert pool.num_active_actors() == 0
+
+    def test_dead_restarting_actor_released_from_pool(self):
+        # Test that RESTARTING -> DEAD transitions release counters cleanly.
+        pool = self._create_actor_pool(min_size=1, max_size=1, max_tasks_in_flight=1)
+        actor = self._add_ready_actor(pool)
+
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
+        assert pool.num_restarting_actors() == 1
+
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.DEAD,
+        ):
+            pool.refresh_actor_state()
+
+        assert pool.num_restarting_actors() == 0
+        assert pool.num_running_actors() == 0
+        assert pool.current_size() == 0
+
+    def test_on_task_completed_after_dead_actor_released(self):
+        # Test that on_task_completed is a no-op for already-released actors.
+        pool = self._create_actor_pool(min_size=1, max_size=1, max_tasks_in_flight=1)
+        actor = self._add_ready_actor(pool)
+        assert self._assign_actor(pool) == actor
+
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.DEAD,
+        ):
+            pool.refresh_actor_state()
+        assert pool.num_running_actors() == 0
+
+        pool.on_task_completed(actor)
+        assert pool.num_running_actors() == 0
+        assert pool.num_active_actors() == 0
+
     def test_repeated_picking(self):
         # Test that we can repeatedly pick the same actor.
         pool = self._create_actor_pool(max_tasks_in_flight=999)
@@ -1303,6 +1364,47 @@ def test_completed_when_downstream_op_has_finished_execution(ray_start_regular_s
     # ASSERT: Since the downstream operator has finished execution, the actor pool
     # operator should consider itself completed.
     assert actor_pool_map_op.has_completed()
+
+
+def test_dead_actor_replaced_in_fixed_size_pool(shutdown_only, restore_data_context):
+    """Test that a fixed-size actor pool replaces a permanently dead actor."""
+    import concurrent.futures
+
+    ray.init(num_cpus=2)
+    ray.data.DataContext.get_current().max_errored_blocks = -1
+
+    class DyingPredictor:
+        def __init__(self):
+            self.counter = 0
+
+        def __call__(self, batch):
+            import sys
+
+            self.counter += 1
+            if self.counter == 3:
+                sys.exit(0)
+            batch["output"] = [x * 2 for x in batch["data"]]
+            return batch
+
+    def run():
+        return (
+            ray.data.from_items([{"data": i} for i in range(100)])
+            .map_batches(
+                DyingPredictor,
+                batch_size=1,
+                compute=ray.data.ActorPoolStrategy(size=1),
+            )
+            .take_all()
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(run)
+        try:
+            result = future.result(timeout=120)
+        except concurrent.futures.TimeoutError:
+            pytest.fail("Pipeline hung; dead actor was not released from the pool")
+
+    assert len(result) > 0
 
 
 def test_actor_pool_fault_tolerance_e2e(ray_start_cluster, restore_data_context):


### PR DESCRIPTION
## Description

When an actor exits with `INTENDED_USER_EXIT` (e.g. `sys.exit(0)`), Ray marks it permanently DEAD bypassing `max_restarts`. `_ActorPool` kept the dead actor in `_running_actors`, so the autoscaler saw the pool at capacity and never created a replacement. With `max_errored_blocks=-1` the pipeline silently hangs forever.

`refresh_actor_state` now releases dead actors via `_release_dead_actor`, which delegates to `_release_running_actor` for cleanup. `on_task_completed` is guarded against the race where dead-actor cleanup runs before the in-flight task callback.

## Related issues

Closes #62746

## Additional information

- Three unit tests cover the state-machine paths (release on DEAD, RESTARTING -> DEAD transition, race-condition guard) 
- One integration test reproduces the exact scenario from the issue (`sys.exit(0)` in UDF + `ActorPoolStrategy(size=1)` + `max_errored_blocks=-1`) under a 120s timeout.