### PR TITLE
[dashboard] Show TPU stats on Cluster tab 

### DIFF
--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -134,10 +134,15 @@ const ActorTable = ({
             const sumGpuUtilization = getSumGpuUtilization(
               actor.pid,
               actor.gpus,
+              actor.tpus,
             );
             return sumGpuUtilization * descMultiplier;
           case gramUsageSorterKey:
-            const sumGRAMUsage = getSumGRAMUsage(actor.pid, actor.gpus);
+            const sumGRAMUsage = getSumGRAMUsage(
+              actor.pid,
+              actor.gpus,
+              actor.tpus,
+            );
             return sumGRAMUsage * descMultiplier;
           default:
             return 0;
@@ -599,6 +604,7 @@ const ActorTable = ({
                 exitDetail,
                 requiredResources,
                 gpus,
+                tpus,
                 processStats,
                 mem,
                 labelSelector,
@@ -748,10 +754,10 @@ const ActorTable = ({
                     )}
                   </TableCell>
                   <TableCell>
-                    <WorkerGpuRow workerPID={pid} gpus={gpus} />
+                    <WorkerGpuRow workerPID={pid} gpus={gpus} tpus={tpus} />
                   </TableCell>
                   <TableCell>
-                    <WorkerGRAM workerPID={pid} gpus={gpus} />
+                    <WorkerGRAM workerPID={pid} gpus={gpus} tpus={tpus} />
                   </TableCell>
                   <TableCell
                     align="center"

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -760,10 +760,18 @@ const ActorTable = ({
                     )}
                   </TableCell>
                   <TableCell>
-                    <WorkerAcceleratorRow workerPID={pid} gpus={gpus} tpus={tpus} />
+                    <WorkerAcceleratorRow
+                      workerPID={pid}
+                      gpus={gpus}
+                      tpus={tpus}
+                    />
                   </TableCell>
                   <TableCell>
-                    <WorkerAcceleratorMemory workerPID={pid} gpus={gpus} tpus={tpus} />
+                    <WorkerAcceleratorMemory
+                      workerPID={pid}
+                      gpus={gpus}
+                      tpus={tpus}
+                    />
                   </TableCell>
                   <TableCell
                     align="center"

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -30,8 +30,14 @@ import {
 } from "../common/ProfilingLink";
 import rowStyles from "../common/RowStyles";
 import { sliceToPage } from "../common/util";
-import { getSumGpuUtilization, WorkerGpuRow } from "../pages/node/GPUColumn";
-import { getSumGRAMUsage, WorkerGRAM } from "../pages/node/GRAMColumn";
+import {
+  getSumAcceleratorUtilization,
+  WorkerAcceleratorRow,
+} from "../pages/node/AcceleratorColumn";
+import {
+  getSumAcceleratorMemoryUsage,
+  WorkerAcceleratorMemory,
+} from "../pages/node/AcceleratorMemoryColumn";
 import { ActorDetail, ActorEnum } from "../type/actor";
 import { Worker } from "../type/worker";
 import { memoryConverter } from "../util/converter";
@@ -131,14 +137,14 @@ const ActorTable = ({
             // so multiply by -1
             return uptime * -1 * descMultiplier;
           case gpuUtilizationSorterKey:
-            const sumGpuUtilization = getSumGpuUtilization(
+            const sumGpuUtilization = getSumAcceleratorUtilization(
               actor.pid,
               actor.gpus,
               actor.tpus,
             );
             return sumGpuUtilization * descMultiplier;
           case gramUsageSorterKey:
-            const sumGRAMUsage = getSumGRAMUsage(
+            const sumGRAMUsage = getSumAcceleratorMemoryUsage(
               actor.pid,
               actor.gpus,
               actor.tpus,
@@ -754,10 +760,10 @@ const ActorTable = ({
                     )}
                   </TableCell>
                   <TableCell>
-                    <WorkerGpuRow workerPID={pid} gpus={gpus} tpus={tpus} />
+                    <WorkerAcceleratorRow workerPID={pid} gpus={gpus} tpus={tpus} />
                   </TableCell>
                   <TableCell>
-                    <WorkerGRAM workerPID={pid} gpus={gpus} tpus={tpus} />
+                    <WorkerAcceleratorMemory workerPID={pid} gpus={gpus} tpus={tpus} />
                   </TableCell>
                   <TableCell
                     align="center"

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../util/accelerator";
 import { memoryConverter } from "../../util/converter";
 
-export type NodeGPUEntryProps = {
+export type NodeAcceleratorEntryProps = {
   slot: number;
   accelerator: UnifiedAcceleratorStat;
 };
@@ -58,7 +58,7 @@ const TpuTooltip = ({ tpu }: { tpu: TPUStats }) => {
   );
 };
 
-export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({
+export const NodeAcceleratorEntry: React.FC<NodeAcceleratorEntryProps> = ({
   accelerator,
   slot,
 }) => {
@@ -90,14 +90,14 @@ export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({
   );
 };
 
-export const NodeGPUView = ({ node }: { node: NodeDetail }) => {
+export const NodeAcceleratorView = ({ node }: { node: NodeDetail }) => {
   const accelerators = normalizeAccelerators(node.gpus, node.tpus);
 
   return (
     <Box sx={{ minWidth: 120 }}>
       {accelerators.length !== 0 ? (
         accelerators.map((acc, i) => (
-          <NodeGPUEntry
+          <NodeAcceleratorEntry
             key={acc.uuid || acc.name + acc.index}
             accelerator={acc}
             slot={acc.index}
@@ -112,7 +112,7 @@ export const NodeGPUView = ({ node }: { node: NodeDetail }) => {
   );
 };
 
-export const WorkerGpuRow = ({
+export const WorkerAcceleratorRow = ({
   workerPID,
   gpus,
   tpus,
@@ -125,10 +125,6 @@ export const WorkerGpuRow = ({
 
   const workerGPUEntries = accelerators
     .map((acc, i) => {
-      // TPUs currently do not report per-process PIDs, so we skip them for worker rows
-      if (acc.type === "TPU") {
-        return undefined;
-      }
       const process = acc.processesPids?.find(
         (process) => process.pid === workerPID,
       );
@@ -136,7 +132,7 @@ export const WorkerGpuRow = ({
         return undefined;
       }
       return (
-        <NodeGPUEntry
+        <NodeAcceleratorEntry
           key={acc.uuid || acc.name + acc.index}
           accelerator={acc}
           slot={acc.index}
@@ -154,7 +150,7 @@ export const WorkerGpuRow = ({
   );
 };
 
-export const getSumGpuUtilization = (
+export const getSumAcceleratorUtilization = (
   workerPID: number | null,
   gpus?: GPUStats[],
   tpus?: TPUStats[],

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -6,10 +6,11 @@ import { GPUStats, NodeDetail, TPUStats } from "../../type/node";
 import {
   normalizeAccelerators,
 } from "../../util/accelerator";
+import { memoryConverter } from "../../util/converter";
 
 const GRAM_COL_WIDTH = 120;
 
-export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
+export const NodeAcceleratorMemory = ({ node }: { node: NodeDetail }) => {
   const accelerators = normalizeAccelerators(node.gpus, node.tpus);
 
   const nodeGRAMEntries = accelerators.map((acc, i) => {
@@ -20,7 +21,7 @@ export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
       total: acc.memoryTotal,
       slot: acc.index,
     };
-    return <GRAMEntry {...props} />;
+    return <AcceleratorMemoryEntry {...props} />;
   });
   return (
     <div style={{ minWidth: 60 }}>
@@ -35,7 +36,7 @@ export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
   );
 };
 
-export const WorkerGRAM = ({
+export const WorkerAcceleratorMemory = ({
   workerPID,
   gpus,
   tpus,
@@ -48,10 +49,6 @@ export const WorkerGRAM = ({
 
   const workerGRAMEntries = accelerators
     .map((acc, i) => {
-      // TPUs currently do not report per-process PIDs, so we skip them for worker rows
-      if (acc.type === "TPU") {
-        return undefined;
-      }
       const process = acc.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
       );
@@ -65,7 +62,7 @@ export const WorkerGRAM = ({
         utilization: process.memoryUsage, // This is already unified
         slot: acc.index,
       };
-      return <GRAMEntry {...props} />;
+      return <AcceleratorMemoryEntry {...props} />;
     })
     .filter((entry) => entry !== undefined);
 
@@ -78,7 +75,7 @@ export const WorkerGRAM = ({
   );
 };
 
-export const getSumGRAMUsage = (
+export const getSumAcceleratorMemoryUsage = (
   workerPID: number | null,
   gpus?: GPUStats[],
   tpus?: TPUStats[],
@@ -100,23 +97,20 @@ export const getSumGRAMUsage = (
 };
 
 const getMemDisplayRatioNoPercent = (used: number, total: number) => {
-  let unit = "MiB"
-  if (total >= 1024) {
-    used /= 1024
-    total /= 1024
-    unit = "GiB"
-  }
-  return `${used.toFixed(1)}${unit}/${total.toFixed(1)}${unit}`;
+  // Convert MiB back to bytes for the memoryConverter
+  const usedBytes = used * 1024 * 1024;
+  const totalBytes = total * 1024 * 1024;
+  return `${memoryConverter(usedBytes)}/${memoryConverter(totalBytes)}`;
 };
 
-type GRAMEntryProps = {
+type AcceleratorMemoryEntryProps = {
   gpuName: string;
   slot: number;
   utilization: number;
   total: number;
 };
 
-const GRAMEntry: React.FC<GRAMEntryProps> = ({
+const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   gpuName,
   slot,
   utilization,

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -3,9 +3,7 @@ import React from "react";
 import { RightPaddedTypography } from "../../common/CustomTypography";
 import PercentageBar from "../../components/PercentageBar";
 import { GPUStats, NodeDetail, TPUStats } from "../../type/node";
-import {
-  normalizeAccelerators,
-} from "../../util/accelerator";
+import { normalizeAccelerators } from "../../util/accelerator";
 import { memoryConverter } from "../../util/converter";
 
 const GRAM_COL_WIDTH = 120;

--- a/python/ray/dashboard/client/src/pages/node/GPUColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/GPUColumn.tsx
@@ -2,22 +2,83 @@ import { Box, Tooltip, Typography } from "@mui/material";
 import React from "react";
 import { RightPaddedTypography } from "../../common/CustomTypography";
 import UsageBar from "../../common/UsageBar";
-import { GPUStats, NodeDetail } from "../../type/node";
+import { GPUStats, NodeDetail, TPUStats } from "../../type/node";
+import {
+  normalizeAccelerators,
+  UnifiedAcceleratorStat,
+} from "../../util/accelerator";
+import { memoryConverter } from "../../util/converter";
 
 export type NodeGPUEntryProps = {
   slot: number;
-  gpu: GPUStats;
+  accelerator: UnifiedAcceleratorStat;
 };
 
-export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
+const GpuTooltip = ({ gpu }: { gpu: GPUStats }) => {
   return (
-    <Tooltip title={gpu.name}>
+    <Box>
+      <Typography variant="body2">Name: {gpu.name}</Typography>
+      {gpu.temperatureC !== undefined && (
+        <Typography variant="body2">
+          Temperature: {gpu.temperatureC}°C
+        </Typography>
+      )}
+      {gpu.powerMw !== undefined && (
+        <Typography variant="body2">
+          Power Draw: {(gpu.powerMw / 1000).toFixed(1)} W
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+const TpuTooltip = ({ tpu }: { tpu: TPUStats }) => {
+  const tensorcoreUtilization = tpu.tensorcoreUtilization ?? 0;
+  const hbmUtilization = tpu.hbmUtilization ?? 0;
+
+  return (
+    <Box>
+      <Typography variant="body2">Name: {tpu.name}</Typography>
+      <Typography variant="body2">Type: {tpu.tpuType}</Typography>
+      <Typography variant="body2">Topology: {tpu.tpuTopology}</Typography>
+      <Typography variant="body2">
+        Tensorcore: {tensorcoreUtilization.toFixed(1)}%
+      </Typography>
+      <Typography variant="body2">
+        HBM Bandwidth: {hbmUtilization.toFixed(1)}%
+      </Typography>
+      <Typography variant="body2">
+        Used Memory: {memoryConverter(tpu.memoryUsed)} /{" "}
+        {memoryConverter(tpu.memoryTotal)}
+      </Typography>
+      <Typography variant="body2">
+        Free Memory: {memoryConverter(tpu.memoryTotal - tpu.memoryUsed)}
+      </Typography>
+    </Box>
+  );
+};
+
+export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({
+  accelerator,
+  slot,
+}) => {
+  const title =
+    accelerator.type === "GPU" && accelerator.rawGpu ? (
+      <GpuTooltip gpu={accelerator.rawGpu} />
+    ) : accelerator.type === "TPU" && accelerator.rawTpu ? (
+      <TpuTooltip tpu={accelerator.rawTpu} />
+    ) : (
+      accelerator.name
+    );
+
+  return (
+    <Tooltip title={title}>
       <Box sx={{ display: "flex", minWidth: 120 }}>
         <RightPaddedTypography variant="body1">[{slot}]:</RightPaddedTypography>
-        {gpu.utilizationGpu !== undefined ? (
+        {accelerator.utilization !== undefined ? (
           <UsageBar
-            percent={gpu.utilizationGpu}
-            text={`${gpu.utilizationGpu.toFixed(1)}%`}
+            percent={accelerator.utilization}
+            text={`${accelerator.utilization.toFixed(1)}%`}
           />
         ) : (
           <Typography color="textSecondary" component="span" variant="inherit">
@@ -30,11 +91,17 @@ export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
 };
 
 export const NodeGPUView = ({ node }: { node: NodeDetail }) => {
+  const accelerators = normalizeAccelerators(node.gpus, node.tpus);
+
   return (
     <Box sx={{ minWidth: 120 }}>
-      {node.gpus !== undefined && node.gpus.length !== 0 ? (
-        node.gpus.map((gpu, i) => (
-          <NodeGPUEntry key={gpu.uuid} gpu={gpu} slot={gpu.index} />
+      {accelerators.length !== 0 ? (
+        accelerators.map((acc, i) => (
+          <NodeGPUEntry
+            key={acc.uuid || acc.name + acc.index}
+            accelerator={acc}
+            slot={acc.index}
+          />
         ))
       ) : (
         <Typography color="textSecondary" component="span" variant="inherit">
@@ -48,19 +115,33 @@ export const NodeGPUView = ({ node }: { node: NodeDetail }) => {
 export const WorkerGpuRow = ({
   workerPID,
   gpus,
+  tpus,
 }: {
   workerPID: number | null;
   gpus?: GPUStats[];
+  tpus?: TPUStats[];
 }) => {
-  const workerGPUEntries = (gpus ?? [])
-    .map((gpu, i) => {
-      const process = gpu.processesPids?.find(
+  const accelerators = normalizeAccelerators(gpus, tpus);
+
+  const workerGPUEntries = accelerators
+    .map((acc, i) => {
+      // TPUs currently do not report per-process PIDs, so we skip them for worker rows
+      if (acc.type === "TPU") {
+        return undefined;
+      }
+      const process = acc.processesPids?.find(
         (process) => process.pid === workerPID,
       );
       if (!process) {
         return undefined;
       }
-      return <NodeGPUEntry key={gpu.uuid} gpu={gpu} slot={gpu.index} />;
+      return (
+        <NodeGPUEntry
+          key={acc.uuid || acc.name + acc.index}
+          accelerator={acc}
+          slot={acc.index}
+        />
+      );
     })
     .filter((entry) => entry !== undefined);
 
@@ -76,18 +157,18 @@ export const WorkerGpuRow = ({
 export const getSumGpuUtilization = (
   workerPID: number | null,
   gpus?: GPUStats[],
+  tpus?: TPUStats[],
 ) => {
-  // Get sum of all GPU utilization values for this worker PID. This is an
-  // aggregate of the WorkerGpuRow and follows the same logic.
-  const workerGPUUtilizationEntries = (gpus ?? [])
-    .map((gpu, i) => {
-      const process = gpu.processesPids?.find(
+  const accelerators = normalizeAccelerators(gpus, tpus);
+  const workerGPUUtilizationEntries = accelerators
+    .map((acc, i) => {
+      const process = acc.processesPids?.find(
         (process) => process.pid === workerPID,
       );
       if (!process) {
         return 0;
       }
-      return gpu.utilizationGpu || 0;
+      return acc.utilization || 0;
     })
     .filter((entry) => entry !== undefined);
   return workerGPUUtilizationEntries.reduce((a, b) => a + b, 0);

--- a/python/ray/dashboard/client/src/pages/node/GRAMColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/GRAMColumn.tsx
@@ -2,18 +2,23 @@ import { Box, Tooltip, Typography } from "@mui/material";
 import React from "react";
 import { RightPaddedTypography } from "../../common/CustomTypography";
 import PercentageBar from "../../components/PercentageBar";
-import { GPUStats, NodeDetail } from "../../type/node";
+import { GPUStats, NodeDetail, TPUStats } from "../../type/node";
+import {
+  normalizeAccelerators,
+} from "../../util/accelerator";
 
 const GRAM_COL_WIDTH = 120;
 
 export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
-  const nodeGRAMEntries = (node.gpus ?? []).map((gpu, i) => {
+  const accelerators = normalizeAccelerators(node.gpus, node.tpus);
+
+  const nodeGRAMEntries = accelerators.map((acc, i) => {
     const props = {
-      key: gpu.uuid,
-      gpuName: gpu.name,
-      utilization: gpu.memoryUsed,
-      total: gpu.memoryTotal,
-      slot: gpu.index,
+      key: acc.uuid || acc.name + acc.index,
+      gpuName: acc.name, // Displaying original name is fine, tooltip will use it. Or we could customize tooltip.
+      utilization: acc.memoryUsed,
+      total: acc.memoryTotal,
+      slot: acc.index,
     };
     return <GRAMEntry {...props} />;
   });
@@ -33,24 +38,32 @@ export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
 export const WorkerGRAM = ({
   workerPID,
   gpus,
+  tpus,
 }: {
   workerPID: number | null;
   gpus?: GPUStats[];
+  tpus?: TPUStats[];
 }) => {
-  const workerGRAMEntries = (gpus ?? [])
-    .map((gpu, i) => {
-      const process = gpu.processesPids?.find(
+  const accelerators = normalizeAccelerators(gpus, tpus);
+
+  const workerGRAMEntries = accelerators
+    .map((acc, i) => {
+      // TPUs currently do not report per-process PIDs, so we skip them for worker rows
+      if (acc.type === "TPU") {
+        return undefined;
+      }
+      const process = acc.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
       );
       if (!process) {
         return undefined;
       }
       const props = {
-        key: gpu.uuid,
-        gpuName: gpu.name,
-        total: gpu.memoryTotal,
-        utilization: process.gpuMemoryUsage,
-        slot: gpu.index,
+        key: acc.uuid || acc.name + acc.index,
+        gpuName: acc.name,
+        total: acc.memoryTotal,
+        utilization: process.memoryUsage, // This is already unified
+        slot: acc.index,
       };
       return <GRAMEntry {...props} />;
     })
@@ -68,18 +81,19 @@ export const WorkerGRAM = ({
 export const getSumGRAMUsage = (
   workerPID: number | null,
   gpus?: GPUStats[],
+  tpus?: TPUStats[],
 ) => {
-  // Get sum of all GRAM usage values for this worker PID. This is an
-  // aggregate of WorkerGRAM and follows the same logic.
-  const workerGRAMEntries = (gpus ?? [])
-    .map((gpu, i) => {
-      const process = gpu.processesPids?.find(
+  const accelerators = normalizeAccelerators(gpus, tpus);
+
+  const workerGRAMEntries = accelerators
+    .map((acc, i) => {
+      const process = acc.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
       );
       if (!process) {
         return 0;
       }
-      return process.gpuMemoryUsage;
+      return process.memoryUsage;
     })
     .filter((entry) => entry !== undefined);
   return workerGRAMEntries.reduce((a, b) => a + b, 0);

--- a/python/ray/dashboard/client/src/pages/node/GRAMColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/GRAMColumn.tsx
@@ -99,8 +99,15 @@ export const getSumGRAMUsage = (
   return workerGRAMEntries.reduce((a, b) => a + b, 0);
 };
 
-const getMiBRatioNoPercent = (used: number, total: number) =>
-  `${used}MiB/${total}MiB`;
+const getMemDisplayRatioNoPercent = (used: number, total: number) => {
+  let unit = "MiB"
+  if (total >= 1024) {
+    used /= 1024
+    total /= 1024
+    unit = "GiB"
+  }
+  return `${used.toFixed(1)}${unit}/${total.toFixed(1)}${unit}`;
+};
 
 type GRAMEntryProps = {
   gpuName: string;
@@ -115,7 +122,7 @@ const GRAMEntry: React.FC<GRAMEntryProps> = ({
   utilization,
   total,
 }) => {
-  const ratioStr = getMiBRatioNoPercent(utilization, total);
+  const ratioStr = getMemDisplayRatioNoPercent(utilization, total);
   return (
     <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -26,7 +26,10 @@ import { NodeDetail } from "../../type/node";
 import { Worker } from "../../type/worker";
 import { memoryConverter } from "../../util/converter";
 import { NodeAcceleratorView, WorkerAcceleratorRow } from "./AcceleratorColumn";
-import { NodeAcceleratorMemory, WorkerAcceleratorMemory } from "./AcceleratorMemoryColumn";
+import {
+  NodeAcceleratorMemory,
+  WorkerAcceleratorMemory,
+} from "./AcceleratorMemoryColumn";
 
 const TEXT_COL_MIN_WIDTH = 100;
 
@@ -298,10 +301,18 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         )}
       </TableCell>
       <TableCell>
-        <WorkerAcceleratorRow workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
+        <WorkerAcceleratorRow
+          workerPID={pid}
+          gpus={node.gpus}
+          tpus={node.tpus}
+        />
       </TableCell>
       <TableCell>
-        <WorkerAcceleratorMemory workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
+        <WorkerAcceleratorMemory
+          workerPID={pid}
+          gpus={node.gpus}
+          tpus={node.tpus}
+        />
       </TableCell>
       <TableCell>N/A</TableCell>
       <TableCell>N/A</TableCell>

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -25,8 +25,8 @@ import { getNodeDetail } from "../../service/node";
 import { NodeDetail } from "../../type/node";
 import { Worker } from "../../type/worker";
 import { memoryConverter } from "../../util/converter";
-import { NodeGPUView, WorkerGpuRow } from "./GPUColumn";
-import { NodeGRAM, WorkerGRAM } from "./GRAMColumn";
+import { NodeAcceleratorView, WorkerAcceleratorRow } from "./AcceleratorColumn";
+import { NodeAcceleratorMemory, WorkerAcceleratorMemory } from "./AcceleratorMemoryColumn";
 
 const TEXT_COL_MIN_WIDTH = 100;
 
@@ -158,10 +158,10 @@ export const NodeRow = ({
         )}
       </TableCell>
       <TableCell>
-        <NodeGPUView node={node} />
+        <NodeAcceleratorView node={node} />
       </TableCell>
       <TableCell>
-        <NodeGRAM node={node} />
+        <NodeAcceleratorMemory node={node} />
       </TableCell>
       <TableCell>
         {raylet && objectStoreTotalMemory && (
@@ -298,10 +298,10 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         )}
       </TableCell>
       <TableCell>
-        <WorkerGpuRow workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
+        <WorkerAcceleratorRow workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
       </TableCell>
       <TableCell>
-        <WorkerGRAM workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
+        <WorkerAcceleratorMemory workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
       </TableCell>
       <TableCell>N/A</TableCell>
       <TableCell>N/A</TableCell>

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -298,10 +298,10 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         )}
       </TableCell>
       <TableCell>
-        <WorkerGpuRow workerPID={pid} gpus={node.gpus} />
+        <WorkerGpuRow workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
       </TableCell>
       <TableCell>
-        <WorkerGRAM workerPID={pid} gpus={node.gpus} />
+        <WorkerGRAM workerPID={pid} gpus={node.gpus} tpus={node.tpus} />
       </TableCell>
       <TableCell>N/A</TableCell>
       <TableCell>N/A</TableCell>

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -34,7 +34,7 @@ import { NodeRows } from "./NodeRow";
 const codeTextStyle = {
   fontFamily: "Roboto Mono, monospace",
 };
-const columns = [
+const getColumns = (hasOnlyGPUs: boolean, hasOnlyTPUs: boolean) => [
   { label: "" }, // Expand button
   { label: "Host / Worker Process name" },
   { label: "State" },
@@ -72,7 +72,7 @@ const columns = [
     ),
   },
   {
-    label: "Accelerator",
+    label: hasOnlyGPUs ? "GPU" : hasOnlyTPUs ? "TPU" : "Accelerator",
     helpInfo: (
       <Typography>
         Usage of each accelerator device (e.g. GPU, TPU). If no usage is detected, here are the
@@ -86,7 +86,13 @@ const columns = [
       </Typography>
     ),
   },
-  { label: "Accelerator Memory" },
+  {
+    label: hasOnlyGPUs
+      ? "GRAM"
+      : hasOnlyTPUs
+        ? "HBM"
+        : "Accelerator Memory",
+  },
   { label: "Object Store Memory" },
   {
     label: "Disk(root)",
@@ -246,6 +252,10 @@ const Nodes = () => {
     constrainedPage,
     maxPage,
   } = sliceToPage(nodeList, page.pageNo, page.pageSize);
+
+  const hasGPUs = nodeList.some((node) => node.gpus && node.gpus.length > 0);
+  const hasTPUs = nodeList.some((node) => node.tpus && node.tpus.length > 0);
+  const columns = getColumns(hasGPUs, hasTPUs);
 
   return (
     <Box

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -34,7 +34,21 @@ import { NodeRows } from "./NodeRow";
 const codeTextStyle = {
   fontFamily: "Roboto Mono, monospace",
 };
-const getColumns = (hasOnlyGPUs: boolean, hasOnlyTPUs: boolean) => [
+const acceleratorColumnLabels = {
+  gpu: {
+    utilization: "GPUs",
+    memory: "GRAM",
+  },
+  tpu: {
+    utilization: "TPUs",
+    memory: "HBM",
+  },
+  generic: {
+    utilization: "Accelerators",
+    memory: "Accelerator Memory",
+  },
+};
+const getColumns = (acceleratorType: keyof typeof acceleratorColumnLabels) => [
   { label: "" }, // Expand button
   { label: "Host / Worker Process name" },
   { label: "State" },
@@ -72,7 +86,7 @@ const getColumns = (hasOnlyGPUs: boolean, hasOnlyTPUs: boolean) => [
     ),
   },
   {
-    label: hasOnlyGPUs ? "GPU" : hasOnlyTPUs ? "TPU" : "Accelerator",
+    label: acceleratorColumnLabels[acceleratorType].utilization,
     helpInfo: (
       <Typography>
         Usage of each accelerator device (e.g. GPU, TPU). If no usage is
@@ -87,7 +101,7 @@ const getColumns = (hasOnlyGPUs: boolean, hasOnlyTPUs: boolean) => [
     ),
   },
   {
-    label: hasOnlyGPUs ? "GRAM" : hasOnlyTPUs ? "HBM" : "Accelerator Memory",
+    label: acceleratorColumnLabels[acceleratorType].memory,
   },
   { label: "Object Store Memory" },
   {
@@ -249,9 +263,16 @@ const Nodes = () => {
     maxPage,
   } = sliceToPage(nodeList, page.pageNo, page.pageSize);
 
-  const hasGPUs = nodeList.some((node) => node.gpus && node.gpus.length > 0);
-  const hasTPUs = nodeList.some((node) => node.tpus && node.tpus.length > 0);
-  const columns = getColumns(hasGPUs, hasTPUs);
+  const accelerators: (keyof typeof acceleratorColumnLabels)[] = [];
+  if (nodeList.some((node) => node.gpus && node.gpus.length > 0)) {
+    accelerators.push("gpu");
+  }
+  if (nodeList.some((node) => node.tpus && node.tpus.length > 0)) {
+    accelerators.push("tpu");
+  }
+  const accelerator = accelerators.length !== 1 ? "generic" : accelerators[0];
+
+  const columns = getColumns(accelerator);
 
   return (
     <Box

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -413,3 +413,4 @@ export const ClusterMainPageLayout = () => {
 };
 
 export default Nodes;
+// cache bust

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -75,11 +75,11 @@ const getColumns = (hasOnlyGPUs: boolean, hasOnlyTPUs: boolean) => [
     label: hasOnlyGPUs ? "GPU" : hasOnlyTPUs ? "TPU" : "Accelerator",
     helpInfo: (
       <Typography>
-        Usage of each accelerator device (e.g. GPU, TPU). If no usage is detected, here are the
-        potential root causes:
+        Usage of each accelerator device (e.g. GPU, TPU). If no usage is
+        detected, here are the potential root causes:
         <br />
-        1. Non-accelerator Ray image is used on this node. Switch to an appropriate image and
-        try again. <br />
+        1. Non-accelerator Ray image is used on this node. Switch to an
+        appropriate image and try again. <br />
         2. Non Nvidia, AMD, or Google TPU accelerators are being used.
         <br />
         3. pynvml, pyamdsmi, or TPU plugin raises an exception.
@@ -87,11 +87,7 @@ const getColumns = (hasOnlyGPUs: boolean, hasOnlyTPUs: boolean) => [
     ),
   },
   {
-    label: hasOnlyGPUs
-      ? "GRAM"
-      : hasOnlyTPUs
-        ? "HBM"
-        : "Accelerator Memory",
+    label: hasOnlyGPUs ? "GRAM" : hasOnlyTPUs ? "HBM" : "Accelerator Memory",
   },
   { label: "Object Store Memory" },
   {

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -72,21 +72,21 @@ const columns = [
     ),
   },
   {
-    label: "GPU",
+    label: "Accelerator",
     helpInfo: (
       <Typography>
-        Usage of each GPU device. If no GPU usage is detected, here are the
+        Usage of each accelerator device (e.g. GPU, TPU). If no usage is detected, here are the
         potential root causes:
         <br />
-        1. non-GPU Ray image is used on this node. Switch to a GPU Ray image and
+        1. Non-accelerator Ray image is used on this node. Switch to an appropriate image and
         try again. <br />
-        2. Non Nvidia or AMD GPUs are being used.
+        2. Non Nvidia, AMD, or Google TPU accelerators are being used.
         <br />
-        3. pynvml or pyamdsmi module raises an exception.
+        3. pynvml, pyamdsmi, or TPU plugin raises an exception.
       </Typography>
     ),
   },
-  { label: "GRAM" },
+  { label: "Accelerator Memory" },
   { label: "Object Store Memory" },
   {
     label: "Disk(root)",
@@ -413,4 +413,3 @@ export const ClusterMainPageLayout = () => {
 };
 
 export default Nodes;
-// cache bust

--- a/python/ray/dashboard/client/src/type/actor.ts
+++ b/python/ray/dashboard/client/src/type/actor.ts
@@ -1,4 +1,4 @@
-import { GPUStats } from "./node";
+import { GPUStats, TPUStats } from "./node";
 
 export enum ActorEnum {
   DEPENDENCIES_UNREADY = "DEPENDENCIES_UNREADY",
@@ -45,6 +45,7 @@ export type ActorDetail = {
   numLocalObjects: number;
   numObjectRefsInScope: number;
   gpus?: GPUStats[]; // GPU stats fetched from node, 1 entry per GPU
+  tpus?: TPUStats[]; // TPU stats fetched from node, 1 entry per TPU
   processStats: {
     cmdline: string[];
     cpuPercent: number;

--- a/python/ray/dashboard/client/src/type/node.d.ts
+++ b/python/ray/dashboard/client/src/type/node.d.ts
@@ -78,7 +78,7 @@ export type GPUStats = {
 export type ProcessTPUUsage = {
   // This tpu usage stats from a process
   pid: number;
-  tpuMemoryUsage: number;
+  tpuMemoryUsage: number; // in bytes (differs from ProcessGPUUsage which is in MiB)
 };
 
 export type TPUStats = {

--- a/python/ray/dashboard/client/src/type/node.d.ts
+++ b/python/ray/dashboard/client/src/type/node.d.ts
@@ -10,6 +10,7 @@ export type NodeDetail = {
   cpus?: number[]; // Logic CPU Count, Physical CPU Count
   mem?: number[]; // total memory, free memory, memory used ratio
   gpus?: GPUStats[]; // GPU stats fetched from node, 1 entry per GPU
+  tpus?: TPUStats[]; // TPU stats fetched from node, 1 entry per TPU
   bootTime: number; // start time
   loadAvg: number[][]; // recent 1，5，15 minitues system load，load per cpu http://man7.org/linux/man-pages/man3/getloadavg.3.html
   disk: {
@@ -72,6 +73,25 @@ export type GPUStats = {
   powerMw?: number;
   /** Temperature in Celsius (e.g. NVIDIA) */
   temperatureC?: number;
+};
+
+export type ProcessTPUUsage = {
+  // This tpu usage stats from a process
+  pid: number;
+  tpuMemoryUsage: number;
+};
+
+export type TPUStats = {
+  // This represents stats fetched from a node about a single TPU
+  name: string;
+  index: number;
+  tpuType: string;
+  tpuTopology: string;
+  memoryUsed: number;
+  memoryTotal: number;
+  tensorcoreUtilization?: number;
+  hbmUtilization?: number;
+  processesPids?: ProcessTPUUsage[];
 };
 
 export type NodeDetailExtend = {

--- a/python/ray/dashboard/client/src/util/accelerator.test.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.test.ts
@@ -1,0 +1,108 @@
+import { GPUStats, TPUStats } from "../type/node";
+import { normalizeAccelerators } from "./accelerator";
+
+describe("normalizeAccelerators", () => {
+  it("handles undefined inputs", () => {
+    expect(normalizeAccelerators(undefined, undefined)).toEqual([]);
+  });
+
+  it("normalizes gpus correctly", () => {
+    const gpus: GPUStats[] = [
+      {
+        uuid: "gpu-1",
+        name: "A100",
+        index: 0,
+        utilizationGpu: 85,
+        memoryUsed: 1024,
+        memoryTotal: 4096,
+        processesPids: [{ pid: 123, gpuMemoryUsage: 512 }],
+      },
+    ];
+
+    const result = normalizeAccelerators(gpus, undefined);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      uuid: "gpu-1",
+      name: "A100",
+      index: 0,
+      type: "GPU",
+      utilization: 85,
+      memoryUsed: 1024,
+      memoryTotal: 4096,
+      processesPids: [{ pid: 123, memoryUsage: 512 }],
+      rawGpu: gpus[0],
+    });
+  });
+
+  it("normalizes tpus correctly and converts bytes to MiB", () => {
+    const tpus: TPUStats[] = [
+      {
+        name: "tpu-1",
+        index: 0,
+        tpuType: "v5e",
+        tpuTopology: "2x2",
+        tensorcoreUtilization: 90,
+        memoryUsed: 1024 * 1024 * 1024, // 1024 MiB in bytes
+        memoryTotal: 4096 * 1024 * 1024, // 4096 MiB in bytes
+        processesPids: [{ pid: 456, tpuMemoryUsage: 512 * 1024 * 1024 }],
+      },
+    ];
+
+    const result = normalizeAccelerators(undefined, tpus);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      name: "tpu-1",
+      index: 0,
+      type: "TPU",
+      utilization: 90,
+      memoryUsed: 1024, // Converted to MiB
+      memoryTotal: 4096, // Converted to MiB
+      processesPids: [{ pid: 456, memoryUsage: 512 }], // Converted to MiB
+      rawTpu: tpus[0],
+    });
+  });
+
+  it("filters out tpus with <= 0 memoryTotal", () => {
+    const tpus: TPUStats[] = [
+      {
+        name: "tpu-1",
+        index: 0,
+        tpuType: "v5e",
+        tpuTopology: "2x2",
+        tensorcoreUtilization: 0,
+        memoryUsed: 0,
+        memoryTotal: 0,
+      },
+    ];
+
+    const result = normalizeAccelerators(undefined, tpus);
+    expect(result).toHaveLength(0);
+  });
+
+  it("combines both gpus and tpus", () => {
+    const gpus: GPUStats[] = [
+      {
+        uuid: "gpu-1",
+        name: "A100",
+        index: 0,
+        memoryUsed: 1024,
+        memoryTotal: 4096,
+      },
+    ];
+    const tpus: TPUStats[] = [
+      {
+        name: "tpu-1",
+        index: 1,
+        tpuType: "v5e",
+        tpuTopology: "2x2",
+        memoryUsed: 1024 * 1024 * 1024,
+        memoryTotal: 4096 * 1024 * 1024,
+      },
+    ];
+
+    const result = normalizeAccelerators(gpus, tpus);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("GPU");
+    expect(result[1].type).toBe("TPU");
+  });
+});

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -43,16 +43,23 @@ export const normalizeAccelerators = (
   }
   if (tpus) {
     tpus.forEach((tpu) => {
+      if (tpu.memoryTotal <= 0) {
+        // Sometimes neighboring chips are reported with placeholders like no
+        // memory capacity; these should be omitted on the dashboard.
+        return
+      }
       normalized.push({
         name: tpu.name,
         index: tpu.index,
         type: "TPU",
         utilization: tpu.tensorcoreUtilization,
-        memoryUsed: tpu.memoryUsed,
-        memoryTotal: tpu.memoryTotal,
+        // Convert Bytes to MiB to match GPUStats
+        memoryUsed: tpu.memoryUsed / (1024 * 1024),
+        memoryTotal: tpu.memoryTotal / (1024 * 1024),
         processesPids: tpu.processesPids?.map((p: ProcessTPUUsage) => ({
           pid: p.pid,
-          memoryUsage: p.tpuMemoryUsage,
+          // ProcessTPUUsage memory is also in bytes, convert if present
+          memoryUsage: p.tpuMemoryUsage / (1024 * 1024),
         })),
         rawTpu: tpu,
       });

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -1,4 +1,9 @@
-import { GPUStats, ProcessGPUUsage, ProcessTPUUsage, TPUStats } from "../type/node";
+import {
+  GPUStats,
+  ProcessGPUUsage,
+  ProcessTPUUsage,
+  TPUStats,
+} from "../type/node";
 
 export type UnifiedProcessAcceleratorUsage = {
   pid: number;
@@ -46,7 +51,7 @@ export const normalizeAccelerators = (
       if (tpu.memoryTotal <= 0) {
         // Sometimes neighboring chips are reported with placeholders like no
         // memory capacity; these should be omitted on the dashboard.
-        return
+        return;
       }
       normalized.push({
         name: tpu.name,

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -1,0 +1,62 @@
+import { GPUStats, ProcessGPUUsage, ProcessTPUUsage, TPUStats } from "../type/node";
+
+export type UnifiedProcessAcceleratorUsage = {
+  pid: number;
+  memoryUsage: number;
+};
+
+export type UnifiedAcceleratorStat = {
+  uuid?: string;
+  name: string;
+  index: number;
+  type: "GPU" | "TPU";
+  utilization?: number;
+  memoryUsed: number;
+  memoryTotal: number;
+  processesPids?: UnifiedProcessAcceleratorUsage[];
+  rawGpu?: GPUStats;
+  rawTpu?: TPUStats;
+};
+
+export const normalizeAccelerators = (
+  gpus?: GPUStats[],
+  tpus?: TPUStats[],
+): UnifiedAcceleratorStat[] => {
+  const normalized: UnifiedAcceleratorStat[] = [];
+  if (gpus) {
+    gpus.forEach((gpu) => {
+      normalized.push({
+        uuid: gpu.uuid,
+        name: gpu.name,
+        index: gpu.index,
+        type: "GPU",
+        utilization: gpu.utilizationGpu,
+        memoryUsed: gpu.memoryUsed,
+        memoryTotal: gpu.memoryTotal,
+        processesPids: gpu.processesPids?.map((p: ProcessGPUUsage) => ({
+          pid: p.pid,
+          memoryUsage: p.gpuMemoryUsage,
+        })),
+        rawGpu: gpu,
+      });
+    });
+  }
+  if (tpus) {
+    tpus.forEach((tpu) => {
+      normalized.push({
+        name: tpu.name,
+        index: tpu.index,
+        type: "TPU",
+        utilization: tpu.tensorcoreUtilization,
+        memoryUsed: tpu.memoryUsed,
+        memoryTotal: tpu.memoryTotal,
+        processesPids: tpu.processesPids?.map((p: ProcessTPUUsage) => ({
+          pid: p.pid,
+          memoryUsage: p.tpuMemoryUsage,
+        })),
+        rawTpu: tpu,
+      });
+    });
+  }
+  return normalized;
+};

--- a/python/ray/dashboard/modules/node/datacenter.py
+++ b/python/ray/dashboard/modules/node/datacenter.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from typing import List, Optional
 
@@ -148,6 +149,23 @@ class DataOrganizer:
         }
 
         node_info = node_physical_stats
+
+        tpus = copy.deepcopy(node_info.get("tpus", []))
+        if tpus:
+            tpu_workers = []
+            for worker in DataSource.node_workers.get(node_id, []):
+                core_stats = worker.get("coreWorkerStats", [])
+                if core_stats:
+                    used = core_stats[0].get("usedResources", {})
+                    if "TPU" in used:
+                        tpu_workers.append(worker["pid"])
+            for tpu in tpus:
+                if "processesPids" not in tpu or tpu["processesPids"] is None:
+                    tpu["processesPids"] = []
+                for pid in tpu_workers:
+                    tpu["processesPids"].append({"pid": pid, "tpuMemoryUsage": 0})
+            node_info["tpus"] = tpus
+
         # Merge node stats to node physical stats under raylet
         node_info["raylet"] = node_stats
         node_info["raylet"].update(ray_stats)
@@ -210,10 +228,11 @@ class DataOrganizer:
         # TODO(fyrestone): remove this, give a link from actor
         # info to worker info in front-end.
         node_id = actor["address"]["nodeId"]
-        pid = core_worker_stats.get("pid")
+        pid = core_worker_stats.get("pid") or actor.get("pid")
         node_physical_stats = DataSource.node_physical_stats.get(node_id, {})
         actor_process_stats = None
         actor_process_gpu_stats = []
+        actor_process_tpu_stats = []
         if pid:
             for process_stats in node_physical_stats.get("workers", []):
                 if process_stats["pid"] == pid:
@@ -236,5 +255,20 @@ class DataOrganizer:
             actor["requiredResources"]
         )
         actor["requiredResources"] = required_resources
+
+        # Infer TPU usage from parsed requiredResources or core_worker_stats
+        uses_tpus = required_resources.get(
+            "TPU", 0
+        ) > 0 or "TPU" in core_worker_stats.get("usedResources", {})
+        logger.info(
+            f"ACTOR DEBUG: uses_tpus={uses_tpus}, required_resources={required_resources}, node_tpus={len(node_physical_stats.get('tpus', [])) if node_physical_stats else None}"
+        )
+        if uses_tpus:
+            actor_process_tpu_stats = copy.deepcopy(node_physical_stats.get("tpus", []))
+            for tpu in actor_process_tpu_stats:
+                if "processesPids" not in tpu or tpu["processesPids"] is None:
+                    tpu["processesPids"] = []
+                tpu["processesPids"].append({"pid": pid, "tpuMemoryUsage": 0})
+        actor["tpus"] = actor_process_tpu_stats
 
         return actor

--- a/python/ray/dashboard/modules/node/datacenter.py
+++ b/python/ray/dashboard/modules/node/datacenter.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 from typing import List, Optional
 
 import ray.dashboard.consts as dashboard_consts
@@ -13,8 +12,6 @@ from ray.dashboard.utils import (
     async_loop_forever,
     compose_state_message,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class DataSource:
@@ -150,22 +147,6 @@ class DataOrganizer:
 
         node_info = node_physical_stats
 
-        tpus = copy.deepcopy(node_info.get("tpus", []))
-        if tpus:
-            tpu_workers = []
-            for worker in DataSource.node_workers.get(node_id, []):
-                core_stats = worker.get("coreWorkerStats", [])
-                if core_stats:
-                    used = core_stats[0].get("usedResources", {})
-                    if "TPU" in used:
-                        tpu_workers.append(worker["pid"])
-            for tpu in tpus:
-                if "processesPids" not in tpu or tpu["processesPids"] is None:
-                    tpu["processesPids"] = []
-                for pid in tpu_workers:
-                    tpu["processesPids"].append({"pid": pid, "tpuMemoryUsage": 0})
-            node_info["tpus"] = tpus
-
         # Merge node stats to node physical stats under raylet
         node_info["raylet"] = node_stats
         node_info["raylet"].update(ray_stats)
@@ -176,6 +157,11 @@ class DataOrganizer:
         node_info["raylet"]["stateMessage"] = compose_state_message(
             death_info.get("reason", None), death_info.get("reasonMessage", None)
         )
+
+        # TODO(spencer-p): TPU process linking is currently prone to over-counting
+        # as it attaches all TPU workers to every chip. This will be addressed
+        # with a more robust mapping in a future update.
+        node_info["tpus"] = copy.deepcopy(node_info.get("tpus", []))
 
         if not get_summary:
             actor_table_entries = DataSource.node_actors.get(node_id, {})
@@ -228,11 +214,10 @@ class DataOrganizer:
         # TODO(fyrestone): remove this, give a link from actor
         # info to worker info in front-end.
         node_id = actor["address"]["nodeId"]
-        pid = core_worker_stats.get("pid") or actor.get("pid")
+        pid = core_worker_stats.get("pid")
         node_physical_stats = DataSource.node_physical_stats.get(node_id, {})
         actor_process_stats = None
         actor_process_gpu_stats = []
-        actor_process_tpu_stats = []
         if pid:
             for process_stats in node_physical_stats.get("workers", []):
                 if process_stats["pid"] == pid:
@@ -256,19 +241,8 @@ class DataOrganizer:
         )
         actor["requiredResources"] = required_resources
 
-        # Infer TPU usage from parsed requiredResources or core_worker_stats
-        uses_tpus = required_resources.get(
-            "TPU", 0
-        ) > 0 or "TPU" in core_worker_stats.get("usedResources", {})
-        logger.info(
-            f"ACTOR DEBUG: uses_tpus={uses_tpus}, required_resources={required_resources}, node_tpus={len(node_physical_stats.get('tpus', [])) if node_physical_stats else None}"
-        )
-        if uses_tpus:
-            actor_process_tpu_stats = copy.deepcopy(node_physical_stats.get("tpus", []))
-            for tpu in actor_process_tpu_stats:
-                if "processesPids" not in tpu or tpu["processesPids"] is None:
-                    tpu["processesPids"] = []
-                tpu["processesPids"].append({"pid": pid, "tpuMemoryUsage": 0})
-        actor["tpus"] = actor_process_tpu_stats
+        # TODO(spencer-p): TPU process linking is currently prone to over-counting.
+        # This will be addressed with a more robust mapping in a future update.
+        actor["tpus"] = []
 
         return actor

--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -52,9 +52,9 @@ if PYDANTIC_INSTALLED:
         name: str
         tpuType: str
         tpuTopology: str
-        tensorcoreUtilization: int  # percentage
-        hbmUtilization: int  # percentage
-        dutyCycle: int  # percentage
+        tensorcoreUtilization: float  # percentage
+        hbmUtilization: float  # percentage
+        dutyCycle: float  # percentage
         memoryUsed: int  # in bytes
         memoryTotal: int  # in bytes
 


### PR DESCRIPTION
## Description

This change shows TPU tensor core utilization and High Bandwidth Memory utilization in the ray cluster dashboard.

* TPU worker rows show tensor core util and HBM usage.
* If the cluster has TPUs and no GPUs, the column names change from "GPU" and "GRAM" to "TPU" and "HBM" respectively.
* If the cluster is mixed, a generic title is shown.

Example screenshot:
<img width="1627" height="573" alt="image" src="https://github.com/user-attachments/assets/e093ac67-ce96-456c-8733-e306945549e4" />


## Related issues

#57829