### PR TITLE
[Data] Avoid scaling nodegroups dedicated to head node

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -77,9 +77,16 @@ def _get_node_resource_spec_and_count(
     """Get the unique node resource specs and their count in the cluster,
     scoped to a single subcluster.
 
-    ``subcluster`` is the value at ``SUBCLUSTER_LABEL_KEY`` to match
-    against. The default ``DEFAULT_SUBCLUSTER`` (None) selects nodes with
-    no subcluster label.
+    The returned specs are the scalable worker shapes used to build scale-up
+    requests, so the head node is deliberately excluded:
+
+      * Head node *instances* are not counted (they can't be used to schedule tasks).
+      * A node group *config* dedicated to the head node is dropped as well
+        (``max_count == 1`` and a shape matching the running head node).
+        Otherwise its shape would be requested as an extra node even though the
+        head can't be scaled. Groups that can also host workers
+        (``max_count > 1``) or that have a non-head shape are kept, including
+        worker types with zero running instances (scale-from-zero).
 
     Quirk: the returned dict also contains a ``node_type: 0`` (ex: `"m5.xlarge": 0`) entry for every
     node type registered in ``cluster_config.node_group_configs`` that
@@ -91,8 +98,38 @@ def _get_node_resource_spec_and_count(
     stamped with the validation label, which the autoscaler can never
     satisfy.
     TODO: get labels from cluster config so the catalog can be filtered.
+
+    Args:
+        subcluster: The value at ``SUBCLUSTER_LABEL_KEY`` to match against.
+            The default ``DEFAULT_SUBCLUSTER`` (None) selects nodes with no
+            subcluster label.
+
+    Returns:
+        A mapping from each scalable worker node shape to its current count of
+        running instances (0 for shapes discovered only from the cluster
+        config).
     """
     nodes_resource_spec_count = defaultdict(int)
+
+    # Split nodes into the head node and worker nodes. There is exactly one head
+    # node, and it can't be scaled up, so it's excluded from the counts and used
+    # below to identify a node group dedicated to the head. Worker nodes are
+    # further scoped to the requester's subcluster, so foreign subclusters'
+    # shapes and counts don't leak into this requester's active / pending
+    # bundles. Head detection is intentionally not subcluster-scoped: the head
+    # node group is global.
+    head_node_spec = None
+    worker_node_resources = []
+    for node in ray.nodes():
+        if not node["Alive"]:
+            continue
+        if "node:__internal_head__" in node["Resources"]:
+            head_node_spec = _NodeResourceSpec.from_bundle(node["Resources"])
+            continue
+        if (node.get("Labels") or {}).get(
+            SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER
+        ) == subcluster:
+            worker_node_resources.append(node["Resources"])
 
     cluster_config = ray._private.state.state.get_cluster_config()
     if cluster_config and cluster_config.node_group_configs:
@@ -103,21 +140,16 @@ def _get_node_resource_spec_and_count(
             node_resource_spec = _NodeResourceSpec.from_bundle(
                 node_group_config.resources
             )
+            # Skip a node group dedicated to the head node, since it can't be scaled up and thus shouldn't be counted towards the current cluster capacity or used as a template for scaling up.
+            if (
+                node_group_config.max_count == 1
+                and node_resource_spec == head_node_spec
+            ):
+                continue
+
             nodes_resource_spec_count[node_resource_spec] = 0
 
-    # Filter out the head node and nodes outside the requester's subcluster.
-    node_resources = [
-        node["Resources"]
-        for node in ray.nodes()
-        if (
-            node["Alive"]
-            and "node:__internal_head__" not in node["Resources"]
-            and (node.get("Labels") or {}).get(SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER)
-            == subcluster
-        )
-    ]
-
-    for r in node_resources:
+    for r in worker_node_resources:
         node_resource_spec = _NodeResourceSpec.from_bundle(r)
         nodes_resource_spec_count[node_resource_spec] += 1
 

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -485,6 +485,135 @@ class TestClusterAutoscaling:
                 result = _get_node_resource_spec_and_count()
                 assert result == expected
 
+    @pytest.mark.parametrize(
+        "nodes,node_groups,subcluster,expected",
+        [
+            pytest.param(
+                # Head node with CPU zeroed out (as configured to avoid
+                # scheduling tasks on the head), plus 2 worker nodes.
+                [
+                    {"resources": {"memory": 32 * GiB, "node:__internal_head__": 1.0}},
+                    {"resources": {"CPU": 8, "memory": 32 * GiB}},
+                    {"resources": {"CPU": 8, "memory": 32 * GiB}},
+                ],
+                [
+                    # Worker group: can scale up to 10 nodes.
+                    {"resources": {"CPU": 8, "memory": 32 * GiB}, "max_count": 10},
+                    # Dedicated head group: matches the head node, max_count == 1.
+                    {"resources": {"memory": 32 * GiB}, "max_count": 1},
+                ],
+                None,
+                # Only the worker shape is present (with the 2 running workers);
+                # the dedicated head group is excluded entirely.
+                {_NodeResourceSpec.of(cpu=8, gpu=0, mem=32 * GiB): 2},
+                id="dedicated_head_group_excluded",
+            ),
+            pytest.param(
+                # Head node group that can also host workers (max_count > 1):
+                # scaling its shape adds a worker, so it must be kept.
+                [
+                    {
+                        "resources": {
+                            "CPU": 4,
+                            "memory": 1000,
+                            "node:__internal_head__": 1.0,
+                        }
+                    }
+                ],
+                [{"resources": {"CPU": 4, "memory": 1000}, "max_count": 3}],
+                None,
+                {_NodeResourceSpec.of(cpu=4, gpu=0, mem=1000): 0},
+                id="head_group_with_workers_kept",
+            ),
+            pytest.param(
+                # Worker group limited to a single node with a shape that does
+                # NOT match the head node: must not be over-excluded.
+                [
+                    {
+                        "resources": {
+                            "CPU": 4,
+                            "memory": 1000,
+                            "node:__internal_head__": 1.0,
+                        }
+                    }
+                ],
+                [
+                    {
+                        "resources": {"CPU": 8, "GPU": 2, "memory": 2000},
+                        "max_count": 1,
+                    }
+                ],
+                None,
+                {_NodeResourceSpec.of(cpu=8, gpu=2, mem=2000): 0},
+                id="single_worker_group_kept",
+            ),
+            pytest.param(
+                # Head + subcluster interaction: the head node has no subcluster
+                # label, and there are workers in two subclusters. Computing for
+                # "training" must drop the dedicated head group (head detection
+                # is global, not subcluster-scoped) and count only the training
+                # workers, ignoring the validation worker.
+                [
+                    {"resources": {"memory": 32 * GiB, "node:__internal_head__": 1.0}},
+                    {
+                        "resources": {"CPU": 8, "memory": 32 * GiB},
+                        "labels": {"__subcluster__": "training"},
+                    },
+                    {
+                        "resources": {"CPU": 8, "memory": 32 * GiB},
+                        "labels": {"__subcluster__": "training"},
+                    },
+                    {
+                        "resources": {"CPU": 4, "memory": 16 * GiB},
+                        "labels": {"__subcluster__": "validation"},
+                    },
+                ],
+                [
+                    {"resources": {"CPU": 8, "memory": 32 * GiB}, "max_count": 10},
+                    {"resources": {"memory": 32 * GiB}, "max_count": 1},
+                ],
+                "training",
+                {_NodeResourceSpec.of(cpu=8, gpu=0, mem=32 * GiB): 2},
+                id="dedicated_head_excluded_and_subcluster_scoped",
+            ),
+        ],
+    )
+    def test_get_node_resource_spec_and_count_head_node_group(
+        self, nodes, node_groups, subcluster, expected
+    ):
+        """The head node must not be scaled up, but worker-capable groups are.
+
+        A node group is only excluded when it's dedicated to the head node
+        (``max_count == 1`` and a shape matching the running head node). Groups
+        that can host workers (``max_count > 1``) or that have a non-head shape
+        are kept so scale-from-zero still works. Head detection spans the whole
+        cluster, while worker counting is scoped to ``subcluster``.
+        """
+        node_table = [
+            {
+                "Resources": node["resources"],
+                "Labels": node.get("labels", {}),
+                "Alive": True,
+            }
+            for node in nodes
+        ]
+
+        cluster_config = autoscaler_pb2.ClusterConfig()
+        for group in node_groups:
+            node_group_config = autoscaler_pb2.NodeGroupConfig()
+            for name, value in group["resources"].items():
+                node_group_config.resources[name] = value
+            node_group_config.max_count = group["max_count"]
+            cluster_config.node_group_configs.append(node_group_config)
+
+        with patch("ray.nodes", return_value=node_table):
+            with patch(
+                "ray._private.state.state.get_cluster_config",
+                return_value=cluster_config,
+            ):
+                result = _get_node_resource_spec_and_count(subcluster=subcluster)
+                assert result == expected
+
     def test_get_node_resource_spec_and_count_missing_all_resources(self):
         """Regression test for nodes with empty resources (ie missing CPU, GPU, and memory keys entirely)."""
 


### PR DESCRIPTION
`_get_node_resource_spec_and_count()` returns a dict mapping each `_NodeResourceSpec` (node shape) to the number of running nodes with that shape. It already skips head nodes when counting running instances (so their count stays at 0), but it still adds an entry for the head node's shape via the cluster config's node groups.

Later, when making scaling decisions, the Ray Data autoscaler scales up every shape in this dict by the configured delta — including the head-only shape. This makes it request an extra instance of the head node group, which can't actually be scaled, leading to incorrect autoscaling decisions:


```
Requesting 1 node(s) of each shape:
  [{CPU: 8, GPU: 0, memory: 32.0GiB}: 2 -> 3]   # workers (correct)
  [{CPU: 0, GPU: 0, memory: 32.0GiB}: 0 -> 1]   # head node (bug)
```

This PR drops node groups dedicated solely to the head node from the `_get_node_resource_spec_and_count() `response. A node group is treated as head-dedicated when `max_count == 1 ` and its shape matches the running head node.

If a node group can host both worker and head nodes (max_count > 1), it is not dropped — scaling such a group adds a worker node, which is the desired behavior. Worker groups with a non-head shape (including those with zero running instances, i.e. scale-from-zero) are also kept.
