### PR TITLE
[Data] Fix Timer JSON serialization broken by DistributionTracker

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -258,19 +258,25 @@ class Timer:
             "_total_count": self._total_count,
         }
 
-    def from_dict(self, state: Dict[str, Optional[float]]) -> None:
+    def from_dict(self, state: Optional[Dict[str, Optional[float]]]) -> None:
         """Restore the scalar stats from a dict produced by :meth:`as_dict`.
 
         ``_distribution`` is left untouched (it keeps the empty tracker
         created in ``__init__``), mirroring that the sketch is not
-        persisted.
+        persisted. A non-dict ``state`` is ignored, and a ``None`` value
+        for any field falls back to its empty-Timer default (``.get``'s
+        default only fires on a missing key, not a present ``None``).
         """
-        self._total = state.get("_total", 0)
-        self._total_count = state.get("_total_count", 0)
+        if not isinstance(state, dict):
+            return
+        _total = state.get("_total")
+        self._total = _total if _total is not None else 0.0
+        _total_count = state.get("_total_count")
+        self._total_count = _total_count if _total_count is not None else 0.0
         _min = state.get("_min")
         self._min = _min if _min is not None else float("inf")
         _max = state.get("_max")
-        self._max = _max if _max is not None else 0
+        self._max = _max if _max is not None else 0.0
 
 
 class _DatasetStatsBuilder:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -241,6 +241,37 @@ class Timer:
         q = self._distribution._quantile(p)
         return q if q is not None else 0
 
+    def as_dict(self) -> Dict[str, Optional[float]]:
+        """Return a JSON-serializable snapshot of the accumulated stats.
+
+        Only the scalar fields are included. ``_distribution`` (a
+        :class:`DistributionTracker`) is intentionally omitted because it
+        is not JSON-serializable and its sketch is not meant to be
+        persisted across checkpoints. ``_min`` / ``_max`` are reported as
+        ``None`` when no samples have been added (rather than the ``inf``
+        sentinel, which JSON cannot represent).
+        """
+        return {
+            "_total": self._total,
+            "_min": self._min if self._total_count > 0 else None,
+            "_max": self._max if self._total_count > 0 else None,
+            "_total_count": self._total_count,
+        }
+
+    def from_dict(self, state: Dict[str, Optional[float]]) -> None:
+        """Restore the scalar stats from a dict produced by :meth:`as_dict`.
+
+        ``_distribution`` is left untouched (it keeps the empty tracker
+        created in ``__init__``), mirroring that the sketch is not
+        persisted.
+        """
+        self._total = state.get("_total", 0)
+        self._total_count = state.get("_total_count", 0)
+        _min = state.get("_min")
+        self._min = _min if _min is not None else float("inf")
+        _max = state.get("_max")
+        self._max = _max if _max is not None else 0
+
 
 class _DatasetStatsBuilder:
     """Helper class for building dataset stats.

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2436,6 +2436,48 @@ class TestTimerPercentile:
         assert t2.percentile(0.5) == pytest.approx(t.percentile(0.5))
         assert t2.percentile(0.9) == pytest.approx(t.percentile(0.9))
 
+    def test_as_dict_is_json_serializable(self):
+        # Regression: Timer.__dict__ holds a DistributionTracker (not
+        # JSON-serializable) since percentile tracking was added. Code
+        # that persists Timer stats to JSON (e.g. the training-ingest
+        # benchmark checkpointing metrics.json) must use as_dict(), which
+        # exposes only the scalar fields.
+        import json
+
+        t = Timer()
+        for v in [0.001, 0.01, 0.1, 1.0]:
+            t.add(v)
+        d = t.as_dict()
+        assert "_distribution" not in d
+        # Must not raise ``Object of type DistributionTracker is not JSON
+        # serializable``.
+        json.loads(json.dumps(d))
+
+    def test_as_dict_from_dict_roundtrip(self):
+        t = Timer()
+        for v in [0.001, 0.01, 0.1, 1.0]:
+            t.add(v)
+
+        restored = Timer()
+        restored.from_dict(t.as_dict())
+        assert restored.get() == pytest.approx(t.get())
+        assert restored.min() == pytest.approx(t.min())
+        assert restored.max() == pytest.approx(t.max())
+        assert restored.avg() == pytest.approx(t.avg())
+
+    def test_as_dict_from_dict_empty(self):
+        # An untouched Timer reports min/max as None (inf is not
+        # JSON-representable) and restores back to the empty sentinels.
+        t = Timer()
+        d = t.as_dict()
+        assert d["_min"] is None and d["_max"] is None
+        assert d["_total"] == 0 and d["_total_count"] == 0
+
+        restored = Timer()
+        restored.from_dict(d)
+        assert restored.min() == float("inf")
+        assert restored.get() == 0
+
 
 def test_streaming_exec_schedule_percentiles_populated(ray_start_regular_shared):
     # KLL-sketch percentile tracking is always on (bounded memory), so

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2478,6 +2478,25 @@ class TestTimerPercentile:
         assert restored.min() == float("inf")
         assert restored.get() == 0
 
+    @pytest.mark.parametrize("bad_state", [None, [], "x", 42])
+    def test_from_dict_ignores_non_dict(self, bad_state):
+        # A malformed/missing checkpoint payload must not crash restore;
+        # the Timer keeps its empty-state defaults.
+        t = Timer()
+        t.from_dict(bad_state)
+        assert t.get() == 0
+        assert t.min() == float("inf")
+
+    def test_from_dict_handles_none_values(self):
+        # Explicit None values must fall back to defaults — .get(k, 0)
+        # would wrongly keep None since the key is present.
+        t = Timer()
+        t.from_dict({"_total": None, "_min": None, "_max": None, "_total_count": None})
+        assert t.get() == 0.0
+        assert t._total_count == 0.0
+        assert t.min() == float("inf")
+        assert t.max() == 0.0
+
 
 def test_streaming_exec_schedule_percentiles_populated(ray_start_regular_shared):
     # KLL-sketch percentile tracking is always on (bounded memory), so

--- a/release/train_tests/benchmark/runner.py
+++ b/release/train_tests/benchmark/runner.py
@@ -275,7 +275,7 @@ class TrainLoopRunner:
             metrics_json = json.load(f)
 
         for k, v in metrics_json.items():
-            self._metrics[k].__dict__.update(v)
+            self._metrics[k].from_dict(v)
 
         if ray.train.get_context().get_world_rank() == 0:
             logger.info(
@@ -300,7 +300,7 @@ class TrainLoopRunner:
             }
             torch.save(run_state, os.path.join(local_dir, "run_state.pt"))
 
-            metrics_json = {k: v.__dict__.copy() for k, v in self._metrics.items()}
+            metrics_json = {k: v.as_dict() for k, v in self._metrics.items()}
             with open(os.path.join(local_dir, "metrics.json"), "w") as f:
                 json.dump(metrics_json, f)
 


### PR DESCRIPTION
## Why

#63586 added a `DistributionTracker` to `Timer` for percentile tracking. `DistributionTracker` is not JSON-serializable, which broke the `training-ingest-benchmark` release test (`image_classification.full_training`, s3_url + parquet):

```
TypeError: Object of type DistributionTracker is not JSON serializable
```

The benchmark checkpoints each `Timer` via `v.__dict__.copy()` + `json.dump`, and `__dict__` now carries the tracker. The tracker's `__getstate__`/`__setstate__` only cover **pickle**, not `json`, so they don't help here.

## Fix

- Add `Timer.as_dict()` / `Timer.from_dict()` that round-trip only the scalar fields (`_total`, `_min`, `_max`, `_total_count`). `_distribution` is excluded — the KLL sketch isn't reconstructable from summary stats and isn't meant to persist across checkpoints, so it restarts empty on restore (same graceful degradation as when `datasketches` isn't installed).
- Switch the benchmark runner to use these instead of poking `__dict__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)