### PR TITLE
[data] Don't invoke `ray_remote_args_fn` in `HighMemoryIssueDetector`

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -544,6 +544,15 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             #       at least 1 task
             self._try_schedule_task(bundled_input, strict=True)
 
+    def _get_static_ray_remote_args(self) -> Dict[str, Any]:
+        """Remote args without invoking ``ray_remote_args_fn``.
+
+        Unlike :meth:`_get_dynamic_ray_remote_args`, never calls
+        ``ray_remote_args_fn``, which may have side effects (e.g. the vLLM engine
+        stage's fn creates a placement group). Use for inspection-only callers.
+        """
+        return copy.deepcopy(self._ray_remote_args)
+
     def _get_dynamic_ray_remote_args(
         self, input_bundle: Optional[RefBundle] = None
     ) -> Dict[str, Any]:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -547,9 +547,9 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def _get_static_ray_remote_args(self) -> Dict[str, Any]:
         """Remote args without invoking ``ray_remote_args_fn``.
 
-        Unlike :meth:`_get_dynamic_ray_remote_args`, never calls
-        ``ray_remote_args_fn``, which may have side effects (e.g. the vLLM engine
-        stage's fn creates a placement group). Use for inspection-only callers.
+        ``ray_remote_args_fn`` may have side effects (e.g. the vLLM engine stage
+        creates a placement group), so inspection-only callers use this rather
+        than :meth:`_get_dynamic_ray_remote_args`.
         """
         return copy.deepcopy(self._ray_remote_args)
 

--- a/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
@@ -54,8 +54,11 @@ class HighMemoryIssueDetector(IssueDetector):
         self._initial_memory_requests: Dict[MapOperator, int] = {}
         for op in operators:
             if isinstance(op, MapOperator):
+                # Static args only: _get_dynamic_ray_remote_args() would invoke
+                # ray_remote_args_fn, which can have side effects (the vLLM stage's
+                # fn creates a placement group), leaking a PG per detector call.
                 self._initial_memory_requests[op] = (
-                    op._get_dynamic_ray_remote_args().get("memory") or 0
+                    op._get_static_ray_remote_args().get("memory") or 0
                 )
 
     @classmethod
@@ -85,7 +88,8 @@ class HighMemoryIssueDetector(IssueDetector):
             if op.metrics.average_max_uss_per_task is None:
                 continue
 
-            remote_args = op._get_dynamic_ray_remote_args()
+            # Static args only (no ray_remote_args_fn side effects); see __init__.
+            remote_args = op._get_static_ray_remote_args()
             num_cpus_per_task = remote_args.get("num_cpus", 1)
             max_memory_per_task = self._MEMORY_PER_CORE_ESTIMATE * num_cpus_per_task
 

--- a/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
@@ -54,9 +54,8 @@ class HighMemoryIssueDetector(IssueDetector):
         self._initial_memory_requests: Dict[MapOperator, int] = {}
         for op in operators:
             if isinstance(op, MapOperator):
-                # Static args only: _get_dynamic_ray_remote_args() would invoke
-                # ray_remote_args_fn, which can have side effects (the vLLM stage's
-                # fn creates a placement group), leaking a PG per detector call.
+                # Static args: the dynamic variant invokes ray_remote_args_fn,
+                # whose side effects (vLLM stage creates a PG) leak a PG per call.
                 self._initial_memory_requests[op] = (
                     op._get_static_ray_remote_args().get("memory") or 0
                 )
@@ -88,7 +87,7 @@ class HighMemoryIssueDetector(IssueDetector):
             if op.metrics.average_max_uss_per_task is None:
                 continue
 
-            # Static args only (no ray_remote_args_fn side effects); see __init__.
+            # Static args (avoid ray_remote_args_fn side effects); see __init__.
             remote_args = op._get_static_ray_remote_args()
             num_cpus_per_task = remote_args.get("num_cpus", 1)
             max_memory_per_task = self._MEMORY_PER_CORE_ESTIMATE * num_cpus_per_task

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -243,9 +243,8 @@ def test_high_memory_detection(
 def test_high_memory_detector_does_not_invoke_ray_remote_args_fn(
     restore_data_context,
 ):
-    # The detector must read remote args statically: invoking
-    # ``ray_remote_args_fn`` can have side effects (e.g. the vLLM engine stage's
-    # fn creates a placement group), leaking one PG per detector call.
+    # The detector must read remote args statically: ray_remote_args_fn can have
+    # side effects (the vLLM stage creates a PG), leaking a PG per detector call.
     ctx = DataContext.get_current()
     num_calls = 0
 

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -240,6 +240,40 @@ def test_high_memory_detection(
     assert should_return_issue == bool(issues)
 
 
+def test_high_memory_detector_does_not_invoke_ray_remote_args_fn(
+    restore_data_context,
+):
+    # The detector must read remote args statically: invoking
+    # ``ray_remote_args_fn`` can have side effects (e.g. the vLLM engine stage's
+    # fn creates a placement group), leaking one PG per detector call.
+    ctx = DataContext.get_current()
+    num_calls = 0
+
+    def ray_remote_args_fn():
+        nonlocal num_calls
+        num_calls += 1
+        return {}
+
+    input_data_buffer = InputDataBuffer(ctx, input_data=[])
+    map_operator = MapOperator.create(
+        map_transformer=MagicMock(),
+        input_op=input_data_buffer,
+        data_context=ctx,
+        ray_remote_args={"memory": 1},
+        ray_remote_args_fn=ray_remote_args_fn,
+    )
+    map_operator._metrics = MagicMock(average_max_uss_per_task=4 * 1024**3)
+
+    detector = HighMemoryIssueDetector(
+        dataset_id="id",
+        operators=[map_operator],
+        config=ctx.issue_detectors_config.high_memory_detector_config,
+    )
+    detector.detect()
+
+    assert num_calls == 0
+
+
 if __name__ == "__main__":
     import sys
 

--- a/release/llm_tests/batch/test_batch_multi_node_vllm.py
+++ b/release/llm_tests/batch/test_batch_multi_node_vllm.py
@@ -1,5 +1,3 @@
-import threading
-
 import pytest
 
 import ray
@@ -60,73 +58,3 @@ def test_vllm_multi_node(tp_size, pp_size):
     outs = ds.take_all()
     assert len(outs) == 60
     assert all("resp" in out for out in outs)
-
-
-def test_vllm_engine_no_pg_double_reservation():
-    """Regression test for GPU placement-group double-reservation.
-
-    A single ``tensor_parallel_size=N`` replica must reserve exactly ``N`` GPUs
-    in one placement group. Previously ``HighMemoryIssueDetector`` invoked the
-    engine stage's ``ray_remote_args_fn``, leaking an extra PG that reserved
-    ``N`` idle GPUs and could starve other replicas (stuck "pending creation").
-    """
-    tp_size = 2
-    config = vLLMEngineProcessorConfig(
-        model_source="facebook/opt-1.3b",
-        engine_kwargs=dict(
-            tensor_parallel_size=tp_size,
-            distributed_executor_backend="ray",
-            max_num_batched_tokens=4096,
-            gpu_memory_utilization=0.6,
-        ),
-        tokenize=False,
-        detokenize=False,
-        concurrency=1,
-        batch_size=16,
-        apply_chat_template=False,
-    )
-    processor = build_processor(
-        config,
-        preprocess=lambda row: dict(
-            prompt=f"You are a calculator. {row['id']} ** 3 = ?",
-            sampling_params=dict(temperature=0.3, max_tokens=20, detokenize=True),
-        ),
-        postprocess=lambda row: dict(resp=row["generated_text"]),
-    )
-
-    ray.init(address="auto", ignore_reinit_error=True)
-    pre_existing = set(ray.util.placement_group_table())
-    peak = {"pgs": 0, "gpus": 0}
-    stop = threading.Event()
-
-    def monitor():
-        # Track the peak count of CREATED GPU placement groups (and GPUs they
-        # reserve) created by this run.
-        while not stop.is_set():
-            pgs = gpus = 0
-            for pg_id, info in ray.util.placement_group_table().items():
-                if pg_id in pre_existing or info.get("state") != "CREATED":
-                    continue
-                n = sum(b.get("GPU", 0) for b in (info.get("bundles") or {}).values())
-                if n:
-                    pgs += 1
-                    gpus += n
-            peak["pgs"], peak["gpus"] = max(peak["pgs"], pgs), max(peak["gpus"], gpus)
-            stop.wait(1.0)
-
-    thread = threading.Thread(target=monitor, daemon=True)
-    thread.start()
-    try:
-        ds = ray.data.range(60)
-        ds = processor(ds).materialize()
-        outs = ds.take_all()
-    finally:
-        stop.set()
-        thread.join(timeout=5)
-
-    assert len(outs) == 60
-    assert all("resp" in out for out in outs)
-    assert peak["gpus"] == tp_size and peak["pgs"] == 1, (
-        f"tp={tp_size} replica reserved {peak['gpus']} GPUs across {peak['pgs']} "
-        f"placement groups; expected {tp_size} GPUs in 1 PG (PG double-reservation)"
-    )

--- a/release/llm_tests/batch/test_batch_multi_node_vllm.py
+++ b/release/llm_tests/batch/test_batch_multi_node_vllm.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 import ray
@@ -58,3 +60,73 @@ def test_vllm_multi_node(tp_size, pp_size):
     outs = ds.take_all()
     assert len(outs) == 60
     assert all("resp" in out for out in outs)
+
+
+def test_vllm_engine_no_pg_double_reservation():
+    """Regression test for GPU placement-group double-reservation.
+
+    A single ``tensor_parallel_size=N`` replica must reserve exactly ``N`` GPUs
+    in one placement group. Previously ``HighMemoryIssueDetector`` invoked the
+    engine stage's ``ray_remote_args_fn``, leaking an extra PG that reserved
+    ``N`` idle GPUs and could starve other replicas (stuck "pending creation").
+    """
+    tp_size = 2
+    config = vLLMEngineProcessorConfig(
+        model_source="facebook/opt-1.3b",
+        engine_kwargs=dict(
+            tensor_parallel_size=tp_size,
+            distributed_executor_backend="ray",
+            max_num_batched_tokens=4096,
+            gpu_memory_utilization=0.6,
+        ),
+        tokenize=False,
+        detokenize=False,
+        concurrency=1,
+        batch_size=16,
+        apply_chat_template=False,
+    )
+    processor = build_processor(
+        config,
+        preprocess=lambda row: dict(
+            prompt=f"You are a calculator. {row['id']} ** 3 = ?",
+            sampling_params=dict(temperature=0.3, max_tokens=20, detokenize=True),
+        ),
+        postprocess=lambda row: dict(resp=row["generated_text"]),
+    )
+
+    ray.init(address="auto", ignore_reinit_error=True)
+    pre_existing = set(ray.util.placement_group_table())
+    peak = {"pgs": 0, "gpus": 0}
+    stop = threading.Event()
+
+    def monitor():
+        # Track the peak count of CREATED GPU placement groups (and GPUs they
+        # reserve) created by this run.
+        while not stop.is_set():
+            pgs = gpus = 0
+            for pg_id, info in ray.util.placement_group_table().items():
+                if pg_id in pre_existing or info.get("state") != "CREATED":
+                    continue
+                n = sum(b.get("GPU", 0) for b in (info.get("bundles") or {}).values())
+                if n:
+                    pgs += 1
+                    gpus += n
+            peak["pgs"], peak["gpus"] = max(peak["pgs"], pgs), max(peak["gpus"], gpus)
+            stop.wait(1.0)
+
+    thread = threading.Thread(target=monitor, daemon=True)
+    thread.start()
+    try:
+        ds = ray.data.range(60)
+        ds = processor(ds).materialize()
+        outs = ds.take_all()
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+    assert len(outs) == 60
+    assert all("resp" in out for out in outs)
+    assert peak["gpus"] == tp_size and peak["pgs"] == 1, (
+        f"tp={tp_size} replica reserved {peak['gpus']} GPUs across {peak['pgs']} "
+        f"placement groups; expected {tp_size} GPUs in 1 PG (PG double-reservation)"
+    )

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -1,5 +1,6 @@
-import sys
 import logging
+import sys
+import threading
 import time
 
 import pytest
@@ -773,6 +774,75 @@ def test_vllm_autoscaling_no_starvation():
     assert all("id" in out for out in results)
     assert all(out.get("resp_1") for out in results)
     assert all(out.get("resp_2") for out in results)
+
+
+def test_vllm_engine_no_pg_double_reservation():
+    """Regression test for GPU placement-group double-reservation.
+
+    A single ``tensor_parallel_size=N`` replica must reserve exactly ``N`` GPUs
+    in one placement group. Previously ``HighMemoryIssueDetector`` invoked the
+    engine stage's ``ray_remote_args_fn``, leaking an extra PG that reserved
+    ``N`` idle GPUs and could starve other replicas (stuck "pending creation").
+    """
+    tp_size = 2
+    config = vLLMEngineProcessorConfig(
+        model_source="facebook/opt-1.3b",
+        engine_kwargs=dict(
+            tensor_parallel_size=tp_size,
+            distributed_executor_backend="ray",
+            max_num_batched_tokens=4096,
+            gpu_memory_utilization=0.6,
+        ),
+        tokenize=False,
+        detokenize=False,
+        concurrency=1,
+        batch_size=16,
+        apply_chat_template=False,
+    )
+    processor = build_processor(
+        config,
+        preprocess=lambda row: dict(
+            prompt=f"You are a calculator. {row['id']} ** 3 = ?",
+            sampling_params=dict(temperature=0.3, max_tokens=20, detokenize=True),
+        ),
+        postprocess=lambda row: dict(resp=row["generated_text"]),
+    )
+
+    ray.init(address="auto", ignore_reinit_error=True)
+    pre_existing = set(ray.util.placement_group_table())
+    peak = {"pgs": 0, "gpus": 0}
+    stop = threading.Event()
+
+    def monitor():
+        # Track peak CREATED GPU placement groups (and GPUs reserved) for this run.
+        while not stop.is_set():
+            pgs = gpus = 0
+            for pg_id, info in ray.util.placement_group_table().items():
+                if pg_id in pre_existing or info.get("state") != "CREATED":
+                    continue
+                n = sum(b.get("GPU", 0) for b in (info.get("bundles") or {}).values())
+                if n:
+                    pgs += 1
+                    gpus += n
+            peak["pgs"], peak["gpus"] = max(peak["pgs"], pgs), max(peak["gpus"], gpus)
+            stop.wait(1.0)
+
+    thread = threading.Thread(target=monitor, daemon=True)
+    thread.start()
+    try:
+        ds = ray.data.range(60)
+        ds = processor(ds).materialize()
+        outs = ds.take_all()
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+    assert len(outs) == 60
+    assert all("resp" in out for out in outs)
+    assert peak["gpus"] == tp_size and peak["pgs"] == 1, (
+        f"tp={tp_size} replica reserved {peak['gpus']} GPUs across {peak['pgs']} "
+        f"placement groups; expected {tp_size} GPUs in 1 PG (PG double-reservation)"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`HighMemoryIssueDetector` reads each `MapOperator`'s remote args via `op._get_dynamic_ray_remote_args()`, which invokes the operator's `ray_remote_args_fn`. For the Ray Data LLM vLLM engine stage, **that function has a side effect: it creates a GPU placement group.**

### What is `ray_remote_args_fn` here?
The vLLM engine stage (`vllm_engine_stage.py`) sets `ray_remote_args_fn = _ray_scheduling_strategy_fn`. That function calls `ray.util.placement_group(...)` with `tp*pp` GPU bundles **on every call** and returns it as the actor's scheduling strategy.

This is correct for the normal path: Ray Data runs `concurrency` engine replicas as an actor pool and calls `ray_remote_args_fn` once per actor to mint a fresh per-replica PG.

### Why the detector triggers it
`_get_dynamic_ray_remote_args()` calls `ray_remote_args_fn`, so each detector call mints an **orphan PG** that nothing schedules into. And the detector runs by default on every execution:
- `IssueDetectionExecutionCallback.before_execution_starts`
- `IssueDetectorManager.__init__`
- `HighMemoryIssueDetector.__init__`
- Calls `ray_remote_args_fn` once per `MapOperator` at the start of every `.materialize()`.
- `HighMemoryIssueDetector.detect()` calls it again on each detection interval (default 30s).

Each leaked PG reserves `tp*pp` GPUs. For a single `tensor_parallel_size=N` replica this **doubles** the GPU reservation and on a tightly-sized cluster the leaked PG sits stuck in "pending creation", starving the real replicas.

## Solution

- Add `MapOperator._get_static_ray_remote_args()`, which returns a copy of the static `_ray_remote_args` **without** invoking `ray_remote_args_fn`
- Use it in `HighMemoryIssueDetector` (both `__init__` and `detect()`)

## Long-term solution

The deeper issue is that PG creation is a **side effect hidden behind a getter** (`ray_remote_args_fn`), whose nominal contract is "return a dict of remote args." Any caller that introspects remote args triggers it — the detector was one such caller. `ray_remote_args_fn` is also a public, user-facing hook, so users can make it side-effecting as well.

### Proposed solution
**Summary**: Make "one placement group per actor" a first-class, lifecycle-managed feature of the actor pool: the stage declares per-actor PG config and the actor pool creates the PG when launching an actor and removes it when the actor dies.

Today a per-actor PG *is* possible, but only as a side effect inside `ray_remote_args_fn`: `ActorPoolMapOperator` merges whatever `scheduling_strategy` the callback returns and launches the actor into that PG, i.e. the pool never creates the PG and has no reference to it.

`actor_pool_map_operator.py` contains no `placement_group` / `remove_placement_group` calls at all; it only `ray.kill()`s actors. So PGs are owned by the job and outlive the actors that used them.

M2ove PG ownership into the actor pool so PG lifetime tracks **actor** lifetime, not **job** lifetime:

   1. The stage declares per-actor PG **config as data** (bundles + strategy), instead of a side-effecting `ray_remote_args_fn`.
   2. When the pool **starts an actor**, it creates that actor's PG and schedules the actor into it.
   3. When the pool **kills an actor** (downscale, restart, or shutdown), it calls `remove_placement_group` for that actor's PG before/after `ray.kill`.
   4. The pool tracks the actor→PG mapping so creation and teardown are paired.
