### PR TITLE
[serve.llm] Add MoRIIO KV-connector backend for prefill/decode

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -18,6 +18,30 @@ if TYPE_CHECKING:
     RequestType = Union[ChatCompletionRequest, CompletionRequest]
 
 
+def base_prefill_kv_transfer_params() -> Dict[str, Any]:
+    """The ``kv_transfer_params`` common to a prefill (producer) request.
+
+    Tells the prefill engine to produce KV for a remote decode. Connectors layer
+    their own keys (e.g. a transfer id, DP/TP routing) on top of these.
+    """
+    return {
+        "do_remote_decode": True,
+        "do_remote_prefill": False,
+        "remote_engine_id": None,
+        "remote_block_ids": None,
+    }
+
+
+def clamp_request_to_single_token(request: "RequestType") -> None:
+    """Clamp a prefill request to a single, non-streaming token (in place)."""
+    request.max_tokens = 1
+    if hasattr(request, "max_completion_tokens"):
+        request.max_completion_tokens = 1
+    request.stream = False
+    if hasattr(request, "stream_options"):
+        request.stream_options = None
+
+
 class BaseConnectorBackend(abc.ABC):
     # ---- P/D coordination protocol ----
     #
@@ -200,19 +224,11 @@ class DefaultPDProtocolMixin:
         ), "kv_transfer_params should be empty before orchestrator"
         prefill_request = request.model_copy(deep=True)
         prefill_request.kv_transfer_params = {
-            "do_remote_decode": True,
-            "do_remote_prefill": False,
-            "remote_engine_id": None,
-            "remote_block_ids": None,
+            **base_prefill_kv_transfer_params(),
             "remote_host": None,
             "remote_port": None,
         }
-        prefill_request.max_tokens = 1
-        if hasattr(prefill_request, "max_completion_tokens"):
-            prefill_request.max_completion_tokens = 1
-        prefill_request.stream = False
-        if hasattr(prefill_request, "stream_options"):
-            prefill_request.stream_options = None
+        clamp_request_to_single_token(prefill_request)
         return prefill_request
 
     def prepare_decode_request(

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -159,33 +159,6 @@ class BaseConnectorBackend(abc.ABC):
         """
         pass
 
-    def engine_request_id(
-        self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
-    ) -> Optional[str]:
-        """The request id both engines must observe for this request, or None.
-
-        Most connectors return None: the engine derives its own id from the
-        Serve request context and the ``X-Request-Id`` header as usual. A
-        connector that encodes coordination data *in the request id itself*
-        (e.g. MoRIIO's ``___prefill_addr_...___decode_addr_..._{uid}``) returns
-        that id here so the orchestrator can deliver it to both the remote
-        prefill and the local decode engine. Returning a value is not enough on
-        its own -- shaping ``request.request_id`` in ``prepare_*`` does not
-        survive, because vLLM reads the engine id from the ``X-Request-Id``
-        header and the local-decode pipeline overwrites ``request.request_id``
-        from the Serve request context. The orchestrator sets both from this
-        value; see ``PDOrchestratorMixin._connector_raw_request_info``.
-
-        Args:
-            request: The incoming chat/completion request.
-            peer: The selected prefill replica's ``replica_metadata`` dict when
-                the connector opted into pre-dispatch peer binding, else None.
-
-        Returns:
-            The id to stamp on both engines, or None to keep the default id.
-        """
-        return None
-
     def replica_metadata(self) -> Dict[str, Any]:
         """Static per-replica coordination data published to the orchestrator.
 

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -159,6 +159,19 @@ class BaseConnectorBackend(abc.ABC):
         """
         pass
 
+    def replica_metadata(self) -> Dict[str, Any]:
+        """Static per-replica coordination data published to the orchestrator.
+
+        Surfaced via the replica-metadata hook on ``ReplicaSelection`` so that a
+        connector opting into ``requires_peer_binding`` can address the selected
+        prefill peer. The default backend publishes nothing; connectors that need
+        to advertise an address (e.g. MoRIIO's zmq endpoint) override this.
+
+        Returns:
+            A JSON-serializable dict of per-replica metadata (empty by default).
+        """
+        return {}
+
 
 class DefaultPDProtocolMixin:
     """The default P/D protocol policy: no peer binding, sequential handoff.

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -159,6 +159,33 @@ class BaseConnectorBackend(abc.ABC):
         """
         pass
 
+    def engine_request_id(
+        self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        """The request id both engines must observe for this request, or None.
+
+        Most connectors return None: the engine derives its own id from the
+        Serve request context and the ``X-Request-Id`` header as usual. A
+        connector that encodes coordination data *in the request id itself*
+        (e.g. MoRIIO's ``___prefill_addr_...___decode_addr_..._{uid}``) returns
+        that id here so the orchestrator can deliver it to both the remote
+        prefill and the local decode engine. Returning a value is not enough on
+        its own -- shaping ``request.request_id`` in ``prepare_*`` does not
+        survive, because vLLM reads the engine id from the ``X-Request-Id``
+        header and the local-decode pipeline overwrites ``request.request_id``
+        from the Serve request context. The orchestrator sets both from this
+        value; see ``PDOrchestratorMixin._connector_raw_request_info``.
+
+        Args:
+            request: The incoming chat/completion request.
+            peer: The selected prefill replica's ``replica_metadata`` dict when
+                the connector opted into pre-dispatch peer binding, else None.
+
+        Returns:
+            The id to stamp on both engines, or None to keep the default id.
+        """
+        return None
+
     def replica_metadata(self) -> Dict[str, Any]:
         """Static per-replica coordination data published to the orchestrator.
 

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
@@ -121,6 +121,7 @@ BUILTIN_BACKENDS = {
     "LMCacheConnectorV1": "ray.llm._internal.serve.engines.vllm.kv_transfer.lmcache:LMCacheConnectorV1Backend",
     "NixlConnector": "ray.llm._internal.serve.engines.vllm.kv_transfer.nixl:NixlConnectorBackend",
     "MultiConnector": "ray.llm._internal.serve.engines.vllm.kv_transfer.multi_connector:MultiConnectorBackend",
+    "MoRIIOConnector": "ray.llm._internal.serve.engines.vllm.kv_transfer.moriio:MoRIIOConnectorBackend",
 }
 
 

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -1,0 +1,358 @@
+"""MoRIIO connector backend for Ray Serve LLM (analogue of nixl.py).
+
+Configures a vLLM engine's ``kv_transfer_config.kv_connector_extra_config`` for
+the MoRIIO connector and computes per-replica handshake/notify ports so colocated
+replicas don't collide. Also builds the engine's advertised zmq address so the
+P/D orchestrator can discover it via the replica-metadata hook
+(``ReplicaSelection.replica_metadata``), and implements the PD connector protocol
+(``requires_peer_binding`` / ``concurrent_handoff`` / ``prepare_prefill_request`` /
+``prepare_decode_request``) so the decode orchestrator can address the selected
+prefill peer by request id.
+
+Unlike NIXL/LMCache, MoRIIO does NOT use ``DefaultPDProtocolMixin``: it has custom
+request shaping (a dual-address request_id + transfer_id) and therefore IMPLEMENTS
+the abstract ``prepare_*`` methods directly on ``BaseConnectorBackend``.
+
+Two transfer disciplines, selected by ``read_mode``:
+  * WRITE (default): prefill PUSHES KV to decode -> concurrent handoff.
+  * READ: decode PULLS KV from prefill -> sequential handoff; the decode request
+    forwards the ``remote_block_ids`` / ``remote_engine_id`` the prefill engine
+    returned.
+
+The dual-address request_id and the transfer_id are derived DETERMINISTICALLY
+from the incoming request id (uuid5), so ``prepare_prefill_request`` and
+``prepare_decode_request`` produce identical ids across their two separate calls
+without per-request backend state (the backend instance is shared across
+requests).
+
+Registered with Ray's public connector registry via the factory.
+"""
+
+import logging
+import os
+import re
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
+import ray
+from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+    BaseConnectorBackend,
+)
+from ray.llm._internal.serve.utils.server_utils import (
+    get_serve_request_id,
+)
+
+if TYPE_CHECKING:
+    from ray.llm._internal.serve.engines.vllm.kv_transfer.base import RequestType
+
+logger = logging.getLogger(__name__)
+
+# Defaults mirror vLLM's MoRIIOConstants (DEFAULT_HANDSHAKE_PORT / NOTIFY_PORT).
+# Prefill uses these bases; decode is shifted (see builder.py) so a colocated
+# P+D pair on one node doesn't collide.
+DEFAULT_HANDSHAKE_PORT_BASE = 6301
+DEFAULT_NOTIFY_PORT_BASE = 61005
+
+# experimental_configs keys understood by this backend.
+HANDSHAKE_PORT_BASE_KEY = "MORI_HANDSHAKE_PORT_BASE"
+NOTIFY_PORT_BASE_KEY = "MORI_NOTIFY_PORT_BASE"
+# Where setup() stashes the advertised zmq address for replica_metadata() to read.
+ZMQ_ADDRESS_KEY = "_mori_zmq_address"
+# Process-env fallback for the advertised zmq address.
+MORI_ZMQ_ADDRESS_ENV = "MORI_ZMQ_ADDRESS"
+
+# ---------------------------------------------------------------------------
+# Dual-address request_id / zmq address encoding.
+#
+# These MUST stay byte-compatible with the regexes vLLM's MoRIIO connector uses
+# to recover peer addresses from the request_id:
+#
+#   vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+#       _PREFILL_ZMQ_RE = re.compile(r"___prefill_addr_(.+?)___decode_addr_")
+#       _DECODE_ZMQ_RE  = re.compile(r"___decode_addr_(.+)_[0-9a-f]{32}(?:-.*)?$")
+#       # zmq address: "host:IP,handshake:PORT,notify:PORT"
+# ---------------------------------------------------------------------------
+
+_PREFILL_PREFIX = "___prefill_addr_"
+_DECODE_PREFIX = "___decode_addr_"
+_TRANSFER_PREFIX = "tx"
+
+# Copies of vLLM's regexes for local validation / round-trip tests.
+_PREFILL_ZMQ_RE = re.compile(r"___prefill_addr_(.+?)___decode_addr_")
+_DECODE_ZMQ_RE = re.compile(r"___decode_addr_(.+)_[0-9a-f]{32}(?:-.*)?$")
+
+# Stable namespace for deterministic uuid5 derivation of the dual-address uid.
+# Fixed so prefill & decode (and any retry) agree on the same id for a request.
+_MORI_UID_NAMESPACE = uuid.UUID("d3b07384-d9a0-4f1b-9c2e-6d6f72690001")
+
+
+def build_zmq_address(host: str, handshake_port: int, notify_port: int) -> str:
+    """Build the MORI zmq address string ``host:IP,handshake:PORT,notify:PORT``."""
+    return f"host:{host},handshake:{handshake_port},notify:{notify_port}"
+
+
+def parse_zmq_address(zmq_address: str) -> Tuple[str, int, int]:
+    """Inverse of :func:`build_zmq_address` -> ``(host, handshake_port, notify_port)``."""
+    parts = {}
+    for segment in zmq_address.split(","):
+        key, _, val = segment.partition(":")
+        parts[key.strip()] = val.strip()
+    return parts["host"], int(parts["handshake"]), int(parts["notify"])
+
+
+def derive_uid(seed: str) -> str:
+    """Deterministically derive the 32-hex uid from a stable per-request seed.
+
+    Using uuid5 (not uuid4) so that ``prepare_prefill_request`` and
+    ``prepare_decode_request`` -- two separate, stateless calls for the same
+    request -- agree on the same dual-address id and transfer_id.
+    """
+    return uuid.uuid5(_MORI_UID_NAMESPACE, seed).hex
+
+
+def build_pd_request_id(prefill_zmq: str, decode_zmq: str, uid: str) -> str:
+    """Build the dual-address request id consumed by both P and D engines.
+
+    Format: ``___prefill_addr_{P}___decode_addr_{D}_{uid32}`` where the trailing
+    32-hex uid is what ``_DECODE_ZMQ_RE`` anchors on. ``uid`` MUST be the
+    deterministic value from :func:`derive_uid` so the two prepare_* calls agree.
+    """
+    return f"{_PREFILL_PREFIX}{prefill_zmq}{_DECODE_PREFIX}{decode_zmq}_{uid}"
+
+
+def build_transfer_id(uid: str) -> str:
+    """Per-(P,D) transfer id. Mirrors vllm-router's ``tx-{uuid32}``.
+
+    Derived from the same deterministic ``uid`` as the request id.
+    """
+    return f"{_TRANSFER_PREFIX}-{uid}"
+
+
+def parse_peer_zmq(request_id: str, is_producer: bool) -> str:
+    """Recover the peer's zmq address from a request id (for tests/debugging).
+
+    Producer (prefill) wants the *decode* address; consumer wants the *prefill*.
+    """
+    rex = _DECODE_ZMQ_RE if is_producer else _PREFILL_ZMQ_RE
+    m = rex.search(request_id)
+    if not m:
+        raise ValueError(f"No peer zmq address in request_id: {request_id!r}")
+    return m.group(1)
+
+
+def _read_mode_enabled(extra_config: Dict[str, Any]) -> bool:
+    """Mirror vLLM's ``get_moriio_mode`` parse of ``read_mode``.
+
+    true / 1 -> READ; anything else -> WRITE (default).
+    """
+    return str(extra_config.get("read_mode", "false")).lower().strip() in (
+        "true",
+        "1",
+    )
+
+
+class MoRIIOConnectorBackend(BaseConnectorBackend):
+    """Set up MoRIIO ports/extra_config and implement the PD connector protocol."""
+
+    # MORI addresses peers by the dual-address request id, so the orchestrator
+    # must bind to the selected prefill replica BEFORE dispatch.
+    requires_peer_binding: bool = True
+
+    def _extra_config(self) -> dict:
+        cfg = self.kv_transfer_config.setdefault("kv_connector_extra_config", {})
+        return cfg
+
+    @property
+    def _read_mode(self) -> bool:
+        """True iff this engine's MoRIIO connector is configured for READ mode."""
+        extra = (self.kv_transfer_config or {}).get("kv_connector_extra_config") or {}
+        return _read_mode_enabled(extra)
+
+    @property
+    def concurrent_handoff(self) -> bool:
+        """WRITE -> concurrent (prefill pushes); READ -> sequential (decode pulls)."""
+        return not self._read_mode
+
+    def setup(self) -> None:
+        offset = self._compute_port_offset()
+
+        handshake_base = int(
+            self.llm_config.experimental_configs.get(
+                HANDSHAKE_PORT_BASE_KEY, DEFAULT_HANDSHAKE_PORT_BASE
+            )
+        )
+        notify_base = int(
+            self.llm_config.experimental_configs.get(
+                NOTIFY_PORT_BASE_KEY, DEFAULT_NOTIFY_PORT_BASE
+            )
+        )
+
+        # NOTE: vLLM internally adds get_port_offset(dp_rank, tp_rank) on top of
+        # these bases. For TP/DP>1, reserve a stride >= tp_size*pp_size when
+        # shifting decode's base in the builder so the two offset schemes never
+        # overlap.
+        handshake_port = handshake_base + offset
+        notify_port = notify_base + offset
+
+        extra = self._extra_config()
+        # Required keys for vLLM's config parser (KeyError otherwise) -- proxyless.
+        extra.setdefault("proxy_ip", "")  # empty => ping/registration thread disabled
+        extra.setdefault("proxy_ping_port", "0")
+        # TODO: real Serve replica HTTP port. Harmless placeholder while
+        # proxy_ip="" (only used to build request_address for the disabled ping).
+        extra.setdefault("http_port", str(8000 + offset))
+        # WRITE mode (prefill pushes). READ would be "true".
+        extra.setdefault("read_mode", "false")
+        extra["handshake_port"] = str(handshake_port)
+        extra["notify_port"] = str(notify_port)
+
+        # Advertise the Ray internal cluster IP as the zmq host.
+        host = ray.util.get_node_ip_address()
+        zmq_address = build_zmq_address(host, handshake_port, notify_port)
+        # Stash so replica_metadata() (the PR1 hook) can publish it; the decode
+        # orchestrator reads the selected prefill replica's copy off the peer.
+        self.llm_config.experimental_configs[ZMQ_ADDRESS_KEY] = zmq_address
+        os.environ.setdefault(MORI_ZMQ_ADDRESS_ENV, zmq_address)
+        # NOTE: cross-node correctness additionally needs MoRIIO's worker to
+        # advertise the node INTERNAL IP (VLLM_HOST_IP inside every worker
+        # process). That fix must live in the worker process (a vLLM general
+        # plugin) -- see the follow-up worker host-IP PR.
+
+    # ---- replica metadata (published via the PR1 hook) ----
+
+    def _own_zmq_address(self) -> Optional[str]:
+        """The replica's own advertised MORI zmq address (set by setup()).
+
+        Prefer the value stashed on llm_config; fall back to the process env the
+        backend also sets (robust if the engine holds a different llm_config copy).
+        """
+        addr = self.llm_config.experimental_configs.get(ZMQ_ADDRESS_KEY)
+        if not addr:
+            addr = os.environ.get(MORI_ZMQ_ADDRESS_ENV)
+        return addr
+
+    def replica_metadata(self) -> dict:
+        """Static per-replica coordination data published to the orchestrator.
+
+        The prefill replica publishes its MORI zmq address; the decode
+        orchestrator reads it off the selected prefill replica's
+        ``ReplicaSelection.replica_metadata``.
+        """
+        return {"mori_zmq_address": self._own_zmq_address()}
+
+    # ---- request shaping (PD connector protocol) ----
+
+    @staticmethod
+    def _request_seed(request: Any) -> str:
+        """Stable per-request seed for the deterministic uid derivation.
+
+        An explicitly-set ``request.request_id`` is authoritative; otherwise the
+        serve-context request id (stable across both ``prepare_*`` calls of one
+        orchestration) is used. The ``id(request)`` last resort only applies
+        outside a Serve request context (e.g. unit tests) and is likewise stable
+        within a single orchestration, which operates on one request object.
+        """
+        seed = getattr(request, "request_id", None)
+        if not seed:
+            seed = get_serve_request_id()
+        if not seed:
+            seed = f"mori-fallback-{id(request)}"
+        return str(seed)
+
+    def _peer_prefill_zmq(self, peer: Optional[Dict[str, Any]]) -> Optional[str]:
+        return (peer or {}).get("mori_zmq_address")
+
+    def _dual_ids(
+        self, request: Any, peer: Optional[Dict[str, Any]]
+    ) -> Tuple[str, str]:
+        """Compute the (dual-address request_id, transfer_id) for this request.
+
+        Deterministic in (request seed, peer prefill zmq, own decode zmq), so the
+        prefill and decode preparation calls produce identical ids with no
+        per-request backend state.
+        """
+        prefill_zmq = self._peer_prefill_zmq(peer)
+        decode_zmq = self._own_zmq_address()
+        if not prefill_zmq:
+            raise ValueError(
+                "MoRIIO peer is missing 'mori_zmq_address': the selected prefill "
+                "replica did not publish its address (is MoRIIOConnector "
+                "configured on the prefill deployment?)."
+            )
+        if not decode_zmq:
+            raise ValueError(
+                "MoRIIO decode zmq address is not set: setup() must run on this "
+                "engine before requests are shaped."
+            )
+        seed = self._request_seed(request)
+        uid = derive_uid(seed)
+        request_id = build_pd_request_id(prefill_zmq, decode_zmq, uid)
+        transfer_id = build_transfer_id(uid)
+        return request_id, transfer_id
+
+    def prepare_prefill_request(
+        self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
+    ) -> "RequestType":
+        request_id, transfer_id = self._dual_ids(request, peer)
+        prefill_request = request.model_copy(deep=True)
+        prefill_request.request_id = request_id
+        prefill_request.kv_transfer_params = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+            "remote_engine_id": None,
+            "remote_block_ids": None,
+            "transfer_id": transfer_id,
+            "remote_dp_size": 1,
+            "remote_tp_size": 1,
+        }
+        prefill_request.max_tokens = 1
+        if hasattr(prefill_request, "max_completion_tokens"):
+            prefill_request.max_completion_tokens = 1
+        prefill_request.stream = False
+        if hasattr(prefill_request, "stream_options"):
+            prefill_request.stream_options = None
+        return prefill_request
+
+    def prepare_decode_request(
+        self,
+        *,
+        request: "RequestType",
+        peer: Optional[Dict[str, Any]],
+        prefill_response: Optional[Any],
+    ) -> "RequestType":
+        request_id, transfer_id = self._dual_ids(request, peer)
+        decode_request = request.model_copy(deep=True)
+        decode_request.request_id = request_id
+
+        if not self._read_mode:
+            # WRITE: prefill pushes KV; decode just needs do_remote_prefill + the
+            # shared transfer_id (no block ids -- they are pushed, not pulled).
+            decode_request.kv_transfer_params = {
+                "do_remote_prefill": True,
+                "do_remote_decode": False,
+                "remote_engine_id": None,
+                "remote_block_ids": None,
+                "transfer_id": transfer_id,
+                "remote_dp_size": 1,
+                "remote_tp_size": 1,
+            }
+            return decode_request
+
+        # READ: decode PULLS KV; forward the remote_block_ids / remote_engine_id
+        # the prefill engine returned on its response. If absent (e.g. prompt <
+        # block_size / full prefix hit), fall back to a local recompute.
+        prefill_kv_params = getattr(prefill_response, "kv_transfer_params", None)
+        params = dict(prefill_kv_params) if prefill_kv_params else {}
+        if params.get("remote_block_ids") and params.get("remote_engine_id"):
+            params.setdefault("transfer_id", transfer_id)
+            params["do_remote_prefill"] = True
+            params["do_remote_decode"] = False
+            decode_request.kv_transfer_params = params
+        else:
+            logger.warning(
+                "[MORI][READ] prefill returned no remote_block_ids/remote_engine_id "
+                "(kv_transfer_params=%s); decode will recompute locally.",
+                prefill_kv_params,
+            )
+            decode_request.kv_transfer_params = None
+        return decode_request

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -240,6 +240,14 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         transfer_id = f"{_TRANSFER_PREFIX}-{uid}"
         return request_id, transfer_id
 
+    def engine_request_id(
+        self, *, request: Any, peer: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        """The MoRIIO dual-address id both engines must observe (peer zmq is
+        encoded in the id itself; the orchestrator delivers it via the
+        ``X-Request-Id`` header and the Serve request context)."""
+        return self._dual_ids(request, peer)[0]
+
     def prepare_prefill_request(
         self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
     ) -> "RequestType":

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -29,7 +29,6 @@ Registered with Ray's public connector registry via the factory.
 """
 
 import logging
-import os
 import re
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
@@ -56,10 +55,6 @@ DEFAULT_NOTIFY_PORT_BASE = 61005
 # experimental_configs keys understood by this backend.
 HANDSHAKE_PORT_BASE_KEY = "MORI_HANDSHAKE_PORT_BASE"
 NOTIFY_PORT_BASE_KEY = "MORI_NOTIFY_PORT_BASE"
-# Where setup() stashes the advertised zmq address for replica_metadata() to read.
-ZMQ_ADDRESS_KEY = "_mori_zmq_address"
-# Process-env fallback for the advertised zmq address.
-MORI_ZMQ_ADDRESS_ENV = "MORI_ZMQ_ADDRESS"
 
 # ---------------------------------------------------------------------------
 # Dual-address request_id / zmq address encoding.
@@ -100,34 +95,6 @@ def parse_zmq_address(zmq_address: str) -> Tuple[str, int, int]:
     return parts["host"], int(parts["handshake"]), int(parts["notify"])
 
 
-def derive_uid(seed: str) -> str:
-    """Deterministically derive the 32-hex uid from a stable per-request seed.
-
-    Using uuid5 (not uuid4) so that ``prepare_prefill_request`` and
-    ``prepare_decode_request`` -- two separate, stateless calls for the same
-    request -- agree on the same dual-address id and transfer_id.
-    """
-    return uuid.uuid5(_MORI_UID_NAMESPACE, seed).hex
-
-
-def build_pd_request_id(prefill_zmq: str, decode_zmq: str, uid: str) -> str:
-    """Build the dual-address request id consumed by both P and D engines.
-
-    Format: ``___prefill_addr_{P}___decode_addr_{D}_{uid32}`` where the trailing
-    32-hex uid is what ``_DECODE_ZMQ_RE`` anchors on. ``uid`` MUST be the
-    deterministic value from :func:`derive_uid` so the two prepare_* calls agree.
-    """
-    return f"{_PREFILL_PREFIX}{prefill_zmq}{_DECODE_PREFIX}{decode_zmq}_{uid}"
-
-
-def build_transfer_id(uid: str) -> str:
-    """Per-(P,D) transfer id. Mirrors vllm-router's ``tx-{uuid32}``.
-
-    Derived from the same deterministic ``uid`` as the request id.
-    """
-    return f"{_TRANSFER_PREFIX}-{uid}"
-
-
 def parse_peer_zmq(request_id: str, is_producer: bool) -> str:
     """Recover the peer's zmq address from a request id (for tests/debugging).
 
@@ -154,6 +121,10 @@ def _read_mode_enabled(extra_config: Dict[str, Any]) -> bool:
 class MoRIIOConnectorBackend(BaseConnectorBackend):
     """Set up MoRIIO ports/extra_config and implement the PD connector protocol."""
 
+    # The advertised zmq address ("host:IP,handshake:PORT,notify:PORT"),
+    # computed by setup(); consumers reach it via this backend instance.
+    _zmq_address: Optional[str] = None
+
     # MORI addresses peers by the dual-address request id, so the orchestrator
     # must bind to the selected prefill replica BEFORE dispatch.
     requires_peer_binding: bool = True
@@ -165,7 +136,7 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
     @property
     def _read_mode(self) -> bool:
         """True iff this engine's MoRIIO connector is configured for READ mode."""
-        extra = (self.kv_transfer_config or {}).get("kv_connector_extra_config") or {}
+        extra = self._extra_config()
         return _read_mode_enabled(extra)
 
     @property
@@ -209,27 +180,15 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         # Advertise the Ray internal cluster IP as the zmq host.
         host = ray.util.get_node_ip_address()
         zmq_address = build_zmq_address(host, handshake_port, notify_port)
-        # Stash so replica_metadata() (the PR1 hook) can publish it; the decode
+        # Stash so replica_metadata() can publish it; the decode
         # orchestrator reads the selected prefill replica's copy off the peer.
-        self.llm_config.experimental_configs[ZMQ_ADDRESS_KEY] = zmq_address
-        os.environ.setdefault(MORI_ZMQ_ADDRESS_ENV, zmq_address)
-        # NOTE: cross-node correctness additionally needs MoRIIO's worker to
+        self._zmq_address = zmq_address
+        # TODO: cross-node correctness additionally needs MoRIIO's worker to
         # advertise the node INTERNAL IP (VLLM_HOST_IP inside every worker
         # process). That fix must live in the worker process (a vLLM general
         # plugin) -- see the follow-up worker host-IP PR.
 
     # ---- replica metadata (published via the PR1 hook) ----
-
-    def _own_zmq_address(self) -> Optional[str]:
-        """The replica's own advertised MORI zmq address (set by setup()).
-
-        Prefer the value stashed on llm_config; fall back to the process env the
-        backend also sets (robust if the engine holds a different llm_config copy).
-        """
-        addr = self.llm_config.experimental_configs.get(ZMQ_ADDRESS_KEY)
-        if not addr:
-            addr = os.environ.get(MORI_ZMQ_ADDRESS_ENV)
-        return addr
 
     def replica_metadata(self) -> dict:
         """Static per-replica coordination data published to the orchestrator.
@@ -238,41 +197,22 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         orchestrator reads it off the selected prefill replica's
         ``ReplicaSelection.replica_metadata``.
         """
-        return {"mori_zmq_address": self._own_zmq_address()}
+        return {"mori_zmq_address": self._zmq_address}
 
     # ---- request shaping (PD connector protocol) ----
-
-    @staticmethod
-    def _request_seed(request: Any) -> str:
-        """Stable per-request seed for the deterministic uid derivation.
-
-        An explicitly-set ``request.request_id`` is authoritative; otherwise the
-        serve-context request id (stable across both ``prepare_*`` calls of one
-        orchestration) is used. The ``id(request)`` last resort only applies
-        outside a Serve request context (e.g. unit tests) and is likewise stable
-        within a single orchestration, which operates on one request object.
-        """
-        seed = getattr(request, "request_id", None)
-        if not seed:
-            seed = get_serve_request_id()
-        if not seed:
-            seed = f"mori-fallback-{id(request)}"
-        return str(seed)
-
-    def _peer_prefill_zmq(self, peer: Optional[Dict[str, Any]]) -> Optional[str]:
-        return (peer or {}).get("mori_zmq_address")
 
     def _dual_ids(
         self, request: Any, peer: Optional[Dict[str, Any]]
     ) -> Tuple[str, str]:
         """Compute the (dual-address request_id, transfer_id) for this request.
 
-        Deterministic in (request seed, peer prefill zmq, own decode zmq), so the
-        prefill and decode preparation calls produce identical ids with no
-        per-request backend state.
+        ``prepare_prefill_request`` and ``prepare_decode_request`` are two
+        independent, stateless calls for the same request, so both ids are
+        derived deterministically (uuid5) from a stable per-request seed plus
+        the two zmq addresses — no per-request backend state.
         """
-        prefill_zmq = self._peer_prefill_zmq(peer)
-        decode_zmq = self._own_zmq_address()
+        prefill_zmq = (peer or {}).get("mori_zmq_address")
+        decode_zmq = self._zmq_address
         if not prefill_zmq:
             raise ValueError(
                 "MoRIIO peer is missing 'mori_zmq_address': the selected prefill "
@@ -284,10 +224,20 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
                 "MoRIIO decode zmq address is not set: setup() must run on this "
                 "engine before requests are shaped."
             )
-        seed = self._request_seed(request)
-        uid = derive_uid(seed)
-        request_id = build_pd_request_id(prefill_zmq, decode_zmq, uid)
-        transfer_id = build_transfer_id(uid)
+        # Seed precedence: an explicitly-set request id, else the serve-context
+        # id (stable across both prepare_* calls of one orchestration). The
+        # id(request) last resort only applies outside a Serve request context
+        # (e.g. unit tests); both calls shape the same request object.
+        seed = str(
+            getattr(request, "request_id", None)
+            or get_serve_request_id()
+            or f"mori-fallback-{id(request)}"
+        )
+        uid = uuid.uuid5(_MORI_UID_NAMESPACE, seed).hex
+        # Wire format consumed by vLLM's MoRIIO connector: the trailing 32-hex
+        # uid is what _PREFILL_ZMQ_RE / _DECODE_ZMQ_RE anchor on.
+        request_id = f"{_PREFILL_PREFIX}{prefill_zmq}{_DECODE_PREFIX}{decode_zmq}_{uid}"
+        transfer_id = f"{_TRANSFER_PREFIX}-{uid}"
         return request_id, transfer_id
 
     def prepare_prefill_request(

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -36,9 +36,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 import ray
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
-)
-from ray.llm._internal.serve.utils.server_utils import (
-    get_serve_request_id,
+    base_prefill_kv_transfer_params,
+    clamp_request_to_single_token,
 )
 
 if TYPE_CHECKING:
@@ -179,21 +178,65 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         # Stash so replica_metadata() can publish it; the decode
         # orchestrator reads the selected prefill replica's copy off the peer.
         self._zmq_address = zmq_address
-        # TODO: cross-node correctness additionally needs MoRIIO's worker to
-        # advertise the node INTERNAL IP (VLLM_HOST_IP inside every worker
-        # process). That fix must live in the worker process (a vLLM general
-        # plugin) -- see the follow-up worker host-IP PR.
+        # NOTE: cross-node correctness additionally needs each worker to
+        # advertise the node INTERNAL IP (set VLLM_HOST_IP inside every worker
+        # process). VLLM_HOST_IP is excluded from vLLM's driver->worker env copy,
+        # so it can only be set in-process -- handled by a vLLM general-plugin
+        # shipped separately. Single-node deployments work without it.
 
-    # ---- replica metadata (published via the PR1 hook) ----
+    # ---- parallelism (data/tensor) ----
+
+    def _dp_rank(self) -> int:
+        rank = self.llm_config.engine_kwargs.get("data_parallel_rank")
+        return rank if isinstance(rank, int) and rank >= 0 else 0
+
+    def _dp_size(self) -> int:
+        return int(self.llm_config.engine_kwargs.get("data_parallel_size") or 1)
+
+    def _tp_size(self) -> int:
+        return int(self.llm_config.engine_kwargs.get("tensor_parallel_size") or 1)
+
+    # ---- replica metadata (published via the replica-metadata hook) ----
 
     def replica_metadata(self) -> dict:
         """Static per-replica coordination data published to the orchestrator.
 
-        The prefill replica publishes its MORI zmq address; the decode
-        orchestrator reads it off the selected prefill replica's
-        ``ReplicaSelection.replica_metadata``.
+        The prefill replica publishes its MORI zmq address and its parallelism
+        (DP rank/size, TP size); the decode orchestrator reads them off the
+        selected prefill replica's ``ReplicaSelection.replica_metadata`` and uses
+        them to address the right remote (dp_rank, tp) workers.
         """
-        return {"mori_zmq_address": self._zmq_address}
+        return {
+            "mori_zmq_address": self._zmq_address,
+            "dp_rank": self._dp_rank(),
+            "dp_size": self._dp_size(),
+            "tp_size": self._tp_size(),
+        }
+
+    def _remote_routing(self, remote: Dict[str, Any]) -> Dict[str, Any]:
+        """``kv_transfer_params`` keys telling vLLM which remote workers to reach.
+
+        ``remote`` is the metadata of the *other* side of the transfer: the
+        decode (this orchestrator) for a prefill request, the selected prefill
+        peer for a decode request. vLLM addresses a remote worker at
+        ``advertised_base + get_port_offset(remote_dp_rank, tp_index)`` and
+        handshakes all ``remote_dp_size`` ranks, so both must match the target
+        replica. ``tp_size`` is the remote's TP (symmetric across P/D).
+        """
+        return {
+            "remote_dp_rank": int(remote.get("dp_rank", 0)),
+            "remote_dp_size": int(remote.get("dp_size", 1)),
+            "tp_size": int(remote.get("tp_size", self._tp_size())),
+        }
+
+    def _own_routing(self) -> Dict[str, Any]:
+        """``_remote_routing`` input describing this (decode orchestrator) replica
+        -- the remote side for a prefill request."""
+        return {
+            "dp_rank": self._dp_rank(),
+            "dp_size": self._dp_size(),
+            "tp_size": self._tp_size(),
+        }
 
     # ---- request shaping (PD connector protocol) ----
 
@@ -220,15 +263,10 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
                 "MoRIIO decode zmq address is not set: setup() must run on this "
                 "engine before requests are shaped."
             )
-        # Seed precedence: an explicitly-set request id, else the serve-context
-        # id (stable across both prepare_* calls of one orchestration). The
-        # id(request) last resort only applies outside a Serve request context
-        # (e.g. unit tests); both calls shape the same request object.
-        seed = str(
-            getattr(request, "request_id", None)
-            or get_serve_request_id()
-            or f"mori-fallback-{id(request)}"
-        )
+        # The incoming request_id (always populated -- OpenAI models default it
+        # to a uuid) is the seed. Both prepare_* calls run on the same request
+        # object, so they agree; uniqueness per request is inherited from it.
+        seed = str(request.request_id)
         # 32 hex chars (the trailing uid _PREFILL_ZMQ_RE / _DECODE_ZMQ_RE
         # anchor on); a hash of the seed, so both prepare_* calls agree.
         uid = hashlib.sha256(seed.encode()).hexdigest()[:32]
@@ -248,20 +286,12 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         # X-Request-Id header that vLLM's MoRIIO connector parses.
         prefill_request.request_id = request_id
         prefill_request.kv_transfer_params = {
-            "do_remote_decode": True,
-            "do_remote_prefill": False,
-            "remote_engine_id": None,
-            "remote_block_ids": None,
+            **base_prefill_kv_transfer_params(),
             "transfer_id": transfer_id,
-            "remote_dp_size": 1,
-            "remote_tp_size": 1,
+            # The prefill engine's remote is the decode (this orchestrator).
+            **self._remote_routing(self._own_routing()),
         }
-        prefill_request.max_tokens = 1
-        if hasattr(prefill_request, "max_completion_tokens"):
-            prefill_request.max_completion_tokens = 1
-        prefill_request.stream = False
-        if hasattr(prefill_request, "stream_options"):
-            prefill_request.stream_options = None
+        clamp_request_to_single_token(prefill_request)
         return prefill_request
 
     def prepare_decode_request(
@@ -274,6 +304,8 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         request_id, transfer_id = self._dual_ids(request, peer)
         decode_request = request.model_copy(deep=True)
         decode_request.request_id = request_id
+        # The decode engine's remote is the selected prefill peer.
+        remote_routing = self._remote_routing(peer or {})
 
         if not self._read_mode:
             # WRITE: prefill pushes KV; decode just needs do_remote_prefill + the
@@ -284,8 +316,7 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
                 "remote_engine_id": None,
                 "remote_block_ids": None,
                 "transfer_id": transfer_id,
-                "remote_dp_size": 1,
-                "remote_tp_size": 1,
+                **remote_routing,
             }
             return decode_request
 
@@ -298,6 +329,8 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
             params.setdefault("transfer_id", transfer_id)
             params["do_remote_prefill"] = True
             params["do_remote_decode"] = False
+            # Address the prefill peer's (dp_rank, dp_size, tp) workers.
+            params.update(remote_routing)
             decode_request.kv_transfer_params = params
         else:
             logger.warning(

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -240,19 +240,15 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         transfer_id = f"{_TRANSFER_PREFIX}-{uid}"
         return request_id, transfer_id
 
-    def engine_request_id(
-        self, *, request: Any, peer: Optional[Dict[str, Any]]
-    ) -> Optional[str]:
-        """The MoRIIO dual-address id both engines must observe (peer zmq is
-        encoded in the id itself; the orchestrator delivers it via the
-        ``X-Request-Id`` header and the Serve request context)."""
-        return self._dual_ids(request, peer)[0]
-
     def prepare_prefill_request(
         self, *, request: "RequestType", peer: Optional[Dict[str, Any]]
     ) -> "RequestType":
         request_id, transfer_id = self._dual_ids(request, peer)
         prefill_request = request.model_copy(deep=True)
+        # The dual-address id (peer zmq encoded in it) must reach the engine:
+        # setting request_id explicitly makes the LLMServer pipeline preserve it
+        # (not clobber it with the Serve id) and the engine copies it into the
+        # X-Request-Id header that vLLM's MoRIIO connector parses.
         prefill_request.request_id = request_id
         prefill_request.kv_transfer_params = {
             "do_remote_decode": True,

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -20,7 +20,7 @@ Two transfer disciplines, selected by ``read_mode``:
     returned.
 
 The dual-address request_id and the transfer_id are derived DETERMINISTICALLY
-from the incoming request id (uuid5), so ``prepare_prefill_request`` and
+from the incoming request id (a hash), so ``prepare_prefill_request`` and
 ``prepare_decode_request`` produce identical ids across their two separate calls
 without per-request backend state (the backend instance is shared across
 requests).
@@ -28,9 +28,9 @@ requests).
 Registered with Ray's public connector registry via the factory.
 """
 
+import hashlib
 import logging
 import re
-import uuid
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import ray
@@ -75,10 +75,6 @@ _TRANSFER_PREFIX = "tx"
 # Copies of vLLM's regexes for local validation / round-trip tests.
 _PREFILL_ZMQ_RE = re.compile(r"___prefill_addr_(.+?)___decode_addr_")
 _DECODE_ZMQ_RE = re.compile(r"___decode_addr_(.+)_[0-9a-f]{32}(?:-.*)?$")
-
-# Stable namespace for deterministic uuid5 derivation of the dual-address uid.
-# Fixed so prefill & decode (and any retry) agree on the same id for a request.
-_MORI_UID_NAMESPACE = uuid.UUID("d3b07384-d9a0-4f1b-9c2e-6d6f72690001")
 
 
 def build_zmq_address(host: str, handshake_port: int, notify_port: int) -> str:
@@ -208,8 +204,8 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
 
         ``prepare_prefill_request`` and ``prepare_decode_request`` are two
         independent, stateless calls for the same request, so both ids are
-        derived deterministically (uuid5) from a stable per-request seed plus
-        the two zmq addresses — no per-request backend state.
+        derived deterministically (hash of a stable per-request seed) — no
+        per-request backend state.
         """
         prefill_zmq = (peer or {}).get("mori_zmq_address")
         decode_zmq = self._zmq_address
@@ -233,9 +229,10 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
             or get_serve_request_id()
             or f"mori-fallback-{id(request)}"
         )
-        uid = uuid.uuid5(_MORI_UID_NAMESPACE, seed).hex
-        # Wire format consumed by vLLM's MoRIIO connector: the trailing 32-hex
-        # uid is what _PREFILL_ZMQ_RE / _DECODE_ZMQ_RE anchor on.
+        # 32 hex chars (the trailing uid _PREFILL_ZMQ_RE / _DECODE_ZMQ_RE
+        # anchor on); a hash of the seed, so both prepare_* calls agree.
+        uid = hashlib.sha256(seed.encode()).hexdigest()[:32]
+        # Wire format consumed by vLLM's MoRIIO connector.
         request_id = f"{_PREFILL_PREFIX}{prefill_zmq}{_DECODE_PREFIX}{decode_zmq}_{uid}"
         transfer_id = f"{_TRANSFER_PREFIX}-{uid}"
         return request_id, transfer_id

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
@@ -183,6 +183,36 @@ class PDServingArgs(BaseModelExtended):
         )
         return self
 
+    @model_validator(mode="after")
+    def _default_decode_moriio_port_base(self):
+        """Shift decode's MoRIIO handshake/notify bases off prefill's defaults.
+
+        Mirrors ``_default_decode_nixl_port_base``: a colocated P+D pair on one
+        node would otherwise share MoRIIO's default handshake/notify ports. Only
+        applies when the decode config uses the MoRIIO connector. The +1000
+        stride is well above any realistic tp_size*pp_size offset added on top.
+        """
+        kv_transfer_config = (
+            self.decode_config.engine_kwargs.get("kv_transfer_config") or {}
+        )
+        if kv_transfer_config.get("kv_connector") != "MoRIIOConnector":
+            return self
+
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.moriio import (
+            DEFAULT_HANDSHAKE_PORT_BASE,
+            DEFAULT_NOTIFY_PORT_BASE,
+            HANDSHAKE_PORT_BASE_KEY,
+            NOTIFY_PORT_BASE_KEY,
+        )
+
+        self.decode_config.experimental_configs.setdefault(
+            HANDSHAKE_PORT_BASE_KEY, DEFAULT_HANDSHAKE_PORT_BASE + 1000
+        )
+        self.decode_config.experimental_configs.setdefault(
+            NOTIFY_PORT_BASE_KEY, DEFAULT_NOTIFY_PORT_BASE + 1000
+        )
+        return self
+
 
 # ---------------------------------------------------------------------------
 # Builder

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -551,6 +551,25 @@ class PDPrefillServer(LLMServer):
     method used during the pre-warm handshake.
     """
 
+    async def record_replica_metadata(self) -> Dict[str, Any]:
+        """Publish this prefill replica's connector coordination metadata.
+
+        Read by the decode orchestrator via the replica-metadata hook
+        (``ReplicaSelection.replica_metadata``) so peer-binding connectors (e.g.
+        MoRIIO) can address the selected prefill replica. Returns ``{}`` for
+        connectors that publish nothing (the ``BaseConnectorBackend`` default).
+
+        Returns the metadata of the backend that engine init
+        (``setup_engine_backend``) created, ``setup()``-ed, and stored on this
+        server's ``_llm_config``. The replica-metadata hook is captured after
+        engine init, so for connector deployments the backend is present by
+        then; with no backend stored there is nothing to publish.
+        """
+        backend = getattr(self._llm_config, "kv_connector_backend", None)
+        if backend is None:
+            return {}
+        return backend.replica_metadata()
+
     async def prewarm_prefill(
         self, prefill_request: CompletionRequest
     ) -> Optional[dict]:

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -6,6 +6,7 @@ decode deployment owns a real engine and orchestrates remote prefill.
 
 import asyncio
 import contextlib
+import dataclasses
 import logging
 import uuid
 import warnings
@@ -40,6 +41,7 @@ from ray.llm._internal.serve.utils.server_utils import (
     get_serve_request_id,
 )
 from ray.serve._private.http_util import session_id_from_headers
+from ray.serve.context import _set_request_context
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 from ray.serve.llm import LLMConfig
@@ -160,6 +162,59 @@ class PDOrchestratorMixin:
             request=request, peer=None, prefill_response=prefill_chunk
         )
 
+    def _connector_raw_request_info(
+        self,
+        backend: BaseConnectorBackend,
+        request: RequestType,
+        peer: Optional[Dict[str, Any]],
+        raw_request_info: Optional[RawRequestInfo],
+    ) -> Optional[RawRequestInfo]:
+        """Deliver a connector-owned engine request id to both engines.
+
+        When the backend encodes coordination data in the request id itself
+        (``engine_request_id`` returns non-None, e.g. MoRIIO's dual-address id),
+        that id must reach both the remote prefill and the local decode engine.
+        Two channels are needed because the engines read the id differently:
+
+        * vLLM derives the engine request id from the ``X-Request-Id`` header of
+          the raw request, so we stamp it there (and the returned info is passed
+          to both the prefill dispatch and the local decode).
+        * The local-decode pipeline (``_maybe_add_request_id_to_request``)
+          overwrites ``request.request_id`` from the Serve request context, so we
+          set the context id too -- otherwise that overwrite would clobber ours.
+
+        For connectors that don't own the id this is a no-op and the original
+        ``raw_request_info`` is returned unchanged.
+
+        Args:
+            backend: The resolved connector backend.
+            request: The incoming request.
+            peer: The selected prefill replica's metadata, or None.
+            raw_request_info: The incoming raw request info, or None.
+
+        Returns:
+            The raw request info to pass to both engines.
+        """
+        engine_request_id = backend.engine_request_id(request=request, peer=peer)
+        if not engine_request_id:
+            return raw_request_info
+        # Set the Serve context so the local-decode pipeline's overwrite copies
+        # our id rather than the incoming Serve request id.
+        _set_request_context(request_id=engine_request_id)
+        # Drop any case/underscore variant of x-request-id before setting ours,
+        # so to_starlette_request() doesn't leave a duplicate header that
+        # shadows it (Starlette's headers.get returns the first match).
+        src = raw_request_info.headers if raw_request_info is not None else {}
+        headers = {
+            k: v
+            for k, v in src.items()
+            if k.replace("_", "-").lower() != "x-request-id"
+        }
+        headers["x-request-id"] = engine_request_id
+        if raw_request_info is None:
+            return RawRequestInfo(headers=headers)
+        return dataclasses.replace(raw_request_info, headers=headers)
+
     # ---- Orchestrated Request Flow ----
 
     async def _pd_handle_request(
@@ -202,6 +257,11 @@ class PDOrchestratorMixin:
             async with prefill_handle_method.choose_replica(request) as selection:
                 # The selected replica's published metadata (empty dict if none).
                 peer = getattr(selection, "replica_metadata", {})
+                # Deliver a connector-owned engine id (e.g. MoRIIO's
+                # dual-address id) to both engines before dispatching.
+                raw_request_info = self._connector_raw_request_info(
+                    backend, request, peer, raw_request_info
+                )
                 prefill_request = backend.prepare_prefill_request(
                     request=request, peer=peer
                 )
@@ -260,6 +320,9 @@ class PDOrchestratorMixin:
 
         # Default path: no pre-dispatch peer binding; dispatch prefill via the
         # standard handle path.
+        raw_request_info = self._connector_raw_request_info(
+            backend, request, None, raw_request_info
+        )
         prefill_request = backend.prepare_prefill_request(request=request, peer=None)
 
         if backend.concurrent_handoff:
@@ -439,9 +502,21 @@ class PDOrchestratorMixin:
 
         logger.info("[PDDecodeServer] Starting pre-warm across all P replicas.")
 
+        backend = self._get_connector_backend()
+        if backend.requires_peer_binding:
+            # Peer-binding connectors (e.g. MoRIIO) shape a prefill request
+            # against a specific selected replica's metadata; a peerless
+            # broadcast prewarm cannot bind one. The connector handshake
+            # completes on the first real request instead.
+            logger.info(
+                "[PDDecodeServer] Skipping pre-warm: connector %s requires peer "
+                "binding (handshake completes on the first real request).",
+                type(backend).__name__,
+            )
+            return
+
         model_id = self._llm_config.model_id
         dummy = self._make_dummy_request(model_id)
-        backend = self._get_connector_backend()
         prefill_req = backend.prepare_prefill_request(request=dummy, peer=None)
 
         # Broadcast to every live P replica; retry until they are up.

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -6,7 +6,6 @@ decode deployment owns a real engine and orchestrates remote prefill.
 
 import asyncio
 import contextlib
-import dataclasses
 import logging
 import uuid
 import warnings
@@ -41,7 +40,6 @@ from ray.llm._internal.serve.utils.server_utils import (
     get_serve_request_id,
 )
 from ray.serve._private.http_util import session_id_from_headers
-from ray.serve.context import _set_request_context
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 from ray.serve.llm import LLMConfig
@@ -162,59 +160,6 @@ class PDOrchestratorMixin:
             request=request, peer=None, prefill_response=prefill_chunk
         )
 
-    def _connector_raw_request_info(
-        self,
-        backend: BaseConnectorBackend,
-        request: RequestType,
-        peer: Optional[Dict[str, Any]],
-        raw_request_info: Optional[RawRequestInfo],
-    ) -> Optional[RawRequestInfo]:
-        """Deliver a connector-owned engine request id to both engines.
-
-        When the backend encodes coordination data in the request id itself
-        (``engine_request_id`` returns non-None, e.g. MoRIIO's dual-address id),
-        that id must reach both the remote prefill and the local decode engine.
-        Two channels are needed because the engines read the id differently:
-
-        * vLLM derives the engine request id from the ``X-Request-Id`` header of
-          the raw request, so we stamp it there (and the returned info is passed
-          to both the prefill dispatch and the local decode).
-        * The local-decode pipeline (``_maybe_add_request_id_to_request``)
-          overwrites ``request.request_id`` from the Serve request context, so we
-          set the context id too -- otherwise that overwrite would clobber ours.
-
-        For connectors that don't own the id this is a no-op and the original
-        ``raw_request_info`` is returned unchanged.
-
-        Args:
-            backend: The resolved connector backend.
-            request: The incoming request.
-            peer: The selected prefill replica's metadata, or None.
-            raw_request_info: The incoming raw request info, or None.
-
-        Returns:
-            The raw request info to pass to both engines.
-        """
-        engine_request_id = backend.engine_request_id(request=request, peer=peer)
-        if not engine_request_id:
-            return raw_request_info
-        # Set the Serve context so the local-decode pipeline's overwrite copies
-        # our id rather than the incoming Serve request id.
-        _set_request_context(request_id=engine_request_id)
-        # Drop any case/underscore variant of x-request-id before setting ours,
-        # so to_starlette_request() doesn't leave a duplicate header that
-        # shadows it (Starlette's headers.get returns the first match).
-        src = raw_request_info.headers if raw_request_info is not None else {}
-        headers = {
-            k: v
-            for k, v in src.items()
-            if k.replace("_", "-").lower() != "x-request-id"
-        }
-        headers["x-request-id"] = engine_request_id
-        if raw_request_info is None:
-            return RawRequestInfo(headers=headers)
-        return dataclasses.replace(raw_request_info, headers=headers)
-
     # ---- Orchestrated Request Flow ----
 
     async def _pd_handle_request(
@@ -230,6 +175,12 @@ class PDOrchestratorMixin:
         the resolved KV-connector backend. With the default backend flags
         (``requires_peer_binding=False``, ``concurrent_handoff=False``) the
         control flow and calls are identical to the historical NIXL/default flow.
+
+        A connector that encodes coordination data in the request id (MoRIIO's
+        dual-address id) just stamps ``request.request_id`` in ``prepare_*``; it
+        then reaches both engines unchanged -- the LLMServer pipeline preserves
+        an explicitly-set request_id (it no longer clobbers it with the Serve
+        id) and the engine copies it into the ``X-Request-Id`` header it reads.
         """
 
         # Determine method name for the handle call
@@ -257,11 +208,6 @@ class PDOrchestratorMixin:
             async with prefill_handle_method.choose_replica(request) as selection:
                 # The selected replica's published metadata (empty dict if none).
                 peer = getattr(selection, "replica_metadata", {})
-                # Deliver a connector-owned engine id (e.g. MoRIIO's
-                # dual-address id) to both engines before dispatching.
-                raw_request_info = self._connector_raw_request_info(
-                    backend, request, peer, raw_request_info
-                )
                 prefill_request = backend.prepare_prefill_request(
                     request=request, peer=peer
                 )
@@ -320,9 +266,6 @@ class PDOrchestratorMixin:
 
         # Default path: no pre-dispatch peer binding; dispatch prefill via the
         # standard handle path.
-        raw_request_info = self._connector_raw_request_info(
-            backend, request, None, raw_request_info
-        )
         prefill_request = backend.prepare_prefill_request(request=request, peer=None)
 
         if backend.concurrent_handoff:

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
@@ -14,7 +14,6 @@ from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
 from ray.llm._internal.serve.engines.vllm.kv_transfer.moriio import (
     DEFAULT_HANDSHAKE_PORT_BASE,
     DEFAULT_NOTIFY_PORT_BASE,
-    ZMQ_ADDRESS_KEY,
     MoRIIOConnectorBackend,
     parse_peer_zmq,
     parse_zmq_address,
@@ -76,7 +75,7 @@ class TestMoRIIOConnectorBackendSetup:
         assert "http_port" in extra
         assert extra["read_mode"] == "false"
 
-        zmq = backend.llm_config.experimental_configs[ZMQ_ADDRESS_KEY]
+        zmq = backend._zmq_address
         host, hs, notify = parse_zmq_address(zmq)
         assert host == _TEST_HOST
         assert hs == DEFAULT_HANDSHAKE_PORT_BASE
@@ -144,9 +143,7 @@ class TestMoRIIOConnectorBackendSetup:
         backend = _make_backend()
         _setup(backend, rank=0)
         meta = backend.replica_metadata()
-        assert meta["mori_zmq_address"] == (
-            backend.llm_config.experimental_configs[ZMQ_ADDRESS_KEY]
-        )
+        assert meta["mori_zmq_address"] == backend._zmq_address
 
     def test_replica_metadata_default_empty(self):
         # The default backend publishes nothing (concrete default on the base).
@@ -183,7 +180,7 @@ class TestMoRIIORequestId:
     def test_prefill_and_decode_share_request_id_and_transfer_id(self):
         backend = _make_backend(read_mode=False)
         _setup(backend, rank=0)
-        decode_zmq = backend.llm_config.experimental_configs[ZMQ_ADDRESS_KEY]
+        decode_zmq = backend._zmq_address
         prefill_zmq = "host:10.0.0.9,handshake:6301,notify:61005"
         peer = {"mori_zmq_address": prefill_zmq}
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
@@ -1,0 +1,304 @@
+import re
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+    BaseConnectorBackend,
+)
+from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
+    KVConnectorBackendFactory,
+)
+from ray.llm._internal.serve.engines.vllm.kv_transfer.moriio import (
+    DEFAULT_HANDSHAKE_PORT_BASE,
+    DEFAULT_NOTIFY_PORT_BASE,
+    ZMQ_ADDRESS_KEY,
+    MoRIIOConnectorBackend,
+    parse_peer_zmq,
+    parse_zmq_address,
+)
+from ray.serve.llm import LLMConfig
+from ray.serve.schema import ReplicaRank
+
+# Copies of the regexes vLLM's MoRIIO connector uses to recover peer addresses.
+_PREFILL_ZMQ_RE = re.compile(r"___prefill_addr_(.+?)___decode_addr_")
+_DECODE_ZMQ_RE = re.compile(r"___decode_addr_(.+)_[0-9a-f]{32}(?:-.*)?$")
+
+_TEST_HOST = "10.0.0.5"
+
+
+def _replica_context(global_rank: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        rank=ReplicaRank(rank=global_rank, node_rank=0, local_rank=global_rank)
+    )
+
+
+def _make_backend(read_mode: bool = False, extra_exp: dict = None):
+    extra_config = {}
+    if read_mode:
+        extra_config["read_mode"] = "true"
+    return MoRIIOConnectorBackend(
+        llm_config=LLMConfig(
+            model_loading_config=dict(model_id="Qwen/Qwen3-0.6B"),
+            engine_kwargs=dict(
+                kv_transfer_config=dict(
+                    kv_connector="MoRIIOConnector",
+                    kv_role="kv_both",
+                    kv_connector_extra_config=extra_config,
+                )
+            ),
+            experimental_configs=extra_exp or {},
+        ),
+    )
+
+
+def _setup(backend, rank: int = 0):
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("ray.util.get_node_ip_address", return_value=_TEST_HOST),
+        patch("ray.serve.get_replica_context", return_value=_replica_context(rank)),
+    ):
+        backend.setup()
+
+
+class TestMoRIIOConnectorBackendSetup:
+    def test_setup_sets_ports_zmq_and_extra_config(self):
+        backend = _make_backend()
+        _setup(backend, rank=0)
+
+        extra = backend.kv_transfer_config["kv_connector_extra_config"]
+        assert extra["handshake_port"] == str(DEFAULT_HANDSHAKE_PORT_BASE)
+        assert extra["notify_port"] == str(DEFAULT_NOTIFY_PORT_BASE)
+        assert extra["proxy_ip"] == ""
+        assert extra["proxy_ping_port"] == "0"
+        assert "http_port" in extra
+        assert extra["read_mode"] == "false"
+
+        zmq = backend.llm_config.experimental_configs[ZMQ_ADDRESS_KEY]
+        host, hs, notify = parse_zmq_address(zmq)
+        assert host == _TEST_HOST
+        assert hs == DEFAULT_HANDSHAKE_PORT_BASE
+        assert notify == DEFAULT_NOTIFY_PORT_BASE
+
+    def test_setup_port_offset_uses_replica_rank(self):
+        backend = _make_backend()
+        num_devices = backend.llm_config.get_engine_config().num_devices
+        _setup(backend, rank=2)
+        extra = backend.kv_transfer_config["kv_connector_extra_config"]
+        assert extra["handshake_port"] == str(
+            DEFAULT_HANDSHAKE_PORT_BASE + 2 * num_devices
+        )
+        assert extra["notify_port"] == str(DEFAULT_NOTIFY_PORT_BASE + 2 * num_devices)
+
+    def test_setup_respects_overridden_bases(self):
+        backend = _make_backend(
+            extra_exp={
+                "MORI_HANDSHAKE_PORT_BASE": 7000,
+                "MORI_NOTIFY_PORT_BASE": 62000,
+            }
+        )
+        _setup(backend, rank=0)
+        extra = backend.kv_transfer_config["kv_connector_extra_config"]
+        assert extra["handshake_port"] == "7000"
+        assert extra["notify_port"] == "62000"
+
+    def test_requires_peer_binding(self):
+        assert MoRIIOConnectorBackend.requires_peer_binding is True
+
+    def test_concurrent_handoff_write_vs_read(self):
+        write_backend = _make_backend(read_mode=False)
+        read_backend = _make_backend(read_mode=True)
+        assert write_backend.concurrent_handoff is True
+        assert read_backend.concurrent_handoff is False
+        assert write_backend._read_mode is False
+        assert read_backend._read_mode is True
+
+    @pytest.mark.parametrize(
+        "value,expected_read",
+        [
+            ("true", True),
+            ("True", True),
+            ("1", True),
+            ("false", False),
+            ("0", False),
+            ("", False),
+        ],
+    )
+    def test_read_mode_parsing(self, value, expected_read):
+        backend = MoRIIOConnectorBackend(
+            llm_config=LLMConfig(
+                model_loading_config=dict(model_id="Qwen/Qwen3-0.6B"),
+                engine_kwargs=dict(
+                    kv_transfer_config=dict(
+                        kv_connector="MoRIIOConnector",
+                        kv_connector_extra_config={"read_mode": value},
+                    )
+                ),
+            ),
+        )
+        assert backend._read_mode is expected_read
+
+    def test_replica_metadata_returns_zmq(self):
+        backend = _make_backend()
+        _setup(backend, rank=0)
+        meta = backend.replica_metadata()
+        assert meta["mori_zmq_address"] == (
+            backend.llm_config.experimental_configs[ZMQ_ADDRESS_KEY]
+        )
+
+    def test_replica_metadata_default_empty(self):
+        # The default backend publishes nothing (concrete default on the base).
+        assert BaseConnectorBackend.replica_metadata(None) == {}
+
+
+class TestMoRIIORequestId:
+    def _prepared_pair(self, backend, request, peer):
+        prefill = backend.prepare_prefill_request(request=request, peer=peer)
+        # prefill_response is unused in WRITE mode; pass a dummy with no params.
+        decode = backend.prepare_decode_request(
+            request=request,
+            peer=peer,
+            prefill_response=SimpleNamespace(kv_transfer_params=None),
+        )
+        return prefill, decode
+
+    def _request_with_copy(self, request_id="user-req-123"):
+        class _Req:
+            def __init__(self, rid):
+                self.request_id = rid
+                self.kv_transfer_params = None
+                self.max_tokens = 128
+                self.max_completion_tokens = 128
+                self.stream = True
+                self.stream_options = {"include_usage": True}
+
+            def model_copy(self, deep=False):
+                new = _Req(self.request_id)
+                return new
+
+        return _Req(request_id)
+
+    def test_prefill_and_decode_share_request_id_and_transfer_id(self):
+        backend = _make_backend(read_mode=False)
+        _setup(backend, rank=0)
+        decode_zmq = backend.llm_config.experimental_configs[ZMQ_ADDRESS_KEY]
+        prefill_zmq = "host:10.0.0.9,handshake:6301,notify:61005"
+        peer = {"mori_zmq_address": prefill_zmq}
+
+        req = self._request_with_copy("user-req-123")
+        prefill, decode = self._prepared_pair(backend, req, peer)
+
+        assert prefill.request_id == decode.request_id
+        assert (
+            prefill.kv_transfer_params["transfer_id"]
+            == decode.kv_transfer_params["transfer_id"]
+        )
+
+        # Round-trips to the right peer zmq via the vLLM regexes.
+        assert _PREFILL_ZMQ_RE.search(prefill.request_id).group(1) == prefill_zmq
+        assert _DECODE_ZMQ_RE.search(prefill.request_id) is not None
+        assert parse_peer_zmq(prefill.request_id, is_producer=False) == prefill_zmq
+        assert parse_peer_zmq(prefill.request_id, is_producer=True) == decode_zmq
+
+        # transfer_id format tx-<32hex>.
+        assert re.fullmatch(
+            r"tx-[0-9a-f]{32}", prefill.kv_transfer_params["transfer_id"]
+        )
+
+    def test_id_is_deterministic_across_calls(self):
+        backend = _make_backend(read_mode=False)
+        _setup(backend, rank=0)
+        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
+
+        p1 = backend.prepare_prefill_request(
+            request=self._request_with_copy("R"), peer=peer
+        )
+        p2 = backend.prepare_prefill_request(
+            request=self._request_with_copy("R"), peer=peer
+        )
+        assert p1.request_id == p2.request_id
+        assert (
+            p1.kv_transfer_params["transfer_id"] == p2.kv_transfer_params["transfer_id"]
+        )
+
+    def test_prefill_kv_params_write(self):
+        backend = _make_backend(read_mode=False)
+        _setup(backend, rank=0)
+        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
+        prefill = backend.prepare_prefill_request(
+            request=self._request_with_copy(), peer=peer
+        )
+        assert prefill.kv_transfer_params["do_remote_decode"] is True
+        assert prefill.kv_transfer_params["do_remote_prefill"] is False
+        assert prefill.max_tokens == 1
+        assert prefill.stream is False
+
+    def test_decode_kv_params_write(self):
+        backend = _make_backend(read_mode=False)
+        _setup(backend, rank=0)
+        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
+        decode = backend.prepare_decode_request(
+            request=self._request_with_copy(),
+            peer=peer,
+            prefill_response=SimpleNamespace(kv_transfer_params=None),
+        )
+        assert decode.kv_transfer_params["do_remote_prefill"] is True
+        assert decode.kv_transfer_params["do_remote_decode"] is False
+        assert decode.kv_transfer_params["remote_block_ids"] is None
+
+    def test_decode_kv_params_read_forwards_prefill_params(self):
+        backend = _make_backend(read_mode=True)
+        _setup(backend, rank=0)
+        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
+        prefill_resp = SimpleNamespace(
+            kv_transfer_params={
+                "remote_block_ids": [1, 2, 3],
+                "remote_engine_id": "eng-7",
+            }
+        )
+        decode = backend.prepare_decode_request(
+            request=self._request_with_copy(), peer=peer, prefill_response=prefill_resp
+        )
+        assert decode.kv_transfer_params["do_remote_prefill"] is True
+        assert decode.kv_transfer_params["remote_block_ids"] == [1, 2, 3]
+        assert decode.kv_transfer_params["remote_engine_id"] == "eng-7"
+        assert "transfer_id" in decode.kv_transfer_params
+
+    def test_decode_read_fallback_when_no_remote_params(self):
+        backend = _make_backend(read_mode=True)
+        _setup(backend, rank=0)
+        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
+        decode = backend.prepare_decode_request(
+            request=self._request_with_copy(),
+            peer=peer,
+            prefill_response=SimpleNamespace(kv_transfer_params=None),
+        )
+        assert decode.kv_transfer_params is None
+
+
+class TestMoRIIOZmqValidation:
+    def test_missing_peer_zmq_raises(self):
+        """A missing/empty peer mori_zmq_address must raise a clear error, not
+        silently build a request id containing "None"."""
+        backend = _make_backend(read_mode=False)
+        _setup(backend, rank=0)
+        request = TestMoRIIORequestId()._request_with_copy("user-req-123")
+        for peer in (None, {}, {"mori_zmq_address": ""}):
+            with pytest.raises(ValueError, match="mori_zmq_address"):
+                backend.prepare_prefill_request(request=request, peer=peer)
+
+
+class TestMoRIIOFactory:
+    def test_registered(self):
+        assert KVConnectorBackendFactory.is_registered("MoRIIOConnector")
+
+    def test_create_backend_returns_class(self):
+        backend_class = KVConnectorBackendFactory.get_backend_class("MoRIIOConnector")
+        assert backend_class is MoRIIOConnectorBackend
+        assert issubclass(backend_class, BaseConnectorBackend)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
@@ -204,6 +204,20 @@ class TestMoRIIORequestId:
             r"tx-[0-9a-f]{32}", prefill.kv_transfer_params["transfer_id"]
         )
 
+    def test_engine_request_id_matches_shaped_request_id(self):
+        """``engine_request_id`` returns the dual-address id the orchestrator
+        must deliver to both engines -- identical to the id stamped on the
+        shaped prefill/decode requests."""
+        backend = _make_backend(read_mode=False)
+        _setup(backend, rank=0)
+        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
+        req = self._request_with_copy("user-req-123")
+
+        engine_id = backend.engine_request_id(request=req, peer=peer)
+        prefill = backend.prepare_prefill_request(request=req, peer=peer)
+        assert engine_id == prefill.request_id
+        assert parse_peer_zmq(engine_id, is_producer=False) == peer["mori_zmq_address"]
+
     def test_id_is_deterministic_across_calls(self):
         backend = _make_backend(read_mode=False)
         _setup(backend, rank=0)

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
@@ -12,6 +12,8 @@ from ray.llm._internal.serve.engines.vllm.kv_transfer.factory import (
     KVConnectorBackendFactory,
 )
 from ray.llm._internal.serve.engines.vllm.kv_transfer.moriio import (
+    _DECODE_ZMQ_RE,
+    _PREFILL_ZMQ_RE,
     DEFAULT_HANDSHAKE_PORT_BASE,
     DEFAULT_NOTIFY_PORT_BASE,
     MoRIIOConnectorBackend,
@@ -20,10 +22,6 @@ from ray.llm._internal.serve.engines.vllm.kv_transfer.moriio import (
 )
 from ray.serve.llm import LLMConfig
 from ray.serve.schema import ReplicaRank
-
-# Copies of the regexes vLLM's MoRIIO connector uses to recover peer addresses.
-_PREFILL_ZMQ_RE = re.compile(r"___prefill_addr_(.+?)___decode_addr_")
-_DECODE_ZMQ_RE = re.compile(r"___decode_addr_(.+)_[0-9a-f]{32}(?:-.*)?$")
 
 _TEST_HOST = "10.0.0.5"
 
@@ -34,20 +32,33 @@ def _replica_context(global_rank: int) -> SimpleNamespace:
     )
 
 
-def _make_backend(read_mode: bool = False, extra_exp: dict = None):
+def _make_backend(
+    read_mode: bool = False,
+    extra_exp: dict = None,
+    dp_rank: int = None,
+    dp_size: int = None,
+    tp_size: int = None,
+):
     extra_config = {}
     if read_mode:
         extra_config["read_mode"] = "true"
+    engine_kwargs = dict(
+        kv_transfer_config=dict(
+            kv_connector="MoRIIOConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config=extra_config,
+        )
+    )
+    if dp_rank is not None:
+        engine_kwargs["data_parallel_rank"] = dp_rank
+    if dp_size is not None:
+        engine_kwargs["data_parallel_size"] = dp_size
+    if tp_size is not None:
+        engine_kwargs["tensor_parallel_size"] = tp_size
     return MoRIIOConnectorBackend(
         llm_config=LLMConfig(
             model_loading_config=dict(model_id="Qwen/Qwen3-0.6B"),
-            engine_kwargs=dict(
-                kv_transfer_config=dict(
-                    kv_connector="MoRIIOConnector",
-                    kv_role="kv_both",
-                    kv_connector_extra_config=extra_config,
-                )
-            ),
+            engine_kwargs=engine_kwargs,
             experimental_configs=extra_exp or {},
         ),
     )
@@ -144,6 +155,16 @@ class TestMoRIIOConnectorBackendSetup:
         _setup(backend, rank=0)
         meta = backend.replica_metadata()
         assert meta["mori_zmq_address"] == backend._zmq_address
+        # Parallelism is published so the orchestrator can address remote workers.
+        assert meta["dp_rank"] == 0 and meta["dp_size"] == 1 and meta["tp_size"] == 1
+
+    def test_replica_metadata_publishes_dp_tp(self):
+        backend = _make_backend(dp_rank=2, dp_size=4, tp_size=8)
+        _setup(backend, rank=0)
+        meta = backend.replica_metadata()
+        assert meta["dp_rank"] == 2
+        assert meta["dp_size"] == 4
+        assert meta["tp_size"] == 8
 
     def test_replica_metadata_default_empty(self):
         # The default backend publishes nothing (concrete default on the base).
@@ -231,6 +252,11 @@ class TestMoRIIORequestId:
         assert prefill.kv_transfer_params["do_remote_prefill"] is False
         assert prefill.max_tokens == 1
         assert prefill.stream is False
+        # vLLM reads "tp_size" (not "remote_tp_size"); DP defaults at dp_size=1.
+        assert "remote_tp_size" not in prefill.kv_transfer_params
+        assert prefill.kv_transfer_params["tp_size"] == 1
+        assert prefill.kv_transfer_params["remote_dp_rank"] == 0
+        assert prefill.kv_transfer_params["remote_dp_size"] == 1
 
     def test_decode_kv_params_write(self):
         backend = _make_backend(read_mode=False)
@@ -244,6 +270,40 @@ class TestMoRIIORequestId:
         assert decode.kv_transfer_params["do_remote_prefill"] is True
         assert decode.kv_transfer_params["do_remote_decode"] is False
         assert decode.kv_transfer_params["remote_block_ids"] is None
+        assert "remote_tp_size" not in decode.kv_transfer_params
+        assert decode.kv_transfer_params["tp_size"] == 1
+        assert decode.kv_transfer_params["remote_dp_rank"] == 0
+        assert decode.kv_transfer_params["remote_dp_size"] == 1
+
+    def test_dp_routing_targets_correct_ranks(self):
+        """With DP>1, the prefill request addresses the decode (this
+        orchestrator) rank; the decode request addresses the selected prefill
+        peer's rank (read from peer metadata)."""
+        # This orchestrator is decode dp_rank=1 of a 2-way DP decode group.
+        backend = _make_backend(read_mode=False, dp_rank=1, dp_size=2, tp_size=4)
+        _setup(backend, rank=0)
+        # The selected prefill peer is dp_rank=3 of a 4-way DP prefill group.
+        peer = {
+            "mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005",
+            "dp_rank": 3,
+            "dp_size": 4,
+            "tp_size": 4,
+        }
+        prefill = backend.prepare_prefill_request(
+            request=self._request_with_copy(), peer=peer
+        )
+        decode = backend.prepare_decode_request(
+            request=self._request_with_copy(),
+            peer=peer,
+            prefill_response=SimpleNamespace(kv_transfer_params=None),
+        )
+        # Prefill engine's remote == this decode orchestrator (rank 1 of 2).
+        assert prefill.kv_transfer_params["remote_dp_rank"] == 1
+        assert prefill.kv_transfer_params["remote_dp_size"] == 2
+        # Decode engine's remote == the selected prefill peer (rank 3 of 4).
+        assert decode.kv_transfer_params["remote_dp_rank"] == 3
+        assert decode.kv_transfer_params["remote_dp_size"] == 4
+        assert decode.kv_transfer_params["tp_size"] == 4
 
     def test_decode_kv_params_read_forwards_prefill_params(self):
         backend = _make_backend(read_mode=True)
@@ -262,6 +322,10 @@ class TestMoRIIORequestId:
         assert decode.kv_transfer_params["remote_block_ids"] == [1, 2, 3]
         assert decode.kv_transfer_params["remote_engine_id"] == "eng-7"
         assert "transfer_id" in decode.kv_transfer_params
+        # READ also stamps the remote (prefill peer) routing.
+        assert decode.kv_transfer_params["remote_dp_rank"] == 0
+        assert decode.kv_transfer_params["remote_dp_size"] == 1
+        assert decode.kv_transfer_params["tp_size"] == 1
 
     def test_decode_read_fallback_when_no_remote_params(self):
         backend = _make_backend(read_mode=True)

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
@@ -204,20 +204,6 @@ class TestMoRIIORequestId:
             r"tx-[0-9a-f]{32}", prefill.kv_transfer_params["transfer_id"]
         )
 
-    def test_engine_request_id_matches_shaped_request_id(self):
-        """``engine_request_id`` returns the dual-address id the orchestrator
-        must deliver to both engines -- identical to the id stamped on the
-        shaped prefill/decode requests."""
-        backend = _make_backend(read_mode=False)
-        _setup(backend, rank=0)
-        peer = {"mori_zmq_address": "host:10.0.0.9,handshake:6301,notify:61005"}
-        req = self._request_with_copy("user-req-123")
-
-        engine_id = backend.engine_request_id(request=req, peer=peer)
-        prefill = backend.prepare_prefill_request(request=req, peer=peer)
-        assert engine_id == prefill.request_id
-        assert parse_peer_zmq(engine_id, is_producer=False) == peer["mori_zmq_address"]
-
     def test_id_is_deterministic_across_calls(self):
         backend = _make_backend(read_mode=False)
         _setup(backend, rank=0)

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -780,6 +780,87 @@ class TestConnectorProtocolHook:
         assert chunks == [prefill_error]
         assert decode_aborted["value"] is True
 
+    def test_connector_raw_request_info_delivers_owned_id(self):
+        """When the backend owns the engine request id, the orchestrator stamps
+        it on the X-Request-Id header (dropping case/underscore variants) and on
+        the Serve request context, so both engines observe it."""
+        from ray.llm._internal.serve.core.protocol import RawRequestInfo
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+        from ray.llm._internal.serve.utils.server_utils import get_serve_request_id
+        from ray.serve.context import _unset_request_context
+
+        class _OwnsIdBackend(BaseConnectorBackend):
+            def prepare_prefill_request(self, *, request, peer):
+                return request
+
+            def prepare_decode_request(self, *, request, peer, prefill_response):
+                return request
+
+            def engine_request_id(self, *, request, peer):
+                return "DUAL-ADDR-ID"
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        backend = _OwnsIdBackend(llm_config=None)
+        raw = RawRequestInfo(headers={"X-Request-ID": "incoming", "accept": "json"})
+        try:
+            out = server._connector_raw_request_info(backend, object(), None, raw)
+            # Only our id survives as x-request-id; other headers preserved.
+            assert out.headers["x-request-id"] == "DUAL-ADDR-ID"
+            assert "X-Request-ID" not in out.headers
+            assert out.headers["accept"] == "json"
+            # Serve context updated so the local-decode overwrite copies our id.
+            assert get_serve_request_id() == "DUAL-ADDR-ID"
+            # None raw info -> a fresh RawRequestInfo carrying the header.
+            out_none = server._connector_raw_request_info(backend, object(), None, None)
+            assert out_none.headers["x-request-id"] == "DUAL-ADDR-ID"
+        finally:
+            _unset_request_context()
+
+    def test_connector_raw_request_info_noop_for_default_backend(self):
+        """A backend that doesn't own the id (engine_request_id -> None) leaves
+        the raw request info untouched."""
+        from ray.llm._internal.serve.core.protocol import RawRequestInfo
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            DefaultConnectorBackend,
+        )
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        backend = DefaultConnectorBackend(llm_config=None)
+        raw = RawRequestInfo(headers={"x-request-id": "incoming"})
+        out = server._connector_raw_request_info(backend, object(), None, raw)
+        assert out is raw
+
+    @pytest.mark.asyncio
+    async def test_prewarm_skipped_for_peer_binding_backend(self):
+        """Pre-warm broadcasts a peerless prefill request, which a peer-binding
+        connector (e.g. MoRIIO) cannot shape -- so it must be skipped rather
+        than crash decode-replica init."""
+        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+            BaseConnectorBackend,
+        )
+
+        class _PeerBindingBackend(BaseConnectorBackend):
+            requires_peer_binding = True
+
+            def prepare_prefill_request(self, *, request, peer):
+                raise AssertionError("prepare_prefill_request must not be called")
+
+            def prepare_decode_request(self, *, request, peer, prefill_response):
+                raise AssertionError("prepare_decode_request must not be called")
+
+        server = PDDecodeServer.__new__(PDDecodeServer)
+        server._llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+            experimental_configs={"_prewarm_prefill_decode": True},
+        )
+        server._llm_config._kv_connector_backend = _PeerBindingBackend(
+            server._llm_config
+        )
+        # Must return without raising (and without touching prepare_*).
+        await server._maybe_prewarm()
+
 
 class TestBuildPDOpenaiApp:
     """Test suite for build_pd_openai_app function."""

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -780,58 +780,6 @@ class TestConnectorProtocolHook:
         assert chunks == [prefill_error]
         assert decode_aborted["value"] is True
 
-    def test_connector_raw_request_info_delivers_owned_id(self):
-        """When the backend owns the engine request id, the orchestrator stamps
-        it on the X-Request-Id header (dropping case/underscore variants) and on
-        the Serve request context, so both engines observe it."""
-        from ray.llm._internal.serve.core.protocol import RawRequestInfo
-        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
-            BaseConnectorBackend,
-        )
-        from ray.llm._internal.serve.utils.server_utils import get_serve_request_id
-        from ray.serve.context import _unset_request_context
-
-        class _OwnsIdBackend(BaseConnectorBackend):
-            def prepare_prefill_request(self, *, request, peer):
-                return request
-
-            def prepare_decode_request(self, *, request, peer, prefill_response):
-                return request
-
-            def engine_request_id(self, *, request, peer):
-                return "DUAL-ADDR-ID"
-
-        server = PDDecodeServer.__new__(PDDecodeServer)
-        backend = _OwnsIdBackend(llm_config=None)
-        raw = RawRequestInfo(headers={"X-Request-ID": "incoming", "accept": "json"})
-        try:
-            out = server._connector_raw_request_info(backend, object(), None, raw)
-            # Only our id survives as x-request-id; other headers preserved.
-            assert out.headers["x-request-id"] == "DUAL-ADDR-ID"
-            assert "X-Request-ID" not in out.headers
-            assert out.headers["accept"] == "json"
-            # Serve context updated so the local-decode overwrite copies our id.
-            assert get_serve_request_id() == "DUAL-ADDR-ID"
-            # None raw info -> a fresh RawRequestInfo carrying the header.
-            out_none = server._connector_raw_request_info(backend, object(), None, None)
-            assert out_none.headers["x-request-id"] == "DUAL-ADDR-ID"
-        finally:
-            _unset_request_context()
-
-    def test_connector_raw_request_info_noop_for_default_backend(self):
-        """A backend that doesn't own the id (engine_request_id -> None) leaves
-        the raw request info untouched."""
-        from ray.llm._internal.serve.core.protocol import RawRequestInfo
-        from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
-            DefaultConnectorBackend,
-        )
-
-        server = PDDecodeServer.__new__(PDDecodeServer)
-        backend = DefaultConnectorBackend(llm_config=None)
-        raw = RawRequestInfo(headers={"x-request-id": "incoming"})
-        out = server._connector_raw_request_info(backend, object(), None, raw)
-        assert out is raw
-
     @pytest.mark.asyncio
     async def test_prewarm_skipped_for_peer_binding_backend(self):
         """Pre-warm broadcasts a peerless prefill request, which a peer-binding


### PR DESCRIPTION
## Why
Add the **MoRIIO** KV-transfer connector to Ray Serve LLM prefill/decode — as a connector backend on
the abstract P/D protocol (#63950), with no new orchestrator concepts.

## What
`MoRIIOConnectorBackend` implements the connector P/D protocol:
- `requires_peer_binding = True` — the orchestrator selects the prefill replica first and passes its
  published `replica_metadata` (zmq address + DP/TP, via #63948's replica-metadata hook) as `peer`.
- `concurrent_handoff` = `not read_mode` — WRITE overlaps prefill push with local decode; READ is
  sequential (decode pulls using the block ids the prefill returns).
- `prepare_prefill_request` / `prepare_decode_request` stamp `kv_transfer_params` (incl. DP/TP routing:
  `remote_dp_rank`/`remote_dp_size`/`tp_size`) and a **stateless, deterministic** dual-address
  `request_id` + `transfer_id` (a hash of the incoming request id, so the two calls agree without
  per-request state). The dual-address id encodes the peer zmq addresses vLLM's MoRIIO connector parses.
- **DP>1 supported**: each replica publishes its `dp_rank`/`dp_size`; the prefill request targets the
  decode orchestrator's rank, the decode request targets the selected prefill peer's rank. Collapses to
  the DP=1 values otherwise. (DP>1 routing is unit-tested; pending a multi-DP-replica GPU run.)
- `PDPrefillServer.record_replica_metadata` publishes the connector's zmq address + parallelism.

The dual-address id reaches both engines by being stamped on `request.request_id`: the LLMServer
pipeline preserves an explicitly-set id (#64044) and the engine copies it into the `X-Request-Id`
header it reads (#63949). No orchestrator-side header/context plumbing.

Registered in `KVConnectorBackendFactory`; the builder shifts decode's MoRIIO port bases (mirrors NIXL).
Pre-warm is skipped for peer-binding connectors.

## Stack
Built on **merged** #63948 (replica-metadata hook), #63949 (`request.request_id` authoritative),
#63950 (PD connector protocol), and #64044 (don't clobber an explicitly-set request_id). All
dependencies are now in master — this is a standalone MoRIIO diff.

**Cross-node correctness** additionally needs a worker host-IP shim (advertise the node-internal IP
inside each vLLM worker, since `VLLM_HOST_IP` is excluded from driver→worker env copy) — a follow-up PR.

## Testing
- `test_moriio_connector.py` (CPU/mock): setup (ports/zmq/read_mode); flags; `replica_metadata`
  (incl. DP/TP); deterministic request_id round-tripping to the right peer zmq; DP-routing stamps the
  correct remote ranks; missing-peer raises; factory registration.
- `test_prefill_decode_disagg.py`: pre-warm skipped for peer-binding backends.
- GPU-validated end-to-end (WRITE+READ, 1P1D/3P1D, DeepSeek-R1 TP8) in the out-of-tree prototype.
  See the PR comments for a `build_pd_openai_app` usage example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
