### PR TITLE
[Data] Fix hash-shuffle aggregator memory estimation: metadata propagation, node-size clamp, and column pruning

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1165,6 +1165,29 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 #       max block size specified as the best partition size estimate
                 estimated_dataset_bytes=estimated_dataset_bytes,
             )
+
+            # A per-aggregator ``memory`` request must fit on a single node,
+            # otherwise the actor is unschedulable. For low-partition shuffles
+            # over large datasets (e.g. a global aggregation with
+            # ``num_partitions=1``) the estimate can exceed the largest node's
+            # memory. In that case clamp it: aggregators hold shuffle data in the
+            # (spillable) object store, so reserving more heap ``memory`` than a
+            # node has would only make the actor unschedulable, not faster.
+            max_node_memory = _get_max_single_node_memory()
+            if (
+                max_node_memory is not None
+                and estimated_aggregator_memory_required > max_node_memory
+            ):
+                logger.warning(
+                    f"Estimated per-aggregator memory requirement "
+                    f"({estimated_aggregator_memory_required / GiB:.1f}GiB) exceeds "
+                    f"the largest node's memory ({max_node_memory / GiB:.1f}GiB); "
+                    f"clamping the reservation to fit on a single node and relying "
+                    f"on object-store spilling for the remainder. Consider "
+                    f"increasing the number of partitions or the cluster's node "
+                    f"size to reduce spilling."
+                )
+                estimated_aggregator_memory_required = max_node_memory
         else:
             # NOTE: In cases when we're unable to estimate dataset size,
             #       we simply fallback to request the minimum of:
@@ -1905,6 +1928,26 @@ def _get_total_cluster_resources() -> ExecutionResources:
         ray._private.state.state.get_max_resources_from_cluster_config()
         or ray.cluster_resources()
     )
+
+
+def _get_max_single_node_memory() -> Optional[int]:
+    """Largest ``memory`` capacity available on any single node, or ``None`` if
+    it can't be determined.
+
+    A per-actor ``memory`` request must fit on a single node, so this is the
+    ceiling for an individual aggregator's memory reservation: requesting more
+    than the largest node has makes the actor unschedulable.
+    """
+    try:
+        per_node_resources = ray._private.state.total_resources_per_node()
+    except Exception:
+        return None
+
+    max_node_memory = max(
+        (res.get("memory", 0) for res in per_node_resources.values()),
+        default=0,
+    )
+    return int(max_node_memory) if max_node_memory > 0 else None
 
 
 # TODO rebase on generic operator output estimation

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -58,6 +58,41 @@ class AbstractOneToOne(LogicalOperator):
     def num_outputs(self) -> Optional[int]:
         return self._num_outputs
 
+    def infer_metadata(self) -> BlockMetadata:
+        """Best-effort output metadata derived from the single input dependency.
+
+        One-to-one operators that don't modify the row count (e.g. ``Project``)
+        preserve the row count and don't grow the data, so the input's row count
+        and byte size are valid output estimates -- an upper bound for the common
+        column-selection case, where projecting away columns only shrinks the
+        data. Operators that can modify the row count (e.g. ``Filter``,
+        ``FlatMap``) can't reuse these estimates, so they fall back to ``None``.
+
+        Propagating ``size_bytes`` is what keeps size-dependent planning correct
+        when a one-to-one op is pushed below a join/shuffle (e.g. by projection
+        pushdown): otherwise ``_try_estimate_output_bytes`` sees ``size_bytes=None``
+        and the hash-shuffle aggregator silently falls back to a fixed default
+        memory reservation instead of one derived from the dataset size.
+        """
+        if len(self.input_dependencies) != 1:
+            return BlockMetadata(
+                num_rows=None, size_bytes=None, input_files=None, exec_stats=None
+            )
+        input_meta = self.input_dependencies[0].infer_metadata()
+        if self.can_modify_num_rows:
+            return BlockMetadata(
+                num_rows=None,
+                size_bytes=None,
+                input_files=input_meta.input_files,
+                exec_stats=None,
+            )
+        return BlockMetadata(
+            num_rows=input_meta.num_rows,
+            size_bytes=input_meta.size_bytes,
+            input_files=input_meta.input_files,
+            exec_stats=None,
+        )
+
 
 @dataclass(frozen=True, repr=False, eq=False)
 class Limit(

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -164,6 +164,23 @@ class Download(AbstractOneToOne):
             )
         object.__setattr__(self, "_num_outputs", None)
 
+    def infer_metadata(self) -> BlockMetadata:
+        # Download preserves the row count but appends a binary blob column per
+        # requested output, so the output is *larger* than the input -- often by
+        # orders of magnitude. Propagating the input's ``size_bytes`` (as the
+        # row-preserving default does) would be a misleading under-estimate that
+        # could starve downstream size-dependent planning (e.g. hash-shuffle
+        # aggregator memory reservation). Keep the accurate row count and input
+        # files, but report ``size_bytes=None`` since we can't estimate the
+        # downloaded bytes ahead of execution.
+        meta = super().infer_metadata()
+        return BlockMetadata(
+            num_rows=meta.num_rows,
+            size_bytes=None,
+            input_files=meta.input_files,
+            exec_stats=None,
+        )
+
     def infer_schema(self) -> Optional["Schema"]:
         # Output = input schema with one binary column appended per requested
         # output name. The runtime (``download_bytes_threaded``) always appends

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -285,9 +285,65 @@ class ProjectionPushdown(Rule):
     def apply(self, plan: LogicalPlan) -> LogicalPlan:
         """Apply projection pushdown optimization to the entire plan."""
         dag = plan.dag
-        new_dag = dag._apply_transform(self._try_fuse_projects)
+        # Insert a pruning projection below consuming ops (e.g. ``Aggregate``)
+        # first, so the fuse/push steps can carry the narrowed columns into the
+        # read.
+        new_dag = dag._apply_transform(self._prune_aggregate_input)
+        new_dag = new_dag._apply_transform(self._try_fuse_projects)
         new_dag = new_dag._apply_transform(self._push_projection_into_read_op)
         return LogicalPlan(new_dag, plan.context) if dag is not new_dag else plan
+
+    @classmethod
+    def _prune_aggregate_input(cls, op: LogicalOperator) -> LogicalOperator:
+        """Insert a ``Project`` below an ``Aggregate`` that keeps only the
+        columns it consumes (group keys + each aggregation's target column).
+
+        The aggregation drops every other column anyway, so pruning them before
+        the shuffle avoids dragging unused (often wide) columns through it --
+        which otherwise inflates both the aggregator's memory reservation and
+        the bytes shuffled. The inserted projection is fused/pushed toward the
+        read by the steps in ``apply``.
+        """
+        from dataclasses import replace
+
+        from ray.data._internal.logical.operators.all_to_all_operator import Aggregate
+        from ray.data.aggregate import AggregateFnV2
+        from ray.data.expressions import col
+
+        if not isinstance(op, Aggregate):
+            return op
+
+        keys = op.key if isinstance(op.key, list) else ([op.key] if op.key else [])
+        required: List[str] = list(keys)
+        for agg in op.aggs:
+            # A generic ``AggregateFn`` may read arbitrary columns, so only
+            # prune when every aggregation declares the column it reads.
+            if not isinstance(agg, AggregateFnV2):
+                return op
+            target = agg.get_target_column()
+            if target is not None:
+                required.append(target)
+
+        # Order-preserving dedup; empty means nothing safe to prune to (e.g. a
+        # global count reading no columns).
+        required = list(dict.fromkeys(required))
+        if not required:
+            return op
+
+        input_op = op.input_dependencies[0]
+        schema = input_op.infer_schema()
+        if schema is None or not hasattr(schema, "names"):
+            return op  # unknown schema: can't prove pruning helps
+
+        # Insert only when ``required`` is a strict subset of the input columns:
+        # this guarantees there's something to drop and keeps the rule
+        # idempotent (once the input yields exactly ``required`` nothing more is
+        # inserted, so the fixed-point optimizer terminates).
+        if not set(required) < set(schema.names):
+            return op
+
+        prune = Project(exprs=[col(c) for c in required], input_dependencies=[input_op])
+        return replace(op, input_dependencies=[prune])
 
     @classmethod
     def _try_fuse_projects(cls, op: LogicalOperator) -> LogicalOperator:

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Set
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
+import pyarrow.parquet as pq
 import pytest
 
 import ray
@@ -16,6 +17,7 @@ from ray.data._internal.logical.rules import (
     ProjectionPushdown,
 )
 from ray.data._internal.util import rows_same
+from ray.data.aggregate import Mean, Sum
 from ray.data.context import DataContext
 from ray.data.expressions import DataType, StarExpr, col, star, udf
 
@@ -1384,6 +1386,97 @@ def test_projection_pushdown_merge_rename_x(ray_start_regular_shared, flavor):
         col("sepal.length").alias("length"),
         col("petal.width").alias("width"),
     ]
+
+
+def _leaf_op(dag):
+    """Return the source (leaf) operator of a logical DAG (e.g. the read)."""
+    op = dag
+    while op.input_dependencies:
+        op = op.input_dependencies[0]
+    return op
+
+
+def _find_op(dag, op_type):
+    """Walk a single-input DAG and return the first op of ``op_type``."""
+    op = dag
+    while op is not None:
+        if isinstance(op, op_type):
+            return op
+        op = op.input_dependencies[0] if op.input_dependencies else None
+    return None
+
+
+class TestAggregateInputPruning:
+    """``ProjectionPushdown`` should prune the columns flowing into an
+    ``Aggregate`` down to the ones it consumes (group keys + aggregation
+    targets), and push that pruning into the read."""
+
+    @pytest.fixture
+    def wide_parquet(self, tmp_path):
+        import os
+
+        path = os.path.join(str(tmp_path), "wide.parquet")
+        pq.write_table(
+            pa.table(
+                {
+                    "k": [i % 3 for i in range(60)],
+                    "a": [float(i) for i in range(60)],
+                    "b": [0.5] * 60,
+                    "unused": ["x" * 32] * 60,  # wide column nothing consumes
+                }
+            ),
+            path,
+        )
+        return path
+
+    @pytest.mark.parametrize(
+        "make_result, expected_input_cols",
+        [
+            pytest.param(
+                lambda ds: ds.with_column("revenue", col("a") * col("b"))
+                .groupby("k")
+                .sum("revenue"),
+                {"k", "revenue"},
+                id="groupby-sum-computed-column",
+            ),
+            pytest.param(
+                lambda ds: ds.groupby("k").sum("a"),
+                {"k", "a"},
+                id="groupby-sum",
+            ),
+            pytest.param(
+                lambda ds: ds.groupby("k").aggregate(Sum("a"), Mean("b")),
+                {"k", "a", "b"},
+                id="groupby-multi-agg",
+            ),
+            pytest.param(
+                # Count reads no column, so only the group key is required.
+                lambda ds: ds.groupby("k").count(),
+                {"k"},
+                id="groupby-count",
+            ),
+        ],
+    )
+    def test_aggregate_input_pruned_to_required_columns(
+        self,
+        wide_parquet,
+        make_result,
+        expected_input_cols,
+        ray_start_regular_shared,
+    ):
+        from ray.data._internal.logical.operators.all_to_all_operator import Aggregate
+
+        ds = make_result(ray.data.read_parquet(wide_parquet))
+        dag = LogicalOptimizer().optimize(ds._logical_plan).dag
+
+        # The op feeding the aggregate must carry only the consumed columns.
+        agg = _find_op(dag, Aggregate)
+        assert (
+            set(agg.input_dependencies[0].infer_schema().names) == expected_input_cols
+        )
+
+        # The wide unused column is always dropped from the read.
+        assert "unused" not in set(_leaf_op(dag).infer_schema().names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The hash-shuffle/join/aggregate operators size each aggregator's `memory` reservation from the estimated input dataset size. That estimate was both **missing** in some plans (causing under-reservation → OOM) and **over-counted** in others (causing over-reservation → unschedulable). This PR makes the estimate available, accurate, and bounded.

### Triggering change

This was surfaced by **#63384 ([Data] Remove column renaming from the read stage)**. Before that PR the read stage performed column renames inline, so a TPCH plan looked like `ReadParquet → Join` with no intervening op. #63384 moved renames out of the read into a separate `Project` (of `AliasExpr`s) above the read, so the plan became `ReadParquet → Project → Join`. That exposed a latent gap: `Project.infer_metadata` returned all-`None`, so once a `Project` sat between a read and a join/aggregate the size estimate disappeared and the aggregator fell back to a fixed default reservation — which under-provisioned the TPCH Q3 autoscaling release test and OOM-killed it. The changes below fix that latent gap and the issues uncovered while fixing it.

### 1. Propagate metadata through one-to-one ops (fixes join OOM)

With a rename `Project` now between the read and the join, the join's input op was a `Project`, which inherited the base all-`None` `infer_metadata`. So `_try_estimate_output_bytes` saw `size_bytes=None` and the `HashShuffleAggregator` silently fell back to a fixed default (`DEFAULT_HASH_SHUFFLE_AGGREGATOR_MEMORY_ALLOCATION`, 1 GiB/aggregator) instead of a size-derived reservation (~5.3 GiB/aggregator for TPCH Q3 SF100). On an autoscaling cluster this under-provisions the aggregators and the worker is OOM-killed mid-join (`ActorDiedError` / `SYSTEM_ERROR: Worker connection closed unexpectedly`).

`AbstractOneToOne.infer_metadata` now propagates `num_rows`/`size_bytes`/`input_files` from its single input, gated on `can_modify_num_rows` (row-preserving ops like `Project` propagate; `Filter`/`FlatMap` fall back to `None`). `Download` overrides this to report `size_bytes=None`, since it appends blob columns and the input size would be a misleading under-estimate.

### 2. Prune unused columns before hash-shuffle aggregations

An `Aggregate` only reads its group keys and each aggregation's target column, but nothing pruned the rest before the shuffle — so wide unused columns (e.g. a string column carried through by `with_column`) were dragged through the aggregator, inflating both its memory reservation and the bytes shuffled. `ProjectionPushdown` now inserts a pruning `Project` below an `Aggregate` keeping only the consumed columns (keys + aggregation targets); the existing fuse/push steps carry the narrowed set into the read. It only fires when the input schema is known and has extra columns (keeping the fixed-point optimizer idempotent), and leaves generic `AggregateFn`s (unknown columns) untouched.

### 3. Clamp the aggregator reservation to the largest node (safety net)

With estimates now firing more often, a low-partition shuffle over a large dataset (e.g. a global aggregation with `num_partitions=1`) could reserve ~2× the whole dataset as a single aggregator's `memory` request — exceeding any node and making the actor unschedulable (`ActorUnschedulableError`). The per-aggregator reservation is now clamped to the largest single node's memory: aggregators hold shuffle data in the (spillable) object store, so reserving more heap `memory` than a node has only makes the actor unschedulable, not faster. The clamp only triggers when the estimate exceeds node capacity (well-sized reservations are unaffected) and logs a warning when it engages.

## Verification

- Join estimate restored through a plan with a `Project` between the read and the join (was `None` → 1 GiB fallback).
- Q6-shaped global aggregation: read is pruned to the consumed columns; end-to-end result matches a pandas ground truth.
- Clamp engages only when the estimate exceeds node memory and the run completes via spilling.
- Correctness validated across combos (filters, group-by, multi-aggregation, post-shuffle join→aggregate, computed columns) by comparing pruned vs unpruned pipelines.
- New parameterized tests in `test_projection_fusion.py` (aggregate input pruning) and existing suites pass (`test_projection_fusion`, `test_predicate_pushdown`, `test_execution_optimizer_basic`, `test_infer_schema`, aggregation tests).

## Related issues

Surfaced by #63384 (column renames moved out of the read stage into a `Project`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)