### PR TITLE
[Train] Fix docstring style (and enable `--check-style-mismatch=True` in pydoclint)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           --check-return-types=False,
           --allow-init-docstring=True,
           --check-class-attributes=False,
-          # --check-style-mismatch=True, # Bring this back once things are a bit cleaner
+          --check-style-mismatch=True,
         ]
         types: [python]
         files: '^python/ray/'

--- a/python/ray/train/_internal/utils.py
+++ b/python/ray/train/_internal/utils.py
@@ -91,8 +91,13 @@ def count_required_parameters(fn: Callable) -> int:
 
     NOTE: *args counts as 1 required parameter.
 
-    Examples
-    --------
+    Args:
+        fn: The function whose required parameters should be counted.
+
+    Returns:
+        The number of required parameters of ``fn``.
+
+    Examples:
 
     >>> def fn(a, b, /, c, *args, d=1, e=2, **kwargs):
     ...    pass

--- a/python/ray/train/_internal/utils.py
+++ b/python/ray/train/_internal/utils.py
@@ -99,20 +99,20 @@ def count_required_parameters(fn: Callable) -> int:
 
     Examples:
 
-    >>> def fn(a, b, /, c, *args, d=1, e=2, **kwargs):
-    ...    pass
-    >>> count_required_parameters(fn)
-    4
+        >>> def fn(a, b, /, c, *args, d=1, e=2, **kwargs):
+        ...    pass
+        >>> count_required_parameters(fn)
+        4
 
-    >>> fn = lambda: 1
-    >>> count_required_parameters(fn)
-    0
+        >>> fn = lambda: 1
+        >>> count_required_parameters(fn)
+        0
 
-    >>> def fn(config, a, b=1, c=2):
-    ...     pass
-    >>> from functools import partial
-    >>> count_required_parameters(partial(fn, a=0))
-    1
+        >>> def fn(config, a, b=1, c=2):
+        ...     pass
+        >>> from functools import partial
+        >>> count_required_parameters(partial(fn, a=0))
+        1
     """
     params = inspect.signature(fn).parameters.values()
 

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -97,8 +97,7 @@ def _lightgbm_train_fn_per_worker(
 class LightGBMTrainer(SimpleLightGBMTrainer):
     """A Trainer for distributed data-parallel LightGBM training.
 
-    Example
-    -------
+    Example:
 
     .. testcode::
         :skipif: True

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -99,68 +99,68 @@ class LightGBMTrainer(SimpleLightGBMTrainer):
 
     Example:
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import lightgbm
+            import lightgbm
 
-        import ray.data
-        import ray.train
-        from ray.train.lightgbm import (
-            LightGBMTrainer,
-            RayTrainReportCallback,
-            normalize_pandas_for_lightgbm,
-        )
-
-        def train_fn_per_worker(config: dict):
-            # (Optional) Add logic to resume training state from a checkpoint.
-            # ray.train.get_checkpoint()
-
-            # 1. Get the dataset shard for the worker and convert to a `lightgbm.Dataset`
-            train_ds_iter, eval_ds_iter = (
-                ray.train.get_dataset_shard("train"),
-                ray.train.get_dataset_shard("validation"),
-            )
-            train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
-            train_df = normalize_pandas_for_lightgbm(train_ds.to_pandas())
-            eval_df = normalize_pandas_for_lightgbm(eval_ds.to_pandas())
-            train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
-            eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
-            dtrain = lightgbm.Dataset(train_X, label=train_y)
-            deval = lightgbm.Dataset(eval_X, label=eval_y)
-
-            params = {
-                "objective": "regression",
-                "metric": "l2",
-                "learning_rate": 1e-4,
-                "subsample": 0.5,
-                "max_depth": 2,
-                # Adding the line below is the only change needed
-                # for your `lgb.train` call!
-                **ray.train.lightgbm.get_network_params(),
-            }
-
-            # 2. Do distributed data-parallel training.
-            # Ray Train sets up the necessary coordinator processes and
-            # environment variables for your workers to communicate with each other.
-            bst = lightgbm.train(
-                params,
-                train_set=dtrain,
-                valid_sets=[deval],
-                valid_names=["validation"],
-                num_boost_round=10,
-                callbacks=[RayTrainReportCallback()],
+            import ray.data
+            import ray.train
+            from ray.train.lightgbm import (
+                LightGBMTrainer,
+                RayTrainReportCallback,
+                normalize_pandas_for_lightgbm,
             )
 
-        train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
-        eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
-        trainer = LightGBMTrainer(
-            train_fn_per_worker,
-            datasets={"train": train_ds, "validation": eval_ds},
-            scaling_config=ray.train.ScalingConfig(num_workers=4),
-        )
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+            def train_fn_per_worker(config: dict):
+                # (Optional) Add logic to resume training state from a checkpoint.
+                # ray.train.get_checkpoint()
+
+                # 1. Get the dataset shard for the worker and convert to a `lightgbm.Dataset`
+                train_ds_iter, eval_ds_iter = (
+                    ray.train.get_dataset_shard("train"),
+                    ray.train.get_dataset_shard("validation"),
+                )
+                train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
+                train_df = normalize_pandas_for_lightgbm(train_ds.to_pandas())
+                eval_df = normalize_pandas_for_lightgbm(eval_ds.to_pandas())
+                train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
+                eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
+                dtrain = lightgbm.Dataset(train_X, label=train_y)
+                deval = lightgbm.Dataset(eval_X, label=eval_y)
+
+                params = {
+                    "objective": "regression",
+                    "metric": "l2",
+                    "learning_rate": 1e-4,
+                    "subsample": 0.5,
+                    "max_depth": 2,
+                    # Adding the line below is the only change needed
+                    # for your `lgb.train` call!
+                    **ray.train.lightgbm.get_network_params(),
+                }
+
+                # 2. Do distributed data-parallel training.
+                # Ray Train sets up the necessary coordinator processes and
+                # environment variables for your workers to communicate with each other.
+                bst = lightgbm.train(
+                    params,
+                    train_set=dtrain,
+                    valid_sets=[deval],
+                    valid_names=["validation"],
+                    num_boost_round=10,
+                    callbacks=[RayTrainReportCallback()],
+                )
+
+            train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+            eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
+            trainer = LightGBMTrainer(
+                train_fn_per_worker,
+                datasets={"train": train_ds, "validation": eval_ds},
+                scaling_config=ray.train.ScalingConfig(num_workers=4),
+            )
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     Args:
         train_loop_per_worker: The training function to execute on each worker.

--- a/python/ray/train/lightgbm/v2.py
+++ b/python/ray/train/lightgbm/v2.py
@@ -15,66 +15,66 @@ class LightGBMTrainer(DataParallelTrainer):
 
     Example:
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import lightgbm as lgb
+            import lightgbm as lgb
 
-        import ray.data
-        import ray.train
-        from ray.train.lightgbm import (
-            LightGBMTrainer,
-            RayTrainReportCallback,
-            normalize_pandas_for_lightgbm,
-        )
-
-
-        def train_fn_per_worker(config: dict):
-            # (Optional) Add logic to resume training state from a checkpoint.
-            # ray.train.get_checkpoint()
-
-            # 1. Get the dataset shard for the worker and convert to a `lgb.Dataset`
-            train_ds_iter, eval_ds_iter = (
-                ray.train.get_dataset_shard("train"),
-                ray.train.get_dataset_shard("validation"),
-            )
-            train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
-            train_df = normalize_pandas_for_lightgbm(train_ds.to_pandas())
-            eval_df = normalize_pandas_for_lightgbm(eval_ds.to_pandas())
-            train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
-            eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
-
-            train_set = lgb.Dataset(train_X, label=train_y)
-            eval_set = lgb.Dataset(eval_X, label=eval_y)
-
-            # 2. Run distributed data-parallel training.
-            # `get_network_params` sets up the necessary configurations for LightGBM
-            # to set up the data parallel training worker group on your Ray cluster.
-            params = {
-                "objective": "regression",
-                # Adding the line below is the only change needed
-                # for your `lgb.train` call!
-                **ray.train.lightgbm.get_network_params(),
-            }
-            lgb.train(
-                params,
-                train_set,
-                valid_sets=[eval_set],
-                valid_names=["eval"],
-                callbacks=[RayTrainReportCallback()],
+            import ray.data
+            import ray.train
+            from ray.train.lightgbm import (
+                LightGBMTrainer,
+                RayTrainReportCallback,
+                normalize_pandas_for_lightgbm,
             )
 
-        train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
-        eval_ds = ray.data.from_items(
-            [{"x": x, "y": x + 1} for x in range(32, 32 + 16)]
-        )
-        trainer = LightGBMTrainer(
-            train_fn_per_worker,
-            datasets={"train": train_ds, "validation": eval_ds},
-            scaling_config=ray.train.ScalingConfig(num_workers=4),
-        )
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+
+            def train_fn_per_worker(config: dict):
+                # (Optional) Add logic to resume training state from a checkpoint.
+                # ray.train.get_checkpoint()
+
+                # 1. Get the dataset shard for the worker and convert to a `lgb.Dataset`
+                train_ds_iter, eval_ds_iter = (
+                    ray.train.get_dataset_shard("train"),
+                    ray.train.get_dataset_shard("validation"),
+                )
+                train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
+                train_df = normalize_pandas_for_lightgbm(train_ds.to_pandas())
+                eval_df = normalize_pandas_for_lightgbm(eval_ds.to_pandas())
+                train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
+                eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
+
+                train_set = lgb.Dataset(train_X, label=train_y)
+                eval_set = lgb.Dataset(eval_X, label=eval_y)
+
+                # 2. Run distributed data-parallel training.
+                # `get_network_params` sets up the necessary configurations for LightGBM
+                # to set up the data parallel training worker group on your Ray cluster.
+                params = {
+                    "objective": "regression",
+                    # Adding the line below is the only change needed
+                    # for your `lgb.train` call!
+                    **ray.train.lightgbm.get_network_params(),
+                }
+                lgb.train(
+                    params,
+                    train_set,
+                    valid_sets=[eval_set],
+                    valid_names=["eval"],
+                    callbacks=[RayTrainReportCallback()],
+                )
+
+            train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+            eval_ds = ray.data.from_items(
+                [{"x": x, "y": x + 1} for x in range(32, 32 + 16)]
+            )
+            trainer = LightGBMTrainer(
+                train_fn_per_worker,
+                datasets={"train": train_ds, "validation": eval_ds},
+                scaling_config=ray.train.ScalingConfig(num_workers=4),
+            )
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     Args:
         train_loop_per_worker: The training function to execute on each worker.

--- a/python/ray/train/lightgbm/v2.py
+++ b/python/ray/train/lightgbm/v2.py
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 class LightGBMTrainer(DataParallelTrainer):
     """A Trainer for distributed data-parallel LightGBM training.
 
-    Example
-    -------
+    Example:
 
     .. testcode::
         :skipif: True

--- a/python/ray/train/v2/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/v2/lightgbm/lightgbm_trainer.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 class LightGBMTrainer(DataParallelTrainer):
     """A Trainer for distributed data-parallel LightGBM training.
 
-    Example
-    -------
+    Example:
 
     .. testcode::
         :skipif: True

--- a/python/ray/train/v2/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/v2/lightgbm/lightgbm_trainer.py
@@ -20,70 +20,70 @@ class LightGBMTrainer(DataParallelTrainer):
 
     Example:
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import lightgbm as lgb
+            import lightgbm as lgb
 
-        import ray.data
-        import ray.train
-        from ray.train.lightgbm import (
-            LightGBMTrainer,
-            RayTrainReportCallback,
-            normalize_pandas_for_lightgbm,
-        )
-
-
-        def train_fn_per_worker(config: dict):
-            # (Optional) Add logic to resume training state from a checkpoint.
-            # ray.train.get_checkpoint()
-
-            # 1. Get the dataset shard for the worker and convert to a `lgb.Dataset`
-            train_ds_iter, eval_ds_iter = (
-                ray.train.get_dataset_shard("train"),
-                ray.train.get_dataset_shard("validation"),
-            )
-            train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
-            train_df = normalize_pandas_for_lightgbm(train_ds.to_pandas())
-            eval_df = normalize_pandas_for_lightgbm(eval_ds.to_pandas())
-            train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
-            eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
-
-            train_set = lgb.Dataset(train_X, label=train_y)
-            eval_set = lgb.Dataset(eval_X, label=eval_y)
-
-            # 2. Run distributed data-parallel training.
-            # `get_network_params` sets up the necessary configurations for LightGBM
-            # to set up the data parallel training worker group on your Ray cluster.
-            params = {
-                "objective": "regression",
-                # Adding the lines below are the only changes needed
-                # for your `lgb.train` call!
-                "tree_learner": "data_parallel",
-                "pre_partition": True,
-                **ray.train.lightgbm.get_network_params(),
-            }
-            lgb.train(
-                params,
-                train_set,
-                valid_sets=[eval_set],
-                valid_names=["eval"],
-                num_boost_round=1,
-                # To access the checkpoint from trainer, you need this callback.
-                callbacks=[RayTrainReportCallback()],
+            import ray.data
+            import ray.train
+            from ray.train.lightgbm import (
+                LightGBMTrainer,
+                RayTrainReportCallback,
+                normalize_pandas_for_lightgbm,
             )
 
-        train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
-        eval_ds = ray.data.from_items(
-            [{"x": x, "y": x + 1} for x in range(32, 32 + 16)]
-        )
-        trainer = LightGBMTrainer(
-            train_fn_per_worker,
-            datasets={"train": train_ds, "validation": eval_ds},
-            scaling_config=ray.train.ScalingConfig(num_workers=2),
-        )
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+
+            def train_fn_per_worker(config: dict):
+                # (Optional) Add logic to resume training state from a checkpoint.
+                # ray.train.get_checkpoint()
+
+                # 1. Get the dataset shard for the worker and convert to a `lgb.Dataset`
+                train_ds_iter, eval_ds_iter = (
+                    ray.train.get_dataset_shard("train"),
+                    ray.train.get_dataset_shard("validation"),
+                )
+                train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
+                train_df = normalize_pandas_for_lightgbm(train_ds.to_pandas())
+                eval_df = normalize_pandas_for_lightgbm(eval_ds.to_pandas())
+                train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
+                eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
+
+                train_set = lgb.Dataset(train_X, label=train_y)
+                eval_set = lgb.Dataset(eval_X, label=eval_y)
+
+                # 2. Run distributed data-parallel training.
+                # `get_network_params` sets up the necessary configurations for LightGBM
+                # to set up the data parallel training worker group on your Ray cluster.
+                params = {
+                    "objective": "regression",
+                    # Adding the lines below are the only changes needed
+                    # for your `lgb.train` call!
+                    "tree_learner": "data_parallel",
+                    "pre_partition": True,
+                    **ray.train.lightgbm.get_network_params(),
+                }
+                lgb.train(
+                    params,
+                    train_set,
+                    valid_sets=[eval_set],
+                    valid_names=["eval"],
+                    num_boost_round=1,
+                    # To access the checkpoint from trainer, you need this callback.
+                    callbacks=[RayTrainReportCallback()],
+                )
+
+            train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+            eval_ds = ray.data.from_items(
+                [{"x": x, "y": x + 1} for x in range(32, 32 + 16)]
+            )
+            trainer = LightGBMTrainer(
+                train_fn_per_worker,
+                datasets={"train": train_ds, "validation": eval_ds},
+                scaling_config=ray.train.ScalingConfig(num_workers=2),
+            )
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     Args:
         train_loop_per_worker: The training function to execute on each worker.

--- a/python/ray/train/v2/xgboost/xgboost_trainer.py
+++ b/python/ray/train/v2/xgboost/xgboost_trainer.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 class XGBoostTrainer(DataParallelTrainer):
     """A Trainer for distributed data-parallel XGBoost training.
 
-    Example
-    -------
+    Example:
 
     .. testcode::
 

--- a/python/ray/train/v2/xgboost/xgboost_trainer.py
+++ b/python/ray/train/v2/xgboost/xgboost_trainer.py
@@ -20,61 +20,61 @@ class XGBoostTrainer(DataParallelTrainer):
 
     Example:
 
-    .. testcode::
+        .. testcode::
 
-        import xgboost
+            import xgboost
 
-        import ray.data
-        import ray.train
-        from ray.train.xgboost import RayTrainReportCallback
-        from ray.train.xgboost import XGBoostTrainer
+            import ray.data
+            import ray.train
+            from ray.train.xgboost import RayTrainReportCallback
+            from ray.train.xgboost import XGBoostTrainer
 
-        def train_fn_per_worker(config: dict):
-            # (Optional) Add logic to resume training state from a checkpoint.
-            # ray.train.get_checkpoint()
+            def train_fn_per_worker(config: dict):
+                # (Optional) Add logic to resume training state from a checkpoint.
+                # ray.train.get_checkpoint()
 
-            # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
-            train_ds_iter, eval_ds_iter = (
-                ray.train.get_dataset_shard("train"),
-                ray.train.get_dataset_shard("validation"),
+                # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
+                train_ds_iter, eval_ds_iter = (
+                    ray.train.get_dataset_shard("train"),
+                    ray.train.get_dataset_shard("validation"),
+                )
+                train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
+
+                train_df, eval_df = train_ds.to_pandas(), eval_ds.to_pandas()
+                train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
+                eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
+
+                dtrain = xgboost.DMatrix(train_X, label=train_y)
+                deval = xgboost.DMatrix(eval_X, label=eval_y)
+
+                params = {
+                    "tree_method": "approx",
+                    "objective": "reg:squarederror",
+                    "eta": 1e-4,
+                    "subsample": 0.5,
+                    "max_depth": 2,
+                }
+
+                # 2. Do distributed data-parallel training.
+                # Ray Train sets up the necessary coordinator processes and
+                # environment variables for your workers to communicate with each other.
+                bst = xgboost.train(
+                    params,
+                    dtrain=dtrain,
+                    evals=[(deval, "validation")],
+                    num_boost_round=1,
+                    callbacks=[RayTrainReportCallback()],
+                )
+
+            train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+            eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
+            trainer = XGBoostTrainer(
+                train_fn_per_worker,
+                datasets={"train": train_ds, "validation": eval_ds},
+                scaling_config=ray.train.ScalingConfig(num_workers=2),
             )
-            train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
-
-            train_df, eval_df = train_ds.to_pandas(), eval_ds.to_pandas()
-            train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
-            eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
-
-            dtrain = xgboost.DMatrix(train_X, label=train_y)
-            deval = xgboost.DMatrix(eval_X, label=eval_y)
-
-            params = {
-                "tree_method": "approx",
-                "objective": "reg:squarederror",
-                "eta": 1e-4,
-                "subsample": 0.5,
-                "max_depth": 2,
-            }
-
-            # 2. Do distributed data-parallel training.
-            # Ray Train sets up the necessary coordinator processes and
-            # environment variables for your workers to communicate with each other.
-            bst = xgboost.train(
-                params,
-                dtrain=dtrain,
-                evals=[(deval, "validation")],
-                num_boost_round=1,
-                callbacks=[RayTrainReportCallback()],
-            )
-
-        train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
-        eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
-        trainer = XGBoostTrainer(
-            train_fn_per_worker,
-            datasets={"train": train_ds, "validation": eval_ds},
-            scaling_config=ray.train.ScalingConfig(num_workers=2),
-        )
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     Args:
         train_loop_per_worker: The training function to execute on each worker.

--- a/python/ray/train/xgboost/_xgboost_utils.py
+++ b/python/ray/train/xgboost/_xgboost_utils.py
@@ -175,8 +175,7 @@ class RayTrainReportCallback(RayReportCallback):
             and returns a modified dict. For example, this can be used to
             average results across CV fold when using ``xgboost.cv``.
 
-    Examples
-    --------
+    Examples:
 
     Reporting checkpoints and metrics to Ray Tune when running many
     independent xgboost trials (without data parallelism within a trial).

--- a/python/ray/train/xgboost/_xgboost_utils.py
+++ b/python/ray/train/xgboost/_xgboost_utils.py
@@ -177,41 +177,41 @@ class RayTrainReportCallback(RayReportCallback):
 
     Examples:
 
-    Reporting checkpoints and metrics to Ray Tune when running many
-    independent xgboost trials (without data parallelism within a trial).
+        Reporting checkpoints and metrics to Ray Tune when running many
+        independent xgboost trials (without data parallelism within a trial).
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import xgboost
+            import xgboost
 
-        from ray.tune import Tuner
-        from ray.train.xgboost import RayTrainReportCallback
+            from ray.tune import Tuner
+            from ray.train.xgboost import RayTrainReportCallback
 
-        def train_fn(config):
-            # Report log loss to Ray Tune after each validation epoch.
-            bst = xgboost.train(
-                ...,
-                callbacks=[
-                    RayTrainReportCallback(
-                        metrics={"loss": "eval-logloss"}, frequency=1
-                    )
-                ],
-            )
+            def train_fn(config):
+                # Report log loss to Ray Tune after each validation epoch.
+                bst = xgboost.train(
+                    ...,
+                    callbacks=[
+                        RayTrainReportCallback(
+                            metrics={"loss": "eval-logloss"}, frequency=1
+                        )
+                    ],
+                )
 
-        tuner = Tuner(train_fn)
-        results = tuner.fit()
+            tuner = Tuner(train_fn)
+            results = tuner.fit()
 
-    Loading a model from a checkpoint reported by this callback.
+        Loading a model from a checkpoint reported by this callback.
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        from ray.train.xgboost import RayTrainReportCallback
+            from ray.train.xgboost import RayTrainReportCallback
 
-        # Get a `Checkpoint` object that is saved by the callback during training.
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+            # Get a `Checkpoint` object that is saved by the callback during training.
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     """
 

--- a/python/ray/train/xgboost/v2.py
+++ b/python/ray/train/xgboost/v2.py
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 class XGBoostTrainer(DataParallelTrainer):
     """A Trainer for distributed data-parallel XGBoost training.
 
-    Example
-    -------
+    Example:
 
     .. testcode::
         :skipif: True

--- a/python/ray/train/xgboost/v2.py
+++ b/python/ray/train/xgboost/v2.py
@@ -15,61 +15,61 @@ class XGBoostTrainer(DataParallelTrainer):
 
     Example:
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import xgboost
+            import xgboost
 
-        import ray.data
-        import ray.train
-        from ray.train.xgboost import RayTrainReportCallback, XGBoostTrainer
+            import ray.data
+            import ray.train
+            from ray.train.xgboost import RayTrainReportCallback, XGBoostTrainer
 
-        def train_fn_per_worker(config: dict):
-            # (Optional) Add logic to resume training state from a checkpoint.
-            # ray.train.get_checkpoint()
+            def train_fn_per_worker(config: dict):
+                # (Optional) Add logic to resume training state from a checkpoint.
+                # ray.train.get_checkpoint()
 
-            # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
-            train_ds_iter, eval_ds_iter = (
-                ray.train.get_dataset_shard("train"),
-                ray.train.get_dataset_shard("validation"),
+                # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
+                train_ds_iter, eval_ds_iter = (
+                    ray.train.get_dataset_shard("train"),
+                    ray.train.get_dataset_shard("validation"),
+                )
+                train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
+
+                train_df, eval_df = train_ds.to_pandas(), eval_ds.to_pandas()
+                train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
+                eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
+
+                dtrain = xgboost.DMatrix(train_X, label=train_y)
+                deval = xgboost.DMatrix(eval_X, label=eval_y)
+
+                params = {
+                    "tree_method": "approx",
+                    "objective": "reg:squarederror",
+                    "eta": 1e-4,
+                    "subsample": 0.5,
+                    "max_depth": 2,
+                }
+
+                # 2. Do distributed data-parallel training.
+                # Ray Train sets up the necessary coordinator processes and
+                # environment variables for your workers to communicate with each other.
+                bst = xgboost.train(
+                    params,
+                    dtrain=dtrain,
+                    evals=[(deval, "validation")],
+                    num_boost_round=10,
+                    callbacks=[RayTrainReportCallback()],
+                )
+
+            train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+            eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
+            trainer = XGBoostTrainer(
+                train_fn_per_worker,
+                datasets={"train": train_ds, "validation": eval_ds},
+                scaling_config=ray.train.ScalingConfig(num_workers=4),
             )
-            train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
-
-            train_df, eval_df = train_ds.to_pandas(), eval_ds.to_pandas()
-            train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
-            eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
-
-            dtrain = xgboost.DMatrix(train_X, label=train_y)
-            deval = xgboost.DMatrix(eval_X, label=eval_y)
-
-            params = {
-                "tree_method": "approx",
-                "objective": "reg:squarederror",
-                "eta": 1e-4,
-                "subsample": 0.5,
-                "max_depth": 2,
-            }
-
-            # 2. Do distributed data-parallel training.
-            # Ray Train sets up the necessary coordinator processes and
-            # environment variables for your workers to communicate with each other.
-            bst = xgboost.train(
-                params,
-                dtrain=dtrain,
-                evals=[(deval, "validation")],
-                num_boost_round=10,
-                callbacks=[RayTrainReportCallback()],
-            )
-
-        train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
-        eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
-        trainer = XGBoostTrainer(
-            train_fn_per_worker,
-            datasets={"train": train_ds, "validation": eval_ds},
-            scaling_config=ray.train.ScalingConfig(num_workers=4),
-        )
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     Args:
         train_loop_per_worker: The training function to execute on each worker.

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -87,61 +87,61 @@ class XGBoostTrainer(SimpleXGBoostTrainer):
 
     Example:
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import xgboost
+            import xgboost
 
-        import ray.data
-        import ray.train
-        from ray.train.xgboost import RayTrainReportCallback, XGBoostTrainer
+            import ray.data
+            import ray.train
+            from ray.train.xgboost import RayTrainReportCallback, XGBoostTrainer
 
-        def train_fn_per_worker(config: dict):
-            # (Optional) Add logic to resume training state from a checkpoint.
-            # ray.train.get_checkpoint()
+            def train_fn_per_worker(config: dict):
+                # (Optional) Add logic to resume training state from a checkpoint.
+                # ray.train.get_checkpoint()
 
-            # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
-            train_ds_iter, eval_ds_iter = (
-                ray.train.get_dataset_shard("train"),
-                ray.train.get_dataset_shard("validation"),
+                # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
+                train_ds_iter, eval_ds_iter = (
+                    ray.train.get_dataset_shard("train"),
+                    ray.train.get_dataset_shard("validation"),
+                )
+                train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
+
+                train_df, eval_df = train_ds.to_pandas(), eval_ds.to_pandas()
+                train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
+                eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
+
+                dtrain = xgboost.DMatrix(train_X, label=train_y)
+                deval = xgboost.DMatrix(eval_X, label=eval_y)
+
+                params = {
+                    "tree_method": "approx",
+                    "objective": "reg:squarederror",
+                    "eta": 1e-4,
+                    "subsample": 0.5,
+                    "max_depth": 2,
+                }
+
+                # 2. Do distributed data-parallel training.
+                # Ray Train sets up the necessary coordinator processes and
+                # environment variables for your workers to communicate with each other.
+                bst = xgboost.train(
+                    params,
+                    dtrain=dtrain,
+                    evals=[(deval, "validation")],
+                    num_boost_round=10,
+                    callbacks=[RayTrainReportCallback()],
+                )
+
+            train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+            eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
+            trainer = XGBoostTrainer(
+                train_fn_per_worker,
+                datasets={"train": train_ds, "validation": eval_ds},
+                scaling_config=ray.train.ScalingConfig(num_workers=4),
             )
-            train_ds, eval_ds = train_ds_iter.materialize(), eval_ds_iter.materialize()
-
-            train_df, eval_df = train_ds.to_pandas(), eval_ds.to_pandas()
-            train_X, train_y = train_df.drop("y", axis=1), train_df["y"]
-            eval_X, eval_y = eval_df.drop("y", axis=1), eval_df["y"]
-
-            dtrain = xgboost.DMatrix(train_X, label=train_y)
-            deval = xgboost.DMatrix(eval_X, label=eval_y)
-
-            params = {
-                "tree_method": "approx",
-                "objective": "reg:squarederror",
-                "eta": 1e-4,
-                "subsample": 0.5,
-                "max_depth": 2,
-            }
-
-            # 2. Do distributed data-parallel training.
-            # Ray Train sets up the necessary coordinator processes and
-            # environment variables for your workers to communicate with each other.
-            bst = xgboost.train(
-                params,
-                dtrain=dtrain,
-                evals=[(deval, "validation")],
-                num_boost_round=10,
-                callbacks=[RayTrainReportCallback()],
-            )
-
-        train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
-        eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])
-        trainer = XGBoostTrainer(
-            train_fn_per_worker,
-            datasets={"train": train_ds, "validation": eval_ds},
-            scaling_config=ray.train.ScalingConfig(num_workers=4),
-        )
-        result = trainer.fit()
-        booster = RayTrainReportCallback.get_model(result.checkpoint)
+            result = trainer.fit()
+            booster = RayTrainReportCallback.get_model(result.checkpoint)
 
     Args:
         train_loop_per_worker: The training function to execute on each worker.

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -85,8 +85,7 @@ def _xgboost_train_fn_per_worker(
 class XGBoostTrainer(SimpleXGBoostTrainer):
     """A Trainer for distributed data-parallel XGBoost training.
 
-    Example
-    -------
+    Example:
 
     .. testcode::
         :skipif: True

--- a/python/ray/tune/integration/xgboost.py
+++ b/python/ray/tune/integration/xgboost.py
@@ -31,8 +31,7 @@ class TuneReportCheckpointCallback(RayReportCallback):
             and returns a modified dict. For example, this can be used to
             average results across CV fold when using ``xgboost.cv``.
 
-    Examples
-    --------
+    Examples:
 
     Reporting checkpoints and metrics to Ray Tune when running many
     independent xgboost trials (without data parallelism within a trial).

--- a/python/ray/tune/integration/xgboost.py
+++ b/python/ray/tune/integration/xgboost.py
@@ -33,30 +33,30 @@ class TuneReportCheckpointCallback(RayReportCallback):
 
     Examples:
 
-    Reporting checkpoints and metrics to Ray Tune when running many
-    independent xgboost trials (without data parallelism within a trial).
+        Reporting checkpoints and metrics to Ray Tune when running many
+        independent xgboost trials (without data parallelism within a trial).
 
-    .. testcode::
-        :skipif: True
+        .. testcode::
+            :skipif: True
 
-        import xgboost
+            import xgboost
 
-        from ray.tune import Tuner
-        from ray.tune.integration.xgboost import TuneReportCheckpointCallback
+            from ray.tune import Tuner
+            from ray.tune.integration.xgboost import TuneReportCheckpointCallback
 
-        def train_fn(config):
-            # Report log loss to Ray Tune after each validation epoch.
-            bst = xgboost.train(
-                ...,
-                callbacks=[
-                    TuneReportCheckpointCallback(
-                        metrics={"loss": "eval-logloss"}, frequency=1
-                    )
-                ],
-            )
+            def train_fn(config):
+                # Report log loss to Ray Tune after each validation epoch.
+                bst = xgboost.train(
+                    ...,
+                    callbacks=[
+                        TuneReportCheckpointCallback(
+                            metrics={"loss": "eval-logloss"}, frequency=1
+                        )
+                    ],
+                )
 
-        tuner = Tuner(train_fn)
-        results = tuner.fit()
+            tuner = Tuner(train_fn)
+            results = tuner.fit()
     """
 
     def __init__(


### PR DESCRIPTION
## Description
The remaining problems for enabling `pydoclint --check-style-mismatch=True` is in Ray Train / Tune. 

This PR fixes docstring that contain non-google style docstrings.