### PR TITLE
[Core][TPU] Support single-host TPUs in `SlicePlacementGroup`

### DIFF
--- a/python/ray/tests/test_tpu.py
+++ b/python/ray/tests/test_tpu.py
@@ -177,6 +177,34 @@ def ray_start_cpu():
 
 
 @pytest.fixture
+def ray_single_host_tpu_cluster(ray_start_cluster):
+    """
+    Simulates a Ray cluster with two single-host v7x (Ironwood) TPU nodes.
+    """
+    pod_type = "tpu7x"
+    topology = "2x2x1"
+
+    cluster = ray_start_cluster
+
+    cluster.add_node(
+        num_cpus=2,
+        resources={"TPU": 4},
+        env_vars={"TPU_NAME": "test-v7x-single-1", "TPU_ACCELERATOR_TYPE": pod_type},
+        labels={"ray.io/tpu-pod-type": pod_type, "ray.io/tpu-topology": topology},
+    )
+    cluster.add_node(
+        num_cpus=2,
+        resources={"TPU": 4},
+        env_vars={"TPU_NAME": "test-v7x-single-2", "TPU_ACCELERATOR_TYPE": pod_type},
+        labels={"ray.io/tpu-pod-type": pod_type, "ray.io/tpu-topology": topology},
+    )
+
+    ray.init(address=cluster.address)
+    yield cluster
+    ray.shutdown()
+
+
+@pytest.fixture
 def ray_tpu_cluster(ray_start_cluster):
     """
     Simulates a Ray cluster with two multi-host TPU v4-16 slices.
@@ -387,6 +415,42 @@ def test_pg_per_slice_false_raises(ray_tpu_cluster):
         ValueError, match="pg_per_slice=False, use `slice_placement_group` instead."
     ):
         _ = multi_slice_placement_group.slice_placement_groups
+
+
+def test_single_host_slice_placement_group(ray_tpu_cluster):
+    """Test that a single-host TPU bypasses gang scheduling logic."""
+    with patch("ray.util.tpu.reserve_tpu_slice") as mock_reserve:
+        slice_placement_group = ray.util.tpu.slice_placement_group(
+            topology="2x2x1",
+            accelerator_version="v7x",
+            num_slices=2,
+        )
+        # Util should skip `reserve_tpu_slice because it is single host
+        mock_reserve.assert_not_called()
+
+        assert slice_placement_group.num_hosts == 2
+        assert slice_placement_group.placement_group.bundle_count == 2
+        assert slice_placement_group.placement_group.bundle_specs == [
+            {"TPU": 4, "CPU": 1.0},
+            {"TPU": 4, "CPU": 1.0},
+        ]
+
+
+def test_single_host_slice_placement_group_integration(ray_single_host_tpu_cluster):
+    """
+    Test that a single-host SlicePlacementGroup actually schedules without hanging
+    on v7x (ironwood) topology.
+    """
+    slice_placement_group = ray.util.tpu.slice_placement_group(
+        topology="2x2x1",
+        accelerator_version="v7x",
+        num_slices=2,
+    )
+
+    # Wait for the placement group to be ready.
+    ray.get(slice_placement_group.placement_group.ready(), timeout=10)
+
+    assert slice_placement_group.placement_group.bundle_count == 2
 
 
 @patch("ray.util.tpu.placement_group")
@@ -895,22 +959,24 @@ def test_user_bundle_label_selector_merged(ray_tpu_cluster):
     assert ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY in slice_pg._bundle_label_selector[1]
 
 
-def test_user_bundle_label_selector_collision_dynamic_wins(ray_v6e_tpu_cluster):
-    """Verifies that dynamic TPU labels take precedence on collision."""
-    user_selectors = [{ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: "user-requested-slice"}]
+def test_user_specified_bundle_label_selector(ray_tpu_cluster):
+    """Verifies that user-provided TPU slice labels take precedence and bypass dynamic reservation."""
+    user_selectors = [
+        {ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: "user-requested-slice"},
+        {ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: "user-requested-slice"},
+    ]
 
-    # v6e-8 is single host (1 bundle)
+    # v4 2x2x2 is multi-host (2 bundles)
     slice_pg = SlicePlacementGroup(
-        topology="2x4", accelerator_version="v6e", bundle_label_selector=user_selectors
+        topology="2x2x2", accelerator_version="v4", bundle_label_selector=user_selectors
     )
 
-    assert len(slice_pg._bundle_label_selector) == 1
-    # The dynamic value should win (it generates test-v6e-slice-N)
+    assert len(slice_pg._bundle_label_selector) == 2
+    # The user value should win and bypass the dynamic test-v4-slice-N generation
     actual_val = slice_pg._bundle_label_selector[0][
         ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY
     ]
-    assert actual_val != "user-requested-slice"
-    assert "test-v6e-slice-" in actual_val
+    assert actual_val == "user-requested-slice"
 
 
 def test_user_bundle_label_selector_length_mismatch_raises():

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -304,9 +304,9 @@ def _get_intact_tpu_slices(
         if node.get("Alive"):
             labels = node.get("Labels") or {}
             if labels.get(ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY) == pod_type:
-                is_single_host = total_chips_expected <= (node.get("Resources") or {}).get(
-                    "TPU", 0
-                )
+                is_single_host = total_chips_expected <= (
+                    node.get("Resources") or {}
+                ).get("TPU", 0)
                 if is_single_host:
                     # Single-host TPUs run on a single Ray node.
                     slice_name = node.get("NodeID")
@@ -318,7 +318,9 @@ def _get_intact_tpu_slices(
 
     intact_slices = {}
     for slice_name, nodes in slice_to_nodes.items():
-        slice_tpu_chips = sum((node.get("Resources") or {}).get("TPU", 0) for node in nodes)
+        slice_tpu_chips = sum(
+            (node.get("Resources") or {}).get("TPU", 0) for node in nodes
+        )
 
         # Validate the slice has all its physical chips.
         if slice_tpu_chips != total_chips_expected:
@@ -645,8 +647,8 @@ class SlicePlacementGroup:
                         if global_bundle_idx < len(self._user_bundle_label_selector)
                         else {}
                     )
-                    # User labels take precedence (though we already extracted the slice name).
-                    merged_labels = {**tpu_slice_name_label, **user_labels}
+                    # TPU slice name label takes precedence; user labels fill in the rest.
+                    merged_labels = {**user_labels, **tpu_slice_name_label}
                     self._bundle_label_selector.append(merged_labels)
                     slice_bundle_label_selector.append(merged_labels)
 

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -302,9 +302,9 @@ def _get_intact_tpu_slices(
     slice_to_nodes = {}
     for node in ray.nodes():
         if node.get("Alive"):
-            labels = node.get("Labels", {})
+            labels = node.get("Labels") or {}
             if labels.get(ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY) == pod_type:
-                is_single_host = total_chips_expected <= node.get("Resources", {}).get(
+                is_single_host = total_chips_expected <= (node.get("Resources") or {}).get(
                     "TPU", 0
                 )
                 if is_single_host:

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -318,7 +318,7 @@ def _get_intact_tpu_slices(
 
     intact_slices = {}
     for slice_name, nodes in slice_to_nodes.items():
-        slice_tpu_chips = sum(node.get("Resources", {}).get("TPU", 0) for node in nodes)
+        slice_tpu_chips = sum((node.get("Resources") or {}).get("TPU", 0) for node in nodes)
 
         # Validate the slice has all its physical chips.
         if slice_tpu_chips != total_chips_expected:

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -603,7 +603,7 @@ class SlicePlacementGroup:
                             self._user_bundle_label_selector[global_bundle_idx]
                             if global_bundle_idx < len(self._user_bundle_label_selector)
                             else {}
-                        )
+                        ) or {}
                         if ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY in user_labels:
                             user_slice_name = user_labels[
                                 ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -327,7 +327,7 @@ def _get_intact_tpu_slices(
         # TPU slices must have a head worker (rank 0).
         # Single-host TPUs are inherently their own head.
         has_head = any(
-            n.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
+            (n.get("Labels") or {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
             for n in nodes
         )
         if not has_head and len(nodes) == 1:

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -244,7 +244,7 @@ def get_tpu_slice_name_from_node(node: Dict[str, Any]) -> Optional[str]:
         node: A dictionary representing a Ray node (returned by ray.nodes()).
 
     Returns:
-        The TPU slice name if the node belongs to a slice, otherwise None.
+        The TPU slice name if the node belongs to a multi-host slice, otherwise None.
     """
     return node.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY)
 
@@ -275,6 +275,72 @@ def get_tpu_nodes_for_slice(
     ]
 
 
+def _get_intact_tpu_slices(
+    topology: str,
+    accelerator_type: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Returns a mapping of slice names to lists of node dictionaries for all
+    TPU slices of the specified topology that are physically intact (alive,
+    matching total chip count, and having a head worker).
+    """
+    if not ray.is_initialized():
+        return {}
+
+    try:
+        pod_type = infer_tpu_pod_type_from_topology(topology, accelerator_type)
+        if not pod_type:
+            return {}
+
+        total_chips_expected = get_num_chips_from_topology(topology)
+        if total_chips_expected <= 0:
+            return {}
+    except Exception as e:
+        logger.warning(f"Failed to parse TPU topology for integrity check: {e}")
+        return {}
+
+    slice_to_nodes = {}
+    for node in ray.nodes():
+        if node.get("Alive"):
+            labels = node.get("Labels", {})
+            if labels.get(ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY) == pod_type:
+                is_single_host = total_chips_expected <= node.get("Resources", {}).get(
+                    "TPU", 0
+                )
+                if is_single_host:
+                    # Single-host TPUs run on a single Ray node.
+                    slice_name = node.get("NodeID")
+                else:
+                    slice_name = get_tpu_slice_name_from_node(node)
+
+                if slice_name:
+                    slice_to_nodes.setdefault(slice_name, []).append(node)
+
+    intact_slices = {}
+    for slice_name, nodes in slice_to_nodes.items():
+        slice_tpu_chips = sum(node.get("Resources", {}).get("TPU", 0) for node in nodes)
+
+        # Validate the slice has all its physical chips.
+        if slice_tpu_chips != total_chips_expected:
+            continue
+
+        # TPU slices must have a head worker (rank 0).
+        # Single-host TPUs are inherently their own head.
+        has_head = any(
+            n.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
+            for n in nodes
+        )
+        if not has_head and len(nodes) == 1:
+            has_head = True
+
+        if not has_head:
+            continue
+
+        intact_slices[slice_name] = nodes
+
+    return intact_slices
+
+
 @PublicAPI(stability="alpha")
 def get_num_ready_tpu_slices(
     topology: str,
@@ -291,20 +357,8 @@ def get_num_ready_tpu_slices(
     Returns:
         The integer count of fully ready and available TPU slices.
     """
-    if not ray.is_initialized():
-        return 0
-
-    try:
-        pod_type = infer_tpu_pod_type_from_topology(topology, accelerator_type)
-        if not pod_type:
-            return 0
-
-        total_chips_expected = get_num_chips_from_topology(topology)
-        if total_chips_expected <= 0:
-            return 0
-
-    except Exception as e:
-        logger.warning(f"Failed to parse TPU topology for readiness check: {e}")
+    intact_slices = _get_intact_tpu_slices(topology, accelerator_type)
+    if not intact_slices:
         return 0
 
     # Fetch live resource usage via the State API to ensure slices are idle.
@@ -312,32 +366,8 @@ def get_num_ready_tpu_slices(
 
     node_avail_resources = available_resources_per_node()
 
-    slice_to_nodes = {}
-    for node in ray.nodes():
-        # Build a mapping of currently alive Ray nodes and the TPU slice they belong to.
-        if node.get("Alive"):
-            labels = node.get("Labels", {})
-            if labels.get(ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY) == pod_type:
-                slice_name = get_tpu_slice_name_from_node(node)
-                if slice_name:
-                    slice_to_nodes.setdefault(slice_name, []).append(node)
-
     ready_and_available_slices = 0
-    for slice_name, nodes in slice_to_nodes.items():
-        slice_tpu_chips = sum(node.get("Resources", {}).get("TPU", 0) for node in nodes)
-
-        # Validate the slice has all its physical chips.
-        if slice_tpu_chips != total_chips_expected:
-            continue
-
-        # TPU slices must have a head worker (rank 0).
-        has_head = any(
-            n.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
-            for n in nodes
-        )
-        if not has_head:
-            continue
-
+    for slice_name, nodes in intact_slices.items():
         # Validate all nodes in this slice are completely idle to avoid
         # scheduling on multi-tenant slices currently in use.
         slice_is_idle = True
@@ -382,39 +412,7 @@ def get_num_tpu_slices(
     Returns:
         The integer count of physically intact TPU slices.
     """
-    if not ray.is_initialized():
-        return 0
-
-    try:
-        pod_type = infer_tpu_pod_type_from_topology(topology, accelerator_type)
-        total_chips_expected = get_num_chips_from_topology(topology)
-    except Exception as e:
-        logger.warning(f"Failed to parse TPU topology for integrity check: {e}")
-        return 0
-
-    if not pod_type or total_chips_expected <= 0:
-        return 0
-
-    slice_to_nodes = {}
-    for node in ray.nodes():
-        if node.get("Alive"):
-            labels = node.get("Labels", {})
-            if labels.get(ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY) == pod_type:
-                slice_name = get_tpu_slice_name_from_node(node)
-                if slice_name:
-                    slice_to_nodes.setdefault(slice_name, []).append(node)
-
-    intact_slices = 0
-    for slice_name, nodes in slice_to_nodes.items():
-        slice_tpu_chips = sum(node.get("Resources", {}).get("TPU", 0) for node in nodes)
-        has_head = any(
-            n.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
-            for n in nodes
-        )
-        if slice_tpu_chips == total_chips_expected and has_head:
-            intact_slices += 1
-
-    return intact_slices
+    return len(_get_intact_tpu_slices(topology, accelerator_type))
 
 
 @PublicAPI(stability="alpha")
@@ -586,31 +584,57 @@ class SlicePlacementGroup:
         all_bundles = []
         bundles_per_slice = self._num_bundles // self._num_slices
 
-        # Construct accelerator format for reserve_tpu_slice. e.g. From "v6e" to "TPU-V6E", "v5p" to "TPU-V5P".
-        accelerator_type = "TPU-" + self.accelerator_version.upper()
+        total_chips = get_num_chips_from_topology(self._topology)
+        is_single_host = total_chips <= self._chips_per_host
 
         try:
+            accelerator_type = "TPU-" + self.accelerator_version.upper()
+
             for slice_idx in range(self.num_slices):
-                reservation = reserve_tpu_slice(
-                    self._topology,
-                    accelerator_type,
-                    timeout_s=self._head_reservation_timeout_s,
-                )
-                if not reservation:
-                    raise RuntimeError(
-                        f"Failed to reserve TPU slice. Requested {self.num_slices} "
-                        f"slice(s) of topology '{self._topology}' with accelerator type "
-                        f"'{accelerator_type}'. Ensure that sufficient TPU resources are "
-                        f"available in the cluster."
-                    )
+                tpu_slice_name_label = {}
 
-                # Store the head placement group for clean-up when un-reserving the slice.
-                slice_name, head_pg = reservation
-                self._head_pgs.append(head_pg)
+                if not is_single_host:
+                    # Reserve a multi-host TPU slice by gang-scheduling using the unique `ray.io/tpu-slice-name`.
+                    # Check if user explicitly requested a slice name for this slice
+                    user_slice_name = None
+                    for bundle_idx in range(bundles_per_slice):
+                        global_bundle_idx = slice_idx * bundles_per_slice + bundle_idx
+                        user_labels = (
+                            self._user_bundle_label_selector[global_bundle_idx]
+                            if global_bundle_idx < len(self._user_bundle_label_selector)
+                            else {}
+                        )
+                        if ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY in user_labels:
+                            user_slice_name = user_labels[
+                                ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY
+                            ]
+                            break
 
-                tpu_slice_name_label = {
-                    ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: slice_name
-                }
+                    if user_slice_name:
+                        tpu_slice_name_label = {
+                            ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: user_slice_name
+                        }
+                    else:
+                        reservation = reserve_tpu_slice(
+                            self._topology,
+                            accelerator_type,
+                            timeout_s=self._head_reservation_timeout_s,
+                        )
+                        if not reservation:
+                            raise RuntimeError(
+                                f"Failed to reserve TPU slice. Requested {self.num_slices} "
+                                f"slice(s) of topology '{self._topology}' with accelerator type "
+                                f"'{accelerator_type}'. Ensure that sufficient TPU resources are "
+                                "available in the cluster."
+                            )
+
+                        # Store the head placement group for clean-up when un-reserving the slice.
+                        slice_name, head_pg = reservation
+                        self._head_pgs.append(head_pg)
+
+                        tpu_slice_name_label = {
+                            ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: slice_name
+                        }
 
                 slice_bundle_label_selector = []
                 for bundle_idx in range(bundles_per_slice):
@@ -621,8 +645,8 @@ class SlicePlacementGroup:
                         if global_bundle_idx < len(self._user_bundle_label_selector)
                         else {}
                     )
-                    # TPU slice name label takes precedence; user labels fill in the rest.
-                    merged_labels = {**user_labels, **tpu_slice_name_label}
+                    # User labels take precedence (though we already extracted the slice name).
+                    merged_labels = {**tpu_slice_name_label, **user_labels}
                     self._bundle_label_selector.append(merged_labels)
                     slice_bundle_label_selector.append(merged_labels)
 


### PR DESCRIPTION
## Description
Currently the `SlicePlacementGroup` API does not support single-host TPU nodes - since these nodes are missing the unique TPU slice label that's utilized for slice scheduling. This was intended, since the gang-scheduling logic of distributed TPU nodes is not required for single-host - where only a single Ray node / k8s Pod is being reserved.

However, it'd be useful if users could still pass a single-host topology and receive the desired placement group, and the `SlicePlacementGroup` API includes TPU metadata and topology information that could still be useful for users running single-host workloads. Therefore, we add single-host support to `SlicePlacementGroup` in this PR.

This PR also includes some refactoring of the `get_num_ready_tpu_slices` and `get_num_tpu_slices` APIs to de-deuplicate some code by adding a helper function. I made this change in this PR because I had to amend those APIs anyway for single-host support.

## Related issues
https://github.com/ray-project/ray/issues/64071

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.