### PR TITLE
[Core] Add RAY_TLS_CLIENT_AUTH env var to disable client certificate auth

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/tls.md
+++ b/doc/source/cluster/kubernetes/user-guides/tls.md
@@ -142,6 +142,7 @@ To enable TLS authentication in your Ray cluster, set the following environment 
 - `RAY_TLS_SERVER_CERT`: Location of a certificate file which is presented to other endpoints so as to achieve mutual authentication (i.e. `tls.crt`).
 - `RAY_TLS_SERVER_KEY`: Location of a private key file which is the cryptographic means to prove to other endpoints that you are the authorized user of a given certificate (i.e. `tls.key`).
 - `RAY_TLS_CA_CERT`: Location of a CA certificate file which allows TLS to decide whether an endpoint’s certificate has been signed by the correct authority (i.e. `ca.crt`).
+- `RAY_TLS_CLIENT_AUTH`: Either 1 or 0 to enable/disable client certificate authentication. When set to 0, the gRPC server will not require client certificates, allowing server-only TLS without mutual TLS (mTLS). Default: 1.
 
 For more information on how to configure Ray with TLS authentication, please refer to [Ray's document](https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication).
 

--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -249,6 +249,7 @@ You enable TLS by setting environment variables.
 - ``RAY_TLS_SERVER_CERT``: Location of a `certificate file (tls.crt)`, which Ray presents to other endpoints to achieve mutual authentication.
 - ``RAY_TLS_SERVER_KEY``: Location of a `private key file (tls.key)`, which is the cryptographic means to prove to other endpoints that you are the authorized user of a given certificate.
 - ``RAY_TLS_CA_CERT``: Location of a `CA certificate file (ca.crt)`, which allows TLS to decide whether an the correct authority signed the endpoint's certificate.
+- ``RAY_TLS_CLIENT_AUTH``: Either 1 or 0 to enable/disable client certificate authentication. When set to 0, the gRPC server will not require client certificates, allowing server-only TLS without mutual TLS (mTLS). Default: 1.
 
 Step 4: Verify TLS authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/ray/_common/tls_utils.py
+++ b/python/ray/_common/tls_utils.py
@@ -71,31 +71,48 @@ def add_port_to_grpc_server(server, address):
     import grpc
 
     if os.environ.get("RAY_USE_TLS", "0").lower() in ("1", "true"):
-        server_cert_chain, private_key, ca_cert = load_certs_from_env()
+        require_client_auth = os.environ.get("RAY_TLS_CLIENT_AUTH", "1").lower() in (
+            "1",
+            "true",
+        )
+        server_cert_chain, private_key, ca_cert = load_certs_from_env(
+            server_side=True, client_auth=require_client_auth
+        )
         credentials = grpc.ssl_server_credentials(
             [(private_key, server_cert_chain)],
-            root_certificates=ca_cert,
-            require_client_auth=ca_cert is not None,
+            root_certificates=ca_cert if require_client_auth else None,
+            require_client_auth=require_client_auth,
         )
         return server.add_secure_port(address, credentials)
     else:
         return server.add_insecure_port(address)
 
 
-def load_certs_from_env():
-    tls_env_vars = ["RAY_TLS_SERVER_CERT", "RAY_TLS_SERVER_KEY", "RAY_TLS_CA_CERT"]
-    if any(v not in os.environ for v in tls_env_vars):
-        raise RuntimeError(
-            "If the environment variable RAY_USE_TLS is set to true "
-            "then RAY_TLS_SERVER_CERT, RAY_TLS_SERVER_KEY and "
-            "RAY_TLS_CA_CERT must also be set."
-        )
+def load_certs_from_env(server_side=True, client_auth=True):
+    require_server_certs = server_side or client_auth
+    require_ca_cert = not server_side or client_auth
 
-    with open(os.environ["RAY_TLS_SERVER_CERT"], "rb") as f:
-        server_cert_chain = f.read()
-    with open(os.environ["RAY_TLS_SERVER_KEY"], "rb") as f:
-        private_key = f.read()
-    with open(os.environ["RAY_TLS_CA_CERT"], "rb") as f:
-        ca_cert = f.read()
+    server_cert_chain = None
+    private_key = None
+    ca_cert = None
+
+    if require_server_certs:
+        for var in ["RAY_TLS_SERVER_CERT", "RAY_TLS_SERVER_KEY"]:
+            if var not in os.environ:
+                raise RuntimeError(
+                    f"The environment variable {var} must be set when TLS is enabled."
+                )
+        with open(os.environ["RAY_TLS_SERVER_CERT"], "rb") as f:
+            server_cert_chain = f.read()
+        with open(os.environ["RAY_TLS_SERVER_KEY"], "rb") as f:
+            private_key = f.read()
+
+    if require_ca_cert:
+        if "RAY_TLS_CA_CERT" not in os.environ:
+            raise RuntimeError(
+                "The environment variable RAY_TLS_CA_CERT must be set when TLS is enabled."
+            )
+        with open(os.environ["RAY_TLS_CA_CERT"], "rb") as f:
+            ca_cert = f.read()
 
     return server_cert_chain, private_key, ca_cert

--- a/python/ray/_private/grpc_utils.py
+++ b/python/ray/_private/grpc_utils.py
@@ -66,10 +66,16 @@ def init_grpc_channel(
         base_args = (address, credentials)
     elif os.environ.get("RAY_USE_TLS", "0").lower() in ("1", "true"):
         # Use TLS from environment variables
-        server_cert_chain, private_key, ca_cert = load_certs_from_env()
+        client_auth = os.environ.get("RAY_TLS_CLIENT_AUTH", "1").lower() in (
+            "1",
+            "true",
+        )
+        server_cert_chain, private_key, ca_cert = load_certs_from_env(
+            server_side=False, client_auth=client_auth
+        )
         tls_credentials = grpc.ssl_channel_credentials(
-            certificate_chain=server_cert_chain,
-            private_key=private_key,
+            certificate_chain=server_cert_chain if client_auth else None,
+            private_key=private_key if client_auth else None,
             root_certificates=ca_cert,
         )
         channel_creator = grpc_module.secure_channel

--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -234,5 +234,128 @@ finally:
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=("Cryptography (TLS dependency) doesn't install in Mac build pipeline"),
+)
+@pytest.mark.parametrize("use_tls", [True], indirect=True)
+def test_tls_without_client_auth_server_credentials(use_tls):
+    """Test that RAY_TLS_CLIENT_AUTH=0 sets require_client_auth=False."""
+    from unittest import mock
+
+    os.environ["RAY_TLS_CLIENT_AUTH"] = "0"
+    try:
+        from ray._common.tls_utils import add_port_to_grpc_server
+
+        server = mock.MagicMock()
+        server.add_secure_port.return_value = 12345
+
+        # Verify ssl_server_credentials was called with require_client_auth=False
+        with mock.patch("grpc.ssl_server_credentials") as mock_ssl:
+            mock_ssl.return_value = mock.MagicMock()
+            result = add_port_to_grpc_server(server, "localhost:12345")
+            mock_ssl.assert_called_once()
+            call_kwargs = mock_ssl.call_args
+            assert call_kwargs[1]["require_client_auth"] is False
+            assert call_kwargs[1]["root_certificates"] is None
+        # Verify add_secure_port was called (TLS is enabled)
+        assert server.add_secure_port.called
+        assert result == 12345
+    finally:
+        os.environ["RAY_TLS_CLIENT_AUTH"] = "1"
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=("Cryptography (TLS dependency) doesn't install in Mac build pipeline"),
+)
+@pytest.mark.parametrize("use_tls", [True], indirect=True)
+def test_tls_with_client_auth_enabled_by_default(use_tls):
+    """Test that RAY_TLS_CLIENT_AUTH defaults to enabled (backward compat)."""
+    from unittest import mock
+
+    # Ensure RAY_TLS_CLIENT_AUTH is NOT set, so it defaults to "1"
+    os.environ.pop("RAY_TLS_CLIENT_AUTH", None)
+
+    from ray._common.tls_utils import add_port_to_grpc_server
+
+    server = mock.MagicMock()
+    with mock.patch("grpc.ssl_server_credentials") as mock_ssl:
+        mock_ssl.return_value = mock.MagicMock()
+        add_port_to_grpc_server(server, "localhost:12345")
+        mock_ssl.assert_called_once()
+        call_kwargs = mock_ssl.call_args
+        assert call_kwargs[1]["require_client_auth"] is True
+        assert call_kwargs[1]["root_certificates"] is not None
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=("Cryptography (TLS dependency) doesn't install in Mac build pipeline"),
+)
+@pytest.mark.parametrize("use_tls", [True], indirect=True)
+def test_init_with_tls_no_client_auth(use_tls):
+    """Test that Ray can start with TLS enabled but client auth disabled."""
+    env = build_env()
+    env["RAY_TLS_CLIENT_AUTH"] = "0"
+    run_string_as_driver(
+        """
+import ray
+try:
+    ray.init()
+    # Basic put/get to verify the connection works
+    obj_ref = ray.put(42)
+    assert ray.get(obj_ref) == 42
+finally:
+    ray.shutdown()
+    """,
+        env=env,
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=("Cryptography (TLS dependency) doesn't install in Mac build pipeline"),
+)
+@pytest.mark.parametrize("use_tls", [True], indirect=True)
+def test_load_certs_from_env_client_without_client_auth(use_tls, tmp_path):
+    """Test load_certs_from_env behavior for client without client auth (only CA cert)."""
+    from ray._common.tls_utils import load_certs_from_env
+
+    ca_cert_file = tmp_path / "ca.crt"
+    ca_cert_file.write_bytes(b"dummy_ca_cert")
+
+    env_backup = os.environ.copy()
+    os.environ["RAY_TLS_CA_CERT"] = str(ca_cert_file)
+    # Remove server cert/key from environment
+    os.environ.pop("RAY_TLS_SERVER_CERT", None)
+    os.environ.pop("RAY_TLS_SERVER_KEY", None)
+
+    try:
+        # Client side without client auth should NOT raise exception, and load ca_cert.
+        # It should ignore server cert/key even if they point to non-existent paths.
+        os.environ["RAY_TLS_SERVER_CERT"] = "/nonexistent/path/server.crt"
+        os.environ["RAY_TLS_SERVER_KEY"] = "/nonexistent/path/server.key"
+        server_cert, private_key, ca_cert = load_certs_from_env(
+            server_side=False, client_auth=False
+        )
+        assert server_cert is None
+        assert private_key is None
+        assert ca_cert == b"dummy_ca_cert"
+
+        # Client side WITH client auth (mTLS) should raise RuntimeError/FileNotFoundError
+        # due to missing/invalid server cert/key.
+        with pytest.raises((RuntimeError, FileNotFoundError)):
+            load_certs_from_env(server_side=False, client_auth=True)
+
+        # Server side without client auth should raise RuntimeError/FileNotFoundError
+        # due to missing/invalid server cert/key.
+        with pytest.raises((RuntimeError, FileNotFoundError)):
+            load_certs_from_env(server_side=True, client_auth=False)
+    finally:
+        os.environ.clear()
+        os.environ.update(env_backup)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -922,6 +922,11 @@ RAY_CONFIG(std::string, TLS_SERVER_CERT, "")
 RAY_CONFIG(std::string, TLS_SERVER_KEY, "")
 RAY_CONFIG(std::string, TLS_CA_CERT, "")
 
+/// Whether to require client certificate authentication when TLS is enabled.
+/// When set to false (RAY_TLS_CLIENT_AUTH=0), the server will not request
+/// or verify client certificates, allowing server-only TLS without mTLS.
+RAY_CONFIG(bool, TLS_CLIENT_AUTH, true)
+
 /// Location of Redis TLS credentials
 /// https://github.com/redis/hiredis/blob/c78d0926bf169670d15cfc1214e4f5d21673396b/README.md#hiredis-openssl-wrappers
 RAY_CONFIG(std::string, REDIS_CA_CERT, "")

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -99,7 +99,9 @@ void GrpcServer::Run() {
     std::string serverkey = ReadCert(RayConfig::instance().TLS_SERVER_KEY());
     grpc::SslServerCredentialsOptions::PemKeyCertPair pkcp = {serverkey, servercert};
     grpc::SslServerCredentialsOptions ssl_opts(
-        GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY);
+        RayConfig::instance().TLS_CLIENT_AUTH()
+            ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
+            : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
     ssl_opts.pem_root_certs = rootcert;
     ssl_opts.pem_key_cert_pairs.push_back(pkcp);
 


### PR DESCRIPTION
# Why are these changes needed?

When TLS is enabled (`RAY_USE_TLS=1`), Ray currently always enforces mutual TLS (mTLS) by requiring client certificate verification on all gRPC channels. This makes it difficult or impossible to connect Ray clients securely (with encrypted transport) from external environments such as Vertex AI pipelines, local development setups, or third-party orchestrators where client-side certificate management is either not feasible or unnecessary.

This PR introduces a new environment variable, `RAY_TLS_CLIENT_AUTH` (default: `1`), to make client certificate verification configurable. Setting `RAY_TLS_CLIENT_AUTH=0` disables client certificate verification on the gRPC server, allowing clients to establish secure TLS connections using only the server's CA certificate without requiring server certificates or private keys on the client side.

# What changes are made?

### Flexible Certificate Loading
**File:** `python/ray/_common/tls_utils.py`

- Updated `load_certs_from_env()` to dynamically determine which certificates are required based on:
  - Whether the caller is a server or client.
  - Whether client authentication (mTLS) is enabled.
- When `RAY_TLS_CLIENT_AUTH=0`, clients no longer require:
  - `RAY_TLS_SERVER_CERT`
  - `RAY_TLS_SERVER_KEY`

### Python Server-side TLS Configuration
**File:** `python/ray/_common/tls_utils.py`

- Conditionally configures gRPC server credentials:
  - `require_client_auth=False`
  - `root_certificates=None`
- Applied only when `RAY_TLS_CLIENT_AUTH` is disabled.

### Python Client-side TLS Configuration
**File:** `python/ray/_private/grpc_utils.py`

- Conditionally omits:
  - `certificate_chain`
  - `private_key`
- From `ssl_channel_credentials()` when client authentication is disabled.

### C++ Configuration and gRPC Server Support
**Files:**
- `src/ray/common/ray_config_def.h`
- `src/ray/rpc/grpc_server.cc`

Changes include:

- Added a new C++ config entry:
  - `TLS_CLIENT_AUTH` (default: `true`)
- Conditionally configures gRPC server credentials with:
  - `GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE`
- Applied when client authentication is disabled.

### Documentation
**Files:**
- `doc/source/ray-core/configure.rst`
- `doc/source/cluster/kubernetes/user-guides/tls.md`

- Added documentation for the new `RAY_TLS_CLIENT_AUTH` environment variable.
- Updated both Ray Core TLS configuration and KubeRay TLS guides.

### Tests
**File:** `python/ray/tests/test_tls_auth.py`

Added test coverage for:

- TLS credential configuration behavior.
- Flexible certificate loading.
- End-to-end Ray initialization with client authentication disabled.

# Does this PR introduce any user-facing change?

Yes.

Users can now set:

```bash
RAY_TLS_CLIENT_AUTH=0
```

(or `false`) to disable client certificate verification on TLS-enabled Ray clusters and use server-only TLS.

By default, `RAY_TLS_CLIENT_AUTH=1` (`true`), preserving full backward compatibility. Existing deployments will continue using mutual TLS (mTLS) without any changes.

# How was this patch tested?

Added the following test cases:

- `test_tls_without_client_auth_server_credentials`
  - Verifies gRPC server credential configuration when client authentication is disabled.

- `test_tls_with_client_auth_enabled_by_default`
  - Ensures backward compatibility and default mTLS behavior.

- `test_init_with_tls_no_client_auth`
  - Verifies that Ray can start and perform basic driver operations successfully without client certificate verification.

- `test_load_certs_from_env_client_without_client_auth`
  - Verifies that clients can load CA certificates and establish secure connections without requiring server certificates or private keys when client authentication is disabled.

## Closes

Closes #43611