### PR TITLE
[Dashboard] Fix file descriptor leak in k8s_utils.py

### DIFF
--- a/python/ray/dashboard/k8s_utils.py
+++ b/python/ray/dashboard/k8s_utils.py
@@ -68,10 +68,12 @@ def _cpu_usage():
     by reading from cpuacct in cgroups v1 or cpu.stat in cgroups v2."""
     try:
         # cgroups v1
-        return int(open(CPU_USAGE_PATH).read())
+        with open(CPU_USAGE_PATH) as f:
+            return int(f.read())
     except FileNotFoundError:
         # cgroups v2
-        cpu_stat_text = open(CPU_USAGE_PATH_V2).read()
+        with open(CPU_USAGE_PATH_V2) as f:
+            cpu_stat_text = f.read()
         # e.g. "usage_usec 16089294616"
         cpu_stat_first_line = cpu_stat_text.split("\n")[0]
         # get the second word of the first line, cast as an integer
@@ -91,7 +93,8 @@ def _system_usage():
     See also the /proc/stat entry here:
     https://man7.org/linux/man-pages/man5/proc.5.html
     """  # noqa
-    cpu_summary_str = open(PROC_STAT_PATH).read().split("\n")[0]
+    with open(PROC_STAT_PATH) as f:
+        cpu_summary_str = f.readline()
     parts = cpu_summary_str.split()
     assert parts[0] == "cpu"
     usage_data = parts[1:8]
@@ -105,7 +108,8 @@ def _host_num_cpus():
     """Number of physical CPUs, obtained by parsing /proc/stat."""
     global host_num_cpus
     if host_num_cpus is None:
-        proc_stat_lines = open(PROC_STAT_PATH).read().split("\n")
+        with open(PROC_STAT_PATH) as f:
+            proc_stat_lines = f.read().split("\n")
         split_proc_stat_lines = [line.split() for line in proc_stat_lines]
         cpu_lines = [
             split_line


### PR DESCRIPTION
The helpers in k8s_utils.py read cgroup and /proc/stat files via open(...).read() without using a context manager. Since cpu_percent() is invoked frequently by the dashboard reporter when Ray runs in a Kubernetes pod, the unclosed file objects leak file descriptors until garbage collection runs and emit ResourceWarning under warning-as-error settings.

Wrap each open() call with a 'with' statement so the file is closed deterministically. Behavior is otherwise unchanged.

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.


## Description

The helpers in `python/ray/dashboard/k8s_utils.py` read cgroup and `/proc/stat`
files via `open(...).read()` without using a context manager. Since
`cpu_percent()` is invoked frequently by the dashboard reporter when Ray runs
in a Kubernetes pod, the unclosed file objects rely on garbage collection for
cleanup, which:

- leaks file descriptors between GC cycles, and
- emits `ResourceWarning: unclosed file ...` under warning-as-error settings
  (e.g. tests run with `-W error`).

This PR wraps each `open()` call with a `with` statement so the file is closed
deterministically. Behavior is otherwise unchanged.

Affected callsites in `k8s_utils.py`:

- `_cpu_usage()` — reading cgroups v1 `cpuacct.usage`
- `_cpu_usage()` — reading cgroups v2 `cpu.stat`
- `_system_usage()` — reading `/proc/stat`
- `_host_num_cpus()` — reading `/proc/stat`

## Related issues

N/A — pure resource-management cleanup, no user-facing behavior change.

