### PR TITLE
[RLlib] Pull-based EnvRunnerStateServer for async weight sync

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1608,6 +1608,17 @@ py_test(
 )
 
 py_test(
+    name = "test_env_runner_state_server",
+    size = "small",
+    srcs = ["algorithms/tests/test_env_runner_state_server.py"],
+    tags = [
+        "algorithms",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
+py_test(
     name = "test_algorithm_export_checkpoint",
     size = "medium",
     srcs = ["algorithms/tests/test_algorithm_export_checkpoint.py"],

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -344,6 +344,9 @@ class AlgorithmConfig(_Config):
         self.add_default_connectors_to_module_to_env_pipeline = True
         self.merge_env_runner_states = "training_only"
         self.broadcast_env_runner_states = True
+        self.use_env_runner_state_server = False
+        self.env_runner_state_server_max_concurrency = 16
+        self.env_runner_state_server_pull_timeout_s = 10.0
         self.episode_lookback_horizon = 1
         # TODO (sven): Rename into `sample_timesteps` (or `sample_duration`
         #  and `sample_duration_unit` (replacing batch_mode), like we do it
@@ -1877,6 +1880,9 @@ class AlgorithmConfig(_Config):
         episode_lookback_horizon: Optional[int] = NotProvided,
         merge_env_runner_states: Optional[Union[str, bool]] = NotProvided,
         broadcast_env_runner_states: Optional[bool] = NotProvided,
+        use_env_runner_state_server: Optional[bool] = NotProvided,
+        env_runner_state_server_max_concurrency: Optional[int] = NotProvided,
+        env_runner_state_server_pull_timeout_s: Optional[float] = NotProvided,
         compress_observations: Optional[bool] = NotProvided,
         rollout_fragment_length: Optional[Union[int, str]] = NotProvided,
         batch_mode: Optional[str] = NotProvided,
@@ -2002,6 +2008,22 @@ class AlgorithmConfig(_Config):
             broadcast_env_runner_states: True, if merged EnvRunner states (from the
                 central connector pipelines) should be broadcast back to all remote
                 EnvRunner actors.
+            use_env_runner_state_server: If True (and on the new API stack with an async
+                algorithm like IMPALA/APPO), EnvRunners PULL the latest weights and
+                merged connector states from a single global `EnvRunnerStateServer`
+                actor at the top of each `sample()` call, instead of having the
+                Algorithm PUSH (broadcast) state to every EnvRunner. This avoids
+                silently dropping newer weight broadcasts under back-pressure while an
+                EnvRunner is busy sampling, keeping the sampling policy fresher (lower
+                `diff_num_grad_updates_vs_sampler_policy`).
+            env_runner_state_server_max_concurrency: The `max_concurrency` (thread-pool
+                size) of the `EnvRunnerStateServer` actor, i.e. how many EnvRunner
+                `pull` requests it can serve concurrently. Raise this for very large
+                EnvRunner fleets. Only used when `use_env_runner_state_server=True`.
+            env_runner_state_server_pull_timeout_s: Timeout (seconds) for an EnvRunner's
+                `pull` from the `EnvRunnerStateServer`. On timeout (e.g. the server is
+                mid-restart), the EnvRunner keeps its current weights for that round
+                instead of blocking. Only used when `use_env_runner_state_server=True`.
             use_worker_filter_stats: Whether to use the workers in the EnvRunnerGroup to
                 update the central filters (held by the local worker). If False, stats
                 from the workers aren't used and are discarded.
@@ -2160,6 +2182,16 @@ class AlgorithmConfig(_Config):
             self.merge_env_runner_states = merge_env_runner_states
         if broadcast_env_runner_states is not NotProvided:
             self.broadcast_env_runner_states = broadcast_env_runner_states
+        if use_env_runner_state_server is not NotProvided:
+            self.use_env_runner_state_server = use_env_runner_state_server
+        if env_runner_state_server_max_concurrency is not NotProvided:
+            self.env_runner_state_server_max_concurrency = (
+                env_runner_state_server_max_concurrency
+            )
+        if env_runner_state_server_pull_timeout_s is not NotProvided:
+            self.env_runner_state_server_pull_timeout_s = (
+                env_runner_state_server_pull_timeout_s
+            )
         if use_worker_filter_stats is not NotProvided:
             self.use_worker_filter_stats = use_worker_filter_stats
         if update_worker_filter_stats is not NotProvided:

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -346,7 +346,6 @@ class AlgorithmConfig(_Config):
         self.broadcast_env_runner_states = True
         self.use_env_runner_state_server = False
         self.env_runner_state_server_max_concurrency = 16
-        self.env_runner_state_server_pull_timeout_s = 10.0
         self.episode_lookback_horizon = 1
         # TODO (sven): Rename into `sample_timesteps` (or `sample_duration`
         #  and `sample_duration_unit` (replacing batch_mode), like we do it
@@ -1882,7 +1881,6 @@ class AlgorithmConfig(_Config):
         broadcast_env_runner_states: Optional[bool] = NotProvided,
         use_env_runner_state_server: Optional[bool] = NotProvided,
         env_runner_state_server_max_concurrency: Optional[int] = NotProvided,
-        env_runner_state_server_pull_timeout_s: Optional[float] = NotProvided,
         compress_observations: Optional[bool] = NotProvided,
         rollout_fragment_length: Optional[Union[int, str]] = NotProvided,
         batch_mode: Optional[str] = NotProvided,
@@ -2020,10 +2018,6 @@ class AlgorithmConfig(_Config):
                 size) of the `EnvRunnerStateServer` actor, i.e. how many EnvRunner
                 `pull` requests it can serve concurrently. Raise this for very large
                 EnvRunner fleets. Only used when `use_env_runner_state_server=True`.
-            env_runner_state_server_pull_timeout_s: Timeout (seconds) for an EnvRunner's
-                `pull` from the `EnvRunnerStateServer`. On timeout (e.g. the server is
-                mid-restart), the EnvRunner keeps its current weights for that round
-                instead of blocking. Only used when `use_env_runner_state_server=True`.
             use_worker_filter_stats: Whether to use the workers in the EnvRunnerGroup to
                 update the central filters (held by the local worker). If False, stats
                 from the workers aren't used and are discarded.
@@ -2187,10 +2181,6 @@ class AlgorithmConfig(_Config):
         if env_runner_state_server_max_concurrency is not NotProvided:
             self.env_runner_state_server_max_concurrency = (
                 env_runner_state_server_max_concurrency
-            )
-        if env_runner_state_server_pull_timeout_s is not NotProvided:
-            self.env_runner_state_server_pull_timeout_s = (
-                env_runner_state_server_pull_timeout_s
             )
         if use_worker_filter_stats is not NotProvided:
             self.use_worker_filter_stats = use_worker_filter_stats

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -2006,18 +2006,14 @@ class AlgorithmConfig(_Config):
             broadcast_env_runner_states: True, if merged EnvRunner states (from the
                 central connector pipelines) should be broadcast back to all remote
                 EnvRunner actors.
-            use_env_runner_state_server: If True (and on the new API stack with an async
-                algorithm like IMPALA/APPO), EnvRunners PULL the latest weights and
-                merged connector states from a single global `EnvRunnerStateServer`
-                actor at the top of each `sample()` call, instead of having the
-                Algorithm PUSH (broadcast) state to every EnvRunner. This avoids
-                silently dropping newer weight broadcasts under back-pressure while an
-                EnvRunner is busy sampling, keeping the sampling policy fresher (lower
-                `diff_num_grad_updates_vs_sampler_policy`).
-            env_runner_state_server_max_concurrency: The `max_concurrency` (thread-pool
-                size) of the `EnvRunnerStateServer` actor, i.e. how many EnvRunner
-                `pull` requests it can serve concurrently. Raise this for very large
-                EnvRunner fleets. Only used when `use_env_runner_state_server=True`.
+            use_env_runner_state_server: If True (new API stack, async algorithms like
+                IMPALA/APPO), EnvRunners pull the latest weights and merged connector
+                states from a single global `EnvRunnerStateServer` actor at the top of
+                each `sample()` call, instead of the Algorithm broadcasting state to
+                every EnvRunner.
+            env_runner_state_server_max_concurrency: `max_concurrency` of the
+                `EnvRunnerStateServer` actor, i.e. how many EnvRunner `pull` requests it
+                serves concurrently. Only used when `use_env_runner_state_server=True`.
             use_worker_filter_stats: Whether to use the workers in the EnvRunnerGroup to
                 update the central filters (held by the local worker). If False, stats
                 from the workers aren't used and are discarded.

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -3,9 +3,11 @@ import unittest
 import ray
 import ray.rllib.algorithms.appo as appo
 from ray.rllib.algorithms.impala.impala import LEARNER_RESULTS_CURR_ENTROPY_COEFF_KEY
+from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.core.rl_module.default_model_config import DefaultModelConfig
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.metrics import (
+    DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
     ENV_RUNNER_RESULTS,
     LEARNER_RESULTS,
     NUM_ENV_STEPS_SAMPLED_LIFETIME,
@@ -214,6 +216,74 @@ class TestAPPO(unittest.TestCase):
         # We should not get the tensors from the target model here or any value function
         # related parameters (inference-only).
         self.assertEqual(len(state), 5)
+
+    def test_env_runner_state_server_on_vs_off(self):
+        """PULL-based EnvRunnerStateServer: APPO learns with the flag ON and OFF.
+
+        Also checks the off-policyness metric is logged on the new-stack path and that
+        the global server actor is created only when the flag is enabled.
+        """
+        off_policyness = {}
+        for use_server in [False, True]:
+            config = (
+                appo.APPOConfig()
+                .environment("CartPole-v1")
+                .env_runners(
+                    num_env_runners=2,
+                    use_env_runner_state_server=use_server,
+                )
+            )
+            algo = config.build()
+            # The global server actor exists iff the flag is enabled.
+            self.assertEqual(algo._env_runner_state_server is not None, use_server)
+
+            for _ in range(5):
+                results = algo.train()
+            check_train_results_new_api_stack(results)
+
+            diff = algo.metrics.peek(
+                (
+                    LEARNER_RESULTS,
+                    DEFAULT_MODULE_ID,
+                    DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
+                ),
+                default=None,
+            )
+            # The off-policyness metric must be present and finite/non-negative.
+            self.assertIsNotNone(diff)
+            self.assertGreaterEqual(diff, 0.0)
+            off_policyness[use_server] = diff
+            algo.stop()
+
+        print("APPO off-policyness (server OFF vs ON):", off_policyness)
+
+    def test_env_runner_state_server_kill_and_recover(self):
+        """Killing the EnvRunnerStateServer must not stop training; it recovers."""
+        config = (
+            appo.APPOConfig()
+            .environment("CartPole-v1")
+            .env_runners(num_env_runners=2, use_env_runner_state_server=True)
+        )
+        algo = config.build()
+        self.assertIsNotNone(algo._env_runner_state_server)
+
+        for _ in range(3):
+            algo.train()
+        version_before = ray.get(algo._env_runner_state_server.get_version.remote())
+        self.assertGreater(version_before, 0)
+
+        # Kill the server. `max_restarts=-1` makes Ray restart it (with empty state).
+        ray.kill(algo._env_runner_state_server, no_restart=False)
+
+        # Training must continue (EnvRunners keep their current weights through the gap)
+        # and the Algorithm must re-push its backup so the version recovers.
+        for _ in range(3):
+            results = algo.train()
+        check_train_results_new_api_stack(results)
+        version_after = ray.get(algo._env_runner_state_server.get_version.remote())
+        self.assertGreaterEqual(version_after, version_before)
+
+        algo.stop()
 
 
 if __name__ == "__main__":

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -276,7 +276,8 @@ class TestAPPO(unittest.TestCase):
         ray.kill(algo._env_runner_state_server, no_restart=False)
 
         # Training must continue (EnvRunners keep their current weights through the gap)
-        # and the Algorithm must re-push its backup so the version recovers.
+        # and the next per-iteration push must re-seed the restarted server so the
+        # version recovers.
         for _ in range(3):
             results = algo.train()
         check_train_results_new_api_stack(results)

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -221,6 +221,7 @@ class TestAPPO(unittest.TestCase):
         Also checks the global server actor is created only when the flag is enabled.
         """
         for use_server in [False, True]:
+            print(f"Testing with use_server={use_server}")
             config = (
                 appo.APPOConfig()
                 .environment("CartPole-v1")

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -275,9 +275,7 @@ class TestAPPO(unittest.TestCase):
         # Kill the server. `max_restarts=-1` makes Ray restart it (with empty state).
         ray.kill(algo._env_runner_state_server, no_restart=False)
 
-        # Training must continue (EnvRunners keep their current weights through the gap)
-        # and the next per-iteration push must re-seed the restarted server so the
-        # version recovers.
+        # Training continues through the gap and the next push re-seeds the server.
         for _ in range(3):
             results = algo.train()
         check_train_results_new_api_stack(results)

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -234,8 +234,7 @@ class TestAPPO(unittest.TestCase):
             # The global server actor exists iff the flag is enabled.
             self.assertEqual(algo._env_runner_state_server is not None, use_server)
 
-            for _ in range(5):
-                results = algo.train()
+            results = algo.train()
             check_train_results_new_api_stack(results)
             algo.stop()
 

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -3,11 +3,9 @@ import unittest
 import ray
 import ray.rllib.algorithms.appo as appo
 from ray.rllib.algorithms.impala.impala import LEARNER_RESULTS_CURR_ENTROPY_COEFF_KEY
-from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.core.rl_module.default_model_config import DefaultModelConfig
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.metrics import (
-    DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
     ENV_RUNNER_RESULTS,
     LEARNER_RESULTS,
     NUM_ENV_STEPS_SAMPLED_LIFETIME,
@@ -220,10 +218,8 @@ class TestAPPO(unittest.TestCase):
     def test_env_runner_state_server_on_vs_off(self):
         """PULL-based EnvRunnerStateServer: APPO learns with the flag ON and OFF.
 
-        Also checks the off-policyness metric is logged on the new-stack path and that
-        the global server actor is created only when the flag is enabled.
+        Also checks the global server actor is created only when the flag is enabled.
         """
-        off_policyness = {}
         for use_server in [False, True]:
             config = (
                 appo.APPOConfig()
@@ -240,22 +236,7 @@ class TestAPPO(unittest.TestCase):
             for _ in range(5):
                 results = algo.train()
             check_train_results_new_api_stack(results)
-
-            diff = algo.metrics.peek(
-                (
-                    LEARNER_RESULTS,
-                    DEFAULT_MODULE_ID,
-                    DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
-                ),
-                default=None,
-            )
-            # The off-policyness metric must be present and finite/non-negative.
-            self.assertIsNotNone(diff)
-            self.assertGreaterEqual(diff, 0.0)
-            off_policyness[use_server] = diff
             algo.stop()
-
-        print("APPO off-policyness (server OFF vs ON):", off_policyness)
 
     def test_env_runner_state_server_kill_and_recover(self):
         """Killing the EnvRunnerStateServer must not stop training; it recovers."""

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import queue
-import uuid
 from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
 from typing_extensions import Self
@@ -610,9 +609,10 @@ class IMPALA(Algorithm):
             self._learner_thread = make_learner_thread(self.env_runner, self.config)
             self._learner_thread.start()
 
-        # For pull-based EnvRunner state sync: create a single, global, NAMED
+        # For pull-based EnvRunner state sync: create a single, global
         # `EnvRunnerStateServer` actor holding the latest merged EnvRunner state.
-        # EnvRunners pull from it at the top of each `sample()` call.
+        # EnvRunners receive the handle by reference (shared below) and pull from it at
+        # the top of each `sample()` call; no one looks the actor up by name.
         self._env_runner_state_server = None
         if (
             self.config.enable_rl_module_and_learner
@@ -625,9 +625,7 @@ class IMPALA(Algorithm):
                 max_restarts=-1,
                 max_concurrency=self.config.env_runner_state_server_max_concurrency,
             )(EnvRunnerStateServer)
-            self._env_runner_state_server = server_cls.options(
-                name=f"EnvRunnerStateServer_{self.trial_id}_{uuid.uuid4().hex[:8]}",
-            ).remote()
+            self._env_runner_state_server = server_cls.remote()
 
             # Share the handle with the (remote, training) EnvRunners only.
             def _share_state_server(env_runner, server=self._env_runner_state_server):

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import queue
+import uuid
 from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
 from typing_extensions import Self
@@ -46,7 +47,6 @@ from ray.rllib.utils.metrics import (
     SAMPLE_TIMER,
     SYNCH_WORKER_WEIGHTS_TIMER,
     TIMERS,
-    WEIGHTS_SEQ_NO,
 )
 from ray.rllib.utils.metrics.learner_info import LearnerInfoBuilder
 from ray.rllib.utils.metrics.ray_metrics import (
@@ -616,11 +616,11 @@ class IMPALA(Algorithm):
         # `EnvRunnerStateServer` actor holding the latest merged EnvRunner state.
         # EnvRunners pull from it at the top of each `sample()` instead of the Algorithm
         # broadcasting (pushing) state, which can silently drop newer weight broadcasts
-        # under back-pressure while an EnvRunner is busy sampling. The Algorithm keeps a
-        # backup of the last pushed state, so the server (pure derived state) is
-        # recoverable and not a single point of failure.
+        # under back-pressure while an EnvRunner is busy sampling. If the server ever
+        # restarts (it comes back empty), the next per-iteration push re-seeds it and
+        # EnvRunners just keep their current weights until then - so it is not a single
+        # point of failure.
         self._env_runner_state_server = None
-        self._last_pushed_env_runner_state = None
         if (
             self.config.enable_rl_module_and_learner
             and self.config.enable_env_runner_and_connector_v2
@@ -632,11 +632,11 @@ class IMPALA(Algorithm):
                 max_restarts=-1,
                 max_concurrency=self.config.env_runner_state_server_max_concurrency,
             )(EnvRunnerStateServer)
+            # Unique name: `self.trial_id` is "default" outside Ray Tune, so a uuid
+            # suffix prevents distinct Algorithms in one cluster from sharing - and
+            # silently corrupting - the same server.
             self._env_runner_state_server = server_cls.options(
-                # Named (incl. trial_id to avoid Tune collisions) so it is re-acquirable
-                # via `ray.get_actor` after a restart.
-                name=f"EnvRunnerStateServer_{self.trial_id}",
-                get_if_exists=True,
+                name=f"EnvRunnerStateServer_{self.trial_id}_{uuid.uuid4().hex[:8]}",
             ).remote()
 
             # Share the handle with the (remote, training) EnvRunners only. Eval
@@ -879,7 +879,8 @@ class IMPALA(Algorithm):
                         if self._env_runner_state_server is not None:
                             # PULL model: assemble the merged state once and push it to
                             # the single global server; EnvRunners pull it from there at
-                            # the top of `sample()`. Keep a backup for server recovery.
+                            # the top of `sample()`. A restarted (empty) server is
+                            # simply re-seeded by this push on the next weight sync.
                             env_runner_state = (
                                 self.env_runner_group.get_merged_env_runner_state(
                                     config=self.config,
@@ -897,7 +898,6 @@ class IMPALA(Algorithm):
                                 )
                             )
                             self._env_runner_state_server.push.remote(env_runner_state)
-                            self._last_pushed_env_runner_state = env_runner_state
                         else:
                             self.env_runner_group.sync_env_runner_states(
                                 config=self.config,
@@ -913,38 +913,6 @@ class IMPALA(Algorithm):
                                 env_to_module=self.env_to_module_connector,
                                 module_to_env=self.module_to_env_connector,
                             )
-
-            # Recover the EnvRunnerStateServer if it was restarted (it comes back empty):
-            # re-push our backup so EnvRunners resume pulling fresh weights.
-            self._maybe_recover_env_runner_state_server()
-
-    def _maybe_recover_env_runner_state_server(self) -> None:
-        """Re-pushes the backup state if the `EnvRunnerStateServer` was restarted.
-
-        The server uses ``max_restarts=-1`` but comes back with empty state after a
-        restart. We compare its reported version (``WEIGHTS_SEQ_NO``) against our last
-        pushed backup and, if the server is behind (or unreachable mid-restart, handled
-        by the timeout), re-push the backup. This keeps the server from being a single
-        point of failure.
-        """
-        if (
-            self._env_runner_state_server is None
-            or self._last_pushed_env_runner_state is None
-        ):
-            return
-        backup_version = self._last_pushed_env_runner_state.get(WEIGHTS_SEQ_NO, 0)
-        try:
-            server_version = ray.get(
-                self._env_runner_state_server.get_version.remote(),
-                timeout=self.config.env_runner_state_server_pull_timeout_s,
-            )
-            if server_version < backup_version:
-                self._env_runner_state_server.push.remote(
-                    self._last_pushed_env_runner_state
-                )
-        except (ray.exceptions.RayActorError, ray.exceptions.GetTimeoutError):
-            # Server is mid-restart/unreachable; retry on the next training iteration.
-            return
 
     @override(Algorithm)
     def restore_env_runners(self, env_runner_group) -> List[int]:

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -627,13 +627,16 @@ class IMPALA(Algorithm):
             )(EnvRunnerStateServer)
             self._env_runner_state_server = server_cls.remote()
 
-            # Share the handle with the (remote, training) EnvRunners only.
+            # Share the handle with all training EnvRunners, including the local one:
+            # IMPALA falls back to sampling on the local EnvRunner when no remote
+            # workers are healthy, and it must pull the latest state too (otherwise the
+            # fallback would sample with stale weights).
             def _share_state_server(env_runner, server=self._env_runner_state_server):
                 env_runner._env_runner_state_server = server
 
             self.env_runner_group.foreach_env_runner(
                 func=_share_state_server,
-                local_env_runner=False,
+                local_env_runner=True,
             )
 
     @override(Algorithm)
@@ -904,7 +907,7 @@ class IMPALA(Algorithm):
         restored = super().restore_env_runners(env_runner_group)
         # Re-share the EnvRunnerStateServer handle with restored (training) EnvRunners:
         # a fresh actor incarnation lost the attribute set post-construction. A restored
-        # runner starts at weights_seq_no=0, so its first pull force-applies the latest.
+        # runner starts at weights_seq_no=-1, so its first pull force-applies the latest.
         if (
             restored
             and self._env_runner_state_server is not None

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -867,8 +867,13 @@ class IMPALA(Algorithm):
                         self._metrics_impala_training_step_sync_env_runner_state_time
                     ):
                         if self._env_runner_state_server is not None:
-                            # Push the merged state to the single global server;
-                            # EnvRunners pull it at the top of `sample()`.
+                            # Push the full merged EnvRunner state (connector
+                            # states + RLModule weights kept as an ObjectRef +
+                            # counters/WEIGHTS_SEQ_NO) to the EnvRunnerStateServer.
+                            # `push` is fire-and-forget and only rebinds the actor's
+                            # stored reference (O(1)); the weights cross the wire only
+                            # when an EnvRunner pulls a newer version at the top of
+                            # its `sample()` call.
                             env_runner_state = (
                                 self.env_runner_group.get_merged_env_runner_state(
                                     config=self.config,

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -912,7 +912,7 @@ class IMPALA(Algorithm):
         restored = super().restore_env_runners(env_runner_group)
         # Re-share the EnvRunnerStateServer handle with restored (training) EnvRunners:
         # a fresh actor incarnation lost the attribute set post-construction. A restored
-        # runner starts at weights_seq_no=-1, so its first pull force-applies the latest.
+        # runner starts at weights_seq_no=0, so its first pull force-applies the latest.
         if (
             restored
             and self._env_runner_state_server is not None

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -160,9 +160,7 @@ class IMPALAConfig(AlgorithmConfig):
         self._dont_auto_sync_env_runner_states = True
         # Use the PULL-based `EnvRunnerStateServer` by default for async IMPALA/APPO:
         # EnvRunners pull the freshest weights/connector states at the top of each
-        # `sample()` call, rather than the Algorithm broadcasting (pushing) state, which
-        # can silently drop newer weight broadcasts under back-pressure while an
-        # EnvRunner is busy sampling. Inherited by APPO (`APPOConfig(IMPALAConfig)`).
+        # `sample()` call.
         self.use_env_runner_state_server = True
 
         # `.debugging()`
@@ -612,14 +610,9 @@ class IMPALA(Algorithm):
             self._learner_thread = make_learner_thread(self.env_runner, self.config)
             self._learner_thread.start()
 
-        # PULL-based EnvRunner state sync: create a single, global, NAMED
+        # For pull-based EnvRunner state sync: create a single, global, NAMED
         # `EnvRunnerStateServer` actor holding the latest merged EnvRunner state.
-        # EnvRunners pull from it at the top of each `sample()` instead of the Algorithm
-        # broadcasting (pushing) state, which can silently drop newer weight broadcasts
-        # under back-pressure while an EnvRunner is busy sampling. If the server ever
-        # restarts (it comes back empty), the next per-iteration push re-seeds it and
-        # EnvRunners just keep their current weights until then - so it is not a single
-        # point of failure.
+        # EnvRunners pull from it at the top of each `sample()` call.
         self._env_runner_state_server = None
         if (
             self.config.enable_rl_module_and_learner
@@ -632,15 +625,11 @@ class IMPALA(Algorithm):
                 max_restarts=-1,
                 max_concurrency=self.config.env_runner_state_server_max_concurrency,
             )(EnvRunnerStateServer)
-            # Unique name: `self.trial_id` is "default" outside Ray Tune, so a uuid
-            # suffix prevents distinct Algorithms in one cluster from sharing - and
-            # silently corrupting - the same server.
             self._env_runner_state_server = server_cls.options(
                 name=f"EnvRunnerStateServer_{self.trial_id}_{uuid.uuid4().hex[:8]}",
             ).remote()
 
-            # Share the handle with the (remote, training) EnvRunners only. Eval
-            # EnvRunners receive weights via the regular `Algorithm.evaluate()` path.
+            # Share the handle with the (remote, training) EnvRunners only.
             def _share_state_server(env_runner, server=self._env_runner_state_server):
                 env_runner._env_runner_state_server = server
 
@@ -877,10 +866,8 @@ class IMPALA(Algorithm):
                         self._metrics_impala_training_step_sync_env_runner_state_time
                     ):
                         if self._env_runner_state_server is not None:
-                            # PULL model: assemble the merged state once and push it to
-                            # the single global server; EnvRunners pull it from there at
-                            # the top of `sample()`. A restarted (empty) server is
-                            # simply re-seeded by this push on the next weight sync.
+                            # Push the merged state to the single global server;
+                            # EnvRunners pull it at the top of `sample()`.
                             env_runner_state = (
                                 self.env_runner_group.get_merged_env_runner_state(
                                     config=self.config,

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -18,6 +18,7 @@ from ray.rllib.core import (
 )
 from ray.rllib.core.learner.training_data import TrainingData
 from ray.rllib.core.rl_module.rl_module import RLModuleSpec
+from ray.rllib.env.env_runner_state_server import EnvRunnerStateServer
 from ray.rllib.execution.buffers.mixin_replay_buffer import MixInMultiAgentReplayBuffer
 from ray.rllib.execution.learner_thread import LearnerThread
 from ray.rllib.execution.multi_gpu_learner_thread import MultiGPULearnerThread
@@ -45,6 +46,7 @@ from ray.rllib.utils.metrics import (
     SAMPLE_TIMER,
     SYNCH_WORKER_WEIGHTS_TIMER,
     TIMERS,
+    WEIGHTS_SEQ_NO,
 )
 from ray.rllib.utils.metrics.learner_info import LearnerInfoBuilder
 from ray.rllib.utils.metrics.ray_metrics import (
@@ -156,6 +158,12 @@ class IMPALAConfig(AlgorithmConfig):
 
         # IMPALA takes care of its own EnvRunner (weights, connector, metrics) synching.
         self._dont_auto_sync_env_runner_states = True
+        # Use the PULL-based `EnvRunnerStateServer` by default for async IMPALA/APPO:
+        # EnvRunners pull the freshest weights/connector states at the top of each
+        # `sample()` call, rather than the Algorithm broadcasting (pushing) state, which
+        # can silently drop newer weight broadcasts under back-pressure while an
+        # EnvRunner is busy sampling. Inherited by APPO (`APPOConfig(IMPALAConfig)`).
+        self.use_env_runner_state_server = True
 
         # `.debugging()`
         self._env_runners_only = False
@@ -604,6 +612,43 @@ class IMPALA(Algorithm):
             self._learner_thread = make_learner_thread(self.env_runner, self.config)
             self._learner_thread.start()
 
+        # PULL-based EnvRunner state sync: create a single, global, NAMED
+        # `EnvRunnerStateServer` actor holding the latest merged EnvRunner state.
+        # EnvRunners pull from it at the top of each `sample()` instead of the Algorithm
+        # broadcasting (pushing) state, which can silently drop newer weight broadcasts
+        # under back-pressure while an EnvRunner is busy sampling. The Algorithm keeps a
+        # backup of the last pushed state, so the server (pure derived state) is
+        # recoverable and not a single point of failure.
+        self._env_runner_state_server = None
+        self._last_pushed_env_runner_state = None
+        if (
+            self.config.enable_rl_module_and_learner
+            and self.config.enable_env_runner_and_connector_v2
+            and self.config.use_env_runner_state_server
+            and self.config.num_env_runners > 0
+        ):
+            server_cls = ray.remote(
+                num_cpus=0,
+                max_restarts=-1,
+                max_concurrency=self.config.env_runner_state_server_max_concurrency,
+            )(EnvRunnerStateServer)
+            self._env_runner_state_server = server_cls.options(
+                # Named (incl. trial_id to avoid Tune collisions) so it is re-acquirable
+                # via `ray.get_actor` after a restart.
+                name=f"EnvRunnerStateServer_{self.trial_id}",
+                get_if_exists=True,
+            ).remote()
+
+            # Share the handle with the (remote, training) EnvRunners only. Eval
+            # EnvRunners receive weights via the regular `Algorithm.evaluate()` path.
+            def _share_state_server(env_runner, server=self._env_runner_state_server):
+                env_runner._env_runner_state_server = server
+
+            self.env_runner_group.foreach_env_runner(
+                func=_share_state_server,
+                local_env_runner=False,
+            )
+
     @override(Algorithm)
     def training_step(self):
         with TimerAndPrometheusLogger(self._metrics_impala_training_step_time):
@@ -831,17 +876,98 @@ class IMPALA(Algorithm):
                     with TimerAndPrometheusLogger(
                         self._metrics_impala_training_step_sync_env_runner_state_time
                     ):
-                        self.env_runner_group.sync_env_runner_states(
-                            config=self.config,
-                            connector_states=connector_states,
-                            rl_module_state=rl_module_state,
-                            env_steps_sampled=self.metrics.peek(
-                                (ENV_RUNNER_RESULTS, NUM_ENV_STEPS_SAMPLED_LIFETIME),
-                                default=0,
-                            ),
-                            env_to_module=self.env_to_module_connector,
-                            module_to_env=self.module_to_env_connector,
-                        )
+                        if self._env_runner_state_server is not None:
+                            # PULL model: assemble the merged state once and push it to
+                            # the single global server; EnvRunners pull it from there at
+                            # the top of `sample()`. Keep a backup for server recovery.
+                            env_runner_state = (
+                                self.env_runner_group.get_merged_env_runner_state(
+                                    config=self.config,
+                                    connector_states=connector_states,
+                                    rl_module_state=rl_module_state,
+                                    env_steps_sampled=self.metrics.peek(
+                                        (
+                                            ENV_RUNNER_RESULTS,
+                                            NUM_ENV_STEPS_SAMPLED_LIFETIME,
+                                        ),
+                                        default=0,
+                                    ),
+                                    env_to_module=self.env_to_module_connector,
+                                    module_to_env=self.module_to_env_connector,
+                                )
+                            )
+                            self._env_runner_state_server.push.remote(env_runner_state)
+                            self._last_pushed_env_runner_state = env_runner_state
+                        else:
+                            self.env_runner_group.sync_env_runner_states(
+                                config=self.config,
+                                connector_states=connector_states,
+                                rl_module_state=rl_module_state,
+                                env_steps_sampled=self.metrics.peek(
+                                    (
+                                        ENV_RUNNER_RESULTS,
+                                        NUM_ENV_STEPS_SAMPLED_LIFETIME,
+                                    ),
+                                    default=0,
+                                ),
+                                env_to_module=self.env_to_module_connector,
+                                module_to_env=self.module_to_env_connector,
+                            )
+
+            # Recover the EnvRunnerStateServer if it was restarted (it comes back empty):
+            # re-push our backup so EnvRunners resume pulling fresh weights.
+            self._maybe_recover_env_runner_state_server()
+
+    def _maybe_recover_env_runner_state_server(self) -> None:
+        """Re-pushes the backup state if the `EnvRunnerStateServer` was restarted.
+
+        The server uses ``max_restarts=-1`` but comes back with empty state after a
+        restart. We compare its reported version (``WEIGHTS_SEQ_NO``) against our last
+        pushed backup and, if the server is behind (or unreachable mid-restart, handled
+        by the timeout), re-push the backup. This keeps the server from being a single
+        point of failure.
+        """
+        if (
+            self._env_runner_state_server is None
+            or self._last_pushed_env_runner_state is None
+        ):
+            return
+        backup_version = self._last_pushed_env_runner_state.get(WEIGHTS_SEQ_NO, 0)
+        try:
+            server_version = ray.get(
+                self._env_runner_state_server.get_version.remote(),
+                timeout=self.config.env_runner_state_server_pull_timeout_s,
+            )
+            if server_version < backup_version:
+                self._env_runner_state_server.push.remote(
+                    self._last_pushed_env_runner_state
+                )
+        except (ray.exceptions.RayActorError, ray.exceptions.GetTimeoutError):
+            # Server is mid-restart/unreachable; retry on the next training iteration.
+            return
+
+    @override(Algorithm)
+    def restore_env_runners(self, env_runner_group) -> List[int]:
+        restored = super().restore_env_runners(env_runner_group)
+        # Re-share the EnvRunnerStateServer handle with restored (training) EnvRunners:
+        # a fresh actor incarnation lost the attribute set post-construction. A restored
+        # runner starts at weights_seq_no=0, so its first pull force-applies the latest.
+        if (
+            restored
+            and self._env_runner_state_server is not None
+            and env_runner_group is self.env_runner_group
+        ):
+
+            def _share_state_server(env_runner, server=self._env_runner_state_server):
+                env_runner._env_runner_state_server = server
+
+            env_runner_group.foreach_env_runner(
+                func=_share_state_server,
+                remote_worker_ids=restored,
+                local_env_runner=False,
+                timeout_seconds=self.config.env_runner_restore_timeout_s,
+            )
+        return restored
 
     def _sample_and_get_connector_states(self):
         with TimerAndPrometheusLogger(

--- a/rllib/algorithms/tests/test_env_runner_state_server.py
+++ b/rllib/algorithms/tests/test_env_runner_state_server.py
@@ -46,5 +46,29 @@ def test_get_version_without_seq_no():
     assert server.get_version() == -1
 
 
+def test_pull_if_newer_only_returns_strictly_newer_state():
+    server = EnvRunnerStateServer()
+    # Empty server -> nothing to return, regardless of the caller's version.
+    assert server.pull_if_newer(-1) is None
+
+    state = _state(5)
+    server.push(state)
+    # Equal-or-newer caller version -> None, so the (heavy) state is NOT transferred.
+    assert server.pull_if_newer(5) is None
+    assert server.pull_if_newer(6) is None
+    # Older caller version -> the full state, returned verbatim (same object).
+    assert server.pull_if_newer(4) is state
+    assert server.pull_if_newer(-1) is state
+
+
+def test_pull_if_newer_without_seq_no():
+    # A state lacking WEIGHTS_SEQ_NO is treated as version -1 ("no usable version"), so
+    # it is never newer than a caller (EnvRunners start at `_weights_seq_no=0`).
+    server = EnvRunnerStateServer()
+    server.push({"rl_module": "WEIGHTS_OBJ_REF"})
+    assert server.pull_if_newer(0) is None
+    assert server.pull_if_newer(-1) is None
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/algorithms/tests/test_env_runner_state_server.py
+++ b/rllib/algorithms/tests/test_env_runner_state_server.py
@@ -38,11 +38,15 @@ def test_push_replaces_and_advances_version():
     assert server.pull()[WEIGHTS_SEQ_NO] == 2
 
 
-def test_get_version_without_seq_no():
-    # A state lacking WEIGHTS_SEQ_NO reports -1 (treated as "no usable version"), so an
-    # EnvRunner comparing `version > self._weights_seq_no` will never apply it.
+def test_push_rejects_state_without_seq_no():
+    # A state without WEIGHTS_SEQ_NO could never be pulled (EnvRunners version-gate via
+    # `pull_if_newer`), so the server rejects it loudly instead of holding state that no
+    # EnvRunner would ever apply.
     server = EnvRunnerStateServer()
-    server.push({"rl_module": "WEIGHTS_OBJ_REF"})
+    with pytest.raises(ValueError, match="WEIGHTS_SEQ_NO"):
+        server.push({"rl_module": "WEIGHTS_OBJ_REF"})
+    # Nothing was stored.
+    assert server.pull() is None
     assert server.get_version() == -1
 
 
@@ -59,15 +63,6 @@ def test_pull_if_newer_only_returns_strictly_newer_state():
     # Older caller version -> the full state, returned verbatim (same object).
     assert server.pull_if_newer(4) is state
     assert server.pull_if_newer(-1) is state
-
-
-def test_pull_if_newer_without_seq_no():
-    # A state lacking WEIGHTS_SEQ_NO is treated as version -1 ("no usable version"), so
-    # it is never newer than a caller (EnvRunners start at `_weights_seq_no=0`).
-    server = EnvRunnerStateServer()
-    server.push({"rl_module": "WEIGHTS_OBJ_REF"})
-    assert server.pull_if_newer(0) is None
-    assert server.pull_if_newer(-1) is None
 
 
 if __name__ == "__main__":

--- a/rllib/algorithms/tests/test_env_runner_state_server.py
+++ b/rllib/algorithms/tests/test_env_runner_state_server.py
@@ -1,0 +1,50 @@
+import sys
+
+import pytest
+
+from ray.rllib.env.env_runner_state_server import EnvRunnerStateServer
+from ray.rllib.utils.metrics import WEIGHTS_SEQ_NO
+
+
+def _state(seq_no, weights="WEIGHTS_OBJ_REF"):
+    # The server stores whatever StateDict it is handed. In production the `rl_module`
+    # value is a `ray.ObjectRef`, but the server never dereferences it, so a plain
+    # sentinel is sufficient to exercise the store/serve logic here.
+    return {WEIGHTS_SEQ_NO: seq_no, "rl_module": weights}
+
+
+def test_empty_server():
+    server = EnvRunnerStateServer()
+    assert server.pull() is None
+    assert server.get_version() == -1
+
+
+def test_push_pull_roundtrip_preserves_state_verbatim():
+    server = EnvRunnerStateServer()
+    state = _state(3)
+    server.push(state)
+    # Returned verbatim (including the - here sentinel - weights "ObjectRef"); the
+    # server must NOT dereference or copy it.
+    assert server.pull() is state
+    assert server.pull()["rl_module"] == "WEIGHTS_OBJ_REF"
+    assert server.get_version() == 3
+
+
+def test_push_replaces_and_advances_version():
+    server = EnvRunnerStateServer()
+    server.push(_state(1))
+    server.push(_state(2))
+    assert server.get_version() == 2
+    assert server.pull()[WEIGHTS_SEQ_NO] == 2
+
+
+def test_get_version_without_seq_no():
+    # A state lacking WEIGHTS_SEQ_NO reports -1 (treated as "no usable version"), so an
+    # EnvRunner comparing `version > self._weights_seq_no` will never apply it.
+    server = EnvRunnerStateServer()
+    server.push({"rl_module": "WEIGHTS_OBJ_REF"})
+    assert server.get_version() == -1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/algorithms/tests/test_env_runner_state_server.py
+++ b/rllib/algorithms/tests/test_env_runner_state_server.py
@@ -13,12 +13,6 @@ def _state(seq_no, weights="WEIGHTS_OBJ_REF"):
     return {WEIGHTS_SEQ_NO: seq_no, "rl_module": weights}
 
 
-def test_empty_server():
-    server = EnvRunnerStateServer()
-    assert server.pull() is None
-    assert server.get_version() == -1
-
-
 def test_push_pull_roundtrip_preserves_state_verbatim():
     server = EnvRunnerStateServer()
     state = _state(3)

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -472,6 +472,14 @@ class EnvRunnerGroup:
         and the env-steps counter into a single state dict, without touching any remote
         EnvRunner.
         """
+        if WEIGHTS_SEQ_NO not in rl_module_state:
+            raise ValueError(
+                "`get_merged_env_runner_state` needs `rl_module_state` to carry a "
+                f"`WEIGHTS_SEQ_NO` (got keys: {list(rl_module_state.keys())}); without "
+                "it the pushed state could never be pulled by EnvRunners (they "
+                "version-gate via `pull_if_newer`), making the `EnvRunnerStateServer` "
+                "useless."
+            )
         # New API stack only, so just the new-stack half of the `merge` predicate.
         merge = config.merge_env_runner_states is True or (
             config.merge_env_runner_states == "training_only"

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -368,6 +368,140 @@ class EnvRunnerGroup:
         """Total number of times managed remote workers have been restarted."""
         return self._worker_manager.total_num_restarts()
 
+    def _merge_env_runner_connector_states(
+        self,
+        *,
+        config: "AlgorithmConfig",
+        connector_states: Optional[List[Dict[str, Any]]],
+        from_worker: Optional[EnvRunner],
+        env_to_module,
+        module_to_env,
+        merge: bool,
+    ) -> Dict[str, Any]:
+        """Gathers and merges the EnvRunners' ConnectorV2 states into one dict.
+
+        Extracted (behavior-preserving) from `sync_env_runner_states` so that both the
+        legacy broadcast path and the PULL-based `get_merged_env_runner_state` share a
+        single connector-merge implementation. Returns a dict that may contain
+        `COMPONENT_ENV_TO_MODULE_CONNECTOR` and/or `COMPONENT_MODULE_TO_ENV_CONNECTOR`.
+        """
+        # Use (merged) states from all remote EnvRunners.
+        if merge:
+            if connector_states == []:
+                env_runner_states = {}
+            else:
+                if connector_states is None:
+                    connector_states = self.foreach_env_runner(
+                        lambda w: w.get_state(
+                            components=[
+                                COMPONENT_ENV_TO_MODULE_CONNECTOR,
+                                COMPONENT_MODULE_TO_ENV_CONNECTOR,
+                            ]
+                        ),
+                        local_env_runner=False,
+                        timeout_seconds=(
+                            config.sync_filters_on_rollout_workers_timeout_s
+                        ),
+                    )
+                env_to_module_states = [
+                    s[COMPONENT_ENV_TO_MODULE_CONNECTOR]
+                    for s in connector_states
+                    if COMPONENT_ENV_TO_MODULE_CONNECTOR in s
+                ]
+                module_to_env_states = [
+                    s[COMPONENT_MODULE_TO_ENV_CONNECTOR]
+                    for s in connector_states
+                    if COMPONENT_MODULE_TO_ENV_CONNECTOR in s
+                ]
+
+                if (
+                    self.local_env_runner is not None
+                    and hasattr(self.local_env_runner, "_env_to_module")
+                    and hasattr(self.local_env_runner, "_module_to_env")
+                ):
+                    assert env_to_module is None
+                    env_to_module = self.local_env_runner._env_to_module
+                    assert module_to_env is None
+                    module_to_env = self.local_env_runner._module_to_env
+
+                env_runner_states = {}
+                if env_to_module_states:
+                    env_runner_states.update(
+                        {
+                            COMPONENT_ENV_TO_MODULE_CONNECTOR: (
+                                env_to_module.merge_states(env_to_module_states)
+                            ),
+                        }
+                    )
+                if module_to_env_states:
+                    env_runner_states.update(
+                        {
+                            COMPONENT_MODULE_TO_ENV_CONNECTOR: (
+                                module_to_env.merge_states(module_to_env_states)
+                            ),
+                        }
+                    )
+        # Ignore states from remote EnvRunners (use the current `from_worker` states
+        # only).
+        else:
+            if from_worker is None:
+                env_runner_states = {
+                    COMPONENT_ENV_TO_MODULE_CONNECTOR: env_to_module.get_state(),
+                    COMPONENT_MODULE_TO_ENV_CONNECTOR: module_to_env.get_state(),
+                }
+            else:
+                env_runner_states = from_worker.get_state(
+                    components=[
+                        COMPONENT_ENV_TO_MODULE_CONNECTOR,
+                        COMPONENT_MODULE_TO_ENV_CONNECTOR,
+                    ]
+                )
+
+        return env_runner_states
+
+    def get_merged_env_runner_state(
+        self,
+        *,
+        config: "AlgorithmConfig",
+        rl_module_state: Dict[str, Any],
+        connector_states: Optional[List[Dict[str, Any]]] = None,
+        env_steps_sampled: Optional[int] = None,
+        env_to_module=None,
+        module_to_env=None,
+    ) -> Dict[str, Any]:
+        """Builds the merged EnvRunner state to push to an `EnvRunnerStateServer`.
+
+        PULL-model counterpart of `sync_env_runner_states`: merges the gathered
+        connector states (reusing `_merge_env_runner_connector_states`, the same logic
+        the legacy broadcast path uses) and combines them with `rl_module_state` (which
+        already carries the `COMPONENT_RL_MODULE` ObjectRef and `WEIGHTS_SEQ_NO`) and the
+        global env-steps counter into a single state dict. Does NOT touch any remote
+        EnvRunner - the Algorithm pushes the returned dict to the server and EnvRunners
+        pull it at the top of `sample()`.
+
+        The `WEIGHTS_SEQ_NO` inside the returned state doubles as its version: EnvRunners
+        apply the state only if it is newer than the one they currently hold.
+        """
+        # This path is gated to the new API stack (IMPALA/APPO), so only the new-stack
+        # half of `sync_env_runner_states`' `merge` predicate applies here.
+        merge = config.merge_env_runner_states is True or (
+            config.merge_env_runner_states == "training_only"
+            and not config.in_evaluation
+        )
+        env_runner_states = self._merge_env_runner_connector_states(
+            config=config,
+            connector_states=connector_states,
+            from_worker=self.local_env_runner,
+            env_to_module=env_to_module,
+            module_to_env=module_to_env,
+            merge=merge,
+        )
+        if env_steps_sampled is not None:
+            env_runner_states[NUM_ENV_STEPS_SAMPLED_LIFETIME] = int(env_steps_sampled)
+        # Add the model weights (a `ray.ObjectRef`) and `WEIGHTS_SEQ_NO` (= version).
+        env_runner_states.update(rl_module_state)
+        return env_runner_states
+
     def sync_env_runner_states(
         self,
         *,
@@ -447,77 +581,16 @@ class EnvRunnerGroup:
         if not merge and not broadcast:
             return
 
-        # Use states from all remote EnvRunners.
-        if merge:
-            if connector_states == []:
-                env_runner_states = {}
-            else:
-                if connector_states is None:
-                    connector_states = self.foreach_env_runner(
-                        lambda w: w.get_state(
-                            components=[
-                                COMPONENT_ENV_TO_MODULE_CONNECTOR,
-                                COMPONENT_MODULE_TO_ENV_CONNECTOR,
-                            ]
-                        ),
-                        local_env_runner=False,
-                        timeout_seconds=(
-                            config.sync_filters_on_rollout_workers_timeout_s
-                        ),
-                    )
-                env_to_module_states = [
-                    s[COMPONENT_ENV_TO_MODULE_CONNECTOR]
-                    for s in connector_states
-                    if COMPONENT_ENV_TO_MODULE_CONNECTOR in s
-                ]
-                module_to_env_states = [
-                    s[COMPONENT_MODULE_TO_ENV_CONNECTOR]
-                    for s in connector_states
-                    if COMPONENT_MODULE_TO_ENV_CONNECTOR in s
-                ]
-
-                if (
-                    self.local_env_runner is not None
-                    and hasattr(self.local_env_runner, "_env_to_module")
-                    and hasattr(self.local_env_runner, "_module_to_env")
-                ):
-                    assert env_to_module is None
-                    env_to_module = self.local_env_runner._env_to_module
-                    assert module_to_env is None
-                    module_to_env = self.local_env_runner._module_to_env
-
-                env_runner_states = {}
-                if env_to_module_states:
-                    env_runner_states.update(
-                        {
-                            COMPONENT_ENV_TO_MODULE_CONNECTOR: (
-                                env_to_module.merge_states(env_to_module_states)
-                            ),
-                        }
-                    )
-                if module_to_env_states:
-                    env_runner_states.update(
-                        {
-                            COMPONENT_MODULE_TO_ENV_CONNECTOR: (
-                                module_to_env.merge_states(module_to_env_states)
-                            ),
-                        }
-                    )
-        # Ignore states from remote EnvRunners (use the current `from_worker` states
-        # only).
-        else:
-            if from_worker is None:
-                env_runner_states = {
-                    COMPONENT_ENV_TO_MODULE_CONNECTOR: env_to_module.get_state(),
-                    COMPONENT_MODULE_TO_ENV_CONNECTOR: module_to_env.get_state(),
-                }
-            else:
-                env_runner_states = from_worker.get_state(
-                    components=[
-                        COMPONENT_ENV_TO_MODULE_CONNECTOR,
-                        COMPONENT_MODULE_TO_ENV_CONNECTOR,
-                    ]
-                )
+        # Gather + merge the remote EnvRunners' connector states (shared with the
+        # PULL-based `get_merged_env_runner_state`).
+        env_runner_states = self._merge_env_runner_connector_states(
+            config=config,
+            connector_states=connector_states,
+            from_worker=from_worker,
+            env_to_module=env_to_module,
+            module_to_env=module_to_env,
+            merge=merge,
+        )
 
         # Update the global number of environment steps, if necessary.
         if env_steps_sampled is not None:

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -411,13 +411,15 @@ class EnvRunnerGroup:
                     if COMPONENT_MODULE_TO_ENV_CONNECTOR in s
                 ]
 
-                if (
-                    self.local_env_runner is not None
-                    and hasattr(self.local_env_runner, "_env_to_module")
-                    and hasattr(self.local_env_runner, "_module_to_env")
+                if self.local_env_runner is not None and hasattr(
+                    self.local_env_runner, "_env_to_module"
                 ):
                     assert env_to_module is None
                     env_to_module = self.local_env_runner._env_to_module
+
+                if self.local_env_runner is not None and hasattr(
+                    self.local_env_runner, "_module_to_env"
+                ):
                     assert module_to_env is None
                     module_to_env = self.local_env_runner._module_to_env
 

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -380,10 +380,7 @@ class EnvRunnerGroup:
     ) -> Dict[str, Any]:
         """Gathers and merges the EnvRunners' ConnectorV2 states into one dict.
 
-        Extracted (behavior-preserving) from `sync_env_runner_states` so that both the
-        legacy broadcast path and the PULL-based `get_merged_env_runner_state` share a
-        single connector-merge implementation. Returns a dict that may contain
-        `COMPONENT_ENV_TO_MODULE_CONNECTOR` and/or `COMPONENT_MODULE_TO_ENV_CONNECTOR`.
+        Shared by `sync_env_runner_states` and `get_merged_env_runner_state`.
         """
         # Use (merged) states from all remote EnvRunners.
         if merge:
@@ -471,19 +468,11 @@ class EnvRunnerGroup:
     ) -> Dict[str, Any]:
         """Builds the merged EnvRunner state to push to an `EnvRunnerStateServer`.
 
-        PULL-model counterpart of `sync_env_runner_states`: merges the gathered
-        connector states (reusing `_merge_env_runner_connector_states`, the same logic
-        the legacy broadcast path uses) and combines them with `rl_module_state` (which
-        already carries the `COMPONENT_RL_MODULE` ObjectRef and `WEIGHTS_SEQ_NO`) and the
-        global env-steps counter into a single state dict. Does NOT touch any remote
-        EnvRunner - the Algorithm pushes the returned dict to the server and EnvRunners
-        pull it at the top of `sample()`.
-
-        The `WEIGHTS_SEQ_NO` inside the returned state doubles as its version: EnvRunners
-        apply the state only if it is newer than the one they currently hold.
+        Merges the connector states with `rl_module_state` (weights + `WEIGHTS_SEQ_NO`)
+        and the env-steps counter into a single state dict, without touching any remote
+        EnvRunner.
         """
-        # This path is gated to the new API stack (IMPALA/APPO), so only the new-stack
-        # half of `sync_env_runner_states`' `merge` predicate applies here.
+        # New API stack only, so just the new-stack half of the `merge` predicate.
         merge = config.merge_env_runner_states is True or (
             config.merge_env_runner_states == "training_only"
             and not config.in_evaluation
@@ -581,8 +570,7 @@ class EnvRunnerGroup:
         if not merge and not broadcast:
             return
 
-        # Gather + merge the remote EnvRunners' connector states (shared with the
-        # PULL-based `get_merged_env_runner_state`).
+        # Gather + merge the remote EnvRunners' connector states.
         env_runner_states = self._merge_env_runner_connector_states(
             config=config,
             connector_states=connector_states,

--- a/rllib/env/env_runner_state_server.py
+++ b/rllib/env/env_runner_state_server.py
@@ -7,69 +7,36 @@ from ray.util.annotations import DeveloperAPI
 
 @DeveloperAPI(stability="alpha")
 class EnvRunnerStateServer:
-    """A single, global parameter-server-style actor holding the latest EnvRunner state.
+    """A single, global actor holding the latest EnvRunner state for pull-based sync.
 
-    This implements the "pull" half of the EnvRunner state synchronization used by the
-    async algorithms (IMPALA/APPO) when ``config.use_env_runner_state_server=True``.
+    Used by async algorithms (IMPALA/APPO) when
+    ``config.use_env_runner_state_server=True``: the Algorithm pushes the merged
+    EnvRunner state here once per weight sync, and every EnvRunner pulls it at the top
+    of each ``sample()`` call.
 
-    Instead of the Algorithm broadcasting (pushing) weights to every EnvRunner - a path
-    that, under back-pressure (``max_requests_in_flight_per_env_runner``), silently drops
-    newer weight broadcasts while an EnvRunner is busy in a long ``sample()`` call and
-    thus leaves EnvRunners training on stale weights - the Algorithm pushes the merged
-    state to exactly one of these servers, and every EnvRunner pulls the latest state at
-    the top of each ``sample()`` call. This guarantees EnvRunners always act with the
-    freshest available weights.
+    The state is the ``StateDict`` built by
+    :py:meth:`~ray.rllib.env.env_runner_group.EnvRunnerGroup.get_merged_env_runner_state`.
+    The RLModule weights are kept as a ``ray.ObjectRef`` (so an unchanged pull stays
+    cheap) and ``WEIGHTS_SEQ_NO`` is the version EnvRunners compare against.
 
-    The held state is the same plain ``StateDict`` that
-    :py:meth:`~ray.rllib.env.env_runner_group.EnvRunnerGroup.sync_env_runner_states`
-    assembles, i.e. it contains (keys are the canonical RLlib component/metric strings):
-
-    - ``COMPONENT_RL_MODULE``: a ``ray.ObjectRef`` pointing to the RLModule weights dict
-      (kept as an ObjectRef on purpose - an unchanged pull is then a cheap, local
-      ``ray.get`` on the EnvRunner side; the weight tensors only transfer when the
-      version actually advances).
-    - ``WEIGHTS_SEQ_NO``: the integer weights sequence number. This doubles as the
-      state's *version*: EnvRunners apply a pulled state only if its ``WEIGHTS_SEQ_NO``
-      is greater than the one they already hold.
-    - ``COMPONENT_ENV_TO_MODULE_CONNECTOR`` / ``COMPONENT_MODULE_TO_ENV_CONNECTOR``: the
-      merged connector states.
-    - ``NUM_ENV_STEPS_SAMPLED_LIFETIME``: the global env-steps-sampled counter.
-
-    This actor must be created with ``max_concurrency > 1`` (see
-    ``config.env_runner_state_server_max_concurrency``) so that many EnvRunners can
-    ``pull`` concurrently without serializing behind each other. ``push`` only ever
-    rebinds the stored reference (never mutates in place), so concurrent reads always
-    observe a coherent, non-torn state and no lock is required.
-
-    The actor holds purely *derived* state (reconstructable from the Learner weights),
-    so it is created with ``max_restarts=-1`` and the Algorithm keeps a backup of the
-    last pushed state; on a restart the Algorithm re-pushes that backup. The server is
-    therefore not a single point of failure.
+    Create with ``max_concurrency > 1`` so many EnvRunners can ``pull`` concurrently;
+    ``push`` only rebinds the stored reference, so no lock is needed.
     """
 
     def __init__(self):
         self._state: Optional[StateDict] = None
 
     def push(self, state: StateDict) -> None:
-        """Stores the latest EnvRunner state (called by the Algorithm, once per sync)."""
-        # Atomic rebind (no in-place mutation) -> safe for concurrent `pull`s.
+        """Stores the latest EnvRunner state (called once per weight sync)."""
+        # Atomic rebind -> safe for concurrent `pull`s.
         self._state = state
 
     def pull(self) -> Optional[StateDict]:
-        """Returns the latest stored state, or None if nothing has been pushed yet.
-
-        The returned state contains the RLModule weights as a ``ray.ObjectRef``; it is
-        intentionally NOT dereferenced here - the calling EnvRunner does a (cheap, often
-        local) ``ray.get`` only when it decides to actually apply the state.
-        """
+        """Returns the latest stored state, or None if nothing has been pushed yet."""
         return self._state
 
     def get_version(self) -> int:
-        """Returns the ``WEIGHTS_SEQ_NO`` of the stored state, or -1 if empty.
-
-        Used by the Algorithm to cheaply detect a restarted (empty) server and re-push
-        its backup, without transferring the full state.
-        """
+        """Returns the `WEIGHTS_SEQ_NO` of the stored state, or -1 if empty."""
         if self._state is None:
             return -1
         return self._state.get(WEIGHTS_SEQ_NO, -1)

--- a/rllib/env/env_runner_state_server.py
+++ b/rllib/env/env_runner_state_server.py
@@ -1,0 +1,75 @@
+from typing import Optional
+
+from ray.rllib.utils.metrics import WEIGHTS_SEQ_NO
+from ray.rllib.utils.typing import StateDict
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI(stability="alpha")
+class EnvRunnerStateServer:
+    """A single, global parameter-server-style actor holding the latest EnvRunner state.
+
+    This implements the "pull" half of the EnvRunner state synchronization used by the
+    async algorithms (IMPALA/APPO) when ``config.use_env_runner_state_server=True``.
+
+    Instead of the Algorithm broadcasting (pushing) weights to every EnvRunner - a path
+    that, under back-pressure (``max_requests_in_flight_per_env_runner``), silently drops
+    newer weight broadcasts while an EnvRunner is busy in a long ``sample()`` call and
+    thus leaves EnvRunners training on stale weights - the Algorithm pushes the merged
+    state to exactly one of these servers, and every EnvRunner pulls the latest state at
+    the top of each ``sample()`` call. This guarantees EnvRunners always act with the
+    freshest available weights.
+
+    The held state is the same plain ``StateDict`` that
+    :py:meth:`~ray.rllib.env.env_runner_group.EnvRunnerGroup.sync_env_runner_states`
+    assembles, i.e. it contains (keys are the canonical RLlib component/metric strings):
+
+    - ``COMPONENT_RL_MODULE``: a ``ray.ObjectRef`` pointing to the RLModule weights dict
+      (kept as an ObjectRef on purpose - an unchanged pull is then a cheap, local
+      ``ray.get`` on the EnvRunner side; the weight tensors only transfer when the
+      version actually advances).
+    - ``WEIGHTS_SEQ_NO``: the integer weights sequence number. This doubles as the
+      state's *version*: EnvRunners apply a pulled state only if its ``WEIGHTS_SEQ_NO``
+      is greater than the one they already hold.
+    - ``COMPONENT_ENV_TO_MODULE_CONNECTOR`` / ``COMPONENT_MODULE_TO_ENV_CONNECTOR``: the
+      merged connector states.
+    - ``NUM_ENV_STEPS_SAMPLED_LIFETIME``: the global env-steps-sampled counter.
+
+    This actor must be created with ``max_concurrency > 1`` (see
+    ``config.env_runner_state_server_max_concurrency``) so that many EnvRunners can
+    ``pull`` concurrently without serializing behind each other. ``push`` only ever
+    rebinds the stored reference (never mutates in place), so concurrent reads always
+    observe a coherent, non-torn state and no lock is required.
+
+    The actor holds purely *derived* state (reconstructable from the Learner weights),
+    so it is created with ``max_restarts=-1`` and the Algorithm keeps a backup of the
+    last pushed state; on a restart the Algorithm re-pushes that backup. The server is
+    therefore not a single point of failure.
+    """
+
+    def __init__(self):
+        self._state: Optional[StateDict] = None
+
+    def push(self, state: StateDict) -> None:
+        """Stores the latest EnvRunner state (called by the Algorithm, once per sync)."""
+        # Atomic rebind (no in-place mutation) -> safe for concurrent `pull`s.
+        self._state = state
+
+    def pull(self) -> Optional[StateDict]:
+        """Returns the latest stored state, or None if nothing has been pushed yet.
+
+        The returned state contains the RLModule weights as a ``ray.ObjectRef``; it is
+        intentionally NOT dereferenced here - the calling EnvRunner does a (cheap, often
+        local) ``ray.get`` only when it decides to actually apply the state.
+        """
+        return self._state
+
+    def get_version(self) -> int:
+        """Returns the ``WEIGHTS_SEQ_NO`` of the stored state, or -1 if empty.
+
+        Used by the Algorithm to cheaply detect a restarted (empty) server and re-push
+        its backup, without transferring the full state.
+        """
+        if self._state is None:
+            return -1
+        return self._state.get(WEIGHTS_SEQ_NO, -1)

--- a/rllib/env/env_runner_state_server.py
+++ b/rllib/env/env_runner_state_server.py
@@ -23,6 +23,14 @@ class EnvRunnerStateServer:
     ``push`` only rebinds the stored reference, so no lock is needed.
     """
 
+    # TODO(Artur): Target state (future PR): make this server the single source of truth
+    #  for the *full* EnvRunner state (connectors + weights + counters), with the
+    #  Algorithm holding a backup copy for server recreation. That collapses the two
+    #  state-assembly paths (`get_merged_env_runner_state` + `sync_env_runner_states`)
+    #  into one "build state" step plus a transport choice (sync algos push to workers,
+    #  async pull from here), and lets us drop `_dont_auto_sync_env_runner_states` and
+    #  the merge/broadcast config knobs. Keep merge on the driver; keep this server dumb.
+
     def __init__(self):
         self._state: Optional[StateDict] = None
 

--- a/rllib/env/env_runner_state_server.py
+++ b/rllib/env/env_runner_state_server.py
@@ -43,6 +43,19 @@ class EnvRunnerStateServer:
         """Returns the latest stored state, or None if nothing has been pushed yet."""
         return self._state
 
+    def pull_if_newer(self, weights_seq_no: int) -> Optional[StateDict]:
+        """Returns the stored state, but only if it is newer than `weights_seq_no`.
+
+        Lets an EnvRunner do its freshness check in a single round-trip: the (heavy)
+        state dict crosses the wire only when there actually is a newer version;
+        otherwise this returns None and the caller keeps its current weights. Reads
+        ``self._state`` exactly once, so it stays lock-free for concurrent pulls.
+        """
+        state = self._state
+        if state is None or state.get(WEIGHTS_SEQ_NO, -1) <= weights_seq_no:
+            return None
+        return state
+
     def get_version(self) -> int:
         """Returns the `WEIGHTS_SEQ_NO` of the stored state, or -1 if empty."""
         if self._state is None:

--- a/rllib/env/env_runner_state_server.py
+++ b/rllib/env/env_runner_state_server.py
@@ -35,7 +35,20 @@ class EnvRunnerStateServer:
         self._state: Optional[StateDict] = None
 
     def push(self, state: StateDict) -> None:
-        """Stores the latest EnvRunner state (called once per weight sync)."""
+        """Stores the latest EnvRunner state (called once per weight sync).
+
+        Raises:
+            ValueError: If `state` carries no `WEIGHTS_SEQ_NO`. Such a state could never
+                be pulled (EnvRunners version-gate via `pull_if_newer`), so we reject it
+                here instead of silently holding state no EnvRunner would ever apply.
+        """
+        if WEIGHTS_SEQ_NO not in state:
+            raise ValueError(
+                "Cannot push an EnvRunner state without a `WEIGHTS_SEQ_NO` (got keys: "
+                f"{list(state.keys())}). EnvRunners only apply a pulled state if its "
+                "version is newer than theirs, so a versionless state would be ignored "
+                "forever, rendering the server useless."
+            )
         # Atomic rebind -> safe for concurrent `pull`s.
         self._state = state
 

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -213,13 +213,6 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                 value=time.perf_counter() - self._time_after_sampling,
             )
 
-        # Log current weight seq no.
-        self.metrics.log_value(
-            key=WEIGHTS_SEQ_NO,
-            value=self._weights_seq_no,
-            window=1,
-        )
-
         # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, ask
         # it for the latest state, transferring it only if it is newer than ours.
         if self._env_runner_state_server is not None:
@@ -246,6 +239,13 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                     )
             if _server_state is not None:
                 self.set_state(_server_state)
+
+        # Log current weight seq no.
+        self.metrics.log_value(
+            key=WEIGHTS_SEQ_NO,
+            value=self._weights_seq_no,
+            window=1,
+        )
 
         with self.metrics.log_time(SAMPLE_TIMER):
             # If no execution details are provided, use the config to try to infer the

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -219,20 +219,22 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             window=1,
         )
 
-        # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
-        # the latest state and apply it only if it is newer than ours.
+        # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, ask
+        # it for the latest state, transferring it only if it is newer than ours.
         if self._env_runner_state_server is not None:
             try:
-                # Block for the freshest weights; fall back to current ones if the
+                # Single round-trip: the server returns the full state only if it is
+                # newer than ours (else None). Fall back to current weights if the
                 # server is unavailable.
                 with self.metrics.log_time(ENV_RUNNER_STATE_SERVER_PULL_TIMER):
-                    _server_state = ray.get(self._env_runner_state_server.pull.remote())
+                    _server_state = ray.get(
+                        self._env_runner_state_server.pull_if_newer.remote(
+                            self._weights_seq_no
+                        )
+                    )
             except ray.exceptions.RayError:
                 _server_state = None
-            if (
-                _server_state
-                and _server_state.get(WEIGHTS_SEQ_NO, 0) > self._weights_seq_no
-            ):
+            if _server_state is not None:
                 self.set_state(_server_state)
 
         with self.metrics.log_time(SAMPLE_TIMER):

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -60,6 +60,7 @@ from ray.rllib.utils.metrics import (
 from ray.rllib.utils.pre_checks.env import check_multiagent_environments
 from ray.rllib.utils.typing import EpisodeID, ModelWeights, ResultDict, StateDict
 from ray.tune.registry import ENV_CREATOR, _global_registry
+from ray.util import log_once
 from ray.util.annotations import PublicAPI
 
 torch, _ = try_import_torch()
@@ -232,8 +233,17 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                             self._weights_seq_no
                         )
                     )
-            except ray.exceptions.RayError:
+            except ray.exceptions.RayError as e:
                 _server_state = None
+                # Logged once per EnvRunner to avoid spamming this per-`sample()` path.
+                if log_once("env_runner_state_server_pull_failed"):
+                    logger.warning(
+                        "EnvRunner failed to pull state from the "
+                        f"`EnvRunnerStateServer` ({type(e).__name__}). Falling back to "
+                        "the current weights/connector states; sampling continues and "
+                        "this should self-heal once the server is reachable again. This "
+                        "warning is logged only once per EnvRunner."
+                    )
             if _server_state is not None:
                 self.set_state(_server_state)
 

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -145,7 +145,9 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         self._ongoing_episodes_for_metrics: DefaultDict[
             EpisodeID, List[MultiAgentEpisode]
         ] = defaultdict(list)
-        self._weights_seq_no: int = 0
+        # -1 (not 0): `pull_if_newer` is strict, so starting at 0 would skip a first
+        # state carrying WEIGHTS_SEQ_NO=0. -1 makes the first pull/apply always take.
+        self._weights_seq_no: int = -1
         # Set by the Algorithm when `config.use_env_runner_state_server=True`.
         self._env_runner_state_server = None
 

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -144,6 +144,10 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             EpisodeID, List[MultiAgentEpisode]
         ] = defaultdict(list)
         self._weights_seq_no: int = 0
+        # Handle to the global `EnvRunnerStateServer` to PULL weights/connector states
+        # from. Set post-construction by the Algorithm when
+        # `config.use_env_runner_state_server=True`; None means use the legacy PUSH path.
+        self._env_runner_state_server = None
 
         # Measures the time passed between returning from `sample()`
         # and receiving the next `sample()` request from the user.
@@ -215,6 +219,26 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             value=self._weights_seq_no,
             window=1,
         )
+
+        # PULL-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
+        # the latest state and apply it only if its `WEIGHTS_SEQ_NO` is newer than ours
+        # (apply-if-newer for the whole state, so connector states reset only on a new
+        # merge). This replaces the back-pressured PUSH path, which could silently drop
+        # newer weight broadcasts while this EnvRunner was busy in a long `sample()`.
+        if self._env_runner_state_server is not None:
+            try:
+                _server_state = ray.get(
+                    self._env_runner_state_server.pull.remote(),
+                    timeout=self.config.env_runner_state_server_pull_timeout_s,
+                )
+            except (ray.exceptions.RayActorError, ray.exceptions.GetTimeoutError):
+                # Server mid-restart/unreachable: keep current weights this round.
+                _server_state = None
+            if (
+                _server_state
+                and _server_state.get(WEIGHTS_SEQ_NO, 0) > self._weights_seq_no
+            ):
+                self.set_state(_server_state)
 
         with self.metrics.log_time(SAMPLE_TIMER):
             # If no execution details are provided, use the config to try to infer the

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -145,9 +145,7 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         self._ongoing_episodes_for_metrics: DefaultDict[
             EpisodeID, List[MultiAgentEpisode]
         ] = defaultdict(list)
-        # -1 (not 0): `pull_if_newer` is strict, so starting at 0 would skip a first
-        # state carrying WEIGHTS_SEQ_NO=0. -1 makes the first pull/apply always take.
-        self._weights_seq_no: int = -1
+        self._weights_seq_no: int = 0
         # Set by the Algorithm when `config.use_env_runner_state_server=True`.
         self._env_runner_state_server = None
 

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -31,6 +31,7 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.framework import get_device, try_import_torch
 from ray.rllib.utils.metrics import (
+    ENV_RUNNER_STATE_SERVER_PULL_TIMER,
     ENV_TO_MODULE_CONNECTOR,
     EPISODE_AGENT_RETURN_MEAN,
     EPISODE_AGENT_STEPS,
@@ -227,12 +228,13 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         # newer weight broadcasts while this EnvRunner was busy in a long `sample()`.
         if self._env_runner_state_server is not None:
             try:
-                _server_state = ray.get(
-                    self._env_runner_state_server.pull.remote(),
-                    timeout=self.config.env_runner_state_server_pull_timeout_s,
-                )
-            except (ray.exceptions.RayActorError, ray.exceptions.GetTimeoutError):
-                # Server mid-restart/unreachable: keep current weights this round.
+                # Fully blocking (no timeout): always wait for the freshest weights
+                # rather than skip an update. Fall back to current weights only if the
+                # server is genuinely unavailable.
+                with self.metrics.log_time(ENV_RUNNER_STATE_SERVER_PULL_TIMER):
+                    _server_state = ray.get(self._env_runner_state_server.pull.remote())
+            except ray.exceptions.RayError:
+                # Server crashed/unavailable: keep current weights this round.
                 _server_state = None
             if (
                 _server_state

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -145,9 +145,7 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             EpisodeID, List[MultiAgentEpisode]
         ] = defaultdict(list)
         self._weights_seq_no: int = 0
-        # Handle to the global `EnvRunnerStateServer` to PULL weights/connector states
-        # from. Set post-construction by the Algorithm when
-        # `config.use_env_runner_state_server=True`; None means use the legacy PUSH path.
+        # Set by the Algorithm when `config.use_env_runner_state_server=True`.
         self._env_runner_state_server = None
 
         # Measures the time passed between returning from `sample()`
@@ -221,20 +219,15 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             window=1,
         )
 
-        # PULL-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
-        # the latest state and apply it only if its `WEIGHTS_SEQ_NO` is newer than ours
-        # (apply-if-newer for the whole state, so connector states reset only on a new
-        # merge). This replaces the back-pressured PUSH path, which could silently drop
-        # newer weight broadcasts while this EnvRunner was busy in a long `sample()`.
+        # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
+        # the latest state and apply it only if it is newer than ours.
         if self._env_runner_state_server is not None:
             try:
-                # Fully blocking (no timeout): always wait for the freshest weights
-                # rather than skip an update. Fall back to current weights only if the
-                # server is genuinely unavailable.
+                # Block for the freshest weights; fall back to current ones if the
+                # server is unavailable.
                 with self.metrics.log_time(ENV_RUNNER_STATE_SERVER_PULL_TIMER):
                     _server_state = ray.get(self._env_runner_state_server.pull.remote())
             except ray.exceptions.RayError:
-                # Server crashed/unavailable: keep current weights this round.
                 _server_state = None
             if (
                 _server_state

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -134,6 +134,10 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
             EpisodeID, List[SingleAgentEpisode]
         ] = defaultdict(list)
         self._weights_seq_no: int = 0
+        # Handle to the global `EnvRunnerStateServer` to PULL weights/connector states
+        # from. Set post-construction by the Algorithm when
+        # `config.use_env_runner_state_server=True`; None means use the legacy PUSH path.
+        self._env_runner_state_server = None
 
         # Measures the time passed between returning from `sample()`
         # and receiving the next `sample()` request from the user.
@@ -209,6 +213,26 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
             value=self._weights_seq_no,
             window=1,
         )
+
+        # PULL-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
+        # the latest state and apply it only if its `WEIGHTS_SEQ_NO` is newer than ours
+        # (apply-if-newer for the whole state, so connector states reset only on a new
+        # merge). This replaces the back-pressured PUSH path, which could silently drop
+        # newer weight broadcasts while this EnvRunner was busy in a long `sample()`.
+        if self._env_runner_state_server is not None:
+            try:
+                _server_state = ray.get(
+                    self._env_runner_state_server.pull.remote(),
+                    timeout=self.config.env_runner_state_server_pull_timeout_s,
+                )
+            except (ray.exceptions.RayActorError, ray.exceptions.GetTimeoutError):
+                # Server mid-restart/unreachable: keep current weights this round.
+                _server_state = None
+            if (
+                _server_state
+                and _server_state.get(WEIGHTS_SEQ_NO, 0) > self._weights_seq_no
+            ):
+                self.set_state(_server_state)
 
         with self.metrics.log_time(SAMPLE_TIMER):
             # If no execution details are provided, use the config to try to infer the

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -135,9 +135,7 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
         self._ongoing_episodes_for_metrics: DefaultDict[
             EpisodeID, List[SingleAgentEpisode]
         ] = defaultdict(list)
-        # -1 (not 0): `pull_if_newer` is strict, so starting at 0 would skip a first
-        # state carrying WEIGHTS_SEQ_NO=0. -1 makes the first pull/apply always take.
-        self._weights_seq_no: int = -1
+        self._weights_seq_no: int = 0
         # Set by the Algorithm when `config.use_env_runner_state_server=True`.
         self._env_runner_state_server = None
 

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -135,7 +135,9 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
         self._ongoing_episodes_for_metrics: DefaultDict[
             EpisodeID, List[SingleAgentEpisode]
         ] = defaultdict(list)
-        self._weights_seq_no: int = 0
+        # -1 (not 0): `pull_if_newer` is strict, so starting at 0 would skip a first
+        # state carrying WEIGHTS_SEQ_NO=0. -1 makes the first pull/apply always take.
+        self._weights_seq_no: int = -1
         # Set by the Algorithm when `config.use_env_runner_state_server=True`.
         self._env_runner_state_server = None
 

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -207,13 +207,6 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
                 value=time.perf_counter() - self._time_after_sampling,
             )
 
-        # Log current weight seq no.
-        self.metrics.log_value(
-            key=WEIGHTS_SEQ_NO,
-            value=self._weights_seq_no,
-            window=1,
-        )
-
         # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, ask
         # it for the latest state, transferring it only if it is newer than ours.
         if self._env_runner_state_server is not None:
@@ -240,6 +233,13 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
                     )
             if _server_state is not None:
                 self.set_state(_server_state)
+
+        # Log current weight seq no.
+        self.metrics.log_value(
+            key=WEIGHTS_SEQ_NO,
+            value=self._weights_seq_no,
+            window=1,
+        )
 
         with self.metrics.log_time(SAMPLE_TIMER):
             # If no execution details are provided, use the config to try to infer the

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -30,6 +30,7 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.framework import get_device
 from ray.rllib.utils.metrics import (
+    ENV_RUNNER_STATE_SERVER_PULL_TIMER,
     ENV_TO_MODULE_CONNECTOR,
     EPISODE_DURATION_SEC_MEAN,
     EPISODE_LEN_MAX,
@@ -221,12 +222,13 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
         # newer weight broadcasts while this EnvRunner was busy in a long `sample()`.
         if self._env_runner_state_server is not None:
             try:
-                _server_state = ray.get(
-                    self._env_runner_state_server.pull.remote(),
-                    timeout=self.config.env_runner_state_server_pull_timeout_s,
-                )
-            except (ray.exceptions.RayActorError, ray.exceptions.GetTimeoutError):
-                # Server mid-restart/unreachable: keep current weights this round.
+                # Fully blocking (no timeout): always wait for the freshest weights
+                # rather than skip an update. Fall back to current weights only if the
+                # server is genuinely unavailable.
+                with self.metrics.log_time(ENV_RUNNER_STATE_SERVER_PULL_TIMER):
+                    _server_state = ray.get(self._env_runner_state_server.pull.remote())
+            except ray.exceptions.RayError:
+                # Server crashed/unavailable: keep current weights this round.
                 _server_state = None
             if (
                 _server_state

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -56,6 +56,7 @@ from ray.rllib.utils.metrics import (
 from ray.rllib.utils.spaces.space_utils import unbatch
 from ray.rllib.utils.typing import EpisodeID, ResultDict, StateDict
 from ray.tune.registry import ENV_CREATOR, _global_registry
+from ray.util import log_once
 from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger("ray.rllib")
@@ -226,8 +227,17 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
                             self._weights_seq_no
                         )
                     )
-            except ray.exceptions.RayError:
+            except ray.exceptions.RayError as e:
                 _server_state = None
+                # Logged once per EnvRunner to avoid spamming this per-`sample()` path.
+                if log_once("env_runner_state_server_pull_failed"):
+                    logger.warning(
+                        "EnvRunner failed to pull state from the "
+                        f"`EnvRunnerStateServer` ({type(e).__name__}). Falling back to "
+                        "the current weights/connector states; sampling continues and "
+                        "this should self-heal once the server is reachable again. This "
+                        "warning is logged only once per EnvRunner."
+                    )
             if _server_state is not None:
                 self.set_state(_server_state)
 

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -135,9 +135,7 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
             EpisodeID, List[SingleAgentEpisode]
         ] = defaultdict(list)
         self._weights_seq_no: int = 0
-        # Handle to the global `EnvRunnerStateServer` to PULL weights/connector states
-        # from. Set post-construction by the Algorithm when
-        # `config.use_env_runner_state_server=True`; None means use the legacy PUSH path.
+        # Set by the Algorithm when `config.use_env_runner_state_server=True`.
         self._env_runner_state_server = None
 
         # Measures the time passed between returning from `sample()`
@@ -215,20 +213,15 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
             window=1,
         )
 
-        # PULL-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
-        # the latest state and apply it only if its `WEIGHTS_SEQ_NO` is newer than ours
-        # (apply-if-newer for the whole state, so connector states reset only on a new
-        # merge). This replaces the back-pressured PUSH path, which could silently drop
-        # newer weight broadcasts while this EnvRunner was busy in a long `sample()`.
+        # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
+        # the latest state and apply it only if it is newer than ours.
         if self._env_runner_state_server is not None:
             try:
-                # Fully blocking (no timeout): always wait for the freshest weights
-                # rather than skip an update. Fall back to current weights only if the
-                # server is genuinely unavailable.
+                # Block for the freshest weights; fall back to current ones if the
+                # server is unavailable.
                 with self.metrics.log_time(ENV_RUNNER_STATE_SERVER_PULL_TIMER):
                     _server_state = ray.get(self._env_runner_state_server.pull.remote())
             except ray.exceptions.RayError:
-                # Server crashed/unavailable: keep current weights this round.
                 _server_state = None
             if (
                 _server_state

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -213,20 +213,22 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
             window=1,
         )
 
-        # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, pull
-        # the latest state and apply it only if it is newer than ours.
+        # Pull-based weight sync: if a global `EnvRunnerStateServer` is configured, ask
+        # it for the latest state, transferring it only if it is newer than ours.
         if self._env_runner_state_server is not None:
             try:
-                # Block for the freshest weights; fall back to current ones if the
+                # Single round-trip: the server returns the full state only if it is
+                # newer than ours (else None). Fall back to current weights if the
                 # server is unavailable.
                 with self.metrics.log_time(ENV_RUNNER_STATE_SERVER_PULL_TIMER):
-                    _server_state = ray.get(self._env_runner_state_server.pull.remote())
+                    _server_state = ray.get(
+                        self._env_runner_state_server.pull_if_newer.remote(
+                            self._weights_seq_no
+                        )
+                    )
             except ray.exceptions.RayError:
                 _server_state = None
-            if (
-                _server_state
-                and _server_state.get(WEIGHTS_SEQ_NO, 0) > self._weights_seq_no
-            ):
+            if _server_state is not None:
                 self.set_state(_server_state)
 
         with self.metrics.log_time(SAMPLE_TIMER):

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -126,6 +126,21 @@ class TestEnvRunnerGroup(unittest.TestCase):
             2,
         )
 
+    def test_get_merged_env_runner_state_requires_weights_seq_no(self):
+        """`get_merged_env_runner_state` must refuse to build a versionless state.
+
+        A pushed state without `WEIGHTS_SEQ_NO` could never be pulled by EnvRunners
+        (they version-gate via `pull_if_newer`), so the builder fails loudly on the
+        driver. The guard runs before any instance/config access, so an uninitialized
+        group exercises it without spinning up EnvRunners.
+        """
+        group = object.__new__(EnvRunnerGroup)
+        with self.assertRaisesRegex(ValueError, "WEIGHTS_SEQ_NO"):
+            group.get_merged_env_runner_state(
+                config=None,
+                rl_module_state={"rl_module": "WEIGHTS_OBJ_REF"},
+            )
+
 
 if __name__ == "__main__":
     import sys

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -126,21 +126,6 @@ class TestEnvRunnerGroup(unittest.TestCase):
             2,
         )
 
-    def test_get_merged_env_runner_state_requires_weights_seq_no(self):
-        """`get_merged_env_runner_state` must refuse to build a versionless state.
-
-        A pushed state without `WEIGHTS_SEQ_NO` could never be pulled by EnvRunners
-        (they version-gate via `pull_if_newer`), so the builder fails loudly on the
-        driver. The guard runs before any instance/config access, so an uninitialized
-        group exercises it without spinning up EnvRunners.
-        """
-        group = object.__new__(EnvRunnerGroup)
-        with self.assertRaisesRegex(ValueError, "WEIGHTS_SEQ_NO"):
-            group.get_merged_env_runner_state(
-                config=None,
-                rl_module_state={"rl_module": "WEIGHTS_OBJ_REF"},
-            )
-
 
 if __name__ == "__main__":
     import sys

--- a/rllib/utils/metrics/__init__.py
+++ b/rllib/utils/metrics/__init__.py
@@ -168,7 +168,10 @@ SYNCH_WORKER_WEIGHTS_TIMER = "synch_weights"
 SYNCH_ENV_CONNECTOR_STATES_TIMER = "synch_env_connectors"
 SYNCH_EVAL_ENV_CONNECTOR_STATES_TIMER = "synch_eval_env_connectors"
 GRAD_WAIT_TIMER = "grad_wait"
-SAMPLE_TIMER = "sample"
+SAMPLE_TIMER = "sample"  # @OldAPIStack
+# Time an EnvRunner spends pulling the latest state from the `EnvRunnerStateServer`
+# (PULL-based weight sync) at the top of each `sample()` call.
+ENV_RUNNER_STATE_SERVER_PULL_TIMER = "env_runner_state_server_pull"
 ENV_RUNNER_SAMPLING_TIMER = "env_runner_sampling_timer"
 ENV_RESET_TIMER = "env_reset_timer"
 ENV_STEP_TIMER = "env_step_timer"

--- a/rllib/utils/metrics/__init__.py
+++ b/rllib/utils/metrics/__init__.py
@@ -168,7 +168,7 @@ SYNCH_WORKER_WEIGHTS_TIMER = "synch_weights"
 SYNCH_ENV_CONNECTOR_STATES_TIMER = "synch_env_connectors"
 SYNCH_EVAL_ENV_CONNECTOR_STATES_TIMER = "synch_eval_env_connectors"
 GRAD_WAIT_TIMER = "grad_wait"
-SAMPLE_TIMER = "sample"  # @OldAPIStack
+SAMPLE_TIMER = "sample"
 # Time an EnvRunner spends pulling the latest state from the `EnvRunnerStateServer`
 # (PULL-based weight sync) at the top of each `sample()` call.
 ENV_RUNNER_STATE_SERVER_PULL_TIMER = "env_runner_state_server_pull"


### PR DESCRIPTION
Async algos (APPO/IMPALA, new API stack) PUSH weights to EnvRunners via the back-pressured set_state path (max in-flight = 1). While a runner is busy in a long sample(), newer weight broadcasts are silently dropped, so it trains on weights from the start of its previous rollout and off-policy staleness (diff_num_grad_updates_vs_sampler_policy) grows.

We replace this with a PULL model behind use_env_runner_state_server (default on for IMPALA/APPO): one global, named EnvRunnerStateServer actor holds the latest merged EnvRunner state (RLModule weights as an ObjectRef + WEIGHTS_SEQ_NO + merged connector states + env-steps). The Algorithm pushes once per weight sync and keeps a backup (re-pushed if the server restarts, so it is not a single point of failure); EnvRunners pull at the top of sample() and apply only if the version advanced.

I have verified the validity of the improvements that this brings experimentally in a couple of setups.
The main point of this is lower off-policy staleness which results in faster learning.
Results:

- PPO unaffected (expected)
- diff_num_grad_updates_vs_sampler_policy for 8,15,56 envrunners with single and multi node training improves by 20% on average in my experiments. Results are strictly better WITH the server.
- No throughput cost
- EnvRunnerStateServer robust to failure (EnvRunner will raise an error and retry to succeed next time)
- Faster learning in all cases