### PR TITLE
[Data] Set `placement_group_capture_child_tasks` in placement groups example

### DIFF
--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -502,7 +502,11 @@ You can do this by using :ref:`placement groups <ray-placement-group-doc-ref>` a
     def ray_remote_args_fn():
         from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
         pg = ray.util.placement_group([{"CPU": 1}] * NUM_SHARDS)
-        return {"scheduling_strategy": PlacementGroupSchedulingStrategy(placement_group=pg)}
+        scheduling_strategy = PlacementGroupSchedulingStrategy(
+            placement_group=pg,
+            placement_group_capture_child_tasks=True,
+        )
+        return {"scheduling_strategy": scheduling_strategy}
 
     ds = ray.data.range(10).map_batches(DistributedModel, ray_remote_args_fn=ray_remote_args_fn)
     ds.take_all()


### PR DESCRIPTION
## Description

The "Transforming Data" guide contains an example of how to perform model sharding with placement groups. The intention is that both the "DistributedModel" and the "ModelShard" get placed in the same placement group, but because the snippet doesn't set `placement_group_capture_child_tasks`, the model shards get scheduled outside of the placement group and in the general cluster.

In this PR, I've fixed the snippet accordingly.

## Related issues

N/A

## Additional information

N/A
