### PR TITLE
[core] Deflake `test_task_metrics.py::test_task_basic`

### DIFF
--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -73,8 +73,11 @@ def test_task_basic(shutdown_only):
     info = ray.init(num_cpus=2, **METRIC_CONFIG)
 
     driver = """
-import ray
 import time
+
+import ray
+from ray._common.test_utils import SignalActor
+from ray._common.test_utils import wait_for_condition
 
 ray.init("auto")
 
@@ -86,11 +89,16 @@ def a():
 def b():
     time.sleep(999)
 
-@ray.remote
+@ray.remote(num_cpus=3)
 def c():
     time.sleep(999)
 
-ray.get([a.remote(), b.remote()] + [c.remote() for _ in range(8)])
+refs = [a.remote(), b.remote()]
+wait_for_condition(
+    lambda: ray.available_resources().get("CPU", 0) == 0,
+)
+
+ray.get(refs + [c.remote() for _ in range(8)])
 """
     proc = run_string_as_driver_nonblocking(driver)
     timeseries = PrometheusTimeseries()

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -76,7 +76,6 @@ def test_task_basic(shutdown_only):
 import time
 
 import ray
-from ray._common.test_utils import SignalActor
 from ray._common.test_utils import wait_for_condition
 
 ray.init("auto")


### PR DESCRIPTION
The assertion assumed that `a` and `b` would always be scheduled and none of `c`, which is not guaranteed.

Added a condition to wait until `a` and `b` are scheduled before submitting the `c`s.

I couldn't use `SignalActor` here because it would add task metrics.