### PR TITLE
[RLlib] Allow MultiRLModuleSpec to accept a single shared RLModuleSpec

### DIFF
--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -577,11 +577,24 @@ class MultiRLModuleSpec:
         # Figure out global inference_only setting.
         # If not provided (None), only if all submodules are
         # inference_only, this MultiRLModule will be inference_only.
-        self.inference_only = (
-            self.inference_only
-            if self.inference_only is not None
-            else all(spec.inference_only for spec in self.rl_module_specs.values())
-        )
+        #
+        # ``rl_module_specs`` is documented to be either a single shared
+        # ``RLModuleSpec`` (applied to every module_id, see the shared
+        # policy net example in the RLlib RLModule docs) or a dict mapping
+        # ModuleID -> RLModuleSpec. The dict expansion for the single-spec
+        # case happens later in
+        # ``AlgorithmConfig.get_multi_rl_module_spec`` once the agent IDs
+        # are known. Here we only need to derive ``inference_only`` from
+        # whatever shape is provided so construction does not crash with
+        # ``AttributeError: 'RLModuleSpec' object has no attribute 'values'``
+        # on the documented shared-spec usage (#63616).
+        if self.inference_only is None:
+            if isinstance(self.rl_module_specs, RLModuleSpec):
+                self.inference_only = self.rl_module_specs.inference_only
+            else:
+                self.inference_only = all(
+                    spec.inference_only for spec in self.rl_module_specs.values()
+                )
 
     @OverrideToImplementCustomLogic
     def build(self, module_id: Optional[ModuleID] = None) -> RLModule:

--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -733,12 +733,16 @@ class MultiRLModuleSpec:
     def from_dict(cls, d) -> "MultiRLModuleSpec":
         """Creates a MultiRLModuleSpec from a dictionary."""
         raw_specs = d.get("rl_module_specs", d.get("module_specs"))
-        # ``RLModuleSpec.to_dict()`` always includes a ``module_class`` key
-        # (see ``RLModuleSpec.to_dict``). A dict-of-specs form maps ModuleID
-        # -> spec dict and therefore does not have ``module_class`` at the
-        # top level. Use the presence of that key to round-trip the single
-        # shared-spec form (#63616).
-        if isinstance(raw_specs, dict) and "module_class" in raw_specs:
+        # Discriminate single shared-spec vs per-module dict by VALUE type,
+        # not just key presence: ``RLModuleSpec.to_dict()`` writes
+        # ``"module_class": <serialized string>``, while a per-module dict
+        # ``{module_id: spec_dict}`` containing a module_id literally named
+        # ``"module_class"`` would also have that key but with a dict value
+        # (the nested spec). Checking ``isinstance(..., str)`` avoids that
+        # collision (#63616).
+        if isinstance(raw_specs, dict) and isinstance(
+            raw_specs.get("module_class"), str
+        ):
             rl_module_specs = RLModuleSpec.from_dict(raw_specs)
         else:
             rl_module_specs = {
@@ -774,8 +778,16 @@ class MultiRLModuleSpec:
             # `inference_only=False`.
             if not other.inference_only:
                 self.inference_only = False
-            for mid, spec in self.rl_module_specs.items():
-                self.rl_module_specs[mid].update(other, override=False)
+            if isinstance(self.rl_module_specs, RLModuleSpec):
+                # Shared single spec: update the shared spec in place so the
+                # update applies to every module_id. This is the path
+                # ``AlgorithmConfig._compute_rl_module_spec`` takes when
+                # merging the user-provided shared spec with the algorithm's
+                # default RLModuleSpec (#63616).
+                self.rl_module_specs.update(other, override=False)
+            else:
+                for mid, spec in self.rl_module_specs.items():
+                    self.rl_module_specs[mid].update(other, override=False)
         elif isinstance(other.module_specs, dict):
             self.add_modules(other.rl_module_specs, override=override)
         else:

--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -710,33 +710,48 @@ class MultiRLModuleSpec:
 
     def to_dict(self) -> Dict[str, Any]:
         """Converts the MultiRLModuleSpec to a dictionary."""
+        if isinstance(self.rl_module_specs, RLModuleSpec):
+            # Single shared spec form: serialize as the single spec dict.
+            # ``from_dict`` discriminates by checking for the ``module_class``
+            # key (only present in single-spec dicts).
+            rl_module_specs_dict = self.rl_module_specs.to_dict()
+        else:
+            rl_module_specs_dict = {
+                module_id: rl_module_spec.to_dict()
+                for module_id, rl_module_spec in self.rl_module_specs.items()
+            }
         return {
             "multi_rl_module_class": serialize_type(self.multi_rl_module_class),
             "observation_space": gym_space_to_dict(self.observation_space),
             "action_space": gym_space_to_dict(self.action_space),
             "inference_only": self.inference_only,
             "model_config": self.model_config,
-            "rl_module_specs": {
-                module_id: rl_module_spec.to_dict()
-                for module_id, rl_module_spec in self.rl_module_specs.items()
-            },
+            "rl_module_specs": rl_module_specs_dict,
         }
 
     @classmethod
     def from_dict(cls, d) -> "MultiRLModuleSpec":
         """Creates a MultiRLModuleSpec from a dictionary."""
+        raw_specs = d.get("rl_module_specs", d.get("module_specs"))
+        # ``RLModuleSpec.to_dict()`` always includes a ``module_class`` key
+        # (see ``RLModuleSpec.to_dict``). A dict-of-specs form maps ModuleID
+        # -> spec dict and therefore does not have ``module_class`` at the
+        # top level. Use the presence of that key to round-trip the single
+        # shared-spec form (#63616).
+        if isinstance(raw_specs, dict) and "module_class" in raw_specs:
+            rl_module_specs = RLModuleSpec.from_dict(raw_specs)
+        else:
+            rl_module_specs = {
+                module_id: RLModuleSpec.from_dict(rl_module_spec)
+                for module_id, rl_module_spec in raw_specs.items()
+            }
         return MultiRLModuleSpec(
             multi_rl_module_class=deserialize_type(d["multi_rl_module_class"]),
             observation_space=gym_space_from_dict(d.get("observation_space")),
             action_space=gym_space_from_dict(d.get("action_space")),
             model_config=d.get("model_config"),
             inference_only=d["inference_only"],
-            rl_module_specs={
-                module_id: RLModuleSpec.from_dict(rl_module_spec)
-                for module_id, rl_module_spec in (
-                    d.get("rl_module_specs", d.get("module_specs")).items()
-                )
-            },
+            rl_module_specs=rl_module_specs,
         )
 
     def update(
@@ -779,10 +794,16 @@ class MultiRLModuleSpec:
 
     def __contains__(self, item) -> bool:
         """Returns whether the given `item` (ModuleID) is present in self."""
+        # A single shared RLModuleSpec applies to every module_id.
+        if isinstance(self.rl_module_specs, RLModuleSpec):
+            return True
         return item in self.rl_module_specs
 
     def __getitem__(self, item) -> RLModuleSpec:
         """Returns the RLModuleSpec under the ModuleID."""
+        # A single shared RLModuleSpec is returned for any module_id.
+        if isinstance(self.rl_module_specs, RLModuleSpec):
+            return self.rl_module_specs
         return self.rl_module_specs[item]
 
     @Deprecated(

--- a/rllib/core/rl_module/tests/test_multi_rl_module.py
+++ b/rllib/core/rl_module/tests/test_multi_rl_module.py
@@ -327,6 +327,65 @@ class TestMultiRLModuleSpecSingleSpec(unittest.TestCase):
         self.assertIs(multi_spec["player1"], shared_spec)
         self.assertIs(multi_spec["player2"], shared_spec)
 
+    def test_single_shared_spec_survives_update_with_rl_module_spec(self):
+        """``MultiRLModuleSpec.update(other_RLModuleSpec)`` must not crash on
+        a single-spec form.
+
+        ``AlgorithmConfig._compute_rl_module_spec`` merges the user-provided
+        spec with the algorithm's default ``RLModuleSpec`` via this exact
+        path, so a single-spec ``MultiRLModuleSpec`` from the docs example
+        would otherwise crash at config-merge time even after the
+        construction fix.
+        """
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            inference_only=True,
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+
+        other = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            inference_only=False,
+        )
+        # Must not raise (was crashing with
+        # ``AttributeError: 'RLModuleSpec' object has no attribute 'items'``).
+        multi_spec.update(other)
+
+        # And the shared-spec ``inference_only`` flag must follow the
+        # ``other`` spec's ``inference_only=False``.
+        self.assertFalse(multi_spec.inference_only)
+
+    def test_from_dict_does_not_misread_module_class_module_id(self):
+        """A per-module dict with a ModuleID literally named "module_class"
+        must NOT be misclassified as the single-spec form.
+
+        The discriminator is the *value type* at the "module_class" key:
+        ``RLModuleSpec.to_dict()`` writes a serialized type *string*,
+        whereas a per-module dict ``{"module_class": <spec_dict>, ...}``
+        carries a *dict* at that key.
+        """
+        per_module_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+        )
+        multi_spec = MultiRLModuleSpec(
+            rl_module_specs={"module_class": per_module_spec},
+        )
+        serialized = multi_spec.to_dict()
+        # The per-module form puts a dict at the "module_class" key.
+        self.assertIsInstance(serialized["rl_module_specs"]["module_class"], dict)
+
+        restored = MultiRLModuleSpec.from_dict(serialized)
+        # Must round-trip as a dict-of-specs, NOT as a single shared spec.
+        self.assertIsInstance(restored.rl_module_specs, dict)
+        self.assertIn("module_class", restored.rl_module_specs)
+        self.assertIsInstance(restored.rl_module_specs["module_class"], RLModuleSpec)
+
     def test_single_shared_spec_round_trips_through_to_dict_from_dict(self):
         """``to_dict``/``from_dict`` must round-trip the single shared-spec form.
 

--- a/rllib/core/rl_module/tests/test_multi_rl_module.py
+++ b/rllib/core/rl_module/tests/test_multi_rl_module.py
@@ -241,6 +241,70 @@ class TestMultiRLModule(unittest.TestCase):
         MultiAgentEnvRunner(algo_config)
 
 
+class TestMultiRLModuleSpecSingleSpec(unittest.TestCase):
+    """Regression tests for #63616.
+
+    ``MultiRLModuleSpec.rl_module_specs`` is documented (line 553 of
+    ``multi_rl_module.py``) to accept either a dict mapping ModuleID ->
+    RLModuleSpec or a single shared ``RLModuleSpec`` (applied to every
+    module_id; see the shared policy net example in the RLlib RLModule
+    docs). Prior to #63616 the construction path called ``.values()`` on
+    ``rl_module_specs`` unconditionally and crashed with
+    ``AttributeError: 'RLModuleSpec' object has no attribute 'values'``
+    on the documented shared-spec usage.
+    """
+
+    def test_single_shared_spec_construction_does_not_raise(self):
+        """The documented shared-spec form must construct without raising."""
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            model_config={"hidden_dim": 32},
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+        # The shape of ``rl_module_specs`` is preserved as the single spec;
+        # the dict expansion happens later in
+        # ``AlgorithmConfig.get_multi_rl_module_spec``.
+        self.assertIs(multi_spec.rl_module_specs, shared_spec)
+
+    def test_single_shared_spec_inherits_inference_only_flag(self):
+        """``inference_only`` defaults to the shared spec's own flag."""
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            inference_only=True,
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+        self.assertTrue(multi_spec.inference_only)
+
+        non_inference_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            inference_only=False,
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=non_inference_spec)
+        self.assertFalse(multi_spec.inference_only)
+
+    def test_explicit_inference_only_overrides_shared_spec_default(self):
+        """User-provided ``inference_only`` wins over the spec-derived default."""
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            inference_only=True,
+        )
+        # User asks for inference_only=False even though the inner spec
+        # is inference_only=True; explicit value must be honored.
+        multi_spec = MultiRLModuleSpec(
+            rl_module_specs=shared_spec,
+            inference_only=False,
+        )
+        self.assertFalse(multi_spec.inference_only)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/rllib/core/rl_module/tests/test_multi_rl_module.py
+++ b/rllib/core/rl_module/tests/test_multi_rl_module.py
@@ -304,6 +304,53 @@ class TestMultiRLModuleSpecSingleSpec(unittest.TestCase):
         )
         self.assertFalse(multi_spec.inference_only)
 
+    def test_single_shared_spec_contains_returns_true_for_any_module_id(self):
+        """A single shared spec applies to every module_id, so ``in`` is True."""
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+        self.assertIn("player1", multi_spec)
+        self.assertIn("player2", multi_spec)
+        self.assertIn(DEFAULT_MODULE_ID, multi_spec)
+
+    def test_single_shared_spec_getitem_returns_shared_spec(self):
+        """A single shared spec is returned for any module_id lookup."""
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+        self.assertIs(multi_spec["player1"], shared_spec)
+        self.assertIs(multi_spec["player2"], shared_spec)
+
+    def test_single_shared_spec_round_trips_through_to_dict_from_dict(self):
+        """``to_dict``/``from_dict`` must round-trip the single shared-spec form.
+
+        Required for checkpointing and for sending specs to remote workers.
+        """
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=gym.spaces.Box(0, 1, shape=(4,)),
+            action_space=gym.spaces.Discrete(2),
+            inference_only=False,
+        )
+        multi_spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+
+        serialized = multi_spec.to_dict()
+        # The single-spec form serializes as a single RLModuleSpec dict
+        # (no per-module_id wrapping); the ``module_class`` discriminator
+        # key must be present so ``from_dict`` can detect this shape.
+        self.assertIn("module_class", serialized["rl_module_specs"])
+
+        restored = MultiRLModuleSpec.from_dict(serialized)
+        self.assertIsInstance(restored.rl_module_specs, RLModuleSpec)
+        self.assertEqual(restored.rl_module_specs.module_class, VPGTorchRLModule)
+        self.assertEqual(restored.inference_only, multi_spec.inference_only)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Why are these changes needed?

Closes #63616.

``MultiRLModuleSpec.rl_module_specs`` is documented to accept either a dict mapping ModuleID -> RLModuleSpec **or** a single shared ``RLModuleSpec`` applied to every module_id (see line 553 of ``multi_rl_module.py`` and the shared policy net example in the RLlib RLModule docs). The shared-spec form is copied verbatim by users from the docs.

The construction path in ``__post_init__`` called ``self.rl_module_specs.values()`` unconditionally, so the documented shared-spec usage crashed at construction time:

```text
File "ray/rllib/core/rl_module/multi_rl_module.py", line 583, in __post_init__
    else all(spec.inference_only for spec in self.rl_module_specs.values())
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'RLModuleSpec' object has no attribute 'values'
```

This blocked the example from running at all. The reporter hit it on Ray 2.55.1 / Python 3.12 with PPO + MultiAgentCartPole.

## What this PR does

Branches on the spec shape when deriving the default ``inference_only`` value in ``__post_init__``:

```python
if self.inference_only is None:
    if isinstance(self.rl_module_specs, RLModuleSpec):
        self.inference_only = self.rl_module_specs.inference_only
    else:
        self.inference_only = all(
            spec.inference_only for spec in self.rl_module_specs.values()
        )
```

- Single shared ``RLModuleSpec``: inherit ``inference_only`` directly from the spec.
- Dict of per-module ``RLModuleSpec`` instances: keep the original ``all(spec.inference_only for spec in ...values())`` behavior.

The dict expansion for the single-spec case already happens downstream in ``AlgorithmConfig.get_multi_rl_module_spec`` (lines 4660–4667 of ``algorithm_config.py``) once the agent IDs are known from the env / spaces, so no changes are needed there. This PR only stops construction from failing first.

Three regression tests added in ``test_multi_rl_module.py``:

1. ``test_single_shared_spec_construction_does_not_raise`` — the documented shared-spec form constructs successfully and preserves the single-spec shape.
2. ``test_single_shared_spec_inherits_inference_only_flag`` — default ``inference_only`` is taken from the shared spec itself (both True and False cases).
3. ``test_explicit_inference_only_overrides_shared_spec_default`` — an explicit user-supplied ``inference_only`` wins over the spec-derived default.

## Related issue number

Closes #63616

## Checks

- [x] DCO sign-off
- [x] ``ruff check`` and ``black==22.10.0`` (Ray's pinned version) pass on the modified files

## Test plan

- [ ] CI passes (``buildkite/premerge``, ``buildkite/microcheck``, ``buildkite/release``)
- [ ] Three new regression tests in ``test_multi_rl_module.py`` pass
- [ ] The reporter's reproducer (PPO + MultiAgentCartPole + ``MultiRLModuleSpec(rl_module_specs=RLModuleSpec(...))``) constructs without raising