### PR TITLE
[llm] Add direct streaming - session affinity tests

### DIFF
--- a/python/ray/llm/tests/BUILD.bazel
+++ b/python/ray/llm/tests/BUILD.bazel
@@ -78,7 +78,35 @@ py_test_module_list(
 py_test_module_list(
     size = "large",
     data = glob(["serve/**/*.yaml"]),
-    files = glob(["serve/cpu/**/test_*.py"]),
+    # *_direct_streaming.py files run only in the dedicated target below,
+    # which sets the direct-streaming + HAProxy env they require.
+    files = glob(
+        ["serve/cpu/**/test_*.py"],
+        exclude = ["serve/cpu/**/*_direct_streaming.py"],
+    ),
+    tags = [
+        "cpu",
+        "exclusive",
+        "team:llm",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+# Direct-streaming session-affinity tests
+py_test_module_list(
+    size = "large",
+    data = glob(["serve/**/*.yaml"]),
+    env = {
+        "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING": "1",
+        "RAY_SERVE_ENABLE_HA_PROXY": "1",
+    },
+    files = [
+        "serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py",
+        "serve/cpu/deployments/routers/test_router_direct_streaming.py",
+    ],
     tags = [
         "cpu",
         "exclusive",

--- a/python/ray/llm/tests/BUILD.bazel
+++ b/python/ray/llm/tests/BUILD.bazel
@@ -104,6 +104,7 @@ py_test_module_list(
         "RAY_SERVE_ENABLE_HA_PROXY": "1",
     },
     files = [
+        "serve/cpu/deployments/data_parallel/test_dp_direct_streaming.py",
         "serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py",
         "serve/cpu/deployments/routers/test_router_direct_streaming.py",
     ],

--- a/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_direct_streaming.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_direct_streaming.py
@@ -29,7 +29,10 @@ class TestDPDirectStreamingConsistentHashRouting:
 
     @pytest.fixture(name="llm_config")
     def _llm_config(self):
-        return LLMConfig(model_loading_config=ModelLoadingConfig(model_id="test-model"))
+        return LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+            engine_kwargs={"data_parallel_size": 2},
+        )
 
     @pytest.fixture(name="base_url")
     def run_dp_app(

--- a/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_direct_streaming.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_direct_streaming.py
@@ -6,9 +6,8 @@ from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
 )
-from ray.llm._internal.serve.core.ingress.builder import (
-    LLMServingArgs,
-    build_openai_app,
+from ray.llm._internal.serve.serving_patterns.data_parallel.builder import (
+    build_dp_openai_app,
 )
 from ray.llm.tests.serve.cpu.deployments.utils.direct_streaming_utils import (
     consistent_hash_deployment_config,
@@ -19,12 +18,13 @@ from ray.llm.tests.serve.cpu.deployments.utils.direct_streaming_utils import (
 
 
 @requires_direct_streaming
-class TestDirectStreamingConsistentHashRouting:
-    """Session affinity over the full direct-streaming path.
+class TestDPDirectStreamingConsistentHashRouting:
+    """Session affinity over the DP direct-streaming path.
 
-    A request flows through HAProxy and the LLMRouter ``/internal/route``
-    decision (ConsistentHashRouter) to a backend replica. The session id
-    reaches the chosen replica, and one session pins to one replica.
+    The DPServer is the ingress LLMRouter pins via ConsistentHashRouter, so a
+    request flows through HAProxy and the ``/internal/route`` decision to one
+    DPServer replica. The session id reaches the chosen replica, and one session
+    pins to one replica.
     """
 
     @pytest.fixture(name="llm_config")
@@ -32,7 +32,7 @@ class TestDirectStreamingConsistentHashRouting:
         return LLMConfig(model_loading_config=ModelLoadingConfig(model_id="test-model"))
 
     @pytest.fixture(name="base_url")
-    def run_direct_streaming_app(
+    def run_dp_app(
         self,
         llm_config_with_mock_engine,
         shutdown_ray_and_serve,
@@ -40,9 +40,7 @@ class TestDirectStreamingConsistentHashRouting:
     ):
         llm_config = llm_config_with_mock_engine
         llm_config.deployment_config = consistent_hash_deployment_config()
-        yield run_app_through_haproxy(
-            build_openai_app(LLMServingArgs(llm_configs=[llm_config]))
-        )
+        yield run_app_through_haproxy(build_dp_openai_app({"llm_config": llm_config}))
 
     def test_session_affinity(self, base_url):
         replicas = {

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py
@@ -1,0 +1,111 @@
+import sys
+
+import httpx
+import pytest
+
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
+from ray.llm._internal.serve.core.configs.llm_config import (
+    LLMConfig,
+    ModelLoadingConfig,
+)
+from ray.llm._internal.serve.serving_patterns.prefill_decode.builder import (
+    build_pd_openai_app,
+)
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_SESSION_ID
+from ray.serve._private.test_utils import check_running, get_application_url
+from ray.serve.config import RequestRouterConfig
+
+CONSISTENT_HASH_ROUTER = (
+    "ray.serve.experimental.consistent_hash_router:ConsistentHashRouter"
+)
+
+
+@pytest.mark.skipif(
+    not (RAY_SERVE_ENABLE_HA_PROXY and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING),
+    reason="Direct streaming requires RAY_SERVE_ENABLE_HA_PROXY=1 and "
+    "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1.",
+)
+class TestPDDirectStreamingConsistentHashRouting:
+    """Session affinity over the full PD direct-streaming path.
+
+    The decode server is the ingress; LLMRouter pins it via ConsistentHashRouter
+    and forwards the session id to the prefill handle, so both legs pin per
+    session. The decode replica comes from the ``x-replica-id`` header; the
+    prefill replica from ``kv_transfer_params.remote_engine_id`` (stamped by the
+    prefill, echoed by the decode).
+    """
+
+    @pytest.fixture(name="llm_config")
+    def _llm_config(self):
+        return LLMConfig(model_loading_config=ModelLoadingConfig(model_id="test-model"))
+
+    @pytest.fixture(name="base_url")
+    def run_pd_app(
+        self,
+        llm_config_with_mock_engine,
+        shutdown_ray_and_serve,
+        disable_placement_bundles,
+    ):
+        def _pd_config():
+            config = llm_config_with_mock_engine.model_copy(deep=True)
+            config.engine_kwargs = {
+                "kv_transfer_config": {
+                    "kv_connector": "NixlConnector",
+                    "kv_role": "kv_both",
+                }
+            }
+            config.deployment_config = {
+                "num_replicas": 4,
+                "request_router_config": RequestRouterConfig(
+                    request_router_class=CONSISTENT_HASH_ROUTER,
+                    request_router_kwargs={
+                        "num_virtual_nodes": 100,
+                        "num_fallback_replicas": 2,
+                    },
+                ),
+            }
+            return config
+
+        serve.run(
+            build_pd_openai_app(
+                {"prefill_config": _pd_config(), "decode_config": _pd_config()}
+            )
+        )
+        wait_for_condition(check_running, timeout=60)
+        yield get_application_url(use_localhost=True)
+
+    def _serving_replicas(self, base_url, session_id):
+        """Return the (decode, prefill) replicas that served a ``session_id`` request."""
+        resp = httpx.post(
+            f"{base_url}/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 1,
+            },
+            headers={SERVE_SESSION_ID: session_id},
+            timeout=30,
+        )
+        assert resp.status_code == 200, resp.text
+        # The session id survived the HAProxy hop to the decode replica.
+        assert resp.headers["x-serve-session-id"] == session_id
+        decode_replica = resp.headers["x-replica-id"]
+        prefill_replica = resp.json()["kv_transfer_params"]["remote_engine_id"]
+        return decode_replica, prefill_replica
+
+    def test_session_affinity(self, base_url):
+        pairs = {self._serving_replicas(base_url, "test-session-id") for _ in range(10)}
+        assert len(pairs) == 1
+
+    def test_different_sessions_spread(self, base_url):
+        pairs = [
+            self._serving_replicas(base_url, f"test-session-id-{i}") for i in range(10)
+        ]
+        assert len({decode for decode, _ in pairs}) > 1
+        assert len({prefill for _, prefill in pairs}) > 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py
@@ -1,11 +1,7 @@
 import sys
 
-import httpx
 import pytest
 
-from ray import serve
-from ray._common.test_utils import wait_for_condition
-from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
@@ -13,20 +9,15 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 from ray.llm._internal.serve.serving_patterns.prefill_decode.builder import (
     build_pd_openai_app,
 )
-from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_SESSION_ID
-from ray.serve._private.test_utils import check_running, get_application_url
-from ray.serve.config import RequestRouterConfig
-
-CONSISTENT_HASH_ROUTER = (
-    "ray.serve.experimental.consistent_hash_router:ConsistentHashRouter"
+from ray.llm.tests.serve.cpu.deployments.utils.direct_streaming_utils import (
+    consistent_hash_deployment_config,
+    requires_direct_streaming,
+    run_app_through_haproxy,
+    session_chat_response,
 )
 
 
-@pytest.mark.skipif(
-    not (RAY_SERVE_ENABLE_HA_PROXY and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING),
-    reason="Direct streaming requires RAY_SERVE_ENABLE_HA_PROXY=1 and "
-    "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1.",
-)
+@requires_direct_streaming
 class TestPDDirectStreamingConsistentHashRouting:
     """Session affinity over the full PD direct-streaming path.
 
@@ -56,41 +47,18 @@ class TestPDDirectStreamingConsistentHashRouting:
                     "kv_role": "kv_both",
                 }
             }
-            config.deployment_config = {
-                "num_replicas": 4,
-                "request_router_config": RequestRouterConfig(
-                    request_router_class=CONSISTENT_HASH_ROUTER,
-                    request_router_kwargs={
-                        "num_virtual_nodes": 100,
-                        "num_fallback_replicas": 2,
-                    },
-                ),
-            }
+            config.deployment_config = consistent_hash_deployment_config()
             return config
 
-        serve.run(
+        yield run_app_through_haproxy(
             build_pd_openai_app(
                 {"prefill_config": _pd_config(), "decode_config": _pd_config()}
             )
         )
-        wait_for_condition(check_running, timeout=60)
-        yield get_application_url(use_localhost=True)
 
     def _serving_replicas(self, base_url, session_id):
         """Return the (decode, prefill) replicas that served a ``session_id`` request."""
-        resp = httpx.post(
-            f"{base_url}/v1/chat/completions",
-            json={
-                "model": "test-model",
-                "messages": [{"role": "user", "content": "hi"}],
-                "max_tokens": 1,
-            },
-            headers={SERVE_SESSION_ID: session_id},
-            timeout=30,
-        )
-        assert resp.status_code == 200, resp.text
-        # The session id survived the HAProxy hop to the decode replica.
-        assert resp.headers["x-serve-session-id"] == session_id
+        resp = session_chat_response(base_url, session_id)
         decode_replica = resp.headers["x-replica-id"]
         prefill_replica = resp.json()["kv_transfer_params"]["remote_engine_id"]
         return decode_replica, prefill_replica

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router_direct_streaming.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router_direct_streaming.py
@@ -1,0 +1,88 @@
+import sys
+
+import httpx
+import pytest
+
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
+from ray.llm._internal.serve.core.ingress.builder import (
+    LLMServingArgs,
+    build_openai_app,
+)
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_SESSION_ID
+from ray.serve._private.test_utils import check_running, get_application_url
+from ray.serve.config import RequestRouterConfig
+
+CONSISTENT_HASH_ROUTER = (
+    "ray.serve.experimental.consistent_hash_router:ConsistentHashRouter"
+)
+
+
+@pytest.mark.skipif(
+    not (RAY_SERVE_ENABLE_HA_PROXY and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING),
+    reason="Direct streaming requires RAY_SERVE_ENABLE_HA_PROXY=1 and "
+    "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1.",
+)
+class TestDirectStreamingConsistentHashRouting:
+    """Session affinity over the full direct-streaming path.
+
+    A request flows through HAProxy and the LLMRouter ``/internal/route``
+    decision (ConsistentHashRouter) to a backend replica. The session id
+    reaches the chosen replica, and one session pins to one replica.
+    """
+
+    @pytest.fixture(name="base_url")
+    def run_direct_streaming_app(
+        self,
+        llm_config_with_mock_engine,
+        shutdown_ray_and_serve,
+        disable_placement_bundles,
+    ):
+        llm_config = llm_config_with_mock_engine
+        llm_config.deployment_config = {
+            "num_replicas": 4,
+            "request_router_config": RequestRouterConfig(
+                request_router_class=CONSISTENT_HASH_ROUTER,
+                request_router_kwargs={
+                    "num_virtual_nodes": 100,
+                    "num_fallback_replicas": 2,
+                },
+            ),
+        }
+        serve.run(build_openai_app(LLMServingArgs(llm_configs=[llm_config])))
+        wait_for_condition(check_running, timeout=60)
+        yield get_application_url(use_localhost=True)
+
+    def _serving_replica(self, base_url, session_id):
+        """Return the replica that served a request carrying ``session_id``."""
+        resp = httpx.post(
+            f"{base_url}/v1/chat/completions",
+            json={
+                "model": "llm_model_id",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 1,
+            },
+            headers={SERVE_SESSION_ID: session_id},
+            timeout=30,
+        )
+        assert resp.status_code == 200, resp.text
+        # The session id survived the HAProxy hop to the replica.
+        assert resp.headers["x-serve-session-id"] == session_id
+        return resp.headers["x-replica-id"]
+
+    def test_session_affinity(self, base_url):
+        replicas = {
+            self._serving_replica(base_url, "test-session-id") for _ in range(10)
+        }
+        assert len(replicas) == 1
+
+    def test_different_sessions_spread(self, base_url):
+        replicas = {
+            self._serving_replica(base_url, f"test-session-id-{i}") for i in range(10)
+        }
+        assert len(replicas) > 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
@@ -1,0 +1,67 @@
+"""
+Shared helpers for direct-streaming session-affinity tests.
+"""
+
+import httpx
+import pytest
+
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_SESSION_ID
+from ray.serve._private.test_utils import check_running, get_application_url
+from ray.serve.config import RequestRouterConfig
+
+CONSISTENT_HASH_ROUTER = (
+    "ray.serve.experimental.consistent_hash_router:ConsistentHashRouter"
+)
+
+# Skip unless the direct-streaming + HAProxy env is set
+requires_direct_streaming = pytest.mark.skipif(
+    not (RAY_SERVE_ENABLE_HA_PROXY and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING),
+    reason="Direct streaming requires RAY_SERVE_ENABLE_HA_PROXY=1 and "
+    "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1.",
+)
+
+
+def consistent_hash_deployment_config() -> dict:
+    return {
+        "num_replicas": 10,
+        "request_router_config": RequestRouterConfig(
+            request_router_class=CONSISTENT_HASH_ROUTER,
+            request_router_kwargs={
+                "num_virtual_nodes": 100,
+                "num_fallback_replicas": 2,
+            },
+        ),
+    }
+
+
+def run_app_through_haproxy(app, timeout_s: int = 60) -> str:
+    """Run ``app`` and return its (HAProxy) URL once all replicas are RUNNING."""
+    serve.run(app)
+    wait_for_condition(check_running, timeout=timeout_s)
+    return get_application_url(use_localhost=True)
+
+
+def session_chat_response(base_url: str, session_id: str, model: str = "test-model"):
+    """POST a one-token chat request carrying ``session_id`` through HAProxy.
+
+    Asserts the request succeeded and the session id survived the HAProxy hop to
+    the serving replica. Returns the response so callers can read the serving
+    replica from the ``x-replica-id`` header (and, for P/D, the prefill replica
+    from ``kv_transfer_params.remote_engine_id``).
+    """
+    resp = httpx.post(
+        f"{base_url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1,
+        },
+        headers={SERVE_SESSION_ID: session_id},
+        timeout=30,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["x-serve-session-id"] == session_id
+    return resp

--- a/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
@@ -26,7 +26,8 @@ requires_direct_streaming = pytest.mark.skipif(
 
 def consistent_hash_deployment_config() -> dict:
     return {
-        "num_replicas": 10,
+        "num_replicas": 4,
+        "ray_actor_options": {"num_cpus": 0},
         "request_router_config": RequestRouterConfig(
             request_router_class=CONSISTENT_HASH_ROUTER,
             request_router_kwargs={

--- a/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
@@ -27,7 +27,7 @@ requires_direct_streaming = pytest.mark.skipif(
 def consistent_hash_deployment_config() -> dict:
     return {
         "num_replicas": 4,
-        "ray_actor_options": {"num_cpus": 0},
+        "ray_actor_options": {"num_cpus": 0.1},
         "request_router_config": RequestRouterConfig(
             request_router_class=CONSISTENT_HASH_ROUTER,
             request_router_kwargs={

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -4,6 +4,9 @@ import random
 from random import randint
 from typing import Any, AsyncGenerator, Dict, Optional, Union
 
+from fastapi import FastAPI, HTTPException, Request
+from starlette.responses import JSONResponse, StreamingResponse
+
 from ray.llm._internal.common.utils.cloud_utils import LoraMirrorConfig
 from ray.llm._internal.serve.core.configs.llm_config import (
     DiskMultiplexConfig,
@@ -29,6 +32,10 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
 from ray.llm._internal.serve.core.engine.protocol import LLMEngine
 from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.utils.lora_serve_utils import LoraModelLoader
+from ray.serve.context import (
+    _get_internal_replica_context,
+    _get_serve_request_context,
+)
 
 
 class MockVLLMEngine(LLMEngine):
@@ -144,10 +151,20 @@ class MockVLLMEngine(LLMEngine):
 
     async def build_asgi_app(self):
         """Build a minimal ASGI app for direct-streaming tests."""
-        from fastapi import FastAPI, HTTPException, Request
-        from starlette.responses import JSONResponse, StreamingResponse
-
         app = FastAPI()
+
+        @app.middleware("http")
+        async def _tag_serving_replica(request: Request, call_next):
+            # Tag each response with the serving replica and the session id it
+            # saw, so direct-streaming tests can assert affinity over HAProxy.
+            response = await call_next(request)
+            ctx = _get_internal_replica_context()
+            if ctx is not None:
+                response.headers["x-replica-id"] = ctx.replica_id.unique_id
+            response.headers[
+                "x-serve-session-id"
+            ] = _get_serve_request_context().session_id
+            return response
 
         def check_model(model: Optional[str]) -> None:
             if model is not None and model != self.llm_config.model_id:
@@ -392,6 +409,25 @@ class MockVLLMEngine(LLMEngine):
         response = DetokenizeResponse(prompt=prompt)
         yield response
 
+    def _maybe_attach_kv_transfer_params(self, request, response) -> None:
+        """Stamp the serving replica id into ``kv_transfer_params`` for P/D tests.
+
+        The orchestrator sends the prefill request with ``remote_engine_id``
+        unset; fill it with this replica's id so the response reports the prefill
+        replica. On the decode request the id is already set and passes through.
+        Lets tests observe that the session id pinned the prefill replica, not
+        just the decode ingress.
+        """
+        params = getattr(request, "kv_transfer_params", None)
+        if not params:
+            return
+        params = dict(params)
+        if params.get("remote_engine_id") is None:
+            ctx = _get_internal_replica_context()
+            if ctx is not None:
+                params["remote_engine_id"] = ctx.replica_id.unique_id
+        response.kv_transfer_params = params
+
     async def _generate_chat_response(
         self, request: ChatCompletionRequest, prompt_text: str, max_tokens: int
     ) -> AsyncGenerator[Union[str, ChatCompletionResponse], None]:
@@ -466,6 +502,7 @@ class MockVLLMEngine(LLMEngine):
                 },
             )
 
+            self._maybe_attach_kv_transfer_params(request, response)
             yield response
 
     async def _generate_completion_response(
@@ -533,6 +570,7 @@ class MockVLLMEngine(LLMEngine):
                 },
             )
 
+            self._maybe_attach_kv_transfer_params(request, response)
             yield response
 
     async def _generate_transcription_response(


### PR DESCRIPTION
## Description
We don't have tests that validate session affinity when `ConsistentHashRouter` is used and direct streaming is enabled. This PR adds tests that verifies session affinity under regular LLM deployments and PD deployments.

These tests exercise the HAProxy Lua routing path end-to-end: a client request with an `x-session-id` header passes through HAProxy, whose Lua action forwards the session-id to LLMRouter's `/internal/route` endpoint, where `ConsistentHashRouter` selects a backend replica and pins all same-session requests to it.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
