### PR TITLE
[Data] Convert `drop_columns` to a `Project` logical operator when input schema is known

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1148,7 +1148,14 @@ class Dataset:
         """  # noqa: E501
         import pyarrow as pa
 
-        if len(cols) != len(set(cols)):
+        # Dropping no columns is a no-op; return early to avoid schema
+        # inference, the uniqueness check, and a redundant ``Project`` that
+        # would just select every column.
+        if not cols:
+            return self
+
+        cols_set = set(cols)
+        if len(cols) != len(cols_set):
             raise ValueError(f"drop_columns expects unique column names, got: {cols}")
 
         # When the input schema is known, reshape into a ``Project`` over the
@@ -1161,13 +1168,14 @@ class Dataset:
         # expect from ``drop_columns``.
         input_schema = self._logical_plan.dag.infer_schema()
         if isinstance(input_schema, pa.Schema):
-            missing = [c for c in cols if c not in input_schema.names]
+            input_schema_names_set = set(input_schema.names)
+            missing = [c for c in cols if c not in input_schema_names_set]
             if missing:
                 raise KeyError(
                     f"drop_columns: column(s) not found in dataset schema: "
                     f"{missing}. Available columns: {input_schema.names}"
                 )
-            keep = [c for c in input_schema.names if c not in cols]
+            keep = [c for c in input_schema.names if c not in cols_set]
             if keep:
                 return self.select_columns(
                     keep,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1133,7 +1133,10 @@ class Dataset:
 
         Args:
             cols: Names of the columns to drop. If any name does not exist,
-                an exception is raised. Column names must be unique.
+                an exception is raised. Column names must be unique. When the
+                input schema is known statically, missing columns are reported
+                at the ``drop_columns`` call; otherwise the error surfaces
+                during materialization.
             compute: This argument is deprecated. Use ``concurrency`` argument.
             concurrency: The maximum number of Ray workers to use concurrently.
             **ray_remote_args: Additional resource requirements to request from
@@ -1143,10 +1146,37 @@ class Dataset:
         Returns:
             A new :class:`Dataset` with the specified columns removed.
         """  # noqa: E501
+        import pyarrow as pa
 
         if len(cols) != len(set(cols)):
             raise ValueError(f"drop_columns expects unique column names, got: {cols}")
 
+        # When the input schema is known, reshape into a ``Project`` over the
+        # surviving columns so the typed schema chain stays intact and
+        # ``Dataset.schema()`` resolves without a ``limit(1)`` execution.
+        # When ``keep`` is empty (all columns dropped), fall through to the
+        # ``MapBatches`` path — ``select_columns([])`` would yield an
+        # internal ``__bsp_stub`` placeholder column, but the empty-table
+        # semantics of ``pyarrow.Table.drop(all_columns)`` are what users
+        # expect from ``drop_columns``.
+        input_schema = self._logical_plan.dag.infer_schema()
+        if isinstance(input_schema, pa.Schema):
+            missing = [c for c in cols if c not in input_schema.names]
+            if missing:
+                raise KeyError(
+                    f"drop_columns: column(s) not found in dataset schema: "
+                    f"{missing}. Available columns: {input_schema.names}"
+                )
+            keep = [c for c in input_schema.names if c not in cols]
+            if keep:
+                return self.select_columns(
+                    keep,
+                    compute=compute,
+                    concurrency=concurrency,
+                    **ray_remote_args,
+                )
+
+        # Fallback: input schema unknown (UDF chain) or all columns dropped.
         def drop_columns(batch):
             return batch.drop(cols)
 

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -155,6 +155,43 @@ class TestProject:
         )
 
 
+class TestDropColumns:
+    """Phase 3: ``Dataset.drop_columns`` reshapes into a ``Project`` over
+    the surviving columns when the input schema is known, so the typed
+    chain stays intact through it."""
+
+    def test_drop_columns_static_schema(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        ds = ray.data.read_parquet(str(parquet_path)).drop_columns(["b"])
+        # Reshaped to a ``Project`` (not a UDF ``MapBatches``), so the
+        # typed schema chain survives.
+        assert isinstance(ds._logical_plan.dag, Project)
+        assert _static_schema(ds) == pa.schema(
+            [pa.field("a", pa.int32()), pa.field("k", pa.string())]
+        )
+
+    def test_drop_columns_missing_raises_eagerly(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        ds = ray.data.read_parquet(str(parquet_path))
+        with pytest.raises(KeyError, match="not found in dataset schema"):
+            ds.drop_columns(["does_not_exist"])
+
+    def test_drop_columns_after_map_batches_falls_back(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        # Input schema is unknown downstream of ``map_batches``, so the
+        # implementation falls back to a ``MapBatches`` closure and the
+        # typed-chain guarantee no longer holds.
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .map_batches(lambda b: b)
+            .drop_columns(["b"])
+        )
+        assert ds.schema(fetch_if_missing=False) is None
+
+
 class TestAggregate:
     def test_groupby_multi_aggs(self, ray_start_regular_shared_2_cpus, parquet_path):
         ds = (

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -668,12 +668,49 @@ def test_drop_columns(
         assert ds.drop_columns([]).take(1) == [{"col1": 1, "col2": 2, "col3": 3}]
         assert ds.drop_columns(["col1", "col2", "col3"]).take(1) == []
         assert ds.drop_columns(["col1", "col2"]).take(1) == [{"col3": 3}]
-        # Test dropping non-existent column
-        with pytest.raises((UserCodeException, KeyError)):
-            ds.drop_columns(["dummy_col", "col1", "col2"]).materialize()
 
     with pytest.raises(ValueError, match="drop_columns expects unique column names"):
         ds1.drop_columns(["col1", "col2", "col2"])
+
+
+@pytest.mark.parametrize(
+    "source,eager",
+    [
+        # Parquet source: input ``pa.Schema`` is known, so ``drop_columns``
+        # raises immediately at the call site.
+        ("parquet", True),
+        # ``from_pandas`` source: input schema is a ``PandasBlockSchema``,
+        # not a ``pa.Schema``, so the typed-chain reshape is skipped and
+        # the error surfaces inside ``materialize`` as a
+        # ``UserCodeException`` wrapping the PyArrow ``KeyError``.
+        ("pandas", False),
+        # UDF chain: input schema is opaque downstream of ``map_batches``,
+        # same fallback as ``pandas``.
+        ("udf", False),
+    ],
+)
+def test_drop_columns_missing_column_raises(
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    source,
+    eager,
+):
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [3, 4, 5]})
+    if source == "parquet":
+        ray.data.from_pandas(df).write_parquet(str(tmp_path))
+        ds = ray.data.read_parquet(str(tmp_path))
+    elif source == "pandas":
+        ds = ray.data.from_pandas(df)
+    else:
+        ds = ray.data.from_pandas(df).map_batches(lambda b: b)
+
+    if eager:
+        with pytest.raises(KeyError, match="not found in dataset schema"):
+            ds.drop_columns(["dummy_col", "col1", "col2"])
+    else:
+        with pytest.raises((UserCodeException, KeyError)):
+            ds.drop_columns(["dummy_col", "col1", "col2"]).materialize()
 
 
 def test_select_rename_columns(


### PR DESCRIPTION
## Change
`drop_columns` reshapes into `self.select_columns(keep_cols)` when the input op's `infer_schema()` returns a `pa.Schema`, keeping the typed schema chain intact so `Dataset.schema()` resolves without a `limit(1)` execution. Missing columns raise `KeyError` eagerly at the call site on the typed path.

When the input schema is opaque (UDF chain, `PandasBlockSchema` source) or all columns are dropped (avoids the internal __bsp_stub placeholder that `select_columns([])` inserts), falls back to the existing `MapBatches` path.
