### PR TITLE
[dashboard] TPU metrics per-actor in Actor table

### DIFF
--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -40,6 +40,10 @@ import {
 } from "../pages/node/AcceleratorMemoryColumn";
 import { ActorDetail, ActorEnum } from "../type/actor";
 import { Worker } from "../type/worker";
+import {
+  acceleratorColumnLabels,
+  getAcceleratorType,
+} from "../util/accelerator";
 import { memoryConverter } from "../util/converter";
 import { useFilter, useSorter } from "../util/hook";
 import OverflowCollapsibleCell from "./OverflowCollapsibleCell";
@@ -170,6 +174,14 @@ const ActorTable = ({
     maxPage,
   } = sliceToPage(sortedActors, pageNo, pageSize ?? 10);
 
+  const hasGpus = Object.values(actors).some(
+    (actor) => actor.gpus && actor.gpus.length > 0,
+  );
+  const hasTpus = Object.values(actors).some(
+    (actor) => actor.tpus && actor.tpus.length > 0,
+  );
+  const acceleratorType = getAcceleratorType(hasGpus, hasTpus);
+
   const columns = [
     { label: "" },
     { label: "ID" },
@@ -281,25 +293,26 @@ const ActorTable = ({
       ),
     },
     {
-      label: "GPU",
+      label: acceleratorColumnLabels[acceleratorType].utilization,
       helpInfo: (
         <Typography>
-          Usage of each GPU device. If no GPU usage is detected, here are the
-          potential root causes:
+          Usage of each accelerator device (e.g. GPU, TPU). If no usage is
+          detected, here are the potential root causes:
           <br />
-          1. non-GPU Ray image is used on this node. Switch to a GPU Ray image
-          and try again. <br />
-          2. Non Nvidia or AMD GPUs are being used.
+          1. Non-accelerator Ray image is used on this node. Switch to an
+          appropriate image and try again. <br />
+          2. Non Nvidia, AMD, or Google TPU accelerators are being used.
           <br />
-          3. pynvml or pyamdsmi module raises an exception.
+          3. pynvml, pyamdsmi, or TPU plugin raises an exception.
         </Typography>
       ),
     },
     {
-      label: "GRAM",
+      label: acceleratorColumnLabels[acceleratorType].memory,
       helpInfo: (
         <Typography>
-          Actor's GRAM usage (from Worker Process). <br />
+          Actor's {acceleratorColumnLabels[acceleratorType].memory} usage (from
+          Worker Process). <br />
         </Typography>
       ),
     },
@@ -547,8 +560,14 @@ const ActorTable = ({
               ["processStats.cpuPercent", "CPU"],
               // Fake attribute key used when sorting by GPU utilization and
               // GRAM usage because aggregate function required on actor key before sorting.
-              [gpuUtilizationSorterKey, "GPU Utilization"],
-              [gramUsageSorterKey, "GRAM Usage"],
+              [
+                gpuUtilizationSorterKey,
+                `${acceleratorColumnLabels[acceleratorType].utilization} Utilization`,
+              ],
+              [
+                gramUsageSorterKey,
+                `${acceleratorColumnLabels[acceleratorType].memory} Usage`,
+              ],
             ]}
             onChange={(val) => setSortKey(val)}
             showAllOption={false}

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -26,6 +26,10 @@ import { StatusChip } from "../../components/StatusChip";
 import TitleCard from "../../components/TitleCard";
 import { HelpInfo } from "../../components/Tooltip";
 import { NodeDetail } from "../../type/node";
+import {
+  acceleratorColumnLabels,
+  getAcceleratorType,
+} from "../../util/accelerator";
 import { memoryConverter } from "../../util/converter";
 import { MainNavPageInfo } from "../layout/mainNavContext";
 import { useNodeList } from "./hook/useNodeList";
@@ -34,20 +38,7 @@ import { NodeRows } from "./NodeRow";
 const codeTextStyle = {
   fontFamily: "Roboto Mono, monospace",
 };
-const acceleratorColumnLabels = {
-  gpu: {
-    utilization: "GPUs",
-    memory: "GRAM",
-  },
-  tpu: {
-    utilization: "TPUs",
-    memory: "HBM",
-  },
-  generic: {
-    utilization: "Accelerators",
-    memory: "Accelerator Memory",
-  },
-};
+
 const getColumns = (acceleratorType: keyof typeof acceleratorColumnLabels) => [
   { label: "" }, // Expand button
   { label: "Host / Worker Process name" },
@@ -263,14 +254,9 @@ const Nodes = () => {
     maxPage,
   } = sliceToPage(nodeList, page.pageNo, page.pageSize);
 
-  const accelerators: (keyof typeof acceleratorColumnLabels)[] = [];
-  if (nodeList.some((node) => node.gpus && node.gpus.length > 0)) {
-    accelerators.push("gpu");
-  }
-  if (nodeList.some((node) => node.tpus && node.tpus.length > 0)) {
-    accelerators.push("tpu");
-  }
-  const accelerator = accelerators.length !== 1 ? "generic" : accelerators[0];
+  const hasGpus = nodeList.some((node) => node.gpus && node.gpus.length > 0);
+  const hasTpus = nodeList.some((node) => node.tpus && node.tpus.length > 0);
+  const accelerator = getAcceleratorType(hasGpus, hasTpus);
 
   const columns = getColumns(accelerator);
 

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -42,14 +42,13 @@ export const getAcceleratorType = (
   hasGpus: boolean,
   hasTpus: boolean,
 ): keyof typeof acceleratorColumnLabels => {
-  const accelerators: (keyof typeof acceleratorColumnLabels)[] = [];
-  if (hasGpus) {
-    accelerators.push("gpu");
+  if (hasGpus && !hasTpus) {
+    return "gpu";
   }
-  if (hasTpus) {
-    accelerators.push("tpu");
+  if (!hasGpus && hasTpus) {
+    return "tpu";
   }
-  return accelerators.length !== 1 ? "generic" : accelerators[0];
+  return "generic";
 };
 
 export const normalizeAccelerators = (

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -23,6 +23,35 @@ export type UnifiedAcceleratorStat = {
   rawTpu?: TPUStats;
 };
 
+export const acceleratorColumnLabels = {
+  gpu: {
+    utilization: "GPUs",
+    memory: "GRAM",
+  },
+  tpu: {
+    utilization: "TPUs",
+    memory: "HBM",
+  },
+  generic: {
+    utilization: "Accelerators",
+    memory: "Accelerator Memory",
+  },
+};
+
+export const getAcceleratorType = (
+  hasGpus: boolean,
+  hasTpus: boolean,
+): keyof typeof acceleratorColumnLabels => {
+  const accelerators: (keyof typeof acceleratorColumnLabels)[] = [];
+  if (hasGpus) {
+    accelerators.push("gpu");
+  }
+  if (hasTpus) {
+    accelerators.push("tpu");
+  }
+  return accelerators.length !== 1 ? "generic" : accelerators[0];
+};
+
 export const normalizeAccelerators = (
   gpus?: GPUStats[],
   tpus?: TPUStats[],

--- a/python/ray/dashboard/modules/node/datacenter.py
+++ b/python/ray/dashboard/modules/node/datacenter.py
@@ -1,4 +1,3 @@
-import copy
 from typing import List, Optional
 
 import ray.dashboard.consts as dashboard_consts
@@ -158,11 +157,6 @@ class DataOrganizer:
             death_info.get("reason", None), death_info.get("reasonMessage", None)
         )
 
-        # TODO(spencer-p): TPU process linking is currently prone to over-counting
-        # as it attaches all TPU workers to every chip. This will be addressed
-        # with a more robust mapping in a future update.
-        node_info["tpus"] = copy.deepcopy(node_info.get("tpus", []))
-
         if not get_summary:
             actor_table_entries = DataSource.node_actors.get(node_id, {})
 
@@ -218,6 +212,7 @@ class DataOrganizer:
         node_physical_stats = DataSource.node_physical_stats.get(node_id, {})
         actor_process_stats = None
         actor_process_gpu_stats = []
+        actor_process_tpu_stats = []
         if pid:
             for process_stats in node_physical_stats.get("workers", []):
                 if process_stats["pid"] == pid:
@@ -232,7 +227,14 @@ class DataOrganizer:
                         actor_process_gpu_stats.append(gpu_stats)
                         break
 
+            for tpu_stats in node_physical_stats.get("tpus", []):
+                for process in tpu_stats.get("processesPids") or []:
+                    if process["pid"] == pid:
+                        actor_process_tpu_stats.append(tpu_stats)
+                        break
+
         actor["gpus"] = actor_process_gpu_stats
+        actor["tpus"] = actor_process_tpu_stats
         actor["processStats"] = actor_process_stats
         actor["mem"] = node_physical_stats.get("mem", [])
 
@@ -240,9 +242,5 @@ class DataOrganizer:
             actor["requiredResources"]
         )
         actor["requiredResources"] = required_resources
-
-        # TODO(spencer-p): TPU process linking is currently prone to over-counting.
-        # This will be addressed with a more robust mapping in a future update.
-        actor["tpus"] = []
 
         return actor

--- a/python/ray/dashboard/modules/node/tests/test_actor.py
+++ b/python/ray/dashboard/modules/node/tests/test_actor.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import time
 import traceback
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -9,6 +10,7 @@ import requests
 import ray
 from ray._private.test_utils import format_web_url, wait_until_server_available
 from ray.dashboard.modules.node import actor_consts
+from ray.dashboard.modules.node.datacenter import DataOrganizer, DataSource
 from ray.dashboard.tests.conftest import *  # noqa
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -372,6 +374,69 @@ def test_actor_cleanup(
                 )
                 ex_stack = "".join(ex_stack)
                 raise Exception(f"Timed out while testing, {ex_stack}")
+
+
+@pytest.mark.asyncio
+async def test_get_actor_info_tpu_linking():
+    # Setup DataSource
+    node_id = "node-1"
+    pid = 1234
+    worker_id = "worker-1"
+
+    DataSource.core_worker_stats = {worker_id: {"pid": pid, "workerId": worker_id}}
+    DataSource.node_physical_stats = {
+        node_id: {
+            "tpus": [
+                {
+                    "index": 0,
+                    "name": "chip-0",
+                    "processesPids": [{"pid": pid, "tpuMemoryUsage": 1000}],
+                },
+                {
+                    "index": 1,
+                    "name": "chip-1",
+                    "processesPids": [{"pid": 5678, "tpuMemoryUsage": 2000}],
+                },
+            ],
+            "workers": [{"pid": pid}],
+            "mem": [100, 50, 0.5],
+        }
+    }
+
+    actor = {
+        "address": {"nodeId": node_id, "workerId": worker_id},
+        "requiredResources": {},
+    }
+
+    with patch(
+        "ray.dashboard.modules.node.datacenter.parse_pg_formatted_resources_to_original",
+        return_value={},
+    ):
+        updated_actor = await DataOrganizer._get_actor_info(actor)
+
+    assert "tpus" in updated_actor
+    assert len(updated_actor["tpus"]) == 1
+    assert updated_actor["tpus"][0]["index"] == 0
+    assert updated_actor["tpus"][0]["name"] == "chip-0"
+
+    # Verify GPU still works (no regressions)
+    DataSource.node_physical_stats[node_id]["gpus"] = [
+        {
+            "index": 0,
+            "name": "gpu-0",
+            "processesPids": [{"pid": pid, "gpuMemoryUsage": 500}],
+        }
+    ]
+
+    with patch(
+        "ray.dashboard.modules.node.datacenter.parse_pg_formatted_resources_to_original",
+        return_value={},
+    ):
+        updated_actor_with_gpu = await DataOrganizer._get_actor_info(actor)
+
+    assert len(updated_actor_with_gpu["gpus"]) == 1
+    assert updated_actor_with_gpu["gpus"][0]["name"] == "gpu-0"
+    assert len(updated_actor_with_gpu["tpus"]) == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -57,6 +57,13 @@ class GpuUtilizationInfo(TypedDict):
     temperature_c: NotRequired[Optional[int]]
 
 
+class ProcessTPUInfo(TypedDict):
+    """Information about TPU usage for a single process."""
+
+    pid: int
+    tpu_memory_usage: Bytes
+
+
 # tpu utilization for google tpu
 class TpuUtilizationInfo(TypedDict):
     index: int
@@ -68,6 +75,7 @@ class TpuUtilizationInfo(TypedDict):
     duty_cycle: Percentage
     memory_used: Bytes
     memory_total: Bytes
+    processes_pids: NotRequired[Optional[Dict[int, ProcessTPUInfo]]]
 
 
 class GpuProvider(abc.ABC):

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1,14 +1,16 @@
 import asyncio
 import datetime
+import glob
 import json
 import logging
 import os
+import re
 import socket
 import sys
 import traceback
 from collections import defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from grpc.aio import ServicerContext
@@ -64,6 +66,7 @@ from ray.dashboard.modules.reporter.gpu_profile_manager import GpuProfilingManag
 from ray.dashboard.modules.reporter.gpu_providers import (
     GpuMetricProvider,
     GpuUtilizationInfo,
+    ProcessTPUInfo,
     TpuUtilizationInfo,
 )
 from ray.dashboard.modules.reporter.profile_manager import (
@@ -761,6 +764,28 @@ class ReporterAgent(
         return self._gpu_metric_provider.get_gpu_usage()
 
     @staticmethod
+    def _get_tpu_pid_mapping() -> Dict[int, int]:
+        """Returns a mapping of TPU chip indices to PIDs using them."""
+        chip_to_pid = {}
+
+        for link in glob.glob("/proc/*/fd/*"):
+            try:
+                target = os.readlink(link)
+            except (FileNotFoundError, OSError):
+                continue
+
+            # Matches /dev/accelN or /dev/vfio/N where N is the chip index.
+            match = re.fullmatch(r"/dev/(?:accel|vfio/)(\d+)", target)
+            if match:
+                chip_index = int(match.group(1))
+                # Extract PID from the /proc/{pid}/fd/... path
+                pid_match = re.match(r"/proc/(\d+)/", link)
+                if pid_match:
+                    chip_to_pid[chip_index] = int(pid_match.group(1))
+
+        return chip_to_pid
+
+    @staticmethod
     def _get_tpu_usage() -> List[TpuUtilizationInfo]:
 
         global enable_tpu_usage_check
@@ -810,6 +835,7 @@ class ReporterAgent(
                             duty_cycle=0.0,
                             memory_used=0,
                             memory_total=0,
+                            processes_pids={},
                         )
                         tpu_utilizations.append(info)
 
@@ -824,6 +850,7 @@ class ReporterAgent(
                             duty_cycle=0.0,
                             memory_used=0,
                             memory_total=0,
+                            processes_pids={},
                         )
                         tpu_utilizations.append(info)
 
@@ -838,6 +865,7 @@ class ReporterAgent(
                             duty_cycle=sample.value,
                             memory_used=0,
                             memory_total=0,
+                            processes_pids={},
                         )
                         tpu_utilizations.append(info)
 
@@ -852,6 +880,7 @@ class ReporterAgent(
                             duty_cycle=0.0,
                             memory_used=sample.value,
                             memory_total=0,
+                            processes_pids={},
                         )
                         tpu_utilizations.append(info)
 
@@ -866,6 +895,7 @@ class ReporterAgent(
                             duty_cycle=0.0,
                             memory_used=0,
                             memory_total=sample.value,
+                            processes_pids={},
                         )
                         tpu_utilizations.append(info)
         except Exception as e:
@@ -877,6 +907,8 @@ class ReporterAgent(
         # sample records together. The aggregated list should be indexed by the
         # TPU accelerator index.
         merged_tpu_utilizations = {}
+
+        pid_mapping = ReporterAgent._get_tpu_pid_mapping()
 
         for info in tpu_utilizations:
             index = int(info.get("index"))
@@ -890,6 +922,15 @@ class ReporterAgent(
                 merged_info["memory_used"] += info.get("memory_used")
                 merged_info["memory_total"] += info.get("memory_total")
             else:
+                # Map TPU index to owner PID found from /proc.
+                processes_pids = {}
+                pid = pid_mapping.get(index)
+                if pid:
+                    processes_pids[pid] = ProcessTPUInfo(
+                        pid=pid,
+                        tpu_memory_usage=0,  # Updated after merging.
+                    )
+
                 merged_info = TpuUtilizationInfo(
                     index=info.get("index"),
                     name=info.get("name"),
@@ -900,12 +941,21 @@ class ReporterAgent(
                     duty_cycle=info.get("duty_cycle"),
                     memory_used=info.get("memory_used"),
                     memory_total=info.get("memory_total"),
+                    processes_pids=processes_pids,
                 )
                 merged_tpu_utilizations[index] = merged_info
 
         sorted_tpu_utilizations = [
             value for _, value in sorted(merged_tpu_utilizations.items())
         ]
+
+        # Since we can assume one PID per TPU device, we can attribute the
+        # entire memory usage of the TPU to that PID.
+        for tpu_info in sorted_tpu_utilizations:
+            if tpu_info.get("processes_pids"):
+                for proc_info in tpu_info["processes_pids"].values():
+                    proc_info["tpu_memory_usage"] = int(tpu_info["memory_used"])
+
         return sorted_tpu_utilizations
 
     @staticmethod
@@ -2021,6 +2071,10 @@ class ReporterAgent(
         for gpu in stats["gpus"]:
             if isinstance(gpu.get("processes_pids"), dict):
                 gpu["processes_pids"] = list(gpu["processes_pids"].values())
+
+        for tpu in stats["tpus"]:
+            if isinstance(tpu.get("processes_pids"), dict):
+                tpu["processes_pids"] = list(tpu["processes_pids"].values())
 
         if StatsPayload is not None:
             stats_dict = dashboard_utils.to_google_style(recursive_asdict(stats))

--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -39,6 +39,18 @@ if PYDANTIC_INSTALLED:
         powerMw: Optional[int] = None  # current power draw in milliwatts
         temperatureC: Optional[int] = None  # temperature in Celsius
 
+    class ProcessTPUInfo(BaseModel):
+        """
+        Information about TPU usage for a single process.
+        NOTE: Backwards compatibility for this model must be maintained.
+        If broken, the downstream dashboard API and UI code will break.
+        If you must make a backwards-incompatible change, you must make sure
+        to update the relevant code in the dashboard API and UI as well.
+        """
+
+        pid: int
+        tpuMemoryUsage: int  # in bytes
+
     class TpuUtilizationInfo(BaseModel):
         """
         TPU utilization information for a single TPU device.
@@ -57,6 +69,7 @@ if PYDANTIC_INSTALLED:
         dutyCycle: float  # percentage
         memoryUsed: int  # in bytes
         memoryTotal: int  # in bytes
+        processesPids: Optional[List[ProcessTPUInfo]] = None
 
     class CpuTimes(BaseModel):
         """

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -714,6 +714,7 @@ def test_get_tpu_usage(tmp_path):
                     duty_cycle=20.0,
                     memory_used=1000,
                     memory_total=4000,
+                    processes_pids={},
                 ),
                 TpuUtilizationInfo(
                     index="1",
@@ -725,6 +726,66 @@ def test_get_tpu_usage(tmp_path):
                     duty_cycle=40.0,
                     memory_used=2000,
                     memory_total=4000,
+                    processes_pids={},
+                ),
+            ]
+            assert tpu_utilizations == expected_utilizations
+
+
+def test_get_tpu_usage_with_pids(tmp_path):
+    dashboard_agent = MagicMock()
+    dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
+    raylet_client = MagicMock()
+    agent = ReporterAgent(dashboard_agent, raylet_client)
+
+    fake_metrics_content = """
+    memory_used{accelerator_id="1234-0",container="ray-head",make="cloud-tpu",model="tpu-v6e-slice",namespace="default",pod="test",tpu_topology="2x2"} 1000
+    memory_total{accelerator_id="1234-0",container="ray-head",make="cloud-tpu",model="tpu-v6e-slice",namespace="default",pod="test",tpu_topology="2x2"} 4000
+    tensorcore_utilization{accelerator_id="1234-0",container="ray-head",make="cloud-tpu",model="tpu-v6e-slice",namespace="default",pod="test",tpu_topology="2x2"} 22
+    """
+    # Mocking glob.glob to return some fake /proc entries
+    fake_links = [
+        "/proc/1234/fd/10",
+    ]
+
+    # Mocking os.readlink to return device paths
+    def mock_readlink(link):
+        if link == "/proc/1234/fd/10":
+            return "/dev/accel0"
+        raise FileNotFoundError()
+
+    with patch.multiple(
+        "ray.dashboard.modules.reporter.reporter_agent",
+        TPU_DEVICE_PLUGIN_ADDR="localhost:2112",
+    ):
+        with patch("requests.get") as mock_get, patch(
+            "glob.glob", return_value=fake_links
+        ), patch("os.readlink", side_effect=mock_readlink):
+            mock_response = MagicMock()
+            mock_response.content = fake_metrics_content.encode("utf-8")
+            mock_get.return_value = mock_response
+
+            tpu_utilizations = agent._get_tpu_usage()
+
+            expected_utilizations = [
+                TpuUtilizationInfo(
+                    index="0",
+                    name="1234-0",
+                    tpu_type="tpu-v6e-slice",
+                    tpu_topology="2x2",
+                    tensorcore_utilization=22.0,
+                    hbm_utilization=0.0,
+                    duty_cycle=0.0,
+                    memory_used=1000,
+                    memory_total=4000,
+                    processes_pids={
+                        1234: {
+                            "pid": 1234,
+                            "tpu_memory_usage": 1000,
+                        }
+                    },
                 ),
             ]
             assert tpu_utilizations == expected_utilizations


### PR DESCRIPTION
## Description

Following up to #63774 adding these metrics to the Clusters page, this adds TPU tensor core and high bandwidth memory utilization to the Actors tab.

This requires correlating actor PIDs with the TPU device info, so a new capability is added to discover the PID associated with each chip.

Most of this PR is refactoring the column title logic: "Accelerators" and "Accelerator memory" is shown by default, but switches to TPU or GPU appropriate names when only TPUs or only GPUs are present.

## Additional information

Here's a Ray train job sorted by TPU usage, and you can see the chips have been split by the PID associated with them (keep in mind each worker has 4x chips).

<img width="1586" height="687" alt="image" src="https://github.com/user-attachments/assets/70fcece8-1bfd-4343-a7ad-35b67fbe497a" />
