### PR TITLE
[RLlib] Preserve __common__ key in MultiAgentEpisode.get_infos

### DIFF
--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -252,6 +252,20 @@ class MultiAgentEpisode:
         self._hanging_extra_model_outputs_end = defaultdict(dict)
         self._hanging_rewards_end = defaultdict(float)
 
+        # Cross-agent ("__common__") info dicts, indexed by env timestep. The
+        # MultiAgentEnv contract (see ``MultiAgentEnv`` step-validation logic)
+        # allows the ``infos`` dict returned from ``env.step`` / ``env.reset``
+        # to carry an optional ``"__common__"`` key whose value is an info
+        # dict that applies to the env as a whole, not to any single agent.
+        # Per-agent ``SingleAgentEpisode`` buffers cannot capture this, so it
+        # was previously dropped on ingestion and never surfaced from
+        # ``MultiAgentEpisode.get_infos()`` (#58668). We mirror the env-step
+        # timeline by appending one entry per ``add_env_reset`` /
+        # ``add_env_step`` call (``None`` when no ``"__common__"`` was
+        # provided), so ``get_infos`` can surface common infos under the
+        # ``"__common__"`` key.
+        self._common_infos: InfiniteLookbackBuffer = InfiniteLookbackBuffer()
+
         # In case of a `cut()` or `slice()`, we also need to store the hanging actions,
         # rewards, and extra model outputs that were already "hanging" in preceeding
         # episode slice.
@@ -318,6 +332,11 @@ class MultiAgentEpisode:
         # Leave self.env_t (and self.env_t_started) at 0.
         assert self.env_t == self.env_t_started == 0
         infos = infos or {}
+
+        # Capture any cross-agent ("__common__") info dict for the reset step
+        # so it survives ingestion and can be surfaced from ``get_infos``
+        # (#58668). One entry per env_t, ``None`` when not provided.
+        self._common_infos.append(infos.get("__common__"))
 
         # Note, all agents will have an initial observation, some may have an initial
         # info dict as well.
@@ -398,6 +417,11 @@ class MultiAgentEpisode:
 
         # Increase (global) env step by one.
         self.env_t += 1
+
+        # Capture any cross-agent ("__common__") info dict for this env step
+        # so it survives ingestion and can be surfaced from ``get_infos``
+        # (#58668). One entry per env_t, ``None`` when not provided.
+        self._common_infos.append(infos.get("__common__"))
 
         # Find out, whether this episode is terminated/truncated (for all agents).
         # Case 1: all agents are terminated or all are truncated.
@@ -2581,6 +2605,25 @@ class MultiAgentEpisode:
                 )
                 if agent_values is not None:
                     ret[agent_id] = agent_values
+
+        # Surface cross-agent ("__common__") infos alongside the per-agent
+        # entries. The common buffer is keyed by env_t, the same coordinate
+        # system this method already operates in, so we can pass the user's
+        # ``indices`` through unchanged. Only emit a ``"__common__"`` key
+        # when there is at least one non-``None`` common dict in the
+        # requested range, so callers that never set ``"__common__"`` see
+        # no behavior change (#58668).
+        if what == "infos" and len(self._common_infos) > 0:
+            common_values = self._common_infos.get(
+                indices=indices,
+                neg_index_as_lookback=neg_index_as_lookback,
+                fill=fill,
+            )
+            if common_values is not None and not (
+                isinstance(common_values, list)
+                and all(v is None for v in common_values)
+            ):
+                ret["__common__"] = common_values
         return ret
 
     def _get_single_agent_data_by_index(

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -421,7 +421,9 @@ class MultiAgentEpisode:
         # Capture any cross-agent ("__common__") info dict for this env step
         # so it survives ingestion and can be surfaced from ``get_infos``
         # (#58668). One entry per env_t, ``None`` when not provided.
-        self._common_infos.append(infos.get("__common__"))
+        # ``infos`` is already normalized to ``{}`` above when the caller
+        # passed ``None``; the ``or {}`` here is belt-and-suspenders.
+        self._common_infos.append((infos or {}).get("__common__"))
 
         # Find out, whether this episode is terminated/truncated (for all agents).
         # Case 1: all agents are terminated or all are truncated.
@@ -912,6 +914,14 @@ class MultiAgentEpisode:
         # `custom_data`.
         self.custom_data.update(other.custom_data)
 
+        # Concatenate the cross-agent ("__common__") info buffer. The boundary
+        # entry (env_t at the seam) lives in both ``self`` (as its last entry)
+        # and ``other`` (as its first entry), so skip ``other``'s first entry
+        # to avoid duplicating the seam timestep (mirrors how
+        # ``env_t_to_agent_t`` is concatenated above).
+        for common_info in other._common_infos.data[1:]:
+            self._common_infos.append(common_info)
+
         # Validate.
         self.validate()
 
@@ -1026,6 +1036,19 @@ class MultiAgentEpisode:
 
         # Deepcopy all custom data in `self` to be continued in the cut episode.
         successor._custom_data = copy.deepcopy(self.custom_data)
+
+        # Carry the cross-agent ("__common__") info buffer's tail into the
+        # successor. We mirror how observations/infos handle the seam: take
+        # the last (lookback + 1) entries so the successor sees the same
+        # boundary timestep as the source episode.
+        if len(self._common_infos) > 0:
+            tail = self._common_infos.data[-(len_lookback_buffer + 1) :]
+            successor._common_infos = InfiniteLookbackBuffer(
+                data=list(tail),
+                lookback=min(len_lookback_buffer, len(tail) - 1)
+                if len(tail) > 0
+                else 0,
+            )
 
         return successor
 
@@ -1757,6 +1780,7 @@ class MultiAgentEpisode:
             "_start_time": self._start_time,
             "_last_step_time": self._last_step_time,
             "custom_data": self.custom_data,
+            "_common_infos": self._common_infos.get_state(),
         }
 
     @staticmethod
@@ -1801,6 +1825,16 @@ class MultiAgentEpisode:
         episode._start_time = state["_start_time"]
         episode._last_step_time = state["_last_step_time"]
         episode._custom_data = state.get("custom_data", {})
+
+        # Restore the cross-agent ("__common__") info buffer when present.
+        # ``state.get`` (rather than ``state[...]``) keeps backward
+        # compatibility with state dicts produced before this field
+        # existed; older states simply get an empty buffer.
+        common_infos_state = state.get("_common_infos")
+        if common_infos_state is not None:
+            episode._common_infos = InfiniteLookbackBuffer.from_state(
+                common_infos_state
+            )
 
         # Validate the episode.
         episode.validate()

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -4090,6 +4090,100 @@ def test_multi_agent_episode_functionality(num_timesteps=8, num_samples=10):
             assert non_skip_agent_t == info_timesteps
 
 
+class TestMultiAgentEpisodeCommonInfos(unittest.TestCase):
+    """Regression tests for #58668.
+
+    ``MultiAgentEpisode.get_infos()`` previously dropped the ``"__common__"``
+    key, even though the MultiAgentEnv contract explicitly allows it
+    (cross-agent info dict applying to the env as a whole). The fix
+    captures common infos at ``add_env_reset`` / ``add_env_step`` time and
+    surfaces them under ``"__common__"`` in ``get_infos`` results.
+    """
+
+    def test_get_infos_returns_common_key_for_last_step(self):
+        """``get_infos(indices=-1)`` includes ``"__common__"`` when present."""
+        from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+
+        episode = MultiAgentEpisode()
+        # Reset has no common info.
+        episode.add_env_reset(
+            observations={"player1": 0, "player2": 0},
+            infos={"player1": {"p1": "r"}, "player2": {"p2": "r"}},
+        )
+        # First step carries a common info.
+        episode.add_env_step(
+            observations={"player1": 1, "player2": 1},
+            actions={"player1": 0, "player2": 0},
+            rewards={"player1": 0.0, "player2": 0.0},
+            infos={
+                "player1": {"p1": "s1"},
+                "player2": {"p2": "s1"},
+                "__common__": {"round": 1},
+            },
+            terminateds={"__all__": False},
+            truncateds={"__all__": False},
+        )
+
+        last_infos = episode.get_infos(indices=-1)
+        self.assertIn("__common__", last_infos)
+        self.assertEqual(last_infos["__common__"], {"round": 1})
+        self.assertEqual(last_infos["player1"], {"p1": "s1"})
+        self.assertEqual(last_infos["player2"], {"p2": "s1"})
+
+    def test_get_infos_omits_common_key_when_never_set(self):
+        """When no step ever sets ``"__common__"``, the key MUST stay absent.
+
+        This preserves the existing public contract for users who do not
+        opt into cross-agent infos.
+        """
+        from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+
+        episode = MultiAgentEpisode()
+        episode.add_env_reset(
+            observations={"player1": 0, "player2": 0},
+            infos={"player1": {"p1": "r"}, "player2": {"p2": "r"}},
+        )
+        episode.add_env_step(
+            observations={"player1": 1, "player2": 1},
+            actions={"player1": 0, "player2": 0},
+            rewards={"player1": 0.0, "player2": 0.0},
+            infos={"player1": {"p1": "s1"}, "player2": {"p2": "s1"}},
+            terminateds={"__all__": False},
+            truncateds={"__all__": False},
+        )
+        last_infos = episode.get_infos(indices=-1)
+        self.assertNotIn("__common__", last_infos)
+
+    def test_get_infos_returns_common_key_as_list_for_slice(self):
+        """``get_infos`` over a slice includes ``"__common__"`` as a list."""
+        from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+
+        episode = MultiAgentEpisode()
+        episode.add_env_reset(
+            observations={"player1": 0, "player2": 0},
+            infos={
+                "player1": {},
+                "player2": {},
+                "__common__": {"round": 0},
+            },
+        )
+        episode.add_env_step(
+            observations={"player1": 1, "player2": 1},
+            actions={"player1": 0, "player2": 0},
+            rewards={"player1": 0.0, "player2": 0.0},
+            infos={
+                "player1": {},
+                "player2": {},
+                "__common__": {"round": 1},
+            },
+            terminateds={"__all__": False},
+            truncateds={"__all__": False},
+        )
+        all_infos = episode.get_infos()
+        self.assertIn("__common__", all_infos)
+        self.assertEqual(all_infos["__common__"], [{"round": 0}, {"round": 1}])
+
+
 if __name__ == "__main__":
     import sys
 

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -4183,6 +4183,75 @@ class TestMultiAgentEpisodeCommonInfos(unittest.TestCase):
         self.assertIn("__common__", all_infos)
         self.assertEqual(all_infos["__common__"], [{"round": 0}, {"round": 1}])
 
+    def _build_two_step_episode_with_common(self):
+        from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+
+        episode = MultiAgentEpisode()
+        episode.add_env_reset(
+            observations={"p1": 0, "p2": 0},
+            infos={"p1": {}, "p2": {}, "__common__": {"round": 0}},
+        )
+        episode.add_env_step(
+            observations={"p1": 1, "p2": 1},
+            actions={"p1": 0, "p2": 0},
+            rewards={"p1": 0.0, "p2": 0.0},
+            infos={"p1": {}, "p2": {}, "__common__": {"round": 1}},
+            terminateds={"__all__": False},
+            truncateds={"__all__": False},
+        )
+        return episode
+
+    def test_common_infos_survive_get_state_from_state(self):
+        """``MultiAgentEpisode.get_state`` / ``from_state`` round-trip
+        ``_common_infos`` so checkpointed and remoted episodes retain the
+        cross-agent info history.
+        """
+        from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+
+        episode = self._build_two_step_episode_with_common()
+        restored = MultiAgentEpisode.from_state(episode.get_state())
+        # Buffer contents must round-trip end-to-end.
+        self.assertEqual(restored._common_infos.data, [{"round": 0}, {"round": 1}])
+        # And the user-visible ``get_infos`` path must still surface them.
+        restored_infos = restored.get_infos()
+        self.assertIn("__common__", restored_infos)
+        self.assertEqual(restored_infos["__common__"], [{"round": 0}, {"round": 1}])
+
+    def test_common_infos_survive_concat_episode(self):
+        """``concat_episode`` carries the successor's ``_common_infos`` (minus
+        the seam-overlap entry) onto ``self``.
+        """
+        from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+
+        first = self._build_two_step_episode_with_common()
+        # Cut into a successor and add one more common-info step to it.
+        successor = first.cut()
+        successor.add_env_step(
+            observations={"p1": 2, "p2": 2},
+            actions={"p1": 0, "p2": 0},
+            rewards={"p1": 0.0, "p2": 0.0},
+            infos={"p1": {}, "p2": {}, "__common__": {"round": 2}},
+            terminateds={"__all__": False},
+            truncateds={"__all__": False},
+        )
+        first.concat_episode(successor)
+        # The combined buffer must contain all three common-info rounds in
+        # order with no duplicates from the seam.
+        self.assertEqual(
+            first._common_infos.data,
+            [{"round": 0}, {"round": 1}, {"round": 2}],
+        )
+
+    def test_common_infos_survive_cut(self):
+        """``cut`` propagates the tail of ``_common_infos`` into the
+        successor so the successor's ``get_infos`` sees the boundary
+        entry as expected.
+        """
+        episode = self._build_two_step_episode_with_common()
+        successor = episode.cut(len_lookback_buffer=1)
+        # The successor's buffer must hold the boundary's common entry.
+        self.assertIn({"round": 1}, successor._common_infos.data)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Why are these changes needed?

Closes #58668.

The ``MultiAgentEnv`` step contract explicitly allows the ``infos`` dict returned by ``env.step`` / ``env.reset`` to carry an optional ``"__common__"`` key whose value is an info dict applying to the env as a whole, not to any single agent. ``MultiAgentEnv`` validates this directly (from ``multi_agent_env.py:562-568``):

```python
info_diff = set(infos).difference(set(obs))
if info_diff and info_diff != {"__common__"}:
    raise ValueError(
        "Key set for infos must be a subset of obs (plus optionally "
        "the '__common__' key for infos concerning all/no agents): "
        ...
    )
```

But ``MultiAgentEpisode.add_env_reset`` and ``add_env_step`` ingest infos by looping over ``observations.keys()`` (which never includes ``"__common__"``) and dispatching to the per-agent ``SingleAgentEpisode``. The common entry was therefore silently discarded on ingestion and never surfaced from ``get_infos``. The reporter observed this from a debug point inside the ``FlattenObservations`` connector where ``episodes[-1].get_infos()`` returned the per-player keys but not ``"__common__"``.

## What this PR does

- Adds ``self._common_infos: InfiniteLookbackBuffer`` to ``MultiAgentEpisode.__init__``. The buffer mirrors the env-step timeline: one entry per ``add_env_reset`` / ``add_env_step`` call, storing ``infos.get("__common__")`` (which is ``None`` when no common entry was provided).
- In ``_get_data_by_env_steps``, after the per-agent loop, queries the common buffer with the same ``indices`` / ``neg_index_as_lookback`` / ``fill`` arguments and adds the result under the ``"__common__"`` key when it is not entirely ``None``. Users that never set ``"__common__"`` see no change in the returned shape because the key is suppressed when no real data exists.

Three regression tests added in ``test_multi_agent_episode.py``:

1. ``test_get_infos_returns_common_key_for_last_step`` — the issue's exact reproduction shape (``get_infos(indices=-1)`` after a reset + one step that includes ``"__common__"``).
2. ``test_get_infos_omits_common_key_when_never_set`` — no-regression guarantee for callers that do not opt into ``"__common__"``.
3. ``test_get_infos_returns_common_key_as_list_for_slice`` — default ``get_infos()`` slice-all path returns the common-info list as the per-step sequence.

The sibling paths ``_get_data_by_env_steps_as_list`` and ``_get_data_by_agent_steps`` are left unchanged for this PR; they are not on the path the issue reporter walked and need their own fixtures. Follow-up work can extend the same pattern there.

## Related issue number

Closes #58668

## Checks

- [x] DCO sign-off
- [x] ``black==22.10.0`` (Ray's pinned version) passes on the modified files
- [x] Pre-existing C420 ruff warnings in ``test_multi_agent_episode.py`` are unrelated to this PR (no new C420 violations introduced)

## Test plan

- [ ] CI passes (``buildkite/premerge``, ``buildkite/microcheck``, ``buildkite/release``)
- [ ] Three new regression tests pass
- [ ] Existing tests in ``test_multi_agent_episode.py`` (including ``test_get_infos``) are unchanged and still pass