### PR TITLE
[ci] windows: fix conda HTTP 000

### DIFF
--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -16,9 +16,11 @@ conda init
 # Conda 26.3.1 crashes on Windows when it tries to clean up a locked exe during
 # a build-variant swap. Preventing self-update avoids that code path.
 conda config --set auto_update_conda false
-conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3
+
 # Force CA trust stack to the newest versions available at build time.
-conda update -c conda-forge -q -y ca-certificates certifi
+conda update -c conda-forge --override-channels -q -y ca-certificates certifi
+conda install -c conda-forge --override-channels -q -y \
+  python="${PYTHON_FULL_VERSION}" requests=2.32.3
 
 # Install torch first, as some dependencies (e.g. torch-spline-conv) need torch to be
 # installed for their own install.


### PR DESCRIPTION
## Description
The Windows CI build image (`windowsbuild`) is cached by wanda on its input digest, so `build_base.sh` only re-runs on a cache miss. After ~2 months of cache hits, recent requirements changes (#63722, #63861) invalidated the digest and forced a rebuild at which point `conda install` failed with `HTTP 000 CONNECTION FAILED` reaching `repo.anaconda.com`, because the base image's bundled CA certs had gone stale. 

The primary problem was that the existing CA-cert refresh was ordered *after* the failing install, so it never ran.
Therefore, reordering such that the CA-cert refresh happens first should fix this