### PR TITLE
[Data] Support ignore_missing_paths in read_parquet

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -394,6 +394,7 @@ class ParquetDatasource(Datasource):
         include_paths: bool = False,
         include_row_hash: bool = False,
         file_extensions: Optional[List[str]] = None,
+        ignore_missing_paths: bool = False,
     ):
         super().__init__()
         _check_pyarrow_version()
@@ -428,12 +429,19 @@ class ParquetDatasource(Datasource):
             filesystem,
             partition_filter=partition_filter,
             file_extensions=file_extensions,
+            ignore_missing_paths=ignore_missing_paths,
         )
 
         if listed_files:
             paths, file_sizes = zip(*listed_files)
         else:
             paths, file_sizes = [], []
+
+        if ignore_missing_paths and len(paths) == 0:
+            raise ValueError(
+                "None of the provided paths exist. "
+                "The 'ignore_missing_paths' field is set to True."
+            )
 
         if dataset_kwargs is not None:
             logger.warning(

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -214,6 +214,7 @@ def _list_files(
     *,
     partition_filter: Optional[PathPartitionFilter],
     file_extensions: Optional[List[str]],
+    ignore_missing_paths: bool = False,
 ) -> List[Tuple[str, int]]:
     return list(
         _list_files_internal(
@@ -221,6 +222,7 @@ def _list_files(
             filesystem,
             partition_filter=partition_filter,
             file_extensions=file_extensions,
+            ignore_missing_paths=ignore_missing_paths,
         )
     )
 
@@ -231,10 +233,13 @@ def _list_files_internal(
     *,
     partition_filter: Optional[PathPartitionFilter],
     file_extensions: Optional[List[str]],
+    ignore_missing_paths: bool = False,
 ) -> Iterator[Tuple[str, int]]:
     default_meta_provider = DefaultFileMetadataProvider()
 
-    for path, file_size in default_meta_provider.expand_paths(paths, filesystem):
+    for path, file_size in default_meta_provider.expand_paths(
+        paths, filesystem, ignore_missing_paths=ignore_missing_paths
+    ):
         # HACK: PyArrow's `ParquetDataset` errors if input paths contain non-parquet
         # files. To avoid this, we expand the input paths with the default metadata
         # provider and then apply the partition filter or file extensions.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1142,6 +1142,7 @@ def read_parquet(
     include_paths: bool = False,
     include_row_hash: bool = False,
     file_extensions: Optional[List[str]] = ParquetDatasource._FILE_EXTENSIONS,
+    ignore_missing_paths: bool = False,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
     **arrow_parquet_args,
@@ -1273,6 +1274,8 @@ def read_parquet(
             returned dataset and include ``'row_hash'`` explicitly in the list
             to retain it.
         file_extensions: A list of file extensions to filter files by.
+        ignore_missing_paths: If True, ignores any file/directory paths in ``paths``
+            that are not found. Defaults to False.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
             to control number of tasks to run concurrently. This doesn't change the
             total number of tasks run or the total number of output blocks. By default,
@@ -1386,6 +1389,7 @@ def read_parquet(
             filesystem=filesystem,
             partitioning=partitioning,
             file_extensions=file_extensions,
+            ignore_missing_paths=ignore_missing_paths,
             include_paths=include_paths,
             include_row_hash=include_row_hash,
             shuffle=shuffle,
@@ -1422,6 +1426,7 @@ def read_parquet(
         include_paths=include_paths,
         include_row_hash=include_row_hash,
         file_extensions=file_extensions,
+        ignore_missing_paths=ignore_missing_paths,
     )
     return read_datasource(
         datasource,

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -3253,6 +3253,47 @@ def test_read_parquet_nested_fallback_skipped_when_only_flat_columns_selected(
         mock_safe.assert_not_called()
 
 
+def test_read_parquet_ignore_missing_paths_true(
+    ray_start_regular_shared, tmp_path, use_datasource_v2
+):
+    path = os.path.join(tmp_path, "data.parquet")
+    table = pa.table({"id": [0, 1, 2]})
+    pq.write_table(table, path)
+
+    missing = os.path.join(tmp_path, "missing.parquet")
+    ds = ray.data.read_parquet([path, missing], ignore_missing_paths=True)
+
+    assert sorted(row["id"] for row in ds.take_all()) == [0, 1, 2]
+
+
+def test_read_parquet_ignore_missing_paths_false(
+    ray_start_regular_shared, tmp_path, use_datasource_v2
+):
+    path = os.path.join(tmp_path, "data.parquet")
+    pq.write_table(pa.table({"id": [0, 1, 2]}), path)
+
+    missing = os.path.join(tmp_path, "missing.parquet")
+    with pytest.raises(FileNotFoundError):
+        ray.data.read_parquet([path, missing], ignore_missing_paths=False).take_all()
+
+
+def test_read_parquet_ignore_missing_paths_all_missing(
+    ray_start_regular_shared, tmp_path, restore_data_context
+):
+    # When every path is missing and ``ignore_missing_paths=True``, the V1
+    # datasource raises, matching ``FileBasedDatasource``'s behavior for the
+    # other file-based readers. (The V2 datasource instead yields an empty
+    # dataset, consistent with its shared ``ListFiles`` empty-input handling.)
+    restore_data_context.use_datasource_v2 = False
+
+    missing1 = os.path.join(tmp_path, "missing1.parquet")
+    missing2 = os.path.join(tmp_path, "missing2.parquet")
+    with pytest.raises(ValueError):
+        ray.data.read_parquet(
+            [missing1, missing2], ignore_missing_paths=True
+        ).take_all()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?

`ray.data.read_parquet` raises `FileNotFoundError` if any input path is
missing, with no way to skip missing paths. Every other file-based `read_*`
function already exposes `ignore_missing_paths` (via `FileBasedDatasource`),
but `ParquetDatasource` extends `Datasource` directly and lacked it.

This adds `ignore_missing_paths: bool = False` to `read_parquet`, wired
through both the V1 (`ParquetDatasource`) and V2 (`ParquetDatasourceV2`)
code paths, threading it into `_list_files` → `expand_paths`. When every
path is missing, V1 raises the same "None of the provided paths exist"
`ValueError` as the other file-based readers.

Tests cover skip-missing, raise-on-missing, and all-missing across both
the V1 and V2 datasource paths.

## Related issue number
CI-1223

## Checks

- [x] Added tests
- [x] Lint (pre-commit) passes