### PR TITLE
[Data] Consistent Fuse Check between Logical and Physical Optimizer

### DIFF
--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -153,6 +153,11 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
         # Resources don't match - cannot fuse
         return downstream_project
 
+    # Do not fuse if either op specifies a `ray_remote_args_fn`,
+    # since it is not known whether the generated args will be compatible.
+    if upstream_project.ray_remote_args_fn or downstream_project.ray_remote_args_fn:
+        return downstream_project
+
     # Check if compute strategies are compatible
     fused_compute = FuseOperators._fuse_compute_strategy(
         upstream_project.compute, downstream_project.compute


### PR DESCRIPTION
## Description
In operator_fusion.py, we define a `_can_fuse` function to check whether two operators can be fused. Here, we check if either operator has `ray_remote_args_fn`, and if either operator has it, then the two operators cannot be fused. This is because we don't know whether the generated arguments will be compatible.

Our logical plan optimizer has the same fuse rules as the physical plan, but it is missing the check on `ray_remote_args_fn`. We should make it consistent.

## Related issues
N/A

## Additional information
N/A