### PR TITLE
[Data] Remove obsolete PyArrow version check blocking Daft installations (#63883)

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3251,13 +3251,7 @@ def from_daft(df: "daft.DataFrame") -> Dataset:
     Returns:
         A :class:`~ray.data.Dataset` holding rows read from the DataFrame.
     """
-    pyarrow_version = get_pyarrow_version()
-    assert pyarrow_version is not None
-    if pyarrow_version >= parse_version("14.0.0"):
-        raise RuntimeError(
-            "`from_daft` only works with PyArrow 13 or lower. For more details, see "
-            "https://github.com/ray-project/ray/issues/53278."
-        )
+    
 
     # NOTE: Today this returns a MaterializedDataset. We should also integrate Daft such
     # that we can stream object references into a Ray dataset. Unfortunately this is

--- a/python/ray/data/tests/datasource/test_daft.py
+++ b/python/ray/data/tests/datasource/test_daft.py
@@ -1,8 +1,6 @@
-from unittest.mock import patch
 
 import pyarrow as pa
 import pytest
-from packaging.version import parse as parse_version
 
 
 @pytest.fixture(scope="module")

--- a/python/ray/data/tests/datasource/test_daft.py
+++ b/python/ray/data/tests/datasource/test_daft.py
@@ -18,25 +18,7 @@ def ray_start(request):
         ray.shutdown()
 
 
-def test_from_daft_raises_error_on_pyarrow_14(ray_start):
-    # This test assumes that `from_daft` calls `get_pyarrow_version` to get the
-    # PyArrow version. We can't mock `__version__` on the module directly because
-    # `get_pyarrow_version` caches the version.
-    with patch(
-        "ray.data.read_api.get_pyarrow_version", return_value=parse_version("14.0.0")
-    ):
-        import daft
 
-        import ray
-
-        with pytest.raises(RuntimeError):
-            ray.data.from_daft(daft.from_pydict({"col": [0]}))
-
-
-@pytest.mark.skipif(
-    parse_version(pa.__version__) >= parse_version("14.0.0"),
-    reason="https://github.com/ray-project/ray/issues/53278",
-)
 def test_daft_round_trip(ray_start):
     import daft
     import numpy as np


### PR DESCRIPTION
### What does this PR do?
This PR removes an obsolete PyArrow version check constraint from `ray.data.from_daft()` which was throwing false `RuntimeError` blocks on modern Daft installations. Daft resolved its internal PyArrow serialization and compatibility bugs a long time ago, making this strict execution constraint completely unnecessary. 

### Implementation Details
- Removed the hardcoded version check `if pyarrow_version >= parse_version("14.0.0")` and its accompanying `RuntimeError` payload inside `python/ray/data/read_api.py`.
- Cleaned up obsolete unit tests asserting this error (`test_from_daft_raises_error_on_pyarrow_14`) in `python/ray/data/tests/datasource/test_daft.py`.
- Removed the `@pytest.mark.skipif` decorator on the primary round-trip test so that Daft data integration pipelines are actively verified on modern PyArrow environments moving forward.

### Related Issue
Closes #63883