### PR TITLE
[core] Use absl::InlinedVector for hot-path ObjectID vectors in AddPendingTask

### DIFF
--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -491,9 +491,9 @@ void ReferenceCounter::RemoveLocalReferenceInternal(const ObjectID &object_id,
 }
 
 void ReferenceCounter::UpdateSubmittedTaskReferences(
-    const std::vector<ObjectID> &return_ids,
-    const std::vector<ObjectID> &argument_ids_to_add,
-    const std::vector<ObjectID> &argument_ids_to_remove,
+    absl::Span<const ObjectID> return_ids,
+    absl::Span<const ObjectID> argument_ids_to_add,
+    absl::Span<const ObjectID> argument_ids_to_remove,
     std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
   for (const auto &return_id : return_ids) {
@@ -603,7 +603,7 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
 }
 
 void ReferenceCounter::RemoveSubmittedTaskReferences(
-    const std::vector<ObjectID> &argument_ids,
+    absl::Span<const ObjectID> argument_ids,
     bool release_lineage,
     std::vector<ObjectID> *deleted) {
   for (const ObjectID &argument_id : argument_ids) {

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -77,9 +77,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> &return_ids,
-      const std::vector<ObjectID> &argument_ids_to_add,
-      const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
+      absl::Span<const ObjectID> return_ids,
+      absl::Span<const ObjectID> argument_ids_to_add,
+      absl::Span<const ObjectID> argument_ids_to_remove = {},
       std::vector<ObjectID> *deleted = nullptr) override ABSL_LOCKS_EXCLUDED(mutex_);
 
   void UpdateResubmittedTaskReferences(const std::vector<ObjectID> &argument_ids) override
@@ -547,7 +547,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// being dependencies to a submitted task. This should be called when
   /// inlined dependencies are inlined or when the task finishes for plasma
   /// dependencies.
-  void RemoveSubmittedTaskReferences(const std::vector<ObjectID> &argument_ids,
+  void RemoveSubmittedTaskReferences(absl::Span<const ObjectID> argument_ids,
                                      bool release_lineage,
                                      std::vector<ObjectID> *deleted)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -21,6 +21,8 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
+#include "absl/types/span.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/lease_policy.h"
 #include "ray/pubsub/publisher_interface.h"
@@ -120,9 +122,9 @@ class ReferenceCounterInterface {
   /// \param[out] deleted Any objects that are newly out of scope after this
   /// function call.
   virtual void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> &return_ids,
-      const std::vector<ObjectID> &argument_ids_to_add,
-      const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
+      absl::Span<const ObjectID> return_ids,
+      absl::Span<const ObjectID> argument_ids_to_add,
+      absl::Span<const ObjectID> argument_ids_to_remove = {},
       std::vector<ObjectID> *deleted = nullptr) = 0;
 
   /// Add references for the object dependencies of a resubmitted task. This

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/lease_policy.h"

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "absl/strings/match.h"
 #include "ray/common/buffer.h"
 #include "ray/common/protobuf_utils.h"
@@ -245,7 +246,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
                  << " retries, " << max_oom_retries << " oom retries";
 
   // Add references for the dependencies to the task.
-  std::vector<ObjectID> task_deps;
+  absl::InlinedVector<ObjectID, 8> task_deps;
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
       task_deps.push_back(spec.ArgObjectId(i));
@@ -268,7 +269,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
   size_t num_returns = spec.NumReturns();
   std::vector<rpc::ObjectReference> returned_refs;
   returned_refs.reserve(num_returns);
-  std::vector<ObjectID> return_ids;
+  absl::InlinedVector<ObjectID, 4> return_ids;
   return_ids.reserve(num_returns);
   auto tensor_transport = spec.TensorTransport();
   for (size_t i = 0; i < num_returns; i++) {


### PR DESCRIPTION
## Summary

Closes #59884 (partial — `AddPendingTask` hot path).

- Changed `task_deps` (`absl::InlinedVector<ObjectID, 8>`) and `return_ids` (`absl::InlinedVector<ObjectID, 4>`) in `TaskManager::AddPendingTask`, which is invoked on every task submission. Tasks typically have 1–4 dependencies and 1–2 return values, so the inline buffer covers the common case with zero heap allocations.
- Changed `UpdateSubmittedTaskReferences` (public virtual) and `RemoveSubmittedTaskReferences` (private helper) to accept `absl::Span<const ObjectID>` instead of `const std::vector<ObjectID>&`. This lets both `std::vector` and `absl::InlinedVector` callers pass their containers without copying — all existing call sites convert implicitly with no changes required.

## Why absl::Span for the interface

`absl::InlinedVector<T, N>` and `std::vector<T>` are distinct types with no implicit conversion between them. Changing the parameter type to `absl::Span<const T>` (a lightweight non-owning view) accepts both. This is the standard pattern for "accept any contiguous sequence of T" in abseil-using codebases.

## Test plan

- [ ] Existing unit tests in `reference_counter_test.cc` and `task_manager_test.cc` cover the changed paths. All test call sites use brace-init lists (`{id1, id2}`) or `std::vector`, both of which convert implicitly to `absl::Span<const ObjectID>` — no test changes needed.
- [ ] `bazelisk build //src/ray/core_worker:reference_counter //src/ray/core_worker:task_manager` — changed files compile cleanly.