### PR TITLE
[serve] Resolve bundled ray-haproxy binary before RAY_SERVE_HAPROXY_BINARY_PATH

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -187,8 +187,8 @@ def get_haproxy_binary() -> str:
     RAY_SERVE_HAPROXY_BINARY_PATH (defaults to "haproxy", i.e. system PATH).
 
     When enabled, resolution order:
-      1. ``RAY_SERVE_HAPROXY_BINARY_PATH`` if explicitly set to an absolute path.
-      2. The binary bundled in the ``ray-haproxy`` package.
+      1. The binary bundled in the ``ray-haproxy`` package.
+      2. ``RAY_SERVE_HAPROXY_BINARY_PATH`` if explicitly set to an absolute path.
       3. ``haproxy`` on the system PATH (fallback).
 
     Raises ``FileNotFoundError`` if no usable binary is found.
@@ -202,7 +202,20 @@ def _resolve_haproxy_binary() -> str:
     if not RAY_SERVE_EXPERIMENTAL_PIP_HAPROXY:
         return RAY_SERVE_HAPROXY_BINARY_PATH
 
-    # 1. If RAY_SERVE_HAPROXY_BINARY_PATH was explicitly set (not the default),
+    # 1. Bundled binary from the ray-haproxy package. Tried first so the flag
+    # forces the pip binary even when the runtime image bakes in an explicit
+    # RAY_SERVE_HAPROXY_BINARY_PATH (e.g. /usr/local/bin/haproxy); otherwise the
+    # override below would shadow it and the flag would be a no-op.
+    try:
+        from ray_haproxy import get_haproxy_binary as _pip_binary
+
+        return _pip_binary()
+    except ImportError:
+        pass
+    except OSError:
+        pass
+
+    # 2. If RAY_SERVE_HAPROXY_BINARY_PATH was explicitly set (not the default),
     # use it as an override.
     if RAY_SERVE_HAPROXY_BINARY_PATH != "haproxy":
         if os.path.isfile(RAY_SERVE_HAPROXY_BINARY_PATH) and os.access(
@@ -213,16 +226,6 @@ def _resolve_haproxy_binary() -> str:
             f"RAY_SERVE_HAPROXY_BINARY_PATH={RAY_SERVE_HAPROXY_BINARY_PATH!r} "
             "does not point to an executable file."
         )
-
-    # 2. Bundled binary from the ray-haproxy package.
-    try:
-        from ray_haproxy import get_haproxy_binary as _pip_binary
-
-        return _pip_binary()
-    except ImportError:
-        pass
-    except OSError:
-        pass
 
     # 3. System PATH fallback.
     system_haproxy = shutil.which("haproxy")

--- a/python/ray/serve/tests/unit/test_haproxy_binary.py
+++ b/python/ray/serve/tests/unit/test_haproxy_binary.py
@@ -2,8 +2,8 @@
 
 get_haproxy_binary() resolves an HAProxy binary path with this priority:
   0. Flag off  → return RAY_SERVE_HAPROXY_BINARY_PATH verbatim (no resolution).
-  1. Explicit RAY_SERVE_HAPROXY_BINARY_PATH override → validate and return.
-  2. Bundled binary from the ``ray-haproxy`` PyPI package.
+  1. Bundled binary from the ``ray-haproxy`` PyPI package.
+  2. Explicit RAY_SERVE_HAPROXY_BINARY_PATH override → validate and return.
   3. System ``haproxy`` on PATH.
   4. FileNotFoundError with an actionable message.
 """

--- a/python/ray/serve/tests/unit/test_haproxy_binary.py
+++ b/python/ray/serve/tests/unit/test_haproxy_binary.py
@@ -32,10 +32,13 @@ def test_flag_off_is_noop():
     assert get_haproxy_binary() == "haproxy"
 
 
+@patch.dict("sys.modules", {"ray_haproxy": None})
 @patch(FLAG_PATCH, True)
 def test_explicit_path_validates_executable(tmp_path):
-    """When a user sets RAY_SERVE_HAPROXY_BINARY_PATH, we check that the file
-    exists and is executable before returning it."""
+    """When the bundled ray-haproxy package is unavailable, RAY_SERVE_HAPROXY_BINARY_PATH
+    is used as an override: we check that the file exists and is executable
+    before returning it. (ray_haproxy is patched absent so resolution reaches
+    this branch rather than the now-higher-priority bundled binary.)"""
     binary = tmp_path / "haproxy"
     binary.write_bytes(b"")
     binary.chmod(binary.stat().st_mode | stat.S_IXUSR)


### PR DESCRIPTION
## Why

`RAY_SERVE_EXPERIMENTAL_PIP_HAPROXY=1` is supposed to make Ray Serve use the HAProxy binary bundled in the `ray-haproxy` PyPI package. In practice it was a **no-op** whenever the runtime image sets `RAY_SERVE_HAPROXY_BINARY_PATH` — which the Ray images do (`docker/base-deps/Dockerfile` sets `RAY_SERVE_HAPROXY_BINARY_PATH=/usr/local/bin/haproxy`).

`_resolve_haproxy_binary()` honored the explicit-path override *before* trying the bundled wheel, so with the flag on it returned `/usr/local/bin/haproxy` and never reached the `ray_haproxy` package. As a result the `*.aws.pip_haproxy` nightly release variants (`serve_controller_benchmark_haproxy`, `pytest_serve_autoscaling_load_test`) silently benchmarked the image's system build, not the pip binary they were meant to validate.

Confirmed from a `pip_haproxy` release run's proxy logs: every proxy logged `Using HAProxy binary: /usr/local/bin/haproxy`; the wheel path never appeared.

## What

- Resolve the bundled `ray-haproxy` binary **first**, so the flag takes precedence over an image-baked `RAY_SERVE_HAPROXY_BINARY_PATH`.
- The explicit-path override and system-PATH fallback are unchanged, and still apply when the `ray-haproxy` package is unavailable.
- Flag-off (default) behavior is unchanged: return `RAY_SERVE_HAPROXY_BINARY_PATH` verbatim.

No change needed in `release_tests.yaml`: the existing `pip_haproxy` variants now actually exercise the pip binary.

## Testing

Existing `python/ray/serve/tests/unit/test_haproxy_binary.py` suite passes against the new ordering (4 tests). Docstring updated to reflect the resolution order.
