### PR TITLE
[DO-NOT-MERGE] [Data][release] Investigate `iter_batches` regression

### DIFF
--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -32,11 +32,96 @@ def parse_args() -> argparse.Namespace:
     )
     consume_group.add_argument("--write", action="store_true")
 
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument(
+        "--batch-target-bytes",
+        type=int,
+        default=None,
+        help=(
+            "Target in-memory batch size in bytes for --iter-batches. When set, "
+            "batch_size is computed at runtime from a sampled batch's bytes/row in "
+            "the active representation, so the same target fills differently with "
+            "and without --types-mapper. Overrides --batch-size."
+        ),
+    )
+    parser.add_argument(
+        "--types-mapper",
+        choices=["on", "off"],
+        default="off",
+        help=(
+            "Whether ArrowBlockAccessor.to_pandas uses the pd.ArrowDtype types_mapper "
+            "(PR #63017). 'off' (default) matches master; 'on' injects the mapper to "
+            "measure its iter_batches(pandas) cost."
+        ),
+    )
+
     return parser.parse_args()
+
+
+def set_types_mapper(mode: str) -> None:
+    """Release-test-only: deterministically set ArrowBlockAccessor.to_pandas to the
+    mapper path ('on' = PR #63017's pd.ArrowDtype types_mapper) or the no-mapper path
+    ('off' = pre-#63017), OVERRIDING whatever the checked-out code does. This lets one
+    branch A/B the mapper regardless of whether the base has it (the fix has a
+    revert/reapply history), with no product code change.
+
+    Patches the driver-side class method; iter_batches formats batches in the driver
+    threadpool, so this covers the consumed batches. The 'on' body mirrors #63017.
+    """
+    import pandas as pd
+    import pyarrow
+
+    from ray.data._internal import arrow_block
+    from ray.data.context import DataContext
+    from ray.data.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+
+    def to_pandas(self):
+        ctx = DataContext.get_current()
+        kwargs = {"ignore_metadata": ctx.pandas_block_ignore_metadata}
+        if mode == "on":
+
+            def _types_mapper(t):
+                if isinstance(t, pyarrow.BaseExtensionType) or pyarrow.types.is_dictionary(t):
+                    return None
+                return pd.ArrowDtype(t)
+
+            kwargs["types_mapper"] = _types_mapper
+
+        df = self._table.to_pandas(**kwargs)
+        if ctx.enable_tensor_extension_casting:
+            df = _cast_tensor_columns_to_ndarrays(df, arrow_schema=self._table.schema)
+        return df
+
+    arrow_block.ArrowBlockAccessor.to_pandas = to_pandas
+
+
+def compute_batch_size_for_target_bytes(args) -> int:
+    """Translate --batch-target-bytes into a row batch_size by sampling one batch
+    (untimed) and measuring its bytes/row in the active representation. Must run
+    after set_types_mapper so the sample reflects mapper on vs off."""
+    sample = get_read_fn(args)(args.path).take_batch(
+        4096, batch_format=args.iter_batches
+    )
+    bytes_per_row = sample.memory_usage(deep=True).sum() / len(sample)
+    batch_size = max(1, int(args.batch_target_bytes / bytes_per_row))
+    print(
+        f"[batch-target] {args.batch_target_bytes} bytes / "
+        f"{bytes_per_row:.1f} bytes-per-row -> batch_size={batch_size} "
+        f"(types_mapper={args.types_mapper})"
+    )
+    return batch_size
 
 
 def main(args):
     benchmark = Benchmark()
+
+    # Force the mapper on/off deterministically before any read so sampling and the
+    # timed run use the same representation (independent of the base's to_pandas).
+    set_types_mapper(args.types_mapper)
+
+    # Translate a byte target into a row batch_size using the actual data (untimed).
+    if args.batch_target_bytes and args.iter_batches:
+        args.batch_size = compute_batch_size_for_target_bytes(args)
 
     def benchmark_fn():
         read_fn = get_read_fn(args)
@@ -82,7 +167,8 @@ def get_consume_fn(args: argparse.Namespace) -> Callable[[ray.data.Dataset], Non
     elif args.iter_batches:
 
         def consume_fn(ds):
-            for _ in ds.iter_batches(batch_format=args.iter_batches):
+            kwargs = {} if args.batch_size is None else {"batch_size": args.batch_size}
+            for _ in ds.iter_batches(batch_format=args.iter_batches, **kwargs):
                 pass
 
     elif args.iter_torch_batches:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -528,7 +528,7 @@
     anyscale_sdk_2026: true
   matrix:
     setup:
-      batch_size: [32, 64, 128, 256, 1024, 4096]
+      batch_size: [32, 64, 128, 256, 512, 1024, 4096]
       mapper: ["on", "off"]
 
   run:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -519,6 +519,42 @@
       s3://ray-benchmark-data/tpch/parquet/sf10/lineitem --format parquet
       --iter-batches {{format}}
 
+# A/B the PR #63017 pd.ArrowDtype types_mapper against the row-count batch size.
+# The benchmark harness forces to_pandas on/off deterministically (no product code
+# change, independent of the base's to_pandas). bs256/mapper_on == regressed runtime.
+- name: "iter_batches_pandas_bs{{batch_size}}_mapper_{{mapper}}"
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+  matrix:
+    setup:
+      batch_size: [256, 1024, 4096]
+      mapper: ["on", "off"]
+
+  run:
+    timeout: 2400
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf10/lineitem --format parquet
+      --iter-batches pandas --batch-size {{batch_size}} --types-mapper {{mapper}}
+
+# Byte-target dimension: fill ~16 MiB batches, sized at runtime from the actual
+# bytes/row in each representation (~96K rows with the mapper, ~28K without).
+- name: "iter_batches_pandas_16mib_mapper_{{mapper}}"
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+  matrix:
+    setup:
+      mapper: ["on", "off"]
+
+  run:
+    timeout: 2400
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf10/lineitem --format parquet
+      --iter-batches pandas --batch-target-bytes 16777216 --types-mapper {{mapper}}
+
 - name: to_tf
   python: "3.10"
   cluster:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -528,7 +528,7 @@
     anyscale_sdk_2026: true
   matrix:
     setup:
-      batch_size: [256, 1024, 4096]
+      batch_size: [32, 64, 128, 256, 1024, 4096]
       mapper: ["on", "off"]
 
   run:


### PR DESCRIPTION
## Why

Investigating a regression in `iter_batches` for Pandas batch formats, owing to conversion to native Arrow-backed `Arrow.Dtype`s using `types_mapper`.
Local profiling + a batch-size sweep point to a **fixed per-batch construction cost**: `ArrowDtype` columns each become a non-consolidating pandas `ExtensionBlock`, so building a DataFrame costs ~0.24 ms/batch more than the numpy path. At the default `batch_size=256` that is ~234K batches at sf10 (≈+56s ≈ the observed regression). Per *row*, `ArrowDtype` is actually cheaper (zero-copy), so the penalty shrinks and reverses as `batch_size` grows (crossover ≈ 2.3K rows).

This PR adds **release tests only** to confirm that hypothesis on real cluster hardware. No product code changes.

## What

A matrix over `s3://ray-benchmark-data/tpch/parquet/sf10/lineitem`:

| dimension | values |
|---|---|
| `batch_size` (rows) | 256, 1024, 4096 |
| `types_mapper` | on (#63017), off (pre-#63017) |
| byte-target | 16 MiB batches (rows computed at runtime per representation: ≈96K on / ≈28K off) |

→ 8 tests: `iter_batches_pandas_bs{256,1024,4096}_mapper_{on,off}` + `iter_batches_pandas_16mib_mapper_{on,off}`. `bs256_mapper_on` is the regressed runtime; `bs256_mapper_off` is the baseline.

The benchmark harness (`read_and_consume_benchmark.py`) gains three backward-compatible flags — `--batch-size`, `--batch-target-bytes`, `--types-mapper {on,off}` — and **forces `to_pandas` on/off deterministically** so a single branch can A/B the mapper regardless of the base (the fix has a revert/reapply history). `--batch-target-bytes` sizes the row count from a sampled batch's bytes/row in the active representation, so "16 MiB" fills correctly with and without the mapper.

## Expected reading

- `delta(on vs off)` should be largest at `bs256`, shrink through `bs1024`, and go negative by `bs4096` — the fixed-per-batch signature.
- The 16 MiB arms test whether sizing batches by bytes (rather than the tiny 256-row default) neutralizes the regression.

## Checks

- `read_and_consume_benchmark.py` compiles; existing `--iter-batches` tests are unaffected (new flags default to current behavior).
- Smoke-tested locally on a schema-matched parquet: `--types-mapper on` → 174 B/row → 96,318-row batches; `off` → 600 B/row → 27,953-row batches.
