### PR TITLE
[Data][2/n] Eager StarExpr expansion + optimizer-rule narrowing

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -22,7 +22,12 @@ from ray.data._internal.logical.interfaces import (
 )
 from ray.data._internal.logical.operators.one_to_one_operator import AbstractOneToOne
 from ray.data.block import UserDefinedFunction
-from ray.data.expressions import Expr, StarExpr, exprlist_to_fields
+from ray.data.expressions import (
+    Expr,
+    StarExpr,
+    _expand_star_exprs,
+    exprlist_to_fields,
+)
 from ray.data.preprocessor import Preprocessor
 
 if TYPE_CHECKING:
@@ -356,6 +361,20 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
 
     def __post_init__(self):
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        # Eagerly expand ``StarExpr`` when the input schema is known. This
+        # is DataFusion's ``Projection::try_new`` pattern: by the time
+        # optimizer rules see this op, the projection list contains only
+        # explicit ``col()`` and computed expressions, no ``StarExpr``.
+        # When the input schema is opaque (e.g., upstream UDF map), the
+        # ``StarExpr`` is preserved and runtime ``eval_projection``
+        # expands it on a per-block basis.
+        import pyarrow as pa
+
+        input_schema = self.input_dependencies[0].infer_schema()
+        if isinstance(input_schema, pa.Schema):
+            object.__setattr__(
+                self, "exprs", _expand_star_exprs(self.exprs, input_schema)
+            )
         if self.compute is None:
             object.__setattr__(
                 self, "compute", self._detect_and_get_compute_strategy(self.exprs)

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -25,7 +25,7 @@ from ray.data.block import UserDefinedFunction
 from ray.data.expressions import (
     Expr,
     StarExpr,
-    _expand_star_exprs,
+    expand_star_exprs,
     exprlist_to_fields,
 )
 from ray.data.preprocessor import Preprocessor
@@ -371,7 +371,7 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
         input_schema = self.input_dependencies[0].infer_schema()
         if isinstance(input_schema, pa.Schema):
             object.__setattr__(
-                self, "exprs", _expand_star_exprs(self.exprs, input_schema)
+                self, "exprs", expand_star_exprs(self.exprs, input_schema)
             )
         if self.compute is None:
             object.__setattr__(

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -31,7 +31,6 @@ from ray.data.expressions import (
 from ray.data.preprocessor import Preprocessor
 
 if TYPE_CHECKING:
-
     from ray.data.block import Schema
 
 __all__ = [
@@ -361,8 +360,7 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
 
     def __post_init__(self):
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        # Eagerly expand ``StarExpr`` when the input schema is known. This
-        # is DataFusion's ``Projection::try_new`` pattern: by the time
+        # Eagerly expand ``StarExpr`` when the input schema is known. By the time
         # optimizer rules see this op, the projection list contains only
         # explicit ``col()`` and computed expressions, no ``StarExpr``.
         # When the input schema is opaque (e.g., upstream UDF map), the

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -125,8 +125,11 @@ class PredicatePushdown(Rule):
                 if is_rename_expr(expr):
                     original_columns_being_renamed.add(expr.expr.name)
 
-        # Check if filter references columns removed by explicit select
-        # Valid if: projection includes all columns (star) OR predicate columns exist in output
+        # Check if filter references columns removed by explicit select.
+        # Valid if: projection includes all columns (star, UDF-fallback path)
+        # OR predicate columns exist in the explicit output set (typed path,
+        # since Phase 2a expands ``StarExpr`` into explicit ``col()`` refs
+        # in ``Project.__post_init__`` when the input schema is known).
         has_required_columns = (
             projection_op.has_star_expr() or predicate_columns.issubset(output_columns)
         )

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -128,8 +128,8 @@ class PredicatePushdown(Rule):
         # Check if filter references columns removed by explicit select.
         # Valid if: projection includes all columns (star, UDF-fallback path)
         # OR predicate columns exist in the explicit output set (typed path,
-        # since Phase 2a expands ``StarExpr`` into explicit ``col()`` refs
-        # in ``Project.__post_init__`` when the input schema is known).
+        # where ``StarExpr`` is expanded into explicit ``col()`` refs in
+        # ``Project.__post_init__`` when the input schema is known).
         has_required_columns = (
             projection_op.has_star_expr() or predicate_columns.issubset(output_columns)
         )

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -219,8 +219,8 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
 
     if not downstream_project.has_star_expr():
         # Projection case: this is when downstream is a *selection* (ie, not including
-        # the upstream columns with ``StarExpr``). After Phase 2a's eager
-        # expansion in ``Project.__post_init__`` this is the common case
+        # the upstream columns with ``StarExpr``). With eager expansion of
+        # ``StarExpr`` in ``Project.__post_init__`` this is the common case
         # for typed chains (no ``StarExpr`` reaches the optimizer).
         #
         # Example:

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -33,10 +33,12 @@ def _collect_referenced_columns(exprs: List[Expr]) -> Optional[List[str]]:
 
     Example: For expression "col1 + col2", returns {"col1", "col2"}
     """
-    # If any expression is star(), we need all columns
+    # ``StarExpr`` is eagerly expanded to explicit ``col()`` refs in
+    # ``Project.__post_init__`` when the input schema is known. So this
+    # branch is hit only on the UDF-fallback path (Project on top of an
+    # opaque-schema input like ``MapBatches``), where we can't enumerate
+    # columns and have to fall back to "all columns" (``None``).
     if any(isinstance(expr, StarExpr) for expr in exprs):
-        # TODO (goutam): Instead of using None to refer to All columns, resolve the AST against the schema.
-        # https://github.com/ray-project/ray/issues/57720
         return None
 
     collector = _ColumnReferenceCollector()
@@ -217,7 +219,9 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
 
     if not downstream_project.has_star_expr():
         # Projection case: this is when downstream is a *selection* (ie, not including
-        # the upstream columns with ``StarExpr``)
+        # the upstream columns with ``StarExpr``). After Phase 2a's eager
+        # expansion in ``Project.__post_init__`` this is the common case
+        # for typed chains (no ``StarExpr`` reaches the optimizer).
         #
         # Example:
         #   Upstream: Project([col("a").alias("b")])
@@ -227,7 +231,10 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
         new_exprs = rebound_downstream_exprs
     else:
         # Composition case: downstream has ``StarExpr`` (entailing that downstream
-        # output will be including all of the upstream output columns)
+        # output will be including all of the upstream output columns). This
+        # is the UDF-fallback path; for typed chains
+        # ``Project.__post_init__`` would have replaced the ``StarExpr``
+        # with explicit ``col()`` refs already.
         #
         # Example 1:
         #   Upstream: [star(), col("a").alias("b")],
@@ -334,8 +341,15 @@ class ProjectionPushdown(Rule):
             # in a single column namespace (the scanner's on-disk names)
             # and avoids the predicate-pushdown rebinding dance.
             if current_project.has_star_expr():
+                # UDF-fallback path: if ``StarExpr`` survives to this rule
+                # the input schema was unknown at construction time, so
+                # we can't enumerate columns and have to push "all".
                 required_columns = None
             else:
+                # Otherwise, collect required columns to push projection down
+                # into the reader. (``Project.__post_init__`` expands
+                # ``StarExpr`` to explicit ``col()`` refs when the input
+                # schema is known, so this is the common path.)
                 required_columns = _collect_referenced_columns(current_project.exprs)
 
             # Build a pure-prune projection map (identity, no renames).

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -848,7 +848,10 @@ def eval_projection(projection_exprs: List[Expr], block: Block) -> Block:
     # Collect input column rename map from the projection list
     input_column_rename_map = _extract_input_columns_renaming_mapping(projection_exprs)
 
-    # Expand star expr (if any)
+    # Expand star expr (if any). After Phase 2a, ``Project.__post_init__``
+    # eagerly expands ``StarExpr`` to explicit ``col()`` refs whenever the
+    # input schema is known, so this runtime branch is hit only on the
+    # UDF-fallback path (Project on top of an opaque-schema input).
     if isinstance(projection_exprs[0], StarExpr):
         # Bucket the trailing exprs: rename ``AliasExpr``s of an input
         # column get placed into the original column's position (so the

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -848,8 +848,8 @@ def eval_projection(projection_exprs: List[Expr], block: Block) -> Block:
     # Collect input column rename map from the projection list
     input_column_rename_map = _extract_input_columns_renaming_mapping(projection_exprs)
 
-    # Expand star expr (if any). After Phase 2a, ``Project.__post_init__``
-    # eagerly expands ``StarExpr`` to explicit ``col()`` refs whenever the
+    # Expand star expr (if any). ``Project.__post_init__`` eagerly expands
+    # ``StarExpr`` to explicit ``col()`` refs whenever the
     # input schema is known, so this runtime branch is hit only on the
     # UDF-fallback path (Project on top of an opaque-schema input).
     if isinstance(projection_exprs[0], StarExpr):

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1810,15 +1810,21 @@ class UUIDExpr(Expr):
 
 def _expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> List[Expr]:
     """Replace any ``StarExpr`` in ``exprs`` with explicit ``col(name)``
-    references for each input schema column (minus columns listed as a
-    rename source by any ``AliasExpr`` with ``_is_rename=True``).
+    references for each input schema column, substituting any rename
+    ``AliasExpr`` (``_is_rename=True`` wrapping a ``ColumnExpr``) in place
+    of its source column.
 
     Mirrors the runtime expansion in
-    ``ray.data._internal.planner.plan_expression.expression_evaluator.eval_projection``,
-    so plan-time and runtime semantics agree by construction. Called
-    eagerly from ``Project.__post_init__`` when the input schema is
-    known, so downstream optimizer rules can treat projection lists
-    uniformly without ``StarExpr`` special cases.
+    ``ray.data._internal.planner.plan_expression.expression_evaluator.eval_projection``
+    and the schema resolution in ``exprlist_to_fields``, so plan-time and
+    runtime semantics — including the position of renamed columns — agree
+    by construction. Called eagerly from ``Project.__post_init__`` when the
+    input schema is known, so downstream optimizer rules can treat
+    projection lists uniformly without ``StarExpr`` special cases.
+
+    A rename whose source column is not in ``input_schema`` is left in its
+    original (trailing) position so it still evaluates — and raises a
+    "column not found" error — at runtime, matching ``eval_projection``.
 
     When ``input_schema`` is ``None`` or the projection has no
     ``StarExpr``, the input list is returned unchanged.
@@ -1826,24 +1832,26 @@ def _expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> Lis
     if input_schema is None or not any(isinstance(e, StarExpr) for e in exprs):
         return exprs
 
-    rename_sources = set()
+    input_names = set(input_schema.names)
+    rename_by_source: Dict[str, AliasExpr] = {}
     for expr in exprs:
-        if (
-            isinstance(expr, AliasExpr)
-            and expr._is_rename
-            and isinstance(expr.expr, ColumnExpr)
-        ):
-            rename_sources.add(expr.expr.name)
+        if is_rename_expr(expr) and expr.expr.name in input_names:
+            rename_by_source[expr.expr.name] = expr
 
     expanded: List[Expr] = []
     for expr in exprs:
         if isinstance(expr, StarExpr):
             for name in input_schema.names:
-                if name not in rename_sources:
-                    expanded.append(ColumnExpr(name))
+                rename = rename_by_source.get(name)
+                expanded.append(rename if rename is not None else ColumnExpr(name))
+        elif is_rename_expr(expr) and expr.expr.name in input_names:
+            # Substituted in place during star expansion above; drop the
+            # trailing copy so the renamed column keeps its source position.
+            continue
         else:
             expanded.append(expr)
     return expanded
+
 
 @DeveloperAPI(stability="alpha")
 def exprlist_to_fields(
@@ -1851,11 +1859,13 @@ def exprlist_to_fields(
 ) -> Optional[List["pyarrow.Field"]]:
     """Resolve a list of expressions against the input schema into PyArrow fields.
 
-    Handles ``StarExpr`` inline: when encountered, splices in the input
-    schema's fields, with each rename ``AliasExpr`` (``_is_rename=True``
-    wrapping a ``ColumnExpr``) substituted in place of its source field.
-    This preserves the source column's position in the output, matching
-    runtime ``eval_projection``.
+    Any ``StarExpr`` is first expanded in place via ``_expand_star_exprs``
+    (each rename ``AliasExpr`` substituted at its source column's position),
+    yielding a fully ordered, star-free projection list. The expanded list
+    is then resolved positionally. Sharing ``_expand_star_exprs`` with the
+    runtime ``eval_projection`` (which expands the star the same way) keeps
+    plan-time schema order and runtime output order identical by
+    construction, including the position of renamed columns.
 
     Deduplicates on field name with last-wins semantics, matching the
     runtime ``eval_projection`` (which uses ``fill_column``/upsert when
@@ -1864,9 +1874,9 @@ def exprlist_to_fields(
     produce a single ``a`` field equal to the new expression's output type
     even if ``a`` was already in the input schema.
 
-    Returns ``None`` if any non-star expression cannot be resolved
-    (e.g., a UDFExpr without a declared ``return_dtype`` or a column
-    not present in ``input_schema``). Callers (typically
+    Returns ``None`` if any expression cannot be resolved (e.g., a
+    UDFExpr without a declared ``return_dtype``, or a column — including
+    a rename source — not present in ``input_schema``). Callers (typically
     ``Project.infer_schema``) propagate that ``None`` upward so that
     ``Dataset.schema()`` falls back to a ``limit(1)`` execution.
 
@@ -1880,21 +1890,6 @@ def exprlist_to_fields(
         A list of ``pa.Field`` in projection order, or ``None`` if
         any expression is unresolvable.
     """
-    # Bucket the projection list: rename AliasExprs substitute for their
-    # source column during StarExpr expansion (preserving on-disk column
-    # order, matching runtime ``eval_projection``); non-rename exprs are
-    # emitted afterwards in original order.
-    has_star = False
-    rename_by_source_name: Dict[str, AliasExpr] = {}
-    non_rename_exprs: List[Expr] = []
-    for expr in exprs:
-        if isinstance(expr, StarExpr):
-            has_star = True
-        elif is_rename_expr(expr):
-            rename_by_source_name[expr.expr.name] = expr
-        else:
-            non_rename_exprs.append(expr)
-
     # Output fields, deduped by name with last-wins semantics (matching
     # runtime ``eval_projection``'s ``fill_column``/upsert behavior).
     output_field_index: Dict[str, int] = {}
@@ -1908,27 +1903,16 @@ def exprlist_to_fields(
         else:
             output_fields[idx] = field_
 
-    def _resolve_and_upsert(expr: Expr) -> bool:
+    # ``_expand_star_exprs`` substitutes renames in place and drops the
+    # ``StarExpr``; a rename whose source is missing stays in the list and
+    # fails ``to_field`` below -> ``None`` (matching the runtime's
+    # "column not found" error). ``ColumnExpr.to_field`` returns the input
+    # field verbatim, so star-expanded columns preserve type and metadata.
+    for expr in _expand_star_exprs(exprs, input_schema):
         resolved = expr.to_field(input_schema)
         if resolved is None:
-            return False
-        _upsert_field(resolved)
-        return True
-
-    if has_star:
-        for input_field in input_schema:
-            rename_expr = rename_by_source_name.pop(input_field.name, None)
-            if rename_expr is None:
-                _upsert_field(input_field)
-            elif not _resolve_and_upsert(rename_expr):
-                return None
-
-    # Any rename whose source isn't in ``input_schema`` falls through
-    # here and will fail resolution -> None, matching the runtime's
-    # "column not found" error.
-    for expr in (*rename_by_source_name.values(), *non_rename_exprs):
-        if not _resolve_and_upsert(expr):
             return None
+        _upsert_field(resolved)
 
     return output_fields
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1808,7 +1808,8 @@ class UUIDExpr(Expr):
         return False
 
 
-def _expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> List[Expr]:
+@DeveloperAPI(stability="alpha")
+def expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> List[Expr]:
     """Replace any ``StarExpr`` in ``exprs`` with explicit ``col(name)``
     references for each input schema column, substituting any rename
     ``AliasExpr`` (``_is_rename=True`` wrapping a ``ColumnExpr``) in place
@@ -1859,10 +1860,10 @@ def exprlist_to_fields(
 ) -> Optional[List["pyarrow.Field"]]:
     """Resolve a list of expressions against the input schema into PyArrow fields.
 
-    Any ``StarExpr`` is first expanded in place via ``_expand_star_exprs``
+    Any ``StarExpr`` is first expanded in place via ``expand_star_exprs``
     (each rename ``AliasExpr`` substituted at its source column's position),
     yielding a fully ordered, star-free projection list. The expanded list
-    is then resolved positionally. Sharing ``_expand_star_exprs`` with the
+    is then resolved positionally. Sharing ``expand_star_exprs`` with the
     runtime ``eval_projection`` (which expands the star the same way) keeps
     plan-time schema order and runtime output order identical by
     construction, including the position of renamed columns.
@@ -1903,12 +1904,12 @@ def exprlist_to_fields(
         else:
             output_fields[idx] = field_
 
-    # ``_expand_star_exprs`` substitutes renames in place and drops the
+    # ``expand_star_exprs`` substitutes renames in place and drops the
     # ``StarExpr``; a rename whose source is missing stays in the list and
     # fails ``to_field`` below -> ``None`` (matching the runtime's
     # "column not found" error). ``ColumnExpr.to_field`` returns the input
     # field verbatim, so star-expanded columns preserve type and metadata.
-    for expr in _expand_star_exprs(exprs, input_schema):
+    for expr in expand_star_exprs(exprs, input_schema):
         resolved = expr.to_field(input_schema)
         if resolved is None:
             return None

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1808,6 +1808,43 @@ class UUIDExpr(Expr):
         return False
 
 
+def _expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> List[Expr]:
+    """Replace any ``StarExpr`` in ``exprs`` with explicit ``col(name)``
+    references for each input schema column (minus columns listed as a
+    rename source by any ``AliasExpr`` with ``_is_rename=True``).
+
+    Mirrors the runtime expansion in
+    ``ray.data._internal.planner.plan_expression.expression_evaluator.eval_projection``,
+    so plan-time and runtime semantics agree by construction. Called
+    eagerly from ``Project.__post_init__`` when the input schema is
+    known, so downstream optimizer rules can treat projection lists
+    uniformly without ``StarExpr`` special cases.
+
+    When ``input_schema`` is ``None`` or the projection has no
+    ``StarExpr``, the input list is returned unchanged.
+    """
+    if input_schema is None or not any(isinstance(e, StarExpr) for e in exprs):
+        return exprs
+
+    rename_sources = set()
+    for expr in exprs:
+        if (
+            isinstance(expr, AliasExpr)
+            and expr._is_rename
+            and isinstance(expr.expr, ColumnExpr)
+        ):
+            rename_sources.add(expr.expr.name)
+
+    expanded: List[Expr] = []
+    for expr in exprs:
+        if isinstance(expr, StarExpr):
+            for name in input_schema.names:
+                if name not in rename_sources:
+                    expanded.append(ColumnExpr(name))
+        else:
+            expanded.append(expr)
+    return expanded
+
 @DeveloperAPI(stability="alpha")
 def exprlist_to_fields(
     exprs: List[Expr], input_schema: "pyarrow.Schema"

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -18,8 +18,9 @@ import pytest
 import ray
 from ray.data._internal.logical.operators import Project
 from ray.data.aggregate import Count, Max, Mean, Min, Sum
-from ray.data.expressions import StarExpr, col, lit
+from ray.data.expressions import col, lit, star
 from ray.data.tests.conftest import *  # noqa: F401,F403
+from ray.data.tests.util import assert_exprs_equal
 
 
 @pytest.fixture(scope="module")
@@ -353,9 +354,12 @@ class TestEagerStarExpansion:
         )
         project = ds._logical_plan.dag
         assert isinstance(project, Project)
-        assert not any(isinstance(e, StarExpr) for e in project.exprs)
-        # Names should be input columns + the new aliased column.
-        assert [e.name for e in project.exprs] == ["a", "b", "k", "new"]
+        # Star expanded to explicit input cols + the new aliased expr; no
+        # ``StarExpr`` remains on this typed chain.
+        assert_exprs_equal(
+            project.exprs,
+            [col("a"), col("b"), col("k"), (col("a") + lit(10)).alias("new")],
+        )
 
     def test_rename_columns_expands_star(
         self, ray_start_regular_shared_2_cpus, parquet_path
@@ -363,11 +367,10 @@ class TestEagerStarExpansion:
         ds = ray.data.read_parquet(str(parquet_path)).rename_columns({"a": "A"})
         project = ds._logical_plan.dag
         assert isinstance(project, Project)
-        assert not any(isinstance(e, StarExpr) for e in project.exprs)
-        # The rename AliasExpr "A" substitutes for its source column "a"
-        # *in place* (position preserved), matching runtime
-        # ``eval_projection`` / ``exprlist_to_fields`` ordering.
-        assert [e.name for e in project.exprs] == ["A", "b", "k"]
+        # The rename AliasExpr substitutes for its source column "a" *in
+        # place* (position preserved), matching runtime ``eval_projection``
+        # / ``exprlist_to_fields`` ordering.
+        assert_exprs_equal(project.exprs, [col("a")._rename("A"), col("b"), col("k")])
 
     def test_udf_chain_preserves_star(
         self, ray_start_regular_shared_2_cpus, parquet_path
@@ -381,7 +384,7 @@ class TestEagerStarExpansion:
         )
         project = ds._logical_plan.dag
         assert isinstance(project, Project)
-        assert any(isinstance(e, StarExpr) for e in project.exprs)
+        assert_exprs_equal(project.exprs, [star(), (col("a") + lit(10)).alias("new")])
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -342,7 +342,7 @@ class TestEndToEndStaticResolution:
 
 
 class TestEagerStarExpansion:
-    """Phase 2a: ``Project.__post_init__`` should expand ``StarExpr`` to
+    """``Project.__post_init__`` should expand ``StarExpr`` to
     explicit ``col()`` references when the input schema is known, so
     downstream optimizer rules never see ``StarExpr`` on typed chains."""
 

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -16,8 +16,9 @@ import pyarrow.parquet as pq
 import pytest
 
 import ray
+from ray.data._internal.logical.operators import Project
 from ray.data.aggregate import Count, Max, Mean, Min, Sum
-from ray.data.expressions import col, lit
+from ray.data.expressions import StarExpr, col, lit
 from ray.data.tests.conftest import *  # noqa: F401,F403
 
 
@@ -337,6 +338,49 @@ class TestEndToEndStaticResolution:
                 pa.field("mean(b)", pa.float64()),
             ]
         )
+
+
+class TestEagerStarExpansion:
+    """Phase 2a: ``Project.__post_init__`` should expand ``StarExpr`` to
+    explicit ``col()`` references when the input schema is known, so
+    downstream optimizer rules never see ``StarExpr`` on typed chains."""
+
+    def test_with_column_expands_star(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        ds = ray.data.read_parquet(str(parquet_path)).with_column(
+            "new", col("a") + lit(10)
+        )
+        project = ds._logical_plan.dag
+        assert isinstance(project, Project)
+        assert not any(isinstance(e, StarExpr) for e in project.exprs)
+        # Names should be input columns + the new aliased column.
+        assert [e.name for e in project.exprs] == ["a", "b", "k", "new"]
+
+    def test_rename_columns_expands_star(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        ds = ray.data.read_parquet(str(parquet_path)).rename_columns({"a": "A"})
+        project = ds._logical_plan.dag
+        assert isinstance(project, Project)
+        assert not any(isinstance(e, StarExpr) for e in project.exprs)
+        # "a" is removed from star expansion (rename source); "A" appears
+        # at the end as the rename AliasExpr.
+        assert [e.name for e in project.exprs] == ["b", "k", "A"]
+
+    def test_udf_chain_preserves_star(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        # Input schema is unknown after map_batches, so StarExpr must
+        # stay for runtime ``eval_projection`` to expand per-block.
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .map_batches(lambda b: b)
+            .with_column("new", col("a") + lit(10))
+        )
+        project = ds._logical_plan.dag
+        assert isinstance(project, Project)
+        assert any(isinstance(e, StarExpr) for e in project.exprs)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -364,9 +364,10 @@ class TestEagerStarExpansion:
         project = ds._logical_plan.dag
         assert isinstance(project, Project)
         assert not any(isinstance(e, StarExpr) for e in project.exprs)
-        # "a" is removed from star expansion (rename source); "A" appears
-        # at the end as the rename AliasExpr.
-        assert [e.name for e in project.exprs] == ["b", "k", "A"]
+        # The rename AliasExpr "A" substitutes for its source column "a"
+        # *in place* (position preserved), matching runtime
+        # ``eval_projection`` / ``exprlist_to_fields`` ordering.
+        assert [e.name for e in project.exprs] == ["A", "b", "k"]
 
     def test_udf_chain_preserves_star(
         self, ray_start_regular_shared_2_cpus, parquet_path

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -11,11 +11,9 @@ import pytest
 
 from ray.data.datatype import DataType
 from ray.data.expressions import (
-    ColumnExpr,
     DownloadExpr,
     MonotonicallyIncreasingIdExpr,
     RandomExpr,
-    StarExpr,
     UDFExpr,
     UUIDExpr,
     _expand_star_exprs,
@@ -25,6 +23,7 @@ from ray.data.expressions import (
     star,
     udf,
 )
+from ray.data.tests.util import assert_exprs_equal
 
 
 @pytest.fixture
@@ -282,30 +281,25 @@ class TestExpandStarExprs:
     def test_simple_star(self, schema):
         # ``[star()]`` -> one ``col()`` per input column.
         result = _expand_star_exprs([star()], schema)
-        assert [type(e) for e in result] == [ColumnExpr] * 4
-        assert [e.name for e in result] == ["a", "b", "name", "flag"]
+        assert_exprs_equal(result, [col("a"), col("b"), col("name"), col("flag")])
 
     def test_star_with_with_column(self, schema):
         # ``with_column``-style: ``[star(), expr.alias("new")]`` expands
         # to ``[col(a), col(b), col(name), col(flag), expr.alias("new")]``.
         new_expr = (col("a") + col("b")).alias("new")
         result = _expand_star_exprs([star(), new_expr], schema)
-        assert len(result) == 5
-        assert [e.name for e in result[:4]] == ["a", "b", "name", "flag"]
-        assert result[-1] is new_expr
+        assert_exprs_equal(
+            result, [col("a"), col("b"), col("name"), col("flag"), new_expr]
+        )
 
     def test_star_with_rename(self, schema):
-        # ``rename_columns({"a": "renamed_a"})``: ``[star(), col(a)._rename("renamed_a")]``
-        # -> ``[col(a)._rename("renamed_a"), col(b), col(name), col(flag)]``.
-        # The rename substitutes for its source column *in place* (matching
-        # runtime ``eval_projection`` / ``exprlist_to_fields``), so output
-        # column order is preserved rather than moving the renamed column
-        # to the end.
+        # ``rename_columns({"a": "renamed_a"})``: the rename substitutes for
+        # its source column *in place* (matching runtime ``eval_projection``
+        # / ``exprlist_to_fields``), so ``a`` becomes ``renamed_a`` at
+        # position 0 rather than moving to the end.
         rename = col("a")._rename("renamed_a")
         result = _expand_star_exprs([star(), rename], schema)
-        assert len(result) == 4
-        assert result[0] is rename
-        assert [e.name for e in result[1:]] == ["b", "name", "flag"]
+        assert_exprs_equal(result, [rename, col("b"), col("name"), col("flag")])
 
     def test_star_with_rename_source_missing(self, schema):
         # A rename whose source column isn't in the input schema stays in
@@ -313,15 +307,18 @@ class TestExpandStarExprs:
         # runtime instead of being silently dropped.
         rename = col("missing")._rename("renamed")
         result = _expand_star_exprs([star(), rename], schema)
-        assert len(result) == 5
-        assert [e.name for e in result[:4]] == ["a", "b", "name", "flag"]
-        assert result[-1] is rename
+        assert_exprs_equal(
+            result, [col("a"), col("b"), col("name"), col("flag"), rename]
+        )
 
     def test_no_star_no_op(self, schema):
-        # Verify ``StarExpr`` is gone from the result of ``with_column``
-        # expansion.
-        result = _expand_star_exprs([star(), (col("a") + lit(1)).alias("new")], schema)
-        assert not any(isinstance(e, StarExpr) for e in result)
+        # ``with_column`` expansion drops the ``StarExpr``, leaving explicit
+        # cols plus the new expr.
+        new_expr = (col("a") + lit(1)).alias("new")
+        result = _expand_star_exprs([star(), new_expr], schema)
+        assert_exprs_equal(
+            result, [col("a"), col("b"), col("name"), col("flag"), new_expr]
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -11,11 +11,14 @@ import pytest
 
 from ray.data.datatype import DataType
 from ray.data.expressions import (
+    ColumnExpr,
     DownloadExpr,
     MonotonicallyIncreasingIdExpr,
     RandomExpr,
+    StarExpr,
     UDFExpr,
     UUIDExpr,
+    _expand_star_exprs,
     col,
     exprlist_to_fields,
     lit,
@@ -262,6 +265,49 @@ class TestExprlistToFields:
             data_type=DataType(object),
         )
         assert exprlist_to_fields([e.alias("out")], schema) is None
+
+
+class TestExpandStarExprs:
+    """Tests for ``_expand_star_exprs`` (Phase 2a eager expansion)."""
+
+    def test_passthrough_without_star(self, schema):
+        # No StarExpr -> input list returned unchanged.
+        exprs = [col("a"), (col("a") + col("b")).alias("sum")]
+        assert _expand_star_exprs(exprs, schema) is exprs
+
+    def test_passthrough_when_schema_is_none(self):
+        exprs = [star(), col("a")]
+        assert _expand_star_exprs(exprs, None) is exprs
+
+    def test_simple_star(self, schema):
+        # ``[star()]`` -> one ``col()`` per input column.
+        result = _expand_star_exprs([star()], schema)
+        assert [type(e) for e in result] == [ColumnExpr] * 4
+        assert [e.name for e in result] == ["a", "b", "name", "flag"]
+
+    def test_star_with_with_column(self, schema):
+        # ``with_column``-style: ``[star(), expr.alias("new")]`` expands
+        # to ``[col(a), col(b), col(name), col(flag), expr.alias("new")]``.
+        new_expr = (col("a") + col("b")).alias("new")
+        result = _expand_star_exprs([star(), new_expr], schema)
+        assert len(result) == 5
+        assert [e.name for e in result[:4]] == ["a", "b", "name", "flag"]
+        assert result[-1] is new_expr
+
+    def test_star_with_rename(self, schema):
+        # ``rename_columns({"a": "renamed_a"})``: ``[star(), col(a)._rename("renamed_a")]``
+        # -> ``[col(b), col(name), col(flag), col(a)._rename("renamed_a")]``.
+        rename = col("a")._rename("renamed_a")
+        result = _expand_star_exprs([star(), rename], schema)
+        assert len(result) == 4
+        assert [e.name for e in result[:3]] == ["b", "name", "flag"]
+        assert result[-1] is rename
+
+    def test_no_star_no_op(self, schema):
+        # Verify ``StarExpr`` is gone from the result of ``with_column``
+        # expansion.
+        result = _expand_star_exprs([star(), (col("a") + lit(1)).alias("new")], schema)
+        assert not any(isinstance(e, StarExpr) for e in result)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -296,11 +296,25 @@ class TestExpandStarExprs:
 
     def test_star_with_rename(self, schema):
         # ``rename_columns({"a": "renamed_a"})``: ``[star(), col(a)._rename("renamed_a")]``
-        # -> ``[col(b), col(name), col(flag), col(a)._rename("renamed_a")]``.
+        # -> ``[col(a)._rename("renamed_a"), col(b), col(name), col(flag)]``.
+        # The rename substitutes for its source column *in place* (matching
+        # runtime ``eval_projection`` / ``exprlist_to_fields``), so output
+        # column order is preserved rather than moving the renamed column
+        # to the end.
         rename = col("a")._rename("renamed_a")
         result = _expand_star_exprs([star(), rename], schema)
         assert len(result) == 4
-        assert [e.name for e in result[:3]] == ["b", "name", "flag"]
+        assert result[0] is rename
+        assert [e.name for e in result[1:]] == ["b", "name", "flag"]
+
+    def test_star_with_rename_source_missing(self, schema):
+        # A rename whose source column isn't in the input schema stays in
+        # its trailing position so it still errors ("column not found") at
+        # runtime instead of being silently dropped.
+        rename = col("missing")._rename("renamed")
+        result = _expand_star_exprs([star(), rename], schema)
+        assert len(result) == 5
+        assert [e.name for e in result[:4]] == ["a", "b", "name", "flag"]
         assert result[-1] is rename
 
     def test_no_star_no_op(self, schema):

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -311,15 +311,6 @@ class TestExpandStarExprs:
             result, [col("a"), col("b"), col("name"), col("flag"), rename]
         )
 
-    def test_no_star_no_op(self, schema):
-        # ``with_column`` expansion drops the ``StarExpr``, leaving explicit
-        # cols plus the new expr.
-        new_expr = (col("a") + lit(1)).alias("new")
-        result = _expand_star_exprs([star(), new_expr], schema)
-        assert_exprs_equal(
-            result, [col("a"), col("b"), col("name"), col("flag"), new_expr]
-        )
-
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -16,8 +16,8 @@ from ray.data.expressions import (
     RandomExpr,
     UDFExpr,
     UUIDExpr,
-    _expand_star_exprs,
     col,
+    expand_star_exprs,
     exprlist_to_fields,
     lit,
     star,
@@ -267,27 +267,27 @@ class TestExprlistToFields:
 
 
 class TestExpandStarExprs:
-    """Tests for ``_expand_star_exprs`` (Phase 2a eager expansion)."""
+    """Tests for ``expand_star_exprs`` (eager expansion in ``Project``)."""
 
     def test_passthrough_without_star(self, schema):
         # No StarExpr -> input list returned unchanged.
         exprs = [col("a"), (col("a") + col("b")).alias("sum")]
-        assert _expand_star_exprs(exprs, schema) is exprs
+        assert expand_star_exprs(exprs, schema) is exprs
 
     def test_passthrough_when_schema_is_none(self):
         exprs = [star(), col("a")]
-        assert _expand_star_exprs(exprs, None) is exprs
+        assert expand_star_exprs(exprs, None) is exprs
 
     def test_simple_star(self, schema):
         # ``[star()]`` -> one ``col()`` per input column.
-        result = _expand_star_exprs([star()], schema)
+        result = expand_star_exprs([star()], schema)
         assert_exprs_equal(result, [col("a"), col("b"), col("name"), col("flag")])
 
     def test_star_with_with_column(self, schema):
         # ``with_column``-style: ``[star(), expr.alias("new")]`` expands
         # to ``[col(a), col(b), col(name), col(flag), expr.alias("new")]``.
         new_expr = (col("a") + col("b")).alias("new")
-        result = _expand_star_exprs([star(), new_expr], schema)
+        result = expand_star_exprs([star(), new_expr], schema)
         assert_exprs_equal(
             result, [col("a"), col("b"), col("name"), col("flag"), new_expr]
         )
@@ -298,7 +298,7 @@ class TestExpandStarExprs:
         # / ``exprlist_to_fields``), so ``a`` becomes ``renamed_a`` at
         # position 0 rather than moving to the end.
         rename = col("a")._rename("renamed_a")
-        result = _expand_star_exprs([star(), rename], schema)
+        result = expand_star_exprs([star(), rename], schema)
         assert_exprs_equal(result, [rename, col("b"), col("name"), col("flag")])
 
     def test_star_with_rename_source_missing(self, schema):
@@ -306,7 +306,7 @@ class TestExpandStarExprs:
         # its trailing position so it still errors ("column not found") at
         # runtime instead of being silently dropped.
         rename = col("missing")._rename("renamed")
-        result = _expand_star_exprs([star(), rename], schema)
+        result = expand_star_exprs([star(), rename], schema)
         assert_exprs_equal(
             result, [col("a"), col("b"), col("name"), col("flag"), rename]
         )

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -20,6 +20,7 @@ from ray.data._internal.execution.operators.map_transformer import (
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data.block import Block
+from ray.data.expressions import Expr
 
 
 @ray.remote
@@ -81,6 +82,22 @@ def named_values(col_names, tuples):
 
 def extract_values(col_name, tuples):
     return [t[col_name] for t in tuples]
+
+
+def assert_exprs_equal(actual: List[Expr], expected: List[Expr]):
+    """Assert two expression lists match element-wise.
+
+    ``Expr`` overloads ``==`` to build a comparison expression (e.g.
+    ``col("a") == 5``), so it can't be used to compare exprs for equality;
+    use ``structurally_equals`` instead.
+    """
+    actual_names = [e.name for e in actual]
+    expected_names = [e.name for e in expected]
+    assert len(actual) == len(expected), (actual_names, expected_names)
+    assert all(a.structurally_equals(b) for a, b in zip(actual, expected)), (
+        actual_names,
+        expected_names,
+    )
 
 
 def run_op_tasks_sync(op: PhysicalOperator, only_existing=False):


### PR DESCRIPTION
Phase 2a: Eager StarExpr expansion in Project.__post_init__.

``Project.__post_init__`` calls a new ``_expand_star_exprs(exprs, input_schema)`` helper when the upstream input schema is a ``pa.Schema``. The resulting ``Project.exprs`` contains explicit ``col()`` references rather than ``StarExpr``, so downstream optimizer rules treat projection lists uniformly on every typed chain. When the input is opaque (UDF map upstream), ``StarExpr`` is preserved and the runtime ``eval_projection`` expands it per-block.

Phase 2b: Narrow star handling in optimizer rules to UDF-fallback.

After Phase 2a, every typed chain reaches the optimizer with no ``StarExpr`` in the projection list. The defensive ``StarExpr`` branches in ``projection_pushdown`` (``_collect_referenced_columns``, ``_push_projection_into_read_op``, ``_try_fuse``), ``predicate_pushdown`` (``_can_push_filter_through_projection``), and ``eval_projection`` are now only hit on the UDF-fallback path; document this and remove the resolved TODO at ``_collect_referenced_columns`` (issue #57720).

Tests: 6 unit tests for ``_expand_star_exprs`` and 3 integration tests verifying ``Project.exprs`` after ``with_column`` / ``rename_columns`` / ``map_batches -> with_column``, plus a fixed ``exprlist_to_fields`` regression test for column overrides.
