### PR TITLE
[7/N] [HAProxy stability] - Preserve direct-ingress port quarantine across node-manager prune

### DIFF
--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -52,6 +52,11 @@ class PortAllocator:
                 f"node {self._node_id}; returning it to the available pool."
             )
 
+    def has_pending_quarantine(self) -> bool:
+        """True if any port is still quarantined (drains expired entries first)."""
+        self._drain_expired_quarantine()
+        return bool(self._quarantined_ports)
+
     def update_port_if_missing(self, replica_id: str, port: Optional[int]):
         """Update port value for a replica."""
         if replica_id in self._allocated_ports:
@@ -226,12 +231,15 @@ class NodePortManager:
     def prune(cls, node_id_to_alive_replica_ids: Dict[str, Set[str]]):
         # this doesn't need to be behind a lock because it will already be called from same thread
         for node_id in list(cls._node_managers):
-            if node_id not in node_id_to_alive_replica_ids:
+            manager = cls._node_managers[node_id]
+            alive = node_id_to_alive_replica_ids.get(node_id, set())
+            # Release ports of replicas no longer alive (quarantines them).
+            manager._prune_replica_ports(alive)
+            # Keep the manager until its quarantine drains; dropping it early
+            # would discard the deadline and let the port be reused immediately.
+            if not alive and not manager.has_pending_quarantine():
                 logger.info(f"Removing node manager for node {node_id}")
                 del cls._node_managers[node_id]
-            else:
-                manager = cls._node_managers[node_id]
-                manager._prune_replica_ports(node_id_to_alive_replica_ids[node_id])
 
     @classmethod
     def update_ports(cls, ingress_replicas_info: List[Tuple[str, str, int, int]]):
@@ -308,3 +316,10 @@ class NodePortManager:
             return self._grpc_allocator.is_port_allocated(replica_id)
         else:
             raise ValueError(f"Unsupported protocol: {protocol}")
+
+    def has_pending_quarantine(self) -> bool:
+        """True if either allocator still holds a quarantined port."""
+        # Evaluate both (no short-circuit) so each allocator drains expired ports.
+        http_pending = self._http_allocator.has_pending_quarantine()
+        grpc_pending = self._grpc_allocator.has_pending_quarantine()
+        return http_pending or grpc_pending

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -101,6 +101,13 @@ def _shared_serve_instance():
         # that condition on specific ports assignments.
         os.environ[env_var_name] = "6"
 
+    # These tests assert specific, immediately-reused port assignments. Disable
+    # the freed-port quarantine so reuse is deterministic; the quarantine itself
+    # is covered by test_node_port_manager.py.
+    quarantine_env_var = "RAY_SERVE_PORT_QUARANTINE_S"
+    quarantine_original = os.environ.get(quarantine_env_var)
+    os.environ[quarantine_env_var] = "0"
+
     ray.init(
         num_cpus=36,
         namespace="default_test_namespace",
@@ -125,6 +132,12 @@ def _shared_serve_instance():
         os.environ[env_var_name] = original_value
     elif env_var_name in os.environ:
         del os.environ[env_var_name]
+
+    # Restore the quarantine env var.
+    if quarantine_original is not None:
+        os.environ[quarantine_env_var] = quarantine_original
+    elif quarantine_env_var in os.environ:
+        del os.environ[quarantine_env_var]
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/unit/test_node_port_manager.py
+++ b/python/ray/serve/tests/unit/test_node_port_manager.py
@@ -3,6 +3,7 @@ from typing import Set
 
 import pytest
 
+from ray._common.test_utils import wait_for_condition
 from ray.serve._private.common import RequestProtocol
 from ray.serve._private.node_port_manager import NoAvailablePortError, NodePortManager
 
@@ -42,6 +43,8 @@ def setup_port_constants(monkeypatch, port_range_constants):
         0.0,
     )
     yield
+    # _node_managers is class-level and persists across tests; reset for isolation.
+    NodePortManager._node_managers.clear()
 
 
 def test_http_port_allocation_and_release(port_range_constants):
@@ -300,6 +303,53 @@ def test_allocate_skips_quarantined_recovered_port(monkeypatch, port_range_const
     next_port = manager.allocate_port("replica-new", RequestProtocol.HTTP)
     assert next_port != recovered
     assert recovered in alloc._quarantined_ports  # still held
+
+
+def test_prune_keeps_manager_while_port_quarantined(monkeypatch, port_range_constants):
+    """A node losing its last replica must NOT have its manager (and quarantine
+    state) dropped while a freed port is still quarantined, and the quarantined
+    port must not be handed to the next replica scheduled there."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        60.0,
+    )
+    node_id = "node-prune-quarantine"
+    manager = NodePortManager.get_node_manager(node_id)
+
+    port = manager.allocate_port("replica-old", RequestProtocol.HTTP)
+    manager.release_port("replica-old", port, RequestProtocol.HTTP)
+    assert port in manager._http_allocator._quarantined_ports
+
+    # Node now has zero alive replicas; the manager must survive the prune.
+    NodePortManager.prune(node_id_to_alive_replica_ids={})
+    assert node_id in NodePortManager._node_managers
+    assert manager.has_pending_quarantine()
+
+    # The next replica on this node must not reuse the quarantined port.
+    new_port = manager.allocate_port("replica-new", RequestProtocol.HTTP)
+    assert new_port != port
+
+
+def test_prune_drops_empty_manager_after_quarantine(monkeypatch, port_range_constants):
+    """Once the quarantine drains, an empty node's manager is reclaimed."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        0.05,
+    )
+    node_id = "node-prune-quarantine-expire"
+    manager = NodePortManager.get_node_manager(node_id)
+    port = manager.allocate_port("replica-old", RequestProtocol.HTTP)
+    manager.release_port("replica-old", port, RequestProtocol.HTTP)
+
+    NodePortManager.prune(node_id_to_alive_replica_ids={})
+    assert node_id in NodePortManager._node_managers  # still quarantined -> kept
+
+    def _manager_reclaimed():
+        # Drives prune each poll; True once the expired quarantine lets it go.
+        NodePortManager.prune(node_id_to_alive_replica_ids={})
+        return node_id not in NodePortManager._node_managers
+
+    wait_for_condition(_manager_reclaimed, timeout=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

In direct-ingress mode, `NodePortManager.prune()` deletes a node's manager the moment the node has no alive replicas — which is exactly when a just-freed port was released into quarantine. Deleting the manager discards its `_quarantined_ports` map, so the quarantine deadline is lost.

The freed `host:port` can then be recycled into a **different app's** replica well within the quarantine window. A stale/old HAProxy worker (kept alive by `hard-stop-after` after a seamless reload) still maps the old replica to that `host:port`, routes a request there, and hits the live wrong-app replica → an **unretried 404** (a valid HTTP response, so HAProxy does not redispatch it). Health checks can't catch this: they validate an address, not a replica identity, and the recycled address answers `/-/healthz` with 200.

Observed in load testing: a replica drained and exited cleanly; ~42s later its node:port was handed to a replica of another app (despite a 300s quarantine), and ~78s after exit a stale HAProxy worker routed to it → 404.

## What

Keep a node's manager until its quarantine drains:
- Always release the ports of replicas no longer alive on a node, so an emptying node's ports are quarantined rather than silently dropped.
- Only delete the manager once it has **no live replicas and no pending quarantine**. Managers self-reap within one quarantine window, so `_node_managers` stays bounded.

This converts the unretried wrong-app 404 into a retryable connection failure, since the freed address stays empty for the quarantine window.

Adds unit tests covering: an emptying node keeps its manager + quarantine and does not re-hand the quarantined port; and the manager is reclaimed once the quarantine expires.

## Related

Split out of #63886 (HAProxy-stability series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)