### PR TITLE
[Data] Fix loading-data doctest: download example images anonymously

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -350,6 +350,8 @@ The following example shows how to download a batch of images from URLs listed i
 
 .. testcode::
 
+    import pyarrow.fs
+
     import ray
     from ray.data.expressions import download
 
@@ -360,7 +362,10 @@ The following example shows how to download a batch of images from URLs listed i
     # This creates a new column 'bytes' with the downloaded file contents.
     ds = ds.with_column(
         "bytes",
-        download("image_url"),
+        download(
+            "image_url",
+            filesystem=pyarrow.fs.S3FileSystem(anonymous=True, region="us-west-2"),
+        ),
     )
 
     ds.take(1)


### PR DESCRIPTION
## Problem

The `download("image_url")` example in `doc/source/data/loading-data.rst` downloads ImageNet JPEGs from the public `ray-example-data` bucket using **ambient AWS credentials**. On CI the PR-runner role lacks `s3:GetObject` on that bucket, so the download is denied:

```
<Error><Code>AccessDenied</Code> ... not authorized to perform: s3:GetObject on
  arn:aws:s3:::ray-example-data/imagenet/train/n01440764/n01440764_10026.JPEG
FAILED doc/source/data/loading-data.rst::loading-data.rst - SystemExit: 15
//doc:source/data/loading-data   TIMEOUT in 3 out of 3 in 303.2s
```

This fails the `:database: data: doc tests` premerge job on **every PR that actually re-runs that doctest** (i.e. a Bazel cache miss). Confirmed identical across unrelated PRs — premerge builds 68131, 68134, 68140.

## Fix

Every other read on the page already uses anonymous access (`s3://anonymous@…`), but the image URLs are baked into the metadata parquet without it. Pass an anonymous pyarrow S3 filesystem to `download()` so the example reads the public bucket **unsigned**, independent of runner credentials.

Prerequisite (fixes anonymous downloads):
https://github.com/ray-project/ray/pull/64089