### PR TITLE
[llm][ci] Add ai-dynamo runtime dependency to enable KV-aware routing

### DIFF
--- a/ci/docker/llm.build.Dockerfile
+++ b/ci/docker/llm.build.Dockerfile
@@ -98,6 +98,10 @@ PY
     git apply "${VLLM_CUDA_VISIBLE_DEVICES_PATCH}"
 )
 
+# Sanity check: the ai-dynamo-runtime wheel must be importable, including the
+# symbols the KV-aware router relies on.
+python -c "import dynamo._core; from dynamo.llm import KvRouter; from dynamo.runtime import DistributedRuntime"
+
 EOF
 
 

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -88,6 +88,10 @@ curl -fsSL "${VLLM_RAW}/tools/ep_kernels/install_python_libraries.sh" | \
 # Install DeepGEMM
 curl -fsSL "${VLLM_RAW}/tools/install_deepgemm.sh" | bash
 
+# Sanity check: the ai-dynamo-runtime wheel must be importable, including the
+# symbols the KV-aware router relies on.
+python -c "import dynamo._core; from dynamo.llm import KvRouter; from dynamo.runtime import DistributedRuntime"
+
 # Export installed packages
 $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt
 

--- a/python/deplocks/llm/rayllm_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_py312_cpu.lock
@@ -7,6 +7,11 @@ absl-py==2.4.0 \
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cpu.lock
     #   dm-tree
+ai-dynamo-runtime @ https://air-example-data.s3.us-west-2.amazonaws.com/rayllm-ossci/dynamo/1.2.1/ai_dynamo_runtime-1.2.1-cp310-abi3-manylinux_2_35_x86_64.whl \
+    --hash=sha256:9ca26a9d410e61393fcf4f3a783983dc06ccc5754abd8b306bec8ada6738fa69
+    # via
+    #   -c python/deplocks/llm/rayllm_test_py312_cpu.lock
+    #   -r python/requirements/llm/llm-requirements.txt
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
@@ -3754,6 +3759,7 @@ pydantic==2.12.3 \
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cpu.lock
     #   -r python/requirements.txt
+    #   ai-dynamo-runtime
     #   anthropic
     #   compressed-tensors
     #   fastapi
@@ -5354,7 +5360,7 @@ uvicorn==0.22.0 \
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
-uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' \
+uvloop==0.22.1 \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
     --hash=sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e \
     --hash=sha256:05e4b5f86e621cf3927631789999e697e58f0d2d32675b67d9ca9eb0bca55743 \
@@ -5406,6 +5412,7 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
     --hash=sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cpu.lock
+    #   ai-dynamo-runtime
     #   uvicorn
 vine==5.1.0 \
     --hash=sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc \

--- a/python/deplocks/llm/rayllm_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_py312_cu130.lock
@@ -7,6 +7,11 @@ absl-py==2.4.0 \
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cu130.lock
     #   dm-tree
+ai-dynamo-runtime @ https://air-example-data.s3.us-west-2.amazonaws.com/rayllm-ossci/dynamo/1.2.1/ai_dynamo_runtime-1.2.1-cp310-abi3-manylinux_2_35_x86_64.whl \
+    --hash=sha256:9ca26a9d410e61393fcf4f3a783983dc06ccc5754abd8b306bec8ada6738fa69
+    # via
+    #   -c python/deplocks/llm/rayllm_test_py312_cu130.lock
+    #   -r python/requirements/llm/llm-requirements.txt
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
@@ -3856,6 +3861,7 @@ pydantic==2.12.3 \
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cu130.lock
     #   -r python/requirements.txt
+    #   ai-dynamo-runtime
     #   anthropic
     #   compressed-tensors
     #   fastapi
@@ -5450,7 +5456,7 @@ uvicorn==0.22.0 \
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
-uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' \
+uvloop==0.22.1 \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
     --hash=sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e \
     --hash=sha256:05e4b5f86e621cf3927631789999e697e58f0d2d32675b67d9ca9eb0bca55743 \
@@ -5502,6 +5508,7 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
     --hash=sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cu130.lock
+    #   ai-dynamo-runtime
     #   uvicorn
 vine==5.1.0 \
     --hash=sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc \

--- a/python/deplocks/llm/rayllm_test_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cpu.lock
@@ -13,6 +13,9 @@ adlfs==2026.4.0 \
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   -r python/requirements/cloud-requirements.txt
+ai-dynamo-runtime @ https://air-example-data.s3.us-west-2.amazonaws.com/rayllm-ossci/dynamo/1.2.1/ai_dynamo_runtime-1.2.1-cp310-abi3-manylinux_2_35_x86_64.whl \
+    --hash=sha256:9ca26a9d410e61393fcf4f3a783983dc06ccc5754abd8b306bec8ada6738fa69
+    # via -r python/requirements/llm/llm-requirements.txt
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
@@ -4389,6 +4392,7 @@ pydantic==2.12.3 \
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   -r python/requirements.txt
+    #   ai-dynamo-runtime
     #   anthropic
     #   compressed-tensors
     #   fastapi
@@ -6135,7 +6139,7 @@ uvicorn==0.22.0 \
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
-uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' \
+uvloop==0.22.1 \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
     --hash=sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e \
     --hash=sha256:05e4b5f86e621cf3927631789999e697e58f0d2d32675b67d9ca9eb0bca55743 \
@@ -6185,7 +6189,9 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
     --hash=sha256:ea721dd3203b809039fcc2983f14608dae82b212288b346e0bfe46ec2fab0b7c \
     --hash=sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c \
     --hash=sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42
-    # via uvicorn
+    # via
+    #   ai-dynamo-runtime
+    #   uvicorn
 vine==5.1.0 \
     --hash=sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc \
     --hash=sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0

--- a/python/deplocks/llm/rayllm_test_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cu130.lock
@@ -13,6 +13,9 @@ adlfs==2026.4.0 \
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
     #   -r python/requirements/cloud-requirements.txt
+ai-dynamo-runtime @ https://air-example-data.s3.us-west-2.amazonaws.com/rayllm-ossci/dynamo/1.2.1/ai_dynamo_runtime-1.2.1-cp310-abi3-manylinux_2_35_x86_64.whl \
+    --hash=sha256:9ca26a9d410e61393fcf4f3a783983dc06ccc5754abd8b306bec8ada6738fa69
+    # via -r python/requirements/llm/llm-requirements.txt
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
@@ -4467,6 +4470,7 @@ pydantic==2.12.3 \
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
     #   -r python/requirements.txt
+    #   ai-dynamo-runtime
     #   anthropic
     #   compressed-tensors
     #   fastapi
@@ -6207,7 +6211,7 @@ uvicorn==0.22.0 \
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
-uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' \
+uvloop==0.22.1 \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
     --hash=sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e \
     --hash=sha256:05e4b5f86e621cf3927631789999e697e58f0d2d32675b67d9ca9eb0bca55743 \
@@ -6257,7 +6261,9 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
     --hash=sha256:ea721dd3203b809039fcc2983f14608dae82b212288b346e0bfe46ec2fab0b7c \
     --hash=sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c \
     --hash=sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42
-    # via uvicorn
+    # via
+    #   ai-dynamo-runtime
+    #   uvicorn
 vine==5.1.0 \
     --hash=sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc \
     --hash=sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0

--- a/python/requirements/llm/llm-requirements.txt
+++ b/python/requirements/llm/llm-requirements.txt
@@ -5,6 +5,9 @@ prometheus-fastapi-instrumentator>=8.0.0  # for starlette v1.0.1+
 # https://github.com/vllm-project/vllm/blob/v0.22.0/requirements/kv_connectors.txt#L2
 nixl==1.2.0
 nixl-cu13==1.2.0
+# Now kept out of ray[llm] extra: PyPI rejects direct-URL dependencies.
+# TODO (jeffreywang): Move to official wheels once dynamo changes are upstreamed.
+ai-dynamo-runtime @ https://air-example-data.s3.us-west-2.amazonaws.com/rayllm-ossci/dynamo/1.2.1/ai_dynamo_runtime-1.2.1-cp310-abi3-manylinux_2_35_x86_64.whl
 anyio>=4.5.0
 # For json mode
 jsonref>=1.1.0

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1306,6 +1306,8 @@ numpy==1.26.4
     #   webdataset
     #   xgboost
     #   zoopt
+nvidia-ml-py==13.610.43
+    # via deepspeed
 nvidia-nccl-cu12==2.26.2
     # via xgboost
 oauth2client==4.1.3

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1306,8 +1306,6 @@ numpy==1.26.4
     #   webdataset
     #   xgboost
     #   zoopt
-nvidia-ml-py==13.610.43
-    # via deepspeed
 nvidia-nccl-cu12==2.26.2
     # via xgboost
 oauth2client==4.1.3


### PR DESCRIPTION
## Description
We aren't using the official wheel to develop necessary changes for dynamo at our own pace. The `ai-dynamo` wheel is built privately with the following commands:

```
cd /home/ray/default/dynamo
git fetch origin
git checkout release/1.2.1

# Prerequisites
pip install maturin

# Build the release wheel
RUSTFLAGS="-C target-cpu=x86-64-v3 --cfg tokio_unstable" \
  maturin build --release -m /home/ray/default/dynamo/lib/bindings/python/Cargo.toml
```

Eventually, once all changes are upstreamed to dynamo, we will switch over to the official wheel.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
