### PR TITLE
[Data] Remove `max_concurrency` from GPU batch inference release test

### DIFF
--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -112,7 +112,6 @@ def main(args):
         compute=compute,
         num_gpus=num_gpus,
         fn_constructor_kwargs={"model": model_ref},
-        max_concurrency=2,
     )
 
     total_images = 0


### PR DESCRIPTION
## Description

The GPU batch inference release test sets `max_concurrency=2`, which diverges from the default behavior we want the test to exercise. Since `max_concurrency` is a low-level tuning parameter, I'm removing it so the test matches defaults.

## Related issues

## Additional information
