### PR TITLE
[Data][3/n] Fix cross-region S3 bucket access in obstore download path

### DIFF
--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -550,6 +550,8 @@ def _discover_aws_bucket_region(bucket: str) -> Optional[str]:
         if bucket in _BUCKET_REGION_CACHE:
             return _BUCKET_REGION_CACHE[bucket]
 
+    # Probe outside the lock so concurrent first-time lookups don't serialize
+    # on a network round-trip.
     region: Optional[str] = None
     try:
         region = pyarrow.fs.resolve_s3_region(bucket)
@@ -559,8 +561,16 @@ def _discover_aws_bucket_region(bucket: str) -> Optional[str]:
         logger.debug("Failed to discover region for bucket %r: %s", bucket, e)
 
     with _BUCKET_REGION_CACHE_LOCK:
+        # Another thread may have resolved the same bucket while we probed.
+        # A real region must win over a ``None`` result: never let a failed
+        # probe overwrite a region a concurrent thread already cached, or
+        # later ``StoreRegistry.get`` calls would skip region injection and
+        # cross-region downloads could fail intermittently.
+        cached = _BUCKET_REGION_CACHE.get(bucket)
+        if cached is not None:
+            return cached
         _BUCKET_REGION_CACHE[bucket] = region
-    return region
+        return region
 
 
 class StoreRegistry:

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -906,7 +906,7 @@ async def _resolve_size(
     import obstore as obs
 
     try:
-        store_url, path = _split_uri(uri)
+        store_url, path = _split_obstore_uri(uri)
         store = registry.get(store_url)
         async with semaphore:
             meta = await obs.head_async(store, path)

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -531,38 +531,31 @@ _BUCKET_REGION_CACHE: Dict[str, Optional[str]] = {}
 _BUCKET_REGION_CACHE_LOCK = threading.Lock()
 
 
-def _discover_aws_bucket_region(bucket: str, *, timeout: float = 5.0) -> Optional[str]:
-    """Discover an AWS S3 bucket's region via a HEAD probe.
+def _discover_aws_bucket_region(bucket: str) -> Optional[str]:
+    """Discover an AWS S3 bucket's region, cached per-process.
 
-    Cached per-process. AWS returns ``x-amz-bucket-region`` in the response
-    headers for both 200 OK and 301 PermanentRedirect, so the probe is cheap
-    whether or not the default endpoint happens to be the correct region.
+    Delegates to :func:`pyarrow.fs.resolve_s3_region`, which issues a HEAD
+    probe and reads ``x-amz-bucket-region`` (AWS returns it for both 200 OK
+    and 301 PermanentRedirect responses). PyArrow is already a required Ray
+    Data dependency and caches region lookups in its C++ S3 layer; the extra
+    per-process dict here also caches negative results, so a bucket that can't
+    be resolved (network error, non-AWS endpoint, or a PyArrow build without
+    S3 support) is probed at most once.
 
-    Returns ``None`` on network errors, non-AWS endpoints, or any case where
-    the header is absent. Callers fall back to obstore's default region
-    handling, which preserves prior behavior for non-AWS S3-compatible
-    backends (MinIO, R2, etc.).
+    Returns ``None`` when the region cannot be determined. Callers fall back
+    to obstore's default region handling, which preserves prior behavior for
+    non-AWS S3-compatible backends (MinIO, R2, etc.).
     """
     with _BUCKET_REGION_CACHE_LOCK:
         if bucket in _BUCKET_REGION_CACHE:
             return _BUCKET_REGION_CACHE[bucket]
 
-    import urllib.error
-    import urllib.request
-
     region: Optional[str] = None
     try:
-        req = urllib.request.Request(
-            f"https://s3.us-east-1.amazonaws.com/{bucket}",
-            method="HEAD",
-        )
-        try:
-            resp = urllib.request.urlopen(req, timeout=timeout)
-            region = resp.headers.get("x-amz-bucket-region")
-        except urllib.error.HTTPError as e:
-            # 301 PermanentRedirect / 403 / 404 still carry the header.
-            region = e.headers.get("x-amz-bucket-region") if e.headers else None
+        region = pyarrow.fs.resolve_s3_region(bucket)
     except Exception as e:
+        # Includes AttributeError on PyArrow builds compiled without S3
+        # support, where ``resolve_s3_region`` is absent.
         logger.debug("Failed to discover region for bucket %r: %s", bucket, e)
 
     with _BUCKET_REGION_CACHE_LOCK:

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -2,9 +2,11 @@ import asyncio
 import inspect
 import logging
 import os
+import re
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     import s3fs  # noqa: F401
@@ -96,6 +98,45 @@ def _log_fallback_warning() -> None:
             "slower for large or numerous files. "
             "Install it with: pip install obstore"
         )
+
+
+# Path-style AWS S3 host: ``s3.amazonaws.com`` (legacy global) or
+# ``s3.<region>.amazonaws.com`` (regional). Virtual-host hosts like
+# ``<bucket>.s3.<region>.amazonaws.com`` already carry the bucket in the
+# netloc and route correctly through obstore without rewriting.
+_AWS_PATH_STYLE_HOST_RE = re.compile(
+    r"^s3(?:\.[a-z0-9-]+)?\.amazonaws\.com$", re.IGNORECASE
+)
+
+
+def _split_obstore_uri(uri: str) -> Tuple[str, str]:
+    """Split a URI into ``(store_url, path)`` for ``obstore.store.from_url``.
+
+    Wraps :func:`_split_uri` to rewrite AWS path-style HTTPS URLs of the
+    form ``https://s3.<region>.amazonaws.com/<bucket>/<key>`` into
+    ``store_url='s3://<bucket>'`` / ``path='<key>'``. Without this, obstore
+    constructs an ``S3Store`` keyed by the regional host endpoint, which
+    pins region from the URL and bails with ``BareRedirect`` whenever the
+    bucket actually lives in a different region (AWS's PermanentRedirect
+    omits the ``Location`` header, so generic redirect-following fails).
+    Rewriting to ``s3://<bucket>`` lets ``S3Store`` discover the bucket's
+    real region once and cache it for the store's lifetime.
+
+    Pre-signed HTTPS URLs (any URI with a query string) are passed through
+    unchanged because their signature is bound to host + path + query, so
+    rewriting would invalidate the signature.
+    """
+    parsed = urlparse(uri, allow_fragments=False)
+    if (
+        parsed.scheme in ("http", "https")
+        and not parsed.query
+        and _AWS_PATH_STYLE_HOST_RE.match(parsed.netloc)
+    ):
+        raw_path = parsed.path[1:] if parsed.path.startswith("/") else parsed.path
+        bucket, _, key = raw_path.partition("/")
+        if bucket:
+            return f"s3://{bucket}", key
+    return _split_uri(uri)
 
 
 def _is_obstore_supported_url(path: str) -> bool:
@@ -484,6 +525,51 @@ def _plan_obstore_routing(
     return True, fs_kwargs
 
 
+# Per-process cache: AWS bucket name -> region (``None`` if discovery failed).
+# Buckets do not change region, so caching for the process lifetime is safe.
+_BUCKET_REGION_CACHE: Dict[str, Optional[str]] = {}
+_BUCKET_REGION_CACHE_LOCK = threading.Lock()
+
+
+def _discover_aws_bucket_region(bucket: str, *, timeout: float = 5.0) -> Optional[str]:
+    """Discover an AWS S3 bucket's region via a HEAD probe.
+
+    Cached per-process. AWS returns ``x-amz-bucket-region`` in the response
+    headers for both 200 OK and 301 PermanentRedirect, so the probe is cheap
+    whether or not the default endpoint happens to be the correct region.
+
+    Returns ``None`` on network errors, non-AWS endpoints, or any case where
+    the header is absent. Callers fall back to obstore's default region
+    handling, which preserves prior behavior for non-AWS S3-compatible
+    backends (MinIO, R2, etc.).
+    """
+    with _BUCKET_REGION_CACHE_LOCK:
+        if bucket in _BUCKET_REGION_CACHE:
+            return _BUCKET_REGION_CACHE[bucket]
+
+    import urllib.error
+    import urllib.request
+
+    region: Optional[str] = None
+    try:
+        req = urllib.request.Request(
+            f"https://s3.us-east-1.amazonaws.com/{bucket}",
+            method="HEAD",
+        )
+        try:
+            resp = urllib.request.urlopen(req, timeout=timeout)
+            region = resp.headers.get("x-amz-bucket-region")
+        except urllib.error.HTTPError as e:
+            # 301 PermanentRedirect / 403 / 404 still carry the header.
+            region = e.headers.get("x-amz-bucket-region") if e.headers else None
+    except Exception as e:
+        logger.debug("Failed to discover region for bucket %r: %s", bucket, e)
+
+    with _BUCKET_REGION_CACHE_LOCK:
+        _BUCKET_REGION_CACHE[bucket] = region
+    return region
+
+
 class StoreRegistry:
     """Cache of store_url -> ObjectStore instances.
 
@@ -506,6 +592,23 @@ class StoreRegistry:
     def get(self, store_url: str) -> Any:
         if store_url not in self._cache:
             kwargs = dict(self._filesystem_kwargs)
+            # obstore's S3Store defaults ``region`` to ``us-east-1`` and does
+            # not auto-discover the bucket's real region, so cross-region
+            # buckets fail with ``BareRedirect`` (AWS's PermanentRedirect
+            # omits the ``Location`` header, defeating generic redirect
+            # following). Probe ``x-amz-bucket-region`` once per bucket and
+            # supply the discovered region explicitly. Skip when the caller
+            # already provided a region or a custom endpoint (MinIO/R2/etc.).
+            if (
+                store_url.startswith(("s3://", "s3a://"))
+                and "region" not in kwargs
+                and "endpoint" not in kwargs
+            ):
+                bucket = store_url.split("://", 1)[1].split("/", 1)[0]
+                if bucket:
+                    region = _discover_aws_bucket_region(bucket)
+                    if region:
+                        kwargs["region"] = region
             if store_url.startswith("http://"):
                 # obstore's reqwest client rejects http:// by default. Auto-enable it
                 # to maintain parity with PyArrow (which accepts http:// via fsspec),
@@ -851,7 +954,7 @@ async def _fetch_ranged(
     pipeline never loses a file due to a transient range error.
     """
     try:
-        store_url, path = _split_uri(uri)
+        store_url, path = _split_obstore_uri(uri)
         store = registry.get(store_url)
         result = bytearray(size)
 
@@ -914,6 +1017,6 @@ async def _fetch(uri: str, registry: StoreRegistry) -> bytes:
     """Download a single URI as a whole-file GET and return raw bytes."""
     import obstore as obs
 
-    store_url, path = _split_uri(uri)
+    store_url, path = _split_obstore_uri(uri)
     result = await obs.get_async(registry.get(store_url), path)
     return bytes(await result.bytes_async())

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -14,11 +14,12 @@ from ray.data._internal.planner._obstore_download import (
     StoreRegistry,
     _extract_credentials_from_filesystem,
     _is_obstore_supported_url,
+    _split_obstore_uri,
 )
 from ray.data._internal.util import RetryingPyFileSystem, _arrow_batcher
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
-from ray.data.datasource.path_util import _resolve_paths_and_filesystem, _split_uri
+from ray.data.datasource.path_util import _resolve_paths_and_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -268,7 +269,7 @@ class AsyncPartitionActor(PartitionActor):
 
         async def _head_one(uri: str) -> int:
             try:
-                store_url, path = _split_uri(uri)
+                store_url, path = _split_obstore_uri(uri)
                 store = self._registry.get(store_url)
                 async with sem:
                     meta = await obs.head_async(store, path)

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -10,13 +10,17 @@ import pyarrow.fs as pafs
 import pytest
 
 from ray.data._internal.planner._obstore_download import (
+    _BUCKET_REGION_CACHE,
     _FILE_SIZE_COLUMN_PREFIX,
+    StoreRegistry,
+    _discover_aws_bucket_region,
     _download_uris_with_obstore,
     _extract_credentials_from_filesystem,
     _is_obstore_supported_url,
     _obstore_filesystem_requires_threaded_download,
     _plan_obstore_routing,
     _S3FSSessionCredentialProvider,
+    _split_obstore_uri,
     download_bytes_async,
 )
 from ray.data._internal.planner.plan_download_op import (
@@ -56,6 +60,210 @@ def test_split_uri(uri, expected_store_url, expected_path):
     store_url, path = _split_uri(uri)
     assert store_url == expected_store_url
     assert path == expected_path
+
+
+# TestSplitObstoreUri — AWS path-style HTTPS URLs must be rewritten to s3://
+# so obstore's S3Store keys off the bucket (with region discovery) instead of
+# off the regional host endpoint (which pins region and fails with
+# BareRedirect on cross-region buckets).
+@pytest.mark.parametrize(
+    "uri, expected_store_url, expected_path",
+    [
+        # Path-style regional: must rewrite to s3://<bucket>.
+        (
+            "https://s3.us-east-1.amazonaws.com/ray-example-data/imagenet/foo.jpg",
+            "s3://ray-example-data",
+            "imagenet/foo.jpg",
+        ),
+        # Path-style legacy global endpoint: also rewrite.
+        (
+            "https://s3.amazonaws.com/my-bucket/key.bin",
+            "s3://my-bucket",
+            "key.bin",
+        ),
+        # Virtual-host style: bucket already in netloc, leave alone.
+        (
+            "https://my-bucket.s3.us-west-2.amazonaws.com/key.bin",
+            "https://my-bucket.s3.us-west-2.amazonaws.com",
+            "key.bin",
+        ),
+        # Native s3:// URIs: no change.
+        (
+            "s3://my-bucket/prefix/key.jpg",
+            "s3://my-bucket",
+            "prefix/key.jpg",
+        ),
+        # Pre-signed URLs (any query string): signature is bound to host +
+        # path + query, so rewriting would invalidate it. Pass through.
+        (
+            "https://s3.us-east-1.amazonaws.com/bucket/key?X-Amz-Signature=abc",
+            "https://s3.us-east-1.amazonaws.com",
+            "bucket/key?X-Amz-Signature=abc",
+        ),
+        # Non-AWS HTTPS (MinIO, R2 custom domain, generic file server):
+        # leave alone — only AWS S3 needs the region-discovery rewrite.
+        (
+            "https://files.example.com/bucket/key.bin",
+            "https://files.example.com",
+            "bucket/key.bin",
+        ),
+        # Other clouds: untouched.
+        ("gs://bucket/path", "gs://bucket", "path"),
+        # Path-style with nested key.
+        (
+            "https://s3.eu-central-1.amazonaws.com/bucket/a/b/c.parquet",
+            "s3://bucket",
+            "a/b/c.parquet",
+        ),
+        # Path-style with only a bucket (no key): bucket is preserved, key
+        # is empty. Edge case; downstream obstore call would fail but that's
+        # the caller's problem.
+        (
+            "https://s3.amazonaws.com/just-a-bucket",
+            "s3://just-a-bucket",
+            "",
+        ),
+    ],
+)
+def test_split_obstore_uri(uri, expected_store_url, expected_path):
+    store_url, path = _split_obstore_uri(uri)
+    assert store_url == expected_store_url
+    assert path == expected_path
+
+
+# TestBucketRegionDiscovery — exercise the HEAD-probe path used by
+# StoreRegistry to discover the real region of cross-region S3 buckets.
+class TestBucketRegionDiscovery:
+    @staticmethod
+    def _clear_cache():
+        _BUCKET_REGION_CACHE.clear()
+
+    def test_region_from_200_response(self):
+        # Same-region buckets respond 200 OK with x-amz-bucket-region.
+        self._clear_cache()
+        mock_resp = MagicMock()
+        mock_resp.headers = {"x-amz-bucket-region": "us-east-1"}
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            assert _discover_aws_bucket_region("east-bucket") == "us-east-1"
+
+    def test_region_from_301_redirect(self):
+        # Cross-region buckets respond 301 PermanentRedirect. The header is on
+        # the HTTPError, not on a raised-then-lost response. This is the
+        # path the user's workload actually hits.
+        import urllib.error
+
+        self._clear_cache()
+        mock_headers = MagicMock()
+        mock_headers.get.return_value = "us-west-2"
+        err = urllib.error.HTTPError(
+            url="https://s3.us-east-1.amazonaws.com/cross-region-bucket",
+            code=301,
+            msg="Moved Permanently",
+            hdrs=mock_headers,
+            fp=None,
+        )
+        err.headers = mock_headers
+        with patch("urllib.request.urlopen", side_effect=err):
+            assert _discover_aws_bucket_region("cross-region-bucket") == "us-west-2"
+
+    def test_cache_hit_avoids_second_probe(self):
+        # First call probes; second call must not invoke urlopen.
+        self._clear_cache()
+        mock_resp = MagicMock()
+        mock_resp.headers = {"x-amz-bucket-region": "eu-west-1"}
+        with patch("urllib.request.urlopen", return_value=mock_resp) as urlopen:
+            _discover_aws_bucket_region("euro-bucket")
+            _discover_aws_bucket_region("euro-bucket")
+            assert urlopen.call_count == 1
+
+    def test_network_failure_returns_none_and_caches(self):
+        # On network errors (e.g. probing a non-AWS bucket via this code path)
+        # return None so StoreRegistry leaves obstore's defaults intact for
+        # MinIO/R2/etc. Cache the negative result so we don't keep probing.
+        self._clear_cache()
+        with patch(
+            "urllib.request.urlopen", side_effect=ConnectionError("nope")
+        ) as urlopen:
+            assert _discover_aws_bucket_region("unreachable") is None
+            assert _discover_aws_bucket_region("unreachable") is None
+            assert urlopen.call_count == 1
+
+
+# TestStoreRegistryRegionInjection — verify region discovery happens at
+# store-construction time for s3:// URLs without an explicit region, and is
+# correctly skipped when the caller has already configured one.
+class TestStoreRegistryRegionInjection:
+    @staticmethod
+    def _make_registry_capturing_kwargs():
+        _BUCKET_REGION_CACHE.clear()
+        captured = {}
+
+        def fake_from_url(url, **kwargs):
+            captured["store_url"] = url
+            captured["kwargs"] = kwargs
+            return MagicMock(name="fake-store")
+
+        reg = StoreRegistry()
+        reg._from_url = fake_from_url
+        return reg, captured
+
+    def test_s3_url_injects_discovered_region(self):
+        reg, captured = self._make_registry_capturing_kwargs()
+        with patch(
+            "ray.data._internal.planner._obstore_download._discover_aws_bucket_region",
+            return_value="us-west-2",
+        ):
+            reg.get("s3://ray-example-data")
+        assert captured["kwargs"].get("region") == "us-west-2"
+
+    def test_s3a_url_also_injects_region(self):
+        reg, captured = self._make_registry_capturing_kwargs()
+        with patch(
+            "ray.data._internal.planner._obstore_download._discover_aws_bucket_region",
+            return_value="us-west-2",
+        ):
+            reg.get("s3a://some-bucket")
+        assert captured["kwargs"].get("region") == "us-west-2"
+
+    def test_explicit_region_not_overridden(self):
+        # Caller (e.g., creds extracted from PyArrow S3FileSystem) already
+        # supplied region; do not probe and do not override.
+        reg = StoreRegistry(region="eu-central-1")
+        captured = {}
+
+        def fake_from_url(url, **kwargs):
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        reg._from_url = fake_from_url
+        with patch(
+            "ray.data._internal.planner._obstore_download._discover_aws_bucket_region"
+        ) as probe:
+            reg.get("s3://bucket")
+        probe.assert_not_called()
+        assert captured["kwargs"]["region"] == "eu-central-1"
+
+    def test_custom_endpoint_skips_probe(self):
+        # MinIO / R2 / localstack: caller configured a custom endpoint, so
+        # the AWS region probe would be both wrong and wasteful.
+        reg = StoreRegistry(endpoint="http://localhost:9000")
+        reg._from_url = lambda *a, **k: MagicMock()
+        with patch(
+            "ray.data._internal.planner._obstore_download._discover_aws_bucket_region"
+        ) as probe:
+            reg.get("s3://bucket")
+        probe.assert_not_called()
+
+    def test_https_url_does_not_probe(self):
+        # Virtual-hosted-style or presigned HTTPS URLs reach get() unchanged
+        # (after _split_obstore_uri). obstore parses the region from the
+        # netloc directly, so probing would be redundant.
+        reg, captured = self._make_registry_capturing_kwargs()
+        with patch(
+            "ray.data._internal.planner._obstore_download._discover_aws_bucket_region"
+        ) as probe:
+            reg.get("https://bucket.s3.us-east-1.amazonaws.com")
+        probe.assert_not_called()
 
 
 # TestDownloadHelpers

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -131,62 +131,49 @@ def test_split_obstore_uri(uri, expected_store_url, expected_path):
     assert path == expected_path
 
 
-# TestBucketRegionDiscovery — exercise the HEAD-probe path used by
-# StoreRegistry to discover the real region of cross-region S3 buckets.
+# TestBucketRegionDiscovery — exercise the region-discovery path used by
+# StoreRegistry to find the real region of cross-region S3 buckets. Region
+# resolution is delegated to ``pyarrow.fs.resolve_s3_region``; these tests
+# patch it to avoid real network calls.
 class TestBucketRegionDiscovery:
     @staticmethod
     def _clear_cache():
         _BUCKET_REGION_CACHE.clear()
 
-    def test_region_from_200_response(self):
-        # Same-region buckets respond 200 OK with x-amz-bucket-region.
+    def test_resolved_region_is_returned(self):
+        # Whether the bucket is same-region (200 OK) or cross-region (301
+        # PermanentRedirect), PyArrow reads x-amz-bucket-region and returns it.
         self._clear_cache()
-        mock_resp = MagicMock()
-        mock_resp.headers = {"x-amz-bucket-region": "us-east-1"}
-        with patch("urllib.request.urlopen", return_value=mock_resp):
-            assert _discover_aws_bucket_region("east-bucket") == "us-east-1"
-
-    def test_region_from_301_redirect(self):
-        # Cross-region buckets respond 301 PermanentRedirect. The header is on
-        # the HTTPError, not on a raised-then-lost response. This is the
-        # path the user's workload actually hits.
-        import urllib.error
-
-        self._clear_cache()
-        mock_headers = MagicMock()
-        mock_headers.get.return_value = "us-west-2"
-        err = urllib.error.HTTPError(
-            url="https://s3.us-east-1.amazonaws.com/cross-region-bucket",
-            code=301,
-            msg="Moved Permanently",
-            hdrs=mock_headers,
-            fp=None,
-        )
-        err.headers = mock_headers
-        with patch("urllib.request.urlopen", side_effect=err):
+        with patch("pyarrow.fs.resolve_s3_region", return_value="us-west-2"):
             assert _discover_aws_bucket_region("cross-region-bucket") == "us-west-2"
 
     def test_cache_hit_avoids_second_probe(self):
-        # First call probes; second call must not invoke urlopen.
+        # First call probes; second call must not invoke resolve_s3_region.
         self._clear_cache()
-        mock_resp = MagicMock()
-        mock_resp.headers = {"x-amz-bucket-region": "eu-west-1"}
-        with patch("urllib.request.urlopen", return_value=mock_resp) as urlopen:
+        with patch("pyarrow.fs.resolve_s3_region", return_value="eu-west-1") as resolve:
             _discover_aws_bucket_region("euro-bucket")
             _discover_aws_bucket_region("euro-bucket")
-            assert urlopen.call_count == 1
+            assert resolve.call_count == 1
 
-    def test_network_failure_returns_none_and_caches(self):
-        # On network errors (e.g. probing a non-AWS bucket via this code path)
-        # return None so StoreRegistry leaves obstore's defaults intact for
-        # MinIO/R2/etc. Cache the negative result so we don't keep probing.
+    def test_failure_returns_none_and_caches(self):
+        # On resolution failure (network error, non-AWS endpoint) return None
+        # so StoreRegistry leaves obstore's defaults intact for MinIO/R2/etc.
+        # Cache the negative result so we don't keep probing.
         self._clear_cache()
         with patch(
-            "urllib.request.urlopen", side_effect=ConnectionError("nope")
-        ) as urlopen:
+            "pyarrow.fs.resolve_s3_region", side_effect=OSError("nope")
+        ) as resolve:
             assert _discover_aws_bucket_region("unreachable") is None
             assert _discover_aws_bucket_region("unreachable") is None
-            assert urlopen.call_count == 1
+            assert resolve.call_count == 1
+
+    def test_missing_resolve_s3_region_returns_none(self):
+        # PyArrow builds compiled without S3 support lack resolve_s3_region,
+        # so the attribute access raises AttributeError; discovery must degrade
+        # to None rather than propagate it.
+        self._clear_cache()
+        with patch("pyarrow.fs.resolve_s3_region", side_effect=AttributeError("no S3")):
+            assert _discover_aws_bucket_region("no-s3-support") is None
 
 
 # TestStoreRegistryRegionInjection — verify region discovery happens at

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -19,6 +19,7 @@ from ray.data._internal.planner._obstore_download import (
     _is_obstore_supported_url,
     _obstore_filesystem_requires_threaded_download,
     _plan_obstore_routing,
+    _resolve_size,
     _S3FSSessionCredentialProvider,
     _split_obstore_uri,
     download_bytes_async,
@@ -271,6 +272,44 @@ class TestStoreRegistryRegionInjection:
         ) as probe:
             reg.get("https://bucket.s3.us-east-1.amazonaws.com")
         probe.assert_not_called()
+
+
+# TestResolveSizeRewrite — the HEAD size probe must apply the same path-style
+# -> s3:// rewrite as the download paths. Otherwise a cross-region path-style
+# URL keeps the regional HTTPS store, hits BareRedirect, returns size 0, and
+# wrongly skips ranged downloads even when a whole-file GET would succeed.
+class TestResolveSizeRewrite:
+    def test_resolve_size_rewrites_path_style_uri(self):
+        _BUCKET_REGION_CACHE.clear()
+        captured = {}
+
+        def fake_from_url(url, **kwargs):
+            captured["store_url"] = url
+            return MagicMock(name="store")
+
+        registry = StoreRegistry()
+        registry._from_url = fake_from_url
+
+        async def fake_head_async(store, path):
+            captured["path"] = path
+            return {"size": 4096}
+
+        with patch(
+            "ray.data._internal.planner._obstore_download._discover_aws_bucket_region",
+            return_value="us-west-2",
+        ), patch("obstore.head_async", side_effect=fake_head_async):
+            size = asyncio.run(
+                _resolve_size(
+                    "https://s3.us-east-1.amazonaws.com/cross-region-bucket/key.bin",
+                    registry,
+                    asyncio.Semaphore(),
+                )
+            )
+
+        # Rewritten to s3://<bucket> so region discovery applies; HEAD succeeds.
+        assert size == 4096
+        assert captured["store_url"] == "s3://cross-region-bucket"
+        assert captured["path"] == "key.bin"
 
 
 # TestDownloadHelpers

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -175,6 +175,26 @@ class TestBucketRegionDiscovery:
         with patch("pyarrow.fs.resolve_s3_region", side_effect=AttributeError("no S3")):
             assert _discover_aws_bucket_region("no-s3-support") is None
 
+    def test_none_result_does_not_overwrite_cached_region(self):
+        # Race: this thread probes (outside the lock) and gets None, while a
+        # concurrent thread resolves and caches the real region. The failed
+        # probe must not clobber the cached region, otherwise later
+        # StoreRegistry.get calls skip region injection and cross-region
+        # downloads fail intermittently.
+        self._clear_cache()
+
+        def resolve_then_simulate_concurrent_win(bucket):
+            # Stand in for another thread caching the real region mid-probe.
+            _BUCKET_REGION_CACHE[bucket] = "us-west-2"
+            return None
+
+        with patch(
+            "pyarrow.fs.resolve_s3_region",
+            side_effect=resolve_then_simulate_concurrent_win,
+        ):
+            assert _discover_aws_bucket_region("racy-bucket") == "us-west-2"
+        assert _BUCKET_REGION_CACHE["racy-bucket"] == "us-west-2"
+
 
 # TestStoreRegistryRegionInjection — verify region discovery happens at
 # store-construction time for s3:// URLs without an explicit region, and is


### PR DESCRIPTION
obstore's S3Store defaults region to us-east-1 and does not follow AWS PermanentRedirect responses, so any obstore-routed S3 request against a bucket in a different region fails non-retryably with BareRedirect.

- `_split_obstore_uri` rewrites `https://s3.<region>.amazonaws.com/<bucket>/<key>` to s3://<bucket> + <key> so StoreRegistry can apply region discovery.
- `_discover_aws_bucket_region` resolves a bucket's region via `pyarrow.fs.resolve_s3_region` (already a required Ray Data dependency), cached per bucket. PyArrow issues the `x-amz-bucket-region` HEAD probe and handles the legacy global endpoint / IMDS edge cases; we additionally cache negative results so unresolvable buckets are probed at most once. The probe runs outside the cache lock, and the write-back never lets a `None` result overwrite a region a concurrent thread already cached (a real region always wins), so racing first-time lookups can't intermittently disable region injection.
- `StoreRegistry.get` injects the discovered region for `s3://, s3a://` URLs, skipping injection when the caller already supplied a region or a custom endpoint (MinIO/R2/etc.).
- All obstore call sites — the HEAD size probe (`_resolve_size`), the actor HEAD path (`_head_one`), ranged downloads (`_fetch_ranged`), and whole-file GET (`_fetch`) — go through `_split_obstore_uri`, so a path-style cross-region URL no longer slips past the rewrite (which previously left the size probe on the regional HTTPS store, returning size 0 and wrongly skipping ranged downloads).

GCS and Azure are unaffected: neither encodes region in the endpoint (GCS uses a global endpoint addressed by bucket name; Azure is keyed by storage account), so they have no cross-region redirect failure mode.
