### PR TITLE
[Data] Support passing iterators to from_arrow

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3657,17 +3657,9 @@ def from_arrow(
         fit in memory at once, since the tables are moved to the Ray object store
         one at a time instead of being buffered in a list.
 
-        >>> ray.data.from_arrow(pa.table({"x": [1]}) for _ in range(2))  # doctest: +ELLIPSIS
-        shape: (2, 1)
-        ╭───────╮
-        │ x     │
-        │ ---   │
-        │ int64 │
-        ╞═══════╡
-        │ 1     │
-        │ 1     │
-        ╰───────╯
-        (Showing 2 of 2 rows)
+        >>> gen = (pa.table({"x": [1]}) for _ in range(2))
+        >>> ray.data.from_arrow(gen).count()
+        2
 
 
     Args:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3617,9 +3617,7 @@ def from_numpy_refs(
 
 @PublicAPI
 def from_arrow(
-    tables: Union[
-        "pyarrow.Table", bytes, Iterable[Union["pyarrow.Table", bytes]]
-    ],
+    tables: Union["pyarrow.Table", bytes, Iterable[Union["pyarrow.Table", bytes]]],
     *,
     override_num_blocks: Optional[int] = None,
 ) -> MaterializedDataset:
@@ -3659,7 +3657,7 @@ def from_arrow(
         fit in memory at once, since the tables are moved to the Ray object store
         one at a time instead of being buffered in a list.
 
-        >>> ray.data.from_arrow(table for _ in range(2))  # doctest: +ELLIPSIS
+        >>> ray.data.from_arrow(pa.table({"x": [1]}) for _ in range(2))  # doctest: +ELLIPSIS
         shape: (2, 1)
         ╭───────╮
         │ x     │

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3657,7 +3657,7 @@ def from_arrow(
         fit in memory at once, since the tables are moved to the Ray object store
         one at a time instead of being buffered in a list.
 
-        >>> gen = (pa.table({"x": [1]}) for _ in range(2))
+        >>> gen = (pa.table({"x": [1]}) for _ in (0, 1))
         >>> ray.data.from_arrow(gen).count()
         2
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3688,8 +3688,8 @@ def from_arrow(
         tables = list(tables)
         if not tables:
             raise ValueError(
-                "`override_num_blocks` was provided, but `tables` is empty. "
-                "Pass at least one PyArrow table, or omit `override_num_blocks`."
+                "The input tables iterable is empty. At least one table must "
+                "be provided when `override_num_blocks` is specified."
             )
         combined_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
         total_rows = len(combined_table)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3696,6 +3696,11 @@ def from_arrow(
         # Re-blocking needs to inspect every table, so eagerly materialize the
         # iterable into a list before concatenating and slicing.
         tables = list(tables)
+        if not tables:
+            raise ValueError(
+                "`override_num_blocks` was provided, but `tables` is empty. "
+                "Pass at least one PyArrow table, or omit `override_num_blocks`."
+            )
         combined_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
         total_rows = len(combined_table)
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Literal,
     Optional,
@@ -3616,7 +3617,9 @@ def from_numpy_refs(
 
 @PublicAPI
 def from_arrow(
-    tables: Union["pyarrow.Table", bytes, List[Union["pyarrow.Table", bytes]]],
+    tables: Union[
+        "pyarrow.Table", bytes, Iterable[Union["pyarrow.Table", bytes]]
+    ],
     *,
     override_num_blocks: Optional[int] = None,
 ) -> MaterializedDataset:
@@ -3651,10 +3654,27 @@ def from_arrow(
         ╰───────╯
         (Showing 2 of 2 rows)
 
+        You can also pass any iterable (for example, a generator) of PyArrow
+        tables. This is useful when the tables are produced lazily and don't all
+        fit in memory at once, since the tables are moved to the Ray object store
+        one at a time instead of being buffered in a list.
+
+        >>> ray.data.from_arrow(table for _ in range(2))  # doctest: +ELLIPSIS
+        shape: (2, 1)
+        ╭───────╮
+        │ x     │
+        │ ---   │
+        │ int64 │
+        ╞═══════╡
+        │ 1     │
+        │ 1     │
+        ╰───────╯
+        (Showing 2 of 2 rows)
+
 
     Args:
-        tables: A PyArrow table, or a list of PyArrow tables,
-                or its streaming format in bytes.
+        tables: A PyArrow table, or an iterable (for example, a list or
+                generator) of PyArrow tables, or its streaming format in bytes.
         override_num_blocks: Override the number of output blocks from all read tasks.
             By default, the number of output blocks is dynamically decided based on
             input data size and available resources. You shouldn't manually set this
@@ -3673,6 +3693,9 @@ def from_arrow(
     if override_num_blocks is not None:
         if override_num_blocks <= 0:
             raise ValueError("override_num_blocks must be > 0")
+        # Re-blocking needs to inspect every table, so eagerly materialize the
+        # iterable into a list before concatenating and slicing.
+        tables = list(tables)
         combined_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
         total_rows = len(combined_table)
 
@@ -3699,6 +3722,8 @@ def from_arrow(
 
             tables = slices
 
+    # Iterate lazily so that, for generators/iterators, at most one table is
+    # held in driver memory at a time before being moved to the object store.
     return from_arrow_refs([ray.put(t) for t in tables])
 
 

--- a/python/ray/data/tests/datasource/test_arrow.py
+++ b/python/ray/data/tests/datasource/test_arrow.py
@@ -39,6 +39,54 @@ def test_from_arrow(ray_start_regular_shared, sample_dataframes):
     assert "FromArrow" in ds.stats()
 
 
+def test_from_arrow_iterator(ray_start_regular_shared, sample_dataframes):
+    """Test that from_arrow accepts arbitrary iterables/generators of tables."""
+    df1, df2 = sample_dataframes
+    table1 = pa.Table.from_pandas(df1)
+    table2 = pa.Table.from_pandas(df2)
+    expected = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
+
+    # Generator (consumable, no __len__, not a Sequence).
+    def table_generator():
+        yield table1
+        yield table2
+
+    ds = ray.data.from_arrow(table_generator())
+    values = [(r["one"], r["two"]) for r in ds.take(6)]
+    assert values == expected
+    assert "FromArrow" in ds.stats()
+
+    # Plain iterator.
+    ds = ray.data.from_arrow(iter([table1, table2]))
+    values = [(r["one"], r["two"]) for r in ds.take(6)]
+    assert values == expected
+
+    # Tuple input.
+    ds = ray.data.from_arrow((table1, table2))
+    values = [(r["one"], r["two"]) for r in ds.take(6)]
+    assert values == expected
+
+
+def test_from_arrow_iterator_with_override_num_blocks(
+    ray_start_regular_shared, sample_dataframes
+):
+    """Test that override_num_blocks works when passing a generator."""
+    df1, df2 = sample_dataframes
+    table1 = pa.Table.from_pandas(df1)
+    table2 = pa.Table.from_pandas(df2)
+    expected = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
+
+    def table_generator():
+        yield table1
+        yield table2
+
+    ds = ray.data.from_arrow(table_generator(), override_num_blocks=3)
+    assert ds.num_blocks() == 3
+    assert ds.count() == 6
+    values = [(r["one"], r["two"]) for r in ds.take_all()]
+    assert values == expected
+
+
 @pytest.mark.parametrize(
     "tables,override_num_blocks,expected_blocks,expected_rows",
     [

--- a/python/ray/data/tests/datasource/test_arrow.py
+++ b/python/ray/data/tests/datasource/test_arrow.py
@@ -87,6 +87,15 @@ def test_from_arrow_iterator_with_override_num_blocks(
     assert values == expected
 
 
+@pytest.mark.parametrize("empty", [[], iter([]), (_ for _ in [])])
+def test_from_arrow_empty_iterable_with_override_num_blocks(
+    ray_start_regular_shared, empty
+):
+    """Empty input with override_num_blocks should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="tables.*empty"):
+        ray.data.from_arrow(empty, override_num_blocks=2)
+
+
 @pytest.mark.parametrize(
     "tables,override_num_blocks,expected_blocks,expected_rows",
     [


### PR DESCRIPTION
## Description

`ray.data.from_arrow` previously accepted only a single PyArrow table or a `List` of tables. This PR widens the signature to accept any `Iterable` of tables (for example, a generator or iterator).

When `override_num_blocks` is `None`, the tables are consumed lazily and moved to the Ray object store one at a time, so a generator producing tables that don't all fit in driver memory can be passed without first buffering them in a list. When `override_num_blocks` is set, re-blocking requires inspecting every table, so the iterable is materialized before concatenation/slicing.

This keeps existing `List`/single-table callers fully backward compatible (the one internal caller, `from_huggingface`, passes a sliced table and is unaffected).

## Related issues

Closes #39737

## Additional information

Usage:

```python
import pyarrow as pa
import ray

def table_generator():
    for path in big_list_of_files:
        yield pa.parquet.read_table(path)  # produced lazily

ds = ray.data.from_arrow(table_generator())
```

API change:
- `from_arrow(tables: Union[pa.Table, bytes, List[...]])` → `from_arrow(tables: Union[pa.Table, bytes, Iterable[...]])`

Tests added in `python/ray/data/tests/datasource/test_arrow.py`:
- `test_from_arrow_iterator` — generator, plain iterator, and tuple inputs.
- `test_from_arrow_iterator_with_override_num_blocks` — generator combined with `override_num_blocks`.

Made with [Cursor](https://cursor.com)