### PR TITLE
[serve.llm][release test] Bump LLM serve startup timeout 600s -> 900s

### DIFF
--- a/release/llm_tests/serve/run_llm_serve_test_and_bms.py
+++ b/release/llm_tests/serve/run_llm_serve_test_and_bms.py
@@ -81,7 +81,7 @@ SERVICE_NAME = "serve_llm_release_test_service"
     help="Don't query AWS Secrets Manager for HuggingFace token",
 )
 @click.option(
-    "--timeout", type=int, default=600, help="Ray LLM service timeout parameter."
+    "--timeout", type=int, default=900, help="Ray LLM service timeout parameter."
 )
 @click.option(
     "--run-vllm-profiler",

--- a/release/llm_tests/serve/test_utils.py
+++ b/release/llm_tests/serve/test_utils.py
@@ -84,7 +84,7 @@ def start_service(
     add_unique_suffix: bool = True,
     cloud: Optional[str] = None,
     env_vars: Optional[Dict[str, str]] = None,
-    timeout_s: int = 600,  # seconds
+    timeout_s: int = 900,  # seconds
 ):
     """Starts an Anyscale Service with the specified configs.
 


### PR DESCRIPTION
## Why

`llm_serve_llama_3dot1_8B_tp_2` and `llm_serve_llama_3dot1_8B_tp_2_direct_streaming` intermittently fail at service startup:

```
AssertionError: Service ... is STARTING, expected RUNNING.
```

The service starts successfully, just slowly. Inspecting the service logs from a failing run, the 600s budget is dominated by cold infra, not the engine:

| phase | ~duration |
|---|---|
| head node provisioning | ~80s |
| GPU worker node autoscale + cu130 image pull + cluster join (replica `PENDING`; controller repeatedly logs "waiting for the cluster to auto-scale") | ~300s |
| vLLM engine init (weight download, load, torch.compile, CUDA graph capture) | ~100s |

In the failing build the `LLMServer` replica became healthy at **459s** and the service reached RUNNING just after the **600s** deadline, so the test terminated it ~30s short. The variance is almost entirely in GPU node provisioning, so 600s is too tight.

## Change

Raise the `--timeout` default in `run_llm_serve_test_and_bms.py` (the value these tests actually use) and the `start_service` default in `test_utils.py` to **900s**, matching the value `llm_serve_llama_3dot1_8b_lora` already passes explicitly for the same reason.

No behavioral change beyond the longer startup grace period.