### PR TITLE
docs(serve): add FunASR ASR integration example

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -302,6 +302,20 @@ py_test_run_all_subdirectory(
 # Test all doc/source/serve/doc_code code included in rst/md files.
 # --------------------------------------------------------------------
 
+py_test(
+    name = "funasr_asr_test",
+    size = "small",
+    srcs = [
+        "source/serve/doc_code/funasr_asr.py",
+        "source/serve/doc_code/test_funasr_asr.py",
+    ],
+    main = "source/serve/doc_code/test_funasr_asr.py",
+    tags = ["team:serve"],
+    deps = [
+        ci_require("pytest"),
+    ],
+)
+
 py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/serve/doc_code/**/*.py"],
@@ -315,6 +329,7 @@ py_test_run_all_subdirectory(
         "source/serve/doc_code/stable_diffusion.py",
         "source/serve/doc_code/object_detection.py",
         "source/serve/doc_code/vllm_example.py",
+        "source/serve/doc_code/test_funasr_asr.py",
         "source/serve/doc_code/cross_node_parallelism_example.py",
         "source/serve/doc_code/llm/llm_yaml_config_example.py",
         "source/serve/doc_code/llm/qwen_example.py",

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -286,6 +286,20 @@ py_test_run_all_subdirectory(
 # Test all doc/source/serve/doc_code code included in rst/md files.
 # --------------------------------------------------------------------
 
+py_test(
+    name = "funasr_asr_test",
+    size = "small",
+    srcs = [
+        "source/serve/doc_code/funasr_asr.py",
+        "source/serve/doc_code/test_funasr_asr.py",
+    ],
+    main = "source/serve/doc_code/test_funasr_asr.py",
+    tags = ["team:serve"],
+    deps = [
+        ci_require("pytest"),
+    ],
+)
+
 py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/serve/doc_code/**/*.py"],
@@ -299,6 +313,7 @@ py_test_run_all_subdirectory(
         "source/serve/doc_code/stable_diffusion.py",
         "source/serve/doc_code/object_detection.py",
         "source/serve/doc_code/vllm_example.py",
+        "source/serve/doc_code/test_funasr_asr.py",
         "source/serve/doc_code/cross_node_parallelism_example.py",
         "source/serve/doc_code/llm/llm_yaml_config_example.py",
         "source/serve/doc_code/llm/qwen_example.py",

--- a/doc/source/serve/doc_code/funasr_asr.py
+++ b/doc/source/serve/doc_code/funasr_asr.py
@@ -1,0 +1,176 @@
+# __example_code_start__
+import contextlib
+import os
+import tempfile
+from typing import Any, Iterable, List, Optional
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse
+
+from ray import serve
+from ray.serve.handle import DeploymentHandle
+
+
+fastapi_app = FastAPI()
+DEFAULT_MODEL = "iic/SenseVoiceSmall"
+ALLOWED_MODELS = {DEFAULT_MODEL}
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": 1,
+        "initial_replicas": 1,
+        "max_replicas": 2,
+        "target_ongoing_requests": 20,
+    },
+    max_ongoing_requests=40,
+)
+@serve.ingress(fastapi_app)
+class OpenAICompatibleIngress:
+    def __init__(self, asr_handle: DeploymentHandle):
+        self._asr_handle = asr_handle
+
+    @fastapi_app.post("/v1/audio/transcriptions")
+    async def create_transcription(
+        self,
+        file: UploadFile = File(...),
+        model: str = Form(DEFAULT_MODEL),
+        language: Optional[str] = Form(None),
+        response_format: str = Form("json"),
+    ):
+        if model not in ALLOWED_MODELS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unsupported model '{model}'. Supported models: "
+                    f"{sorted(ALLOWED_MODELS)}"
+                ),
+            )
+
+        if response_format not in {"json", "text", "verbose_json"}:
+            raise HTTPException(
+                status_code=400,
+                detail=("response_format must be one of: json, text, verbose_json"),
+            )
+
+        audio_bytes = await file.read()
+        asr_handle = self._asr_handle.options(multiplexed_model_id=model)
+        result = await asr_handle.transcribe.remote(
+            audio_bytes, file.filename, language, response_format
+        )
+
+        if response_format == "text":
+            return PlainTextResponse(result["text"])
+        return result
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": 0,
+        "initial_replicas": 1,
+        "max_replicas": 4,
+        "target_ongoing_requests": 4,
+    },
+    max_ongoing_requests=8,
+    ray_actor_options={"num_gpus": 1},
+)
+class FunASRModel:
+    def __init__(
+        self,
+        default_model: str = DEFAULT_MODEL,
+        allowed_models: Iterable[str] = tuple(ALLOWED_MODELS),
+        device: Optional[str] = None,
+    ):
+        import torch
+        from funasr import AutoModel
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        self._device = device or ("cuda:0" if torch.cuda.is_available() else "cpu")
+        self._default_model = default_model
+        self._allowed_models = set(allowed_models)
+        self._auto_model_cls = AutoModel
+        self._postprocess = rich_transcription_postprocess
+
+    @serve.multiplexed(max_num_models_per_replica=1)
+    async def _get_model(self, model_name: str) -> Any:
+        if model_name not in self._allowed_models:
+            raise ValueError(
+                f"Unsupported model '{model_name}'. Supported models: "
+                f"{sorted(self._allowed_models)}"
+            )
+
+        return self._auto_model_cls(
+            model=model_name,
+            vad_model="fsmn-vad",
+            vad_kwargs={"max_single_segment_time": 30000},
+            device=self._device,
+        )
+
+    @serve.batch(max_batch_size=4, batch_wait_timeout_s=0.1)
+    async def transcribe(
+        self,
+        audio_bytes: List[bytes],
+        filenames: List[Optional[str]],
+        languages: List[Optional[str]],
+        response_formats: List[str],
+    ) -> List[dict]:
+        model_name = serve.get_multiplexed_model_id() or self._default_model
+        model = await self._get_model(model_name)
+        audio_paths = []
+        try:
+            for audio, filename in zip(audio_bytes, filenames):
+                suffix = os.path.splitext(filename or "")[1] or ".wav"
+                with tempfile.NamedTemporaryFile(
+                    suffix=suffix, delete=False
+                ) as audio_file:
+                    audio_paths.append(audio_file.name)
+                    audio_file.write(audio)
+
+            requests_by_language = {}
+            for request_index, (audio_path, language) in enumerate(
+                zip(audio_paths, languages)
+            ):
+                requests_by_language.setdefault(language or "auto", []).append(
+                    (request_index, audio_path)
+                )
+
+            indexed_results = []
+            for language, requests in requests_by_language.items():
+                batch_results = model.generate(
+                    input=[audio_path for _, audio_path in requests],
+                    language=language,
+                    use_itn=True,
+                    batch_size_s=60,
+                    merge_vad=True,
+                    merge_length_s=15,
+                )
+                indexed_results.extend(
+                    (request_index, result)
+                    for (request_index, _), result in zip(requests, batch_results)
+                )
+
+            indexed_results.sort(key=lambda indexed_result: indexed_result[0])
+            results = [result for _, result in indexed_results]
+        finally:
+            for audio_path in audio_paths:
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(audio_path)
+
+        responses = []
+        for transcription, response_format in zip(results, response_formats):
+            text = self._postprocess(transcription.get("text", ""))
+            if response_format == "verbose_json":
+                responses.append(
+                    {
+                        "text": text,
+                        "segments": transcription.get("sentence_info", []),
+                        "model": model_name,
+                    }
+                )
+            else:
+                responses.append({"text": text})
+        return responses
+
+
+entrypoint = OpenAICompatibleIngress.bind(FunASRModel.bind())
+# __example_code_end__

--- a/doc/source/serve/doc_code/test_funasr_asr.py
+++ b/doc/source/serve/doc_code/test_funasr_asr.py
@@ -1,0 +1,168 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("funasr_asr.py")
+
+
+def _identity_decorator(*args, **kwargs):
+    def decorator(obj):
+        return obj
+
+    return decorator
+
+
+def _deployment_decorator(*args, **kwargs):
+    def decorator(cls):
+        cls.bind = classmethod(lambda cls, *args, **kwargs: None)
+        return cls
+
+    return decorator
+
+
+class _FastAPI:
+    def post(self, *args, **kwargs):
+        return _identity_decorator()
+
+
+def _parameter(default=..., **kwargs):
+    return default
+
+
+def _load_funasr_asr():
+    fastapi = types.ModuleType("fastapi")
+    fastapi.FastAPI = _FastAPI
+    fastapi.File = _parameter
+    fastapi.Form = _parameter
+    fastapi.HTTPException = Exception
+    fastapi.UploadFile = object
+
+    fastapi_responses = types.ModuleType("fastapi.responses")
+    fastapi_responses.PlainTextResponse = str
+
+    serve = types.ModuleType("ray.serve")
+    serve.batch = _identity_decorator
+    serve.deployment = _deployment_decorator
+    serve.get_multiplexed_model_id = lambda: ""
+    serve.ingress = _identity_decorator
+    serve.multiplexed = _identity_decorator
+
+    ray = types.ModuleType("ray")
+    ray.serve = serve
+
+    ray_serve_handle = types.ModuleType("ray.serve.handle")
+    ray_serve_handle.DeploymentHandle = object
+
+    module_spec = importlib.util.spec_from_file_location(
+        "_funasr_asr_under_test", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(module_spec)
+    fake_modules = {
+        "fastapi": fastapi,
+        "fastapi.responses": fastapi_responses,
+        "ray": ray,
+        "ray.serve": serve,
+        "ray.serve.handle": ray_serve_handle,
+    }
+    with patch.dict(sys.modules, fake_modules):
+        module_spec.loader.exec_module(module)
+    return module
+
+
+class _RecordingModel:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, **kwargs):
+        language = kwargs["language"]
+        if not isinstance(language, str):
+            raise TypeError(f"unhashable type: '{type(language).__name__}'")
+
+        audio_batch = [Path(audio_path).read_bytes() for audio_path in kwargs["input"]]
+        self.calls.append((language, audio_batch))
+        return [
+            {
+                "text": audio.decode(),
+                "sentence_info": [{"text": audio.decode()}],
+            }
+            for audio in audio_batch
+        ]
+
+
+def _make_asr(module, model):
+    asr = module.FunASRModel.__new__(module.FunASRModel)
+    asr._default_model = "test-model"
+
+    async def get_model(model_name):
+        assert model_name == "test-model"
+        return model
+
+    def postprocess(text):
+        return text
+
+    asr._get_model = get_model
+    asr._postprocess = postprocess
+    return asr
+
+
+def test_transcribe_uses_scalar_auto_language_for_single_request():
+    module = _load_funasr_asr()
+    recording_model = _RecordingModel()
+    asr = _make_asr(module, recording_model)
+
+    responses = asyncio.run(
+        asr.transcribe(
+            audio_bytes=[b"default"],
+            filenames=["default.wav"],
+            languages=[None],
+            response_formats=["json"],
+        )
+    )
+
+    assert recording_model.calls == [("auto", [b"default"])]
+    assert responses == [{"text": "default"}]
+
+
+def test_transcribe_groups_mixed_languages_and_restores_request_order():
+    module = _load_funasr_asr()
+    recording_model = _RecordingModel()
+    asr = _make_asr(module, recording_model)
+
+    responses = asyncio.run(
+        asr.transcribe(
+            audio_bytes=[b"first", b"second", b"third", b"fourth"],
+            filenames=["first.wav", "second.wav", "third.wav", "fourth.wav"],
+            languages=["en", "zh", "en", None],
+            response_formats=["json", "verbose_json", "json", "verbose_json"],
+        )
+    )
+
+    assert recording_model.calls == [
+        ("en", [b"first", b"third"]),
+        ("zh", [b"second"]),
+        ("auto", [b"fourth"]),
+    ]
+    assert responses == [
+        {"text": "first"},
+        {
+            "text": "second",
+            "segments": [{"text": "second"}],
+            "model": "test-model",
+        },
+        {"text": "third"},
+        {
+            "text": "fourth",
+            "segments": [{"text": "fourth"}],
+            "model": "test-model",
+        },
+    ]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/doc/source/serve/examples.yml
+++ b/doc/source/serve/examples.yml
@@ -28,6 +28,13 @@ examples:
       - natural language processing
     link: tutorials/text-classification
     related_technology: ml applications
+  - title: Serve a FunASR Speech Recognition Model
+    skill_level: intermediate
+    use_cases:
+      - natural language processing
+      - generative ai
+    link: tutorials/funasr-asr
+    related_technology: ml applications
   - title: Serve an Object Detection Model
     skill_level: beginner
     use_cases:

--- a/doc/source/serve/tutorials/funasr-asr.md
+++ b/doc/source/serve/tutorials/funasr-asr.md
@@ -1,0 +1,167 @@
+---
+orphan: true
+---
+
+(serve-funasr-asr-tutorial)=
+
+# Serve a FunASR Speech Recognition Model
+
+This tutorial shows how to deploy an automatic speech recognition (ASR) service
+with [FunASR](https://github.com/modelscope/FunASR) and Ray Serve. The example
+exposes an OpenAI-compatible `POST /v1/audio/transcriptions` endpoint and scales
+the FunASR deployment independently from the HTTP ingress.
+
+## Install Dependencies
+
+Install Ray Serve and the packages used by this example:
+
+```bash
+pip install "ray[serve]" funasr modelscope python-multipart openai
+```
+
+FunASR models can run on CPU, but GPU replicas are recommended for production
+traffic. The example requests one GPU per ASR replica. If you want to try the
+example on a CPU-only machine, remove `ray_actor_options={"num_gpus": 1}` from
+the `FunASRModel` deployment in the code.
+
+## Define the Serve Application
+
+Save the following code to a file named `funasr_asr.py`:
+
+```{literalinclude} ../doc_code/funasr_asr.py
+:language: python
+:start-after: __example_code_start__
+:end-before: __example_code_end__
+```
+
+The application has two deployments:
+
+1. `OpenAICompatibleIngress` accepts multipart form uploads at `/v1/audio/transcriptions`.
+2. `FunASRModel` loads FunASR models and runs batched ASR inference. Serve can
+   autoscale this deployment separately from the ingress deployment.
+
+The ingress deployment is lightweight, so the example keeps one to two ingress
+replicas and allows each replica to queue more concurrent requests. The ASR
+deployment owns the GPU and is the bottleneck, so it uses more conservative
+concurrency: `max_ongoing_requests=8`, `target_ongoing_requests=4`, and
+`@serve.batch(max_batch_size=4, batch_wait_timeout_s=0.1)`. This keeps
+`max_ongoing_requests` high enough for a full batch while avoiding too many
+simultaneous GPU-bound requests per replica. Tune these values with the
+benchmark below for your model, GPU, and audio duration distribution.
+
+The default model is `iic/SenseVoiceSmall`. The example restricts requests to a
+preconfigured model allowlist to avoid loading arbitrary models. Requests pass
+the selected model as a Serve multiplexed model ID, and `FunASRModel` uses
+`@serve.multiplexed(max_num_models_per_replica=1)` so Serve handles model
+affinity and LRU eviction instead of using an unbounded per-replica cache. To
+serve additional FunASR models, add their model names to `ALLOWED_MODELS` and
+pass one of those names in the multipart `model` field.
+
+## Run the Service
+
+Start the Serve application:
+
+```bash
+serve run funasr_asr:entrypoint
+```
+
+The first request downloads the configured FunASR model, so it may take longer
+than later requests.
+
+## Query the Endpoint
+
+Send an audio file with the OpenAI Python client:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="not-needed")
+
+with open("audio.wav", "rb") as audio_file:
+    transcription = client.audio.transcriptions.create(
+        model="iic/SenseVoiceSmall",
+        file=audio_file,
+        response_format="json",
+    )
+
+print(transcription.text)
+```
+
+You can also use `curl`:
+
+```bash
+curl http://127.0.0.1:8000/v1/audio/transcriptions \
+    -F "model=iic/SenseVoiceSmall" \
+    -F "file=@audio.wav" \
+    -F "response_format=json"
+```
+
+Set `response_format=text` to return plain transcript text, or
+`response_format=verbose_json` to include FunASR segment metadata when the
+selected model returns it.
+
+## Benchmark the Deployment
+
+ASR throughput depends heavily on the model, GPU, audio duration, sample rate,
+and batching settings. Before using this example for production traffic, measure
+latency and requests per second with representative audio files. For example,
+save this script as `benchmark_funasr_asr.py` and pass audio clips of different
+durations:
+
+```python
+import argparse
+import statistics
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from openai import OpenAI
+
+
+def transcribe(client, path, model):
+    start = time.perf_counter()
+    with open(path, "rb") as audio_file:
+        client.audio.transcriptions.create(
+            model=model,
+            file=audio_file,
+            response_format="json",
+        )
+    return time.perf_counter() - start
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("audio", nargs="+")
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--requests-per-file", type=int, default=10)
+    parser.add_argument("--model", default="iic/SenseVoiceSmall")
+    args = parser.parse_args()
+
+    client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="not-needed")
+
+    for path in args.audio:
+        work = [path] * args.requests_per_file
+        start = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [pool.submit(transcribe, client, item, args.model) for item in work]
+            latencies = [future.result() for future in as_completed(futures)]
+        elapsed = time.perf_counter() - start
+        p50 = statistics.median(latencies)
+        p95 = statistics.quantiles(latencies, n=20)[18]
+        rps = len(latencies) / elapsed
+        print(f"{path}: rps={rps:.2f}, p50={p50:.2f}s, p95={p95:.2f}s")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Run it against short, medium, and long clips:
+
+```bash
+python benchmark_funasr_asr.py short.wav medium.wav long.wav --concurrency 8
+```
+
+If p95 latency is high and GPU utilization is low, increase `max_batch_size` or
+`batch_wait_timeout_s`. If p95 latency rises while GPU memory is saturated,
+reduce `max_batch_size`, `max_ongoing_requests`, or the ASR deployment's
+`target_ongoing_requests`.

--- a/doc/source/serve/tutorials/funasr-asr.md
+++ b/doc/source/serve/tutorials/funasr-asr.md
@@ -1,0 +1,170 @@
+---
+orphan: true
+myst:
+  html_meta:
+    description: "Deploy an automatic speech recognition (ASR) service with FunASR and Ray Serve behind an OpenAI-compatible transcription endpoint."
+---
+
+(serve-funasr-asr-tutorial)=
+
+# Serve a FunASR speech recognition model
+
+This tutorial shows how to deploy an automatic speech recognition (ASR) service
+with [FunASR](https://github.com/modelscope/FunASR) and Ray Serve. The example
+exposes an OpenAI-compatible `POST /v1/audio/transcriptions` endpoint and scales
+the FunASR deployment independently from the HTTP ingress.
+
+## Install dependencies
+
+Install Ray Serve and the packages used by this example:
+
+```bash
+pip install "ray[serve]" funasr modelscope python-multipart openai
+```
+
+FunASR models can run on CPU, but GPU replicas are recommended for production
+traffic. The example requests one GPU per ASR replica. If you want to try the
+example on a CPU-only machine, remove `ray_actor_options={"num_gpus": 1}` from
+the `FunASRModel` deployment in the code.
+
+## Define the Serve application
+
+Save the following code to a file named `funasr_asr.py`:
+
+```{literalinclude} ../doc_code/funasr_asr.py
+:language: python
+:start-after: __example_code_start__
+:end-before: __example_code_end__
+```
+
+The application has two deployments:
+
+1. `OpenAICompatibleIngress` accepts multipart form uploads at `/v1/audio/transcriptions`.
+1. `FunASRModel` loads FunASR models and runs batched ASR inference. Serve can
+   autoscale this deployment separately from the ingress deployment.
+
+The ingress deployment is lightweight, so the example keeps one to two ingress
+replicas, with each replica handling more concurrent requests. The ASR
+deployment owns the GPU and is the bottleneck, so it uses more conservative
+concurrency: `max_ongoing_requests=8`, `target_ongoing_requests=4`, and
+`@serve.batch(max_batch_size=4, batch_wait_timeout_s=0.1)`. This keeps
+`max_ongoing_requests` high enough for a full batch while avoiding too many
+simultaneous GPU-bound requests per replica. Tune these values with the
+benchmark below for your model, GPU, and audio duration distribution.
+
+The default model is `iic/SenseVoiceSmall`. The example restricts requests to a
+preconfigured model allowlist to avoid loading arbitrary models. Requests pass
+the selected model as a Serve multiplexed model ID, and `FunASRModel` uses
+`@serve.multiplexed(max_num_models_per_replica=1)` so Serve handles model
+affinity and LRU eviction instead of using an unbounded per-replica cache. To
+serve additional FunASR models, add their model names to `ALLOWED_MODELS` and
+pass one of those names in the multipart `model` field.
+
+## Run the service
+
+Start the Serve application:
+
+```bash
+serve run funasr_asr:entrypoint
+```
+
+The first request downloads the configured FunASR model, so it may take longer
+than later requests.
+
+## Query the endpoint
+
+Send an audio file with the OpenAI Python client:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="not-needed")
+
+with open("audio.wav", "rb") as audio_file:
+    transcription = client.audio.transcriptions.create(
+        model="iic/SenseVoiceSmall",
+        file=audio_file,
+        response_format="json",
+    )
+
+print(transcription.text)
+```
+
+You can also use `curl`:
+
+```bash
+curl http://127.0.0.1:8000/v1/audio/transcriptions \
+    -F "model=iic/SenseVoiceSmall" \
+    -F "file=@audio.wav" \
+    -F "response_format=json"
+```
+
+Set `response_format=text` to return plain transcript text, or
+`response_format=verbose_json` to include FunASR segment metadata when the
+selected model returns it.
+
+## Benchmark the deployment
+
+ASR throughput depends heavily on the model, GPU, audio duration, sample rate,
+and batching settings. Before using this example for production traffic, measure
+latency and requests per second with representative audio files. For example,
+save this script as `benchmark_funasr_asr.py` and pass audio clips of different
+durations:
+
+```python
+import argparse
+import statistics
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from openai import OpenAI
+
+
+def transcribe(client, path, model):
+    start = time.perf_counter()
+    with open(path, "rb") as audio_file:
+        client.audio.transcriptions.create(
+            model=model,
+            file=audio_file,
+            response_format="json",
+        )
+    return time.perf_counter() - start
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("audio", nargs="+")
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--requests-per-file", type=int, default=10)
+    parser.add_argument("--model", default="iic/SenseVoiceSmall")
+    args = parser.parse_args()
+
+    client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="not-needed")
+
+    for path in args.audio:
+        work = [path] * args.requests_per_file
+        start = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [pool.submit(transcribe, client, item, args.model) for item in work]
+            latencies = [future.result() for future in as_completed(futures)]
+        elapsed = time.perf_counter() - start
+        p50 = statistics.median(latencies)
+        p95 = statistics.quantiles(latencies, n=20)[18]
+        rps = len(latencies) / elapsed
+        print(f"{path}: rps={rps:.2f}, p50={p50:.2f}s, p95={p95:.2f}s")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Run it against short, medium, and long clips:
+
+```bash
+python benchmark_funasr_asr.py short.wav medium.wav long.wav --concurrency 8
+```
+
+If p95 latency is high and GPU utilization is low, increase `max_batch_size` or
+`batch_wait_timeout_s`. If p95 latency rises while GPU memory is saturated,
+reduce `max_batch_size`, `max_ongoing_requests`, or the ASR deployment's
+`target_ongoing_requests`.


### PR DESCRIPTION
## Description

Adds a Ray Serve tutorial and runnable doc code example for serving FunASR automatic speech recognition (ASR) models.

This PR includes:
- A new `funasr_asr.py` Serve application with a FastAPI ingress endpoint compatible with `POST /v1/audio/transcriptions`.
- A separate autoscaling `FunASRModel` deployment for ASR inference.
- A new Serve tutorial showing installation, deployment with `serve run`, and requests using both the OpenAI Python client and `curl`.
- A new entry in the Serve examples catalog.

This addresses the request for a FunASR Ray Serve integration example and demonstrates scalable speech-to-text serving with Ray Serve.

## Related issues

Closes #64052

## Additional information

Validation performed:
- `python -m py_compile doc/source/serve/doc_code/funasr_asr.py`
- `git diff --check`
- Parsed `doc/source/serve/examples.yml` with PyYAML

I did not run full FunASR inference locally because it requires downloading model weights.