### PR TITLE
[serve] Default RAY_SERVE_PORT_QUARANTINE_S to hard-stop-after + margin

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -936,8 +936,15 @@ RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT = int(
 
 # Hold released replica ports out of the pool this long so proxies can
 # drop their stale slot before a new replica grabs the same port. 0 disables.
+# Defaults to hard-stop-after plus a margin: soft-stopped (reloaded-out)
+# HAProxy workers run no health checks and keep routing to their frozen
+# server list until hard-stop-after fires, so a freed port must stay out
+# of the pool at least that long or another app's replica can inherit the
+# old app's traffic. The margin covers the broadcast/reload lag before an
+# old worker's hard-stop clock starts.
 RAY_SERVE_PORT_QUARANTINE_S = get_env_float_non_negative(
-    "RAY_SERVE_PORT_QUARANTINE_S", 10.0
+    "RAY_SERVE_PORT_QUARANTINE_S",
+    float(RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S + 30),
 )
 # The minimum drain period for a HTTP proxy.
 # If RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS is set to 1,


### PR DESCRIPTION
## Why are these changes needed?

`RAY_SERVE_PORT_QUARANTINE_S` holds a released direct-ingress replica port out of the allocation pool so that stale routing state pointing at the old replica drains before another replica can inherit the port. It currently defaults to **10 seconds**.

The consumers that hold stale routing state the longest are soft-stopped (reloaded-out) HAProxy worker processes: they run no health checks (see [haproxy#3330](https://github.com/haproxy/haproxy/issues/3330)) and keep routing to their frozen server list until `hard-stop-after` fires — **120s by default** (`RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S`), commonly configured higher. With the current defaults the quarantine is 12x shorter than the window it exists to outlive: a freed port can be handed to a *different app's* replica at +10s while old workers keep sending it the previous app's traffic for up to +120s.

Observed in sustained load testing: a just-freed direct-ingress port was recycled into another app's replica inside the stale-worker window, and a soft-stopped worker routed the old app's traffic to it — surfacing as unretried wrong-app 404s at the client. Health checks cannot catch this (they validate the address is serving, not which app is serving).

## What does this change do?

Derives the default quarantine from the hard-stop window instead of a fixed 10s:

```python
RAY_SERVE_PORT_QUARANTINE_S = get_env_float_non_negative(
    "RAY_SERVE_PORT_QUARANTINE_S",
    float(RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S + 30),
)
```

The `+30s` margin covers the broadcast/coalesce/reload latency that elapses before an old worker's hard-stop clock starts (the clock runs from the worker's *orphaning* at reload, which can lag the port release). An explicit `RAY_SERVE_PORT_QUARANTINE_S` still overrides, and `0` still disables quarantining entirely.

Sizing rule this encodes (must hold for correctness, now holds by default):

```
port quarantine >= hard-stop-after + reload propagation lag
```