### PR TITLE
[dashboard] Fix TPU metrics

### DIFF
--- a/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx
@@ -7,7 +7,6 @@ import {
   normalizeAccelerators,
   UnifiedAcceleratorStat,
 } from "../../util/accelerator";
-import { memoryConverter } from "../../util/converter";
 
 export type NodeAcceleratorEntryProps = {
   slot: number;
@@ -45,14 +44,7 @@ const TpuTooltip = ({ tpu }: { tpu: TPUStats }) => {
         Tensorcore: {tensorcoreUtilization.toFixed(1)}%
       </Typography>
       <Typography variant="body2">
-        HBM Bandwidth: {hbmUtilization.toFixed(1)}%
-      </Typography>
-      <Typography variant="body2">
-        Used Memory: {memoryConverter(tpu.memoryUsed)} /{" "}
-        {memoryConverter(tpu.memoryTotal)}
-      </Typography>
-      <Typography variant="body2">
-        Free Memory: {memoryConverter(tpu.memoryTotal - tpu.memoryUsed)}
+        HBM Utilization: {hbmUtilization.toFixed(1)}%
       </Typography>
     </Box>
   );

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -20,7 +20,7 @@ export const NodeAcceleratorMemory = ({ node }: { node: NodeDetail }) => {
       slot: acc.index,
       // TPUs report a raw ratio which is present even in cases where the
       // absolute usage is not available.
-      percentUtil: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
+      utilRatio: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
     };
     return <AcceleratorMemoryEntry {...props} />;
   });
@@ -64,7 +64,7 @@ export const WorkerAcceleratorMemory = ({
         slot: acc.index,
         // TPUs report a raw ratio which is present even in cases where the
         // absolute usage is not available.
-        percentUtil: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
+        utilRatio: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
       };
       return <AcceleratorMemoryEntry {...props} />;
     })
@@ -112,7 +112,7 @@ type AcceleratorMemoryEntryProps = {
   slot: number;
   utilization: number;
   total: number;
-  percentUtil?: number;
+  utilRatio?: number;
 };
 
 const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
@@ -120,14 +120,14 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   slot,
   utilization,
   total,
-  percentUtil,
+  utilRatio,
 }) => {
   let ratioStr = getMemDisplayRatioNoPercent(utilization, total);
   // When the utilization percentage is present but absolute usage is missing
   // (as is the case on some TPU generations), spoof the bar with just a percentage.
-  if (percentUtil !== undefined && (total === 0 || isNaN(total))) {
-    ratioStr = `${(percentUtil * 100).toFixed(1)}%`;
-    utilization = percentUtil;
+  if (utilRatio !== undefined && (total === 0 || isNaN(total))) {
+    ratioStr = `${(utilRatio * 100).toFixed(1)}%`;
+    utilization = utilRatio;
     total = 1;
   }
   return (

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -20,7 +20,7 @@ export const NodeAcceleratorMemory = ({ node }: { node: NodeDetail }) => {
       slot: acc.index,
       // TPUs report a raw ratio which is present even in cases where the
       // absolute usage is not available.
-      utilRatio: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
+      utilPercent: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
     };
     return <AcceleratorMemoryEntry {...props} />;
   });
@@ -64,7 +64,7 @@ export const WorkerAcceleratorMemory = ({
         slot: acc.index,
         // TPUs report a raw ratio which is present even in cases where the
         // absolute usage is not available.
-        utilRatio: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
+        utilPercent: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
       };
       return <AcceleratorMemoryEntry {...props} />;
     })
@@ -112,7 +112,7 @@ type AcceleratorMemoryEntryProps = {
   slot: number;
   utilization: number;
   total: number;
-  utilRatio?: number;
+  utilPercent?: number;
 };
 
 const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
@@ -120,15 +120,15 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   slot,
   utilization,
   total,
-  utilRatio,
+  utilPercent,
 }) => {
   let ratioStr = getMemDisplayRatioNoPercent(utilization, total);
   // When the utilization percentage is present but absolute usage is missing
   // (as is the case on some TPU generations), spoof the bar with just a percentage.
-  if (utilRatio !== undefined && (total === 0 || isNaN(total))) {
-    ratioStr = `${(utilRatio * 100).toFixed(1)}%`;
-    utilization = utilRatio;
-    total = 1;
+  if (utilPercent !== undefined && (total === 0 || isNaN(total))) {
+    ratioStr = `${utilPercent.toFixed(1)}%`;
+    utilization = utilPercent;
+    total = 100;
   }
   return (
     <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -14,10 +14,13 @@ export const NodeAcceleratorMemory = ({ node }: { node: NodeDetail }) => {
   const nodeGRAMEntries = accelerators.map((acc, i) => {
     const props = {
       key: acc.uuid || acc.name + acc.index,
-      gpuName: acc.name, // Displaying original name is fine, tooltip will use it. Or we could customize tooltip.
+      gpuName: acc.name,
       utilization: acc.memoryUsed,
       total: acc.memoryTotal,
       slot: acc.index,
+      // TPUs report a raw ratio which is present even in cases where the
+      // absolute usage is not available.
+      percentUtil: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
     };
     return <AcceleratorMemoryEntry {...props} />;
   });
@@ -57,8 +60,11 @@ export const WorkerAcceleratorMemory = ({
         key: acc.uuid || acc.name + acc.index,
         gpuName: acc.name,
         total: acc.memoryTotal,
-        utilization: process.memoryUsage, // This is already unified
+        utilization: process.memoryUsage,
         slot: acc.index,
+        // TPUs report a raw ratio which is present even in cases where the
+        // absolute usage is not available.
+        percentUtil: acc.rawTpu ? acc.rawTpu.hbmUtilization : undefined,
       };
       return <AcceleratorMemoryEntry {...props} />;
     })
@@ -106,6 +112,7 @@ type AcceleratorMemoryEntryProps = {
   slot: number;
   utilization: number;
   total: number;
+  percentUtil?: number;
 };
 
 const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
@@ -113,8 +120,16 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   slot,
   utilization,
   total,
+  percentUtil,
 }) => {
-  const ratioStr = getMemDisplayRatioNoPercent(utilization, total);
+  let ratioStr = getMemDisplayRatioNoPercent(utilization, total);
+  // When the utilization percentage is present but absolute usage is missing
+  // (as is the case on some TPU generations), spoof the bar with just a percentage.
+  if (percentUtil !== undefined && (total === 0 || isNaN(total))) {
+    ratioStr = `${(percentUtil*100).toFixed(1)}%`
+    utilization = percentUtil
+    total = 1
+  }
   return (
     <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -126,9 +126,9 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   // When the utilization percentage is present but absolute usage is missing
   // (as is the case on some TPU generations), spoof the bar with just a percentage.
   if (percentUtil !== undefined && (total === 0 || isNaN(total))) {
-    ratioStr = `${(percentUtil*100).toFixed(1)}%`
-    utilization = percentUtil
-    total = 1
+    ratioStr = `${(percentUtil * 100).toFixed(1)}%`;
+    utilization = percentUtil;
+    total = 1;
   }
   return (
     <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>

--- a/python/ray/dashboard/client/src/util/accelerator.test.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.test.ts
@@ -57,12 +57,11 @@ describe("normalizeAccelerators", () => {
       utilization: 90,
       memoryUsed: 1024, // Converted to MiB
       memoryTotal: 4096, // Converted to MiB
-      processesPids: [{ pid: 456, memoryUsage: 512 }], // Converted to MiB
       rawTpu: tpus[0],
     });
   });
 
-  it("filters out tpus with <= 0 memoryTotal", () => {
+  it("does not filter out tpus with <= 0 memoryTotal", () => {
     const tpus: TPUStats[] = [
       {
         name: "tpu-1",
@@ -76,7 +75,25 @@ describe("normalizeAccelerators", () => {
     ];
 
     const result = normalizeAccelerators(undefined, tpus);
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+  });
+
+  it("handles missing memory metrics for tpus", () => {
+    const tpus: any[] = [
+      {
+        name: "tpu-1",
+        index: 0,
+        tpuType: "v5e",
+        tpuTopology: "2x2",
+        tensorcoreUtilization: 90,
+        // memoryUsed and memoryTotal missing
+      },
+    ];
+
+    const result = normalizeAccelerators(undefined, tpus as TPUStats[]);
+    expect(result).toHaveLength(1);
+    expect(result[0].memoryUsed).toBeNaN();
+    expect(result[0].memoryTotal).toBeNaN();
   });
 
   it("combines both gpus and tpus", () => {

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -1,8 +1,4 @@
-import {
-  GPUStats,
-  ProcessGPUUsage,
-  TPUStats,
-} from "../type/node";
+import { GPUStats, ProcessGPUUsage, TPUStats } from "../type/node";
 
 export type UnifiedProcessAcceleratorUsage = {
   pid: number;

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -1,7 +1,6 @@
 import {
   GPUStats,
   ProcessGPUUsage,
-  ProcessTPUUsage,
   TPUStats,
 } from "../type/node";
 
@@ -48,24 +47,15 @@ export const normalizeAccelerators = (
   }
   if (tpus) {
     tpus.forEach((tpu) => {
-      if (tpu.memoryTotal <= 0) {
-        // Sometimes neighboring chips are reported with placeholders like no
-        // memory capacity; these should be omitted on the dashboard.
-        return;
-      }
       normalized.push({
         name: tpu.name,
         index: tpu.index,
         type: "TPU",
         utilization: tpu.tensorcoreUtilization,
-        // Convert Bytes to MiB to match GPUStats
+        // Convert Bytes to MiB to match GPUStats.
+        // Note these metrics are missing on some TPU types.
         memoryUsed: tpu.memoryUsed / (1024 * 1024),
         memoryTotal: tpu.memoryTotal / (1024 * 1024),
-        processesPids: tpu.processesPids?.map((p: ProcessTPUUsage) => ({
-          pid: p.pid,
-          // ProcessTPUUsage memory is also in bytes, convert if present
-          memoryUsage: p.tpuMemoryUsage / (1024 * 1024),
-        })),
         rawTpu: tpu,
       });
     });

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -807,7 +807,7 @@ class ReporterAgent(
                         continue
                     labels = sample.labels
                     accelerator_id = labels["accelerator_id"]
-                    index = accelerator_id.split("-")[1]
+                    index = int(accelerator_id.split("-")[1])
 
                     info = TpuUtilizationInfo(
                         index=index,
@@ -848,8 +848,8 @@ class ReporterAgent(
             logger.debug(f"Failed to parse metrics from device plugin: {metrics} {e}")
             return []
 
-        desired_indices = sorted({int(i["index"]) for i in tpu_utilizations_host})
-        rewrite_indices = sorted({int(i["index"]) for i in tpu_utilizations_other})
+        desired_indices = sorted({i["index"] for i in tpu_utilizations_host})
+        rewrite_indices = sorted({i["index"] for i in tpu_utilizations_other})
 
         # Some TPU types do not have runtime metrics reported from the device
         # plugin and the rewrite_indices list will be empty.
@@ -860,7 +860,7 @@ class ReporterAgent(
                 )
                 return []
 
-            index_map = dict(zip(map(str, rewrite_indices), map(str, desired_indices)))
+            index_map = dict(zip(rewrite_indices, desired_indices))
             for info in tpu_utilizations_other:
                 info["index"] = index_map[info["index"]]
 

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -848,8 +848,8 @@ class ReporterAgent(
             logger.debug(f"Failed to parse metrics from device plugin: {metrics} {e}")
             return []
 
-        desired_indices = sorted(list({int(i["index"]) for i in tpu_utilizations_host}))
-        rewrite_indices = sorted(list({int(i["index"]) for i in tpu_utilizations_other}))
+        desired_indices = sorted({int(i["index"]) for i in tpu_utilizations_host})
+        rewrite_indices = sorted({int(i["index"]) for i in tpu_utilizations_other})
 
         # Some TPU types do not have runtime metrics reported from the device
         # plugin and the rewrite_indices list will be empty.

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -783,10 +783,20 @@ class ReporterAgent(
             return []
 
         tpu_utilizations = []
-        # Sample should look like:
-        # Name: tensorcore_utilization_node Labels: {'accelerator_id': '4804690994094478883-0', 'make': 'cloud-tpu', 'model': 'tpu-v6e-slice', 'tpu_topology': '2x4'} Value: 0.0
+        # TPU metrics have a quirk where tensor core and memory bandwidth
+        # metrics are host metrics and indexed by chip 0 to N-1, while the
+        # other metrics are runtime metrics and are indexed globally in the
+        # slice.
+        # To make these useful in the dashboard, we want to re-canonicalize the
+        # global indices onto the local host indices.
+        # We partition the metrics into two groups to perform this re-indexing.
+        tpu_utilizations_host = []
+        tpu_utilizations_other = []
+
         # See https://cloud.google.com/monitoring/api/metrics_gcp#gcp-tpu for
         # schema.
+        # Sample should look like:
+        # Name: tensorcore_utilization_node Labels: {'accelerator_id': '4804690994094478883-0', 'make': 'cloud-tpu', 'model': 'tpu-v6e-slice', 'tpu_topology': '2x4'} Value: 0.0
         try:
             for family in text_string_to_metric_families(metrics):
                 for sample in family.samples:
@@ -812,25 +822,49 @@ class ReporterAgent(
                     )
 
                     known = True
+                    is_host_metric = False
                     match sample.name:
                         case "memory_bandwidth_utilization":
-                            info.hbm_utilization = sample.value
+                            info["hbm_utilization"] = sample.value
+                            is_host_metric = True
                         case "tensorcore_utilization":
-                            info.tensorcore_utilization = sample.value
+                            info["tensorcore_utilization"] = sample.value
+                            is_host_metric = True
                         case "duty_cycle":
-                            info.duty_cycle = sample.value
+                            info["duty_cycle"] = sample.value
                         case "memory_used":
-                            info.memory_used = sample.value
+                            info["memory_used"] = sample.value
                         case "memory_total":
-                            info.memory_total = sample.value
+                            info["memory_total"] = sample.value
                         case _:
                             known = False
 
                     if known:
-                        tpu_utilizations.append(info)
+                        if is_host_metric:
+                            tpu_utilizations_host.append(info)
+                        else:
+                            tpu_utilizations_other.append(info)
         except Exception as e:
             logger.debug(f"Failed to parse metrics from device plugin: {metrics} {e}")
             return []
+
+        desired_indices = sorted(list({int(i["index"]) for i in tpu_utilizations_host}))
+        rewrite_indices = sorted(list({int(i["index"]) for i in tpu_utilizations_other}))
+
+        # Some TPU types do not have runtime metrics reported from the device
+        # plugin and the rewrite_indices list will be empty.
+        if len(rewrite_indices) > 0:
+            if len(rewrite_indices) != len(desired_indices):
+                logger.warning(
+                    f"Failed to parse metrics from device plugin: two sets of metrics for different chip counts, {len(desired_indices)} vs {len(rewrite_indices)}"
+                )
+                return []
+
+            index_map = dict(zip(map(str, rewrite_indices), map(str, desired_indices)))
+            for info in tpu_utilizations_other:
+                info["index"] = index_map[info["index"]]
+
+        tpu_utilizations = tpu_utilizations_host + tpu_utilizations_other
 
         # Each collected sample records only one metric (e.g. duty cycle) during
         # the metric interval for one TPU. So here we need to aggregate the

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -799,74 +799,34 @@ class ReporterAgent(
                     accelerator_id = labels["accelerator_id"]
                     index = accelerator_id.split("-")[1]
 
-                    if sample.name == "memory_bandwidth_utilization":
-                        info = TpuUtilizationInfo(
-                            index=index,
-                            name=accelerator_id,
-                            tpu_type=labels["model"],
-                            tpu_topology=labels["tpu_topology"],
-                            tensorcore_utilization=0.0,
-                            hbm_utilization=sample.value,
-                            duty_cycle=0.0,
-                            memory_used=0,
-                            memory_total=0,
-                        )
-                        tpu_utilizations.append(info)
+                    info = TpuUtilizationInfo(
+                        index=index,
+                        name=accelerator_id,
+                        tpu_type=labels["model"],
+                        tpu_topology=labels["tpu_topology"],
+                        tensorcore_utilization=0.0,
+                        hbm_utilization=0.0,
+                        duty_cycle=0.0,
+                        memory_used=0,
+                        memory_total=0,
+                    )
 
-                    if sample.name == "tensorcore_utilization":
-                        info = TpuUtilizationInfo(
-                            index=index,
-                            name=accelerator_id,
-                            tpu_type=labels["model"],
-                            tpu_topology=labels["tpu_topology"],
-                            tensorcore_utilization=sample.value,
-                            hbm_utilization=0.0,
-                            duty_cycle=0.0,
-                            memory_used=0,
-                            memory_total=0,
-                        )
-                        tpu_utilizations.append(info)
+                    known = True
+                    match sample.name:
+                        case "memory_bandwidth_utilization":
+                            info.hbm_utilization = sample.value
+                        case "tensorcore_utilization":
+                            info.tensorcore_utilization = sample.value
+                        case "duty_cycle":
+                            info.duty_cycle = sample.value
+                        case "memory_used":
+                            info.memory_used = sample.value
+                        case "memory_total":
+                            info.memory_total = sample.value
+                        case _:
+                            known = False
 
-                    if sample.name == "duty_cycle":
-                        info = TpuUtilizationInfo(
-                            index=index,
-                            name=accelerator_id,
-                            tpu_type=labels["model"],
-                            tpu_topology=labels["tpu_topology"],
-                            tensorcore_utilization=0.0,
-                            hbm_utilization=0.0,
-                            duty_cycle=sample.value,
-                            memory_used=0,
-                            memory_total=0,
-                        )
-                        tpu_utilizations.append(info)
-
-                    if sample.name == "memory_used":
-                        info = TpuUtilizationInfo(
-                            index=index,
-                            name=accelerator_id,
-                            tpu_type=labels["model"],
-                            tpu_topology=labels["tpu_topology"],
-                            tensorcore_utilization=0.0,
-                            hbm_utilization=0.0,
-                            duty_cycle=0.0,
-                            memory_used=sample.value,
-                            memory_total=0,
-                        )
-                        tpu_utilizations.append(info)
-
-                    if sample.name == "memory_total":
-                        info = TpuUtilizationInfo(
-                            index=index,
-                            name=accelerator_id,
-                            tpu_type=labels["model"],
-                            tpu_topology=labels["tpu_topology"],
-                            tensorcore_utilization=0.0,
-                            hbm_utilization=0.0,
-                            duty_cycle=0.0,
-                            memory_used=0,
-                            memory_total=sample.value,
-                        )
+                    if known:
                         tpu_utilizations.append(info)
         except Exception as e:
             logger.debug(f"Failed to parse metrics from device plugin: {metrics} {e}")

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -705,7 +705,7 @@ def test_get_tpu_usage(tmp_path):
 
             expected_utilizations = [
                 TpuUtilizationInfo(
-                    index="0",
+                    index=0,
                     name="1234-0",
                     tpu_type="tpu-v6e-slice",
                     tpu_topology="2x2",
@@ -716,7 +716,7 @@ def test_get_tpu_usage(tmp_path):
                     memory_total=4000,
                 ),
                 TpuUtilizationInfo(
-                    index="1",
+                    index=1,
                     name="1234-1",
                     tpu_type="tpu-v6e-slice",
                     tpu_topology="2x2",
@@ -775,9 +775,9 @@ def test_get_tpu_usage_idle_and_duplicates(tmp_path):
             # Should have 4 unique TPUs
             assert len(tpu_utilizations) == 4
             # Verify mapping (10 mapped to 0, 11 to 1, etc.)
-            assert tpu_utilizations[0]["index"] == "0"
+            assert tpu_utilizations[0]["index"] == 0
             assert tpu_utilizations[0]["memory_total"] == 4000
-            assert tpu_utilizations[3]["index"] == "3"
+            assert tpu_utilizations[3]["index"] == 3
             assert tpu_utilizations[3]["memory_total"] == 4000
 
 

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -730,6 +730,57 @@ def test_get_tpu_usage(tmp_path):
             assert tpu_utilizations == expected_utilizations
 
 
+def test_get_tpu_usage_idle_and_duplicates(tmp_path):
+    dashboard_agent = MagicMock()
+    dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
+    raylet_client = MagicMock()
+    agent = ReporterAgent(dashboard_agent, raylet_client)
+
+    # 4 TPUs, all idle (0.0 utilization)
+    # Utilization metrics use indices 0-3
+    # Other metrics use indices 10, 11, 14, 15
+    # Also includes duplicate samples for index 0 and 10 to test robustness.
+    fake_metrics_content = """
+    # Duplicate samples for duty_cycle index 10
+    duty_cycle{accelerator_id="1234-10",container="ray-worker",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    duty_cycle{accelerator_id="1234-10",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    duty_cycle{accelerator_id="1234-11",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    duty_cycle{accelerator_id="1234-14",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    duty_cycle{accelerator_id="1234-15",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    # Duplicate samples for tensorcore_utilization index 0
+    tensorcore_utilization{accelerator_id="1234-0",container="ray-worker",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    tensorcore_utilization{accelerator_id="1234-0",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    tensorcore_utilization{accelerator_id="1234-1",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    tensorcore_utilization{accelerator_id="1234-2",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    tensorcore_utilization{accelerator_id="1234-3",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 0.0
+    # Memory metrics
+    memory_total{accelerator_id="1234-10",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 4000
+    memory_total{accelerator_id="1234-11",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 4000
+    memory_total{accelerator_id="1234-14",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 4000
+    memory_total{accelerator_id="1234-15",make="cloud-tpu",model="v6e",tpu_topology="2x2"} 4000
+    """
+    with patch.multiple(
+        "ray.dashboard.modules.reporter.reporter_agent",
+        TPU_DEVICE_PLUGIN_ADDR="localhost:2112",
+    ):
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.content = fake_metrics_content.encode("utf-8")
+            mock_get.return_value = mock_response
+
+            tpu_utilizations = agent._get_tpu_usage()
+
+            # Should have 4 unique TPUs
+            assert len(tpu_utilizations) == 4
+            # Verify mapping (10 mapped to 0, 11 to 1, etc.)
+            assert tpu_utilizations[0]["index"] == "0"
+            assert tpu_utilizations[0]["memory_total"] == 4000
+            assert tpu_utilizations[3]["index"] == "3"
+            assert tpu_utilizations[3]["memory_total"] == 4000
+
+
 def test_report_stats_tpu(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)


### PR DESCRIPTION
## Description

Metrics from the TPU device plugin have some quirks that cause issues for the
dashboard:

1. Tensor core and memory bandwidth utilization are indexed by host (i.e. zero
   to N-1 where N is chips per host), while the other metrics are "runtime
   metrics" and indexed across the complete running slice. They will sometimes
   but almost never line up precisely.
2. V7X clusters I've tested against only have the host metrics, which means the
   dashboard must gracefully degrade to show memory utilization without absolute
   byte info.

To work around this, the reporter agent can re-index the non-host metrics to
share the same indices as the host metrics by assigning them in-order.

Additionally, I've cleaned the TPU path for the accelerator rows to gracefully
degrade on the missing metrics paths.

## Related issues

- Addresses bugs in #63774
- To unblock chip-to-pid mapping in #63976

## Additional information

Example dashboard with correct chip ids and absolute memory:
<img width="1473" height="1057" alt="image" src="https://github.com/user-attachments/assets/06b8d492-4db8-4247-99ea-72daef66716b" />


Example dashboard missing absolute GiB memory (some 0.0 rows show different visual bars because it was animating while screenshotting): 
<img width="1378" height="1120" alt="image" src="https://github.com/user-attachments/assets/f807bcbf-0c7a-4fa7-a8e3-94c25ad16e0b" />