### PR TITLE
[Core] Add ray_num_submissible_tasks and ray_submissible_task_spec_bytes metrics

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -479,6 +479,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
       gcs_client,
       *task_by_state_gauge_,
       *total_lineage_bytes_gauge_,
+      *num_submissible_tasks_gauge_,
+      *submissible_task_spec_bytes_gauge_,
       /*free_actor_object_callback=*/
       [this](const ObjectID &object_id) {
         auto core_worker = GetCoreWorker();
@@ -823,6 +825,10 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
       new ray::stats::Gauge(GetActorByStateGaugeMetric()));
   total_lineage_bytes_gauge_ = std::unique_ptr<ray::stats::Gauge>(
       new ray::stats::Gauge(GetTotalLineageBytesGaugeMetric()));
+  num_submissible_tasks_gauge_ = std::unique_ptr<ray::stats::Gauge>(
+      new ray::stats::Gauge(GetNumSubmissibleTasksGaugeMetric()));
+  submissible_task_spec_bytes_gauge_ = std::unique_ptr<ray::stats::Gauge>(
+      new ray::stats::Gauge(GetSubmissibleTaskSpecBytesGaugeMetric()));
   owned_objects_counter_ = std::unique_ptr<ray::stats::Gauge>(
       new ray::stats::Gauge(GetOwnedObjectsByStateGaugeMetric()));
   owned_objects_size_counter_ = std::unique_ptr<ray::stats::Gauge>(

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -188,6 +188,8 @@ class CoreWorkerProcessImpl {
   std::unique_ptr<ray::stats::Gauge> task_by_state_gauge_;
   std::unique_ptr<ray::stats::Gauge> actor_by_state_gauge_;
   std::unique_ptr<ray::stats::Gauge> total_lineage_bytes_gauge_;
+  std::unique_ptr<ray::stats::Gauge> num_submissible_tasks_gauge_;
+  std::unique_ptr<ray::stats::Gauge> submissible_task_spec_bytes_gauge_;
   std::unique_ptr<ray::stats::Gauge> owned_objects_counter_;
   std::unique_ptr<ray::stats::Gauge> owned_objects_size_counter_;
   std::unique_ptr<ray::stats::PercentileMetric> scheduler_placement_time_percentile_ms_;

--- a/src/ray/core_worker/metrics.h
+++ b/src/ray/core_worker/metrics.h
@@ -75,6 +75,30 @@ inline ray::stats::Gauge GetTotalLineageBytesGaugeMetric() {
   };
 }
 
+inline ray::stats::Gauge GetNumSubmissibleTasksGaugeMetric() {
+  return ray::stats::Gauge{
+      /*name=*/"num_submissible_tasks",
+      /*description=*/
+      "Number of tasks currently in TaskManager's submissible_tasks_ map. "
+      "Includes both pending-execution tasks and completed tasks retained for "
+      "lineage reconstruction. High values indicate many task specs are buffered.",
+      /*unit=*/"",
+      /*tag_keys=*/{},
+  };
+}
+
+inline ray::stats::Gauge GetSubmissibleTaskSpecBytesGaugeMetric() {
+  return ray::stats::Gauge{
+      /*name=*/"submissible_task_spec_bytes",
+      /*description=*/
+      "Total serialized protobuf byte size of TaskSpecifications currently held in "
+      "TaskManager's submissible_tasks_ map. This is a proxy for task-spec payload "
+      "size and does not include C++ object, allocator, or hash-map overhead.",
+      /*unit=*/"",
+      /*tag_keys=*/{},
+  };
+}
+
 inline std::unique_ptr<ray::stats::PercentileMetric>
 GetSchedulerPlacementTimePercentileMsMetric() {
   return std::make_unique<ray::stats::PercentileMetric>(

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -336,6 +336,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     auto inserted = submissible_tasks_.try_emplace(
         spec.TaskId(), spec, max_retries, num_returns, task_counter_, max_oom_retries);
     RAY_CHECK(inserted.second);
+    total_submissible_task_bytes_ += inserted.first->second.spec_byte_size_;
     num_pending_tasks_++;
   }
 
@@ -1071,7 +1072,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
             total_lineage_footprint_bytes_ - (max_lineage_bytes_ / 2);
       }
     } else {
-      submissible_tasks_.erase(it);
+      EraseSubmissibleTask(it);
     }
   }
 
@@ -1310,7 +1311,7 @@ void TaskManager::FailPendingTask(const TaskID &task_id,
                     rpc::TaskStatus::FAILED,
                     worker::TaskStatusEvent::TaskStateUpdate(error_info));
     }
-    submissible_tasks_.erase(it);
+    EraseSubmissibleTask(it);
     num_pending_tasks_--;
 
     // Throttled logging of task failure errors.
@@ -1485,7 +1486,7 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
     total_lineage_footprint_bytes_ -= it->second.lineage_footprint_bytes_;
     // The task has finished and none of the return IDs are in scope anymore,
     // so it is safe to remove the task spec.
-    submissible_tasks_.erase(it);
+    EraseSubmissibleTask(it);
   }
 
   return total_lineage_footprint_bytes_ - total_lineage_footprint_bytes_prev;
@@ -1807,7 +1808,15 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 void TaskManager::RecordMetrics() {
   absl::MutexLock lock(&mu_);
   total_lineage_bytes_gauge_.Record(total_lineage_footprint_bytes_);
+  num_submissible_tasks_gauge_.Record(static_cast<int64_t>(submissible_tasks_.size()));
+  submissible_task_spec_bytes_gauge_.Record(total_submissible_task_bytes_);
   task_counter_.FlushOnChangeCallbacks();
+}
+
+void TaskManager::EraseSubmissibleTask(
+    absl::flat_hash_map<TaskID, TaskEntry>::iterator it) {
+  total_submissible_task_bytes_ -= it->second.spec_byte_size_;
+  submissible_tasks_.erase(it);
 }
 
 ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -207,6 +207,8 @@ class TaskManager : public TaskManagerInterface {
       std::shared_ptr<gcs::GcsClient> gcs_client,
       ray::observability::MetricInterface &task_by_state_counter,
       ray::observability::MetricInterface &total_lineage_bytes_gauge,
+      ray::observability::MetricInterface &num_submissible_tasks_gauge,
+      ray::observability::MetricInterface &submissible_task_spec_bytes_gauge,
       FreeActorObjectCallback free_actor_object_callback,
       SetDirectTransportMetadata set_direct_transport_metadata)
       : in_memory_store_(in_memory_store),
@@ -221,6 +223,8 @@ class TaskManager : public TaskManagerInterface {
         gcs_client_(std::move(gcs_client)),
         task_by_state_counter_(task_by_state_counter),
         total_lineage_bytes_gauge_(total_lineage_bytes_gauge),
+        num_submissible_tasks_gauge_(num_submissible_tasks_gauge),
+        submissible_task_spec_bytes_gauge_(submissible_task_spec_bytes_gauge),
         free_actor_object_callback_(std::move(free_actor_object_callback)),
         set_direct_transport_metadata_(std::move(set_direct_transport_metadata)) {
     task_counter_.SetOnChangeCallback(
@@ -541,6 +545,7 @@ class TaskManager : public TaskManagerInterface {
               TaskStatusCounter &counter,
               int64_t num_oom_retries_left)
         : spec_(std::move(spec)),
+          spec_byte_size_(spec_.GetMessage().ByteSizeLong()),
           num_retries_left_(num_retries_left),
           counter_(&counter),
           num_oom_retries_left_(num_oom_retries_left),
@@ -597,6 +602,8 @@ class TaskManager : public TaskManagerInterface {
     /// TaskSpec for tasks that cannot be retried (e.g., actor tasks), or by
     /// storing a shared_ptr to a PushTaskRequest protobuf for all tasks.
     TaskSpecification spec_;
+    // Cached serialized size of spec_ in bytes; set once at construction.
+    int64_t spec_byte_size_ = 0;
     // Number of times this task may be resubmitted. If this reaches 0, then
     // the task entry may be erased.
     int32_t num_retries_left_;
@@ -640,6 +647,10 @@ class TaskManager : public TaskManagerInterface {
   // canceled.
   void MarkTaskNoRetryInternal(const TaskID &task_id, bool canceled)
       ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Erase a task from submissible_tasks_ and update total_submissible_task_bytes_.
+  void EraseSubmissibleTask(absl::flat_hash_map<TaskID, TaskEntry>::iterator it)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Update nested ref count info and store the task's return object.
   /// Returns StatusOr<bool> where the bool indicates the object was returned
@@ -814,6 +825,9 @@ class TaskManager : public TaskManagerInterface {
 
   int64_t total_lineage_footprint_bytes_ ABSL_GUARDED_BY(mu_) = 0;
 
+  // Running total of serialized TaskSpec sizes for all entries in submissible_tasks_.
+  int64_t total_submissible_task_bytes_ ABSL_GUARDED_BY(mu_) = 0;
+
   /// Optional shutdown hook to call when pending tasks all finish.
   std::function<void()> shutdown_hook_ ABSL_GUARDED_BY(mu_) = nullptr;
 
@@ -840,6 +854,12 @@ class TaskManager : public TaskManagerInterface {
   /// Metric to track the total amount of memory used to store task specs for lineage
   /// reconstruction.
   observability::MetricInterface &total_lineage_bytes_gauge_;
+
+  /// Metric to track the number of entries in submissible_tasks_.
+  observability::MetricInterface &num_submissible_tasks_gauge_;
+
+  /// Metric to track the total serialized size of TaskSpecs in submissible_tasks_.
+  observability::MetricInterface &submissible_task_spec_bytes_gauge_;
 
   /// Callback to free GPU object from the in-actor RDT store.
   FreeActorObjectCallback free_actor_object_callback_;

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -186,6 +186,8 @@ class TaskManagerTest : public ::testing::Test {
             mock_gcs_client_,
             fake_task_by_state_counter_,
             fake_total_lineage_bytes_gauge_,
+            fake_num_submissible_tasks_gauge_,
+            fake_submissible_task_spec_bytes_gauge_,
             /*free_actor_object_callback=*/[](const ObjectID &object_id) {},
             /*set_direct_transport_metadata=*/
             [](const ObjectID &, const std::string &) {}) {}
@@ -236,6 +238,8 @@ class TaskManagerTest : public ::testing::Test {
   std::unordered_set<ObjectID> stored_in_plasma;
   ray::observability::FakeGauge fake_task_by_state_counter_;
   ray::observability::FakeGauge fake_total_lineage_bytes_gauge_;
+  ray::observability::FakeGauge fake_num_submissible_tasks_gauge_;
+  ray::observability::FakeGauge fake_submissible_task_spec_bytes_gauge_;
 };
 
 class TaskManagerLineageTest : public TaskManagerTest {
@@ -1521,6 +1525,8 @@ TEST_F(TaskManagerTest, PlasmaPut_ObjectStoreFull_FailsTaskAndWritesError) {
       mock_gcs_client_,
       fake_task_by_state_counter_,
       fake_total_lineage_bytes_gauge_,
+      fake_num_submissible_tasks_gauge_,
+      fake_submissible_task_spec_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {},
       /*set_direct_transport_metadata=*/[](const ObjectID &, const std::string &) {});
 
@@ -1587,6 +1593,8 @@ TEST_F(TaskManagerTest, PlasmaPut_TransientFull_RetriesThenSucceeds) {
       mock_gcs_client_,
       fake_task_by_state_counter_,
       fake_total_lineage_bytes_gauge_,
+      fake_num_submissible_tasks_gauge_,
+      fake_submissible_task_spec_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {},
       /*set_direct_transport_metadata=*/[](const ObjectID &, const std::string &) {});
 
@@ -1651,6 +1659,8 @@ TEST_F(TaskManagerTest, DynamicReturn_PlasmaPutFailure_FailsTaskImmediately) {
       mock_gcs_client_,
       fake_task_by_state_counter_,
       fake_total_lineage_bytes_gauge_,
+      fake_num_submissible_tasks_gauge_,
+      fake_submissible_task_spec_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {},
       /*set_direct_transport_metadata=*/[](const ObjectID &, const std::string &) {});
 
@@ -3142,6 +3152,8 @@ TEST_F(TaskManagerTest, TestRetryErrorMessageSentToCallback) {
       mock_gcs_client_,
       fake_task_by_state_counter_,
       fake_total_lineage_bytes_gauge_,
+      fake_num_submissible_tasks_gauge_,
+      fake_submissible_task_spec_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {},
       /*set_direct_transport_metadata=*/[](const ObjectID &, const std::string &) {});
 
@@ -3225,6 +3237,8 @@ TEST_F(TaskManagerTest, TestErrorLogWhenPushErrorCallbackFails) {
       mock_gcs_client_,
       fake_task_by_state_counter_,
       fake_total_lineage_bytes_gauge_,
+      fake_num_submissible_tasks_gauge_,
+      fake_submissible_task_spec_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {},
       /*set_direct_transport_metadata=*/[](const ObjectID &, const std::string &) {});
 


### PR DESCRIPTION
Add two new Prometheus gauges from CoreWorker to catch large in-flight task-spec buffers.

`ray_num_submissible_tasks` — count of entries in TaskManager::submissible_tasks_ (O(1) read).

`ray_submissible_task_spec_bytes` — sum of serialized TaskSpec sizes for all entries in submissible_tasks_. Since this measures serialized TaskSpec size, it only approximates actual memory usage.