### PR TITLE
[serve.llm] Don't clobber an explicitly-set request_id with the Serve id

### DIFF
--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -297,7 +297,17 @@ class LLMServer(LLMServerProtocol):
             "TranscriptionRequest",
         ],
     ):
-        """Add the request id to the request."""
+        """Stamp the Serve request id, unless the caller set request_id explicitly.
+
+        request_id defaults to a random uuid (never None), so use model_fields_set
+        to avoid clobbering an id a caller deliberately set (e.g. a P/D connector's
+        coordination id). Some request types (tokenize/detokenize) have no
+        request_id field at all -- skip those.
+        """
+        if not hasattr(request, "request_id"):
+            return
+        if "request_id" in request.model_fields_set:
+            return
         request_id = get_serve_request_id()
         if request_id:
             request.request_id = request_id

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -14,6 +14,7 @@ from ray.llm._internal.serve.core.configs.llm_config import (
     LoraConfig,
     ModelLoadingConfig,
 )
+from ray.llm._internal.serve.core.configs.openai_api_models import CompletionRequest
 from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.engines.vllm.vllm_engine import (
@@ -729,6 +730,59 @@ class TestCanonicalizeRequestIdHeader:
             _canonicalize_request_id_header(SimpleNamespace(request_id=None), raw)
             is raw
         )
+
+
+class TestMaybeAddRequestId:
+    """``_maybe_add_request_id_to_request`` fills the Serve request id for a
+    defaulted request_id but never clobbers one the caller set explicitly."""
+
+    def _set_ctx(self, request_id):
+        serve.context._serve_request_context.set(
+            serve.context._RequestContext(request_id=request_id)
+        )
+
+    @pytest.mark.asyncio
+    async def test_defaulted_request_id_is_overwritten_with_serve_id(self):
+        server = LLMServer.__new__(LLMServer)
+        req = CompletionRequest(model="m", prompt="hi")  # request_id defaulted
+        assert "request_id" not in req.model_fields_set
+        self._set_ctx("serve-ctx-id")
+        try:
+            await server._maybe_add_request_id_to_request(req)
+        finally:
+            serve.context._serve_request_context.set(serve.context._RequestContext())
+        assert req.request_id == "serve-ctx-id"
+
+    @pytest.mark.asyncio
+    async def test_explicit_request_id_is_preserved(self):
+        server = LLMServer.__new__(LLMServer)
+        req = CompletionRequest(model="m", prompt="hi", request_id="caller-set-id")
+        assert "request_id" in req.model_fields_set
+        self._set_ctx("serve-ctx-id")
+        try:
+            await server._maybe_add_request_id_to_request(req)
+        finally:
+            serve.context._serve_request_context.set(serve.context._RequestContext())
+        # Caller's id wins; the Serve context id does not clobber it.
+        assert req.request_id == "caller-set-id"
+
+    @pytest.mark.asyncio
+    async def test_request_without_request_id_field_is_skipped(self):
+        """Request types without a request_id field (e.g. tokenize/detokenize)
+        must be handled gracefully, not raise."""
+        from pydantic import BaseModel
+
+        class _NoRequestId(BaseModel):
+            pass
+
+        server = LLMServer.__new__(LLMServer)
+        req = _NoRequestId()
+        self._set_ctx("serve-ctx-id")
+        try:
+            await server._maybe_add_request_id_to_request(req)
+        finally:
+            serve.context._serve_request_context.set(serve.context._RequestContext())
+        assert not hasattr(req, "request_id")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
`request.request_id` has a `default_factory` (a random uuid), so it is **never None**. The engine
pipeline (`LLMServer._maybe_add_request_id_to_request`, run before every engine call) therefore
*unconditionally* overwrote it with the Serve request-context id. That silently discards a
`request_id` a caller set deliberately — e.g. a prefill/decode connector that encodes coordination
data in the request id (MoRIIO's dual-address id), or any caller that passes its own `request_id`.

## What
Fill the Serve id only when `request_id` was **defaulted**, using `request.model_fields_set` (which
contains `"request_id"` only when it was set explicitly, and survives `model_copy` + RPC
serialization). A plain `is None` check can't work — the field is never None.

```python
if "request_id" in request.model_fields_set:
    return
request_id = get_serve_request_id()
if request_id:
    request.request_id = request_id
```

- Ordinary requests (id defaulted) are unchanged: the Serve id is still stamped, so trace-id
  continuity is preserved. The ingress does not set `request_id`, so the common path is unaffected.
- A deliberately-set `request_id` is now respected instead of clobbered — matching the field's own
  documented contract ("If the caller does not set it, a random_uuid will be generated").

This unblocks connector-based P/D (e.g. MoRIIO) from carrying an engine-visible coordination id
without a separate header/context workaround in the orchestrator.

## Testing
`TestMaybeAddRequestId`: a defaulted `request_id` is overwritten with the Serve context id; an
explicitly-set `request_id` is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
