### PR TITLE
Remove obsolete PyArrow version check in from_daft()

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import numpy as np
-from packaging.version import parse as parse_version
 
 import ray
 from ray._private.auto_init_hook import wrap_auto_init
@@ -89,7 +88,6 @@ from ray.data._internal.util import (
     ndarray_to_block,
     pandas_df_to_arrow_block,
 )
-from ray.data._internal.utils.arrow_utils import get_pyarrow_version
 from ray.data.block import (
     Block,
     BlockExecStats,
@@ -3240,25 +3238,12 @@ def read_hudi(
 def from_daft(df: "daft.DataFrame") -> Dataset:
     """Create a :class:`~ray.data.Dataset` from a `Daft DataFrame <https://docs.getdaft.io/en/stable/api/dataframe/>`_.
 
-    .. warning::
-
-        This function only works with PyArrow 13 or lower. For more details, see
-        https://github.com/ray-project/ray/issues/53278.
-
     Args:
         df: A Daft DataFrame
 
     Returns:
         A :class:`~ray.data.Dataset` holding rows read from the DataFrame.
     """
-    pyarrow_version = get_pyarrow_version()
-    assert pyarrow_version is not None
-    if pyarrow_version >= parse_version("14.0.0"):
-        raise RuntimeError(
-            "`from_daft` only works with PyArrow 13 or lower. For more details, see "
-            "https://github.com/ray-project/ray/issues/53278."
-        )
-
     # NOTE: Today this returns a MaterializedDataset. We should also integrate Daft such
     # that we can stream object references into a Ray dataset. Unfortunately this is
     # very tricky today because of the way Ray Datasources are implemented with a fully-

--- a/python/ray/data/tests/datasource/test_daft.py
+++ b/python/ray/data/tests/datasource/test_daft.py
@@ -1,8 +1,6 @@
-from unittest.mock import patch
-
-import pyarrow as pa
+import numpy as np
+import pandas as pd
 import pytest
-from packaging.version import parse as parse_version
 
 
 @pytest.fixture(scope="module")
@@ -18,29 +16,8 @@ def ray_start(request):
         ray.shutdown()
 
 
-def test_from_daft_raises_error_on_pyarrow_14(ray_start):
-    # This test assumes that `from_daft` calls `get_pyarrow_version` to get the
-    # PyArrow version. We can't mock `__version__` on the module directly because
-    # `get_pyarrow_version` caches the version.
-    with patch(
-        "ray.data.read_api.get_pyarrow_version", return_value=parse_version("14.0.0")
-    ):
-        import daft
-
-        import ray
-
-        with pytest.raises(RuntimeError):
-            ray.data.from_daft(daft.from_pydict({"col": [0]}))
-
-
-@pytest.mark.skipif(
-    parse_version(pa.__version__) >= parse_version("14.0.0"),
-    reason="https://github.com/ray-project/ray/issues/53278",
-)
 def test_daft_round_trip(ray_start):
     import daft
-    import numpy as np
-    import pandas as pd
 
     import ray
 


### PR DESCRIPTION
## Why are these changes needed?

`ray.data.from_daft()` raises `RuntimeError` when PyArrow >= 14.0.0 due to a hardcoded version check. This check was added because Daft previously had compatibility issues with PyArrow >= 14 (#53278).

However, Daft has since fixed this — as of March 2026, Daft's minimum PyArrow requirement is >= 15.0.0. The version check is now obsolete and **blocks all modern Daft installations** from using `from_daft()`.

## What changes are made?

- Remove the PyArrow version check and `RuntimeError` from `from_daft()`
- Remove the now-unused `get_pyarrow_version` and `parse_version` imports from `read_api.py`
- Remove `test_from_daft_raises_error_on_pyarrow_14` test (the behavior it tests no longer exists)
- Remove `@pytest.mark.skipif` from `test_daft_round_trip` so it runs on all PyArrow versions

## Does this PR introduce any user-facing change?

Yes — `from_daft()` will no longer raise `RuntimeError` for PyArrow >= 14. Users with modern Daft installations can now use the function as expected.

## How was this patch tested?

- Verified that `get_pyarrow_version` and `parse_version` are only used inside `from_daft()` — no other usages exist in `read_api.py`, so removing them is safe
- The existing `test_daft_round_trip` test (now un-skipped) covers the end-to-end round-trip and will run on all PyArrow versions going forward
- Confirmed that Daft's current minimum PyArrow requirement is >= 15.0.0, so the old version check can never pass anyway

Closes #63883