### PR TITLE
[ci] Build and publish cu130 ray and ray-extra images

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -161,6 +161,7 @@ steps:
         - "12.6.3-cudnn"
         - "12.8.1-cudnn"
         - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env_file: rayci.env
     env:
       PYTHON_VERSION: "{{array.python}}"
@@ -192,6 +193,7 @@ steps:
         --platform cu12.6.3-cudnn
         --platform cu12.8.1-cudnn
         --platform cu12.9.1-cudnn
+        --platform cu13.0.0-cudnn
         --image-type ray
         --architecture x86_64
     array:
@@ -250,6 +252,7 @@ steps:
         - "12.6.3-cudnn"
         - "12.8.1-cudnn"
         - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env_file: rayci.env
     env:
       PYTHON_VERSION: "{{array.python}}"
@@ -322,6 +325,7 @@ steps:
         --platform cu12.6.3-cudnn
         --platform cu12.8.1-cudnn
         --platform cu12.9.1-cudnn
+        --platform cu13.0.0-cudnn
         --image-type ray-extra
         --architecture x86_64
     array:

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -83,6 +83,7 @@ steps:
         - "12.6.3-cudnn"
         - "12.8.1-cudnn"
         - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     instance_type: builder-arm64
     env:
       PYTHON_VERSION: "{{array.python}}"
@@ -108,6 +109,7 @@ steps:
         - "12.6.3-cudnn"
         - "12.8.1-cudnn"
         - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     instance_type: builder-arm64
     env:
       PYTHON_VERSION: "{{array.python}}"
@@ -290,6 +292,7 @@ steps:
         - "12.6.3-cudnn"
         - "12.8.1-cudnn"
         - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env_file: rayci.env
     env:
       PYTHON_VERSION: "{{array.python}}"
@@ -321,6 +324,7 @@ steps:
         --platform cu12.6.3-cudnn
         --platform cu12.8.1-cudnn
         --platform cu12.9.1-cudnn
+        --platform cu13.0.0-cudnn
         --image-type ray
         --architecture aarch64
     array:
@@ -379,6 +383,7 @@ steps:
         - "12.6.3-cudnn"
         - "12.8.1-cudnn"
         - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env_file: rayci.env
     env:
       PYTHON_VERSION: "{{array.python}}"
@@ -410,6 +415,7 @@ steps:
         --platform cu12.6.3-cudnn
         --platform cu12.8.1-cudnn
         --platform cu12.9.1-cudnn
+        --platform cu13.0.0-cudnn
         --image-type ray-extra
         --architecture aarch64
     array:


### PR DESCRIPTION
## Description

`cu13.0.0-cudnn` is listed in `PLATFORMS_RAY` (`ray-images.json`), so the nightly image verification (`check_nightly_ray_commit`) expects `rayproject/ray:nightly-cu130` and `nightly-cu130-aarch64` to exist. But the build/publish pipeline only produced images up to `cu12.9.1`, so the cu130 tags were never pushed and verification failed at the `docker pull` step:

```
docker_tags_lib.py: 111  Pulling image rayproject/ray:nightly-cu130
# -> 404, tag not found
```

This PR enables cu130 across both architectures and both image types so the tags are actually built and published:

- **`.buildkite/build.rayci.yml`** (x86_64): add `13.0.0-cudnn` to `ray-image-cuda-build` and `ray-extra-image-cuda-build`; add `--platform cu13.0.0-cudnn` to `ray_images_push` and `ray_extra_images_push`.
- **`.buildkite/linux_aarch64.rayci.yml`**: add `13.0.0-cudnn` to the `raycudabase-aarch64` and `raycudabaseextra-aarch64` base images (the x86_64 bases already had it), to the `ray`/`ray-extra` cuda image builds, and to the corresponding push steps.

No change to `ray-images.json` — `PLATFORMS_RAY` already lists `cu13.0.0-cudnn`; this PR makes the pipeline match it.

## Related issues

N/A

## Additional information

- Both YAML files validate, and no test parses these configs for consistency.
- The upstream `raycudabase*` cu130 base images already build for x86_64; the aarch64 bases are added here so the `depends_on($)` fan-outs resolve.
- Real validation is the first nightly build after merge (CI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)