### PR TITLE
[6/N] [HAProxy stability] - Graceful drain waits for in-flight and queued requests (direct ingress)

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1919,22 +1919,27 @@ class Replica:
         finally:
             self._semaphore.release()
 
-    async def _drain_ongoing_requests(self):
-        """Wait for any ongoing requests to finish.
+    async def _drain_ongoing_requests(self, min_draining_period_s: float = 0.0):
+        """Wait until the minimum draining period has elapsed and no ongoing
+        requests remain.
 
-        Sleep for a grace period before the first time we check the number of ongoing
-        requests to allow the notification to remove this replica to propagate to
-        callers first.
+        The period is folded into the loop (not slept concurrently) so a request
+        admitted during it -- before load balancers deregister this replica --
+        becomes ongoing and is waited for, not reset at teardown.
         """
         wait_loop_period_s = self._deployment_config.graceful_shutdown_wait_loop_s
+        deadline = time.monotonic() + min_draining_period_s
         while True:
             await asyncio.sleep(wait_loop_period_s)
 
             num_ongoing_requests = self.get_num_ongoing_requests()
-            if num_ongoing_requests > 0:
+            min_period_remaining_s = deadline - time.monotonic()
+            if num_ongoing_requests > 0 or min_period_remaining_s > 0:
                 logger.info(
-                    f"Waiting for an additional {wait_loop_period_s}s to shut down "
-                    f"because there are {num_ongoing_requests} ongoing requests."
+                    f"Waiting for an additional {wait_loop_period_s}s to shut down: "
+                    f"{num_ongoing_requests} ongoing requests, "
+                    f"{max(0.0, min_period_remaining_s):.1f}s minimum draining "
+                    f"period remaining."
                 )
             else:
                 logger.info(
@@ -1963,33 +1968,27 @@ class Replica:
     async def perform_graceful_shutdown(self):
         self._shutting_down = True
 
-        coros = []
-        if (
-            RAY_SERVE_ENABLE_DIRECT_INGRESS
-            and self._ingress
-            and self._user_callable_initialized
-        ):
-            # In direct ingress mode, we need to wait at least
-            # RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S to give external load
-            # balancers (e.g., ALB) time to deregister the replica, in addition to
-            # waiting for requests to drain.
-            coros.append(asyncio.sleep(RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S))
-
         # If the replica was never initialized it never served traffic, so we
-        # can skip the wait period.
+        # can skip the drain entirely.
         if self._user_callable_initialized:
-            coros.append(self._drain_ongoing_requests())
+            # In direct ingress mode, hold the replica open at least
+            # RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S so load balancers can
+            # deregister it; the drain also waits for in-flight requests.
+            min_draining_period_s = (
+                RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S
+                if RAY_SERVE_ENABLE_DIRECT_INGRESS and self._ingress
+                else 0.0
+            )
+            await self._drain_ongoing_requests(min_draining_period_s)
 
-        if coros:
-            await asyncio.gather(*coros)
-
-        await self.shutdown()
-
-        # Cancel direct ingress HTTP/gRPC server tasks if they exist.
+        # Close listeners before tearing down user code so a late connection
+        # can't hit a mid-shutdown replica (the drain above ensured none remain).
         if self._direct_ingress_http_server_task:
             self._direct_ingress_http_server_task.cancel()
         if self._direct_ingress_grpc_server_task:
             self._direct_ingress_grpc_server_task.cancel()
+
+        await self.shutdown()
 
     async def check_health(self):
         try:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1923,9 +1923,9 @@ class Replica:
         """Wait until the minimum draining period has elapsed and no ongoing
         requests remain.
 
-        The period is folded into the loop (not slept concurrently) so a request
-        admitted during it -- before load balancers deregister this replica --
-        becomes ongoing and is waited for, not reset at teardown.
+        The minimum draining period gives load balancers time to deregister
+        this replica; a request admitted during it becomes ongoing and is
+        waited for like any other.
         """
         wait_loop_period_s = self._deployment_config.graceful_shutdown_wait_loop_s
         deadline = time.monotonic() + min_draining_period_s

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -527,6 +527,39 @@ class TestReplicaSlotReservation:
             if not drain_task.done():
                 drain_task.cancel()
 
+    async def test_drain_honors_min_period_then_waits_for_ongoing(self):
+        # The minimum draining period keeps the replica alive (still serving) so
+        # external load balancers deregister it. The drain must not exit until the
+        # period has elapsed AND there are no ongoing requests -- so a request
+        # admitted during the period and still running keeps it alive, instead of
+        # being reset when the replica tears down.
+        replica = FakeServeReplicaForSlotReservation(graceful_shutdown_wait_loop_s=0.02)
+        min_period_s = 0.2
+
+        drain_task = asyncio.create_task(
+            replica._drain_ongoing_requests(min_draining_period_s=min_period_s)
+        )
+        try:
+            # Nothing in flight, but the minimum period has not elapsed yet.
+            await asyncio.sleep(0.1)
+            assert not drain_task.done(), "drain must honor the minimum period"
+
+            # A request becomes ongoing partway through the period.
+            replica._metrics_manager.num_ongoing_requests = 1
+
+            # The period elapses, but the request is still ongoing -> keep waiting.
+            await asyncio.sleep(0.2)
+            assert (
+                not drain_task.done()
+            ), "drain must not exit while a request is still ongoing"
+
+            # Request finishes; only now may the drain complete.
+            replica._metrics_manager.num_ongoing_requests = 0
+            await asyncio.wait_for(drain_task, timeout=1.0)
+        finally:
+            if not drain_task.done():
+                drain_task.cancel()
+
     async def test_direct_ingress_request_is_rejected(self):
         replica = FakeServeReplicaForSlotReservation()
 


### PR DESCRIPTION
## Problem

In per-node HAProxy direct-ingress mode, a draining replica could reset requests it had already accepted, surfacing to clients as `SH`/502 (rewritten to 500) during downscales. `retry-on conn-failure` does not retry a post-connect hangup, so the client sees a hard error.

Root cause: `perform_graceful_shutdown` ran the minimum-draining-period sleep and the in-flight wait **concurrently** — `asyncio.gather(asyncio.sleep(MIN_DRAINING_PERIOD), _drain_ongoing_requests())`. `_drain_ongoing_requests` returned as soon as it first observed zero ongoing requests (often ~one loop iteration in), leaving the `gather` blocked only on the remaining sleep, with the ingress listener still open. A request admitted during that window — observed in practice as a stale HAProxy worker routing on a pooled keep-alive connection several seconds into the drain, after every live worker had already marked the replica DOWN — was dispatched but no longer waited for, and got reset when the replica tore down.

## Fix

- **Fold the minimum draining period into the drain loop.** `_drain_ongoing_requests(min_draining_period_s)` now exits only once the period has elapsed **and** there are no ongoing requests, so a request admitted during the period becomes ongoing and is waited for instead of being orphaned by an early return.
- **Close the ingress listener before `shutdown()`** (rather than after), so a late connection can't be accepted into a replica that is mid-teardown. Safe because the drain above guarantees nothing is in flight.

No change to the request-accounting path; this is purely in `perform_graceful_shutdown` / `_drain_ongoing_requests`.

## Tests

`python/ray/serve/tests/unit/test_router.py::test_drain_honors_min_period_then_waits_for_ongoing` — the drain does not exit until both the minimum period has elapsed and ongoing requests have cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)