### PR TITLE
[Core] Fix SafeFallbackEncoder to serialize objects using to_dict

### DIFF
--- a/python/ray/air/_internal/json.py
+++ b/python/ray/air/_internal/json.py
@@ -11,6 +11,10 @@ class SafeFallbackEncoder(json.JSONEncoder):
 
     def default(self, value):
         try:
+            to_dict = getattr(value, "to_dict", None)
+            if callable(to_dict):
+                return to_dict()
+
             if type(value).__module__ == np.__name__ and isinstance(value, np.ndarray):
                 return value.tolist()
 

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -175,6 +175,23 @@ class LoggerSuite(unittest.TestCase):
 
         self.assertEqual(loaded_config, config)
 
+    def testJSONWithToDict(self):
+        class MyConfig:
+            def to_dict(self):
+                return {"foo": "bar"}
+
+        config = {"a": 2, "algo_config": MyConfig()}
+        t = Trial(evaluated_params=config, trial_id="json2", logdir=self.test_dir)
+        logger = JsonLoggerCallback()
+        logger.on_trial_result(0, [], t, result(0, 4))
+        logger.on_trial_complete(1, [], t)
+
+        config_file = os.path.join(self.test_dir, EXPR_PARAM_FILE)
+        with open(config_file, "rt") as fp:
+            loaded_config = json.load(fp)
+
+        self.assertEqual(loaded_config, {"a": 2, "algo_config": {"foo": "bar"}})
+
     def testTBX(self):
         config = {
             "a": 2,

--- a/rllib/algorithms/tests/test_algorithm.py
+++ b/rllib/algorithms/tests/test_algorithm.py
@@ -574,6 +574,40 @@ class TestAlgorithm(unittest.TestCase):
         counter_values2 = list(algo2._counters.values())
         self.assertEqual(counter_values, counter_values2)
 
+    def test_params_json_serialization(self):
+        """Test that Tune properly serializes RLlib config to params.json."""
+        import json
+        import os
+
+        from ray import tune
+
+        config = ppo.PPOConfig().environment(env="CartPole-v1")
+
+        tuner = tune.Tuner(
+            "PPO",
+            param_space=config,
+            run_config=tune.RunConfig(
+                stop={"training_iteration": 1},
+                storage_path=os.path.abspath("test_params_json"),
+                name="test_params_json_exp",
+            ),
+        )
+        results = tuner.fit()
+        logdir = results.get_best_result().path
+        params_json_path = os.path.join(logdir, "params.json")
+
+        # Verify params.json exists
+        self.assertTrue(os.path.exists(params_json_path))
+
+        # Verify it can be loaded as a dictionary (and not a string)
+        with open(params_json_path, "rt") as f:
+            params = json.load(f)
+
+        self.assertTrue(isinstance(params, dict))
+        # Ensure it's not the string representation of PPOConfig
+        self.assertTrue("env" in params)
+        self.assertEqual(params["env"], "CartPole-v1")
+
     def _assert_modules_added(
         self,
         *,


### PR DESCRIPTION
## Why are these changes needed?

Fixes #50051 

Currently, when running training using the PPO algorithm (or other RLlib algorithms), the `params.json` file generated in the experiment directory contains a string representation of the `AlgorithmConfig` object (e.g., `"<ray.rllib.algorithms.ppo.ppo.PPOConfig object at 0x...>"`) instead of a valid JSON dictionary of parameters. This prevents users from having an interoperable, human-readable JSON log of the algorithm configuration.

This occurs because `PPOConfig` does not subclass the primitive types that the `SafeFallbackEncoder` inherently supports, causing the encoder to fallback to `str(value)`. 

This PR fixes the issue by updating `SafeFallbackEncoder` in `ray/air/_internal/json.py` to check if the provided object has a callable `to_dict` method. Since `AlgorithmConfig` classes implement `to_dict()`, this ensures they are correctly serialized as a dictionary structure, recursively parsing the rest of the configuration.

## Related issue number

Closes #50051 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
