### PR TITLE
[RLlib] Forward parallel_train_future to custom_evaluation_function

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -3,6 +3,7 @@ import copy
 import functools
 import importlib
 import importlib.metadata
+import inspect
 import json
 import logging
 import os
@@ -1477,7 +1478,9 @@ class Algorithm(Checkpointable, Trainable):
                         eval_results,
                         env_steps,
                         agent_steps,
-                    ) = self._evaluate_with_custom_eval_function()
+                    ) = self._evaluate_with_custom_eval_function(
+                        parallel_train_future=parallel_train_future,
+                    )
                 else:
                     eval_results = self.config.custom_evaluation_function()
             # No eval EnvRunnerGroup -> Run on (training) local EnvRunner.
@@ -1598,17 +1601,51 @@ class Algorithm(Checkpointable, Trainable):
         # Also return the results here for convenience.
         return eval_results
 
-    def _evaluate_with_custom_eval_function(self) -> Tuple[ResultDict, int, int]:
+    def _evaluate_with_custom_eval_function(
+        self,
+        parallel_train_future: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+    ) -> Tuple[ResultDict, int, int]:
+        """Runs the user-provided ``custom_evaluation_function``.
+
+        Args:
+            parallel_train_future: The currently running training
+                ``ThreadPoolExecutor``, when training and evaluation run in
+                parallel (``evaluation_duration="auto"``). Passed through to
+                the user function as a keyword argument only if its signature
+                accepts ``parallel_train_future`` (by name or via
+                ``**kwargs``); existing custom eval functions that do not
+                declare the parameter are unaffected.
+        """
         logger.info(
             f"Evaluating current state of {self} using the custom eval function "
             f"{self.config.custom_evaluation_function}"
         )
         if self.config.enable_env_runner_and_connector_v2:
+            extra_kwargs = {}
+            try:
+                sig = inspect.signature(self.config.custom_evaluation_function)
+                params = sig.parameters
+                accepts_parallel_train_future = (
+                    "parallel_train_future" in params
+                    or any(
+                        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                    )
+                )
+            except (TypeError, ValueError):
+                # Builtin / C-implemented callable without an introspectable
+                # signature; fall back to the legacy positional call.
+                accepts_parallel_train_future = False
+            if accepts_parallel_train_future:
+                extra_kwargs["parallel_train_future"] = parallel_train_future
             (
                 eval_results,
                 env_steps,
                 agent_steps,
-            ) = self.config.custom_evaluation_function(self, self.eval_env_runner_group)
+            ) = self.config.custom_evaluation_function(
+                self,
+                self.eval_env_runner_group,
+                **extra_kwargs,
+            )
             if not isinstance(env_steps, int) or not isinstance(agent_steps, int):
                 raise ValueError(
                     "Custom eval function must return "

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1376,15 +1376,15 @@ class Algorithm(Checkpointable, Trainable):
     @PublicAPI
     def evaluate(
         self,
-        parallel_train_future: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+        parallel_train_future: Optional[concurrent.futures.Future] = None,
     ) -> ResultDict:
         """Evaluates current policy under `evaluation_config` settings.
 
         Args:
             parallel_train_future: In case, we are training and avaluating in parallel,
-                this arg carries the currently running ThreadPoolExecutor object that
-                runs the training iteration. Use `parallel_train_future.done()` to
-                check, whether the parallel training job has completed and
+                this arg carries the currently running ``concurrent.futures.Future``
+                that runs the training iteration. Use `parallel_train_future.done()`
+                to check, whether the parallel training job has completed and
                 `parallel_train_future.result()` to get its return values.
 
         Returns:
@@ -1603,18 +1603,18 @@ class Algorithm(Checkpointable, Trainable):
 
     def _evaluate_with_custom_eval_function(
         self,
-        parallel_train_future: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+        parallel_train_future: Optional[concurrent.futures.Future] = None,
     ) -> Tuple[ResultDict, int, int]:
         """Runs the user-provided ``custom_evaluation_function``.
 
         Args:
             parallel_train_future: The currently running training
-                ``ThreadPoolExecutor``, when training and evaluation run in
-                parallel (``evaluation_duration="auto"``). Passed through to
-                the user function as a keyword argument only if its signature
-                accepts ``parallel_train_future`` (by name or via
-                ``**kwargs``); existing custom eval functions that do not
-                declare the parameter are unaffected.
+                ``concurrent.futures.Future``, when training and evaluation
+                run in parallel (``evaluation_duration="auto"``). Passed
+                through to the user function as a keyword argument only if
+                its signature accepts ``parallel_train_future`` (by name or
+                via ``**kwargs``); existing custom eval functions that do
+                not declare the parameter are unaffected.
         """
         logger.info(
             f"Evaluating current state of {self} using the custom eval function "
@@ -3923,15 +3923,15 @@ class Algorithm(Checkpointable, Trainable):
 
     def _run_one_evaluation(
         self,
-        parallel_train_future: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+        parallel_train_future: Optional[concurrent.futures.Future] = None,
     ) -> ResultDict:
         """Runs evaluation step via `self.evaluate()` and handling worker failures.
 
         Args:
             parallel_train_future: In case, we are training and avaluating in parallel,
-                this arg carries the currently running ThreadPoolExecutor object that
-                runs the training iteration. Use `parallel_train_future.done()` to
-                check, whether the parallel training job has completed and
+                this arg carries the currently running ``concurrent.futures.Future``
+                that runs the training iteration. Use `parallel_train_future.done()`
+                to check, whether the parallel training job has completed and
                 `parallel_train_future.result()` to get its return values.
 
         Returns:


### PR DESCRIPTION
## Why are these changes needed?

Closes #61584.

When ``evaluation_duration=\"auto\"``, RLlib evaluates in parallel with the training iteration and hands the built-in eval paths a reference to the running training ``ThreadPoolExecutor`` (``parallel_train_future``). The eval loop uses that handle to check whether training is done and to align its cadence with training:

```python
# rllib/algorithms/algorithm.py:1513 (built-in auto-duration path)
self._evaluate_with_auto_duration(parallel_train_future)
```

```python
# rllib/algorithms/algorithm.py:1859
and (_round == -1 or not parallel_train_future.done())
```

The custom-eval path at line 1480 never received the future:

```python
self._evaluate_with_custom_eval_function()
```

So user-provided eval functions had no way to mirror the built-in ``evaluation_duration=\"auto\"`` semantics. The reporter raised this from an ELO eval function that wants to keep running matchups exactly as long as training is still ongoing — `see [their example](https://github.com/MatthewCWeston/rllib_sw/blob/master/callbacks/elo_eval.py).

## What this PR does

Forwards ``parallel_train_future`` to the custom eval function as a **keyword argument**, gated on signature introspection so existing user code stays source-compatible:

```python
extra_kwargs = {}
try:
    sig = inspect.signature(self.config.custom_evaluation_function)
    params = sig.parameters
    accepts_parallel_train_future = (
        \"parallel_train_future\" in params
        or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
    )
except (TypeError, ValueError):
    # Builtin / C-implemented callable without an introspectable
    # signature; fall back to the legacy positional call.
    accepts_parallel_train_future = False
if accepts_parallel_train_future:
    extra_kwargs[\"parallel_train_future\"] = parallel_train_future
(eval_results, env_steps, agent_steps) = self.config.custom_evaluation_function(
    self, self.eval_env_runner_group, **extra_kwargs,
)
```

- Existing custom eval functions: unchanged behavior. The future is only passed if the user opts in.
- Opt-in surface: add ``parallel_train_future=None`` (or ``**kwargs``) to the signature and use ``parallel_train_future.done()`` / ``.result()`` from the function body.
- ``inspect.signature`` failures are absorbed so C-implemented callables still work.

## Related issue number

Closes #61584

## Checks

- [x] DCO sign-off
- [x] ``ruff check`` and ``black==22.10.0`` (Ray's pinned version) pass on the modified file

## Test plan

- [ ] CI passes (``buildkite/premerge``, ``buildkite/microcheck``, ``buildkite/release``)
- [ ] Existing custom-eval tests are unaffected (function signature unchanged for legacy callers)
- [ ] Manual verification: a custom eval function declaring ``parallel_train_future=None`` receives a non-``None`` future when ``evaluation_duration=\"auto\"`` is set and a parallel training iteration is in flight