### PR TITLE
[core] Fall back to GCS for sidecar node discovery

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -377,6 +377,7 @@ def find_node_ids():
 
 
 _find_gcs_addresses_lock = threading.Lock()
+_NODE_DISCOVERY_FALLBACK_GRACE_S = 5
 
 
 @cache
@@ -539,17 +540,69 @@ def get_node_to_connect_for_driver(
     start_time = time.time()
     possible_node_ids = []
     filtered_node_to_connect_infos = []
+    no_visible_raylet_processes_since = None
+    last_resolution_path = None
+    fallback_candidate_count = None
+    resolved_node_ip_address = None
     while not possible_node_ids or not filtered_node_to_connect_infos:
         time_left = timeout_seconds - (time.time() - start_time)
         if time_left <= 0:
             break
 
         possible_node_ids = find_node_ids()
-        # no need to make gcs call if raylets are not ready yet
         if len(possible_node_ids) == 0:
+            if no_visible_raylet_processes_since is None:
+                no_visible_raylet_processes_since = time.time()
+            if (
+                time.time() - no_visible_raylet_processes_since
+                < _NODE_DISCOVERY_FALLBACK_GRACE_S
+            ):
+                time.sleep(1)
+                continue
+
+            fallback_node_ip_address = node_ip_address
+            if fallback_node_ip_address is None:
+                if resolved_node_ip_address is None:
+                    resolved_node_ip_address = get_node_ip_address()
+                fallback_node_ip_address = resolved_node_ip_address
+
+            time_left = timeout_seconds - (time.time() - start_time)
+            if time_left <= 0:
+                break
+
+            try:
+                last_resolution_path = "fallback"
+                node_to_connect_infos = gcs_client.get_all_node_info(
+                    timeout=time_left,
+                    state_filter=GcsNodeInfo.GcsNodeState.ALIVE,
+                ).values()
+            except Exception as e:
+                raise RuntimeError(
+                    "Failed to get node info when no local raylet processes were "
+                    f"visible while trying to resolve node to connect to. Error: {repr(e)}"
+                )
+
+            fallback_candidates = []
+            for node_info in node_to_connect_infos:
+                if (
+                    (
+                        fallback_node_ip_address is None
+                        or node_info.node_manager_address == fallback_node_ip_address
+                    )
+                    and (node_name is None or node_info.node_name == node_name)
+                    and (temp_dir is None or node_info.temp_dir == temp_dir)
+                ):
+                    fallback_candidates.append(node_info)
+
+            fallback_candidate_count = len(fallback_candidates)
+            if fallback_candidate_count == 1:
+                filtered_node_to_connect_infos = fallback_candidates
+                break
+
             time.sleep(1)
             continue
 
+        last_resolution_path = "process"
         node_selectors = []
         for id in possible_node_ids:
             id_node_selector = GetAllNodeInfoRequest.NodeSelector(
@@ -583,6 +636,17 @@ def get_node_to_connect_for_driver(
     if not filtered_node_to_connect_infos:
         attrs = [node_ip_address, node_name, temp_dir]
         attrs_str = ", ".join(f"{attr}" for attr in attrs if attr is not None)
+        if last_resolution_path == "fallback":
+            raise RuntimeError(
+                f"No node info found matching attributes: '{attrs_str}' when trying "
+                "to resolve node to connect to. No local raylet process was visible "
+                "from this process, and the GCS fallback did not find a unique local "
+                f"node match (last matched {fallback_candidate_count or 0} nodes). "
+                "If you are running Ray in a Kubernetes sidecar or another "
+                "environment with separate PID namespaces, make sure the driver "
+                "container can identify the local Ray node by passing _node_ip_address, "
+                "_temp_dir, or by sharing the process namespace."
+            )
         raise RuntimeError(
             f"No node info found matching attributes: '{attrs_str}' when trying to resolve node to connect to."
         )

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -602,6 +602,7 @@ def get_node_to_connect_for_driver(
             time.sleep(1)
             continue
 
+        no_visible_raylet_processes_since = None
         last_resolution_path = "process"
         node_selectors = []
         for id in possible_node_ids:

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -412,7 +412,9 @@ def test_get_node_to_connect_for_driver_falls_back_to_local_ip(monkeypatch):
 
     monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
     monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: set())
-    monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.2")
+    monkeypatch.setattr(
+        ray._private.services, "get_node_ip_address", lambda: "10.0.0.2"
+    )
 
     node_info = ray._private.services.get_node_to_connect_for_driver(gcs_client)
 
@@ -452,7 +454,9 @@ def test_get_node_to_connect_for_driver_fallback_uses_explicit_temp_dir(monkeypa
 
     monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
     monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: set())
-    monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.2")
+    monkeypatch.setattr(
+        ray._private.services, "get_node_ip_address", lambda: "10.0.0.2"
+    )
 
     node_info = ray._private.services.get_node_to_connect_for_driver(
         gcs_client, temp_dir="/ray-sidecar"

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -509,6 +509,37 @@ def test_get_node_to_connect_for_driver_waits_before_fallback(monkeypatch):
     assert len(gcs_client.calls[0]["node_selectors"]) == 1
 
 
+def test_get_node_to_connect_for_driver_resets_fallback_grace_timer(monkeypatch):
+    process_node_id = ray.NodeID.from_random()
+    process_node = _make_gcs_node_info("10.0.0.3", node_id=process_node_id)
+    gcs_client = _FakeGcsClient([process_node])
+
+    find_node_ids_results = iter(
+        [set(), {process_node_id.hex()}, set(), {process_node_id.hex()}]
+    )
+    monkeypatch.setattr(
+        ray._private.services,
+        "find_node_ids",
+        lambda: next(find_node_ids_results),
+    )
+    time_values = chain([0, 0, 0, 6, 6, 6, 6, 10], repeat(10))
+    monkeypatch.setattr(ray._private.services.time, "time", lambda: next(time_values))
+    monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="No node info found matching attributes: '10.0.0.2'",
+    ) as exc_info:
+        ray._private.services.get_node_to_connect_for_driver(
+            gcs_client,
+            node_ip_address="10.0.0.2",
+            timeout_seconds=10,
+        )
+
+    assert "No local raylet process was visible" not in str(exc_info.value)
+    assert all("node_selectors" in call for call in gcs_client.calls)
+
+
 def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
     monkeypatch,
 ):

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -526,7 +526,7 @@ def test_get_node_to_connect_for_driver_resets_fallback_grace_timer(monkeypatch)
         "find_node_ids",
         lambda: next(find_node_ids_results),
     )
-    time_values = chain([0, 0, 0, 6, 6, 6, 6, 10], repeat(10))
+    time_values = chain([0, 0, 0, 0, 6, 6, 6, 6, 10], repeat(10))
     monkeypatch.setattr(ray._private.services.time, "time", lambda: next(time_values))
     monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
 

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -511,6 +511,8 @@ def test_get_node_to_connect_for_driver_waits_before_fallback(monkeypatch):
 def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
     monkeypatch,
 ):
+    from itertools import chain, repeat
+
     process_node_id = ray.NodeID.from_random()
     process_node = _make_gcs_node_info("10.0.0.3", node_id=process_node_id)
     gcs_client = _FakeGcsClient([process_node])
@@ -526,6 +528,8 @@ def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
 
     monkeypatch.setattr(ray._private.services, "find_node_ids", find_node_ids)
     monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
+    time_values = chain([0, 0, 0, 0, 0, 0, 2], repeat(2))
+    monkeypatch.setattr(ray._private.services.time, "time", lambda: next(time_values))
     monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
     monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.4")
 
@@ -536,7 +540,7 @@ def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
         ray._private.services.get_node_to_connect_for_driver(
             gcs_client,
             node_ip_address="10.0.0.2",
-            timeout_seconds=0.001,
+            timeout_seconds=1,
         )
 
     assert "No local raylet process was visible" not in str(exc_info.value)

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import tempfile
 import unittest.mock
+from itertools import chain, repeat
 from unittest.mock import patch
 
 import pytest
@@ -511,8 +512,6 @@ def test_get_node_to_connect_for_driver_waits_before_fallback(monkeypatch):
 def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
     monkeypatch,
 ):
-    from itertools import chain, repeat
-
     process_node_id = ray.NodeID.from_random()
     process_node = _make_gcs_node_info("10.0.0.3", node_id=process_node_id)
     gcs_client = _FakeGcsClient([process_node])
@@ -531,7 +530,9 @@ def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
     time_values = chain([0, 0, 0, 0, 0, 0, 2], repeat(2))
     monkeypatch.setattr(ray._private.services.time, "time", lambda: next(time_values))
     monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
-    monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.4")
+    monkeypatch.setattr(
+        ray._private.services, "get_node_ip_address", lambda: "10.0.0.4"
+    )
 
     with pytest.raises(
         RuntimeError,

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -18,6 +18,7 @@ from ray._common.test_utils import (
 from ray._private.ray_constants import DEFAULT_RESOURCES, RAY_OVERRIDE_DASHBOARD_URL
 from ray._private.services import get_node_ip_address
 from ray._private.test_utils import get_current_unused_port
+from ray.core.generated.gcs_pb2 import GcsNodeInfo
 from ray.dashboard.utils import ray_address_to_api_server_url
 from ray.util.client.ray_client_helpers import ray_start_client_server
 
@@ -353,6 +354,195 @@ def test_get_node_to_connect_for_driver_filters_by_node_name(ray_start_cluster):
     )
     assert node_info.node_manager_port == node2.node_manager_port
     assert node_info.node_name == "node_two"
+
+
+class _FakeGcsClient:
+    def __init__(self, nodes):
+        self.nodes = nodes
+        self.calls = []
+
+    def get_all_node_info(self, **kwargs):
+        self.calls.append(kwargs)
+        return {node.node_id: node for node in self.nodes}
+
+
+def _make_gcs_node_info(
+    node_manager_address: str,
+    *,
+    node_id=None,
+    node_name: str = "",
+    temp_dir: str = "/tmp/ray",
+    is_head_node: bool = False,
+):
+    node_id = node_id or ray.NodeID.from_random()
+    return GcsNodeInfo(
+        node_id=node_id.binary(),
+        state=GcsNodeInfo.GcsNodeState.ALIVE,
+        node_manager_address=node_manager_address,
+        node_name=node_name,
+        temp_dir=temp_dir,
+        is_head_node=is_head_node,
+    )
+
+
+def test_get_node_to_connect_for_driver_uses_process_discovered_node_ids(monkeypatch):
+    node_id = ray.NodeID.from_random()
+    node = _make_gcs_node_info("10.0.0.2", node_id=node_id)
+    gcs_client = _FakeGcsClient([node])
+
+    monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: {node_id.hex()})
+    monkeypatch.setattr(
+        ray._private.services,
+        "get_node_ip_address",
+        unittest.mock.Mock(side_effect=AssertionError("should not use IP fallback")),
+    )
+
+    node_info = ray._private.services.get_node_to_connect_for_driver(gcs_client)
+
+    assert node_info == node
+    assert len(gcs_client.calls) == 1
+    assert len(gcs_client.calls[0]["node_selectors"]) == 1
+
+
+def test_get_node_to_connect_for_driver_falls_back_to_local_ip(monkeypatch):
+    matching_node = _make_gcs_node_info("10.0.0.2")
+    other_node = _make_gcs_node_info("10.0.0.3")
+    gcs_client = _FakeGcsClient([matching_node, other_node])
+
+    monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
+    monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: set())
+    monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.2")
+
+    node_info = ray._private.services.get_node_to_connect_for_driver(gcs_client)
+
+    assert node_info == matching_node
+    assert len(gcs_client.calls) == 1
+    assert "node_selectors" not in gcs_client.calls[0]
+
+
+def test_get_node_to_connect_for_driver_fallback_uses_explicit_node_ip(
+    monkeypatch,
+):
+    matching_node = _make_gcs_node_info("10.0.0.2")
+    other_node = _make_gcs_node_info("10.0.0.3")
+    gcs_client = _FakeGcsClient([matching_node, other_node])
+
+    monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
+    monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: set())
+    get_node_ip_address = unittest.mock.Mock(
+        side_effect=AssertionError("explicit IP should be used")
+    )
+    monkeypatch.setattr(
+        ray._private.services, "get_node_ip_address", get_node_ip_address
+    )
+
+    node_info = ray._private.services.get_node_to_connect_for_driver(
+        gcs_client, node_ip_address="10.0.0.2"
+    )
+
+    assert node_info == matching_node
+    get_node_ip_address.assert_not_called()
+
+
+def test_get_node_to_connect_for_driver_fallback_uses_explicit_temp_dir(monkeypatch):
+    matching_node = _make_gcs_node_info("10.0.0.2", temp_dir="/ray-sidecar")
+    other_node = _make_gcs_node_info("10.0.0.2", temp_dir="/tmp/ray")
+    gcs_client = _FakeGcsClient([matching_node, other_node])
+
+    monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
+    monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: set())
+    monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.2")
+
+    node_info = ray._private.services.get_node_to_connect_for_driver(
+        gcs_client, temp_dir="/ray-sidecar"
+    )
+
+    assert node_info == matching_node
+
+
+def test_get_node_to_connect_for_driver_fallback_requires_unique_match(monkeypatch):
+    head_node = _make_gcs_node_info("10.0.0.2", is_head_node=True)
+    worker_node = _make_gcs_node_info("10.0.0.2")
+    gcs_client = _FakeGcsClient([head_node, worker_node])
+
+    monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
+    monkeypatch.setattr(ray._private.services, "find_node_ids", lambda: set())
+    get_node_ip_address = unittest.mock.Mock(return_value="10.0.0.2")
+    monkeypatch.setattr(
+        ray._private.services, "get_node_ip_address", get_node_ip_address
+    )
+    monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="No local raylet process was visible.*last matched 2 nodes",
+    ):
+        ray._private.services.get_node_to_connect_for_driver(
+            gcs_client, timeout_seconds=0.001
+        )
+    assert get_node_ip_address.call_count == 1
+
+
+def test_get_node_to_connect_for_driver_waits_before_fallback(monkeypatch):
+    process_node_id = ray.NodeID.from_random()
+    process_node = _make_gcs_node_info("10.0.0.2", node_id=process_node_id)
+    gcs_client = _FakeGcsClient([process_node])
+
+    find_node_ids_results = iter([set(), {process_node_id.hex()}])
+    monkeypatch.setattr(
+        ray._private.services,
+        "find_node_ids",
+        lambda: next(find_node_ids_results),
+    )
+    monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        ray._private.services,
+        "get_node_ip_address",
+        unittest.mock.Mock(side_effect=AssertionError("fallback should not run")),
+    )
+
+    node_info = ray._private.services.get_node_to_connect_for_driver(gcs_client)
+
+    assert node_info == process_node
+    assert len(gcs_client.calls) == 1
+    assert len(gcs_client.calls[0]["node_selectors"]) == 1
+
+
+def test_get_node_to_connect_for_driver_does_not_use_sticky_fallback_error(
+    monkeypatch,
+):
+    process_node_id = ray.NodeID.from_random()
+    process_node = _make_gcs_node_info("10.0.0.3", node_id=process_node_id)
+    gcs_client = _FakeGcsClient([process_node])
+
+    did_return_empty = False
+
+    def find_node_ids():
+        nonlocal did_return_empty
+        if not did_return_empty:
+            did_return_empty = True
+            return set()
+        return {process_node_id.hex()}
+
+    monkeypatch.setattr(ray._private.services, "find_node_ids", find_node_ids)
+    monkeypatch.setattr(ray._private.services, "_NODE_DISCOVERY_FALLBACK_GRACE_S", 0)
+    monkeypatch.setattr(ray._private.services.time, "sleep", lambda _: None)
+    monkeypatch.setattr(ray._private.services, "get_node_ip_address", lambda: "10.0.0.4")
+
+    with pytest.raises(
+        RuntimeError,
+        match="No node info found matching attributes: '10.0.0.2'",
+    ) as exc_info:
+        ray._private.services.get_node_to_connect_for_driver(
+            gcs_client,
+            node_ip_address="10.0.0.2",
+            timeout_seconds=0.001,
+        )
+
+    assert "No local raylet process was visible" not in str(exc_info.value)
+    assert len(gcs_client.calls) == 2
+    assert "node_selectors" not in gcs_client.calls[0]
+    assert len(gcs_client.calls[1]["node_selectors"]) == 1
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="skip except linux")


### PR DESCRIPTION
## Summary
- Preserve process-based raylet node discovery as the primary path for drivers connecting to existing clusters.
- Add a conservative GCS fallback when no local raylet process is visible, which supports sidecar/separate-PID-namespace deployments when a unique local node can be identified.
- Improve the timeout error for hidden-raylet scenarios and add regression coverage for fallback and ambiguity cases.

## Test plan
- `python3 -m py_compile python/ray/_private/services.py python/ray/tests/test_ray_init_2.py`
- `git diff --check`
- `ReadLints` on edited files
- `black --check python/ray/_private/services.py python/ray/tests/test_ray_init_2.py`
- `ruff check python/ray/_private/services.py python/ray/tests/test_ray_init_2.py`
- `ruff check --select I python/ray/_private/services.py python/ray/tests/test_ray_init_2.py`

Note: Focused pytest could not run locally because importing local Ray requires the compiled `ray._raylet` extension, which is not built in this checkout.

Fixes #63923

Made with [Cursor](https://cursor.com)