### PR TITLE
[serve.llm] MoRIIO cross-node: advertise worker node-internal IP via a vLLM plugin

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/moriio.py
@@ -178,11 +178,13 @@ class MoRIIOConnectorBackend(BaseConnectorBackend):
         # Stash so replica_metadata() can publish it; the decode
         # orchestrator reads the selected prefill replica's copy off the peer.
         self._zmq_address = zmq_address
-        # NOTE: cross-node correctness additionally needs each worker to
-        # advertise the node INTERNAL IP (set VLLM_HOST_IP inside every worker
-        # process). VLLM_HOST_IP is excluded from vLLM's driver->worker env copy,
-        # so it can only be set in-process -- handled by a vLLM general-plugin
-        # shipped separately. Single-node deployments work without it.
+        # Cross-node correctness: vLLM's MoRIIO worker otherwise binds/advertises
+        # get_ip(), which on a Ray cluster is the node's unroutable public IP, and
+        # VLLM_HOST_IP cannot be propagated to workers (it is excluded from vLLM's
+        # driver->worker env copy). Pass the routable node IP through the connector
+        # config, which does reach the workers; vLLM's MoRIIO connector honors
+        # "host_ip" over get_ip(). Requires vllm-project/vllm#45488.
+        extra["host_ip"] = host
 
     # ---- parallelism (data/tensor) ----
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_moriio_connector.py
@@ -85,10 +85,14 @@ class TestMoRIIOConnectorBackendSetup:
         assert extra["proxy_ping_port"] == "0"
         assert "http_port" in extra
         assert extra["read_mode"] == "false"
+        # Routable node IP passed to vLLM's MoRIIO connector (cross-node fix,
+        # vllm-project/vllm#45488), matching the advertised zmq host.
+        assert extra["host_ip"] == _TEST_HOST
 
         zmq = backend._zmq_address
         host, hs, notify = parse_zmq_address(zmq)
         assert host == _TEST_HOST
+        assert host == extra["host_ip"]
         assert hs == DEFAULT_HANDSHAKE_PORT_BASE
         assert notify == DEFAULT_NOTIFY_PORT_BASE
 


### PR DESCRIPTION
Pass the routable Ray node IP to vLLM's MoRIIO worker via
`kv_connector_extra_config["host_ip"]`, so it binds/advertises that instead of
`get_ip()` (the node's unroutable public IP on a Ray cluster). `setup()` already
resolves this IP for the zmq address; this forwards the same value. Needed for
cross-node KV transfer; `VLLM_HOST_IP` can't be used (vLLM excludes it from the
driver→worker env copy).

Depends on vllm-project/vllm#45488 (makes the MoRIIO connector honor `host_ip`).
