### PR TITLE
[Data][Expressions] Add `.dt.assume_timezone` and `.dt.tz_convert` to expression namespace

### DIFF
--- a/python/ray/data/namespace_expressions/dt_namespace.py
+++ b/python/ray/data/namespace_expressions/dt_namespace.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING, Literal
 import pyarrow.compute as pc
 
 from ray.data.datatype import DataType
-from ray.data.expressions import _create_pyarrow_compute_udf
+from ray.data.expressions import _create_pyarrow_compute_udf, pyarrow_udf
 
 if TYPE_CHECKING:
-    from ray.data.expressions import Expr, PyArrowComputeUDFExpr
+    import pyarrow
+
+    from ray.data.expressions import Expr, PyArrowComputeUDFExpr, UDFExpr
 
 TemporalUnit = Literal[
     "year",
@@ -85,3 +87,71 @@ class _DatetimeNamespace:
         return _create_pyarrow_compute_udf(pc.round_temporal, self._expr.data_type)(
             self._expr, multiple=1, unit=unit
         )
+
+    # timezone operations
+
+    def assume_timezone(
+        self, timezone: str, *, ambiguous: str = "raise", nonexistent: str = "raise"
+    ) -> "PyArrowComputeUDFExpr":
+        """Localize naive (timezone-unaware) timestamps to a given timezone.
+
+        Args:
+            timezone: The timezone to assign (e.g., "America/New_York", "UTC").
+            ambiguous: How to handle ambiguous times ("raise", "earliest", "latest").
+            nonexistent: How to handle nonexistent times ("raise", "earliest", "latest").
+
+        Returns:
+            Expression with timezone-aware timestamps.
+        """
+        import pyarrow as pa
+        import pyarrow.types
+
+        return_dtype = self._expr.data_type
+        try:
+            arrow_type = return_dtype.to_arrow_dtype()
+            if pyarrow.types.is_timestamp(arrow_type):
+                return_dtype = DataType.from_arrow(
+                    pa.timestamp(arrow_type.unit, tz=timezone)
+                )
+        except Exception:
+            pass
+
+        return _create_pyarrow_compute_udf(pc.assume_timezone, return_dtype)(
+            self._expr, timezone=timezone, ambiguous=ambiguous, nonexistent=nonexistent
+        )
+
+    def tz_convert(self, target_tz: str) -> "UDFExpr":
+        """Convert timezone-aware timestamps to a different timezone.
+
+        This uses ``pyarrow_udf`` rather than ``_create_pyarrow_compute_udf``
+        because timezone conversion requires ``pc.cast`` with a dynamically
+        constructed target type, which is not a direct 1:1 ``pc.*`` call and
+        cannot participate in predicate pushdown.
+
+        Args:
+            target_tz: The target timezone (e.g., "Europe/London", "US/Pacific").
+
+        Returns:
+            Expression with timestamps converted to the target timezone.
+        """
+        import pyarrow as pa
+        import pyarrow.types
+
+        return_dtype = self._expr.data_type
+        try:
+            arrow_type = return_dtype.to_arrow_dtype()
+            if pyarrow.types.is_timestamp(arrow_type):
+                return_dtype = DataType.from_arrow(
+                    pa.timestamp(arrow_type.unit, tz=target_tz)
+                )
+        except Exception:
+            pass
+
+        @pyarrow_udf(return_dtype=return_dtype)
+        def _tz_convert(
+            arr: "pyarrow.Array",
+        ) -> "pyarrow.Array":
+            target_type = pa.timestamp(arr.type.unit, tz=target_tz)
+            return pc.cast(arr, target_type)
+
+        return _tz_convert(self._expr)

--- a/python/ray/data/tests/expressions/test_namespace_datetime.py
+++ b/python/ray/data/tests/expressions/test_namespace_datetime.py
@@ -74,6 +74,48 @@ class TestDatetimeNamespace:
         with pytest.raises(Exception):
             ds.with_column("year", col("value").dt.year()).to_pandas()
 
+    def test_dt_assume_timezone(self, ray_start_regular_shared):
+        """Test assume_timezone expression."""
+        import pyarrow as pa
+
+        # Naive timestamps
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [1704067200000000],
+                    type=pa.timestamp("us"),  # 2024-01-01 00:00:00
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+        result = ds.with_column(
+            "ts_utc", col("ts").dt.assume_timezone("UTC")
+        ).to_pandas()
+        assert result["ts_utc"].dt.tz is not None
+        assert str(result["ts_utc"].dt.tz) == "UTC"
+
+    def test_dt_tz_convert(self, ray_start_regular_shared):
+        """Test tz_convert expression."""
+        import pyarrow as pa
+
+        # UTC timestamps
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [1704067200000000],
+                    type=pa.timestamp("us", tz="UTC"),  # 2024-01-01 00:00:00 UTC
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+        result = ds.with_column(
+            "ts_ny", col("ts").dt.tz_convert("America/New_York")
+        ).to_pandas()
+        # UTC midnight = NY 19:00 previous day
+        assert result["ts_ny"].dt.tz is not None
+        assert str(result["ts_ny"].dt.tz) == "America/New_York"
+        assert result["ts_ny"].iloc[0].hour == 19
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description
This PR adds timezone support to the `.dt` datetime expression namespace for Ray Data, as part of the ongoing expression namespace system expansion tracked in #58674.

Two new methods are added to `_DatetimeNamespace`:

- **`assume_timezone(timezone, *, ambiguous="raise", nonexistent="raise")`** — Localizes naive (timezone-unaware) timestamps to a given timezone by wrapping `pc.assume_timezone`. Supports handling of ambiguous and nonexistent local times (e.g. around DST transitions).

- **`tz_convert(target_tz)`** — Converts timezone-aware timestamps to a different timezone. Uses `pc.cast` to the target `pa.timestamp(unit, tz=...)` type while preserving the original time unit.

Both methods resolve the return `DataType` at plan-time (when the input expression type is known), enabling accurate static schema inference rather than falling back to `DataType(object)` at runtime.

## Related issues
Related to #58674

## Additional information
**Usage example:**
```python
import ray
import pyarrow as pa
from ray.data.expressions import col

# assume_timezone: attach UTC to a naive timestamp column
ds = ray.data.from_arrow(pa.table({"ts": pa.array([...], type=pa.timestamp("us"))}))
ds = ds.with_column("ts_utc", col("ts").dt.assume_timezone("UTC"))

# tz_convert: convert to a different timezone
ds = ds.with_column("ts_ny", col("ts_utc").dt.tz_convert("America/New_York"))
