### PR TITLE
[serve] Log RAY_SERVE* env var overrides at controller startup

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -180,6 +180,8 @@ class ServeController:
             global_logging_config = pickle.loads(log_config_checkpoint)
         self.reconfigure_global_logging_config(global_logging_config)
 
+        self._log_serve_env_vars()
+
         configure_component_memory_profiler(
             component_name="controller", component_id=str(os.getpid())
         )
@@ -304,6 +306,19 @@ class ServeController:
         self._last_broadcasted_target_groups: Optional[List[TargetGroup]] = None
 
         self._last_broadcasted_fallback_targets: Dict[RequestProtocol, Target] = {}
+
+    def _log_serve_env_vars(self) -> None:
+        """Log all RAY_SERVE* env var overrides at controller startup.
+
+        Reads os.environ directly (not constants.py) so vars that aren't declared
+        as module constants are still captured for debugging.
+        """
+        serve_env_vars = {
+            k: v for k, v in sorted(os.environ.items()) if k.startswith("RAY_SERVE")
+        }
+        if serve_env_vars:
+            overrides = ", ".join(f"{k}={v}" for k, v in serve_env_vars.items())
+            logger.info(f"Serve environment overrides: {overrides}")
 
     def _log_throughput_opt_message(self) -> None:
         msg = "Throughput optimized Ray Serve enabled with the following configurations:\n"

--- a/python/ray/serve/tests/unit/test_controller.py
+++ b/python/ray/serve/tests/unit/test_controller.py
@@ -1,9 +1,13 @@
+import os
 from copy import deepcopy
+from unittest import mock
 
 import pytest
 
+from ray.serve._private import controller as controller_module
 from ray.serve._private.common import TargetCapacityDirection
 from ray.serve._private.controller import (
+    ServeController,
     applications_match,
     calculate_target_capacity_direction,
 )
@@ -712,6 +716,32 @@ class TestControllerHealthMetricsTracker:
         assert len(tracker.dsm_update_durations) == _HEALTH_METRICS_HISTORY_SIZE
         # The oldest values should have been dropped
         assert tracker.dsm_update_durations[0] == 50.0
+
+
+def test_log_serve_env_vars_logs_only_serve_prefixed(monkeypatch):
+    monkeypatch.setenv("RAY_SERVE_FOO", "1")
+    monkeypatch.setenv("RAY_SERVE_BAR", "abc")
+    monkeypatch.setenv("RAY_OTHER", "ignored")
+
+    with mock.patch.object(controller_module, "logger") as mock_logger:
+        ServeController._log_serve_env_vars(None)
+
+    mock_logger.info.assert_called_once()
+    logged = mock_logger.info.call_args.args[0]
+    assert "RAY_SERVE_BAR=abc" in logged
+    assert "RAY_SERVE_FOO=1" in logged
+    assert "RAY_OTHER" not in logged
+
+
+def test_log_serve_env_vars_no_op_when_unset(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("RAY_SERVE"):
+            monkeypatch.delenv(key, raising=False)
+
+    with mock.patch.object(controller_module, "logger") as mock_logger:
+        ServeController._log_serve_env_vars(None)
+
+    mock_logger.info.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

When debugging a Serve cluster it's useful to see which `RAY_SERVE_*` env var overrides are active. Today there's no single place that surfaces them; only a handful of features log their own enablement (HAProxy, direct ingress, throughput-opt).

This adds `ServeController._log_serve_env_vars`, called once during controller init right after logging is configured. It scans `os.environ` for the `RAY_SERVE` prefix and logs the active overrides as a single line. It reads `os.environ` directly rather than `constants.py` so vars that aren't declared as module constants are still captured.

Example log line:
```
Serve environment overrides: RAY_SERVE_ENABLE_HA_PROXY=1, RAY_SERVE_LOG_TO_STDERR=0
```

## Related issue number

## Checks
- [x] I've added unit tests for the new behavior (logs only RAY_SERVE-prefixed vars; no-op when none set).
- [x] Signed off with DCO.