### PR TITLE
[Data][1/n] Extract generic `WeightedRoundRobinPartitioner`

### DIFF
--- a/python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py
@@ -1,9 +1,5 @@
-import collections
 import logging
-from dataclasses import dataclass, field
-from typing import Optional
 
-from ray.data._internal.datasource_v2.chunkers.file_chunker import ChunkMetadata
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
     FilePartitioner,
@@ -11,36 +7,9 @@ from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
 from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
     InMemorySizeEstimator,
 )
+from ray.data._internal.weighted_round_robin import WeightedRoundRobinPartitioner
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class _FileBucket:
-    """A bucket of paths."""
-
-    paths: list = field(default_factory=list)
-    file_sizes: list = field(default_factory=list)
-    file_chunk_metadatas: list = field(default_factory=list)
-    in_memory_size: int = 0
-
-    def add(
-        self,
-        path: str,
-        file_size: int,
-        file_chunk_metadata: Optional[ChunkMetadata],
-        in_memory_size: int,
-    ):
-        self.paths.append(path)
-        self.file_sizes.append(file_size)
-        self.file_chunk_metadatas.append(file_chunk_metadata)
-        self.in_memory_size += in_memory_size
-
-    def clear(self):
-        self.paths.clear()
-        self.file_sizes.clear()
-        self.file_chunk_metadatas.clear()
-        self.in_memory_size = 0
 
 
 class RoundRobinPartitioner(FilePartitioner):
@@ -74,13 +43,11 @@ class RoundRobinPartitioner(FilePartitioner):
         num_buckets: int,
     ):
         self._in_memory_size_estimator = in_memory_size_estimator
-        self._num_buckets = num_buckets
-        self._min_bucket_size = min_bucket_size
-        self._max_bucket_size = max_bucket_size
-
-        self._buckets = [_FileBucket() for _ in range(num_buckets)]
-        self._current_bucket_index = 0
-        self._output_queue: collections.deque[FileManifest] = collections.deque()
+        self._partitioner = WeightedRoundRobinPartitioner(
+            min_bucket_size=min_bucket_size,
+            max_bucket_size=max_bucket_size,
+            num_buckets=num_buckets,
+        )
 
     def add_input(self, input_manifest: FileManifest):
         in_memory_size_estimates = (
@@ -97,61 +64,26 @@ class RoundRobinPartitioner(FilePartitioner):
             input_manifest.file_chunk_metadatas,
             in_memory_size_estimates,
         ):
-            current_bucket = self._buckets[self._current_bucket_index]
-
-            # If an in-memory size estimate isn't available, add the file to the current
-            # bucket and move to the next bucket. This has the effect of spreading the
-            # files evenly across the buckets if no in-memory size estimates are
-            # available.
-            #
-            # This is a special-case for file systems that don't provide file sizes
-            # like HTTP-based file systems.
-            if in_memory_size_estimate is None:
-                current_bucket.add(
-                    file_path,
-                    file_size,
-                    file_chunk_metadata,
-                    0,
-                )
-                self._current_bucket_index = (
-                    self._current_bucket_index + 1
-                ) % self._num_buckets
-                continue
-
-            current_bucket.add(
-                file_path,
-                file_size,
-                file_chunk_metadata,
+            self._partitioner.add_item(
+                (file_path, file_size, file_chunk_metadata),
                 in_memory_size_estimate,
             )
-            if current_bucket.in_memory_size >= self._max_bucket_size:
-                manifest = FileManifest.construct_manifest(
-                    current_bucket.paths,
-                    current_bucket.file_sizes,
-                    current_bucket.file_chunk_metadatas,
-                )
-                self._output_queue.append(manifest)
-                self._current_bucket_index = (
-                    self._current_bucket_index + 1
-                ) % self._num_buckets
-                current_bucket.clear()
-            elif current_bucket.in_memory_size >= self._min_bucket_size:
-                self._current_bucket_index = (
-                    self._current_bucket_index + 1
-                ) % self._num_buckets
 
     def has_partition(self) -> bool:
-        return len(self._output_queue) > 0
+        return self._partitioner.has_partition()
+
+    @property
+    def num_buckets(self) -> int:
+        return self._partitioner.num_buckets
 
     def next_partition(self) -> FileManifest:
-        return self._output_queue.popleft()
+        partition = self._partitioner.next_partition()
+        paths, file_sizes, file_chunk_metadatas = zip(*partition)
+        return FileManifest.construct_manifest(
+            list(paths),
+            list(file_sizes),
+            list(file_chunk_metadatas),
+        )
 
     def finalize(self):
-        for bucket in self._buckets:
-            if bucket.paths:
-                manifest = FileManifest.construct_manifest(
-                    bucket.paths,
-                    bucket.file_sizes,
-                    bucket.file_chunk_metadatas,
-                )
-                self._output_queue.append(manifest)
+        self._partitioner.finalize()

--- a/python/ray/data/_internal/datasource_v2/tests/test_file_partitioners.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_file_partitioners.py
@@ -16,6 +16,7 @@ from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner impor
 from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
     InMemorySizeEstimator,
 )
+from ray.data._internal.weighted_round_robin import WeightedRoundRobinPartitioner
 
 
 @pytest.mark.parametrize(
@@ -116,6 +117,25 @@ def test_round_robin_partitioner_with_no_size_estimates():
     assert len(partitions) == 2
     assert partitions[0] == ["path0", "path2"]
     assert partitions[1] == ["path1"]
+
+
+def test_weighted_round_robin_partitioner_can_emit_before_overflow():
+    partitioner = WeightedRoundRobinPartitioner(
+        num_buckets=1,
+        min_bucket_size=1,
+        max_bucket_size=3,
+        emit_before_overflow=True,
+    )
+
+    partitioner.add_item("a", 2)
+    partitioner.add_item("b", 2)
+
+    assert partitioner.has_partition()
+    assert partitioner.next_partition() == ["a"]
+
+    partitioner.finalize()
+    assert partitioner.has_partition()
+    assert partitioner.next_partition() == ["b"]
 
 
 if __name__ == "__main__":

--- a/python/ray/data/_internal/weighted_round_robin.py
+++ b/python/ray/data/_internal/weighted_round_robin.py
@@ -64,7 +64,7 @@ class WeightedRoundRobinPartitioner(Generic[T]):
         # (e.g. file_size * encoding_ratio), and truncating each per-item
         # estimate would shift bucket-fullness and emit/advance timing relative
         # to accumulating the raw values.
-        weight = max(0, weight)
+        weight = max(0.0, weight)
         while (
             self._emit_before_overflow
             and current_bucket.items

--- a/python/ray/data/_internal/weighted_round_robin.py
+++ b/python/ray/data/_internal/weighted_round_robin.py
@@ -1,0 +1,111 @@
+import collections
+from dataclasses import dataclass, field
+from typing import Generic, List, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class _WeightedBucket(Generic[T]):
+    """A bucket of weighted items."""
+
+    items: List[T] = field(default_factory=list)
+    weight: float = 0
+
+    def add(
+        self,
+        item: T,
+        weight: float,
+    ):
+        self.items.append(item)
+        self.weight += weight
+
+    def clear(self):
+        self.items.clear()
+        self.weight = 0
+
+
+class WeightedRoundRobinPartitioner(Generic[T]):
+    """Partitions weighted items into round-robin buckets.
+
+    Each item has an optional weight. If a weight is missing, the item is still
+    spread round-robin but doesn't contribute to bucket fullness.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_bucket_size: int,
+        max_bucket_size: int,
+        num_buckets: int,
+        emit_before_overflow: bool = False,
+    ):
+        self._num_buckets = max(1, num_buckets)
+        self._min_bucket_size = min_bucket_size
+        self._max_bucket_size = max_bucket_size
+        self._emit_before_overflow = emit_before_overflow
+
+        self._buckets = [_WeightedBucket[T]() for _ in range(self._num_buckets)]
+        self._current_bucket_index = 0
+        self._output_queue: collections.deque[List[T]] = collections.deque()
+
+    def add_item(self, item: T, weight: Optional[float]) -> None:
+        current_bucket = self._current_bucket
+
+        # If a weight estimate isn't available, add the item to the current
+        # bucket and move on. This spreads unknown-size items evenly across
+        # buckets without pretending to know their size.
+        if weight is None:
+            current_bucket.add(item, 0)
+            self._advance_bucket()
+            return
+
+        # Do not truncate to int: in-memory size estimates are floating-point
+        # (e.g. file_size * encoding_ratio), and truncating each per-item
+        # estimate would shift bucket-fullness and emit/advance timing relative
+        # to accumulating the raw values.
+        weight = max(0, weight)
+        while (
+            self._emit_before_overflow
+            and current_bucket.items
+            and current_bucket.weight + weight > self._max_bucket_size
+        ):
+            self._emit_current_bucket()
+            current_bucket = self._current_bucket
+
+        current_bucket.add(item, weight)
+        if current_bucket.weight >= self._max_bucket_size:
+            self._emit_current_bucket()
+        elif current_bucket.weight >= self._min_bucket_size:
+            self._advance_bucket()
+
+    def has_partition(self) -> bool:
+        return len(self._output_queue) > 0
+
+    def next_partition(self) -> List[T]:
+        return self._output_queue.popleft()
+
+    def finalize(self):
+        for bucket in self._buckets:
+            if bucket.items:
+                self._output_queue.append(list(bucket.items))
+                bucket.clear()
+
+    @property
+    def num_buckets(self) -> int:
+        return self._num_buckets
+
+    @property
+    def _current_bucket(self) -> _WeightedBucket[T]:
+        return self._buckets[self._current_bucket_index]
+
+    def _advance_bucket(self):
+        self._current_bucket_index = (
+            self._current_bucket_index + 1
+        ) % self._num_buckets
+
+    def _emit_current_bucket(self):
+        current_bucket = self._current_bucket
+        self._output_queue.append(list(current_bucket.items))
+        current_bucket.clear()
+        self._advance_bucket()

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -137,7 +137,7 @@ def test_read_parquet_v2_override_num_blocks_drives_partitioner(tmp_path, restor
     list_files_op = ds._logical_plan.dag.input_dependencies[0]
     assert isinstance(list_files_op, ListFiles)
     assert isinstance(list_files_op.file_partitioner, RoundRobinPartitioner)
-    assert list_files_op.file_partitioner._num_buckets == 7
+    assert list_files_op.file_partitioner.num_buckets == 7
     assert restore_ctx.read_op_min_num_blocks == original
 
 


### PR DESCRIPTION
## Description
Pull the bucketing logic out of `RoundRobinPartitioner` into a reusable, generic `WeightedRoundRobinPartitioner` in `ray.data._internal`. No behavior change; `RoundRobinPartitioner` now delegates to it.

The purpose is to have the abstraction be shareable between `ReadFiles` and `download()`