### PR TITLE
[serve.llm] Make request.request_id authoritative for the engine

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -97,7 +97,10 @@ def _canonicalize_request_id_header(
         if k.replace("_", "-").lower() != "x-request-id"
     }
     headers["x-request-id"] = str(rid)
-    return RawRequestInfo(headers=headers)
+    if raw_request_info is None:
+        return RawRequestInfo(headers=headers)
+    # Preserve any non-header fields RawRequestInfo carries (now or in the future).
+    return dataclasses.replace(raw_request_info, headers=headers)
 
 
 def _convert_config_dicts(merged: dict) -> dict:

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -75,6 +75,31 @@ vllm = try_import("vllm")
 logger = get_logger(__name__)
 
 
+def _canonicalize_request_id_header(
+    request: Any, raw_request_info: Optional[RawRequestInfo]
+) -> Optional[RawRequestInfo]:
+    """Ensure raw_request_info carries X-Request-Id == request.request_id so vLLM's
+    OpenAI layer (which prefers the header) sees the authoritative request id.
+
+    Returns a RawRequestInfo (new or mutated) with a single, correctly-cased header.
+    If the request has no request_id, this is a no-op and returns raw_request_info
+    unchanged (so embeddings/score/transcription requests are unaffected).
+    """
+    rid = getattr(request, "request_id", None)
+    if not rid:
+        return raw_request_info
+    headers = dict(raw_request_info.headers) if raw_request_info is not None else {}
+    # Drop any existing variant of the header (case- and separator-insensitive,
+    # e.g. "X-Request-Id" or "x_request_id") before setting the canonical one.
+    headers = {
+        k: v
+        for k, v in headers.items()
+        if k.replace("_", "-").lower() != "x-request-id"
+    }
+    headers["x-request-id"] = str(rid)
+    return RawRequestInfo(headers=headers)
+
+
 def _convert_config_dicts(merged: dict) -> dict:
     """Convert dict values to their proper vLLM config classes based on type hints.
 
@@ -556,6 +581,7 @@ class VLLMEngine(LLMEngine):
             yield error
             return
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
@@ -590,6 +616,7 @@ class VLLMEngine(LLMEngine):
             yield error
             return
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
@@ -626,6 +653,7 @@ class VLLMEngine(LLMEngine):
             yield error
             return
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
@@ -654,6 +682,7 @@ class VLLMEngine(LLMEngine):
         # Extract audio data from the request file
         audio_data = await request.file.read()
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
@@ -691,6 +720,7 @@ class VLLMEngine(LLMEngine):
             yield error
             return
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
@@ -716,6 +746,7 @@ class VLLMEngine(LLMEngine):
             yield error
             return
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
@@ -742,6 +773,7 @@ class VLLMEngine(LLMEngine):
             yield error
             return
 
+        raw_request_info = _canonicalize_request_id_header(request, raw_request_info)
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -14,7 +14,11 @@ from ray.llm._internal.serve.core.configs.llm_config import (
     LoraConfig,
     ModelLoadingConfig,
 )
+from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
+from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+    _canonicalize_request_id_header,
+)
 from ray.llm.tests.serve.mocks.mock_vllm_engine import (
     FakeLoraModelLoader,
     MockVLLMEngine,
@@ -697,19 +701,9 @@ class TestGetDeploymentOptions:
 class TestCanonicalizeRequestIdHeader:
     """Unit tests for the X-Request-Id header canonicalization helper."""
 
-    @staticmethod
-    def _canonicalize():
-        from ray.llm._internal.serve.engines.vllm.vllm_engine import (
-            _canonicalize_request_id_header,
-        )
-
-        return _canonicalize_request_id_header
-
     def test_uncanonical_variants_dropped(self):
         """Any case/separator variant of the header is dropped and replaced by a
         single canonical ``x-request-id`` equal to ``request.request_id``."""
-        from ray.llm._internal.serve.core.protocol import RawRequestInfo
-
         request = SimpleNamespace(request_id="canonical-id")
         raw = RawRequestInfo(
             headers={
@@ -718,7 +712,7 @@ class TestCanonicalizeRequestIdHeader:
                 "content-type": "application/json",
             }
         )
-        out = self._canonicalize()(request, raw)
+        out = _canonicalize_request_id_header(request, raw)
 
         rid_keys = [
             k for k in out.headers if k.replace("_", "-").lower() == "x-request-id"
@@ -730,10 +724,11 @@ class TestCanonicalizeRequestIdHeader:
 
     def test_noop_when_request_id_unset(self):
         """With no request_id the helper is a no-op (returns the same object)."""
-        from ray.llm._internal.serve.core.protocol import RawRequestInfo
-
         raw = RawRequestInfo(headers={"x-request-id": "keep"})
-        assert self._canonicalize()(SimpleNamespace(request_id=None), raw) is raw
+        assert (
+            _canonicalize_request_id_header(SimpleNamespace(request_id=None), raw)
+            is raw
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import time
+from types import SimpleNamespace
 from typing import AsyncGenerator, Optional
 from unittest.mock import patch
 
@@ -691,6 +692,48 @@ class TestGetDeploymentOptions:
 
         assert "placement_group_bundles" not in serve_options
         assert "placement_group_strategy" not in serve_options
+
+
+class TestCanonicalizeRequestIdHeader:
+    """Unit tests for the X-Request-Id header canonicalization helper."""
+
+    @staticmethod
+    def _canonicalize():
+        from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+            _canonicalize_request_id_header,
+        )
+
+        return _canonicalize_request_id_header
+
+    def test_uncanonical_variants_dropped(self):
+        """Any case/separator variant of the header is dropped and replaced by a
+        single canonical ``x-request-id`` equal to ``request.request_id``."""
+        from ray.llm._internal.serve.core.protocol import RawRequestInfo
+
+        request = SimpleNamespace(request_id="canonical-id")
+        raw = RawRequestInfo(
+            headers={
+                "X-Request-ID": "stale-upper",
+                "x_request_id": "stale-underscore",
+                "content-type": "application/json",
+            }
+        )
+        out = self._canonicalize()(request, raw)
+
+        rid_keys = [
+            k for k in out.headers if k.replace("_", "-").lower() == "x-request-id"
+        ]
+        assert rid_keys == ["x-request-id"], rid_keys
+        assert out.headers["x-request-id"] == "canonical-id"
+        # Unrelated headers are preserved.
+        assert out.headers["content-type"] == "application/json"
+
+    def test_noop_when_request_id_unset(self):
+        """With no request_id the helper is a no-op (returns the same object)."""
+        from ray.llm._internal.serve.core.protocol import RawRequestInfo
+
+        raw = RawRequestInfo(headers={"x-request-id": "keep"})
+        assert self._canonicalize()(SimpleNamespace(request_id=None), raw) is raw
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Make `request.request_id` the single authoritative engine request id. Today
`_maybe_add_request_id_to_request` unconditionally overwrites it with the serve-context (proxy) id,
while the vLLM OpenAI layer prefers the `X-Request-Id` header — so anything that wants to control the
engine id (e.g. a P/D orchestrator or KV-connector that encodes routing info in the id) must steer
both. This makes setting `request.request_id` sufficient.

## What
- `_maybe_add_request_id_to_request`: fill from the serve id only when `request.request_id` is unset
  (no longer clobbers an explicitly-set id).
- vLLM engine wrapper canonicalizes the `X-Request-Id` header from `request.request_id` across all
  engine methods, so the header and the request id can't disagree.

Behavior for normal requests is unchanged (unset id → filled from serve id → header stamped to match).

## Stack
Part of the KV-connector / prefill-decode series: lets a connector control the engine request id by
setting `request.request_id` alone (no header juggling).

## Testing
- `test_llm_server.py`: a preset `request_id` survives to the engine; unset still fills from serve context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
