### PR TITLE
[Core] Fix resource leaks in subprocess management

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1544,6 +1544,7 @@ class Node:
         process_infos = self.all_processes[process_type]
         if process_type != ray_constants.PROCESS_TYPE_REDIS_SERVER:
             assert len(process_infos) == 1
+        wait_timeout_seconds = 1
         for process_info in process_infos:
             process = process_info.process
             # Handle the case where the process has already exited.
@@ -1582,20 +1583,19 @@ class Node:
             if allow_graceful:
                 process.terminate()
                 # Allow the process one second to exit gracefully.
-                timeout_seconds = 1
                 try:
-                    process.wait(timeout_seconds)
+                    process.wait(timeout=wait_timeout_seconds)
                 except subprocess.TimeoutExpired:
                     pass
 
             # If the process did not exit, force kill it.
             if process.poll() is None:
                 process.kill()
+                # After kill, wait must be called
                 # The reason we usually don't set timeout=None here is that
                 # there's some chance we'd end up waiting a really long time.
-                # After kill, wait must be called
                 try:
-                    process.wait(timeout=None if wait else 1)
+                    process.wait(timeout=None if wait else wait_timeout_seconds)
                 except subprocess.TimeoutExpired:
                     pass
 

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1591,10 +1591,13 @@ class Node:
             # If the process did not exit, force kill it.
             if process.poll() is None:
                 process.kill()
-                # The reason we usually don't call process.wait() here is that
+                # The reason we usually don't set timeout=None here is that
                 # there's some chance we'd end up waiting a really long time.
-                if wait:
-                    process.wait()
+                # After kill, wait must be called
+                try:
+                    process.wait(timeout=None if wait else 1)
+                except subprocess.TimeoutExpired:
+                    pass
 
         del self.all_processes[process_type]
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1061,6 +1061,8 @@ def start_ray_process(
             raise
 
     def _get_stream_name(stream):
+        if stream == subprocess.DEVNULL:
+            return os.devnull
         if stream is not None:
             try:
                 return stream.name
@@ -1182,13 +1184,8 @@ def start_log_monitor(
         )
         command.append(f"--logging-format={logging_format}")
 
-    stdout_file = None
-    if stdout_filepath:
-        stdout_file = open(os.devnull, "w")
-
-    stderr_file = None
-    if stderr_filepath:
-        stderr_file = open(os.devnull, "w")
+    stdout_file = subprocess.DEVNULL if stdout_filepath else None
+    stderr_file = subprocess.DEVNULL if stderr_filepath else None
 
     process_info = start_ray_process(
         command,
@@ -1356,13 +1353,8 @@ def start_api_server(
             command.append("--modules-to-load=UsageStatsHead")
             command.append("--disable-frontend")
 
-        stdout_file = None
-        if stdout_filepath:
-            stdout_file = open(os.devnull, "w")
-
-        stderr_file = None
-        if stderr_filepath:
-            stderr_file = open(os.devnull, "w")
+        stdout_file = subprocess.DEVNULL if stdout_filepath else None
+        stderr_file = subprocess.DEVNULL if stderr_filepath else None
 
         process_info = start_ray_process(
             command,
@@ -1567,13 +1559,8 @@ def start_gcs_server(
     if redis_password:
         command += [f"--redis_password={redis_password}"]
 
-    stdout_file = None
-    if stdout_filepath:
-        stdout_file = open(os.devnull, "w")
-
-    stderr_file = None
-    if stderr_filepath:
-        stderr_file = open(os.devnull, "w")
+    stdout_file = subprocess.DEVNULL if stdout_filepath else None
+    stderr_file = subprocess.DEVNULL if stderr_filepath else None
 
     process_info = start_ray_process(
         command,
@@ -2016,13 +2003,8 @@ def start_raylet(
             f"--node-name={node_name}",
         )
 
-    stdout_file = None
-    if raylet_stdout_filepath:
-        stdout_file = open(os.devnull, "w")
-
-    stderr_file = None
-    if raylet_stderr_filepath:
-        stderr_file = open(os.devnull, "w")
+    stdout_file = subprocess.DEVNULL if raylet_stdout_filepath else None
+    stderr_file = subprocess.DEVNULL if raylet_stderr_filepath else None
 
     process_info = start_ray_process(
         command,
@@ -2384,13 +2366,8 @@ def start_monitor(
     if monitor_ip:
         command.append("--monitor-ip=" + monitor_ip)
 
-    stdout_file = None
-    if stdout_filepath:
-        stdout_file = open(os.devnull, "w")
-
-    stderr_file = None
-    if stderr_filepath:
-        stderr_file = open(os.devnull, "w")
+    stdout_file = subprocess.DEVNULL if stdout_filepath else None
+    stderr_file = subprocess.DEVNULL if stderr_filepath else None
 
     process_info = start_ray_process(
         command,


### PR DESCRIPTION
## Description

- Five startup methods in services.py create output handlers using `open(os.devnull, "w")` but never close, causing `ResourceWarning: unclosed file` warnings. Replaced with `subprocess.DEVNULL`.
- Kill process method in Node do not call `wait()` after `kill()` when the argument `wait` is False, causing `ResourceWarning: subprocess is still running` warnings. Change to call `wait()` after `kill()` to prevent zombie processes.

## Related issues

Fixes #9546, Fixes #59782