### PR TITLE
[serve.llm] Delegate P/D orchestration to the KV-connector backend

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Optional,
@@ -49,6 +50,11 @@ from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
 )
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.serve._private.config import DeploymentConfig, handle_num_replicas_auto
+
+if TYPE_CHECKING:
+    from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+        BaseConnectorBackend,
+    )
 
 transformers = try_import("transformers")
 
@@ -255,7 +261,7 @@ class LLMConfig(BaseModelExtended):
     _model_architecture: str = PrivateAttr("UNSPECIFIED")
     _engine_config: EngineConfigType = PrivateAttr(None)
     _callback_instance: Optional[CallbackBase] = PrivateAttr(None)
-    _kv_connector_backend: Optional[Any] = PrivateAttr(None)
+    _kv_connector_backend: Optional["BaseConnectorBackend"] = PrivateAttr(None)
 
     def _load_hf_config(self, model_id_or_path: str, trust_remote_code: bool = False):
         """Load the HuggingFace config for a model.
@@ -634,7 +640,7 @@ class LLMConfig(BaseModelExtended):
         self._kv_connector_backend = kv_connector_backend
 
     @property
-    def kv_connector_backend(self) -> Optional[Any]:
+    def kv_connector_backend(self) -> Optional["BaseConnectorBackend"]:
         """The KV-connector backend instance created by ``setup_engine_backend``.
 
         Returns None if no KV transfer connector is configured, or if the

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -255,6 +255,7 @@ class LLMConfig(BaseModelExtended):
     _model_architecture: str = PrivateAttr("UNSPECIFIED")
     _engine_config: EngineConfigType = PrivateAttr(None)
     _callback_instance: Optional[CallbackBase] = PrivateAttr(None)
+    _kv_connector_backend: Optional[Any] = PrivateAttr(None)
 
     def _load_hf_config(self, model_id_or_path: str, trust_remote_code: bool = False):
         """Load the HuggingFace config for a model.
@@ -626,6 +627,20 @@ class LLMConfig(BaseModelExtended):
             kv_connector, self
         )
         kv_connector_backend.setup()
+        # 3. Stash the instance so the P/D orchestrator can reach the connector's
+        # coordination protocol (request shaping, peer binding, handoff
+        # discipline) without re-creating it. May be None on configs that never
+        # call setup_engine_backend(); the orchestrator falls back to the factory.
+        self._kv_connector_backend = kv_connector_backend
+
+    @property
+    def kv_connector_backend(self) -> Optional[Any]:
+        """The KV-connector backend instance created by ``setup_engine_backend``.
+
+        Returns None if no KV transfer connector is configured, or if the
+        backend has not been set up yet on this config copy.
+        """
+        return self._kv_connector_backend
 
 
 class DiskMultiplexConfig(BaseModelExtended):

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -1,7 +1,7 @@
 import abc
 import random
 import string
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from ray import serve
 
@@ -10,6 +10,23 @@ if TYPE_CHECKING:
 
 
 class BaseConnectorBackend(abc.ABC):
+    # ---- P/D coordination protocol ----
+    #
+    # These class attributes and methods let the P/D orchestrator
+    # (``PDOrchestratorMixin``) delegate request shaping, peer addressing, and
+    # handoff discipline to the connector. The defaults reproduce the existing
+    # NIXL/default flow exactly:
+    #   * ``requires_peer_binding`` is False, so the orchestrator routes prefill
+    #     via the standard ``handle.<method>.remote(...)`` path (no peer is
+    #     resolved before dispatch).
+    #   * ``concurrent_handoff`` is False, so prefill runs to its first chunk
+    #     before local decode starts, and decode forwards the prefill chunk's
+    #     ``kv_transfer_params``.
+    # Connectors that address peers by request id (and push KV, e.g. MORI WRITE
+    # mode) can opt into pre-dispatch peer binding + concurrent handoff.
+    requires_peer_binding: bool = False
+    concurrent_handoff: bool = False
+
     def __init__(self, llm_config: "LLMConfig"):
         """Base class for connector backends.
 
@@ -66,6 +83,68 @@ class BaseConnectorBackend(abc.ABC):
         engine_config = self.llm_config.get_engine_config()
         num_devices = engine_config.num_devices
         return rc.rank.rank * num_devices
+
+    def prepare_prefill_request(self, request: Any, peer: Optional[Dict[str, Any]]):
+        """Shape the request sent to the remote prefill engine.
+
+        The default reproduces today's NIXL/default flow: deep-copy the request,
+        stamp the standard ``kv_transfer_params`` that tell the prefill engine to
+        produce KV for a remote decode, and clamp it to a single, non-streaming
+        token (prefill only needs to run, not generate output).
+
+        Args:
+            request: The incoming chat/completion request.
+            peer: The selected prefill replica's ``replica_metadata`` dict, or
+                None when no pre-dispatch peer binding was performed (the
+                default). The default implementation ignores it.
+
+        Returns:
+            A new request object to dispatch to the prefill engine.
+        """
+        assert (
+            getattr(request, "kv_transfer_params", None) is None
+        ), "kv_transfer_params should be empty before orchestrator"
+        prefill_request = request.model_copy(deep=True)
+        prefill_request.kv_transfer_params = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+            "remote_engine_id": None,
+            "remote_block_ids": None,
+            "remote_host": None,
+            "remote_port": None,
+        }
+        prefill_request.max_tokens = 1
+        if hasattr(prefill_request, "max_completion_tokens"):
+            prefill_request.max_completion_tokens = 1
+        prefill_request.stream = False
+        if hasattr(prefill_request, "stream_options"):
+            prefill_request.stream_options = None
+        return prefill_request
+
+    def prepare_decode_request(
+        self, request: Any, peer: Optional[Dict[str, Any]], prefill_response: Any
+    ):
+        """Shape the request run on the local decode engine.
+
+        The default reproduces today's NIXL/default flow: deep-copy the request
+        and forward the ``kv_transfer_params`` that the prefill engine returned on
+        its first response chunk (``remote_block_ids``/``remote_engine_id``/...),
+        so the decode engine pulls/receives the KV produced by prefill.
+
+        Args:
+            request: The incoming chat/completion request.
+            peer: The selected prefill replica's ``replica_metadata`` dict, or
+                None (the default). The default implementation ignores it.
+            prefill_response: The captured prefill response chunk whose
+                ``kv_transfer_params`` are forwarded. In concurrent-handoff mode
+                this is None (no chunk is captured before decode starts).
+
+        Returns:
+            A new request object to run on the local decode engine.
+        """
+        decode_request = request.model_copy(deep=True)
+        decode_request.kv_transfer_params = prefill_response.kv_transfer_params
+        return decode_request
 
     def setup(self) -> None:
         """Setup the connector backend.

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -40,10 +40,18 @@ class BaseConnectorBackend(abc.ABC):
     #     (sequential handoff).
     #   * True  -> prefill dispatch and local decode run concurrently.
     #
-    # The two flags are independent. For example: a standard (pull-on-response)
-    # connector is (False, False); a push-based, request-id-addressed connector
-    # is (True, True); a pull-based request-id-addressed connector is
-    # (True, False).
+    # The two flags are independent; the known combos:
+    #   * (False, False) — e.g. NixlConnector / LMCacheConnectorV1: decode learns
+    #     everything it needs (remote engine id / block ids) from the prefill
+    #     response, so it must wait for that response (sequential).
+    #   * (True, True)   — e.g. MoRIIO WRITE mode: the peer address is bound
+    #     into the request id before dispatch and prefill *pushes* KV to decode,
+    #     so decode needs nothing from prefill's response and can start
+    #     immediately (concurrent). Concurrent handoff is only possible because
+    #     peer binding happens up front.
+    #   * (True, False)  — e.g. MoRIIO READ mode: the peer is bound up front,
+    #     but decode *pulls* KV using block ids returned in prefill's response,
+    #     so it still waits for prefill to finish (sequential).
     requires_peer_binding: bool = False
     concurrent_handoff: bool = False
 

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -1,12 +1,21 @@
 import abc
 import random
 import string
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ray import serve
 
 if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+    from ray.llm._internal.serve.core.configs.openai_api_models import (
+        ChatCompletionRequest,
+        CompletionRequest,
+    )
+
+    # The two OpenAI request models the P/D orchestrator shapes. Defined under
+    # TYPE_CHECKING (and used as a string annotation) to avoid an import cycle
+    # between this module and the config/openai-models modules.
+    RequestType = Union[ChatCompletionRequest, CompletionRequest]
 
 
 class BaseConnectorBackend(abc.ABC):
@@ -14,16 +23,27 @@ class BaseConnectorBackend(abc.ABC):
     #
     # These class attributes and methods let the P/D orchestrator
     # (``PDOrchestratorMixin``) delegate request shaping, peer addressing, and
-    # handoff discipline to the connector. The defaults reproduce the existing
-    # NIXL/default flow exactly:
-    #   * ``requires_peer_binding`` is False, so the orchestrator routes prefill
-    #     via the standard ``handle.<method>.remote(...)`` path (no peer is
-    #     resolved before dispatch).
-    #   * ``concurrent_handoff`` is False, so prefill runs to its first chunk
-    #     before local decode starts, and decode forwards the prefill chunk's
-    #     ``kv_transfer_params``.
-    # Connectors that address peers by request id (and push KV, e.g. MORI WRITE
-    # mode) can opt into pre-dispatch peer binding + concurrent handoff.
+    # handoff discipline to the connector. They are connector-agnostic: a
+    # connector picks a quadrant of (``requires_peer_binding``,
+    # ``concurrent_handoff``) and implements ``prepare_prefill_request`` /
+    # ``prepare_decode_request`` accordingly.
+    #
+    # ``requires_peer_binding``:
+    #   * False -> the orchestrator dispatches prefill via the standard handle
+    #     path; the peer (if any) is resolved post-hoc from the prefill response.
+    #   * True  -> the orchestrator selects the prefill replica first
+    #     (``choose_replica``) and passes its ``replica_metadata`` to the backend
+    #     as ``peer`` (pre-dispatch addressing).
+    #
+    # ``concurrent_handoff``:
+    #   * False -> prefill runs to its first chunk before local decode starts
+    #     (sequential handoff).
+    #   * True  -> prefill dispatch and local decode run concurrently.
+    #
+    # The two flags are independent. For example: a standard (pull-on-response)
+    # connector is (False, False); a push-based, request-id-addressed connector
+    # is (True, True); a pull-based request-id-addressed connector is
+    # (True, False).
     requires_peer_binding: bool = False
     concurrent_handoff: bool = False
 
@@ -84,22 +104,75 @@ class BaseConnectorBackend(abc.ABC):
         num_devices = engine_config.num_devices
         return rc.rank.rank * num_devices
 
-    def prepare_prefill_request(self, request: Any, peer: Optional[Dict[str, Any]]):
+    @abc.abstractmethod
+    def prepare_prefill_request(
+        self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
+    ) -> "RequestType":
         """Shape the request sent to the remote prefill engine.
-
-        The default reproduces today's NIXL/default flow: deep-copy the request,
-        stamp the standard ``kv_transfer_params`` that tell the prefill engine to
-        produce KV for a remote decode, and clamp it to a single, non-streaming
-        token (prefill only needs to run, not generate output).
 
         Args:
             request: The incoming chat/completion request.
-            peer: The selected prefill replica's ``replica_metadata`` dict, or
-                None when no pre-dispatch peer binding was performed (the
-                default). The default implementation ignores it.
+            peer: The selected prefill replica's ``replica_metadata`` dict when
+                the connector opted into pre-dispatch peer binding
+                (``requires_peer_binding=True``), else None.
 
         Returns:
             A new request object to dispatch to the prefill engine.
+        """
+        ...
+
+    @abc.abstractmethod
+    def prepare_decode_request(
+        self,
+        *,
+        request: "RequestType",
+        peer: Optional[Dict[str, Any]],
+        prefill_response: Optional[Any],
+    ) -> "RequestType":
+        """Shape the request run on the local decode engine.
+
+        Args:
+            request: The incoming chat/completion request.
+            peer: The selected prefill replica's ``replica_metadata`` dict when
+                the connector opted into pre-dispatch peer binding, else None.
+            prefill_response: The captured prefill response chunk whose
+                ``kv_transfer_params`` may be forwarded, or None when no chunk is
+                captured before decode starts (concurrent-handoff mode).
+
+        Returns:
+            A new request object to run on the local decode engine.
+        """
+        ...
+
+    def setup(self) -> None:
+        """Setup the connector backend.
+
+        This method is called to setup the connector backend.
+        """
+        pass
+
+
+class DefaultPDProtocolMixin:
+    """The default P/D protocol policy: no peer binding, sequential handoff.
+
+    Implements ``prepare_prefill_request`` / ``prepare_decode_request`` for
+    connectors that follow the standard policy: the prefill engine is told to
+    produce KV for a remote decode (clamped to a single non-streaming token),
+    and the decode engine forwards the ``kv_transfer_params`` that the prefill
+    engine returned on its first response chunk.
+
+    Mix this in *before* ``BaseConnectorBackend`` in a backend's bases so its
+    concrete methods satisfy the abstract methods.
+    """
+
+    def prepare_prefill_request(
+        self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
+    ) -> "RequestType":
+        """Shape the prefill request under the default P/D protocol policy.
+
+        Deep-copies the request, stamps the standard ``kv_transfer_params`` that
+        tell the prefill engine to produce KV for a remote decode, and clamps it
+        to a single, non-streaming token. ``peer`` is ignored.
         """
         assert (
             getattr(request, "kv_transfer_params", None) is None
@@ -122,33 +195,33 @@ class BaseConnectorBackend(abc.ABC):
         return prefill_request
 
     def prepare_decode_request(
-        self, request: Any, peer: Optional[Dict[str, Any]], prefill_response: Any
-    ):
-        """Shape the request run on the local decode engine.
+        self,
+        *,
+        request: "RequestType",
+        peer: Optional[Dict[str, Any]],
+        prefill_response: Optional[Any],
+    ) -> "RequestType":
+        """Shape the decode request under the default P/D protocol policy.
 
-        The default reproduces today's NIXL/default flow: deep-copy the request
-        and forward the ``kv_transfer_params`` that the prefill engine returned on
-        its first response chunk (``remote_block_ids``/``remote_engine_id``/...),
-        so the decode engine pulls/receives the KV produced by prefill.
-
-        Args:
-            request: The incoming chat/completion request.
-            peer: The selected prefill replica's ``replica_metadata`` dict, or
-                None (the default). The default implementation ignores it.
-            prefill_response: The captured prefill response chunk whose
-                ``kv_transfer_params`` are forwarded. In concurrent-handoff mode
-                this is None (no chunk is captured before decode starts).
-
-        Returns:
-            A new request object to run on the local decode engine.
+        Deep-copies the request and, only when a prefill response chunk was
+        captured, forwards its ``kv_transfer_params`` so the decode engine
+        pulls/receives the KV produced by prefill. In concurrent-handoff mode
+        ``prefill_response`` is None and the request is left unmodified. ``peer``
+        is ignored.
         """
         decode_request = request.model_copy(deep=True)
-        decode_request.kv_transfer_params = prefill_response.kv_transfer_params
+        if prefill_response is not None:
+            decode_request.kv_transfer_params = prefill_response.kv_transfer_params
         return decode_request
 
-    def setup(self) -> None:
-        """Setup the connector backend.
 
-        This method is called to setup the connector backend.
-        """
-        pass
+class DefaultConnectorBackend(DefaultPDProtocolMixin, BaseConnectorBackend):
+    """Concrete connector backend using the default P/D protocol policy.
+
+    Used as the factory fallback for connectors that are not registered with a
+    dedicated backend class: they get a no-op ``setup()`` and the default
+    request-shaping policy. ``BaseConnectorBackend`` is abstract, so the factory
+    must return a concrete class like this one.
+    """
+
+    pass

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Type, Union
 
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
+    DefaultConnectorBackend,
 )
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.utils.registry import get_registry
@@ -56,9 +57,11 @@ class KVConnectorBackendFactory:
         """Get the connector backend class by name.
 
         For registered connectors, returns the registered backend class.
-        For unregistered connectors, returns BaseConnectorBackend which has
-        a no-op setup() method, allowing connectors that don't require
-        Ray Serve orchestration to work without registration.
+        For unregistered connectors, returns DefaultConnectorBackend (a concrete
+        backend with a no-op setup() and the default P/D protocol policy),
+        allowing connectors that don't require Ray Serve orchestration to work
+        without registration. (BaseConnectorBackend itself is abstract and
+        cannot be instantiated.)
 
         Args:
             name: The name of the connector backend
@@ -74,9 +77,9 @@ class KVConnectorBackendFactory:
         except ValueError:
             logger.warning(
                 f"Unsupported connector backend: {name}. "
-                f"Using default: {BaseConnectorBackend.__name__}."
+                f"Using default: {DefaultConnectorBackend.__name__}."
             )
-            return BaseConnectorBackend
+            return DefaultConnectorBackend
         except Exception as e:
             raise ImportError(
                 f"Failed to load connector backend '{name}': {type(e).__name__}: {e}"

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/lmcache.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/lmcache.py
@@ -1,5 +1,6 @@
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
+    DefaultPDProtocolMixin,
 )
 from ray.llm._internal.serve.observability.logging import get_logger
 
@@ -15,7 +16,7 @@ def _check_lmcache_installed():
         )
 
 
-class LMCacheConnectorV1Backend(BaseConnectorBackend):
+class LMCacheConnectorV1Backend(DefaultPDProtocolMixin, BaseConnectorBackend):
 
     KV_CONNECTOR_EXTRA_CONFIG_FIELD_NAME = "kv_connector_extra_config"
     LMCACHE_RPC_PORT_FIELD_NAME = "lmcache_rpc_port"

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/multi_connector.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/multi_connector.py
@@ -32,6 +32,13 @@ class MultiConnectorBackend(BaseConnectorBackend):
         connectors = kv_transfer_config.get("kv_connector_extra_config", {}).get(
             "connectors", []
         )
+        if not connectors:
+            # Fail fast at setup rather than with a cryptic error when the
+            # orchestrator later delegates to a (missing) top-most sub-connector.
+            raise ValueError(
+                "MultiConnector requires at least one sub-connector in "
+                "kv_connector_extra_config.connectors."
+            )
 
         for connector in connectors:
             connector_backend_str = connector.get("kv_connector")

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/multi_connector.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/multi_connector.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
+    DefaultPDProtocolMixin,
 )
 from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
     KVConnectorBackendFactory,
@@ -12,7 +13,14 @@ if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 
 
-class MultiConnectorBackend(BaseConnectorBackend):
+# MRO note: list ``DefaultPDProtocolMixin`` before ``BaseConnectorBackend`` so
+# its concrete ``prepare_*`` methods satisfy the abstract methods.
+#
+# MultiConnector uses the default request-shaping policy on the assumption that
+# its sub-connectors all follow the standard (no-peer, sequential) protocol. If
+# a future sub-connector needs custom shaping, Multi should delegate to that
+# sub-connector's backend's ``prepare_*`` rather than apply the default here.
+class MultiConnectorBackend(DefaultPDProtocolMixin, BaseConnectorBackend):
     def __init__(self, llm_config: "LLMConfig"):
         super().__init__(llm_config)
 

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/multi_connector.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/multi_connector.py
@@ -1,9 +1,8 @@
 import copy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
-    DefaultPDProtocolMixin,
 )
 from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
     KVConnectorBackendFactory,
@@ -13,16 +12,19 @@ if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 
 
-# MRO note: list ``DefaultPDProtocolMixin`` before ``BaseConnectorBackend`` so
-# its concrete ``prepare_*`` methods satisfy the abstract methods.
-#
-# MultiConnector uses the default request-shaping policy on the assumption that
-# its sub-connectors all follow the standard (no-peer, sequential) protocol. If
-# a future sub-connector needs custom shaping, Multi should delegate to that
-# sub-connector's backend's ``prepare_*`` rather than apply the default here.
-class MultiConnectorBackend(DefaultPDProtocolMixin, BaseConnectorBackend):
+class MultiConnectorBackend(BaseConnectorBackend):
+    """Wraps multiple sub-connectors.
+
+    The P/D protocol (``prepare_prefill_request`` / ``prepare_decode_request`` and
+    the ``requires_peer_binding`` / ``concurrent_handoff`` policy) is delegated to
+    the *first* (top-most) sub-connector listed in ``connectors`` — that
+    connector's policy governs request shaping and handoff for the group. Each
+    sub-connector's ``setup()`` still runs.
+    """
+
     def __init__(self, llm_config: "LLMConfig"):
         super().__init__(llm_config)
+        self._connector_backends: List[BaseConnectorBackend] = []
 
     def setup(self) -> None:
         """Setup all connectors listed in the kv_transfer_config."""
@@ -57,3 +59,29 @@ class MultiConnectorBackend(DefaultPDProtocolMixin, BaseConnectorBackend):
                 connector_backend_str, sub_llm_config
             )
             connector_backend.setup()
+            self._connector_backends.append(connector_backend)
+
+    @property
+    def _primary(self) -> BaseConnectorBackend:
+        """The top-most sub-connector, whose protocol governs the group."""
+        if not self._connector_backends:
+            raise ValueError(
+                "MultiConnectorBackend has no sub-connectors; was setup() called?"
+            )
+        return self._connector_backends[0]
+
+    @property
+    def requires_peer_binding(self) -> bool:
+        return bool(self._connector_backends) and self._primary.requires_peer_binding
+
+    @property
+    def concurrent_handoff(self) -> bool:
+        return bool(self._connector_backends) and self._primary.concurrent_handoff
+
+    def prepare_prefill_request(self, *, request, peer):
+        return self._primary.prepare_prefill_request(request=request, peer=peer)
+
+    def prepare_decode_request(self, *, request, peer, prefill_response):
+        return self._primary.prepare_decode_request(
+            request=request, peer=peer, prefill_response=prefill_response
+        )

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/nixl.py
@@ -3,10 +3,11 @@ import os
 import ray
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
+    DefaultPDProtocolMixin,
 )
 
 
-class NixlConnectorBackend(BaseConnectorBackend):
+class NixlConnectorBackend(DefaultPDProtocolMixin, BaseConnectorBackend):
     def _set_side_channel_port(self):
         from vllm import envs as vllm_envs
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -5,6 +5,7 @@ decode deployment owns a real engine and orchestrates remote prefill.
 """
 
 import asyncio
+import contextlib
 import logging
 import uuid
 import warnings
@@ -306,8 +307,12 @@ class PDOrchestratorMixin:
     ):
         """Run local decode while a remote prefill drains concurrently.
 
-        Yields the local decode chunks. The background prefill task is always
-        awaited so it never leaks on the prefill/decode engines.
+        While prefill is in flight, each decode chunk is raced against the
+        prefill task so a prefill failure surfaces to the client as an
+        ``ErrorResponse`` (instead of a hung — decode may be waiting on KV that
+        will never arrive — or seemingly-successful decode stream). The
+        background prefill task is always awaited so it never leaks on the
+        prefill/decode engines.
 
         Args:
             cancel_on_failure: Whether to cancel the in-flight prefill when
@@ -319,14 +324,51 @@ class PDOrchestratorMixin:
         """
         prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
         completed = False
+        local_gen = None
+        next_fut = None
         try:
             local_gen = await getattr(super(), method)(decode_request, raw_request_info)
-            async for chunk in local_gen:
-                yield chunk
+            gen = local_gen.__aiter__()
+            while True:
+                # Surface a failed prefill as soon as it is observed.
+                if prefill_task.done() and isinstance(
+                    prefill_task.result(), ErrorResponse
+                ):
+                    err = prefill_task.result()
+                    logger.error("Remote prefill returned error: %s", err)
+                    yield err
+                    return
+                if next_fut is None:
+                    next_fut = asyncio.ensure_future(gen.__anext__())
+                # Race the next decode chunk against the in-flight prefill;
+                # once prefill has completed (successfully), just stream.
+                awaitables = {next_fut}
+                if not prefill_task.done():
+                    awaitables.add(prefill_task)
+                done, _ = await asyncio.wait(
+                    awaitables, return_when=asyncio.FIRST_COMPLETED
+                )
+                if next_fut in done:
+                    try:
+                        chunk = next_fut.result()
+                    except StopAsyncIteration:
+                        break
+                    next_fut = None
+                    yield chunk
+                # else: prefill finished first; loop back to inspect it.
             completed = True
         finally:
-            if not completed and cancel_on_failure:
-                prefill_task.cancel()
+            if next_fut is not None and not next_fut.done():
+                next_fut.cancel()
+                with contextlib.suppress(BaseException):
+                    await next_fut
+            if not completed:
+                # Abort the local decode request if we bailed early.
+                if local_gen is not None:
+                    with contextlib.suppress(BaseException):
+                        await local_gen.aclose()
+                if cancel_on_failure:
+                    prefill_task.cancel()
             try:
                 err = await prefill_task
                 if isinstance(err, ErrorResponse):

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -298,10 +298,10 @@ class PDOrchestratorMixin:
 
     async def _concurrent_decode(
         self,
-        method,
-        decode_request,
-        prefill_resp,
-        raw_request_info,
+        method: str,
+        decode_request: RequestType,
+        prefill_resp: AsyncGenerator,
+        raw_request_info: Optional[RawRequestInfo],
         *,
         cancel_on_failure: bool = True,
     ):
@@ -315,6 +315,10 @@ class PDOrchestratorMixin:
         prefill/decode engines.
 
         Args:
+            method: The handle method name ("chat" or "completions").
+            decode_request: The request to run on the local decode engine.
+            prefill_resp: The in-flight remote prefill response stream.
+            raw_request_info: Raw HTTP request info forwarded to the engine.
             cancel_on_failure: Whether to cancel the in-flight prefill when
                 local decode does not complete. Must be False for
                 ``dispatch()``-based prefill (the choose_replica path): its

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -143,7 +143,7 @@ class PDOrchestratorMixin:
     #
     # Thin instance delegates to the resolved backend's protocol so existing
     # callers/tests that reference these names keep working. The orchestrator
-    # itself goes through ``be.prepare_*`` directly.
+    # itself goes through ``backend.prepare_*`` directly.
 
     def _prepare_prefill_request(self, request: RequestType) -> RequestType:
         return self._get_connector_backend().prepare_prefill_request(
@@ -184,7 +184,7 @@ class PDOrchestratorMixin:
         else:
             raise ValueError(f"Unsupported request type: {type(request)}")
 
-        be = self._get_connector_backend()
+        backend = self._get_connector_backend()
 
         prefill_handle = self._prefill_handle
         if raw_request_info is not None:
@@ -193,7 +193,7 @@ class PDOrchestratorMixin:
                 prefill_handle = prefill_handle.options(session_id=session_id)
         prefill_handle_method = getattr(prefill_handle, method)
 
-        if be.requires_peer_binding:
+        if backend.requires_peer_binding:
             # Connector needs to bind to the selected prefill replica *before*
             # dispatch (e.g. request-id-addressed transfers). Reserve a replica
             # via choose_replica, expose its metadata to the backend, then
@@ -201,20 +201,31 @@ class PDOrchestratorMixin:
             async with prefill_handle_method.choose_replica(request) as selection:
                 # The selected replica's published metadata (empty dict if none).
                 peer = getattr(selection, "replica_metadata", {})
-                prefill_request = be.prepare_prefill_request(request=request, peer=peer)
+                prefill_request = backend.prepare_prefill_request(
+                    request=request, peer=peer
+                )
 
-                if be.concurrent_handoff:
+                if backend.concurrent_handoff:
                     # Concurrent handoff: start remote prefill and run local decode
                     # together, draining prefill before leaving the choose_replica
                     # context (so on_request_completed fires once).
-                    decode_request = be.prepare_decode_request(
+                    decode_request = backend.prepare_decode_request(
                         request=request, peer=peer, prefill_response=None
                     )
                     prefill_resp = prefill_handle_method.dispatch(
                         selection, prefill_request, raw_request_info
                     )
+                    # dispatch()'s completion accounting fires when its result
+                    # completes, so the response must be drained to exhaustion
+                    # inside the choose_replica context — never cancelled
+                    # (prefill is clamped to a single token, so draining is
+                    # bounded).
                     async for chunk in self._concurrent_decode(
-                        method, decode_request, prefill_resp, raw_request_info
+                        method,
+                        decode_request,
+                        prefill_resp,
+                        raw_request_info,
+                        cancel_on_failure=False,
                     ):
                         yield chunk
                     return
@@ -225,11 +236,18 @@ class PDOrchestratorMixin:
                     selection, prefill_request, raw_request_info
                 )
                 prefill_chunk = await prefill_gen.__anext__()
+                # Drain the dispatched stream to exhaustion inside the
+                # choose_replica context: dispatch()'s completion accounting
+                # (queue-length cache decrement) fires when the result
+                # completes. Prefill is clamped to a single token, so this is
+                # at most one trivial extra iteration.
+                async for _ in prefill_gen:
+                    pass
                 if isinstance(prefill_chunk, ErrorResponse):
                     logger.error(f"Prefill returned error: {prefill_chunk}")
                     yield prefill_chunk
                     return
-                decode_request = be.prepare_decode_request(
+                decode_request = backend.prepare_decode_request(
                     request=request, peer=peer, prefill_response=prefill_chunk
                 )
                 local_gen = await getattr(super(), method)(
@@ -241,12 +259,12 @@ class PDOrchestratorMixin:
 
         # Default path: no pre-dispatch peer binding; dispatch prefill via the
         # standard handle path.
-        prefill_request = be.prepare_prefill_request(request=request, peer=None)
+        prefill_request = backend.prepare_prefill_request(request=request, peer=None)
 
-        if be.concurrent_handoff:
+        if backend.concurrent_handoff:
             # Concurrent handoff: dispatch via remote() and run local decode
             # together.
-            decode_request = be.prepare_decode_request(
+            decode_request = backend.prepare_decode_request(
                 request=request, peer=None, prefill_response=None
             )
             prefill_resp = prefill_handle_method.remote(
@@ -270,7 +288,7 @@ class PDOrchestratorMixin:
         # 2. Local decode via super().chat / super().completions so the
         # standard LLMServer request pipeline (request_id, LoRA multiplex,
         # batch_output_stream) runs on the decode side.
-        decode_request = be.prepare_decode_request(
+        decode_request = backend.prepare_decode_request(
             request=request, peer=None, prefill_response=prefill_chunk
         )
         local_gen = await getattr(super(), method)(decode_request, raw_request_info)
@@ -278,13 +296,26 @@ class PDOrchestratorMixin:
             yield chunk
 
     async def _concurrent_decode(
-        self, method, decode_request, prefill_resp, raw_request_info
+        self,
+        method,
+        decode_request,
+        prefill_resp,
+        raw_request_info,
+        *,
+        cancel_on_failure: bool = True,
     ):
         """Run local decode while a remote prefill drains concurrently.
 
         Yields the local decode chunks. The background prefill task is always
-        awaited, and is cancelled if local decode does not complete (so it never
-        leaks on the prefill/decode engines).
+        awaited so it never leaks on the prefill/decode engines.
+
+        Args:
+            cancel_on_failure: Whether to cancel the in-flight prefill when
+                local decode does not complete. Must be False for
+                ``dispatch()``-based prefill (the choose_replica path): its
+                completion accounting fires when the response completes, so the
+                stream must be drained to exhaustion, never abandoned. Prefill
+                is clamped to a single token, so draining is bounded either way.
         """
         prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
         completed = False
@@ -294,7 +325,7 @@ class PDOrchestratorMixin:
                 yield chunk
             completed = True
         finally:
-            if not completed:
+            if not completed and cancel_on_failure:
                 prefill_task.cancel()
             try:
                 err = await prefill_task
@@ -364,8 +395,8 @@ class PDOrchestratorMixin:
 
         model_id = self._llm_config.model_id
         dummy = self._make_dummy_request(model_id)
-        be = self._get_connector_backend()
-        prefill_req = be.prepare_prefill_request(request=dummy, peer=None)
+        backend = self._get_connector_backend()
+        prefill_req = backend.prepare_prefill_request(request=dummy, peer=None)
 
         # Broadcast to every live P replica; retry until they are up.
         kv_params_list: List[Any] = []

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -33,9 +33,6 @@ from ray.llm._internal.serve.core.ingress.utils import (
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import BaseConnectorBackend
-from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
-    KVConnectorBackendFactory,
-)
 from ray.llm._internal.serve.serving_patterns.data_parallel.dp_server import DPServer
 from ray.llm._internal.serve.utils.broadcast import broadcast
 from ray.llm._internal.serve.utils.server_utils import (
@@ -120,45 +117,25 @@ class PDOrchestratorMixin:
     # ---- Connector backend resolution ----
 
     def _get_connector_backend(self) -> BaseConnectorBackend:
-        """Resolve the KV-connector backend for this decode server.
+        """Return the connector backend that was set up during engine init.
 
-        The backend is used only for its (stateless w.r.t. the request)
-        coordination protocol — flags (``requires_peer_binding``,
-        ``concurrent_handoff``) and the ``prepare_*`` request shapers — so
-        resolving a fresh instance via the factory is equivalent to a stored one.
-
-        Always returns a *concrete* backend (never the abstract
-        ``BaseConnectorBackend``). Resolution order:
-          1. A backend instance already stored on ``self._llm_config``
-             (``setup_engine_backend`` was called on this exact config copy).
-          2. Else, if a KV transfer connector is configured, create one via the
-             factory (nixl/lmcache/multi/... are all concrete; unregistered
-             connectors fall back to a concrete default backend).
+        ``LLMConfig.setup_engine_backend()`` creates the backend and calls its
+        ``setup()`` during engine initialization, storing it on the config. By the
+        time a request reaches the orchestrator it must already be there — a
+        missing backend means engine init was skipped, which is a bug (and a
+        freshly-created, un-``setup()`` backend would mis-shape traffic, e.g. a
+        MultiConnector whose sub-connectors are populated only in ``setup()``).
+        Cached on first access since the request path calls this.
         """
-        # Resolved once and cached: the backend is per-server (per LLMConfig) and
-        # its protocol is stateless w.r.t. the request, so we avoid re-resolving on
-        # every request (the request path calls this).
         cached = getattr(self, "_connector_backend_cache", None)
         if cached is not None:
             return cached
 
-        llm_config = getattr(self, "_llm_config", None)
-        backend = getattr(llm_config, "kv_connector_backend", None)
-        if backend is None:
-            kv_transfer_config = (getattr(llm_config, "engine_kwargs", None) or {}).get(
-                "kv_transfer_config"
-            )
-            kv_connector = (kv_transfer_config or {}).get("kv_connector")
-            if not kv_connector:
-                # For P/D there is always a kv_transfer_config, so we should never
-                # get here. Fail loudly rather than instantiate the abstract base.
-                raise ValueError(
-                    "Cannot resolve a KV-connector backend: no backend was stored "
-                    "on the LLMConfig and no kv_transfer_config.kv_connector is "
-                    "configured."
-                )
-            backend = KVConnectorBackendFactory.create_backend(kv_connector, llm_config)
-
+        backend = getattr(self._llm_config, "kv_connector_backend", None)
+        assert backend is not None, (
+            "No KV-connector backend on the LLMConfig. setup_engine_backend() must "
+            "run during engine init before the P/D orchestrator handles requests."
+        )
         self._connector_backend_cache = backend
         return backend
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -119,7 +119,7 @@ class PDOrchestratorMixin:
 
     # ---- Connector backend resolution ----
 
-    def _get_connector_backend(self):
+    def _get_connector_backend(self) -> BaseConnectorBackend:
         """Resolve the KV-connector backend for this decode server.
 
         The backend is used only for its (stateless w.r.t. the request)
@@ -127,13 +127,13 @@ class PDOrchestratorMixin:
         ``concurrent_handoff``) and the ``prepare_*`` request shapers — so
         resolving a fresh instance via the factory is equivalent to a stored one.
 
-        Resolution order:
+        Always returns a *concrete* backend (never the abstract
+        ``BaseConnectorBackend``). Resolution order:
           1. A backend instance already stored on ``self._llm_config``
              (``setup_engine_backend`` was called on this exact config copy).
           2. Else, if a KV transfer connector is configured, create one via the
-             factory.
-          3. Else a plain ``BaseConnectorBackend`` (default flags == today's
-             NIXL/default behavior).
+             factory (nixl/lmcache/multi/... are all concrete; unregistered
+             connectors fall back to a concrete default backend).
         """
         llm_config = getattr(self, "_llm_config", None)
 
@@ -150,26 +150,31 @@ class PDOrchestratorMixin:
         if kv_connector:
             return KVConnectorBackendFactory.create_backend(kv_connector, llm_config)
 
-        return BaseConnectorBackend(llm_config)
+        # For P/D there is always a kv_transfer_config, so we should never get
+        # here. Fail loudly rather than instantiate the abstract base.
+        raise ValueError(
+            "Cannot resolve a KV-connector backend: no backend was stored on the "
+            "LLMConfig and no kv_transfer_config.kv_connector is configured."
+        )
 
     # ---- Request Preparation ----
     #
-    # Kept as thin static delegates to the default ``BaseConnectorBackend``
-    # protocol so existing callers/tests that reference these names keep working.
-    # The orchestrator itself goes through ``be.prepare_*`` on the resolved
-    # backend (which may override these for connector-specific shaping).
+    # Thin instance delegates to the resolved backend's protocol so existing
+    # callers/tests that reference these names keep working. The orchestrator
+    # itself goes through ``be.prepare_*`` directly.
 
-    @staticmethod
-    def _prepare_prefill_request(request: RequestType) -> RequestType:
-        return BaseConnectorBackend.prepare_prefill_request(None, request, None)
+    def _prepare_prefill_request(self, request: RequestType) -> RequestType:
+        return self._get_connector_backend().prepare_prefill_request(
+            request=request, peer=None
+        )
 
-    @staticmethod
     def _prepare_decode_request(
+        self,
         request: RequestType,
         prefill_chunk: Union[ChatCompletionResponse, CompletionResponse],
     ) -> RequestType:
-        return BaseConnectorBackend.prepare_decode_request(
-            None, request, None, prefill_chunk
+        return self._get_connector_backend().prepare_decode_request(
+            request=request, peer=None, prefill_response=prefill_chunk
         )
 
     # ---- Orchestrated Request Flow ----
@@ -215,28 +220,38 @@ class PDOrchestratorMixin:
                 # ``replica_metadata`` is the public field added in the metadata
                 # PR; this branch may run on a checkout that lacks it, so guard.
                 peer = getattr(selection, "replica_metadata", {})
-                prefill_request = be.prepare_prefill_request(request, peer)
+                prefill_request = be.prepare_prefill_request(request=request, peer=peer)
 
                 if be.concurrent_handoff:
                     # WRITE-style handoff: start remote prefill and run local
                     # decode concurrently, draining prefill before leaving the
                     # choose_replica context (so on_request_completed fires once).
-                    decode_request = be.prepare_decode_request(request, peer, None)
+                    decode_request = be.prepare_decode_request(
+                        request=request, peer=peer, prefill_response=None
+                    )
                     prefill_resp = prefill_handle_method.dispatch(
                         selection, prefill_request, raw_request_info
                     )
                     prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
+                    completed = False
                     try:
                         local_gen = await getattr(super(), method)(
                             decode_request, raw_request_info
                         )
                         async for chunk in local_gen:
                             yield chunk
+                        completed = True
                     finally:
+                        if not completed:
+                            # Local decode failed/cancelled; don't leak the
+                            # background prefill task.
+                            prefill_task.cancel()
                         try:
                             err = await prefill_task
                             if isinstance(err, ErrorResponse):
                                 logger.error("Remote prefill returned error: %s", err)
+                        except asyncio.CancelledError:
+                            pass
                         except Exception as exc:  # pragma: no cover - defensive
                             logger.error("Remote prefill failed: %s", exc)
                     return
@@ -251,7 +266,9 @@ class PDOrchestratorMixin:
                     logger.error(f"Prefill returned error: {prefill_chunk}")
                     yield prefill_chunk
                     return
-                decode_request = be.prepare_decode_request(request, peer, prefill_chunk)
+                decode_request = be.prepare_decode_request(
+                    request=request, peer=peer, prefill_response=prefill_chunk
+                )
                 local_gen = await getattr(super(), method)(
                     decode_request, raw_request_info
                 )
@@ -262,27 +279,37 @@ class PDOrchestratorMixin:
         # Default / NIXL path: no pre-dispatch peer binding. This is byte-for-byte
         # the historical flow, just routed through the backend's request shapers.
         peer = None
-        prefill_request = be.prepare_prefill_request(request, peer)
+        prefill_request = be.prepare_prefill_request(request=request, peer=peer)
 
         if be.concurrent_handoff:
             # Concurrent handoff without peer binding: dispatch via remote() and
             # run local decode concurrently.
-            decode_request = be.prepare_decode_request(request, peer, None)
+            decode_request = be.prepare_decode_request(
+                request=request, peer=peer, prefill_response=None
+            )
             prefill_resp = prefill_handle_method.remote(
                 prefill_request, raw_request_info
             )
             prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
+            completed = False
             try:
                 local_gen = await getattr(super(), method)(
                     decode_request, raw_request_info
                 )
                 async for chunk in local_gen:
                     yield chunk
+                completed = True
             finally:
+                if not completed:
+                    # Local decode failed/cancelled; don't leak the background
+                    # prefill task.
+                    prefill_task.cancel()
                 try:
                     err = await prefill_task
                     if isinstance(err, ErrorResponse):
                         logger.error("Remote prefill returned error: %s", err)
+                except asyncio.CancelledError:
+                    pass
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.error("Remote prefill failed: %s", exc)
             return
@@ -299,7 +326,9 @@ class PDOrchestratorMixin:
         # 2. Local decode via super().chat / super().completions so the
         # standard LLMServer request pipeline (request_id, LoRA multiplex,
         # batch_output_stream) runs on the decode side.
-        decode_request = be.prepare_decode_request(request, peer, prefill_chunk)
+        decode_request = be.prepare_decode_request(
+            request=request, peer=peer, prefill_response=prefill_chunk
+        )
         local_gen = await getattr(super(), method)(decode_request, raw_request_info)
         async for chunk in local_gen:
             yield chunk
@@ -363,7 +392,8 @@ class PDOrchestratorMixin:
 
         model_id = self._llm_config.model_id
         dummy = self._make_dummy_request(model_id)
-        prefill_req = self._prepare_prefill_request(dummy)
+        be = self._get_connector_backend()
+        prefill_req = be.prepare_prefill_request(request=dummy, peer=None)
 
         # Broadcast to every live P replica; retry until they are up.
         kv_params_list: List[Any] = []

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -135,27 +135,32 @@ class PDOrchestratorMixin:
              factory (nixl/lmcache/multi/... are all concrete; unregistered
              connectors fall back to a concrete default backend).
         """
+        # Resolved once and cached: the backend is per-server (per LLMConfig) and
+        # its protocol is stateless w.r.t. the request, so we avoid re-resolving on
+        # every request (the request path calls this).
+        cached = getattr(self, "_connector_backend_cache", None)
+        if cached is not None:
+            return cached
+
         llm_config = getattr(self, "_llm_config", None)
+        backend = getattr(llm_config, "kv_connector_backend", None)
+        if backend is None:
+            kv_transfer_config = (getattr(llm_config, "engine_kwargs", None) or {}).get(
+                "kv_transfer_config"
+            )
+            kv_connector = (kv_transfer_config or {}).get("kv_connector")
+            if not kv_connector:
+                # For P/D there is always a kv_transfer_config, so we should never
+                # get here. Fail loudly rather than instantiate the abstract base.
+                raise ValueError(
+                    "Cannot resolve a KV-connector backend: no backend was stored "
+                    "on the LLMConfig and no kv_transfer_config.kv_connector is "
+                    "configured."
+                )
+            backend = KVConnectorBackendFactory.create_backend(kv_connector, llm_config)
 
-        stored = getattr(llm_config, "kv_connector_backend", None)
-        if stored is not None:
-            return stored
-
-        kv_transfer_config = (
-            (getattr(llm_config, "engine_kwargs", None) or {}).get("kv_transfer_config")
-            if llm_config is not None
-            else None
-        )
-        kv_connector = (kv_transfer_config or {}).get("kv_connector")
-        if kv_connector:
-            return KVConnectorBackendFactory.create_backend(kv_connector, llm_config)
-
-        # For P/D there is always a kv_transfer_config, so we should never get
-        # here. Fail loudly rather than instantiate the abstract base.
-        raise ValueError(
-            "Cannot resolve a KV-connector backend: no backend was stored on the "
-            "LLMConfig and no kv_transfer_config.kv_connector is configured."
-        )
+        self._connector_backend_cache = backend
+        return backend
 
     # ---- Request Preparation ----
     #
@@ -217,43 +222,24 @@ class PDOrchestratorMixin:
             # via choose_replica, expose its metadata to the backend, then
             # dispatch onto that exact selection.
             async with prefill_handle_method.choose_replica(request) as selection:
-                # ``replica_metadata`` is the public field added in the metadata
-                # PR; this branch may run on a checkout that lacks it, so guard.
+                # The selected replica's published metadata (empty dict if none).
                 peer = getattr(selection, "replica_metadata", {})
                 prefill_request = be.prepare_prefill_request(request=request, peer=peer)
 
                 if be.concurrent_handoff:
-                    # WRITE-style handoff: start remote prefill and run local
-                    # decode concurrently, draining prefill before leaving the
-                    # choose_replica context (so on_request_completed fires once).
+                    # Concurrent handoff: start remote prefill and run local decode
+                    # together, draining prefill before leaving the choose_replica
+                    # context (so on_request_completed fires once).
                     decode_request = be.prepare_decode_request(
                         request=request, peer=peer, prefill_response=None
                     )
                     prefill_resp = prefill_handle_method.dispatch(
                         selection, prefill_request, raw_request_info
                     )
-                    prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
-                    completed = False
-                    try:
-                        local_gen = await getattr(super(), method)(
-                            decode_request, raw_request_info
-                        )
-                        async for chunk in local_gen:
-                            yield chunk
-                        completed = True
-                    finally:
-                        if not completed:
-                            # Local decode failed/cancelled; don't leak the
-                            # background prefill task.
-                            prefill_task.cancel()
-                        try:
-                            err = await prefill_task
-                            if isinstance(err, ErrorResponse):
-                                logger.error("Remote prefill returned error: %s", err)
-                        except asyncio.CancelledError:
-                            pass
-                        except Exception as exc:  # pragma: no cover - defensive
-                            logger.error("Remote prefill failed: %s", exc)
+                    async for chunk in self._concurrent_decode(
+                        method, decode_request, prefill_resp, raw_request_info
+                    ):
+                        yield chunk
                     return
 
                 # Sequential handoff with peer binding: run prefill to its first
@@ -276,42 +262,23 @@ class PDOrchestratorMixin:
                     yield chunk
                 return
 
-        # Default / NIXL path: no pre-dispatch peer binding. This is byte-for-byte
-        # the historical flow, just routed through the backend's request shapers.
-        peer = None
-        prefill_request = be.prepare_prefill_request(request=request, peer=peer)
+        # Default path: no pre-dispatch peer binding; dispatch prefill via the
+        # standard handle path.
+        prefill_request = be.prepare_prefill_request(request=request, peer=None)
 
         if be.concurrent_handoff:
-            # Concurrent handoff without peer binding: dispatch via remote() and
-            # run local decode concurrently.
+            # Concurrent handoff: dispatch via remote() and run local decode
+            # together.
             decode_request = be.prepare_decode_request(
-                request=request, peer=peer, prefill_response=None
+                request=request, peer=None, prefill_response=None
             )
             prefill_resp = prefill_handle_method.remote(
                 prefill_request, raw_request_info
             )
-            prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
-            completed = False
-            try:
-                local_gen = await getattr(super(), method)(
-                    decode_request, raw_request_info
-                )
-                async for chunk in local_gen:
-                    yield chunk
-                completed = True
-            finally:
-                if not completed:
-                    # Local decode failed/cancelled; don't leak the background
-                    # prefill task.
-                    prefill_task.cancel()
-                try:
-                    err = await prefill_task
-                    if isinstance(err, ErrorResponse):
-                        logger.error("Remote prefill returned error: %s", err)
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:  # pragma: no cover - defensive
-                    logger.error("Remote prefill failed: %s", exc)
+            async for chunk in self._concurrent_decode(
+                method, decode_request, prefill_resp, raw_request_info
+            ):
+                yield chunk
             return
 
         # 1. Remote prefill
@@ -327,11 +294,39 @@ class PDOrchestratorMixin:
         # standard LLMServer request pipeline (request_id, LoRA multiplex,
         # batch_output_stream) runs on the decode side.
         decode_request = be.prepare_decode_request(
-            request=request, peer=peer, prefill_response=prefill_chunk
+            request=request, peer=None, prefill_response=prefill_chunk
         )
         local_gen = await getattr(super(), method)(decode_request, raw_request_info)
         async for chunk in local_gen:
             yield chunk
+
+    async def _concurrent_decode(
+        self, method, decode_request, prefill_resp, raw_request_info
+    ):
+        """Run local decode while a remote prefill drains concurrently.
+
+        Yields the local decode chunks. The background prefill task is always
+        awaited, and is cancelled if local decode does not complete (so it never
+        leaks on the prefill/decode engines).
+        """
+        prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
+        completed = False
+        try:
+            local_gen = await getattr(super(), method)(decode_request, raw_request_info)
+            async for chunk in local_gen:
+                yield chunk
+            completed = True
+        finally:
+            if not completed:
+                prefill_task.cancel()
+            try:
+                err = await prefill_task
+                if isinstance(err, ErrorResponse):
+                    logger.error("Remote prefill returned error: %s", err)
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Remote prefill failed: %s", exc)
 
     # ---- Direct-streaming ASGI app ----
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -32,6 +32,10 @@ from ray.llm._internal.serve.core.ingress.utils import (
 )
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
+from ray.llm._internal.serve.engines.vllm.kv_transfer.base import BaseConnectorBackend
+from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
+    KVConnectorBackendFactory,
+)
 from ray.llm._internal.serve.serving_patterns.data_parallel.dp_server import DPServer
 from ray.llm._internal.serve.utils.broadcast import broadcast
 from ray.llm._internal.serve.utils.server_utils import (
@@ -113,38 +117,60 @@ class PDOrchestratorMixin:
     # Set by __init__ of the concrete class that mixes this in.
     _prefill_handle: DeploymentHandle
 
+    # ---- Connector backend resolution ----
+
+    def _get_connector_backend(self):
+        """Resolve the KV-connector backend for this decode server.
+
+        The backend is used only for its (stateless w.r.t. the request)
+        coordination protocol — flags (``requires_peer_binding``,
+        ``concurrent_handoff``) and the ``prepare_*`` request shapers — so
+        resolving a fresh instance via the factory is equivalent to a stored one.
+
+        Resolution order:
+          1. A backend instance already stored on ``self._llm_config``
+             (``setup_engine_backend`` was called on this exact config copy).
+          2. Else, if a KV transfer connector is configured, create one via the
+             factory.
+          3. Else a plain ``BaseConnectorBackend`` (default flags == today's
+             NIXL/default behavior).
+        """
+        llm_config = getattr(self, "_llm_config", None)
+
+        stored = getattr(llm_config, "kv_connector_backend", None)
+        if stored is not None:
+            return stored
+
+        kv_transfer_config = (
+            (getattr(llm_config, "engine_kwargs", None) or {}).get("kv_transfer_config")
+            if llm_config is not None
+            else None
+        )
+        kv_connector = (kv_transfer_config or {}).get("kv_connector")
+        if kv_connector:
+            return KVConnectorBackendFactory.create_backend(kv_connector, llm_config)
+
+        return BaseConnectorBackend(llm_config)
+
     # ---- Request Preparation ----
+    #
+    # Kept as thin static delegates to the default ``BaseConnectorBackend``
+    # protocol so existing callers/tests that reference these names keep working.
+    # The orchestrator itself goes through ``be.prepare_*`` on the resolved
+    # backend (which may override these for connector-specific shaping).
 
     @staticmethod
     def _prepare_prefill_request(request: RequestType) -> RequestType:
-        assert (
-            getattr(request, "kv_transfer_params", None) is None
-        ), "kv_transfer_params should be empty before orchestrator"
-        prefill_request = request.model_copy(deep=True)
-        prefill_request.kv_transfer_params = {
-            "do_remote_decode": True,
-            "do_remote_prefill": False,
-            "remote_engine_id": None,
-            "remote_block_ids": None,
-            "remote_host": None,
-            "remote_port": None,
-        }
-        prefill_request.max_tokens = 1
-        if hasattr(prefill_request, "max_completion_tokens"):
-            prefill_request.max_completion_tokens = 1
-        prefill_request.stream = False
-        if hasattr(prefill_request, "stream_options"):
-            prefill_request.stream_options = None
-        return prefill_request
+        return BaseConnectorBackend.prepare_prefill_request(None, request, None)
 
     @staticmethod
     def _prepare_decode_request(
         request: RequestType,
         prefill_chunk: Union[ChatCompletionResponse, CompletionResponse],
     ) -> RequestType:
-        decode_request = request.model_copy(deep=True)
-        decode_request.kv_transfer_params = prefill_chunk.kv_transfer_params
-        return decode_request
+        return BaseConnectorBackend.prepare_decode_request(
+            None, request, None, prefill_chunk
+        )
 
     # ---- Orchestrated Request Flow ----
 
@@ -155,7 +181,13 @@ class PDOrchestratorMixin:
     ) -> AsyncGenerator[
         Union[str, ChatCompletionResponse, CompletionResponse, ErrorResponse], None
     ]:
-        """Orchestrate prefill (remote) then decode (local engine)."""
+        """Orchestrate prefill (remote) then decode (local engine).
+
+        Request shaping, peer addressing, and handoff discipline are delegated to
+        the resolved KV-connector backend. With the default backend flags
+        (``requires_peer_binding=False``, ``concurrent_handoff=False``) the
+        control flow and calls are identical to the historical NIXL/default flow.
+        """
 
         # Determine method name for the handle call
         if isinstance(request, ChatCompletionRequest):
@@ -165,17 +197,98 @@ class PDOrchestratorMixin:
         else:
             raise ValueError(f"Unsupported request type: {type(request)}")
 
-        # 1. Remote prefill
-        prefill_request = self._prepare_prefill_request(request)
+        be = self._get_connector_backend()
+
         prefill_handle = self._prefill_handle
         if raw_request_info is not None:
             session_id = session_id_from_headers(raw_request_info.headers)
             if session_id:
                 prefill_handle = prefill_handle.options(session_id=session_id)
+        prefill_handle_method = getattr(prefill_handle, method)
 
-        prefill_gen = getattr(prefill_handle, method).remote(
-            prefill_request, raw_request_info
-        )
+        if be.requires_peer_binding:
+            # Connector needs to bind to the selected prefill replica *before*
+            # dispatch (e.g. request-id-addressed transfers). Reserve a replica
+            # via choose_replica, expose its metadata to the backend, then
+            # dispatch onto that exact selection.
+            async with prefill_handle_method.choose_replica(request) as selection:
+                # ``replica_metadata`` is the public field added in the metadata
+                # PR; this branch may run on a checkout that lacks it, so guard.
+                peer = getattr(selection, "replica_metadata", {})
+                prefill_request = be.prepare_prefill_request(request, peer)
+
+                if be.concurrent_handoff:
+                    # WRITE-style handoff: start remote prefill and run local
+                    # decode concurrently, draining prefill before leaving the
+                    # choose_replica context (so on_request_completed fires once).
+                    decode_request = be.prepare_decode_request(request, peer, None)
+                    prefill_resp = prefill_handle_method.dispatch(
+                        selection, prefill_request, raw_request_info
+                    )
+                    prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
+                    try:
+                        local_gen = await getattr(super(), method)(
+                            decode_request, raw_request_info
+                        )
+                        async for chunk in local_gen:
+                            yield chunk
+                    finally:
+                        try:
+                            err = await prefill_task
+                            if isinstance(err, ErrorResponse):
+                                logger.error("Remote prefill returned error: %s", err)
+                        except Exception as exc:  # pragma: no cover - defensive
+                            logger.error("Remote prefill failed: %s", exc)
+                    return
+
+                # Sequential handoff with peer binding: run prefill to its first
+                # chunk, then drive local decode with the returned params.
+                prefill_gen = prefill_handle_method.dispatch(
+                    selection, prefill_request, raw_request_info
+                )
+                prefill_chunk = await prefill_gen.__anext__()
+                if isinstance(prefill_chunk, ErrorResponse):
+                    logger.error(f"Prefill returned error: {prefill_chunk}")
+                    yield prefill_chunk
+                    return
+                decode_request = be.prepare_decode_request(request, peer, prefill_chunk)
+                local_gen = await getattr(super(), method)(
+                    decode_request, raw_request_info
+                )
+                async for chunk in local_gen:
+                    yield chunk
+                return
+
+        # Default / NIXL path: no pre-dispatch peer binding. This is byte-for-byte
+        # the historical flow, just routed through the backend's request shapers.
+        peer = None
+        prefill_request = be.prepare_prefill_request(request, peer)
+
+        if be.concurrent_handoff:
+            # Concurrent handoff without peer binding: dispatch via remote() and
+            # run local decode concurrently.
+            decode_request = be.prepare_decode_request(request, peer, None)
+            prefill_resp = prefill_handle_method.remote(
+                prefill_request, raw_request_info
+            )
+            prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
+            try:
+                local_gen = await getattr(super(), method)(
+                    decode_request, raw_request_info
+                )
+                async for chunk in local_gen:
+                    yield chunk
+            finally:
+                try:
+                    err = await prefill_task
+                    if isinstance(err, ErrorResponse):
+                        logger.error("Remote prefill returned error: %s", err)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.error("Remote prefill failed: %s", exc)
+            return
+
+        # 1. Remote prefill
+        prefill_gen = prefill_handle_method.remote(prefill_request, raw_request_info)
         prefill_chunk = await prefill_gen.__anext__()
 
         if isinstance(prefill_chunk, ErrorResponse):
@@ -186,7 +299,7 @@ class PDOrchestratorMixin:
         # 2. Local decode via super().chat / super().completions so the
         # standard LLMServer request pipeline (request_id, LoRA multiplex,
         # batch_output_stream) runs on the decode side.
-        decode_request = self._prepare_decode_request(request, prefill_chunk)
+        decode_request = be.prepare_decode_request(request, peer, prefill_chunk)
         local_gen = await getattr(super(), method)(decode_request, raw_request_info)
         async for chunk in local_gen:
             yield chunk
@@ -324,6 +437,27 @@ class PDOrchestratorMixin:
         await asyncio.gather(*[_decode_one(r, i) for i, r in enumerate(decode_reqs)])
 
         logger.info("[PDDecodeServer] Pre-warm complete — all P replicas registered.")
+
+
+async def _drain_prefill(prefill_resp) -> Optional[ErrorResponse]:
+    """Consume a concurrent-handoff prefill response to completion.
+
+    In concurrent (e.g. WRITE-mode) handoff the remote prefill produces no useful
+    tokens — it only needs to run so the connector pushes/registers the KV. We
+    drain it so the response is fully awaited before the ``choose_replica``
+    context (if any) exits. Returns an ``ErrorResponse`` if one is observed.
+    Handles both streaming (``DeploymentResponseGenerator``) and non-streaming
+    (single ``DeploymentResponse``) results.
+    """
+    try:
+        async for chunk in prefill_resp:
+            if isinstance(chunk, ErrorResponse):
+                return chunk
+    except TypeError:
+        result = await prefill_resp
+        if isinstance(result, ErrorResponse):
+            return result
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
@@ -7,6 +7,7 @@ import pytest
 from ray import serve
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
+    DefaultConnectorBackend,
     DefaultPDProtocolMixin,
 )
 from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
@@ -81,10 +82,6 @@ class TestKVConnectorBackendFactory:
         subclass (``DefaultConnectorBackend``) that is instantiable and provides
         the default P/D protocol policy.
         """
-        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
-            DefaultConnectorBackend,
-        )
-
         backend_class = KVConnectorBackendFactory.get_backend_class(
             "UnregisteredConnector"
         )

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
@@ -7,6 +7,7 @@ import pytest
 from ray import serve
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
+    DefaultPDProtocolMixin,
 )
 from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
     KVConnectorBackendFactory,
@@ -29,7 +30,7 @@ def test_deployment_handle():
     """Fixture that creates a Serve deployment for testing cross-process registry access."""
 
     # This ensures proper serialization when sent to child processes
-    class TestCrossProcessConnector(BaseConnectorBackend):
+    class TestCrossProcessConnector(DefaultPDProtocolMixin, BaseConnectorBackend):
         def setup(self):
             pass
 
@@ -73,13 +74,24 @@ class TestKVConnectorBackendFactory:
         assert backend_class is not None
         assert hasattr(backend_class, "setup")
 
-    def test_get_backend_class_not_registered_returns_base(self):
-        """Test that getting a non-registered backend returns BaseConnectorBackend."""
+    def test_get_backend_class_not_registered_returns_default(self):
+        """Getting a non-registered backend returns a concrete default backend.
+
+        ``BaseConnectorBackend`` is abstract, so the fallback must be a concrete
+        subclass (``DefaultConnectorBackend``) that is instantiable and provides
+        the default P/D protocol policy.
+        """
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            DefaultConnectorBackend,
+        )
+
         backend_class = KVConnectorBackendFactory.get_backend_class(
             "UnregisteredConnector"
         )
-        assert backend_class == BaseConnectorBackend
+        assert backend_class is DefaultConnectorBackend
         assert issubclass(backend_class, BaseConnectorBackend)
+        # Concrete: can be instantiated.
+        DefaultConnectorBackend(llm_config=None)
 
     def test_create_backend_success(self):
         """Test successful creation of a backend instance."""
@@ -120,7 +132,7 @@ class TestKVConnectorBackendFactory:
     def test_register_backend_with_class_directly(self):
         """Test registering a backend class directly."""
 
-        class CustomBackend(BaseConnectorBackend):
+        class CustomBackend(DefaultPDProtocolMixin, BaseConnectorBackend):
             def setup(self):
                 pass
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_multi_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_multi_connector.py
@@ -46,6 +46,21 @@ class TestMultiConnectorBackend:
         assert isinstance(multi_backend, MultiConnectorBackend)
         assert isinstance(multi_backend, BaseConnectorBackend)
 
+    def test_setup_rejects_empty_connectors(self):
+        """An empty `connectors` list is a misconfig: setup() fails fast rather
+        than crash later when the orchestrator delegates to a missing primary."""
+        llm_config = LLMConfig(
+            model_loading_config=dict(model_id="test-model"),
+            engine_kwargs=dict(
+                kv_transfer_config=dict(
+                    kv_connector="MultiConnector",
+                    kv_connector_extra_config=dict(connectors=[]),
+                )
+            ),
+        )
+        with pytest.raises(ValueError, match="at least one sub-connector"):
+            MultiConnectorBackend(llm_config).setup()
+
     def test_setup_calls_all_connectors(self, multi_backend):
         """Test that setup calls setup on all configured connectors."""
         mock_backend1 = MagicMock(spec=BaseConnectorBackend)

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_pd_protocol.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_pd_protocol.py
@@ -1,8 +1,9 @@
 """Tests for the P/D coordination protocol on the KV connector backends.
 
-Proves that the concrete connector backends (NIXL, LMCache, Multi) are migrated
-onto the abstract ``BaseConnectorBackend`` protocol via ``DefaultPDProtocolMixin``,
-and that the abstract base itself cannot be instantiated.
+Proves that NIXL, LMCache, and the default backend are migrated onto the abstract
+``BaseConnectorBackend`` protocol via ``DefaultPDProtocolMixin``, that Multi delegates
+the protocol to its top-most sub-connector, and that the abstract base itself cannot
+be instantiated.
 """
 
 import sys
@@ -56,10 +57,9 @@ def test_base_connector_backend_is_abstract():
     [
         lambda: NixlConnectorBackend(llm_config=_llm_config("NixlConnector")),
         lambda: LMCacheConnectorV1Backend(llm_config=_llm_config("LMCacheConnectorV1")),
-        lambda: MultiConnectorBackend(llm_config=_llm_config("MultiConnector")),
         lambda: DefaultConnectorBackend(llm_config=None),
     ],
-    ids=["nixl", "lmcache", "multi", "default"],
+    ids=["nixl", "lmcache", "default"],
 )
 class TestMigratedBackendsProtocol:
     """All migrated concrete backends expose the default P/D protocol shaping."""
@@ -110,6 +110,46 @@ class TestMigratedBackendsProtocol:
             request=request, peer=None, prefill_response=None
         )
         assert getattr(decode, "kv_transfer_params", None) is None
+
+
+class TestMultiConnectorDelegation:
+    """MultiConnectorBackend delegates the P/D protocol to its top-most
+    sub-connector rather than inheriting the default mixin."""
+
+    def _multi_with_primary(self, primary):
+        multi = MultiConnectorBackend(llm_config=_llm_config("MultiConnector"))
+        multi._connector_backends = [primary]
+        return multi
+
+    def test_no_subconnectors_flags_false(self):
+        multi = MultiConnectorBackend(llm_config=_llm_config("MultiConnector"))
+        assert multi.requires_peer_binding is False
+        assert multi.concurrent_handoff is False
+
+    def test_delegates_prepare_to_primary(self):
+        multi = self._multi_with_primary(DefaultConnectorBackend(llm_config=None))
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            max_completion_tokens=8,
+        )
+        prefill = multi.prepare_prefill_request(request=request, peer=None)
+        assert prefill.kv_transfer_params["do_remote_decode"] is True
+        assert prefill.max_tokens == 1
+        chunk = SimpleNamespace(kv_transfer_params={"remote_engine_id": "p1"})
+        decode = multi.prepare_decode_request(
+            request=CompletionRequest(model="test-model", prompt="hi"),
+            peer=None,
+            prefill_response=chunk,
+        )
+        assert decode.kv_transfer_params == {"remote_engine_id": "p1"}
+
+    def test_flags_follow_primary(self):
+        # A primary that opts into peer binding + concurrent handoff governs the group.
+        primary = SimpleNamespace(requires_peer_binding=True, concurrent_handoff=True)
+        multi = self._multi_with_primary(primary)
+        assert multi.requires_peer_binding is True
+        assert multi.concurrent_handoff is True
 
 
 @patch(

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_pd_protocol.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_pd_protocol.py
@@ -1,6 +1,6 @@
 """Tests for the P/D coordination protocol on the KV connector backends.
 
-Proves that NIXL, LMCache, and the default backend are migrated onto the abstract
+Proves that NIXL, LMCache, and the default backend implement the abstract
 ``BaseConnectorBackend`` protocol via ``DefaultPDProtocolMixin``, that Multi delegates
 the protocol to its top-most sub-connector, and that the abstract base itself cannot
 be instantiated.
@@ -61,8 +61,8 @@ def test_base_connector_backend_is_abstract():
     ],
     ids=["nixl", "lmcache", "default"],
 )
-class TestMigratedBackendsProtocol:
-    """All migrated concrete backends expose the default P/D protocol shaping."""
+class TestConcreteBackendsProtocol:
+    """The concrete backends expose the default P/D protocol shaping."""
 
     def test_is_concrete_subclass(self, backend_factory):
         be = backend_factory()
@@ -156,7 +156,7 @@ class TestMultiConnectorDelegation:
     "ray.llm._internal.serve.engines.vllm.kv_transfer.lmcache._check_lmcache_installed"
 )
 def test_lmcache_setup_still_works(_mock_check):
-    """Migration must not break the connector-specific setup() behavior."""
+    """The P/D protocol must not break the connector-specific setup() behavior."""
     be = LMCacheConnectorV1Backend(llm_config=_llm_config("LMCacheConnectorV1"))
     be.setup()  # no-op path (no kv_connector_extra_config), must not raise
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_pd_protocol.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_pd_protocol.py
@@ -1,0 +1,125 @@
+"""Tests for the P/D coordination protocol on the KV connector backends.
+
+Proves that the concrete connector backends (NIXL, LMCache, Multi) are migrated
+onto the abstract ``BaseConnectorBackend`` protocol via ``DefaultPDProtocolMixin``,
+and that the abstract base itself cannot be instantiated.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ray.llm._internal.serve.core.configs.openai_api_models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+)
+from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+    BaseConnectorBackend,
+    DefaultConnectorBackend,
+    DefaultPDProtocolMixin,
+)
+from ray.llm._internal.serve.engines.vllm.kv_transfer.lmcache import (
+    LMCacheConnectorV1Backend,
+)
+from ray.llm._internal.serve.engines.vllm.kv_transfer.multi_connector import (
+    MultiConnectorBackend,
+)
+from ray.llm._internal.serve.engines.vllm.kv_transfer.nixl import (
+    NixlConnectorBackend,
+)
+from ray.serve.llm import LLMConfig
+
+
+def _llm_config(kv_connector: str) -> LLMConfig:
+    return LLMConfig(
+        model_loading_config=dict(model_id="Qwen/Qwen3-0.6B"),
+        engine_kwargs=dict(
+            kv_transfer_config=dict(
+                kv_connector=kv_connector,
+                kv_role="kv_both",
+            )
+        ),
+    )
+
+
+def test_base_connector_backend_is_abstract():
+    """``BaseConnectorBackend`` is abstract: its ``prepare_*`` methods are
+    abstractmethods, so direct instantiation raises ``TypeError``."""
+    with pytest.raises(TypeError):
+        BaseConnectorBackend(llm_config=None)
+
+
+@pytest.mark.parametrize(
+    "backend_factory",
+    [
+        lambda: NixlConnectorBackend(llm_config=_llm_config("NixlConnector")),
+        lambda: LMCacheConnectorV1Backend(llm_config=_llm_config("LMCacheConnectorV1")),
+        lambda: MultiConnectorBackend(llm_config=_llm_config("MultiConnector")),
+        lambda: DefaultConnectorBackend(llm_config=None),
+    ],
+    ids=["nixl", "lmcache", "multi", "default"],
+)
+class TestMigratedBackendsProtocol:
+    """All migrated concrete backends expose the default P/D protocol shaping."""
+
+    def test_is_concrete_subclass(self, backend_factory):
+        be = backend_factory()
+        assert isinstance(be, BaseConnectorBackend)
+        assert isinstance(be, DefaultPDProtocolMixin)
+        # Default flags == standard (no-peer, sequential) policy.
+        assert be.requires_peer_binding is False
+        assert be.concurrent_handoff is False
+
+    def test_prepare_prefill_shaping(self, backend_factory):
+        be = backend_factory()
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            max_completion_tokens=32,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        prefill = be.prepare_prefill_request(request=request, peer=None)
+        assert prefill.kv_transfer_params["do_remote_decode"] is True
+        assert prefill.kv_transfer_params["do_remote_prefill"] is False
+        assert prefill.max_tokens == 1
+        assert prefill.max_completion_tokens == 1
+        assert prefill.stream is False
+        assert prefill.stream_options is None
+        # Original request untouched.
+        assert request.max_completion_tokens == 32
+        assert request.stream is True
+
+    def test_prepare_decode_forwards_params(self, backend_factory):
+        be = backend_factory()
+        request = CompletionRequest(model="test-model", prompt="hi")
+        chunk = SimpleNamespace(kv_transfer_params={"remote_engine_id": "p1"})
+        decode = be.prepare_decode_request(
+            request=request, peer=None, prefill_response=chunk
+        )
+        assert decode.kv_transfer_params == {"remote_engine_id": "p1"}
+
+    def test_prepare_decode_none_prefill_response_no_crash(self, backend_factory):
+        """Concurrent-handoff mode passes ``prefill_response=None``: must not
+        crash and must leave kv_transfer_params unset (the gemini None-guard)."""
+        be = backend_factory()
+        request = CompletionRequest(model="test-model", prompt="hi")
+        decode = be.prepare_decode_request(
+            request=request, peer=None, prefill_response=None
+        )
+        assert getattr(decode, "kv_transfer_params", None) is None
+
+
+@patch(
+    "ray.llm._internal.serve.engines.vllm.kv_transfer.lmcache._check_lmcache_installed"
+)
+def test_lmcache_setup_still_works(_mock_check):
+    """Migration must not break the connector-specific setup() behavior."""
+    be = LMCacheConnectorV1Backend(llm_config=_llm_config("LMCacheConnectorV1"))
+    be.setup()  # no-op path (no kv_connector_extra_config), must not raise
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -340,6 +340,14 @@ class TestPDOrchestratorMixin:
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model")
         )
+        # Engine init stores the backend on the config; the orchestrator reads it.
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            DefaultConnectorBackend,
+        )
+
+        server._llm_config._kv_connector_backend = DefaultConnectorBackend(
+            server._llm_config
+        )
         # The direct-streaming app starts from the engine-native ASGI app, so
         # the decode server needs a (mock) engine. PD only re-points the
         # chat/completions routes at the orchestrator, patched below.
@@ -591,6 +599,15 @@ class TestConnectorProtocolHook:
                     "kv_role": "kv_both",
                 }
             },
+        )
+        # Engine init (setup_engine_backend) stores the backend on the config;
+        # the orchestrator reads it from there.
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.nixl import (
+            NixlConnectorBackend,
+        )
+
+        server._llm_config._kv_connector_backend = NixlConnectorBackend(
+            server._llm_config
         )
         prefill = _FakePrefillHandle()
         server._prefill_handle = prefill

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -708,6 +708,78 @@ class TestConnectorProtocolHook:
 
         assert prefill_cancelled["value"] is True
 
+    @pytest.mark.asyncio
+    async def test_concurrent_handoff_surfaces_prefill_error(self):
+        """In concurrent-handoff mode, a prefill ErrorResponse must surface to
+        the client (and abort the hung local decode) instead of being only
+        logged — decode may be waiting on KV that will never arrive."""
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ErrorInfo,
+            ErrorResponse,
+        )
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+
+        prefill_error = ErrorResponse(
+            error=ErrorInfo(message="prefill boom", code=500, type="InternalError")
+        )
+        decode_aborted = {"value": False}
+
+        class _ErrorPrefillHandle:
+            def options(self, **kwargs):
+                return self
+
+            @property
+            def completions(self):
+                async def _gen():
+                    yield prefill_error
+
+                def remote(request, raw_request_info):
+                    return _gen()
+
+                return SimpleNamespace(remote=remote)
+
+        class _ConcurrentBackend(BaseConnectorBackend):
+            requires_peer_binding = False
+            concurrent_handoff = True
+
+            def prepare_prefill_request(self, *, request, peer):
+                return request.model_copy(deep=True)
+
+            def prepare_decode_request(self, *, request, peer, prefill_response):
+                return request.model_copy(deep=True)
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model")
+        )
+        server._llm_config._kv_connector_backend = _ConcurrentBackend(
+            server._llm_config
+        )
+        server._prefill_handle = _ErrorPrefillHandle()
+
+        async def _hanging_super_completions(self, req, raw_info):
+            async def _gen():
+                try:
+                    # Decode never produces output (waiting on KV that the
+                    # failed prefill will never push).
+                    await asyncio.sleep(100)
+                    yield "never"
+                except (asyncio.CancelledError, GeneratorExit):
+                    decode_aborted["value"] = True
+                    raise
+
+            return _gen()
+
+        request = CompletionRequest(model="test-model", prompt="hi")
+
+        with patch.object(LLMServer, "completions", _hanging_super_completions):
+            chunks = [c async for c in server._pd_handle_request(request, None)]
+
+        assert chunks == [prefill_error]
+        assert decode_aborted["value"] is True
+
 
 class TestBuildPDOpenaiApp:
     """Test suite for build_pd_openai_app function."""

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -11,6 +11,7 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 )
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
+    CompletionRequest,
 )
 from ray.llm._internal.serve.core.ingress.builder import (
     IngressClsConfig,
@@ -359,6 +360,204 @@ class TestPDOrchestratorMixin:
         assert server._prefill_handle.calls[0]["method"] == method
         assert server._prefill_handle.calls[0]["session_id"] == "session-a"
         assert decode_calls[0].kv_transfer_params == {"remote_engine_id": "prefill-1"}
+
+
+class _ChooseReplicaPrefillHandle:
+    """Fake prefill DeploymentHandle exercising the choose_replica/dispatch path.
+
+    Mirrors the connector-protocol opt-in flow: the orchestrator opens a
+    ``choose_replica`` async context manager, reads ``selection.replica_metadata``,
+    then calls ``dispatch(selection, request, raw_info)``.
+    """
+
+    def __init__(self, calls=None, replica_metadata=None):
+        self.calls = calls if calls is not None else []
+        self._replica_metadata = (
+            replica_metadata if replica_metadata is not None else {"peer": "prefill-7"}
+        )
+
+    def options(self, **kwargs):
+        return self
+
+    def _method(self, name):
+        handle = self
+
+        class _Selection:
+            replica_metadata = handle._replica_metadata
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _Selection()
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        def choose_replica(request):
+            handle.calls.append({"phase": "choose_replica", "method": name})
+            return _Ctx()
+
+        def dispatch(selection, request, raw_request_info):
+            handle.calls.append(
+                {"phase": "dispatch", "method": name, "request": request}
+            )
+            return _aiter(
+                [SimpleNamespace(kv_transfer_params={"remote_engine_id": "prefill-7"})]
+            )
+
+        return SimpleNamespace(choose_replica=choose_replica, dispatch=dispatch)
+
+    @property
+    def chat(self):
+        return self._method("chat")
+
+    @property
+    def completions(self):
+        return self._method("completions")
+
+
+class TestConnectorProtocolHook:
+    """The orchestrator delegates request shaping + handoff to the backend."""
+
+    def test_default_backend_reproduces_legacy_prepare(self):
+        """The default ``BaseConnectorBackend.prepare_*`` must produce the exact
+        same requests as the legacy ``_prepare_prefill_request`` /
+        ``_prepare_decode_request`` static methods (behavior-preserving)."""
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            max_completion_tokens=16,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+
+        be = BaseConnectorBackend.__new__(BaseConnectorBackend)
+        be.llm_config = None
+
+        legacy_prefill = PDOrchestratorMixin._prepare_prefill_request(
+            request.model_copy(deep=True)
+        )
+        backend_prefill = be.prepare_prefill_request(
+            request.model_copy(deep=True), None
+        )
+        assert backend_prefill.model_dump() == legacy_prefill.model_dump()
+
+        chunk = SimpleNamespace(kv_transfer_params={"remote_engine_id": "p1"})
+        legacy_decode = PDOrchestratorMixin._prepare_decode_request(
+            request.model_copy(deep=True), chunk
+        )
+        backend_decode = be.prepare_decode_request(
+            request.model_copy(deep=True), None, chunk
+        )
+        assert backend_decode.model_dump() == legacy_decode.model_dump()
+        assert backend_decode.kv_transfer_params == {"remote_engine_id": "p1"}
+
+    def test_get_connector_backend_resolution_order(self):
+        """``_get_connector_backend`` prefers a stored instance, else resolves via
+        the factory when a kv_connector is configured, else a plain base backend."""
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+
+        # No kv_transfer_config -> plain BaseConnectorBackend.
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model")
+        )
+        be = server._get_connector_backend()
+        assert isinstance(be, BaseConnectorBackend)
+        assert be.requires_peer_binding is False
+        assert be.concurrent_handoff is False
+
+        # kv_connector configured -> factory-created backend (NixlConnectorBackend),
+        # which inherits the default flags (so still behavior-preserving).
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+            engine_kwargs={
+                "kv_transfer_config": {
+                    "kv_connector": "NixlConnector",
+                    "kv_role": "kv_both",
+                }
+            },
+        )
+        be2 = server._get_connector_backend()
+        assert isinstance(be2, BaseConnectorBackend)
+        assert be2.requires_peer_binding is False
+        assert be2.concurrent_handoff is False
+
+        # A stored instance wins over factory resolution.
+        sentinel = BaseConnectorBackend.__new__(BaseConnectorBackend)
+        sentinel.llm_config = server._llm_config
+        server._llm_config._kv_connector_backend = sentinel
+        assert server._get_connector_backend() is sentinel
+
+    @pytest.mark.asyncio
+    async def test_peer_binding_concurrent_handoff_takes_choose_replica_path(self):
+        """A backend opting into requires_peer_binding + concurrent_handoff must
+        drive the orchestrator down the choose_replica/dispatch + concurrent
+        local-decode path, calling the backend's prepare_* with the peer."""
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+
+        seen = {}
+
+        class _DummyBackend(BaseConnectorBackend):
+            requires_peer_binding = True
+            concurrent_handoff = True
+
+            def prepare_prefill_request(self, request, peer):
+                seen["prefill_peer"] = peer
+                out = request.model_copy(deep=True)
+                out.kv_transfer_params = {"role": "prefill", "peer": peer}
+                return out
+
+            def prepare_decode_request(self, request, peer, prefill_response):
+                seen["decode_peer"] = peer
+                seen["prefill_response"] = prefill_response
+                out = request.model_copy(deep=True)
+                out.kv_transfer_params = {"role": "decode", "peer": peer}
+                return out
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model")
+        )
+        dummy_backend = _DummyBackend(server._llm_config)
+        server._llm_config._kv_connector_backend = dummy_backend
+        prefill = _ChooseReplicaPrefillHandle(replica_metadata={"peer": "prefill-7"})
+        server._prefill_handle = prefill
+
+        decode_calls = []
+
+        async def _fake_super_completions(self, req, raw_info):
+            decode_calls.append(req)
+            return _aiter(["decode-chunk"])
+
+        request = CompletionRequest(model="test-model", prompt="hi")
+
+        # Patch the super() local-decode target (LLMServer.completions in the MRO).
+        with patch.object(LLMServer, "completions", _fake_super_completions):
+            chunks = [c async for c in server._pd_handle_request(request, None)]
+
+        # choose_replica + dispatch were used (not .remote()).
+        phases = [c["phase"] for c in prefill.calls]
+        assert phases == ["choose_replica", "dispatch"], phases
+        # Backend saw the peer metadata from the selection on both prepares.
+        assert seen["prefill_peer"] == {"peer": "prefill-7"}
+        assert seen["decode_peer"] == {"peer": "prefill-7"}
+        # Concurrent handoff -> no prefill chunk captured before decode.
+        assert seen["prefill_response"] is None
+        # Local decode ran with the backend-shaped decode request.
+        assert decode_calls[0].kv_transfer_params == {
+            "role": "decode",
+            "peer": {"peer": "prefill-7"},
+        }
+        assert chunks == ["decode-chunk"]
 
 
 class TestBuildPDOpenaiApp:

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -478,9 +478,9 @@ class TestConnectorProtocolHook:
         )
         assert getattr(decode_none, "kv_transfer_params", None) is None
 
-    def test_get_connector_backend_resolution_order(self):
-        """``_get_connector_backend`` prefers a stored instance, else resolves via
-        the factory when a kv_connector is configured, else raises."""
+    def test_get_connector_backend_returns_stored_backend(self):
+        """``_get_connector_backend`` returns the backend that engine init stored
+        on the LLMConfig (and caches it); asserts if none was stored."""
         from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
             BaseConnectorBackend,
         )
@@ -489,17 +489,6 @@ class TestConnectorProtocolHook:
         )
 
         server = PDDecodeServer.__new__(PDDecodeServer)
-
-        # No kv_transfer_config and no stored backend -> raises (PD always has a
-        # kv_transfer_config, so this path is a misconfiguration).
-        server._llm_config = LLMConfig(
-            model_loading_config=ModelLoadingConfig(model_id="test-model")
-        )
-        with pytest.raises(ValueError):
-            server._get_connector_backend()
-
-        # kv_connector configured -> factory-created concrete backend
-        # (NixlConnectorBackend), which inherits the default flags.
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model"),
             engine_kwargs={
@@ -509,16 +498,20 @@ class TestConnectorProtocolHook:
                 }
             },
         )
-        be2 = server._get_connector_backend()
-        assert isinstance(be2, NixlConnectorBackend)
-        assert be2.requires_peer_binding is False
-        assert be2.concurrent_handoff is False
 
-        # A stored instance wins over factory resolution.
-        sentinel = NixlConnectorBackend(llm_config=server._llm_config)
-        assert isinstance(sentinel, BaseConnectorBackend)
-        server._llm_config._kv_connector_backend = sentinel
-        assert server._get_connector_backend() is sentinel
+        # No backend stored (engine init / setup_engine_backend didn't run) -> assert.
+        with pytest.raises(AssertionError):
+            server._get_connector_backend()
+
+        # The backend setup_engine_backend would store is returned.
+        stored = NixlConnectorBackend(llm_config=server._llm_config)
+        assert isinstance(stored, BaseConnectorBackend)
+        server._llm_config._kv_connector_backend = stored
+        assert server._get_connector_backend() is stored
+
+        # Cached on first access: a later config change isn't re-read.
+        server._llm_config._kv_connector_backend = None
+        assert server._get_connector_backend() is stored
 
     @pytest.mark.asyncio
     async def test_peer_binding_concurrent_handoff_takes_choose_replica_path(self):

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import warnings
 from types import SimpleNamespace
@@ -24,7 +25,6 @@ from ray.llm._internal.serve.serving_patterns.prefill_decode.builder import (
 )
 from ray.llm._internal.serve.serving_patterns.prefill_decode.pd_server import (
     PDDecodeServer,
-    PDOrchestratorMixin,
     PDPrefillServer,
 )
 from ray.serve._private.http_util import SERVE_SESSION_ID
@@ -288,6 +288,10 @@ class TestServingArgsParsing:
 
 class TestPDOrchestratorMixin:
     def test_prepare_prefill_request_limits_chat_to_one_token(self):
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            DefaultConnectorBackend,
+        )
+
         request = ChatCompletionRequest(
             model="test-model",
             messages=[{"role": "user", "content": "hello"}],
@@ -296,7 +300,8 @@ class TestPDOrchestratorMixin:
             stream_options={"include_usage": True},
         )
 
-        prefill_request = PDOrchestratorMixin._prepare_prefill_request(request)
+        be = DefaultConnectorBackend(llm_config=None)
+        prefill_request = be.prepare_prefill_request(request=request, peer=None)
 
         assert prefill_request.max_tokens == 1
         assert prefill_request.max_completion_tokens == 1
@@ -418,12 +423,23 @@ class _ChooseReplicaPrefillHandle:
 class TestConnectorProtocolHook:
     """The orchestrator delegates request shaping + handoff to the backend."""
 
-    def test_default_backend_reproduces_legacy_prepare(self):
-        """The default ``BaseConnectorBackend.prepare_*`` must produce the exact
-        same requests as the legacy ``_prepare_prefill_request`` /
-        ``_prepare_decode_request`` static methods (behavior-preserving)."""
+    def test_base_connector_backend_is_abstract(self):
+        """``BaseConnectorBackend`` is abstract and cannot be instantiated:
+        ``prepare_prefill_request`` / ``prepare_decode_request`` are abstract."""
         from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
             BaseConnectorBackend,
+        )
+
+        with pytest.raises(TypeError):
+            BaseConnectorBackend(llm_config=None)
+
+    def test_default_protocol_mixin_shaping(self):
+        """The ``DefaultPDProtocolMixin`` policy: prefill stamps the standard
+        kv_transfer_params + clamps to one non-streaming token; decode forwards
+        the prefill response's kv_transfer_params, and tolerates a None prefill
+        response (concurrent-handoff mode) without crashing."""
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            DefaultConnectorBackend,
         )
 
         request = ChatCompletionRequest(
@@ -434,47 +450,56 @@ class TestConnectorProtocolHook:
             stream_options={"include_usage": True},
         )
 
-        be = BaseConnectorBackend.__new__(BaseConnectorBackend)
-        be.llm_config = None
+        be = DefaultConnectorBackend(llm_config=None)
 
-        legacy_prefill = PDOrchestratorMixin._prepare_prefill_request(
-            request.model_copy(deep=True)
+        prefill = be.prepare_prefill_request(
+            request=request.model_copy(deep=True), peer=None
         )
-        backend_prefill = be.prepare_prefill_request(
-            request.model_copy(deep=True), None
-        )
-        assert backend_prefill.model_dump() == legacy_prefill.model_dump()
+        assert prefill.kv_transfer_params["do_remote_decode"] is True
+        assert prefill.kv_transfer_params["do_remote_prefill"] is False
+        assert prefill.max_tokens == 1
+        assert prefill.max_completion_tokens == 1
+        assert prefill.stream is False
+        assert prefill.stream_options is None
+        # Original untouched.
+        assert request.max_completion_tokens == 16
+        assert request.stream is True
 
         chunk = SimpleNamespace(kv_transfer_params={"remote_engine_id": "p1"})
-        legacy_decode = PDOrchestratorMixin._prepare_decode_request(
-            request.model_copy(deep=True), chunk
+        decode = be.prepare_decode_request(
+            request=request.model_copy(deep=True), peer=None, prefill_response=chunk
         )
-        backend_decode = be.prepare_decode_request(
-            request.model_copy(deep=True), None, chunk
+        assert decode.kv_transfer_params == {"remote_engine_id": "p1"}
+
+        # None prefill_response (concurrent mode) must not crash and leaves
+        # kv_transfer_params unset.
+        decode_none = be.prepare_decode_request(
+            request=request.model_copy(deep=True), peer=None, prefill_response=None
         )
-        assert backend_decode.model_dump() == legacy_decode.model_dump()
-        assert backend_decode.kv_transfer_params == {"remote_engine_id": "p1"}
+        assert getattr(decode_none, "kv_transfer_params", None) is None
 
     def test_get_connector_backend_resolution_order(self):
         """``_get_connector_backend`` prefers a stored instance, else resolves via
-        the factory when a kv_connector is configured, else a plain base backend."""
+        the factory when a kv_connector is configured, else raises."""
         from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
             BaseConnectorBackend,
+        )
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.nixl import (
+            NixlConnectorBackend,
         )
 
         server = PDDecodeServer.__new__(PDDecodeServer)
 
-        # No kv_transfer_config -> plain BaseConnectorBackend.
+        # No kv_transfer_config and no stored backend -> raises (PD always has a
+        # kv_transfer_config, so this path is a misconfiguration).
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model")
         )
-        be = server._get_connector_backend()
-        assert isinstance(be, BaseConnectorBackend)
-        assert be.requires_peer_binding is False
-        assert be.concurrent_handoff is False
+        with pytest.raises(ValueError):
+            server._get_connector_backend()
 
-        # kv_connector configured -> factory-created backend (NixlConnectorBackend),
-        # which inherits the default flags (so still behavior-preserving).
+        # kv_connector configured -> factory-created concrete backend
+        # (NixlConnectorBackend), which inherits the default flags.
         server._llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-model"),
             engine_kwargs={
@@ -485,13 +510,13 @@ class TestConnectorProtocolHook:
             },
         )
         be2 = server._get_connector_backend()
-        assert isinstance(be2, BaseConnectorBackend)
+        assert isinstance(be2, NixlConnectorBackend)
         assert be2.requires_peer_binding is False
         assert be2.concurrent_handoff is False
 
         # A stored instance wins over factory resolution.
-        sentinel = BaseConnectorBackend.__new__(BaseConnectorBackend)
-        sentinel.llm_config = server._llm_config
+        sentinel = NixlConnectorBackend(llm_config=server._llm_config)
+        assert isinstance(sentinel, BaseConnectorBackend)
         server._llm_config._kv_connector_backend = sentinel
         assert server._get_connector_backend() is sentinel
 
@@ -510,13 +535,13 @@ class TestConnectorProtocolHook:
             requires_peer_binding = True
             concurrent_handoff = True
 
-            def prepare_prefill_request(self, request, peer):
+            def prepare_prefill_request(self, *, request, peer):
                 seen["prefill_peer"] = peer
                 out = request.model_copy(deep=True)
                 out.kv_transfer_params = {"role": "prefill", "peer": peer}
                 return out
 
-            def prepare_decode_request(self, request, peer, prefill_response):
+            def prepare_decode_request(self, *, request, peer, prefill_response):
                 seen["decode_peer"] = peer
                 seen["prefill_response"] = prefill_response
                 out = request.model_copy(deep=True)
@@ -558,6 +583,120 @@ class TestConnectorProtocolHook:
             "peer": {"peer": "prefill-7"},
         }
         assert chunks == ["decode-chunk"]
+
+    @pytest.mark.asyncio
+    async def test_default_nixl_backend_shapes_prefill_and_forwards_decode(self):
+        """End-to-end (mock handle) default path through a resolved NIXL backend:
+        prefill is shaped (max_tokens=1, do_remote_decode), and decode forwards
+        the prefill chunk's kv_transfer_params."""
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+            engine_kwargs={
+                "kv_transfer_config": {
+                    "kv_connector": "NixlConnector",
+                    "kv_role": "kv_both",
+                }
+            },
+        )
+        prefill = _FakePrefillHandle()
+        server._prefill_handle = prefill
+
+        decode_calls = []
+
+        async def _fake_super_completions(self, req, raw_info):
+            decode_calls.append(req)
+            return _aiter(["decode-chunk"])
+
+        request = CompletionRequest(model="test-model", prompt="hi")
+
+        with patch.object(LLMServer, "completions", _fake_super_completions):
+            chunks = [c async for c in server._pd_handle_request(request, None)]
+
+        # Standard (non choose_replica) path: .remote() was used.
+        sent_prefill = prefill.calls[0]["request"]
+        assert sent_prefill.max_tokens == 1
+        assert sent_prefill.kv_transfer_params["do_remote_decode"] is True
+        # Decode forwarded prefill's kv_transfer_params.
+        assert decode_calls[0].kv_transfer_params == {"remote_engine_id": "prefill-1"}
+        assert chunks == ["decode-chunk"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_handoff_cancels_prefill_on_decode_failure(self):
+        """In concurrent-handoff mode, if local decode raises, the background
+        prefill task must be cancelled (no leak)."""
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+
+        prefill_started = asyncio.Event()
+        prefill_cancelled = {"value": False}
+
+        class _SlowPrefillHandle:
+            def __init__(self):
+                self.calls = []
+
+            def options(self, **kwargs):
+                return self
+
+            def _method(self, name):
+                async def _gen():
+                    prefill_started.set()
+                    try:
+                        await asyncio.sleep(100)
+                        yield SimpleNamespace(kv_transfer_params={})
+                    except asyncio.CancelledError:
+                        prefill_cancelled["value"] = True
+                        raise
+
+                def remote(request, raw_request_info):
+                    self.calls.append({"method": name})
+                    return _gen()
+
+                return SimpleNamespace(remote=remote)
+
+            @property
+            def completions(self):
+                return self._method("completions")
+
+        class _ConcurrentBackend(BaseConnectorBackend):
+            requires_peer_binding = False
+            concurrent_handoff = True
+
+            def prepare_prefill_request(self, *, request, peer):
+                out = request.model_copy(deep=True)
+                out.kv_transfer_params = {"do_remote_decode": True}
+                return out
+
+            def prepare_decode_request(self, *, request, peer, prefill_response):
+                return request.model_copy(deep=True)
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model")
+        )
+        server._llm_config._kv_connector_backend = _ConcurrentBackend(
+            server._llm_config
+        )
+        server._prefill_handle = _SlowPrefillHandle()
+
+        async def _failing_super_completions(self, req, raw_info):
+            await prefill_started.wait()
+
+            async def _gen():
+                raise RuntimeError("decode boom")
+                yield  # pragma: no cover
+
+            return _gen()
+
+        request = CompletionRequest(model="test-model", prompt="hi")
+
+        with patch.object(LLMServer, "completions", _failing_super_completions):
+            with pytest.raises(RuntimeError, match="decode boom"):
+                async for _ in server._pd_handle_request(request, None):
+                    pass
+
+        assert prefill_cancelled["value"] is True
 
 
 class TestBuildPDOpenaiApp:


### PR DESCRIPTION
## Why
Make the KV-transfer connector backend the single place that owns prefill/decode (P/D)
request shaping, peer addressing, and handoff discipline — so connectors plug into the P/D
orchestrator without bespoke orchestrator branches. This generalizes the orchestrator beyond a
single hard-coded policy and is the foundation for connectors (e.g. a request-id-addressed,
push-based one) that need pre-dispatch peer binding and/or a concurrent handoff.

## What
`BaseConnectorBackend` defines an **abstract** P/D protocol:
- `prepare_prefill_request(*, request, peer)` and `prepare_decode_request(*, request, peer, prefill_response)`
  (keyword-only, typed `RequestType = ChatCompletionRequest | CompletionRequest`).
- Two independent policy flags:
  - `requires_peer_binding` — when True, the orchestrator selects the prefill replica first
    (`choose_replica`) and passes its `replica_metadata` to the backend as `peer` (pre-dispatch
    addressing); when False, prefill is dispatched via the standard handle path.
  - `concurrent_handoff` — when True, remote prefill and local decode run concurrently; when
    False, prefill runs to its first chunk before decode starts (sequential).
  - These are independent: standard connectors are `(False, False)`; a push-based,
    request-id-addressed connector is `(True, True)`; a pull-based one is `(True, False)`.

The standard (no-peer, sequential) policy lives in a shared `DefaultPDProtocolMixin`:
- **NIXL** and **LMCache** backends inherit it (migrated onto the interface).
- **Multi** connector backend **delegates** `prepare_*` and the policy flags to its **top-most**
  sub-connector, so that sub-connector's policy governs the group.
- A connector with a different protocol overrides `prepare_*` and opts into the flags.

`PDOrchestratorMixin` resolves the backend once (cached) via `_get_connector_backend()` and routes
**all** connectors' request shaping + handoff through it. The concurrent handoff is a single
`_concurrent_decode` helper that always drains the remote prefill and cancels it if local decode
doesn't complete (no leaked background prefill).

## Stack
Part of a series enabling new KV connectors for Ray Serve LLM P/D; pairs with the per-replica
metadata hook (exposes `ReplicaSelection.replica_metadata` for pre-dispatch peer binding) and the
engine request-id PR. A MoRIIO connector backend (request-id-addressed) builds on this in a follow-up.

## Testing
- `test_pd_protocol.py`: abstract base can't be instantiated; NIXL/LMCache/default expose the
  default-mixin shaping (incl. the `prefill_response=None` guard for concurrent mode); Multi
  delegates `prepare_*`/flags to its top-most sub-connector.
- `test_prefill_decode_disagg.py` / `test_factory.py`: orchestration routes prefill/decode shaping
  through the resolved backend; concurrent-handoff cancels the background prefill on decode failure;
  factory resolution + fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
