### PR TITLE
[Data] Sample checkpoint object arrays uniformly for size estimation

### DIFF
--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -40,15 +40,20 @@ def _numpy_size(array: np.ndarray) -> int:
     total_size = array.nbytes
     if array.dtype == object:
         sample_count = 10**4
+        item_count = array.size
 
-        if len(array) <= sample_count:
+        if item_count <= sample_count:
             for item in array.flat:
                 total_size += sys.getsizeof(item)
         else:
             sample_total_size = 0
-            for item in array[:sample_count].flat:
-                sample_total_size += sys.getsizeof(item)
-            total_size += int(sample_total_size / sample_count * len(array))
+            flat_array = array.flat
+            for sample_index in range(sample_count):
+                item_index = (
+                    sample_index * item_count + item_count // 2
+                ) // sample_count
+                sample_total_size += sys.getsizeof(flat_array[item_index])
+            total_size += int(sample_total_size / sample_count * item_count)
     return total_size
 
 

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -1,6 +1,7 @@
 import csv
 import os
 import random
+import sys
 from typing import List, Literal, Union
 
 import numpy as np
@@ -35,6 +36,7 @@ from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import (
     IdColumnCheckpointManager,
     NumpyArrayBasedCheckpointFilter,
+    _numpy_size,
 )
 from ray.data.checkpoint.checkpoint_writer import (
     PENDING_CHECKPOINT_SUFFIX,
@@ -61,6 +63,18 @@ pytestmark = [
     pytest.mark.usefixtures("restore_data_context"),
     pytest.mark.timeout(300),
 ]
+
+
+def test_numpy_size_object_array_samples_across_full_array():
+    sample_count = 10**4
+    small_items = [bytes(1) for _ in range(sample_count)]
+    large_items = [bytes(1000) for _ in range(sample_count)]
+    array = np.array(small_items + large_items, dtype=object)
+
+    actual_size = array.nbytes + sum(sys.getsizeof(item) for item in array.flat)
+
+    assert abs(_numpy_size(array) - actual_size) / actual_size < 0.01
+    assert abs(_numpy_size(array[::-1]) - actual_size) / actual_size < 0.01
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why are these changes needed?

Fixes #62709.

`_numpy_size()` previously estimated large object-dtype ndarray payloads by sampling only the first 10,000 elements. When object sizes are correlated with array order, that prefix-only sample can severely under- or over-estimate checkpoint memory size.

This changes the object-array estimation path to sample 10,000 positions uniformly across the flattened array, so the estimate is stable for the same values regardless of whether large objects appear at the beginning or end of the array. It also uses `array.size` for the object count so multi-dimensional object arrays are estimated by element count instead of first-axis length.

## Related issue number

Closes #62709.

## Checks

- [x] `python -m ruff check python/ray/data/checkpoint/checkpoint_filter.py python/ray/data/tests/test_checkpoint.py`
- [x] `python -m ruff format --check python/ray/data/checkpoint/checkpoint_filter.py python/ray/data/tests/test_checkpoint.py`
- [x] `python -m py_compile python/ray/data/checkpoint/checkpoint_filter.py python/ray/data/tests/test_checkpoint.py`
- [x] `git diff --check`
- [x] Local red/green function-level reproduction: `origin/master` estimated the same object array as `840000` forward and `20820000` reversed, while the actual value was `10830000`; the patched implementation estimates `10830000` in both orders.

`python -m pytest python/ray/data/tests/test_checkpoint.py::test_numpy_size_object_array_samples_across_full_array -q` could not run in this local workspace because importing the test conftest fails before collection with a pandas/numpy ABI mismatch: `ValueError: numpy.dtype size changed, may indicate binary incompatibility`.
