### PR TITLE
[Data] Add path_column support to ParquetDatasource

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -393,6 +393,7 @@ class ParquetDatasource(Datasource):
         shuffle: "FileShuffleConfig" | Literal["files"] | None = None,
         include_paths: bool = False,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
         file_extensions: Optional[List[str]] = None,
     ):
         super().__init__()
@@ -536,6 +537,7 @@ class ParquetDatasource(Datasource):
             shuffle=shuffle,
             include_paths=include_paths,
             include_row_hash=include_row_hash,
+            path_column=path_column,
         )
 
     def _init_state(
@@ -559,6 +561,7 @@ class ParquetDatasource(Datasource):
         shuffle: Union["FileShuffleConfig", Literal["files"], None],
         include_paths: bool,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
     ):
         """Shared initialization for all instance state and sampling estimates.
 
@@ -592,6 +595,8 @@ class ParquetDatasource(Datasource):
         self._file_metadata_shuffler = None
         self._include_paths = include_paths
         self._include_row_hash = include_row_hash
+        # Normalize path_column to default value 'path' if not specified
+        self._path_column = path_column if path_column is not None else "path"
         self._partitioning = partitioning
         _validate_shuffle_arg(shuffle)
         self._shuffle = shuffle
@@ -651,6 +656,7 @@ class ParquetDatasource(Datasource):
         shuffle: "FileShuffleConfig" | Literal["files"] | None = None,
         include_paths: bool = False,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
     ) -> "ParquetDatasource":
         """Create a ParquetDatasource from a pre-built PyArrow dataset.
 
@@ -711,14 +717,15 @@ class ParquetDatasource(Datasource):
             partition_columns_selected=False,
             partition_schema=pa.schema([]),
             partitioning=None,
-            projection_map={col: col for col in columns}
-            if columns is not None
-            else None,
+            projection_map=(
+                {col: col for col in columns} if columns is not None else None
+            ),
             to_batch_kwargs=to_batch_kwargs,
             _block_udf=_block_udf,
             shuffle=shuffle,
             include_paths=include_paths,
             include_row_hash=include_row_hash,
+            path_column=path_column,
         )
 
     @property
@@ -797,6 +804,7 @@ class ParquetDatasource(Datasource):
             _block_udf=self._block_udf,
             include_paths=self._include_paths,
             include_row_hash=self._include_row_hash,
+            path_column=self._path_column,
         )
 
         read_tasks = []
@@ -831,6 +839,7 @@ class ParquetDatasource(Datasource):
                 read_schema,
                 include_paths,
                 include_row_hash,
+                path_column,
                 partitioning,
             ) = (
                 self._block_udf,
@@ -840,6 +849,7 @@ class ParquetDatasource(Datasource):
                 self._read_schema,
                 self._include_paths,
                 self._include_row_hash,
+                self._path_column,
                 self._partitioning,
             )
 
@@ -859,6 +869,7 @@ class ParquetDatasource(Datasource):
                         filter_expr,
                         filter_columns,
                         allow_pickle,
+                        path_column,
                     ),
                     meta,
                     schema=target_schema,
@@ -898,8 +909,8 @@ class ParquetDatasource(Datasource):
             # If include_paths is True, make sure to include the path column in the projection
             # NOTE: When result is None (no projection), the path column is already added
             #       via _derive_schema, so we only need to add it when there is a projection.
-            if self._include_paths and "path" not in result:
-                result = result + ["path"]
+            if self._include_paths and self._path_column not in result:
+                result = result + [self._path_column]
             if self._include_row_hash and "row_hash" not in result:
                 result = result + ["row_hash"]
 
@@ -965,7 +976,7 @@ class ParquetDatasource(Datasource):
         # added after reading from the file
         cols_to_filter = set(partition_cols)
         if self._include_paths:
-            cols_to_filter.add("path")
+            cols_to_filter.add(self._path_column)
         if self._include_row_hash:
             cols_to_filter.add("row_hash")
         data_cols = [
@@ -1056,6 +1067,7 @@ class ParquetDatasource(Datasource):
         _block_udf,
         include_paths: bool = False,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
     ) -> "pyarrow.Schema":
         """Derives target schema for read operation"""
 
@@ -1085,9 +1097,13 @@ class ParquetDatasource(Datasource):
                 metadata=file_schema.metadata,
             )
 
-        # Add path column if include_paths is True and path column is not already present
-        if include_paths and target_schema.get_field_index("path") == -1:
-            target_schema = target_schema.append(pa.field("path", pa.string()))
+        # Add path column if include_paths is True
+        # Use custom path_column name if provided, otherwise default to "path"
+        if include_paths:
+            path_col = path_column if path_column is not None else "path"
+            # Only add the path column if it doesn't already exist in the schema
+            if target_schema.get_field_index(path_col) == -1:
+                target_schema = target_schema.append(pa.field(path_col, pa.string()))
 
         if include_row_hash:
             idx = target_schema.get_field_index("row_hash")
@@ -1157,6 +1173,7 @@ def read_fragments(
     filter_expr: Optional["pyarrow.dataset.Expression"] = None,
     filter_columns: Optional[List[str]] = None,
     allow_pickle: bool = False,
+    path_column: Optional[str] = None,
 ) -> Iterator["pyarrow.Table"]:
     """Yield Arrow tables from Parquet fragments via ``to_batches_kwargs``."""
     # This import is necessary to load the tensor extension type.
@@ -1179,6 +1196,7 @@ def read_fragments(
                 partitioning=partitioning,
                 include_path=include_paths,
                 include_row_hash=include_row_hash,
+                path_column=path_column,
                 filter_expr=filter_expr,
                 filter_columns=filter_columns,
                 to_batches_kwargs=to_batches_kwargs,
@@ -1544,6 +1562,7 @@ def _read_batches_from(
     filter_columns: Optional[List[str]] = None,
     include_path: bool = False,
     include_row_hash: bool = False,
+    path_column: Optional[str] = None,
     use_threads: bool = False,
     to_batches_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Iterable["pyarrow.Table"]:
@@ -1552,6 +1571,7 @@ def _read_batches_from(
     Row batching is controlled via ``to_batches_kwargs["batch_size"]`` (when
     present), which is coerced to values PyArrow accepts as a C ``int``.
     """
+    path_column = path_column or "path"
 
     import pyarrow as pa
 
@@ -1593,7 +1613,7 @@ def _read_batches_from(
 
             if include_path:
                 table = ArrowBlockAccessor.for_block(table).fill_column(
-                    "path", fragment.path
+                    path_column, fragment.path
                 )
 
             # ``ParquetFileFragment.to_batches`` returns ``RecordBatch``,

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -76,6 +76,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         ignore_missing_paths: bool = False,
         include_paths: bool = False,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
         shuffle: Optional[Union[Literal["files"], "FileShuffleConfig"]] = None,
         arrow_parquet_args: Optional[dict] = None,
         schema: Optional[pa.Schema] = None,
@@ -100,6 +101,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         self._ignore_missing_paths = ignore_missing_paths
         self._include_paths = include_paths
         self._include_row_hash = include_row_hash
+        self._path_column = path_column
         self._shuffle = shuffle
         self._arrow_parquet_args = arrow_parquet_args or {}
         # ``pds.ParquetFileFormat`` kwargs forwarded from the deprecated
@@ -143,6 +145,10 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
     @property
     def include_paths(self) -> bool:
         return self._include_paths
+
+    @property
+    def path_column(self) -> Optional[str]:
+        return self._path_column
 
     @property
     def shuffle(self) -> Optional[Union[Literal["files"], "FileShuffleConfig"]]:
@@ -266,11 +272,13 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
                     pa_type = partition_pa_schema.field(field_name).type
                     schema = schema.append(pa.field(field_name, pa_type))
 
-        if (
-            self._include_paths
-            and schema.get_field_index(INCLUDE_PATHS_COLUMN_NAME) == -1
-        ):
-            schema = schema.append(pa.field(INCLUDE_PATHS_COLUMN_NAME, pa.string()))
+        path_col = (
+            self._path_column
+            if self._path_column is not None
+            else INCLUDE_PATHS_COLUMN_NAME
+        )
+        if self._include_paths and schema.get_field_index(path_col) == -1:
+            schema = schema.append(pa.field(path_col, pa.string()))
 
         if self._include_row_hash:
             # ``row_hash`` is synthesized post-read as ``uint64``. Replace
@@ -302,6 +310,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
             partitioning=partitioning,
             include_paths=self._include_paths,
             include_row_hash=self._include_row_hash,
+            path_column=self._path_column,
             shuffle=self._shuffle,
             ignore_prefixes=options.get("ignore_prefixes"),
             target_block_size=DataContext.get_current().target_max_block_size,

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -77,6 +77,7 @@ class FileReader(Reader[FileManifest]):
         ignore_prefixes: Optional[List[str]] = None,
         include_paths: bool = False,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
         schema: Optional[pa.Schema] = None,
     ):
         """Initialize the reader.
@@ -95,13 +96,16 @@ class FileReader(Reader[FileManifest]):
                 batch is read, producing string-typed columns (V1 parity).
             ignore_prefixes: Prefixes to ignore when reading files. Default is ['.', '_'] set by PyArrow.
             include_paths: If True, include the source file path in a
-                ``'path'`` column for each row.
+                ``'path'`` column (or the column specified by ``path_column``)
+                for each row.
             include_row_hash: If True, include a deterministic uint64 hash
                 per row in a ``'row_hash'`` column. The hash is derived from
                 the source file path and the row's post-filter output
                 position within the fragment, matching V1 semantics. If a
                 ``'row_hash'`` column already exists in the file, it is
                 overwritten.
+            path_column: The name of the column to store file paths when
+                ``include_paths`` is True. Defaults to ``'path'``.
             schema: Caller-supplied unified schema used both to override
                 pyarrow's per-fragment inference (so a file whose column
                 is all-null doesn't pin the type to ``null``) and to cast
@@ -121,6 +125,7 @@ class FileReader(Reader[FileManifest]):
         self._ignore_prefixes = ignore_prefixes
         self._include_paths = include_paths
         self._include_row_hash = include_row_hash
+        self._path_column = path_column
         self._schema = schema
 
     @cached_property
@@ -156,7 +161,12 @@ class FileReader(Reader[FileManifest]):
             if self._partition_parser is not None
             else set()
         )
-        synthesized = {INCLUDE_PATHS_COLUMN_NAME}
+        path_col = (
+            self._path_column
+            if self._path_column is not None
+            else INCLUDE_PATHS_COLUMN_NAME
+        )
+        synthesized = {path_col}
         if self._include_row_hash:
             # ``row_hash`` is synthesized post-read, and the schema's type
             # (``uint64``) may not match the on-disk column's type when a
@@ -263,12 +273,17 @@ class FileReader(Reader[FileManifest]):
                     table = table.slice(0, self._limit - rows_read)
 
             # Build the list of (name, value) pairs to synthesize from
-            # the fragment path: hive partitions + optional ``path``.
+            # the fragment path: hive partitions + optional path column.
             derived_items: List[Tuple[str, Any]] = []
             if self._partition_parser is not None:
                 derived_items.extend(self._partition_parser(fragment_path).items())
             if self._include_paths:
-                derived_items.append((INCLUDE_PATHS_COLUMN_NAME, fragment_path))
+                path_col = (
+                    self._path_column
+                    if self._path_column is not None
+                    else INCLUDE_PATHS_COLUMN_NAME
+                )
+                derived_items.append((path_col, fragment_path))
 
             for name, value in derived_items:
                 if (

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -161,6 +161,7 @@ class ParquetFileReader(FileReader):
         target_block_size: Optional[int] = None,
         include_paths: bool = False,
         include_row_hash: bool = False,
+        path_column: Optional[str] = None,
         schema: Optional[pa.Schema] = None,
         parquet_format_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -179,9 +180,12 @@ class ParquetFileReader(FileReader):
             target_block_size: Target in-memory size per batch in bytes.
                 Used for adaptive batch sizing when ``batch_size`` is not set.
             include_paths: If True, include the source file path in a
-                ``'path'`` column for each row.
+                ``'path'`` column (or the column specified by ``path_column``)
+                for each row.
             include_row_hash: If True, include a deterministic uint64 hash
                 per row in a ``'row_hash'`` column.
+            path_column: The name of the column to store file paths when
+                ``include_paths`` is True. Defaults to ``'path'``.
             schema: Caller-supplied unified schema forwarded to the base
                 :class:`FileReader` for per-fragment inference override
                 and partition-column type casting.
@@ -202,6 +206,7 @@ class ParquetFileReader(FileReader):
             ignore_prefixes=ignore_prefixes,
             include_paths=include_paths,
             include_row_hash=include_row_hash,
+            path_column=path_column,
             schema=schema,
         )
         self._explicit_batch_size = batch_size

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -33,6 +33,7 @@ class ParquetScanner(ArrowFileScanner):
     target_block_size: Optional[int] = None
     include_paths: bool = False
     include_row_hash: bool = False
+    path_column: Optional[str] = None
     # Extra kwargs forwarded to ``pds.ParquetFileFormat(**kwargs)`` inside
     # the per-task ``ParquetFileReader`` (e.g. ``coerce_int96_timestamp_unit``,
     # ``pre_buffer``, ``dictionary_columns``). Carries the deprecated
@@ -50,8 +51,13 @@ class ParquetScanner(ArrowFileScanner):
         only append when no projection is active or when it survives.
         """
         schema = super().read_schema()
+        path_col = (
+            self.path_column
+            if self.path_column is not None
+            else INCLUDE_PATHS_COLUMN_NAME
+        )
         synthesized = (
-            (self.include_paths, INCLUDE_PATHS_COLUMN_NAME, pa.string()),
+            (self.include_paths, path_col, pa.string()),
             (self.include_row_hash, ROW_HASH_COLUMN_NAME, pa.uint64()),
         )
         for enabled, name, dtype in synthesized:
@@ -83,6 +89,7 @@ class ParquetScanner(ArrowFileScanner):
             target_block_size=self.target_block_size,
             include_paths=self.include_paths,
             include_row_hash=self.include_row_hash,
+            path_column=self.path_column,
             schema=self.schema,
             parquet_format_kwargs=dict(self.parquet_format_kwargs),
         )

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -86,6 +86,62 @@ def test_infer_schema_with_include_paths(tmp_path):
     assert schema.field("path").type == pa.string()
 
 
+def test_infer_schema_with_custom_path_column(tmp_path):
+    """Test that custom path_column is respected in V2 path."""
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1, 2]}))
+
+    # Test with custom path_column
+    datasource = ParquetDatasourceV2(
+        [str(file_path)], include_paths=True, path_column="source_file"
+    )
+    schema = datasource.infer_schema(_manifest_of([str(file_path)]))
+
+    assert "source_file" in schema.names
+    assert schema.field("source_file").type == pa.string()
+    # Verify default "path" is NOT in schema when custom name is used
+    assert "path" not in schema.names
+
+    # Test with existing "path" column in data - custom name should avoid conflict
+    file_with_path = tmp_path / "data_with_path.parquet"
+    _write_parquet(str(file_with_path), pa.table({"a": [1, 2], "path": ["x", "y"]}))
+    datasource2 = ParquetDatasourceV2(
+        [str(file_with_path)], include_paths=True, path_column="file_path"
+    )
+    schema2 = datasource2.infer_schema(_manifest_of([str(file_with_path)]))
+
+    assert "file_path" in schema2.names
+    assert "path" in schema2.names  # Original data column preserved
+    assert schema2.field("file_path").type == pa.string()
+
+
+def test_infer_schema_with_explicit_none_path_column(tmp_path):
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1, 2]}))
+
+    datasource = ParquetDatasourceV2(
+        [str(file_path)], include_paths=True, path_column=None
+    )
+    schema = datasource.infer_schema(_manifest_of([str(file_path)]))
+
+    assert "path" in schema.names
+    assert schema.field("path").type == pa.string()
+
+
+def test_infer_schema_ignores_path_column_when_include_paths_disabled(tmp_path):
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1, 2]}))
+
+    datasource = ParquetDatasourceV2(
+        [str(file_path)], include_paths=False, path_column="source_file"
+    )
+    schema = datasource.infer_schema(_manifest_of([str(file_path)]))
+
+    assert "a" in schema.names
+    assert "path" not in schema.names
+    assert "source_file" not in schema.names
+
+
 def test_infer_schema_returns_empty_schema_on_empty_manifest(tmp_path):
     datasource = ParquetDatasourceV2([str(tmp_path)])
     empty = FileManifest.construct_manifest([], [], [])

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -151,6 +151,7 @@ class FileBasedDatasource(Datasource):
         ignore_missing_paths: bool = False,
         shuffle: Optional[Union[Literal["files"], FileShuffleConfig]] = None,
         include_paths: bool = False,
+        path_column: Optional[str] = None,
         file_extensions: Optional[List[str]] = None,
     ):
         super().__init__()
@@ -172,6 +173,7 @@ class FileBasedDatasource(Datasource):
         self._partitioning = partitioning
         self._ignore_missing_paths = ignore_missing_paths
         self._include_paths = include_paths
+        self._path_column = path_column or "path"
         # Need this property for lineage tracking. We should not directly assign paths
         # to self since it is captured every read_task_fn during serialization and
         # causing this data being duplicated and excessive object store spilling.
@@ -296,7 +298,9 @@ class FileBasedDatasource(Datasource):
                             block = _add_partitions(block, partitions)
                         if self._include_paths:
                             block_accessor = BlockAccessor.for_block(block)
-                            block = block_accessor.fill_column("path", read_path)
+                            block = block_accessor.fill_column(
+                                self._path_column, read_path
+                            )
                         yield block
 
         def create_read_task_fn(read_paths, num_threads):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1141,6 +1141,7 @@ def read_parquet(
     shuffle: Optional[Union[Literal["files"], FileShuffleConfig]] = None,
     include_paths: bool = False,
     include_row_hash: bool = False,
+    path_column: Optional[str] = None,
     file_extensions: Optional[List[str]] = ParquetDatasource._FILE_EXTENSIONS,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
@@ -1259,11 +1260,21 @@ def read_parquet(
             If setting to :class:`~ray.data.FileShuffleConfig`, you can pass a seed to
             shuffle the input files. Defaults to not shuffle with ``None``.
         include_paths: If ``True``, include the path to each file. File paths are
-            stored in the ``'path'`` column. To downselect to fewer columns,
-            use :meth:`~ray.data.Dataset.select_columns` on the returned
-            dataset and include ``'path'`` explicitly in the list to retain
-            it.
+            stored in the ``'path'`` column (or the column specified by
+            ``path_column``). To downselect to fewer columns, use
+            :meth:`~ray.data.Dataset.select_columns` on the returned dataset and
+            include the path column name explicitly in the list to retain it.
         include_row_hash: If ``True``, include a deterministic hash for each row.
+            The hash is a uint64 computed from the source file path and the row's
+            output position, making it reproducible across repeated reads of the
+            same data with the same pipeline configuration. Stored in the
+            ``'row_hash'`` column. If a column named ``'row_hash'`` already
+            exists in the file, it will be overwritten. To downselect to fewer
+            columns, use :meth:`~ray.data.Dataset.select_columns` on the
+            returned dataset and include ``'row_hash'`` explicitly in the list
+            to retain it.
+        path_column: The name of the column to store file paths when
+            ``include_paths`` is True. Defaults to ``'path'``.
             The hash is a uint64 computed from the source file path and the row's
             output position, making it reproducible across repeated reads of the
             same data with the same pipeline configuration. Stored in the
@@ -1360,9 +1371,10 @@ def read_parquet(
             # ``select_columns([...])`` is literal, so preserve V1's
             # behavior by appending those columns when applying the
             # projection on the caller's behalf.
+            v2_path_column = path_column if path_column is not None else "path"
             select_columns_after_read = list(columns)
-            if include_paths and "path" not in select_columns_after_read:
-                select_columns_after_read.append("path")
+            if include_paths and v2_path_column not in select_columns_after_read:
+                select_columns_after_read.append(v2_path_column)
             if include_row_hash and "row_hash" not in select_columns_after_read:
                 select_columns_after_read.append("row_hash")
             warnings.warn(
@@ -1388,6 +1400,7 @@ def read_parquet(
             file_extensions=file_extensions,
             include_paths=include_paths,
             include_row_hash=include_row_hash,
+            path_column=path_column,
             shuffle=shuffle,
             arrow_parquet_args=arrow_parquet_args,
             schema=schema,
@@ -1421,6 +1434,7 @@ def read_parquet(
         shuffle=shuffle,
         include_paths=include_paths,
         include_row_hash=include_row_hash,
+        path_column=path_column,
         file_extensions=file_extensions,
     )
     return read_datasource(

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -391,6 +391,116 @@ def test_include_row_hash_existing_column_with_projection(
     assert all(row["row_hash"] not in (10, 20) for row in rows)
 
 
+def test_include_paths_with_custom_column(
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    use_datasource_v2,
+):
+    """Test custom path column name functionality for Parquet files.
+
+    This test is parameterized to run on both V1 (legacy) and V2 (new) datasources
+    via the use_datasource_v2 fixture.
+    """
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"animals": ["cat", "dog"], "path": ["a", "b"]})
+    pq.write_table(table, path)
+
+    # Test custom column name to avoid conflict with existing "path" column
+    ds = ray.data.read_parquet(path, include_paths=True, path_column="source_path")
+
+    rows = ds.take_all()
+    for row in rows:
+        assert "source_path" in row
+        assert row["source_path"] == path
+        # Verify existing "path" column from data is preserved
+        assert "path" in row
+        assert row["path"] in ["a", "b"]
+
+
+def test_include_paths_with_custom_column_projection(
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    use_datasource_v2,
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict(
+        {"animals": ["cat", "dog"], "id": [1, 2], "path": ["a", "b"]}
+    )
+    pq.write_table(table, path)
+
+    if ray.data.DataContext.get_current().use_datasource_v2:
+        warn_ctx = pytest.warns(
+            DeprecationWarning, match="`columns=` on `read_parquet`"
+        )
+    else:
+        warn_ctx = contextlib.nullcontext()
+    with warn_ctx:
+        ds = ray.data.read_parquet(
+            path,
+            columns=["id"],
+            include_paths=True,
+            path_column="source_path",
+        )
+
+    schema_names = ds.schema().names
+    assert "id" in schema_names
+    assert "source_path" in schema_names
+    assert "animals" not in schema_names
+    assert "path" not in schema_names
+
+    rows = ds.take_all()
+    for row in rows:
+        assert row["id"] in [1, 2]
+        assert row["source_path"] == path
+        assert "animals" not in row
+        assert "path" not in row
+
+
+def test_include_paths_with_explicit_none_path_column(
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    use_datasource_v2,
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"animals": ["cat", "dog"]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, include_paths=True, path_column=None)
+
+    schema_names = ds.schema().names
+    assert "path" in schema_names, f"'path' column not found in schema: {schema_names}"
+
+    rows = ds.take_all()
+    for row in rows:
+        assert row["path"] == path
+
+
+def test_path_column_ignored_without_include_paths(
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    use_datasource_v2,
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"animals": ["cat", "dog"]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, include_paths=False, path_column="source_path")
+
+    schema_names = ds.schema().names
+    assert "animals" in schema_names
+    assert "path" not in schema_names
+    assert "source_path" not in schema_names
+
+    rows = ds.take_all()
+    for row in rows:
+        assert "path" not in row
+        assert "source_path" not in row
+
+
 @pytest.mark.parametrize(
     "fs,data_path",
     [


### PR DESCRIPTION
## Motivation
This change addresses a limitation in Ray's Parquet reading functionality where the file path column name is hardcoded to "path". This causes data loss when reading files that already contain a "path" column, as the original column values are overwritten with file paths.

The fix enables users to:
- Avoid column name conflicts by specifying a custom name
- Use more descriptive column names for their use cases
- Maintain backward compatibility with existing code

## Related Issue
Closed #63757

## Implementation Details

### Core API Changes
1. **`python/ray/data/read_api.py`** 
   - Added `path_column` parameter to `read_parquet()` function signature
   - Updated documentation to describe the new parameter
   - Handled V2 datasource path column logic in column selection

2. **`python/ray/data/datasource/file_based_datasource.py`**
   - Added `path_column` parameter to `__init__`
   - Stored as instance variable with default "path"
   - Updated `fill_column` call to use custom name

### Key Design Decisions

1. **Default behavior preserved**: When `path_column=None`, defaults to "path" for full backward compatibility

2. **Consistent across versions**: Both V1 and V2 datasources support the feature identically

3. **Schema inference aware**: The custom column name is respected during schema inference, preventing duplicate columns

4. **Minimal API surface**: Only exposes `path_column` at the `read_parquet()` API level; internal threading is transparent

## Verification

### Unit Tests
1. **V1 datasource test**:
   ```bash
   pytest python/ray/data/tests/datasource/test_parquet.py::test_include_paths_with_custom_column -v
   ```

2. **V2 datasource test**:
   ```bash
   pytest python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py::test_infer_schema_with_custom_path_column -v
   ```

### Manual Verification
1. **Test conflict avoidance**:
   ```python
   import ray
   import pyarrow.parquet as pq
   import pyarrow as pa
   
   # Create file with existing "path" column
   table = pa.Table.from_pydict({"animals": ["cat", "dog"], "path": ["a", "b"]})
   pq.write_table(table, "test.parquet")
   
   # Read with custom path column name
   ds = ray.data.read_parquet("test.parquet", include_paths=True, path_column="source_path")
   rows = ds.take_all()
   
   # Verify both columns exist
   assert "path" in rows[0]  # Original data column
   assert "source_path" in rows[0]  # Custom file path column
   assert rows[0]["path"] in ["a", "b"]  # Original values preserved
   assert rows[0]["source_path"] == "test.parquet"  # File path correct
   ```

2. **Test backward compatibility**:
   ```python
   # Default behavior unchanged
   ds = ray.data.read_parquet("file.parquet", include_paths=True)
   assert "path" in ds.schema()
   ```

3. **Test schema inference**:
   ```python
   datasource = ParquetDatasourceV2(
       ["file.parquet"], 
       include_paths=True, 
       path_column="file_path"
   )
   schema = datasource.infer_schema(manifest)
   assert "file_path" in schema.names
   ```

### Integration Testing
Run the full parquet datasource test suite:
```bash
pytest python/ray/data/tests/datasource/test_parquet.py -v
pytest python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py -v

