### PR TITLE
[cpp] Fix buildifier module-docstring warning

### DIFF
--- a/cpp/example/_BUILD.bazel
+++ b/cpp/example/_BUILD.bazel
@@ -1,3 +1,5 @@
+"""BUILD rules for Ray C++ examples."""
+
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 cc_binary(


### PR DESCRIPTION
What does this PR do?

Adds a module docstring to cpp/example/_BUILD.bazel to fix the buildifier module-docstring warning.

Related issue

Part of #50875.