### PR TITLE
[Data][Docs] Document `isolate_read_workers` for `read_parquet`

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1289,6 +1289,20 @@ def read_parquet(
     Returns:
         :class:`~ray.data.Dataset` producing records read from the specified parquet
         files.
+
+    .. tip::
+
+        If you're reading large Parquet files and getting out-of-memory errors, try
+        setting ``ray.data.DataContext.isolate_read_workers = True``.
+
+        Parquet reads can allocate lots of heap memory because of issues like
+        https://github.com/apache/arrow/issues/39808. Since Ray Data re-uses workers
+        for different operators, downstream tasks can look like they're using too much
+        memory when they're not. By setting ``isolate_read_workers``, Ray Data ensures
+        downstream tasks run on distinct workers.
+
+        The tradeoff is that you might see a performance regression if Ray needs to
+        restart more workers.
     """
     _validate_shuffle_arg(shuffle)
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1299,7 +1299,7 @@ def read_parquet(
         https://github.com/apache/arrow/issues/39808. Since Ray Data re-uses workers
         for different operators, downstream tasks can look like they're using too much
         memory when they're not. By setting ``isolate_read_workers``, Ray Data ensures
-        downstream tasks run on distinct workers.
+        downstream tasks run on distinct workers without memory bloat.
 
         The tradeoff is that you might see a performance regression if Ray needs to
         restart more workers.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1293,7 +1293,7 @@ def read_parquet(
     .. tip::
 
         If you're reading large Parquet files and getting out-of-memory errors, try
-        setting ``ray.data.DataContext.isolate_read_workers = True``.
+        setting ``ray.data.DataContext.get_current().isolate_read_workers = True``.
 
         Parquet reads can allocate lots of heap memory because of issues like
         https://github.com/apache/arrow/issues/39808. Since Ray Data re-uses workers


### PR DESCRIPTION
In https://github.com/ray-project/ray/pull/63490, I added a flag to `DataContext` called `isolate_read_workers`.

In this PR, I'm adding documentation to `read_parquet` describing how to use the flag. 