### PR TITLE
[DO NOT MERGE][core] Fix actor arg fetch pipelining v2

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -19,6 +19,7 @@ from ray._private.test_utils import (
     make_global_state_accessor,
     wait_for_pid_to_exit,
 )
+from ray.experimental import get_object_locations
 from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put
 from ray.util.state import list_actors
 
@@ -54,18 +55,7 @@ def test_actor_load_balancing(ray_start_cluster):
 
 
 def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
-    """Verify args for queued actor tasks are pulled in parallel with the
-    execution of an earlier task.
-
-    The IPC that tells the local raylet to pull a task's args runs on
-    io_service_. The user task body runs on task_execution_service_ (or a
-    concurrency-group pool). These are separate event loops, so while one
-    task body is executing, args for the next queued task can be pulled in
-    parallel.
-
-    Previously the IPC and the body shared task_execution_service_, so once
-    a body was running, IPCs for queued tasks could not fire and pulling was
-    delayed until the body completed.
+    """Args for queued actor tasks are pulled while an earlier task body is running.
 
     The test sets up a producer and consumer on different nodes.
     Producer produces N objects. Consumer first calls a `block()` task
@@ -74,26 +64,19 @@ def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
     pipelining, the consumers would be able to pull exactly N args even
     when block() is running on the consumer. Without it, it won't be
     able to pull any args.
-
     """
-    from ray.experimental import get_object_locations
-
     cluster = ray_start_cluster
 
     OBJECT_BYTES = 100 * 1024 * 1024
     N = 5
 
-    # Head node (driver) — no actor work.
     cluster.add_node(num_cpus=0)
     ray.init(address=cluster.address)
-    # Producer node.
     cluster.add_node(
         num_cpus=1,
         resources={"producer": 1},
         object_store_memory=900 * 1024 * 1024,
     )
-    # Consumer node — sized to hold all N producer objects when pipelining
-    # works.
     cluster.add_node(
         num_cpus=1,
         resources={"consumer": 1},
@@ -113,10 +96,6 @@ def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
             self.release = release
 
         def block(self):
-            # No remote args. Signal that the consumer's
-            # task_execution_service_ is now busy, then block until the
-            # test releases us so that the consume.remote() calls
-            # submitted after this stay queued.
             ray.get(self.started.send.remote())
             ray.get(self.release.wait.remote())
 
@@ -128,18 +107,14 @@ def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
     producer = Producer.remote()
     consumer = Consumer.remote(started, release)
 
-    # Produce N large objects on the producer node.
     prod_refs = [producer.produce.remote() for _ in range(N)]
     ray.wait(prod_refs, num_returns=N, timeout=30)
 
-    # Run a body with NO remote args to occupy the consumer's
-    # task_execution_service_ first.
+    # block() occupies the consumer before any consume gets submitted, so the
+    # only way the queued consumes' args can land is via parallel arg-fetch.
     block_ref = consumer.block.remote()
     ray.get(started.wait.remote())
 
-    # Consumer's task_execution_service_ is held by block(). Submit all N
-    # consume tasks; without pipelining these sit queued behind block() and
-    # their arg-pull IPCs never fire.
     consume_refs = [consumer.consume.remote(p) for p in prod_refs]
 
     consumer_node_id = next(
@@ -156,10 +131,6 @@ def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
             if consumer_node_id in locs.get(ref, {}).get("node_ids", [])
         )
 
-    # Exactly N producer objects must land on the consumer. With pipelining
-    # all N are pulled while block() is running. Without pipelining the
-    # arg-fetch IPCs are stuck behind block() on task_execution_service_
-    # so nothing is pulled and this wait times out.
     try:
         wait_for_condition(
             lambda: num_pulled_to_consumer() == N,
@@ -169,14 +140,9 @@ def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
     except RuntimeError:
         observed = num_pulled_to_consumer()
         raise AssertionError(
-            f"Consumer has {observed} of {N} producer objects in its "
-            f"plasma. Args for queued actor tasks were not pulled in "
-            f"parallel with the running task body (arg-fetch pipelining "
-            f"regression)."
+            f"Consumer has {observed} of {N} producer objects in its plasma."
         )
     finally:
-        # Whether we passed or not, release the consumer so cleanup
-        # doesn't hang waiting on block().
         release.send.remote()
         ray.get([block_ref] + consume_refs)
 

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -53,6 +53,134 @@ def test_actor_load_balancing(ray_start_cluster):
     assert set(node_ids) == worker_node_ids
 
 
+def test_actor_arg_fetch_is_pipelined_with_task_execution(ray_start_cluster):
+    """Verify args for queued actor tasks are pulled in parallel with the
+    execution of an earlier task.
+
+    The IPC that tells the local raylet to pull a task's args runs on
+    io_service_. The user task body runs on task_execution_service_ (or a
+    concurrency-group pool). These are separate event loops, so while one
+    task body is executing, args for the next queued task can be pulled in
+    parallel.
+
+    Previously the IPC and the body shared task_execution_service_, so once
+    a body was running, IPCs for queued tasks could not fire and pulling was
+    delayed until the body completed.
+
+    The test sets up a producer and consumer on different nodes.
+    Producer produces N objects. Consumer first calls a `block()` task
+    that takes no remote args and hangs until signaled. Then driver submits
+    N consumer tasks that require fetching args from producer. With correct
+    pipelining, the consumers would be able to pull exactly N args even
+    when block() is running on the consumer. Without it, it won't be
+    able to pull any args.
+
+    """
+    from ray.experimental import get_object_locations
+
+    cluster = ray_start_cluster
+
+    OBJECT_BYTES = 100 * 1024 * 1024
+    N = 5
+
+    # Head node (driver) — no actor work.
+    cluster.add_node(num_cpus=0)
+    ray.init(address=cluster.address)
+    # Producer node.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"producer": 1},
+        object_store_memory=900 * 1024 * 1024,
+    )
+    # Consumer node — sized to hold all N producer objects when pipelining
+    # works.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"consumer": 1},
+        object_store_memory=900 * 1024 * 1024,
+    )
+    cluster.wait_for_nodes()
+
+    @ray.remote(resources={"producer": 0.01})
+    class Producer:
+        def produce(self):
+            return b"\x00" * OBJECT_BYTES
+
+    @ray.remote(resources={"consumer": 0.01})
+    class Consumer:
+        def __init__(self, started, release):
+            self.started = started
+            self.release = release
+
+        def block(self):
+            # No remote args. Signal that the consumer's
+            # task_execution_service_ is now busy, then block until the
+            # test releases us so that the consume.remote() calls
+            # submitted after this stay queued.
+            ray.get(self.started.send.remote())
+            ray.get(self.release.wait.remote())
+
+        def consume(self, x):
+            return len(x)
+
+    started = SignalActor.remote()
+    release = SignalActor.remote()
+    producer = Producer.remote()
+    consumer = Consumer.remote(started, release)
+
+    # Produce N large objects on the producer node.
+    prod_refs = [producer.produce.remote() for _ in range(N)]
+    ray.wait(prod_refs, num_returns=N, timeout=30)
+
+    # Run a body with NO remote args to occupy the consumer's
+    # task_execution_service_ first.
+    block_ref = consumer.block.remote()
+    ray.get(started.wait.remote())
+
+    # Consumer's task_execution_service_ is held by block(). Submit all N
+    # consume tasks; without pipelining these sit queued behind block() and
+    # their arg-pull IPCs never fire.
+    consume_refs = [consumer.consume.remote(p) for p in prod_refs]
+
+    consumer_node_id = next(
+        n["NodeID"]
+        for n in ray.nodes()
+        if n["Alive"] and n.get("Resources", {}).get("consumer", 0) > 0
+    )
+
+    def num_pulled_to_consumer():
+        locs = get_object_locations(prod_refs)
+        return sum(
+            1
+            for ref in prod_refs
+            if consumer_node_id in locs.get(ref, {}).get("node_ids", [])
+        )
+
+    # Exactly N producer objects must land on the consumer. With pipelining
+    # all N are pulled while block() is running. Without pipelining the
+    # arg-fetch IPCs are stuck behind block() on task_execution_service_
+    # so nothing is pulled and this wait times out.
+    try:
+        wait_for_condition(
+            lambda: num_pulled_to_consumer() == N,
+            timeout=30,
+            retry_interval_ms=200,
+        )
+    except RuntimeError:
+        observed = num_pulled_to_consumer()
+        raise AssertionError(
+            f"Consumer has {observed} of {N} producer objects in its "
+            f"plasma. Args for queued actor tasks were not pulled in "
+            f"parallel with the running task body (arg-fetch pipelining "
+            f"regression)."
+        )
+    finally:
+        # Whether we passed or not, release the consumer so cleanup
+        # doesn't hang waiting on block().
+        release.send.remote()
+        ray.get([block_ref] + consume_refs)
+
+
 @pytest.mark.parametrize(
     "ray_start_regular",
     [

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3354,10 +3354,9 @@ void CoreWorker::HandlePushTask(rpc::PushTaskRequest request,
   std::string func_name = request.task_spec().name();
   task_counter_.IncPending(func_name, request.task_spec().attempt_number() > 0);
 
-  // We are already on io_service_ (this is a gRPC handler). Actor task queuing
-  // (including the args-fetch IPC) runs on io_service_; only the user task body
-  // gets posted to task_execution_service_ inside the actor queue's
-  // ExecuteRequest path. So we can invoke QueueTaskForExecution inline.
+  // Invoke the task queueing (and arg fetching, which takes place in further flow in
+  // task_receiver_->QueueTaskForExecution) on io_service_. Only queue task execution on
+  // task_execution_service_.
   if (request.task_spec().type() == TaskType::ACTOR_TASK) {
     if (IsExiting()) {
       RAY_LOG(INFO) << "Queued task " << func_name
@@ -3394,11 +3393,9 @@ void CoreWorker::HandleActorCallArgWaitComplete(
   }
 
   // Waiter state lives on io_service_ (AsyncWait is invoked from the actor
-  // queue's EnqueueTask, which runs on io_service_). HandleActorCallArgWaitComplete
-  // is a gRPC handler — also on io_service_ — so we can invoke MarkReady
-  // inline. The MarkReady callback may trigger downstream work (ExecuteQueuedTasks),
-  // which is also fine to run on io_service_; the actual task body posts to
-  // task_execution_service_ inside the queue's ExecuteRequest path.
+  // queue's EnqueueTask, which runs on io_service_). Therefore, call MarkReady
+  // from io_service_ too. The task execution triggered as part of MarkReady is
+  // then queued on task_execution_service_.
   RAY_LOG(DEBUG) << "Actor task args are ready for tag: " << request.tag();
   actor_task_execution_arg_waiter_->MarkReady(request.tag());
 
@@ -3996,14 +3993,7 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
     on_canceled(success, is_running);
   };
 
-  // We are already on io_service_ (HandleCancelTask is a gRPC handler). The
-  // cancel body's only thread requirement is io_service_ access to
-  // actor_task_execution_queues_ (via task_receiver_->CancelQueuedActorTask),
-  // which is satisfied. The pre-refactor distinction between sync/async actors
-  // existed because the original code posted to task_execution_service_ for
-  // async actors (to land on the asyncio loop) and called inline for sync
-  // actors (because task_execution_service_ was blocked by the in-flight body).
-  // Post-refactor neither motivation applies — just call inline.
+  // cancel runs on io_service_ for both asyncio actors and regular actors.
   cancel();
 
   if (recursive) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3354,10 +3354,10 @@ void CoreWorker::HandlePushTask(rpc::PushTaskRequest request,
   std::string func_name = request.task_spec().name();
   task_counter_.IncPending(func_name, request.task_spec().attempt_number() > 0);
 
-  // Invoke the task queueing (and arg fetching, which takes place in further flow in
-  // task_receiver_->QueueTaskForExecution) on io_service_. Only queue task execution on
-  // task_execution_service_.
+  // For actor tasks, we just need to enqueue them onto the actor queue.
   if (request.task_spec().type() == TaskType::ACTOR_TASK) {
+    // We have posted an exit task onto the main event loop,
+    // so shouldn't bother executing any further work.
     if (IsExiting()) {
       RAY_LOG(INFO) << "Queued task " << func_name
                     << " won't be executed because the worker already exited.";
@@ -3392,10 +3392,6 @@ void CoreWorker::HandleActorCallArgWaitComplete(
     return;
   }
 
-  // Waiter state lives on io_service_ (AsyncWait is invoked from the actor
-  // queue's EnqueueTask, which runs on io_service_). Therefore, call MarkReady
-  // from io_service_ too. The task execution triggered as part of MarkReady is
-  // then queued on task_execution_service_.
   RAY_LOG(DEBUG) << "Actor task args are ready for tag: " << request.tag();
   actor_task_execution_arg_waiter_->MarkReady(request.tag());
 
@@ -3993,7 +3989,6 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
     on_canceled(success, is_running);
   };
 
-  // cancel runs on io_service_ for both asyncio actors and regular actors.
   cancel();
 
   if (recursive) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -393,7 +393,8 @@ CoreWorker::CoreWorker(
           RAY_CHECK_OK(raylet_ipc_client_->WaitForActorCallArgs(args, tag))
               << "WaitForActorCallArgs IPC failed unexpectedly";
         });
-    task_receiver_ = std::make_unique<TaskReceiver>(task_execution_service_,
+    task_receiver_ = std::make_unique<TaskReceiver>(io_service_,
+                                                    task_execution_service_,
                                                     *task_event_buffer_,
                                                     execute_task,
                                                     *actor_task_execution_arg_waiter_,
@@ -3353,26 +3354,17 @@ void CoreWorker::HandlePushTask(rpc::PushTaskRequest request,
   std::string func_name = request.task_spec().name();
   task_counter_.IncPending(func_name, request.task_spec().attempt_number() > 0);
 
-  // For actor tasks, we just need to post a HandleActorTask instance to the task
-  // execution service.
+  // We are already on io_service_ (this is a gRPC handler). Actor task queuing
+  // (including the args-fetch IPC) runs on io_service_; only the user task body
+  // gets posted to task_execution_service_ inside the actor queue's
+  // ExecuteRequest path. So we can invoke QueueTaskForExecution inline.
   if (request.task_spec().type() == TaskType::ACTOR_TASK) {
-    task_execution_service_.post(
-        [this,
-         request = std::move(request),
-         reply,
-         send_reply_callback = std::move(send_reply_callback),
-         func_name]() mutable {
-          // We have posted an exit task onto the main event loop,
-          // so shouldn't bother executing any further work.
-          if (IsExiting()) {
-            RAY_LOG(INFO) << "Queued task " << func_name
-                          << " won't be executed because the worker already exited.";
-            return;
-          }
-          task_receiver_->QueueTaskForExecution(
-              std::move(request), reply, send_reply_callback);
-        },
-        "CoreWorker.HandlePushTaskActor");
+    if (IsExiting()) {
+      RAY_LOG(INFO) << "Queued task " << func_name
+                    << " won't be executed because the worker already exited.";
+      return;
+    }
+    task_receiver_->QueueTaskForExecution(std::move(request), reply, send_reply_callback);
   } else {
     // Normal tasks are enqueued here, and we post a ExecuteQueuedNormalTasks instance to
     // the task execution service.
@@ -3401,14 +3393,14 @@ void CoreWorker::HandleActorCallArgWaitComplete(
     return;
   }
 
-  // Post on the task execution event loop since this may trigger the
-  // execution of a task that is now ready to run.
-  task_execution_service_.post(
-      [this, tag = request.tag()] {
-        RAY_LOG(DEBUG) << "Actor task args are ready for tag: " << tag;
-        actor_task_execution_arg_waiter_->MarkReady(tag);
-      },
-      "CoreWorker.MarkActorTaskArgsReady");
+  // Waiter state lives on io_service_ (AsyncWait is invoked from the actor
+  // queue's EnqueueTask, which runs on io_service_). HandleActorCallArgWaitComplete
+  // is a gRPC handler — also on io_service_ — so we can invoke MarkReady
+  // inline. The MarkReady callback may trigger downstream work (ExecuteQueuedTasks),
+  // which is also fine to run on io_service_; the actual task body posts to
+  // task_execution_service_ inside the queue's ExecuteRequest path.
+  RAY_LOG(DEBUG) << "Actor task args are ready for tag: " << request.tag();
+  actor_task_execution_arg_waiter_->MarkReady(request.tag());
 
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
@@ -4005,18 +3997,15 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
   };
 
   if (is_async_actor) {
-    // If it is an async actor, post it to an execution service
-    // to avoid thread issues. Note that when it is an async actor
-    // task_execution_service_ won't actually run a task but it will
-    // just create coroutines.
-    task_execution_service_.post([cancel = std::move(cancel)]() { cancel(); },
-                                 "CoreWorker.CancelActorTaskOnExecutor");
+    // task_receiver_'s state lives on io_service_, so post the cancel there.
+    // (Previously this was posted to task_execution_service_, but with the
+    // refactor that moved actor-queue bookkeeping onto io_service_, the
+    // canceler must run there too to access actor_task_execution_queues_.)
+    io_service_.post([cancel = std::move(cancel)]() { cancel(); },
+                     "CoreWorker.CancelActorTaskOnExecutor");
   } else {
-    // For regular actor, we cannot post it to task_execution_service because
-    // main thread is blocked. Threaded actor can do both (dispatching to
-    // task execution service, or just directly call it in io_service).
-    // There's no special reason why we don't dispatch
-    // cancel to task_execution_service_ for threaded actors.
+    // For regular (sync) actor, we are already on io_service_ here (this is
+    // invoked from a gRPC handler), so call inline.
     cancel();
   }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3399,6 +3399,9 @@ void CoreWorker::HandleActorCallArgWaitComplete(
   // inline. The MarkReady callback may trigger downstream work (ExecuteQueuedTasks),
   // which is also fine to run on io_service_; the actual task body posts to
   // task_execution_service_ inside the queue's ExecuteRequest path.
+  // TOCHECK(karticam): check if all methods of actor_task_execution_arg_waiter_ are
+  // called from io_service. check even if actor_task_execution_arg_waiter_ is passed
+  // somewhere by reference then too its used only from io_service.
   RAY_LOG(DEBUG) << "Actor task args are ready for tag: " << request.tag();
   actor_task_execution_arg_waiter_->MarkReady(request.tag());
 
@@ -3996,18 +3999,15 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
     on_canceled(success, is_running);
   };
 
-  if (is_async_actor) {
-    // task_receiver_'s state lives on io_service_, so post the cancel there.
-    // (Previously this was posted to task_execution_service_, but with the
-    // refactor that moved actor-queue bookkeeping onto io_service_, the
-    // canceler must run there too to access actor_task_execution_queues_.)
-    io_service_.post([cancel = std::move(cancel)]() { cancel(); },
-                     "CoreWorker.CancelActorTaskOnExecutor");
-  } else {
-    // For regular (sync) actor, we are already on io_service_ here (this is
-    // invoked from a gRPC handler), so call inline.
-    cancel();
-  }
+  // We are already on io_service_ (HandleCancelTask is a gRPC handler). The
+  // cancel body's only thread requirement is io_service_ access to
+  // actor_task_execution_queues_ (via task_receiver_->CancelQueuedActorTask),
+  // which is satisfied. The pre-refactor distinction between sync/async actors
+  // existed because the original code posted to task_execution_service_ for
+  // async actors (to land on the asyncio loop) and called inline for sync
+  // actors (because task_execution_service_ was blocked by the in-flight body).
+  // Post-refactor neither motivation applies — just call inline.
+  cancel();
 
   if (recursive) {
     auto recursive_cancel = CancelChildren(task_id, force_kill);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3399,9 +3399,6 @@ void CoreWorker::HandleActorCallArgWaitComplete(
   // inline. The MarkReady callback may trigger downstream work (ExecuteQueuedTasks),
   // which is also fine to run on io_service_; the actual task body posts to
   // task_execution_service_ inside the queue's ExecuteRequest path.
-  // TOCHECK(karticam): check if all methods of actor_task_execution_arg_waiter_ are
-  // called from io_service. check even if actor_task_execution_arg_waiter_ is passed
-  // somewhere by reference then too its used only from io_service.
   RAY_LOG(DEBUG) << "Actor task args are ready for tag: " << request.tag();
   actor_task_execution_arg_waiter_->MarkReady(request.tag());
 

--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -188,7 +188,11 @@ void CoreWorkerShutdownExecutor::ExecuteExit(
       return;
     }
 
-    worker->task_execution_service_.post(
+    // task_receiver_'s state and the actor task queues' state both live on
+    // io_service_ now (post the actor-queue-on-io_service refactor). Posting
+    // Stop() to io_service_ ensures it runs on the same thread that touches
+    // actor_task_execution_queues_ and queue internals.
+    worker->io_service_.post(
         [this, weak_core_worker, shutdown_callback]() {
           auto worker_inner = weak_core_worker.lock();
           if (!worker_inner) {

--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -189,9 +189,8 @@ void CoreWorkerShutdownExecutor::ExecuteExit(
     }
 
     // task_receiver_'s state and the actor task queues' state both live on
-    // io_service_ now (post the actor-queue-on-io_service refactor). Posting
-    // Stop() to io_service_ ensures it runs on the same thread that touches
-    // actor_task_execution_queues_ and queue internals.
+    // io_service_ now. Posting Stop() to io_service_ ensures it runs on
+    // the same thread that touches actor_task_execution_queues_ and queue internals.
     worker->io_service_.post(
         [this, weak_core_worker, shutdown_callback]() {
           auto worker_inner = weak_core_worker.lock();

--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -188,9 +188,9 @@ void CoreWorkerShutdownExecutor::ExecuteExit(
       return;
     }
 
-    // task_receiver_'s state and the actor task queues' state both live on
-    // io_service_ now. Posting Stop() to io_service_ ensures it runs on
-    // the same thread that touches actor_task_execution_queues_ and queue internals.
+    // task_receiver_'s state and the actor task queues' state live on io_service_.
+    // Posting Stop() to io_service_ ensures it runs on the same thread that
+    // touches actor_task_execution_queues_ and queue internals.
     worker->io_service_.post(
         [this, weak_core_worker, shutdown_callback]() {
           auto worker_inner = weak_core_worker.lock();

--- a/src/ray/core_worker/task_execution/BUILD.bazel
+++ b/src/ray/core_worker/task_execution/BUILD.bazel
@@ -34,6 +34,7 @@ ray_cc_library(
     hdrs = ["fiber.h"],
     visibility = [":__subpackages__"],
     deps = [
+        ":common",
         "//src/ray/util:logging",
         "@boost//:fiber",
     ],
@@ -45,6 +46,7 @@ ray_cc_library(
     hdrs = ["thread_pool.h"],
     visibility = [":__subpackages__"],
     deps = [
+        ":common",
         "//src/ray/util:logging",
         "@boost//:asio",
         "@boost//:thread",
@@ -69,6 +71,7 @@ ray_cc_library(
     hdrs = ["common.h"],
     visibility = [":__subpackages__"],
     deps = [
+        "//src/ray/asio:instrumented_io_context",
         "//src/ray/common:id",
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",

--- a/src/ray/core_worker/task_execution/common.h
+++ b/src/ray/core_worker/task_execution/common.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "ray/asio/instrumented_io_context.h"
 #include "ray/common/id.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task_spec.h"
@@ -27,6 +28,28 @@
 
 namespace ray {
 namespace core {
+
+/// Handle for posting a piece of work onto an execution context
+/// (an io_context, a thread pool, an asyncio fiber, etc.). Lets callers
+/// dispatch a task body without knowing the underlying executor.
+class Postable {
+ public:
+  virtual ~Postable() = default;
+  virtual void Post(std::function<void()> fn) = 0;
+};
+
+/// Adapts an `instrumented_io_context` to the `Postable` interface.
+class IoContextPostable : public Postable {
+ public:
+  IoContextPostable(instrumented_io_context &io_context, std::string name)
+      : io_context_(io_context), name_(std::move(name)) {}
+
+  void Post(std::function<void()> fn) override { io_context_.post(std::move(fn), name_); }
+
+ private:
+  instrumented_io_context &io_context_;
+  std::string name_;
+};
 
 /// Wraps the state and callbacks associated with a task queued for execution on this
 /// worker.

--- a/src/ray/core_worker/task_execution/fiber.h
+++ b/src/ray/core_worker/task_execution/fiber.h
@@ -90,7 +90,12 @@ class FiberRateLimiter {
   int num_ = 1;
 };
 
-using FiberChannel = boost::fibers::unbuffered_channel<std::function<void()>>;
+// Buffered so that pushing a task does not block the submitter. The submitter is
+// the worker's io_service_ (the single RPC thread); an unbuffered channel's push
+// blocks until the fiber runner pops it, which would stall RPC handling (e.g.
+// health checks) under load. The buffer only queues closures (not fibers), so it
+// does not change the concurrency bound — that is still the FiberRateLimiter.
+using FiberChannel = boost::fibers::buffered_channel<std::function<void()>>;
 
 class FiberState : public Postable {
  public:
@@ -170,12 +175,15 @@ class FiberState : public Postable {
 
  private:
   static constexpr size_t kStackSize = 1024 * 256;
+  // Channel capacity (power of two). Far above the number of in-flight actor
+  // tasks in practice; if it ever filled, push would block again.
+  static constexpr size_t kFiberChannelCapacity = 1 << 14;
 
   // The fiber stack allocator.
   boost::fibers::fixedsize_stack allocator_;
-  /// The fiber channel used to send task between the submitter thread
-  /// (main direct_actor_trasnport thread) and the fiber_runner_thread
-  FiberChannel channel_;
+  /// The fiber channel used to send tasks from the submitter (io_service_) to the
+  /// fiber_runner_thread.
+  FiberChannel channel_{kFiberChannelCapacity};
   /// The fiber semaphore used to limit the number of concurrent fibers
   /// running at once.
   FiberRateLimiter rate_limiter_;

--- a/src/ray/core_worker/task_execution/fiber.h
+++ b/src/ray/core_worker/task_execution/fiber.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <utility>
 
+#include "ray/core_worker/task_execution/common.h"
 #include "ray/util/logging.h"
 #include "ray/util/macros.h"
 
@@ -91,7 +92,7 @@ class FiberRateLimiter {
 
 using FiberChannel = boost::fibers::unbuffered_channel<std::function<void()>>;
 
-class FiberState {
+class FiberState : public Postable {
  public:
   static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group,
                                   bool has_other_concurrency_groups) {
@@ -160,6 +161,8 @@ class FiberState {
     });
     RAY_CHECK(op_status == boost::fibers::channel_op_status::success);
   }
+
+  void Post(std::function<void()> fn) override { EnqueueFiber(std::move(fn)); }
 
   void Stop() { channel_.close(); }
 

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -295,24 +295,18 @@ void OrderedActorTaskExecutionQueue::ExecuteRequest(TaskToExecute &&request) {
   auto task_id = request.TaskID();
   auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                          request.FunctionDescriptor());
-  if (pool == nullptr) {
-    // No concurrency-group pool: post the user task body onto
-    // task_execution_service_ so it never blocks io_service_ (which runs the
-    // gRPC handlers and the queue's bookkeeping).
-    task_execution_service_.post(
-        [this, request = std::move(request), task_id]() mutable {
-          AcceptRequestOrRejectIfCanceled(task_id, request);
-        },
-        "OrderedActorTaskExecutionQueue.AcceptRequest");
-  } else {
-    pool->Post([this, request = std::move(request), task_id]() mutable {
-      AcceptRequestOrRejectIfCanceled(task_id, request);
-    });
-  }
+  // AcceptRequestOrRejectIfCanceled runs inline on io_service_ (we're called
+  // from ExecuteQueuedTasks, already on io_service_). Only request.Execute()
+  // is posted off io_service_ -- to the concurrency-group pool if present,
+  // otherwise to task_execution_service_. This serializes the is_canceled
+  // check with CancelTaskIfFound (also on io_service_), eliminating the race
+  // where a cancel arriving mid-Execute would report success but the task
+  // would still run.
+  AcceptRequestOrRejectIfCanceled(task_id, std::move(request), std::move(pool));
 }
 
 void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
-    TaskID task_id, TaskToExecute &request) {
+    TaskID task_id, TaskToExecute request, std::shared_ptr<BoundedExecutor> pool) {
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);
@@ -322,16 +316,27 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     }
   }
 
-  // Accept can be very long, and we shouldn't hold a lock.
   if (is_canceled) {
     request.Cancel(
         Status::SchedulingCancelled("Task is canceled before it is scheduled."));
-  } else {
-    request.Execute();
+    absl::MutexLock lock(&mu_);
+    pending_task_id_to_is_canceled.erase(task_id);
+    return;
   }
 
-  absl::MutexLock lock(&mu_);
-  pending_task_id_to_is_canceled.erase(task_id);
+  // Post just the user task body. The post handler also erases the
+  // cancellation-flag entry under mu_ after Execute returns.
+  auto execute_handler = [this, task_id, request = std::move(request)]() mutable {
+    request.Execute();
+    absl::MutexLock lock(&mu_);
+    pending_task_id_to_is_canceled.erase(task_id);
+  };
+  if (pool == nullptr) {
+    task_execution_service_.post(std::move(execute_handler),
+                                 "OrderedActorTaskExecutionQueue.Execute");
+  } else {
+    pool->Post(std::move(execute_handler));
+  }
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -79,8 +79,7 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   TaskSpecification task_spec = task.TaskSpec();
   const std::string &group = task_spec.ConcurrencyGroupName();
   // wait_timer_ is bound to io_service_ because the queue's bookkeeping
-  // (and therefore the timer's manipulation: expires_from_now / async_wait /
-  // cancel + the expiry handler) all run on io_service_.
+  // runs on io_service_ now.
   auto [iter, _] =
       group_states_.try_emplace(group, ConcurrencyGroupOrderingState(io_service_));
   auto &group_state = iter->second;
@@ -295,13 +294,16 @@ void OrderedActorTaskExecutionQueue::ExecuteRequest(TaskToExecute &&request) {
   auto task_id = request.TaskID();
   auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                          request.FunctionDescriptor());
-  // AcceptRequestOrRejectIfCanceled runs inline on io_service_ (we're called
+  // AcceptRequestOrRejectIfCanceled runs inline on io_service_ (this is called
   // from ExecuteQueuedTasks, already on io_service_). Only request.Execute()
   // is posted off io_service_ -- to the concurrency-group pool if present,
-  // otherwise to task_execution_service_. This serializes the is_canceled
-  // check with CancelTaskIfFound (also on io_service_), eliminating the race
-  // where a cancel arriving mid-Execute would report success but the task
-  // would still run.
+  // otherwise to task_execution_service_.
+
+  // This is done for two reasons:
+  // 1. all operations except for task execution happen on io_service_
+  // 2. This serializes the is_canceled check with CancelTaskIfFound (also on
+  // io_service_), eliminating the race where a cancel arriving mid-Execute would report
+  // success but the task would still run.
   AcceptRequestOrRejectIfCanceled(task_id, std::move(request), std::move(pool));
 }
 
@@ -326,6 +328,7 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
 
   // Post just the user task body. The post handler also erases the
   // cancellation-flag entry under mu_ after Execute returns.
+  // Lock should not be held during execute since it can be long.
   auto execute_handler = [this, task_id, request = std::move(request)]() mutable {
     request.Execute();
     absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -24,13 +24,13 @@ namespace core {
 
 OrderedActorTaskExecutionQueue::OrderedActorTaskExecutionQueue(
     instrumented_io_context &io_service,
-    instrumented_io_context &task_execution_service,
+    std::shared_ptr<Postable> default_postable,
     ActorTaskExecutionArgWaiterInterface &waiter,
     worker::TaskEventBuffer &task_event_buffer,
     std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
     int64_t reorder_wait_seconds)
     : io_service_(io_service),
-      task_execution_service_(task_execution_service),
+      default_postable_(std::move(default_postable)),
       reorder_wait_seconds_(reorder_wait_seconds),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
@@ -292,16 +292,20 @@ void OrderedActorTaskExecutionQueue::ExecuteRequest(TaskToExecute &&request) {
   auto task_id = request.TaskID();
   auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                          request.FunctionDescriptor());
+  std::shared_ptr<Postable> post_execute = default_postable_;
+  if (pool) {
+    post_execute = std::move(pool);
+  }
   // This runs on io_service_ for two reasons:
   // 1. all operations except for task execution happen on io_service_
   // 2. This serializes the is_canceled check with CancelTaskIfFound (also on
   // io_service_), eliminating the race where a cancel arriving mid-Execute would report
   // success but the task would still run.
-  AcceptRequestOrRejectIfCanceled(task_id, std::move(request), std::move(pool));
+  AcceptRequestOrRejectIfCanceled(task_id, std::move(request), std::move(post_execute));
 }
 
 void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
-    TaskID task_id, TaskToExecute request, std::shared_ptr<BoundedExecutor> pool) {
+    TaskID task_id, TaskToExecute request, std::shared_ptr<Postable> post_execute) {
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);
@@ -325,12 +329,7 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     absl::MutexLock lock(&mu_);
     pending_task_id_to_is_canceled.erase(task_id);
   };
-  if (pool == nullptr) {
-    task_execution_service_.post(std::move(execute_handler),
-                                 "OrderedActorTaskExecutionQueue.Execute");
-  } else {
-    pool->Post(std::move(execute_handler));
-  }
+  post_execute->Post(std::move(execute_handler));
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -23,12 +23,14 @@ namespace ray {
 namespace core {
 
 OrderedActorTaskExecutionQueue::OrderedActorTaskExecutionQueue(
+    instrumented_io_context &io_service,
     instrumented_io_context &task_execution_service,
     ActorTaskExecutionArgWaiterInterface &waiter,
     worker::TaskEventBuffer &task_event_buffer,
     std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
     int64_t reorder_wait_seconds)
-    : task_execution_service_(task_execution_service),
+    : io_service_(io_service),
+      task_execution_service_(task_execution_service),
       reorder_wait_seconds_(reorder_wait_seconds),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
@@ -76,8 +78,11 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   // Make a copy of the task spec because `task` is moved below.
   TaskSpecification task_spec = task.TaskSpec();
   const std::string &group = task_spec.ConcurrencyGroupName();
-  auto [iter, _] = group_states_.try_emplace(
-      group, ConcurrencyGroupOrderingState(task_execution_service_));
+  // wait_timer_ is bound to io_service_ because the queue's bookkeeping
+  // (and therefore the timer's manipulation: expires_from_now / async_wait /
+  // cancel + the expiry handler) all run on io_service_.
+  auto [iter, _] =
+      group_states_.try_emplace(group, ConcurrencyGroupOrderingState(io_service_));
   auto &group_state = iter->second;
 
   if (client_processed_up_to >= group_state.next_seq_no) {
@@ -291,7 +296,14 @@ void OrderedActorTaskExecutionQueue::ExecuteRequest(TaskToExecute &&request) {
   auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                          request.FunctionDescriptor());
   if (pool == nullptr) {
-    AcceptRequestOrRejectIfCanceled(task_id, request);
+    // No concurrency-group pool: post the user task body onto
+    // task_execution_service_ so it never blocks io_service_ (which runs the
+    // gRPC handlers and the queue's bookkeeping).
+    task_execution_service_.post(
+        [this, request = std::move(request), task_id]() mutable {
+          AcceptRequestOrRejectIfCanceled(task_id, request);
+        },
+        "OrderedActorTaskExecutionQueue.AcceptRequest");
   } else {
     pool->Post([this, request = std::move(request), task_id]() mutable {
       AcceptRequestOrRejectIfCanceled(task_id, request);

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -78,8 +78,6 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   // Make a copy of the task spec because `task` is moved below.
   TaskSpecification task_spec = task.TaskSpec();
   const std::string &group = task_spec.ConcurrencyGroupName();
-  // wait_timer_ is bound to io_service_ because the queue's bookkeeping
-  // runs on io_service_ now.
   auto [iter, _] =
       group_states_.try_emplace(group, ConcurrencyGroupOrderingState(io_service_));
   auto &group_state = iter->second;
@@ -294,12 +292,7 @@ void OrderedActorTaskExecutionQueue::ExecuteRequest(TaskToExecute &&request) {
   auto task_id = request.TaskID();
   auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                          request.FunctionDescriptor());
-  // AcceptRequestOrRejectIfCanceled runs inline on io_service_ (this is called
-  // from ExecuteQueuedTasks, already on io_service_). Only request.Execute()
-  // is posted off io_service_ -- to the concurrency-group pool if present,
-  // otherwise to task_execution_service_.
-
-  // This is done for two reasons:
+  // This runs on io_service_ for two reasons:
   // 1. all operations except for task execution happen on io_service_
   // 2. This serializes the is_canceled check with CancelTaskIfFound (also on
   // io_service_), eliminating the race where a cancel arriving mid-Execute would report
@@ -326,9 +319,7 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     return;
   }
 
-  // Post just the user task body. The post handler also erases the
-  // cancellation-flag entry under mu_ after Execute returns.
-  // Lock should not be held during execute since it can be long.
+  // Execute can be very long, and we shouldn't hold a lock.
   auto execute_handler = [this, task_id, request = std::move(request)]() mutable {
     request.Execute();
     absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -39,12 +39,8 @@ namespace core {
 class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
   /// \param io_service The io_context this queue's bookkeeping runs on.
-  ///   Used for: timer binding, re-posts of bookkeeping work, and the thread enforced by
-  ///   `RAY_CHECK(this_thread == main_thread_id_)`. Constructed-on-this-thread.
   /// \param task_execution_service The io_context that user task bodies
-  ///   (`request.Execute()`) are posted to when no concurrency-group thread pool
-  ///   is available. Decoupled from `io_service` so a long-running user task
-  ///   never blocks bookkeeping / arg-fetch IPCs on `io_service`.
+  /// run on (when no concurrency-group thread pool is available).
   OrderedActorTaskExecutionQueue(
       instrumented_io_context &io_service,
       instrumented_io_context &task_execution_service,
@@ -72,10 +68,8 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// Executes as many queued tasks as are ready to execute.
   void ExecuteQueuedTasks();
 
-  /// Accept the given TaskToExecute or reject it if the task id is canceled via
-  /// CancelTaskIfFound. Runs on `io_service_`. Only `request.Execute()`
-  /// (the user task body) is posted off `io_service_` — to `pool` if non-null,
-  /// otherwise to `task_execution_service_`.
+  /// Accept the given TaskToExecute or reject it if a task id is canceled via
+  /// CancelTaskIfFound.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id,
                                        TaskToExecute request,
                                        std::shared_ptr<BoundedExecutor> pool);
@@ -100,12 +94,7 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
     boost::asio::deadline_timer wait_timer_;
   };
 
-  /// io_context the queue's bookkeeping runs on (timer, EnqueueTask /
-  /// ExecuteQueuedTasks, waiter callbacks).
   instrumented_io_context &io_service_;
-
-  /// io_context user task bodies are posted to when no concurrency-group pool
-  /// is available.
   instrumented_io_context &task_execution_service_;
 
   /// Max time in seconds to wait for an earlier seq no to arrive.

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -38,9 +38,8 @@ namespace core {
 /// See core_worker.proto for a description of the ordering protocol.
 class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
-  /// \param io_service The io_context this queue's bookkeeping runs on (e.g. the
-  ///   gRPC handler thread / CoreWorker's io_service_). Used for: timer binding,
-  ///   re-posts of bookkeeping work, and the thread enforced by
+  /// \param io_service The io_context this queue's bookkeeping runs on.
+  ///   Used for: timer binding, re-posts of bookkeeping work, and the thread enforced by
   ///   `RAY_CHECK(this_thread == main_thread_id_)`. Constructed-on-this-thread.
   /// \param task_execution_service The io_context that user task bodies
   ///   (`request.Execute()`) are posted to when no concurrency-group thread pool
@@ -74,10 +73,7 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   void ExecuteQueuedTasks();
 
   /// Accept the given TaskToExecute or reject it if the task id is canceled via
-  /// CancelTaskIfFound. Runs on `io_service_` so the is_canceled check is
-  /// serialized with CancelTaskIfFound (which also runs on `io_service_`),
-  /// eliminating a race where a cancel arriving mid-Execute would report
-  /// "successfully cancelled" while the task still ran. Only `request.Execute()`
+  /// CancelTaskIfFound. Runs on `io_service_`. Only `request.Execute()`
   /// (the user task body) is posted off `io_service_` — to `pool` if non-null,
   /// otherwise to `task_execution_service_`.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id,
@@ -105,12 +101,11 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   };
 
   /// io_context the queue's bookkeeping runs on (timer, EnqueueTask /
-  /// ExecuteQueuedTasks, waiter callbacks). Same context as CoreWorker's
-  /// io_service_ — i.e. the gRPC handler thread.
+  /// ExecuteQueuedTasks, waiter callbacks).
   instrumented_io_context &io_service_;
 
   /// io_context user task bodies are posted to when no concurrency-group pool
-  /// is available. See ctor doc.
+  /// is available.
   instrumented_io_context &task_execution_service_;
 
   /// Max time in seconds to wait for an earlier seq no to arrive.

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -39,11 +39,11 @@ namespace core {
 class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
   /// \param io_service The io_context this queue's bookkeeping runs on.
-  /// \param task_execution_service The io_context that user task bodies
-  /// run on (when no concurrency-group thread pool is available).
+  /// \param default_postable Where to dispatch user task bodies when no
+  ///   concurrency-group thread pool applies.
   OrderedActorTaskExecutionQueue(
       instrumented_io_context &io_service,
-      instrumented_io_context &task_execution_service,
+      std::shared_ptr<Postable> default_postable,
       ActorTaskExecutionArgWaiterInterface &waiter,
       worker::TaskEventBuffer &task_event_buffer,
       std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
@@ -72,7 +72,7 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// CancelTaskIfFound.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id,
                                        TaskToExecute request,
-                                       std::shared_ptr<BoundedExecutor> pool);
+                                       std::shared_ptr<Postable> post_execute);
 
   void ExecuteRequest(TaskToExecute &&request);
 
@@ -95,7 +95,7 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   };
 
   instrumented_io_context &io_service_;
-  instrumented_io_context &task_execution_service_;
+  std::shared_ptr<Postable> default_postable_;
 
   /// Max time in seconds to wait for an earlier seq no to arrive.
   const int64_t reorder_wait_seconds_;

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -73,9 +73,16 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// Executes as many queued tasks as are ready to execute.
   void ExecuteQueuedTasks();
 
-  /// Accept the given TaskToExecute or reject it if a task id is canceled via
-  /// CancelTaskIfFound.
-  void AcceptRequestOrRejectIfCanceled(TaskID task_id, TaskToExecute &request);
+  /// Accept the given TaskToExecute or reject it if the task id is canceled via
+  /// CancelTaskIfFound. Runs on `io_service_` so the is_canceled check is
+  /// serialized with CancelTaskIfFound (which also runs on `io_service_`),
+  /// eliminating a race where a cancel arriving mid-Execute would report
+  /// "successfully cancelled" while the task still ran. Only `request.Execute()`
+  /// (the user task body) is posted off `io_service_` — to `pool` if non-null,
+  /// otherwise to `task_execution_service_`.
+  void AcceptRequestOrRejectIfCanceled(TaskID task_id,
+                                       TaskToExecute request,
+                                       std::shared_ptr<BoundedExecutor> pool);
 
   void ExecuteRequest(TaskToExecute &&request);
 

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -38,7 +38,16 @@ namespace core {
 /// See core_worker.proto for a description of the ordering protocol.
 class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
+  /// \param io_service The io_context this queue's bookkeeping runs on (e.g. the
+  ///   gRPC handler thread / CoreWorker's io_service_). Used for: timer binding,
+  ///   re-posts of bookkeeping work, and the thread enforced by
+  ///   `RAY_CHECK(this_thread == main_thread_id_)`. Constructed-on-this-thread.
+  /// \param task_execution_service The io_context that user task bodies
+  ///   (`request.Execute()`) are posted to when no concurrency-group thread pool
+  ///   is available. Decoupled from `io_service` so a long-running user task
+  ///   never blocks bookkeeping / arg-fetch IPCs on `io_service`.
   OrderedActorTaskExecutionQueue(
+      instrumented_io_context &io_service,
       instrumented_io_context &task_execution_service,
       ActorTaskExecutionArgWaiterInterface &waiter,
       worker::TaskEventBuffer &task_event_buffer,
@@ -88,6 +97,13 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
     boost::asio::deadline_timer wait_timer_;
   };
 
+  /// io_context the queue's bookkeeping runs on (timer, EnqueueTask /
+  /// ExecuteQueuedTasks, waiter callbacks). Same context as CoreWorker's
+  /// io_service_ — i.e. the gRPC handler thread.
+  instrumented_io_context &io_service_;
+
+  /// io_context user task bodies are posted to when no concurrency-group pool
+  /// is available. See ctor doc.
   instrumented_io_context &task_execution_service_;
 
   /// Max time in seconds to wait for an earlier seq no to arrive.

--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -220,6 +220,7 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                    allow_out_of_order_execution_
                        ? std::unique_ptr<ActorTaskExecutionQueueInterface>(
                              std::make_unique<UnorderedActorTaskExecutionQueue>(
+                                 io_service_,
                                  task_execution_service_,
                                  waiter_,
                                  task_event_buffer_,
@@ -230,6 +231,7 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                                  concurrency_groups_))
                        : std::unique_ptr<ActorTaskExecutionQueueInterface>(
                              std::make_unique<OrderedActorTaskExecutionQueue>(
+                                 io_service_,
                                  task_execution_service_,
                                  waiter_,
                                  task_event_buffer_,

--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -214,6 +214,8 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
   } else if (task_spec.IsActorTask()) {
     auto it = actor_task_execution_queues_.find(task_spec.CallerWorkerId());
     if (it == actor_task_execution_queues_.end()) {
+      auto default_postable = std::make_shared<IoContextPostable>(
+          task_execution_service_, "ActorTaskExecutionQueue.Execute");
       it = actor_task_execution_queues_
                .emplace(
                    task_spec.CallerWorkerId(),
@@ -221,7 +223,7 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                        ? std::unique_ptr<ActorTaskExecutionQueueInterface>(
                              std::make_unique<UnorderedActorTaskExecutionQueue>(
                                  io_service_,
-                                 task_execution_service_,
+                                 std::move(default_postable),
                                  waiter_,
                                  task_event_buffer_,
                                  pool_manager_,
@@ -232,7 +234,7 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                        : std::unique_ptr<ActorTaskExecutionQueueInterface>(
                              std::make_unique<OrderedActorTaskExecutionQueue>(
                                  io_service_,
-                                 task_execution_service_,
+                                 std::move(default_postable),
                                  waiter_,
                                  task_event_buffer_,
                                  pool_manager_,

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -54,11 +54,6 @@ class TaskReceiver {
       std::string *actor_repr_name,
       std::string *application_error)>;
 
-  /// \param io_service The io_context the queue's bookkeeping runs on. All
-  ///   public TaskReceiver methods MUST be invoked from this thread.
-  /// \param task_execution_service The io_context user task bodies are posted
-  ///   to when no concurrency-group pool is available (forwarded to actor
-  ///   queues).
   TaskReceiver(instrumented_io_context &io_service,
                instrumented_io_context &task_execution_service,
                worker::TaskEventBuffer &task_event_buffer,
@@ -124,12 +119,8 @@ class TaskReceiver {
   /// The callback function to process a task.
   TaskHandler task_handler_;
 
-  /// The event loop the queue's bookkeeping runs on (gRPC handler thread).
-  /// Public TaskReceiver methods MUST be invoked from this thread.
   instrumented_io_context &io_service_;
 
-  /// The event loop user task bodies (`request.Execute()`) are posted to when
-  /// no concurrency-group pool is available. Forwarded to actor queues.
   instrumented_io_context &task_execution_service_;
 
   worker::TaskEventBuffer &task_event_buffer_;

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -121,6 +121,7 @@ class TaskReceiver {
 
   instrumented_io_context &io_service_;
 
+  /// The event loop for running tasks on.
   instrumented_io_context &task_execution_service_;
 
   worker::TaskEventBuffer &task_event_buffer_;

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -54,12 +54,19 @@ class TaskReceiver {
       std::string *actor_repr_name,
       std::string *application_error)>;
 
-  TaskReceiver(instrumented_io_context &task_execution_service,
+  /// \param io_service The io_context the queue's bookkeeping runs on. All
+  ///   public TaskReceiver methods MUST be invoked from this thread.
+  /// \param task_execution_service The io_context user task bodies are posted
+  ///   to when no concurrency-group pool is available (forwarded to actor
+  ///   queues).
+  TaskReceiver(instrumented_io_context &io_service,
+               instrumented_io_context &task_execution_service,
                worker::TaskEventBuffer &task_event_buffer,
                TaskHandler task_handler,
                ActorTaskExecutionArgWaiter &actor_task_execution_arg_waiter,
                std::function<std::function<void()>()> initialize_thread_callback)
       : task_handler_(std::move(task_handler)),
+        io_service_(io_service),
         task_execution_service_(task_execution_service),
         task_event_buffer_(task_event_buffer),
         waiter_(actor_task_execution_arg_waiter),
@@ -117,7 +124,12 @@ class TaskReceiver {
   /// The callback function to process a task.
   TaskHandler task_handler_;
 
-  /// The event loop for running tasks on.
+  /// The event loop the queue's bookkeeping runs on (gRPC handler thread).
+  /// Public TaskReceiver methods MUST be invoked from this thread.
+  instrumented_io_context &io_service_;
+
+  /// The event loop user task bodies (`request.Execute()`) are posted to when
+  /// no concurrency-group pool is available. Forwarded to actor queues.
   instrumented_io_context &task_execution_service_;
 
   worker::TaskEventBuffer &task_event_buffer_;

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -105,7 +105,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
@@ -176,7 +176,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestInOrder) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
@@ -211,7 +211,7 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   // One running task that blocks until we signal.
   std::promise<void> running_started;
   std::promise<void> allow_finish;
@@ -261,7 +261,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
 
@@ -312,7 +312,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
 
@@ -355,7 +355,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSeqWaitTimeout) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
 
@@ -396,7 +396,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSkipAlreadyProcessedByClient) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
   auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
@@ -450,7 +450,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 2);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 2);
   std::vector<int64_t> accept_seq_nos;
   std::vector<int64_t> reject_seq_nos;
   std::atomic<int> n_accept = 0;
@@ -507,7 +507,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 2);
+      io_service, io_service, waiter, task_event_buffer, pool_manager, 2);
 
   // Track accepted tasks as (group_name, seq_no) pairs.
   std::vector<std::pair<std::string, int64_t>> accepted;
@@ -569,6 +569,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   UnorderedActorTaskExecutionQueue queue(io_service,
+                                         io_service,
                                          waiter,
                                          task_event_buffer,
                                          pool_manager,
@@ -644,6 +645,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
   MockTaskEventBuffer task_event_buffer;
   UnorderedActorTaskExecutionQueue queue(
       io_service,
+      io_service,
       waiter,
       task_event_buffer,
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
@@ -710,6 +712,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
   MockWaiter waiter;
   MockTaskEventBuffer task_event_buffer;
   UnorderedActorTaskExecutionQueue queue(
+      io_service,
       io_service,
       waiter,
       task_event_buffer,

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -33,6 +33,12 @@ using std::chrono_literals::operator""s;
 namespace ray {
 namespace core {
 
+// Tests run the queue's user-task-body dispatch on the same io_context as the
+// queue's bookkeeping for simplicity.
+std::shared_ptr<Postable> IoServicePostable(instrumented_io_context &io_service) {
+  return std::make_shared<IoContextPostable>(io_service, "TestPostable");
+}
+
 class MockWaiter : public ActorTaskExecutionArgWaiterInterface {
  public:
   MockWaiter() {}
@@ -104,8 +110,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
@@ -175,8 +185,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestInOrder) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
@@ -210,8 +224,12 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   // One running task that blocks until we signal.
   std::promise<void> running_started;
   std::promise<void> allow_finish;
@@ -260,8 +278,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
 
@@ -311,8 +333,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
 
@@ -354,8 +380,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSeqWaitTimeout) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
 
@@ -395,8 +425,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSkipAlreadyProcessedByClient) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 1);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
   auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
@@ -449,8 +483,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 2);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       2);
   std::vector<int64_t> accept_seq_nos;
   std::vector<int64_t> reject_seq_nos;
   std::atomic<int> n_accept = 0;
@@ -506,8 +544,12 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, io_service, waiter, task_event_buffer, pool_manager, 2);
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       IoServicePostable(io_service),
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       2);
 
   // Track accepted tasks as (group_name, seq_no) pairs.
   std::vector<std::pair<std::string, int64_t>> accepted;
@@ -569,7 +611,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
   UnorderedActorTaskExecutionQueue queue(io_service,
-                                         io_service,
+                                         IoServicePostable(io_service),
                                          waiter,
                                          task_event_buffer,
                                          pool_manager,
@@ -645,7 +687,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
   MockTaskEventBuffer task_event_buffer;
   UnorderedActorTaskExecutionQueue queue(
       io_service,
-      io_service,
+      IoServicePostable(io_service),
       waiter,
       task_event_buffer,
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
@@ -713,7 +755,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
   MockTaskEventBuffer task_event_buffer;
   UnorderedActorTaskExecutionQueue queue(
       io_service,
-      io_service,
+      IoServicePostable(io_service),
       waiter,
       task_event_buffer,
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(

--- a/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
+++ b/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
@@ -139,6 +139,9 @@ class TaskReceiverTest : public ::testing::Test {
     RayConfig::instance().initialize(
         R"({"actor_scheduling_queue_max_reorder_wait_seconds": 1})");
     receiver_ = std::make_unique<TaskReceiver>(
+        // Tests share one io_context; in production io_service_ and
+        // task_execution_service_ are distinct.
+        task_execution_service_,
         task_execution_service_,
         task_event_buffer_,
         execute_task,

--- a/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
+++ b/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
@@ -139,8 +139,7 @@ class TaskReceiverTest : public ::testing::Test {
     RayConfig::instance().initialize(
         R"({"actor_scheduling_queue_max_reorder_wait_seconds": 1})");
     receiver_ = std::make_unique<TaskReceiver>(
-        // Tests share one io_context; in production io_service_ and
-        // task_execution_service_ are distinct.
+        // Test uses one io_context for both io_service and task_execution_service.
         task_execution_service_,
         task_execution_service_,
         task_event_buffer_,
@@ -189,11 +188,7 @@ TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
 
   int callback_count = 0;
 
-  // Replies are passed by pointer into QueueTaskForExecution and accessed by
-  // the actor queue's posted Execute() handler (which runs on
-  // task_execution_service_ — via the no-pool post path). They must therefore
-  // outlive StartIOService() below. Declare them at function scope so they're
-  // alive through the whole test (in production, gRPC manages reply lifetime).
+  // Replies must outlive StartIOService() below since posted handlers reference them.
   rpc::PushTaskReply reply0;
   rpc::PushTaskReply reply1;
   rpc::PushTaskReply reply2;

--- a/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
+++ b/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
@@ -189,19 +189,28 @@ TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
 
   int callback_count = 0;
 
+  // Replies are passed by pointer into QueueTaskForExecution and accessed by
+  // the actor queue's posted Execute() handler (which runs on
+  // task_execution_service_ — via the no-pool post path). They must therefore
+  // outlive StartIOService() below. Declare them at function scope so they're
+  // alive through the whole test (in production, gRPC manages reply lifetime).
+  rpc::PushTaskReply reply0;
+  rpc::PushTaskReply reply1;
+  rpc::PushTaskReply reply2;
+  rpc::PushTaskReply reply3;
+
   // Push a task request with actor counter 0. This should succeed
   // on the receiver.
   {
     auto request =
         CreatePushTaskRequestHelper(actor_id, 0, worker_id, caller_id, curr_timestamp);
-    rpc::PushTaskReply reply;
     auto reply_callback = [&callback_count](Status status,
                                             std::function<void()> success,
                                             std::function<void()> failure) {
       ++callback_count;
       ASSERT_TRUE(status.ok());
     };
-    receiver_->QueueTaskForExecution(request, &reply, reply_callback);
+    receiver_->QueueTaskForExecution(request, &reply0, reply_callback);
   }
 
   // Push a task request with actor counter 1. This should succeed
@@ -209,14 +218,13 @@ TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
   {
     auto request =
         CreatePushTaskRequestHelper(actor_id, 1, worker_id, caller_id, curr_timestamp);
-    rpc::PushTaskReply reply;
     auto reply_callback = [&callback_count](Status status,
                                             std::function<void()> success,
                                             std::function<void()> failure) {
       ++callback_count;
       ASSERT_TRUE(status.ok());
     };
-    receiver_->QueueTaskForExecution(request, &reply, reply_callback);
+    receiver_->QueueTaskForExecution(request, &reply1, reply_callback);
   }
 
   // Create another request with the same caller id, but a different worker id,
@@ -228,14 +236,13 @@ TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
     worker_id = WorkerID::FromRandom();
     auto request =
         CreatePushTaskRequestHelper(actor_id, 0, worker_id, caller_id, new_timestamp);
-    rpc::PushTaskReply reply;
     auto reply_callback = [&callback_count](Status status,
                                             std::function<void()> success,
                                             std::function<void()> failure) {
       ++callback_count;
       ASSERT_TRUE(status.ok());
     };
-    receiver_->QueueTaskForExecution(request, &reply, reply_callback);
+    receiver_->QueueTaskForExecution(request, &reply2, reply_callback);
   }
 
   // Push a task request with actor counter 1, but with a different worker id,
@@ -244,14 +251,13 @@ TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
     worker_id = WorkerID::FromRandom();
     auto request =
         CreatePushTaskRequestHelper(actor_id, 1, worker_id, caller_id, old_timestamp);
-    rpc::PushTaskReply reply;
     auto reply_callback = [&callback_count](Status status,
                                             std::function<void()> success,
                                             std::function<void()> failure) {
       ++callback_count;
       ASSERT_TRUE(!status.ok());
     };
-    receiver_->QueueTaskForExecution(request, &reply, reply_callback);
+    receiver_->QueueTaskForExecution(request, &reply3, reply_callback);
   }
 
   StartIOService();

--- a/src/ray/core_worker/task_execution/thread_pool.h
+++ b/src/ray/core_worker/task_execution/thread_pool.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "ray/core_worker/task_execution/common.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -30,7 +31,7 @@ namespace core {
 
 /// Thread pool implementation that provides backpressure by blocking until there is
 /// a thread available.
-class BoundedExecutor {
+class BoundedExecutor : public Postable {
  public:
   static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group,
                                   bool has_other_concurrency_groups) {
@@ -54,7 +55,7 @@ class BoundedExecutor {
 
   /// Posts work to the pool. This is a non-blocking call. In addition, the execution
   /// order of the tasks is not guaranteed if there are multiple threads in the pool.
-  void Post(std::function<void()> fn);
+  void Post(std::function<void()> fn) override;
 
   /// Stop the thread pool.
   void Stop();

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -247,20 +247,7 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     request.Execute();
     post_task_cleanup();
   };
-  if (is_asyncio_) {
-    // For asyncio actors post_execute is a FiberState, whose Post() blocks the
-    // caller until the fiber runner picks the task up (unbuffered fiber-channel
-    // rendezvous, see fiber.h). This code runs on io_service_, the single thread
-    // that also services health-check and other RPCs, so blocking here can stall
-    // the whole worker. Hand the blocking dispatch to task_execution_service_
-    // instead; arg fetching still runs on io_service_, so pipelining is unaffected.
-    default_postable_->Post([post_execute = std::move(post_execute),
-                             execute_handler = std::move(execute_handler)]() mutable {
-      post_execute->Post(std::move(execute_handler));
-    });
-  } else {
-    post_execute->Post(std::move(execute_handler));
-  }
+  post_execute->Post(std::move(execute_handler));
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -27,7 +27,7 @@ namespace core {
 
 UnorderedActorTaskExecutionQueue::UnorderedActorTaskExecutionQueue(
     instrumented_io_context &io_service,
-    instrumented_io_context &task_execution_service,
+    std::shared_ptr<Postable> default_postable,
     ActorTaskExecutionArgWaiterInterface &waiter,
     worker::TaskEventBuffer &task_event_buffer,
     std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
@@ -36,7 +36,7 @@ UnorderedActorTaskExecutionQueue::UnorderedActorTaskExecutionQueue(
     int fiber_max_concurrency,
     const std::vector<ConcurrencyGroup> &concurrency_groups)
     : io_service_(io_service),
-      task_execution_service_(task_execution_service),
+      default_postable_(std::move(default_postable)),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),
@@ -148,30 +148,17 @@ void UnorderedActorTaskExecutionQueue::RunRequestWithResolvedDependencies(
   RAY_CHECK(request.DependenciesResolved());
   const auto task_id = request.TaskID();
 
-  // Package the "post user task body off io_service_" decision into a
-  // PostExecuteFn that captures the correct target (fiber / pool /
-  // task_execution_service_).
-  PostExecuteFn post_execute;
+  // Pick where to run the user task body: fiber, concurrency-group pool,
+  // or the default postable.
+  std::shared_ptr<Postable> post_execute;
   if (is_asyncio_) {
-    auto fiber = fiber_state_manager_->GetExecutor(request.ConcurrencyGroupName(),
-                                                   request.FunctionDescriptor());
-    post_execute = [fiber = std::move(fiber)](std::function<void()> task) mutable {
-      fiber->EnqueueFiber(std::move(task));
-    };
+    post_execute = fiber_state_manager_->GetExecutor(request.ConcurrencyGroupName(),
+                                                     request.FunctionDescriptor());
   } else {
     RAY_CHECK(pool_manager_ != nullptr);
     auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                            request.FunctionDescriptor());
-    if (pool == nullptr) {
-      post_execute = [this](std::function<void()> task) {
-        task_execution_service_.post(std::move(task),
-                                     "UnorderedActorTaskExecutionQueue.Execute");
-      };
-    } else {
-      post_execute = [pool = std::move(pool)](std::function<void()> task) mutable {
-        pool->Post(std::move(task));
-      };
-    }
+    post_execute = pool ? std::shared_ptr<Postable>(std::move(pool)) : default_postable_;
   }
   AcceptRequestOrRejectIfCanceled(task_id, std::move(request), std::move(post_execute));
 }
@@ -217,7 +204,7 @@ void UnorderedActorTaskExecutionQueue::RunRequest(TaskToExecute request) {
 }
 
 void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
-    TaskID task_id, TaskToExecute request, PostExecuteFn post_execute) {
+    TaskID task_id, TaskToExecute request, std::shared_ptr<Postable> post_execute) {
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);
@@ -260,7 +247,7 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     request.Execute();
     post_task_cleanup();
   };
-  post_execute(std::move(execute_handler));
+  post_execute->Post(std::move(execute_handler));
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -247,7 +247,20 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     request.Execute();
     post_task_cleanup();
   };
-  post_execute->Post(std::move(execute_handler));
+  if (is_asyncio_) {
+    // For asyncio actors post_execute is a FiberState, whose Post() blocks the
+    // caller until the fiber runner picks the task up (unbuffered fiber-channel
+    // rendezvous, see fiber.h). This code runs on io_service_, the single thread
+    // that also services health-check and other RPCs, so blocking here can stall
+    // the whole worker. Hand the blocking dispatch to task_execution_service_
+    // instead; arg fetching still runs on io_service_, so pipelining is unaffected.
+    default_postable_->Post([post_execute = std::move(post_execute),
+                             execute_handler = std::move(execute_handler)]() mutable {
+      post_execute->Post(std::move(execute_handler));
+    });
+  } else {
+    post_execute->Post(std::move(execute_handler));
+  }
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -147,32 +147,33 @@ void UnorderedActorTaskExecutionQueue::RunRequestWithResolvedDependencies(
     TaskToExecute request) {
   RAY_CHECK(request.DependenciesResolved());
   const auto task_id = request.TaskID();
+
+  // AcceptRequestOrRejectIfCanceled runs inline on io_service_; we package the
+  // "post user task body off io_service_" decision into a PostExecuteFn that
+  // captures the correct target (fiber / pool / task_execution_service_).
+  PostExecuteFn post_execute;
   if (is_asyncio_) {
-    // Process async actor task.
     auto fiber = fiber_state_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                                    request.FunctionDescriptor());
-    fiber->EnqueueFiber([this, request = std::move(request), task_id]() mutable {
-      AcceptRequestOrRejectIfCanceled(task_id, request);
-    });
+    post_execute = [fiber = std::move(fiber)](std::function<void()> task) mutable {
+      fiber->EnqueueFiber(std::move(task));
+    };
   } else {
-    // Process actor tasks.
     RAY_CHECK(pool_manager_ != nullptr);
     auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                            request.FunctionDescriptor());
     if (pool == nullptr) {
-      // No concurrency-group pool: post the user task body onto
-      // task_execution_service_ so it never blocks io_service_.
-      task_execution_service_.post(
-          [this, request = std::move(request), task_id]() mutable {
-            AcceptRequestOrRejectIfCanceled(task_id, request);
-          },
-          "UnorderedActorTaskExecutionQueue.AcceptRequest");
+      post_execute = [this](std::function<void()> task) {
+        task_execution_service_.post(std::move(task),
+                                     "UnorderedActorTaskExecutionQueue.Execute");
+      };
     } else {
-      pool->Post([this, request = std::move(request), task_id]() mutable {
-        AcceptRequestOrRejectIfCanceled(task_id, request);
-      });
+      post_execute = [pool = std::move(pool)](std::function<void()> task) mutable {
+        pool->Post(std::move(task));
+      };
     }
   }
+  AcceptRequestOrRejectIfCanceled(task_id, std::move(request), std::move(post_execute));
 }
 
 void UnorderedActorTaskExecutionQueue::RunRequest(TaskToExecute request) {
@@ -216,7 +217,7 @@ void UnorderedActorTaskExecutionQueue::RunRequest(TaskToExecute request) {
 }
 
 void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
-    TaskID task_id, TaskToExecute &request) {
+    TaskID task_id, TaskToExecute request, PostExecuteFn post_execute) {
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);
@@ -226,35 +227,46 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     }
   }
 
-  // Accept can be very long, and we shouldn't hold a lock.
+  // Helper: run the post-task-completion bookkeeping (check for a queued next
+  // attempt; if present, run it; otherwise, erase the cancellation flag).
+  // Called either inline (cancel branch) or from the execute_handler (post
+  // branch). Always uses mu_, so thread-safe regardless of caller.
+  auto post_task_cleanup = [this, task_id]() {
+    std::optional<TaskToExecute> request_to_run;
+    {
+      absl::MutexLock lock(&mu_);
+      auto it = queued_actor_tasks_.find(task_id);
+      if (it != queued_actor_tasks_.end()) {
+        request_to_run = std::move(it->second);
+        queued_actor_tasks_.erase(it);
+      } else {
+        pending_task_id_to_is_canceled.erase(task_id);
+      }
+    }
+    if (request_to_run.has_value()) {
+      // Re-run on io_service_ where the queue's bookkeeping lives.
+      io_service_.post(
+          [this, request = std::move(*request_to_run)]() mutable {
+            RunRequest(std::move(request));
+          },
+          "UnorderedActorTaskExecutionQueue.RunRequest");
+    }
+  };
+
   if (is_canceled) {
     request.Cancel(
         Status::SchedulingCancelled("Task is canceled before it is scheduled."));
-  } else {
+    post_task_cleanup();
+    return;
+  }
+
+  // Post just the user task body. The post handler also runs post-task cleanup
+  // after Execute returns.
+  auto execute_handler = [request = std::move(request), post_task_cleanup]() mutable {
     request.Execute();
-  }
-
-  std::optional<TaskToExecute> request_to_run;
-  {
-    absl::MutexLock lock(&mu_);
-    auto it = queued_actor_tasks_.find(task_id);
-    if (it != queued_actor_tasks_.end()) {
-      request_to_run = std::move(it->second);
-      queued_actor_tasks_.erase(it);
-    } else {
-      pending_task_id_to_is_canceled.erase(task_id);
-    }
-  }
-
-  if (request_to_run.has_value()) {
-    // Post the deferred RunRequest to io_service_ — that's where the queue's
-    // bookkeeping (and waiter callback) lives now.
-    io_service_.post(
-        [this, request = std::move(*request_to_run)]() mutable {
-          RunRequest(std::move(request));
-        },
-        "UnorderedActorTaskExecutionQueue.RunRequest");
-  }
+    post_task_cleanup();
+  };
+  post_execute(std::move(execute_handler));
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -26,6 +26,7 @@ namespace ray {
 namespace core {
 
 UnorderedActorTaskExecutionQueue::UnorderedActorTaskExecutionQueue(
+    instrumented_io_context &io_service,
     instrumented_io_context &task_execution_service,
     ActorTaskExecutionArgWaiterInterface &waiter,
     worker::TaskEventBuffer &task_event_buffer,
@@ -34,7 +35,8 @@ UnorderedActorTaskExecutionQueue::UnorderedActorTaskExecutionQueue(
     bool is_asyncio,
     int fiber_max_concurrency,
     const std::vector<ConcurrencyGroup> &concurrency_groups)
-    : task_execution_service_(task_execution_service),
+    : io_service_(io_service),
+      task_execution_service_(task_execution_service),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),
@@ -158,7 +160,13 @@ void UnorderedActorTaskExecutionQueue::RunRequestWithResolvedDependencies(
     auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                            request.FunctionDescriptor());
     if (pool == nullptr) {
-      AcceptRequestOrRejectIfCanceled(task_id, request);
+      // No concurrency-group pool: post the user task body onto
+      // task_execution_service_ so it never blocks io_service_.
+      task_execution_service_.post(
+          [this, request = std::move(request), task_id]() mutable {
+            AcceptRequestOrRejectIfCanceled(task_id, request);
+          },
+          "UnorderedActorTaskExecutionQueue.AcceptRequest");
     } else {
       pool->Post([this, request = std::move(request), task_id]() mutable {
         AcceptRequestOrRejectIfCanceled(task_id, request);
@@ -239,7 +247,9 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
   }
 
   if (request_to_run.has_value()) {
-    task_execution_service_.post(
+    // Post the deferred RunRequest to io_service_ — that's where the queue's
+    // bookkeeping (and waiter callback) lives now.
+    io_service_.post(
         [this, request = std::move(*request_to_run)]() mutable {
           RunRequest(std::move(request));
         },

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -148,9 +148,9 @@ void UnorderedActorTaskExecutionQueue::RunRequestWithResolvedDependencies(
   RAY_CHECK(request.DependenciesResolved());
   const auto task_id = request.TaskID();
 
-  // AcceptRequestOrRejectIfCanceled runs inline on io_service_; we package the
-  // "post user task body off io_service_" decision into a PostExecuteFn that
-  // captures the correct target (fiber / pool / task_execution_service_).
+  // Package the "post user task body off io_service_" decision into a
+  // PostExecuteFn that captures the correct target (fiber / pool /
+  // task_execution_service_).
   PostExecuteFn post_execute;
   if (is_asyncio_) {
     auto fiber = fiber_state_manager_->GetExecutor(request.ConcurrencyGroupName(),
@@ -227,9 +227,6 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     }
   }
 
-  // Helper: run the post-task-completion bookkeeping .
-  // Called either inline (cancel branch) or from the execute_handler (post
-  // branch). Always uses mu_, so thread-safe regardless of caller.
   auto post_task_cleanup = [this, task_id]() {
     std::optional<TaskToExecute> request_to_run;
     {
@@ -243,7 +240,6 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
       }
     }
     if (request_to_run.has_value()) {
-      // Re-run on io_service_ where the queue's bookkeeping lives.
       io_service_.post(
           [this, request = std::move(*request_to_run)]() mutable {
             RunRequest(std::move(request));
@@ -253,15 +249,13 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
   };
 
   if (is_canceled) {
-    // Note that cancel is now called on io_service_
     request.Cancel(
         Status::SchedulingCancelled("Task is canceled before it is scheduled."));
     post_task_cleanup();
     return;
   }
 
-  // Post just the user task body. The post handler also runs post-task cleanup
-  // after Execute returns.
+  // Execute can be very long, and we shouldn't hold a lock.
   auto execute_handler = [request = std::move(request), post_task_cleanup]() mutable {
     request.Execute();
     post_task_cleanup();

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -254,6 +254,7 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
   };
 
   if (is_canceled) {
+    // Note that cancel is now called on io_service_
     request.Cancel(
         Status::SchedulingCancelled("Task is canceled before it is scheduled."));
     post_task_cleanup();

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -227,8 +227,7 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
     }
   }
 
-  // Helper: run the post-task-completion bookkeeping (check for a queued next
-  // attempt; if present, run it; otherwise, erase the cancellation flag).
+  // Helper: run the post-task-completion bookkeeping .
   // Called either inline (cancel branch) or from the execute_handler (post
   // branch). Always uses mu_, so thread-safe regardless of caller.
   auto post_task_cleanup = [this, task_id]() {

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -39,7 +39,10 @@ namespace core {
 /// Does not guarantee that tasks are executed in submission order.
 class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
+  /// See OrderedActorTaskExecutionQueue's ctor for the io_service /
+  /// task_execution_service distinction.
   UnorderedActorTaskExecutionQueue(
+      instrumented_io_context &io_service,
       instrumented_io_context &task_execution_service,
       ActorTaskExecutionArgWaiterInterface &waiter,
       worker::TaskEventBuffer &task_event_buffer,
@@ -72,6 +75,12 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
   /// CancelTaskIfFound.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id, TaskToExecute &request);
 
+  /// io_context the queue's bookkeeping runs on. Same as CoreWorker's
+  /// io_service_ — i.e. the gRPC handler thread.
+  instrumented_io_context &io_service_;
+
+  /// io_context user task bodies are posted to when no concurrency-group pool
+  /// is available.
   instrumented_io_context &task_execution_service_;
   /// The id of the thread that constructed this scheduling queue.
   std::thread::id main_thread_id_;

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -40,12 +40,11 @@ namespace core {
 class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
   /// \param io_service The io_context this queue's bookkeeping runs on.
-  /// \param task_execution_service The io_context that user task bodies
-  ///   (`request.Execute()`) are posted to when no concurrency-group thread pool
-  ///   is available.
+  /// \param default_postable Where to dispatch user task bodies when no
+  ///   concurrency-group thread pool or fiber applies.
   UnorderedActorTaskExecutionQueue(
       instrumented_io_context &io_service,
-      instrumented_io_context &task_execution_service,
+      std::shared_ptr<Postable> default_postable,
       ActorTaskExecutionArgWaiterInterface &waiter,
       worker::TaskEventBuffer &task_event_buffer,
       std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
@@ -73,16 +72,14 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
 
   void RunRequestWithResolvedDependencies(TaskToExecute request);
 
-  using PostExecuteFn = std::function<void(std::function<void()>)>;
-
   /// Accept the given TaskToExecute or reject it if a task id is canceled via
   /// CancelTaskIfFound.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id,
                                        TaskToExecute request,
-                                       PostExecuteFn post_execute);
+                                       std::shared_ptr<Postable> post_execute);
 
   instrumented_io_context &io_service_;
-  instrumented_io_context &task_execution_service_;
+  std::shared_ptr<Postable> default_postable_;
   /// The id of the thread that constructed this scheduling queue.
   std::thread::id main_thread_id_;
   ActorTaskExecutionArgWaiterInterface &waiter_;

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -39,8 +39,13 @@ namespace core {
 /// Does not guarantee that tasks are executed in submission order.
 class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
-  /// See OrderedActorTaskExecutionQueue's ctor for the io_service /
-  /// task_execution_service distinction.
+  /// \param io_service The io_context this queue's bookkeeping runs on.
+  ///   Used for: timer binding, re-posts of bookkeeping work, and the thread enforced by
+  ///   `RAY_CHECK(this_thread == main_thread_id_)`. Constructed-on-this-thread.
+  /// \param task_execution_service The io_context that user task bodies
+  ///   (`request.Execute()`) are posted to when no concurrency-group thread pool
+  ///   is available. Decoupled from `io_service` so a long-running user task
+  ///   never blocks bookkeeping / arg-fetch IPCs on `io_service`.
   UnorderedActorTaskExecutionQueue(
       instrumented_io_context &io_service,
       instrumented_io_context &task_execution_service,
@@ -76,19 +81,14 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
   using PostExecuteFn = std::function<void(std::function<void()>)>;
 
   /// Accept the given TaskToExecute or reject it if the task id is canceled via
-  /// CancelTaskIfFound. Runs on `io_service_` so the is_canceled check is
-  /// serialized with CancelTaskIfFound (also on `io_service_`). Only the user
+  /// CancelTaskIfFound. Runs on `io_service_`. Only the user
   /// task body is posted off `io_service_`, via `post_execute`.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id,
                                        TaskToExecute request,
                                        PostExecuteFn post_execute);
 
-  /// io_context the queue's bookkeeping runs on. Same as CoreWorker's
-  /// io_service_ — i.e. the gRPC handler thread.
   instrumented_io_context &io_service_;
 
-  /// io_context user task bodies are posted to when no concurrency-group pool
-  /// is available.
   instrumented_io_context &task_execution_service_;
   /// The id of the thread that constructed this scheduling queue.
   std::thread::id main_thread_id_;

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -71,9 +71,17 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
 
   void RunRequestWithResolvedDependencies(TaskToExecute request);
 
-  /// Accept the given TaskToExecute or reject it if a task id is canceled via
-  /// CancelTaskIfFound.
-  void AcceptRequestOrRejectIfCanceled(TaskID task_id, TaskToExecute &request);
+  /// How to dispatch the user task body off io_service_. Captures the choice
+  /// of asyncio fiber, concurrency-group thread pool, or task_execution_service_.
+  using PostExecuteFn = std::function<void(std::function<void()>)>;
+
+  /// Accept the given TaskToExecute or reject it if the task id is canceled via
+  /// CancelTaskIfFound. Runs on `io_service_` so the is_canceled check is
+  /// serialized with CancelTaskIfFound (also on `io_service_`). Only the user
+  /// task body is posted off `io_service_`, via `post_execute`.
+  void AcceptRequestOrRejectIfCanceled(TaskID task_id,
+                                       TaskToExecute request,
+                                       PostExecuteFn post_execute);
 
   /// io_context the queue's bookkeeping runs on. Same as CoreWorker's
   /// io_service_ — i.e. the gRPC handler thread.

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -40,12 +40,9 @@ namespace core {
 class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
  public:
   /// \param io_service The io_context this queue's bookkeeping runs on.
-  ///   Used for: timer binding, re-posts of bookkeeping work, and the thread enforced by
-  ///   `RAY_CHECK(this_thread == main_thread_id_)`. Constructed-on-this-thread.
   /// \param task_execution_service The io_context that user task bodies
   ///   (`request.Execute()`) are posted to when no concurrency-group thread pool
-  ///   is available. Decoupled from `io_service` so a long-running user task
-  ///   never blocks bookkeeping / arg-fetch IPCs on `io_service`.
+  ///   is available.
   UnorderedActorTaskExecutionQueue(
       instrumented_io_context &io_service,
       instrumented_io_context &task_execution_service,
@@ -76,19 +73,15 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
 
   void RunRequestWithResolvedDependencies(TaskToExecute request);
 
-  /// How to dispatch the user task body off io_service_. Captures the choice
-  /// of asyncio fiber, concurrency-group thread pool, or task_execution_service_.
   using PostExecuteFn = std::function<void(std::function<void()>)>;
 
-  /// Accept the given TaskToExecute or reject it if the task id is canceled via
-  /// CancelTaskIfFound. Runs on `io_service_`. Only the user
-  /// task body is posted off `io_service_`, via `post_execute`.
+  /// Accept the given TaskToExecute or reject it if a task id is canceled via
+  /// CancelTaskIfFound.
   void AcceptRequestOrRejectIfCanceled(TaskID task_id,
                                        TaskToExecute request,
                                        PostExecuteFn post_execute);
 
   instrumented_io_context &io_service_;
-
   instrumented_io_context &task_execution_service_;
   /// The id of the thread that constructed this scheduling queue.
   std::thread::id main_thread_id_;


### PR DESCRIPTION
**Issue**
Actor task arg-fetching was getting blocked by in-flight actor task execution. When a PushTask RPC arrives, the worker sends an IPC to the raylet asking it to pull the args; that IPC was being dispatched on `task_execution_service_`, the same loop that runs user actor task bodies. If the actor was busy executing a task, the IPC sat in the queue behind it — defeating the whole point of pipelining args-fetch with execution.

**Fix**
Restructure so that only the user task body (request.Execute()) runs on `task_execution_service_ `(or a concurrency-group pool / asyncio fiber). Everything else — queue bookkeeping, args-fetch IPC dispatch, cancellation decisions, dependency resolution, timer management — runs on `io_service_`

Changes:
  - `OrderedActorTaskExecutionQueue` and `UnorderedActorTaskExecutionQueue` now take both `io_service_` and
  `task_execution_service_`. The `wait_timer_` and all internal state live on `io_service_`.
  - `TaskReceiver::QueueTaskForExecution` for actor tasks is no longer wrapped in `task_execution_service_.post(...)` — it runs inline on `io_service_` from `HandlePushTask`.
  - `CoreWorker::HandleActorCallArgWaitComplete` invokes `MarkReady` inline on `io_service_` instead of posting to `task_execution_service_`.
  - `CoreWorker::CancelActorTaskOnExecutor` async-actor branch posts to `io_service_` (where the queue state now lives) instead of `task_execution_service_`; the post is now a self-post and can be done inline.
  - `CoreWorkerShutdownExecutor::ExecuteExit` posts the drain/Stop chain to `io_service_` instead of
  `task_execution_service_`.
  - Inside `AcceptRequestOrRejectIfCanceled`: the cancellation check runs on `io_service_`; only `request.Execute()` is posted off to the pool / fiber / `task_execution_service_`.
  
**Notes**:
Additionally I also found two potential bugs in existing code: 
1. Concurrent read/write on `actor_task_execution_queues_` without a mutex.
In master:
  - `QueueTaskForExecution` wrote the per-caller map (find+emplace) on `task_execution_service_`.
  - `CancelQueuedActorTask` for sync actors read the map on `io_service_` 
 Accessing the hashmap from two threads is UB. After this change, both access paths are on `io_service_`.
 
2. Accept-vs-Cancel 
In master, `AcceptRequestOrRejectIfCanceled` adn `CancelTaskIfFound` can run on different threads, Due to the release of `mu_` before `request.Execute()`, we could have this race: 
a. Accept reads is_canceled=false, releases mu_.
b. CancelTaskIfFound (concurrently) sets pending_task_id_to_is_canceled[task_id]=true, returns task_present=true.
c. The cancel RPC reports success=true ("cancelled in queue") to the caller.
d. Accept then calls request.Execute(). Task runs to completion anyway.

After this PR, both functions run on `io_service_`, and therefore are serialized. 

**Results**:
I tested the change against a ray script which spins up a producer actor and a consumer actor on different nodes. The producer produces large objects which are consumed by the consumer triggering plasma object pulls. The consumer is slow (sleeps infinitely). Without the fix, the consumer pulls some objects, but as soon as it starts executing the task (which sleeps infinitely), object pulling stops and as a result, only some of the objects are pulled from the producer side. With the fix, all objects are pulled from producer. 

Observe the object store memory column below (each object is 128MB)

<img width="1580" height="723" alt="image" src="https://github.com/user-attachments/assets/4b8e28b0-6cd1-487b-996f-645a3b321edd" />
Producer produced 10 objects, consumer pulled only 3 (buggy case)

<img width="1578" height="726" alt="image" src="https://github.com/user-attachments/assets/02af1966-781a-4187-8bf7-e23d41d375c0" />
Producer produced 10 objects, consumer pulled all (fixed case)

**TODO**:
With the change in this PR, all submitted actor tasks will have their arguments prefetched. This might result in OOM issues or starvation of one actor tasks due to prefetching args of another actor tasks. To fix this, the solution would be to impose a limit on prefetches per concurrency group. I will take that up in a followup PR.

It is also important to note that the current design too doesn't protect against it intentionally. The current implementation also queues up arg fetches for all tasks until the time first arg fetch is complete and the task starts executing. In the worst case, it could also tigger prefetches enough to OOM if the first fetch takes a long time and the task is not scheduled.

