### PR TITLE
[serve][llm] Improve Serve LLM docs landing pages and add config reference

### DIFF
--- a/doc/source/serve/llm/architecture/core.md
+++ b/doc/source/serve/llm/architecture/core.md
@@ -84,7 +84,7 @@ Ray Serve LLM deeply integrates with vLLM since it has end-to-end Ray support in
 
 ### LLMConfig
 
-`LLMConfig` is the central configuration object that specifies everything needed to deploy an LLM:
+`LLMConfig` is the central configuration object that specifies everything needed to deploy an LLM. The fields below are the most important ones. For a complete field-by-field reference with defaults, see the {doc}`Configuration reference <../user-guides/configuration>`.
 
 ```python
 @dataclass
@@ -146,7 +146,7 @@ class LoraConfig:
     dynamic_lora_loading_path: Optional[str] = None
     
     # Maximum number of adapters per replica
-    max_num_adapters_per_replica: int = 1
+    max_num_adapters_per_replica: int = 16
 ```
 
 Ray Serve's multiplexing feature automatically routes requests to replicas that have the requested LoRA adapter loaded, using an LRU cache for adapter management.

--- a/doc/source/serve/llm/architecture/core.md
+++ b/doc/source/serve/llm/architecture/core.md
@@ -68,7 +68,7 @@ class LLMEngine(ABC):
 
 Ray Serve LLM provides:
 
-- **VLLMEngine**: Production-ready implementation using vLLM.
+- **VLLMEngine**: Implementation using vLLM.
   - Supports continuous batching and paged attention.
   - Supports all kinds of parallelism.
   - KV cache transfer for prefill-decode disaggregation.

--- a/doc/source/serve/llm/architecture/index.md
+++ b/doc/source/serve/llm/architecture/index.md
@@ -1,8 +1,16 @@
 # Architecture
 
-Technical documentation for Ray Serve LLM architecture, components, and patterns.
+How Ray Serve LLM is built: the components a deployment is made of, how a request flows through them, and the patterns that scale serving across GPUs and nodes. Read these to extend the system or to reason about performance. To deploy models, see the {doc}`User guides <../user-guides/index>` instead.
+
+Start with the overview, then read the pages relevant to your use case:
+
+- {doc}`Architecture overview <overview>`: the components of a deployment (engine, server, ingress) and how a request flows through them. Read this first.
+- {doc}`Core components <core>`: the key abstractions and extension points, including the engine protocol, `LLMConfig`, the builder functions, and custom server classes.
+- {doc}`Serving patterns <serving-patterns/index>`: distributed patterns (data parallel attention, prefill-decode disaggregation) and how they compose.
+- {doc}`Request routing <routing-policies>`: how the ingress picks a replica, the built-in policies, and how to write a custom router.
 
 ```{toctree}
+:hidden:
 :maxdepth: 1
 
 Architecture overview <overview>
@@ -10,4 +18,3 @@ Core components <core>
 Serving patterns <serving-patterns/index>
 Request routing <routing-policies>
 ```
-

--- a/doc/source/serve/llm/architecture/index.md
+++ b/doc/source/serve/llm/architecture/index.md
@@ -7,7 +7,7 @@ Start with the overview, then read the pages relevant to your use case:
 - {doc}`Architecture overview <overview>`: the components of a deployment (engine, server, ingress) and how a request flows through them. Read this first.
 - {doc}`Core components <core>`: the key abstractions and extension points, including the engine protocol, `LLMConfig`, the builder functions, and custom server classes.
 - {doc}`Serving patterns <serving-patterns/index>`: distributed patterns (data parallel attention, prefill-decode disaggregation) and how they compose.
-- {doc}`Request routing <routing-policies>`: how the ingress picks a replica, the built-in policies, and how to write a custom router.
+- {doc}`Request routing <routing-policies>`: how a replica is selected for each request, the built-in policies, and how to write a custom router.
 
 ```{toctree}
 :hidden:

--- a/doc/source/serve/llm/architecture/routing-policies.md
+++ b/doc/source/serve/llm/architecture/routing-policies.md
@@ -82,7 +82,7 @@ For more details, see {ref}`prefix-aware-routing-guide`.
 
 Customizing request routers is a feature in Ray Serve's native APIs that you can define per deployment. For each deployment, you can customize the routing logic that executes every time you call `.remote()` on the deployment handle from a caller. Because deployment handles are globally available objects across the cluster, you can call them from any actor or task in the Ray cluster. For more details on this API, see {ref}`custom-request-router-guide`.
 
-This allows you to run the same routing logic even if you have multiple handles. The default request router in Ray Serve is Power of Two Choices, which balances load equalization and prioritizes locality routing. However, you can customize this to use LLM-specific metrics.
+As a result, the same routing logic runs even when you have multiple handles. The default request router in Ray Serve is Power of Two Choices, which balances load equalization and prioritizes locality routing. However, you can customize this to use LLM-specific metrics.
 
 Ray Serve LLM includes prefix-aware routing in the framework. There are two common architectural patterns for customizing request routers. There are clear trade-offs between them, so choose the suitable one and balance simplicity with performance:
 

--- a/doc/source/serve/llm/architecture/serving-patterns/data-parallel.md
+++ b/doc/source/serve/llm/architecture/serving-patterns/data-parallel.md
@@ -154,7 +154,7 @@ The key difference from basic serving is that all the `dp_size` replicas coordin
 
 ### Autoscaling behavior
 
-Data parallel attention deployments support autoscaling based on request queue length. Specify `min_replicas`, `max_replicas`, `initial_replicas` to configure autoscaling bound and starting point. Note that all `min_replicas`, `max_replicas`, `initial_replicas` refer to the number of DP groups, where each group has `dp_size` of engine instances.
+Data parallel attention deployments support autoscaling based on request queue length. Specify `min_replicas`, `max_replicas`, and `initial_replicas` to configure the autoscaling bounds and starting point. All three refer to the number of DP groups, where each group has `dp_size` engine instances.
 
 
 ```{literalinclude} ../../../../llm/doc_code/serve/multi_gpu/dp_autoscaling_example.py

--- a/doc/source/serve/llm/architecture/serving-patterns/index.md
+++ b/doc/source/serve/llm/architecture/serving-patterns/index.md
@@ -3,6 +3,7 @@
 Architecture documentation for distributed LLM serving patterns.
 
 ```{toctree}
+:hidden:
 :maxdepth: 1
 
 Data parallel attention <data-parallel>
@@ -13,8 +14,8 @@ Prefill-decode disaggregation <prefill-decode>
 
 Ray Serve LLM supports several serving patterns that can be combined for complex deployment scenarios:
 
-- **Data parallel attention**: Scale throughput by running multiple coordinated engine instances that shard requests across attention layers.
-- **Prefill-decode disaggregation**: Optimize resource utilization by separating prompt processing from token generation.
+- {doc}`Data parallel attention <data-parallel>`: scale throughput by running multiple coordinated engine replicas that process requests in parallel, replicating attention while sharding requests across the replicas.
+- {doc}`Prefill-decode disaggregation <prefill-decode>`: optimize resource utilization by separating prompt processing from token generation.
 
 These patterns are composable and can be mixed to meet specific requirements for throughput, latency, and cost optimization.
 

--- a/doc/source/serve/llm/architecture/serving-patterns/index.md
+++ b/doc/source/serve/llm/architecture/serving-patterns/index.md
@@ -18,3 +18,5 @@ Ray Serve LLM supports several serving patterns that can be combined for complex
 
 These patterns are composable and can be mixed to meet specific requirements for throughput, latency, and cost optimization.
 
+These pages describe how each pattern works. For step-by-step configuration, see the matching how-to guides: {doc}`Data parallel attention <../../user-guides/data-parallel-attention>` and {doc}`Prefill/decode disaggregation <../../user-guides/prefill-decode>`.
+

--- a/doc/source/serve/llm/benchmarks.md
+++ b/doc/source/serve/llm/benchmarks.md
@@ -1,7 +1,18 @@
 # Benchmarks
 
-Performance in LLM serving depends heavily on your specific workload characteristics and hardware stack. From a Ray Serve perspective, the focus is on orchestration overhead and the effectiveness of serving pattern implementations. The Ray team maintains the [ray-serve-llm-perf-examples](https://github.com/anyscale/ray-serve-llm-perf-examples) repository with benchmarking snapshots, tooling, and lessons learned. These benchmarks validate the correctness and effectiveness of different serving patterns. You can use these benchmarks to validate your production stack more systematically. 
+Performance in LLM serving depends heavily on your specific workload characteristics and hardware stack. From a Ray Serve perspective, the focus is on orchestration overhead and the effectiveness of serving pattern implementations. The Ray team maintains the [ray-serve-llm-perf-examples](https://github.com/anyscale/ray-serve-llm-perf-examples) repository with benchmarking snapshots, tooling, and lessons learned. These benchmarks validate the correctness and effectiveness of different serving patterns. You can use them to validate your production stack more systematically.
 
-## Replica Startup Latency
+## What to measure
 
-Replica startup times involving large models can be slow, leading to slow autoscaling and poor response to changing workloads. Experiments on replica startup can be found [here](https://github.com/anyscale/ray-serve-llm-perf-examples/tree/master/replica_initialization). The experiments illustrate the effects of the various techniques mentioned in [this guide](./user-guides/deployment-initialization.md), primarily targeting the latency cost of model loading and Torch Compile. As models grow larger, the effects of these optimizations become increasingly pronounced. As an example, we get nearly 3.88x reduction in latency on `Qwen/Qwen3-235B-A22B`.
+When you benchmark a deployment, track the metrics that map to your service objectives:
+
+- **Time to first token (TTFT)**: latency from request arrival to the first streamed token. Dominated by queueing and the prefill phase.
+- **Inter-token latency (ITL)**: time between successive tokens during generation. Determines perceived streaming speed.
+- **Throughput**: tokens per second and requests per second at a target latency. Driven by batching, parallelism, and replica count.
+- **Replica startup latency**: time for a new replica to become ready. Determines how quickly autoscaling responds to load. See below.
+
+Ray Serve LLM exposes these as built-in metrics. See {doc}`Observability and monitoring <user-guides/observability>` to collect them, and the serving-pattern guides ({doc}`prefill/decode <user-guides/prefill-decode>`, {doc}`data parallel attention <user-guides/data-parallel-attention>`) for the levers that move them.
+
+## Replica startup latency
+
+Replica startup times involving large models can be slow, leading to slow autoscaling and poor response to changing workloads. Experiments on replica startup can be found [here](https://github.com/anyscale/ray-serve-llm-perf-examples/tree/master/replica_initialization). The experiments illustrate the effects of the various techniques described in {doc}`Deployment initialization <user-guides/deployment-initialization>`, primarily targeting the latency cost of model loading and Torch Compile. As models grow larger, the effects of these optimizations become increasingly pronounced. As an example, we get nearly 3.88x reduction in latency on `Qwen/Qwen3-235B-A22B`.

--- a/doc/source/serve/llm/benchmarks.md
+++ b/doc/source/serve/llm/benchmarks.md
@@ -7,11 +7,11 @@ Performance in LLM serving depends heavily on your specific workload characteris
 When you benchmark a deployment, track the metrics that map to your service objectives:
 
 - **Time to first token (TTFT)**: latency from request arrival to the first streamed token. Dominated by queueing and the prefill phase.
-- **Inter-token latency (ITL)**: time between successive tokens during generation. Determines perceived streaming speed.
-- **Throughput**: tokens per second and requests per second at a target latency. Driven by batching, parallelism, and replica count.
+- **Time per output token (TPOT)**: average latency per generated token during decode. Determines perceived streaming speed.
+- **Throughput**: tokens per second and requests per second the deployment sustains. Driven by batching, parallelism, and replica count.
 - **Replica startup latency**: time for a new replica to become ready. Determines how quickly autoscaling responds to load. See below.
 
-Ray Serve LLM exposes these as built-in metrics. See {doc}`Observability and monitoring <user-guides/observability>` to collect them, and the serving-pattern guides ({doc}`prefill/decode <user-guides/prefill-decode>`, {doc}`data parallel attention <user-guides/data-parallel-attention>`) for the levers that move them.
+Ray Serve LLM exposes TTFT, TPOT, and throughput as built-in metrics. See {doc}`Observability and monitoring <user-guides/observability>` to collect them, and the serving-pattern guides ({doc}`prefill/decode <user-guides/prefill-decode>`, {doc}`data parallel attention <user-guides/data-parallel-attention>`) for the levers that move them.
 
 ## Replica startup latency
 

--- a/doc/source/serve/llm/examples.md
+++ b/doc/source/serve/llm/examples.md
@@ -1,18 +1,19 @@
 # Examples
 
-Production examples for deploying LLMs with Ray Serve.
+End-to-end tutorials for deploying LLMs with Ray Serve. Each one walks through configuration, deployment, and querying for a representative model. For the minimal path, start with the {doc}`Quickstart <quick-start>`.
 
-## Tutorials
+## By model size
 
-Complete end-to-end tutorials for deploying different types of LLMs:
+- {doc}`Deploy a small-sized LLM </_collections/serve/tutorials/deployment-serve-llm/small-size-llm/README>`: serve a model that fits on a single GPU. The best starting point.
+- {doc}`Deploy a medium-sized LLM </_collections/serve/tutorials/deployment-serve-llm/medium-size-llm/README>`: shard a model across multiple GPUs on one node with tensor parallelism.
+- {doc}`Deploy a large-sized LLM </_collections/serve/tutorials/deployment-serve-llm/large-size-llm/README>`: span a model across multiple nodes with cross-node parallelism.
 
-- {doc}`Deploy a small-sized LLM </_collections/serve/tutorials/deployment-serve-llm/small-size-llm/README>`
-- {doc}`Deploy a medium-sized LLM </_collections/serve/tutorials/deployment-serve-llm/medium-size-llm/README>`
-- {doc}`Deploy a large-sized LLM </_collections/serve/tutorials/deployment-serve-llm/large-size-llm/README>`
-- {doc}`Deploy a vision LLM </_collections/serve/tutorials/deployment-serve-llm/vision-llm/README>`
-- {doc}`Deploy a reasoning LLM </_collections/serve/tutorials/deployment-serve-llm/reasoning-llm/README>`
-- {doc}`Deploy a hybrid reasoning LLM </_collections/serve/tutorials/deployment-serve-llm/hybrid-reasoning-llm/README>`
-- {doc}`Deploy gpt-oss </_collections/serve/tutorials/deployment-serve-llm/gpt-oss/README>`
+## By capability
+
+- {doc}`Deploy a vision LLM </_collections/serve/tutorials/deployment-serve-llm/vision-llm/README>`: serve a vision-language model that accepts image inputs.
+- {doc}`Deploy a reasoning LLM </_collections/serve/tutorials/deployment-serve-llm/reasoning-llm/README>`: serve a reasoning model and handle its reasoning output.
+- {doc}`Deploy a hybrid reasoning LLM </_collections/serve/tutorials/deployment-serve-llm/hybrid-reasoning-llm/README>`: serve a model that can switch reasoning on and off per request.
+- {doc}`Deploy gpt-oss </_collections/serve/tutorials/deployment-serve-llm/gpt-oss/README>`: deploy OpenAI's open-weight gpt-oss model.
 
 ```{toctree}
 :hidden:
@@ -25,4 +26,3 @@ Complete end-to-end tutorials for deploying different types of LLMs:
 /_collections/serve/tutorials/deployment-serve-llm/hybrid-reasoning-llm/README
 /_collections/serve/tutorials/deployment-serve-llm/gpt-oss/README
 ```
-

--- a/doc/source/serve/llm/index.md
+++ b/doc/source/serve/llm/index.md
@@ -24,11 +24,36 @@ Ray Serve LLM excels at highly distributed multi-node inference workloads:
 - 📊 Built-in metrics and Grafana dashboards
 - 🎯 Advanced serving patterns (PD disaggregation, data parallel attention)
 
-## Requirements
+## Install
+
+Ray Serve LLM ships with Ray. Install it together with the serve and llm extras:
 
 ```bash
-pip install ray[serve,llm]
+pip install "ray[serve,llm]"
 ```
+
+This pulls in vLLM and the OpenAI-compatible server stack. You need a GPU to run most models; the quickstart below uses a small model that fits on a single A10G or L4. To serve gated models from the Hugging Face Hub (for example, Llama), set `HF_TOKEN` in the deployment's runtime environment. See {doc}`Deployment initialization <user-guides/deployment-initialization>`.
+
+## Deploy your first model
+
+Define an {class}`~ray.serve.llm.LLMConfig`, build an OpenAI-compatible app, and run it:
+
+```{literalinclude} ../../llm/doc_code/serve/qwen/qwen_example.py
+:language: python
+:start-after: __qwen_example_start__
+:end-before: __qwen_example_end__
+```
+
+Once it is running, query it with any OpenAI client at `http://localhost:8000/v1`. See the {doc}`Quickstart <quick-start>` for client snippets, multi-model apps, and config-driven (YAML) deployments.
+
+## Find your path
+
+- **New here?** Start with the {doc}`Quickstart <quick-start>` to deploy and query a model.
+- **Configuring a deployment?** The {doc}`Configuration reference <user-guides/configuration>` explains every `LLMConfig` field.
+- **Scaling up?** The {doc}`User guides <user-guides/index>` cover parallelism, routing, caching, LoRA, and observability.
+- **Want the internals?** The {doc}`Architecture <architecture/index>` docs explain components, request flow, and serving patterns.
+- **Deploying a specific model?** The {doc}`Examples <examples>` walk through small, medium, large, vision, and reasoning models end to end.
+- **Hitting an issue?** Check {doc}`Troubleshooting <troubleshooting>` and {doc}`Benchmarks <benchmarks>`.
 
 ```{toctree}
 :hidden:
@@ -40,11 +65,3 @@ Architecture <architecture/index>
 Benchmarks <benchmarks>
 Troubleshooting <troubleshooting>
 ```
-
-## Next steps
-
-- {doc}`Quickstart <quick-start>` - Deploy your first LLM with Ray Serve
-- {doc}`Examples <examples>` - Production-ready deployment tutorials
-- {doc}`User Guides <user-guides/index>` - Practical guides for advanced features
-- {doc}`Architecture <architecture/index>` - Technical design and implementation details
-- {doc}`Troubleshooting <troubleshooting>` - Common issues and solutions

--- a/doc/source/serve/llm/index.md
+++ b/doc/source/serve/llm/index.md
@@ -32,7 +32,7 @@ Ray Serve LLM ships with Ray. Install it together with the serve and llm extras:
 pip install "ray[serve,llm]"
 ```
 
-This pulls in vLLM and the OpenAI-compatible server stack. You need a GPU to run most models; the quickstart below uses a small model that fits on a single A10G or L4. To serve gated models from the Hugging Face Hub (for example, Llama), set `HF_TOKEN` in the deployment's runtime environment. See {doc}`Deployment initialization <user-guides/deployment-initialization>`.
+This pulls in vLLM and the OpenAI-compatible server stack. You need a GPU to run most models. The {doc}`Quickstart <quick-start>` covers prerequisites, supported hardware, and gated-model setup.
 
 ## Deploy your first model
 

--- a/doc/source/serve/llm/index.md
+++ b/doc/source/serve/llm/index.md
@@ -2,34 +2,25 @@
 
 # Serving LLMs
 
-Ray Serve LLM provides a high-performance, scalable framework for deploying Large Language Models (LLMs) in production. It specializes Ray Serve primitives for distributed LLM serving workloads, offering enterprise-grade features with OpenAI API compatibility.
+Ray Serve LLM deploys large language models in production. It builds on Ray Serve primitives for distributed, multi-node LLM serving and exposes an OpenAI-compatible API.
 
-## Why Ray Serve LLM?
+## Key features
 
-Ray Serve LLM excels at highly distributed multi-node inference workloads:
-
-- **Advanced parallelism strategies**: Seamlessly combine pipeline parallelism, tensor parallelism, expert parallelism, and data parallel attention for models of any size.
-- **Prefill-decode disaggregation**: Separates and optimizes prefill and decode phases independently for better resource utilization and cost efficiency.
-- **Custom request routing**: Implements prefix-aware, session-aware, or custom routing logic to maximize cache hits and reduce latency.
-- **Multi-node deployments**: Serves massive models that span multiple nodes with automatic placement and coordination.
-- **Production-ready**: Has built-in autoscaling, monitoring, fault tolerance, and observability.
-
-## Features
-
-- ⚡️ Automatic scaling and load balancing
-- 🌐 Unified multi-node multi-model deployment
-- 🔌 OpenAI-compatible API
-- 🔄 Multi-LoRA support with shared base models
-- 🚀 Engine-agnostic architecture (vLLM, SGLang, etc.)
-- 📊 Built-in metrics and Grafana dashboards
-- 🎯 Advanced serving patterns (PD disaggregation, data parallel attention)
+- OpenAI-compatible API for chat, completions, and embeddings.
+- Multi-node, multi-model deployment with autoscaling and load balancing.
+- Parallelism strategies: tensor, pipeline, expert, and data parallel attention.
+- Prefill-decode disaggregation to scale the prefill and decode phases independently.
+- Custom request routing, including prefix-aware routing for higher cache hit rates.
+- Multi-LoRA serving on a shared base model.
+- Engine-agnostic backends such as vLLM and SGLang.
+- Built-in metrics and Grafana dashboards.
 
 ## Install
 
-Ray Serve LLM ships with Ray. Install it together with the serve and llm extras:
+Ray Serve LLM ships with Ray. Install it with the `llm` extra:
 
 ```bash
-pip install "ray[serve,llm]"
+pip install "ray[llm]"
 ```
 
 This pulls in vLLM and the OpenAI-compatible server stack. You need a GPU to run most models. The {doc}`Quickstart <quick-start>` covers prerequisites, supported hardware, and gated-model setup.

--- a/doc/source/serve/llm/quick-start.md
+++ b/doc/source/serve/llm/quick-start.md
@@ -1,6 +1,19 @@
 (quick-start)=
 # Quickstart examples
 
+## Prerequisites
+
+```bash
+pip install "ray[serve,llm]"
+```
+
+Before you start:
+
+- **GPU**: most models need at least one GPU. The examples below use small Qwen models that fit on a single A10G or L4. Set `accelerator_type` to a GPU available in your cluster.
+- **Gated models**: to pull gated weights (for example, Llama) from the Hugging Face Hub, set `HF_TOKEN` in the deployment's `runtime_env`. See {doc}`Deployment initialization <user-guides/deployment-initialization>`.
+
+For a full description of every configuration field used below, see the {doc}`Configuration reference <user-guides/configuration>`.
+
 ## Deployment through OpenAiIngress
 
 You can deploy LLM models using either the builder pattern or bind pattern.
@@ -270,11 +283,15 @@ serve run config.yaml
 
 For monitoring and observability, see {doc}`Observability <user-guides/observability>`.
 
-## Advanced usage patterns
+## Next steps
 
-For each usage pattern, Ray Serve LLM provides a server and client code snippet.
+Once you can deploy and query a model, the {doc}`User guides <user-guides/index>` cover the next steps:
 
-### Cross-node parallelism
+- **Configure the deployment**: every field is documented in the {doc}`Configuration reference <user-guides/configuration>`.
+- **Scale across GPUs and nodes**: {doc}`Cross-node parallelism <user-guides/cross-node-parallelism>` distributes a model with tensor and pipeline parallelism; {doc}`Data parallel attention <user-guides/data-parallel-attention>` raises throughput by replicating the model.
+- **Tune latency and throughput**: {doc}`Prefill/decode disaggregation <user-guides/prefill-decode>`, {doc}`KV cache offloading <user-guides/kv-cache-offloading>`, and {doc}`Prefix-aware routing <user-guides/prefix-aware-routing>`.
+- **Serve LoRA adapters**: {doc}`Multi-LoRA deployment <user-guides/multi-lora>`.
+- **Monitor in production**: {doc}`Observability and monitoring <user-guides/observability>`.
 
-Ray Serve LLM supports cross-node tensor parallelism (TP) and pipeline parallelism (PP), allowing you to distribute model inference across multiple GPUs and nodes. See {doc}`Cross-node parallelism <user-guides/cross-node-parallelism>` for a comprehensive guide on configuring and deploying models with cross-node parallelism.
+To understand how these pieces fit together, see the {doc}`Architecture <architecture/index>` docs.
 

--- a/doc/source/serve/llm/quick-start.md
+++ b/doc/source/serve/llm/quick-start.md
@@ -4,7 +4,7 @@
 ## Prerequisites
 
 ```bash
-pip install "ray[serve,llm]"
+pip install "ray[llm]"
 ```
 
 Before you start:

--- a/doc/source/serve/llm/quick-start.md
+++ b/doc/source/serve/llm/quick-start.md
@@ -1,5 +1,5 @@
 (quick-start)=
-# Quickstart examples
+# Quickstart
 
 ## Prerequisites
 
@@ -288,7 +288,7 @@ For monitoring and observability, see {doc}`Observability <user-guides/observabi
 Once you can deploy and query a model, the {doc}`User guides <user-guides/index>` cover the next steps:
 
 - **Configure the deployment**: every field is documented in the {doc}`Configuration reference <user-guides/configuration>`.
-- **Scale across GPUs and nodes**: {doc}`Cross-node parallelism <user-guides/cross-node-parallelism>` distributes a model with tensor and pipeline parallelism; {doc}`Data parallel attention <user-guides/data-parallel-attention>` raises throughput by replicating the model.
+- **Scale across GPUs and nodes**: {doc}`Cross-node parallelism <user-guides/cross-node-parallelism>` distributes a model with tensor and pipeline parallelism. {doc}`Data parallel attention <user-guides/data-parallel-attention>` raises throughput by replicating the model.
 - **Tune latency and throughput**: {doc}`Prefill/decode disaggregation <user-guides/prefill-decode>`, {doc}`KV cache offloading <user-guides/kv-cache-offloading>`, and {doc}`Prefix-aware routing <user-guides/prefix-aware-routing>`.
 - **Serve LoRA adapters**: {doc}`Multi-LoRA deployment <user-guides/multi-lora>`.
 - **Monitor in production**: {doc}`Observability and monitoring <user-guides/observability>`.

--- a/doc/source/serve/llm/user-guides/configuration.md
+++ b/doc/source/serve/llm/user-guides/configuration.md
@@ -8,7 +8,7 @@ This page documents every field. For the design behind these abstractions, see {
 
 ## Minimal configuration
 
-Only `model_loading_config` is required. Everything else has a default:
+Only `model_loading_config` is required. Every other field has a default. The example also sets `accelerator_type` so replicas schedule onto the right GPU:
 
 ```python
 from ray.serve.llm import LLMConfig
@@ -29,7 +29,7 @@ llm_config = LLMConfig(
 | `model_loading_config` | dict or `ModelLoadingConfig` | required | Which model to serve and where to load it from. See [Model loading](#model-loading). |
 | `engine_kwargs` | dict | `{}` | Arguments forwarded to the inference engine (vLLM). See [Engine arguments](#engine-arguments). |
 | `accelerator_type` | str | `None` | The accelerator the model runs on, for example `"A10G"`. See [Accelerators](#accelerators-and-placement). |
-| `accelerator_config` | dict | inferred | Hardware-specific config (GPU, TPU, CPU). Inferred from `accelerator_type` or `placement_group_config` when omitted. |
+| `accelerator_config` | dict | `None` | Hardware-specific config (GPU, TPU, CPU). Inferred from `accelerator_type` or `placement_group_config` when omitted. |
 | `placement_group_config` | dict | `None` | Resource bundles and placement strategy for engine workers. See [Accelerators and placement](#accelerators-and-placement). |
 | `deployment_config` | dict | `{}` | Ray Serve deployment options such as autoscaling and replicas. See [Deployment options](#deployment-options). |
 | `lora_config` | dict or `LoraConfig` | `None` | LoRA adapter settings. See [LoRA](#lora). |
@@ -47,8 +47,8 @@ llm_config = LLMConfig(
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `model_id` | str | required | The ID end users pass as `model` in API requests. |
-| `model_source` | str or `CloudMirrorConfig` | `model_id` | Where to load weights from. When omitted, defaults to `model_id` as a Hugging Face ID. |
-| `tokenizer_source` | str | `None` | Where to load the tokenizer from. Defaults to the model source. Hugging Face IDs only. |
+| `model_source` | str or `CloudMirrorConfig` | `None` | Where to load weights from. When unset, defaults to `model_id` as a Hugging Face ID. |
+| `tokenizer_source` | str | `None` | Where to load the tokenizer from. When unset, the tokenizer is loaded from the model source. Hugging Face IDs only. |
 
 `model_source` accepts several forms:
 
@@ -85,7 +85,7 @@ For the full list, see the [vLLM engine arguments](https://docs.vllm.ai/en/lates
 
 ## Accelerators and placement
 
-Set `accelerator_type` to the accelerator each replica should be scheduled on. Common GPU values include `A10G`, `A100`, `H100`, `H200`, `L4`, `L40S`, and `T4`; TPUs such as `TPU-V4` and `TPU-V5P` are also supported. `A10` is normalized to `A10G`. An unsupported value raises a validation error.
+Set `accelerator_type` to the accelerator each replica should be scheduled on. Common GPU values include `A10G`, `A100`, `H100`, `H200`, `L4`, `L40S`, and `T4`. TPUs such as `TPU-V4` and `TPU-V5P` are also supported. `A10` is normalized to `A10G`. An unsupported value raises a validation error.
 
 `accelerator_config` is inferred from `accelerator_type` (or from `placement_group_config` bundles) and rarely needs to be set explicitly.
 
@@ -131,8 +131,8 @@ When `lora_config` is set, the deployment serves LoRA adapters on top of the bas
 |-------|------|---------|-------------|
 | `dynamic_lora_loading_path` | str | `None` | Cloud storage path (`s3://`, `gs://`, `abfss://`, or `azure://`) holding adapter weights. |
 | `max_num_adapters_per_replica` | int | `16` | Maximum adapters loaded on each replica, evicted LRU. |
-| `download_timeout_s` | float | set by default | Per-adapter download timeout. `None` disables the timeout. |
-| `max_download_tries` | int | set by default | Maximum adapter download retries. |
+| `download_timeout_s` | float | `30` | Per-adapter download timeout in seconds. A value `<= 0` disables the timeout. |
+| `max_download_tries` | int | `3` | Maximum adapter download retries. |
 
 See {doc}`Multi-LoRA deployment <multi-lora>` for the full workflow.
 
@@ -142,12 +142,12 @@ See {doc}`Multi-LoRA deployment <multi-lora>` for the full workflow.
 
 | Key | Description |
 |-----|-------------|
-| `stream_batching_interval_ms` | How long to batch streaming responses before flushing them. |
-| `num_ingress_replicas` | Number of ingress (router) replicas. Defaults to roughly two per model replica. |
+| `stream_batching_interval_ms` | How long to batch streaming responses before flushing them. Defaults to `50`. |
+| `num_ingress_replicas` | Number of ingress (router) replicas. |
 
 ## YAML equivalent
 
-The same configuration in a Serve config file. `LLMConfig` fields map one to one onto YAML keys:
+A config-file (YAML) deployment. `LLMConfig` fields map one to one onto YAML keys:
 
 ```yaml
 applications:
@@ -174,5 +174,4 @@ Deploy it with `serve run config.yaml`.
 ## See also
 
 - {doc}`Quickstart <../quick-start>`: deploy and query a model.
-- {doc}`Core components <../architecture/core>`: the abstractions behind these fields.
 - {class}`LLMConfig API reference <ray.serve.llm.LLMConfig>`: the generated API docs.

--- a/doc/source/serve/llm/user-guides/configuration.md
+++ b/doc/source/serve/llm/user-guides/configuration.md
@@ -81,7 +81,7 @@ A cloud mirror is validated against `CloudMirrorConfig` and supports `s3://`, `g
 | `max_num_seqs` | Maximum number of sequences batched together per step. |
 | `kv_transfer_config` | KV connector settings for prefill/decode and cache offloading. See {doc}`KV cache offloading <kv-cache-offloading>`. |
 
-For the full list, see the [vLLM engine arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html). Note that `disable_log_stats=True` is rejected when `log_engine_metrics` is enabled, because engine metrics require log stats.
+For the full list, see the [vLLM engine arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html). `disable_log_stats=True` is rejected when `log_engine_metrics` is enabled, because engine metrics require log stats.
 
 ## Accelerators and placement
 

--- a/doc/source/serve/llm/user-guides/configuration.md
+++ b/doc/source/serve/llm/user-guides/configuration.md
@@ -26,13 +26,13 @@ llm_config = LLMConfig(
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `model_loading_config` | dict or `ModelLoadingConfig` | required | Which model to serve and where to load it from. See [Model loading](#model-loading). |
+| `model_loading_config` | dict or {class}`~ray.serve.llm.ModelLoadingConfig` | required | Which model to serve and where to load it from. See [Model loading](#model-loading). |
 | `engine_kwargs` | dict | `{}` | Arguments forwarded to the inference engine (vLLM). See [Engine arguments](#engine-arguments). |
 | `accelerator_type` | str | `None` | The accelerator the model runs on, for example `"A10G"`. See [Accelerators](#accelerators-and-placement). |
 | `accelerator_config` | dict | `None` | Hardware-specific config (GPU, TPU, CPU). Inferred from `accelerator_type` or `placement_group_config` when omitted. |
 | `placement_group_config` | dict | `None` | Resource bundles and placement strategy for engine workers. See [Accelerators and placement](#accelerators-and-placement). |
 | `deployment_config` | dict | `{}` | Ray Serve deployment options such as autoscaling and replicas. See [Deployment options](#deployment-options). |
-| `lora_config` | dict or `LoraConfig` | `None` | LoRA adapter settings. See [LoRA](#lora). |
+| `lora_config` | dict or {class}`~ray.serve.llm.LoraConfig` | `None` | LoRA adapter settings. See [LoRA](#lora). |
 | `runtime_env` | dict | `None` | Ray runtime environment applied to the replica and engine workers (for example, `env_vars`). |
 | `llm_engine` | str | `"vLLM"` | The inference engine. `"vLLM"` is the supported value. |
 | `server_cls` | str or class | `None` | Custom server class, for example `SGLangServer`. Accepts an import path string or a class. See {doc}`SGLang integration <sglang>`. |
@@ -42,7 +42,7 @@ llm_config = LLMConfig(
 
 ## Model loading
 
-`model_loading_config` is validated against `ModelLoadingConfig`:
+`model_loading_config` is validated against {class}`~ray.serve.llm.ModelLoadingConfig`:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -66,7 +66,7 @@ model_loading_config=dict(
 )
 ```
 
-A cloud mirror is validated against `CloudMirrorConfig` and supports `s3://`, `gs://`, `abfss://`, and `azure://` URIs. Mirroring weights from cloud storage avoids per-replica Hugging Face downloads. See {doc}`Deployment initialization <deployment-initialization>`.
+A cloud mirror is validated against {class}`~ray.serve.llm.CloudMirrorConfig` and supports `s3://`, `gs://`, `abfss://`, and `azure://` URIs. Mirroring weights from cloud storage avoids per-replica Hugging Face downloads. See {doc}`Deployment initialization <deployment-initialization>`.
 
 ## Engine arguments
 
@@ -125,7 +125,7 @@ Set `num_replicas="auto"` to let Serve autoscale. Use `request_router_config` to
 
 ## LoRA
 
-When `lora_config` is set, the deployment serves LoRA adapters on top of the base model. It is validated against `LoraConfig`:
+When `lora_config` is set, the deployment serves LoRA adapters on top of the base model. It is validated against {class}`~ray.serve.llm.LoraConfig`:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/doc/source/serve/llm/user-guides/configuration.md
+++ b/doc/source/serve/llm/user-guides/configuration.md
@@ -1,0 +1,178 @@
+(serve-llm-configuration)=
+
+# Configuration reference
+
+{class}`LLMConfig <ray.serve.llm.LLMConfig>` is the central configuration object for a Ray Serve LLM deployment. It describes which model to serve, which engine and hardware to run it on, how to scale it, and how to expose it. You pass one `LLMConfig` per model to a builder such as {func}`build_openai_app <ray.serve.llm.build_openai_app>`, or you write the equivalent YAML.
+
+This page documents every field. For the design behind these abstractions, see {doc}`Core components <../architecture/core>`.
+
+## Minimal configuration
+
+Only `model_loading_config` is required. Everything else has a default:
+
+```python
+from ray.serve.llm import LLMConfig
+
+llm_config = LLMConfig(
+    model_loading_config=dict(
+        model_id="qwen-0.5b",
+        model_source="Qwen/Qwen2.5-0.5B-Instruct",
+    ),
+    accelerator_type="A10G",
+)
+```
+
+## Top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model_loading_config` | dict or `ModelLoadingConfig` | required | Which model to serve and where to load it from. See [Model loading](#model-loading). |
+| `engine_kwargs` | dict | `{}` | Arguments forwarded to the inference engine (vLLM). See [Engine arguments](#engine-arguments). |
+| `accelerator_type` | str | `None` | The accelerator the model runs on, for example `"A10G"`. See [Accelerators](#accelerators-and-placement). |
+| `accelerator_config` | dict | inferred | Hardware-specific config (GPU, TPU, CPU). Inferred from `accelerator_type` or `placement_group_config` when omitted. |
+| `placement_group_config` | dict | `None` | Resource bundles and placement strategy for engine workers. See [Accelerators and placement](#accelerators-and-placement). |
+| `deployment_config` | dict | `{}` | Ray Serve deployment options such as autoscaling and replicas. See [Deployment options](#deployment-options). |
+| `lora_config` | dict or `LoraConfig` | `None` | LoRA adapter settings. See [LoRA](#lora). |
+| `runtime_env` | dict | `None` | Ray runtime environment applied to the replica and engine workers (for example, `env_vars`). |
+| `llm_engine` | str | `"vLLM"` | The inference engine. `"vLLM"` is the supported value. |
+| `server_cls` | str or class | `None` | Custom server class, for example `SGLangServer`. Accepts an import path string or a class. See {doc}`SGLang integration <sglang>`. |
+| `experimental_configs` | dict | `{}` | Experimental knobs. See [Experimental configs](#experimental-configs). |
+| `log_engine_metrics` | bool | `True` | Export engine metrics through the Ray Prometheus port. See {doc}`Observability <observability>`. |
+| `callback_config` | `CallbackConfig` | default | Initialization callbacks. See {doc}`Deployment initialization <deployment-initialization>`. |
+
+## Model loading
+
+`model_loading_config` is validated against `ModelLoadingConfig`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model_id` | str | required | The ID end users pass as `model` in API requests. |
+| `model_source` | str or `CloudMirrorConfig` | `model_id` | Where to load weights from. When omitted, defaults to `model_id` as a Hugging Face ID. |
+| `tokenizer_source` | str | `None` | Where to load the tokenizer from. Defaults to the model source. Hugging Face IDs only. |
+
+`model_source` accepts several forms:
+
+```python
+# Hugging Face Hub ID
+model_loading_config=dict(model_id="qwen", model_source="Qwen/Qwen2.5-0.5B-Instruct")
+
+# Local path
+model_loading_config=dict(model_id="qwen", model_source="/mnt/models/qwen")
+
+# Cloud storage mirror (S3, GCS, or Azure)
+model_loading_config=dict(
+    model_id="qwen",
+    model_source=dict(bucket_uri="s3://my-bucket/path/to/qwen"),
+)
+```
+
+A cloud mirror is validated against `CloudMirrorConfig` and supports `s3://`, `gs://`, `abfss://`, and `azure://` URIs. Mirroring weights from cloud storage avoids per-replica Hugging Face downloads. See {doc}`Deployment initialization <deployment-initialization>`.
+
+## Engine arguments
+
+`engine_kwargs` are passed straight through to the engine, so any vLLM engine argument is valid here. Commonly used ones:
+
+| Argument | Description |
+|----------|-------------|
+| `tensor_parallel_size` | Number of GPUs to shard each model replica across. See {doc}`Cross-node parallelism <cross-node-parallelism>`. |
+| `pipeline_parallel_size` | Number of pipeline stages, used to span nodes. |
+| `max_model_len` | Maximum context length (prompt plus generated tokens). |
+| `gpu_memory_utilization` | Fraction of GPU memory the engine may use for weights and KV cache. |
+| `max_num_seqs` | Maximum number of sequences batched together per step. |
+| `kv_transfer_config` | KV connector settings for prefill/decode and cache offloading. See {doc}`KV cache offloading <kv-cache-offloading>`. |
+
+For the full list, see the [vLLM engine arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html). Note that `disable_log_stats=True` is rejected when `log_engine_metrics` is enabled, because engine metrics require log stats.
+
+## Accelerators and placement
+
+Set `accelerator_type` to the accelerator each replica should be scheduled on. Common GPU values include `A10G`, `A100`, `H100`, `H200`, `L4`, `L40S`, and `T4`; TPUs such as `TPU-V4` and `TPU-V5P` are also supported. `A10` is normalized to `A10G`. An unsupported value raises a validation error.
+
+`accelerator_config` is inferred from `accelerator_type` (or from `placement_group_config` bundles) and rarely needs to be set explicitly.
+
+Use `placement_group_config` to control how engine workers are packed onto nodes, for example for multi-node tensor or pipeline parallelism. Provide either `bundle_per_worker` (auto-replicated by `tensor_parallel_size * pipeline_parallel_size`) or an explicit `bundles` list, plus an optional `strategy`:
+
+```python
+# One GPU bundle per worker, spread across nodes
+placement_group_config=dict(
+    bundle_per_worker={"CPU": 1, "GPU": 1},
+    strategy="SPREAD",
+)
+
+# Explicit bundle list
+placement_group_config=dict(
+    bundles=[{"CPU": 1, "GPU": 1}] * 4,
+    strategy="STRICT_PACK",
+)
+```
+
+`strategy` is one of `PACK`, `STRICT_PACK`, `SPREAD`, or `STRICT_SPREAD`. See {doc}`Cross-node parallelism <cross-node-parallelism>` for worked examples.
+
+## Deployment options
+
+`deployment_config` holds standard Ray Serve `@serve.deployment` options. Supported keys: `name`, `num_replicas`, `ray_actor_options`, `max_ongoing_requests`, `autoscaling_config`, `max_queued_requests`, `user_config`, `health_check_period_s`, `health_check_timeout_s`, `graceful_shutdown_wait_loop_s`, `graceful_shutdown_timeout_s`, `logging_config`, and `request_router_config`.
+
+```python
+deployment_config=dict(
+    autoscaling_config=dict(
+        min_replicas=1,
+        max_replicas=4,
+    ),
+    max_ongoing_requests=64,
+)
+```
+
+Set `num_replicas="auto"` to let Serve autoscale. Use `request_router_config` to plug in a custom router, for example for {doc}`prefix-aware routing <prefix-aware-routing>`. For the meaning of each option, see the [Ray Serve deployment configuration](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html) docs.
+
+## LoRA
+
+When `lora_config` is set, the deployment serves LoRA adapters on top of the base model. It is validated against `LoraConfig`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dynamic_lora_loading_path` | str | `None` | Cloud storage path (`s3://`, `gs://`, `abfss://`, or `azure://`) holding adapter weights. |
+| `max_num_adapters_per_replica` | int | `16` | Maximum adapters loaded on each replica, evicted LRU. |
+| `download_timeout_s` | float | set by default | Per-adapter download timeout. `None` disables the timeout. |
+| `max_download_tries` | int | set by default | Maximum adapter download retries. |
+
+See {doc}`Multi-LoRA deployment <multi-lora>` for the full workflow.
+
+## Experimental configs
+
+`experimental_configs` is a dictionary of opt-in knobs that may change between releases:
+
+| Key | Description |
+|-----|-------------|
+| `stream_batching_interval_ms` | How long to batch streaming responses before flushing them. |
+| `num_ingress_replicas` | Number of ingress (router) replicas. Defaults to roughly two per model replica. |
+
+## YAML equivalent
+
+The same configuration in a Serve config file. `LLMConfig` fields map one to one onto YAML keys:
+
+```yaml
+applications:
+- args:
+    llm_configs:
+    - model_loading_config:
+        model_id: qwen-0.5b
+        model_source: Qwen/Qwen2.5-0.5B-Instruct
+      accelerator_type: A10G
+      engine_kwargs:
+        tensor_parallel_size: 2
+        max_model_len: 8192
+      deployment_config:
+        autoscaling_config:
+          min_replicas: 1
+          max_replicas: 4
+  import_path: ray.serve.llm:build_openai_app
+  name: llm_app
+  route_prefix: "/"
+```
+
+Deploy it with `serve run config.yaml`.
+
+## See also
+
+- {doc}`Quickstart <../quick-start>`: deploy and query a model.
+- {doc}`Core components <../architecture/core>`: the abstractions behind these fields.
+- {class}`LLMConfig API reference <ray.serve.llm.LLMConfig>`: the generated API docs.

--- a/doc/source/serve/llm/user-guides/cross-node-parallelism.md
+++ b/doc/source/serve/llm/user-guides/cross-node-parallelism.md
@@ -1,11 +1,11 @@
 (cross-node-parallelism)=
 # Cross-node parallelism
 
-Ray Serve LLM supports cross-node tensor parallelism (TP) and pipeline parallelism (PP), allowing you to distribute model inference across multiple GPUs and nodes. This capability enables you to:
+Ray Serve LLM supports cross-node tensor parallelism (TP) and pipeline parallelism (PP), which distribute model inference across multiple GPUs and nodes. Use cross-node parallelism to:
 
 - Deploy models that don't fit on a single GPU or node.
 - Scale model serving across your cluster's available resources.
-- Leverage Ray's placement group strategies to control worker placement for performance or fault tolerance.
+- Use Ray's placement group strategies to control worker placement for performance or fault tolerance.
 
 ::::{note}
 By default, Ray Serve LLM uses the `PACK` placement strategy, which tries to place workers on as few nodes as possible. If workers can't fit on a single node, they automatically spill to other nodes. This enables cross-node deployments when single-node resources are insufficient.
@@ -77,7 +77,7 @@ You can customize how Ray places vLLM engine workers across nodes using `placeme
 
 ### Basic configuration with bundle_per_worker
 
-The `bundle_per_worker` option inside `placement_group_config` lets you specify resources for each worker without manually creating the full bundle list. Ray automatically replicates this bundle based on `tensor_parallel_size * pipeline_parallel_size`. This field is mutually exclusive with `bundles`.
+Use the `bundle_per_worker` option inside `placement_group_config` to specify resources for each worker without manually creating the full bundle list. Ray automatically replicates this bundle based on `tensor_parallel_size * pipeline_parallel_size`. This field is mutually exclusive with `bundles`.
 
 :::{note}
 In each bundle dict, `CPU` and `GPU` are numeric amounts. If you omit either key, it is treated as **0** — set both explicitly when your workers need CPUs and GPUs (there is no implicit default GPU when you only specify CPU, or vice versa).

--- a/doc/source/serve/llm/user-guides/data-parallel-attention.md
+++ b/doc/source/serve/llm/user-guides/data-parallel-attention.md
@@ -151,7 +151,7 @@ This configuration creates:
 - **PDDecodeServer**: Orchestrates remote prefill then runs local decode
 - **OpenAI ingress**: Provides OpenAI-compatible API endpoints
 
-This allows you to:
+With this setup, you can:
 - Optimize prefill and decode phases independently based on workload characteristics
 - Use data parallel attention within each phase for increased throughput
 

--- a/doc/source/serve/llm/user-guides/direct-streaming.md
+++ b/doc/source/serve/llm/user-guides/direct-streaming.md
@@ -85,7 +85,7 @@ Ray Serve sets `TCP_NODELAY` by default (`RAY_SERVE_HAPROXY_TCP_NODELAY=1`) so t
 
 ## When to use direct streaming
 
-Direct streaming is the high-performance, experimental serving path for Ray Serve LLM. Removing the ingress proxy hop cuts per-token overhead on streaming responses, which matters most for long generations and latency-sensitive, high-throughput deployments. It's intended to become the default serving path as it matures.
+Direct streaming is an experimental serving path for Ray Serve LLM. Removing the ingress proxy hop cuts per-token overhead on streaming responses, which matters most for long generations and latency-sensitive, high-throughput deployments. Ray intends it to become the default serving path as it matures.
 
 ## How it works
 

--- a/doc/source/serve/llm/user-guides/fractional-gpu.md
+++ b/doc/source/serve/llm/user-guides/fractional-gpu.md
@@ -7,7 +7,7 @@ Serve multiple small models on the same GPU for cost-efficient deployments.
 This feature hasn't been extensively tested in production. If you encounter any issues, report them on [GitHub](https://github.com/ray-project/ray/issues) with reproducible code.
 :::
 
-Fractional GPU allocation allows you to run multiple model replicas on a single GPU by customizing placement groups. This approach maximizes GPU utilization and reduces costs when serving small models that don't require a full GPU's resources.
+Fractional GPU allocation runs multiple model replicas on a single GPU by customizing placement groups. Use it to raise GPU utilization and reduce cost when serving small models that don't need a full GPU.
 
 ## When to use fractional GPUs
 

--- a/doc/source/serve/llm/user-guides/index.md
+++ b/doc/source/serve/llm/user-guides/index.md
@@ -1,21 +1,50 @@
 # User guides
 
-How-to guides for deploying and configuring Ray Serve LLM features.
+How-to guides for deploying, scaling, and operating Ray Serve LLM. If you are new, start with the {doc}`Quickstart <../quick-start>`, then come back here to go deeper.
+
+## Configure and deploy
+
+- {doc}`Configuration reference <configuration>`: every `LLMConfig` field, from model loading and engine kwargs to accelerators, placement, and deployment options.
+- {doc}`Deployment initialization <deployment-initialization>`: speed up model loading and replica startup with caching, streaming load formats, and initialization callbacks.
+- {doc}`Multi-LoRA deployment <multi-lora>`: serve many LoRA adapters on a shared base model with runtime switching and an LRU cache.
+
+## Scale across GPUs and nodes
+
+- {doc}`Cross-node parallelism <cross-node-parallelism>`: distribute a model across GPUs and nodes with tensor and pipeline parallelism and placement groups.
+- {doc}`Data parallel attention <data-parallel-attention>`: replicate the model into coordinated data-parallel groups to raise throughput, especially for MoE models.
+- {doc}`Fractional GPU serving <fractional-gpu>`: pack multiple small-model replicas onto a single GPU.
+
+## Optimize latency and throughput
+
+- {doc}`Prefill/decode disaggregation <prefill-decode>`: split prompt processing and token generation onto separate replicas to tune each independently.
+- {doc}`KV cache offloading <kv-cache-offloading>`: extend KV cache capacity with LMCache and tiered storage backends.
+- {doc}`Prefix-aware routing <prefix-aware-routing>`: route requests to replicas that already hold a matching prefix to maximize cache hits.
+- {doc}`Direct streaming <direct-streaming>`: bypass the ingress when streaming tokens to cut per-token latency.
+
+## Choose an engine
+
+- {doc}`vLLM compatibility <vllm-compatibility>`: use vLLM features such as embeddings, structured outputs, vision, and reasoning through Ray Serve LLM.
+- {doc}`SGLang integration <sglang>`: run SGLang as the inference engine instead of vLLM.
+
+## Operate in production
+
+- {doc}`Observability and monitoring <observability>`: engine and request metrics, Grafana dashboards, and Prometheus integration.
 
 ```{toctree}
+:hidden:
 :maxdepth: 1
 
+Configuration reference <configuration>
+Deployment initialization <deployment-initialization>
+Multi-LoRA deployment <multi-lora>
 Cross-node parallelism <cross-node-parallelism>
 Data parallel attention <data-parallel-attention>
-Deployment Initialization <deployment-initialization>
+Fractional GPU serving <fractional-gpu>
 Prefill/decode disaggregation <prefill-decode>
 KV cache offloading <kv-cache-offloading>
-Direct streaming <direct-streaming>
 Prefix-aware routing <prefix-aware-routing>
-Multi-LoRA deployment <multi-lora>
-SGLang integration <sglang>
+Direct streaming <direct-streaming>
 vLLM compatibility <vllm-compatibility>
-Fractional GPU serving <fractional-gpu>
+SGLang integration <sglang>
 Observability and monitoring <observability>
 ```
-

--- a/doc/source/serve/llm/user-guides/kv-cache-offloading.md
+++ b/doc/source/serve/llm/user-guides/kv-cache-offloading.md
@@ -4,7 +4,7 @@
 Extend KV cache capacity by offloading to CPU memory or local disk for larger batch sizes and reduced GPU memory pressure.
 
 :::{note}
-Ray Serve doesn't provide KV cache offloading out of the box, but integrates seamlessly with vLLM solutions. This guide demonstrates one such integration: LMCache.
+Ray Serve doesn't provide KV cache offloading out of the box, but it integrates with vLLM solutions. This guide demonstrates one such integration: LMCache.
 :::
 
 
@@ -266,4 +266,4 @@ Extending KV cache beyond local GPU memory introduces overhead for managing and 
 ## See also
 
 - {doc}`Prefill/decode disaggregation <prefill-decode>` - Deploy LLMs with separated prefill and decode phases
-- [LMCache documentation](https://docs.lmcache.ai/) - Comprehensive LMCache configuration and features
+- [LMCache documentation](https://docs.lmcache.ai/) - LMCache configuration and features

--- a/doc/source/serve/llm/user-guides/observability.md
+++ b/doc/source/serve/llm/user-guides/observability.md
@@ -3,7 +3,7 @@
 
 Monitor your LLM deployments with built-in metrics, dashboards, and logging.
 
-Ray Serve LLM provides comprehensive observability with the following features:
+Ray Serve LLM includes the following observability features:
 
 - **Service-level metrics**: Request and token behavior across deployed models.
 - **Engine metrics**: vLLM-specific performance metrics such as TTFT and TPOT.

--- a/doc/source/serve/llm/user-guides/prefill-decode.md
+++ b/doc/source/serve/llm/user-guides/prefill-decode.md
@@ -208,7 +208,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \
 
 - **Choose the right backend**: Use NIXLConnector for simpler deployments. Use LMCacheConnectorV1 when you need advanced caching or multiple storage backends.
 - **Monitor KV transfer overhead**: Ensure that the benefits of disaggregation outweigh the network transfer costs. Monitor latency and throughput.
-- **Scale independently**: Take advantage of independent scaling by monitoring resource utilization for each phase separately.
+- **Scale independently**: Monitor resource utilization for each phase separately and scale each one on its own.
 - **Test with realistic workloads**: Validate performance improvements with your actual traffic patterns before production deployment.
 - **Ensure network connectivity**: For NIXLConnector, verify that prefill and decode instances can communicate over the network.
 - **Secure etcd access**: For LMCacheConnectorV1, ensure your etcd server is properly secured and accessible only to authorized services.

--- a/doc/source/serve/llm/user-guides/sglang.md
+++ b/doc/source/serve/llm/user-guides/sglang.md
@@ -18,7 +18,7 @@ Community SGLang support is in early development. Track progress and provide fee
 ## Prerequisites
 
 ```bash
-pip install ray[serve,llm] "sglang[all,ray]"
+pip install "ray[llm]" "sglang[all,ray]"
 ```
 
 Set the following environment variable before running any example:

--- a/doc/source/serve/llm/user-guides/vllm-compatibility.md
+++ b/doc/source/serve/llm/user-guides/vllm-compatibility.md
@@ -6,9 +6,9 @@ Ray Serve LLM provides an OpenAI-compatible API that aligns with vLLM's OpenAI-c
 This compatibility means you can:
 
 - Use the same model configurations and engine arguments as vLLM
-- Leverage vLLM's latest features (multimodal, structured output, reasoning models)
+- Use vLLM features such as multimodal, structured output, and reasoning models
 - Switch between `vllm serve` and Ray Serve LLM with no code changes and scale
-- Take advantage of Ray Serve's production features (autoscaling, multi-model serving, advanced routing)
+- Use Ray Serve's production features such as autoscaling, multi-model serving, and advanced routing
 
 This guide shows how to use vLLM features such as embeddings, structured output, vision language models, and reasoning models with Ray Serve.
 


### PR DESCRIPTION
## Why are these changes needed?

The Ray Serve LLM docs entry points are hard to navigate. The landing pages list links without describing them, the user-guide and architecture indexes are flat lists, and there is no single reference for `LLMConfig` fields, so users have to read the source to learn what each field does.

This PR reworks the entry points and adds the missing configuration reference. It is docs-only.

### Landing pages
- `index.md`: add an install section, a runnable first-deploy example (reuses the CI-tested `qwen_example.py` so it cannot drift), and goal-oriented navigation in place of a list that duplicated the toctree.
- `user-guides/index.md`: group the guides by task (configure and deploy, scale, optimize, engines, operate) with a one-line description for each.
- `architecture/index.md`: add orientation and a suggested reading order.
- `examples.md`: describe each tutorial and group by model size and capability.
- `architecture/serving-patterns/index.md`: link each pattern to its how-to guide.

### Other pages
- `benchmarks.md`: add a "what to measure" section covering TTFT, inter-token latency, throughput, and replica startup latency.
- `quick-start.md`: add prerequisites and next-steps sections, and replace the stub advanced-usage section with links to the full guide set.
- New `user-guides/configuration.md`: a field-by-field `LLMConfig` reference covering model loading, engine kwargs, accelerators and placement, deployment options, LoRA, and experimental configs, with a YAML equivalent. Field names, defaults, and accepted values are taken from `llm_config.py`.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- [x] Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
