### PR TITLE
[data] Native per-actor placement groups for `map_batches`

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -46,6 +46,7 @@ Developer API
   :nosignatures:
   :toctree: doc/
 
+  Dataset.map_batches_internal
   Dataset.to_pandas_refs
   Dataset.to_numpy_refs
   Dataset.to_arrow_refs

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -64,9 +64,12 @@ from ray.data._internal.utils.heapdict import heapdict
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import (
     DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
+    DEFAULT_PLACEMENT_GROUP_STRATEGY,
     DataContext,
 )
 from ray.types import ObjectRef
+from ray.util.placement_group import PlacementGroup
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +119,8 @@ class ActorPoolMapOperator(MapOperator):
         target_max_block_size_override: Optional[int] = None,
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         default_logical_memory_enabled: bool = False,
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
     ):
         """Create an ActorPoolMapOperator instance.
 
@@ -150,6 +155,13 @@ class ActorPoolMapOperator(MapOperator):
             default_logical_memory_enabled: If ``True``, the operator launches actors
                 with a default logical ``memory``. The method for choosing the
                 default is an implementation detail.
+            placement_group_bundles: If specified, the actor pool creates one
+                placement group per actor from these bundles and schedules the
+                actor into the first bundle, capturing child tasks and actors.
+                The pool owns the placement group lifecycle: it's removed when
+                the actor is released from the pool.
+            placement_group_strategy: The strategy of the placement groups
+                created from ``placement_group_bundles``. Defaults to ``PACK``.
         """
         super().__init__(
             map_transformer,
@@ -184,6 +196,8 @@ class ActorPoolMapOperator(MapOperator):
         # class per operator with a unique name.
         self._map_worker_cls = type(map_worker_cls_name, (_MapWorker,), {})
 
+        self._placement_group_bundles = placement_group_bundles
+        self._placement_group_strategy = placement_group_strategy
         self._actor_pool = self._create_actor_pool(compute_strategy)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
@@ -213,16 +227,41 @@ class ActorPoolMapOperator(MapOperator):
             create_actor_fn=self._start_actor,
             config=config,
             map_worker_cls_name=self._map_worker_cls_name,
+            placement_group_bundles=self._placement_group_bundles,
+            placement_group_strategy=self._placement_group_strategy,
         )
+
+    def _placement_group_resource_usage(self) -> Optional[ExecutionResources]:
+        """Resources reserved by a single actor's placement group, or ``None``.
+
+        When a per-actor placement group is provisioned, the cluster reserves
+        the sum of all bundles for that actor's lifetime. Attributing the full
+        bundle sum to the actor keeps resource-manager budgeting and autoscaling
+        accurate.
+        """
+        if self._placement_group_bundles is None:
+            return None
+        usage = ExecutionResources.zero()
+        for bundle in self._placement_group_bundles:
+            usage = usage.add(
+                ExecutionResources(
+                    cpu=bundle.get("CPU", 0),
+                    gpu=bundle.get("GPU", 0),
+                    memory=bundle.get("memory", 0),
+                )
+            )
+        return usage
 
     def _create_actor_pool_config(
         self, compute_strategy: ActorPoolStrategy
     ) -> "AutoscalingActorConfig":
-        per_actor_resource_usage = ExecutionResources(
-            cpu=self._ray_remote_args.get("num_cpus"),
-            gpu=self._ray_remote_args.get("num_gpus"),
-            memory=self._ray_remote_args.get("memory"),
-        )
+        per_actor_resource_usage = self._placement_group_resource_usage()
+        if per_actor_resource_usage is None:
+            per_actor_resource_usage = ExecutionResources(
+                cpu=self._ray_remote_args.get("num_cpus"),
+                gpu=self._ray_remote_args.get("num_gpus"),
+                memory=self._ray_remote_args.get("memory"),
+            )
         max_actor_concurrency = self._ray_remote_args.get("max_concurrency", 1)
         config = AutoscalingActorConfig(
             min_size=compute_strategy.min_size,
@@ -312,13 +351,19 @@ class ActorPoolMapOperator(MapOperator):
         return self._actor_pool.can_schedule_task()
 
     def _start_actor(
-        self, labels: Dict[str, str], logical_actor_id: LogicalActorId
+        self,
+        labels: Dict[str, str],
+        logical_actor_id: LogicalActorId,
+        placement_group: Optional[PlacementGroup] = None,
     ) -> Tuple[ActorHandle, ObjectRef, ExecutionResources]:
         """Start a new actor and add it to the actor pool as a pending actor.
 
         Args:
             labels: The key-value labels to launch the actor with.
             logical_actor_id: The logical id of the actor.
+            placement_group: If specified, the actor's own placement group. The
+                actor is scheduled into the first bundle, and child tasks and
+                actors it spawns are captured into the same placement group.
 
         Returns:
             A tuple of the actor handle, the object ref to the actor's location,
@@ -326,12 +371,28 @@ class ActorPoolMapOperator(MapOperator):
         """
         assert self._actor_cls is not None
         actual_remote_args = dict(self._merge_ray_remote_args())
+        if placement_group is not None:
+            # NOTE: This intentionally overrides any `scheduling_strategy` produced
+            # by `ray_remote_args_fn`, so that the actor always lands in its own
+            # placement group.
+            actual_remote_args[
+                "scheduling_strategy"
+            ] = PlacementGroupSchedulingStrategy(
+                placement_group=placement_group,
+                placement_group_bundle_index=0,
+                placement_group_capture_child_tasks=True,
+            )
         extra_labels = actual_remote_args.pop("_labels", {})
-        actor_resource_usage = ExecutionResources(
-            cpu=actual_remote_args.get("num_cpus", 0),
-            gpu=actual_remote_args.get("num_gpus", 0),
-            memory=actual_remote_args.get("memory", 0),
-        )
+        # When a placement group is provisioned, the cluster reserves the whole
+        # PG for this actor, so attribute that to the actor. Otherwise fall back
+        # to the per-actor remote args.
+        actor_resource_usage = self._placement_group_resource_usage()
+        if actor_resource_usage is None:
+            actor_resource_usage = ExecutionResources(
+                cpu=actual_remote_args.get("num_cpus", 0),
+                gpu=actual_remote_args.get("num_gpus", 0),
+                memory=actual_remote_args.get("memory", 0),
+            )
         actor = self._actor_cls.options(
             _labels={self._OPERATOR_ID_LABEL_KEY: self.id, **labels, **extra_labels},
             **actual_remote_args,
@@ -514,9 +575,15 @@ class ActorPoolMapOperator(MapOperator):
         max_actors = self._actor_pool.max_size()
         assert min_actors is not None, min_actors
 
-        num_cpus_per_actor = self._ray_remote_args.get("num_cpus", 0)
-        num_gpus_per_actor = self._ray_remote_args.get("num_gpus", 0)
-        memory_per_actor = self._ray_remote_args.get("memory", 0)
+        pg_resources = self._placement_group_resource_usage()
+        if pg_resources is not None:
+            num_cpus_per_actor = pg_resources.cpu
+            num_gpus_per_actor = pg_resources.gpu
+            memory_per_actor = pg_resources.memory
+        else:
+            num_cpus_per_actor = self._ray_remote_args.get("num_cpus", 0)
+            num_gpus_per_actor = self._ray_remote_args.get("num_gpus", 0)
+            memory_per_actor = self._ray_remote_args.get("memory", 0)
 
         min_resource_usage = ExecutionResources(
             cpu=num_cpus_per_actor * min_actors,
@@ -742,29 +809,43 @@ class _ActorPool(AutoscalingActorPool):
 
     def __init__(
         self,
-        create_actor_fn: "Callable[[Dict[str, str]], Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]]",
+        create_actor_fn: "Callable[[Dict[str, str], LogicalActorId, Optional[PlacementGroup]], Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]]",
         config: AutoscalingActorConfig,
         map_worker_cls_name: str = "MapWorker",
         debounce_period_s: int = _ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S,
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
     ):
         """Initialize the actor pool.
 
         Args:
-            create_actor_fn: Callable that takes key-value labels as input and
-                creates an actor with those labels. Returns the actor handle, a
-                reference to the actor's node ID, and the actor's resource usage.
+            create_actor_fn: Callable that takes key-value labels, the logical
+                actor id, and an optional per-actor placement group as input
+                and creates an actor with those labels. Returns the actor
+                handle, a reference to the actor's node ID, and the actor's
+                resource usage.
             config: Configuration for the autoscaling actor pool, including
                 min/max/initial pool sizes, concurrency, and resource usage.
             map_worker_cls_name: Name of the map worker class for logging
                 purposes.
             debounce_period_s: Debounce period for scaling down after scaling
                 up.
+            placement_group_bundles: If specified, the pool creates one
+                placement group per actor from these bundles and passes it to
+                ``create_actor_fn``. The placement group is removed when the actor
+                is released from the pool, so reserved resources don't outlive
+                the actor.
+            placement_group_strategy: The strategy of the placement groups
+                created from ``placement_group_bundles``. Defaults to ``PACK``.
         """
         super().__init__(config=config)
 
         self._create_actor_fn = create_actor_fn
         self._map_worker_cls_name = map_worker_cls_name
         self._debounce_period_s = debounce_period_s
+        self._placement_group_bundles = placement_group_bundles
+        self._placement_group_strategy = placement_group_strategy
+        self._actor_to_placement_group: Dict[ActorHandle, PlacementGroup] = {}
         # Timestamp of the last scale up action
         self._last_upscaled_at: Optional[float] = None
         self._last_downscaling_debounce_warning_ts: Optional[float] = None
@@ -938,6 +1019,7 @@ class _ActorPool(AutoscalingActorPool):
                 self._pending_or_restarting_usage.subtract(usage)
             )
             self._actor_to_logical_id.pop(actor, None)
+            self._remove_actor_placement_group(actor)
             raise
         self._running_actors[actor] = _ActorState(
             num_tasks_in_flight=0,
@@ -1062,11 +1144,50 @@ class _ActorPool(AutoscalingActorPool):
     ) -> Tuple[ActorHandle, ObjectRef, ExecutionResources]:
         logical_actor_id = str(uuid.uuid4())
         labels = {self.get_logical_id_label_key(): logical_actor_id}
-        actor, ready_ref, resource_usage = self._create_actor_fn(
-            labels, logical_actor_id
-        )
+        placement_group = self._maybe_create_placement_group()
+        try:
+            actor, ready_ref, resource_usage = self._create_actor_fn(
+                labels, logical_actor_id, placement_group
+            )
+        except Exception:
+            # Clean up the placement group so it doesn't leak, but never let a
+            # cleanup failure mask the original actor-creation error.
+            if placement_group is not None:
+                try:
+                    ray.util.remove_placement_group(placement_group)
+                except Exception:
+                    logger.exception(
+                        "Failed to remove placement group after actor creation failed."
+                    )
+            raise
         self._actor_to_logical_id[actor] = logical_actor_id
+        if placement_group is not None:
+            self._actor_to_placement_group[actor] = placement_group
         return actor, ready_ref, resource_usage
+
+    def _maybe_create_placement_group(self) -> Optional[PlacementGroup]:
+        """Create the placement group for a single new actor, if configured."""
+        if self._placement_group_bundles is None:
+            return None
+        return ray.util.placement_group(
+            self._placement_group_bundles,
+            strategy=self._placement_group_strategy or DEFAULT_PLACEMENT_GROUP_STRATEGY,
+        )
+
+    def _remove_actor_placement_group(self, actor: ActorHandle):
+        """Remove the placement group associated with the actor."""
+        placement_group = self._actor_to_placement_group.pop(actor, None)
+        if placement_group is None:
+            return
+        try:
+            ray.util.remove_placement_group(placement_group)
+        except ValueError:
+            # ValueError thrown from ray.util.remove_placement_group means the
+            # placement group has already been removed. Non-fatal.
+            logger.debug(
+                f"Placement group {placement_group.id.hex()} for "
+                f"{self._map_worker_cls_name} was already removed."
+            )
 
     def _update_running_actor_state(self, actor: ActorHandle):
         """Update running actor state. This is called for every actor
@@ -1186,6 +1307,7 @@ class _ActorPool(AutoscalingActorPool):
                 self._pending_or_restarting_usage.subtract(usage)
             )
             del self._actor_to_logical_id[actor]
+            self._remove_actor_placement_group(actor)
             return True
         # No pending actors, so indicate to the caller that no actors were killed.
         return False
@@ -1211,6 +1333,7 @@ class _ActorPool(AutoscalingActorPool):
                 self._pending_or_restarting_usage.subtract(usage)
             )
             self._actor_to_logical_id.pop(actor, None)
+            self._remove_actor_placement_group(actor)
 
         if force:
             for actor in pending.values():
@@ -1271,6 +1394,12 @@ class _ActorPool(AutoscalingActorPool):
             self._pending_or_restarting_usage = (
                 self._pending_or_restarting_usage.subtract(usage)
             )
+
+        # Remove the actor's placement group (if any) so reserved resources
+        # don't outlive it. NOTE: removing the PG force-kills the actor even on
+        # the ref-counting path above, so a PG-backed actor can't be
+        # reconstructed for object lineage once it's released.
+        self._remove_actor_placement_group(actor)
 
     def _find_actor_with_locality(self, bundle: RefBundle) -> Optional[ActorHandle]:
         """Find the least-busy alive actor on the preferred node with the most data.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1314,7 +1314,10 @@ class _ActorPool(AutoscalingActorPool):
 
     def _try_remove_idle_actor(self) -> bool:
         for actor, state in self._running_actors.items():
-            if state.num_tasks_in_flight == 0:
+            # Skip restarting actors: they're idle (0 in-flight) only because Ray
+            # is recovering them. Releasing one removes its placement group and
+            # force-kills the actor mid-restart.
+            if state.num_tasks_in_flight == 0 and not state.is_restarting:
                 # At least one idle actor, so kill first one found.
                 # NOTE: This is a fire-and-forget op
                 self._release_running_actor(actor)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -365,6 +365,8 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         per_block_limit: Optional[int] = None,
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         isolate_workers: bool = False,
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
     ) -> "MapOperator":
         """Create a MapOperator.
 
@@ -405,6 +407,12 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 scheduled on the same worker processes as this operator's. This flag
                 is useful to prevent side-effects from affecting other operators, like
                 large PyArrow memory allocations.
+            placement_group_bundles: If specified, the bundles of the placement
+                group created for each map worker actor. Only valid with
+                ``ActorPoolStrategy``.
+            placement_group_strategy: The strategy of the placement group
+                created for each map worker actor. Only valid together with
+                ``placement_group_bundles``.
 
         Returns:
             A ``MapOperator`` instance whose concrete subclass depends on the
@@ -426,6 +434,15 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 map_transformer, per_block_limit
             )
         if isinstance(compute_strategy, TaskPoolStrategy):
+            if (
+                placement_group_bundles is not None
+                or placement_group_strategy is not None
+            ):
+                raise ValueError(
+                    "`placement_group_bundles` and `placement_group_strategy` "
+                    "are only supported with `ActorPoolStrategy`."
+                )
+
             from ray.data._internal.execution.operators import (
                 get_task_pool_map_operator_cls,
             )
@@ -475,6 +492,8 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 ray_remote_args=ray_remote_args,
                 on_start=on_start,
                 default_logical_memory_enabled=data_context.default_map_logical_memory_enabled,
+                placement_group_bundles=placement_group_bundles,
+                placement_group_strategy=placement_group_strategy,
             )
         else:
             raise ValueError(f"Unsupported execution strategy {compute_strategy}")

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     Literal,
     Optional,
     Union,
@@ -65,6 +66,8 @@ class AbstractMap(AbstractOneToOne):
         ray_remote_args: Optional[Dict[str, Any]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         compute: Optional[ComputeStrategy] = None,
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
     ):
         """Initialize an ``AbstractMap`` logical operator that will later
         be converted into a physical ``MapOperator``.
@@ -90,6 +93,12 @@ class AbstractMap(AbstractOneToOne):
             compute: The compute strategy, either ``TaskPoolStrategy`` (default)
                 to use Ray tasks, or ``ActorPoolStrategy`` to use an
                 autoscaling actor pool.
+            placement_group_bundles: If specified, the bundles of the placement
+                group created for each map worker actor. Only valid with
+                ``ActorPoolStrategy``.
+            placement_group_strategy: The strategy of the placement group
+                created for each map worker actor. Only valid together with
+                ``placement_group_bundles``.
         """
         super().__init__(
             input_op=input_op,
@@ -104,6 +113,8 @@ class AbstractMap(AbstractOneToOne):
         object.__setattr__(self, "ray_remote_args_fn", ray_remote_args_fn)
         object.__setattr__(self, "compute", compute or TaskPoolStrategy())
         object.__setattr__(self, "per_block_limit", None)
+        object.__setattr__(self, "placement_group_bundles", placement_group_bundles)
+        object.__setattr__(self, "placement_group_strategy", placement_group_strategy)
 
     def set_per_block_limit(self, per_block_limit: int):
         object.__setattr__(self, "per_block_limit", per_block_limit)
@@ -117,8 +128,12 @@ class AbstractMap(AbstractOneToOne):
             "ray_remote_args_fn",
             "compute",
             "per_block_limit",
+            "placement_group_bundles",
+            "placement_group_strategy",
         ]:
-            args[f"_{key}"] = getattr(self, key)
+            # Only `MapBatches` carry the placement group fields, so default to `None`
+            # for other subclasses.
+            args[f"_{key}"] = getattr(self, key, None)
         return args
 
 
@@ -150,6 +165,8 @@ class AbstractUDFMap(AbstractMap):
         compute: Optional[ComputeStrategy] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
     ):
         """Initialize AbstractUDFMap.
 
@@ -178,6 +195,12 @@ class AbstractUDFMap(AbstractMap):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Args to provide to :func:`ray.remote`.
+            placement_group_bundles: If specified, the bundles of the placement
+                group created for each map worker actor. Only valid with
+                ``ActorPoolStrategy``.
+            placement_group_strategy: The strategy of the placement group
+                created for each map worker actor. Only valid together with
+                ``placement_group_bundles``.
         """
         name = self._get_operator_name(name, fn)
         super().__init__(
@@ -187,6 +210,8 @@ class AbstractUDFMap(AbstractMap):
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
             compute=compute,
+            placement_group_bundles=placement_group_bundles,
+            placement_group_strategy=placement_group_strategy,
         )
         object.__setattr__(self, "fn", fn)
         object.__setattr__(self, "fn_args", fn_args)
@@ -244,6 +269,8 @@ class MapBatches(AbstractUDFMap):
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     per_block_limit: Optional[int] = None
+    placement_group_bundles: Optional[List[Dict[str, float]]] = None
+    placement_group_strategy: Optional[str] = None
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -490,6 +490,15 @@ class FuseOperators(Rule):
         ray_remote_args_fn = (
             up_logical_op.ray_remote_args_fn or down_logical_op.ray_remote_args_fn
         )
+        # Only actor-pool ops can carry a placement group config, and only the
+        # downstream op can be actor-based (the upstream op is always a task
+        # pool), so propagate the downstream op's placement group config.
+        placement_group_bundles = getattr(
+            down_logical_op, "placement_group_bundles", None
+        )
+        placement_group_strategy = getattr(
+            down_logical_op, "placement_group_strategy", None
+        )
         # Make the upstream operator's inputs the new, fused operator's inputs.
         input_deps = up_op.input_dependencies
         assert len(input_deps) == 1
@@ -544,6 +553,8 @@ class FuseOperators(Rule):
             ray_remote_args_fn=ray_remote_args_fn,
             on_start=on_start,
             isolate_workers=isolate_workers,
+            placement_group_bundles=placement_group_bundles,
+            placement_group_strategy=placement_group_strategy,
         )
         op.set_logical_operators(*up_op._logical_operators, *down_op._logical_operators)
         for map_task_kwargs_fn in itertools.chain(
@@ -577,6 +588,8 @@ class FuseOperators(Rule):
                 can_modify_num_rows=can_modify_num_rows,
                 ray_remote_args_fn=ray_remote_args_fn,
                 ray_remote_args=ray_remote_args,
+                placement_group_bundles=placement_group_bundles,
+                placement_group_strategy=placement_group_strategy,
             )
         else:
             # The downstream op is AbstractMap instead of AbstractUDFMap.
@@ -587,6 +600,8 @@ class FuseOperators(Rule):
                 min_rows_per_bundled_input=min_rows_per_bundled_input,
                 ray_remote_args_fn=ray_remote_args_fn,
                 ray_remote_args=ray_remote_args,
+                placement_group_bundles=placement_group_bundles,
+                placement_group_strategy=placement_group_strategy,
             )
         self._op_map[op] = logical_op
         # Return the fused physical operator.

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -338,6 +338,9 @@ def plan_udf_map_op(
         ray_remote_args_fn=op.ray_remote_args_fn,
         ray_remote_args=op.ray_remote_args,
         per_block_limit=op.per_block_limit,
+        # NOTE: Only `MapBatches` carries the placement group fields.
+        placement_group_bundles=getattr(op, "placement_group_bundles", None),
+        placement_group_strategy=getattr(op, "placement_group_strategy", None),
     )
 
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -38,7 +38,12 @@ import pyarrow.fs
 
 import ray
 from ray._common.retry import call_with_retry, format_exception, matches_error
-from ray.data.context import DEFAULT_READ_OP_MIN_NUM_BLOCKS, WARN_PREFIX, DataContext
+from ray.data.context import (
+    DEFAULT_PLACEMENT_GROUP_STRATEGY,
+    DEFAULT_READ_OP_MIN_NUM_BLOCKS,
+    WARN_PREFIX,
+    DataContext,
+)
 from ray.util.annotations import DeveloperAPI
 
 import psutil
@@ -697,6 +702,94 @@ def get_compute_strategy(
             return ActorPoolStrategy(min_size=1, max_size=None)
         else:
             return TaskPoolStrategy()
+
+
+def validate_actor_placement_group_config(
+    placement_group_bundles: Optional[List[Dict[str, float]]],
+    placement_group_strategy: Optional[str],
+    compute: "ComputeStrategy",
+    ray_remote_args: Dict[str, Any],
+) -> None:
+    """Validate the per-actor placement group configuration for a map operation.
+
+    Raises ValueError if the configuration is invalid.
+    """
+    # Lazily import these objects to avoid circular imports.
+    from ray.data._internal.compute import ActorPoolStrategy
+    from ray.util.placement_group import validate_placement_group
+
+    if placement_group_strategy is not None and placement_group_bundles is None:
+        raise ValueError(
+            "If `placement_group_strategy` is provided, "
+            "`placement_group_bundles` must also be provided."
+        )
+
+    if placement_group_bundles is None:
+        return
+
+    if not isinstance(compute, ActorPoolStrategy):
+        raise ValueError(
+            "`placement_group_bundles` is only supported for actor-based "
+            "transforms. To fix this error, provide a callable class UDF and "
+            "pass an `ActorPoolStrategy` to `compute`."
+        )
+
+    if "scheduling_strategy" in ray_remote_args:
+        raise ValueError(
+            "Manually setting `scheduling_strategy` is not supported when "
+            "`placement_group_bundles` is provided."
+        )
+
+    validate_placement_group(
+        bundles=placement_group_bundles,
+        strategy=placement_group_strategy or DEFAULT_PLACEMENT_GROUP_STRATEGY,
+    )
+
+    resource_error_prefix = (
+        "When using `placement_group_bundles`, the map worker actor will be "
+        "placed in the first bundle, so the resource requirements for the "
+        "actor must be a subset of the first bundle."
+    )
+    first_bundle = placement_group_bundles[0]
+
+    num_cpus = ray_remote_args.get("num_cpus")
+    if num_cpus is None:
+        # Map workers default to 1 CPU when neither CPU nor GPU is specified.
+        # See `_canonicalize_ray_remote_args`.
+        num_cpus = 1 if "num_gpus" not in ray_remote_args else 0
+    bundle_cpu = first_bundle.get("CPU", 0)
+
+    if bundle_cpu < num_cpus:
+        raise ValueError(
+            f"{resource_error_prefix} `num_cpus` for the actor is "
+            f"{num_cpus}, but the bundle only has {bundle_cpu} `CPU` specified."
+        )
+
+    num_gpus = ray_remote_args.get("num_gpus", 0)
+    bundle_gpu = first_bundle.get("GPU", 0)
+    if bundle_gpu < num_gpus:
+        raise ValueError(
+            f"{resource_error_prefix} `num_gpus` for the actor is "
+            f"{num_gpus}, but the bundle only has {bundle_gpu} `GPU` specified."
+        )
+
+    memory = ray_remote_args.get("memory", 0)
+    bundle_memory = first_bundle.get("memory", 0)
+    if bundle_memory < memory:
+        raise ValueError(
+            f"{resource_error_prefix} `memory` for the actor is "
+            f"{memory}, but the bundle only has {bundle_memory} `memory` "
+            "specified."
+        )
+
+    for resource, value in (ray_remote_args.get("resources") or {}).items():
+        bundle_value = first_bundle.get(resource, 0)
+        if bundle_value < value:
+            raise ValueError(
+                f"{resource_error_prefix} `{resource}` requirement for the "
+                f"actor is {value}, but the bundle only has {bundle_value} "
+                f"`{resource}` specified."
+            )
 
 
 def get_compute_strategy_for_read_api(

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -103,6 +103,10 @@ DEFAULT_SCHEDULING_STRATEGY = "SPREAD"
 # transfer is a bottleneck.
 DEFAULT_SCHEDULING_STRATEGY_LARGE_ARGS = "DEFAULT"
 
+# Default strategy for the per-actor placement groups created by map operators
+# when `placement_group_bundles` is specified (see `Dataset.map_batches`).
+DEFAULT_PLACEMENT_GROUP_STRATEGY = "PACK"
+
 DEFAULT_LARGE_ARGS_THRESHOLD = 50 * 1024 * 1024
 
 DEFAULT_USE_POLARS = False

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -104,6 +104,7 @@ from ray.data._internal.util import (
     explain_plan,
     get_compute_strategy,
     merge_resources_to_ray_remote_args,
+    validate_actor_placement_group_config,
 )
 from ray.data.aggregate import (
     AggregateFn,
@@ -771,6 +772,70 @@ class Dataset:
         Returns:
             A new :class:`Dataset` with the transformation applied to each batch.
         """  # noqa: E501
+        return self.map_batches_internal(
+            fn,
+            batch_size=batch_size,
+            compute=compute,
+            batch_format=batch_format,
+            zero_copy_batch=zero_copy_batch,
+            fn_args=fn_args,
+            fn_kwargs=fn_kwargs,
+            fn_constructor_args=fn_constructor_args,
+            fn_constructor_kwargs=fn_constructor_kwargs,
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            memory=memory,
+            concurrency=concurrency,
+            udf_modifying_row_count=udf_modifying_row_count,
+            ray_remote_args_fn=ray_remote_args_fn,
+            **ray_remote_args,
+        )
+
+    @DeveloperAPI
+    def map_batches_internal(
+        self,
+        fn: UserDefinedFunction[DataBatch, DataBatch],
+        *,
+        batch_size: Union[int, None, Literal["auto"]] = None,
+        compute: Optional[ComputeStrategy] = None,
+        batch_format: Optional[str] = "default",
+        zero_copy_batch: bool = True,
+        fn_args: Optional[Iterable[Any]] = None,
+        fn_kwargs: Optional[Dict[str, Any]] = None,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
+        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
+        num_cpus: Optional[float] = None,
+        num_gpus: Optional[float] = None,
+        memory: Optional[float] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
+        udf_modifying_row_count: bool = True,
+        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
+        **ray_remote_args,
+    ) -> "Dataset":
+        """:meth:`map_batches` with additional low-level options exposed for power
+        users and library developers.
+
+        Accepts all arguments of :meth:`map_batches`, plus the following:
+
+        ``placement_group_bundles``: If specified, Ray Data creates one placement
+        group *per map worker actor* from these bundles and schedules the actor
+        into the first bundle. Child tasks and actors spawned by the worker are
+        captured into the same placement group, so this can be used to
+        gang-schedule a group of processes alongside each map worker. Ray Data
+        owns the placement group lifecycle: it's created when the actor starts
+        and removed when the actor is released from the pool (on downscaling,
+        failure, or operator shutdown), so reserved resources don't outlive the
+        actor. The worker's resource requirements (``num_cpus``, ``num_gpus``,
+        ``memory``, ``resources``) must fit in the first bundle. Only supported
+        with actor-based transforms (``compute=ray.data.ActorPoolStrategy(...)``).
+        This option overrides any ``scheduling_strategy`` returned by
+        ``ray_remote_args_fn``.
+
+        ``placement_group_strategy``: The placement strategy for the placement
+        groups created from ``placement_group_bundles``. Defaults to ``"PACK"``.
+        """
         use_gpus = num_gpus is not None and num_gpus > 0
         if use_gpus and (batch_size is None or batch_size == "auto"):
             raise ValueError(
@@ -800,6 +865,8 @@ class Dataset:
             concurrency=concurrency,
             udf_modifying_row_count=udf_modifying_row_count,
             ray_remote_args_fn=ray_remote_args_fn,
+            placement_group_bundles=placement_group_bundles,
+            placement_group_strategy=placement_group_strategy,
             **ray_remote_args,
         )
 
@@ -821,6 +888,8 @@ class Dataset:
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]],
         udf_modifying_row_count: bool,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
+        placement_group_bundles: Optional[List[Dict[str, float]]] = None,
+        placement_group_strategy: Optional[str] = None,
         **ray_remote_args,
     ):
         # NOTE: The `map_groups` implementation calls `map_batches` with
@@ -849,6 +918,13 @@ class Dataset:
         if memory is not None:
             ray_remote_args["memory"] = memory
 
+        validate_actor_placement_group_config(
+            placement_group_bundles=placement_group_bundles,
+            placement_group_strategy=placement_group_strategy,
+            compute=compute,
+            ray_remote_args=ray_remote_args,
+        )
+
         batch_format = _apply_batch_format(batch_format)
 
         map_batches_op = MapBatches(
@@ -866,6 +942,8 @@ class Dataset:
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
+            placement_group_bundles=placement_group_bundles,
+            placement_group_strategy=placement_group_strategy,
         )
         logical_plan = LogicalPlan(map_batches_op, self.context)
         return Dataset._from_parent(self, logical_plan)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -814,27 +814,69 @@ class Dataset:
         placement_group_strategy: Optional[str] = None,
         **ray_remote_args,
     ) -> "Dataset":
-        """:meth:`map_batches` with additional low-level options exposed for power
-        users and library developers.
+        """:meth:`~Dataset.map_batches` with additional low-level options, namely placement group
+        bundles and strategy.
 
-        Accepts all arguments of :meth:`map_batches`, plus the following:
+        Args:
+            fn: The function or generator to apply to a record batch, or a class type
+                that can be instantiated to create such a callable. Note ``fn`` must be
+                pickle-able.
+            batch_size: The desired number of rows in each batch. Use ``"auto"`` to
+                dynamically determine batch size based on the per-row size of the data.
+                Use ``None`` to pass entire blocks as batches (blocks may contain
+                different numbers of rows). When ``num_gpus`` is set, ``batch_size``
+                must be an explicit integer value, not ``"auto"`` or ``None``.
+            compute: The compute strategy to use for the map operation, either
+                ``ray.data.TaskPoolStrategy`` (default) to use Ray tasks, or
+                ``ray.data.ActorPoolStrategy`` to use an autoscaling actor pool.
+            batch_format: If ``"default"`` or ``"numpy"``, batches are
+                ``Dict[str, numpy.ndarray]``. If ``"pandas"``, batches are
+                ``pandas.DataFrame``. If ``"pyarrow"``, batches are ``pyarrow.Table``.
+                If ``None``, the input block format is used.
+            zero_copy_batch: Whether ``fn`` should be provided zero-copy, read-only
+                batches. If ``True`` and no copy is required for the ``batch_format``
+                conversion, the batch is a zero-copy, read-only view on data in Ray's
+                object store. If ``False``, a copy of the *whole* batch is made,
+                allowing ``fn`` to modify the underlying data buffers in place.
+            fn_args: Positional arguments to pass to ``fn`` after the first argument.
+                These arguments are top-level arguments to the underlying Ray task.
+            fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are
+                top-level arguments to the underlying Ray task.
+            fn_constructor_args: Positional arguments to pass to ``fn``'s constructor.
+                You can only provide this if ``fn`` is a callable class. These arguments
+                are top-level arguments in the underlying Ray actor construction task.
+            fn_constructor_kwargs: Keyword arguments to pass to ``fn``'s constructor.
+                This can only be provided if ``fn`` is a callable class. These arguments
+                are top-level arguments in the underlying Ray actor construction task.
+            num_cpus: The number of CPUs to reserve for each parallel map worker.
+            num_gpus: The number of GPUs to reserve for each parallel map worker. For
+                example, specify ``num_gpus=1`` to request 1 GPU for each parallel map
+                worker.
+            memory: The heap memory in bytes to reserve for each parallel map worker.
+            concurrency: This argument is deprecated. Use ``compute`` argument.
+            udf_modifying_row_count: If your UDF produces the same number of output rows
+                as it receives, set this parameter to False. It allows Ray Data to
+                perform more optimizations like limit pushdown.
+            ray_remote_args_fn: A function that returns a dictionary of remote args
+                passed to each map worker. The purpose of this argument is to generate
+                dynamic arguments for each actor/task, and will be called each time prior
+                to initializing the worker. Args returned from this dict will always
+                override the args in ``ray_remote_args``. Note: this is an advanced,
+                experimental feature.
+            placement_group_bundles: If specified, Ray Data creates one placement group
+                per map worker actor from these bundles and schedules the actor into
+                the first bundle. Child tasks and actors spawned by the worker are
+                captured into the same placement group. Only supported for actor-based
+                transforms (``compute=ray.data.ActorPoolStrategy(...)``). This option overrides
+                any ``scheduling_strategy`` returned by ``ray_remote_args_fn``.
+            placement_group_strategy: The placement strategy for the placement groups
+                created from ``placement_group_bundles``. Requires ``placement_group_bundles``.
+                Defaults to ``"PACK"``.
+            **ray_remote_args: Additional resource requirements to request from
+                Ray for each map worker. See :func:`ray.remote` for details.
 
-        ``placement_group_bundles``: If specified, Ray Data creates one placement
-        group *per map worker actor* from these bundles and schedules the actor
-        into the first bundle. Child tasks and actors spawned by the worker are
-        captured into the same placement group, so this can be used to
-        gang-schedule a group of processes alongside each map worker. Ray Data
-        owns the placement group lifecycle: it's created when the actor starts
-        and removed when the actor is released from the pool (on downscaling,
-        failure, or operator shutdown), so reserved resources don't outlive the
-        actor. The worker's resource requirements (``num_cpus``, ``num_gpus``,
-        ``memory``, ``resources``) must fit in the first bundle. Only supported
-        with actor-based transforms (``compute=ray.data.ActorPoolStrategy(...)``).
-        This option overrides any ``scheduling_strategy`` returned by
-        ``ray_remote_args_fn``.
-
-        ``placement_group_strategy``: The placement strategy for the placement
-        groups created from ``placement_group_bundles``. Defaults to ``"PACK"``.
+        Returns:
+            A new :class:`Dataset` with the transformation applied to each batch.
         """
         use_gpus = num_gpus is not None and num_gpus > 0
         if use_gpus and (batch_size is None or batch_size == "auto"):

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -1879,6 +1879,41 @@ class TestPlacementGroup:
         # The placement group is retained across the restart (not removed).
         assert get_pg_states()[pg_id] == "CREATED"
 
+    def test_idle_downscale_skips_restarting_actor(self, shutdown_only):
+        """Idle downscale must skip a restarting actor: it has 0 in-flight tasks
+        but Ray is recovering it, and releasing it would remove its PG and kill
+        it mid-restart."""
+        ray.shutdown()
+        ray.init(num_cpus=1)
+
+        pool = _make_actor_pool(
+            _create_actor_in_pg_fn,
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        pool.scale(ActorPoolScalingRequest(delta=1, reason="test"))
+        ready_ref = pool.get_pending_actor_refs()[0]
+        ray.get(ready_ref)
+        actor = pool.pending_to_running(ready_ref)
+        [pg_id] = list(get_pg_states())
+
+        # Mark the idle actor as restarting
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
+            assert pool.num_restarting_actors() == 1
+            # Nothing is released: the only idle actor is restarting, so it's skipped.
+            released = pool.scale(
+                ActorPoolScalingRequest.downscale(delta=-1, reason="test", force=True)
+            )
+            assert released == 0
+
+        assert pool.num_running_actors() == 1
+        assert get_pg_states()[pg_id] == "CREATED"
+
     def test_removed_when_creation_fails(self, shutdown_only):
         """If the actor factory raises, the PG created for it is removed, not
         leaked, and the error propagates."""

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -66,6 +66,8 @@ from ray.data.tests.util import (
 from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.tests.conftest import *  # noqa
 from ray.types import ObjectRef
+from ray.util.placement_group import PlacementGroup
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 @ray.remote
@@ -110,6 +112,35 @@ def _schedule_bundles(
     return results
 
 
+def _make_actor_pool(
+    create_actor_fn,
+    *,
+    min_size=1,
+    max_size=4,
+    initial_size=1,
+    max_tasks_in_flight=4,
+    max_actor_concurrency=1,
+    map_worker_cls_name="MapWorker",
+    placement_group_bundles=None,
+    placement_group_strategy=None,
+) -> _ActorPool:
+    config = AutoscalingActorConfig(
+        min_size=min_size,
+        max_size=max_size,
+        initial_size=initial_size,
+        max_tasks_in_flight_per_actor=max_tasks_in_flight,
+        max_actor_concurrency=max_actor_concurrency,
+        per_actor_resource_usage=ExecutionResources(cpu=1),
+    )
+    return _ActorPool(
+        create_actor_fn=create_actor_fn,
+        config=config,
+        map_worker_cls_name=map_worker_cls_name,
+        placement_group_bundles=placement_group_bundles,
+        placement_group_strategy=placement_group_strategy,
+    )
+
+
 class TestActorPool(unittest.TestCase):
     def setup_class(self):
         self._last_created_actor_and_ready_ref: Optional[
@@ -144,6 +175,7 @@ class TestActorPool(unittest.TestCase):
         self,
         labels: Dict[str, Any],
         logical_actor_id: str = "Actor1",
+        placement_group: Optional[PlacementGroup] = None,
     ) -> Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]:
         actor = PoolWorker.options(_labels=labels).remote(self._actor_node_id)
         ready_ref = actor.get_location.remote()
@@ -158,20 +190,14 @@ class TestActorPool(unittest.TestCase):
         max_tasks_in_flight=4,
         map_worker_cls_name="MapWorker",
     ):
-        config = AutoscalingActorConfig(
+        return _make_actor_pool(
+            self._create_actor_fn,
             min_size=min_size,
             max_size=max_size,
             initial_size=initial_size,
-            max_tasks_in_flight_per_actor=max_tasks_in_flight,
-            max_actor_concurrency=1,
-            per_actor_resource_usage=ExecutionResources(cpu=1),
-        )
-        pool = _ActorPool(
-            create_actor_fn=self._create_actor_fn,
+            max_tasks_in_flight=max_tasks_in_flight,
             map_worker_cls_name=map_worker_cls_name,
-            config=config,
         )
-        return pool
 
     def _add_pending_actor(
         self, pool: _ActorPool, node_id="node1"
@@ -914,6 +940,7 @@ def test_actor_pool_scale_logs_include_map_worker_cls_name(
     def create_actor_fn(
         labels: Dict[str, Any],
         logical_actor_id: str = "Actor1",
+        placement_group: Optional[PlacementGroup] = None,
     ) -> Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]:
         actor = PoolWorker.options(_labels=labels).remote("node1")
         return actor, actor.get_location.remote(), ExecutionResources(cpu=1)
@@ -1702,6 +1729,365 @@ def test_merge_ray_remote_args_op_wins_on_collision(restore_data_context):
     )
     merged = op._merge_ray_remote_args()
     assert merged["label_selector"] == {"subcluster": "val", "node": "X"}
+
+
+def get_pg_states() -> Dict[str, str]:
+    return {
+        pg_id: info["state"] for pg_id, info in ray.util.placement_group_table().items()
+    }
+
+
+def _create_actor_in_pg_fn(
+    labels: Dict[str, Any],
+    logical_actor_id: str,
+    placement_group: Optional[PlacementGroup] = None,
+) -> Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]:
+    assert placement_group is not None
+    actor = PoolWorker.options(
+        _labels=labels,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group,
+            placement_group_bundle_index=0,
+            placement_group_capture_child_tasks=True,
+        ),
+    ).remote("node1")
+    return actor, actor.get_location.remote(), ExecutionResources(cpu=1)
+
+
+class TestPlacementGroup:
+    """Per-actor placement groups: Ray Data owns the placement group lifecycle,
+    attributes the bundle resources to each actor, and validates the config."""
+
+    def test_resource_accounting(self, restore_data_context):
+        """With per-actor placement groups, the operator attributes the sum of
+        all PG bundles to each actor."""
+        data_context = ray.data.DataContext.get_current()
+        op = MapOperator.create(
+            map_transformer=MagicMock(),
+            input_op=InputDataBuffer(data_context, input_data=MagicMock()),
+            data_context=data_context,
+            compute_strategy=ray.data.ActorPoolStrategy(min_size=1, max_size=2),
+            ray_remote_args={"num_cpus": 1, "num_gpus": 0},
+            placement_group_bundles=[{"CPU": 1, "GPU": 1}, {"CPU": 1, "GPU": 1}],
+            placement_group_strategy="STRICT_PACK",
+        )
+        op._metrics = MagicMock(obj_store_mem_max_pending_output_per_task=0)
+
+        # Per-actor usage is the sum of all bundles (2 CPU, 2 GPU)
+        bundle_sum = ExecutionResources(cpu=2, gpu=2)
+        assert op._placement_group_resource_usage() == bundle_sum
+        assert op._actor_pool.per_actor_resource_usage() == bundle_sum
+        assert op.min_scheduling_resources() == bundle_sum
+        assert op.per_task_resource_allocation() == bundle_sum
+
+        # min/max requirements scale the bundle sum by the pool's min/max size.
+        min_bound, max_bound = op.min_max_resource_requirements()
+        assert min_bound == ExecutionResources(cpu=2, gpu=2, object_store_memory=0)
+        assert max_bound == ExecutionResources(
+            cpu=4, gpu=4, object_store_memory=float("inf")
+        )
+
+    def test_pool_owns_lifecycle(self, shutdown_only):
+        """The pool creates one placement group per actor and removes it when
+        the actor is released, both on downscaling and on shutdown."""
+        num_actors = 2
+        ray.shutdown()
+        ray.init(num_cpus=num_actors)
+
+        pool = _make_actor_pool(
+            _create_actor_in_pg_fn,
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        pool.scale(ActorPoolScalingRequest(delta=num_actors, reason="test"))
+        for ready_ref in pool.get_pending_actor_refs():
+            ray.get(ready_ref)
+            pool.pending_to_running(ready_ref)
+        assert pool.num_running_actors() == num_actors
+
+        pg_states = get_pg_states()
+        assert len(pg_states) == num_actors
+        assert all(state == "CREATED" for state in pg_states.values())
+
+        # Downscaling releases an idle actor along with its placement group.
+        assert (
+            pool.scale(
+                ActorPoolScalingRequest.downscale(delta=-1, reason="test", force=True)
+            )
+            == -1
+        )
+        wait_for_condition(
+            lambda: sorted(get_pg_states().values()) == ["CREATED", "REMOVED"]
+        )
+
+        # Shutdown releases the remaining actor and its placement group.
+        pool.shutdown()
+        wait_for_condition(
+            lambda: sorted(get_pg_states().values()) == ["REMOVED", "REMOVED"]
+        )
+
+    def test_pending_actor_removed(self, shutdown_only):
+        """Releasing an actor that's still pending removes its placement group."""
+        ray.shutdown()
+        # A single actor occupying a single `{"CPU": 1}` bundle.
+        ray.init(num_cpus=1)
+
+        pool = _make_actor_pool(
+            _create_actor_in_pg_fn,
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        pool.scale(ActorPoolScalingRequest(delta=1, reason="test"))
+        assert pool.num_pending_actors() == 1
+        assert len(get_pg_states()) == 1
+
+        assert (
+            pool.scale(
+                ActorPoolScalingRequest.downscale(delta=-1, reason="test", force=True)
+            )
+            == -1
+        )
+        assert pool.num_pending_actors() == 0
+        wait_for_condition(lambda: list(get_pg_states().values()) == ["REMOVED"])
+
+    def test_restart_keeps_placement_group(self, shutdown_only):
+        """A transient actor restart must NOT remove its placement group; only
+        release does."""
+        ray.shutdown()
+        ray.init(num_cpus=1)
+
+        pool = _make_actor_pool(
+            _create_actor_in_pg_fn,
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        pool.scale(ActorPoolScalingRequest(delta=1, reason="test"))
+        ready_ref = pool.get_pending_actor_refs()[0]
+        ray.get(ready_ref)
+        actor = pool.pending_to_running(ready_ref)
+        [pg_id] = list(get_pg_states())
+
+        # Simulate a transient restart of the running actor.
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
+        assert pool.num_restarting_actors() == 1
+
+        # The placement group is retained across the restart (not removed).
+        assert get_pg_states()[pg_id] == "CREATED"
+
+    def test_removed_when_creation_fails(self, shutdown_only):
+        """If the actor factory raises, the PG created for it is removed, not
+        leaked, and the error propagates."""
+        ray.shutdown()
+        ray.init(num_cpus=1)
+
+        def failing_fn(labels, logical_actor_id, placement_group=None):
+            raise RuntimeError("actor creation boom")
+
+        pool = _make_actor_pool(
+            failing_fn,
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        with pytest.raises(RuntimeError, match="actor creation boom"):
+            pool.scale(ActorPoolScalingRequest(delta=1, reason="test"))
+
+        assert pool.num_pending_actors() == 0
+        wait_for_condition(
+            lambda: all(state == "REMOVED" for state in get_pg_states().values())
+        )
+
+    def test_removed_when_init_fails(self, shutdown_only):
+        """If actor init fails (ready future errors), `pending_to_running`
+        removes the PG instead of leaking it."""
+        ray.shutdown()
+        ray.init(num_cpus=1)
+
+        @ray.remote
+        class FailingWorker:
+            def get_location(self):
+                raise RuntimeError("actor init boom")
+
+        def fn(labels, logical_actor_id, placement_group=None):
+            actor = FailingWorker.options(
+                _labels=labels,
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=placement_group,
+                    placement_group_bundle_index=0,
+                ),
+            ).remote()
+            return actor, actor.get_location.remote(), ExecutionResources(cpu=1)
+
+        pool = _make_actor_pool(
+            fn,
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        pool.scale(ActorPoolScalingRequest(delta=1, reason="test"))
+        ready_ref = pool.get_pending_actor_refs()[0]
+        with pytest.raises(Exception):
+            pool.pending_to_running(ready_ref)
+
+        wait_for_condition(
+            lambda: all(state == "REMOVED" for state in get_pg_states().values())
+        )
+
+    def test_requires_actor_pool(self, ray_start_regular_shared):
+        # A function UDF resolves to a task pool, which can't carry a PG.
+        with pytest.raises(ValueError, match="only supported for actor-based"):
+            ray.data.range(10).map_batches_internal(
+                lambda batch: batch, placement_group_bundles=[{"CPU": 1}]
+            )
+
+    def test_strategy_requires_bundles(self, ray_start_regular_shared):
+        with pytest.raises(
+            ValueError, match="`placement_group_bundles` must also be provided"
+        ):
+            ray.data.range(10).map_batches_internal(
+                lambda batch: batch, placement_group_strategy="PACK"
+            )
+
+    def test_rejects_scheduling_strategy(self, ray_start_regular_shared):
+        class UDFClass:
+            def __call__(self, batch):
+                return batch
+
+        with pytest.raises(ValueError, match="Manually setting `scheduling_strategy`"):
+            ray.data.range(10).map_batches_internal(
+                UDFClass,
+                compute=ray.data.ActorPoolStrategy(size=1),
+                placement_group_bundles=[{"CPU": 1}],
+                scheduling_strategy="SPREAD",
+            )
+
+    def test_rejects_invalid_strategy(self, ray_start_regular_shared):
+        class UDFClass:
+            def __call__(self, batch):
+                return batch
+
+        with pytest.raises(ValueError, match="Invalid placement group strategy"):
+            ray.data.range(10).map_batches_internal(
+                UDFClass,
+                compute=ray.data.ActorPoolStrategy(size=1),
+                placement_group_bundles=[{"CPU": 1}],
+                placement_group_strategy="INVALID",
+            )
+
+    def test_default_cpus_exceed_bundle(self, ray_start_regular_shared):
+        class UDFClass:
+            def __call__(self, batch):
+                return batch
+
+        # Map workers default to 1 CPU when no resources are specified.
+        with pytest.raises(ValueError, match="subset of the first bundle"):
+            ray.data.range(10).map_batches_internal(
+                UDFClass,
+                compute=ray.data.ActorPoolStrategy(size=1),
+                placement_group_bundles=[{"CPU": 0.5}],
+            )
+
+    def test_actor_exceeds_bundle(self, ray_start_regular_shared):
+        class UDFClass:
+            def __call__(self, batch):
+                return batch
+
+        with pytest.raises(ValueError, match="subset of the first bundle"):
+            ray.data.range(10).map_batches_internal(
+                UDFClass,
+                compute=ray.data.ActorPoolStrategy(size=1),
+                placement_group_bundles=[{"CPU": 1}],
+                num_gpus=1,
+                batch_size=2,
+            )
+
+    def test_config_survives_fusion(self, ray_start_regular_shared):
+        """Fusing an upstream task-based map into a downstream actor-based map
+        preserves the downstream op's placement group config."""
+        from ray.data._internal.logical.optimizers import get_execution_plan
+
+        class UDFClass:
+            def __call__(self, batch):
+                return batch
+
+        ds = (
+            ray.data.range(10)
+            .map_batches(lambda batch: batch)
+            .map_batches_internal(
+                UDFClass,
+                compute=ray.data.ActorPoolStrategy(size=1),
+                placement_group_bundles=[{"CPU": 1}, {"CPU": 1}],
+                placement_group_strategy="SPREAD",
+            )
+        )
+        physical_plan, _ = get_execution_plan(ds._logical_plan)
+        op = physical_plan.dag
+
+        assert op._placement_group_bundles == [{"CPU": 1}, {"CPU": 1}]
+        assert op._placement_group_strategy == "SPREAD"
+        # The fused operator's resource accounting also reflects the bundle sum,
+        # so the config survives fusion down to budgeting/autoscaling.
+        assert op._actor_pool.per_actor_resource_usage() == ExecutionResources(cpu=2)
+
+    def test_removed_after_execution(self, shutdown_only):
+        """End-to-end: Ray Data spawns the map worker actor into its placement
+        group, captures the actor's child tasks into it, and removes the group
+        once execution finishes instead of leaking until the driver exits."""
+        num_actors = 1
+        ray.shutdown()
+        # One CPU per actor (its placement group's single bundle) plus one for
+        # the upstream read tasks, which run outside the placement groups.
+        ray.init(num_cpus=num_actors + 1)
+
+        # NOTE: Defined inside the test so that cloudpickle serializes the class
+        # by value (map workers can't import the test module).
+        class PlacementGroupProbe:
+            """Records the placement group of the map worker actor and of a child
+            task it spawns (which should be captured into the same group)."""
+
+            def __init__(self):
+                pg = ray.util.get_current_placement_group()
+                assert pg is not None, "Map worker should run inside its PG"
+                self._pg_id = pg.id.hex()
+
+                # `num_cpus=0` so the captured child fits in the same single
+                # bundle as the actor (keeps the test within `num_actors` CPUs).
+                @ray.remote(num_cpus=0)
+                def child_pg_id() -> Optional[str]:
+                    child_pg = ray.util.get_current_placement_group()
+                    return child_pg.id.hex() if child_pg is not None else None
+
+                self._child_pg_id = ray.get(child_pg_id.remote())
+
+            def __call__(self, batch):
+                batch["pg_id"] = [self._pg_id] * len(batch["id"])
+                batch["child_pg_id"] = [self._child_pg_id] * len(batch["id"])
+                return batch
+
+        ds = ray.data.range(8, override_num_blocks=4).map_batches_internal(
+            PlacementGroupProbe,
+            batch_size=2,
+            compute=ray.data.ActorPoolStrategy(size=num_actors),
+            placement_group_bundles=[{"CPU": 1}],
+            placement_group_strategy="PACK",
+        )
+        rows = ds.take_all()
+        assert len(rows) == 8
+
+        # The map worker (and the child task it spawned) ran inside a placement
+        # group, one per actor.
+        pg_ids = {row["pg_id"] for row in rows}
+        assert len(pg_ids) == num_actors
+        assert all(row["child_pg_id"] == row["pg_id"] for row in rows)
+
+        # The placement group is removed once execution finishes.
+        assert pg_ids <= set(get_pg_states())
+        wait_for_condition(
+            lambda: all(state == "REMOVED" for state in get_pg_states().values())
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -2035,18 +2035,16 @@ class TestPlacementGroup:
     def test_removed_after_execution(self, shutdown_only):
         """End-to-end: Ray Data spawns the map worker actor into its placement
         group, captures the actor's child tasks into it, and removes the group
-        once execution finishes instead of leaking until the driver exits."""
+        once execution finishes."""
         num_actors = 1
         ray.shutdown()
         # One CPU per actor (its placement group's single bundle) plus one for
         # the upstream read tasks, which run outside the placement groups.
         ray.init(num_cpus=num_actors + 1)
 
-        # NOTE: Defined inside the test so that cloudpickle serializes the class
-        # by value (map workers can't import the test module).
         class PlacementGroupProbe:
             """Records the placement group of the map worker actor and of a child
-            task it spawns (which should be captured into the same group)."""
+            task it spawns which should be captured into the same group."""
 
             def __init__(self):
                 pg = ray.util.get_current_placement_group()


### PR DESCRIPTION
## Description

When a `map_batches` stage creates a placement group with `ray_remote_args_fn`, nobody owns that placement group. It is created as a side effect of the user callback, the actor is scheduled into it, but no code ever calls `remove_placement_group`, leaking the placement group until the driver exits.

This PR makes a per-actor placement group a declarative property of the actor pool whose lifetime is bound to the actor. This feature is particularly useful for sharded model batch inference, e.g. vLLM with `TP * PP > 1`.

### API shape
Adds two options to a new developer API `Dataset.map_batches_internal`. The public `map_batches` API is unchanged.

```python
ds.map_batches_internal(
    DummyActor,
    compute=ray.data.ActorPoolStrategy(size=4),
    placement_group_bundles=[{"CPU": 1, "GPU": 1}, {"CPU": 1, "GPU": 1}],
    placement_group_strategy="STRICT_PACK",
)
```

### Gotchas
- Each map actor is placed in the **first bundle** of its own PG with `placement_group_capture_child_tasks=True`, so child tasks/actors the worker spawns land in the same PG.

### Limitations

- `map_batches_internal` only.
- Valid **only** with `compute=ActorPoolStrategy`. An error is raised for task compute.
- `scheduling_strategy` may not be set alongside bundles.
- Actor must fit in the first bundle, i.e. resources for the actor must be a subset of bundle 0 (the actor is pinned to `bundle_index=0`).
- Custom resources (e.g. TPU) aren't in accounting: Ray Data's logical accounting models only CPU/GPU/memory, so a bundle reserving a custom resource isn't reflected in budgeting/autoscaling. This is pre-existing, and this PR likewise doesn't account for custom resources reserved by placement group bundles.
- **No lineage reconstruction**: Ray recovers a lost object by re-running the actor task that produced it (lineage reconstruction); Ray Data drops actor refs instead of killing to keep this possible, but removing the PG force-kills the actor, breaking it. To enable lineage reconstruction, Ray Core needs to model PG creation as part of the actor's lineage. Out-of-scope for this PR.

## Implementation details
### Lifecycle ownership (`ActorPoolMapOperator` / `_ActorPool`)

The pool owns an actor → placement_group map (`_actor_to_placement_group`):

- **On actor start**: create the PG, then launch the actor into it.
- **On actor release**: idle downscale, pending downscale, operator shutdown, actor-init failure, or actor-creation failure call `remove_placement_group` and drop the map entry.
- **On restart**: the PG is retained (only release removes it), so a transient actor restart does not leak or duplicate PGs.

### Resource accounting

When a PG is provisioned, the cluster reserves the **sum of all bundles** for the actor's lifetime. The operator now attributes that bundle sum to each actor across `per_actor_resource_usage`, `min_max_resource_requirements`, and
`per_task_resource_allocation`. This keeps resource-manager budgeting and autoscaling correct, e.g. an actor that declares `num_gpus=0` but reserves GPUs in its bundles is still budgeted against those GPUs.

### Fusion
Operator fusion propagates the **downstream** op's PG config onto the fused operator (the upstream of a fusable
pair is always a task pool, which can't carry a PG), so `Read→MapBatches(actor, pg=...)` keeps its placement groups after fusion.

### Plumbing

The placement-group config threads through the existing path:
`map_batches_internal` → `MapBatches` (logical op) → `plan_udf_map_op` →
`MapOperator.create` → `ActorPoolMapOperator`.

## Follow-ups

- [x] Migrate `vLLMEngineStage` off `ray_remote_args_fn = _ray_scheduling_strategy_fn`: https://github.com/ray-project/ray/pull/64091.

## Related issues
Closes #64035.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
