### PR TITLE
[serve.llm] Add TTFT, TPOT, and generation time metrics

### DIFF
--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -31,6 +31,9 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 from ray.llm._internal.serve.core.engine.protocol import LLMEngine
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
 from ray.llm._internal.serve.observability.logging import get_logger
+from ray.llm._internal.serve.observability.metrics.stream_metrics import (
+    instrumented_stream,
+)
 from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     push_telemetry_report_for_all_models,
 )
@@ -352,8 +355,12 @@ class LLMServer(LLMServerProtocol):
         is_stream = hasattr(request, "stream") and request.stream
         engine_stream = getattr(self.engine, engine_method)(request, raw_request_info)
 
-        if is_stream and batch_output_stream:
-            stream = self._batch_output_stream(engine_stream)
+        if is_stream:
+            engine_stream = instrumented_stream(engine_stream, engine_method)
+            if batch_output_stream:
+                stream = self._batch_output_stream(engine_stream)
+            else:
+                stream = engine_stream
         else:
             stream = engine_stream
 

--- a/python/ray/llm/_internal/serve/observability/metrics/stream_metrics.py
+++ b/python/ray/llm/_internal/serve/observability/metrics/stream_metrics.py
@@ -1,0 +1,71 @@
+"""TTFT, TPOT, and generation time metrics for LLM streaming responses."""
+
+import time
+from typing import AsyncGenerator, TypeVar
+
+from ray.llm._internal.serve.observability.metrics.utils import (
+    SHORT_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS,
+)
+from ray.util import metrics
+
+T = TypeVar("T")
+
+_TPOT_HISTOGRAM_BUCKETS_MS = [
+    1, 5, 10, 25, 50, 100, 150, 250, 500, 1000, 2500, 5000,
+]
+
+llm_ttft_ms = metrics.Histogram(
+    "ray_llm_ttft_ms",
+    description=(
+        "Time to first token in milliseconds, "
+        "measured at the LLMServer boundary."
+    ),
+    boundaries=SHORT_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS,
+    tag_keys=("api_type",),
+)
+
+llm_tpot_ms = metrics.Histogram(
+    "ray_llm_tpot_ms",
+    description=(
+        "Time per output token in milliseconds, "
+        "measured at the LLMServer boundary."
+    ),
+    boundaries=_TPOT_HISTOGRAM_BUCKETS_MS,
+    tag_keys=("api_type",),
+)
+
+llm_generation_time_ms = metrics.Histogram(
+    "ray_llm_generation_time_ms",
+    description=(
+        "Total generation time in milliseconds from first token to last, "
+        "measured at the LLMServer boundary."
+    ),
+    boundaries=SHORT_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS,
+    tag_keys=("api_type",),
+)
+
+
+async def instrumented_stream(
+    stream: AsyncGenerator[T, None],
+    api_type: str,
+) -> AsyncGenerator[T, None]:
+    """Wraps an engine stream to record TTFT and TPOT metrics."""
+    tags = {"api_type": api_type}
+    start = time.perf_counter()
+    is_first = True
+    prev = start
+    try:
+        async for item in stream:
+            now = time.perf_counter()
+            if is_first:
+                llm_ttft_ms.observe((now - start) * 1e3, tags)
+                is_first = False
+            else:
+                llm_tpot_ms.observe((now - prev) * 1e3, tags)
+            prev = now
+            yield item
+    finally:
+        if not is_first:
+            llm_generation_time_ms.observe(
+                (time.perf_counter() - start) * 1e3, tags
+            )

--- a/python/ray/llm/_internal/serve/observability/metrics/stream_metrics.py
+++ b/python/ray/llm/_internal/serve/observability/metrics/stream_metrics.py
@@ -52,6 +52,7 @@ async def instrumented_stream(
     """Wraps an engine stream to record TTFT and TPOT metrics."""
     tags = {"api_type": api_type}
     start = time.perf_counter()
+    first_token_time = 0.0
     is_first = True
     prev = start
     try:
@@ -59,6 +60,7 @@ async def instrumented_stream(
             now = time.perf_counter()
             if is_first:
                 llm_ttft_ms.observe((now - start) * 1e3, tags)
+                first_token_time = now
                 is_first = False
             else:
                 llm_tpot_ms.observe((now - prev) * 1e3, tags)
@@ -67,5 +69,5 @@ async def instrumented_stream(
     finally:
         if not is_first:
             llm_generation_time_ms.observe(
-                (time.perf_counter() - start) * 1e3, tags
+                (prev - first_token_time) * 1e3, tags
             )

--- a/python/ray/llm/_internal/serve/observability/metrics/utils.py
+++ b/python/ray/llm/_internal/serve/observability/metrics/utils.py
@@ -1,14 +1,9 @@
 import time
 from enum import Enum
 from typing import (
-    AsyncGenerator,
-    Callable,
     List,
-    Set,
     TypeVar,
 )
-
-from ray.util import metrics
 
 # Histogram buckets for short-range latencies measurements:
 # Min=1ms, Max=30s
@@ -68,77 +63,3 @@ class MsClock:
 
 
 T = TypeVar("T")
-
-
-class InstrumentTokenAsyncGenerator:
-    """This class instruments an asynchronous generator.
-
-    It gathers 3 metrics:
-    1. Time to first time
-    2. Time between tokens
-    3. Total completion time
-
-    Usage:
-
-    @InstrumentTokenAsyncGenerator("my_special_fn")
-    async def to_instrument():
-        yield ...
-    """
-
-    all_instrument_names: Set[str] = set()
-
-    def __init__(
-        self, generator_name: str, latency_histogram_buckets: List[float] = None
-    ):
-        self.generator_name = f"rayllm_{generator_name}"
-
-        target_latency_histogram_buckets = (
-            latency_histogram_buckets or SHORT_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS
-        )
-
-        assert (
-            self.generator_name not in self.all_instrument_names
-        ), "This generator name was already used elsewhere. Please specify another one."
-        self.all_instrument_names.add(self.generator_name)
-
-        self.token_latency_histogram = metrics.Histogram(
-            f"{self.generator_name}_per_token_latency_ms",
-            f"Generator metrics for {self.generator_name}",
-            boundaries=target_latency_histogram_buckets,
-        )
-
-        self.first_token_latency_histogram = metrics.Histogram(
-            f"{self.generator_name}_first_token_latency_ms",
-            f"Generator metrics for {self.generator_name}",
-            boundaries=target_latency_histogram_buckets,
-        )
-        self.total_latency_histogram = metrics.Histogram(
-            f"{self.generator_name}_total_latency_ms",
-            f"Generator metrics for {self.generator_name}",
-            boundaries=target_latency_histogram_buckets,
-        )
-
-    def __call__(
-        self, async_generator_fn: Callable[..., AsyncGenerator[T, None]]
-    ) -> Callable[..., AsyncGenerator[T, None]]:
-        async def new_gen(*args, **kwargs):
-            interval_clock = MsClock()
-            total_clock = MsClock()
-            is_first_token = True
-            try:
-                async for x in async_generator_fn(*args, **kwargs):
-                    if is_first_token:
-                        self.first_token_latency_histogram.observe(
-                            total_clock.interval()
-                        )
-                        interval_clock.reset()
-                        is_first_token = False
-                    else:
-                        self.token_latency_histogram.observe(
-                            interval_clock.reset_interval()
-                        )
-                    yield x
-            finally:
-                self.total_latency_histogram.observe(total_clock.interval())
-
-        return new_gen

--- a/python/ray/llm/_internal/serve/observability/metrics/utils.py
+++ b/python/ray/llm/_internal/serve/observability/metrics/utils.py
@@ -1,9 +1,4 @@
-import time
-from enum import Enum
-from typing import (
-    List,
-    TypeVar,
-)
+from typing import List
 
 # Histogram buckets for short-range latencies measurements:
 # Min=1ms, Max=30s
@@ -29,37 +24,3 @@ SHORT_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS: List[float] = [
     20000,
     30000,
 ]
-
-# Histogram buckets for long-range latencies measurements:
-# Min=10ms, Max=300s
-LONG_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS = [
-    x * 10 for x in SHORT_RANGE_LATENCY_HISTOGRAM_BUCKETS_MS
-]
-
-
-class ClockUnit(int, Enum):
-    ms = 1000
-    s = 1
-
-
-class MsClock:
-    """A clock that tracks intervals in milliseconds"""
-
-    def __init__(self, unit: ClockUnit = ClockUnit.ms):
-        self.reset()
-        self.unit = unit.value
-        self.start_time = time.perf_counter()
-
-    def reset(self):
-        self.start_time = time.perf_counter()
-
-    def interval(self):
-        return (time.perf_counter() - self.start_time) * self.unit
-
-    def reset_interval(self):
-        interval = self.interval()
-        self.reset()
-        return interval
-
-
-T = TypeVar("T")

--- a/python/ray/llm/tests/serve/cpu/observability/test_stream_metrics.py
+++ b/python/ray/llm/tests/serve/cpu/observability/test_stream_metrics.py
@@ -1,0 +1,96 @@
+"""Unit tests for instrumented_stream TTFT/TPOT metrics."""
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from ray.llm._internal.serve.observability.metrics.stream_metrics import (
+    instrumented_stream,
+    llm_generation_time_ms,
+    llm_tpot_ms,
+    llm_ttft_ms,
+)
+
+
+async def _fake_stream(items, delay_s=0.01):
+    for item in items:
+        await asyncio.sleep(delay_s)
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_ttft_recorded_on_first_token():
+    with mock.patch.object(llm_ttft_ms, "observe") as mock_ttft:
+        items = []
+        async for item in instrumented_stream(_fake_stream(["a", "b", "c"]), "chat"):
+            items.append(item)
+
+        assert items == ["a", "b", "c"]
+        assert mock_ttft.call_count == 1
+        ttft_ms = mock_ttft.call_args[0][0]
+        assert ttft_ms > 0
+
+
+@pytest.mark.asyncio
+async def test_tpot_recorded_between_tokens():
+    with mock.patch.object(llm_tpot_ms, "observe") as mock_tpot:
+        items = []
+        async for item in instrumented_stream(
+            _fake_stream(["a", "b", "c", "d"]), "completions"
+        ):
+            items.append(item)
+
+        assert len(items) == 4
+        assert mock_tpot.call_count == 3
+        for call in mock_tpot.call_args_list:
+            tpot_ms = call[0][0]
+            assert tpot_ms > 0
+
+
+@pytest.mark.asyncio
+async def test_generation_time_recorded():
+    with mock.patch.object(llm_generation_time_ms, "observe") as mock_gen:
+        async for _ in instrumented_stream(_fake_stream(["a", "b"]), "chat"):
+            pass
+
+        assert mock_gen.call_count == 1
+        gen_ms = mock_gen.call_args[0][0]
+        assert gen_ms > 0
+
+
+@pytest.mark.asyncio
+async def test_no_metrics_on_empty_stream():
+    with mock.patch.object(llm_ttft_ms, "observe") as mock_ttft, mock.patch.object(
+        llm_tpot_ms, "observe"
+    ) as mock_tpot, mock.patch.object(
+        llm_generation_time_ms, "observe"
+    ) as mock_gen:
+        async for _ in instrumented_stream(_fake_stream([]), "chat"):
+            pass
+
+        mock_ttft.assert_not_called()
+        mock_tpot.assert_not_called()
+        mock_gen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_single_token_records_ttft_only():
+    with mock.patch.object(llm_ttft_ms, "observe") as mock_ttft, mock.patch.object(
+        llm_tpot_ms, "observe"
+    ) as mock_tpot:
+        async for _ in instrumented_stream(_fake_stream(["only"]), "chat"):
+            pass
+
+        assert mock_ttft.call_count == 1
+        mock_tpot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_api_type_tag_passed():
+    with mock.patch.object(llm_ttft_ms, "observe") as mock_ttft:
+        async for _ in instrumented_stream(_fake_stream(["a"]), "completions"):
+            pass
+
+        tags = mock_ttft.call_args[0][1]
+        assert tags == {"api_type": "completions"}


### PR DESCRIPTION
## Why are these changes needed?

Ray Serve LLM has no live metric for TTFT or TPOT, and no way to distinguish time spent in the Serve framework from time spent in the inference engine. Operators tuning latency can only see `http_request_duration_seconds` (total HTTP duration) and have no signal for where the time goes.

Closes #63585

## Related issue number

#63585

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. For new Python APIs, I've added it in `doc/source/ray-core/api/doc/{some_module}.rst` and added it in `doc/source/ray-core/api/index.md` under the corresponding `.rst` file section.
- [x] I've made sure the tests are passing. Testing command: `pytest python/ray/llm/tests/serve/cpu/observability/test_stream_metrics.py`
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Changes

**New metrics** (in `stream_metrics.py`):
- `ray_llm_ttft_ms`: Histogram of time to first token in milliseconds, measured at the LLMServer boundary
- `ray_llm_tpot_ms`: Histogram of time per output token in milliseconds
- `ray_llm_generation_time_ms`: Histogram of total generation time from first to last token
- All tagged by `api_type` (chat/completions) for per-endpoint breakdown

**Instrumentation** (in `llm_server.py`):
- `_run_request()` wraps the engine async generator with `instrumented_stream()` before batching, so metrics reflect pre-batch token timing
- Only applied to streaming requests; non-streaming requests are unaffected

**Dead code removal** (in `utils.py`):
- Removed `InstrumentTokenAsyncGenerator` class (lines 73-144), which defined `rayllm_*_first_token_latency_ms`, `_per_token_latency_ms`, and `_total_latency_ms` histograms but was never imported or applied anywhere in the codebase

**Tests** (in `test_stream_metrics.py`):
- 6 unit tests covering: TTFT on first token, TPOT between tokens, generation time, empty stream, single token, api_type tag propagation