### PR TITLE
[Serve] Fix vLLM bundle indices mismatch in DP gang scheduling

### DIFF
--- a/python/ray/llm/_internal/serve/serving_patterns/data_parallel/dp_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/data_parallel/dp_server.py
@@ -235,7 +235,13 @@ class DPServer(LLMServer):
         Returns:
             Comma-separated bundle indices, e.g. "0,2".
         """
-        start = dp_rank * bundles_per_replica
+        dp_size = len(sorted_indices) // bundles_per_replica
+        sorted_ranks = sorted(
+            range(dp_size),
+            key=lambda rank: sorted_indices.index(rank * bundles_per_replica),
+        )
+        rank_idx = sorted_ranks.index(dp_rank)
+        start = rank_idx * bundles_per_replica
         return ",".join(
             str(sorted_indices[start + i]) for i in range(bundles_per_replica)
         )

--- a/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_server.py
@@ -176,7 +176,7 @@ class TestBundleIndices:
             ),
             # Out-of-order sorted_indices: bundles reordered by node
             ({"tensor_parallel_size": 2}, None, 1, [0, 2, 1, 3], "1,3"),
-            ({"tensor_parallel_size": 1}, None, 0, [2, 0, 3, 1], "2"),
+            ({"tensor_parallel_size": 1}, None, 0, [2, 0, 3, 1], "0"),
         ],
     )
     def test_bundle_indices(


### PR DESCRIPTION
## Description

This PR fixes a bug in Ray Serve's Data Parallel (DP) gang scheduling for vLLM where replica actors are scheduled on a specific node but assigned vLLM bundle indices belonging to a different node.

### What happened
When using Ray Serve Gang Scheduling with a DP deployment (`data_parallel_size=2`, `data_parallel_backend="ray"`, `TP=1`, `PP=1`) across multiple nodes, the vLLM engine worker is scheduled on the wrong node, leading to `RuntimeError: Every node should have a unique IP address.`

### Root Cause
In `python/ray/llm/_internal/serve/serving_patterns/data_parallel/dp_server.py`, the `_compute_bundle_indices()` method uses `dp_rank * bundles_per_replica` to slice into `sorted_indices` (bundle indices reordered by node, driver node first). However, `dp_rank` follows the original PG bundle allocation order from Ray's PACK strategy, which does not necessarily match `sorted_indices` ordering.

When PACK places bundle 0 on a non-driver node, `sorted_indices` places the driver node's bundle (bundle 1) first at index 0. The method then assigns `sorted_indices[0]` (bundle 1 on driver node) to `dp_rank=0`, even though `dp_rank=0`'s replica is on the non-driver node. This mismatch splits the EngineCore and its vLLM worker across different physical nodes.

### Proposed Changes
This patch fixes the issue by mapping the `dp_rank` to the correct position of its first bundle inside `sorted_indices` using `sorted_indices.index(first_bundle)`. This ensures that each DP replica is assigned to the bundle indices that reside on its local node.

---

## Related issues

Closes #63917.

---

## Additional information

### Verification
- Updated and ran the unit tests in `python/ray/llm/tests/serve/cpu/deployments/data_parallel/test_dp_server.py`. All tests passed successfully.
