### PR TITLE
[data] Rename subcluster label key from __subcluster__ to ray-subcluster

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 HEAD_NODE_RESOURCE_LABEL = "node:__internal_head__"
 # Label key the cluster autoscaler uses to bucket nodes by subcluster.
 # Hardcoded so all components agree without per-Dataset configuration.
-SUBCLUSTER_LABEL_KEY = "subcluster"
+SUBCLUSTER_LABEL_KEY = "ray-subcluster"
 # Sentinel for "no subcluster" — used as both a node-label fallback and
 # the bucket key for unlabeled nodes in ``_cluster_node_resources``.
 DEFAULT_SUBCLUSTER: Optional[str] = None

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 HEAD_NODE_RESOURCE_LABEL = "node:__internal_head__"
 # Label key the cluster autoscaler uses to bucket nodes by subcluster.
 # Hardcoded so all components agree without per-Dataset configuration.
-SUBCLUSTER_LABEL_KEY = "__subcluster__"
+SUBCLUSTER_LABEL_KEY = "subcluster"
 # Sentinel for "no subcluster" — used as both a node-label fallback and
 # the bucket key for unlabeled nodes in ``_cluster_node_resources``.
 DEFAULT_SUBCLUSTER: Optional[str] = None

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -384,7 +384,7 @@ class ExecutionOptions:
             aggregator actors) carries this label selector in its remote args,
             constraining placement to nodes whose labels satisfy the selector.
             Used to scope a Dataset to a labeled subset of the cluster (e.g.
-            ``{"subcluster": "training"}``). Operator-level ``label_selector``
+            ``{"ray-subcluster": "training"}``). Operator-level ``label_selector``
             entries in ``ray_remote_args`` take precedence on key conflicts so
             existing node-pin selectors are preserved.
     """

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -384,7 +384,7 @@ class ExecutionOptions:
             aggregator actors) carries this label selector in its remote args,
             constraining placement to nodes whose labels satisfy the selector.
             Used to scope a Dataset to a labeled subset of the cluster (e.g.
-            ``{"__subcluster__": "training"}``). Operator-level ``label_selector``
+            ``{"subcluster": "training"}``). Operator-level ``label_selector``
             entries in ``ray_remote_args`` take precedence on key conflicts so
             existing node-pin selectors are preserved.
     """

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -546,14 +546,14 @@ def test_sdk_forwarding_merges_subcluster_into_each_bundle():
             # Empty per-bundle entry — should still receive the subcluster.
             {},
         ],
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
     )
     mock_send.assert_called_once_with(
         [{"CPU": 1}, {"CPU": 1}],
         label_selectors=[
-            {"node_id": "n1", "subcluster": "training"},
-            {"subcluster": "training"},
+            {"node_id": "n1", "ray-subcluster": "training"},
+            {"ray-subcluster": "training"},
         ],
     )
 
@@ -586,10 +586,10 @@ def test_request_rejects_per_bundle_cross_subcluster():
             requester_id="r",
             resources=[{"CPU": 1}, {"CPU": 1}],
             label_selectors=[
-                {"subcluster": "training"},
-                {"subcluster": "validation"},
+                {"ray-subcluster": "training"},
+                {"ray-subcluster": "validation"},
             ],
-            subcluster_selector={"subcluster": "training"},
+            subcluster_selector={"ray-subcluster": "training"},
             expire_after_s=10,
         )
 
@@ -605,18 +605,18 @@ def test_request_rejects_changing_subcluster_selector():
     coord.request_resources(
         requester_id="r",
         resources=[{"CPU": 1}],
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
     )
     with pytest.raises(ValueError, match="Cannot change subcluster_selector"):
         coord.request_resources(
             requester_id="r",
             resources=[{"CPU": 1}],
-            subcluster_selector={"subcluster": "validation"},
+            subcluster_selector={"ray-subcluster": "validation"},
             expire_after_s=10,
         )
     # Registry must be unchanged after the rejected call.
-    assert coord._subcluster_selectors["r"] == {"subcluster": "training"}
+    assert coord._subcluster_selectors["r"] == {"ray-subcluster": "training"}
 
 
 def test_label_selector_change_triggers_resend():
@@ -649,19 +649,19 @@ LABELED_CLUSTER_NODES = [
     {
         "NodeID": "n-train-1",
         "Resources": {"CPU": 8, "object_store_memory": 1000},
-        "Labels": {"subcluster": "training"},
+        "Labels": {"ray-subcluster": "training"},
         "Alive": True,
     },
     {
         "NodeID": "n-train-2",
         "Resources": {"CPU": 8, "object_store_memory": 1000},
-        "Labels": {"subcluster": "training"},
+        "Labels": {"ray-subcluster": "training"},
         "Alive": True,
     },
     {
         "NodeID": "n-val-1",
         "Resources": {"CPU": 4, "object_store_memory": 500},
-        "Labels": {"subcluster": "validation"},
+        "Labels": {"ray-subcluster": "validation"},
         "Alive": True,
     },
     {
@@ -686,14 +686,14 @@ def test_label_selector_disjoint_requesters_dont_cross_talk():
     coord.request_resources(
         requester_id="train",
         resources=[{"CPU": 4}],
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
     coord.request_resources(
         requester_id="val",
         resources=[{"CPU": 4}],
-        subcluster_selector={"subcluster": "validation"},
+        subcluster_selector={"ray-subcluster": "validation"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -735,7 +735,7 @@ def test_labeled_and_unlabeled_requesters_are_isolated():
     coord.request_resources(
         requester_id="train",
         resources=[{"CPU": 1}],
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -761,7 +761,7 @@ def test_label_selector_unmatched_yields_no_allocation():
     coord.request_resources(
         requester_id="ghost",
         resources=[{"CPU": 1}],
-        subcluster_selector={"subcluster": "nonexistent"},
+        subcluster_selector={"ray-subcluster": "nonexistent"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -775,7 +775,7 @@ def test_label_selector_partial_fit_when_demand_exceeds_capacity():
     coord.request_resources(
         requester_id="val",
         resources=[{"CPU": 3}, {"CPU": 3}, {"CPU": 3}],
-        subcluster_selector={"subcluster": "validation"},
+        subcluster_selector={"ray-subcluster": "validation"},
         expire_after_s=10,
     )
     # Validation has one 4-CPU node; only the first 3-CPU bundle fits.
@@ -789,7 +789,7 @@ def test_full_tick_exercises_update_merge_reallocate():
         {
             "NodeID": "n1",
             "Resources": {"CPU": 4},
-            "Labels": {"subcluster": "training"},
+            "Labels": {"ray-subcluster": "training"},
             "Alive": True,
         },
     ]
@@ -802,7 +802,7 @@ def test_full_tick_exercises_update_merge_reallocate():
     coord.request_resources(
         requester_id="train",
         resources=[{"CPU": 1}],
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -816,7 +816,7 @@ def test_full_tick_exercises_update_merge_reallocate():
         {
             "NodeID": "n2",
             "Resources": {"CPU": 8},
-            "Labels": {"subcluster": "training"},
+            "Labels": {"ray-subcluster": "training"},
             "Alive": True,
         }
     )
@@ -837,7 +837,7 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
     coord.request_resources(
         requester_id="train_idle",
         resources=[],
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -846,7 +846,7 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
     coord.request_resources(
         requester_id="val_active",
         resources=[{"CPU": 2}],
-        subcluster_selector={"subcluster": "validation"},
+        subcluster_selector={"ray-subcluster": "validation"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -877,11 +877,11 @@ def test_proxy_forwards_label_selector_from_init():
     proxy = DefaultAutoscalingCoordinator(
         requester_id="r",
         autoscaling_coordinator_actor=mock_actor,
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
     )
     proxy.request_resources(resources=[{"CPU": 1}, {"CPU": 2}], expire_after_s=10)
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
-    assert kwargs["subcluster_selector"] == {"subcluster": "training"}
+    assert kwargs["subcluster_selector"] == {"ray-subcluster": "training"}
 
 
 def test_proxy_forwards_label_selector_on_empty_resources():
@@ -892,12 +892,12 @@ def test_proxy_forwards_label_selector_on_empty_resources():
     proxy = DefaultAutoscalingCoordinator(
         requester_id="r",
         autoscaling_coordinator_actor=mock_actor,
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
     )
     proxy.request_resources(resources=[], expire_after_s=10, request_remaining=True)
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
     assert kwargs["resources"] == []
-    assert kwargs["subcluster_selector"] == {"subcluster": "training"}
+    assert kwargs["subcluster_selector"] == {"ray-subcluster": "training"}
 
 
 def test_proxy_passes_caller_label_selectors_through():
@@ -908,7 +908,7 @@ def test_proxy_passes_caller_label_selectors_through():
     proxy = DefaultAutoscalingCoordinator(
         requester_id="r",
         autoscaling_coordinator_actor=mock_actor,
-        subcluster_selector={"subcluster": "training"},
+        subcluster_selector={"ray-subcluster": "training"},
     )
     proxy.request_resources(
         resources=[{"CPU": 1}],
@@ -917,7 +917,7 @@ def test_proxy_passes_caller_label_selectors_through():
     )
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
     assert kwargs["label_selectors"] == [{"node_id": "n1"}]
-    assert kwargs["subcluster_selector"] == {"subcluster": "training"}
+    assert kwargs["subcluster_selector"] == {"ray-subcluster": "training"}
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -546,14 +546,14 @@ def test_sdk_forwarding_merges_subcluster_into_each_bundle():
             # Empty per-bundle entry — should still receive the subcluster.
             {},
         ],
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
         expire_after_s=10,
     )
     mock_send.assert_called_once_with(
         [{"CPU": 1}, {"CPU": 1}],
         label_selectors=[
-            {"node_id": "n1", "__subcluster__": "training"},
-            {"__subcluster__": "training"},
+            {"node_id": "n1", "subcluster": "training"},
+            {"subcluster": "training"},
         ],
     )
 
@@ -586,10 +586,10 @@ def test_request_rejects_per_bundle_cross_subcluster():
             requester_id="r",
             resources=[{"CPU": 1}, {"CPU": 1}],
             label_selectors=[
-                {"__subcluster__": "training"},
-                {"__subcluster__": "validation"},
+                {"subcluster": "training"},
+                {"subcluster": "validation"},
             ],
-            subcluster_selector={"__subcluster__": "training"},
+            subcluster_selector={"subcluster": "training"},
             expire_after_s=10,
         )
 
@@ -605,18 +605,18 @@ def test_request_rejects_changing_subcluster_selector():
     coord.request_resources(
         requester_id="r",
         resources=[{"CPU": 1}],
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
         expire_after_s=10,
     )
     with pytest.raises(ValueError, match="Cannot change subcluster_selector"):
         coord.request_resources(
             requester_id="r",
             resources=[{"CPU": 1}],
-            subcluster_selector={"__subcluster__": "validation"},
+            subcluster_selector={"subcluster": "validation"},
             expire_after_s=10,
         )
     # Registry must be unchanged after the rejected call.
-    assert coord._subcluster_selectors["r"] == {"__subcluster__": "training"}
+    assert coord._subcluster_selectors["r"] == {"subcluster": "training"}
 
 
 def test_label_selector_change_triggers_resend():
@@ -649,19 +649,19 @@ LABELED_CLUSTER_NODES = [
     {
         "NodeID": "n-train-1",
         "Resources": {"CPU": 8, "object_store_memory": 1000},
-        "Labels": {"__subcluster__": "training"},
+        "Labels": {"subcluster": "training"},
         "Alive": True,
     },
     {
         "NodeID": "n-train-2",
         "Resources": {"CPU": 8, "object_store_memory": 1000},
-        "Labels": {"__subcluster__": "training"},
+        "Labels": {"subcluster": "training"},
         "Alive": True,
     },
     {
         "NodeID": "n-val-1",
         "Resources": {"CPU": 4, "object_store_memory": 500},
-        "Labels": {"__subcluster__": "validation"},
+        "Labels": {"subcluster": "validation"},
         "Alive": True,
     },
     {
@@ -686,14 +686,14 @@ def test_label_selector_disjoint_requesters_dont_cross_talk():
     coord.request_resources(
         requester_id="train",
         resources=[{"CPU": 4}],
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
     coord.request_resources(
         requester_id="val",
         resources=[{"CPU": 4}],
-        subcluster_selector={"__subcluster__": "validation"},
+        subcluster_selector={"subcluster": "validation"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -735,7 +735,7 @@ def test_labeled_and_unlabeled_requesters_are_isolated():
     coord.request_resources(
         requester_id="train",
         resources=[{"CPU": 1}],
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -761,7 +761,7 @@ def test_label_selector_unmatched_yields_no_allocation():
     coord.request_resources(
         requester_id="ghost",
         resources=[{"CPU": 1}],
-        subcluster_selector={"__subcluster__": "nonexistent"},
+        subcluster_selector={"subcluster": "nonexistent"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -775,7 +775,7 @@ def test_label_selector_partial_fit_when_demand_exceeds_capacity():
     coord.request_resources(
         requester_id="val",
         resources=[{"CPU": 3}, {"CPU": 3}, {"CPU": 3}],
-        subcluster_selector={"__subcluster__": "validation"},
+        subcluster_selector={"subcluster": "validation"},
         expire_after_s=10,
     )
     # Validation has one 4-CPU node; only the first 3-CPU bundle fits.
@@ -789,7 +789,7 @@ def test_full_tick_exercises_update_merge_reallocate():
         {
             "NodeID": "n1",
             "Resources": {"CPU": 4},
-            "Labels": {"__subcluster__": "training"},
+            "Labels": {"subcluster": "training"},
             "Alive": True,
         },
     ]
@@ -802,7 +802,7 @@ def test_full_tick_exercises_update_merge_reallocate():
     coord.request_resources(
         requester_id="train",
         resources=[{"CPU": 1}],
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -816,7 +816,7 @@ def test_full_tick_exercises_update_merge_reallocate():
         {
             "NodeID": "n2",
             "Resources": {"CPU": 8},
-            "Labels": {"__subcluster__": "training"},
+            "Labels": {"subcluster": "training"},
             "Alive": True,
         }
     )
@@ -837,7 +837,7 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
     coord.request_resources(
         requester_id="train_idle",
         resources=[],
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -846,7 +846,7 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
     coord.request_resources(
         requester_id="val_active",
         resources=[{"CPU": 2}],
-        subcluster_selector={"__subcluster__": "validation"},
+        subcluster_selector={"subcluster": "validation"},
         expire_after_s=10,
         request_remaining=True,
     )
@@ -877,11 +877,11 @@ def test_proxy_forwards_label_selector_from_init():
     proxy = DefaultAutoscalingCoordinator(
         requester_id="r",
         autoscaling_coordinator_actor=mock_actor,
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
     )
     proxy.request_resources(resources=[{"CPU": 1}, {"CPU": 2}], expire_after_s=10)
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
-    assert kwargs["subcluster_selector"] == {"__subcluster__": "training"}
+    assert kwargs["subcluster_selector"] == {"subcluster": "training"}
 
 
 def test_proxy_forwards_label_selector_on_empty_resources():
@@ -892,12 +892,12 @@ def test_proxy_forwards_label_selector_on_empty_resources():
     proxy = DefaultAutoscalingCoordinator(
         requester_id="r",
         autoscaling_coordinator_actor=mock_actor,
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
     )
     proxy.request_resources(resources=[], expire_after_s=10, request_remaining=True)
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
     assert kwargs["resources"] == []
-    assert kwargs["subcluster_selector"] == {"__subcluster__": "training"}
+    assert kwargs["subcluster_selector"] == {"subcluster": "training"}
 
 
 def test_proxy_passes_caller_label_selectors_through():
@@ -908,7 +908,7 @@ def test_proxy_passes_caller_label_selectors_through():
     proxy = DefaultAutoscalingCoordinator(
         requester_id="r",
         autoscaling_coordinator_actor=mock_actor,
-        subcluster_selector={"__subcluster__": "training"},
+        subcluster_selector={"subcluster": "training"},
     )
     proxy.request_resources(
         resources=[{"CPU": 1}],
@@ -917,7 +917,7 @@ def test_proxy_passes_caller_label_selectors_through():
     )
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
     assert kwargs["label_selectors"] == [{"node_id": "n1"}]
-    assert kwargs["subcluster_selector"] == {"__subcluster__": "training"}
+    assert kwargs["subcluster_selector"] == {"subcluster": "training"}
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -129,24 +129,24 @@ class TestClusterAutoscaling:
             assert _get_node_resource_spec_and_count() == expected
 
     def test_get_node_resource_spec_and_count_filters_by_subcluster(self):
-        """Only nodes whose ``__subcluster__`` label matches contribute to
+        """Only nodes whose ``subcluster`` label matches contribute to
         the counts. Prevents ``try_trigger_scaling`` from pulling shapes
         and counts from foreign subclusters into a labeled requester's
         active / pending bundles."""
         node_table = [
             {
                 "Resources": self._node_type1,
-                "Labels": {"__subcluster__": "training"},
+                "Labels": {"subcluster": "training"},
                 "Alive": True,
             },
             {
                 "Resources": self._node_type1,
-                "Labels": {"__subcluster__": "training"},
+                "Labels": {"subcluster": "training"},
                 "Alive": True,
             },
             {
                 "Resources": self._node_type2,
-                "Labels": {"__subcluster__": "validation"},
+                "Labels": {"subcluster": "validation"},
                 "Alive": True,
             },
             {
@@ -798,9 +798,9 @@ def test_v2_autoscaler_passes_label_selector_to_coordinator(monkeypatch):
         DefaultClusterAutoscalerV2(
             resource_manager=Mock(),
             execution_id="exec-1",
-            label_selector={"__subcluster__": "training"},
+            label_selector={"subcluster": "training"},
         )
-    assert captured["subcluster_selector"] == {"__subcluster__": "training"}
+    assert captured["subcluster_selector"] == {"subcluster": "training"}
 
 
 def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
@@ -816,7 +816,7 @@ def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
 
     data_context = Mock()
     data_context.execution_options.resource_limits = Mock()
-    data_context.execution_options.label_selector = {"__subcluster__": "training"}
+    data_context.execution_options.label_selector = {"subcluster": "training"}
 
     create_cluster_autoscaler(
         topology=Mock(),
@@ -824,7 +824,7 @@ def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
         data_context=data_context,
         execution_id="exec-1",
     )
-    assert captured["label_selector"] == {"__subcluster__": "training"}
+    assert captured["label_selector"] == {"subcluster": "training"}
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -136,17 +136,17 @@ class TestClusterAutoscaling:
         node_table = [
             {
                 "Resources": self._node_type1,
-                "Labels": {"subcluster": "training"},
+                "Labels": {"ray-subcluster": "training"},
                 "Alive": True,
             },
             {
                 "Resources": self._node_type1,
-                "Labels": {"subcluster": "training"},
+                "Labels": {"ray-subcluster": "training"},
                 "Alive": True,
             },
             {
                 "Resources": self._node_type2,
-                "Labels": {"subcluster": "validation"},
+                "Labels": {"ray-subcluster": "validation"},
                 "Alive": True,
             },
             {
@@ -798,9 +798,9 @@ def test_v2_autoscaler_passes_label_selector_to_coordinator(monkeypatch):
         DefaultClusterAutoscalerV2(
             resource_manager=Mock(),
             execution_id="exec-1",
-            label_selector={"subcluster": "training"},
+            label_selector={"ray-subcluster": "training"},
         )
-    assert captured["subcluster_selector"] == {"subcluster": "training"}
+    assert captured["subcluster_selector"] == {"ray-subcluster": "training"}
 
 
 def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
@@ -816,7 +816,7 @@ def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
 
     data_context = Mock()
     data_context.execution_options.resource_limits = Mock()
-    data_context.execution_options.label_selector = {"subcluster": "training"}
+    data_context.execution_options.label_selector = {"ray-subcluster": "training"}
 
     create_cluster_autoscaler(
         topology=Mock(),
@@ -824,7 +824,7 @@ def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
         data_context=data_context,
         execution_id="exec-1",
     )
-    assert captured["label_selector"] == {"subcluster": "training"}
+    assert captured["label_selector"] == {"ray-subcluster": "training"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/63375 doesn't work because `__subcluster__` is not a valid label name. I am testing whether `subcluster` works on this PR (https://github.com/ray-project/ray/pull/63737) and cherrypicked that change here.