### PR TITLE
[core] Fix event_logger and export_event_logger to flush all handlers safely

### DIFF
--- a/python/ray/_private/event/event_logger.py
+++ b/python/ray/_private/event/event_logger.py
@@ -100,8 +100,12 @@ class EventLoggerAdapter:
             )
         )
 
-        # Force flush so that we won't lose events
-        self.logger.handlers[0].flush()
+        # Force flush all handlers so that we won't lose events.
+        for handler in self.logger.handlers[:]:
+            try:
+                handler.flush()
+            except Exception:
+                global_logger.exception("Failed to flush event logger handler.")
 
 
 def _build_event_file_logger(source: Event.SourceType, sink_dir: str):

--- a/python/ray/_private/event/export_event_logger.py
+++ b/python/ray/_private/event/export_event_logger.py
@@ -118,8 +118,12 @@ class ExportEventLoggerAdapter:
         event_as_str = self._export_event_to_string(event)
 
         self.logger.info(event_as_str)
-        # Force flush so that we won't lose events
-        self.logger.handlers[0].flush()
+        # Force flush all handlers so that we won't lose events.
+        for handler in self.logger.handlers[:]:
+            try:
+                handler.flush()
+            except Exception:
+                global_logger.exception("Failed to flush export event logger handler.")
 
     def _create_export_event(self, event_data: ExportEventDataType) -> ExportEvent:
         event = ExportEvent()

--- a/python/ray/dashboard/modules/event/tests/test_event.py
+++ b/python/ray/dashboard/modules/event/tests/test_event.py
@@ -724,9 +724,7 @@ def test_export_event_logger_flushes_all_handlers():
     handlers = [MagicMock() for _ in range(3)]
     mock_logger.handlers = handlers
 
-    adapter = ExportEventLoggerAdapter(
-        EventLogType.SUBMISSION_JOB, mock_logger
-    )
+    adapter = ExportEventLoggerAdapter(EventLogType.SUBMISSION_JOB, mock_logger)
     event_data = export_submission_job_event_pb2.ExportSubmissionJobEventData(
         submission_job_id="submission_job_id0",
         status=(
@@ -745,9 +743,7 @@ def test_export_event_logger_allows_empty_handlers():
     mock_logger = MagicMock()
     mock_logger.handlers = []
 
-    adapter = ExportEventLoggerAdapter(
-        EventLogType.SUBMISSION_JOB, mock_logger
-    )
+    adapter = ExportEventLoggerAdapter(EventLogType.SUBMISSION_JOB, mock_logger)
     event_data = export_submission_job_event_pb2.ExportSubmissionJobEventData(
         submission_job_id="submission_job_id0",
         status=(
@@ -766,9 +762,7 @@ def test_export_event_logger_continues_flushing_after_handler_error():
     handler2 = MagicMock()
     mock_logger.handlers = [handler1, handler2]
 
-    adapter = ExportEventLoggerAdapter(
-        EventLogType.SUBMISSION_JOB, mock_logger
-    )
+    adapter = ExportEventLoggerAdapter(EventLogType.SUBMISSION_JOB, mock_logger)
     event_data = export_submission_job_event_pb2.ExportSubmissionJobEventData(
         submission_job_id="submission_job_id0",
         status=(

--- a/python/ray/dashboard/modules/event/tests/test_event.py
+++ b/python/ray/dashboard/modules/event/tests/test_event.py
@@ -11,6 +11,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pprint import pprint
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -20,12 +21,14 @@ import ray
 from ray._common.test_utils import wait_for_condition
 from ray._common.utils import binary_to_hex
 from ray._private.event.event_logger import (
+    EventLoggerAdapter,
     filter_event_by_level,
     get_event_id,
     get_event_logger,
 )
 from ray._private.event.export_event_logger import (
     EventLogType,
+    ExportEventLoggerAdapter,
     get_export_event_logger,
 )
 from ray._private.protobuf_compat import message_to_dict
@@ -694,6 +697,89 @@ def test_export_event_logger(tmp_path):
             preserving_proto_field_name=True,
             use_integers_for_enums=False,
         )
+
+
+def test_event_logger_flushes_all_handlers():
+    mock_logger = MagicMock()
+    handlers = [MagicMock() for _ in range(3)]
+    mock_logger.handlers = handlers
+
+    adapter = EventLoggerAdapter(event_pb2.Event.GCS, mock_logger)
+    adapter.info("message")
+
+    for handler in handlers:
+        handler.flush.assert_called_once()
+
+
+def test_event_logger_allows_empty_handlers():
+    mock_logger = MagicMock()
+    mock_logger.handlers = []
+
+    adapter = EventLoggerAdapter(event_pb2.Event.GCS, mock_logger)
+    adapter.info("message")
+
+
+def test_export_event_logger_flushes_all_handlers():
+    mock_logger = MagicMock()
+    handlers = [MagicMock() for _ in range(3)]
+    mock_logger.handlers = handlers
+
+    adapter = ExportEventLoggerAdapter(
+        EventLogType.SUBMISSION_JOB, mock_logger
+    )
+    event_data = export_submission_job_event_pb2.ExportSubmissionJobEventData(
+        submission_job_id="submission_job_id0",
+        status=(
+            export_submission_job_event_pb2.ExportSubmissionJobEventData.JobStatus.RUNNING
+        ),
+        entrypoint="ls",
+        metadata={},
+    )
+    adapter.send_event(event_data)
+
+    for handler in handlers:
+        handler.flush.assert_called_once()
+
+
+def test_export_event_logger_allows_empty_handlers():
+    mock_logger = MagicMock()
+    mock_logger.handlers = []
+
+    adapter = ExportEventLoggerAdapter(
+        EventLogType.SUBMISSION_JOB, mock_logger
+    )
+    event_data = export_submission_job_event_pb2.ExportSubmissionJobEventData(
+        submission_job_id="submission_job_id0",
+        status=(
+            export_submission_job_event_pb2.ExportSubmissionJobEventData.JobStatus.RUNNING
+        ),
+        entrypoint="ls",
+        metadata={},
+    )
+    adapter.send_event(event_data)
+
+
+def test_export_event_logger_continues_flushing_after_handler_error():
+    mock_logger = MagicMock()
+    handler1 = MagicMock()
+    handler1.flush.side_effect = RuntimeError("flush failed")
+    handler2 = MagicMock()
+    mock_logger.handlers = [handler1, handler2]
+
+    adapter = ExportEventLoggerAdapter(
+        EventLogType.SUBMISSION_JOB, mock_logger
+    )
+    event_data = export_submission_job_event_pb2.ExportSubmissionJobEventData(
+        submission_job_id="submission_job_id0",
+        status=(
+            export_submission_job_event_pb2.ExportSubmissionJobEventData.JobStatus.RUNNING
+        ),
+        entrypoint="ls",
+        metadata={},
+    )
+    adapter.send_event(event_data)
+
+    handler2.flush.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Fixes a `handlers[0].flush()` bug found in two files in the event subsystem.
Both `_emit()` and `send_event()` had the same three problems:

- **IndexError risk** — `handlers[0]` raises if the list is empty
- **Silent event loss** — only the first handler was ever flushed; events in
  all other handlers were lost on crash or shutdown
- **Exception propagation** — if `handlers[0].flush()` raised, subsequent
  handlers were never reached (flagged in review of #61956, never fixed)

The `export_event_logger` bug is especially impactful for users relying on
external collectors via `RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR`.

## Changes

Both files now use:

```python
for handler in self.logger.handlers:
    try:
        handler.flush()
    except Exception:
        pass
```

## Files changed

- `python/ray/_private/event/event_logger.py` — fixed `_emit()`
- `python/ray/_private/event/export_event_logger.py` — fixed `send_event()`
- `python/ray/dashboard/modules/event/tests/test_event.py` — 5 new regression tests

## Tests

Added 5 regression tests covering both loggers:

- `test_event_logger_flushes_all_handlers` — all handlers flushed, not just index 0
- `test_event_logger_allows_empty_handlers` — no IndexError when handler list is empty
- `test_export_event_logger_flushes_all_handlers` — same, for `send_event()`
- `test_export_event_logger_allows_empty_handlers` — same, for `send_event()`
- `test_export_event_logger_continues_flushing_after_handler_error` — a failing handler does not block subsequent handlers

Local run (Windows, Python 3.11.9, pytest 7.4.4):

```
$ python -m pytest ray\dashboard\modules\event\tests\test_event.py -k "event_logger or export_event_logger" -v

test_event.py::test_python_global_event_logger                                 PASSED
test_event.py::test_export_event_logger                                        PASSED
test_event.py::test_event_logger_flushes_all_handlers                          PASSED
test_event.py::test_event_logger_allows_empty_handlers                         PASSED
test_event.py::test_export_event_logger_flushes_all_handlers                   PASSED
test_event.py::test_export_event_logger_allows_empty_handlers                  PASSED
test_event.py::test_export_event_logger_continues_flushing_after_handler_error PASSED

Results (3.56s): 7 passed, 11 deselected
```

## Related

Closes #61873
Extends #61956 (closed stale — missed `export_event_logger.py` and the exception-safety gap)

## Checklist

- [x] Signed off every commit (`git commit -s`)
- [x] Only three intended files in this PR
- [x] 5 new regression tests, 7 total pass locally