### PR TITLE
[train][Preemption handling 2/n] Fan out preemption signal to workers

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/preemption_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/preemption_callback.py
@@ -45,15 +45,17 @@ class PreemptionCallback(WorkerGroupCallback):
         self._stop_watcher()
 
         node_to_ranks: Dict[str, List[int]] = {}
+        worker_actors_by_rank: Dict[int, ActorHandle] = {}
         for w in worker_group.get_workers():
-            node_to_ranks.setdefault(w.metadata.node_id, []).append(
-                w.distributed_context.world_rank
-            )
+            rank = w.distributed_context.world_rank
+            node_to_ranks.setdefault(w.metadata.node_id, []).append(rank)
+            worker_actors_by_rank[rank] = w.actor
 
         watcher_cls = ray.remote(num_cpus=0, max_restarts=-1)(PreemptionWatcher)
         self._watcher = watcher_cls.remote(
             node_to_ranks=node_to_ranks,
             poll_interval_s=self._poll_interval_s,
+            worker_actors_by_rank=worker_actors_by_rank,
         )
 
         logger.debug(

--- a/python/ray/train/v2/_internal/callbacks/preemption_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/preemption_callback.py
@@ -44,6 +44,12 @@ class PreemptionCallback(WorkerGroupCallback):
         # this also prevents leaking an orphaned watcher across a reschedule.
         self._stop_watcher()
 
+        # These handles are captured once per worker-group start. With the
+        # standard backend, any worker replacement goes through a full worker
+        # group restart (this hook runs again with fresh handles), so they
+        # never go stale.
+        # TODO(lehui): refresh worker handles on in-place replica replacement
+        # when adding preemption support for replica groups (TorchFT).
         node_to_ranks: Dict[str, List[int]] = {}
         worker_actors_by_rank: Dict[int, ActorHandle] = {}
         for w in worker_group.get_workers():

--- a/python/ray/train/v2/_internal/execution/context.py
+++ b/python/ray/train/v2/_internal/execution/context.py
@@ -125,6 +125,7 @@ class TrainContext:
     distributed_context: DistributedContext
     execution_context: ExecutionContext
     storage_context: StorageContext
+    preemption_context: PreemptionContext
     controller_actor: ActorHandle
 
     dataset_shard_provider: "DatasetShardProvider"
@@ -135,7 +136,6 @@ class TrainContext:
     current_report_index: int = 0
     report_call_index: int = 0
     report_order_condition: threading.Condition = threading.Condition()
-    preemption_context: PreemptionContext = field(default_factory=PreemptionContext)
     checkpoint_upload_threadpool: ThreadPoolExecutor = ThreadPoolExecutor(
         max_workers=MAX_CHECKPOINT_UPLOAD_THREADS
     )

--- a/python/ray/train/v2/_internal/execution/context.py
+++ b/python/ray/train/v2/_internal/execution/context.py
@@ -21,6 +21,7 @@ from ray.train.v2._internal.execution.checkpoint.sync_actor import (
     SynchronizationActor,
     SynchronizationBarrierResetError,
 )
+from ray.train.v2._internal.execution.preemption import PreemptionContext
 from ray.train.v2._internal.execution.storage import StorageContext, delete_fs_path
 from ray.train.v2._internal.execution.training_report import (
     _TrainingReport,
@@ -134,6 +135,7 @@ class TrainContext:
     current_report_index: int = 0
     report_call_index: int = 0
     report_order_condition: threading.Condition = threading.Condition()
+    preemption_context: PreemptionContext = field(default_factory=PreemptionContext)
     checkpoint_upload_threadpool: ThreadPoolExecutor = ThreadPoolExecutor(
         max_workers=MAX_CHECKPOINT_UPLOAD_THREADS
     )

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -42,8 +42,8 @@ class PreemptionInfo:
 class PreemptionContext:
     """Thread-shared preemption signal for one worker actor."""
 
-    _preemption_info: Optional[PreemptionInfo] = None
-    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _preemption_info: Optional[PreemptionInfo] = field(default=None, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
     def set(self, info: PreemptionInfo) -> None:
         with self._lock:

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -51,12 +51,12 @@ class PreemptionContext:
 
     def set(self, info: PreemptionInfo) -> None:
         with self._lock:
-            self._info = info
+            self._preemption_info = info
 
     def get(self) -> Optional[PreemptionInfo]:
         """Return the current preemption signal, or ``None`` if none received."""
         with self._lock:
-            return self._info
+            return self._preemption_info
 
 
 def _get_draining_nodes() -> Dict[str, int]:

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -1,9 +1,10 @@
 import logging
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set
 
 import ray
+from ray.actor import ActorHandle
 from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_POLL_INTERVAL_S
 from ray.util.tpu import get_tpu_slice_name_from_node
 
@@ -37,6 +38,27 @@ class PreemptionInfo:
         )
 
 
+@dataclass
+class PreemptionContext:
+    """Thread-shared preemption signal for one worker actor.
+
+    Written by the actor's main thread (the ``mark_preempt`` RPC handler) and
+    read by the UDF thread; all access goes through the lock-guarded methods.
+    """
+
+    _preemption_info: Optional[PreemptionInfo] = None
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def set(self, info: PreemptionInfo) -> None:
+        with self._lock:
+            self._info = info
+
+    def get(self) -> Optional[PreemptionInfo]:
+        """Return the current preemption signal, or ``None`` if none received."""
+        with self._lock:
+            return self._info
+
+
 def _get_draining_nodes() -> Dict[str, int]:
     """Ray Core's draining nodes as ``{node_id_hex: deadline_ms}`` (0 = no deadline)."""
     return ray._private.state.state.get_draining_nodes()
@@ -59,17 +81,23 @@ class PreemptionWatcher:
             as the set of nodes we care about (drains elsewhere are ignored)
             and as the seed for failure-domain expansion.
         poll_interval_s: Seconds between drain-state polls.
+        worker_actors_by_rank: Map ``world_rank -> worker actor handle``. On a
+            detected preemption, ``mark_preempt`` is called on every worker.
     """
 
     def __init__(
         self,
         node_to_ranks: Dict[str, List[int]],
         poll_interval_s: float = DEFAULT_PREEMPTION_POLL_INTERVAL_S,
+        worker_actors_by_rank: Optional[Dict[int, ActorHandle]] = None,
     ):
         self._node_to_ranks: Dict[str, List[int]] = {
             nid: sorted(ranks) for nid, ranks in node_to_ranks.items()
         }
         self._poll_interval_s = poll_interval_s
+        self._worker_actors_by_rank: Dict[int, ActorHandle] = (
+            worker_actors_by_rank or {}
+        )
         self._failure_domain_map: Dict[str, List[int]] = self._build_failure_domain_map(
             self._node_to_ranks
         )
@@ -206,8 +234,16 @@ class PreemptionWatcher:
             info.preempted_ranks,
             deadline_ms,
         )
-        # TODO(lehui): forward the detected preemption to the workers so the
-        # training loop can react to it.
+
+        for rank, actor in self._worker_actors_by_rank.items():
+            try:
+                actor.mark_preempt.remote(info)
+            except Exception:
+                logger.warning(
+                    "Failed to send preemption signal to rank %d.",
+                    rank,
+                    exc_info=True,
+                )
         # TODO(lehui): coalesce preemptions seen within one window into a single
         # worker-group restart, so a staggered drain (node A at t, node B at
         # t+60s) doesn't cause back-to-back restarts.

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -1,12 +1,15 @@
 import logging
 import threading
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 import ray
 from ray.actor import ActorHandle
 from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_POLL_INTERVAL_S
 from ray.util.tpu import get_tpu_slice_name_from_node
+
+if TYPE_CHECKING:
+    from ray.train.v2._internal.worker import RayTrainWorker
 
 logger = logging.getLogger(__name__)
 
@@ -85,13 +88,15 @@ class PreemptionWatcher:
         self,
         node_to_ranks: Dict[str, List[int]],
         poll_interval_s: float = DEFAULT_PREEMPTION_POLL_INTERVAL_S,
-        worker_actors_by_rank: Optional[Dict[int, ActorHandle]] = None,
+        worker_actors_by_rank: Optional[
+            Dict[int, ActorHandle["RayTrainWorker"]]
+        ] = None,
     ):
         self._node_to_ranks: Dict[str, List[int]] = {
             nid: sorted(ranks) for nid, ranks in node_to_ranks.items()
         }
         self._poll_interval_s = poll_interval_s
-        self._worker_actors_by_rank: Dict[int, ActorHandle] = (
+        self._worker_actors_by_rank: Dict[int, ActorHandle["RayTrainWorker"]] = (
             worker_actors_by_rank or {}
         )
         self._failure_domain_map: Dict[str, List[int]] = self._build_failure_domain_map(
@@ -232,14 +237,7 @@ class PreemptionWatcher:
         )
 
         for rank, actor in self._worker_actors_by_rank.items():
-            try:
-                actor.mark_preempt.remote(info)
-            except Exception:
-                logger.warning(
-                    "Failed to send preemption signal to rank %d.",
-                    rank,
-                    exc_info=True,
-                )
+            actor.mark_preempt.remote(info)
         # TODO(lehui): coalesce preemptions seen within one window into a single
         # worker-group restart, so a staggered drain (node A at t, node B at
         # t+60s) doesn't cause back-to-back restarts.

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -40,11 +40,7 @@ class PreemptionInfo:
 
 @dataclass
 class PreemptionContext:
-    """Thread-shared preemption signal for one worker actor.
-
-    Written by the actor's main thread (the ``mark_preempt`` RPC handler) and
-    read by the UDF thread; all access goes through the lock-guarded methods.
-    """
+    """Thread-shared preemption signal for one worker actor."""
 
     _preemption_info: Optional[PreemptionInfo] = None
     _lock: threading.Lock = field(default_factory=threading.Lock)

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -8,6 +8,7 @@ from ray.train.v2._internal.exceptions import (
     UserExceptionWithTraceback,
     WorkerHealthCheckFailedError,
 )
+from ray.train.v2._internal.execution.preemption import PreemptionInfo
 from ray.train.v2._internal.execution.training_report import _TrainingReport
 from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.types import ObjectRef
@@ -41,6 +42,7 @@ class WorkerStatus:
     error: Optional[Exception] = None
     training_report: Optional[_TrainingReport] = None
     return_value: Any = field(default=None)
+    preemption_info: Optional[PreemptionInfo] = None
 
 
 @dataclass(frozen=True)

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -28,6 +28,7 @@ from ray.train.v2._internal.execution.context import (
     get_train_context,
     set_train_context,
 )
+from ray.train.v2._internal.execution.preemption import PreemptionInfo
 from ray.train.v2._internal.execution.storage import StorageContext
 from ray.train.v2._internal.execution.train_fn_utils import (
     DistributedTrainFnUtils,
@@ -180,8 +181,27 @@ class RayTrainWorker:
             accelerator_ids=ray.get_runtime_context().get_accelerator_ids(),
         )
 
+    def mark_preempt(self, info: PreemptionInfo) -> None:
+        """Store an incoming preemption signal for the UDF to read.
+
+        Called by the PreemptionWatcher on every worker when a preemption
+        affecting the worker group is detected.
+        """
+        train_context = get_train_context()
+        rank = train_context.get_world_rank()
+        train_context.preemption_context.set(info)
+        logger.info(
+            "Rank %d received preemption signal "
+            "(this_worker_preempted=%s, preempted_ranks=%s, deadline_ms=%s).",
+            rank,
+            rank in info.preempted_ranks,
+            info.preempted_ranks,
+            info.deadline_ms,
+        )
+
     def poll_status(self) -> WorkerStatus:
-        execution_context = get_train_context().execution_context
+        train_context = get_train_context()
+        execution_context = train_context.execution_context
 
         # TODO: We can implement two phase commit here.
         # Only mark the task done when the result has been processed by the controller.
@@ -207,11 +227,14 @@ class RayTrainWorker:
             else None
         )
 
+        # Echo the latest preemption signal so the controller can observe it
+        # via poll (and so it acts as a dead-worker fallback in later stages).
         return WorkerStatus(
             running=running,
             error=error,
             training_report=training_report,
             return_value=return_value,
+            preemption_info=train_context.preemption_context.get(),
         )
 
     def clear_result_queue(self) -> bool:

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -227,8 +227,6 @@ class RayTrainWorker:
             else None
         )
 
-        # Echo the latest preemption signal so the controller can observe it
-        # via poll (and so it acts as a dead-worker fallback in later stages).
         return WorkerStatus(
             running=running,
             error=error,

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -28,7 +28,10 @@ from ray.train.v2._internal.execution.context import (
     get_train_context,
     set_train_context,
 )
-from ray.train.v2._internal.execution.preemption import PreemptionInfo
+from ray.train.v2._internal.execution.preemption import (
+    PreemptionContext,
+    PreemptionInfo,
+)
 from ray.train.v2._internal.execution.storage import StorageContext
 from ray.train.v2._internal.execution.train_fn_utils import (
     DistributedTrainFnUtils,
@@ -293,6 +296,7 @@ class RayTrainWorker:
                 train_context_callbacks=context_callbacks_to_propagate,
             ),
             storage_context=storage_context,
+            preemption_context=PreemptionContext(),
             controller_actor=controller_actor,
             checkpoint=checkpoint,
             dataset_shard_provider=dataset_shard_provider,

--- a/python/ray/train/v2/tests/test_preemption_watcher.py
+++ b/python/ray/train/v2/tests/test_preemption_watcher.py
@@ -1,5 +1,4 @@
 """Unit tests for the preemption watcher."""
-from types import SimpleNamespace
 from typing import Dict, Optional
 from unittest.mock import Mock, patch
 
@@ -7,11 +6,7 @@ import pytest
 
 import ray
 from ray.train.v2._internal.callbacks.preemption_callback import PreemptionCallback
-from ray.train.v2._internal.execution.preemption import (
-    PreemptionContext,
-    PreemptionInfo,
-    PreemptionWatcher,
-)
+from ray.train.v2._internal.execution.preemption import PreemptionWatcher
 
 _PREEMPTION_MOD = "ray.train.v2._internal.execution.preemption"
 
@@ -141,35 +136,6 @@ class TestPreemptionWatcher:
         )
         _poll_once_with(watcher, return_value={})
         actor0.mark_preempt.remote.assert_not_called()
-
-
-class TestPreemptionContext:
-    def test_get_returns_none_before_set(self):
-        assert PreemptionContext().get() is None
-
-    def test_set_then_get(self):
-        ctx = PreemptionContext()
-        info = PreemptionInfo(
-            deadline_ms=30_000, preempted_node_to_ranks={"node-a": [0]}
-        )
-        ctx.set(info)
-        assert ctx.get() is info
-
-
-class TestMarkPreempt:
-    def test_mark_preempt_stores_info(self):
-        from ray.train.v2._internal.execution.worker_group import worker as worker_mod
-
-        ctx = PreemptionContext()
-        stub_context = SimpleNamespace(preemption_context=ctx, get_world_rank=lambda: 0)
-        worker = worker_mod.RayTrainWorker.__new__(worker_mod.RayTrainWorker)
-        info = PreemptionInfo(
-            deadline_ms=30_000, preempted_node_to_ranks={"node-a": [0]}
-        )
-        with patch.object(worker_mod, "get_train_context", return_value=stub_context):
-            worker.mark_preempt(info)
-
-        assert ctx.get() is info
 
 
 class TestBuildFailureDomainMap:

--- a/python/ray/train/v2/tests/test_preemption_watcher.py
+++ b/python/ray/train/v2/tests/test_preemption_watcher.py
@@ -1,12 +1,17 @@
 """Unit tests for the preemption watcher."""
-from typing import Dict
+from types import SimpleNamespace
+from typing import Dict, Optional
 from unittest.mock import Mock, patch
 
 import pytest
 
 import ray
 from ray.train.v2._internal.callbacks.preemption_callback import PreemptionCallback
-from ray.train.v2._internal.execution.preemption import PreemptionWatcher
+from ray.train.v2._internal.execution.preemption import (
+    PreemptionContext,
+    PreemptionInfo,
+    PreemptionWatcher,
+)
 
 _PREEMPTION_MOD = "ray.train.v2._internal.execution.preemption"
 
@@ -14,6 +19,7 @@ _PREEMPTION_MOD = "ray.train.v2._internal.execution.preemption"
 def _make_watcher(
     node_to_ranks: Dict[str, list],
     fd_map: Dict[str, list],
+    worker_actors_by_rank: Optional[Dict[int, object]] = None,
 ) -> PreemptionWatcher:
     """Construct a watcher with a fixed failure-domain map, then halt its loop.
 
@@ -24,7 +30,10 @@ def _make_watcher(
     with patch.object(
         PreemptionWatcher, "_build_failure_domain_map", return_value=fd
     ), patch(f"{_PREEMPTION_MOD}._get_draining_nodes", return_value={}):
-        watcher = PreemptionWatcher(node_to_ranks=node_to_ranks)
+        watcher = PreemptionWatcher(
+            node_to_ranks=node_to_ranks,
+            worker_actors_by_rank=worker_actors_by_rank,
+        )
         watcher._stop_event.set()
         watcher._monitor_thread.join(timeout=5)
     return watcher
@@ -105,6 +114,62 @@ class TestPreemptionWatcher:
         watcher = _make_watcher(node_to_ranks={"node-a": [0]}, fd_map={"node-a": [0]})
         _poll_once_with(watcher, return_value=None)  # must not raise
         assert watcher.get_latest_preemption_info() is None
+
+    def test_fans_out_mark_preempt_to_all_workers(self):
+        """On a preemption, mark_preempt is sent to every worker (preempted or not)."""
+        actor0, actor1 = Mock(), Mock()
+        watcher = _make_watcher(
+            node_to_ranks={"node-a": [0], "node-b": [1]},
+            fd_map={"node-a": [0], "node-b": [1]},
+            worker_actors_by_rank={0: actor0, 1: actor1},
+        )
+        # Only node-a is preempted, but both workers must be notified.
+        _poll_once_with(watcher, return_value={"node-a": 30_000})
+
+        for actor in (actor0, actor1):
+            actor.mark_preempt.remote.assert_called_once()
+            (sent_info,) = actor.mark_preempt.remote.call_args.args
+            assert sent_info.preempted_node_ids == ["node-a"]
+            assert sent_info.preempted_ranks == [0]
+
+    def test_no_fan_out_without_preemption(self):
+        actor0 = Mock()
+        watcher = _make_watcher(
+            node_to_ranks={"node-a": [0]},
+            fd_map={"node-a": [0]},
+            worker_actors_by_rank={0: actor0},
+        )
+        _poll_once_with(watcher, return_value={})
+        actor0.mark_preempt.remote.assert_not_called()
+
+
+class TestPreemptionContext:
+    def test_get_returns_none_before_set(self):
+        assert PreemptionContext().get() is None
+
+    def test_set_then_get(self):
+        ctx = PreemptionContext()
+        info = PreemptionInfo(
+            deadline_ms=30_000, preempted_node_to_ranks={"node-a": [0]}
+        )
+        ctx.set(info)
+        assert ctx.get() is info
+
+
+class TestMarkPreempt:
+    def test_mark_preempt_stores_info(self):
+        from ray.train.v2._internal.execution.worker_group import worker as worker_mod
+
+        ctx = PreemptionContext()
+        stub_context = SimpleNamespace(preemption_context=ctx, get_world_rank=lambda: 0)
+        worker = worker_mod.RayTrainWorker.__new__(worker_mod.RayTrainWorker)
+        info = PreemptionInfo(
+            deadline_ms=30_000, preempted_node_to_ranks={"node-a": [0]}
+        )
+        with patch.object(worker_mod, "get_train_context", return_value=stub_context):
+            worker.mark_preempt(info)
+
+        assert ctx.get() is info
 
 
 class TestBuildFailureDomainMap:

--- a/python/ray/train/v2/tests/test_worker.py
+++ b/python/ray/train/v2/tests/test_worker.py
@@ -11,6 +11,7 @@ from ray.train.v2._internal.execution.context import (
     TrainRunContext,
     get_train_context,
 )
+from ray.train.v2._internal.execution.preemption import PreemptionInfo
 from ray.train.v2._internal.execution.storage import StorageContext
 from ray.train.v2._internal.execution.worker_group.worker import RayTrainWorker
 from ray.train.v2._internal.util import ObjectRefWrapper
@@ -68,6 +69,33 @@ def test_worker_finished_after_all_threads_finish(monkeypatch, created_nested_th
         assert queue_contents == ["nested"]
     else:
         assert queue_contents == ["main"]
+
+
+def test_mark_preempt_stores_info(monkeypatch):
+    """mark_preempt stores the signal in the worker's PreemptionContext."""
+    # Disable this to avoid TypeError from logging MagicMock
+    monkeypatch.setenv(ENABLE_WORKER_STRUCTURED_LOGGING_ENV_VAR, False)
+
+    worker = RayTrainWorker()
+    worker.init_train_context(
+        train_run_context=create_autospec(TrainRunContext, instance=True),
+        distributed_context=DistributedContext(
+            world_rank=0,
+            world_size=1,
+            local_rank=0,
+            local_world_size=1,
+            node_rank=0,
+        ),
+        synchronization_actor=create_autospec(ActorHandle, instance=True),
+        storage_context=create_autospec(StorageContext, instance=True),
+        worker_callbacks=[],
+        controller_actor=create_autospec(ActorHandle, instance=True),
+    )
+
+    info = PreemptionInfo(deadline_ms=30_000, preempted_node_to_ranks={"node-a": [0]})
+    worker.mark_preempt(info)
+
+    assert get_train_context().preemption_context.get() is info
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
1. Builds on top of the Stage 1 preemption watcher (#63807): when the watcher detects a preemption, it now fans the signal out to the worker actors and stores in `PreemptionContext` in the TrainContext
2. added a rpc for mark_preempt in Train worker
3. watcher fans out preemptionInfo through every worker handle.
4. follow up PR will add public apis and controller state.

## Related issues
#63968 

## Additional information
1. added unit tests
2. ran this script: https://gist.github.com/liulehui/fc9bd4a6fe58b72a85363c0cda619f7e/edit
logs to ensure information got fan out to workers:
```
[14:10:49.909 PDT] [drain] node=62e4d889... drained via GCS, deadline=+15s (14:11:04.905 PDT)
(RayTrainWorker pid=99129) Rank 0 received preemption signal (this_worker_preempted=False, preempted_ranks=[1], deadline_ms=1781557864905).
(RayTrainWorker pid=99128) Rank 1 received preemption signal (this_worker_preempted=True, preempted_ranks=[1], deadline_ms=1781557864905).
(PreemptionWatcher pid=99150) PreemptionWatcher: preemption detected — preempted_node_ids=['62e4d8896da4bad4ce970556147a5a927425ab980253cdcd3af74f6e'], preempted_ranks=[1], deadline_ms=1781557864905
(RayTrainWorker pid=99129) [rank 0] PREEMPT signal: this=False ranks=[1] sec_left=13.7
(RayTrainWorker pid=99128) [rank 1] PREEMPT signal: this=True ranks=[1] sec_left=13.7
(RayTrainWorker pid=99128) [rank 1] PREEMPT signal: this=True ranks=[1] sec_left=13.7
```


