### PR TITLE
[Active-passive] Phase1: Introduces a native, lightweight C++ leader election client

### DIFF
--- a/src/ray/gcs/leader_election/BUILD.bazel
+++ b/src/ray/gcs/leader_election/BUILD.bazel
@@ -30,7 +30,10 @@ ray_cc_test(
     srcs = [
         "k8s_lease_client_test.cc",
     ],
-    tags = ["small"],
+    tags = [
+        "small",
+        "team:core",
+    ],
     deps = [
         ":leader_election",
     ],

--- a/src/ray/gcs/leader_election/BUILD.bazel
+++ b/src/ray/gcs/leader_election/BUILD.bazel
@@ -41,7 +41,10 @@ ray_cc_test(
     srcs = [
         "leader_elector_test.cc",
     ],
-    tags = ["small"],
+    tags = [
+        "small",
+        "team:core",
+    ],
     deps = [
         ":leader_election",
     ],

--- a/src/ray/gcs/leader_election/BUILD.bazel
+++ b/src/ray/gcs/leader_election/BUILD.bazel
@@ -7,11 +7,13 @@ ray_cc_library(
     srcs = [
         "k8s_lease_client.cc",
         "leader_election_client_factory.cc",
+        "leader_elector.cc",
     ],
     hdrs = [
         "k8s_lease_client.h",
         "leader_election_client_factory.h",
         "leader_election_client_interface.h",
+        "leader_elector.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -27,6 +29,18 @@ ray_cc_test(
     name = "k8s_lease_client_test",
     srcs = [
         "k8s_lease_client_test.cc",
+    ],
+    tags = ["small"],
+    deps = [
+        ":leader_election",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
+    name = "leader_elector_test",
+    srcs = [
+        "leader_elector_test.cc",
     ],
     tags = ["small"],
     deps = [

--- a/src/ray/gcs/leader_election/BUILD.bazel
+++ b/src/ray/gcs/leader_election/BUILD.bazel
@@ -1,0 +1,36 @@
+# Bazel build file for the generic distributed leader election library.
+
+load("//bazel:ray.bzl", "ray_cc_library", "ray_cc_test")
+
+ray_cc_library(
+    name = "leader_election",
+    srcs = [
+        "k8s_lease_client.cc",
+        "leader_election_client_factory.cc",
+    ],
+    hdrs = [
+        "k8s_lease_client.h",
+        "leader_election_client_factory.h",
+        "leader_election_client_interface.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/ray/rpc/authentication:k8s_util",
+        "//src/ray/rpc:grpc_client",
+        "//src/ray/util:logging",
+        "@com_google_absl//absl/time",
+        "@nlohmann_json",
+    ],
+)
+
+ray_cc_test(
+    name = "k8s_lease_client_test",
+    srcs = [
+        "k8s_lease_client_test.cc",
+    ],
+    tags = ["small"],
+    deps = [
+        ":leader_election",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/gcs/leader_election/BUILD.bazel
+++ b/src/ray/gcs/leader_election/BUILD.bazel
@@ -17,8 +17,8 @@ ray_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/ray/rpc/authentication:k8s_util",
         "//src/ray/rpc:grpc_client",
+        "//src/ray/rpc/authentication:k8s_util",
         "//src/ray/util:logging",
         "@com_google_absl//absl/time",
         "@nlohmann_json",
@@ -33,7 +33,6 @@ ray_cc_test(
     tags = ["small"],
     deps = [
         ":leader_election",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -45,6 +44,5 @@ ray_cc_test(
     tags = ["small"],
     deps = [
         ":leader_election",
-        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/ray/gcs/leader_election/k8s_lease_client.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client.cc
@@ -1,0 +1,277 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/leader_election/k8s_lease_client.h"
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace gcs {
+
+K8sLeaseClient::K8sLeaseClient(
+    std::string lease_namespace,
+    std::string lease_key,
+    std::function<Status(const std::string &, nlohmann::json &)> get_api,
+    std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
+        post_api,
+    std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
+        put_api)
+    : lease_namespace_(std::move(lease_namespace)),
+      lease_key_(std::move(lease_key)),
+      get_api_(std::move(get_api)),
+      post_api_(std::move(post_api)),
+      put_api_(std::move(put_api)) {}
+
+StatusOr<LeaseMetadata> K8sLeaseClient::GetLeaseMetadata() {
+  std::string get_path = "/apis/coordination.k8s.io/v1/namespaces/" + lease_namespace_ +
+                         "/leases/" + lease_key_;
+  nlohmann::json response;
+  Status status = get_api_(get_path, response);
+  if (!status.ok()) {
+    return status;
+  }
+
+  LeaseMetadata metadata;
+  metadata.exists = true;
+  metadata.lease_record = response;
+
+  absl::Time server_now = absl::Now();
+  if (response.contains("__api_server_date__")) {
+    std::string date_str = response["__api_server_date__"].get<std::string>();
+    std::string err;
+    if (!absl::ParseTime("%a, %d %b %Y %H:%M:%S %Z", date_str, &server_now, &err)) {
+      RAY_LOG(WARNING) << "Failed to parse API server date: " << date_str
+                       << ", error: " << err << ". Falling back to local pod timestamp.";
+    }
+  }
+  metadata.server_now = server_now;
+
+  if (response.contains("spec")) {
+    auto &spec = response["spec"];
+    if (spec.contains("holderIdentity")) {
+      metadata.holder_id = spec["holderIdentity"].get<std::string>();
+    }
+    if (spec.contains("leaseDurationSeconds")) {
+      metadata.duration_seconds = spec["leaseDurationSeconds"].get<int>();
+    }
+    if (spec.contains("renewTime")) {
+      std::string renew_str = spec["renewTime"].get<std::string>();
+      std::string parse_err;
+      if (!absl::ParseTime(
+              absl::RFC3339_full, renew_str, &metadata.renew_time, &parse_err)) {
+        metadata.renew_time = server_now;
+      }
+    }
+  }
+
+  if (response.contains("metadata") && response["metadata"].contains("resourceVersion")) {
+    metadata.resource_version =
+        response["metadata"]["resourceVersion"].get<std::string>();
+  }
+
+  return metadata;
+}
+
+Status K8sLeaseClient::CreateLease(const std::string &holder_id,
+                                   int ttl_seconds,
+                                   absl::Time now) {
+  std::string now_str =
+      absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", now, absl::UTCTimeZone());
+  nlohmann::json create_req = {
+      {"apiVersion", "coordination.k8s.io/v1"},
+      {"kind", "Lease"},
+      {"metadata", {{"name", lease_key_}, {"namespace", lease_namespace_}}},
+      {"spec",
+       {{"holderIdentity", holder_id},
+        {"leaseDurationSeconds", ttl_seconds},
+        {"renewTime", now_str}}}};
+
+  std::string post_path =
+      "/apis/coordination.k8s.io/v1/namespaces/" + lease_namespace_ + "/leases";
+  nlohmann::json create_resp;
+  Status status = post_api_(post_path, create_req, create_resp);
+  if (status.ok()) {
+    if (create_resp.contains("metadata") &&
+        create_resp["metadata"].contains("resourceVersion")) {
+      cached_resource_version_ =
+          create_resp["metadata"]["resourceVersion"].get<std::string>();
+    }
+  }
+  return status;
+}
+
+Status K8sLeaseClient::UpdateLease(const LeaseMetadata &metadata,
+                                   const std::string &holder_id,
+                                   int ttl_seconds,
+                                   absl::Time now) {
+  std::string now_str =
+      absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", now, absl::UTCTimeZone());
+  nlohmann::json update_req = metadata.lease_record;
+  update_req["spec"]["holderIdentity"] = holder_id;
+  update_req["spec"]["leaseDurationSeconds"] = ttl_seconds;
+  update_req["spec"]["renewTime"] = now_str;
+
+  if (!metadata.resource_version.empty()) {
+    update_req["metadata"]["resourceVersion"] = metadata.resource_version;
+  }
+
+  std::string put_path = "/apis/coordination.k8s.io/v1/namespaces/" + lease_namespace_ +
+                         "/leases/" + lease_key_;
+  nlohmann::json update_resp;
+  Status status = put_api_(put_path, update_req, update_resp);
+  if (status.ok()) {
+    if (update_resp.contains("metadata") &&
+        update_resp["metadata"].contains("resourceVersion")) {
+      cached_resource_version_ =
+          update_resp["metadata"]["resourceVersion"].get<std::string>();
+    }
+  }
+  return status;
+}
+
+bool K8sLeaseClient::CanAcquireLease(const LeaseMetadata &metadata,
+                                     const std::string &holder_id,
+                                     absl::Time now) {
+  // Scenario A: No one currently holds the lease (it was voluntarily released).
+  if (metadata.holder_id.empty()) {
+    return true;
+  }
+
+  // Scenario B: We currently hold the lease (performing a lease renewal).
+  if (metadata.holder_id == holder_id) {
+    return true;
+  }
+
+  // Scenario C: Another candidate holds the lease. We can only preempt if it has expired.
+  absl::Time expiration_time =
+      metadata.renew_time + absl::Seconds(metadata.duration_seconds);
+  if (now > expiration_time) {
+    return true;
+  }
+
+  return false;
+}
+
+Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
+                                  int ttl_seconds,
+                                  std::string &current_leader) {
+  auto metadata_or = GetLeaseMetadata();
+  if (metadata_or.IsNotFound()) {
+    Status create_status = CreateLease(holder_id, ttl_seconds, absl::Now());
+    if (create_status.ok()) {
+      RAY_LOG(INFO) << "Successfully created Lease and acquired leadership.";
+      current_leader = holder_id;
+      return Status::OK();
+    }
+    current_leader = "";
+    return create_status;
+  }
+
+  if (!metadata_or.ok()) {
+    current_leader = "";
+    return metadata_or.status();
+  }
+
+  const auto &metadata = metadata_or.value();
+  current_leader = metadata.holder_id;
+
+  if (CanAcquireLease(metadata, holder_id, metadata.server_now)) {
+    Status update_status =
+        UpdateLease(metadata, holder_id, ttl_seconds, metadata.server_now);
+    if (update_status.ok()) {
+      current_leader = holder_id;
+      return Status::OK();
+    }
+    return update_status;
+  }
+
+  return Status::OK();
+}
+
+Status K8sLeaseClient::Renew(const std::string &holder_id,
+                             int ttl_seconds,
+                             std::string &current_leader) {
+  if (!cached_resource_version_.empty()) {
+    absl::Time now = absl::Now();
+    std::string now_str =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", now, absl::UTCTimeZone());
+    nlohmann::json update_req = {{"apiVersion", "coordination.k8s.io/v1"},
+                                 {"kind", "Lease"},
+                                 {"metadata",
+                                  {{"name", lease_key_},
+                                   {"namespace", lease_namespace_},
+                                   {"resourceVersion", cached_resource_version_}}},
+                                 {"spec",
+                                  {{"holderIdentity", holder_id},
+                                   {"leaseDurationSeconds", ttl_seconds},
+                                   {"renewTime", now_str}}}};
+
+    std::string put_path = "/apis/coordination.k8s.io/v1/namespaces/" + lease_namespace_ +
+                           "/leases/" + lease_key_;
+    nlohmann::json response;
+    Status status = put_api_(put_path, update_req, response);
+    if (status.ok()) {
+      if (response.contains("metadata") &&
+          response["metadata"].contains("resourceVersion")) {
+        cached_resource_version_ =
+            response["metadata"]["resourceVersion"].get<std::string>();
+      }
+      current_leader = holder_id;
+      return Status::OK();
+    }
+    // If direct PUT fails (due to resourceVersion mismatch/conflict, network error,
+    // or request timeout), invalidate the cache and fall back to the slow-path
+    // TryAcquire() (which performs a GET to refresh the resource version).
+    cached_resource_version_ = "";
+  }
+
+  return TryAcquire(holder_id, ttl_seconds, current_leader);
+}
+
+void K8sLeaseClient::Release(const std::string &holder_id) {
+  std::string get_path = "/apis/coordination.k8s.io/v1/namespaces/" + lease_namespace_ +
+                         "/leases/" + lease_key_;
+  nlohmann::json response;
+  if (!get_api_(get_path, response).ok()) {
+    return;
+  }
+
+  std::string current_holder = "";
+  if (response.contains("spec") && response["spec"].contains("holderIdentity")) {
+    current_holder = response["spec"]["holderIdentity"].get<std::string>();
+  }
+
+  if (current_holder == holder_id) {
+    nlohmann::json update_req = response;
+    update_req["spec"]["holderIdentity"] = "";
+    update_req["spec"]["renewTime"] = "1970-01-01T00:00:00Z";
+
+    std::string resource_version = "";
+    if (response.contains("metadata") &&
+        response["metadata"].contains("resourceVersion")) {
+      resource_version = response["metadata"]["resourceVersion"].get<std::string>();
+    }
+    if (!resource_version.empty()) {
+      update_req["metadata"]["resourceVersion"] = resource_version;
+    }
+
+    nlohmann::json update_resp;
+    put_api_(get_path, update_req, update_resp);
+  }
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/k8s_lease_client.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client.cc
@@ -104,11 +104,7 @@ Status K8sLeaseClient::CreateLease(const std::string &holder_id,
   nlohmann::json create_resp;
   Status status = post_api_(post_path, create_req, create_resp);
   if (status.ok()) {
-    if (create_resp.contains("metadata") &&
-        create_resp["metadata"].contains("resourceVersion")) {
-      cached_resource_version_ =
-          create_resp["metadata"]["resourceVersion"].get<std::string>();
-    }
+    cached_lease_record_ = create_resp;
   }
   return status;
 }
@@ -120,6 +116,7 @@ Status K8sLeaseClient::UpdateLease(const LeaseMetadata &metadata,
   std::string now_str =
       absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", now, absl::UTCTimeZone());
   nlohmann::json update_req = metadata.lease_record;
+  update_req.erase("__api_server_date__");
   update_req["spec"]["holderIdentity"] = holder_id;
   update_req["spec"]["leaseDurationSeconds"] = ttl_seconds;
   update_req["spec"]["renewTime"] = now_str;
@@ -133,11 +130,7 @@ Status K8sLeaseClient::UpdateLease(const LeaseMetadata &metadata,
   nlohmann::json update_resp;
   Status status = put_api_(put_path, update_req, update_resp);
   if (status.ok()) {
-    if (update_resp.contains("metadata") &&
-        update_resp["metadata"].contains("resourceVersion")) {
-      cached_resource_version_ =
-          update_resp["metadata"]["resourceVersion"].get<std::string>();
-    }
+    cached_lease_record_ = update_resp;
   }
   return status;
 }
@@ -169,7 +162,7 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
                                   int ttl_seconds,
                                   std::string &current_leader) {
   auto metadata_or = GetLeaseMetadata();
-  if (metadata_or.IsNotFound()) {
+  if (metadata_or.status().IsNotFound()) {
     Status create_status = CreateLease(holder_id, ttl_seconds, absl::Now());
     if (create_status.ok()) {
       RAY_LOG(INFO) << "Successfully created Lease and acquired leadership.";
@@ -204,38 +197,29 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
 Status K8sLeaseClient::Renew(const std::string &holder_id,
                              int ttl_seconds,
                              std::string &current_leader) {
-  if (!cached_resource_version_.empty()) {
+  if (!cached_lease_record_.empty()) {
     absl::Time now = absl::Now();
     std::string now_str =
         absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", now, absl::UTCTimeZone());
-    nlohmann::json update_req = {{"apiVersion", "coordination.k8s.io/v1"},
-                                 {"kind", "Lease"},
-                                 {"metadata",
-                                  {{"name", lease_key_},
-                                   {"namespace", lease_namespace_},
-                                   {"resourceVersion", cached_resource_version_}}},
-                                 {"spec",
-                                  {{"holderIdentity", holder_id},
-                                   {"leaseDurationSeconds", ttl_seconds},
-                                   {"renewTime", now_str}}}};
+    nlohmann::json update_req = cached_lease_record_;
+    update_req.erase("__api_server_date__");
+    update_req["spec"]["holderIdentity"] = holder_id;
+    update_req["spec"]["leaseDurationSeconds"] = ttl_seconds;
+    update_req["spec"]["renewTime"] = now_str;
 
     std::string put_path = "/apis/coordination.k8s.io/v1/namespaces/" + lease_namespace_ +
                            "/leases/" + lease_key_;
     nlohmann::json response;
-    Status status = put_api_(put_path, update_req, response);
-    if (status.ok()) {
-      if (response.contains("metadata") &&
-          response["metadata"].contains("resourceVersion")) {
-        cached_resource_version_ =
-            response["metadata"]["resourceVersion"].get<std::string>();
-      }
+    Status update_status = put_api_(put_path, update_req, response);
+    if (update_status.ok()) {
+      cached_lease_record_ = response;
       current_leader = holder_id;
       return Status::OK();
     }
     // If direct PUT fails (due to resourceVersion mismatch/conflict, network error,
     // or request timeout), invalidate the cache and fall back to the slow-path
     // TryAcquire() (which performs a GET to refresh the resource version).
-    cached_resource_version_ = "";
+    cached_lease_record_ = nlohmann::json();
   }
 
   return TryAcquire(holder_id, ttl_seconds, current_leader);
@@ -256,6 +240,7 @@ void K8sLeaseClient::Release(const std::string &holder_id) {
 
   if (current_holder == holder_id) {
     nlohmann::json update_req = response;
+    update_req.erase("__api_server_date__");
     update_req["spec"]["holderIdentity"] = "";
     update_req["spec"]["renewTime"] = "1970-01-01T00:00:00Z";
 

--- a/src/ray/gcs/leader_election/k8s_lease_client.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client.cc
@@ -47,7 +47,8 @@ LeaseMetadata ParseLeaseMetadata(const nlohmann::json &response) {
       std::string parse_err;
       if (!absl::ParseTime(
               absl::RFC3339_full, renew_str, &metadata.renew_time, &parse_err)) {
-        metadata.renew_time = absl::UnixEpoch();
+        RAY_LOG(ERROR) << "Failed to parse lease renewTime: " << parse_err;
+        metadata.renew_time = absl::InfiniteFuture();
       }
     }
   }
@@ -121,7 +122,11 @@ Status K8sLeaseClient::UpdateLease(const LeaseMetadata &metadata,
   std::string now_str =
       absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", now, absl::UTCTimeZone());
   nlohmann::json update_req = metadata.lease_record;
+  if (!update_req.is_object()) {
+    return Status::Invalid("Lease record is not a valid JSON object.");
+  }
   update_req.erase("__api_server_date__");
+
   update_req["spec"]["holderIdentity"] = holder_id;
   update_req["spec"]["leaseDurationSeconds"] = ttl_seconds;
   update_req["spec"]["renewTime"] = now_str;
@@ -164,8 +169,9 @@ bool K8sLeaseClient::CanAcquireLease(const LeaseMetadata &metadata,
     return true;
   }
 
-  absl::Duration elapsed = now - local_observed_time_;
-  if (elapsed > absl::Seconds(metadata.duration_seconds)) {
+  auto now_steady = std::chrono::steady_clock::now();
+  auto elapsed = now_steady - local_observed_time_steady_;
+  if (elapsed > std::chrono::seconds(metadata.duration_seconds)) {
     return true;
   }
 
@@ -183,7 +189,7 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
       RAY_LOG(INFO) << "Successfully created Lease and acquired leadership.";
       last_observed_holder_id_ = holder_id;
       last_observed_renew_time_ = now;
-      local_observed_time_ = now;
+      local_observed_time_steady_ = std::chrono::steady_clock::now();
       current_leader = holder_id;
       return Status::OK();
     }
@@ -201,12 +207,12 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
 
   absl::Time now = absl::Now();
 
-  // Update local_observed_time_ ONLY if the holder_id or renew_time has changed.
+  // Update local_observed_time_steady_ ONLY if the holder_id or renew_time has changed.
   if (metadata.holder_id != last_observed_holder_id_ ||
       metadata.renew_time != last_observed_renew_time_) {
     last_observed_holder_id_ = metadata.holder_id;
     last_observed_renew_time_ = metadata.renew_time;
-    local_observed_time_ = now;
+    local_observed_time_steady_ = std::chrono::steady_clock::now();
   }
 
   if (CanAcquireLease(metadata, holder_id, now)) {
@@ -214,7 +220,7 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
     if (update_status.ok()) {
       last_observed_holder_id_ = holder_id;
       last_observed_renew_time_ = now;
-      local_observed_time_ = now;
+      local_observed_time_steady_ = std::chrono::steady_clock::now();
       current_leader = holder_id;
       return Status::OK();
     }
@@ -245,7 +251,7 @@ Status K8sLeaseClient::Renew(const std::string &holder_id,
       cached_lease_record_ = response;
       last_observed_holder_id_ = holder_id;
       last_observed_renew_time_ = now;
-      local_observed_time_ = now;
+      local_observed_time_steady_ = std::chrono::steady_clock::now();
       current_leader = holder_id;
       return Status::OK();
     }
@@ -289,7 +295,7 @@ void K8sLeaseClient::Release(const std::string &holder_id) {
 
   last_observed_holder_id_ = "";
   last_observed_renew_time_ = absl::UnixEpoch();
-  local_observed_time_ = absl::UnixEpoch();
+  local_observed_time_steady_ = std::chrono::steady_clock::time_point();
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/leader_election/k8s_lease_client.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client.cc
@@ -21,6 +21,49 @@
 namespace ray {
 namespace gcs {
 
+namespace {
+
+/// Helper function to parse a raw JSON Lease response into type-safe LeaseMetadata
+/// with complete type validation guards to prevent exceptions/crashes.
+LeaseMetadata ParseLeaseMetadata(const nlohmann::json &response) {
+  LeaseMetadata metadata;
+  if (!response.is_object()) {
+    return metadata;
+  }
+  metadata.exists = true;
+  metadata.lease_record = response;
+
+  if (response.contains("spec") && response["spec"].is_object()) {
+    const auto &spec = response["spec"];
+    if (spec.contains("holderIdentity") && spec["holderIdentity"].is_string()) {
+      metadata.holder_id = spec["holderIdentity"].get<std::string>();
+    }
+    if (spec.contains("leaseDurationSeconds") &&
+        spec["leaseDurationSeconds"].is_number_integer()) {
+      metadata.duration_seconds = spec["leaseDurationSeconds"].get<int>();
+    }
+    if (spec.contains("renewTime") && spec["renewTime"].is_string()) {
+      std::string renew_str = spec["renewTime"].get<std::string>();
+      std::string parse_err;
+      if (!absl::ParseTime(
+              absl::RFC3339_full, renew_str, &metadata.renew_time, &parse_err)) {
+        metadata.renew_time = absl::UnixEpoch();
+      }
+    }
+  }
+
+  if (response.contains("metadata") && response["metadata"].is_object() &&
+      response["metadata"].contains("resourceVersion") &&
+      response["metadata"]["resourceVersion"].is_string()) {
+    metadata.resource_version =
+        response["metadata"]["resourceVersion"].get<std::string>();
+  }
+
+  return metadata;
+}
+
+}  // namespace
+
 K8sLeaseClient::K8sLeaseClient(
     std::string lease_namespace,
     std::string lease_key,
@@ -44,45 +87,7 @@ StatusOr<LeaseMetadata> K8sLeaseClient::GetLeaseMetadata() {
     return status;
   }
 
-  LeaseMetadata metadata;
-  metadata.exists = true;
-  metadata.lease_record = response;
-
-  absl::Time server_now = absl::Now();
-  if (response.contains("__api_server_date__")) {
-    std::string date_str = response["__api_server_date__"].get<std::string>();
-    std::string err;
-    if (!absl::ParseTime("%a, %d %b %Y %H:%M:%S %Z", date_str, &server_now, &err)) {
-      RAY_LOG(WARNING) << "Failed to parse API server date: " << date_str
-                       << ", error: " << err << ". Falling back to local pod timestamp.";
-    }
-  }
-  metadata.server_now = server_now;
-
-  if (response.contains("spec")) {
-    auto &spec = response["spec"];
-    if (spec.contains("holderIdentity")) {
-      metadata.holder_id = spec["holderIdentity"].get<std::string>();
-    }
-    if (spec.contains("leaseDurationSeconds")) {
-      metadata.duration_seconds = spec["leaseDurationSeconds"].get<int>();
-    }
-    if (spec.contains("renewTime")) {
-      std::string renew_str = spec["renewTime"].get<std::string>();
-      std::string parse_err;
-      if (!absl::ParseTime(
-              absl::RFC3339_full, renew_str, &metadata.renew_time, &parse_err)) {
-        metadata.renew_time = server_now;
-      }
-    }
-  }
-
-  if (response.contains("metadata") && response["metadata"].contains("resourceVersion")) {
-    metadata.resource_version =
-        response["metadata"]["resourceVersion"].get<std::string>();
-  }
-
-  return metadata;
+  return ParseLeaseMetadata(response);
 }
 
 Status K8sLeaseClient::CreateLease(const std::string &holder_id,
@@ -148,10 +153,19 @@ bool K8sLeaseClient::CanAcquireLease(const LeaseMetadata &metadata,
     return true;
   }
 
-  // Scenario C: Another candidate holds the lease. We can only preempt if it has expired.
-  absl::Time expiration_time =
+  // Scenario C: Another candidate holds the lease. We can preempt if either:
+  // 1. The lease has expired relative to the leader's written renew_time (zero startup
+  // delay for dead leases).
+  // 2. Or our local observed time countdown has elapsed (clock-skew rate/drift
+  // immunity).
+  absl::Time absolute_expiration =
       metadata.renew_time + absl::Seconds(metadata.duration_seconds);
-  if (now > expiration_time) {
+  if (now > absolute_expiration) {
+    return true;
+  }
+
+  absl::Duration elapsed = now - local_observed_time_;
+  if (elapsed > absl::Seconds(metadata.duration_seconds)) {
     return true;
   }
 
@@ -163,9 +177,13 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
                                   std::string &current_leader) {
   auto metadata_or = GetLeaseMetadata();
   if (metadata_or.status().IsNotFound()) {
-    Status create_status = CreateLease(holder_id, ttl_seconds, absl::Now());
+    absl::Time now = absl::Now();
+    Status create_status = CreateLease(holder_id, ttl_seconds, now);
     if (create_status.ok()) {
       RAY_LOG(INFO) << "Successfully created Lease and acquired leadership.";
+      last_observed_holder_id_ = holder_id;
+      last_observed_renew_time_ = now;
+      local_observed_time_ = now;
       current_leader = holder_id;
       return Status::OK();
     }
@@ -181,10 +199,22 @@ Status K8sLeaseClient::TryAcquire(const std::string &holder_id,
   const auto &metadata = metadata_or.value();
   current_leader = metadata.holder_id;
 
-  if (CanAcquireLease(metadata, holder_id, metadata.server_now)) {
-    Status update_status =
-        UpdateLease(metadata, holder_id, ttl_seconds, metadata.server_now);
+  absl::Time now = absl::Now();
+
+  // Update local_observed_time_ ONLY if the holder_id or renew_time has changed.
+  if (metadata.holder_id != last_observed_holder_id_ ||
+      metadata.renew_time != last_observed_renew_time_) {
+    last_observed_holder_id_ = metadata.holder_id;
+    last_observed_renew_time_ = metadata.renew_time;
+    local_observed_time_ = now;
+  }
+
+  if (CanAcquireLease(metadata, holder_id, now)) {
+    Status update_status = UpdateLease(metadata, holder_id, ttl_seconds, now);
     if (update_status.ok()) {
+      last_observed_holder_id_ = holder_id;
+      last_observed_renew_time_ = now;
+      local_observed_time_ = now;
       current_leader = holder_id;
       return Status::OK();
     }
@@ -213,12 +243,17 @@ Status K8sLeaseClient::Renew(const std::string &holder_id,
     Status update_status = put_api_(put_path, update_req, response);
     if (update_status.ok()) {
       cached_lease_record_ = response;
+      last_observed_holder_id_ = holder_id;
+      last_observed_renew_time_ = now;
+      local_observed_time_ = now;
       current_leader = holder_id;
       return Status::OK();
     }
     // If direct PUT fails (due to resourceVersion mismatch/conflict, network error,
     // or request timeout), invalidate the cache and fall back to the slow-path
     // TryAcquire() (which performs a GET to refresh the resource version).
+    RAY_LOG(WARNING) << "Failed to renew lease directly with cached resourceVersion: "
+                     << update_status.ToString();
     cached_lease_record_ = nlohmann::json();
   }
 
@@ -233,29 +268,28 @@ void K8sLeaseClient::Release(const std::string &holder_id) {
     return;
   }
 
-  std::string current_holder = "";
-  if (response.contains("spec") && response["spec"].contains("holderIdentity")) {
-    current_holder = response["spec"]["holderIdentity"].get<std::string>();
-  }
+  LeaseMetadata metadata = ParseLeaseMetadata(response);
 
-  if (current_holder == holder_id) {
+  if (metadata.holder_id == holder_id) {
     nlohmann::json update_req = response;
     update_req.erase("__api_server_date__");
     update_req["spec"]["holderIdentity"] = "";
     update_req["spec"]["renewTime"] = "1970-01-01T00:00:00Z";
 
-    std::string resource_version = "";
-    if (response.contains("metadata") &&
-        response["metadata"].contains("resourceVersion")) {
-      resource_version = response["metadata"]["resourceVersion"].get<std::string>();
-    }
-    if (!resource_version.empty()) {
-      update_req["metadata"]["resourceVersion"] = resource_version;
+    if (!metadata.resource_version.empty()) {
+      update_req["metadata"]["resourceVersion"] = metadata.resource_version;
     }
 
     nlohmann::json update_resp;
-    put_api_(get_path, update_req, update_resp);
+    Status status = put_api_(get_path, update_req, update_resp);
+    if (!status.ok()) {
+      RAY_LOG(WARNING) << "Failed to release lease gracefully: " << status.ToString();
+    }
   }
+
+  last_observed_holder_id_ = "";
+  last_observed_renew_time_ = absl::UnixEpoch();
+  local_observed_time_ = absl::UnixEpoch();
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/leader_election/k8s_lease_client.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client.cc
@@ -47,6 +47,9 @@ LeaseMetadata ParseLeaseMetadata(const nlohmann::json &response) {
       std::string parse_err;
       if (!absl::ParseTime(
               absl::RFC3339_full, renew_str, &metadata.renew_time, &parse_err)) {
+        // Leave renew_time at its default (absl::InfiniteFuture()) so an unparseable
+        // timestamp is treated as "unknown / not yet expired" rather than triggering
+        // an eager preemption via the absolute-expiration path.
         RAY_LOG(ERROR) << "Failed to parse lease renewTime: " << parse_err;
         metadata.renew_time = absl::InfiniteFuture();
       }
@@ -126,6 +129,19 @@ Status K8sLeaseClient::UpdateLease(const LeaseMetadata &metadata,
     return Status::Invalid("Lease record is not a valid JSON object.");
   }
   update_req.erase("__api_server_date__");
+
+  // Split-brain guard: taking over a lease from a *different* holder must go through
+  // Kubernetes optimistic concurrency control (OCC). If we don't have a
+  // resourceVersion to condition the PUT on, an unconditional write could overwrite a
+  // concurrent acquirer and let two nodes believe they hold the lease. In that case,
+  // refuse to acquire and let the caller retry after a fresh GET. Renewing our own
+  // lease (same holder) does not need this guard.
+  const bool is_takeover = !metadata.holder_id.empty() && metadata.holder_id != holder_id;
+  if (is_takeover && metadata.resource_version.empty()) {
+    return Status::Invalid(
+        "Refusing to acquire lease from another holder without a resourceVersion "
+        "(no optimistic concurrency guard available).");
+  }
 
   update_req["spec"]["holderIdentity"] = holder_id;
   update_req["spec"]["leaseDurationSeconds"] = ttl_seconds;

--- a/src/ray/gcs/leader_election/k8s_lease_client.h
+++ b/src/ray/gcs/leader_election/k8s_lease_client.h
@@ -102,12 +102,13 @@ class K8sLeaseClient : public LeaderLeaseClientInterface {
       post_api_;
   std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
       put_api_;
-  // The cached resourceVersion of the Lease object, used to execute the Direct-PUT
-  // fast-path optimization. When holding leadership, the client uses this cached version
-  // to perform renewals in exactly one HTTP PUT call (skipping the initial GET query).
+  // The cached full JSON record of the Lease object, used to execute the Direct-PUT
+  // fast-path optimization. When holding leadership, the client uses this cached record
+  // to perform renewals in exactly one HTTP PUT call (skipping the initial GET query)
+  // while preserving all metadata (labels, annotations, owner references).
   // This cache is cleared on any API errors (such as conflicts or timeouts) to force
   // a fallback to the standard GET-then-PUT flow.
-  std::string cached_resource_version_;
+  nlohmann::json cached_lease_record_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/leader_election/k8s_lease_client.h
+++ b/src/ray/gcs/leader_election/k8s_lease_client.h
@@ -42,8 +42,6 @@ struct LeaseMetadata {
   std::string resource_version;
   // The raw JSON body record of the Lease object returned from the API Server.
   nlohmann::json lease_record;
-  // The centralized API Server time ground truth parsed from the response Date header.
-  absl::Time server_now = absl::UnixEpoch();
 };
 
 /// Concrete implementation of the LeaderLeaseClientInterface using Kubernetes Leases.
@@ -109,6 +107,11 @@ class K8sLeaseClient : public LeaderLeaseClientInterface {
   // This cache is cleared on any API errors (such as conflicts or timeouts) to force
   // a fallback to the standard GET-then-PUT flow.
   nlohmann::json cached_lease_record_;
+  // Track the last observed lease details to implement client-go's local duration
+  // tracking.
+  std::string last_observed_holder_id_;
+  absl::Time last_observed_renew_time_ = absl::UnixEpoch();
+  absl::Time local_observed_time_ = absl::UnixEpoch();
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/leader_election/k8s_lease_client.h
+++ b/src/ray/gcs/leader_election/k8s_lease_client.h
@@ -111,7 +111,7 @@ class K8sLeaseClient : public LeaderLeaseClientInterface {
   // tracking.
   std::string last_observed_holder_id_;
   absl::Time last_observed_renew_time_ = absl::UnixEpoch();
-  absl::Time local_observed_time_ = absl::UnixEpoch();
+  std::chrono::steady_clock::time_point local_observed_time_steady_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/leader_election/k8s_lease_client.h
+++ b/src/ray/gcs/leader_election/k8s_lease_client.h
@@ -1,0 +1,114 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "absl/time/time.h"
+#include "nlohmann/json.hpp"
+#include "ray/common/status_or.h"
+#include "ray/gcs/leader_election/leader_election_client_interface.h"
+
+namespace ray {
+namespace gcs {
+
+/// Represents a type-safe, parsed view of the Kubernetes Lease object retrieved from the
+/// API Server.
+struct LeaseMetadata {
+  // True if the Lease object exists in the specified namespace in Kubernetes.
+  bool exists = false;
+  // The identity (pod hostname) of the GCS instance currently holding the lease.
+  std::string holder_id;
+  // The lease lock TTL duration in seconds, default to 15 seconds.
+  int duration_seconds = 15;
+  // The timestamp of the last successful lease renewal.
+  absl::Time renew_time = absl::UnixEpoch();
+  // The Optimistic Concurrency Control (OCC) version token required by K8s for safe
+  // updates.
+  std::string resource_version;
+  // The raw JSON body record of the Lease object returned from the API Server.
+  nlohmann::json lease_record;
+  // The centralized API Server time ground truth parsed from the response Date header.
+  absl::Time server_now = absl::UnixEpoch();
+};
+
+/// Concrete implementation of the LeaderLeaseClientInterface using Kubernetes Leases.
+class K8sLeaseClient : public LeaderLeaseClientInterface {
+ public:
+  K8sLeaseClient(
+      std::string lease_namespace,
+      std::string lease_key,
+      std::function<Status(const std::string &, nlohmann::json &)> get_api,
+      std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
+          post_api,
+      std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
+          put_api);
+
+  /// Attempt to acquire leadership by taking ownership of the Kubernetes Lease.
+  /// It first gets the current Lease state. If it does not exist, it attempts to create
+  /// it. If it exists but has no holder or is expired, it updates the lease record.
+  /// \return Status::OK() if the API call succeeded (check current_leader == holder_id
+  /// for ownership).
+  Status TryAcquire(const std::string &holder_id,
+                    int ttl_seconds,
+                    std::string &current_leader) override;
+
+  /// Attempt to renew leadership of an already acquired lease.
+  /// This optimizes renewal by using a cached resourceVersion to run a Direct-PUT
+  /// fast-path. If the direct PUT fails due to network error, timeout, or version
+  /// conflict, it invalidates the cached version and falls back to TryAcquire().
+  /// \return Status::OK() if leadership renewal was successful.
+  Status Renew(const std::string &holder_id,
+               int ttl_seconds,
+               std::string &current_leader) override;
+
+  /// Voluntarily release the lease by clearing holderIdentity and setting renewTime to
+  /// epoch. Called during graceful GCS shutdown to allow standby promotion in sub-2
+  /// seconds.
+  void Release(const std::string &holder_id) override;
+
+ private:
+  StatusOr<LeaseMetadata> GetLeaseMetadata();
+
+  Status CreateLease(const std::string &holder_id, int ttl_seconds, absl::Time now);
+
+  Status UpdateLease(const LeaseMetadata &metadata,
+                     const std::string &holder_id,
+                     int ttl_seconds,
+                     absl::Time now);
+
+  bool CanAcquireLease(const LeaseMetadata &metadata,
+                       const std::string &holder_id,
+                       absl::Time now);
+
+  std::string lease_namespace_;
+  std::string lease_key_;
+  std::function<Status(const std::string &, nlohmann::json &)> get_api_;
+  std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
+      post_api_;
+  std::function<Status(const std::string &, const nlohmann::json &, nlohmann::json &)>
+      put_api_;
+  // The cached resourceVersion of the Lease object, used to execute the Direct-PUT
+  // fast-path optimization. When holding leadership, the client uses this cached version
+  // to perform renewals in exactly one HTTP PUT call (skipping the initial GET query).
+  // This cache is cleared on any API errors (such as conflicts or timeouts) to force
+  // a fallback to the standard GET-then-PUT flow.
+  std::string cached_resource_version_;
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/k8s_lease_client.h
+++ b/src/ray/gcs/leader_election/k8s_lease_client.h
@@ -35,8 +35,11 @@ struct LeaseMetadata {
   std::string holder_id;
   // The lease lock TTL duration in seconds, default to 15 seconds.
   int duration_seconds = 15;
-  // The timestamp of the last successful lease renewal.
-  absl::Time renew_time = absl::UnixEpoch();
+  // The timestamp of the last successful lease renewal. Defaults to
+  // absl::InfiniteFuture() so that a missing/unparseable renewTime is treated as
+  // "not yet expired" (fail-safe: never fast-preempt a possibly-live leader via the
+  // absolute-expiration path; fall back to the local observed countdown instead).
+  absl::Time renew_time = absl::InfiniteFuture();
   // The Optimistic Concurrency Control (OCC) version token required by K8s for safe
   // updates.
   std::string resource_version;

--- a/src/ray/gcs/leader_election/k8s_lease_client_test.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client_test.cc
@@ -1,0 +1,262 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/leader_election/k8s_lease_client.h"
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace gcs {
+
+class K8sLeaseClientTest : public ::testing::Test {
+ protected:
+  std::string lease_namespace_ = "ray-cluster";
+  std::string lease_key_ = "gcs-lease";
+  std::string my_id_ = "node-1";
+};
+
+TEST_F(K8sLeaseClientTest, InitialAcquireSuccess) {
+  auto get_api = [](const std::string &, nlohmann::json &) {
+    return Status::NotFound("Not found");  // Lease does not exist initially
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();  // Creation succeeds
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  EXPECT_TRUE(client.TryAcquire(my_id_, 10000, leader).ok());
+  EXPECT_EQ(leader, my_id_);
+}
+
+TEST_F(K8sLeaseClientTest, AcquireFailsWhenHeldActive) {
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    // Held by another ID, not expired
+    resp["spec"]["holderIdentity"] = "node-2";
+    resp["spec"]["leaseDurationSeconds"] = 10;
+    absl::Time future = absl::Now() + absl::Seconds(100);
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", future, absl::UTCTimeZone());
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  EXPECT_TRUE(client.TryAcquire(my_id_, 10000, leader).ok());
+  EXPECT_EQ(leader, "node-2");
+}
+
+TEST_F(K8sLeaseClientTest, AcquireSuccessWhenExpired) {
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    // Held by another ID, but expired
+    resp["spec"]["holderIdentity"] = "node-2";
+    resp["spec"]["leaseDurationSeconds"] = 1;
+    absl::Time past = absl::Now() - absl::Seconds(100);
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", past, absl::UTCTimeZone());
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();  // Takeover PUT succeeds
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  EXPECT_TRUE(client.TryAcquire(my_id_, 10000, leader).ok());
+  EXPECT_EQ(leader, my_id_);
+}
+
+TEST_F(K8sLeaseClientTest, AcquireGetErrorPropagated) {
+  auto get_api = [](const std::string &, nlohmann::json &) {
+    return Status::IOError("Connection refused");  // GET fails with network error
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  Status status = client.TryAcquire(my_id_, 10000, leader);
+  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(status.IsIOError());
+  EXPECT_EQ(status.message(), "Connection refused");
+  EXPECT_EQ(leader, "");
+}
+
+TEST_F(K8sLeaseClientTest, AcquirePostErrorPropagated) {
+  auto get_api = [](const std::string &, nlohmann::json &) {
+    return Status::NotFound("Missing lease object");  // GET returns NotFound
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("K8s API Limit exceeded");  // POST fails
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  Status status = client.TryAcquire(my_id_, 10000, leader);
+  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(status.IsIOError());
+  EXPECT_EQ(status.message(), "K8s API Limit exceeded");
+  EXPECT_EQ(leader, "");
+}
+
+TEST_F(K8sLeaseClientTest, RenewSuccess) {
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    // Currently held by us
+    resp["spec"]["holderIdentity"] = my_id_;
+    resp["spec"]["leaseDurationSeconds"] = 10;
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", absl::Now(), absl::UTCTimeZone());
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();  // Renewal PUT succeeds
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  EXPECT_TRUE(client.Renew(my_id_, 10000, leader).ok());
+  EXPECT_EQ(leader, my_id_);
+}
+
+TEST_F(K8sLeaseClientTest, RenewFallbackPutThenGetThenPut) {
+  std::atomic<int> put_calls{0};
+  std::atomic<int> get_calls{0};
+
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    get_calls++;
+    resp["spec"]["holderIdentity"] = my_id_;
+    resp["spec"]["leaseDurationSeconds"] = 10;
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", absl::Now(), absl::UTCTimeZone());
+    if (get_calls == 1) {
+      resp["metadata"]["resourceVersion"] = "version-after-first-get";
+    } else {
+      resp["metadata"]["resourceVersion"] = "version-after-fallback-get";
+    }
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api =
+      [&](const std::string &, const nlohmann::json &body, nlohmann::json &resp) {
+        put_calls++;
+        if (put_calls == 1) {
+          // First PUT call (TryAcquire setup) succeeds
+          EXPECT_EQ(body["metadata"]["resourceVersion"].get<std::string>(),
+                    "version-after-first-get");
+          resp["metadata"]["resourceVersion"] = "cached-version-1";
+          return Status::OK();
+        } else if (put_calls == 2) {
+          // Second PUT call (Renew direct-PUT fast-path) fails (mismatch/conflict)
+          EXPECT_EQ(body["metadata"]["resourceVersion"].get<std::string>(),
+                    "cached-version-1");
+          return Status::IOError("Conflict / Stale resourceVersion");
+        } else {
+          // Third PUT call (fallback path after GET) succeeds
+          EXPECT_EQ(body["metadata"]["resourceVersion"].get<std::string>(),
+                    "version-after-fallback-get");
+          resp["metadata"]["resourceVersion"] = "cached-version-2";
+          return Status::OK();
+        }
+      };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+
+  // 1. Initial acquire to populate the cached resource version
+  EXPECT_TRUE(client.TryAcquire(my_id_, 10, leader).ok());
+  EXPECT_EQ(leader, my_id_);
+  EXPECT_EQ(get_calls.load(), 1);
+  EXPECT_EQ(put_calls.load(), 1);
+
+  // 2. Renewal call. This triggers:
+  //    a. Direct PUT with 'cached-version-1' -> Fails.
+  //    b. GET -> returns 'version-after-fallback-get'.
+  //    c. PUT with 'version-after-fallback-get' -> Succeeds.
+  EXPECT_TRUE(client.Renew(my_id_, 10, leader).ok());
+  EXPECT_EQ(leader, my_id_);
+  EXPECT_EQ(get_calls.load(), 2);
+  EXPECT_EQ(put_calls.load(), 3);
+}
+
+TEST_F(K8sLeaseClientTest, ReleaseSuccess) {
+  std::atomic<bool> put_called{false};
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    // Currently held by us
+    resp["spec"]["holderIdentity"] = my_id_;
+    resp["spec"]["leaseDurationSeconds"] = 10;
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", absl::Now(), absl::UTCTimeZone());
+    resp["metadata"]["resourceVersion"] = "12345";
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [&](const std::string &, const nlohmann::json &body, nlohmann::json &) {
+    put_called = true;
+    // Assert that holderIdentity is cleared to empty string, and resourceVersion is
+    // passed correctly
+    EXPECT_EQ(body["spec"]["holderIdentity"].get<std::string>(), "");
+    EXPECT_EQ(body["metadata"]["resourceVersion"].get<std::string>(), "12345");
+    return Status::OK();
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  client.Release(my_id_);
+  EXPECT_TRUE(put_called.load());
+}
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/k8s_lease_client_test.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client_test.cc
@@ -97,6 +97,44 @@ TEST_F(K8sLeaseClientTest, AcquireSuccessWhenExpired) {
   EXPECT_EQ(leader, my_id_);
 }
 
+TEST_F(K8sLeaseClientTest, AcquireSuccessWhenExpiredByLocalObservedTime) {
+  // Leader's clock is fast, writing renewTime in the future.
+  // Standby node should still preempt the lease exactly 1 second (lease duration)
+  // after the first observation, even though renewTime is in the future.
+  absl::Time static_future = absl::Now() + absl::Seconds(100);
+  auto get_api = [=](const std::string &, nlohmann::json &resp) {
+    resp["spec"]["holderIdentity"] = "node-2";
+    resp["spec"]["leaseDurationSeconds"] = 1;
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", static_future, absl::UTCTimeZone());
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::OK();  // Takeover PUT succeeds
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+
+  // First attempt: absolute check is false, local observed time is initialized to now.
+  // No takeover should happen.
+  EXPECT_TRUE(client.TryAcquire(my_id_, 1, leader).ok());
+  EXPECT_EQ(leader, "node-2");
+
+  // Wait for 2 seconds to elapse locally (exceeding the 1-second lease duration).
+  absl::SleepFor(absl::Seconds(2));
+
+  // Second attempt: absolute check is still false (future renewTime), but local
+  // observed duration check (Condition 2) is now true! Takeover should succeed.
+  EXPECT_TRUE(client.TryAcquire(my_id_, 1, leader).ok());
+  EXPECT_EQ(leader, my_id_);
+}
+
 TEST_F(K8sLeaseClientTest, AcquireGetErrorPropagated) {
   auto get_api = [](const std::string &, nlohmann::json &) {
     return Status::IOError("Connection refused");  // GET fails with network error

--- a/src/ray/gcs/leader_election/k8s_lease_client_test.cc
+++ b/src/ray/gcs/leader_election/k8s_lease_client_test.cc
@@ -80,6 +80,9 @@ TEST_F(K8sLeaseClientTest, AcquireSuccessWhenExpired) {
     absl::Time past = absl::Now() - absl::Seconds(100);
     resp["spec"]["renewTime"] =
         absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", past, absl::UTCTimeZone());
+    // Real Kubernetes always assigns a resourceVersion; it is required for the
+    // optimistic-concurrency-guarded takeover PUT.
+    resp["metadata"]["resourceVersion"] = "v1";
     return Status::OK();
   };
 
@@ -107,6 +110,9 @@ TEST_F(K8sLeaseClientTest, AcquireSuccessWhenExpiredByLocalObservedTime) {
     resp["spec"]["leaseDurationSeconds"] = 1;
     resp["spec"]["renewTime"] =
         absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", static_future, absl::UTCTimeZone());
+    // Real Kubernetes always assigns a resourceVersion; it is required for the
+    // optimistic-concurrency-guarded takeover PUT.
+    resp["metadata"]["resourceVersion"] = "v1";
     return Status::OK();
   };
 
@@ -295,6 +301,71 @@ TEST_F(K8sLeaseClientTest, ReleaseSuccess) {
   K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
   client.Release(my_id_);
   EXPECT_TRUE(put_called.load());
+}
+
+TEST_F(K8sLeaseClientTest, AcquireDoesNotInstantPreemptWhenRenewTimeMissing) {
+  // A lease is held by another node but the record has no renewTime field (e.g. a
+  // freshly-created lease, a partial patch, or a foreign writer). renew_time defaults
+  // to absl::InfiniteFuture(), so the absolute-expiration path must NOT fire; the
+  // standby must fall back to the local observed countdown and wait instead of
+  // instantly preempting a possibly-live leader (split-brain guard).
+  std::atomic<bool> put_called{false};
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    resp["spec"]["holderIdentity"] = "node-2";
+    resp["spec"]["leaseDurationSeconds"] = 100;
+    // Intentionally omit "renewTime".
+    resp["metadata"]["resourceVersion"] = "v1";
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [&](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    put_called = true;
+    return Status::OK();
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  // Should observe the current holder and NOT take over.
+  EXPECT_TRUE(client.TryAcquire(my_id_, 100, leader).ok());
+  EXPECT_EQ(leader, "node-2");
+  EXPECT_FALSE(put_called.load());
+}
+
+TEST_F(K8sLeaseClientTest, AcquireRefusedOnTakeoverWithoutResourceVersion) {
+  // A different node holds an expired lease, but the record carries no resourceVersion,
+  // so an acquiring PUT could not be guarded by optimistic concurrency control. To
+  // avoid an unconditional overwrite that could cause split-brain, the takeover must be
+  // refused with Status::Invalid and no PUT should be issued.
+  std::atomic<bool> put_called{false};
+  auto get_api = [&](const std::string &, nlohmann::json &resp) {
+    resp["spec"]["holderIdentity"] = "node-2";
+    resp["spec"]["leaseDurationSeconds"] = 1;
+    absl::Time past = absl::Now() - absl::Seconds(100);
+    resp["spec"]["renewTime"] =
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E6SZ", past, absl::UTCTimeZone());
+    // Intentionally omit "resourceVersion".
+    return Status::OK();
+  };
+
+  auto post_api = [](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    return Status::IOError("Failure");
+  };
+
+  auto put_api = [&](const std::string &, const nlohmann::json &, nlohmann::json &) {
+    put_called = true;
+    return Status::OK();
+  };
+
+  K8sLeaseClient client(lease_namespace_, lease_key_, get_api, post_api, put_api);
+  std::string leader = "";
+  Status status = client.TryAcquire(my_id_, 10000, leader);
+  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(status.IsInvalid());
+  EXPECT_FALSE(put_called.load());
 }
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/leader_election/leader_election_client_factory.cc
+++ b/src/ray/gcs/leader_election/leader_election_client_factory.cc
@@ -1,0 +1,40 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/leader_election/leader_election_client_factory.h"
+
+#include "ray/gcs/leader_election/k8s_lease_client.h"
+#include "ray/rpc/authentication/k8s_util.h"
+
+namespace ray {
+namespace gcs {
+
+std::unique_ptr<LeaderLeaseClientInterface> LeaderLeaseClientFactory::Create(
+    const std::string &lease_namespace, const std::string &lease_key) {
+  return std::make_unique<K8sLeaseClient>(
+      lease_namespace,
+      lease_key,
+      [](const std::string &path, nlohmann::json &resp) {
+        return rpc::k8s::K8sApiGet(path, resp);
+      },
+      [](const std::string &path, const nlohmann::json &body, nlohmann::json &resp) {
+        return rpc::k8s::K8sApiPost(path, body, resp);
+      },
+      [](const std::string &path, const nlohmann::json &body, nlohmann::json &resp) {
+        return rpc::k8s::K8sApiPut(path, body, resp);
+      });
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/leader_election_client_factory.cc
+++ b/src/ray/gcs/leader_election/leader_election_client_factory.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/leader_election/leader_election_client_factory.h"
 
+#include <mutex>
+
 #include "ray/gcs/leader_election/k8s_lease_client.h"
 #include "ray/rpc/authentication/k8s_util.h"
 
@@ -22,6 +24,13 @@ namespace gcs {
 
 std::unique_ptr<LeaderLeaseClientInterface> LeaderLeaseClientFactory::Create(
     const std::string &lease_namespace, const std::string &lease_key) {
+  // Ensure the in-cluster Kubernetes client configuration is initialized before any
+  // K8sApiGet/Post/Put call. Otherwise those helpers return Status::Invalid until some
+  // other subsystem (currently only the auth-token validator) happens to initialize it
+  // first. Using the same shared std::once_flag makes this idempotent and independent of
+  // call order.
+  std::call_once(rpc::k8s::k8s_client_config_flag, rpc::k8s::InitK8sClientConfig);
+
   return std::make_unique<K8sLeaseClient>(
       lease_namespace,
       lease_key,

--- a/src/ray/gcs/leader_election/leader_election_client_factory.h
+++ b/src/ray/gcs/leader_election/leader_election_client_factory.h
@@ -1,0 +1,33 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "ray/gcs/leader_election/leader_election_client_interface.h"
+
+namespace ray {
+namespace gcs {
+
+class LeaderLeaseClientFactory {
+ public:
+  /// Creates a platform-agnostic lease client based on configuration.
+  static std::unique_ptr<LeaderLeaseClientInterface> Create(
+      const std::string &lease_namespace, const std::string &lease_key);
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/leader_election_client_interface.h
+++ b/src/ray/gcs/leader_election/leader_election_client_interface.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <string>
+
 #include "ray/common/status.h"
 
 namespace ray {

--- a/src/ray/gcs/leader_election/leader_election_client_interface.h
+++ b/src/ray/gcs/leader_election/leader_election_client_interface.h
@@ -1,0 +1,53 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include "ray/common/status.h"
+
+namespace ray {
+namespace gcs {
+
+/// Generic, platform-agnostic interface for distributed leader election and lease
+/// management.
+class LeaderLeaseClientInterface {
+ public:
+  virtual ~LeaderLeaseClientInterface() = default;
+
+  /// Attempt to acquire the distributed lock/lease.
+  /// \param holder_id The identity of the participant attempting to acquire the lease.
+  /// \param ttl_seconds The requested lease duration in seconds.
+  /// \param[out] current_leader Stored identity of the current lease holder.
+  /// \return Status::OK() if the API call succeeded (check current_leader == holder_id
+  /// for ownership).
+  virtual Status TryAcquire(const std::string &holder_id,
+                            int ttl_seconds,
+                            std::string &current_leader) = 0;
+
+  /// Attempt to renew an existing lease.
+  /// \param holder_id The identity of the participant attempting to renew the lease.
+  /// \param ttl_seconds The requested lease duration in seconds.
+  /// \param[out] current_leader Stored identity of the current lease holder.
+  /// \return Status::OK() if the API call succeeded and lease was renewed.
+  virtual Status Renew(const std::string &holder_id,
+                       int ttl_seconds,
+                       std::string &current_leader) = 0;
+
+  /// Release the distributed lock/lease voluntarily.
+  virtual void Release(const std::string &holder_id) = 0;
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/leader_elector.cc
+++ b/src/ray/gcs/leader_election/leader_elector.cc
@@ -65,23 +65,13 @@ void LeaderElector::Stop() {
   watchdog_cv_.notify_all();
   election_cv_.notify_all();
 
-  // Safely join background execution threads first. Enforce self-join checks to prevent
-  // deadlocks if Stop() is called from within callback loops.
+  // Safely join background execution threads first.
   if (election_thread_ && election_thread_->joinable()) {
-    if (std::this_thread::get_id() != election_thread_->get_id()) {
-      election_thread_->join();
-    } else {
-      election_thread_->detach();
-    }
+    election_thread_->join();
   }
   election_thread_.reset();
-
   if (watchdog_thread_ && watchdog_thread_->joinable()) {
-    if (std::this_thread::get_id() != watchdog_thread_->get_id()) {
-      watchdog_thread_->join();
-    } else {
-      watchdog_thread_->detach();
-    }
+    watchdog_thread_->join();
   }
   watchdog_thread_.reset();
 
@@ -202,12 +192,13 @@ void LeaderElector::Renew() {
     if (status.ok() && !renewed) {
       RAY_LOG(ERROR) << "Lease ownership has been acquired by another node. Stepping "
                         "down immediately.";
+      bool was_leading = false;
       {
         std::lock_guard<std::mutex> lock(watchdog_mutex_);
-        is_leading_ = false;
+        was_leading = is_leading_.exchange(false);
       }
       watchdog_cv_.notify_all();
-      if (config_.on_stopped_leading) {
+      if (was_leading && config_.on_stopped_leading) {
         config_.on_stopped_leading();
       }
       return;
@@ -253,14 +244,15 @@ void LeaderElector::WatchdogLoop() {
       RAY_LOG(ERROR) << "WATCHDOG: GCS leader lease renewal deadline exceeded ("
                      << elapsed_ms / 1000.0 << "s > " << config_.renew_deadline_seconds
                      << "s). Stepping down immediately!";
+      bool was_leading = false;
       {
         // Acquire election_mutex_ to prevent a lost wake-up race condition with the
         // election thread waiting on election_cv_.
         std::lock_guard<std::mutex> lock(election_mutex_);
-        is_leading_ = false;
+        was_leading = is_leading_.exchange(false);
       }
       election_cv_.notify_all();
-      if (config_.on_stopped_leading) {
+      if (was_leading && config_.on_stopped_leading) {
         // Note: In GCS, this callback is bound to immediately suicide-terminate the
         // GCS process (RAY_LOG(FATAL)) to prevent split-brain zombie writes to Redis.
         config_.on_stopped_leading();

--- a/src/ray/gcs/leader_election/leader_elector.cc
+++ b/src/ray/gcs/leader_election/leader_elector.cc
@@ -50,19 +50,7 @@ void LeaderElector::Stop() {
   watchdog_cv_.notify_all();
   election_cv_.notify_all();
 
-  if (is_leading_.load()) {
-    is_leading_ = false;
-    try {
-      // Graceful exit: Voluntarily release the lease in Kubernetes to allow the
-      // standby node to promote itself immediately.
-      config_.lease_client->Release(config_.holder_id);
-    } catch (const std::exception &e) {
-      RAY_LOG(WARNING) << "Exception occurred during voluntary lease release: "
-                       << e.what();
-    }
-  }
-
-  // Safely join background execution threads. Enforce self-join checks to prevent
+  // Safely join background execution threads first. Enforce self-join checks to prevent
   // deadlocks if Stop() is called from within callback loops.
   if (election_thread_ && election_thread_->joinable()) {
     if (std::this_thread::get_id() != election_thread_->get_id()) {
@@ -76,6 +64,18 @@ void LeaderElector::Stop() {
       watchdog_thread_->join();
     } else {
       watchdog_thread_->detach();
+    }
+  }
+
+  if (is_leading_.load()) {
+    is_leading_ = false;
+    try {
+      // Graceful exit: Voluntarily release the lease in Kubernetes to allow the
+      // standby node to promote itself immediately.
+      config_.lease_client->Release(config_.holder_id);
+    } catch (const std::exception &e) {
+      RAY_LOG(WARNING) << "Exception occurred during voluntary lease release: "
+                       << e.what();
     }
   }
 }
@@ -207,22 +207,27 @@ void LeaderElector::WatchdogLoop() {
     }
 
     // 2. Calculate monotonic elapsed time since the last successful lease renewal.
+    // Load the last successful renewal steady timestamp first.
+    int64_t last_renew_ns = last_successful_renew_steady_ns_.load();
+
+    // Capture current steady clock next. This order guarantees that last_renew_ns
+    // is always <= now_steady_ns, preventing negative elapsed time calculations.
     auto now_steady = std::chrono::steady_clock::now().time_since_epoch();
     int64_t now_steady_ns =
         std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady).count();
-    int64_t last_renew_ns = last_successful_renew_steady_ns_.load();
 
     int64_t elapsed_ms = (now_steady_ns - last_renew_ns) / 1000000;
     int64_t remaining_ms = (config_.renew_deadline_seconds * 1000) - elapsed_ms;
 
     // 3. If the elapsed time has breached the renew deadline, step GCS down immediately!
-    // GCS must suicide (RAY_LOG(FATAL)) to ensure zero zombie writes reach the database.
     if (remaining_ms <= 0) {
       RAY_LOG(ERROR) << "WATCHDOG: GCS leader lease renewal deadline exceeded ("
                      << elapsed_ms / 1000.0 << "s > " << config_.renew_deadline_seconds
                      << "s). Stepping down immediately!";
       is_leading_ = false;
       if (config_.on_stopped_leading) {
+        // Note: In GCS, this callback is bound to immediately suicide-terminate the
+        // GCS process (RAY_LOG(FATAL)) to prevent split-brain zombie writes to Redis.
         config_.on_stopped_leading();
       }
       continue;

--- a/src/ray/gcs/leader_election/leader_elector.cc
+++ b/src/ray/gcs/leader_election/leader_elector.cc
@@ -29,11 +29,18 @@ LeaderElector::LeaderElector(LeaderElectionConfig config)
   // GCS steps down/suicides before another standby node can preemptively steal the lock.
   RAY_CHECK(config_.renew_deadline_seconds < config_.lease_duration_seconds)
       << "Renew deadline must be smaller than lease duration.";
+  RAY_CHECK(config_.retry_period_seconds < config_.renew_deadline_seconds)
+      << "Retry period must be smaller than renew deadline.";
 }
 
 LeaderElector::~LeaderElector() { Stop(); }
 
 void LeaderElector::Run() {
+  if (election_thread_ || watchdog_thread_) {
+    RAY_LOG(WARNING) << "Leader elector is already running.";
+    return;
+  }
+  is_stopped_ = false;
   RAY_LOG(INFO) << "Starting leader election background thread for candidate: "
                 << config_.holder_id;
   // Thread 1: Executes the network I/O loop to acquire and renew the Kubernetes Lease.
@@ -44,8 +51,10 @@ void LeaderElector::Run() {
 }
 
 void LeaderElector::Stop() {
-  // Flag background loops to exit immediately
-  is_stopped_ = true;
+  // Flag background loops to exit immediately. If already stopped, return.
+  if (is_stopped_.exchange(true)) {
+    return;
+  }
   // Wake up all background threads from their wait/sleep states so they can exit.
   watchdog_cv_.notify_all();
   election_cv_.notify_all();
@@ -59,6 +68,8 @@ void LeaderElector::Stop() {
       election_thread_->detach();
     }
   }
+  election_thread_.reset();
+
   if (watchdog_thread_ && watchdog_thread_->joinable()) {
     if (std::this_thread::get_id() != watchdog_thread_->get_id()) {
       watchdog_thread_->join();
@@ -66,6 +77,7 @@ void LeaderElector::Stop() {
       watchdog_thread_->detach();
     }
   }
+  watchdog_thread_.reset();
 
   if (is_leading_.load()) {
     is_leading_ = false;
@@ -238,9 +250,12 @@ void LeaderElector::WatchdogLoop() {
     // early to recalculate. If the process stops, notify_all() wakes us to exit
     // instantly.
     std::unique_lock<std::mutex> lock(watchdog_mutex_);
-    watchdog_cv_.wait_for(lock, std::chrono::milliseconds(remaining_ms), [this]() {
-      return is_stopped_.load();
-    });
+    watchdog_cv_.wait_for(
+        lock, std::chrono::milliseconds(remaining_ms), [this, last_renew_ns]() {
+          return is_stopped_.load() ||
+                 last_successful_renew_steady_ns_.load() != last_renew_ns ||
+                 !is_leading_.load();
+        });
   }
 }
 

--- a/src/ray/gcs/leader_election/leader_elector.cc
+++ b/src/ray/gcs/leader_election/leader_elector.cc
@@ -1,0 +1,243 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/leader_election/leader_elector.h"
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace gcs {
+
+LeaderElector::LeaderElector(LeaderElectionConfig config)
+    : config_(std::move(config)), is_stopped_(false), is_leading_(false) {
+  RAY_CHECK(config_.lease_client) << "Lease client must be non-null.";
+  RAY_CHECK(!config_.holder_id.empty()) << "Holder ID must be non-empty.";
+  // The safety deadline must be strictly smaller than the lease TTL duration to ensure
+  // GCS steps down/suicides before another standby node can preemptively steal the lock.
+  RAY_CHECK(config_.renew_deadline_seconds < config_.lease_duration_seconds)
+      << "Renew deadline must be smaller than lease duration.";
+}
+
+LeaderElector::~LeaderElector() { Stop(); }
+
+void LeaderElector::Run() {
+  RAY_LOG(INFO) << "Starting leader election background thread for candidate: "
+                << config_.holder_id;
+  // Thread 1: Executes the network I/O loop to acquire and renew the Kubernetes Lease.
+  election_thread_ = std::make_unique<std::thread>([this]() { Loop(); });
+  // Thread 2: Lightweight watchdog that continuously checks that lease renewals are
+  // succeeding within the safety renew deadline.
+  watchdog_thread_ = std::make_unique<std::thread>([this]() { WatchdogLoop(); });
+}
+
+void LeaderElector::Stop() {
+  // Flag background loops to exit immediately
+  is_stopped_ = true;
+  // Wake up all background threads from their wait/sleep states so they can exit.
+  watchdog_cv_.notify_all();
+  election_cv_.notify_all();
+
+  if (is_leading_.load()) {
+    is_leading_ = false;
+    try {
+      // Graceful exit: Voluntarily release the lease in Kubernetes to allow the
+      // standby node to promote itself immediately.
+      config_.lease_client->Release(config_.holder_id);
+    } catch (const std::exception &e) {
+      RAY_LOG(WARNING) << "Exception occurred during voluntary lease release: "
+                       << e.what();
+    }
+  }
+
+  // Safely join background execution threads. Enforce self-join checks to prevent
+  // deadlocks if Stop() is called from within callback loops.
+  if (election_thread_ && election_thread_->joinable()) {
+    if (std::this_thread::get_id() != election_thread_->get_id()) {
+      election_thread_->join();
+    } else {
+      election_thread_->detach();
+    }
+  }
+  if (watchdog_thread_ && watchdog_thread_->joinable()) {
+    if (std::this_thread::get_id() != watchdog_thread_->get_id()) {
+      watchdog_thread_->join();
+    } else {
+      watchdog_thread_->detach();
+    }
+  }
+}
+
+void LeaderElector::Loop() {
+  while (!is_stopped_.load()) {
+    // 1. Standby mode: Poll K8s to acquire the lease.
+    Acquire();
+    // 2. Active mode: Periodically renew lease heartbeats as long as we hold leadership.
+    if (is_leading_.load() && !is_stopped_.load()) {
+      Renew();
+    }
+  }
+}
+
+Status LeaderElector::TryAcquireOrRenew(
+    std::function<Status(const std::string &, int, std::string &)> lease_op,
+    const std::string &op_name,
+    bool &success) {
+  success = false;
+  std::string current_leader = "";
+  int ttl_seconds = config_.lease_duration_seconds;
+
+  Status status = Status::OK();
+  try {
+    status = lease_op(config_.holder_id, ttl_seconds, current_leader);
+    success = status.ok() && (current_leader == config_.holder_id);
+  } catch (const std::exception &e) {
+    std::string err_msg =
+        std::string("Exception occurred during lease ") + op_name + ": " + e.what();
+    RAY_LOG(WARNING) << err_msg;
+    status = Status::IOError(err_msg);
+    success = false;
+    current_leader = "";
+  }
+
+  // If a new leader is observed in the cluster, fire the notification callback.
+  if (!current_leader.empty() && current_leader != last_observed_leader_) {
+    last_observed_leader_ = current_leader;
+    if (config_.on_new_leader) {
+      config_.on_new_leader(current_leader);
+    }
+  }
+
+  if (success) {
+    // Lock successfully acquired or renewed.
+    auto now_steady = std::chrono::steady_clock::now().time_since_epoch();
+    last_successful_renew_steady_ns_.store(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady).count());
+    // Wake up the watchdog thread early to recalculate the remaining safety window.
+    watchdog_cv_.notify_all();
+  }
+
+  return status;
+}
+
+void LeaderElector::Acquire() {
+  while (!is_leading_.load() && !is_stopped_.load()) {
+    bool acquired = false;
+    Status status = TryAcquireOrRenew(
+        [this](
+            const std::string &holder_id, int ttl_seconds, std::string &current_leader) {
+          return config_.lease_client->TryAcquire(holder_id, ttl_seconds, current_leader);
+        },
+        "acquisition",
+        acquired);
+    if (!status.ok()) {
+      RAY_LOG(WARNING) << "Error during lease acquisition: " << status.ToString();
+    }
+
+    if (acquired) {
+      RAY_LOG(INFO) << "Successfully acquired leader lease. Promoting to Leader!";
+      is_leading_ = true;
+      watchdog_cv_.notify_all();
+      if (config_.on_started_leading) {
+        config_.on_started_leading();
+      }
+      return;
+    }
+
+    std::unique_lock<std::mutex> lock(election_mutex_);
+    election_cv_.wait_for(lock,
+                          std::chrono::seconds(config_.retry_period_seconds),
+                          [this]() { return is_stopped_.load(); });
+  }
+}
+
+void LeaderElector::Renew() {
+  while (is_leading_.load() && !is_stopped_.load()) {
+    bool renewed = false;
+    Status status = TryAcquireOrRenew(
+        [this](
+            const std::string &holder_id, int ttl_seconds, std::string &current_leader) {
+          return config_.lease_client->Renew(holder_id, ttl_seconds, current_leader);
+        },
+        "renewal",
+        renewed);
+    if (!status.ok()) {
+      RAY_LOG(WARNING) << "Transient lease renewal failure: " << status.ToString();
+    }
+    // If the API call succeeded, but renewed is false (e.g. lease acquired by another
+    // node), step down immediately to prevent split-brain writes.
+    if (status.ok() && !renewed) {
+      RAY_LOG(ERROR) << "Lease ownership has been acquired by another node. Stepping "
+                        "down immediately.";
+      is_leading_ = false;
+      if (config_.on_stopped_leading) {
+        config_.on_stopped_leading();
+      }
+      return;
+    }
+
+    std::unique_lock<std::mutex> lock(election_mutex_);
+    election_cv_.wait_for(lock,
+                          std::chrono::seconds(config_.retry_period_seconds),
+                          [this]() { return is_stopped_.load(); });
+  }
+}
+
+void LeaderElector::WatchdogLoop() {
+  while (!is_stopped_.load()) {
+    // 1. If we are in standby (not leading), sleep on CV to prevent high CPU spin cycles.
+    if (!is_leading_.load()) {
+      std::unique_lock<std::mutex> lock(watchdog_mutex_);
+      watchdog_cv_.wait_for(lock, kWatchdogStandbySleepMs, [this]() {
+        return is_leading_.load() || is_stopped_.load();
+      });
+      continue;
+    }
+
+    // 2. Calculate monotonic elapsed time since the last successful lease renewal.
+    auto now_steady = std::chrono::steady_clock::now().time_since_epoch();
+    int64_t now_steady_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady).count();
+    int64_t last_renew_ns = last_successful_renew_steady_ns_.load();
+
+    int64_t elapsed_ms = (now_steady_ns - last_renew_ns) / 1000000;
+    int64_t remaining_ms = (config_.renew_deadline_seconds * 1000) - elapsed_ms;
+
+    // 3. If the elapsed time has breached the renew deadline, step GCS down immediately!
+    // GCS must suicide (RAY_LOG(FATAL)) to ensure zero zombie writes reach the database.
+    if (remaining_ms <= 0) {
+      RAY_LOG(ERROR) << "WATCHDOG: GCS leader lease renewal deadline exceeded ("
+                     << elapsed_ms / 1000.0 << "s > " << config_.renew_deadline_seconds
+                     << "s). Stepping down immediately!";
+      is_leading_ = false;
+      if (config_.on_stopped_leading) {
+        config_.on_stopped_leading();
+      }
+      continue;
+    }
+
+    // 4. Sleep on the CV for the exact duration of the remaining safety deadline window.
+    // If a renewal succeeds early, the election thread will call notify_all(), waking us
+    // early to recalculate. If the process stops, notify_all() wakes us to exit
+    // instantly.
+    std::unique_lock<std::mutex> lock(watchdog_mutex_);
+    watchdog_cv_.wait_for(lock, std::chrono::milliseconds(remaining_ms), [this]() {
+      return is_stopped_.load();
+    });
+  }
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/leader_elector.cc
+++ b/src/ray/gcs/leader_election/leader_elector.cc
@@ -25,6 +25,9 @@ LeaderElector::LeaderElector(LeaderElectionConfig config)
     : config_(std::move(config)), is_stopped_(false), is_leading_(false) {
   RAY_CHECK(config_.lease_client) << "Lease client must be non-null.";
   RAY_CHECK(!config_.holder_id.empty()) << "Holder ID must be non-empty.";
+  RAY_CHECK(config_.lease_duration_seconds > 0);
+  RAY_CHECK(config_.renew_deadline_seconds > 0);
+  RAY_CHECK(config_.retry_period_seconds > 0);
   // The safety deadline must be strictly smaller than the lease TTL duration to ensure
   // GCS steps down/suicides before another standby node can preemptively steal the lock.
   RAY_CHECK(config_.renew_deadline_seconds < config_.lease_duration_seconds)
@@ -52,8 +55,11 @@ void LeaderElector::Run() {
 
 void LeaderElector::Stop() {
   // Flag background loops to exit immediately. If already stopped, return.
-  if (is_stopped_.exchange(true)) {
-    return;
+  {
+    std::lock_guard<std::mutex> lock(watchdog_mutex_);
+    if (is_stopped_.exchange(true)) {
+      return;
+    }
   }
   // Wake up all background threads from their wait/sleep states so they can exit.
   watchdog_cv_.notify_all();
@@ -160,7 +166,10 @@ void LeaderElector::Acquire() {
 
     if (acquired) {
       RAY_LOG(INFO) << "Successfully acquired leader lease. Promoting to Leader!";
-      is_leading_ = true;
+      {
+        std::lock_guard<std::mutex> lock(watchdog_mutex_);
+        is_leading_ = true;
+      }
       watchdog_cv_.notify_all();
       if (config_.on_started_leading) {
         config_.on_started_leading();
@@ -193,17 +202,25 @@ void LeaderElector::Renew() {
     if (status.ok() && !renewed) {
       RAY_LOG(ERROR) << "Lease ownership has been acquired by another node. Stepping "
                         "down immediately.";
-      is_leading_ = false;
+      {
+        std::lock_guard<std::mutex> lock(watchdog_mutex_);
+        is_leading_ = false;
+      }
+      watchdog_cv_.notify_all();
       if (config_.on_stopped_leading) {
         config_.on_stopped_leading();
       }
       return;
     }
 
+    // Wake up the election thread if one of the conditions below is met:
+    // 1. Stop() is called.
+    // 2. Leadership lost.
+    // 3. retry_period_seconds has elapsed.
     std::unique_lock<std::mutex> lock(election_mutex_);
     election_cv_.wait_for(lock,
                           std::chrono::seconds(config_.retry_period_seconds),
-                          [this]() { return is_stopped_.load(); });
+                          [this]() { return is_stopped_.load() || !is_leading_.load(); });
   }
 }
 
@@ -212,9 +229,9 @@ void LeaderElector::WatchdogLoop() {
     // 1. If we are in standby (not leading), sleep on CV to prevent high CPU spin cycles.
     if (!is_leading_.load()) {
       std::unique_lock<std::mutex> lock(watchdog_mutex_);
-      watchdog_cv_.wait_for(lock, kWatchdogStandbySleepMs, [this]() {
-        return is_leading_.load() || is_stopped_.load();
-      });
+      // Wake up if we are elected as leader or stop() is called.
+      watchdog_cv_.wait(lock,
+                        [this]() { return is_leading_.load() || is_stopped_.load(); });
       continue;
     }
 
@@ -236,7 +253,13 @@ void LeaderElector::WatchdogLoop() {
       RAY_LOG(ERROR) << "WATCHDOG: GCS leader lease renewal deadline exceeded ("
                      << elapsed_ms / 1000.0 << "s > " << config_.renew_deadline_seconds
                      << "s). Stepping down immediately!";
-      is_leading_ = false;
+      {
+        // Acquire election_mutex_ to prevent a lost wake-up race condition with the
+        // election thread waiting on election_cv_.
+        std::lock_guard<std::mutex> lock(election_mutex_);
+        is_leading_ = false;
+      }
+      election_cv_.notify_all();
       if (config_.on_stopped_leading) {
         // Note: In GCS, this callback is bound to immediately suicide-terminate the
         // GCS process (RAY_LOG(FATAL)) to prevent split-brain zombie writes to Redis.

--- a/src/ray/gcs/leader_election/leader_elector.cc
+++ b/src/ray/gcs/leader_election/leader_elector.cc
@@ -14,8 +14,6 @@
 
 #include "ray/gcs/leader_election/leader_elector.h"
 
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -56,10 +54,11 @@ void LeaderElector::Run() {
 void LeaderElector::Stop() {
   // Flag background loops to exit immediately. If already stopped, return.
   {
-    std::lock_guard<std::mutex> lock(watchdog_mutex_);
-    if (is_stopped_.exchange(true)) {
+    std::scoped_lock lock(mutex_);
+    if (is_stopped_) {
       return;
     }
+    is_stopped_ = true;
   }
   // Wake up all background threads from their wait/sleep states so they can exit.
   watchdog_cv_.notify_all();
@@ -75,8 +74,16 @@ void LeaderElector::Stop() {
   }
   watchdog_thread_.reset();
 
-  if (is_leading_.load()) {
-    is_leading_ = false;
+  bool was_leading = false;
+  {
+    std::scoped_lock lock(mutex_);
+    if (is_leading_) {
+      is_leading_ = false;
+      was_leading = true;
+    }
+  }
+
+  if (was_leading) {
     try {
       // Graceful exit: Voluntarily release the lease in Kubernetes to allow the
       // standby node to promote itself immediately.
@@ -89,11 +96,22 @@ void LeaderElector::Stop() {
 }
 
 void LeaderElector::Loop() {
-  while (!is_stopped_.load()) {
+  while (true) {
+    {
+      std::scoped_lock lock(mutex_);
+      if (is_stopped_) {
+        break;
+      }
+    }
     // 1. Standby mode: Poll K8s to acquire the lease.
     Acquire();
     // 2. Active mode: Periodically renew lease heartbeats as long as we hold leadership.
-    if (is_leading_.load() && !is_stopped_.load()) {
+    bool should_renew = false;
+    {
+      std::scoped_lock lock(mutex_);
+      should_renew = is_leading_ && !is_stopped_;
+    }
+    if (should_renew) {
       Renew();
     }
   }
@@ -131,8 +149,11 @@ Status LeaderElector::TryAcquireOrRenew(
   if (success) {
     // Lock successfully acquired or renewed.
     auto now_steady = std::chrono::steady_clock::now().time_since_epoch();
-    last_successful_renew_steady_ns_.store(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady).count());
+    {
+      std::scoped_lock lock(mutex_);
+      last_successful_renew_steady_ns_ =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady).count();
+    }
     // Wake up the watchdog thread early to recalculate the remaining safety window.
     watchdog_cv_.notify_all();
   }
@@ -141,7 +162,13 @@ Status LeaderElector::TryAcquireOrRenew(
 }
 
 void LeaderElector::Acquire() {
-  while (!is_leading_.load() && !is_stopped_.load()) {
+  while (true) {
+    {
+      std::scoped_lock lock(mutex_);
+      if (is_leading_ || is_stopped_) {
+        return;
+      }
+    }
     bool acquired = false;
     Status status = TryAcquireOrRenew(
         [this](
@@ -157,7 +184,7 @@ void LeaderElector::Acquire() {
     if (acquired) {
       RAY_LOG(INFO) << "Successfully acquired leader lease. Promoting to Leader!";
       {
-        std::lock_guard<std::mutex> lock(watchdog_mutex_);
+        std::scoped_lock lock(mutex_);
         is_leading_ = true;
       }
       watchdog_cv_.notify_all();
@@ -167,15 +194,21 @@ void LeaderElector::Acquire() {
       return;
     }
 
-    std::unique_lock<std::mutex> lock(election_mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     election_cv_.wait_for(lock,
                           std::chrono::seconds(config_.retry_period_seconds),
-                          [this]() { return is_stopped_.load(); });
+                          [this]() { return is_stopped_; });
   }
 }
 
 void LeaderElector::Renew() {
-  while (is_leading_.load() && !is_stopped_.load()) {
+  while (true) {
+    {
+      std::scoped_lock lock(mutex_);
+      if (!is_leading_ || is_stopped_) {
+        return;
+      }
+    }
     bool renewed = false;
     Status status = TryAcquireOrRenew(
         [this](
@@ -194,8 +227,11 @@ void LeaderElector::Renew() {
                         "down immediately.";
       bool was_leading = false;
       {
-        std::lock_guard<std::mutex> lock(watchdog_mutex_);
-        was_leading = is_leading_.exchange(false);
+        std::scoped_lock lock(mutex_);
+        if (is_leading_) {
+          is_leading_ = false;
+          was_leading = true;
+        }
       }
       watchdog_cv_.notify_all();
       if (was_leading && config_.on_stopped_leading) {
@@ -208,27 +244,41 @@ void LeaderElector::Renew() {
     // 1. Stop() is called.
     // 2. Leadership lost.
     // 3. retry_period_seconds has elapsed.
-    std::unique_lock<std::mutex> lock(election_mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     election_cv_.wait_for(lock,
                           std::chrono::seconds(config_.retry_period_seconds),
-                          [this]() { return is_stopped_.load() || !is_leading_.load(); });
+                          [this]() { return is_stopped_ || !is_leading_; });
   }
 }
 
 void LeaderElector::WatchdogLoop() {
-  while (!is_stopped_.load()) {
+  while (true) {
+    {
+      std::scoped_lock lock(mutex_);
+      if (is_stopped_) {
+        return;
+      }
+    }
     // 1. If we are in standby (not leading), sleep on CV to prevent high CPU spin cycles.
-    if (!is_leading_.load()) {
-      std::unique_lock<std::mutex> lock(watchdog_mutex_);
+    bool leading = false;
+    {
+      std::scoped_lock lock(mutex_);
+      leading = is_leading_;
+    }
+    if (!leading) {
+      std::unique_lock<std::mutex> lock(mutex_);
       // Wake up if we are elected as leader or stop() is called.
-      watchdog_cv_.wait(lock,
-                        [this]() { return is_leading_.load() || is_stopped_.load(); });
+      watchdog_cv_.wait(lock, [this]() { return is_leading_ || is_stopped_; });
       continue;
     }
 
     // 2. Calculate monotonic elapsed time since the last successful lease renewal.
     // Load the last successful renewal steady timestamp first.
-    int64_t last_renew_ns = last_successful_renew_steady_ns_.load();
+    int64_t last_renew_ns;
+    {
+      std::scoped_lock lock(mutex_);
+      last_renew_ns = last_successful_renew_steady_ns_;
+    }
 
     // Capture current steady clock next. This order guarantees that last_renew_ns
     // is always <= now_steady_ns, preventing negative elapsed time calculations.
@@ -246,10 +296,13 @@ void LeaderElector::WatchdogLoop() {
                      << "s). Stepping down immediately!";
       bool was_leading = false;
       {
-        // Acquire election_mutex_ to prevent a lost wake-up race condition with the
+        // Acquire mutex_ to prevent a lost wake-up race condition with the
         // election thread waiting on election_cv_.
-        std::lock_guard<std::mutex> lock(election_mutex_);
-        was_leading = is_leading_.exchange(false);
+        std::scoped_lock lock(mutex_);
+        if (is_leading_) {
+          is_leading_ = false;
+          was_leading = true;
+        }
       }
       election_cv_.notify_all();
       if (was_leading && config_.on_stopped_leading) {
@@ -261,15 +314,15 @@ void LeaderElector::WatchdogLoop() {
     }
 
     // 4. Sleep on the CV for the exact duration of the remaining safety deadline window.
-    // If a renewal succeeds early, the election thread will call notify_all(), waking us
-    // early to recalculate. If the process stops, notify_all() wakes us to exit
-    // instantly.
-    std::unique_lock<std::mutex> lock(watchdog_mutex_);
+    // We will wake up early to stop waiting if:
+    //   - The process stops (is_stopped_ is true).
+    //   - A renewal succeeds early (last_successful_renew_steady_ns_ changes).
+    //   - Leadership is lost (is_leading_ is false).
+    std::unique_lock<std::mutex> lock(mutex_);
     watchdog_cv_.wait_for(
         lock, std::chrono::milliseconds(remaining_ms), [this, last_renew_ns]() {
-          return is_stopped_.load() ||
-                 last_successful_renew_steady_ns_.load() != last_renew_ns ||
-                 !is_leading_.load();
+          return is_stopped_ || last_successful_renew_steady_ns_ != last_renew_ns ||
+                 !is_leading_;
         });
   }
 }

--- a/src/ray/gcs/leader_election/leader_elector.h
+++ b/src/ray/gcs/leader_election/leader_elector.h
@@ -1,0 +1,105 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/common/status.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include "ray/gcs/leader_election/leader_election_client_interface.h"
+
+namespace ray {
+namespace gcs {
+
+struct LeaderElectionConfig {
+  // The platform-agnostic lease client.
+  std::shared_ptr<LeaderLeaseClientInterface> lease_client;
+
+  // Identity of the candidate (e.g., GCS hostname).
+  std::string holder_id;
+
+  // Lease duration in seconds.
+  int lease_duration_seconds = 15;
+
+  // Renew deadline in seconds (must be smaller than lease_duration_seconds).
+  int renew_deadline_seconds = 10;
+
+  // Interval between retry attempts in seconds.
+  int retry_period_seconds = 2;
+
+  // Callbacks
+  std::function<void()> on_started_leading;
+  std::function<void()> on_stopped_leading;
+  std::function<void(const std::string &)> on_new_leader;
+};
+
+class LeaderElector {
+ public:
+  explicit LeaderElector(LeaderElectionConfig config);
+  ~LeaderElector();
+
+  // Start the continuous leader election background loop. Non-blocking.
+  void Run();
+
+  // Stop the leader election loop and release lease if held.
+  void Stop();
+
+  // Check if the elector currently holds the lease.
+  bool IsLeader() const { return is_leading_.load(); }
+
+ private:
+  // The background loop execution function.
+  void Loop();
+
+  // Inner loop to acquire the lease.
+  void Acquire();
+
+  // Inner loop to continuously renew the lease when we are the leader.
+  void Renew();
+
+  // Helper to execute either TryAcquire or Renew based on role.
+  Status TryAcquireOrRenew(
+      std::function<Status(const std::string &, int, std::string &)> lease_op,
+      const std::string &op_name,
+      bool &success);
+
+  // Watchdog loop to verify leader lease renewal deadline asynchronously.
+  void WatchdogLoop();
+
+
+  LeaderElectionConfig config_;
+  // Flashed to true by GCS main thread to request background loops to exit gracefully.
+  std::atomic<bool> is_stopped_{false};
+  // Tracks whether this candidate currently holds the leader election lease successfully.
+  std::atomic<bool> is_leading_{false};
+  std::unique_ptr<std::thread> election_thread_;
+  std::unique_ptr<std::thread> watchdog_thread_;
+  std::condition_variable watchdog_cv_;
+  std::mutex watchdog_mutex_;
+  std::condition_variable election_cv_;
+  std::mutex election_mutex_;
+  std::atomic<int64_t> last_successful_renew_steady_ns_{0};
+  std::string last_observed_leader_;
+
+  static constexpr std::chrono::milliseconds kWatchdogStandbySleepMs{100};
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/leader_elector.h
+++ b/src/ray/gcs/leader_election/leader_elector.h
@@ -102,8 +102,6 @@ class LeaderElector {
   std::mutex election_mutex_;
   std::atomic<int64_t> last_successful_renew_steady_ns_{0};
   std::string last_observed_leader_;
-
-  static constexpr std::chrono::milliseconds kWatchdogStandbySleepMs{100};
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/leader_election/leader_elector.h
+++ b/src/ray/gcs/leader_election/leader_elector.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include "ray/common/status.h"
-
 #include <atomic>
 #include <condition_variable>
 #include <functional>
@@ -23,6 +21,8 @@
 #include <mutex>
 #include <string>
 #include <thread>
+
+#include "ray/common/status.h"
 #include "ray/gcs/leader_election/leader_election_client_interface.h"
 
 namespace ray {
@@ -82,7 +82,6 @@ class LeaderElector {
 
   // Watchdog loop to verify leader lease renewal deadline asynchronously.
   void WatchdogLoop();
-
 
   LeaderElectionConfig config_;
   // Flashed to true by GCS main thread to request background loops to exit gracefully.

--- a/src/ray/gcs/leader_election/leader_elector.h
+++ b/src/ray/gcs/leader_election/leader_elector.h
@@ -45,6 +45,12 @@ struct LeaderElectionConfig {
   int retry_period_seconds = 2;
 
   // Callbacks
+  // NOTE: Callbacks are invoked from background threads (election or watchdog threads).
+  // Callbacks MUST NOT synchronously destroy the LeaderElector instance (e.g. by deleting
+  // it or resetting its owning unique_ptr directly in the callback), as that would cause
+  // a deadlock or use-after-free during thread joining/detaching inside Stop() or the
+  // destructor. Any destruction or cleanup of the LeaderElector must be dispatched
+  // asynchronously to another thread.
   std::function<void()> on_started_leading;
   std::function<void()> on_stopped_leading;
   std::function<void(const std::string &)> on_new_leader;

--- a/src/ray/gcs/leader_election/leader_elector.h
+++ b/src/ray/gcs/leader_election/leader_elector.h
@@ -64,7 +64,7 @@ class LeaderElector {
   // Start the continuous leader election background loop. Non-blocking.
   void Run();
 
-  // Stop the leader election loop and release lease if held.
+  // Stop the leader election loop and release lease gracefully if held.
   void Stop();
 
   // Check if the elector currently holds the lease.

--- a/src/ray/gcs/leader_election/leader_elector.h
+++ b/src/ray/gcs/leader_election/leader_elector.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -68,7 +67,10 @@ class LeaderElector {
   void Stop();
 
   // Check if the elector currently holds the lease.
-  bool IsLeader() const { return is_leading_.load(); }
+  bool IsLeader() const {
+    std::scoped_lock lock(mutex_);
+    return is_leading_;
+  }
 
  private:
   // The background loop execution function.
@@ -91,16 +93,15 @@ class LeaderElector {
 
   LeaderElectionConfig config_;
   // Flashed to true by GCS main thread to request background loops to exit gracefully.
-  std::atomic<bool> is_stopped_{false};
+  bool is_stopped_{false};
   // Tracks whether this candidate currently holds the leader election lease successfully.
-  std::atomic<bool> is_leading_{false};
+  bool is_leading_{false};
   std::unique_ptr<std::thread> election_thread_;
   std::unique_ptr<std::thread> watchdog_thread_;
   std::condition_variable watchdog_cv_;
-  std::mutex watchdog_mutex_;
   std::condition_variable election_cv_;
-  std::mutex election_mutex_;
-  std::atomic<int64_t> last_successful_renew_steady_ns_{0};
+  mutable std::mutex mutex_;
+  int64_t last_successful_renew_steady_ns_{0};
   std::string last_observed_leader_;
 };
 

--- a/src/ray/gcs/leader_election/leader_elector_test.cc
+++ b/src/ray/gcs/leader_election/leader_elector_test.cc
@@ -1,0 +1,711 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/leader_election/leader_elector.h"
+
+#include <unordered_set>
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace gcs {
+
+class MockLeaseClient : public LeaderLeaseClientInterface {
+ public:
+  MockLeaseClient(
+      std::function<Status(const std::string &, int, std::string &)> try_acquire,
+      std::function<Status(const std::string &, int, std::string &)> renew,
+      std::function<void(const std::string &)> release)
+      : try_acquire_(std::move(try_acquire)),
+        renew_(std::move(renew)),
+        release_(std::move(release)) {}
+
+  Status TryAcquire(const std::string &holder_id,
+                    int ttl_ms,
+                    std::string &current_leader) override {
+    return try_acquire_(holder_id, ttl_ms, current_leader);
+  }
+
+  Status Renew(const std::string &holder_id,
+               int ttl_ms,
+               std::string &current_leader) override {
+    return renew_(holder_id, ttl_ms, current_leader);
+  }
+
+  void Release(const std::string &holder_id) override { release_(holder_id); }
+
+ private:
+  std::function<Status(const std::string &, int, std::string &)> try_acquire_;
+  std::function<Status(const std::string &, int, std::string &)> renew_;
+  std::function<void(const std::string &)> release_;
+};
+
+class SharedMockLeaseClient : public LeaderLeaseClientInterface {
+ public:
+  void Crash(const std::string &holder_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    crashed_holders_.insert(holder_id);
+  }
+
+  Status TryAcquire(const std::string &holder_id,
+                    int ttl_seconds,
+                    std::string &current_leader) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (crashed_holders_.count(holder_id)) {
+      return Status::IOError("Crashed node cannot communicate");
+    }
+    auto now = absl::Now();
+    if (!lease_holder_.empty() &&
+        now < lease_renew_time_ + absl::Seconds(lease_duration_seconds_)) {
+      current_leader = lease_holder_;
+      return Status::OK();
+    }
+    lease_holder_ = holder_id;
+    lease_renew_time_ = now;
+    lease_duration_seconds_ = ttl_seconds;
+    current_leader = holder_id;
+    return Status::OK();
+  }
+
+  Status Renew(const std::string &holder_id,
+               int ttl_seconds,
+               std::string &current_leader) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (crashed_holders_.count(holder_id)) {
+      return Status::IOError("Crashed node cannot communicate");
+    }
+    auto now = absl::Now();
+    if (lease_holder_ == holder_id) {
+      lease_renew_time_ = now;
+      lease_duration_seconds_ = ttl_seconds;
+      current_leader = holder_id;
+      return Status::OK();
+    }
+    current_leader = lease_holder_;
+    return Status::OK();
+  }
+
+  void Release(const std::string &holder_id) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (crashed_holders_.count(holder_id)) {
+      return;  // Crashed node fails to execute Release
+    }
+    if (lease_holder_ == holder_id) {
+      lease_holder_ = "";
+    }
+  }
+
+ private:
+  std::mutex mutex_;
+  std::string lease_holder_ = "";
+  absl::Time lease_renew_time_ = absl::UnixEpoch();
+  int lease_duration_seconds_ = 0;
+  std::unordered_set<std::string> crashed_holders_;
+};
+
+class LeaderElectorTest : public ::testing::Test {
+ protected:
+  std::string holder_id_ = "node-1";
+};
+
+// Group 1: Elector Core Lifecycle & Happy Paths
+TEST_F(LeaderElectorTest, SuccessfulAcquisitionAndRenewal) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<int> renew_calls{0};
+  std::atomic<bool> started_leading{false};
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    current = holder;
+    return Status::OK();
+  };
+
+  auto renew = [&](const std::string &holder, int, std::string &current) {
+    renew_calls++;
+    current = holder;
+    return Status::OK();
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 3;
+  config.renew_deadline_seconds = 2;
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  elector.Stop();
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_GE(acquire_calls.load(), 1);
+  EXPECT_GE(renew_calls.load(), 1);
+}
+
+TEST_F(LeaderElectorTest, AcquireFailureRetriesAndSucceeds) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<bool> started_leading{false};
+  std::string lease_holder = "node-2";  // Initially held by node-2
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    if (acquire_calls == 1) {
+      current = "node-2";  // First attempt: held by node-2
+      return Status::OK();
+    } else {
+      lease_holder = holder;  // Second attempt: Node A wins it
+      current = holder;
+      return Status::OK();
+    }
+  };
+
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 5;
+  config.renew_deadline_seconds = 3;
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  // Sleep for 1.5s (should run first acquire at T=0s which fails, retry at T=1s which
+  // succeeds)
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_TRUE(elector.IsLeader());
+  EXPECT_EQ(acquire_calls.load(), 2);
+
+  elector.Stop();
+}
+
+TEST_F(LeaderElectorTest, AcquireFailsOnErrorButRetries) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<bool> started_leading{false};
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    if (acquire_calls == 1) {
+      return Status::IOError(
+          "API server overloaded");  // First try fails with network error
+    } else {
+      current = holder;
+      return Status::OK();  // Second try succeeds
+    }
+  };
+
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 5;
+  config.renew_deadline_seconds = 3;
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  // Sleep for 1.5s (should run first failed check at T=0s, and second successful check at
+  // T=1s)
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_TRUE(elector.IsLeader());
+  EXPECT_EQ(acquire_calls.load(), 2);
+
+  elector.Stop();
+}
+
+TEST_F(LeaderElectorTest, DestructorCleanStopAndRelease) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<bool> release_called{false};
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    current = holder;
+    return Status::OK();
+  };
+
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+
+  auto release = [&](const std::string &) { release_called = true; };
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 5;
+  config.renew_deadline_seconds = 3;
+  config.retry_period_seconds = 1;
+
+  {
+    LeaderElector elector(config);
+    elector.Run();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    // Elector goes out of scope and destructor is triggered
+  }
+
+  EXPECT_TRUE(release_called.load());
+}
+
+// Group 2: Elector Step-Down & Safety Watchdog Cases
+TEST_F(LeaderElectorTest, StepDownOnRenewDeadlineExceeded) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<bool> started_leading{false};
+  std::atomic<bool> stopped_leading{false};
+  std::string lease_holder = "";
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    if (lease_holder.empty() || lease_holder == holder) {
+      lease_holder = holder;
+      current = holder;
+      return Status::OK();
+    }
+    current = lease_holder;
+    return Status::OK();
+  };
+
+  auto renew = [&](const std::string &, int, std::string &current) {
+    lease_holder = "node-2";  // Fail renewal because someone else grabbed the lease
+    current = "node-2";
+    return Status::OK();
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 2;
+  config.renew_deadline_seconds = 1;
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+  config.on_stopped_leading = [&]() { stopped_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  elector.Stop();
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_TRUE(stopped_leading.load());
+  EXPECT_FALSE(elector.IsLeader());
+}
+
+TEST_F(LeaderElectorTest, StepDownImmediatelyIfLeaseStolen) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<int> renew_calls{0};
+  std::atomic<bool> started_leading{false};
+  std::atomic<bool> stopped_leading{false};
+  std::string lease_holder = "";
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    if (lease_holder.empty() || lease_holder == holder) {
+      lease_holder = holder;
+      current = holder;
+      return Status::OK();
+    }
+    current = lease_holder;
+    return Status::OK();
+  };
+
+  auto renew = [&](const std::string &, int, std::string &current) {
+    renew_calls++;
+    // Simulate that another node has successfully acquired the lease
+    lease_holder = "node-2";
+    current = "node-2";
+    return Status::OK();  // API succeeded, but lease stolen!
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 10;  // Large TTL
+  config.renew_deadline_seconds = 8;   // Large deadline
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+  config.on_stopped_leading = [&]() { stopped_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  // Sleep for 1.5 seconds.
+  // GCS acquires at T = 0s.
+  // The first renewal loop starts at T = 0.001s, calls Renew, which returns Node-2.
+  // GCS should immediately step down, without waiting for the 8s deadline!
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  elector.Stop();
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_TRUE(stopped_leading.load());  // Should step down immediately!
+  EXPECT_FALSE(elector.IsLeader());
+}
+
+TEST_F(LeaderElectorTest, StepDownOnPersistentRenewalFailure) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<int> renew_calls{0};
+  std::atomic<bool> started_leading{false};
+  std::atomic<bool> stopped_leading{false};
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    current = holder;
+    return Status::OK();
+  };
+
+  auto renew = [&](const std::string &, int, std::string &) {
+    renew_calls++;
+    return Status::IOError("Persistent Connection Timeout");  // Keep failing!
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 2;
+  config.renew_deadline_seconds = 1;
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+  config.on_stopped_leading = [&]() { stopped_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  // Sleep for 1.5 seconds (watchdog deadline is 1s, so it should trigger step down at
+  // ~1.01s)
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_TRUE(stopped_leading.load());  // Watchdog should have forced a step-down!
+  EXPECT_FALSE(elector.IsLeader());
+
+  elector.Stop();
+}
+
+TEST_F(LeaderElectorTest, RenewTransientFailureDoesNotStepDown) {
+  std::atomic<int> acquire_calls{0};
+  std::atomic<int> renew_calls{0};
+  std::atomic<bool> started_leading{false};
+  std::atomic<bool> stopped_leading{false};
+
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    current = holder;
+    return Status::OK();
+  };
+
+  auto renew = [&](const std::string &holder, int, std::string &current) {
+    renew_calls++;
+    current = holder;
+    if (renew_calls == 1) {
+      // First renewal fails temporarily (transient network issue)
+      return Status::IOError("Transient Network Drop");
+    } else {
+      // Subsequent renewals succeed
+      return Status::OK();
+    }
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  // Large enough safety window to survive 1 failure (retry_period = 1s, renew_deadline =
+  // 3s)
+  config.lease_duration_seconds = 4;
+  config.renew_deadline_seconds = 3;
+  config.retry_period_seconds = 1;
+  config.on_started_leading = [&]() { started_leading = true; };
+  config.on_stopped_leading = [&]() { stopped_leading = true; };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  // Sleep for 2.5 seconds (should have run 1 failed renewal at ~1s, and 1 successful
+  // retry at ~2s)
+  std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+
+  EXPECT_TRUE(started_leading.load());
+  EXPECT_FALSE(stopped_leading.load());  // Should not step down!
+  EXPECT_TRUE(elector.IsLeader());
+  EXPECT_GE(renew_calls.load(), 2);
+
+  elector.Stop();
+}
+
+// Group 3: Telemetry & Transition Callbacks
+TEST_F(LeaderElectorTest, LeadershipTransitionCallback) {
+  std::atomic<int> leader_changes{0};
+  std::string observed_leader = "";
+
+  auto try_acquire = [&](const std::string &, int, std::string &current) {
+    current = "node-2";  // Lease actively held by node-2
+    return Status::OK();
+  };
+
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 2;
+  config.renew_deadline_seconds = 1;
+  config.retry_period_seconds = 1;
+  config.on_new_leader = [&](const std::string &leader) {
+    leader_changes++;
+    observed_leader = leader;
+  };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  elector.Stop();
+
+  EXPECT_GE(leader_changes.load(), 1);
+  EXPECT_EQ(observed_leader, "node-2");
+}
+
+TEST_F(LeaderElectorTest, NewLeaderCallbackTriggersOnce) {
+  std::atomic<int> leader_changes{0};
+  std::string observed_leader = "";
+  std::atomic<int> acquire_calls{0};
+
+  auto try_acquire = [&](const std::string &, int, std::string &current) {
+    acquire_calls++;
+    if (acquire_calls <= 2) {
+      current = "node-2";  // First and second attempts return "node-2"
+    } else {
+      current = "node-3";  // Third attempt returns "node-3"
+    }
+    return Status::OK();
+  };
+
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 10;
+  config.renew_deadline_seconds = 8;
+  config.retry_period_seconds = 1;
+  config.on_new_leader = [&](const std::string &leader) {
+    leader_changes++;
+    observed_leader = leader;
+  };
+
+  LeaderElector elector(config);
+  elector.Run();
+
+  // Sleep for 2.5s (runs 3 acquire checks: T=0s [node-2], T=1s [node-2], T=2s [node-3])
+  std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+  elector.Stop();
+
+  // Total callbacks should be exactly 2 (once for node-2, once for node-3)
+  EXPECT_EQ(leader_changes.load(), 2);
+  EXPECT_EQ(observed_leader, "node-3");
+}
+
+// Group 4: Multi-Replica Election & Failover
+TEST_F(LeaderElectorTest, TwoReplicasElectionWithGracefulExit) {
+  // 1. Setup a shared coordinate client
+  auto shared_client = std::make_shared<SharedMockLeaseClient>();
+
+  // 2. Setup Elector A
+  LeaderElectionConfig config_a;
+  config_a.lease_client = shared_client;
+  config_a.holder_id = "node-a";
+  config_a.lease_duration_seconds = 4;
+  config_a.renew_deadline_seconds = 3;
+  config_a.retry_period_seconds = 1;
+  std::atomic<bool> leading_a{false};
+  std::atomic<bool> stopped_leading_a{false};
+  config_a.on_started_leading = [&]() { leading_a = true; };
+  config_a.on_stopped_leading = [&]() { stopped_leading_a = true; };
+  LeaderElector elector_a(config_a);
+
+  // 3. Setup Elector B
+  LeaderElectionConfig config_b;
+  config_b.lease_client = shared_client;
+  config_b.holder_id = "node-b";
+  config_b.lease_duration_seconds = 4;
+  config_b.renew_deadline_seconds = 3;
+  config_b.retry_period_seconds = 1;
+  std::atomic<bool> leading_b{false};
+  std::atomic<bool> stopped_leading_b{false};
+  config_b.on_started_leading = [&]() { leading_b = true; };
+  config_b.on_stopped_leading = [&]() { stopped_leading_b = true; };
+  LeaderElector elector_b(config_b);
+
+  // 4. Start both concurrently
+  elector_a.Run();
+  elector_b.Run();
+
+  // Sleep for 1.5s to let both loops run initial acquire checks
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  // Assert only exactly one replica successfully became the leader
+  EXPECT_TRUE(elector_a.IsLeader() != elector_b.IsLeader());
+  EXPECT_TRUE(leading_a.load() != leading_b.load());
+
+  // Determine who won and who is standby
+  LeaderElector *winner = elector_a.IsLeader() ? &elector_a : &elector_b;
+  LeaderElector *loser = elector_a.IsLeader() ? &elector_b : &elector_a;
+  std::atomic<bool> *winner_stopped =
+      elector_a.IsLeader() ? &stopped_leading_a : &stopped_leading_b;
+  std::atomic<bool> *loser_leading = elector_a.IsLeader() ? &leading_b : &leading_a;
+
+  // 5. Simulate leader crash/graceful exit by stopping the winner
+  winner->Stop();
+
+  // Sleep for 1.5s (loser should wake up, detect vacant lease, and promote itself)
+  // The loser does not have to wait for 4s to acquire the lease.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  // Assert failover took place: standby promoted to leader
+  EXPECT_TRUE(loser->IsLeader());
+  EXPECT_TRUE(loser_leading->load());
+  EXPECT_FALSE(
+      winner_stopped->load());  // Graceful stop shouldn't trigger watchdog step-down logs
+
+  loser->Stop();
+}
+
+TEST_F(LeaderElectorTest, TwoReplicasElectionWithNonGracefulExit) {
+  auto shared_client = std::make_shared<SharedMockLeaseClient>();
+
+  // 1. Setup elector A
+  LeaderElectionConfig config_a;
+  config_a.lease_client = shared_client;
+  config_a.holder_id = "node-a";
+  config_a.lease_duration_seconds = 3;  // TTL of 3 seconds
+  config_a.renew_deadline_seconds = 2;  // Watchdog deadline of 2 seconds
+  config_a.retry_period_seconds = 1;    // Retry heartbeat every 1 second
+  std::atomic<bool> leading_a{false};
+  std::atomic<bool> stopped_leading_a{false};
+  config_a.on_started_leading = [&]() { leading_a = true; };
+  config_a.on_stopped_leading = [&]() { stopped_leading_a = true; };
+  LeaderElector elector_a(config_a);
+
+  // 2. Setup elector B
+  LeaderElectionConfig config_b;
+  config_b.lease_client = shared_client;
+  config_b.holder_id = "node-b";
+  config_b.lease_duration_seconds = 3;  // TTL of 3 seconds
+  config_b.renew_deadline_seconds = 2;  // Watchdog deadline of 2 seconds
+  config_b.retry_period_seconds = 1;    // Retry heartbeat every 1 second
+  std::atomic<bool> leading_b{false};
+  std::atomic<bool> stopped_leading_b{false};
+  config_b.on_started_leading = [&]() { leading_b = true; };
+  config_b.on_stopped_leading = [&]() { stopped_leading_b = true; };
+  LeaderElector elector_b(config_b);
+
+  // Start both concurrently
+  elector_a.Run();
+  elector_b.Run();
+
+  // Sleep to resolve initial race
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+  // Determine who won
+  LeaderElector *winner = elector_a.IsLeader() ? &elector_a : &elector_b;
+  LeaderElector *loser = elector_a.IsLeader() ? &elector_b : &elector_a;
+  std::string winner_id = elector_a.IsLeader() ? "node-a" : "node-b";
+  std::atomic<bool> *loser_leading = elector_a.IsLeader() ? &leading_b : &leading_a;
+
+  // 3. Simulate Node A crashes abruptly (we call Crash on client to block further
+  // renewals/releases)
+  shared_client->Crash(winner_id);
+  winner->Stop();  // Calls Stop which triggers release internally, but client ignores it!
+
+  // 4. Sleep for 1.2s (TTL is 2s, so Node B shouldn't be promoted yet because lease
+  // hasn't expired)
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+  EXPECT_FALSE(loser->IsLeader());
+  EXPECT_FALSE(loser_leading->load());
+
+  // 5. Sleep for another 2.0s (Total 3.2s since crash. Lock duration of 3s has expired!)
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+  // Assert Node B successfully took over the expired lease!
+  EXPECT_TRUE(loser->IsLeader());
+  EXPECT_TRUE(loser_leading->load());
+
+  loser->Stop();
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/leader_election/leader_elector_test.cc
+++ b/src/ray/gcs/leader_election/leader_elector_test.cc
@@ -402,6 +402,9 @@ TEST_F(LeaderElectorTest, StepDownOnPersistentRenewalFailure) {
 
   auto try_acquire = [&](const std::string &holder, int, std::string &current) {
     acquire_calls++;
+    if (acquire_calls > 1) {
+      return Status::IOError("Persistent Connection Timeout");
+    }
     current = holder;
     return Status::OK();
   };

--- a/src/ray/gcs/leader_election/leader_elector_test.cc
+++ b/src/ray/gcs/leader_election/leader_elector_test.cc
@@ -323,8 +323,8 @@ TEST_F(LeaderElectorTest, StepDownOnRenewDeadlineExceeded) {
   LeaderElectionConfig config;
   config.lease_client = lease_client;
   config.holder_id = holder_id_;
-  config.lease_duration_seconds = 2;
-  config.renew_deadline_seconds = 1;
+  config.lease_duration_seconds = 3;
+  config.renew_deadline_seconds = 2;
   config.retry_period_seconds = 1;
   config.on_started_leading = [&]() { started_leading = true; };
   config.on_stopped_leading = [&]() { stopped_leading = true; };
@@ -332,7 +332,7 @@ TEST_F(LeaderElectorTest, StepDownOnRenewDeadlineExceeded) {
   LeaderElector elector(config);
   elector.Run();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2500));
   elector.Stop();
 
   EXPECT_TRUE(started_leading.load());
@@ -418,8 +418,8 @@ TEST_F(LeaderElectorTest, StepDownOnPersistentRenewalFailure) {
   LeaderElectionConfig config;
   config.lease_client = lease_client;
   config.holder_id = holder_id_;
-  config.lease_duration_seconds = 2;
-  config.renew_deadline_seconds = 1;
+  config.lease_duration_seconds = 3;
+  config.renew_deadline_seconds = 2;
   config.retry_period_seconds = 1;
   config.on_started_leading = [&]() { started_leading = true; };
   config.on_stopped_leading = [&]() { stopped_leading = true; };
@@ -427,9 +427,9 @@ TEST_F(LeaderElectorTest, StepDownOnPersistentRenewalFailure) {
   LeaderElector elector(config);
   elector.Run();
 
-  // Sleep for 1.5 seconds (watchdog deadline is 1s, so it should trigger step down at
-  // ~1.01s)
-  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  // Sleep for 2.5 seconds (watchdog deadline is 2s, so it should trigger step down at
+  // ~2.01s)
+  std::this_thread::sleep_for(std::chrono::milliseconds(2500));
 
   EXPECT_TRUE(started_leading.load());
   EXPECT_TRUE(stopped_leading.load());  // Watchdog should have forced a step-down!
@@ -514,8 +514,8 @@ TEST_F(LeaderElectorTest, LeadershipTransitionCallback) {
   LeaderElectionConfig config;
   config.lease_client = lease_client;
   config.holder_id = holder_id_;
-  config.lease_duration_seconds = 2;
-  config.renew_deadline_seconds = 1;
+  config.lease_duration_seconds = 3;
+  config.renew_deadline_seconds = 2;
   config.retry_period_seconds = 1;
   config.on_new_leader = [&](const std::string &leader) {
     leader_changes++;
@@ -705,6 +705,72 @@ TEST_F(LeaderElectorTest, TwoReplicasElectionWithNonGracefulExit) {
   EXPECT_TRUE(loser_leading->load());
 
   loser->Stop();
+}
+
+TEST_F(LeaderElectorTest, RunMultipleTimesIsSafe) {
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 5;
+  config.renew_deadline_seconds = 3;
+  config.retry_period_seconds = 1;
+
+  LeaderElector elector(config);
+  // Invoke Run multiple times concurrently/back-to-back
+  elector.Run();
+  elector.Run();
+  elector.Run();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  elector.Stop();
+}
+
+TEST_F(LeaderElectorTest, RunCanBeRestartedAfterStop) {
+  std::atomic<int> acquire_calls{0};
+  auto try_acquire = [&](const std::string &holder, int, std::string &current) {
+    acquire_calls++;
+    current = holder;
+    return Status::OK();
+  };
+  auto renew = [](const std::string &holder, int, std::string &current) {
+    current = holder;
+    return Status::OK();
+  };
+  auto release = [](const std::string &) {};
+
+  auto lease_client = std::make_shared<MockLeaseClient>(try_acquire, renew, release);
+
+  LeaderElectionConfig config;
+  config.lease_client = lease_client;
+  config.holder_id = holder_id_;
+  config.lease_duration_seconds = 5;
+  config.renew_deadline_seconds = 3;
+  config.retry_period_seconds = 1;
+
+  LeaderElector elector(config);
+  elector.Run();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_TRUE(elector.IsLeader());
+  elector.Stop();
+  EXPECT_FALSE(elector.IsLeader());
+
+  // Restart elector
+  elector.Run();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_TRUE(elector.IsLeader());
+  elector.Stop();
 }
 
 }  // namespace gcs

--- a/src/ray/rpc/authentication/BUILD.bazel
+++ b/src/ray/rpc/authentication/BUILD.bazel
@@ -35,6 +35,7 @@ ray_cc_library(
     deps = [
         ":authentication_token",
         ":k8s_constants",
+        "//src/ray/common:status",
         "//src/ray/util:logging",
         "@boost//:asio_ssl",
         "@boost//:beast",

--- a/src/ray/rpc/authentication/k8s_util.cc
+++ b/src/ray/rpc/authentication/k8s_util.cc
@@ -94,7 +94,8 @@ void InitK8sClientConfig() {
 static Status EstablishSslConnection(net::io_context &ioc,
                                      ssl::context &ctx,
                                      ssl::stream<beast::tcp_stream> &stream,
-                                     tcp::resolver &resolver) {
+                                     tcp::resolver &resolver,
+                                     std::chrono::steady_clock::time_point deadline) {
   beast::error_code ec;
   ctx.load_verify_file(kK8sCaCertPath, ec);
   if (ec) {
@@ -105,7 +106,7 @@ static Status EstablishSslConnection(net::io_context &ioc,
     return Status::IOError(absl::StrCat("Failed to set verify mode: ", ec.message()));
   }
 
-  beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(kK8sApiTimeoutSecs));
+  beast::get_lowest_layer(stream).expires_at(deadline);
 
   if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
     ec = beast::error_code{static_cast<int>(::ERR_get_error()),
@@ -123,6 +124,7 @@ static Status EstablishSslConnection(net::io_context &ioc,
     return Status::IOError(absl::StrCat("Failed to connect to K8s host: ", ec.message()));
   }
 
+  beast::get_lowest_layer(stream).expires_at(deadline);
   stream.handshake(ssl::stream_base::client, ec);
   if (ec) {
     return Status::IOError(absl::StrCat("SSL handshake failed: ", ec.message()));
@@ -141,12 +143,14 @@ Status K8sApiPost(const std::string &path,
   std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
+    auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(kK8sApiTimeoutSecs);
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
-    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver));
+    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver, deadline));
 
     http::request<http::string_body> req{http::verb::post, path, 11};
     req.set(http::field::host, k8s_host);
@@ -157,12 +161,10 @@ Status K8sApiPost(const std::string &path,
     req.body() = body.dump();
     req.prepare_payload();
 
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
+    beast::get_lowest_layer(stream).expires_at(deadline);
     http::write(stream, req);
 
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
+    beast::get_lowest_layer(stream).expires_at(deadline);
     beast::flat_buffer buffer;
     http::response<http::string_body> res;
     http::read(stream, buffer, res);
@@ -210,12 +212,14 @@ Status K8sApiGet(const std::string &path, nlohmann::json &response_json) {
   std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
+    auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(kK8sApiTimeoutSecs);
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
-    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver));
+    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver, deadline));
 
     http::request<http::empty_body> req{http::verb::get, path, 11};
     req.set(http::field::host, k8s_host);
@@ -223,12 +227,10 @@ Status K8sApiGet(const std::string &path, nlohmann::json &response_json) {
     std::string auth_header = "Bearer " + k8s_sa_token;
     req.set(http::field::authorization, auth_header);
 
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
+    beast::get_lowest_layer(stream).expires_at(deadline);
     http::write(stream, req);
 
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
+    beast::get_lowest_layer(stream).expires_at(deadline);
     beast::flat_buffer buffer;
     http::response<http::string_body> res;
     http::read(stream, buffer, res);
@@ -282,12 +284,14 @@ Status K8sApiPut(const std::string &path,
   std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
+    auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(kK8sApiTimeoutSecs);
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
-    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver));
+    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver, deadline));
 
     http::request<http::string_body> req{http::verb::put, path, 11};
     req.set(http::field::host, k8s_host);
@@ -298,12 +302,10 @@ Status K8sApiPut(const std::string &path,
     req.body() = body.dump();
     req.prepare_payload();
 
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
+    beast::get_lowest_layer(stream).expires_at(deadline);
     http::write(stream, req);
 
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
+    beast::get_lowest_layer(stream).expires_at(deadline);
     beast::flat_buffer buffer;
     http::response<http::string_body> res;
     http::read(stream, buffer, res);

--- a/src/ray/rpc/authentication/k8s_util.cc
+++ b/src/ray/rpc/authentication/k8s_util.cc
@@ -21,6 +21,7 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
+#include <chrono>
 #include <fstream>
 #include <string>
 
@@ -49,6 +50,8 @@ std::string ReadFile(const std::string &path) {
   return std::string((std::istreambuf_iterator<char>(file)),
                      std::istreambuf_iterator<char>());
 }
+
+constexpr int kK8sApiTimeoutSecs = 5;
 
 }  // namespace
 
@@ -88,9 +91,9 @@ void InitK8sClientConfig() {
   k8s_client_initialized = true;
 }
 
-bool K8sApiPost(const std::string &path,
-                const nlohmann::json &body,
-                nlohmann::json &response_json) {
+Status K8sApiPost(const std::string &path,
+                  const nlohmann::json &body,
+                  nlohmann::json &response_json) {
   static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
@@ -103,11 +106,17 @@ bool K8sApiPost(const std::string &path,
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
+    // Set a timeout on the connection and operations to prevent infinite hangs.
+    // If the timeout expires during any synchronous operation, the stream will abort
+    // the operation and throw a boost::system::system_error exception.
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
+
     if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
       beast::error_code ec{static_cast<int>(::ERR_get_error()),
                            net::error::get_ssl_category()};
       RAY_LOG(ERROR) << "Failed to set SNI hostname: " << ec.message();
-      return false;
+      return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
     }
 
     auto const results = resolver.resolve(k8s_host, k8s_port);
@@ -130,9 +139,12 @@ bool K8sApiPost(const std::string &path,
     http::read(stream, buffer, res);
 
     if (res.result() != http::status::ok && res.result() != http::status::created) {
-      RAY_LOG(WARNING) << "Kubernetes API request returned HTTP status "
+      RAY_LOG(WARNING) << "Kubernetes API Post request returned HTTP status "
                        << res.result_int() << ". Response: " << res.body();
-      return false;
+      if (res.result() == http::status::conflict) {
+        return Status::AlreadyExists(absl::StrCat("Conflict: ", res.body()));
+      }
+      return Status::IOError(absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
     }
 
     response_json = nlohmann::json::parse(res.body());
@@ -146,11 +158,172 @@ bool K8sApiPost(const std::string &path,
       RAY_LOG(WARNING) << "SSL stream shutdown failed: " << ec.message();
     }
   } catch (const std::exception &e) {
-    RAY_LOG(ERROR) << "Kubernetes API request failed: " << e.what();
-    return false;
+    RAY_LOG(ERROR) << "Kubernetes API Post request failed: " << e.what();
+    std::string err_msg(e.what());
+    if (err_msg.find("Operation aborted") != std::string::npos || err_msg.find("timeout") != std::string::npos) {
+      return Status::TimedOut(absl::StrCat("Kubernetes API Post request timed out: ", e.what()));
+    }
+    return Status::IOError(absl::StrCat("Kubernetes API Post request failed: ", e.what()));
   }
 
-  return true;
+  return Status::OK();
+}
+
+Status K8sApiGet(const std::string &path,
+                nlohmann::json &response_json) {
+  static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
+
+  try {
+    net::io_context ioc;
+    ssl::context ctx(ssl::context::tlsv12_client);
+
+    ctx.load_verify_file(kK8sCaCertPath);
+    ctx.set_verify_mode(ssl::verify_peer);
+
+    tcp::resolver resolver(ioc);
+    ssl::stream<beast::tcp_stream> stream(ioc, ctx);
+
+    // Set a timeout on the connection and operations to prevent infinite hangs.
+    // If the timeout expires during any synchronous operation, the stream will abort
+    // the operation and throw a boost::system::system_error exception.
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
+
+    if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
+      beast::error_code ec{static_cast<int>(::ERR_get_error()),
+                           net::error::get_ssl_category()};
+      RAY_LOG(ERROR) << "Failed to set SNI hostname: " << ec.message();
+      return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
+    }
+
+    auto const results = resolver.resolve(k8s_host, k8s_port);
+    beast::get_lowest_layer(stream).connect(results);
+    stream.handshake(ssl::stream_base::client);
+
+    http::request<http::empty_body> req{http::verb::get, path, 11};
+    req.set(http::field::host, k8s_host);
+    req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+    std::string auth_header = "Bearer " + k8s_sa_token;
+    req.set(http::field::authorization, auth_header);
+
+    http::write(stream, req);
+
+    beast::flat_buffer buffer;
+    http::response<http::string_body> res;
+    http::read(stream, buffer, res);
+
+    if (res.result() != http::status::ok) {
+      RAY_LOG(WARNING) << "Kubernetes API Get request returned HTTP status "
+                       << res.result_int() << ". Response: " << res.body();
+      if (res.result() == http::status::not_found) {
+        return Status::NotFound(absl::StrCat("Resource not found: ", res.body()));
+      }
+      return Status::IOError(absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
+    }
+
+    response_json = nlohmann::json::parse(res.body());
+
+    auto date_hdr = res[http::field::date];
+    if (!date_hdr.empty()) {
+      response_json["__api_server_date__"] = std::string(date_hdr);
+    }
+
+    beast::error_code ec;
+    stream.shutdown(ec);
+    if (ec == net::error::eof) {
+      ec.assign(0, ec.category());
+    }
+    if (ec) {
+      RAY_LOG(WARNING) << "SSL stream shutdown failed: " << ec.message();
+    }
+  } catch (const std::exception &e) {
+    RAY_LOG(ERROR) << "Kubernetes API Get request failed: " << e.what();
+    std::string err_msg(e.what());
+    if (err_msg.find("Operation aborted") != std::string::npos || err_msg.find("timeout") != std::string::npos) {
+      return Status::TimedOut(absl::StrCat("Kubernetes API Get request timed out: ", e.what()));
+    }
+    return Status::IOError(absl::StrCat("Kubernetes API Get request failed: ", e.what()));
+  }
+
+  return Status::OK();
+}
+
+Status K8sApiPut(const std::string &path,
+                 const nlohmann::json &body,
+                 nlohmann::json &response_json) {
+  static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
+
+  try {
+    net::io_context ioc;
+    ssl::context ctx(ssl::context::tlsv12_client);
+
+    ctx.load_verify_file(kK8sCaCertPath);
+    ctx.set_verify_mode(ssl::verify_peer);
+
+    tcp::resolver resolver(ioc);
+    ssl::stream<beast::tcp_stream> stream(ioc, ctx);
+
+    // Set a timeout on the connection and operations to prevent infinite hangs.
+    // If the timeout expires during any synchronous operation, the stream will abort
+    // the operation and throw a boost::system::system_error exception.
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
+
+    if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
+      beast::error_code ec{static_cast<int>(::ERR_get_error()),
+                           net::error::get_ssl_category()};
+      RAY_LOG(ERROR) << "Failed to set SNI hostname: " << ec.message();
+      return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
+    }
+
+    auto const results = resolver.resolve(k8s_host, k8s_port);
+    beast::get_lowest_layer(stream).connect(results);
+    stream.handshake(ssl::stream_base::client);
+
+    http::request<http::string_body> req{http::verb::put, path, 11};
+    req.set(http::field::host, k8s_host);
+    req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+    req.set(http::field::content_type, "application/json");
+    std::string auth_header = "Bearer " + k8s_sa_token;
+    req.set(http::field::authorization, auth_header);
+    req.body() = body.dump();
+    req.prepare_payload();
+
+    http::write(stream, req);
+
+    beast::flat_buffer buffer;
+    http::response<http::string_body> res;
+    http::read(stream, buffer, res);
+
+    if (res.result() != http::status::ok && res.result() != http::status::created) {
+      RAY_LOG(WARNING) << "Kubernetes API Put request returned HTTP status "
+                       << res.result_int() << ". Response: " << res.body();
+      if (res.result() == http::status::conflict) {
+        return Status::AlreadyExists(absl::StrCat("Conflict: ", res.body()));
+      }
+      return Status::IOError(absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
+    }
+
+    response_json = nlohmann::json::parse(res.body());
+
+    beast::error_code ec;
+    stream.shutdown(ec);
+    if (ec == net::error::eof) {
+      ec.assign(0, ec.category());
+    }
+    if (ec) {
+      RAY_LOG(WARNING) << "SSL stream shutdown failed: " << ec.message();
+    }
+  } catch (const std::exception &e) {
+    RAY_LOG(ERROR) << "Kubernetes API Put request failed: " << e.what();
+    std::string err_msg(e.what());
+    if (err_msg.find("Operation aborted") != std::string::npos || err_msg.find("timeout") != std::string::npos) {
+      return Status::TimedOut(absl::StrCat("Kubernetes API Put request timed out: ", e.what()));
+    }
+    return Status::IOError(absl::StrCat("Kubernetes API Put request failed: ", e.what()));
+  }
+
+  return Status::OK();
 }
 
 bool ValidateToken(const AuthenticationToken &token) {
@@ -162,7 +335,7 @@ bool ValidateToken(const AuthenticationToken &token) {
   nlohmann::json token_review_resp;
 
   if (!k8s::K8sApiPost(
-          kAuthenticationV1TokenReviewPath, token_review_req, token_review_resp)) {
+          kAuthenticationV1TokenReviewPath, token_review_req, token_review_resp).ok()) {
     RAY_LOG(WARNING) << "Kubernetes TokenReview request failed.";
     return false;
   }
@@ -214,7 +387,7 @@ bool ValidateToken(const AuthenticationToken &token) {
 
   if (!k8s::K8sApiPost(kAuthorizationV1SubjectAccessReviewPath,
                        subject_access_review_req,
-                       subject_access_review_resp)) {
+                       subject_access_review_resp).ok()) {
     RAY_LOG(WARNING) << "Kubernetes SubjectAccessReview request failed.";
     return false;
   }

--- a/src/ray/rpc/authentication/k8s_util.cc
+++ b/src/ray/rpc/authentication/k8s_util.cc
@@ -91,24 +91,43 @@ void InitK8sClientConfig() {
   k8s_client_initialized = true;
 }
 
-Status EstablishSslConnection(net::io_context &ioc,
-                              ssl::context &ctx,
-                              ssl::stream<beast::tcp_stream> &stream,
-                              tcp::resolver &resolver) {
-  ctx.load_verify_file(kK8sCaCertPath);
-  ctx.set_verify_mode(ssl::verify_peer);
+static Status EstablishSslConnection(net::io_context &ioc,
+                                     ssl::context &ctx,
+                                     ssl::stream<beast::tcp_stream> &stream,
+                                     tcp::resolver &resolver) {
+  beast::error_code ec;
+  ctx.load_verify_file(kK8sCaCertPath, ec);
+  if (ec) {
+    return Status::IOError(absl::StrCat("Failed to load CA cert: ", ec.message()));
+  }
+  ctx.set_verify_mode(ssl::verify_peer, ec);
+  if (ec) {
+    return Status::IOError(absl::StrCat("Failed to set verify mode: ", ec.message()));
+  }
 
   beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(kK8sApiTimeoutSecs));
 
   if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
-    beast::error_code ec{static_cast<int>(::ERR_get_error()),
-                         net::error::get_ssl_category()};
+    ec = beast::error_code{static_cast<int>(::ERR_get_error()),
+                           net::error::get_ssl_category()};
     return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
   }
 
-  auto const results = resolver.resolve(k8s_host, k8s_port);
-  beast::get_lowest_layer(stream).connect(results);
-  stream.handshake(ssl::stream_base::client);
+  auto const results = resolver.resolve(k8s_host, k8s_port, ec);
+  if (ec) {
+    return Status::IOError(absl::StrCat("Failed to resolve K8s host: ", ec.message()));
+  }
+
+  beast::get_lowest_layer(stream).connect(results, ec);
+  if (ec) {
+    return Status::IOError(absl::StrCat("Failed to connect to K8s host: ", ec.message()));
+  }
+
+  stream.handshake(ssl::stream_base::client, ec);
+  if (ec) {
+    return Status::IOError(absl::StrCat("SSL handshake failed: ", ec.message()));
+  }
+
   return Status::OK();
 }
 
@@ -119,7 +138,7 @@ Status K8sApiPost(const std::string &path,
     return Status::Invalid("Kubernetes client configuration is not initialized.");
   }
 
-  static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
+  std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
     net::io_context ioc;
@@ -138,8 +157,12 @@ Status K8sApiPost(const std::string &path,
     req.body() = body.dump();
     req.prepare_payload();
 
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
     http::write(stream, req);
 
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
     beast::flat_buffer buffer;
     http::response<http::string_body> res;
     http::read(stream, buffer, res);
@@ -184,7 +207,7 @@ Status K8sApiGet(const std::string &path, nlohmann::json &response_json) {
     return Status::Invalid("Kubernetes client configuration is not initialized.");
   }
 
-  static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
+  std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
     net::io_context ioc;
@@ -200,8 +223,12 @@ Status K8sApiGet(const std::string &path, nlohmann::json &response_json) {
     std::string auth_header = "Bearer " + k8s_sa_token;
     req.set(http::field::authorization, auth_header);
 
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
     http::write(stream, req);
 
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
     beast::flat_buffer buffer;
     http::response<http::string_body> res;
     http::read(stream, buffer, res);
@@ -252,7 +279,7 @@ Status K8sApiPut(const std::string &path,
     return Status::Invalid("Kubernetes client configuration is not initialized.");
   }
 
-  static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
+  std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
     net::io_context ioc;
@@ -271,8 +298,12 @@ Status K8sApiPut(const std::string &path,
     req.body() = body.dump();
     req.prepare_payload();
 
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
     http::write(stream, req);
 
+    beast::get_lowest_layer(stream).expires_after(
+        std::chrono::seconds(kK8sApiTimeoutSecs));
     beast::flat_buffer buffer;
     http::response<http::string_body> res;
     http::read(stream, buffer, res);

--- a/src/ray/rpc/authentication/k8s_util.cc
+++ b/src/ray/rpc/authentication/k8s_util.cc
@@ -91,37 +91,43 @@ void InitK8sClientConfig() {
   k8s_client_initialized = true;
 }
 
+Status EstablishSslConnection(net::io_context &ioc,
+                              ssl::context &ctx,
+                              ssl::stream<beast::tcp_stream> &stream,
+                              tcp::resolver &resolver) {
+  ctx.load_verify_file(kK8sCaCertPath);
+  ctx.set_verify_mode(ssl::verify_peer);
+
+  beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(kK8sApiTimeoutSecs));
+
+  if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
+    beast::error_code ec{static_cast<int>(::ERR_get_error()),
+                         net::error::get_ssl_category()};
+    return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
+  }
+
+  auto const results = resolver.resolve(k8s_host, k8s_port);
+  beast::get_lowest_layer(stream).connect(results);
+  stream.handshake(ssl::stream_base::client);
+  return Status::OK();
+}
+
 Status K8sApiPost(const std::string &path,
                   const nlohmann::json &body,
                   nlohmann::json &response_json) {
+  if (!k8s_client_initialized || k8s_host == nullptr || k8s_port == nullptr) {
+    return Status::Invalid("Kubernetes client configuration is not initialized.");
+  }
+
   static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
-
-    ctx.load_verify_file(kK8sCaCertPath);
-    ctx.set_verify_mode(ssl::verify_peer);
-
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
-    // Set a timeout on the connection and operations to prevent infinite hangs.
-    // If the timeout expires during any synchronous operation, the stream will abort
-    // the operation and throw a boost::system::system_error exception.
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
-
-    if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
-      beast::error_code ec{static_cast<int>(::ERR_get_error()),
-                           net::error::get_ssl_category()};
-      RAY_LOG(ERROR) << "Failed to set SNI hostname: " << ec.message();
-      return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
-    }
-
-    auto const results = resolver.resolve(k8s_host, k8s_port);
-    beast::get_lowest_layer(stream).connect(results);
-    stream.handshake(ssl::stream_base::client);
+    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver));
 
     http::request<http::string_body> req{http::verb::post, path, 11};
     req.set(http::field::host, k8s_host);
@@ -144,7 +150,8 @@ Status K8sApiPost(const std::string &path,
       if (res.result() == http::status::conflict) {
         return Status::AlreadyExists(absl::StrCat("Conflict: ", res.body()));
       }
-      return Status::IOError(absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
+      return Status::IOError(
+          absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
     }
 
     response_json = nlohmann::json::parse(res.body());
@@ -160,45 +167,32 @@ Status K8sApiPost(const std::string &path,
   } catch (const std::exception &e) {
     RAY_LOG(ERROR) << "Kubernetes API Post request failed: " << e.what();
     std::string err_msg(e.what());
-    if (err_msg.find("Operation aborted") != std::string::npos || err_msg.find("timeout") != std::string::npos) {
-      return Status::TimedOut(absl::StrCat("Kubernetes API Post request timed out: ", e.what()));
+    if (err_msg.find("Operation aborted") != std::string::npos ||
+        err_msg.find("timeout") != std::string::npos) {
+      return Status::TimedOut(
+          absl::StrCat("Kubernetes API Post request timed out: ", e.what()));
     }
-    return Status::IOError(absl::StrCat("Kubernetes API Post request failed: ", e.what()));
+    return Status::IOError(
+        absl::StrCat("Kubernetes API Post request failed: ", e.what()));
   }
 
   return Status::OK();
 }
 
-Status K8sApiGet(const std::string &path,
-                nlohmann::json &response_json) {
+Status K8sApiGet(const std::string &path, nlohmann::json &response_json) {
+  if (!k8s_client_initialized || k8s_host == nullptr || k8s_port == nullptr) {
+    return Status::Invalid("Kubernetes client configuration is not initialized.");
+  }
+
   static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
-
-    ctx.load_verify_file(kK8sCaCertPath);
-    ctx.set_verify_mode(ssl::verify_peer);
-
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
-    // Set a timeout on the connection and operations to prevent infinite hangs.
-    // If the timeout expires during any synchronous operation, the stream will abort
-    // the operation and throw a boost::system::system_error exception.
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
-
-    if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
-      beast::error_code ec{static_cast<int>(::ERR_get_error()),
-                           net::error::get_ssl_category()};
-      RAY_LOG(ERROR) << "Failed to set SNI hostname: " << ec.message();
-      return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
-    }
-
-    auto const results = resolver.resolve(k8s_host, k8s_port);
-    beast::get_lowest_layer(stream).connect(results);
-    stream.handshake(ssl::stream_base::client);
+    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver));
 
     http::request<http::empty_body> req{http::verb::get, path, 11};
     req.set(http::field::host, k8s_host);
@@ -218,7 +212,8 @@ Status K8sApiGet(const std::string &path,
       if (res.result() == http::status::not_found) {
         return Status::NotFound(absl::StrCat("Resource not found: ", res.body()));
       }
-      return Status::IOError(absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
+      return Status::IOError(
+          absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
     }
 
     response_json = nlohmann::json::parse(res.body());
@@ -239,8 +234,10 @@ Status K8sApiGet(const std::string &path,
   } catch (const std::exception &e) {
     RAY_LOG(ERROR) << "Kubernetes API Get request failed: " << e.what();
     std::string err_msg(e.what());
-    if (err_msg.find("Operation aborted") != std::string::npos || err_msg.find("timeout") != std::string::npos) {
-      return Status::TimedOut(absl::StrCat("Kubernetes API Get request timed out: ", e.what()));
+    if (err_msg.find("Operation aborted") != std::string::npos ||
+        err_msg.find("timeout") != std::string::npos) {
+      return Status::TimedOut(
+          absl::StrCat("Kubernetes API Get request timed out: ", e.what()));
     }
     return Status::IOError(absl::StrCat("Kubernetes API Get request failed: ", e.what()));
   }
@@ -251,34 +248,19 @@ Status K8sApiGet(const std::string &path,
 Status K8sApiPut(const std::string &path,
                  const nlohmann::json &body,
                  nlohmann::json &response_json) {
+  if (!k8s_client_initialized || k8s_host == nullptr || k8s_port == nullptr) {
+    return Status::Invalid("Kubernetes client configuration is not initialized.");
+  }
+
   static std::string k8s_sa_token = ReadFile(kK8sSaTokenPath);
 
   try {
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
-
-    ctx.load_verify_file(kK8sCaCertPath);
-    ctx.set_verify_mode(ssl::verify_peer);
-
     tcp::resolver resolver(ioc);
     ssl::stream<beast::tcp_stream> stream(ioc, ctx);
 
-    // Set a timeout on the connection and operations to prevent infinite hangs.
-    // If the timeout expires during any synchronous operation, the stream will abort
-    // the operation and throw a boost::system::system_error exception.
-    beast::get_lowest_layer(stream).expires_after(
-        std::chrono::seconds(kK8sApiTimeoutSecs));
-
-    if (!SSL_set_tlsext_host_name(stream.native_handle(), k8s_host)) {
-      beast::error_code ec{static_cast<int>(::ERR_get_error()),
-                           net::error::get_ssl_category()};
-      RAY_LOG(ERROR) << "Failed to set SNI hostname: " << ec.message();
-      return Status::IOError(absl::StrCat("Failed to set SNI hostname: ", ec.message()));
-    }
-
-    auto const results = resolver.resolve(k8s_host, k8s_port);
-    beast::get_lowest_layer(stream).connect(results);
-    stream.handshake(ssl::stream_base::client);
+    RAY_RETURN_NOT_OK(EstablishSslConnection(ioc, ctx, stream, resolver));
 
     http::request<http::string_body> req{http::verb::put, path, 11};
     req.set(http::field::host, k8s_host);
@@ -301,7 +283,8 @@ Status K8sApiPut(const std::string &path,
       if (res.result() == http::status::conflict) {
         return Status::AlreadyExists(absl::StrCat("Conflict: ", res.body()));
       }
-      return Status::IOError(absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
+      return Status::IOError(
+          absl::StrCat("HTTP error ", res.result_int(), ": ", res.body()));
     }
 
     response_json = nlohmann::json::parse(res.body());
@@ -317,8 +300,10 @@ Status K8sApiPut(const std::string &path,
   } catch (const std::exception &e) {
     RAY_LOG(ERROR) << "Kubernetes API Put request failed: " << e.what();
     std::string err_msg(e.what());
-    if (err_msg.find("Operation aborted") != std::string::npos || err_msg.find("timeout") != std::string::npos) {
-      return Status::TimedOut(absl::StrCat("Kubernetes API Put request timed out: ", e.what()));
+    if (err_msg.find("Operation aborted") != std::string::npos ||
+        err_msg.find("timeout") != std::string::npos) {
+      return Status::TimedOut(
+          absl::StrCat("Kubernetes API Put request timed out: ", e.what()));
     }
     return Status::IOError(absl::StrCat("Kubernetes API Put request failed: ", e.what()));
   }
@@ -335,7 +320,8 @@ bool ValidateToken(const AuthenticationToken &token) {
   nlohmann::json token_review_resp;
 
   if (!k8s::K8sApiPost(
-          kAuthenticationV1TokenReviewPath, token_review_req, token_review_resp).ok()) {
+           kAuthenticationV1TokenReviewPath, token_review_req, token_review_resp)
+           .ok()) {
     RAY_LOG(WARNING) << "Kubernetes TokenReview request failed.";
     return false;
   }
@@ -387,7 +373,8 @@ bool ValidateToken(const AuthenticationToken &token) {
 
   if (!k8s::K8sApiPost(kAuthorizationV1SubjectAccessReviewPath,
                        subject_access_review_req,
-                       subject_access_review_resp).ok()) {
+                       subject_access_review_resp)
+           .ok()) {
     RAY_LOG(WARNING) << "Kubernetes SubjectAccessReview request failed.";
     return false;
   }

--- a/src/ray/rpc/authentication/k8s_util.h
+++ b/src/ray/rpc/authentication/k8s_util.h
@@ -21,6 +21,8 @@
 #include "nlohmann/json.hpp"
 #include "ray/rpc/authentication/authentication_token.h"
 
+#include "ray/common/status.h"
+
 namespace ray {
 namespace rpc {
 namespace k8s {
@@ -37,10 +39,26 @@ void InitK8sClientConfig();
 /// \param path The API path for the request.
 /// \param body The JSON body of the request.
 /// \param[out] response_json The JSON response from the API server.
-/// \return true if the request was successful, false otherwise.
-bool K8sApiPost(const std::string &path,
-                const nlohmann::json &body,
-                nlohmann::json &response_json);
+/// \return Status::OK() if the request was successful, otherwise error status.
+Status K8sApiPost(const std::string &path,
+                  const nlohmann::json &body,
+                  nlohmann::json &response_json);
+
+/// Performs an HTTP GET request to the Kubernetes API server.
+/// \param path The API path for the request.
+/// \param[out] response_json The JSON response from the API server.
+/// \return Status::OK() if the request was successful, otherwise error status.
+Status K8sApiGet(const std::string &path,
+                 nlohmann::json &response_json);
+
+/// Performs an HTTP PUT request to the Kubernetes API server.
+/// \param path The API path for the request.
+/// \param body The JSON body of the request.
+/// \param[out] response_json The JSON response from the API server.
+/// \return Status::OK() if the request was successful, otherwise error status.
+Status K8sApiPut(const std::string &path,
+                 const nlohmann::json &body,
+                 nlohmann::json &response_json);
 
 // Validates a token by calling the Kubernetes API server.
 /// \param token The token to validate.

--- a/src/ray/rpc/authentication/k8s_util.h
+++ b/src/ray/rpc/authentication/k8s_util.h
@@ -19,9 +19,8 @@
 #include <string>
 
 #include "nlohmann/json.hpp"
-#include "ray/rpc/authentication/authentication_token.h"
-
 #include "ray/common/status.h"
+#include "ray/rpc/authentication/authentication_token.h"
 
 namespace ray {
 namespace rpc {
@@ -48,8 +47,7 @@ Status K8sApiPost(const std::string &path,
 /// \param path The API path for the request.
 /// \param[out] response_json The JSON response from the API server.
 /// \return Status::OK() if the request was successful, otherwise error status.
-Status K8sApiGet(const std::string &path,
-                 nlohmann::json &response_json);
+Status K8sApiGet(const std::string &path, nlohmann::json &response_json);
 
 /// Performs an HTTP PUT request to the Kubernetes API server.
 /// \param path The API path for the request.


### PR DESCRIPTION
## Description
This PR implements the phase 1 of Active-passive Ray head replicas.
It introduces a native, lightweight C++ Kubernetes Lease client and a robust background leader elector state machine with an integrated watchdog. 

### Kubernetes API Integration
Extended the internal Kubernetes client (k8s_util) to support SSL-verified GET and PUT REST requests

### Kubernetes Lease Client
- LeaderLeaseClientInterface: Defined a platform-agnostic interface for lease acquisition, renewal, and release.
- K8sLeaseClient: Implemented a concrete client that interacts with the Kubernetes /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases API.
- Best practice adopted from client-go lib:
  - Clock-skew resilience
  - Cache lease object and direct-put the renewed lease object
  - Implement both graceful exit and fail-fast step-down

### Generic Leader Elector State Machine with Watchdog
- Election Thread: Implements a continuous loop with two modes:
  - Standby Mode: Polls the lease client periodically to acquire the lease. Sleeps on a condition variable to avoid high CPU spin cycles.
  - Active Mode: Periodically renews the lease heartbeat. Steps down immediately if the lease has been pre-empted by another node.
- Safety Watchdog Thread: Continuously monitors the elapsed time since the last successful lease renewal using monotonic clock time. If renewals fail persistently and exceed the safety renew_deadline_seconds, the watchdog forces an immediate step-down (triggering the on_stopped_leading suicide callback) before another candidate can steal the lease.
- Responsive Thread Wakeups: Enabled immediate thread wakeup signals so that when the watchdog triggers a step-down, the election thread immediately stops any ongoing renewal attempts instead of waiting for retry timeouts.

### Unit tests
- k8s_lease_client_test.cc: Tests lease acquisition, heartbeats, conflicts, and error handling.
- leader_elector_test.cc: Tests promotion state transitions, transient network failures, persistent renewal timeouts, watchdog expiration steps, and multi-replica election with graceful/non-graceful exits.

### Risk
Low, as it is just a unused library.

## Related issues
https://github.com/ray-project/ray/issues/63643

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
