### PR TITLE
[Fix] Issue 62933: ClusterStatus default constructor

### DIFF
--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -175,7 +175,7 @@ class Stats:
     # How long it took to get the GCS request.
     # This is required when initializing the Stats since it should be calculated before
     # the request was made.
-    gcs_request_time_s: float
+    gcs_request_time_s: float = 0.0
     # How long it took to get all live instances from node provider.
     none_terminated_node_request_time_s: Optional[float] = None
     # How long for autoscaler to process the scaling decision.


### PR DESCRIPTION
<!-- Please give a short summary of the change and the problem this solves. -->

## Why are these changes needed?

Fixes #62933

Currently, `ClusterStatus()` cannot be default-constructed because its `stats` field uses `default_factory=Stats`, but the `Stats` dataclass requires a positional argument `gcs_request_time_s`. This raises a `TypeError` and breaks any code or test that attempts to create an empty `ClusterStatus` as a baseline object.

This PR addresses the issue by adding a default value of `0.0` to the `gcs_request_time_s` field in the `Stats` dataclass. This allows `Stats()` to be instantiated without arguments, which in turn enables `ClusterStatus()` to successfully produce an empty/default status object.

## Related issue number

Closes #62933

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing.
- [ ] Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
