### PR TITLE
[serve][llm] Co-locate DP rank 0 worker with advertised master address

### DIFF
--- a/python/ray/llm/_internal/serve/serving_patterns/data_parallel/dp_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/data_parallel/dp_server.py
@@ -5,6 +5,7 @@ import os
 import time
 from typing import List, Optional, Tuple, Type
 
+import ray
 from ray import serve
 from ray.experimental.internal_kv import (
     _internal_kv_del,
@@ -41,10 +42,12 @@ class GangMasterInfoRegistry:
         return (cls._KEY_PREFIX + gang_id).encode("utf-8")
 
     @classmethod
-    def register(cls, gang_id: str, address: str, port: int) -> None:
+    def register(cls, gang_id: str, address: str, port: int, node_id: str) -> None:
         """Store the DP master info in GCS KV store."""
         key = cls._make_key(gang_id)
-        value = json.dumps({"address": address, "port": port}).encode("utf-8")
+        value = json.dumps(
+            {"address": address, "port": port, "node_id": node_id}
+        ).encode("utf-8")
         _internal_kv_put(key, value, overwrite=True)
 
     @classmethod
@@ -65,7 +68,7 @@ class GangMasterInfoRegistry:
         gang_id: str,
         timeout: float = TIMEOUT_SECONDS,
         poll_interval: float = POLL_INTERVAL_SECONDS,
-    ) -> Tuple[str, int]:
+    ) -> Tuple[str, int, str]:
         """Retrieve the DP master info for gang_id, polling until available.
 
         Args:
@@ -74,7 +77,7 @@ class GangMasterInfoRegistry:
             poll_interval: The poll interval in seconds.
 
         Returns:
-            A tuple of (address, port).
+            A tuple of (address, port, node_id).
 
         Raises:
             TimeoutError: If the info is not available within timeout_seconds seconds.
@@ -85,7 +88,7 @@ class GangMasterInfoRegistry:
             data = _internal_kv_get(key)
             if data is not None:
                 info = json.loads(data)
-                return info["address"], info["port"]
+                return info["address"], info["port"], info["node_id"]
             if time.monotonic() >= deadline:
                 raise TimeoutError(
                     f"Timed out waiting for DP master info for gang {gang_id} "
@@ -129,23 +132,32 @@ class DPServer(LLMServer):
 
         if self.dp_rank == 0:
             self.dp_address, self.dp_rpc_port = get_address_and_port()
+            # Record rank 0's node so every replica places vLLM's global rank 0
+            # worker (which hosts the distributed rendezvous store) on the same
+            # node whose address we advertise below. See the bundle-ordering
+            # comment in __init__ for why this matters.
+            self.dp_node_id = ray.get_runtime_context().get_node_id()
             GangMasterInfoRegistry.register(
-                self.gang_id, self.dp_address, self.dp_rpc_port
+                self.gang_id, self.dp_address, self.dp_rpc_port, self.dp_node_id
             )
             logger.info(
                 f"DP rank {self.dp_rank} has set DP master info: "
                 f"data_parallel_address={self.dp_address}, "
-                f"data_parallel_rpc_port={self.dp_rpc_port}"
+                f"data_parallel_rpc_port={self.dp_rpc_port}, "
+                f"data_parallel_node_id={self.dp_node_id}"
             )
         else:
             timestamp = time.time()
-            self.dp_address, self.dp_rpc_port = await GangMasterInfoRegistry.get(
-                self.gang_id
-            )
+            (
+                self.dp_address,
+                self.dp_rpc_port,
+                self.dp_node_id,
+            ) = await GangMasterInfoRegistry.get(self.gang_id)
             logger.info(
                 f"DP rank {self.dp_rank} got DP master info: "
                 f"data_parallel_address={self.dp_address}, "
                 f"data_parallel_rpc_port={self.dp_rpc_port}, "
+                f"data_parallel_node_id={self.dp_node_id}, "
                 f"waited {time.time() - timestamp:.3f} seconds"
             )
 
@@ -165,9 +177,21 @@ class DPServer(LLMServer):
         #
         # However, adjacent bundle indices in a placement group don't necessarily
         # map to adjacent physical ranks. We use get_bundle_indices_sorted_by_node
-        # to reorder bundle indices so that same-node bundles are adjacent and the
-        # driver node's bundles come first. This prevents us from scattering adjacent
-        # TP ranks in the same DP rank across nodes.
+        # to reorder bundle indices so that same-node bundles are adjacent and
+        # rank 0's node bundles come first. This prevents us from scattering
+        # adjacent TP ranks in the same DP rank across nodes.
+        #
+        # Ordering rank 0's node first is also required for correctness: vLLM
+        # forms a single distributed group across all DP workers whose rendezvous
+        # store is hosted by global rank 0 and reached at the advertised
+        # data_parallel_address (set above from rank 0's node). vLLM pins global
+        # rank 0 to sorted_indices[0], so that bundle must live on the same node
+        # whose address we advertised. Sorting by the cluster head node instead
+        # (the previous default) breaks this whenever the head node owns no
+        # bundles in the gang (e.g. a CPU-only head in a GPU cluster): rank 0
+        # then lands on an arbitrary node, the store binds there, and every
+        # worker hangs connecting to the wrong (advertised) address until the
+        # distributed-init timeout fires and the gang is restarted.
         #
         # Example: dp_size=2, tp_size=2, 2 GPUs per node for simplicity
         #   Gang placement group = [{GPU: 1}, {GPU: 1}, {GPU: 1}, {GPU: 1}]
@@ -179,7 +203,9 @@ class DPServer(LLMServer):
         # not the per-replica placement group.
         bundles_per_replica = len(engine_config.placement_bundles)
         pg = get_placement_group(gang_context.pg_name)
-        sorted_indices = get_bundle_indices_sorted_by_node(pg)
+        sorted_indices = get_bundle_indices_sorted_by_node(
+            pg, driver_node_id=self.dp_node_id
+        )
         os.environ["VLLM_RAY_BUNDLE_INDICES"] = self._compute_bundle_indices(
             self.dp_rank, bundles_per_replica, sorted_indices
         )

--- a/python/ray/llm/_internal/serve/utils/pg_utils.py
+++ b/python/ray/llm/_internal/serve/utils/pg_utils.py
@@ -1,7 +1,7 @@
 """Placement group utilities for Ray LLM Serve."""
 
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ray.serve._private.utils import get_head_node_id
 from ray.util.placement_group import PlacementGroup, placement_group_table
@@ -38,6 +38,7 @@ def _sort_bundle_indices_by_node(
 
 def get_bundle_indices_sorted_by_node(
     pg: PlacementGroup,
+    driver_node_id: Optional[str] = None,
 ) -> List[int]:
     """Return bundle indices sorted such that same-node bundles are adjacent, driver node first.
 
@@ -45,15 +46,23 @@ def get_bundle_indices_sorted_by_node(
     necessarily map to the same physical node. This utility reorders bundle
     indices so that bundles on the same node are grouped together.
 
-    The driver node's bundles come first so that rank 0 is co-located with the driver.
+    The driver node's bundles come first so that global rank 0 (which hosts the
+    distributed rendezvous store) is co-located with the driver.
 
     Args:
         pg: A ready placement group.
+        driver_node_id: Node ID whose bundles should be ordered first. Callers
+            should pass the node that advertises the distributed master address
+            so that global rank 0 is co-located with it. Defaults to the cluster
+            head node, which may not own any of the placement group's bundles
+            (e.g. a CPU-only head node in a GPU cluster), in which case rank 0
+            falls back to the lexicographically-first node.
 
     Returns:
         List of bundle indices sorted such that same-node bundles are adjacent, driver node first.
     """
     table = placement_group_table(pg)
     bundles_to_node_id = table["bundles_to_node_id"]
-    driver_node_id = get_head_node_id()
+    if driver_node_id is None:
+        driver_node_id = get_head_node_id()
     return _sort_bundle_indices_by_node(bundles_to_node_id, driver_node_id)

--- a/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_server.py
@@ -120,15 +120,19 @@ class TestGangMasterInfoRegistry:
         mock_put.side_effect = fake_put
         mock_get.side_effect = fake_get
 
-        GangMasterInfoRegistry.register("gang-1", "10.0.0.1", 1111)
-        GangMasterInfoRegistry.register("gang-2", "10.0.0.2", 2222)
+        GangMasterInfoRegistry.register("gang-1", "10.0.0.1", 1111, "node-1")
+        GangMasterInfoRegistry.register("gang-2", "10.0.0.2", 2222, "node-2")
 
         loop = asyncio.get_event_loop()
-        addr1, port1 = loop.run_until_complete(GangMasterInfoRegistry.get("gang-1"))
-        addr2, port2 = loop.run_until_complete(GangMasterInfoRegistry.get("gang-2"))
+        addr1, port1, node1 = loop.run_until_complete(
+            GangMasterInfoRegistry.get("gang-1")
+        )
+        addr2, port2, node2 = loop.run_until_complete(
+            GangMasterInfoRegistry.get("gang-2")
+        )
 
-        assert (addr1, port1) == ("10.0.0.1", 1111)
-        assert (addr2, port2) == ("10.0.0.2", 2222)
+        assert (addr1, port1, node1) == ("10.0.0.1", 1111, "node-1")
+        assert (addr2, port2, node2) == ("10.0.0.2", 2222, "node-2")
 
 
 class TestBundleIndices:

--- a/python/ray/llm/tests/serve/utils/test_pg_utils.py
+++ b/python/ray/llm/tests/serve/utils/test_pg_utils.py
@@ -79,6 +79,47 @@ def test_sort_bundle_indices_by_node(
     assert result == expected_sorted_bundle_indices
 
 
+@pytest.mark.parametrize(
+    "bundles_to_node_id,driver_node_id,expected_sorted_bundle_indices",
+    [
+        # Explicit driver node orders that node's bundles first, even though the
+        # head node (NODE_A) also owns bundles.
+        pytest.param(
+            {0: NODE_A, 1: NODE_B, 2: NODE_A, 3: NODE_B},
+            NODE_B,
+            [1, 3, 0, 2],
+        ),
+        # Head node (NODE_A) owns no bundles; explicit driver still wins over
+        # lexicographic fallback (which would otherwise pick NODE_B first).
+        pytest.param(
+            {0: NODE_B, 1: NODE_C, 2: NODE_B, 3: NODE_C},
+            NODE_C,
+            [1, 3, 0, 2],
+        ),
+    ],
+)
+def test_explicit_driver_node_ordered_first(
+    bundles_to_node_id, driver_node_id, expected_sorted_bundle_indices
+):
+    mock_pg = MagicMock()
+
+    with (
+        patch(
+            "ray.llm._internal.serve.utils.pg_utils.placement_group_table",
+            return_value={"bundles_to_node_id": bundles_to_node_id},
+        ),
+        patch(
+            "ray.llm._internal.serve.utils.pg_utils.get_head_node_id",
+            return_value=NODE_A,
+        ),
+    ):
+        result = get_bundle_indices_sorted_by_node(
+            mock_pg, driver_node_id=driver_node_id
+        )
+
+    assert result == expected_sorted_bundle_indices
+
+
 # Integration test: verifies the full path through a real cluster, though
 # bundle ordering across nodes is non-deterministic and may already be sorted.
 @pytest.mark.parametrize("strategy", ["SPREAD", "PACK"])


### PR DESCRIPTION
## Why are these changes needed?

In multi-node data-parallel (DP) Serve deployments, `DPServer` advertises **rank 0's node address** as the vLLM distributed master (`data_parallel_address`), but `get_bundle_indices_sorted_by_node` ordered the gang placement-group bundles by the **cluster head node**. On a GPU cluster the head node typically owns *no* GPU bundles, so vLLM's global rank 0 worker — the process that binds the `world_size=N` torch-distributed rendezvous store — was pinned to `sorted_indices[0]` on an arbitrary node, **decoupled from the advertised master address**.

When those two diverged, the store bound on one node while every worker was told to connect to a different (advertised) address. The workers then hung for the full distributed-init connect timeout (`600000ms`) and raised:

```
torch.distributed.DistNetworkError: The client socket has timed out after 600000ms
while trying to connect to (<advertised-ip>, <port>).
```

The EngineCore died, and the deployment's `RESTART_GANG` failure policy tore down and restarted all replicas. The fresh gang hit the same mismatch, looping at ~20 min per attempt (dominated by the 600 s connect timeout) until a placement happened to align rank 0's worker with the advertised address. Observed in the `test_llm_serve_data_parallelism[1-8-...]` multi-node release test, where a single DP=8 case consumed ~42 min and blew the 1-hour workload timeout (the run exited 124; all individual tests that ran actually passed).

## What this changes

Order bundles so that **DP rank 0's own node comes first**, co-locating the rank 0 worker (rendezvous store host) with the replica whose address is advertised as the master. Concretely:

- `pg_utils.get_bundle_indices_sorted_by_node` gains an optional `driver_node_id` argument (defaults to the cluster head node, so existing callers are unchanged).
- `DPServer` rank 0 records its `node_id` in the gang master-info registry; all replicas read it back and pass it as `driver_node_id`, guaranteeing `sorted_indices[0]` lives on rank 0's node.

This keeps the rank 0 worker, the advertised `data_parallel_address`, and the DP coordinator on the same node, so the rendezvous address is always reachable and the gang comes up on the first attempt.

## Related issue number

N/A

## Checks

- [x] Added unit coverage: `test_pg_utils.py::test_explicit_driver_node_ordered_first` (driver node ordered first even when the head node owns no bundles); updated `test_dp_server.py` registry test for the new `node_id` field.
- [ ] **Needs a maintainer with a multi-node GPU env to run** `test_llm_serve_data_parallelism[1-8-...]` and confirm the DP=8 gang starts first-try (no `RESTART_GANG` loop). I could not run `ray`/`pytest` or reproduce multi-node behavior locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)