### PR TITLE
[RLlib] Fix EnvContext.vector_index always being 0 in MultiAgentEnvRunner sub-envs

### DIFF
--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -822,16 +822,17 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         elif isinstance(self.config.env, str) and _global_registry.contains(
             ENV_CREATOR, self.config.env
         ):
-            entry_point = partial(
-                _global_registry.get(ENV_CREATOR, self.config.env),
-                env_ctx,
-            )
+            env_creator = _global_registry.get(ENV_CREATOR, self.config.env)
         else:
-            entry_point = partial(
-                _gym_env_creator,
-                env_descriptor=self.config.env,
-                env_context=env_ctx,
-            )
+            env_creator = partial(_gym_env_creator, env_descriptor=self.config.env)
+
+        def entry_point(vector_index: int = 0):
+            # `make_vec` passes the sub-environment's index within the vector
+            # env into this entry point (through `gym.make`). Provide each
+            # sub-environment with its own `EnvContext` copy, in which
+            # `vector_index` is set correctly.
+            return env_creator(env_ctx.copy_with_overrides(vector_index=vector_index))
+
         gym.register(
             "rllib-multi-agent-env-v0",
             entry_point=entry_point,

--- a/rllib/env/tests/test_multi_agent_env_runner.py
+++ b/rllib/env/tests/test_multi_agent_env_runner.py
@@ -9,6 +9,15 @@ from ray.rllib.utils.metrics import (
     EPISODE_MODULE_RETURN_MEAN,
 )
 from ray.rllib.utils.test_utils import check
+from ray.tune.registry import register_env
+
+
+class CtxTrackingMultiAgentCartPole(MultiAgentCartPole):
+    """A MultiAgentCartPole that stores the config it was created with."""
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        self._env_ctx = config
 
 
 class TestMultiAgentEnvRunner(unittest.TestCase):
@@ -159,6 +168,34 @@ class TestMultiAgentEnvRunner(unittest.TestCase):
             == module_episode_returns_mean
             == sum_agent_episode_returns_mean
         )
+
+    def test_vector_index_in_env_context(self):
+        """Checks that each sub-env is created with its correct `vector_index`.
+
+        Related to https://github.com/ray-project/ray/issues/53419
+        """
+
+        # Register an env creator that stores the `EnvContext` on the created
+        # env instance.
+        def _env_creator(ctx):
+            env = MultiAgentCartPole(ctx)
+            env._env_ctx = ctx
+            return env
+
+        register_env("ctx_tracking_multi_agent_cartpole", _env_creator)
+
+        # Check both the registered env creator and the env class code paths.
+        for env in ["ctx_tracking_multi_agent_cartpole", CtxTrackingMultiAgentCartPole]:
+            config = self._build_config().environment(env)
+            config.env_runners(num_envs_per_env_runner=4)
+            # Create a `MultiAgentEnvRunner` instance.
+            env_runner = MultiAgentEnvRunner(config=config)
+            env_ctxs = [e.unwrapped._env_ctx for e in env_runner.env.envs]
+            # Each sub-environment must have been created with its own
+            # `vector_index` ...
+            check(sorted(ctx.vector_index for ctx in env_ctxs), [0, 1, 2, 3])
+            # ... while all other context contents are shared.
+            check([ctx["num_agents"] for ctx in env_ctxs], [2] * 4)
 
 
 if __name__ == "__main__":

--- a/rllib/env/vector/registration.py
+++ b/rllib/env/vector/registration.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from functools import partial
 from typing import Any, Dict, Optional
 
 import gymnasium as gym
@@ -58,8 +59,13 @@ def make_vec(
             )
     assert isinstance(vectorization_mode, VectorizeMode)
 
-    def create_single_env() -> MultiAgentEnv:
-        single_env = gym.make(env_spec, **env_spec_kwargs.copy())
+    def create_single_env(index: int) -> MultiAgentEnv:
+        single_env_kwargs = env_spec_kwargs.copy()
+        # Pass the sub-environment's index within the vector env into the
+        # entry point (through `gym.make`), such that each sub-environment
+        # can be created with its correct `vector_index`.
+        single_env_kwargs["vector_index"] = index
+        single_env = gym.make(env_spec, **single_env_kwargs)
 
         return single_env
 
@@ -67,7 +73,7 @@ def make_vec(
     if vectorization_mode == VectorizeMode.SYNC:
         # Create the synchronized vector environemnt.
         env = SyncVectorMultiAgentEnv(
-            env_fns=(create_single_env for _ in range(num_envs)),
+            env_fns=(partial(create_single_env, index) for index in range(num_envs)),
             **vector_kwargs,
         )
     # Other modes are not implemented, yet.


### PR DESCRIPTION
## Description

The index can be threaded through without changing the env-creator interface (the
concern that stalled the draft in the issue thread): `make_vec` now passes each
sub-environment's index into the registered entry point as a `vector_index` kwarg
(through `gym.make`), and `MultiAgentEnvRunner.make_env` registers an entry point that
hands each sub-env its own `EnvContext.copy_with_overrides(vector_index=...)` — the same
per-sub-env context the old API stack's `RolloutWorker` provided.

The entry point defaults to `vector_index=0`, so a bare
`gym.make("rllib-multi-agent-env-v0")` keeps working, and env creators/`EnvContext`
see no interface change — creators simply receive the correct `vector_index` now.

Added a regression test in `rllib/env/tests/test_multi_agent_env_runner.py` that builds
a `MultiAgentEnvRunner` with `num_envs_per_env_runner=4` and asserts the sub-envs were
created with vector indices `[0, 1, 2, 3]`, covering both the registered-env-creator and
env-class code paths. It fails on master (all indices 0) and passes with this change.

## Related issues

Fixes #53419.
