### PR TITLE
[serve,data][llm] LLM telemetry bugfixes

### DIFF
--- a/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, Tuple, Union
 
 import ray
 from ray._common.usage.usage_lib import record_extra_usage_tag
@@ -50,51 +50,66 @@ class _TelemetryAgent:
     """Named Actor to keep the state of all deployed models and record telemetry."""
 
     def __init__(self):
-        self._tracking_telemetries: List[BatchModelTelemetry] = []
+        # Keyed by telemetry identity so repeated identical processor builds
+        # overwrite rather than accumulate.
+        self._tracking_telemetries: Dict[str, BatchModelTelemetry] = {}
         self._record_tag_func = record_extra_usage_tag
 
     def _update_record_tag_func(self, record_tag_func: Callable) -> None:
         self._record_tag_func = record_tag_func
 
+    def _reset(self) -> None:
+        """Only used in tests to clear accumulated telemetries."""
+        self._tracking_telemetries = {}
+
     def generate_report(self) -> Dict[str, str]:
         return {
             BatchTelemetryTags.LLM_BATCH_PROCESSOR_CONFIG_NAME: ",".join(
-                [t.processor_config_name for t in self._tracking_telemetries]
+                [t.processor_config_name for t in self._tracking_telemetries.values()]
             ),
             BatchTelemetryTags.LLM_BATCH_MODEL_ARCHITECTURE: ",".join(
-                [t.model_architecture for t in self._tracking_telemetries]
+                [t.model_architecture for t in self._tracking_telemetries.values()]
             ),
             BatchTelemetryTags.LLM_BATCH_SIZE: ",".join(
-                [str(t.batch_size) for t in self._tracking_telemetries]
+                [str(t.batch_size) for t in self._tracking_telemetries.values()]
             ),
             BatchTelemetryTags.LLM_BATCH_ACCELERATOR_TYPE: ",".join(
-                [t.accelerator_type for t in self._tracking_telemetries]
+                [t.accelerator_type for t in self._tracking_telemetries.values()]
             ),
             BatchTelemetryTags.LLM_BATCH_CONCURRENCY: ",".join(
-                [str(t.concurrency) for t in self._tracking_telemetries]
+                [str(t.concurrency) for t in self._tracking_telemetries.values()]
             ),
             BatchTelemetryTags.LLM_BATCH_TASK_TYPE: ",".join(
-                [t.task_type for t in self._tracking_telemetries]
+                [t.task_type for t in self._tracking_telemetries.values()]
             ),
             BatchTelemetryTags.LLM_BATCH_PIPELINE_PARALLEL_SIZE: ",".join(
-                [str(t.pipeline_parallel_size) for t in self._tracking_telemetries]
+                [
+                    str(t.pipeline_parallel_size)
+                    for t in self._tracking_telemetries.values()
+                ]
             ),
             BatchTelemetryTags.LLM_BATCH_TENSOR_PARALLEL_SIZE: ",".join(
-                [str(t.tensor_parallel_size) for t in self._tracking_telemetries]
+                [
+                    str(t.tensor_parallel_size)
+                    for t in self._tracking_telemetries.values()
+                ]
             ),
             BatchTelemetryTags.LLM_BATCH_DATA_PARALLEL_SIZE: ",".join(
-                [str(t.data_parallel_size) for t in self._tracking_telemetries]
+                [str(t.data_parallel_size) for t in self._tracking_telemetries.values()]
             ),
         }
 
     def record(self, telemetry: BatchModelTelemetry) -> None:
-        """Append and record telemetries."""
+        """Upsert by identity and record telemetries."""
         from ray._common.usage.usage_lib import TagKey
 
-        self._tracking_telemetries.append(telemetry)
-        telemetry_dict = self.generate_report()
-        for key, value in telemetry_dict.items():
-            self._record_tag_func(TagKey.Value(key), value)
+        self._tracking_telemetries[telemetry.model_dump_json()] = telemetry
+        for key, value in self.generate_report().items():
+            try:
+                self._record_tag_func(TagKey.Value(key), value)
+            except ValueError:
+                # Tag not in the installed usage proto; skip rather than fail.
+                continue
 
 
 class TelemetryAgent:
@@ -102,28 +117,29 @@ class TelemetryAgent:
     push_telemetry_report is called."""
 
     def __init__(self):
-        try:
-            self.remote_telemetry_agent = ray.get_actor(
-                LLM_BATCH_TELEMETRY_ACTOR_NAME, namespace=LLM_BATCH_TELEMETRY_NAMESPACE
-            )
-        except ValueError:
-            from ray._common.constants import HEAD_NODE_RESOURCE_NAME
-            from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+        from ray._common.constants import HEAD_NODE_RESOURCE_NAME
+        from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-            self.remote_telemetry_agent = _TelemetryAgent.options(
-                # Ensure the actor is created on the head node.
-                resources={HEAD_NODE_RESOURCE_NAME: 0.001},
-                # Ensure the actor is not scheduled with the existing placement group.
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=None
-                ),
-            ).remote()
+        # get_if_exists makes creation atomic across concurrent drivers.
+        self.remote_telemetry_agent = _TelemetryAgent.options(
+            name=LLM_BATCH_TELEMETRY_ACTOR_NAME,
+            namespace=LLM_BATCH_TELEMETRY_NAMESPACE,
+            get_if_exists=True,
+            # Ensure the actor is created on the head node.
+            resources={HEAD_NODE_RESOURCE_NAME: 0.001},
+            # Ensure the actor is not scheduled with the existing placement group.
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=None),
+        ).remote()
 
     def _update_record_tag_func(self, record_tag_func: Callable):
         self.remote_telemetry_agent._update_record_tag_func.remote(record_tag_func)
 
     def push_telemetry_report(self, telemetry: BatchModelTelemetry):
-        ray.get(self.remote_telemetry_agent.record.remote(telemetry))
+        # Telemetry must never break processor construction.
+        try:
+            ray.get(self.remote_telemetry_agent.record.remote(telemetry))
+        except Exception:
+            logger.exception("Failed to push LLM batch telemetry")
 
 
 def get_or_create_telemetry_agent() -> TelemetryAgent:

--- a/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
@@ -2,9 +2,11 @@ from enum import Enum
 from typing import Callable, Dict, Tuple, Union
 
 import ray
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._common.usage.usage_lib import record_extra_usage_tag
 from ray.llm._internal.batch.observability.logging import get_logger
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 LLM_BATCH_TELEMETRY_NAMESPACE = "llm_batch_telemetry"
 LLM_BATCH_TELEMETRY_ACTOR_NAME = "llm_batch_telemetry"
@@ -117,9 +119,6 @@ class TelemetryAgent:
     push_telemetry_report is called."""
 
     def __init__(self):
-        from ray._common.constants import HEAD_NODE_RESOURCE_NAME
-        from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-
         # Creation must never break processor construction, so swallow failures
         # (e.g. Ray not initialized, transient GCS issues) and degrade to a no-op.
         try:

--- a/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
@@ -15,6 +15,10 @@ logger = get_logger(__name__)
 
 
 class BatchModelTelemetry(BaseModelExtended):
+    # Dedup identity only; never recorded as a tag value. A hash of model_source
+    # so distinct models that share an architecture stay separate in the dedup
+    # key while the cleartext model name never reaches the head-node actor.
+    model_id_hash: str = ""
     processor_config_name: str = ""
     model_architecture: str = ""
     batch_size: int = 0
@@ -52,8 +56,9 @@ class _TelemetryAgent:
     """Named Actor to keep the state of all deployed models and record telemetry."""
 
     def __init__(self):
-        # Keyed by telemetry identity so repeated identical processor builds
-        # overwrite rather than accumulate.
+        # Keyed by full telemetry identity (incl. model_id_hash) so repeated
+        # identical processor builds overwrite while distinct models/configs
+        # remain separate.
         self._tracking_telemetries: Dict[str, BatchModelTelemetry] = {}
         self._record_tag_func = record_extra_usage_tag
 

--- a/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
@@ -120,22 +120,33 @@ class TelemetryAgent:
         from ray._common.constants import HEAD_NODE_RESOURCE_NAME
         from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-        # get_if_exists makes creation atomic across concurrent drivers.
-        self.remote_telemetry_agent = _TelemetryAgent.options(
-            name=LLM_BATCH_TELEMETRY_ACTOR_NAME,
-            namespace=LLM_BATCH_TELEMETRY_NAMESPACE,
-            get_if_exists=True,
-            # Ensure the actor is created on the head node.
-            resources={HEAD_NODE_RESOURCE_NAME: 0.001},
-            # Ensure the actor is not scheduled with the existing placement group.
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=None),
-        ).remote()
+        # Creation must never break processor construction, so swallow failures
+        # (e.g. Ray not initialized, transient GCS issues) and degrade to a no-op.
+        try:
+            # get_if_exists makes creation atomic across concurrent drivers.
+            self.remote_telemetry_agent = _TelemetryAgent.options(
+                name=LLM_BATCH_TELEMETRY_ACTOR_NAME,
+                namespace=LLM_BATCH_TELEMETRY_NAMESPACE,
+                get_if_exists=True,
+                # Ensure the actor is created on the head node.
+                resources={HEAD_NODE_RESOURCE_NAME: 0.001},
+                # Ensure the actor is not scheduled with the existing placement group.
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=None
+                ),
+            ).remote()
+        except Exception:
+            self.remote_telemetry_agent = None
+            logger.exception("Failed to initialize LLM batch telemetry agent")
 
     def _update_record_tag_func(self, record_tag_func: Callable):
-        self.remote_telemetry_agent._update_record_tag_func.remote(record_tag_func)
+        if self.remote_telemetry_agent is not None:
+            self.remote_telemetry_agent._update_record_tag_func.remote(record_tag_func)
 
     def push_telemetry_report(self, telemetry: BatchModelTelemetry):
         # Telemetry must never break processor construction.
+        if self.remote_telemetry_agent is None:
+            return
         try:
             ray.get(self.remote_telemetry_agent.record.remote(telemetry))
         except Exception:

--- a/python/ray/llm/_internal/batch/processor/http_request_proc.py
+++ b/python/ray/llm/_internal/batch/processor/http_request_proc.py
@@ -124,6 +124,7 @@ def build_http_request_processor(
     telemetry_agent.push_telemetry_report(
         BatchModelTelemetry(
             processor_config_name=type(config).__name__,
+            batch_size=config.batch_size,
             concurrency=config.concurrency,
         )
     )

--- a/python/ray/llm/_internal/batch/processor/http_request_proc.py
+++ b/python/ray/llm/_internal/batch/processor/http_request_proc.py
@@ -1,5 +1,6 @@
 """The HTTP request processor."""
 
+import hashlib
 from typing import Any, Dict, Optional
 
 from pydantic import Field
@@ -123,6 +124,9 @@ def build_http_request_processor(
     telemetry_agent = get_or_create_telemetry_agent()
     telemetry_agent.push_telemetry_report(
         BatchModelTelemetry(
+            # Hash the target URL so distinct endpoints stay separate in the
+            # dedup key without the cleartext URL reaching the head-node actor.
+            model_id_hash=hashlib.sha256(config.url.encode("utf-8")).hexdigest(),
             processor_config_name=type(config).__name__,
             batch_size=config.batch_size,
             concurrency=config.concurrency,

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -1,5 +1,6 @@
 """The SGLang engine processor."""
 
+import hashlib
 import logging
 from typing import Any, Dict, Optional
 
@@ -250,6 +251,9 @@ def build_sglang_engine_processor(
     telemetry_agent = get_or_create_telemetry_agent()
     telemetry_agent.push_telemetry_report(
         BatchModelTelemetry(
+            model_id_hash=hashlib.sha256(
+                config.model_source.encode("utf-8")
+            ).hexdigest(),
             processor_config_name=type(config).__name__,
             model_architecture=architecture,
             batch_size=config.batch_size,

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -1,5 +1,6 @@
 """The vLLM engine processor."""
 
+import hashlib
 import logging
 from typing import Any, Dict, Optional
 
@@ -350,6 +351,9 @@ def build_vllm_engine_processor(
     telemetry_agent = get_or_create_telemetry_agent()
     telemetry_agent.push_telemetry_report(
         BatchModelTelemetry(
+            model_id_hash=hashlib.sha256(
+                config.model_source.encode("utf-8")
+            ).hexdigest(),
             processor_config_name=type(config).__name__,
             model_architecture=architecture,
             batch_size=config.batch_size,

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -360,6 +360,7 @@ def build_vllm_engine_processor(
                 "pipeline_parallel_size", 1
             ),
             tensor_parallel_size=config.engine_kwargs.get("tensor_parallel_size", 1),
+            data_parallel_size=config.engine_kwargs.get("data_parallel_size", 1),
         )
     )
 

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -325,8 +325,11 @@ def _push_model_telemetry(
         min_replicas = autoscaling_config.min_replicas
         max_replicas = autoscaling_config.max_replicas
     else:
-        # Fixed replica count; honor the configured value, defaulting to 1.
-        num_replicas = deployment_config.get("num_replicas") or 1
+        # Fixed replica count; honor the configured value (including 0),
+        # defaulting to 1 only when unset.
+        num_replicas = deployment_config.get("num_replicas")
+        if num_replicas is None:
+            num_replicas = 1
         min_replicas = max_replicas = num_replicas
 
     engine_config = model.get_engine_config()

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -1,3 +1,4 @@
+import hashlib
 import random
 import time
 from enum import Enum
@@ -43,11 +44,12 @@ class TelemetryTags(str, Enum):
 class TelemetryModel(BaseModelExtended):
     """Telemetry model for LLM Serve.
 
-    ``model_id`` is the dedup identity used by the telemetry agent and is never
-    recorded as a tag value.
+    ``model_id_hash`` is the dedup identity used by the telemetry agent and is
+    never recorded as a tag value. It is a hash of the model id so the raw model
+    name never reaches the head-node actor.
     """
 
-    model_id: str
+    model_id_hash: str
     model_architecture: str
     num_replicas: int
     use_lora: bool
@@ -70,8 +72,8 @@ class TelemetryAgent:
     """Named Actor to keep the state of all deployed models and record telemetry."""
 
     def __init__(self):
-        # Keyed by model_id so repeated reports from replicas/restarts of the
-        # same model overwrite rather than accumulate.
+        # Keyed by model_id_hash so repeated reports from replicas/restarts of
+        # the same model overwrite rather than accumulate.
         self.models: Dict[str, TelemetryModel] = {}
         self.record_tag_func = record_extra_usage_tag
 
@@ -188,7 +190,7 @@ class TelemetryAgent:
         from ray._common.usage.usage_lib import TagKey
 
         if model:
-            self.models[model.model_id] = model
+            self.models[model.model_id_hash] = model
 
         for key, value in self.generate_report().items():
             try:
@@ -332,7 +334,9 @@ def _push_model_telemetry(
     hardware_usage = HardwareUsage(get_hardware_fn)
 
     telemetry_model = TelemetryModel(
-        model_id=model.model_id,
+        # Hash so the cleartext model name (possibly proprietary) never reaches
+        # the head-node actor; deterministic across replicas/restarts so dedup holds.
+        model_id_hash=hashlib.sha256(model.model_id.encode("utf-8")).hexdigest(),
         model_architecture=model.model_architecture,
         num_replicas=num_replicas,
         use_lora=use_lora,

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -1,7 +1,7 @@
 import random
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence
 
 import ray
 from ray import serve
@@ -28,8 +28,6 @@ class TelemetryTags(str, Enum):
 
     LLM_SERVE_SERVE_MULTIPLE_MODELS = "LLM_SERVE_SERVE_MULTIPLE_MODELS"
     LLM_SERVE_SERVE_MULTIPLE_APPS = "LLM_SERVE_SERVE_MULTIPLE_APPS"
-    LLM_SERVE_JSON_MODE_MODELS = "LLM_SERVE_JSON_MODE_MODELS"
-    LLM_SERVE_JSON_MODE_NUM_REPLICAS = "LLM_SERVE_JSON_MODE_NUM_REPLICAS"
     LLM_SERVE_LORA_BASE_MODELS = "LLM_SERVE_LORA_BASE_MODELS"
     LLM_SERVE_INITIAL_NUM_LORA_ADAPTERS = "LLM_SERVE_INITIAL_NUM_LORA_ADAPTERS"
     LLM_SERVE_AUTOSCALING_ENABLED_MODELS = "LLM_SERVE_AUTOSCALING_ENABLED_MODELS"
@@ -43,11 +41,15 @@ class TelemetryTags(str, Enum):
 
 
 class TelemetryModel(BaseModelExtended):
-    """Telemetry model for LLM Serve."""
+    """Telemetry model for LLM Serve.
 
+    ``model_id`` is the dedup identity used by the telemetry agent and is never
+    recorded as a tag value.
+    """
+
+    model_id: str
     model_architecture: str
     num_replicas: int
-    use_json_mode: bool
     use_lora: bool
     initial_num_lora_adapters: int
     use_autoscaling: bool
@@ -68,7 +70,9 @@ class TelemetryAgent:
     """Named Actor to keep the state of all deployed models and record telemetry."""
 
     def __init__(self):
-        self.models: List[TelemetryModel] = []
+        # Keyed by model_id so repeated reports from replicas/restarts of the
+        # same model overwrite rather than accumulate.
+        self.models: Dict[str, TelemetryModel] = {}
         self.record_tag_func = record_extra_usage_tag
 
     def _update_record_tag_func(self, record_tag_func: Callable) -> None:
@@ -78,86 +82,95 @@ class TelemetryAgent:
 
     def _reset_models(self):
         """This method is only used in tests to clean up the models list."""
-        self.models = []
+        self.models = {}
 
     def _multiple_models(self) -> str:
-        unique_models = {model.model_architecture for model in self.models}
+        unique_models = {model.model_architecture for model in self.models.values()}
         return "1" if len(unique_models) > 1 else "0"
 
     @staticmethod
     def _multiple_apps() -> str:
         try:
-            serve_status = serve.status()
-        except ray.exceptions.ActorDiedError:
-            # This only happens in a workspace and when multiple Serve sessions are
-            # used. Since telemetry agent is long running, it might be connecting to the
-            # previous Serve session, which is already dead. In this case, we need to
-            # call `serve.shutdown()` before the telemetry agent can re-connect to the
-            # existing Serve session.
-            serve.shutdown()
-            serve_status = serve.status()
-        return "1" if len(serve_status.applications) > 1 else "0"
-
-    def _json_mode_models(self) -> str:
-        return ",".join(
-            [model.model_architecture for model in self.models if model.use_json_mode]
-        )
-
-    def _json_mode_num_deployments(self) -> str:
-        return ",".join(
-            [str(model.num_replicas) for model in self.models if model.use_json_mode]
-        )
+            try:
+                serve_status = serve.status()
+            except ray.exceptions.ActorDiedError:
+                # In a workspace with multiple Serve sessions, the long-running
+                # telemetry agent may still be connected to a previous, now-dead
+                # session. Shut down so we can reconnect to the live one.
+                serve.shutdown()
+                serve_status = serve.status()
+            return "1" if len(serve_status.applications) > 1 else "0"
+        except Exception:
+            # Telemetry must never fail; fall back to "not multiple".
+            logger.debug("Failed to query serve.status() for telemetry", exc_info=True)
+            return "0"
 
     def _lora_base_nodes(self) -> str:
         return ",".join(
-            [model.model_architecture for model in self.models if model.use_lora]
+            [
+                model.model_architecture
+                for model in self.models.values()
+                if model.use_lora
+            ]
         )
 
     def _lora_initial_num_adaptors(self) -> str:
         return ",".join(
             [
                 str(model.initial_num_lora_adapters)
-                for model in self.models
+                for model in self.models.values()
                 if model.use_lora
             ]
         )
 
     def _autoscaling_enabled_models(self) -> str:
         return ",".join(
-            [model.model_architecture for model in self.models if model.use_autoscaling]
+            [
+                model.model_architecture
+                for model in self.models.values()
+                if model.use_autoscaling
+            ]
         )
 
     def _autoscaling_min_replicas(self) -> str:
         return ",".join(
-            [str(model.min_replicas) for model in self.models if model.use_autoscaling]
+            [
+                str(model.min_replicas)
+                for model in self.models.values()
+                if model.use_autoscaling
+            ]
         )
 
     def _autoscaling_max_replicas(self) -> str:
         return ",".join(
-            [str(model.max_replicas) for model in self.models if model.use_autoscaling]
+            [
+                str(model.max_replicas)
+                for model in self.models.values()
+                if model.use_autoscaling
+            ]
         )
 
     def _model_architectures(self) -> str:
-        return ",".join([model.model_architecture for model in self.models])
+        return ",".join([model.model_architecture for model in self.models.values()])
 
     def _tensor_parallel_degree(self) -> str:
-        return ",".join([str(model.tensor_parallel_degree) for model in self.models])
+        return ",".join(
+            [str(model.tensor_parallel_degree) for model in self.models.values()]
+        )
 
     def _num_replicas(self) -> str:
-        return ",".join([str(model.num_replicas) for model in self.models])
+        return ",".join([str(model.num_replicas) for model in self.models.values()])
 
     def _gpu_type(self) -> str:
-        return ",".join([model.gpu_type for model in self.models])
+        return ",".join([model.gpu_type for model in self.models.values()])
 
     def _num_gpus(self) -> str:
-        return ",".join([str(model.num_gpus) for model in self.models])
+        return ",".join([str(model.num_gpus) for model in self.models.values()])
 
     def generate_report(self) -> Dict[str, str]:
         return {
             TelemetryTags.LLM_SERVE_SERVE_MULTIPLE_MODELS: self._multiple_models(),
             TelemetryTags.LLM_SERVE_SERVE_MULTIPLE_APPS: self._multiple_apps(),
-            TelemetryTags.LLM_SERVE_JSON_MODE_MODELS: self._json_mode_models(),
-            TelemetryTags.LLM_SERVE_JSON_MODE_NUM_REPLICAS: self._json_mode_num_deployments(),
             TelemetryTags.LLM_SERVE_LORA_BASE_MODELS: self._lora_base_nodes(),
             TelemetryTags.LLM_SERVE_INITIAL_NUM_LORA_ADAPTERS: self._lora_initial_num_adaptors(),
             TelemetryTags.LLM_SERVE_AUTOSCALING_ENABLED_MODELS: self._autoscaling_enabled_models(),
@@ -175,7 +188,7 @@ class TelemetryAgent:
         from ray._common.usage.usage_lib import TagKey
 
         if model:
-            self.models.append(model)
+            self.models[model.model_id] = model
 
         for key, value in self.generate_report().items():
             try:
@@ -186,52 +199,40 @@ class TelemetryAgent:
 
 
 def _get_or_create_telemetry_agent() -> TelemetryAgent:
-    """Helper to get or create the telemetry agent."""
-    try:
-        telemetry_agent = ray.get_actor(
-            LLM_SERVE_TELEMETRY_ACTOR_NAME, namespace=LLM_SERVE_TELEMETRY_NAMESPACE
-        )
-    except ValueError:
-        from ray._common.constants import HEAD_NODE_RESOURCE_NAME
-        from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+    """Get or create the detached telemetry agent.
 
-        telemetry_agent = TelemetryAgent.options(
-            # Ensure the actor is created on the head node.
-            resources={HEAD_NODE_RESOURCE_NAME: 0.001},
-            # Ensure the actor is not scheduled with the existing placement group.
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=None),
-        ).remote()
+    ``get_if_exists`` makes creation atomic, so concurrent replicas converge on a
+    single actor without racing on the name.
+    """
+    from ray._common.constants import HEAD_NODE_RESOURCE_NAME
+    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-    return telemetry_agent
+    return TelemetryAgent.options(
+        name=LLM_SERVE_TELEMETRY_ACTOR_NAME,
+        namespace=LLM_SERVE_TELEMETRY_NAMESPACE,
+        get_if_exists=True,
+        # Ensure the actor is created on the head node.
+        resources={HEAD_NODE_RESOURCE_NAME: 0.001},
+        # Ensure the actor is not scheduled with the existing placement group.
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=None),
+    ).remote()
 
 
 def _retry_get_telemetry_agent(
     max_retries: int = 5, base_delay: float = 0.1
 ) -> TelemetryAgent:
-    max_retries = 5
-    base_delay = 0.1
-
-    telemetry_agent = None
+    """Get-or-create the telemetry agent, retrying transient failures."""
     for attempt in range(max_retries):
         try:
-            telemetry_agent = _get_or_create_telemetry_agent()
-            return telemetry_agent
-        except ValueError as e:
-            # Due to race conditions among multiple replicas, we may get:
-            #   ValueError: Actor with name 'llm_serve_telemetry' already
-            #   exists in the namespace llm_serve_telemetry
+            return _get_or_create_telemetry_agent()
+        except Exception as e:
             logger.info(
                 "Attempt %s/%s to get telemetry agent failed", attempt + 1, max_retries
             )
             if attempt == max_retries - 1:
                 raise e
-
-            # Exponential backoff with jitter
-            exponential_delay = base_delay * (2**attempt)
-            jitter = random.uniform(0, 0.5)
-            delay = exponential_delay + jitter
-            # Max total wait time is ~3.5 seconds for 5 attempts.
-            time.sleep(delay)
+            # Exponential backoff with jitter; ~3.5s total over 5 attempts.
+            time.sleep(base_delay * (2**attempt) + random.uniform(0, 0.5))
 
 
 def _push_telemetry_report(model: Optional[TelemetryModel] = None) -> None:
@@ -268,51 +269,69 @@ def push_telemetry_report_for_all_models(
     get_lora_model_func: Callable = get_lora_model_ids,
     get_hardware_fn: Callable = get_hardware_usages_to_report,
 ):
-    """Push telemetry report for all models."""
+    """Push a telemetry report for each model. Never raises."""
     if not all_models:
         return
 
     for model in all_models:
-        use_lora = (
-            model.lora_config is not None
-            and model.lora_config.dynamic_lora_loading_path is not None
+        # Telemetry must never break the caller (e.g. engine start).
+        try:
+            _push_model_telemetry(model, get_lora_model_func, get_hardware_fn)
+        except Exception:
+            logger.exception(
+                "Failed to push telemetry for model %s",
+                getattr(model, "model_id", "<unknown>"),
+            )
+
+
+def _push_model_telemetry(
+    model: "LLMConfig",
+    get_lora_model_func: Callable,
+    get_hardware_fn: Callable,
+) -> None:
+    use_lora = (
+        model.lora_config is not None
+        and model.lora_config.dynamic_lora_loading_path is not None
+    )
+    initial_num_lora_adapters = 0
+    if use_lora:
+        lora_model_ids = get_lora_model_func(
+            dynamic_lora_loading_path=model.lora_config.dynamic_lora_loading_path,
+            base_model_id=model.model_id,
         )
-        initial_num_lora_adapters = 0
-        if use_lora:
-            lora_model_ids = get_lora_model_func(
-                dynamic_lora_loading_path=model.lora_config.dynamic_lora_loading_path,
-                base_model_id=model.model_id,
-            )
-            initial_num_lora_adapters = len(lora_model_ids)
+        initial_num_lora_adapters = len(lora_model_ids)
 
-        use_autoscaling = model.deployment_config.get("autoscaling_config") is not None
-        num_replicas, min_replicas, max_replicas = 1, 1, 1
-        if use_autoscaling:
-            from ray.serve.config import AutoscalingConfig
+    use_autoscaling = model.deployment_config.get("autoscaling_config") is not None
+    if use_autoscaling:
+        from ray.serve.config import AutoscalingConfig
 
-            autoscaling_config = AutoscalingConfig(
-                **model.deployment_config["autoscaling_config"]
-            )
-            num_replicas = (
-                autoscaling_config.initial_replicas or autoscaling_config.min_replicas
-            )
-            min_replicas = autoscaling_config.min_replicas
-            max_replicas = autoscaling_config.max_replicas
-
-        engine_config = model.get_engine_config()
-        hardware_usage = HardwareUsage(get_hardware_fn)
-
-        telemetry_model = TelemetryModel(
-            model_architecture=model.model_architecture,
-            num_replicas=num_replicas,
-            use_json_mode=True,
-            use_lora=use_lora,
-            initial_num_lora_adapters=initial_num_lora_adapters,
-            use_autoscaling=use_autoscaling,
-            min_replicas=min_replicas,
-            max_replicas=max_replicas,
-            tensor_parallel_degree=engine_config.tensor_parallel_degree,
-            gpu_type=model.accelerator_type or hardware_usage.infer_gpu_from_hardware(),
-            num_gpus=engine_config.num_devices,
+        autoscaling_config = AutoscalingConfig(
+            **model.deployment_config["autoscaling_config"]
         )
-        _push_telemetry_report(telemetry_model)
+        num_replicas = (
+            autoscaling_config.initial_replicas or autoscaling_config.min_replicas
+        )
+        min_replicas = autoscaling_config.min_replicas
+        max_replicas = autoscaling_config.max_replicas
+    else:
+        # Fixed replica count; honor the configured value rather than assuming 1.
+        num_replicas = model.deployment_config.get("num_replicas", 1)
+        min_replicas = max_replicas = num_replicas
+
+    engine_config = model.get_engine_config()
+    hardware_usage = HardwareUsage(get_hardware_fn)
+
+    telemetry_model = TelemetryModel(
+        model_id=model.model_id,
+        model_architecture=model.model_architecture,
+        num_replicas=num_replicas,
+        use_lora=use_lora,
+        initial_num_lora_adapters=initial_num_lora_adapters,
+        use_autoscaling=use_autoscaling,
+        min_replicas=min_replicas,
+        max_replicas=max_replicas,
+        tensor_parallel_degree=engine_config.tensor_parallel_degree,
+        gpu_type=model.accelerator_type or hardware_usage.infer_gpu_from_hardware(),
+        num_gpus=engine_config.num_devices,
+    )
+    _push_telemetry_report(telemetry_model)

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence
 
 import ray
 from ray import serve
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._common.usage.usage_lib import (
     get_hardware_usages_to_report,
     record_extra_usage_tag,
@@ -14,6 +15,7 @@ from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.observability.telemetry_utils import DEFAULT_GPU_TYPE
 from ray.llm._internal.common.utils.lora_utils import get_lora_model_ids
 from ray.llm._internal.serve.observability.logging import get_logger
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
@@ -206,9 +208,6 @@ def _get_or_create_telemetry_agent() -> TelemetryAgent:
     ``get_if_exists`` makes creation atomic, so concurrent replicas converge on a
     single actor without racing on the name.
     """
-    from ray._common.constants import HEAD_NODE_RESOURCE_NAME
-    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-
     return TelemetryAgent.options(
         name=LLM_SERVE_TELEMETRY_ACTOR_NAME,
         namespace=LLM_SERVE_TELEMETRY_NAMESPACE,

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -301,21 +301,31 @@ def _push_model_telemetry(
         )
         initial_num_lora_adapters = len(lora_model_ids)
 
-    use_autoscaling = model.deployment_config.get("autoscaling_config") is not None
+    deployment_config = model.deployment_config
+    autoscaling_config = deployment_config.get("autoscaling_config")
+    if deployment_config.get("num_replicas") == "auto":
+        # "auto" resolves to an autoscaling config; mirror LLMConfig validation
+        # since the stored deployment_config keeps the literal "auto".
+        from ray.serve._private.config import handle_num_replicas_auto
+
+        _, autoscaling_config = handle_num_replicas_auto(
+            deployment_config.get("max_ongoing_requests"), autoscaling_config
+        )
+
+    use_autoscaling = autoscaling_config is not None
     if use_autoscaling:
         from ray.serve.config import AutoscalingConfig
 
-        autoscaling_config = AutoscalingConfig(
-            **model.deployment_config["autoscaling_config"]
-        )
+        if isinstance(autoscaling_config, dict):
+            autoscaling_config = AutoscalingConfig(**autoscaling_config)
         num_replicas = (
             autoscaling_config.initial_replicas or autoscaling_config.min_replicas
         )
         min_replicas = autoscaling_config.min_replicas
         max_replicas = autoscaling_config.max_replicas
     else:
-        # Fixed replica count; honor the configured value rather than assuming 1.
-        num_replicas = model.deployment_config.get("num_replicas", 1)
+        # Fixed replica count; honor the configured value, defaulting to 1.
+        num_replicas = deployment_config.get("num_replicas") or 1
         min_replicas = max_replicas = num_replicas
 
     engine_config = model.get_engine_config()

--- a/python/ray/llm/tests/batch/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/batch/observability/usage_telemetry/test_usage.py
@@ -35,6 +35,7 @@ def test_push_telemetry_report():
         recorder.record.remote(key, value)
 
     telemetry_agent = get_or_create_telemetry_agent()
+    ray.get(telemetry_agent.remote_telemetry_agent._reset.remote())
     telemetry_agent._update_record_tag_func(record_tag_func)
 
     config = vLLMEngineProcessorConfig(
@@ -73,13 +74,13 @@ def test_push_telemetry_report():
     assert telemetry == {
         TagKey.LLM_BATCH_PROCESSOR_CONFIG_NAME: "vLLMEngineProcessorConfig,HttpRequestProcessorConfig",
         TagKey.LLM_BATCH_MODEL_ARCHITECTURE: "OPTForCausalLM,",
-        TagKey.LLM_BATCH_SIZE: "64,0",
+        TagKey.LLM_BATCH_SIZE: "64,64",
         TagKey.LLM_BATCH_ACCELERATOR_TYPE: "A10G,",
         TagKey.LLM_BATCH_CONCURRENCY: "4,4",
         TagKey.LLM_BATCH_TASK_TYPE: "generate,",
         TagKey.LLM_BATCH_PIPELINE_PARALLEL_SIZE: "1,0",
         TagKey.LLM_BATCH_TENSOR_PARALLEL_SIZE: "1,0",
-        TagKey.LLM_BATCH_DATA_PARALLEL_SIZE: "0,0",
+        TagKey.LLM_BATCH_DATA_PARALLEL_SIZE: "1,0",
     }, f"actual telemetry: {telemetry}"
 
 

--- a/python/ray/llm/tests/batch/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/batch/observability/usage_telemetry/test_usage.py
@@ -5,6 +5,7 @@ import pytest
 import ray
 from ray._common.usage.usage_lib import TagKey
 from ray.llm._internal.batch.observability.usage_telemetry.usage import (
+    BatchModelTelemetry,
     get_or_create_telemetry_agent,
 )
 from ray.llm._internal.batch.processor import ProcessorBuilder
@@ -82,6 +83,42 @@ def test_push_telemetry_report():
         TagKey.LLM_BATCH_TENSOR_PARALLEL_SIZE: "1,0",
         TagKey.LLM_BATCH_DATA_PARALLEL_SIZE: "1,0",
     }, f"actual telemetry: {telemetry}"
+
+
+def test_telemetry_dedups_by_model_identity():
+    """Distinct models sharing reported fields stay separate; identical builds merge."""
+    recorder = FakeTelemetryRecorder.remote()
+
+    def record_tag_func(key, value):
+        ray.get(recorder.record.remote(key, value))
+
+    telemetry_agent = get_or_create_telemetry_agent()
+    ray.get(telemetry_agent.remote_telemetry_agent._reset.remote())
+    telemetry_agent._update_record_tag_func(record_tag_func)
+
+    # Two distinct models with identical reported fields (same architecture/config).
+    common = dict(
+        model_architecture="LlamaForCausalLM",
+        batch_size=64,
+        concurrency=4,
+        task_type="generate",
+    )
+    telemetry_agent.push_telemetry_report(
+        BatchModelTelemetry(model_id_hash="hash_a", **common)
+    )
+    telemetry_agent.push_telemetry_report(
+        BatchModelTelemetry(model_id_hash="hash_b", **common)
+    )
+    # A repeated identical build of model A must not add a third entry.
+    telemetry_agent.push_telemetry_report(
+        BatchModelTelemetry(model_id_hash="hash_a", **common)
+    )
+
+    telemetry = ray.get(recorder.telemetry.remote())
+    assert (
+        telemetry[TagKey.LLM_BATCH_MODEL_ARCHITECTURE]
+        == "LlamaForCausalLM,LlamaForCausalLM"
+    ), f"actual telemetry: {telemetry}"
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
@@ -239,6 +239,34 @@ def test_telemetry_reports_fixed_num_replicas(disable_placement_bundles):
     assert telemetry[TagKey.LLM_SERVE_NUM_REPLICAS] == "4"
 
 
+def test_telemetry_reports_zero_num_replicas(disable_placement_bundles):
+    """An explicit num_replicas=0 is reported as 0, not coerced to 1."""
+    recorder = TelemetryRecorder.remote()
+
+    def record_tag_func(key, value):
+        ray.get(recorder.record.remote(key, value))
+
+    telemetry_agent = _get_or_create_telemetry_agent()
+    telemetry_agent._reset_models.remote()
+    telemetry_agent._update_record_tag_func.remote(record_tag_func)
+
+    config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="zero_replicas_model"),
+        llm_engine=LLMEngine.vLLM,
+        accelerator_type="L4",
+        deployment_config=dict(num_replicas=0),
+    )
+    config._set_model_architecture(model_architecture="zero_arch")
+
+    push_telemetry_report_for_all_models(
+        all_models=[config],
+        get_hardware_fn=lambda *a, **k: ["L4"],
+    )
+
+    telemetry = ray.get(recorder.telemetry.remote())
+    assert telemetry[TagKey.LLM_SERVE_NUM_REPLICAS] == "0"
+
+
 def test_telemetry_reports_auto_num_replicas(disable_placement_bundles):
     """num_replicas="auto" is reported as autoscaling, not dropped."""
     recorder = TelemetryRecorder.remote()

--- a/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
@@ -239,5 +239,35 @@ def test_telemetry_reports_fixed_num_replicas(disable_placement_bundles):
     assert telemetry[TagKey.LLM_SERVE_NUM_REPLICAS] == "4"
 
 
+def test_telemetry_reports_auto_num_replicas(disable_placement_bundles):
+    """num_replicas="auto" is reported as autoscaling, not dropped."""
+    recorder = TelemetryRecorder.remote()
+
+    def record_tag_func(key, value):
+        recorder.record.remote(key, value)
+
+    telemetry_agent = _get_or_create_telemetry_agent()
+    telemetry_agent._reset_models.remote()
+    telemetry_agent._update_record_tag_func.remote(record_tag_func)
+
+    config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="auto_replicas_model"),
+        llm_engine=LLMEngine.vLLM,
+        accelerator_type="L4",
+        deployment_config=dict(num_replicas="auto"),
+    )
+    config._set_model_architecture(model_architecture="auto_arch")
+
+    push_telemetry_report_for_all_models(
+        all_models=[config],
+        get_hardware_fn=lambda *a, **k: ["L4"],
+    )
+
+    telemetry = ray.get(recorder.telemetry.remote())
+    # Recorded as autoscaling with an integer replica count (not the string "auto").
+    assert telemetry[TagKey.LLM_SERVE_AUTOSCALING_ENABLED_MODELS] == "auto_arch"
+    assert telemetry[TagKey.LLM_SERVE_NUM_REPLICAS].isdigit()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
@@ -34,7 +34,7 @@ def test_push_telemetry_report_for_all_models(disable_placement_bundles):
     recorder = TelemetryRecorder.remote()
 
     def record_tag_func(key, value):
-        recorder.record.remote(key, value)
+        ray.get(recorder.record.remote(key, value))
 
     telemetry_agent = _get_or_create_telemetry_agent()
     telemetry_agent._reset_models.remote()
@@ -185,7 +185,7 @@ def test_telemetry_dedups_replicas_and_restarts(disable_placement_bundles):
     recorder = TelemetryRecorder.remote()
 
     def record_tag_func(key, value):
-        recorder.record.remote(key, value)
+        ray.get(recorder.record.remote(key, value))
 
     telemetry_agent = _get_or_create_telemetry_agent()
     telemetry_agent._reset_models.remote()
@@ -216,7 +216,7 @@ def test_telemetry_reports_fixed_num_replicas(disable_placement_bundles):
     recorder = TelemetryRecorder.remote()
 
     def record_tag_func(key, value):
-        recorder.record.remote(key, value)
+        ray.get(recorder.record.remote(key, value))
 
     telemetry_agent = _get_or_create_telemetry_agent()
     telemetry_agent._reset_models.remote()
@@ -244,7 +244,7 @@ def test_telemetry_reports_auto_num_replicas(disable_placement_bundles):
     recorder = TelemetryRecorder.remote()
 
     def record_tag_func(key, value):
-        recorder.record.remote(key, value)
+        ray.get(recorder.record.remote(key, value))
 
     telemetry_agent = _get_or_create_telemetry_agent()
     telemetry_agent._reset_models.remote()

--- a/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/serve/cpu/observability/usage_telemetry/test_usage.py
@@ -122,8 +122,6 @@ def test_push_telemetry_report_for_all_models(disable_placement_bundles):
     assert telemetry == {
         TagKey.LLM_SERVE_SERVE_MULTIPLE_MODELS: "1",
         TagKey.LLM_SERVE_SERVE_MULTIPLE_APPS: "0",
-        TagKey.LLM_SERVE_JSON_MODE_MODELS: "llm_model_arch,llm_config_autoscale_model_arch,llm_config_json_model_arch,llm_config_lora_model_arch,llm_config_no_accelerator_type_arch",
-        TagKey.LLM_SERVE_JSON_MODE_NUM_REPLICAS: "1,2,1,1,1",
         TagKey.LLM_SERVE_LORA_BASE_MODELS: "llm_config_lora_model_arch",
         TagKey.LLM_SERVE_INITIAL_NUM_LORA_ADAPTERS: "2",
         TagKey.LLM_SERVE_AUTOSCALING_ENABLED_MODELS: "llm_config_autoscale_model_arch",
@@ -180,6 +178,65 @@ def test_infer_gpu_from_hardware():
 
     result = HardwareUsage(fake_get_gpu_type).infer_gpu_from_hardware()
     assert result == "UNSPECIFIED"
+
+
+def test_telemetry_dedups_replicas_and_restarts(disable_placement_bundles):
+    """The same model reported by many replicas/restarts collapses to one entry."""
+    recorder = TelemetryRecorder.remote()
+
+    def record_tag_func(key, value):
+        recorder.record.remote(key, value)
+
+    telemetry_agent = _get_or_create_telemetry_agent()
+    telemetry_agent._reset_models.remote()
+    telemetry_agent._update_record_tag_func.remote(record_tag_func)
+
+    config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="dup_model_id"),
+        llm_engine=LLMEngine.vLLM,
+        accelerator_type="L4",
+    )
+    config._set_model_architecture(model_architecture="dup_arch")
+
+    # Simulate three replicas (or restarts) of the SAME model reporting.
+    for _ in range(3):
+        push_telemetry_report_for_all_models(
+            all_models=[config],
+            get_hardware_fn=lambda *a, **k: ["L4"],
+        )
+
+    telemetry = ray.get(recorder.telemetry.remote())
+    assert telemetry[TagKey.LLM_SERVE_MODELS] == "dup_arch"
+    assert telemetry[TagKey.LLM_SERVE_NUM_REPLICAS] == "1"
+    assert telemetry[TagKey.LLM_SERVE_GPU_TYPE] == "L4"
+
+
+def test_telemetry_reports_fixed_num_replicas(disable_placement_bundles):
+    """A fixed (non-autoscaling) num_replicas is reported, not hardcoded to 1."""
+    recorder = TelemetryRecorder.remote()
+
+    def record_tag_func(key, value):
+        recorder.record.remote(key, value)
+
+    telemetry_agent = _get_or_create_telemetry_agent()
+    telemetry_agent._reset_models.remote()
+    telemetry_agent._update_record_tag_func.remote(record_tag_func)
+
+    config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="fixed_replicas_model"),
+        llm_engine=LLMEngine.vLLM,
+        accelerator_type="L4",
+        deployment_config=dict(num_replicas=4),
+    )
+    config._set_model_architecture(model_architecture="fixed_arch")
+
+    push_telemetry_report_for_all_models(
+        all_models=[config],
+        get_hardware_fn=lambda *a, **k: ["L4"],
+    )
+
+    telemetry = ray.get(recorder.telemetry.remote())
+    assert telemetry[TagKey.LLM_SERVE_NUM_REPLICAS] == "4"
 
 
 if __name__ == "__main__":

--- a/src/ray/protobuf/usage.proto
+++ b/src/ray/protobuf/usage.proto
@@ -223,10 +223,11 @@ enum TagKey {
   // Whether or not multiple applications are getting deployed in the
   // cluster ("1" if used).
   LLM_SERVE_SERVE_MULTIPLE_APPS = 601;
-  // Comma separated list of models that supports json mode.
-  LLM_SERVE_JSON_MODE_MODELS = 602;
-  // Comma separated list of number of replicas that supports json mode.
-  LLM_SERVE_JSON_MODE_NUM_REPLICAS = 603;
+  // 602, 603 were JSON_MODE_MODELS / JSON_MODE_NUM_REPLICAS. JSON/structured
+  // output is a per-request feature with no deployment-time toggle, so these
+  // duplicated MODELS/NUM_REPLICAS and are no longer recorded.
+  reserved 602, 603;
+  reserved "LLM_SERVE_JSON_MODE_MODELS", "LLM_SERVE_JSON_MODE_NUM_REPLICAS";
   // Comma separated list of models that supports LoRA.
   LLM_SERVE_LORA_BASE_MODELS = 604;
   // Comma separated list of initial number of LoRA adapters.
@@ -261,7 +262,7 @@ enum TagKey {
   // Comma separated list of accelerator types used to build processor.
   // Example: "A10G,L40S"
   LLM_BATCH_ACCELERATOR_TYPE = 617;
-  // Comma separated list of numbers of workers for data parallelism.
+  // Comma separated list of concurrency values used to build processor.
   // Example: "4"
   LLM_BATCH_CONCURRENCY = 618;
   // Comma separated list of task types used to build vLLM engine processor.


### PR DESCRIPTION
## Why are these changes needed?

An audit of the LLM usage telemetry found the per-model statistics are structurally wrong, independent of any particular deployment. The detached telemetry actor appends one entry to its model list **per replica engine-start** (and again on every restart / autoscale / redeploy) and is never reset, so each comma-joined tag:

- grows **without bound** over a long-lived cluster's lifetime (risking silent truncation at the usage-tag value size limit), and
- duplicates each model by its replica/restart count, inflating every per-model list and count.

Two values were also wrong by construction: `num_replicas` was hardcoded to `1` for non-autoscaling deployments (and `num_replicas="auto"` was dropped entirely, since the stored config keeps the literal string), and the JSON_MODE tags were built from a hardcoded `use_json_mode=True` for a dimension that has no deployment-time config, making them duplicates of the MODELS / NUM_REPLICAS tags. These are observable failure modes, not hypothetical.

### Serve (`observability/usage_telemetry/usage.py`)
- **Dedup by `model_id`** (last-write-wins dict) instead of an append-only list. Fixes the double-counting across replicas/restarts and the unbounded memory growth on the head-node actor; tags now carry one entry per distinct model. `model_id` is identity only and is never recorded as a value.
- **Report the configured replica count**: fixed `num_replicas` instead of hardcoded `1`, and resolve `num_replicas="auto"` to its autoscaling config (reported as autoscaling) rather than dropping it.
- **Drop the JSON_MODE tags** (proto 602/603 `reserved`); they carried no signal.
- **Telemetry can no longer break engine start**: `_multiple_apps` never raises, and per-model reporting is wrapped so a failure is logged, not propagated.
- **Atomic agent creation** via `get_if_exists`; removed the shadowed retry args.

### Batch (`batch/observability/usage_telemetry/usage.py` + processors)
- Same dedup fix (key by telemetry identity) plus a `_reset` hook.
- Guarded, atomic agent creation and a non-raising push path so telemetry cannot break processor construction.
- HTTP processor now passes `batch_size`; vLLM processor now sources `data_parallel_size` (both previously reported 0).
- Fixed the `LLM_BATCH_CONCURRENCY` proto comment.

### Tests
Updated existing expectations and added regression tests: replica/restart dedup, fixed `num_replicas`, and `num_replicas="auto"` reported as autoscaling.

> [!NOTE]
> This reserves two released usage tags (602/603) and stops recording them. Per the proto header, data-collection changes need sign-off from @pcmoritz / @thomasdesr.

## Checks
- [x] Added regression tests.
- [x] Signed off with DCO.