### PR TITLE
[Core] Scope prom_metrics_service_discovery.json to session dir

### DIFF
--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -839,13 +839,23 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         os.replace(temp_file_name, self.get_target_file_name())
         # Create a backward-compatible symlink at the old temp_dir location
         # so that existing Prometheus configurations that reference the old
-        # path continue to work. Only attempt once to avoid unnecessary disk
-        # I/O, race conditions, and log flooding on every periodic write.
+        # path continue to work. Verify if the symlink is still valid and
+        # pointing to the correct target, repairing it if it has been deleted or modified.
         if self.session_dir != self.temp_dir:
             legacy_path = os.path.join(
                 self.temp_dir,
                 ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE,
             )
+            if self._symlink_created and not self._use_fallback_copy:
+                try:
+                    if not (
+                        os.path.islink(legacy_path)
+                        and os.readlink(legacy_path) == self.get_target_file_name()
+                    ):
+                        self._symlink_created = False
+                except OSError:
+                    self._symlink_created = False
+
             if not self._symlink_created and not self._use_fallback_copy:
                 try:
                     if os.path.islink(legacy_path) or os.path.exists(legacy_path):

--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -785,6 +785,7 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         self.temp_dir = temp_dir
         self.session_dir = session_dir if session_dir else temp_dir
         self._symlink_created = False
+        self._use_fallback_copy = False
         self.default_service_discovery_flush_period = 5
 
         # The last service discovery content that PrometheusServiceDiscoveryWriter has seen
@@ -834,24 +835,35 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         # so that existing Prometheus configurations that reference the old
         # path continue to work. Only attempt once to avoid unnecessary disk
         # I/O, race conditions, and log flooding on every periodic write.
-        if self.session_dir != self.temp_dir and not self._symlink_created:
+        if self.session_dir != self.temp_dir:
             legacy_path = os.path.join(
                 self.temp_dir,
                 ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE,
             )
-            try:
-                if os.path.islink(legacy_path) or os.path.exists(legacy_path):
-                    os.remove(legacy_path)
-                os.symlink(self.get_target_file_name(), legacy_path)
-                self._symlink_created = True
-            except OSError:
-                logger.warning(
-                    f"Failed to create backward-compatible symlink at "
-                    f"{legacy_path}. Existing Prometheus configurations "
-                    f"referencing this path may not work."
-                )
-                # Mark as created to avoid retrying and flooding logs.
-                self._symlink_created = True
+            if not self._symlink_created and not self._use_fallback_copy:
+                try:
+                    if os.path.islink(legacy_path) or os.path.exists(legacy_path):
+                        os.remove(legacy_path)
+                    os.symlink(self.get_target_file_name(), legacy_path)
+                    self._symlink_created = True
+                except OSError:
+                    logger.warning(
+                        f"Failed to create backward-compatible symlink at "
+                        f"{legacy_path}. Falling back to copying the service discovery file."
+                    )
+                    self._use_fallback_copy = True
+
+            if self._use_fallback_copy:
+                try:
+                    import shutil
+
+                    temp_legacy_path = legacy_path + ".tmp"
+                    shutil.copy(self.get_target_file_name(), temp_legacy_path)
+                    os.replace(temp_legacy_path, legacy_path)
+                except OSError as e:
+                    logger.warning(
+                        f"Failed to copy service discovery file to legacy path {legacy_path}: {e}"
+                    )
 
     def get_target_file_name(self):
         return os.path.join(

--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -784,7 +784,13 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         ray._private.state.state._initialize_global_state(gcs_client_options)
         self.temp_dir = temp_dir
         self.session_dir = session_dir if session_dir else temp_dir
+        # Tracks whether the backward-compatible symlink has been successfully created.
+        # This prevents recreating the symlink on every periodic write, avoiding
+        # unnecessary disk I/O, race conditions, and log flooding.
         self._symlink_created = False
+        # If symlink creation fails (e.g., due to lack of permissions on Windows
+        # without developer mode, or restricted filesystems), this fallback flag is set
+        # to True. When True, the writer copies the file directly instead of symlinking.
         self._use_fallback_copy = False
         self.default_service_discovery_flush_period = 5
 

--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -441,7 +441,6 @@ class OpenCensusProxyCollector:
             return
 
         elif isinstance(agg_data, DistributionAggregationData):
-
             assert agg_data.bounds == sorted(agg_data.bounds)
             # buckets are a list of buckets. Each bucket is another list with
             # a pair of bucket name and value, or a triple of bucket name,
@@ -770,9 +769,13 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         gcs_address: Gcs address for this cluster.
         temp_dir: Temporary directory used by
             Ray to store logs and metadata.
+        session_dir: Session-specific directory for this Ray session.
+            If provided, the discovery file is written here instead of
+            temp_dir, and a backward-compatible symlink is created at
+            the old temp_dir location.
     """
 
-    def __init__(self, gcs_address: str, temp_dir: str):
+    def __init__(self, gcs_address: str, temp_dir: str, session_dir: str = None):
         gcs_client_options = ray._raylet.GcsClientOptions.create(
             gcs_address, None, allow_cluster_id_nil=True, fetch_cluster_id_if_nil=False
         )
@@ -780,6 +783,8 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
 
         ray._private.state.state._initialize_global_state(gcs_client_options)
         self.temp_dir = temp_dir
+        self.session_dir = session_dir if session_dir else temp_dir
+        self._symlink_created = False
         self.default_service_discovery_flush_period = 5
 
         # The last service discovery content that PrometheusServiceDiscoveryWriter has seen
@@ -825,15 +830,38 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         # NOTE: os.replace is atomic on both Linux and Windows, so we won't
         # have race condition reading this file.
         os.replace(temp_file_name, self.get_target_file_name())
+        # Create a backward-compatible symlink at the old temp_dir location
+        # so that existing Prometheus configurations that reference the old
+        # path continue to work. Only attempt once to avoid unnecessary disk
+        # I/O, race conditions, and log flooding on every periodic write.
+        if self.session_dir != self.temp_dir and not self._symlink_created:
+            legacy_path = os.path.join(
+                self.temp_dir,
+                ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE,
+            )
+            try:
+                if os.path.islink(legacy_path) or os.path.exists(legacy_path):
+                    os.remove(legacy_path)
+                os.symlink(self.get_target_file_name(), legacy_path)
+                self._symlink_created = True
+            except OSError:
+                logger.warning(
+                    f"Failed to create backward-compatible symlink at "
+                    f"{legacy_path}. Existing Prometheus configurations "
+                    f"referencing this path may not work."
+                )
+                # Mark as created to avoid retrying and flooding logs.
+                self._symlink_created = True
 
     def get_target_file_name(self):
         return os.path.join(
-            self.temp_dir, ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE
+            self.session_dir,
+            ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE,
         )
 
     def get_temp_file_name(self):
         return os.path.join(
-            self.temp_dir,
+            self.session_dir,
             "{}_{}".format(
                 "tmp", ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE
             ),
@@ -846,8 +874,9 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
                 self.write()
             except Exception as e:
                 logger.warning(
-                    "Writing a service discovery file, {},"
-                    "failed.".format(self.get_target_file_name())
+                    "Writing a service discovery file, {},failed.".format(
+                        self.get_target_file_name()
+                    )
                 )
                 logger.warning(traceback.format_exc())
                 logger.warning(f"Error message: {e}")

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -77,8 +77,7 @@ def parse_prom_headers(prometheus_headers):
 class PrometheusQueryError(Exception):
     def __init__(self, status, message):
         self.message = (
-            "Error fetching data from prometheus. "
-            f"status: {status}, message: {message}"
+            f"Error fetching data from prometheus. status: {status}, message: {message}"
         )
         super().__init__(self.message)
 
@@ -299,11 +298,11 @@ class MetricsHead(SubprocessModule):
                     prometheus_host=prometheus_host,
                     prometheus_name=self._prometheus_name,
                     jsonData={
-                        f"httpHeaderName{i+1}": header
+                        f"httpHeaderName{i + 1}": header
                         for i, (header, _) in enumerate(prometheus_header_pairs)
                     },
                     secureJsonData={
-                        f"httpHeaderValue{i+1}": value
+                        f"httpHeaderValue{i + 1}": value
                         for i, (_, value) in enumerate(prometheus_header_pairs)
                     },
                 )
@@ -410,7 +409,7 @@ class MetricsHead(SubprocessModule):
         # Other than the root path, the config file generated here is identical to that
         # hardcoded config file.
         prom_discovery_file_path = os.path.join(
-            self.temp_dir, PROMETHEUS_SERVICE_DISCOVERY_FILE
+            self.session_dir, PROMETHEUS_SERVICE_DISCOVERY_FILE
         )
         with open(prometheus_config_output_path, "w") as f:
             f.write(

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -69,7 +69,7 @@ class ReportHead(SubprocessModule):
         # will be hang when the ray.state is connected and the GCS is exit.
         # Please refer to: https://github.com/ray-project/ray/issues/16328
         self.service_discovery = PrometheusServiceDiscoveryWriter(
-            self.gcs_address, self.temp_dir
+            self.gcs_address, self.temp_dir, self.session_dir
         )
         self._state_api = None
         self._executor = ThreadPoolExecutor(
@@ -876,8 +876,7 @@ class ReportHead(SubprocessModule):
             if "node_id" not in req.query:
                 raise aiohttp.web.HTTPBadRequest(
                     text=(
-                        "Failed to execute task profiling: "
-                        "task's node id is required"
+                        "Failed to execute task profiling: task's node id is required"
                     )
                 )
 

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -932,6 +932,7 @@ def test_prometheus_file_based_service_discovery(ray_start_cluster):
     writer = PrometheusServiceDiscoveryWriter(
         addr["gcs_address"],
         "/tmp/ray",
+        "/tmp/ray/session_latest",
     )
 
     def get_metrics_export_address_from_node(nodes):
@@ -966,13 +967,60 @@ def test_prometheus_file_based_service_discovery(ray_start_cluster):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlinks may need privileges.")
+def test_prom_service_discovery_session_scoped(ray_start_cluster, tmp_path):
+    """Test that the discovery file is written to session_dir and a
+    backward-compatible symlink is created at temp_dir."""
+    cluster = ray_start_cluster
+    cluster.add_node()
+    cluster.wait_for_nodes()
+    addr = ray.init(address=cluster.address)
+
+    temp_dir = str(tmp_path / "ray")
+    session_dir = str(tmp_path / "ray" / "session_test")
+    os.makedirs(temp_dir, exist_ok=True)
+    os.makedirs(session_dir, exist_ok=True)
+
+    writer = PrometheusServiceDiscoveryWriter(
+        addr["gcs_address"],
+        temp_dir,
+        session_dir,
+    )
+
+    # Verify the target file is in session_dir, not temp_dir
+    assert writer.get_target_file_name().startswith(session_dir)
+    assert writer.get_temp_file_name().startswith(session_dir)
+
+    # Write the discovery file
+    writer.write()
+
+    # Verify the file exists in session_dir
+    target_file = writer.get_target_file_name()
+    assert os.path.exists(target_file)
+
+    # Verify the symlink exists at the old temp_dir location
+    legacy_path = os.path.join(
+        temp_dir,
+        ray._private.ray_constants.PROMETHEUS_SERVICE_DISCOVERY_FILE,
+    )
+    assert os.path.islink(legacy_path)
+    assert os.path.realpath(legacy_path) == os.path.realpath(target_file)
+
+    # Verify the content is valid JSON and matches
+    with open(target_file) as f:
+        session_content = json.load(f)
+    with open(legacy_path) as f:
+        legacy_content = json.load(f)
+    assert session_content == legacy_content
+
+
 def test_prome_file_discovery_run_by_dashboard(shutdown_only):
     ray.init(num_cpus=0)
     global_node = ray._private.worker._global_node
-    temp_dir = global_node.get_temp_dir_path()
+    session_dir = global_node.get_session_dir_path()
 
     def is_service_discovery_exist():
-        for path in pathlib.Path(temp_dir).iterdir():
+        for path in pathlib.Path(session_dir).iterdir():
             if PROMETHEUS_SERVICE_DISCOVERY_FILE in str(path):
                 return True
         return False

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -72,7 +72,9 @@ def test_metrics_folder_and_content(is_temp_dir_set, temp_dir_val):
 
         assert os.path.exists(f"{session_dir}/metrics/prometheus/prometheus.yml")
         with open(f"{session_dir}/metrics/prometheus/prometheus.yml", "r") as f:
-            target_path = os.path.join(temp_dir, "prom_metrics_service_discovery.json")
+            target_path = os.path.join(
+                session_dir, "prom_metrics_service_discovery.json"
+            )
             assert f"- '{target_path}'" in f.read()
 
 

--- a/python/ray/tests/test_tempdir.py
+++ b/python/ray/tests/test_tempdir.py
@@ -194,6 +194,8 @@ def test_head_temp_dir_shared_with_worker(ray_start_cluster):
         "Worker node default temp dir resolution logic maybe wrong."
     )
 
+    ray.shutdown()
+    cluster.shutdown()
     shutil.rmtree(head_temp_dir)
 
 
@@ -228,6 +230,8 @@ def test_worker_temp_dir_different_from_head(ray_start_cluster):
         worker_temp_dir != default_head_temp_dir
     ), "Worker temp_dir should be different from head node's default temp_dir"
 
+    ray.shutdown()
+    cluster.shutdown()
     shutil.rmtree(worker_temp_dir)
     shutil.rmtree(default_head_temp_dir)
 
@@ -273,6 +277,8 @@ def test_both_nodes_different_temp_dirs(ray_start_cluster):
     assert os.path.exists(head_temp_dir), "Head temp_dir should exist"
     assert os.path.exists(worker_temp_dir), "Worker temp_dir should exist"
 
+    ray.shutdown()
+    cluster.shutdown()
     shutil.rmtree(head_temp_dir)
     shutil.rmtree(worker_temp_dir)
 


### PR DESCRIPTION
## Why are these changes needed?

`prom_metrics_service_discovery.json` is currently written to `temp_dir` (e.g., `/tmp/ray/`) instead of the session-specific directory (e.g., `/tmp/ray/session_<timestamp>/`). When multiple Ray sessions share the same `/tmp/ray` directory (e.g., multiple users on the same machine, or shared NFS filesystems), sessions overwrite each other's discovery files, causing Prometheus monitoring conflicts.

This PR moves the discovery file to the session directory and creates a backward-compatible symlink at the old `temp_dir` location, as suggested by @ijrsvt in https://github.com/ray-project/ray/issues/12662#issuecomment-818759284.

## Related issue number

Fixes #12662

## Description

Changes:
- `PrometheusServiceDiscoveryWriter` now accepts an optional `session_dir` parameter. When provided, the discovery file is written to `session_dir` instead of `temp_dir`.
- `get_target_file_name()` and `get_temp_file_name()` now use `session_dir`.
- `write()` creates a symlink at `temp_dir/prom_metrics_service_discovery.json` pointing to the session-scoped file for backward compatibility.
- Updated `ReportHead` and `MetricsHead` to pass `session_dir`.
- Updated Prometheus config generation to reference `session_dir` path.
- Added test `test_prom_service_discovery_session_scoped` for session-scoped file writing and symlink creation.
- Updated `test_prome_file_discovery_run_by_dashboard` to check `session_dir`.

## Additional information

- **Backward compatible**: When `session_dir` is not provided (default `None`), the writer falls back to `temp_dir`, preserving the existing behavior.
- **Graceful error handling**: Symlink creation failures (e.g., on Windows or insufficient permissions) are caught and logged as warnings without crashing.
- Files modified:
  - `python/ray/_private/metrics_agent.py`
  - `python/ray/dashboard/modules/reporter/reporter_head.py`
  - `python/ray/dashboard/modules/metrics/metrics_head.py`
  - `python/ray/tests/test_metrics_agent.py`
