### PR TITLE
[autoscaler] Allow default ClusterStatus construction

### DIFF
--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -173,9 +173,7 @@ class ResourceDemandSummary:
 @dataclass
 class Stats:
     # How long it took to get the GCS request.
-    # This is required when initializing the Stats since it should be calculated before
-    # the request was made.
-    gcs_request_time_s: float
+    gcs_request_time_s: float = 0.0
     # How long it took to get all live instances from node provider.
     none_terminated_node_request_time_s: Optional[float] = None
     # How long for autoscaler to process the scaling decision.

--- a/python/ray/autoscaler/v2/tests/test_schema.py
+++ b/python/ray/autoscaler/v2/tests/test_schema.py
@@ -4,7 +4,12 @@ import time
 
 import pytest
 
-from ray.autoscaler.v2.schema import AutoscalerInstance, IPPRGroupSpec, IPPRStatus
+from ray.autoscaler.v2.schema import (
+    AutoscalerInstance,
+    ClusterStatus,
+    IPPRGroupSpec,
+    IPPRStatus,
+)
 from ray.core.generated.autoscaler_pb2 import NodeState, NodeStatus
 from ray.core.generated.instance_manager_pb2 import Instance
 
@@ -24,6 +29,14 @@ def _make_ippr_status() -> IPPRStatus:
         desired_cpu=1.0,
         desired_memory=2,
     )
+
+
+def test_cluster_status_default_constructor():
+    status = ClusterStatus()
+
+    assert status.active_nodes == []
+    assert status.idle_nodes == []
+    assert status.stats.gcs_request_time_s == 0.0
 
 
 def test_autoscaler_instance():


### PR DESCRIPTION
## Summary
- Make autoscaler v2 `Stats` default-constructible so `ClusterStatus()` no longer raises when using its default `stats` factory.
- Add a regression test covering default `ClusterStatus` construction.

## Test plan
- `python3 -m py_compile python/ray/autoscaler/v2/schema.py python/ray/autoscaler/v2/tests/test_schema.py`
- `ReadLints` on edited files

Note: I could not run the full pytest/Bazel target locally because this environment lacks `pytest`, Ray is not built for direct imports, and Bazel dependency fetches are blocked by network restrictions.

Made with [Cursor](https://cursor.com)