### PR TITLE
[Serve][LLM] Fix sequential streaming in SGLangServer completions() for multi-prompt requests

### DIFF
--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -12,7 +12,7 @@ import copy
 import json
 import signal
 import time
-import asyncio 
+import asyncio
 import uuid
 from typing import (
     Any,
@@ -45,6 +45,7 @@ from ray.llm._internal.serve.core.server.llm_server import (
 
 
 class SGLangServer:
+
     def __init__(self, llm_config: LLMConfig):
 
         self._llm_config = llm_config
@@ -452,10 +453,6 @@ class SGLangServer:
                 for t in tasks:
                     t.cancel()
             return
-
-            
-
-            
 
         results = await self._generate_and_extract_metadata(request, prompts_to_process)
 

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -8,11 +8,11 @@ Community SGLang support is in early development. Track progress and
 provide feedback at https://github.com/ray-project/ray/issues/61114.
 """
 
+import asyncio
 import copy
 import json
 import signal
 import time
-import asyncio
 import uuid
 from typing import (
     Any,
@@ -45,7 +45,6 @@ from ray.llm._internal.serve.core.server.llm_server import (
 
 
 class SGLangServer:
-
     def __init__(self, llm_config: LLMConfig):
 
         self._llm_config = llm_config
@@ -435,7 +434,7 @@ class SGLangServer:
                 asyncio.create_task(_produce_stream(i, p))
                 for i, p in enumerate(prompts_to_process)
             ]
-
+            
             finished_tasks = 0
             try:
                 while finished_tasks < active_tasks:
@@ -449,7 +448,6 @@ class SGLangServer:
                     else:
                         yield item
             finally:
-                # Cancel all producer tasks on early exit or client disconnect
                 for t in tasks:
                     t.cancel()
             return

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -436,16 +436,21 @@ class SGLangServer:
             ]
 
             finished_tasks = 0
-            while finished_tasks < active_tasks:
-                item = await queue.get()
-                if item is None:
-                    finished_tasks += 1
-                elif isinstance(item, Exception):
-                    for t in tasks:
-                        t.cancel()
-                    raise item
-                else:
-                    yield item
+            try:
+                while finished_tasks < active_tasks:
+                    item = await queue.get()
+                    if item is None:
+                        finished_tasks += 1
+                    elif isinstance(item, Exception):
+                        for t in tasks:
+                            t.cancel()
+                        raise item
+                    else:
+                        yield item
+            finally:
+                # Cancel all producer tasks on early exit or client disconnect
+                for t in tasks:
+                    t.cancel()
             return
 
             

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -12,6 +12,7 @@ import copy
 import json
 import signal
 import time
+import asyncio 
 import uuid
 from typing import (
     Any,
@@ -401,22 +402,38 @@ class SGLangServer:
         if request.stream:
             gen_id = f"sglang-gen-{uuid.uuid4().hex}"
             created = int(time.time())
-            for i, prompt_string in enumerate(prompts_to_process):
+
+            async def _collect_stream(i: int, prompt_string: str) -> list:
+                """Collect all SSE chunks for one prompt into a list."""
+                chunks = []
                 async for delta_text, finish_reason in self._stream_generate(
                     request, prompt_string
                 ):
-                    yield self._build_sse_chunk(
-                        gen_id,
-                        "text_completion",
-                        created,
-                        request.model,
-                        {
-                            "index": i,
-                            "text": delta_text,
-                            "logprobs": None,
-                            "finish_reason": finish_reason,
-                        },
+                    chunks.append(
+                        self._build_sse_chunk(
+                            gen_id,
+                            "text_completion",
+                            created,
+                            request.model,
+                            {
+                                "index": i,
+                                "text": delta_text,
+                                "logprobs": None,
+                                "finish_reason": finish_reason,
+                            },
+                        )
                     )
+                return chunks
+
+            
+
+            # Run all prompt streams concurrently instead of sequentially
+            all_chunks = await asyncio.gather(
+                *[_collect_stream(i, p) for i, p in enumerate(prompts_to_process)]
+            )
+            for prompt_chunks in all_chunks:
+                for chunk in prompt_chunks:
+                    yield chunk
             return
 
         results = await self._generate_and_extract_metadata(request, prompts_to_process)

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -434,7 +434,6 @@ class SGLangServer:
                 asyncio.create_task(_produce_stream(i, p))
                 for i, p in enumerate(prompts_to_process)
             ]
-            
             finished_tasks = 0
             try:
                 while finished_tasks < active_tasks:

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -403,38 +403,54 @@ class SGLangServer:
             gen_id = f"sglang-gen-{uuid.uuid4().hex}"
             created = int(time.time())
 
-            async def _collect_stream(i: int, prompt_string: str) -> list:
-                """Collect all SSE chunks for one prompt into a list."""
-                chunks = []
-                async for delta_text, finish_reason in self._stream_generate(
-                    request, prompt_string
-                ):
-                    chunks.append(
-                        self._build_sse_chunk(
-                            gen_id,
-                            "text_completion",
-                            created,
-                            request.model,
-                            {
-                                "index": i,
-                                "text": delta_text,
-                                "logprobs": None,
-                                "finish_reason": finish_reason,
-                            },
+            queue: asyncio.Queue = asyncio.Queue()
+            active_tasks = len(prompts_to_process)
+
+            async def _produce_stream(i: int, prompt_string: str) -> None:
+                try:
+                    async for delta_text, finish_reason in self._stream_generate(
+                        request, prompt_string
+                    ):
+                        await queue.put(
+                            self._build_sse_chunk(
+                                gen_id,
+                                "text_completion",
+                                created,
+                                request.model,
+                                {
+                                    "index": i,
+                                    "text": delta_text,
+                                    "logprobs": None,
+                                    "finish_reason": finish_reason,
+                                },
+                            )
                         )
-                    )
-                return chunks
+                except Exception as e:
+                    await queue.put(e)
+                finally:
+                    await queue.put(None)
+
+            tasks = [
+                asyncio.create_task(_produce_stream(i, p))
+                for i, p in enumerate(prompts_to_process)
+            ]
+
+            finished_tasks = 0
+            while finished_tasks < active_tasks:
+                item = await queue.get()
+                if item is None:
+                    finished_tasks += 1
+                elif isinstance(item, Exception):
+                    for t in tasks:
+                        t.cancel()
+                    raise item
+                else:
+                    yield item
+            return
 
             
 
-            # Run all prompt streams concurrently instead of sequentially
-            all_chunks = await asyncio.gather(
-                *[_collect_stream(i, p) for i, p in enumerate(prompts_to_process)]
-            )
-            for prompt_chunks in all_chunks:
-                for chunk in prompt_chunks:
-                    yield chunk
-            return
+            
 
         results = await self._generate_and_extract_metadata(request, prompts_to_process)
 


### PR DESCRIPTION
## Summary
Fixes sequential streaming in `SGLangServer.completions()` when multiple 
prompts are provided.

## Problem
When `request.stream=True` and multiple prompts are passed, the previous 
code processed them in a sequential `for` loop — one prompt at a time. 
This caused unnecessary latency under concurrent load.

## Fix
Replace the sequential loop with `asyncio.gather()` to stream all prompts 
concurrently, matching how the non-streaming batch path already works.

## Related
Relates to tracker #61114