### PR TITLE
[RLlib] Fix stateful module crash in learner connector for multi-agent episodes with sequentially acting agents

### DIFF
--- a/rllib/connectors/common/add_states_from_episodes_to_batch.py
+++ b/rllib/connectors/common/add_states_from_episodes_to_batch.py
@@ -242,13 +242,22 @@ class AddStatesFromEpisodesToBatch(ConnectorV2):
 
                 max_seq_len = sa_module.model_config["max_seq_len"]
 
+                state_outs_buffer = sa_episode.extra_model_outputs.get(
+                    Columns.STATE_OUT
+                )
                 # look_back_state.shape=([state-dim],)
                 look_back_state = (
                     # Episode has a (reset) beginning -> Prepend initial
                     # state.
                     convert_to_numpy(sa_module.get_initial_state())
-                    if sa_episode.t_started == 0
-                    or (Columns.STATE_OUT not in sa_episode.extra_model_outputs)
+                    if sa_episode.t_started == 0 or state_outs_buffer is None
+                    # Episode chunk has no STATE_OUT lookback data. This may happen
+                    # in multi-agent setups with sequentially acting agents, where
+                    # an agent's last STATE_OUT before the cut lies further back
+                    # than the (env timestep based) lookback horizon and is thus
+                    # not part of this continuation chunk anymore. In this case,
+                    # fall back to the initial state.
+                    or state_outs_buffer.lookback == 0
                     # Episode starts somewhere in the middle (is a cut
                     # continuation chunk) -> Use previous chunk's last
                     # STATE_OUT as initial state.

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import gymnasium as gym
 import numpy as np
+import tree  # pip install dm_tree
 
 import ray
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
@@ -2984,6 +2985,113 @@ class TestMultiAgentEpisode(unittest.TestCase):
         # Also assert that agent 1's action b uffer was emptied with the last
         # observations.
         self.assertTrue(episode_2.agent_buffers["agent_1"]["actions"].empty())
+
+    def test_cut_and_stateful_learner_connector(self):
+        # Multi-agent episode with sequentially acting agents and a stateful module
+        # (https://github.com/ray-project/ray/issues/56771): After a `cut()`, an
+        # agent's last STATE_OUT before the cut may lie further back than the (env
+        # timestep based) lookback horizon and is then NOT part of the continuation
+        # chunk anymore. The learner connector pipeline
+        # (`AddStatesFromEpisodesToBatch`) must fall back to the module's initial
+        # state in this case (instead of erroring out with an IndexError).
+        from ray.rllib.connectors.common import AddStatesFromEpisodesToBatch
+
+        class _StatefulModule:
+            model_config = {"max_seq_len": 2}
+
+            def __init__(self, initial_state):
+                self._initial_state = initial_state
+
+            def is_stateful(self):
+                return True
+
+            def get_initial_state(self):
+                return self._initial_state
+
+        class _MultiRLModule:
+            def __init__(self, initial_state):
+                self._module = _StatefulModule(initial_state)
+
+            def is_stateful(self):
+                return True
+
+            def __getitem__(self, module_id):
+                return self._module
+
+        # Test both a simple (ndarray) state and a nested (LSTM h/c-style) state.
+        for initial_state, state_fn in [
+            (
+                np.zeros((2,), dtype=np.float32),
+                lambda x: np.full((2,), x, dtype=np.float32),
+            ),
+            (
+                {
+                    "h": np.zeros((2,), dtype=np.float32),
+                    "c": np.zeros((2,), dtype=np.float32),
+                },
+                lambda x: {
+                    "h": np.full((2,), x, dtype=np.float32),
+                    "c": np.full((2,), x, dtype=np.float32),
+                },
+            ),
+        ]:
+            # Two agents acting in alternating (turn-based) order: a0 acts at even
+            # env timesteps, a1 at odd ones.
+            episode = MultiAgentEpisode(
+                agent_to_module_mapping_fn=lambda aid, eps: "p0",
+            )
+            episode.add_env_reset(observations={"a0": 0})
+            for env_t in range(2):
+                agent, next_agent = ("a0", "a1") if env_t % 2 == 0 else ("a1", "a0")
+                episode.add_env_step(
+                    observations={next_agent: env_t + 1},
+                    actions={agent: 0},
+                    rewards={agent: 0.0},
+                    extra_model_outputs={
+                        agent: {Columns.STATE_OUT: state_fn(env_t + 1.0)},
+                    },
+                )
+            # Cut with the default lookback horizon of 1 env timestep. a0 last acted
+            # 2 env timesteps ago -> its STATE_OUT lookback in the successor is
+            # empty (while its `t_started` is already 1).
+            successor = episode.cut(len_lookback_buffer=1)
+            for env_t in range(2, 6):
+                agent, next_agent = ("a0", "a1") if env_t % 2 == 0 else ("a1", "a0")
+                successor.add_env_step(
+                    observations={next_agent: env_t + 1},
+                    actions={agent: 0},
+                    rewards={agent: 0.0},
+                    extra_model_outputs={
+                        agent: {Columns.STATE_OUT: state_fn(env_t + 1.0)},
+                    },
+                )
+            check(successor.agent_episodes["a0"].t_started, 1)
+            check(
+                successor.agent_episodes["a0"]
+                .extra_model_outputs[Columns.STATE_OUT]
+                .lookback,
+                0,
+            )
+            successor.to_numpy()
+
+            # Run the learner connector piece on the continuation chunk. Before the
+            # fix, this raised an IndexError (nested state) or silently used the
+            # chunk's own last STATE_OUT as its first STATE_IN (simple state).
+            connector = AddStatesFromEpisodesToBatch(as_learner_connector=True)
+            batch = connector(
+                rl_module=_MultiRLModule(initial_state),
+                batch={},
+                episodes=[successor],
+                shared_data={},
+            )
+            # Both agents' first STATE_IN must be the module's initial state (the
+            # actual pre-cut state of a0 is no longer available in the chunk).
+            for agent_id in ["a0", "a1"]:
+                state_in = batch[Columns.STATE_IN][(successor.id_, agent_id, "p0")]
+                check(
+                    tree.map_structure(lambda s: s[0], state_in[0]),
+                    initial_state,
+                )
 
     def test_slice(self):
         # Generate a simple multi-agent episode.


### PR DESCRIPTION
## Description

The crash happens because `MultiAgentEpisode.cut()` measures its lookback horizon in
env timesteps (default 1). With sequentially acting agents, an agent's last
`STATE_OUT` before the cut can lie 2+ env steps back, so its continuation chunk has
`t_started > 0` but an empty `STATE_OUT` lookback buffer. The learner branch of
`AddStatesFromEpisodesToBatch` assumes every chunk with `t_started > 0` carries the
previous chunk's last `STATE_OUT` in its lookback, and the `-1` lookback fetch then
hits the invalidated-index path in `InfiniteLookbackBuffer._get_int_index` and raises.

There is also a second, silent failure mode: for plain `np.ndarray` states (no h/c
dict), the finalized-ndarray fast path in `_get_int_index` resolves the same fetch to
`data[-1]`, so the chunk's own *last* `STATE_OUT` is used as its *first* `STATE_IN` —
no crash, just a temporally leaked state. Nested LSTM-style states take the slow path
and crash, which is why the issue manifests with `use_lstm`.

The fix makes the connector fall back to the module's initial state whenever the
chunk's `STATE_OUT` buffer has no lookback data. This mirrors the file's existing
fallback for episodes without any `STATE_OUT` (offline data) and matches what the
env-to-module branch already does in this exact situation. The condition is a strict
superset of the broken cases, so no currently-correct behavior changes. Carrying the
true pre-cut state across `MultiAgentEpisode.cut()` would be a more invasive follow-up
if exact state continuity at cut boundaries is wanted.

Added a regression test (`test_cut_and_stateful_learner_connector`) that builds a
turn-based two-agent episode, cuts it with the default lookback horizon, and runs the
learner connector on the continuation chunk — covering both the nested-state (crash)
and flat-state (leaked state) modes. Also verified the reporter's scenario end-to-end:
PPO + TicTacToe + `use_lstm` now trains past iteration 2 (previously deterministic
`IndexError` in the second `train()`).

## Related issues

Fixes #56771.

## Additional information

Authored with the assistance of Claude Code.
