### PR TITLE
[ci] Remove temp --run-flaky-tests from ml torch trainer tests step

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -96,14 +96,9 @@ steps:
     tags: train
     instance_type: small
     commands:
-      # TEMP: --run-flaky-tests forces the flaky-classified torchft target to
-      # run (intersection with the flaky set) so we get a real pass/fail signal
-      # for the gloo-timeout fix. REVERT before merge -- once the test is
-      # un-flaked this flips to "No tests to run".
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml
         --python-version 3.10 --build-name mltorchft-py3.10
         --only-tags torchft
-        --run-flaky-tests
         --except-tags needs_credentials,data_integration
     depends_on: [ "mltorchft", "forge" ]
 


### PR DESCRIPTION
The "ml: train v2 torch trainer tests (torchft image)" step had a TEMP --run-flaky-tests flag added to force the flaky-classified torchft target to run. The test (//python/ray/train/v2:test_torch_trainer) is now passing in the test DB, so revert to normal behavior: run torchft targets minus the flaky set. The flaky variant of this step is unaffected.