### PR TITLE
[Core][gcs] Fix replica actor zombie process issue after GCS restart

### DIFF
--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1763,18 +1763,15 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
         created_actors_[actor->GetNodeID()].emplace(actor->GetWorkerID(),
                                                     actor->GetActorID());
         // Restore local raylet address for ALIVE actors after GCS restart.
-        // This is necessary because local_raylet_address_ is not persisted to Redis,
+        // This is necessary because local_raylet_address_ is not persisted with GCS FT,
         // but is required to send KillLocalActorRequest when destroying the actor.
         // Without this, GCS will log "Actor has not been assigned a lease" and
         // the worker process will not be killed, leaving a zombie process.
-        if (!actor->GetNodeID().IsNil() && !actor->GetWorkerID().IsNil()) {
+        if (!actor->GetNodeID().IsNil()) {
           const auto &node_id = actor->GetNodeID();
           const auto &nodes = gcs_init_data.Nodes();
           auto node_it = nodes.find(node_id);
-          // Only restore local raylet address if the node is still alive.
-          // If the node is dead, the raylet is unreachable anyway.
-          if (node_it != nodes.end() &&
-              node_it->second.state() == rpc::GcsNodeInfo::ALIVE) {
+          if (node_it != nodes.end()) {
             const auto &node_info = node_it->second;
             rpc::Address actor_local_raylet_address;
             actor_local_raylet_address.set_node_id(node_info.node_id());

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1762,6 +1762,27 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       } else if (actor_table_data.state() == ray::rpc::ActorTableData::ALIVE) {
         created_actors_[actor->GetNodeID()].emplace(actor->GetWorkerID(),
                                                     actor->GetActorID());
+        // Restore local raylet address for ALIVE actors after GCS restart.
+        // This is necessary because local_raylet_address_ is not persisted to Redis,
+        // but is required to send KillLocalActorRequest when destroying the actor.
+        // Without this, GCS will log "Actor has not been assigned a lease" and
+        // the worker process will not be killed, leaving a zombie process.
+        if (!actor->GetNodeID().IsNil() && !actor->GetWorkerID().IsNil()) {
+          const auto &node_id = actor->GetNodeID();
+          const auto &nodes = gcs_init_data.Nodes();
+          auto node_it = nodes.find(node_id);
+          // Only restore local raylet address if the node is still alive.
+          // If the node is dead, the raylet is unreachable anyway.
+          if (node_it != nodes.end() &&
+              node_it->second.state() == rpc::GcsNodeInfo::ALIVE) {
+            const auto &node_info = node_it->second;
+            rpc::Address actor_local_raylet_address;
+            actor_local_raylet_address.set_node_id(node_info.node_id());
+            actor_local_raylet_address.set_ip_address(node_info.node_manager_address());
+            actor_local_raylet_address.set_port(node_info.node_manager_port());
+            actor->UpdateLocalRayletAddress(actor_local_raylet_address);
+          }
+        }
       }
 
       if (!actor->IsDetached()) {

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -68,11 +68,6 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
     }
   }
 
-  size_t GetPendingActorsCount() const { return 0; }
-  bool CancelInFlightActorScheduling(const std::shared_ptr<gcs::GcsActor> &actor) {
-    return false;
-  }
-
   MOCK_CONST_METHOD0(DebugString, std::string());
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const NodeID &node_id));
   MOCK_METHOD2(CancelOnWorker, ActorID(const NodeID &node_id, const WorkerID &worker_id));

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -2541,7 +2541,9 @@ TEST_F(GcsActorManagerTest, TestInitializeRestoresLocalRayletAddressForAliveActo
       *fake_ray_event_recorder_,
       "test_session_name",
       fake_actor_by_state_gauge_,
-      fake_gcs_actor_by_state_gauge_);
+      fake_gcs_actor_by_state_gauge_,
+      observability_publisher_.get(),
+      clock_);
 
   // Step 7: Call Initialize() with the populated GcsInitData
   test_gcs_actor_manager->Initialize(gcs_init_data);
@@ -2643,7 +2645,9 @@ TEST_F(GcsActorManagerTest, TestInitializeDoesNotRestoreLocalRayletAddressForDea
       *fake_ray_event_recorder_,
       "test_session_name",
       fake_actor_by_state_gauge_,
-      fake_gcs_actor_by_state_gauge_);
+      fake_gcs_actor_by_state_gauge_,
+      observability_publisher_.get(),
+      clock_);
 
   // Step 7: Call Initialize() with the populated GcsInitData
   test_gcs_actor_manager->Initialize(gcs_init_data);

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -111,6 +111,28 @@ class MockWorkerClient : public rpc::FakeCoreWorkerClient {
   instrumented_io_context &io_service_;
 };
 
+class TestGcsInitData : public GcsInitData {
+ public:
+  using GcsInitData::GcsInitData;
+
+  void SetJobTableData(absl::flat_hash_map<JobID, rpc::JobTableData> job_data) {
+    job_table_data_ = std::move(job_data);
+  }
+
+  void SetNodeTableData(absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_data) {
+    node_table_data_ = std::move(node_data);
+  }
+
+  void SetActorTableData(absl::flat_hash_map<ActorID, rpc::ActorTableData> actor_data) {
+    actor_table_data_ = std::move(actor_data);
+  }
+
+  void SetActorTaskSpecTableData(
+      absl::flat_hash_map<ActorID, rpc::TaskSpec> actor_task_spec_data) {
+    actor_task_spec_table_data_ = std::move(actor_task_spec_data);
+  }
+};
+
 class GcsActorManagerTest : public ::testing::Test {
  public:
   GcsActorManagerTest() : periodical_runner_(PeriodicalRunner::Create(io_service_)) {
@@ -227,6 +249,37 @@ class GcsActorManagerTest : public ::testing::Test {
   const absl::flat_hash_map<ActorID, std::vector<std::function<void(Status)>>>
       &GetActorRegisterCallbacks() const {
     return gcs_actor_manager_->actor_to_register_callbacks_;
+  }
+
+  std::unique_ptr<gcs::GcsActorManager> CreateActorManagerForInitializeTest() {
+    auto scheduler = std::make_unique<MockActorScheduler>();
+    return std::make_unique<gcs::GcsActorManager>(
+        std::move(scheduler),
+        gcs_table_storage_.get(),
+        io_service_,
+        gcs_publisher_.get(),
+        *runtime_env_mgr_,
+        *function_manager_,
+        [](const ActorID &actor_id) {},
+        *raylet_client_pool_,
+        *worker_client_pool_,
+        *fake_ray_event_recorder_,
+        "test_session_name",
+        fake_actor_by_state_gauge_,
+        fake_gcs_actor_by_state_gauge_,
+        observability_publisher_.get(),
+        clock_);
+  }
+
+  size_t RegisteredActorCount(const gcs::GcsActorManager &actor_manager) const {
+    return actor_manager.registered_actors_.size();
+  }
+
+  std::shared_ptr<gcs::GcsActor> GetRegisteredActor(
+      const gcs::GcsActorManager &actor_manager, const ActorID &actor_id) const {
+    auto actor_it = actor_manager.registered_actors_.find(actor_id);
+    return actor_it != actor_manager.registered_actors_.end() ? actor_it->second
+                                                              : nullptr;
   }
 
   /**
@@ -2522,34 +2575,16 @@ TEST_F(GcsActorManagerTest, TestInitializeRestoresLocalRayletAddressForAliveActo
 
   // Step 6: Create a new GcsActorManager to test Initialize()
   // We need a fresh instance since the original one was already initialized
-  auto scheduler = std::make_unique<MockActorScheduler>();
-  auto test_gcs_actor_manager = std::make_unique<gcs::GcsActorManager>(
-      std::move(scheduler),
-      gcs_table_storage_.get(),
-      io_service_,
-      gcs_publisher_.get(),
-      *runtime_env_mgr_,
-      *function_manager_,
-      [](const ActorID &actor_id) {},
-      *raylet_client_pool_,
-      *worker_client_pool_,
-      *fake_ray_event_recorder_,
-      "test_session_name",
-      fake_actor_by_state_gauge_,
-      fake_gcs_actor_by_state_gauge_,
-      observability_publisher_.get(),
-      clock_);
+  auto test_gcs_actor_manager = CreateActorManagerForInitializeTest();
 
   // Step 7: Call Initialize() with the populated GcsInitData
   test_gcs_actor_manager->Initialize(gcs_init_data);
 
   // Step 8: Verify that the actor was registered and local_raylet_address_ was restored
-  const auto &registered_actors = test_gcs_actor_manager->GetRegisteredActors();
-  ASSERT_EQ(registered_actors.size(), 1);
+  ASSERT_EQ(RegisteredActorCount(*test_gcs_actor_manager), 1u);
 
-  auto actor_it = registered_actors.find(actor_id);
-  ASSERT_NE(actor_it, registered_actors.end());
-  auto actor = actor_it->second;
+  auto actor = GetRegisteredActor(*test_gcs_actor_manager, actor_id);
+  ASSERT_NE(actor, nullptr);
 
   // Verify that local_raylet_address_ was properly restored
   const auto &local_raylet_address = actor->LocalRayletAddress();
@@ -2560,106 +2595,6 @@ TEST_F(GcsActorManagerTest, TestInitializeRestoresLocalRayletAddressForAliveActo
   ASSERT_EQ(local_raylet_address->node_id(), node_id.Binary());
   ASSERT_EQ(local_raylet_address->ip_address(), "127.0.0.1");
   ASSERT_EQ(local_raylet_address->port(), 9999);
-}
-
-TEST_F(GcsActorManagerTest, TestInitializeDoesNotRestoreLocalRayletAddressForDeadNodes) {
-  // This test verifies that local_raylet_address_ is NOT restored for actors on DEAD
-  // nodes, since the raylet is unreachable anyway.
-
-  // Step 1: Create a node that is DEAD
-  rpc::GcsNodeInfo node_info;
-  auto node_id = NodeID::FromRandom();
-  node_info.set_node_id(node_id.Binary());
-  node_info.set_state(rpc::GcsNodeInfo::DEAD);  // Node is DEAD
-  node_info.set_node_manager_address("127.0.0.1");
-  node_info.set_node_manager_port(9999);
-
-  // Step 2: Create a job that is ALIVE
-  auto job_id = JobID::FromInt(1);
-  rpc::JobTableData job_data;
-  job_data.set_job_id(job_id.Binary());
-  job_data.set_is_dead(false);
-
-  // Step 3: Create an ALIVE actor on that dead node
-  auto worker_id = WorkerID::FromRandom();
-  auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
-  rpc::ActorTableData actor_table_data;
-  actor_table_data.set_actor_id(actor_id.Binary());
-  actor_table_data.set_state(rpc::ActorTableData::ALIVE);
-  actor_table_data.set_node_id(node_id.Binary());
-  actor_table_data.mutable_address()->set_node_id(node_id.Binary());
-  actor_table_data.mutable_address()->set_worker_id(worker_id.Binary());
-  actor_table_data.mutable_address()->set_ip_address("127.0.0.1");
-  actor_table_data.mutable_address()->set_port(12345);
-  // Set owner address (owner is the driver/job)
-  auto *owner_address = actor_table_data.mutable_owner_address();
-  owner_address->set_node_id(node_id.Binary());
-  owner_address->set_worker_id(WorkerID::FromRandom().Binary());
-  owner_address->set_ip_address("127.0.0.1");
-  owner_address->set_port(12345);
-  actor_table_data.set_max_restarts(0);
-  actor_table_data.set_is_detached(false);
-
-  // Step 4: Create task spec for the actor
-  rpc::TaskSpec task_spec;
-  auto *actor_creation_spec = task_spec.mutable_actor_creation_task_spec();
-  actor_creation_spec->set_actor_id(actor_id.Binary());
-  // Set root_detached_actor_id to empty (Nil) to indicate owner is job
-  task_spec.set_root_detached_actor_id("");
-
-  // Step 5: Populate GcsInitData with test data
-  TestGcsInitData gcs_init_data(*gcs_table_storage_);
-  absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_data;
-  node_data[node_id] = node_info;
-  gcs_init_data.SetNodeTableData(node_data);
-
-  absl::flat_hash_map<JobID, rpc::JobTableData> job_data_map;
-  job_data_map[job_id] = job_data;
-  gcs_init_data.SetJobTableData(job_data_map);
-
-  absl::flat_hash_map<ActorID, rpc::ActorTableData> actor_data;
-  actor_data[actor_id] = actor_table_data;
-  gcs_init_data.SetActorTableData(actor_data);
-
-  absl::flat_hash_map<ActorID, rpc::TaskSpec> task_spec_data;
-  task_spec_data[actor_id] = task_spec;
-  gcs_init_data.SetActorTaskSpecTableData(task_spec_data);
-
-  // Step 6: Create a new GcsActorManager to test Initialize()
-  auto scheduler = std::make_unique<MockActorScheduler>();
-  auto test_gcs_actor_manager = std::make_unique<gcs::GcsActorManager>(
-      std::move(scheduler),
-      gcs_table_storage_.get(),
-      io_service_,
-      gcs_publisher_.get(),
-      *runtime_env_mgr_,
-      *function_manager_,
-      [](const ActorID &actor_id) {},
-      *raylet_client_pool_,
-      *worker_client_pool_,
-      *fake_ray_event_recorder_,
-      "test_session_name",
-      fake_actor_by_state_gauge_,
-      fake_gcs_actor_by_state_gauge_,
-      observability_publisher_.get(),
-      clock_);
-
-  // Step 7: Call Initialize() with the populated GcsInitData
-  test_gcs_actor_manager->Initialize(gcs_init_data);
-
-  // Step 8: Verify that the actor was registered but local_raylet_address_ was NOT
-  // restored (because the node is dead)
-  const auto &registered_actors = test_gcs_actor_manager->GetRegisteredActors();
-  ASSERT_EQ(registered_actors.size(), 1);
-
-  auto actor_it = registered_actors.find(actor_id);
-  ASSERT_NE(actor_it, registered_actors.end());
-  auto actor = actor_it->second;
-
-  // Verify that local_raylet_address_ was NOT restored for actors on dead nodes
-  const auto &local_raylet_address = actor->LocalRayletAddress();
-  ASSERT_FALSE(local_raylet_address.has_value())
-      << "local_raylet_address_ should NOT be restored for actors on DEAD nodes";
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -32,6 +32,7 @@
 #include "ray/gcs/actor/gcs_actor.h"
 #include "ray/gcs/actor/gcs_actor_scheduler.h"
 #include "ray/gcs/gcs_function_manager.h"
+#include "ray/gcs/gcs_init_data.h"
 #include "ray/gcs/store_client/in_memory_store_client.h"
 #include "ray/observability/fake_metric.h"
 #include "ray/pubsub/fake_publisher.h"
@@ -65,6 +66,11 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
     if (pending_it != actors.end()) {
       actors.erase(pending_it);
     }
+  }
+
+  size_t GetPendingActorsCount() const { return 0; }
+  bool CancelInFlightActorScheduling(const std::shared_ptr<gcs::GcsActor> &actor) {
+    return false;
   }
 
   MOCK_CONST_METHOD0(DebugString, std::string());
@@ -2449,6 +2455,212 @@ TEST_F(GcsActorManagerTest, TestGetNamedActorOnInScopeActorReturnsSameActor) {
 
   // Actor is still ALIVE (in scope)
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+}
+
+TEST_F(GcsActorManagerTest, TestInitializeRestoresLocalRayletAddressForAliveActors) {
+  // This test verifies that after GCS restart, the local_raylet_address_ is properly
+  // restored for ALIVE actors on ALIVE nodes. This is critical because without the
+  // local raylet address, the GCS cannot send KillLocalActorRequest to kill zombie
+  // actor processes.
+
+  // Step 1: Create a node that is ALIVE
+  rpc::GcsNodeInfo node_info;
+  auto node_id = NodeID::FromRandom();
+  node_info.set_node_id(node_id.Binary());
+  node_info.set_state(rpc::GcsNodeInfo::ALIVE);
+  node_info.set_node_manager_address("127.0.0.1");
+  node_info.set_node_manager_port(9999);
+
+  // Step 2: Create a job that is ALIVE
+  auto job_id = JobID::FromInt(1);
+  rpc::JobTableData job_data;
+  job_data.set_job_id(job_id.Binary());
+  job_data.set_is_dead(false);
+
+  // Step 3: Create an ALIVE actor on that node
+  auto worker_id = WorkerID::FromRandom();
+  auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+  rpc::ActorTableData actor_table_data;
+  actor_table_data.set_actor_id(actor_id.Binary());
+  actor_table_data.set_state(rpc::ActorTableData::ALIVE);
+  actor_table_data.set_node_id(node_id.Binary());
+  actor_table_data.mutable_address()->set_node_id(node_id.Binary());
+  actor_table_data.mutable_address()->set_worker_id(worker_id.Binary());
+  actor_table_data.mutable_address()->set_ip_address("127.0.0.1");
+  actor_table_data.mutable_address()->set_port(12345);
+  // Set owner address (owner is the driver/job)
+  auto *owner_address = actor_table_data.mutable_owner_address();
+  owner_address->set_node_id(node_id.Binary());
+  owner_address->set_worker_id(WorkerID::FromRandom().Binary());
+  owner_address->set_ip_address("127.0.0.1");
+  owner_address->set_port(12345);
+  actor_table_data.set_max_restarts(0);
+  actor_table_data.set_is_detached(false);
+
+  // Step 4: Create task spec for the actor
+  // Need to properly set up the task spec so RootDetachedActorId() returns Nil()
+  rpc::TaskSpec task_spec;
+  auto *actor_creation_spec = task_spec.mutable_actor_creation_task_spec();
+  actor_creation_spec->set_actor_id(actor_id.Binary());
+  // Set root_detached_actor_id to empty (Nil) to indicate owner is job
+  // This field is in TaskSpec, not ActorCreationTaskSpec
+  task_spec.set_root_detached_actor_id("");
+
+  // Step 5: Populate GcsInitData with test data
+  TestGcsInitData gcs_init_data(*gcs_table_storage_);
+
+  absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_data;
+  node_data[node_id] = node_info;
+  gcs_init_data.SetNodeTableData(node_data);
+
+  absl::flat_hash_map<JobID, rpc::JobTableData> job_data_map;
+  job_data_map[job_id] = job_data;
+  gcs_init_data.SetJobTableData(job_data_map);
+
+  absl::flat_hash_map<ActorID, rpc::ActorTableData> actor_data;
+  actor_data[actor_id] = actor_table_data;
+  gcs_init_data.SetActorTableData(actor_data);
+
+  absl::flat_hash_map<ActorID, rpc::TaskSpec> task_spec_data;
+  task_spec_data[actor_id] = task_spec;
+  gcs_init_data.SetActorTaskSpecTableData(task_spec_data);
+
+  // Step 6: Create a new GcsActorManager to test Initialize()
+  // We need a fresh instance since the original one was already initialized
+  auto scheduler = std::make_unique<MockActorScheduler>();
+  auto test_gcs_actor_manager = std::make_unique<gcs::GcsActorManager>(
+      std::move(scheduler),
+      gcs_table_storage_.get(),
+      io_service_,
+      gcs_publisher_.get(),
+      *runtime_env_mgr_,
+      *function_manager_,
+      [](const ActorID &actor_id) {},
+      *raylet_client_pool_,
+      *worker_client_pool_,
+      *fake_ray_event_recorder_,
+      "test_session_name",
+      fake_actor_by_state_gauge_,
+      fake_gcs_actor_by_state_gauge_);
+
+  // Step 7: Call Initialize() with the populated GcsInitData
+  test_gcs_actor_manager->Initialize(gcs_init_data);
+
+  // Step 8: Verify that the actor was registered and local_raylet_address_ was restored
+  const auto &registered_actors = test_gcs_actor_manager->GetRegisteredActors();
+  ASSERT_EQ(registered_actors.size(), 1);
+
+  auto actor_it = registered_actors.find(actor_id);
+  ASSERT_NE(actor_it, registered_actors.end());
+  auto actor = actor_it->second;
+
+  // Verify that local_raylet_address_ was properly restored
+  const auto &local_raylet_address = actor->LocalRayletAddress();
+  ASSERT_TRUE(local_raylet_address.has_value())
+      << "local_raylet_address_ should be restored for ALIVE actors on ALIVE nodes";
+
+  // Verify the restored address matches the node info
+  ASSERT_EQ(local_raylet_address->node_id(), node_id.Binary());
+  ASSERT_EQ(local_raylet_address->ip_address(), "127.0.0.1");
+  ASSERT_EQ(local_raylet_address->port(), 9999);
+}
+
+TEST_F(GcsActorManagerTest, TestInitializeDoesNotRestoreLocalRayletAddressForDeadNodes) {
+  // This test verifies that local_raylet_address_ is NOT restored for actors on DEAD
+  // nodes, since the raylet is unreachable anyway.
+
+  // Step 1: Create a node that is DEAD
+  rpc::GcsNodeInfo node_info;
+  auto node_id = NodeID::FromRandom();
+  node_info.set_node_id(node_id.Binary());
+  node_info.set_state(rpc::GcsNodeInfo::DEAD);  // Node is DEAD
+  node_info.set_node_manager_address("127.0.0.1");
+  node_info.set_node_manager_port(9999);
+
+  // Step 2: Create a job that is ALIVE
+  auto job_id = JobID::FromInt(1);
+  rpc::JobTableData job_data;
+  job_data.set_job_id(job_id.Binary());
+  job_data.set_is_dead(false);
+
+  // Step 3: Create an ALIVE actor on that dead node
+  auto worker_id = WorkerID::FromRandom();
+  auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+  rpc::ActorTableData actor_table_data;
+  actor_table_data.set_actor_id(actor_id.Binary());
+  actor_table_data.set_state(rpc::ActorTableData::ALIVE);
+  actor_table_data.set_node_id(node_id.Binary());
+  actor_table_data.mutable_address()->set_node_id(node_id.Binary());
+  actor_table_data.mutable_address()->set_worker_id(worker_id.Binary());
+  actor_table_data.mutable_address()->set_ip_address("127.0.0.1");
+  actor_table_data.mutable_address()->set_port(12345);
+  // Set owner address (owner is the driver/job)
+  auto *owner_address = actor_table_data.mutable_owner_address();
+  owner_address->set_node_id(node_id.Binary());
+  owner_address->set_worker_id(WorkerID::FromRandom().Binary());
+  owner_address->set_ip_address("127.0.0.1");
+  owner_address->set_port(12345);
+  actor_table_data.set_max_restarts(0);
+  actor_table_data.set_is_detached(false);
+
+  // Step 4: Create task spec for the actor
+  rpc::TaskSpec task_spec;
+  auto *actor_creation_spec = task_spec.mutable_actor_creation_task_spec();
+  actor_creation_spec->set_actor_id(actor_id.Binary());
+  // Set root_detached_actor_id to empty (Nil) to indicate owner is job
+  task_spec.set_root_detached_actor_id("");
+
+  // Step 5: Populate GcsInitData with test data
+  TestGcsInitData gcs_init_data(*gcs_table_storage_);
+  absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_data;
+  node_data[node_id] = node_info;
+  gcs_init_data.SetNodeTableData(node_data);
+
+  absl::flat_hash_map<JobID, rpc::JobTableData> job_data_map;
+  job_data_map[job_id] = job_data;
+  gcs_init_data.SetJobTableData(job_data_map);
+
+  absl::flat_hash_map<ActorID, rpc::ActorTableData> actor_data;
+  actor_data[actor_id] = actor_table_data;
+  gcs_init_data.SetActorTableData(actor_data);
+
+  absl::flat_hash_map<ActorID, rpc::TaskSpec> task_spec_data;
+  task_spec_data[actor_id] = task_spec;
+  gcs_init_data.SetActorTaskSpecTableData(task_spec_data);
+
+  // Step 6: Create a new GcsActorManager to test Initialize()
+  auto scheduler = std::make_unique<MockActorScheduler>();
+  auto test_gcs_actor_manager = std::make_unique<gcs::GcsActorManager>(
+      std::move(scheduler),
+      gcs_table_storage_.get(),
+      io_service_,
+      gcs_publisher_.get(),
+      *runtime_env_mgr_,
+      *function_manager_,
+      [](const ActorID &actor_id) {},
+      *raylet_client_pool_,
+      *worker_client_pool_,
+      *fake_ray_event_recorder_,
+      "test_session_name",
+      fake_actor_by_state_gauge_,
+      fake_gcs_actor_by_state_gauge_);
+
+  // Step 7: Call Initialize() with the populated GcsInitData
+  test_gcs_actor_manager->Initialize(gcs_init_data);
+
+  // Step 8: Verify that the actor was registered but local_raylet_address_ was NOT
+  // restored (because the node is dead)
+  const auto &registered_actors = test_gcs_actor_manager->GetRegisteredActors();
+  ASSERT_EQ(registered_actors.size(), 1);
+
+  auto actor_it = registered_actors.find(actor_id);
+  ASSERT_NE(actor_it, registered_actors.end());
+  auto actor = actor_it->second;
+
+  // Verify that local_raylet_address_ was NOT restored for actors on dead nodes
+  const auto &local_raylet_address = actor->LocalRayletAddress();
+  ASSERT_FALSE(local_raylet_address.has_value())
+      << "local_raylet_address_ should NOT be restored for actors on DEAD nodes";
 }
 
 }  // namespace gcs


### PR DESCRIPTION
## Motivation

This change fixes a bug where actor processes become unkillable zombies after GCS restart. The issue occurs because the `local_raylet_address_` field, which is required for sending termination requests, is not persisted as part of GCS FT and was not being restored during GCS initialization.

Impact:
- Zombie actor processes consume resources indefinitely
- Cannot clean up actors after GCS restart
- Resource leaks in long-running clusters with GCS restarts

## Related issue
Fixed #63763

## Implementation Details

**Files Changed:**
1. `src/ray/gcs/actor/gcs_actor_manager.cc`
2. `src/ray/gcs/actor/tests/gcs_actor_manager_test.cc`

**Key Changes:**

### 1. GCS actor recovery fix (`gcs_actor_manager.cc`)

Restore `local_raylet_address_` in `GcsActorManager::Initialize()` for restored
`ALIVE` actors using the actor's assigned node metadata:

```cpp
} else if (actor_table_data.state() == ray::rpc::ActorTableData::ALIVE) {
  created_actors_[actor->GetNodeID()].emplace(actor->GetWorkerID(),
                                              actor->GetActorID());
  // Restore local raylet address for ALIVE actors after GCS restart.
  // This is necessary because local_raylet_address_ is not persisted with GCS FT,
  // but is required to send KillLocalActorRequest when destroying the actor.
  if (!actor->GetNodeID().IsNil()) {
    const auto &node_id = actor->GetNodeID();
    const auto &nodes = gcs_init_data.Nodes();
    auto node_it = nodes.find(node_id);
    if (node_it != nodes.end()) {
      const auto &node_info = node_it->second;
      rpc::Address actor_local_raylet_address;
      actor_local_raylet_address.set_node_id(node_info.node_id());
      actor_local_raylet_address.set_ip_address(node_info.node_manager_address());
      actor_local_raylet_address.set_port(node_info.node_manager_port());
      actor->UpdateLocalRayletAddress(actor_local_raylet_address);
    }
  }
}
```

This keeps `LocalRayletAddress()` consistent with the actor's assigned node during
recovery and allows later cleanup paths to send `KillLocalActorRequest`.

### 2. Regression test (`gcs_actor_manager_test.cc`)

Added `TestInitializeRestoresLocalRayletAddressForAliveActors`, plus test-only
helpers for constructing `GcsInitData` and inspecting restored actors.

**Test Coverage:**
- Verifies an `ALIVE` actor is restored during `GcsActorManager::Initialize()`
- Verifies `local_raylet_address_` is reconstructed from persisted node metadata
- Verifies the restored address matches the node manager address and port

### Scope

This PR is limited to restoring the missing `local_raylet_address_` during
initialization.

It does not change broader recovery behavior for cases where persisted actor state
and node liveness may already be inconsistent after restart.

## Verification

### Automated Tests

Run the GCS actor manager test target:
```bash
bazel test //src/ray/gcs/actor/tests:gcs_actor_manager_test
```

### Test Assertions Verified

```cpp
ASSERT_EQ(RegisteredActorCount(*test_gcs_actor_manager), 1u);
ASSERT_TRUE(local_raylet_address.has_value());
ASSERT_EQ(local_raylet_address->node_id(), node_id.Binary());
ASSERT_EQ(local_raylet_address->ip_address(), "127.0.0.1");
ASSERT_EQ(local_raylet_address->port(), 9999);
```