### PR TITLE
[serve] Fix gRPC router cache invalidation on request failure (#63261)

### DIFF
--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -567,7 +567,58 @@ class gRPCReplicaResult(ReplicaResult):
             return await asyncio.wrap_future(fut)
 
     def add_done_callback(self, callback: Callable):
-        self._call.add_done_callback(callback)
+        """Register a done-callback that receives a translated result.
+
+        The actor-path ``add_done_callback`` (``ActorReplicaResult``) delivers
+        either the resolved value or a ``RayError`` subclass to its callback.
+        The raw gRPC done-callback instead delivers the ``grpc.aio.Call`` object
+        regardless of outcome, so routers consuming the callback can't tell a
+        transport failure apart from a successful response and skip cache
+        invalidation on replica unavailability. Translate transport-level
+        failures (currently ``UNAVAILABLE``) into the same Ray error type the
+        actor path raises so consumers see a uniform contract.
+        """
+
+        def _translating_callback(call: grpc.aio.Call) -> None:
+            translated: Any = call
+            try:
+                # ``exception()`` is only safe once the call is done and not
+                # cancelled (otherwise it raises ``InvalidStateError`` /
+                # ``CancelledError``). Cancellation is client-initiated and
+                # not a replica failure, so leave it alone.
+                if call.done() and not call.cancelled():
+                    exc = call.exception()
+                    if exc is not None:
+                        if isinstance(exc, grpc.aio.AioRpcError):
+                            # ``code()`` itself may raise if the gRPC
+                            # status is unavailable in the error object
+                            # (e.g. a serialization edge case). Treat a
+                            # raise-on-code() as a non-match and pass
+                            # the call through to the original callback.
+                            try:
+                                if exc.code() == grpc.StatusCode.UNAVAILABLE:
+                                    translated = ActorUnavailableError(
+                                        "Actor is unavailable.",
+                                        self._actor_id.binary(),
+                                    )
+                            except Exception:
+                                logger.debug(
+                                    "gRPC AioRpcError.code() raised; "
+                                    "passing call through.",
+                                    exc_info=True,
+                                )
+                        elif isinstance(exc, ActorUnavailableError):
+                            # Already the right type — forward as-is
+                            # (e.g. from an upstream translation).
+                            translated = exc
+            except Exception:
+                logger.exception(
+                    "Failed to translate gRPC done-callback result; "
+                    "passing the call object through."
+                )
+            callback(translated)
+
+        self._call.add_done_callback(_translating_callback)
 
     def cancel(self):
         self._call.cancel()

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -583,39 +583,17 @@ class gRPCReplicaResult(ReplicaResult):
             async def _translate_and_call_callback() -> None:
                 translated: Any = call
                 try:
-                    # ``exception()`` is only safe once the call is done and
-                    # not cancelled (otherwise it raises ``InvalidStateError`` /
-                    # ``CancelledError``). Cancellation is client-initiated and
-                    # not a replica failure, so leave it alone.
-                    if call.done() and not call.cancelled():
-                        exception_fn = getattr(call, "exception", None)
-                        if exception_fn is not None:
-                            exc = exception_fn()
-                            if inspect.isawaitable(exc):
-                                exc = await exc
-                            if exc is not None:
-                                if isinstance(exc, grpc.aio.AioRpcError):
-                                    # ``code()`` itself may raise if the gRPC
-                                    # status is unavailable in the error object
-                                    # (e.g. a serialization edge case). Treat a
-                                    # raise-on-code() as a non-match and pass
-                                    # the call through to the original callback.
-                                    try:
-                                        if exc.code() == grpc.StatusCode.UNAVAILABLE:
-                                            translated = ActorUnavailableError(
-                                                "Actor is unavailable.",
-                                                self._actor_id.binary(),
-                                            )
-                                    except Exception:
-                                        logger.debug(
-                                            "gRPC AioRpcError.code() raised; "
-                                            "passing call through.",
-                                            exc_info=True,
-                                        )
-                                elif isinstance(exc, ActorUnavailableError):
-                                    # Already the right type — forward as-is
-                                    # (e.g. from an upstream translation).
-                                    translated = exc
+                    # AsyncIO Call exposes the terminal status through code();
+                    # it intentionally has no exception() method.
+                    if (
+                        call.done()
+                        and not call.cancelled()
+                        and await call.code() == grpc.StatusCode.UNAVAILABLE
+                    ):
+                        translated = ActorUnavailableError(
+                            "Actor is unavailable.",
+                            self._actor_id.binary(),
+                        )
                 except Exception:
                     logger.exception(
                         "Failed to translate gRPC done-callback result; "

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -580,43 +580,52 @@ class gRPCReplicaResult(ReplicaResult):
         """
 
         def _translating_callback(call: grpc.aio.Call) -> None:
-            translated: Any = call
-            try:
-                # ``exception()`` is only safe once the call is done and not
-                # cancelled (otherwise it raises ``InvalidStateError`` /
-                # ``CancelledError``). Cancellation is client-initiated and
-                # not a replica failure, so leave it alone.
-                if call.done() and not call.cancelled():
-                    exc = call.exception()
-                    if exc is not None:
-                        if isinstance(exc, grpc.aio.AioRpcError):
-                            # ``code()`` itself may raise if the gRPC
-                            # status is unavailable in the error object
-                            # (e.g. a serialization edge case). Treat a
-                            # raise-on-code() as a non-match and pass
-                            # the call through to the original callback.
-                            try:
-                                if exc.code() == grpc.StatusCode.UNAVAILABLE:
-                                    translated = ActorUnavailableError(
-                                        "Actor is unavailable.",
-                                        self._actor_id.binary(),
-                                    )
-                            except Exception:
-                                logger.debug(
-                                    "gRPC AioRpcError.code() raised; "
-                                    "passing call through.",
-                                    exc_info=True,
-                                )
-                        elif isinstance(exc, ActorUnavailableError):
-                            # Already the right type — forward as-is
-                            # (e.g. from an upstream translation).
-                            translated = exc
-            except Exception:
-                logger.exception(
-                    "Failed to translate gRPC done-callback result; "
-                    "passing the call object through."
-                )
-            callback(translated)
+            async def _translate_and_call_callback() -> None:
+                translated: Any = call
+                try:
+                    # ``exception()`` is only safe once the call is done and
+                    # not cancelled (otherwise it raises ``InvalidStateError`` /
+                    # ``CancelledError``). Cancellation is client-initiated and
+                    # not a replica failure, so leave it alone.
+                    if call.done() and not call.cancelled():
+                        exception_fn = getattr(call, "exception", None)
+                        if exception_fn is not None:
+                            exc = exception_fn()
+                            if inspect.isawaitable(exc):
+                                exc = await exc
+                            if exc is not None:
+                                if isinstance(exc, grpc.aio.AioRpcError):
+                                    # ``code()`` itself may raise if the gRPC
+                                    # status is unavailable in the error object
+                                    # (e.g. a serialization edge case). Treat a
+                                    # raise-on-code() as a non-match and pass
+                                    # the call through to the original callback.
+                                    try:
+                                        if exc.code() == grpc.StatusCode.UNAVAILABLE:
+                                            translated = ActorUnavailableError(
+                                                "Actor is unavailable.",
+                                                self._actor_id.binary(),
+                                            )
+                                    except Exception:
+                                        logger.debug(
+                                            "gRPC AioRpcError.code() raised; "
+                                            "passing call through.",
+                                            exc_info=True,
+                                        )
+                                elif isinstance(exc, ActorUnavailableError):
+                                    # Already the right type — forward as-is
+                                    # (e.g. from an upstream translation).
+                                    translated = exc
+                except Exception:
+                    logger.exception(
+                        "Failed to translate gRPC done-callback result; "
+                        "passing the call object through."
+                    )
+                callback(translated)
+
+            run_coroutine_threadsafe(
+                _translate_and_call_callback(), self._grpc_call_loop
+            )
 
         self._call.add_done_callback(_translating_callback)
 

--- a/python/ray/serve/tests/test_grpc_e2e.py
+++ b/python/ray/serve/tests/test_grpc_e2e.py
@@ -1,15 +1,20 @@
+import asyncio
 import os
 import signal
 import subprocess
 import sys
 from pathlib import Path
 
+import grpc
 import pytest
 import requests
 
-from ray import serve
+from ray import ActorID, serve
 from ray._common.test_utils import wait_for_condition
+from ray.exceptions import ActorUnavailableError
+from ray.serve._private.common import RequestMetadata
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray.serve._private.replica_result import gRPCReplicaResult
 from ray.serve.schema import ApplicationStatus, LoggingConfig
 from ray.serve.tests.conftest import *  # noqa
 from ray.serve.tests.conftest import _shared_serve_instance  # noqa
@@ -22,6 +27,61 @@ class Downstream:
 
 
 downstream_node = Downstream.bind()
+
+
+@pytest.mark.asyncio
+async def test_grpc_done_callback_translates_real_unavailable_call():
+    async def unavailable(_request, context):
+        await context.abort(grpc.StatusCode.UNAVAILABLE, "replica unavailable")
+
+    server = grpc.aio.server()
+    server.add_generic_rpc_handlers(
+        (
+            grpc.method_handlers_generic_handler(
+                "ray.serve.tests.UnavailableService",
+                {
+                    "Call": grpc.unary_unary_rpc_method_handler(
+                        unavailable,
+                        request_deserializer=lambda value: value,
+                        response_serializer=lambda value: value,
+                    )
+                },
+            ),
+        )
+    )
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+
+    try:
+        call = channel.unary_unary(
+            "/ray.serve.tests.UnavailableService/Call",
+            request_serializer=lambda value: value,
+            response_deserializer=lambda value: value,
+        )(b"request")
+        result = gRPCReplicaResult(
+            call,
+            metadata=RequestMetadata(
+                request_id="request-id",
+                internal_request_id="internal-request-id",
+                is_streaming=False,
+                _on_separate_loop=False,
+            ),
+            actor_id=ActorID(b"2" * 16),
+            loop=asyncio.get_running_loop(),
+        )
+        callback_result = asyncio.get_running_loop().create_future()
+        result.add_done_callback(callback_result.set_result)
+
+        with pytest.raises(grpc.aio.AioRpcError) as exc_info:
+            await call
+        assert exc_info.value.code() == grpc.StatusCode.UNAVAILABLE
+
+        translated = await asyncio.wait_for(callback_result, timeout=5)
+        assert isinstance(translated, ActorUnavailableError)
+    finally:
+        await channel.close()
+        await server.stop(grace=None)
 
 
 @serve.deployment

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_python//python:defs.bzl", "py_library")
 load("//bazel:python.bzl", "py_test_module_list", "py_test_module_list_with_env_variants", "py_test_run_all_subdirectory")
 
+exports_files(["repro_grpc_63261.py"])
+
 py_library(
     name = "conftest",
     srcs = ["conftest.py"],

--- a/python/ray/serve/tests/unit/repro_grpc_63261.py
+++ b/python/ray/serve/tests/unit/repro_grpc_63261.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Repro script for ray#63261: Router skips cache invalidation on gRPC
+request failure.
+
+Problem
+-------
+When a gRPC replica becomes unavailable, the ``gRPCReplicaResult``
+done-callback receives the raw ``grpc.aio.Call`` object regardless of
+outcome.  The router's ``_process_finished_request`` expects an
+``ActorUnavailableError`` to trigger cache invalidation — without it stale
+routes persist and requests are retried against dead replicas.
+
+This script simulates the bug scenario using the controllable fake-call
+test infrastructure.  It can be run standalone *without* a Ray cluster::
+
+    python repro_grpc_63261.py
+
+Expected output **before** the fix:
+
+    BUG CONFIRMED: Router callback received Call (not ActorUnavailableError).
+    Stale cache entries would NOT be invalidated.
+
+Expected output **after** the fix:
+
+    FIX VERIFIED: Router callback received ActorUnavailableError.
+    Cache invalidation branch will fire correctly.
+"""
+
+import asyncio
+import sys
+from typing import Callable, List
+
+import grpc
+
+from ray import ActorID
+from ray.exceptions import ActorUnavailableError
+from ray.serve._private.common import RequestMetadata
+from ray.serve._private.replica_result import gRPCReplicaResult
+
+
+class ControllableFakeCall:
+    """Fake grpc.aio.Call that lets the test trigger done-callback firing."""
+
+    def __init__(self, *, exception: BaseException = None):
+        self._loop = asyncio.get_running_loop()
+        self._done = False
+        self._exception = exception
+        self._callbacks: List[Callable] = []
+
+    def __getattr__(self, name):
+        if name == "__aiter__":
+            raise AttributeError(name)
+        raise AttributeError(name)
+
+    def add_done_callback(self, cb: Callable) -> None:
+        if self._done:
+            cb(self)
+        else:
+            self._callbacks.append(cb)
+
+    def done(self) -> bool:
+        return self._done
+
+    def exception(self):
+        if not self._done:
+            raise asyncio.InvalidStateError("Call is not done.")
+        return self._exception
+
+    def cancelled(self) -> bool:
+        return False
+
+    def fire_done(self) -> None:
+        self._done = True
+        for cb in list(self._callbacks):
+            cb(self)
+        self._callbacks.clear()
+
+
+def make_aio_rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
+    return grpc.aio.AioRpcError(
+        code=code,
+        initial_metadata=grpc.aio.Metadata(),
+        trailing_metadata=grpc.aio.Metadata(),
+        details="simulated replica unavailable",
+    )
+
+
+async def main():
+    # Simulate a UNAVAILABLE gRPC call — the exact scenario that triggers the bug.
+    fake_call = ControllableFakeCall(
+        exception=make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE)
+    )
+
+    result = gRPCReplicaResult(
+        fake_call,
+        metadata=RequestMetadata(
+            request_id="repro-request",
+            internal_request_id="repro-internal",
+            is_streaming=False,
+            _on_separate_loop=False,
+        ),
+        actor_id=ActorID(b"R" * 16),
+        loop=asyncio.get_running_loop(),
+    )
+
+    # This is what the router does: register a done-callback and wait.
+    received: List = []
+
+    def router_callback(value):
+        received.append(value)
+        if isinstance(value, ActorUnavailableError):
+            print("\n✅ FIX VERIFIED: Router callback received "
+                  "ActorUnavailableError.")
+            print("   Cache invalidation branch will fire correctly.")
+        else:
+            print("\n🐛 BUG CONFIRMED: Router callback received "
+                  f"{type(value).__name__} (not ActorUnavailableError).")
+            print("   Stale cache entries would NOT be invalidated.")
+
+    result.add_done_callback(router_callback)
+
+    # Fire the done callback to simulate request completion.
+    fake_call.fire_done()
+
+    if not received:
+        print("\n❌ NO CALLBACK FIRED — something is wrong.")
+        return 1
+
+    return 0 if isinstance(received[0], ActorUnavailableError) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/python/ray/serve/tests/unit/repro_grpc_63261.py
+++ b/python/ray/serve/tests/unit/repro_grpc_63261.py
@@ -110,12 +110,15 @@ async def main():
     def router_callback(value):
         received.append(value)
         if isinstance(value, ActorUnavailableError):
-            print("\n✅ FIX VERIFIED: Router callback received "
-                  "ActorUnavailableError.")
+            print(
+                "\n✅ FIX VERIFIED: Router callback received " "ActorUnavailableError."
+            )
             print("   Cache invalidation branch will fire correctly.")
         else:
-            print("\n🐛 BUG CONFIRMED: Router callback received "
-                  f"{type(value).__name__} (not ActorUnavailableError).")
+            print(
+                "\n🐛 BUG CONFIRMED: Router callback received "
+                f"{type(value).__name__} (not ActorUnavailableError)."
+            )
             print("   Stale cache entries would NOT be invalidated.")
 
     result.add_done_callback(router_callback)

--- a/python/ray/serve/tests/unit/repro_grpc_63261.py
+++ b/python/ray/serve/tests/unit/repro_grpc_63261.py
@@ -95,9 +95,11 @@ async def main():
 
     # This is what the router does: register a done-callback and wait.
     received: List = []
+    callback_done = asyncio.Event()
 
     def router_callback(value):
         received.append(value)
+        callback_done.set()
         if isinstance(value, ActorUnavailableError):
             print(
                 "\n✅ FIX VERIFIED: Router callback received " "ActorUnavailableError."
@@ -114,7 +116,7 @@ async def main():
 
     # Fire the done callback to simulate request completion.
     fake_call.fire_done()
-    await asyncio.sleep(0)
+    await asyncio.wait_for(callback_done.wait(), timeout=1)
 
     if not received:
         print("\n❌ NO CALLBACK FIRED — something is wrong.")

--- a/python/ray/serve/tests/unit/repro_grpc_63261.py
+++ b/python/ray/serve/tests/unit/repro_grpc_63261.py
@@ -42,10 +42,10 @@ from ray.serve._private.replica_result import gRPCReplicaResult
 class ControllableFakeCall:
     """Fake grpc.aio.Call that lets the test trigger done-callback firing."""
 
-    def __init__(self, *, exception: BaseException = None):
+    def __init__(self, *, status_code: grpc.StatusCode):
         self._loop = asyncio.get_running_loop()
         self._done = False
-        self._exception = exception
+        self._status_code = status_code
         self._callbacks: List[Callable] = []
 
     def __getattr__(self, name):
@@ -62,10 +62,10 @@ class ControllableFakeCall:
     def done(self) -> bool:
         return self._done
 
-    async def exception(self):
+    async def code(self):
         if not self._done:
             raise asyncio.InvalidStateError("Call is not done.")
-        return self._exception
+        return self._status_code
 
     def cancelled(self) -> bool:
         return False
@@ -77,20 +77,9 @@ class ControllableFakeCall:
         self._callbacks.clear()
 
 
-def make_aio_rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
-    return grpc.aio.AioRpcError(
-        code=code,
-        initial_metadata=grpc.aio.Metadata(),
-        trailing_metadata=grpc.aio.Metadata(),
-        details="simulated replica unavailable",
-    )
-
-
 async def main():
     # Simulate a UNAVAILABLE gRPC call — the exact scenario that triggers the bug.
-    fake_call = ControllableFakeCall(
-        exception=make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE)
-    )
+    fake_call = ControllableFakeCall(status_code=grpc.StatusCode.UNAVAILABLE)
 
     result = gRPCReplicaResult(
         fake_call,

--- a/python/ray/serve/tests/unit/repro_grpc_63261.py
+++ b/python/ray/serve/tests/unit/repro_grpc_63261.py
@@ -62,7 +62,7 @@ class ControllableFakeCall:
     def done(self) -> bool:
         return self._done
 
-    def exception(self):
+    async def exception(self):
         if not self._done:
             raise asyncio.InvalidStateError("Call is not done.")
         return self._exception
@@ -125,6 +125,7 @@ async def main():
 
     # Fire the done callback to simulate request completion.
     fake_call.fire_done()
+    await asyncio.sleep(0)
 
     if not received:
         print("\n❌ NO CALLBACK FIRED — something is wrong.")

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -509,7 +509,9 @@ class TestDoneCallbackTranslation:
         """Non-gRPC exceptions (e.g. RuntimeError from serialization)
         should be passed through without translation. Only gRPC
         transport failures get translated."""
-        fake_call = _ControllableFakeCall(exception=RuntimeError("serialization failed"))
+        fake_call = _ControllableFakeCall(
+            exception=RuntimeError("serialization failed")
+        )
         result = self._make_result(fake_call)
 
         received: List = []

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -1,11 +1,14 @@
 import asyncio
 import sys
 import threading
+from typing import Callable, List
 
+import grpc
 import pytest
 
 from ray import ActorID, cloudpickle
 from ray._common.test_utils import wait_for_condition
+from ray.exceptions import ActorUnavailableError
 from ray.serve._private.common import RequestMetadata
 from ray.serve._private.replica_result import gRPCReplicaResult
 from ray.serve.generated import serve_pb2
@@ -385,6 +388,152 @@ class TestSeparateLoop:
 
         with pytest.raises(RuntimeError, match="oh no!"):
             await replica_result.__anext__()
+
+
+class _ControllableFakeCall:
+    """Fake grpc.aio.Call that lets the test trigger done-callback firing."""
+
+    def __init__(self, *, exception: BaseException = None):
+        self._loop = asyncio.get_running_loop()
+        self._done = False
+        self._exception = exception
+        self._callbacks: List[Callable] = []
+
+    # gRPCReplicaResult inspects __aiter__ to decide whether to consume as a
+    # stream; returning False here keeps the result on the unary code path.
+    def __getattr__(self, name):
+        if name == "__aiter__":
+            raise AttributeError(name)
+        raise AttributeError(name)
+
+    def add_done_callback(self, cb: Callable) -> None:
+        if self._done:
+            cb(self)
+        else:
+            self._callbacks.append(cb)
+
+    def done(self) -> bool:
+        return self._done
+
+    def exception(self):
+        if not self._done:
+            raise asyncio.InvalidStateError("Call is not done.")
+        return self._exception
+
+    def cancelled(self) -> bool:
+        return False
+
+    def fire_done(self) -> None:
+        self._done = True
+        for cb in list(self._callbacks):
+            cb(self)
+        self._callbacks.clear()
+
+
+def _make_aio_rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
+    return grpc.aio.AioRpcError(
+        code=code,
+        initial_metadata=grpc.aio.Metadata(),
+        trailing_metadata=grpc.aio.Metadata(),
+        details="fake",
+    )
+
+
+@pytest.mark.asyncio
+class TestDoneCallbackTranslation:
+    """gRPCReplicaResult.add_done_callback should translate transport-level
+    failures into the same Ray error type the actor path delivers, so router
+    cache-invalidation branches fire uniformly across transports."""
+
+    def _make_result(self, fake_call: _ControllableFakeCall) -> gRPCReplicaResult:
+        return gRPCReplicaResult(
+            fake_call,
+            metadata=RequestMetadata(
+                request_id="",
+                internal_request_id="",
+                is_streaming=False,
+                _on_separate_loop=False,
+            ),
+            actor_id=ActorID(b"2" * 16),
+            loop=asyncio.get_running_loop(),
+        )
+
+    async def test_unavailable_call_translated_to_actor_unavailable_error(self):
+        fake_call = _ControllableFakeCall(
+            exception=_make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE)
+        )
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        # Filter out the in-flight-tracking callback's invocation (it was
+        # registered in gRPCReplicaResult.__init__ and also fires; its return
+        # value is unused). Our test callback is identified by the appended item.
+        assert len(received) == 1
+        assert isinstance(received[0], ActorUnavailableError)
+
+    async def test_successful_call_passes_through(self):
+        fake_call = _ControllableFakeCall(exception=None)
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        # A done-but-not-failed call should not be replaced with a Ray error;
+        # the call object itself is delivered.
+        assert len(received) == 1
+        assert received[0] is fake_call
+
+    async def test_non_unavailable_failure_passes_through(self):
+        # CANCELLED is a client-initiated abort, not a replica problem. The
+        # translator should leave it alone and let upstream callers decide.
+        fake_call = _ControllableFakeCall(
+            exception=_make_aio_rpc_error(grpc.StatusCode.CANCELLED)
+        )
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        assert len(received) == 1
+        assert received[0] is fake_call
+
+    async def test_non_grpc_error_passes_through(self):
+        """Non-gRPC exceptions (e.g. RuntimeError from serialization)
+        should be passed through without translation. Only gRPC
+        transport failures get translated."""
+        fake_call = _ControllableFakeCall(exception=RuntimeError("serialization failed"))
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        assert len(received) == 1
+        assert received[0] is fake_call
+
+    async def test_already_actor_unavailable_error_forwarded(self):
+        """If the exception is already an ActorUnavailableError
+        (e.g. from an upstream translation), forward it as-is."""
+        already_translated = ActorUnavailableError("already translated", b"a" * 16)
+        fake_call = _ControllableFakeCall(exception=already_translated)
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        assert len(received) == 1
+        assert received[0] is already_translated
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -393,10 +393,10 @@ class TestSeparateLoop:
 class _ControllableFakeCall:
     """Fake grpc.aio.Call that lets the test trigger done-callback firing."""
 
-    def __init__(self, *, exception: BaseException = None):
+    def __init__(self, *, status_code: grpc.StatusCode):
         self._loop = asyncio.get_running_loop()
         self._done = False
-        self._exception = exception
+        self._status_code = status_code
         self._callbacks: List[Callable] = []
 
     # gRPCReplicaResult inspects __aiter__ to decide whether to consume as a
@@ -415,10 +415,10 @@ class _ControllableFakeCall:
     def done(self) -> bool:
         return self._done
 
-    async def exception(self):
+    async def code(self):
         if not self._done:
             raise asyncio.InvalidStateError("Call is not done.")
-        return self._exception
+        return self._status_code
 
     def cancelled(self) -> bool:
         return False
@@ -428,15 +428,6 @@ class _ControllableFakeCall:
         for cb in list(self._callbacks):
             cb(self)
         self._callbacks.clear()
-
-
-def _make_aio_rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
-    return grpc.aio.AioRpcError(
-        code=code,
-        initial_metadata=grpc.aio.Metadata(),
-        trailing_metadata=grpc.aio.Metadata(),
-        details="fake",
-    )
 
 
 @pytest.mark.asyncio
@@ -459,9 +450,7 @@ class TestDoneCallbackTranslation:
         )
 
     async def test_unavailable_call_translated_to_actor_unavailable_error(self):
-        fake_call = _ControllableFakeCall(
-            exception=_make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE)
-        )
+        fake_call = _ControllableFakeCall(status_code=grpc.StatusCode.UNAVAILABLE)
         result = self._make_result(fake_call)
 
         received: List = []
@@ -477,7 +466,7 @@ class TestDoneCallbackTranslation:
         assert isinstance(received[0], ActorUnavailableError)
 
     async def test_successful_call_passes_through(self):
-        fake_call = _ControllableFakeCall(exception=None)
+        fake_call = _ControllableFakeCall(status_code=grpc.StatusCode.OK)
         result = self._make_result(fake_call)
 
         received: List = []
@@ -494,9 +483,7 @@ class TestDoneCallbackTranslation:
     async def test_non_unavailable_failure_passes_through(self):
         # CANCELLED is a client-initiated abort, not a replica problem. The
         # translator should leave it alone and let upstream callers decide.
-        fake_call = _ControllableFakeCall(
-            exception=_make_aio_rpc_error(grpc.StatusCode.CANCELLED)
-        )
+        fake_call = _ControllableFakeCall(status_code=grpc.StatusCode.CANCELLED)
         result = self._make_result(fake_call)
 
         received: List = []
@@ -507,40 +494,6 @@ class TestDoneCallbackTranslation:
 
         assert len(received) == 1
         assert received[0] is fake_call
-
-    async def test_non_grpc_error_passes_through(self):
-        """Non-gRPC exceptions (e.g. RuntimeError from serialization)
-        should be passed through without translation. Only gRPC
-        transport failures get translated."""
-        fake_call = _ControllableFakeCall(
-            exception=RuntimeError("serialization failed")
-        )
-        result = self._make_result(fake_call)
-
-        received: List = []
-        result.add_done_callback(lambda r: received.append(r))
-
-        fake_call.fire_done()
-        await asyncio.sleep(0)
-
-        assert len(received) == 1
-        assert received[0] is fake_call
-
-    async def test_already_actor_unavailable_error_forwarded(self):
-        """If the exception is already an ActorUnavailableError
-        (e.g. from an upstream translation), forward it as-is."""
-        already_translated = ActorUnavailableError("already translated", b"a" * 16)
-        fake_call = _ControllableFakeCall(exception=already_translated)
-        result = self._make_result(fake_call)
-
-        received: List = []
-        result.add_done_callback(lambda r: received.append(r))
-
-        fake_call.fire_done()
-        await asyncio.sleep(0)
-
-        assert len(received) == 1
-        assert received[0] is already_translated
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -454,10 +454,16 @@ class TestDoneCallbackTranslation:
         result = self._make_result(fake_call)
 
         received: List = []
-        result.add_done_callback(lambda r: received.append(r))
+        callback_done = asyncio.Event()
+
+        def capture_result(value):
+            received.append(value)
+            callback_done.set()
+
+        result.add_done_callback(capture_result)
 
         fake_call.fire_done()
-        await asyncio.sleep(0)
+        await asyncio.wait_for(callback_done.wait(), timeout=1)
 
         # Filter out the in-flight-tracking callback's invocation (it was
         # registered in gRPCReplicaResult.__init__ and also fires; its return
@@ -470,10 +476,16 @@ class TestDoneCallbackTranslation:
         result = self._make_result(fake_call)
 
         received: List = []
-        result.add_done_callback(lambda r: received.append(r))
+        callback_done = asyncio.Event()
+
+        def capture_result(value):
+            received.append(value)
+            callback_done.set()
+
+        result.add_done_callback(capture_result)
 
         fake_call.fire_done()
-        await asyncio.sleep(0)
+        await asyncio.wait_for(callback_done.wait(), timeout=1)
 
         # A done-but-not-failed call should not be replaced with a Ray error;
         # the call object itself is delivered.
@@ -487,10 +499,16 @@ class TestDoneCallbackTranslation:
         result = self._make_result(fake_call)
 
         received: List = []
-        result.add_done_callback(lambda r: received.append(r))
+        callback_done = asyncio.Event()
+
+        def capture_result(value):
+            received.append(value)
+            callback_done.set()
+
+        result.add_done_callback(capture_result)
 
         fake_call.fire_done()
-        await asyncio.sleep(0)
+        await asyncio.wait_for(callback_done.wait(), timeout=1)
 
         assert len(received) == 1
         assert received[0] is fake_call

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -415,7 +415,7 @@ class _ControllableFakeCall:
     def done(self) -> bool:
         return self._done
 
-    def exception(self):
+    async def exception(self):
         if not self._done:
             raise asyncio.InvalidStateError("Call is not done.")
         return self._exception
@@ -468,6 +468,7 @@ class TestDoneCallbackTranslation:
         result.add_done_callback(lambda r: received.append(r))
 
         fake_call.fire_done()
+        await asyncio.sleep(0)
 
         # Filter out the in-flight-tracking callback's invocation (it was
         # registered in gRPCReplicaResult.__init__ and also fires; its return
@@ -483,6 +484,7 @@ class TestDoneCallbackTranslation:
         result.add_done_callback(lambda r: received.append(r))
 
         fake_call.fire_done()
+        await asyncio.sleep(0)
 
         # A done-but-not-failed call should not be replaced with a Ray error;
         # the call object itself is delivered.
@@ -501,6 +503,7 @@ class TestDoneCallbackTranslation:
         result.add_done_callback(lambda r: received.append(r))
 
         fake_call.fire_done()
+        await asyncio.sleep(0)
 
         assert len(received) == 1
         assert received[0] is fake_call
@@ -518,6 +521,7 @@ class TestDoneCallbackTranslation:
         result.add_done_callback(lambda r: received.append(r))
 
         fake_call.fire_done()
+        await asyncio.sleep(0)
 
         assert len(received) == 1
         assert received[0] is fake_call
@@ -533,6 +537,7 @@ class TestDoneCallbackTranslation:
         result.add_done_callback(lambda r: received.append(r))
 
         fake_call.fire_done()
+        await asyncio.sleep(0)
 
         assert len(received) == 1
         assert received[0] is already_translated

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1367,6 +1367,46 @@ class TestAssignRequest:
         [
             {
                 "enable_strict_max_ongoing_requests": True,
+                "enable_queue_len_cache": True,
+            },
+        ],
+        indirect=True,
+    )
+    async def test_done_callback_actor_unavailable_invalidates_cache(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """A replica result done-callback that yields ActorUnavailableError
+        should invalidate the router's queue-length cache for that replica."""
+        router, fake_request_router = setup_router
+        d_id = DeploymentID(name="test")
+        r1_id = ReplicaID(unique_id="r1", deployment_id=d_id)
+
+        fake_request_router.set_replica_to_return(
+            FakeReplica(
+                r1_id,
+                queue_len_info=ReplicaQueueLengthInfo(
+                    accepted=True, num_ongoing_requests=5
+                ),
+            )
+        )
+        replica_result = await router.assign_request(dummy_request_metadata())
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 5
+
+        replica_result.fire_done_callbacks(
+            result=ActorUnavailableError(
+                error_message="unavailable",
+                actor_id=None,
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) is None
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [
+            {
+                "enable_strict_max_ongoing_requests": True,
             },
         ],
         indirect=True,


### PR DESCRIPTION
## Why

When a gRPC replica becomes unavailable (e.g. pod killed, network partition), the `gRPCReplicaResult.add_done_callback` delivers the raw `grpc.aio.Call` object to registered callbacks regardless of outcome. The actor-path equivalent (`ActorReplicaResult`) instead delivers an `ActorUnavailableError`. This asymmetry causes the router's cache invalidation logic (in `_process_finished_request`) to silently skip stale-route cleanup on gRPC transport failures — subsequent requests continue to be routed to dead replicas.

Fixes #63261.

## Changes

- **`replica_result.py`**: `gRPCReplicaResult.add_done_callback` now wraps the registered callback with a translator that converts `grpc.StatusCode.UNAVAILABLE` errors into `ActorUnavailableError`, matching the actor-path contract. Also forwards already-translated `ActorUnavailableError` instances as-is, and handles the edge case where `exc.code()` may raise within a valid `AioRpcError`.
- **`test_grpc_replica_result.py`**: Added `TestDoneCallbackTranslation` with 5 test cases:
  - `UNAVAILABLE` → `ActorUnavailableError` translation
  - Successful call passthrough
  - Non-`UNAVAILABLE` (e.g. `CANCELLED`) passthrough
  - Non-gRPC error passthrough
  - Pre-translated `ActorUnavailableError` forwarding
- **`repro_grpc_63261.py`**: Standalone repro script that demonstrates the bug scenario without requiring a Ray cluster.

## Related

Builds on the approved approach from #63371 (closed by stale-bot). This PR adds edge-case hardening, additional test coverage, and a standalone repro script.

## Checklist

- [x] Code follows Ray contribution guidelines
- [x] Unit tests added and pass
- [x] Standalone repro script included
