### PR TITLE
[core] Timeout actor PushTask RPCs without replies

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -465,6 +465,13 @@ RAY_CONFIG(uint32_t, task_actor_unavailable_retry_delay_base_ms, 100)
 /// The maximum retry delay for ACTOR_UNAVAILABLE exponential backoff.
 RAY_CONFIG(uint32_t, task_actor_unavailable_retry_max_delay_ms, 5000)
 
+/// Timeout for actor PushTask RPCs that are sent but do not receive a reply.
+/// Disabled when set to 0.
+RAY_CONFIG(int64_t, task_actor_push_task_inflight_timeout_ms, 0)
+
+/// Whether to disconnect the actor RPC client when an in-flight PushTask times out.
+RAY_CONFIG(bool, task_actor_push_task_refresh_client_on_timeout, false)
+
 /// Duration to wait between retrying to kill a task.
 RAY_CONFIG(uint32_t, cancellation_retry_ms, 2000)
 

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "ray/common/protobuf_utils.h"
+#include "ray/common/ray_config.h"
 #include "ray/core_worker/task_submission/task_submission_util.h"
 #include "ray/util/time.h"
 
@@ -336,6 +337,7 @@ void ActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
       DisconnectRpcClient(queue->second);
       inflight_task_callbacks = std::move(queue->second.inflight_task_callbacks_);
       queue->second.inflight_task_callbacks_.clear();
+      queue->second.inflight_task_metadata_.clear();
     }
 
     queue->second.state_ = rpc::ActorTableData::ALIVE;
@@ -409,6 +411,7 @@ void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
     DisconnectRpcClient(queue->second);
     inflight_task_callbacks = std::move(queue->second.inflight_task_callbacks_);
     queue->second.inflight_task_callbacks_.clear();
+    queue->second.inflight_task_metadata_.clear();
 
     if (dead) {
       queue->second.state_ = rpc::ActorTableData::DEAD;
@@ -511,7 +514,17 @@ void ActorTaskSubmitter::CheckTimeoutTasks() {
   // FailPendingTask requires the opposite. So we copy the tasks out from the queue
   // within the lock. This requires putting the data into shared_ptr.
   std::vector<std::shared_ptr<PendingTaskWaitingForDeathInfo>> timeout_tasks;
+  struct InflightPushTaskTimeout {
+    TaskAttempt task_attempt;
+    ActorID actor_id;
+    ActorTaskSubmitter::ClientQueue::InflightTaskMetadata metadata;
+    int64_t age_ms;
+    rpc::ClientCallback<rpc::PushTaskReply> callback;
+  };
+  std::vector<InflightPushTaskTimeout> inflight_push_timeouts;
   int64_t now = current_time_ms();
+  const auto inflight_push_timeout_ms =
+      RayConfig::instance().task_actor_push_task_inflight_timeout_ms();
   {
     absl::MutexLock lock(&mu_);
     for (auto &[actor_id, client_queue] : client_queues_) {
@@ -524,11 +537,63 @@ void ActorTaskSubmitter::CheckTimeoutTasks() {
         timeout_tasks.push_back(*deque_itr);
         deque_itr = deque.erase(deque_itr);
       }
+      if (inflight_push_timeout_ms <= 0) {
+        continue;
+      }
+
+      std::vector<TaskAttempt> timed_out_task_attempts;
+      for (const auto &[task_attempt, metadata] : client_queue.inflight_task_metadata_) {
+        if (now - metadata.send_time_ms > inflight_push_timeout_ms) {
+          timed_out_task_attempts.push_back(task_attempt);
+        }
+      }
+      for (const auto &task_attempt : timed_out_task_attempts) {
+        auto callback_it = client_queue.inflight_task_callbacks_.find(task_attempt);
+        auto metadata_it = client_queue.inflight_task_metadata_.find(task_attempt);
+        if (callback_it == client_queue.inflight_task_callbacks_.end() ||
+            metadata_it == client_queue.inflight_task_metadata_.end()) {
+          client_queue.inflight_task_callbacks_.erase(task_attempt);
+          client_queue.inflight_task_metadata_.erase(task_attempt);
+          continue;
+        }
+        inflight_push_timeouts.push_back(
+            {task_attempt,
+             actor_id,
+             metadata_it->second,
+             now - metadata_it->second.send_time_ms,
+             std::move(callback_it->second)});
+        client_queue.inflight_task_callbacks_.erase(callback_it);
+        client_queue.inflight_task_metadata_.erase(metadata_it);
+      }
     }
   }
   // Note: mu_ released.
   for (auto &task : timeout_tasks) {
     FailTaskWithError(*task);
+  }
+  for (auto &timeout : inflight_push_timeouts) {
+    const auto target_worker =
+        WorkerID::FromBinary(timeout.metadata.rpc_address.worker_id());
+    const auto refresh_client =
+        RayConfig::instance().task_actor_push_task_refresh_client_on_timeout();
+    if (refresh_client) {
+      core_worker_client_pool_.Disconnect(target_worker);
+    }
+    RAY_LOG(WARNING).WithField(timeout.task_attempt.first).WithField(timeout.actor_id)
+        << "Actor PushTask RPC did not receive a reply before timeout. "
+        << "task_name=" << timeout.metadata.task_name
+        << ", task_depth=" << timeout.metadata.task_depth
+        << ", sequence_number=" << timeout.metadata.sequence_number
+        << ", attempt_number=" << timeout.task_attempt.second
+        << ", age_ms=" << timeout.age_ms
+        << ", timeout_ms=" << inflight_push_timeout_ms
+        << ", target_worker=" << target_worker
+        << ", target_addr=" << timeout.metadata.rpc_address.ip_address() << ":"
+        << timeout.metadata.rpc_address.port()
+        << ", refreshed_client=" << refresh_client;
+    timeout.callback(
+        Status::IOError("Actor PushTask RPC timed out before receiving a reply"),
+        rpc::PushTaskReply());
   }
 }
 
@@ -605,7 +670,7 @@ void ActorTaskSubmitter::PushActorTask(ClientQueue &queue,
     next_queueing_warn_threshold_ *= 2;
   }
 
-  auto &addr = queue.client_address_.value();
+  const auto addr = queue.client_address_.value();
   rpc::ClientCallback<rpc::PushTaskReply> reply_callback =
       [this, addr, task_spec](const Status &status, const rpc::PushTaskReply &reply) {
         HandlePushTaskReply(status, reply, addr, task_spec);
@@ -613,6 +678,16 @@ void ActorTaskSubmitter::PushActorTask(ClientQueue &queue,
 
   const TaskAttempt task_attempt = std::make_pair(task_id, task_spec.AttemptNumber());
   queue.inflight_task_callbacks_.emplace(task_attempt, std::move(reply_callback));
+  if (RayConfig::instance().task_actor_push_task_inflight_timeout_ms() > 0) {
+    queue.inflight_task_metadata_.emplace(
+        task_attempt,
+        ActorTaskSubmitter::ClientQueue::InflightTaskMetadata{
+            /*send_time_ms=*/current_time_ms(),
+            /*task_name=*/task_spec.GetName(),
+            /*task_depth=*/task_spec.GetDepth(),
+            /*sequence_number=*/request->sequence_number(),
+            /*rpc_address=*/addr});
+  }
   rpc::ClientCallback<rpc::PushTaskReply> wrapped_callback =
       [this, task_attempt, actor_id](const Status &status, rpc::PushTaskReply &&reply) {
         rpc::ClientCallback<rpc::PushTaskReply> push_task_reply_callback;
@@ -629,6 +704,7 @@ void ActorTaskSubmitter::PushActorTask(ClientQueue &queue,
           }
           push_task_reply_callback = std::move(callback_it->second);
           client_queue.inflight_task_callbacks_.erase(callback_it);
+          client_queue.inflight_task_metadata_.erase(task_attempt);
         }
         push_task_reply_callback(status, std::move(reply));
       };

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -340,6 +340,17 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
     absl::flat_hash_map<TaskAttempt, rpc::ClientCallback<rpc::PushTaskReply>>
         inflight_task_callbacks_;
 
+    struct InflightTaskMetadata {
+      int64_t send_time_ms;
+      std::string task_name;
+      int64_t task_depth;
+      int64_t sequence_number;
+      rpc::Address rpc_address;
+    };
+
+    /// Metadata for PushTask RPCs that are sent but have not received a reply yet.
+    absl::flat_hash_map<TaskAttempt, InflightTaskMetadata> inflight_task_metadata_;
+
     /// The max number limit of task capacity used for back pressure.
     /// If the number of tasks in requests >= max_pending_calls, it can't continue to
     /// push task to ClientQueue.

--- a/src/ray/core_worker/task_submission/tests/actor_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/actor_task_submitter_test.cc
@@ -14,14 +14,17 @@
 
 #include "ray/core_worker/task_submission/actor_task_submitter.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
 #include "mock/ray/core_worker/task_manager_interface.h"
 #include "mock/ray/gcs_client/gcs_client.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/test_utils.h"
 #include "ray/core_worker/actor_management/fake_actor_creator.h"
 #include "ray/core_worker/reference_counter.h"
@@ -131,7 +134,15 @@ class ActorTaskSubmitterTest : public ::testing::TestWithParam<bool> {
             io_context,
             reference_counter_) {}
 
-  void TearDown() override { io_context.stop(); }
+  void TearDown() override {
+    RayConfig::instance().task_actor_push_task_inflight_timeout_ms() = 0;
+    RayConfig::instance().task_actor_push_task_refresh_client_on_timeout() = false;
+    io_context.stop();
+  }
+
+  void EnableInflightPushTaskTimeout(int64_t timeout_ms) {
+    RayConfig::instance().task_actor_push_task_inflight_timeout_ms() = timeout_ms;
+  }
 
   int64_t last_queue_warning_ = 0;
   FakeActorCreator actor_creator_;
@@ -188,6 +199,43 @@ TEST_P(ActorTaskSubmitterTest, TestSubmitTask) {
   // not reset `received_seq_nos`.
   submitter_.ConnectActor(actor_id, addr, 0);
   ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1));
+}
+
+TEST_P(ActorTaskSubmitterTest, TestInflightPushTaskTimeout) {
+  EnableInflightPushTaskTimeout(1);
+  auto allow_out_of_order_execution = GetParam();
+  rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueueIfNotExists(actor_id,
+                                      -1,
+                                      allow_out_of_order_execution,
+                                      /*fail_if_actor_unreachable*/ true,
+                                      /*owned*/ false);
+  submitter_.ConnectActor(actor_id, addr, 0);
+
+  auto task = CreateActorTaskHelper(actor_id, worker_id, 0);
+  submitter_.SubmitTask(task);
+  ASSERT_EQ(io_context.poll_one(), 1);
+  ASSERT_EQ(worker_client_->callbacks.size(), 1);
+
+  EXPECT_CALL(*task_manager_, CompletePendingTask(_, _, _, _)).Times(0);
+  EXPECT_CALL(*task_manager_,
+              FailOrRetryPendingTask(task.TaskId(),
+                                     rpc::ErrorType::ACTOR_UNAVAILABLE,
+                                     _,
+                                     _,
+                                     /*mark_task_object_failed=*/false,
+                                     /*fail_immediately=*/false))
+      .Times(1)
+      .WillOnce(Return(true));
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  submitter_.CheckTimeoutTasks();
+
+  // The network reply can still arrive after the timeout. It should be ignored because
+  // the in-flight callback was already failed and erased by CheckTimeoutTasks().
+  ASSERT_TRUE(worker_client_->ReplyPushTask(task.GetTaskAttempt(), Status::OK()));
 }
 
 TEST_P(ActorTaskSubmitterTest, TestQueueingWarning) {


### PR DESCRIPTION
## Why are these changes needed?

Actor tasks can currently get stuck after the `PushTask` RPC has been sent to the target worker if the RPC never returns a callback. In that state the task attempt remains in `inflight_task_callbacks_`, so the existing `ACTOR_UNAVAILABLE` retry path is never reached.

This can happen when the transport/channel stops making progress without delivering a non-OK callback. Existing actor retry/backoff logic only helps after a callback is delivered.

## What changed?

This PR adds an optional, disabled-by-default watchdog for in-flight actor `PushTask` RPCs:

- `task_actor_push_task_inflight_timeout_ms`: timeout for sent `PushTask` RPCs that have not received a reply. `0` disables the watchdog.
- `task_actor_push_task_refresh_client_on_timeout`: optionally disconnects the CoreWorker RPC client for the target worker when the timeout fires, forcing a fresh client on retry.

When a `PushTask` attempt times out, `ActorTaskSubmitter::CheckTimeoutTasks()` removes the callback from the in-flight map and invokes it with an IOError. This feeds the attempt into the existing `ACTOR_UNAVAILABLE` handling and retry path. A late network reply for the old attempt is ignored because the in-flight callback has already been removed.

The default behavior is unchanged because the timeout is disabled by default.

## Related issue number

No public issue.

## Checks

- `git diff --check`
- `env USER=changyi_yang HOME=/tmp/changyi_yang_home bazel test //src/ray/core_worker/task_submission/tests:actor_task_submitter_test --test_filter='*TestInflightPushTaskTimeout*'`

Note: this environment's default `$USER` and `$HOME` contain `@`, which Ray's Bazel workspace status script rejects. The test command above uses temporary clean values for those environment variables.
