### PR TITLE
[Data][Cherry-pick] Add default logical memory for map operators (#63814)

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -115,6 +115,7 @@ class ActorPoolMapOperator(MapOperator):
         ray_actor_task_remote_args: Optional[Dict[str, Any]] = None,
         target_max_block_size_override: Optional[int] = None,
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
+        default_logical_memory_enabled: bool = False,
     ):
         """Create an ActorPoolMapOperator instance.
 
@@ -146,6 +147,9 @@ class ActorPoolMapOperator(MapOperator):
                 include in an output block.
             on_start: Optional callback invoked with the schema from the first input
                 bundle before any tasks are submitted.
+            default_logical_memory_enabled: If ``True``, the operator launches actors
+                with a default logical ``memory``. The method for choosing the
+                default is an implementation detail.
         """
         super().__init__(
             map_transformer,
@@ -160,6 +164,7 @@ class ActorPoolMapOperator(MapOperator):
             ray_remote_args_fn,
             ray_remote_args,
             on_start,
+            default_logical_memory_enabled,
         )
 
         self._min_rows_per_bundle = min_rows_per_bundle

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import functools
 import logging
+import math
 import pickle
 import time
 from abc import ABC, abstractmethod
@@ -12,12 +13,19 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Final,
     Iterable,
     Iterator,
     List,
     Optional,
     Union,
 )
+
+from ray._private.ray_constants import (
+    DEFAULT_OBJECT_STORE_MEMORY_PROPORTION,
+    DEFAULT_SYSTEM_RESERVED_MEMORY_PROPORTION,
+)
+from ray.data._internal.util import GiB
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -153,6 +161,35 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     Warn if the size of the map UDF exceeds this threshold.
     """
 
+    DEFAULT_LOGICAL_MEMORY_PER_CPU: Final[int] = int(
+        4
+        * GiB
+        * (
+            1
+            - DEFAULT_SYSTEM_RESERVED_MEMORY_PROPORTION
+            - DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
+        )
+    )
+    """Default logical memory to request for map tasks and actors per logical CPU.
+
+    Ray Data aims to guarantee that if you set each UDF's logical memory to at least
+    the heap memory that UDF needs, the system won't oversubscribe tasks and actors.
+
+    The problem is that if you set logical memory for some UDFs but not others, the
+    unspecified ones fall back to 0 and the system oversubscribes anyway.
+
+    To avoid that, we default to ~2.57 GiB per CPU core. Here's where that magic number
+    comes from: We want to pick the largest logical memory (so it's safe) that won't
+    decrease concurrency (so we don't regress performance). Hyperscaler nodes usually
+    have 4 GiB per CPU core, and Ray Core sets logical memory to physical memory minus
+    30% for the object store and 10% for system-reserved memory. So, in the typical
+    case, you end up with 4 GiB * 60% = ~2.57 GiB GiB of logical memory per core, and
+    that's the highest you can go before you start decreasing concurrency.
+
+    We use this heuristic over more sophisticated alternatives because a constant
+    default is easy to reason about.
+    """
+
     def __init__(
         self,
         map_transformer: MapTransformer,
@@ -167,6 +204,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
         ray_remote_args: Optional[Dict[str, Any]],
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
+        default_logical_memory_enabled: bool = False,
     ):
         # NOTE: This constructor should not be called directly; use MapOperator.create()
         # instead.
@@ -174,10 +212,24 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         if map_task_kwargs is None:
             map_task_kwargs = {}
 
+        if ray_remote_args is None:
+            ray_remote_args = {}
+
+        ray_remote_args = _canonicalize_ray_remote_args(ray_remote_args)
+
+        # Configure a default logical memory to improve memory safety when the user has
+        # specified memory for some UDFs but not others.
+        if default_logical_memory_enabled:
+            self._set_default_logical_memory(ray_remote_args)
+            logger.debug(
+                f"Operator {name!r} set default logical memory to "
+                f"{ray_remote_args.get('memory')}"
+            )
+
         self._map_transformer = map_transformer
         self._supports_fusion = supports_fusion
         self._map_task_kwargs = map_task_kwargs
-        self._ray_remote_args = _canonicalize_ray_remote_args(ray_remote_args or {})
+        self._ray_remote_args = ray_remote_args
         self._ray_remote_args_fn = ray_remote_args_fn
         self._remote_args_for_metrics = copy.deepcopy(self._ray_remote_args)
 
@@ -212,6 +264,19 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         # (e.g., schema evolution for Iceberg writes via on_write_start).
         self._on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = on_start
         self._on_start_called = False
+
+    def _set_default_logical_memory(self, ray_remote_args: Dict[str, Any]) -> None:
+        num_cpus = ray_remote_args.get("num_cpus")
+        if not num_cpus:
+            # If the map tasks or actors don't require logical CPUs, just assume it
+            # requires one logical CPU for the purpose of computing a default value.
+            default_memory = math.ceil(self.DEFAULT_LOGICAL_MEMORY_PER_CPU)
+        else:
+            default_memory = math.ceil(self.DEFAULT_LOGICAL_MEMORY_PER_CPU * num_cpus)
+
+        assert isinstance(default_memory, int), default_memory
+        assert default_memory > 0, default_memory
+        ray_remote_args.setdefault("memory", default_memory)
 
     @functools.cached_property
     def _map_transformer_ref(self) -> ObjectRef[MapTransformer]:
@@ -376,6 +441,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 ray_remote_args=ray_remote_args,
                 on_start=on_start,
                 isolate_workers=isolate_workers,
+                default_logical_memory_enabled=data_context.default_map_logical_memory_enabled,
             )
         elif isinstance(compute_strategy, ActorPoolStrategy):
             from ray.data._internal.execution.operators import (
@@ -403,6 +469,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 ray_remote_args_fn=ray_remote_args_fn,
                 ray_remote_args=ray_remote_args,
                 on_start=on_start,
+                default_logical_memory_enabled=data_context.default_map_logical_memory_enabled,
             )
         else:
             raise ValueError(f"Unsupported execution strategy {compute_strategy}")

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -45,6 +45,7 @@ class TaskPoolMapOperator(MapOperator):
         ray_remote_args: Optional[Dict[str, Any]] = None,
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         isolate_workers: bool = False,
+        default_logical_memory_enabled: bool = False,
     ):
         """Create an TaskPoolMapOperator instance.
 
@@ -76,6 +77,9 @@ class TaskPoolMapOperator(MapOperator):
                 scheduled on the same worker processes as this operator's. This flag
                 is useful to prevent side-effects from affecting other operators, like
                 large PyArrow memory allocations.
+            default_logical_memory_enabled: If ``True``, the operator launches tasks
+                with a default logical ``memory``. The method for choosing the
+                default is an implementation detail.
         """
         super().__init__(
             map_transformer,
@@ -90,6 +94,7 @@ class TaskPoolMapOperator(MapOperator):
             ray_remote_args_fn,
             ray_remote_args,
             on_start,
+            default_logical_memory_enabled,
         )
 
         self._isolate_workers = isolate_workers

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -284,6 +284,10 @@ DEFAULT_ENABLE_PER_NODE_METRICS = bool(
 
 DEFAULT_ISOLATE_READ_WORKERS = env_bool("RAY_DATA_ISOLATE_READ_WORKERS", False)
 
+DEFAULT_DEFAULT_MAP_LOGICAL_MEMORY_ENABLED = env_bool(
+    "RAY_DATA_DEFAULT_MAP_LOGICAL_MEMORY_ENABLED", False
+)
+
 DEFAULT_MIN_HASH_SHUFFLE_AGGREGATOR_WAIT_TIME_IN_S = env_integer(
     "RAY_DATA_MIN_HASH_SHUFFLE_AGGREGATOR_WAIT_TIME_IN_S", 300
 )
@@ -673,6 +677,11 @@ class DataContext:
             workers that are later reused by downstream operators. Enabling this flag
             can reduce OOMs but also cause performance regressions. Defaults to
             ``False``.
+        default_map_logical_memory_enabled: If ``True``, the system sets logical
+            ``memory`` for map tasks and actors even if you haven't specified a value;
+            otherwise, the system launches map tasks and actors with no logical
+            ``memory``. Enabling this flag can avoid OOMs when you specify ``memory``
+            for some APIs but not others. Defaults to ``False``.
     """
 
     # `None` means the block size is infinite.
@@ -852,6 +861,10 @@ class DataContext:
 
     custom_execution_callback_classes: List[Type["ExecutionCallback"]] = field(
         default_factory=list
+    )
+
+    default_map_logical_memory_enabled: bool = (
+        DEFAULT_DEFAULT_MAP_LOGICAL_MEMORY_ENABLED
     )
 
     def __post_init__(self):

--- a/python/ray/data/tests/test_map_operator.py
+++ b/python/ray/data/tests/test_map_operator.py
@@ -1,5 +1,6 @@
 import time
 from typing import Iterable
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -704,6 +705,55 @@ def test_operator_metrics():
 
         # Check object store metrics
         assert metrics.obj_store_mem_freed == metrics.bytes_task_inputs_processed, i
+
+
+@pytest.mark.parametrize(
+    "ray_remote_args", [{}, {"num_cpus": 0}, {"num_cpus": 0.5}, {"num_cpus": 1}]
+)
+@pytest.mark.parametrize(
+    "compute_strategy",
+    [ray.data.TaskPoolStrategy(), ray.data.ActorPoolStrategy(size=1)],
+)
+def test_map_operator_specifies_default_memory(
+    ray_start_regular_shared, ray_remote_args, compute_strategy
+):
+    data_context = ray.data.DataContext.get_current()
+    data_context.default_map_logical_memory_enabled = True
+    op = MapOperator.create(
+        map_transformer=MagicMock(),
+        input_op=InputDataBuffer(data_context, input_data=MagicMock()),
+        data_context=data_context,
+        compute_strategy=compute_strategy,
+        ray_remote_args=ray_remote_args,
+    )
+
+    # If Ray Data doesn't specify a default memory, then the system can oversubscribe
+    # tasks and actors even if the user has correctly specified memory for some UDFs.
+    #
+    # This assertion just checks that map operators default to *something*, without
+    # making assumptions about the actual heuristic.
+    assert op.min_scheduling_resources().memory > 0
+
+
+@pytest.mark.parametrize(
+    "compute_strategy",
+    [ray.data.TaskPoolStrategy(), ray.data.ActorPoolStrategy(size=1)],
+)
+def test_map_operator_no_default_memory_when_disabled(
+    ray_start_regular_shared, compute_strategy
+):
+    data_context = ray.data.DataContext.get_current()
+    op = MapOperator.create(
+        map_transformer=MagicMock(),
+        input_op=InputDataBuffer(data_context, input_data=MagicMock()),
+        data_context=data_context,
+        compute_strategy=compute_strategy,
+        ray_remote_args={},
+    )
+
+    # When the flag is disabled (the default), map operators shouldn't assign a default
+    # logical memory unless the user explicitly requested it.
+    assert not op.min_scheduling_resources().memory
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Ray Data aims to guarantee that if you set each UDF's logical memory to at least the heap memory that UDF needs, the system won't oversubscribe tasks and actors.

The problem is that if you set logical memory for some UDFs but not others, the unspecified ones fall back to 0 and the system oversubscribes anyway.

To avoid this issue, I'm making map operators default to 4 GiB * 60%. 

Here's how we chose that magic number: 
* Hyperscaler nodes usually have about 4 GiB of physical memory per CPU core. It's sometimes more, but rarely less.
* By default, Ray Core sets logical memory to physical memory minus 10% for the system and 30% for the object store.
* So, in the typical case, you end up with 4 GiB * 60% of logical memory per core. That's the highest you can go before you start decreasing concurrency.

We ended up choosing this heuristic because a constant is easier to reason about than more sophisticated alternatives.

## Related issues

N/A

## Additional information

N/A

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
