### PR TITLE
Capture K8s Pod events in Ray Dashboard Head

### DIFF
--- a/python/ray/dashboard/modules/platform_events/providers/k8s_provider.py
+++ b/python/ray/dashboard/modules/platform_events/providers/k8s_provider.py
@@ -2,7 +2,8 @@ import asyncio
 import logging
 import os
 import threading
-from typing import Any, Callable, Dict, List, Optional
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -20,6 +21,15 @@ except ImportError:
     ApiException = None
 
 logger = logging.getLogger(__name__)
+
+POD_MEMBERSHIP_WATCH_ID = "Pod/__cluster_members__"
+POD_EVENTS_WATCH_ID = "Event/__cluster_pods__"
+# Cap on the number of non-cluster pod names cached by `resolve_cluster_pod`
+# to bound memory in busy multi-tenant namespaces. The oldest entry is evicted
+# (FIFO) once it grows past this size.
+MAX_NON_CLUSTER_POD_CACHE = 1024
+# Key for KubeRay label that identifies the RayCluster name of a resource.
+KUBERAY_LABEL_KEY_CLUSTER = "ray.io/cluster"
 
 
 class KubernetesEventProvider(PlatformEventProvider):
@@ -56,6 +66,16 @@ class KubernetesEventProvider(PlatformEventProvider):
         self._watches_lock: threading.Lock = threading.Lock()
         self._threads: List[threading.Thread] = []
         self._cleaned_up: bool = False
+
+        # Set of pod names belonging to this RayCluster (label ray.io/cluster=<name>).
+        # Maintained by `_run_pod_membership_watch` and read by `_run_pod_events_watch`
+        # to filter namespace-wide pod events down to this cluster's pods.
+        self._cluster_pod_names: Set[str] = set()
+        # Set of pod names resolved to NOT belong to this cluster, so the
+        # events watcher doesn't re-resolve them on every event. Always checked after
+        # `_cluster_pod_names`, so it can never override real membership.
+        self._non_cluster_pod_names: "OrderedDict[str, None]" = OrderedDict()
+        self._pods_lock: threading.Lock = threading.Lock()
 
     async def _init_k8s_client(self) -> bool:
         if not k8s_config:
@@ -148,26 +168,85 @@ class KubernetesEventProvider(PlatformEventProvider):
             for kind, name in targets:
                 target_id = f"{kind}/{name}"
                 self._last_resource_versions[target_id] = None
+            self._last_resource_versions[POD_EVENTS_WATCH_ID] = None
+
+            # Atomically list and build the pod membership cache synchronously
+            # on startup before starting any event watcher threads.
+            label_selector = f"{KUBERAY_LABEL_KEY_CLUSTER}={self._cluster_name}"
+            loop = asyncio.get_running_loop()
+            pods_rv = await loop.run_in_executor(
+                None, self._relist_pod_membership, label_selector
+            )
+
+            # In Kubernetes, a resource version is an opaque string representing the
+            # logical state of the etcd database. By passing the LIST's resource
+            # version to our WATCH request, we tell the API server to only send us
+            # events that occurred *after* the LIST completed. If we didn't set this
+            # (leaving it None), the watch would start from the beginning of history
+            # and redundantly replay ADDED events for every pod we just listed.
+            if pods_rv is not None:
+                self._last_resource_versions[POD_MEMBERSHIP_WATCH_ID] = pods_rv
+            else:
+                logger.warning(
+                    "Initial pod membership LIST failed, pod events watcher may drop events until next list."
+                )
+
+            # Seed the pod-events watch from the EVENT collection's resource version (a separate LIST).
+            # Resourceversions are per resource-type so we can't rely on the pod LIST's resource version.
+            # Starting from NONE instead would replay all historical events in the namespace (a potential
+            # flood), so we only fallback to that if LIST fails.
+            events_rv = await loop.run_in_executor(
+                None, self._latest_event_resource_version
+            )
+            if events_rv is not None:
+                self._last_resource_versions[POD_EVENTS_WATCH_ID] = events_rv
+            else:
+                logger.warning(
+                    "Initial events LIST failed, pod-events watcher may miss some historical events until the next watch reset."
+                )
 
             try:
                 # Start a dedicated, named OS thread for each target to ensure strict execution guarantees
                 for kind, name in targets:
                     t = threading.Thread(
-                        target=self._run_k8s_watch,
+                        target=self._run_kuberay_resource_events_watch,
                         args=(kind, name),
-                        name=f"platform_events_watch_{kind}_{name}",
+                        name=f"kubernetes_events_watch_{kind}_{name}",
                         daemon=True,
                     )
                     t.start()
                     self._threads.append(t)
+
+                # Pod-membership watcher: starts from the RV we just fetched
+                pod_thread = threading.Thread(
+                    target=self._run_pod_membership_watch,
+                    name="kubernetes_events_watch_pods",
+                    daemon=True,
+                )
+                pod_thread.start()
+                self._threads.append(pod_thread)
+
+                # Pod-events watcher: namespace-wide event watch filtered
+                # client-side against the membership cache.
+                pod_events_thread = threading.Thread(
+                    target=self._run_pod_events_watch,
+                    name="kubernetes_events_watch_pod_events",
+                    daemon=True,
+                )
+                pod_events_thread.start()
+                self._threads.append(pod_events_thread)
 
                 # Block the run coroutine until cleanup is called
                 await self._async_stop_event.wait()
             finally:
                 await self.cleanup()
 
-    def _run_k8s_watch(self, kind: str, name: str) -> None:
-        """Blocking method to run in a separate thread."""
+    def _run_kuberay_resource_events_watch(self, kind: str, name: str) -> None:
+        """Watch K8s events for a single named KubeRay CRD instance.
+        `kind` is one of 'RayCluster', 'RayJob', or 'RayService'
+        `name` is its metadata.name. Uses a field-selected event watch
+        scoped to that exact object.
+        """
         if not name:
             logger.error(
                 f"Attempted to watch events for kind {kind} without a specific name. Aborting."
@@ -201,10 +280,13 @@ class KubernetesEventProvider(PlatformEventProvider):
                     )
 
                     for event in stream:
+                        if self._is_watch_error_event(event, target_id):
+                            self._last_resource_versions[target_id] = None
+                            break
                         k8s_event_obj = event["object"]
+                        self._process_k8s_event(k8s_event_obj)
                         rv = k8s_event_obj.metadata.resource_version
                         self._last_resource_versions[target_id] = rv
-                        self._process_k8s_event(k8s_event_obj)
 
                 except ApiException as e:
                     if e.status == 410:
@@ -223,8 +305,259 @@ class KubernetesEventProvider(PlatformEventProvider):
                     )
                     self._stop_event.wait(5)
         finally:
+            w.stop()
             with self._watches_lock:
                 self._active_watches.pop(target_id, None)
+
+    def _relist_pod_membership(self, label_selector: str) -> Optional[str]:
+        """LIST pods matching the cluster label and atomically rebuild the
+        membership cache. Returns the LIST's resourceversion (to start
+        watching from), or None on failure.
+        """
+        if not self._k8s_v1_api or not watch:
+            return None
+        try:
+            pods = self._k8s_v1_api.list_namespaced_pod(
+                namespace=self._namespace,
+                label_selector=label_selector,
+                # resource_version="0" serves this LIST from the apiserver's watch
+                # cache instead of a quorum read against etcd. A quorum read is
+                # resource-intensive and slow as it requires etcd consensus. Since
+                # we immediately follow this LIST with a WATCH starting from the
+                # returned resource version, the eventual consistency of the cache
+                # is sufficient. This significantly reduces load on the K8s control plane.
+                resource_version="0",
+                resource_version_match="NotOlderThan",
+                _request_timeout=30,
+            )
+        except Exception as e:
+            logger.error(f"Failed to list pods for membership cache: {e}")
+            return None
+        names = {p.metadata.name for p in pods.items}
+        with self._pods_lock:
+            self._cluster_pod_names = names
+            return pods.metadata.resource_version
+
+    def _run_pod_membership_watch(self) -> None:
+        """Maintain the cluster's pod-name set via a label-selected pod watch.
+        Filtered by `ray.io/cluster=<cluster_name>`."""
+
+        if not self._k8s_v1_api or not watch:
+            logger.warning(
+                "Halting pod-membership watcher: "
+                "Kubernetes client or watch library is not initialized."
+            )
+            return
+
+        label_selector = f"{KUBERAY_LABEL_KEY_CLUSTER}={self._cluster_name}"
+        logger.info(
+            f"Starting Kubernetes pod-membership watcher (selector: {label_selector})"
+        )
+
+        w = watch.Watch()
+        target_id = POD_MEMBERSHIP_WATCH_ID
+        with self._watches_lock:
+            self._active_watches[target_id] = w
+        try:
+            while not self._stop_event.is_set():
+                if self._last_resource_versions.get(target_id) is None:
+                    rv = self._relist_pod_membership(label_selector)
+                    if rv is None:
+                        self._stop_event.wait(1)
+                        continue
+                    self._last_resource_versions[target_id] = rv
+
+                try:
+                    stream = w.stream(
+                        self._k8s_v1_api.list_namespaced_pod,
+                        namespace=self._namespace,
+                        label_selector=label_selector,
+                        resource_version=self._last_resource_versions.get(target_id),
+                        timeout_seconds=60,
+                        _request_timeout=70,
+                    )
+                    for event in stream:
+                        if self._is_watch_error_event(event, target_id):
+                            self._last_resource_versions[target_id] = None
+                            break
+                        pod_obj = event["object"]
+                        self._update_pod_membership(
+                            event["type"], pod_obj.metadata.name
+                        )
+                        self._last_resource_versions[
+                            target_id
+                        ] = pod_obj.metadata.resource_version
+                except ApiException as e:
+                    if e.status == 410:
+                        logger.warning(
+                            "Resource version expired for pod-membership watch, "
+                            "will re-list pods and resume"
+                        )
+                        self._last_resource_versions[target_id] = None
+                    else:
+                        logger.error(f"Kubernetes API error watching pods: {e}")
+                        self._stop_event.wait(5)
+                except Exception as e:
+                    logger.error(f"Error watching Kubernetes pods: {e}")
+                    self._stop_event.wait(5)
+        finally:
+            w.stop()
+            with self._watches_lock:
+                self._active_watches.pop(target_id, None)
+
+    def _update_pod_membership(self, event_type: str, pod_name: str) -> None:
+        """Apply a single pod watch event to the membership cache."""
+        with self._pods_lock:
+            if event_type == "DELETED":
+                self._cluster_pod_names.discard(pod_name)
+                self._non_cluster_pod_names.pop(pod_name, None)
+            elif event_type in ("ADDED", "MODIFIED"):
+                self._cluster_pod_names.add(pod_name)
+                self._non_cluster_pod_names.pop(pod_name, None)
+            else:
+                logger.debug(
+                    f"Ignored unexpected pod watch event type: {event_type} for pod {pod_name}"
+                )
+
+    def _run_pod_events_watch(self) -> None:
+        """Watch namespace-wide pod events, dropping events for non-ray-cluster pods.
+
+        K8s field selectors don't support set membership across pod names,
+        so we open a single watch scoped to `involvedObject.kind=Pod` and
+        filter client-side via `_resolve_cluster_pod`.
+        """
+        if not self._k8s_v1_api or not watch:
+            logger.warning(
+                "Halting pod-events watcher: "
+                "Kubernetes client or watch library is not initialized."
+            )
+            return
+
+        logger.info("Starting Kubernetes pod-events watcher")
+
+        w = watch.Watch()
+        target_id = POD_EVENTS_WATCH_ID
+        with self._watches_lock:
+            self._active_watches[target_id] = w
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    stream = w.stream(
+                        self._k8s_v1_api.list_namespaced_event,
+                        namespace=self._namespace,
+                        field_selector="involvedObject.kind=Pod",
+                        resource_version=self._last_resource_versions.get(target_id),
+                        timeout_seconds=60,
+                        _request_timeout=70,
+                    )
+                    for event in stream:
+                        if self._is_watch_error_event(event, target_id):
+                            self._last_resource_versions[target_id] = None
+                            break
+                        k8s_event_obj = event["object"]
+                        if self._resolve_cluster_pod(
+                            k8s_event_obj.involved_object.name
+                        ):
+                            self._process_k8s_event(k8s_event_obj)
+                        self._last_resource_versions[
+                            target_id
+                        ] = k8s_event_obj.metadata.resource_version
+                except ApiException as e:
+                    if e.status == 410:
+                        logger.warning(
+                            "Resource version expired for pod-events watch, "
+                            "re-listing to resume"
+                        )
+                        # We intentionally set resource_version to None to replay the event
+                        # history for the namespace. This prevents us from missing any events
+                        # that occurred while the watch was disconnected. We rely on the
+                        # downstream event system to deduplicate the replayed historical events.
+                        self._last_resource_versions[target_id] = None
+                    else:
+                        logger.error(f"Kubernetes API error watching pod events: {e}")
+                        self._stop_event.wait(5)
+                except Exception as e:
+                    logger.error(f"Error watching Kubernetes pod events: {e}")
+                    self._stop_event.wait(5)
+        finally:
+            w.stop()
+            with self._watches_lock:
+                self._active_watches.pop(target_id, None)
+
+    def _is_watch_error_event(self, event, target_id):
+        if event.get("type") == "ERROR":
+            logger.warning(
+                f"Error watching {target_id}, re-esablishing stream: "
+                f"{event.get('raw_object', event.get('object'))}"
+            )
+            return True
+        return False
+
+    def _latest_event_resource_version(self) -> Optional[str]:
+        """Return the latest event resource version of the namespace's
+        event collection via a minimal LIST or None on failure."""
+        if not self._k8s_v1_api:
+            return None
+        try:
+            events = self._k8s_v1_api.list_namespaced_event(
+                namespace=self._namespace,
+                field_selector="involvedObject.kind=Pod",
+                limit=1,
+                # resource version = "0" serves this LIST from the apiserver's
+                # watch cache instead of a quorum read against etcd.
+                resource_version="0",
+                resource_version_match="NotOlderThan",
+                _request_timeout=30,
+            )
+            return events.metadata.resource_version
+        except ApiException as e:
+            logger.error(
+                f"Kubernetes API error fetching latest event resource version: {e}"
+            )
+            return None
+
+    def _resolve_cluster_pod(self, pod_name: str) -> bool:
+        """Return whether pod_name belongs to this cluster."""
+        with self._pods_lock:
+            if pod_name in self._cluster_pod_names:
+                return True
+            if pod_name in self._non_cluster_pod_names:
+                return False
+        is_member = self._lookup_pod_is_member(pod_name)
+        if is_member is None:
+            return False
+
+        with self._pods_lock:
+            # Re-check cache in case the watch updated it during the HTTP GET
+            if pod_name in self._cluster_pod_names:
+                return True
+
+            if is_member:
+                self._cluster_pod_names.add(pod_name)
+            else:
+                while len(self._non_cluster_pod_names) >= MAX_NON_CLUSTER_POD_CACHE:
+                    self._non_cluster_pod_names.popitem(last=False)
+                self._non_cluster_pod_names[pod_name] = None
+        return is_member
+
+    def _lookup_pod_is_member(self, pod_name: str) -> Optional[bool]:
+        """GET a single pod to authoritatively determine cluster membership."""
+        if not self._k8s_v1_api:
+            return None
+        try:
+            pod = self._k8s_v1_api.read_namespaced_pod(
+                name=pod_name, namespace=self._namespace, _request_timeout=30
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return False
+            logger.error(f"Failed to resolve membership for pod {pod_name}: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Error looking up pod {pod_name}: {e}")
+            raise
+        labels = pod.metadata.labels or {}
+        return labels.get(KUBERAY_LABEL_KEY_CLUSTER) == self._cluster_name
 
     def _process_k8s_event(self, event_obj: Any) -> None:
         """Parse a K8s event into a RayEvent proto and deliver it via the
@@ -232,7 +565,11 @@ class KubernetesEventProvider(PlatformEventProvider):
         involved_object = event_obj.involved_object
         uid = event_obj.metadata.uid
 
-        event_timestamp = event_obj.last_timestamp or event_obj.first_timestamp
+        event_timestamp = (
+            event_obj.last_timestamp
+            or event_obj.first_timestamp
+            or event_obj.event_time
+        )
         timestamp = Timestamp()
         if event_timestamp:
             timestamp.FromDatetime(event_timestamp)

--- a/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py
+++ b/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py
@@ -8,10 +8,13 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+from kubernetes.client.rest import ApiException
 
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.core.generated.platform_event_pb2 import Source
 from ray.dashboard.modules.platform_events.providers.k8s_provider import (
+    KUBERAY_LABEL_KEY_CLUSTER,
+    MAX_NON_CLUSTER_POD_CACHE,
     KubernetesEventProvider,
 )
 
@@ -27,6 +30,7 @@ def _make_k8s_event(
     count: int = 1,
     last_timestamp: datetime = None,
     first_timestamp: datetime = None,
+    event_timestamp: datetime = None,
     component: str = "kubelet",
 ) -> MagicMock:
     evt = MagicMock()
@@ -41,6 +45,7 @@ def _make_k8s_event(
     evt.count = count
     evt.last_timestamp = last_timestamp
     evt.first_timestamp = first_timestamp
+    evt.event_time = event_timestamp
     evt.source.component = component
     return evt
 
@@ -183,6 +188,185 @@ def test_timestamp_falls_back_to_first_timestamp():
 
     assert delivered_event is not None
     assert delivered_event.timestamp.seconds == int(ts.timestamp())
+
+
+@pytest.mark.parametrize(
+    "event_type,expected_present",
+    [
+        ("ADDED", True),
+        ("MODIFIED", True),
+        ("DELETED", False),
+    ],
+)
+def test_update_pod_membership(event_type, expected_present):
+    provider = KubernetesEventProvider(lambda e: None)
+    # Seed so DELETED has something to remove.
+    provider._cluster_pod_names.add("ray-worker-0")
+
+    provider._update_pod_membership(event_type, "ray-worker-0")
+
+    assert ("ray-worker-0" in provider._cluster_pod_names) is expected_present
+
+
+def test_update_pod_membership_delete_unknown_is_noop():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._update_pod_membership("DELETED", "never-added")
+    assert "never-added" not in provider._cluster_pod_names
+
+
+def test_relist_pod_membership_replaces_cache():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._namespace = "ns"
+
+    provider._cluster_pod_names = {"stale-pod", "ray-worker-0"}
+
+    live = MagicMock()
+    live.metadata.resource_version = "999"
+    live.items = [MagicMock(), MagicMock()]
+    live.items[0].metadata.name = "ray-worker-0"
+    live.items[1].metadata.name = "ray-worker-1"
+    provider._k8s_v1_api = MagicMock()
+    provider._k8s_v1_api.list_namespaced_pod.return_value = live
+
+    rv = provider._relist_pod_membership(f"{KUBERAY_LABEL_KEY_CLUSTER}=foo")
+
+    assert rv == "999"
+    assert provider._cluster_pod_names == {"ray-worker-0", "ray-worker-1"}
+    assert "stale-pod" not in provider._cluster_pod_names
+
+
+def test_pod_event_dispatched_only_for_cluster_pods():
+    delivered = []
+
+    def callback(event: RayEvent):
+        delivered.append(event)
+
+    provider = KubernetesEventProvider(callback)
+    provider._cluster_name = "my-cluster"
+    provider._update_pod_membership("ADDED", "ray-worker-0")
+    provider._k8s_v1_api = MagicMock()
+    provider._k8s_v1_api.read_namespaced_pod.return_value = _make_pod(
+        "some-other-pod", "other-cluster"
+    )
+
+    # Event for a pod in this cluster — should be delivered.
+    in_cluster_evt = _make_k8s_event(
+        uid="uid-1", kind="Pod", name="ray-worker-0", reason="Scheduled"
+    )
+    if provider._resolve_cluster_pod(in_cluster_evt.involved_object.name):
+        provider._process_k8s_event(in_cluster_evt)
+
+    # Event for a pod outside this cluster — should be filtered out.
+    other_evt = _make_k8s_event(
+        uid="uid-2", kind="Pod", name="some-other-pod", reason="Scheduled"
+    )
+    if provider._resolve_cluster_pod(other_evt.involved_object.name):
+        provider._process_k8s_event(other_evt)
+
+    assert len(delivered) == 1
+    assert delivered[0].event_id == b"uid-1"
+    assert delivered[0].platform_event.object_kind == "Pod"
+    assert delivered[0].platform_event.object_name == "ray-worker-0"
+
+
+def _make_pod(name: str, cluster_label: str) -> MagicMock:
+    pod = MagicMock()
+    pod.metadata.name = name
+    pod.metadata.labels = (
+        {KUBERAY_LABEL_KEY_CLUSTER: cluster_label} if cluster_label is not None else {}
+    )
+    return pod
+
+
+def test_resolve_cluster_pod_positive_cache_hit_skips_get():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._k8s_v1_api = MagicMock()
+    provider._cluster_pod_names.add("ray-worker-0")
+
+    assert provider._resolve_cluster_pod("ray-worker-0") is True
+    provider._k8s_v1_api.read_namespaced_pod.assert_not_called()
+
+
+def test_resolve_cluster_pod_negative_cache_hit_skips_get():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._k8s_v1_api = MagicMock()
+    provider._non_cluster_pod_names["other-pod"] = None
+
+    assert provider._resolve_cluster_pod("other-pod") is False
+    provider._k8s_v1_api.read_namespaced_pod.assert_not_called()
+
+
+def test_resolve_cluster_pod_cold_miss_matching_label_caches_positive():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._cluster_name = "my-cluster"
+    provider._namespace = "ns"
+    provider._k8s_v1_api = MagicMock()
+    provider._k8s_v1_api.read_namespaced_pod.return_value = _make_pod(
+        "ray-worker-1", "my-cluster"
+    )
+
+    assert provider._resolve_cluster_pod("ray-worker-1") is True
+    assert "ray-worker-1" in provider._cluster_pod_names
+    # A second resolution is served from cache without re-issuing the GET.
+    provider._resolve_cluster_pod("ray-worker-1")
+    provider._k8s_v1_api.read_namespaced_pod.assert_called_once()
+
+
+def test_resolve_cluster_pod_cold_miss_not_matching_label_caches_negative():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._cluster_name = "my-cluster"
+    provider._namespace = "ns"
+    provider._k8s_v1_api = MagicMock()
+    provider._k8s_v1_api.read_namespaced_pod.return_value = _make_pod(
+        "other-pod", "other-cluster"
+    )
+    assert provider._resolve_cluster_pod("other-pod") is False
+    assert "other-pod" in provider._non_cluster_pod_names
+    provider._resolve_cluster_pod("other-pod")
+    provider._k8s_v1_api.read_namespaced_pod.assert_called_once()
+
+
+def test_resolve_cluster_pod_deleted_pod_counts_as_not_member():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._cluster_name = "my-cluster"
+    provider._namespace = "ns"
+    provider._k8s_v1_api = MagicMock()
+    provider._k8s_v1_api.read_namespaced_pod.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+    assert provider._resolve_cluster_pod("gone-pod") is False
+    assert "gone-pod" in provider._non_cluster_pod_names
+
+
+def test_resolve_cluster_pod_negative_cache_is_bounded():
+    provider = KubernetesEventProvider(lambda e: None)
+    provider._cluster_name = "my-cluster"
+    provider._namespace = "ns"
+    provider._k8s_v1_api = MagicMock()
+    provider._k8s_v1_api.read_namespaced_pod.side_effect = (
+        lambda name, namespace, _request_timeout: _make_pod(name, "other-cluster")
+    )
+
+    for i in range(MAX_NON_CLUSTER_POD_CACHE + 5):
+        provider._resolve_cluster_pod(f"other-pod-{i}")
+
+    assert len(provider._non_cluster_pod_names) <= MAX_NON_CLUSTER_POD_CACHE
+    assert "other-pod-0" not in provider._non_cluster_pod_names
+    assert (
+        f"other-pod-{MAX_NON_CLUSTER_POD_CACHE + 4}" in provider._non_cluster_pod_names
+    )
+
+
+def test_membership_add_or_delete_purges_negative_cache_entry():
+    provider = KubernetesEventProvider(lambda e: None)
+
+    provider._non_cluster_pod_names["ray-worker-2"] = None
+    provider._update_pod_membership("ADDED", "ray-worker-2")
+    assert "ray-worker-2" not in provider._non_cluster_pod_names
+
+    provider._non_cluster_pod_names["ray-worker-3"] = None
+    provider._update_pod_membership("DELETED", "ray-worker-3")
+    assert "ray-worker-3" not in provider._non_cluster_pod_names
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Add a client-side filtered, namespace-wide event watch to ingest and surface Kubernetes Pod events (e.g. OOMKilled, Evicted, scheduling issues) in the Ray Dashboard Head.

## Additional information
Tested on GKE cluster atop https://github.com/ray-project/ray/pull/63332

<img width="3326" height="1980" alt="image" src="https://github.com/user-attachments/assets/8fe14eb9-c9fa-409e-a6ca-245c0b04e56c" />

<img width="3428" height="1576" alt="image" src="https://github.com/user-attachments/assets/dd0fe046-62a4-4e7d-ac17-7f6d2ee614b1" />
