### PR TITLE
[RLlib] Mask phantom bootstrap timesteps from GAE advantage standardization

### DIFF
--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -154,8 +154,9 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     episode_lens,
                     convert_to_numpy(batch[module_id][Columns.LOSS_MASK]),
                 ).astype(bool)
-                mean = module_advantages.mean(where=loss_mask)
-                std = module_advantages.std(where=loss_mask)
+                masked_advantages = module_advantages[loss_mask]
+                mean = masked_advantages.mean()
+                std = masked_advantages.std()
             else:
                 mean = module_advantages.mean()
                 std = module_advantages.std()

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -144,10 +144,22 @@ class GeneralAdvantageEstimation(ConnectorV2):
             # vf-preds are recomputed with each `forward_train` call anyway to compute
             # the vf loss.
             # Standardize advantages (used for more stable and better weighted
-            # policy gradient computations).
-            module_advantages = (module_advantages - module_advantages.mean()) / max(
-                1e-4, module_advantages.std()
-            )
+            # policy gradient computations). Restrict mean/std to timesteps that
+            # contribute to the loss: AddOneTsToEpisodesAndTruncate appends one
+            # bootstrap phantom timestep per episode chunk and writes
+            # ``Columns.LOSS_MASK = False`` for it, so including those rows in
+            # the standardization stats biases them (#57989).
+            if Columns.LOSS_MASK in batch[module_id]:
+                loss_mask = unpad_data_if_necessary(
+                    episode_lens,
+                    convert_to_numpy(batch[module_id][Columns.LOSS_MASK]),
+                ).astype(bool)
+                mean = module_advantages.mean(where=loss_mask)
+                std = module_advantages.std(where=loss_mask)
+            else:
+                mean = module_advantages.mean()
+                std = module_advantages.std()
+            module_advantages = (module_advantages - mean) / max(1e-4, std)
 
             # Zero-pad the new computations, if necessary.
             if module.is_stateful():


### PR DESCRIPTION
## Why are these changes needed?

Closes #57989.

The reporter pointed out that ``GeneralAdvantageEstimation`` standardizes advantages over the entire unpadded batch, including the phantom bootstrap timesteps that ``AddOneTsToEpisodesAndTruncate`` appends and then explicitly masks out of the loss via ``Columns.LOSS_MASK = False``.

The connector documents the contract directly (see ``add_one_ts_to_episodes_and_truncate.py:151``):

```python
loss_mask = [True for _ in range(len_)] + [False]
```

The phantom step has an arbitrary advantage that does not correspond to a real transition. Including it in the mean/std biases the standardization in proportion to the ratio of bootstrap steps to real steps. The effect is worst for short episode chunks and BPTT-truncated recurrent rollouts, where bootstrap steps are a large fraction of the unpadded batch.

## What this PR does

Restricts the standardization stats to ``LOSS_MASK == True`` rows via numpy's ``mean(where=...)`` / ``std(where=...)`` API:

```python
if Columns.LOSS_MASK in batch[module_id]:
    loss_mask = unpad_data_if_necessary(
        episode_lens,
        convert_to_numpy(batch[module_id][Columns.LOSS_MASK]),
    ).astype(bool)
    mean = module_advantages.mean(where=loss_mask)
    std = module_advantages.std(where=loss_mask)
else:
    mean = module_advantages.mean()
    std = module_advantages.std()
module_advantages = (module_advantages - mean) / max(1e-4, std)
```

Shape of ``module_advantages`` is preserved; only the normalization constants change. The fallback path covers callers that swap ``AddOneTsToEpisodesAndTruncate`` out of the pipeline.

The original issue reporter sketched the same fix and noted that the pre-ConnectorV2 stack handled masking correctly; this restores parity.

## Related issue number

Closes #57989

## Checks

- [x] DCO sign-off
- [x] ``ruff check`` and ``black==22.10.0`` (Ray's pinned version) pass on the modified file

## Test plan

- [ ] CI passes (``buildkite/premerge``, ``buildkite/microcheck``, ``buildkite/release``)
- [ ] Existing PPO learning tests (CartPole sanity check etc.) keep converging — they were the baseline regression for the unmasked code path and should still converge with the masked stats (which are strictly more correct on bootstrap-padded batches)