### PR TITLE
[serve][llm] Make direct streaming LoRA/multiplex-aware

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -17,9 +17,7 @@ from ray.llm._internal.serve.core.ingress.ingress import (
     OpenAiIngress,
     make_fastapi_ingress,
 )
-from ray.llm._internal.serve.core.server.builder import (
-    build_llm_deployment,
-)
+from ray.llm._internal.serve.core.server.builder import build_llm_deployment
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.serve.config import RequestRouterConfig
@@ -76,11 +74,18 @@ def _build_direct_streaming_llm_deployment(
     )
 
 
-def _build_openai_ingress_request_router(*, server: Application) -> Application:
+def _build_openai_ingress_request_router(
+    *, server: Application, multiplex_enabled: bool = False
+) -> Application:
     """Build the ingress request router peer for OpenAI compatible LLM apps.
 
     The returned Application is attached to the ingress application with
     ``Application._with_ingress_request_router``.
+
+    ``multiplex_enabled`` tells the router to read the requested model id from
+    the request body and pin LoRA-adapter requests to a replica that already
+    holds the adapter (see ``LLMRouter``). Set it when the deployment has a
+    LoRA config.
 
     ``num_replicas`` is pinned to 1 because HAProxy's ingress request router
     backend currently expects a single endpoint. TODO(eicherseiji): expose
@@ -93,7 +98,7 @@ def _build_openai_ingress_request_router(*, server: Application) -> Application:
         LLMRouter,
         num_replicas=1,
         max_ongoing_requests=1000,
-    ).bind(server=server)
+    ).bind(server=server, multiplex_enabled=multiplex_enabled)
 
 
 class IngressClsConfig(BaseModelExtended):
@@ -234,7 +239,10 @@ def build_openai_app(builder_config: dict) -> Application:
             "LLMServer=ingress, LLMRouter=ingress_request_router"
         )
         return direct_deployment._with_ingress_request_router(
-            _build_openai_ingress_request_router(server=direct_deployment)
+            _build_openai_ingress_request_router(
+                server=direct_deployment,
+                multiplex_enabled=llm_configs[0].lora_config is not None,
+            )
         )
 
     llm_deployments = {c.model_id: build_llm_deployment(c) for c in llm_configs}

--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -3,6 +3,8 @@ from typing import Optional, Tuple
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
+from ray.llm._internal.common.utils.lora_utils import get_base_model_id
+from ray.llm._internal.serve.utils.server_utils import extract_model_id_from_body
 from ray.serve._private.http_util import _matches_session_id_header
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
@@ -49,6 +51,16 @@ class LLMRouter:
         ``choose_replica`` so session-aware policies (e.g.
         ``ConsistentHashRouter``) pin all turns of a session to one replica.
 
+    Multiplex (LoRA) affinity:
+        When the deployment has a LoRA config (``multiplex_enabled``), this
+        handler reads the requested ``model`` from the forwarded body and, if
+        it names a LoRA adapter (``base:adapter``), applies
+        ``handle.options(multiplexed_model_id=...)`` before ``choose_replica``
+        so multiplex-aware policies (e.g. ``PowerOfTwoChoicesRouter``) steer to
+        a replica that already has the adapter loaded. Requires the body to be
+        forwarded (``RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY=1``); without
+        it the model id is unavailable and routing falls back to load balancing.
+
     Responses:
         200 ``{"host": str, "port": int, "replica_id": str}``: pick
             succeeded.
@@ -60,9 +72,13 @@ class LLMRouter:
         Serve uses ``check_health()`` for replica readiness, not HTTP.
     """
 
-    async def __init__(self, server: DeploymentHandle):
+    async def __init__(self, server: DeploymentHandle, multiplex_enabled: bool = False):
         self._handle: DeploymentHandle = server
         self._handle._init()
+        # Only parse the body for a multiplexed model id when the deployment
+        # actually has a LoRA config; otherwise the requested model is always
+        # the base model and there is nothing to pin on.
+        self._multiplex_enabled = multiplex_enabled
 
     @router_app.post("/internal/route")
     async def route(self, request: Request):
@@ -76,9 +92,13 @@ class LLMRouter:
             (v for k, v in request.headers.items() if _matches_session_id_header(k)),
             None,
         )
-        handle = (
-            self._handle.options(session_id=session_id) if session_id else self._handle
-        )
+        options = {}
+        if session_id:
+            options["session_id"] = session_id
+        multiplexed_model_id = self._multiplexed_model_id(body)
+        if multiplexed_model_id:
+            options["multiplexed_model_id"] = multiplexed_model_id
+        handle = self._handle.options(**options) if options else self._handle
         try:
             host, port, replica_id = await self._pick_replica(
                 handle=handle,
@@ -88,6 +108,22 @@ class LLMRouter:
         except (RuntimeError, DeploymentUnavailableError) as e:
             raise HTTPException(status_code=503, detail=str(e))
         return {"host": host, "port": port, "replica_id": replica_id}
+
+    def _multiplexed_model_id(self, body: bytes) -> Optional[str]:
+        """Return the requested LoRA adapter id to pin on, or None.
+
+        None means "no multiplex hint" (base model, multiplex disabled, or body
+        unavailable), in which case routing falls back to load balancing. A
+        base-model request must not set ``multiplexed_model_id``: doing so would
+        pin every base request to one replica instead of balancing across all
+        of them (the same reasoning as ``OpenAiIngress`` in ingress.py).
+        """
+        if not self._multiplex_enabled:
+            return None
+        model_id = extract_model_id_from_body(body)
+        if model_id and get_base_model_id(model_id) != model_id:
+            return model_id
+        return None
 
     @router_app.get("/health")
     async def health(self):
@@ -101,9 +137,10 @@ class LLMRouter:
     ) -> Tuple[str, int, str]:
         """Pick a backend HTTP replica via the deployment's request router.
 
-        ``handle`` is the LLMServer deployment handle, optionally configured
-        with ``.options(session_id=...)`` by the caller so session-aware
-        routers see the session id on ``RequestMetadata``.
+        ``handle`` is the LLMServer deployment handle, optionally configured by
+        the caller with ``.options(session_id=...)`` and/or
+        ``.options(multiplexed_model_id=...)`` so session-aware and
+        multiplex-aware routers see those fields on ``RequestMetadata``.
 
         ``request_body`` (possibly a HAProxy-truncated prefix, indicated by
         ``body_truncated``) is forwarded to ``choose_replica`` so a future

--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -3,8 +3,7 @@ from typing import Optional, Tuple
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
-from ray.llm._internal.common.utils.lora_utils import get_base_model_id
-from ray.llm._internal.serve.utils.server_utils import extract_model_id_from_body
+from ray.llm._internal.serve.utils.server_utils import extract_adapter_id_from_body
 from ray.serve._private.http_util import _matches_session_id_header
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
@@ -120,10 +119,7 @@ class LLMRouter:
         """
         if not self._multiplex_enabled:
             return None
-        model_id = extract_model_id_from_body(body)
-        if model_id and get_base_model_id(model_id) != model_id:
-            return model_id
-        return None
+        return extract_adapter_id_from_body(body)
 
     @router_app.get("/health")
     async def health(self):

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -17,6 +17,7 @@ import ray
 from ray import serve
 from ray._common.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray._common.utils import import_attr
+from ray.llm._internal.common.utils.lora_utils import get_base_model_id
 from ray.llm._internal.serve.constants import (
     ENABLE_WORKER_PROCESS_SETUP_HOOK,
     ENGINE_START_TIMEOUT_S,
@@ -35,10 +36,9 @@ from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     push_telemetry_report_for_all_models,
 )
 from ray.llm._internal.serve.utils.batcher import Batcher
-from ray.llm._internal.serve.utils.lora_serve_utils import (
-    LoraModelLoader,
-)
+from ray.llm._internal.serve.utils.lora_serve_utils import LoraModelLoader
 from ray.llm._internal.serve.utils.server_utils import (
+    extract_model_id_from_body,
     get_serve_request_id,
 )
 
@@ -99,6 +99,49 @@ def _merge_replica_actor_and_child_actor_bundles(
     return [merged_first_bundle] + [
         copy.copy(bundle) for bundle in child_actor_bundles[1:]
     ]
+
+
+class _DirectStreamingLoRAMiddleware:
+    """ASGI middleware that resolves per-request LoRA adapters for direct streaming.
+
+    The data-plane request reaches the engine ASGI app directly (HAProxy ->
+    replica backend port), bypassing ``_run_request``. This middleware buffers
+    the body, reads the OpenAI ``model`` field, and for an adapter request
+    downloads + registers + advertises the adapter via the server before
+    replaying the buffered body to the engine app. Non-POST requests pass
+    through untouched.
+    """
+
+    def __init__(self, app: Any, server: "LLMServer"):
+        self._app = app
+        self._server = server
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or scope.get("method") != "POST":
+            await self._app(scope, receive, send)
+            return
+
+        # Buffer the body so we can peek the model id, then replay it. The
+        # replica needs the full body to serve the request anyway.
+        messages = []
+        while True:
+            message = await receive()
+            messages.append(message)
+            if not message.get("more_body", False):
+                break
+        body = b"".join(m.get("body", b"") for m in messages)
+
+        await self._server._maybe_resolve_lora_for_direct_streaming(body)
+
+        message_iter = iter(messages)
+
+        async def replay():
+            try:
+                return next(message_iter)
+            except StopIteration:
+                return {"type": "http.disconnect"}
+
+        await self._app(scope, replay, send)
 
 
 class LLMServer(LLMServerProtocol):
@@ -219,6 +262,12 @@ class LLMServer(LLMServerProtocol):
                 raise HTTPException(status_code=404, detail=f"Unknown model: {model}")
             return model_card
 
+        if self._llm_config.lora_config is not None:
+            # Direct-streaming requests reach this app directly, bypassing
+            # _run_request, so per-request LoRA adapters must be resolved and
+            # advertised here for multiplex routing affinity to work.
+            return _DirectStreamingLoRAMiddleware(app, self)
+
         return app
 
     def _init_multiplex_loader(
@@ -302,14 +351,43 @@ class LLMServer(LLMServerProtocol):
         if request_id:
             request.request_id = request_id
 
+    async def _resolve_lora_adapter(self, adapter_id: str) -> None:
+        """Download a LoRA adapter and register it with the engine.
+
+        Loading goes through the multiplexed ``self._load_model`` wrapper, which
+        (besides caching the adapter on disk) advertises it to the controller
+        and request routers, so multiplex-aware routing can steer subsequent
+        requests for this adapter to this replica.
+        """
+        if self._llm_config.lora_config is None:
+            raise ValueError("Must setup lora config for multiplexed requests.")
+        disk_lora_model = await self._load_model(adapter_id)
+        await self.engine.resolve_lora(disk_lora_model)
+
     async def _maybe_resolve_lora_from_multiplex(self) -> None:
         """Handle the lora model for the request."""
         multiplexed_model_id = serve.get_multiplexed_model_id()
         if multiplexed_model_id:
-            if self._llm_config.lora_config is None:
-                raise ValueError("Must setup lora config for multiplexed requests.")
-            disk_lora_model = await self._load_model(multiplexed_model_id)
-            await self.engine.resolve_lora(disk_lora_model)
+            await self._resolve_lora_adapter(multiplexed_model_id)
+
+    async def _maybe_resolve_lora_for_direct_streaming(self, body: bytes) -> None:
+        """Resolve a per-request LoRA adapter on the direct-streaming data path.
+
+        Direct-streaming requests reach the engine ASGI app directly and skip
+        ``_run_request`` (and thus ``_maybe_resolve_lora_from_multiplex``), so
+        the adapter named in the request body is downloaded, registered, and
+        advertised here instead. Best-effort: extraction or load failures are
+        logged and swallowed so the engine's own handling still runs.
+        """
+        model_id = extract_model_id_from_body(body)
+        if not model_id or get_base_model_id(model_id) == model_id:
+            return
+        try:
+            await self._resolve_lora_adapter(model_id)
+        except Exception:
+            logger.exception(
+                "Failed to resolve LoRA adapter '%s' for direct streaming.", model_id
+            )
 
     def _batch_output_stream(
         self, generator: AsyncGenerator[T, None]

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -17,7 +17,6 @@ import ray
 from ray import serve
 from ray._common.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray._common.utils import import_attr
-from ray.llm._internal.common.utils.lora_utils import get_base_model_id
 from ray.llm._internal.serve.constants import (
     ENABLE_WORKER_PROCESS_SETUP_HOOK,
     ENGINE_START_TIMEOUT_S,
@@ -38,7 +37,7 @@ from ray.llm._internal.serve.observability.usage_telemetry.usage import (
 from ray.llm._internal.serve.utils.batcher import Batcher
 from ray.llm._internal.serve.utils.lora_serve_utils import LoraModelLoader
 from ray.llm._internal.serve.utils.server_utils import (
-    extract_model_id_from_body,
+    extract_adapter_id_from_body,
     get_serve_request_id,
 )
 
@@ -101,14 +100,20 @@ def _merge_replica_actor_and_child_actor_bundles(
     ]
 
 
+# Cap how much of a direct-streaming request body is buffered to read the
+# OpenAI ``model`` field. The field sits near the start, so a small prefix is
+# enough; bounding it avoids buffering large (e.g. multimodal) bodies in memory.
+_DIRECT_STREAMING_BODY_PEEK_LIMIT = 256 * 1024
+
+
 class _DirectStreamingLoRAMiddleware:
     """ASGI middleware that resolves per-request LoRA adapters for direct streaming.
 
     The data-plane request reaches the engine ASGI app directly (HAProxy ->
-    replica backend port), bypassing ``_run_request``. This middleware buffers
-    the body, reads the OpenAI ``model`` field, and for an adapter request
-    downloads + registers + advertises the adapter via the server before
-    replaying the buffered body to the engine app. Non-POST requests pass
+    replica backend port), bypassing ``_run_request``. This middleware buffers a
+    bounded prefix of the body, reads the OpenAI ``model`` field, and for an
+    adapter request downloads + registers + advertises the adapter via the
+    server before replaying the body to the engine app. Non-POST requests pass
     through untouched.
     """
 
@@ -121,25 +126,41 @@ class _DirectStreamingLoRAMiddleware:
             await self._app(scope, receive, send)
             return
 
-        # Buffer the body so we can peek the model id, then replay it. The
-        # replica needs the full body to serve the request anyway.
+        # Buffer only enough of the body to peek the model id, then replay the
+        # buffered prefix and stream the rest on demand. Buffering the whole
+        # body would OOM on large (e.g. multimodal) payloads, and the model id
+        # sits near the start anyway; a truncated prefix is handled by
+        # extract_model_id_from_body's regex fallback.
         messages = []
+        body_chunks = []
+        buffered = 0
         while True:
             message = await receive()
             messages.append(message)
-            if not message.get("more_body", False):
+            if message.get("type") == "http.request":
+                chunk = message.get("body", b"")
+                body_chunks.append(chunk)
+                buffered += len(chunk)
+            if buffered >= _DIRECT_STREAMING_BODY_PEEK_LIMIT or not message.get(
+                "more_body", False
+            ):
                 break
-        body = b"".join(m.get("body", b"") for m in messages)
 
-        await self._server._maybe_resolve_lora_for_direct_streaming(body)
+        await self._server._maybe_resolve_lora_for_direct_streaming(
+            b"".join(body_chunks)
+        )
 
         message_iter = iter(messages)
 
         async def replay():
+            # Replay the buffered prefix, then defer to the real transport so the
+            # engine streams the remainder and still observes client disconnects
+            # (used to abort in-flight generation). Returning http.disconnect
+            # here instead would abort streaming as soon as the body is read.
             try:
                 return next(message_iter)
             except StopIteration:
-                return {"type": "http.disconnect"}
+                return await receive()
 
         await self._app(scope, replay, send)
 
@@ -379,14 +400,14 @@ class LLMServer(LLMServerProtocol):
         advertised here instead. Best-effort: extraction or load failures are
         logged and swallowed so the engine's own handling still runs.
         """
-        model_id = extract_model_id_from_body(body)
-        if not model_id or get_base_model_id(model_id) == model_id:
+        adapter_id = extract_adapter_id_from_body(body)
+        if not adapter_id:
             return
         try:
-            await self._resolve_lora_adapter(model_id)
+            await self._resolve_lora_adapter(adapter_id)
         except Exception:
             logger.exception(
-                "Failed to resolve LoRA adapter '%s' for direct streaming.", model_id
+                "Failed to resolve LoRA adapter '%s' for direct streaming.", adapter_id
             )
 
     def _batch_output_stream(

--- a/python/ray/llm/_internal/serve/utils/server_utils.py
+++ b/python/ray/llm/_internal/serve/utils/server_utils.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
+import re
 import threading
 import time
 import traceback
 from functools import partial
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, Optional, TypeVar
 
 from fastapi import HTTPException, status
 from httpx import HTTPStatusError as HTTPXHTTPStatusError
@@ -211,6 +213,30 @@ def get_serve_request_id() -> str:
 
 def get_model_request_id(model: str):
     return model + "-" + get_serve_request_id()
+
+
+def extract_model_id_from_body(body: bytes) -> Optional[str]:
+    """Best-effort extraction of the OpenAI ``model`` field from a request body.
+
+    Used by the direct-streaming path, where the request body (or a
+    HAProxy-truncated prefix of it) is the only place the requested model /
+    adapter id is available. Returns None when the body is empty, unparseable,
+    or has no ``model`` field; callers must treat None as "no multiplex hint"
+    and fall back to load balancing.
+    """
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        # Body may be a truncated prefix (HAProxy bufsize cap) and not valid
+        # JSON. Fall back to a shallow regex for the leading ``model`` field.
+        match = re.search(rb'"model"\s*:\s*"([^"]+)"', body)
+        return match.group(1).decode("utf-8", "replace") if match else None
+    if isinstance(payload, dict):
+        model = payload.get("model")
+        return model if isinstance(model, str) and model else None
+    return None
 
 
 def replace_prefix(model: str) -> str:

--- a/python/ray/llm/_internal/serve/utils/server_utils.py
+++ b/python/ray/llm/_internal/serve/utils/server_utils.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from ray import serve
 from ray.llm._internal.common.errors import VLLM_FATAL_ERRORS
+from ray.llm._internal.common.utils.lora_utils import get_base_model_id
 from ray.llm._internal.serve.constants import DEFAULT_FATAL_ERROR_COOLDOWN_S
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ErrorInfo,
@@ -236,6 +237,21 @@ def extract_model_id_from_body(body: bytes) -> Optional[str]:
     if isinstance(payload, dict):
         model = payload.get("model")
         return model if isinstance(model, str) and model else None
+    return None
+
+
+def extract_adapter_id_from_body(body: bytes) -> Optional[str]:
+    """Return the requested LoRA adapter id from a request body, or None.
+
+    Wraps :func:`extract_model_id_from_body` and keeps the id only when it names
+    a LoRA adapter (``base:adapter``) rather than the base model. None means "no
+    multiplex hint" (base model, empty/unparseable body, or no ``model`` field),
+    so callers fall back to load balancing. Pinning a base-model request would
+    send every base request to one replica instead of balancing across them.
+    """
+    model_id = extract_model_id_from_body(body)
+    if model_id and get_base_model_id(model_id) != model_id:
+        return model_id
     return None
 
 

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -20,6 +20,7 @@ from ray.llm._internal.serve.core.ingress.ingress import (
 )
 from ray.llm._internal.serve.core.ingress.router import LLMRouter
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
+from ray.llm._internal.serve.utils.server_utils import extract_model_id_from_body
 from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
 from ray.serve._private.common import DeploymentID
 from ray.serve.exceptions import DeploymentUnavailableError
@@ -56,9 +57,10 @@ class _DirectRouterReplica:
         self.backend_http_endpoint = endpoint
 
 
-def _new_direct_router(handle=None):
+def _new_direct_router(handle=None, multiplex_enabled=False):
     router = LLMRouter.__new__(LLMRouter)
     router._handle = handle or MagicMock()
+    router._multiplex_enabled = multiplex_enabled
     return router
 
 
@@ -145,6 +147,49 @@ class TestDirectStreamingLLMRouter:
         router._pick_replica.assert_called_once_with(
             handle=router._handle, request_body=body, body_truncated=True
         )
+
+    @pytest.mark.parametrize(
+        ("multiplex_enabled", "model", "expected"),
+        [
+            (False, "base:adapter", None),  # disabled -> never pin
+            (True, "base", None),  # base model -> load balance, don't pin
+            (True, "base:adapter", "base:adapter"),  # adapter -> pin
+            (True, None, None),  # no model field -> nothing to pin
+        ],
+    )
+    def test_multiplexed_model_id(self, multiplex_enabled, model, expected):
+        router = _new_direct_router(multiplex_enabled=multiplex_enabled)
+        body = b"{}" if model is None else b'{"model":"%s"}' % model.encode()
+        assert router._multiplexed_model_id(body) == expected
+
+    @pytest.mark.asyncio
+    async def test_route_pins_adapter_via_options(self):
+        """An adapter request sets multiplexed_model_id on the handle."""
+        router = _new_direct_router(multiplex_enabled=True)
+        pinned_handle = router._handle.options.return_value
+        router._pick_replica = AsyncMock(
+            return_value=("127.0.0.1", 9001, "DeploymentName#replica")
+        )
+
+        await router.route(_FakeRequest(b'{"model":"base:adapter"}'))
+
+        router._handle.options.assert_called_once_with(
+            multiplexed_model_id="base:adapter"
+        )
+        assert router._pick_replica.call_args.kwargs["handle"] is pinned_handle
+
+    @pytest.mark.asyncio
+    async def test_route_does_not_pin_base_model(self):
+        """A base-model request routes on the bare handle (no options copy)."""
+        router = _new_direct_router(multiplex_enabled=True)
+        router._pick_replica = AsyncMock(
+            return_value=("127.0.0.1", 9001, "DeploymentName#replica")
+        )
+
+        await router.route(_FakeRequest(b'{"model":"base"}'))
+
+        router._handle.options.assert_not_called()
+        assert router._pick_replica.call_args.kwargs["handle"] is router._handle
 
     @pytest.mark.asyncio
     async def test_route_returns_503_on_pick_failure(self):
@@ -428,6 +473,23 @@ class TestOpenAiIngress:
         assert len(captured_raw_request_infos) == 1
         assert isinstance(captured_raw_request_infos[0], RawRequestInfo)
         assert captured_raw_request_infos[0].headers == mock_headers
+
+
+class TestExtractModelIdFromBody:
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            (b'{"model":"m","prompt":"hi"}', "m"),
+            (b'{"prompt":"hi","model":"base:adapter"}', "base:adapter"),
+            (b"", None),  # empty body
+            (b'{"prompt":"hi"}', None),  # no model field
+            (b'{"model":123}', None),  # non-string model
+            (b'{"model":"m","prompt":"' + b"x" * 2048, "m"),  # truncated -> regex
+            (b"not json at all", None),  # unparseable, no model
+        ],
+    )
+    def test_extract_model_id_from_body(self, body, expected):
+        assert extract_model_id_from_body(body) == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Direct streaming (`RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING`) routes LoRA-adapter requests adapter-blind, because:

1. **Router side:** the ingress router (`LLMRouter`) never sees the requested adapter id, so it never sets `multiplexed_model_id`. A multiplex-aware policy like `PowerOfTwoChoicesRouter` then can't steer by adapter and falls back to locality routing.
2. **Replica side:** direct-streaming requests reach the engine's ASGI app directly (HAProxy → replica backend port), bypassing `_run_request` / `_maybe_resolve_lora_from_multiplex`. That is the path that loads adapters through the multiplexed loader, which is also what advertises a replica's adapters to the controller/routers. Bypassed, the routers' multiplex map stays empty.

This PR closes both gaps so adapter affinity works end to end in direct streaming (previously documented as a limitation in #63860).

## What this changes

**Router (`LLMRouter`, `builder.py`)**
- Reads `model` from the forwarded body and, when it names a LoRA adapter (`base:adapter`), sets `multiplexed_model_id` before `choose_replica`. Base-model requests load balance (matching `OpenAiIngress`).
- Gated on the deployment having a `lora_config`. Requires `RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY=1`; without it the model id is unavailable and routing falls back to load balancing.

**Replica (`LLMServer`)**
- `_DirectStreamingLoRAMiddleware` resolves the per-request adapter through the existing multiplexed loader before the engine handles the request, which both registers the adapter with the engine and advertises it to the routers. It buffers only a bounded prefix of the body to read `model` and streams the rest, preserving client-disconnect detection.
- LoRA resolution is factored into `_resolve_lora_adapter`, shared by the existing multiplex path and the new direct-streaming path.

**Shared**
- `extract_adapter_id_from_body` (JSON parse with a truncated-prefix regex fallback), used by both paths, plus unit tests for it and the router's pin / no-pin decision.

## Testing / validation status

- [x] Unit tests for body parsing and the router pin decision (`test_router.py`); `ruff` + `black` pass.
- [ ] **End-to-end LoRA affinity on GPU not yet validated** (no GPU/LoRA env at draft time). Needs a `team:llm` run plus a manual check that adapter requests pin to a warm replica and the multiplex map populates from the direct-streaming path.

## Open questions for review

- Requiring `FORWARD_BODY=1` for router-side affinity: acceptable constraint, or worth a lighter-weight model-id-only forward path (e.g. extracting `model` in the HAProxy Lua action, like the session id)?

## Related

- #63860 (docs describing the current limitation)
