### PR TITLE
[serve] Defer application ready log after waiting for proxies to be ready

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -405,6 +405,7 @@ class ServeControllerClient:
         )
 
         handles = []
+        ready_apps = []
         for app in built_apps:
             # The deployment state is not guaranteed to be created after
             # deploy_application returns; the application state manager will
@@ -414,17 +415,27 @@ class ServeControllerClient:
 
             if wait_for_applications_running:
                 self._wait_for_application_running(app.name)
-                if app.route_prefix is not None:
-                    url_part = " at " + self._root_url + app.route_prefix
-                else:
-                    url_part = ""
-                logger.info(f"Application '{app.name}' is ready{url_part}.")
+                ready_apps.append(app)
 
             handles.append(
                 self.get_handle(
                     app.ingress_deployment_name, app.name, check_exists=False
                 )
             )
+
+        # Wait for the proxies to be serving before declaring the applications
+        # ready, so the "is ready" log line only prints once requests can
+        # actually be routed to the applications.
+        self.wait_for_proxies_serving(
+            wait_for_applications_running=wait_for_applications_running
+        )
+
+        for app in ready_apps:
+            if app.route_prefix is not None:
+                url_part = " at " + self._root_url + app.route_prefix
+            else:
+                url_part = ""
+            logger.info(f"Application '{app.name}' is ready{url_part}.")
 
         return handles
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -840,10 +840,6 @@ def _run_many(
             wait_for_ingress_deployment_creation=wait_for_ingress_deployment_creation,
             wait_for_applications_running=wait_for_applications_running,
         )
-
-        client.wait_for_proxies_serving(
-            wait_for_applications_running=wait_for_applications_running
-        )
         return handles
 
 


### PR DESCRIPTION
Log that the applications are ready after we've waiting for proxies to be serving. Before the log line would print before waiting for proxies ready, which is a bit misleading