### PR TITLE
Fix task grouping by custom task name in Dashboard API

### DIFF
--- a/python/ray/dashboard/state_aggregator.py
+++ b/python/ray/dashboard/state_aggregator.py
@@ -569,22 +569,22 @@ class StateAPIManager:
         )
 
     async def summarize_tasks(self, option: SummaryApiOptions) -> SummaryApiResponse:
-        summary_by = option.summary_by or "func_name"
-        if summary_by not in ["func_name", "lineage"]:
-            raise ValueError('summary_by must be one of "func_name" or "lineage".')
+        summary_by = option.summary_by or "task_name"
+        if summary_by not in ["task_name", "lineage"]:
+            raise ValueError('summary_by must be one of "task_name" or "lineage".')
 
         # For summary, try getting as many entries as possible to minimze data loss.
         result = await self.list_tasks(
             option=ListApiOptions(
-                timeout=option.timeout,
                 limit=RAY_MAX_LIMIT_FROM_API_SERVER,
+                timeout=option.timeout,
                 filters=option.filters,
                 detail=summary_by == "lineage",
             )
         )
 
-        if summary_by == "func_name":
-            summary_results = TaskSummaries.to_summary_by_func_name(tasks=result.result)
+        if summary_by == "task_name":
+            summary_results = TaskSummaries.to_summary_by_task_name(tasks=result.result)
         else:
             # We will need the actors info for actor tasks.
             actors = await self.list_actors(

--- a/python/ray/dashboard/state_aggregator.py
+++ b/python/ray/dashboard/state_aggregator.py
@@ -569,9 +569,11 @@ class StateAPIManager:
         )
 
     async def summarize_tasks(self, option: SummaryApiOptions) -> SummaryApiResponse:
-        summary_by = option.summary_by or "task_name"
-        if summary_by not in ["task_name", "lineage"]:
-            raise ValueError('summary_by must be one of "task_name" or "lineage".')
+        summary_by = option.summary_by or "func_name"
+        if summary_by not in ["func_name", "task_name", "lineage"]:
+            raise ValueError(
+                'summary_by must be one of "func_name", "task_name", or "lineage".'
+            )
 
         # For summary, try getting as many entries as possible to minimze data loss.
         result = await self.list_tasks(
@@ -583,8 +585,8 @@ class StateAPIManager:
             )
         )
 
-        if summary_by == "task_name":
-            summary_results = TaskSummaries.to_summary_by_task_name(tasks=result.result)
+        if summary_by in ("func_name", "task_name"):
+            summary_results = TaskSummaries.to_summary_by_func_name(tasks=result.result)
         else:
             # We will need the actors info for actor tasks.
             actors = await self.list_actors(

--- a/python/ray/tests/test_state_api_summary.py
+++ b/python/ray/tests/test_state_api_summary.py
@@ -70,30 +70,35 @@ async def test_api_manager_summary_tasks(state_api_manager):
             [
                 generate_task_event(
                     id=ids[0].binary(),
+                    name="",
                     func_or_class=first_task_name,
                     state=TaskStatus.PENDING_NODE_ASSIGNMENT,
                     type=TaskType.NORMAL_TASK,
                 ),
                 generate_task_event(
                     id=ids[1].binary(),
+                    name="",
                     func_or_class=first_task_name,
                     state=TaskStatus.PENDING_NODE_ASSIGNMENT,
                     type=TaskType.NORMAL_TASK,
                 ),
                 generate_task_event(
                     id=ids[2].binary(),
+                    name="",
                     func_or_class=first_task_name,
                     state=TaskStatus.PENDING_NODE_ASSIGNMENT,
                     type=TaskType.NORMAL_TASK,
                 ),
                 generate_task_event(
                     id=ids[3].binary(),
+                    name="",
                     func_or_class=first_task_name,
                     state=TaskStatus.RUNNING,
                     type=TaskType.NORMAL_TASK,
                 ),
                 generate_task_event(
                     id=ids[4].binary(),
+                    name="",
                     func_or_class=second_task_name,
                     state=TaskStatus.PENDING_NODE_ASSIGNMENT,
                     type=TaskType.ACTOR_TASK,

--- a/python/ray/tests/test_state_api_summary.py
+++ b/python/ray/tests/test_state_api_summary.py
@@ -356,6 +356,22 @@ def test_task_summary(ray_start_cluster):
 
     wait_for_condition(verify)
 
+    # Test custom task name
+    task_wait_for_dep.options(name="custom_task_name").remote(
+        run_long_time_task.remote()
+    )
+
+    def verify_custom_name():
+        task_summary = summarize_tasks()
+        task_summary = task_summary["cluster"]["summary"]
+        assert "custom_task_name" in task_summary
+        assert (
+            task_summary["custom_task_name"]["state_counts"]["PENDING_ARGS_AVAIL"] >= 1
+        )
+        return True
+
+    wait_for_condition(verify_custom_name)
+
     """
     Test CLI
     """

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1060,10 +1060,10 @@ class TaskSummaries:
     total_actor_tasks: int
     #: Total scheduled actors.
     total_actor_scheduled: int
-    summary_by: str = "task_name"
+    summary_by: str = "func_name"
 
     @classmethod
-    def to_summary_by_task_name(cls, *, tasks: List[Dict]) -> "TaskSummaries":
+    def to_summary_by_func_name(cls, *, tasks: List[Dict]) -> "TaskSummaries":
         # NOTE: The argument tasks contains a list of dictionary
         # that have the same k/v as TaskState.
         summary = {}

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1072,7 +1072,7 @@ class TaskSummaries:
         total_actor_scheduled = 0
 
         for task in tasks:
-            key = task["name"] or task["func_or_class_name"]
+            key = task.get("name") or task.get("func_or_class_name")
             if key not in summary:
                 summary[key] = TaskSummaryPerFuncOrClassName(
                     func_or_class_name=key,
@@ -1172,7 +1172,7 @@ class TaskSummaries:
 
             # Use name first which allows users to customize the name of
             # their remote function call using the name option.
-            func_name = task["name"] or task["func_or_class_name"]
+            func_name = task.get("name") or task.get("func_or_class_name")
             task_id = task["task_id"]
             type_enum = TaskType.DESCRIPTOR.values_by_name[task["type"]].number
 

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1072,10 +1072,10 @@ class TaskSummaries:
         total_actor_scheduled = 0
 
         for task in tasks:
-            key = task["func_or_class_name"]
+            key = task["name"] or task["func_or_class_name"]
             if key not in summary:
                 summary[key] = TaskSummaryPerFuncOrClassName(
-                    func_or_class_name=task["func_or_class_name"],
+                    func_or_class_name=key,
                     type=task["type"],
                 )
             task_summary = summary[key]

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1060,10 +1060,10 @@ class TaskSummaries:
     total_actor_tasks: int
     #: Total scheduled actors.
     total_actor_scheduled: int
-    summary_by: str = "func_name"
+    summary_by: str = "task_name"
 
     @classmethod
-    def to_summary_by_func_name(cls, *, tasks: List[Dict]) -> "TaskSummaries":
+    def to_summary_by_task_name(cls, *, tasks: List[Dict]) -> "TaskSummaries":
         # NOTE: The argument tasks contains a list of dictionary
         # that have the same k/v as TaskState.
         summary = {}
@@ -1098,7 +1098,7 @@ class TaskSummaries:
             total_tasks=total_tasks,
             total_actor_tasks=total_actor_tasks,
             total_actor_scheduled=total_actor_scheduled,
-            summary_by="func_name",
+            summary_by="task_name",
         )
 
     @classmethod

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1098,7 +1098,7 @@ class TaskSummaries:
             total_tasks=total_tasks,
             total_actor_tasks=total_actor_tasks,
             total_actor_scheduled=total_actor_scheduled,
-            summary_by="task_name",
+            summary_by="func_name",
         )
 
     @classmethod


### PR DESCRIPTION
## Why are these changes needed?

Fixes #50059. 

Currently, when users assign a custom name to a task using `task.options(name="custom_name").remote()`, the Ray Dashboard and `ray status` still group all task invocations strictly by their Python function name (`func_or_class_name`). This prevents users from tracking tasks efficiently on the dashboard when they have many invocations grouped logically by custom names.

This PR addresses the issue in the State API backend (`common.py` -> `to_summary_by_func_name()`). It updates the grouping logic to prioritize the `task["name"]` attribute (if set) as the grouping key, falling back to the default `func_or_class_name`. This aligns with the logic already used in `to_summary_by_lineage()` and allows the Dashboard frontend to seamlessly display and group tasks by their custom names without requiring any UI changes.

## Related issue number

Closes #50059

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests