### PR TITLE
[ci][train] adding torchft flaky test job

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -337,7 +337,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //... ml --run-flaky-tests
         --python-version 3.10 --build-name mlbuild-py3.10
         --parallelism-per-worker 2
-        --except-tags gpu,needs_credentials,train_v2_gpu,data_integration
+        --except-tags gpu,needs_credentials,train_v2_gpu,data_integration,torchft
     depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
     soft_fail: true
 
@@ -356,6 +356,21 @@ steps:
         --only-tags needs_credentials
         --test-env=WANDB_API_KEY --test-env=COMET_API_KEY
     depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
+    soft_fail: true
+
+  - label: ":bullettrain_front: ml: train v2 torch trainer flaky tests (torchft image)"
+    key: ml_torch_trainer_flaky_tests
+    tags:
+      - train
+      - flaky
+      - skip-on-premerge
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml --run-flaky-tests
+        --python-version 3.10 --build-name mltorchft-py3.10
+        --only-tags torchft
+        --except-tags needs_credentials,data_integration
+    depends_on: [ "mltorchft", "forge" ]
     soft_fail: true
 
   - label: ":train: ml: train gpu flaky tests"


### PR DESCRIPTION
adding torchft flaky test job for torchft tagged bazel tests

Currently torchft flaky tests run on the mlbuild image instead of the mltorchft image which has the torchft-nightly dependency