### PR TITLE
[data][llm] Switch multi-GPU inference to `map_batches`-native placement groups

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -386,9 +386,6 @@ class Processor:
                 batch_size=self.config.batch_size,
                 data_column=self.DATA_COLUMN,
             )
-            # `map_batches_internal` exposes `placement_group_bundles`/`_strategy`,
-            # which stages (e.g. vLLM with a Ray executor) use to request a
-            # Ray Data-owned per-actor placement group.
             dataset = dataset.map_batches_internal(stage.fn, **kwargs)
 
         if self.postprocess is not None:

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -386,7 +386,10 @@ class Processor:
                 batch_size=self.config.batch_size,
                 data_column=self.DATA_COLUMN,
             )
-            dataset = dataset.map_batches(stage.fn, **kwargs)
+            # `map_batches_internal` exposes `placement_group_bundles`/`_strategy`,
+            # which stages (e.g. vLLM with a Ray executor) use to request a
+            # Ray Data-owned per-actor placement group.
+            dataset = dataset.map_batches_internal(stage.fn, **kwargs)
 
         if self.postprocess is not None:
             dataset = dataset.map(self.postprocess, **self.postprocess_map_kwargs)

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -9,7 +9,6 @@ import os
 import time
 import uuid
 from collections import Counter
-from functools import partial
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tuple, Type
 
 import numpy as np
@@ -21,7 +20,6 @@ if TYPE_CHECKING:
 else:
     MultiModalDataDict = Any
 
-import ray
 from ray.llm._internal.batch.constants import TypeVLLMTaskType, vLLMTaskType
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
@@ -39,7 +37,6 @@ from ray.llm._internal.common.utils.download_utils import (
     download_model_files,
 )
 from ray.llm._internal.common.utils.lora_utils import download_lora_adapter
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -813,12 +810,12 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             self.llm.shutdown()
 
 
-def _ray_scheduling_strategy_fn(
+def _get_engine_placement_group_bundles(
     num_bundles_per_replica: int,
     accelerator_type: Optional[str] = None,
     placement_group_config: Optional[Dict[str, Any]] = None,
-):
-    """Create a Ray scheduling strategy for the engine.
+) -> Tuple[List[Dict[str, float]], str]:
+    """Build the placement group bundles and strategy for one engine replica.
 
     Args:
         num_bundles_per_replica: The number of device bundles per
@@ -829,36 +826,26 @@ def _ray_scheduling_strategy_fn(
             If None, we use the default placement group configuration.
 
     Returns:
-        The Ray scheduling strategy.
+        A tuple of the bundle specs and the placement group strategy.
     """
 
     def _get_bundle() -> Dict[str, float]:
-        # GPU bundles
         bundle = {"GPU": 1, "CPU": 1}
-
-        # Accelerator type
         if accelerator_type:
             bundle[f"accelerator_type:{accelerator_type}"] = 0.001
         return bundle
 
     if placement_group_config:
         placement_group_config = copy.deepcopy(placement_group_config)
-
+        bundles = placement_group_config["bundles"]
         if accelerator_type:
-            for bundle in placement_group_config["bundles"]:
+            for bundle in bundles:
                 bundle[f"accelerator_type:{accelerator_type}"] = 0.001
-
-        pg = ray.util.placement_group(**placement_group_config)
+        strategy = placement_group_config.get("strategy", "PACK")
     else:
-        pg = ray.util.placement_group(
-            [_get_bundle()] * num_bundles_per_replica,
-            strategy="PACK",
-        )
-    return dict(
-        scheduling_strategy=PlacementGroupSchedulingStrategy(
-            pg, placement_group_capture_child_tasks=True
-        )
-    )
+        bundles = [_get_bundle() for _ in range(num_bundles_per_replica)]
+        strategy = "PACK"
+    return bundles, strategy
 
 
 class vLLMEngineStage(StatefulStage):
@@ -906,10 +893,6 @@ class vLLMEngineStage(StatefulStage):
         )
         executor_backend = engine_kwargs.get("distributed_executor_backend")
 
-        # When Ray is used in the vLLM engine, we set num_devices to 0 so that
-        # Ray Data won't reserve GPUs in advance. Instead, we specify scheduling
-        # strategy in .map_batches() arguments and let vLLM Ray executor to
-        # create placement groups for each TP/PP worker.
         placement_group_config = fn_constructor_kwargs.pop(
             "placement_group_config", None
         )
@@ -923,14 +906,13 @@ class vLLMEngineStage(StatefulStage):
                     bundle_per_worker.copy() for _ in range(num_bundles_per_replica)
                 ]
         if executor_backend == "ray":
-            # Note that we have to use partial() to pass a function
-            # instead of an object.
-            map_batches_kwargs["ray_remote_args_fn"] = partial(
-                _ray_scheduling_strategy_fn,
+            bundles, strategy = _get_engine_placement_group_bundles(
                 num_bundles_per_replica,
                 accelerator_type,
                 placement_group_config,
             )
+            map_batches_kwargs["placement_group_bundles"] = bundles
+            map_batches_kwargs["placement_group_strategy"] = strategy
             ray_remote_args["num_gpus"] = 0
         else:
             if not placement_group_config:

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -80,16 +80,17 @@ def test_vllm_engine_processor(
     assert isinstance(compute, ray.data._internal.compute.ActorPoolStrategy)
 
     if expected_distributed_executor_backend == "ray":
-        ray_remote_args_fn = stage.map_batches_kwargs.pop("ray_remote_args_fn")
-        assert ray_remote_args_fn is not None
+        bundles = stage.map_batches_kwargs.pop("placement_group_bundles")
+        assert len(bundles) == tensor_parallel_size
         assert stage.map_batches_kwargs == {
             "zero_copy_batch": True,
             "max_concurrency": 8,
             "accelerator_type": gpu_type,
             "num_gpus": 0,
+            "placement_group_strategy": "PACK",
         }
     else:
-        assert "ray_remote_args_fn" not in stage.map_batches_kwargs
+        assert "placement_group_bundles" not in stage.map_batches_kwargs
         assert stage.map_batches_kwargs == {
             "zero_copy_batch": True,
             "max_concurrency": 8,
@@ -210,12 +211,12 @@ def test_vllm_engine_processor_bundle_per_worker(
 
     if expected_num_bundles > 1:
         # TP/PP > 1 -> executor_backend="ray"
-        ray_remote_args_fn = stage.map_batches_kwargs.pop("ray_remote_args_fn")
-        assert ray_remote_args_fn.args[0] == expected_num_bundles
-        assert ray_remote_args_fn.args[1] == gpu_type
-        expected_bundles = [{"CPU": 1, "GPU": 1}] * expected_num_bundles
-        assert ray_remote_args_fn.args[2]["bundles"] == expected_bundles
-        assert ray_remote_args_fn.args[2]["strategy"] == "PACK"
+        bundles = stage.map_batches_kwargs.pop("placement_group_bundles")
+        expected_bundles = [
+            {"CPU": 1, "GPU": 1, f"accelerator_type:{gpu_type}": 0.001}
+        ] * expected_num_bundles
+        assert bundles == expected_bundles
+        expected_kwargs["placement_group_strategy"] = "PACK"
         expected_kwargs["num_gpus"] = 0
     else:
         # TP=1, PP=1 -> executor_backend="uni"

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -16,7 +16,6 @@ from ray.llm._internal.batch.stages.vllm_engine_stage import (
     vLLMEngineWrapper,
     vLLMOutputData,
 )
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 @pytest.fixture
@@ -99,27 +98,26 @@ def test_vllm_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
             "distributed_executor_backend": "ray",
         },
     }
-    ray_remote_args_fn = stage.map_batches_kwargs.pop("ray_remote_args_fn")
     compute = stage.map_batches_kwargs.pop("compute")
     assert isinstance(compute, ActorPoolStrategy)
     assert compute.min_size == 1
     assert compute.max_size == 1
 
+    # The Ray executor path emits declarative placement group bundles that Ray
+    # Data's actor pool owns, instead of a PG-creating ray_remote_args_fn.
+    bundles = stage.map_batches_kwargs.pop("placement_group_bundles")
     assert stage.map_batches_kwargs == {
         "zero_copy_batch": True,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
         "num_gpus": 0,
+        "placement_group_strategy": "PACK",
     }
-    scheduling_strategy = ray_remote_args_fn()["scheduling_strategy"]
-    assert isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy)
-
-    bundle_specs = scheduling_strategy.placement_group.bundle_specs
-    assert len(bundle_specs) == 4
-    for bundle_spec in bundle_specs:
-        assert bundle_spec[f"accelerator_type:{gpu_type}"] == 0.001
-        assert bundle_spec["CPU"] == 1.0
-        assert bundle_spec["GPU"] == 1.0
+    assert len(bundles) == 4
+    for bundle in bundles:
+        assert bundle[f"accelerator_type:{gpu_type}"] == 0.001
+        assert bundle["CPU"] == 1.0
+        assert bundle["GPU"] == 1.0
 
 
 @pytest.mark.asyncio

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -705,6 +705,61 @@ def test_vllm_placement_group(backend, placement_group_config):
     assert all("resp" in out for out in outs)
 
 
+def get_leaked_pgs(pre_existing):
+    """CREATED placement groups holding GPUs not present before the run."""
+    leaked = {}
+    for pg_id, info in ray.util.placement_group_table().items():
+        if pg_id in pre_existing or info.get("state") != "CREATED":
+            continue
+        gpus = sum(b.get("GPU", 0) for b in (info.get("bundles") or {}).values())
+        if gpus:
+            leaked[pg_id] = gpus
+    return leaked
+
+
+def test_vllm_engine_releases_placement_group():
+    ray.init(ignore_reinit_error=True)
+    pre_existing = set(ray.util.placement_group_table())
+
+    def build():
+        config = vLLMEngineProcessorConfig(
+            model_source="facebook/opt-1.3b",
+            engine_kwargs=dict(
+                tensor_parallel_size=2,
+                pipeline_parallel_size=2,
+                distributed_executor_backend="ray",
+                enable_chunked_prefill=True,
+                max_num_batched_tokens=4096,
+            ),
+            tokenize_stage=False,
+            detokenize_stage=False,
+            chat_template_stage=False,
+            concurrency=1,
+            batch_size=16,
+        )
+        return build_processor(
+            config,
+            preprocess=lambda row: dict(
+                prompt=f"{row['id']} ** 2 = ?",
+                sampling_params=dict(temperature=0.0, max_tokens=5, detokenize=True),
+            ),
+            postprocess=lambda row: dict(resp=row["generated_text"]),
+        )
+
+    for _ in range(2):
+        outs = build()(ray.data.range(16)).take_all()
+        assert len(outs) == 16
+
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            if not get_leaked_pgs(pre_existing):
+                break
+            time.sleep(2)
+
+        leaked = get_leaked_pgs(pre_existing)
+        assert not leaked, f"leaked engine placement groups: {leaked}"
+
+
 def test_vllm_autoscaling_no_starvation():
     """Test that chained vLLMEngineProcessor instances with autoscaling
     concurrency can run without starving each other.


### PR DESCRIPTION
## Description
The `vLLMEngineStage` ray-executor path created a placement group inside `ray_remote_args_fn` and returned it in a `PlacementGroupSchedulingStrategy`. That PG was owned by the driver job and never released, so a `TP * PP > 1` pipeline kept its GPUs reserved after the dataset finished; a long-lived driver running multiple `vLLMEngineProcessor` eventually starved and hung.

In this PR, we switch `vLLMEngineStage` to the native per-actor placement-group API on `map_batches`  introduced by #64090. The placement group lifecycle is now handled by ray data's actor pool.

- `vllm_engine_stage.py`: Replace `_ray_scheduling_strategy_fn` with the `_get_engine_placement_group_bundles`; emit `placement_group_bundles` / `placement_group_strategy` instead of a `ray_remote_args_fn`.
- `processor/base.py`: Build stages via `map_batches_internal` so the PG params reach the native API.
- Add a release regression test (`release/llm_tests/batch`) which asserts that PG doesn't leak.
- User-facing config (`placement_group_config`) is **unchanged**.

## Related issues
Closes https://github.com/ray-project/ray/issues/64035.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
