### PR TITLE
[Data] Specify logical memory for `read_large_parquet`

### DIFF
--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -19,6 +19,12 @@ def parse_args() -> argparse.Namespace:
         choices=["image", "parquet", "tfrecords"],
         required=True,
     )
+    parser.add_argument(
+        "--memory",
+        type=int,
+        default=None,
+        help="Logical memory in bytes to pass to the read.",
+    )
 
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--count", action="store_true")
@@ -64,7 +70,7 @@ def get_read_fn(args: argparse.Namespace) -> Callable[[str], ray.data.Dataset]:
     else:
         assert False, f"Invalid data format argument: {args}"
 
-    return read_fn
+    return functools.partial(read_fn, memory=args.memory)
 
 
 def get_consume_fn(args: argparse.Namespace) -> Callable[[ray.data.Dataset], None]:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -46,12 +46,6 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    byod:
-      runtime_env:
-        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=0  # Allow worker OOM during test
-        - RAYTEST_FAIL_ON_DEAD_NODES=0
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
   matrix:
@@ -60,10 +54,15 @@
 
   run:
     timeout: 3600
+    # Ray Data can't guarantee memory safety if you haven't hinted how much heap memory
+    # high-memory operations require. Since reading large Parquet files requires lots of
+    # heap memory, we need to manually specify the memory to prevent OOMs.
+    #
+    # 3650722201 is ~3.4 GiB, the maximum heap memory observed in our tests.
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/large-parquet/ --format parquet
-      --iter-bundles
+      --iter-bundles --memory 3650722201
 
 - name: "read_images_{{scaling}}"
   python: "3.10"


### PR DESCRIPTION
The `read_large_parquet` frequently OOMs. 

This isn't totally unexpected -- Parquet reads allocate lots of memory because of https://github.com/apache/arrow/issues/39808, and the current implementation of Ray Data can't guarantee memory safety unless you specify the heap memory required for high-memory operations.

Since this is a case where we expect the system to need a hint, I've updated the release test to specify 3.4 GiB of heap memory for reads. This was the maximum heap usage per task I observed in the latest release test run.

I've also re-introduced the ratchet that fails the release test on OOMs. If the system upholds its guarantee that it doesn't OOM when you specify the required heap memory, this shouldn't fail anymore.