### PR TITLE
[CI] Add extra logging for anyscale job wrapper for prometheus metrics

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -119,6 +119,7 @@ def collect_metrics(start_time: float, time_taken: float) -> bool:
     # (~7 minutes for a 24h test) but no less than 90s
     # and no more than 900s
     metrics_timeout = max(90, min(time_taken / 200, 900))
+    logger.info(f"Collecting Prometheus metrics (timeout: {metrics_timeout:.0f}s).")
     try:
         subprocess.run(
             [
@@ -131,9 +132,26 @@ def collect_metrics(start_time: float, time_taken: float) -> bool:
             timeout=metrics_timeout,
             check=True,
         )
+        logger.info("Metrics collection subprocess finished successfully.")
         return True
+    # TimeoutExpired and CalledProcessError are SubprocessError subclasses, so
+    # they must be caught first to differentiate them in the logs.
+    except subprocess.TimeoutExpired:
+        logger.error(
+            f"Metrics collection TIMED OUT after {metrics_timeout:.0f}s. The metrics "
+            "file may be missing or incomplete. This is a metrics-collection timeout, "
+            "distinct from an actual metric/OOM/spill issue."
+        )
+        return False
+    except subprocess.CalledProcessError as e:
+        logger.error(
+            f"Metrics collection subprocess exited with non-zero return code "
+            f"{e.returncode}. See the prometheus_metrics.py output above for the "
+            "specific failure."
+        )
+        return False
     except subprocess.SubprocessError:
-        logger.exception("Couldn't collect metrics.")
+        logger.exception("Couldn't collect metrics due to an unexpected error.")
         return False
 
 
@@ -233,71 +251,98 @@ def run_prepare_commands(
     return prepare_passed, prepare_return_codes, prepare_time_taken
 
 
-def run_oom_check():
-    return_code = 0
+def _load_metrics_for_check(check_name: str, env_var: str) -> Optional[dict]:
+    """Load the Prometheus metrics file for a failure check.
+
+    Returns the parsed metrics dict, or ``None`` when the metrics could not be
+    obtained at all (file missing, unreadable, or an empty ``{}`` written
+    because every Prometheus query failed). In every ``None`` case this is a
+    metrics-collection/infra failure rather than an actual metric signal, and
+    the caller should treat it as such.
+    """
+    metrics_path = os.environ.get("METRICS_OUTPUT_JSON", None)
+    if not (metrics_path and Path(metrics_path).exists()):
+        logger.error(
+            f"{check_name}: {env_var} is set to 1, but no metrics file was found "
+            f"at path: {metrics_path}. Metrics collection failed entirely."
+        )
+        return None
     try:
-        metrics_path = os.environ.get("METRICS_OUTPUT_JSON", None)
-        if metrics_path and Path(metrics_path).exists():
-            with open(metrics_path, "r") as f:
-                metrics = json.load(f)
-            oom_kills = metrics.get("worker_oom_kills")
-            if oom_kills is None:
-                logger.error("Could not retrieve 'worker_oom_kills' from metrics file")
-                return_code = 1
-            elif oom_kills:
-                logger.error(
-                    "Test failed: OOM worker kills detected. " f"Details: {oom_kills}"
-                )
-                return_code = 1
-            unexpected_failures = metrics.get("unexpected_worker_failures")
-            if unexpected_failures is None:
-                logger.error(
-                    "Could not retrieve 'unexpected_worker_failures' from metrics file"
-                )
-                return_code = 1
-            elif unexpected_failures:
-                logger.error(
-                    "Test failed: Unexpected worker failures detected "
-                    "(potential kernel OOM kills or SIGKILLs not captured by Ray's memory monitor). "
-                    f"Details: {unexpected_failures}"
-                )
-                return_code = 1
-        else:
-            logger.error(
-                f"RAYTEST_FAIL_ON_WORKER_OOM is set to 1, but no metrics file found at path: {metrics_path}"
-            )
-            return_code = 1
-    except (OSError, json.JSONDecodeError, AttributeError) as e:
-        logger.exception(f"Error during OOM check: {e}")
+        with open(metrics_path, "r") as f:
+            metrics = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.error(f"{check_name}: could not read metrics file {metrics_path}: {e}")
+        return None
+    if not isinstance(metrics, dict) or not metrics:
+        logger.error(
+            f"{check_name}: metrics file at {metrics_path} is empty. "
+            "See the prometheus_metrics.py output above for the cause."
+        )
+        return None
+    return metrics
+
+
+def _metric_unavailable(check_name: str, metrics: dict, key: str) -> bool:
+    """Return True if ``key`` could not be collected (missing or null).
+
+    Distinguishes a metrics-collection/infra failure (logged here) from an
+    actual metric signal, which the caller inspects when this returns False.
+    A ``None`` value means the Prometheus query failed; an empty list ``[]``
+    means the query succeeded but matched no series (i.e. a healthy result).
+    """
+    if key not in metrics:
+        logger.error(
+            f"{check_name}: '{key}' is missing from the metrics file, like a collection issue."
+        )
+        return True
+    if metrics[key] is None:
+        logger.error(
+            f"{check_name}: '{key}' is None, likely the Prometheus query failed "
+            "(timeout / connection error / non-200)"
+        )
+        return True
+    return False
+
+
+def run_oom_check():
+    metrics = _load_metrics_for_check("OOM check", "RAYTEST_FAIL_ON_WORKER_OOM")
+    if metrics is None:
+        return 1
+
+    return_code = 0
+    if _metric_unavailable("OOM check", metrics, "worker_oom_kills"):
+        return_code = 1
+    elif metrics["worker_oom_kills"]:
+        logger.error(
+            f"Test failed: OOM worker kills detected. Details: {metrics['worker_oom_kills']}"
+        )
+        return_code = 1
+
+    if _metric_unavailable("OOM check", metrics, "unexpected_worker_failures"):
+        return_code = 1
+    elif metrics["unexpected_worker_failures"]:
+        logger.error(
+            "Test failed: Unexpected worker failures detected "
+            "(potential kernel OOM kills or SIGKILLs not captured by Ray's memory monitor). "
+            f"Details: {metrics['unexpected_worker_failures']}"
+        )
         return_code = 1
     return return_code
 
 
 def run_spilling_check():
+    metrics = _load_metrics_for_check("Spilling check", "RAYTEST_FAIL_ON_SPILLING")
+    if metrics is None:
+        return 1
+
     return_code = 0
-    try:
-        metrics_path = os.environ.get("METRICS_OUTPUT_JSON", None)
-        if metrics_path and Path(metrics_path).exists():
-            with open(metrics_path, "r") as f:
-                metrics = json.load(f)
-            spilled_bytes = metrics.get("spilled_bytes")
-            if spilled_bytes is None:
-                logger.error("Could not retrieve 'spilled_bytes' from metrics file")
-                return_code = 1
-            elif spilled_bytes:
-                logger.error(
-                    "Test failed: unexpected object-store spilling detected. "
-                    f"Details: {spilled_bytes}"
-                )
-                return_code = 1
-        else:
-            logger.error(
-                "RAYTEST_FAIL_ON_SPILLING is set to 1, but no metrics file "
-                f"found at path: {metrics_path}"
-            )
-            return_code = 1
-    except (OSError, json.JSONDecodeError, AttributeError) as e:
-        logger.exception(f"Error during spilling check: {e}")
+    if _metric_unavailable("Spilling check", metrics, "spilled_bytes"):
+        return_code = 1
+    elif metrics["spilled_bytes"]:
+        logger.error(
+            "Test failed: unexpected object-store spilling detected. "
+            f"Details: {metrics['spilled_bytes']}"
+        )
         return_code = 1
     return return_code
 

--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -292,7 +292,7 @@ def _metric_unavailable(check_name: str, metrics: dict, key: str) -> bool:
     """
     if key not in metrics:
         logger.error(
-            f"{check_name}: '{key}' is missing from the metrics file, like a collection issue."
+            f"{check_name}: '{key}' is missing from the metrics file, likely a collection issue."
         )
         return True
     if metrics[key] is None:

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -37,14 +37,43 @@ class PrometheusClient:
         url = f"{self.prometheus_host}/api/v1/{query_type}?" + "&".join(
             [f"{k}={quote(str(v), safe='')}" for k, v in kwargs.items()]
         )
+        query_str = kwargs.get("query", url)
         logger.debug(f"Running Prometheus query {url}")
+        last_error = None
         for attempt in range(RETRIES):
-            async with self.http_session.get(url) as resp:
-                if resp.status == 200:
-                    prom_data = await resp.json()
-                    return prom_data["data"]["result"]
+            try:
+                async with self.http_session.get(url) as resp:
+                    if resp.status == 200:
+                        prom_data = await resp.json()
+                        return prom_data["data"]["result"]
+                    body = (await resp.text())[:500]
+                    last_error = f"non-200 status {resp.status}: {body}"
+                    logger.warning(
+                        f"Prometheus query returned non-200 status {resp.status} "
+                        f"(attempt {attempt + 1}/{RETRIES}). Query: {query_str!r}. "
+                        f"Body: {body}"
+                    )
+            except asyncio.TimeoutError:
+                last_error = "request timed out"
+                logger.warning(
+                    f"Prometheus query timed out "
+                    f"(attempt {attempt + 1}/{RETRIES}). Query: {query_str!r}."
+                )
+            except aiohttp.ClientError as e:
+                last_error = f"connection error: {e}"
+                logger.warning(
+                    f"Prometheus query connection error "
+                    f"(attempt {attempt + 1}/{RETRIES}). Query: {query_str!r}. "
+                    f"Error: {e}"
+                )
             if attempt < RETRIES - 1:
                 await asyncio.sleep(1)
+        logger.error(
+            f"Prometheus query failed after {RETRIES} attempts and returned no data. "
+            f"Query: {query_str!r}. Last error: {last_error}. "
+            "This is a metrics-collection failure (Prometheus unreachable/erroring), "
+            "NOT an empty result for a healthy metric."
+        )
         return None
 
     async def close(self):
@@ -149,6 +178,26 @@ async def _get_prometheus_metrics(
     }
     metrics = {k: await v for k, v in metrics.items()}
     await client.close()
+
+    # Summarise the outcome so a glance at the logs tells whether the metrics
+    # are trustworthy. `None` => the query failed to collect (infra/timeout);
+    # `[]` => collected fine but no matching series (e.g. no OOMs happened);
+    # truthy => collected data.
+    failed = sorted(k for k, v in metrics.items() if v is None)
+    empty = sorted(k for k, v in metrics.items() if v == [])
+    with_data = sorted(k for k, v in metrics.items() if v)
+    logger.info(
+        f"Prometheus collection summary: {len(with_data)} metric(s) with data, "
+        f"{len(empty)} empty, {len(failed)} failed to collect "
+        f"(out of {len(metrics)} total)."
+    )
+    if failed:
+        logger.error(
+            f"{len(failed)} metric(s) FAILED to collect and will be null in the "
+            f"output: {failed}. See the per-query warnings above for the cause "
+            "(timeout / connection error / non-200). This indicates a "
+            "metrics-collection/infra problem, not a real metric signal."
+        )
     return metrics
 
 
@@ -209,6 +258,10 @@ def save_prometheus_metrics(
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(levelname)s %(asctime)s] %(filename)s: %(lineno)d  %(message)s",
+    )
     parser = argparse.ArgumentParser()
     parser.add_argument("start_time", type=float, help="Start time")
     parser.add_argument(


### PR DESCRIPTION
## Description
For release tests, we wrap each in `_anyscale_job_wrapper.py` which after the job is finished, we poll prometheus to get several metrics for checking if OOMs or spilling has occurred. 
However, this is a flaky mechanism as prometheus will time out meaning that no metric is returned and thus the checks fail. The problem is that we have limited logs for understanding whats gone wrong. 

This PR aims to improve our logging for these jobs that are failing in `anyscale_job_wrapper.py`