### PR TITLE
[tune] Make BayesOptSearch float-hash precision configurable

### DIFF
--- a/python/ray/tune/search/bayesopt/bayesopt_search.py
+++ b/python/ray/tune/search/bayesopt/bayesopt_search.py
@@ -165,6 +165,8 @@ class BayesOptSearch(Searcher):
             assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
         self._config_counter = defaultdict(int)
         self._patience = patience
+        if not isinstance(repeat_float_precision, int):
+            raise TypeError("repeat_float_precision must be an integer.")
         if repeat_float_precision < 0:
             raise ValueError("repeat_float_precision must be non-negative.")
         # int: Precision at which to hash float values when checking for

--- a/python/ray/tune/search/bayesopt/bayesopt_search.py
+++ b/python/ray/tune/search/bayesopt/bayesopt_search.py
@@ -89,6 +89,10 @@ class BayesOptSearch(Searcher):
             we terminate the experiment.
         skip_duplicate: skip duplicate config
         analysis: Optionally, the previous analysis to integrate.
+        repeat_float_precision: Decimal precision used when hashing float
+            values in a config to detect duplicate suggestions. Higher
+            values make the duplicate check stricter, so fewer distinct
+            configurations are treated as repeats and skipped. Defaults to 5.
 
     Tune automatically converts search spaces to BayesOptSearch's format:
 
@@ -151,6 +155,7 @@ class BayesOptSearch(Searcher):
         patience: int = 5,
         skip_duplicate: bool = True,
         analysis: Optional["ExperimentAnalysis"] = None,
+        repeat_float_precision: int = 5,
     ):
         assert byo is not None, (
             "BayesOpt must be installed!. You can install BayesOpt with"
@@ -160,8 +165,11 @@ class BayesOptSearch(Searcher):
             assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
         self._config_counter = defaultdict(int)
         self._patience = patience
-        # int: Precision at which to hash values.
-        self.repeat_float_precision = 5
+        if repeat_float_precision < 0:
+            raise ValueError("repeat_float_precision must be non-negative.")
+        # int: Precision at which to hash float values when checking for
+        # duplicate suggestions.
+        self.repeat_float_precision = repeat_float_precision
         if self._patience <= 0:
             raise ValueError("patience must be set to a value greater than 0!")
         self._skip_duplicate = skip_duplicate

--- a/python/ray/tune/search/bayesopt/bayesopt_search.py
+++ b/python/ray/tune/search/bayesopt/bayesopt_search.py
@@ -165,7 +165,9 @@ class BayesOptSearch(Searcher):
             assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
         self._config_counter = defaultdict(int)
         self._patience = patience
-        if not isinstance(repeat_float_precision, int):
+        if isinstance(repeat_float_precision, bool) or not isinstance(
+            repeat_float_precision, int
+        ):
             raise TypeError("repeat_float_precision must be an integer.")
         if repeat_float_precision < 0:
             raise ValueError("repeat_float_precision must be non-negative.")

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -822,12 +822,18 @@ class BayesOptHashPrecisionTest(unittest.TestCase):
         searcher = BayesOptSearch(repeat_float_precision=16)
         self.assertEqual(searcher.repeat_float_precision, 16)
 
-    def testNegativeRepeatFloatPrecisionRaises(self):
+    def testInvalidRepeatFloatPrecisionRaises(self):
         pytest.importorskip("bayes_opt")
         from ray.tune.search.bayesopt import BayesOptSearch
 
         with self.assertRaises(ValueError):
             BayesOptSearch(repeat_float_precision=-1)
+
+        with self.assertRaises(TypeError):
+            BayesOptSearch(repeat_float_precision="5")
+
+        with self.assertRaises(TypeError):
+            BayesOptSearch(repeat_float_precision=5.5)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -835,6 +835,9 @@ class BayesOptHashPrecisionTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             BayesOptSearch(repeat_float_precision=5.5)
 
+        with self.assertRaises(TypeError):
+            BayesOptSearch(repeat_float_precision=True)
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -801,6 +801,35 @@ class MultiObjectiveTest(unittest.TestCase):
         self.assertTrue(os.path.exists(storage_file_path))
 
 
+class BayesOptHashPrecisionTest(unittest.TestCase):
+    def testDictHashPrecisionDistinguishesNearFloats(self):
+        from ray.tune.search.bayesopt.bayesopt_search import _dict_hash
+
+        a = {"lr": 1.00001e-05}
+        b = {"lr": 1.46532e-05}
+        # The default precision of 5 rounds both to the same string, so the
+        # two distinct configs collide and one suggestion would be skipped.
+        self.assertEqual(_dict_hash(a, 5), _dict_hash(b, 5))
+        # A higher precision keeps them apart.
+        self.assertNotEqual(_dict_hash(a, 16), _dict_hash(b, 16))
+
+    def testRepeatFloatPrecisionIsConfigurable(self):
+        pytest.importorskip("bayes_opt")
+        from ray.tune.search.bayesopt import BayesOptSearch
+
+        # Default stays at 5 for backward compatibility.
+        self.assertEqual(BayesOptSearch().repeat_float_precision, 5)
+        searcher = BayesOptSearch(repeat_float_precision=16)
+        self.assertEqual(searcher.repeat_float_precision, 16)
+
+    def testNegativeRepeatFloatPrecisionRaises(self):
+        pytest.importorskip("bayes_opt")
+        from ray.tune.search.bayesopt import BayesOptSearch
+
+        with self.assertRaises(ValueError):
+            BayesOptSearch(repeat_float_precision=-1)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?

`BayesOptSearch` hashes each suggested config to decide whether it has already been tried, and `_dict_hash` encodes float values at a fixed precision of 5 decimals (`repeat_float_precision = 5`). For small-magnitude parameters that is too coarse. In a learning-rate search, `1.00001e-05` and `1.46532e-05` both round to `"0.00001"`, so two genuinely different suggestions look identical and one gets counted as a repeat and skipped. With `patience` set, enough false repeats can end the run early.

This exposes `repeat_float_precision` as a constructor argument so it can be raised when needed (the issue notes it can already be set by hand after init, just awkwardly). The default stays at 5 so existing runs are unaffected, and negative values are rejected.

Verified locally against the installed package: at precision 5 the two learning rates above hash to the same string, at precision 16 they stay distinct, and the default remains 5.

## Related issue number

Closes #50315

## Checks

- [x] Added tests in `test_searchers.py` (`BayesOptHashPrecisionTest`): hashing at low vs high precision, the new argument, and the negative-value guard. All pass.
- [x] `ruff check` passes on the changed files.