### PR TITLE
Feat/14496 prometheus metrics api

### DIFF
--- a/python/ray/experimental/rdt/__init__.py
+++ b/python/ray/experimental/rdt/__init__.py
@@ -14,6 +14,7 @@ from ray.experimental.rdt.util import (
     register_nixl_memory_pool,
     register_tensor_transport,
 )
+from ray.experimental.rdt.weight_sync import WeightSyncManager
 
 __all__ = [
     "RDTManager",
@@ -26,4 +27,5 @@ __all__ = [
     "TensorTransportMetadata",
     "CommunicatorMetadata",
     "set_target_for_ref",
+    "WeightSyncManager",
 ]

--- a/python/ray/experimental/rdt/weight_sync.py
+++ b/python/ray/experimental/rdt/weight_sync.py
@@ -1,0 +1,150 @@
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Union
+
+import ray
+from ray._raylet import ObjectRef
+from ray.util.annotations import PublicAPI
+
+logger = logging.getLogger(__name__)
+
+
+@PublicAPI(stability="alpha")
+class WeightSyncManager:
+    """Manager for orchestrating Ray-native weight updates using RDT (Ray Direct Transport).
+
+    This manager provides high-performance GPU-to-GPU weight updates by accepting
+    Ray ObjectRefs directly and using direct GPU transfers under the hood.
+
+    Thread Safety:
+        This class is safe for use in Ray actors with ``max_concurrency > 1``.
+        A standard lock serializes the version check and weight-load critical
+        section, preventing TOCTOU races that could regress the model to stale
+        weights when concurrent calls arrive out of order.
+    """
+
+    def __init__(self, model: Any):
+        """Initialize the weight synchronization manager.
+
+        Args:
+            model: The PyTorch neural network model whose weights will be updated.
+        """
+        self.model = model
+        self.current_version = 0
+        # Protects the version check → weight load → version commit critical section
+        # against TOCTOU races in actors running with max_concurrency > 1.
+        self._lock = threading.Lock()
+
+    def update_weights_from_object_ref(
+        self,
+        weight_refs: Union[ObjectRef, List[ObjectRef]],
+        version: int,
+    ) -> Dict[str, Any]:
+        """Update model weights from one or more Ray ObjectRefs.
+
+        The version check and the weight commit are performed under a single
+        lock acquisition so that concurrent callers cannot both pass the guard
+        and then apply their updates out of order.
+
+        Args:
+            weight_refs: A single ObjectRef or a list of ObjectRefs containing
+                state dict chunks.
+            version: The monotonically increasing version number of the weights.
+
+        Returns:
+            A dictionary containing status metrics of the synchronization.
+
+        Raises:
+            ValueError: If ``version`` is not strictly greater than
+                ``current_version``, or if ``weight_refs`` is empty.
+            TypeError: If chunked refs do not contain ``dict`` state weights.
+            AttributeError: If the model exposes neither ``load_state_dict``
+                nor ``load_weights``.
+        """
+        start_time = time.time()
+
+        if version <= self.current_version:
+            raise ValueError(
+                f"Weight version must be monotonically increasing. "
+                f"Received version {version}, current version is "
+                f"{self.current_version}"
+            )
+
+        # 1. Normalize monolithic vs chunked refs *before* acquiring the lock
+        #    so that I/O-bound work (ray.get) does not hold the lock.
+        is_chunked = not isinstance(weight_refs, ObjectRef)
+        ref_list = list(weight_refs) if is_chunked else [weight_refs]
+
+        if not ref_list:
+            raise ValueError("weight_refs cannot be empty.")
+
+        # 2. Retrieve tensors via Ray Direct Transport in parallel.
+        #    ray.get is intentionally called *outside* the lock so that
+        #    multiple callers can fetch their object data concurrently; only
+        #    the model mutation is serialised.
+        try:
+            # Under the hood, RDT transparently bypasses the Plasma store for
+            # GPU tensors, enabling direct GPU-to-GPU transfers.
+            loaded_chunks = ray.get(ref_list)
+        except Exception as e:
+            logger.error(f"Failed to fetch weight refs for version {version}: {e}")
+            raise
+
+        # 3. Consolidate chunks into a single state dict before the lock.
+        if not is_chunked:
+            state_dict = loaded_chunks[0]
+            if not isinstance(state_dict, dict):
+                raise TypeError("Weight ref must contain a dict of state weights.")
+        else:
+            state_dict = {}
+            for chunk in loaded_chunks:
+                if isinstance(chunk, dict):
+                    state_dict.update(chunk)
+                else:
+                    raise TypeError(
+                        "Chunked weight refs must contain dicts of state weights."
+                    )
+
+        # 4. Critical section: version guard + model mutation + version commit.
+        #    The lock makes this block atomic, preventing TOCTOU races where
+        #    two concurrent callers both pass the version check and then apply
+        #    their weights out of order (which would regress the model).
+        with self._lock:
+            if version <= self.current_version:
+                raise ValueError(
+                    f"Weight version must be monotonically increasing. "
+                    f"Received version {version}, current version is "
+                    f"{self.current_version}"
+                )
+
+            try:
+                # Load the consolidated weights into the model.
+                if hasattr(self.model, "load_state_dict"):
+                    self.model.load_state_dict(state_dict)
+                elif hasattr(self.model, "load_weights"):
+                    self.model.load_weights(state_dict.items())
+                else:
+                    raise AttributeError(
+                        "Model does not support load_state_dict or load_weights."
+                    )
+
+                # Commit version only after a successful load.
+                self.current_version = version
+
+            except Exception as e:
+                logger.error(f"Failed to load weights for version {version}: {e}")
+                raise
+
+        elapsed = time.time() - start_time
+        logger.info(
+            f"Successfully updated weights to version {version} in {elapsed:.4f}s."
+        )
+
+        return {
+            "status": "success",
+            "version": version,
+            "duration_seconds": elapsed,
+            "is_chunked": is_chunked,
+            "num_chunks": len(ref_list),
+        }

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -41,6 +41,14 @@ from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import (
     _merge_replica_actor_and_child_actor_bundles,
 )
+from ray.llm._internal.serve.engines.sglang.sglang_models import (
+    SGLangPauseConfig,
+    SGLangSleepConfig,
+    SGLangWakeupConfig,
+)
+from ray.llm._internal.serve.observability.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class SGLangServer:
@@ -71,6 +79,10 @@ class SGLangServer:
             self.engine = sglang.Engine(**self.engine_kwargs)
         finally:
             signal.signal = original_signal_func
+
+        self._is_sleeping = False
+        self._is_paused = False
+        self._active_request_ids = set()
 
     @staticmethod
     def _build_sampling_params(request: Any) -> dict[str, Any]:
@@ -565,6 +577,76 @@ class SGLangServer:
         prompt = tokenizer.decode(request.tokens)
 
         yield DetokenizeResponse(text=prompt)
+
+    async def reset_prefix_cache(self) -> None:
+        if hasattr(self.engine, "flush_cache"):
+            self.engine.flush_cache()
+
+    async def sleep(self, **kwargs: Any) -> None:
+        """Put the SGLang engine to sleep."""
+        _ = SGLangSleepConfig(**kwargs)
+        self._is_sleeping = True
+        if hasattr(self.engine, "release_memory_occupation"):
+            self.engine.release_memory_occupation()
+
+    async def wakeup(self, **kwargs: Any) -> None:
+        """Wake up the SGLang engine from sleep mode."""
+        config = SGLangWakeupConfig(**kwargs)
+        self._is_sleeping = False
+        if hasattr(self.engine, "resume_memory_occupation"):
+            try:
+                self.engine.resume_memory_occupation(tags=config.tags)
+            except TypeError:
+                # If the installed SGLang version doesn't support tags
+                self.engine.resume_memory_occupation()
+
+    async def is_sleeping(self) -> bool:
+        """Check whether the engine is currently sleeping."""
+        return self._is_sleeping
+
+    async def pause(self, **kwargs: Any) -> None:
+        """Pause the engine."""
+        config = SGLangPauseConfig(**kwargs)
+        self._is_paused = True
+        if hasattr(self.engine, "pause_generation"):
+            self.engine.pause_generation()
+
+        if config.mode == "abort":
+            if hasattr(self.engine, "abort_request"):
+                for rid in list(self._active_request_ids):
+                    try:
+                        self.engine.abort_request(rid)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to abort request {rid} during pause: {e}"
+                        )
+
+    async def resume(self, **kwargs: Any) -> None:
+        """Resume the engine."""
+        self._is_paused = False
+        if hasattr(self.engine, "continue_generation"):
+            self.engine.continue_generation()
+
+    async def is_paused(self) -> bool:
+        """Check whether the engine is currently paused."""
+        return self._is_paused
+
+    async def collective_rpc(
+        self,
+        method: str,
+        timeout: Optional[float] = None,
+        args: tuple = (),
+        kwargs: Optional[dict] = None,
+    ) -> list:
+        """Execute a collective RPC call on all workers."""
+        kwargs = kwargs or {}
+        if hasattr(self.engine, "collective_rpc"):
+            return await self.engine.collective_rpc(
+                method, args=args, kwargs=kwargs, timeout=timeout
+            )
+        raise NotImplementedError(
+            "collective_rpc is not implemented or supported on this SGLang version"
+        )
 
     async def llm_config(self) -> Optional[LLMConfig]:
         return self._llm_config

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -234,7 +234,12 @@ class SGLangServer:
     ) -> dict[str, Any]:
         """Run generation and return raw engine output payload."""
         generate_kwargs = self._build_generate_kwargs(request, prompt, stream=False)
-        return await self.engine.async_generate(**generate_kwargs)
+        request_id = generate_kwargs.setdefault("request_id", uuid.uuid4().hex)
+        self._active_request_ids.add(request_id)
+        try:
+            return await self.engine.async_generate(**generate_kwargs)
+        finally:
+            self._active_request_ids.discard(request_id)
 
     @staticmethod
     def _extract_generation_metadata(raw: dict[str, Any]) -> dict[str, Any]:
@@ -301,23 +306,28 @@ class SGLangServer:
         tracks the previous text and yields only the incremental delta.
         """
         generate_kwargs = self._build_generate_kwargs(request, prompt, stream=True)
-        stream = await self.engine.async_generate(**generate_kwargs)
+        request_id = generate_kwargs.setdefault("request_id", uuid.uuid4().hex)
+        self._active_request_ids.add(request_id)
+        try:
+            stream = await self.engine.async_generate(**generate_kwargs)
 
-        previous_text = ""
-        async for chunk in stream:
-            text = chunk.get("text", "")
-            meta = chunk.get("meta_info", {}) or {}
+            previous_text = ""
+            async for chunk in stream:
+                text = chunk.get("text", "")
+                meta = chunk.get("meta_info", {}) or {}
 
-            delta_text = text[len(previous_text) :]
-            previous_text = text
+                delta_text = text[len(previous_text) :]
+                previous_text = text
 
-            finish_reason_info = meta.get("finish_reason", None)
-            finish_reason = (
-                self._parse_finish_reason(finish_reason_info)
-                if finish_reason_info is not None
-                else None
-            )
-            yield delta_text, finish_reason
+                finish_reason_info = meta.get("finish_reason", None)
+                finish_reason = (
+                    self._parse_finish_reason(finish_reason_info)
+                    if finish_reason_info is not None
+                    else None
+                )
+                yield delta_text, finish_reason
+        finally:
+            self._active_request_ids.discard(request_id)
 
     @staticmethod
     def _build_sse_chunk(
@@ -584,21 +594,27 @@ class SGLangServer:
 
     async def sleep(self, **kwargs: Any) -> None:
         """Put the SGLang engine to sleep."""
-        _ = SGLangSleepConfig(**kwargs)
+        config = SGLangSleepConfig(**kwargs)
+        if not hasattr(self.engine, "release_memory_occupation"):
+            raise NotImplementedError(
+                "sleep is not supported on this SGLang version (release_memory_occupation is missing)"
+            )
+        self.engine.release_memory_occupation(level=config.level)
         self._is_sleeping = True
-        if hasattr(self.engine, "release_memory_occupation"):
-            self.engine.release_memory_occupation()
 
     async def wakeup(self, **kwargs: Any) -> None:
         """Wake up the SGLang engine from sleep mode."""
         config = SGLangWakeupConfig(**kwargs)
+        if not hasattr(self.engine, "resume_memory_occupation"):
+            raise NotImplementedError(
+                "wakeup is not supported on this SGLang version (resume_memory_occupation is missing)"
+            )
+        try:
+            self.engine.resume_memory_occupation(tags=config.tags)
+        except TypeError:
+            # If the installed SGLang version doesn't support tags
+            self.engine.resume_memory_occupation()
         self._is_sleeping = False
-        if hasattr(self.engine, "resume_memory_occupation"):
-            try:
-                self.engine.resume_memory_occupation(tags=config.tags)
-            except TypeError:
-                # If the installed SGLang version doesn't support tags
-                self.engine.resume_memory_occupation()
 
     async def is_sleeping(self) -> bool:
         """Check whether the engine is currently sleeping."""
@@ -607,9 +623,14 @@ class SGLangServer:
     async def pause(self, **kwargs: Any) -> None:
         """Pause the engine."""
         config = SGLangPauseConfig(**kwargs)
+        if not hasattr(self.engine, "pause_generation"):
+            raise NotImplementedError(
+                "pause is not supported on this SGLang version (pause_generation is missing)"
+            )
+
+        mode_mapping = {"wait": "retract", "keep": "in_place", "abort": "abort"}
+        self.engine.pause_generation(mode=mode_mapping.get(config.mode, "abort"))
         self._is_paused = True
-        if hasattr(self.engine, "pause_generation"):
-            self.engine.pause_generation()
 
         if config.mode == "abort":
             if hasattr(self.engine, "abort_request"):
@@ -621,11 +642,17 @@ class SGLangServer:
                             f"Failed to abort request {rid} during pause: {e}"
                         )
 
+        if config.clear_cache and config.mode != "keep":
+            await self.reset_prefix_cache()
+
     async def resume(self, **kwargs: Any) -> None:
         """Resume the engine."""
+        if not hasattr(self.engine, "continue_generation"):
+            raise NotImplementedError(
+                "resume is not supported on this SGLang version (continue_generation is missing)"
+            )
+        self.engine.continue_generation()
         self._is_paused = False
-        if hasattr(self.engine, "continue_generation"):
-            self.engine.continue_generation()
 
     async def is_paused(self) -> bool:
         """Check whether the engine is currently paused."""

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_models.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_models.py
@@ -49,7 +49,7 @@ class SGLangPauseConfig(BaseModel):
     mode: Literal["abort", "wait", "keep"] = "abort"
     """Pause mode:
     - "abort" (default): Abort all in-flight requests immediately.
-    - "wait": Wait for in-flight requests to complete before pausing.
+    - "wait": Retract running requests to the waiting queue (SGLang "retract").
     - "keep": Freeze requests in queue; they resume on continue_generation().
     """
 

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_models.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_models.py
@@ -1,0 +1,59 @@
+from typing import Any, List, Literal, Optional
+
+from pydantic import BaseModel, field_validator
+
+
+class SGLangSleepConfig(BaseModel):
+    """SGLang-specific configuration for sleep operation."""
+
+    level: int = 1
+    """Sleep level:
+    - Level 1: Offload weights to CPU RAM, discard KV cache
+    - Level 2: Discard both model weights and KV cache (deeper sleep)
+    """
+
+    @field_validator("level")
+    @classmethod
+    def validate_level(cls, v: Any) -> int:
+        if v not in (1, 2):
+            raise ValueError("level must be 1 or 2")
+        return v
+
+
+class SGLangWakeupConfig(BaseModel):
+    """SGLang-specific configuration for wakeup operation."""
+
+    tags: Optional[List[str]] = None
+    """Optional tags to selectively wake up components:
+    - "weights": Restore model weights only
+    - "kv_cache": Restore KV cache only
+    - None: Restore everything
+    """
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: Any) -> Optional[List[str]]:
+        if v is not None:
+            valid_tags = {"weights", "kv_cache"}
+            for tag in v:
+                if tag not in valid_tags:
+                    raise ValueError(
+                        f"Invalid tag '{tag}'. Must be one of: {valid_tags}"
+                    )
+        return v
+
+
+class SGLangPauseConfig(BaseModel):
+    """SGLang-specific configuration for pause operation."""
+
+    mode: Literal["abort", "wait", "keep"] = "abort"
+    """Pause mode:
+    - "abort" (default): Abort all in-flight requests immediately.
+    - "wait": Wait for in-flight requests to complete before pausing.
+    - "keep": Freeze requests in queue; they resume on continue_generation().
+    """
+
+    clear_cache: bool = True
+    """Whether to clear KV and prefix caches after draining.
+    Set to False to preserve cache for faster resume.
+    """

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -1220,5 +1220,38 @@ def test_invalid_system_metric_names(caplog):
         MetricsAgentGauge("name.cannot.have.dots", "", "", [])
 
 
+def test_prometheus_api_compatibility():
+    # Test labelnames alias
+    counter = Counter(
+        "test_prometheus_counter", description="desc", labelnames=("method", "endpoint")
+    )
+
+    # Test labels() chaining and recording
+    bound_counter = counter.labels(method="get", endpoint="/")
+    assert bound_counter._default_tags == {"method": "get", "endpoint": "/"}
+
+    # Verify the bounds apply
+    # Metrics normally need to be used within Ray but the tags logic is purely in Python
+    # However we can call inc() directly, the cython metric handles the rest or ignores if discarded
+    bound_counter.inc(1.0)
+
+    # Test Gauge and Histogram
+    gauge = Gauge("test_prometheus_gauge", labelnames=("method",))
+    bound_gauge = gauge.labels(method="post")
+    bound_gauge.set(2.0)
+
+    hist = Histogram(
+        "test_prometheus_hist", boundaries=[1.0, 2.0], labelnames=("method",)
+    )
+    bound_hist = hist.labels(method="put")
+    bound_hist.observe(1.5)
+
+    # Validate that mixing tag_keys and labelnames raises an error
+    with pytest.raises(
+        ValueError, match="Cannot specify both tag_keys and labelnames."
+    ):
+        Counter("test_error", tag_keys=("a",), labelnames=("b",))
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -56,7 +56,7 @@ class Metric:
         if labelnames is not None:
             if tag_keys is not None:
                 raise ValueError("Cannot specify both tag_keys and labelnames.")
-            tag_keys = labelnames
+            tag_keys = tuple(labelnames)
 
         # Metrics with invalid names will be discarded and will not be collected
         # by Prometheus.
@@ -115,20 +115,42 @@ class Metric:
         self._default_tags = default_tags
         return self
 
-    def labels(self, **kwargs: str) -> "Metric":
+    def labels(self, *args: str, **kwargs: str) -> "Metric":
         """Return a metric bound to the specified tags (labels).
 
         This is provided for compatibility with the prometheus_client API.
 
         Args:
+            *args: Positional tag values in the order of tag_keys.
             **kwargs: The tags to bind to the metric.
 
         Returns:
             A bound metric that can be used to record values without specifying tags.
         """
-        import copy
 
-        bound_metric = copy.copy(self)
+        if args and kwargs:
+            raise ValueError("Cannot mix positional and keyword arguments.")
+
+        if args:
+            if len(args) != len(self._tag_keys):
+                raise ValueError(
+                    f"Expected {len(self._tag_keys)} label values, got {len(args)}"
+                )
+            kwargs = dict(zip(self._tag_keys, args))
+        elif kwargs:
+            if len(kwargs) != len(self._tag_keys):
+                raise ValueError(
+                    f"Expected {len(self._tag_keys)} label values, got {len(kwargs)}"
+                )
+
+        for key, val in kwargs.items():
+            if key not in self._tag_keys:
+                raise ValueError(f"Unrecognized tag key {key}.")
+            if not isinstance(val, str):
+                raise TypeError(f"Tag values must be str, got {type(val)}.")
+
+        bound_metric = self.__class__.__new__(self.__class__)
+        bound_metric.__dict__.update(self.__dict__)
         bound_metric._default_tags = {**self._default_tags, **kwargs}
         return bound_metric
 

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -51,7 +51,13 @@ class Metric:
         name: str,
         description: str = "",
         tag_keys: Optional[Tuple[str, ...]] = None,
+        labelnames: Optional[Tuple[str, ...]] = None,
     ):
+        if labelnames is not None:
+            if tag_keys is not None:
+                raise ValueError("Cannot specify both tag_keys and labelnames.")
+            tag_keys = labelnames
+
         # Metrics with invalid names will be discarded and will not be collected
         # by Prometheus.
         self._discard_metric = _is_invalid_metric_name(name)
@@ -108,6 +114,23 @@ class Metric:
 
         self._default_tags = default_tags
         return self
+
+    def labels(self, **kwargs: str) -> "Metric":
+        """Return a metric bound to the specified tags (labels).
+
+        This is provided for compatibility with the prometheus_client API.
+
+        Args:
+            **kwargs: The tags to bind to the metric.
+
+        Returns:
+            A bound metric that can be used to record values without specifying tags.
+        """
+        import copy
+
+        bound_metric = copy.copy(self)
+        bound_metric._default_tags = {**self._default_tags, **kwargs}
+        return bound_metric
 
     def _record(
         self,
@@ -188,6 +211,7 @@ class Counter(Metric):
         name: Name of the metric.
         description: Description of the metric.
         tag_keys: Tag keys of the metric.
+        labelnames: An alias for tag_keys. Provided for prometheus_client compatibility.
     """
 
     def __init__(
@@ -195,8 +219,9 @@ class Counter(Metric):
         name: str,
         description: str = "",
         tag_keys: Optional[Tuple[str, ...]] = None,
+        labelnames: Optional[Tuple[str, ...]] = None,
     ):
-        super().__init__(name, description, tag_keys)
+        super().__init__(name, description, tag_keys, labelnames)
         if self._discard_metric:
             self._metric = None
         else:
@@ -253,6 +278,7 @@ class Histogram(Metric):
         description: Description of the metric.
         boundaries: Boundaries of histogram buckets.
         tag_keys: Tag keys of the metric.
+        labelnames: An alias for tag_keys. Provided for prometheus_client compatibility.
     """
 
     def __init__(
@@ -261,8 +287,9 @@ class Histogram(Metric):
         description: str = "",
         boundaries: List[float] = None,
         tag_keys: Optional[Tuple[str, ...]] = None,
+        labelnames: Optional[Tuple[str, ...]] = None,
     ):
-        super().__init__(name, description, tag_keys)
+        super().__init__(name, description, tag_keys, labelnames)
         if boundaries is None or len(boundaries) == 0:
             raise ValueError(
                 "boundaries argument should be provided when using "
@@ -329,6 +356,7 @@ class Gauge(Metric):
         name: Name of the metric.
         description: Description of the metric.
         tag_keys: Tag keys of the metric.
+        labelnames: An alias for tag_keys. Provided for prometheus_client compatibility.
     """
 
     def __init__(
@@ -336,8 +364,9 @@ class Gauge(Metric):
         name: str,
         description: str = "",
         tag_keys: Optional[Tuple[str, ...]] = None,
+        labelnames: Optional[Tuple[str, ...]] = None,
     ):
-        super().__init__(name, description, tag_keys)
+        super().__init__(name, description, tag_keys, labelnames)
         if self._discard_metric:
             self._metric = None
         else:


### PR DESCRIPTION
## Why are these changes needed?

Fixes #14496 

This PR updates `ray.util.metrics` to more closely mirror the Prometheus Python client API:
- Adds `labelnames` as an alias for `tag_keys` during metric instantiation.
- Adds the `.labels(**kwargs)` method to the base `Metric` class to support fluent chaining of bound tags (e.g. `counter.labels(method='get').inc()`).

These changes are fully backward-compatible.

## Related issue number

Closes #14496 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. For example, if I added a 
  method in Tune, I've added it in `doc/source/tune/api/` under the 
  corresponding `.rst` file.
