### PR TITLE
[llm][kv][1/N] Add KV-aware routing interfaces (`KVAwareRouter` + `KVRouterActor`)

### DIFF
--- a/python/ray/llm/_internal/serve/core/server/builder.py
+++ b/python/ray/llm/_internal/serve/core/server/builder.py
@@ -16,6 +16,14 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 )
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.observability.logging import get_logger
+from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_actor import (
+    KV_ROUTER_ACTOR_NAME,
+    KVRouterActor,
+)
+from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_router import (
+    KVAwareRouter,
+)
+from ray.serve.config import DeploymentActorConfig, RequestRouterConfig
 from ray.serve.deployment import Application
 
 logger = get_logger(__name__)
@@ -33,6 +41,32 @@ DEFAULT_DEPLOYMENT_OPTIONS = {
 
 def _get_deployment_name(llm_config: LLMConfig) -> str:
     return llm_config.model_id.replace("/", "--").replace(".", "_")
+
+
+def _maybe_setup_kv_aware_routing(deployment_options: dict) -> None:
+    """Set up KV-aware routing when the deployment's request router is a
+    KVAwareRouter.
+
+    Currently attaches the KVRouterActor, which owns the deployment's global KV
+    radix tree for KV-aware request scoring.
+    """
+    request_router_config = deployment_options.get("request_router_config")
+    if isinstance(request_router_config, dict):
+        request_router_config = RequestRouterConfig(**request_router_config)
+    if not isinstance(request_router_config, RequestRouterConfig):
+        return
+    if not issubclass(request_router_config.get_request_router_class(), KVAwareRouter):
+        return
+
+    # TODO (jeffreywang): KVRouterActor requires init_kwargs such as block_size.
+    deployment_options["deployment_actors"] = [
+        *deployment_options.get("deployment_actors", []),
+        DeploymentActorConfig(
+            name=KV_ROUTER_ACTOR_NAME,
+            actor_class=KVRouterActor,
+            actor_options={"num_cpus": 0},
+        ),
+    ]
 
 
 def build_llm_deployment(
@@ -75,6 +109,8 @@ def build_llm_deployment(
     deployment_options = maybe_apply_llm_deployment_config_defaults(
         DEFAULT_DEPLOYMENT_OPTIONS, deployment_options
     )
+
+    _maybe_setup_kv_aware_routing(deployment_options)
 
     logger.info("============== Deployment Options ==============")
     logger.info(pprint.pformat(deployment_options))

--- a/python/ray/llm/_internal/serve/core/server/builder.py
+++ b/python/ray/llm/_internal/serve/core/server/builder.py
@@ -16,14 +16,9 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 )
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.observability.logging import get_logger
-from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_actor import (
-    KV_ROUTER_ACTOR_NAME,
-    KVRouterActor,
+from ray.llm._internal.serve.routing_policies.kv_aware.utils import (
+    _maybe_setup_kv_aware_routing,
 )
-from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_router import (
-    KVAwareRouter,
-)
-from ray.serve.config import DeploymentActorConfig, RequestRouterConfig
 from ray.serve.deployment import Application
 
 logger = get_logger(__name__)
@@ -41,32 +36,6 @@ DEFAULT_DEPLOYMENT_OPTIONS = {
 
 def _get_deployment_name(llm_config: LLMConfig) -> str:
     return llm_config.model_id.replace("/", "--").replace(".", "_")
-
-
-def _maybe_setup_kv_aware_routing(deployment_options: dict) -> None:
-    """Set up KV-aware routing when the deployment's request router is a
-    KVAwareRouter.
-
-    Currently attaches the KVRouterActor, which owns the deployment's global KV
-    radix tree for KV-aware request scoring.
-    """
-    request_router_config = deployment_options.get("request_router_config")
-    if isinstance(request_router_config, dict):
-        request_router_config = RequestRouterConfig(**request_router_config)
-    if not isinstance(request_router_config, RequestRouterConfig):
-        return
-    if not issubclass(request_router_config.get_request_router_class(), KVAwareRouter):
-        return
-
-    # TODO (jeffreywang): KVRouterActor requires init_kwargs such as block_size.
-    deployment_options["deployment_actors"] = [
-        *deployment_options.get("deployment_actors", []),
-        DeploymentActorConfig(
-            name=KV_ROUTER_ACTOR_NAME,
-            actor_class=KVRouterActor,
-            actor_options={"num_cpus": 0},
-        ),
-    ]
 
 
 def build_llm_deployment(

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
@@ -30,7 +30,7 @@ class KVRouterActor:
     independent of any replica's lifetime. It exposes the KV-aware routing
     interfaces: ``select_worker`` and the request-lifecycle hooks.
 
-    TODO (jeffreywang): Implement these:
+    TODO (jeffreywang): Implement these
     1. Created once per deployment, attached to the LLMServer deployment via
        Serve's ``DeploymentActorConfig`` (independent of any replica's lifetime).
     2. Owns an in-process Dynamo ``SelectionService``.

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
@@ -1,0 +1,109 @@
+import logging
+from typing import List, Optional, TypedDict
+
+import ray
+from ray.serve._private.constants import SERVE_LOGGER_NAME
+
+logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+KV_ROUTER_ACTOR_NAME = "serve_llm_kv_router"
+
+
+class WorkerSelection(TypedDict):
+    """The worker chosen by ``KVRouterActor.select_worker`` for a request."""
+
+    # The chosen worker.
+    worker_id: int
+    # Data-parallel rank within the worker.
+    dp_rank: int
+    # KV blocks already cached on that worker.
+    overlap_blocks: int
+    # The worker's routing score.
+    score: float
+
+
+@ray.remote
+class KVRouterActor:
+    """Deployment-scoped Ray actor backing KV-aware routing.
+
+    Attached to the LLMServer deployment via Serve's ``DeploymentActorConfig``,
+    independent of any replica's lifetime. It exposes the KV-aware routing
+    interfaces: ``select_worker`` and the request-lifecycle hooks.
+
+    TODO (jeffreywang): Implement these:
+    1. Created once per deployment, attached to the LLMServer deployment via
+       Serve's ``DeploymentActorConfig`` (independent of any replica's lifetime).
+    2. Owns an in-process Dynamo ``SelectionService``.
+    3. Tracks live replicas via a ``LongPollClient`` on ``DEPLOYMENT_TARGETS``:
+       replicas advertise their engine KV-events endpoint through
+       ``record_routing_stats``, and ``_on_deployment_targets`` registers new
+       workers (the service dials them connect-out) and evicts departed ones.
+    4. The ``SelectionService`` maintains a global KV index radix tree, fed by
+       every replica's KV events; each node records which workers hold that KV
+       block.
+    5. Scoring ranks candidate workers by KV-cache overlap (queried from the KV
+       index) plus prefill/decode load to pick the best worker.
+    """
+
+    async def select_worker(
+        self,
+        request_id: str,
+        token_ids: List[int],
+        allowed_worker_ids: List[int],
+    ) -> WorkerSelection:
+        """Score the allowed workers for a request based on KV-cache overlap and
+        load and pick the best one.
+
+        Args:
+            request_id: Unique identifier for the request being routed.
+            token_ids: Prompt token ids used to compute KV-cache overlap.
+            allowed_worker_ids: Candidate worker ids the router may select from.
+
+        Returns:
+            The selected worker (see ``WorkerSelection``).
+        """
+        raise NotImplementedError("KVRouterActor.select_worker is not implemented")
+
+    async def on_request_added(
+        self,
+        request_id: str,
+        expected_output_tokens: Optional[int] = None,
+    ) -> None:
+        """Commit a routed request to the worker chosen by ``select_worker``.
+
+        Args:
+            request_id: Unique identifier for the request.
+            expected_output_tokens: Predicted number of output tokens.
+        """
+        raise NotImplementedError("KVRouterActor.on_request_added is not implemented")
+
+    async def on_prefill_complete(self, request_id: str) -> None:
+        """Record a request's transition from prefill to decode.
+
+        Args:
+            request_id: Unique identifier for the request.
+        """
+        raise NotImplementedError(
+            "KVRouterActor.on_prefill_complete is not implemented"
+        )
+
+    async def on_decode_progress(
+        self, request_id: str, cumulative_output_tokens: int
+    ) -> None:
+        """Adds any newly crossed decode blocks to the request's accounted load.
+
+        Args:
+            request_id: Unique identifier for the request.
+            cumulative_output_tokens: Total output tokens generated so far.
+        """
+        raise NotImplementedError("KVRouterActor.on_decode_progress is not implemented")
+
+    async def on_request_completed(self, request_id: str) -> None:
+        """Release the KV-cache accounting for a finished request.
+
+        Args:
+            request_id: Unique identifier for the request.
+        """
+        raise NotImplementedError(
+            "KVRouterActor.on_request_completed is not implemented"
+        )

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_router.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_router.py
@@ -1,0 +1,31 @@
+import logging
+from typing import List, Optional
+
+from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.request_router.common import PendingRequest
+from ray.serve._private.request_router.replica_wrapper import RunningReplica
+from ray.serve._private.request_router.request_router import RequestRouter
+
+logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+class KVAwareRouter(RequestRouter):
+    """Routes each request to the candidate that best balances expected KV-cache
+    overlap against the worker's current prefill/decode load.
+    """
+
+    async def choose_replicas(
+        self,
+        candidate_replicas: List[RunningReplica],
+        pending_request: Optional[PendingRequest] = None,
+    ) -> List[List[RunningReplica]]:
+        """Choose the candidate replica(s) to route ``pending_request`` to.
+
+        Args:
+            candidate_replicas: The replicas eligible to serve the request.
+            pending_request: The request being routed.
+
+        Returns:
+            Ranked groups of replicas.
+        """
+        raise NotImplementedError("KVAwareRouter.choose_replicas is not implemented")

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/utils.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/utils.py
@@ -1,0 +1,36 @@
+"""Helpers for wiring KV-aware routing into an LLM deployment."""
+
+from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_actor import (
+    KV_ROUTER_ACTOR_NAME,
+    KVRouterActor,
+)
+from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_router import (
+    KVAwareRouter,
+)
+from ray.serve.config import DeploymentActorConfig, RequestRouterConfig
+
+
+def _maybe_setup_kv_aware_routing(deployment_options: dict) -> None:
+    """Set up KV-aware routing when the deployment's request router is a
+    KVAwareRouter.
+
+    Currently attaches the KVRouterActor, which owns the deployment's global KV
+    radix tree for KV-aware request scoring.
+    """
+    request_router_config = deployment_options.get("request_router_config")
+    if isinstance(request_router_config, dict):
+        request_router_config = RequestRouterConfig(**request_router_config)
+    if not isinstance(request_router_config, RequestRouterConfig):
+        return
+    if not issubclass(request_router_config.get_request_router_class(), KVAwareRouter):
+        return
+
+    # TODO (jeffreywang): KVRouterActor requires init_kwargs such as block_size.
+    deployment_options["deployment_actors"] = [
+        *deployment_options.get("deployment_actors", []),
+        DeploymentActorConfig(
+            name=KV_ROUTER_ACTOR_NAME,
+            actor_class=KVRouterActor,
+            actor_options={"num_cpus": 0},
+        ),
+    ]

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_config_files/llm_kv_aware_deployment.yaml
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_config_files/llm_kv_aware_deployment.yaml
@@ -1,0 +1,21 @@
+applications:
+  - name: kv-llm
+    route_prefix: /
+    import_path: ray.serve.llm:build_openai_app
+    runtime_env:
+      env_vars:
+        RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING: "1"
+        RAY_SERVE_ENABLE_HA_PROXY: "1"
+    args:
+      llm_configs:
+        - model_loading_config:
+            model_id: qwen3-0.6b
+            model_source: Qwen/Qwen3-0.6B
+          accelerator_type: null
+          deployment_config:
+            autoscaling_config:
+              min_replicas: 0
+              initial_replicas: 0
+              max_replicas: 1
+            request_router_config:
+              request_router_class: ray.serve.llm.request_router.KVAwareRouter

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_kv_aware_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_kv_aware_router.py
@@ -1,0 +1,109 @@
+"""The KVRouterActor is attached iff the request router is a KVAwareRouter.
+
+Covered two ways: ``build_openai_app`` with a Python ``LLMConfig``, and a
+declarative YAML config deployed via ``serve deploy`` (the dotted-string router
+class only YAML can express).
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+import ray
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.core.ingress.builder import (
+    LLMServingArgs,
+    build_openai_app,
+)
+from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_actor import (
+    KV_ROUTER_ACTOR_NAME,
+    KVRouterActor,
+)
+from ray.serve._private.constants import SERVE_DEPLOYMENT_ACTOR_PREFIX
+from ray.serve.llm.request_router import KVAwareRouter
+from ray.util.state import list_actors
+
+
+def get_kv_actor_configs(deployment):
+    return [
+        cfg
+        for cfg in (deployment._deployment_config.deployment_actors or [])
+        if (cfg["name"] if isinstance(cfg, dict) else cfg.name) == KV_ROUTER_ACTOR_NAME
+    ]
+
+
+def build_test_llm_config() -> LLMConfig:
+    return LLMConfig(
+        model_loading_config={
+            "model_id": "qwen3-0.6b",
+            "model_source": "Qwen/Qwen3-0.6B",
+        },
+        accelerator_type=None,
+        deployment_config={
+            "autoscaling_config": {"min_replicas": 1, "max_replicas": 1},
+            "request_router_config": {"request_router_class": KVAwareRouter},
+        },
+    )
+
+
+def get_kv_actor_names(app_name: str) -> list:
+    prefix = f"{SERVE_DEPLOYMENT_ACTOR_PREFIX}{app_name}::"
+    suffix = f"::{KV_ROUTER_ACTOR_NAME}"
+    return [
+        a["name"]
+        for a in list_actors(filters=[("state", "=", "ALIVE")])
+        if a["name"] and a["name"].startswith(prefix) and a["name"].endswith(suffix)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def enable_direct_streaming(monkeypatch):
+    monkeypatch.setattr(
+        "ray.llm._internal.serve.core.ingress.builder."
+        "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+        True,
+    )
+
+
+@pytest.fixture(scope="module")
+def serve_instance():
+    if not ray.is_initialized():
+        ray.init(address="auto")
+    yield
+    serve.shutdown()
+
+
+def test_build_openai_app_attaches_kv_actor():
+    """A KVAwareRouter on the LLMConfig attaches the KVRouterActor."""
+    app = build_openai_app(LLMServingArgs(llm_configs=[build_test_llm_config()]))
+
+    configs = get_kv_actor_configs(app._bound_deployment)
+    assert len(configs) == 1
+    actor_cfg = configs[0]
+    assert (
+        actor_cfg.get_actor_class().__ray_actor_class__
+        is KVRouterActor.__ray_actor_class__
+    )
+    assert actor_cfg.actor_options["num_cpus"] == 0
+
+
+def test_yaml_config_attaches_kv_actor(serve_instance):
+    """Deploying a YAML config that selects KVAwareRouter creates the KVRouterActor."""
+    config_file = os.path.join(
+        os.path.dirname(__file__), "test_config_files", "llm_kv_aware_deployment.yaml"
+    )
+    app_name = "kv-llm"
+
+    subprocess.check_output(["serve", "deploy", config_file], stderr=subprocess.STDOUT)
+    try:
+        wait_for_condition(lambda: len(get_kv_actor_names(app_name)) == 1, timeout=60)
+    finally:
+        serve.delete(app_name, _blocking=True)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/llm/request_router.py
+++ b/python/ray/serve/llm/request_router.py
@@ -1,3 +1,6 @@
+from ray.llm._internal.serve.routing_policies.kv_aware.kv_aware_router import (
+    KVAwareRouter as _KVAwareRouter,
+)
 from ray.llm._internal.serve.routing_policies.prefix_aware.prefix_aware_router import (
     PrefixCacheAffinityRouter as _PrefixCacheAffinityRouter,
 )
@@ -38,5 +41,12 @@ class PrefixCacheAffinityRouter(_PrefixCacheAffinityRouter):
         eviction_interval_secs: How often (in seconds) to run the eviction
         policy.
     """
+
+    pass
+
+
+@PublicAPI(stability="alpha")
+class KVAwareRouter(_KVAwareRouter):
+    """A request router that routes by KV-cache overlap via a KV router actor."""
 
     pass


### PR DESCRIPTION
## Description
Introduces the interface for KV-aware request routing in Ray Serve LLM. This is the base of a stack: method bodies are `NotImplementedError` stubs filled by follow-up PRs.

## What's in this PR
- **`KVAwareRouter`** (`RequestRouter`): routes each request to the replica that best balances KV-cache overlap against worker load (`choose_replicas`).
- **`KVRouterActor`**: deployment-scoped Ray actor that _will_ own the deployment's global KV radix tree. Defines the routing + request-lifecycle contract.
- **Auto-attach**: `build_llm_deployment` attaches `KVRouterActor` as a deployment actor when the configured request router is a `KVAwareRouter` (`_maybe_setup_kv_aware_routing`).
- **Tests**: attachment via `build_openai_app` and via declarative YAML.

<img width="2173" height="885" alt="image" src="https://github.com/user-attachments/assets/59ac7e98-e148-4b0c-814e-662416a83c9a" />

## Related issues
Next PR: https://github.com/ray-project/ray/pull/64085.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
