### PR TITLE
[core] Deflake `test_task_metrics.py::test_pull_manager_stats`

### DIFF
--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -739,7 +739,14 @@ ray.get([a.remote(buf[0]), b.remote(buf[1])] + [c.remote(x) for x in buf[2:]])
         assert running == 2, stats
         assert 7 <= stats["PENDING_NODE_ASSIGNMENT"] <= 17, stats
         assert 81 <= stats["PENDING_OBJ_STORE_MEM_AVAIL"] <= 91, stats
-        assert set(stats.keys()).issubset({"RUNNING", "SUBMITTED_TO_WORKER", "PENDING_NODE_ASSIGNMENT", "PENDING_OBJ_STORE_MEM_AVAIL"}), stats
+        assert set(stats.keys()).issubset(
+            {
+                "RUNNING",
+                "SUBMITTED_TO_WORKER",
+                "PENDING_NODE_ASSIGNMENT",
+                "PENDING_OBJ_STORE_MEM_AVAIL",
+            }
+        ), stats
         assert sum(stats.values()) == 100, stats
         return True
 

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -695,7 +695,11 @@ ray.get(a)
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on macos")
-def test_pull_manager_stats(shutdown_only):
+# Run repeatedly to guard against regressions in flakiness (see the SUBMITTED_TO_WORKER
+# handling in close_to_expected below).
+# XXX: remove before merging.
+@pytest.mark.parametrize("trial", range(50))
+def test_pull_manager_stats(shutdown_only, trial):
     info = ray.init(num_cpus=2, object_store_memory=100_000_000, **METRIC_CONFIG)
     timeseries = PrometheusTimeseries()
     driver = """
@@ -731,8 +735,12 @@ ray.get([a.remote(buf[0]), b.remote(buf[1])] + [c.remote(x) for x in buf[2:]])
     # This test is non-deterministic since pull bundles can sometimes end up fallback
     # allocated. This leads to slightly more objects pulled than you'd expect.
     def close_to_expected(stats):
-        assert len(stats) == 3, stats
-        assert stats["RUNNING"] == 2, stats
+        # A scheduled task can momentarily sit in SUBMITTED_TO_WORKER (lease granted,
+        # waiting on the worker to fetch its spilled arg) before it reports RUNNING.
+        # Under the object store pressure this test creates, that transition can be
+        # slow, so count SUBMITTED_TO_WORKER as running to avoid flakiness.
+        running = stats.get("RUNNING", 0) + stats.get("SUBMITTED_TO_WORKER", 0)
+        assert running == 2, stats
         assert 7 <= stats["PENDING_NODE_ASSIGNMENT"] <= 17, stats
         assert 81 <= stats["PENDING_OBJ_STORE_MEM_AVAIL"] <= 91, stats
         assert sum(stats.values()) == 100, stats

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -739,6 +739,7 @@ ray.get([a.remote(buf[0]), b.remote(buf[1])] + [c.remote(x) for x in buf[2:]])
         assert running == 2, stats
         assert 7 <= stats["PENDING_NODE_ASSIGNMENT"] <= 17, stats
         assert 81 <= stats["PENDING_OBJ_STORE_MEM_AVAIL"] <= 91, stats
+        assert set(stats.keys()).issubset({"RUNNING", "SUBMITTED_TO_WORKER", "PENDING_NODE_ASSIGNMENT", "PENDING_OBJ_STORE_MEM_AVAIL"}), stats
         assert sum(stats.values()) == 100, stats
         return True
 

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -695,10 +695,6 @@ ray.get(a)
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on macos")
-# Run repeatedly to guard against regressions in flakiness (see the SUBMITTED_TO_WORKER
-# handling in close_to_expected below).
-# XXX: remove before merging.
-@pytest.mark.parametrize("trial", range(50))
 def test_pull_manager_stats(shutdown_only, trial):
     info = ray.init(num_cpus=2, object_store_memory=100_000_000, **METRIC_CONFIG)
     timeseries = PrometheusTimeseries()

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -695,7 +695,7 @@ ray.get(a)
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on macos")
-def test_pull_manager_stats(shutdown_only, trial):
+def test_pull_manager_stats(shutdown_only):
     info = ray.init(num_cpus=2, object_store_memory=100_000_000, **METRIC_CONFIG)
     timeseries = PrometheusTimeseries()
     driver = """


### PR DESCRIPTION
Loosen task state condition to include `SUBMITTED_TO_WORKER`.