### PR TITLE
docs(serve): fix RequestRouterConfig stats docstring to reference record_routing_stats

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -242,10 +242,10 @@ class RequestRouterConfig(BaseModel):
     request_routing_stats_period_s: PositiveFloat = Field(
         default=DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S,
         description=(
-            "Duration between record scheduling stats calls for the replica. "
-            "Defaults to 10s. The health check is by default a no-op Actor call "
-            "to the replica, but you can define your own request scheduling stats "
-            "using the 'record_scheduling_stats' method in your deployment."
+            "Duration between record routing stats calls for the replica. "
+            "Defaults to 10s. Recording routing stats is by default a no-op Actor "
+            "call to the replica, but you can define your own routing stats "
+            "using the 'record_routing_stats' method in your deployment."
         ),
     )
 


### PR DESCRIPTION
The `request_routing_stats_period_s` field description in `RequestRouterConfig` tells users to define a `record_scheduling_stats` method, but that name does not exist in Ray — the replica looks up `record_routing_stats` (`REQUEST_ROUTING_STATS_METHOD` in `serve/_private/constants.py`, resolved in `_private/replica.py`). The text also carries copy-paste residue referring to the health check. This corrects the method name and wording so the documented hook matches the one Ray actually calls.