### PR TITLE
[Serve] Add set_max_concurrent_batches setter to @serve.batch

### DIFF
--- a/doc/source/serve/advanced-guides/dyn-req-batch.md
+++ b/doc/source/serve/advanced-guides/dyn-req-batch.md
@@ -36,7 +36,7 @@ You can supply 4 optional parameters to the decorators:
 Once the first request arrives, the batching decorator waits for a full batch (up to `max_batch_size`) until `batch_wait_timeout_s` is reached. If the timeout is reached, Serve sends the batch to the model regardless of the batch size.
 
 :::{tip}
-You can reconfigure your `batch_wait_timeout_s` and `max_batch_size` parameters using the `set_batch_wait_timeout_s` and `set_max_batch_size` methods:
+You can reconfigure your `batch_wait_timeout_s`, `max_batch_size`, and `max_concurrent_batches` parameters using the `set_batch_wait_timeout_s`, `set_max_batch_size`, and `set_max_concurrent_batches` methods:
 
 ```{literalinclude} ../doc_code/batching_guide.py
 ---

--- a/doc/source/serve/doc_code/batching_guide.py
+++ b/doc/source/serve/doc_code/batching_guide.py
@@ -47,10 +47,11 @@ from typing import Dict
     user_config={
         "max_batch_size": 10,
         "batch_wait_timeout_s": 0.5,
+        "max_concurrent_batches": 2,
     }
 )
 class Model:
-    @serve.batch(max_batch_size=8, batch_wait_timeout_s=0.1)
+    @serve.batch(max_batch_size=8, batch_wait_timeout_s=0.1, max_concurrent_batches=1)
     async def __call__(self, multiple_samples: List[int]) -> List[int]:
         # Use numpy's vectorized computation to efficiently process a batch.
         return np.array(multiple_samples) * 2
@@ -58,6 +59,7 @@ class Model:
     def reconfigure(self, user_config: Dict):
         self.__call__.set_max_batch_size(user_config["max_batch_size"])
         self.__call__.set_batch_wait_timeout_s(user_config["batch_wait_timeout_s"])
+        self.__call__.set_max_concurrent_batches(user_config["max_concurrent_batches"])
 
 
 # __batch_params_update_end__

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -24,6 +24,8 @@ from typing import (
     overload,
 )
 
+import anyio
+
 from ray import serve
 from ray._common.signature import extract_signature, flatten_args, recover_args
 from ray._common.utils import get_or_create_event_loop
@@ -153,7 +155,7 @@ class _BatchQueue:
         self.batch_wait_timeout_s = batch_wait_timeout_s
         self.max_concurrent_batches = max_concurrent_batches
         self.batch_size_fn = batch_size_fn
-        self.semaphore = asyncio.Semaphore(max_concurrent_batches)
+        self._limiter = anyio.CapacityLimiter(max_concurrent_batches)
         self.requests_available_event = asyncio.Event()
         self.tasks: Set[asyncio.Task] = set()
 
@@ -229,6 +231,23 @@ class _BatchQueue:
         """Updates queue's max_batch_size."""
         self.max_batch_size = new_max_batch_size
         self._warn_if_max_batch_size_exceeds_max_ongoing_requests()
+
+    def set_max_concurrent_batches(self, new_max_concurrent_batches: int) -> None:
+        """Updates queue's max_concurrent_batches.
+
+        Raising the limit admits waiting batches immediately; lowering it takes
+        effect as in-flight batches drain. In-flight batches are never cancelled.
+        """
+        self.max_concurrent_batches = new_max_concurrent_batches
+        self._warn_if_max_batch_size_exceeds_max_ongoing_requests()
+        # total_tokens wakes waiters via asyncio.Event, so apply it on the loop thread:
+        # reconfigure may run on a worker thread under RAY_SERVE_RUN_SYNC_IN_THREADPOOL.
+        if self._loop.is_running():
+            self._loop.call_soon_threadsafe(
+                setattr, self._limiter, "total_tokens", new_max_concurrent_batches
+            )
+        else:
+            self._limiter.total_tokens = new_max_concurrent_batches
 
     def put(self, request: Tuple[_SingleRequest, asyncio.Future]) -> None:
         self.queue.put_nowait(request)
@@ -485,9 +504,9 @@ class _BatchQueue:
             # for different models would not work correctly.
             sub_batches = self._split_batch_by_model_id(batch)
 
-            # Process all sub-batches together under a single semaphore permit.
+            # Process all sub-batches together under a single concurrency slot.
             # This ensures sub-batches from the same original batch run concurrently
-            # rather than being serialized by the semaphore.
+            # rather than being serialized by the concurrency limit.
             promise = self._process_sub_batches(func, sub_batches)
             task = asyncio.create_task(promise)
             self.tasks.add(task)
@@ -497,14 +516,13 @@ class _BatchQueue:
     async def _process_sub_batches(
         self, func: Callable, sub_batches: List[List[_SingleRequest]]
     ) -> None:
-        """Processes multiple sub-batches concurrently under a single semaphore permit.
+        """Processes multiple sub-batches concurrently under a single concurrency slot.
 
-        This method acquires the semaphore once and then processes all sub-batches
+        This method acquires one concurrency slot and then processes all sub-batches
         in parallel, ensuring that sub-batches from the same original batch don't
-        compete for semaphore permits.
+        compete for slots.
         """
-        # NOTE: this semaphore caps the number of concurrent batches specified by `max_concurrent_batches`
-        async with self.semaphore:
+        async with self._limiter:
             # Create tasks for each sub-batch. We use asyncio.create_task() instead
             # of passing coroutines directly to asyncio.gather() because create_task
             # copies the current context, giving each sub-batch its own isolated
@@ -520,10 +538,10 @@ class _BatchQueue:
     async def _process_batch_inner(
         self, func: Callable, batch: List[_SingleRequest]
     ) -> None:
-        """Processes a single batch without acquiring the semaphore.
+        """Processes a single batch without acquiring a concurrency slot.
 
         This is the inner implementation called by _process_sub_batches after
-        the semaphore has already been acquired.
+        the concurrency slot has already been acquired.
         """
         # Remove requests that have been cancelled from the batch. If
         # all requests have been cancelled, simply return and wait for
@@ -677,11 +695,22 @@ class _LazyBatchQueueWrapper:
         if self._queue is not None:
             self._queue.batch_wait_timeout_s = new_batch_wait_timeout_s
 
+    def set_max_concurrent_batches(self, new_max_concurrent_batches: int) -> None:
+        # Reject < 1: unlike max_batch_size, it would hang the gate, not shrink batches.
+        _validate_max_concurrent_batches(new_max_concurrent_batches)
+        self.max_concurrent_batches = new_max_concurrent_batches
+
+        if self._queue is not None:
+            self._queue.set_max_concurrent_batches(new_max_concurrent_batches)
+
     def get_max_batch_size(self) -> int:
         return self.max_batch_size
 
     def get_batch_wait_timeout_s(self) -> float:
         return self.batch_wait_timeout_s
+
+    def get_max_concurrent_batches(self) -> int:
+        return self.max_concurrent_batches
 
     def _get_curr_iteration_start_times(self) -> _RuntimeSummaryStatistics:
         """Gets summary statistics of current iteration's start times."""
@@ -742,8 +771,12 @@ def _validate_batch_wait_timeout_s(batch_wait_timeout_s):
 
 
 def _validate_max_concurrent_batches(max_concurrent_batches: int) -> None:
-    if not isinstance(max_concurrent_batches, int) or max_concurrent_batches < 1:
+    if not isinstance(max_concurrent_batches, int):
         raise TypeError(
+            f"max_concurrent_batches must be an integer >= 1, got {max_concurrent_batches}"
+        )
+    if max_concurrent_batches < 1:
+        raise ValueError(
             f"max_concurrent_batches must be an integer >= 1, got {max_concurrent_batches}"
         )
 
@@ -853,9 +886,9 @@ def batch(
     and executed asynchronously once there is a batch of `max_batch_size`
     or `batch_wait_timeout_s` has elapsed, whichever occurs first.
 
-    `max_batch_size` and `batch_wait_timeout_s` can be updated using setter
-    methods from the batch_handler (`set_max_batch_size` and
-    `set_batch_wait_timeout_s`).
+    `max_batch_size`, `batch_wait_timeout_s`, and `max_concurrent_batches` can be
+    updated using setter methods from the batch_handler (`set_max_batch_size`,
+    `set_batch_wait_timeout_s`, and `set_max_concurrent_batches`).
 
     Example:
 
@@ -987,9 +1020,15 @@ def batch(
         wrapper._get_batch_wait_timeout_s = (
             lazy_batch_queue_wrapper.get_batch_wait_timeout_s
         )
+        wrapper._get_max_concurrent_batches = (
+            lazy_batch_queue_wrapper.get_max_concurrent_batches
+        )
         wrapper.set_max_batch_size = lazy_batch_queue_wrapper.set_max_batch_size
         wrapper.set_batch_wait_timeout_s = (
             lazy_batch_queue_wrapper.set_batch_wait_timeout_s
+        )
+        wrapper.set_max_concurrent_batches = (
+            lazy_batch_queue_wrapper.set_max_concurrent_batches
         )
 
         # Store debugging methods in the lazy_batch_queue wrapper

--- a/python/ray/serve/tests/unit/test_batching.py
+++ b/python/ray/serve/tests/unit/test_batching.py
@@ -590,6 +590,97 @@ async def test_batch_setters(use_class):
 
 
 @pytest.mark.asyncio
+async def test_set_max_concurrent_batches():
+    """The concurrency limit is enforced, and raising it admits queued batches immediately."""
+    loop = get_or_create_event_loop()
+    # `started` counts handlers that have entered (released once each); awaiting N acquires
+    # blocks deterministically until exactly N batches are running — no sleeps.
+    started = asyncio.Semaphore(0)
+    release = asyncio.Event()
+    state = {"running": 0, "peak": 0}
+
+    @serve.batch(max_batch_size=1, batch_wait_timeout_s=0, max_concurrent_batches=1)
+    async def func(numbers):
+        # Each request is its own batch (max_batch_size=1) and blocks until released,
+        # so state["peak"] tracks how many batches run concurrently.
+        state["running"] += 1
+        state["peak"] = max(state["peak"], state["running"])
+        started.release()
+        await release.wait()
+        state["running"] -= 1
+        return list(numbers)
+
+    async def wait_until_running(n):
+        for _ in range(n):
+            await started.acquire()
+
+    assert func._get_max_concurrent_batches() == 1
+    tasks = [loop.create_task(func(i)) for i in range(4)]
+    await wait_until_running(1)  # only one of four batches runs under the limit
+    assert state["peak"] == 1
+
+    # Raise the limit while the first batch is still blocked: queued batches must be
+    # admitted immediately, not only when an in-flight batch completes.
+    func.set_max_concurrent_batches(3)
+    assert func._get_max_concurrent_batches() == 3
+    await wait_until_running(2)  # two more admitted now that the limit was raised
+    assert state["peak"] == 3
+
+    release.set()
+    await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_set_max_concurrent_batches_lower():
+    """Lowering the limit is not applied retroactively: in-flight batches finish,
+    and new batches are admitted under the lowered limit."""
+    loop = get_or_create_event_loop()
+    started = asyncio.Semaphore(0)
+    release = asyncio.Event()
+    state = {"running": 0, "peak": 0}
+
+    @serve.batch(max_batch_size=1, batch_wait_timeout_s=0, max_concurrent_batches=2)
+    async def func(numbers):
+        state["running"] += 1
+        state["peak"] = max(state["peak"], state["running"])
+        started.release()
+        await release.wait()
+        state["running"] -= 1
+        return list(numbers)
+
+    tasks = [loop.create_task(func(i)) for i in range(4)]
+    await started.acquire()
+    await started.acquire()  # two of four batches run under the limit
+    assert state["peak"] == 2
+
+    func.set_max_concurrent_batches(1)
+    assert func._get_max_concurrent_batches() == 1
+
+    # The two in-flight batches are never preempted; once they drain, the two
+    # queued batches must be admitted one at a time under the lowered limit.
+    state["peak"] = 0
+    release.set()
+    await asyncio.gather(*tasks)
+    assert state["peak"] == 1
+
+
+@pytest.mark.asyncio
+async def test_set_max_concurrent_batches_rejects_invalid():
+    """set_max_concurrent_batches rejects values < 1 (would hang the gate)."""
+
+    @serve.batch(max_batch_size=1, batch_wait_timeout_s=0)
+    async def func(numbers):
+        return list(numbers)
+
+    with pytest.raises(ValueError):
+        func.set_max_concurrent_batches(0)
+    with pytest.raises(ValueError):
+        func.set_max_concurrent_batches(-1)
+    with pytest.raises(TypeError):
+        func.set_max_concurrent_batches(1.5)
+
+
+@pytest.mark.asyncio
 async def test_batch_use_earliest_setters():
     """@serve.batch should use the right settings when constructing a batch.
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -47,6 +47,7 @@ prometheus_client>=0.7.1
 pandas>=2.2.3
 tensorboardX
 aiohttp>=3.13.3
+anyio>=4.2
 starlette>=1.0.1
 typer
 fsspec

--- a/python/setup.py
+++ b/python/setup.py
@@ -276,6 +276,9 @@ if setup_spec.type == SetupType.RAY:
         "serve": [
             "uvicorn[standard]",
             "requests",
+            # >= 4.2 for CapacityLimiter.total_tokens updates dequeuing waiters
+            # (used by serve.batching); older versions hang batch admission.
+            "anyio >= 4.2",
             "starlette >= 1.0.1",  # >= 1.0.1 for CVE fix.
             "fastapi >= 0.133.0",  # >= 0.133.0 required for starlette >= 1.0.
             "watchfiles",


### PR DESCRIPTION
## Why are these changes needed?

`@serve.batch` lets you update `max_batch_size` and `batch_wait_timeout_s` at runtime (typically from `reconfigure` / `user_config`), but not `max_concurrent_batches` — it was baked into a fixed `asyncio.Semaphore` at queue construction, which can't be resized.

This swaps that semaphore for a counter gated by an `asyncio.Condition` that reads the live `max_concurrent_batches` on each admission, and adds `set_max_concurrent_batches` (and a getter) wired through `_LazyBatchQueueWrapper` and the decorator, mirroring the existing two setters. Raising the limit admits queued batches as in-flight ones complete; lowering it takes effect as they drain (in-flight batches are never cancelled). The setter rejects values `< 1`, which would otherwise leave the gate admitting nothing.

## Related issue number

Closes #64036

## Checks

- [x] Signed off every commit (DCO)
- [x] Unit tests added in `test_batching.py` (limit enforced, runtime update, invalid-value rejection)
- [x] Docs updated (`dyn-req-batch.md`, `batching_guide.py`)
