### PR TITLE
[Data] Add union/intersection/difference to list expression namespace

### DIFF
--- a/python/ray/data/namespace_expressions/list_namespace.py
+++ b/python/ray/data/namespace_expressions/list_namespace.py
@@ -358,9 +358,12 @@ class _ListNamespace:
             A UDFExpr whose lists hold the elements present in both lists, in the
             order they appear in the first list.
         """
-        return self._apply_set_operation(
-            other, lambda a, b: [x for x in dict.fromkeys(a) if x in set(b)]
-        )
+
+        def _intersection(a, b):
+            b_set = set(b)
+            return [x for x in dict.fromkeys(a) if x in b_set]
+
+        return self._apply_set_operation(other, _intersection)
 
     def difference(self, other: "Expr") -> "UDFExpr":
         """Set difference of each list and the corresponding list in ``other``.
@@ -372,9 +375,12 @@ class _ListNamespace:
             A UDFExpr whose lists hold the elements in the first list but not the
             second, in the order they appear in the first list.
         """
-        return self._apply_set_operation(
-            other, lambda a, b: [x for x in dict.fromkeys(a) if x not in set(b)]
-        )
+
+        def _difference(a, b):
+            b_set = set(b)
+            return [x for x in dict.fromkeys(a) if x not in b_set]
+
+        return self._apply_set_operation(other, _difference)
 
     def _apply_set_operation(self, other: "Expr", op) -> "UDFExpr":
         # Set operations change list lengths, so a FixedSizeList result type must

--- a/python/ray/data/namespace_expressions/list_namespace.py
+++ b/python/ray/data/namespace_expressions/list_namespace.py
@@ -333,3 +333,69 @@ class _ListNamespace:
             )
 
         return _list_flatten(self._expr)
+
+    def union(self, other: "Expr") -> "UDFExpr":
+        """Set union of each list with the corresponding list in ``other``.
+
+        Args:
+            other: A list-typed expression to union with.
+
+        Returns:
+            A UDFExpr whose lists hold the deduplicated elements of both lists,
+            in first-seen order.
+        """
+        return self._apply_set_operation(
+            other, lambda a, b: list(dict.fromkeys([*a, *b]))
+        )
+
+    def intersection(self, other: "Expr") -> "UDFExpr":
+        """Set intersection of each list with the corresponding list in ``other``.
+
+        Args:
+            other: A list-typed expression to intersect with.
+
+        Returns:
+            A UDFExpr whose lists hold the elements present in both lists, in the
+            order they appear in the first list.
+        """
+        return self._apply_set_operation(
+            other, lambda a, b: [x for x in dict.fromkeys(a) if x in set(b)]
+        )
+
+    def difference(self, other: "Expr") -> "UDFExpr":
+        """Set difference of each list and the corresponding list in ``other``.
+
+        Args:
+            other: A list-typed expression to subtract.
+
+        Returns:
+            A UDFExpr whose lists hold the elements in the first list but not the
+            second, in the order they appear in the first list.
+        """
+        return self._apply_set_operation(
+            other, lambda a, b: [x for x in dict.fromkeys(a) if x not in set(b)]
+        )
+
+    def _apply_set_operation(self, other: "Expr", op) -> "UDFExpr":
+        # Set operations change list lengths, so a FixedSizeList result type must
+        # widen to a variable-length list.
+        return_dtype = self._expr.data_type
+        if return_dtype.is_arrow_type():
+            arrow_type = return_dtype.to_arrow_dtype()
+            if pyarrow.types.is_fixed_size_list(arrow_type):
+                return_dtype = DataType.from_arrow(pyarrow.list_(arrow_type.value_type))
+
+        @pyarrow_udf(return_dtype=return_dtype)
+        def _list_set_op(arr1: pyarrow.Array, arr2: pyarrow.Array) -> pyarrow.Array:
+            pa_type = arr1.type
+            if pyarrow.types.is_fixed_size_list(pa_type):
+                pa_type = pyarrow.list_(pa_type.value_type)
+
+            # A null input row yields a null output row.
+            result = [
+                None if l1 is None or l2 is None else op(l1, l2)
+                for l1, l2 in zip(arr1.to_pylist(), arr2.to_pylist())
+            ]
+            return pyarrow.array(result, type=pa_type)
+
+        return _list_set_op(self._expr, other)

--- a/python/ray/data/tests/expressions/test_namespace_list.py
+++ b/python/ray/data/tests/expressions/test_namespace_list.py
@@ -176,6 +176,35 @@ class TestListNamespace:
         )
         assert result_table.select(["flattened"]).combine_chunks().equals(expected)
 
+    def test_list_union(self, ray_start_regular_shared, dataset_format):
+        """Test list.union() returns deduplicated elements in first-seen order."""
+        data = [{"a": [3, 1, 2], "b": [2, 3, 4]}, {"a": [1, 2], "b": [5]}]
+        ds = _create_dataset(data, dataset_format)
+        result = ds.with_column("u", col("a").list.union(col("b"))).to_pandas()
+        assert [list(v) for v in result["u"]] == [[3, 1, 2, 4], [1, 2, 5]]
+
+    def test_list_intersection(self, ray_start_regular_shared, dataset_format):
+        """Test list.intersection() returns elements present in both lists."""
+        data = [{"a": [1, 2, 3], "b": [2, 3, 4]}, {"a": [1, 2], "b": [5]}]
+        ds = _create_dataset(data, dataset_format)
+        result = ds.with_column("i", col("a").list.intersection(col("b"))).to_pandas()
+        assert [list(v) for v in result["i"]] == [[2, 3], []]
+
+    def test_list_difference(self, ray_start_regular_shared, dataset_format):
+        """Test list.difference() returns elements in the first list only."""
+        data = [{"a": [1, 2, 3], "b": [2, 3, 4]}, {"a": [1, 2], "b": [5]}]
+        ds = _create_dataset(data, dataset_format)
+        result = ds.with_column("d", col("a").list.difference(col("b"))).to_pandas()
+        assert [list(v) for v in result["d"]] == [[1], [1, 2]]
+
+    def test_list_set_op_null_row(self, ray_start_regular_shared, dataset_format):
+        """A null input row produces a null output row."""
+        data = [{"a": [1, 2], "b": [2, 3]}, {"a": None, "b": [4]}]
+        ds = _create_dataset(data, dataset_format)
+        result = ds.with_column("u", col("a").list.union(col("b"))).to_pandas()
+        assert list(result["u"][0]) == [1, 2, 3]
+        assert result["u"][1] is None
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description
Adds `union`, `intersection`, and `difference` to the `.list` expression namespace, e.g. `col("a").list.union(col("b"))`. 
Each computes the per-row set operation against another list-typed expression, preserving first-seen order (matching Spark/Polars semantics). Null input rows yield null output.

## Related issues
Related to #58674

## Additional information
Adds end-to-end tests covering all three operations and null handling across the pandas and Arrow dataset formats.