### PR TITLE
[jobs] Add in-place retry_policy to the Ray Job Submission API

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/index.md
+++ b/doc/source/cluster/running-applications/job-submission/index.md
@@ -28,6 +28,44 @@ To get started with the Ray Jobs API, check out the [quickstart](jobs-quickstart
 This is suitable for any client that can communicate over HTTP to the Ray Cluster.
 If needed, the Ray Jobs API also provides APIs for [programmatic job submission](ray-job-sdk) and [job submission using REST](ray-job-rest-api).
 
+## Retrying failed jobs in place
+
+By default, a submitted job runs once to completion or failure (see the note above). You can instead ask Ray to retry a job's driver *in place* on failure by passing an optional `retry_policy`. An in-place retry re-runs the driver using the **same** `submission_id` and the **same** Ray cluster, after an exponential backoff, instead of failing immediately. This is useful for recovering from transient failures (for example, a driver out-of-memory caused by another process, or a preempted worker) without recreating the cluster.
+
+The `retry_policy` accepts the following fields:
+
+- `max_retries`: Maximum number of retries after the initial attempt. `0` (the default) disables retries.
+- `backoff`: Exponential backoff between retries, with `initial_delay_seconds`, `max_delay_seconds`, and `multiplier` (which must be `>= 1`).
+- `retry_on`: Conditions under which to retry. One or more of `"NON_ZERO_EXIT"` (any non-zero driver exit code) and `"DRIVER_OOM"` (a driver that appears to have been OOM-killed). Defaults to `["NON_ZERO_EXIT"]`.
+- `no_retry_on_exit_codes`: Driver exit codes that should never be retried. Takes precedence over `retry_on`.
+
+For example, using the Python SDK:
+
+```python
+from ray.job_submission import JobSubmissionClient
+
+client = JobSubmissionClient("http://127.0.0.1:8265")
+submission_id = client.submit_job(
+    entrypoint="python my_script.py",
+    retry_policy={
+        "max_retries": 3,
+        "backoff": {
+            "initial_delay_seconds": 30,
+            "max_delay_seconds": 600,
+            "multiplier": 2.0,
+        },
+        "retry_on": ["NON_ZERO_EXIT", "DRIVER_OOM"],
+        "no_retry_on_exit_codes": [130],
+    },
+)
+```
+
+While retrying, the job stays in the `RUNNING` state and its `attempt_number` is incremented (observable through the status APIs). Only a terminal `SUCCEEDED` or `FAILED` state is written once retries are exhausted or the job succeeds.
+
+```{note}
+In-place retries recover from driver and worker failures on the existing cluster. A head node failure still requires the cluster to be restarted, which is outside the scope of `retry_policy`.
+```
+
 ## Running Jobs Interactively
 
 If you would like to run an application *interactively* and see the output in real time (for example, during development or debugging), you can:

--- a/doc/source/cluster/running-applications/job-submission/openapi.yml
+++ b/doc/source/cluster/running-applications/job-submission/openapi.yml
@@ -380,6 +380,16 @@ components:
           title: Driver Node Id
           description: Driver node id.
           type: string
+        retry_policy:
+          title: Retry Policy
+          description: The in-place retry policy configured for this job, if any.
+          type: object
+        attempt_number:
+          title: Attempt Number
+          description: >-
+            The current driver attempt number (0 = original run, 1 = first
+            retry, ...).
+          type: integer
       required:
         - type
         - entrypoint
@@ -419,8 +429,46 @@ components:
           description: "The quantity of various custom resources to allocate for the execution of the entrypoint command, separately from any Ray tasks or actors that are created by it."
           additionalProperties:
             type: number
+        retry_policy:
+          description: "Optional policy to retry the job's driver in place (using the same submission_id and Ray cluster) on failure, instead of failing immediately."
+          allOf:
+            - $ref: '#/components/schemas/RetryPolicy'
       required:
         - entrypoint
+
+    RetryPolicy:
+      type: object
+      description: "In-place retry policy for a submitted job."
+      properties:
+        max_retries:
+          type: integer
+          description: "Maximum number of retries after the initial attempt. 0 disables retries."
+        backoff:
+          type: object
+          description: "Exponential backoff applied between retries."
+          properties:
+            initial_delay_seconds:
+              type: number
+              description: "Delay before the first retry, in seconds."
+            max_delay_seconds:
+              type: number
+              description: "Maximum delay between retries, in seconds."
+            multiplier:
+              type: number
+              description: "Multiplier applied to the delay after each retry (must be >= 1)."
+        retry_on:
+          type: array
+          description: "Conditions under which to retry. Defaults to ['NON_ZERO_EXIT']."
+          items:
+            type: string
+            enum:
+              - NON_ZERO_EXIT
+              - DRIVER_OOM
+        no_retry_on_exit_codes:
+          type: array
+          description: "Driver exit codes that should never be retried (takes precedence over retry_on)."
+          items:
+            type: integer
 
     JobSubmitResponse:
       type: object

--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import asdict, dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ray._private import ray_constants
 from ray._private.event.export_event_logger import (
@@ -86,6 +86,110 @@ class JobErrorType(str, Enum):
     JOB_ENTRYPOINT_COMMAND_ERROR = "JOB_ENTRYPOINT_COMMAND_ERROR"
 
 
+# The exit code reported for a process killed by SIGKILL (128 + 9). The Linux
+# OOM killer uses SIGKILL, so this is used as a best-effort heuristic to detect
+# driver OOMs. NOTE: this is indistinguishable from a process that was killed
+# with SIGKILL for any other reason (e.g. an external `kill -9`).
+OOM_EXIT_CODE = 137
+
+
+@PublicAPI(stability="alpha")
+class JobRetryCondition(str, Enum):
+    """Conditions under which a job's driver should be retried in place.
+
+    Used by ``RetryPolicy.retry_on``.
+    """
+
+    #: Retry on any non-zero driver exit code (subject to
+    #: ``RetryPolicy.no_retry_on_exit_codes``).
+    NON_ZERO_EXIT = "NON_ZERO_EXIT"
+    #: Retry when the driver appears to have been OOM-killed (exit code 137).
+    DRIVER_OOM = "DRIVER_OOM"
+
+
+@PublicAPI(stability="alpha")
+@dataclass
+class RetryPolicy:
+    """Policy controlling in-place retries of a job's driver.
+
+    When set on a job, a retryable driver failure causes the job to be retried
+    using the *same* ``submission_id`` (and the same RayCluster) instead of
+    failing immediately. The driver subprocess is re-executed after an
+    exponential backoff, up to ``max_retries`` times.
+
+    The fields are stored in a flattened form. The public REST/SDK wire format
+    accepts a nested ``backoff`` object which is flattened by
+    ``JobSubmitRequest``.
+    """
+
+    #: Maximum number of retries after the initial attempt. 0 disables retries.
+    max_retries: int = 0
+    #: Delay before the first retry, in seconds.
+    backoff_initial_delay_seconds: float = 30.0
+    #: Maximum delay between retries, in seconds.
+    backoff_max_delay_seconds: float = 600.0
+    #: Multiplier applied to the delay after each retry.
+    backoff_multiplier: float = 2.0
+    #: List of ``JobRetryCondition`` values. Defaults to ``["NON_ZERO_EXIT"]``.
+    retry_on: Optional[List[str]] = None
+    #: Driver exit codes that should never be retried (takes precedence over
+    #: ``retry_on``).
+    no_retry_on_exit_codes: Optional[List[int]] = None
+
+    def __post_init__(self):
+        if not isinstance(self.max_retries, int) or isinstance(self.max_retries, bool):
+            raise TypeError(
+                f"max_retries must be an integer, got {type(self.max_retries)}"
+            )
+        if self.max_retries < 0:
+            raise ValueError(
+                f"max_retries must be non-negative, got {self.max_retries}"
+            )
+
+        for name in ("backoff_initial_delay_seconds", "backoff_max_delay_seconds"):
+            value = getattr(self, name)
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise TypeError(f"{name} must be a number, got {type(value)}")
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+
+        if self.backoff_max_delay_seconds < self.backoff_initial_delay_seconds:
+            raise ValueError(
+                "backoff_max_delay_seconds must be >= backoff_initial_delay_seconds, "
+                f"got {self.backoff_max_delay_seconds} < "
+                f"{self.backoff_initial_delay_seconds}"
+            )
+
+        if not isinstance(self.backoff_multiplier, (int, float)) or isinstance(
+            self.backoff_multiplier, bool
+        ):
+            raise TypeError(
+                f"backoff_multiplier must be a number, got {type(self.backoff_multiplier)}"
+            )
+        if self.backoff_multiplier < 1:
+            raise ValueError(
+                f"backoff_multiplier must be >= 1, got {self.backoff_multiplier}"
+            )
+
+        if self.retry_on is not None:
+            if not isinstance(self.retry_on, list):
+                raise TypeError(f"retry_on must be a list, got {type(self.retry_on)}")
+            valid_conditions = {c.value for c in JobRetryCondition}
+            for condition in self.retry_on:
+                if condition not in valid_conditions:
+                    raise ValueError(
+                        f"Invalid retry_on condition {condition!r}. "
+                        f"Valid conditions are {sorted(valid_conditions)}."
+                    )
+
+        if self.no_retry_on_exit_codes is not None:
+            if not isinstance(self.no_retry_on_exit_codes, list):
+                raise TypeError("no_retry_on_exit_codes must be a list of integers")
+            for code in self.no_retry_on_exit_codes:
+                if not isinstance(code, int) or isinstance(code, bool):
+                    raise TypeError(f"Exit code must be an integer, got {type(code)}")
+
+
 # TODO(aguo): Convert to pydantic model
 @PublicAPI(stability="stable")
 @dataclass
@@ -127,6 +231,11 @@ class JobInfo:
     #: The driver process exit code after the driver executed. Return None if driver
     #: doesn't finish executing
     driver_exit_code: Optional[int] = None
+    #: The in-place retry policy for this job (flattened RetryPolicy dict), or
+    #: None if retries are not configured.
+    retry_policy: Optional[Dict[str, Any]] = None
+    #: The current driver attempt number (0 = original run, 1 = first retry, ...).
+    attempt_number: int = 0
 
     def __post_init__(self):
         if isinstance(self.status, str):
@@ -468,6 +577,10 @@ class JobSubmitRequest:
     entrypoint_resources: Optional[Dict[str, float]] = None
     # Label selector for the entrypoint command.
     entrypoint_label_selector: Optional[Dict[str, str]] = None
+    # In-place retry policy for the job. Accepts a nested ``backoff`` object,
+    # e.g. {"max_retries": 3, "backoff": {"initial_delay_seconds": 30, ...},
+    # "retry_on": ["NON_ZERO_EXIT"], "no_retry_on_exit_codes": [130]}.
+    retry_policy: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         if not isinstance(self.entrypoint, str):
@@ -571,6 +684,39 @@ class JobSubmitRequest:
                             "entrypoint_label_selector values must be strings, "
                             f"got {type(v)}"
                         )
+
+        if self.retry_policy is not None:
+            self.retry_policy = self._normalize_and_validate_retry_policy(
+                self.retry_policy
+            )
+
+    @staticmethod
+    def _normalize_and_validate_retry_policy(
+        retry_policy: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Flatten the nested ``backoff`` wire format and validate.
+
+        The public wire format nests backoff parameters under a ``backoff``
+        key; internally we store a flattened dict matching ``RetryPolicy``.
+        Returns the flattened, validated dict. Raises TypeError/ValueError on
+        invalid input (surfaced to clients as HTTP 400).
+        """
+        if not isinstance(retry_policy, dict):
+            raise TypeError(f"retry_policy must be a dict, got {type(retry_policy)}")
+        flat = dict(retry_policy)
+        backoff = flat.pop("backoff", {}) or {}
+        if not isinstance(backoff, dict):
+            raise TypeError(
+                f"retry_policy['backoff'] must be a dict, got {type(backoff)}"
+            )
+        flat["backoff_initial_delay_seconds"] = backoff.get(
+            "initial_delay_seconds", 30.0
+        )
+        flat["backoff_max_delay_seconds"] = backoff.get("max_delay_seconds", 600.0)
+        flat["backoff_multiplier"] = backoff.get("multiplier", 2.0)
+        # This will raise TypeError if there are unknown keys or if the types/values are invalid.
+        RetryPolicy(**flat)
+        return flat
 
 
 @dataclass

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -52,6 +52,7 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
                 entrypoint_memory=submit_request.entrypoint_memory,
                 entrypoint_resources=submit_request.entrypoint_resources,
                 entrypoint_label_selector=submit_request.entrypoint_label_selector,
+                retry_policy=submit_request.retry_policy,
             )
 
             resp = JobSubmitResponse(job_id=submission_id, submission_id=submission_id)

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -474,6 +474,7 @@ class JobManager:
         entrypoint_memory: Optional[int] = None,
         entrypoint_resources: Optional[Dict[str, float]] = None,
         entrypoint_label_selector: Optional[Dict[str, str]] = None,
+        retry_policy: Optional[Dict[str, Any]] = None,
         _start_signal_actor: Optional[ActorHandle] = None,
     ) -> str:
         """
@@ -511,6 +512,9 @@ class JobManager:
                 to reserve for the entrypoint command, separately from any tasks or
                 actors launched by it.
             entrypoint_label_selector: Label selector for the entrypoint command.
+            retry_policy: Optional in-place retry policy (flattened RetryPolicy
+                dict). When set, a retryable driver failure re-runs the driver
+                using the same submission_id and RayCluster instead of failing.
             _start_signal_actor: Used in testing only to capture state
                 transitions between PENDING -> RUNNING. Regular user shouldn't
                 need this.
@@ -547,6 +551,7 @@ class JobManager:
             entrypoint_num_gpus=entrypoint_num_gpus,
             entrypoint_memory=entrypoint_memory,
             entrypoint_resources=entrypoint_resources,
+            retry_policy=retry_policy,
         )
         new_key_added = await self._job_info_client.put_info(
             submission_id, job_info, overwrite=False
@@ -606,6 +611,7 @@ class JobManager:
                 self._gcs_address,
                 self._cluster_id_hex,
                 self._logs_dir,
+                retry_policy,
             )
             supervisor.run.remote(
                 _start_signal_actor=_start_signal_actor,

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -23,7 +23,10 @@ from ray.actor import ActorHandle
 from ray.dashboard.modules.job.common import (
     JOB_ID_METADATA_KEY,
     JOB_NAME_METADATA_KEY,
+    OOM_EXIT_CODE,
     JobInfoStorageClient,
+    JobRetryCondition,
+    RetryPolicy,
 )
 from ray.dashboard.modules.job.job_log_storage_client import JobLogStorageClient
 from ray.job_submission import JobErrorType, JobStatus
@@ -76,12 +79,15 @@ class JobSupervisor:
         gcs_address: str,
         cluster_id_hex: str,
         logs_dir: Optional[str] = None,
+        retry_policy: Optional[Dict[str, Any]] = None,
     ):
         self._job_id = job_id
         gcs_client = GcsClient(address=gcs_address, cluster_id=cluster_id_hex)
         self._job_info_client = JobInfoStorageClient(gcs_client, logs_dir)
         self._log_client = JobLogStorageClient()
         self._entrypoint = entrypoint
+        # In-place retry policy (parsed from the flattened dict), or None.
+        self._retry_policy = RetryPolicy(**retry_policy) if retry_policy else None
 
         # Default metadata if not passed by the user.
         self._metadata = {JOB_ID_METADATA_KEY: job_id, JOB_NAME_METADATA_KEY: job_id}
@@ -306,6 +312,63 @@ class JobSupervisor:
             except ProcessLookupError:
                 # Process is already dead
                 pass
+
+    def _should_retry(self, return_code: int, attempt: int) -> bool:
+        """Return whether the driver should be retried after a non-zero exit.
+
+        ``attempt`` is the index of the attempt that just finished (0 = the
+        original run). ``return_code`` is its non-zero driver exit code.
+        """
+        if self._retry_policy is None or self._retry_policy.max_retries <= 0:
+            return False
+        if attempt >= self._retry_policy.max_retries:
+            return False
+        if (
+            self._retry_policy.no_retry_on_exit_codes
+            and return_code in self._retry_policy.no_retry_on_exit_codes
+        ):
+            return False
+        retry_conditions = self._retry_policy.retry_on or [
+            JobRetryCondition.NON_ZERO_EXIT.value
+        ]
+        for condition in retry_conditions:
+            if condition == JobRetryCondition.NON_ZERO_EXIT.value and return_code != 0:
+                return True
+            if (
+                condition == JobRetryCondition.DRIVER_OOM.value
+                and return_code == OOM_EXIT_CODE
+            ):
+                return True
+        return False
+
+    def _compute_backoff(self, attempt: int) -> float:
+        """Compute the (capped) exponential backoff delay before ``attempt``.
+
+        delay = initial_delay * multiplier ** attempt, capped at max_delay.
+        """
+
+        delay = self._retry_policy.backoff_initial_delay_seconds * (
+            self._retry_policy.backoff_multiplier**attempt
+        )
+        return min(delay, self._retry_policy.backoff_max_delay_seconds)
+
+    async def _interruptible_backoff(self, delay: float) -> bool:
+        """Sleep for ``delay`` seconds, returning early if a stop is requested.
+
+        Returns True if the stop event fired during the wait (caller should
+        abort and mark the job STOPPED), False if the full delay elapsed.
+
+        Use ``self._stop_event`` rather than ``asyncio.sleep`` so that a
+        ``stop_job`` call takes effect immediately instead of waiting out the
+        whole backoff window.
+        """
+        if delay <= 0:
+            return self._stop_event.is_set()
+        try:
+            await asyncio.wait_for(self._stop_event.wait(), timeout=delay)
+            return True
+        except asyncio.TimeoutError:
+            return False
 
     async def run(
         self,

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -370,6 +370,107 @@ class JobSupervisor:
         except asyncio.TimeoutError:
             return False
 
+    async def _run_attempt(
+        self, attempt: int, resources_specified: bool
+    ) -> Optional[int]:
+        """Execute the driver subprocess once.
+
+        Returns the driver's exit code, or None if the job was stopped (via the
+        stop event) before the driver finished.
+        """
+        # Configure environment variables for the child process.
+        env = os.environ.copy()
+        # Remove internal Ray flags. They are present because the JobSupervisor
+        # itself is a Ray worker process, but we don't want to pass them to the
+        # driver.
+        remove_ray_internal_flags_from_env(env)
+        # These will *not* be set in the runtime_env, so they apply to the driver
+        # only, not its tasks & actors.
+        env.update(self._get_driver_env_vars(resources_specified))
+
+        self._logger.info(
+            "Submitting job with RAY_ADDRESS = "
+            f"{env[ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE]}"
+        )
+        log_path = self._log_client.get_log_file_path(self._job_id)
+        child_process = self._exec_entrypoint(env, log_path)
+        child_pid = child_process.pid
+
+        polling_task = create_task(self._polling(child_process))
+        stop_task = create_task(self._stop_event.wait())
+        finished, pending = await asyncio.wait(
+            [polling_task, stop_task],
+            return_when=FIRST_COMPLETED,
+        )
+        # Cancel whichever task is still pending so it doesn't leak across
+        # retries (e.g. the stop-event waiter when the driver finishes first).
+        for task in pending:
+            task.cancel()
+
+        if self._stop_event.is_set():
+            polling_task.cancel()
+            if sys.platform == "win32" and self._win32_job_object:
+                win32job.TerminateJobObject(self._win32_job_object, -1)
+            elif sys.platform != "win32":
+                stop_signal = os.environ.get("RAY_JOB_STOP_SIGNAL", "SIGTERM")
+                if stop_signal not in self.VALID_STOP_SIGNALS:
+                    self._logger.warning(
+                        f"{stop_signal} not a valid stop signal. Terminating "
+                        "job with SIGTERM."
+                    )
+                    stop_signal = "SIGTERM"
+
+                job_process = psutil.Process(child_pid)
+                proc_to_kill = [job_process] + job_process.children(recursive=True)
+
+                # Send stop signal and wait for job to terminate gracefully,
+                # otherwise SIGKILL job forcefully after timeout.
+                self._kill_processes(proc_to_kill, getattr(signal, stop_signal))
+                try:
+                    stop_job_wait_time = int(
+                        os.environ.get(
+                            "RAY_JOB_STOP_WAIT_TIME_S",
+                            self.DEFAULT_RAY_JOB_STOP_WAIT_TIME_S,
+                        )
+                    )
+                    poll_job_stop_task = create_task(self._poll_all(proc_to_kill))
+                    await asyncio.wait_for(poll_job_stop_task, stop_job_wait_time)
+                    self._logger.info(
+                        f"Job {self._job_id} has been terminated gracefully "
+                        f"with {stop_signal}."
+                    )
+                except asyncio.TimeoutError:
+                    self._logger.warning(
+                        f"Attempt to gracefully terminate job {self._job_id} "
+                        f"through {stop_signal} has timed out after "
+                        f"{stop_job_wait_time} seconds. Job is now being "
+                        "force-killed with SIGKILL."
+                    )
+                    self._kill_processes(proc_to_kill, signal.SIGKILL)
+            return None
+
+        # Child process finished execution and no stop event is set.
+        assert len(finished) == 1, "Should have only one coroutine done"
+        [child_process_task] = finished
+        return_code = child_process_task.result()
+        self._logger.info(
+            f"Job {self._job_id} entrypoint command exited with code {return_code}"
+        )
+        return return_code
+
+    async def _failure_message(self, return_code: int) -> str:
+        """Build the FAILED status message, including a tail of the driver logs."""
+        log_tail = await self._log_client.get_last_n_log_lines(self._job_id)
+        if log_tail is not None and log_tail != "":
+            return (
+                f"Job entrypoint command failed with exit code {return_code}, "
+                "last available logs (truncated to 20,000 chars):\n" + log_tail
+            )
+        return (
+            f"Job entrypoint command failed with exit code {return_code}. "
+            "No logs available."
+        )
+
     async def run(
         self,
         # Signal actor used in testing to capture PENDING -> RUNNING cases
@@ -419,108 +520,61 @@ class JobSupervisor:
         )
 
         try:
-            # Configure environment variables for the child process.
-            env = os.environ.copy()
-            # Remove internal Ray flags. They present because JobSuperVisor itself is
-            # a Ray worker process but we don't want to pass them to the driver.
-            remove_ray_internal_flags_from_env(env)
-            # These will *not* be set in the runtime_env, so they apply to the driver
-            # only, not its tasks & actors.
-            env.update(self._get_driver_env_vars(resources_specified))
-
-            self._logger.info(
-                "Submitting job with RAY_ADDRESS = "
-                f"{env[ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE]}"
-            )
-            log_path = self._log_client.get_log_file_path(self._job_id)
-            child_process = self._exec_entrypoint(env, log_path)
-            child_pid = child_process.pid
-
-            polling_task = create_task(self._polling(child_process))
-            finished, _ = await asyncio.wait(
-                [polling_task, create_task(self._stop_event.wait())],
-                return_when=FIRST_COMPLETED,
-            )
-
-            if self._stop_event.is_set():
-                polling_task.cancel()
-                if sys.platform == "win32" and self._win32_job_object:
-                    win32job.TerminateJobObject(self._win32_job_object, -1)
-                elif sys.platform != "win32":
-                    stop_signal = os.environ.get("RAY_JOB_STOP_SIGNAL", "SIGTERM")
-                    if stop_signal not in self.VALID_STOP_SIGNALS:
-                        self._logger.warning(
-                            f"{stop_signal} not a valid stop signal. Terminating "
-                            "job with SIGTERM."
-                        )
-                        stop_signal = "SIGTERM"
-
-                    job_process = psutil.Process(child_pid)
-                    proc_to_kill = [job_process] + job_process.children(recursive=True)
-
-                    # Send stop signal and wait for job to terminate gracefully,
-                    # otherwise SIGKILL job forcefully after timeout.
-                    self._kill_processes(proc_to_kill, getattr(signal, stop_signal))
-                    try:
-                        stop_job_wait_time = int(
-                            os.environ.get(
-                                "RAY_JOB_STOP_WAIT_TIME_S",
-                                self.DEFAULT_RAY_JOB_STOP_WAIT_TIME_S,
-                            )
-                        )
-                        poll_job_stop_task = create_task(self._poll_all(proc_to_kill))
-                        await asyncio.wait_for(poll_job_stop_task, stop_job_wait_time)
-                        self._logger.info(
-                            f"Job {self._job_id} has been terminated gracefully "
-                            f"with {stop_signal}."
-                        )
-                    except asyncio.TimeoutError:
-                        self._logger.warning(
-                            f"Attempt to gracefully terminate job {self._job_id} "
-                            f"through {stop_signal} has timed out after "
-                            f"{stop_job_wait_time} seconds. Job is now being "
-                            "force-killed with SIGKILL."
-                        )
-                        self._kill_processes(proc_to_kill, signal.SIGKILL)
-
-                await self._job_info_client.put_status(self._job_id, JobStatus.STOPPED)
-            else:
-                # Child process finished execution and no stop event is set
-                # at the same time
-                assert len(finished) == 1, "Should have only one coroutine done"
-                [child_process_task] = finished
-                return_code = child_process_task.result()
-                self._logger.info(
-                    f"Job {self._job_id} entrypoint command "
-                    f"exited with code {return_code}"
-                )
-                if return_code == 0:
+            attempt = 0
+            while True:
+                return_code = await self._run_attempt(attempt, resources_specified)
+                if return_code is None:
+                    await self._job_info_client.put_status(
+                        self._job_id,
+                        JobStatus.STOPPED,
+                        message="Job was stopped before completion.",
+                    )
+                    return
+                elif return_code == 0:
                     await self._job_info_client.put_status(
                         self._job_id,
                         JobStatus.SUCCEEDED,
                         driver_exit_code=return_code,
+                        jobinfo_replace_kwargs={"attempt_number": attempt},
                     )
+                    return
+                elif self._should_retry(return_code, attempt):
+                    delay = self._compute_backoff(attempt)
+                    await self._job_info_client.put_status(
+                        self._job_id,
+                        JobStatus.RUNNING,
+                        message=(
+                            f"Job entrypoint command failed with exit code "
+                            f"{return_code}. Retrying attempt "
+                            f"{attempt + 1} after {delay:.1f}s..."
+                        ),
+                        jobinfo_replace_kwargs={"attempt_number": attempt + 1},
+                    )
+                    if await self._interruptible_backoff(delay):
+                        await self._job_info_client.put_status(
+                            self._job_id,
+                            JobStatus.STOPPED,
+                            message=(
+                                "Job was stopped during retry backoff window. "
+                                "No further attempts will be made."
+                            ),
+                        )
+                        return
+                    attempt += 1
+                    # loop will retry and call _run_attempt again
+                    # with the new attempt index
+                    continue
                 else:
-                    log_tail = await self._log_client.get_last_n_log_lines(self._job_id)
-                    if log_tail is not None and log_tail != "":
-                        message = (
-                            "Job entrypoint command "
-                            f"failed with exit code {return_code}, "
-                            "last available logs (truncated to 20,000 chars):\n"
-                            + log_tail
-                        )
-                    else:
-                        message = (
-                            "Job entrypoint command "
-                            f"failed with exit code {return_code}. No logs available."
-                        )
+                    failure_message = await self._failure_message(return_code)
                     await self._job_info_client.put_status(
                         self._job_id,
                         JobStatus.FAILED,
-                        message=message,
+                        message=failure_message,
                         driver_exit_code=return_code,
                         error_type=JobErrorType.JOB_ENTRYPOINT_COMMAND_ERROR,
+                        jobinfo_replace_kwargs={"attempt_number": attempt},
                     )
+                    return
         except Exception:
             self._logger.error(
                 "Got unexpected exception while trying to execute driver "

--- a/python/ray/dashboard/modules/job/pydantic_models.py
+++ b/python/ray/dashboard/modules/job/pydantic_models.py
@@ -103,6 +103,15 @@ if PYDANTIC_INSTALLED:
             description="The driver process exit code after the driver executed. "
             "Return None if driver doesn't finish executing.",
         )
+        retry_policy: Optional[Dict[str, Any]] = Field(
+            None,
+            description="The in-place retry policy configured for this job, if any.",
+        )
+        attempt_number: int = Field(
+            0,
+            description="The current driver attempt number "
+            "(0 = original run, 1 = first retry, ...).",
+        )
 
 else:
     DriverInfo = None

--- a/python/ray/dashboard/modules/job/sdk.py
+++ b/python/ray/dashboard/modules/job/sdk.py
@@ -143,6 +143,7 @@ class JobSubmissionClient(SubmissionClient):
         entrypoint_memory: Optional[int] = None,
         entrypoint_resources: Optional[Dict[str, float]] = None,
         entrypoint_label_selector: Optional[Dict[str, str]] = None,
+        retry_policy: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Submit and execute a job asynchronously.
 
@@ -182,6 +183,24 @@ class JobSubmissionClient(SubmissionClient):
                 execution of the entrypoint command, separately from any tasks or
                 actors launched by it.
             entrypoint_label_selector: Label selector for the entrypoint command.
+            retry_policy: Optional policy to retry the job's driver in place using
+                the same submission_id (and the same Ray cluster) on failure,
+                instead of failing immediately. Accepts a dict with keys
+                ``max_retries`` (int), ``backoff`` (dict with
+                ``initial_delay_seconds``, ``max_delay_seconds``, ``multiplier``),
+                ``retry_on`` (list of "NON_ZERO_EXIT"/"DRIVER_OOM"), and
+                ``no_retry_on_exit_codes`` (list of ints). For example::
+
+                    {
+                        "max_retries": 3,
+                        "backoff": {
+                            "initial_delay_seconds": 30,
+                            "max_delay_seconds": 600,
+                            "multiplier": 2.0,
+                        },
+                        "retry_on": ["NON_ZERO_EXIT"],
+                        "no_retry_on_exit_codes": [130],
+                    }
 
         Returns:
             The submission ID of the submitted job.  If not specified,
@@ -216,6 +235,13 @@ class JobSubmissionClient(SubmissionClient):
                 version_error_message="`entrypoint_memory` kwarg "
                 "is not supported on the Ray cluster. Please ensure the cluster is "
                 "running Ray 2.8 or higher.",
+            )
+        if retry_policy:
+            self._check_connection_and_version(
+                min_version="3.0",
+                version_error_message="`retry_policy` kwarg "
+                "is not supported on the Ray cluster. Please ensure the cluster is "
+                "running Ray 3.0 or higher.",
             )
 
         runtime_env = copy.deepcopy(runtime_env or {})
@@ -252,6 +278,7 @@ class JobSubmissionClient(SubmissionClient):
             entrypoint_memory=entrypoint_memory,
             entrypoint_resources=entrypoint_resources,
             entrypoint_label_selector=entrypoint_label_selector,
+            retry_policy=retry_policy,
         )
 
         # Remove keys with value None so that new clients with new optional fields

--- a/python/ray/dashboard/modules/job/tests/test_common.py
+++ b/python/ray/dashboard/modules/job/tests/test_common.py
@@ -13,6 +13,7 @@ from ray.dashboard.modules.job.common import (
     JobInfoStorageClient,
     JobStatus,
     JobSubmitRequest,
+    RetryPolicy,
     http_uri_components_to_uri,
     uri_to_http_components,
     validate_request_type,
@@ -127,6 +128,125 @@ class TestJobSubmitRequestValidation:
                 {"entrypoint": "abc", "entrypoint_resources": {"Custom": "1"}},
                 JobSubmitRequest,
             )
+
+    def test_retry_policy_flattens_nested_backoff(self):
+        r = validate_request_type(
+            {
+                "entrypoint": "abc",
+                "retry_policy": {
+                    "max_retries": 3,
+                    "backoff": {
+                        "initial_delay_seconds": 5,
+                        "max_delay_seconds": 50,
+                        "multiplier": 3,
+                    },
+                    "retry_on": ["NON_ZERO_EXIT"],
+                    "no_retry_on_exit_codes": [130],
+                },
+            },
+            JobSubmitRequest,
+        )
+        # The nested ``backoff`` object is flattened into the internal form.
+        assert r.retry_policy == {
+            "max_retries": 3,
+            "backoff_initial_delay_seconds": 5,
+            "backoff_max_delay_seconds": 50,
+            "backoff_multiplier": 3,
+            "retry_on": ["NON_ZERO_EXIT"],
+            "no_retry_on_exit_codes": [130],
+        }
+
+    def test_retry_policy_minimal(self):
+        r = validate_request_type(
+            {"entrypoint": "abc", "retry_policy": {"max_retries": 1}},
+            JobSubmitRequest,
+        )
+        # The normalizer always fills in the backoff defaults.
+        assert r.retry_policy == {
+            "max_retries": 1,
+            "backoff_initial_delay_seconds": 30.0,
+            "backoff_max_delay_seconds": 600.0,
+            "backoff_multiplier": 2.0,
+        }
+
+    def test_retry_policy_none(self):
+        r = validate_request_type({"entrypoint": "abc"}, JobSubmitRequest)
+        assert r.retry_policy is None
+
+    def test_retry_policy_invalid(self):
+        # Only cover the cases specific to the request/flatten layer here;
+        # field-level validation is covered by TestRetryPolicyValidation.
+        with pytest.raises(TypeError, match="retry_policy must be a dict"):
+            validate_request_type(
+                {"entrypoint": "abc", "retry_policy": "bad"}, JobSubmitRequest
+            )
+        with pytest.raises(TypeError, match="backoff.* must be a dict"):
+            validate_request_type(
+                {"entrypoint": "abc", "retry_policy": {"backoff": 1}},
+                JobSubmitRequest,
+            )
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            validate_request_type(
+                {"entrypoint": "abc", "retry_policy": {"bogus_key": 1}},
+                JobSubmitRequest,
+            )
+
+
+class TestRetryPolicyValidation:
+    def test_valid(self):
+        # Defaults.
+        RetryPolicy()
+        # Fully specified.
+        RetryPolicy(
+            max_retries=3,
+            backoff_initial_delay_seconds=5,
+            backoff_max_delay_seconds=50,
+            backoff_multiplier=2,
+            retry_on=["NON_ZERO_EXIT", "DRIVER_OOM"],
+            no_retry_on_exit_codes=[130],
+        )
+
+    @pytest.mark.parametrize(
+        "kwargs,exc,match",
+        [
+            ({"max_retries": -1}, ValueError, "max_retries must be non-negative"),
+            ({"max_retries": True}, TypeError, "max_retries must be an integer"),
+            ({"max_retries": 1.5}, TypeError, "max_retries must be an integer"),
+            (
+                {"backoff_initial_delay_seconds": -1},
+                ValueError,
+                "backoff_initial_delay_seconds must be non-negative",
+            ),
+            (
+                {"backoff_multiplier": 0.5},
+                ValueError,
+                "backoff_multiplier must be >= 1",
+            ),
+            (
+                {
+                    "backoff_initial_delay_seconds": 100,
+                    "backoff_max_delay_seconds": 10,
+                },
+                ValueError,
+                "backoff_max_delay_seconds must be >=",
+            ),
+            ({"retry_on": "NON_ZERO_EXIT"}, TypeError, "retry_on must be a list"),
+            ({"retry_on": ["NOPE"]}, ValueError, "Invalid retry_on condition"),
+            (
+                {"no_retry_on_exit_codes": 130},
+                TypeError,
+                "no_retry_on_exit_codes must be a list",
+            ),
+            (
+                {"no_retry_on_exit_codes": [1.5]},
+                TypeError,
+                "Exit code must be an integer",
+            ),
+        ],
+    )
+    def test_invalid(self, kwargs, exc, match):
+        with pytest.raises(exc, match=match):
+            RetryPolicy(**kwargs)
 
 
 def test_uri_to_http_and_back():
@@ -265,8 +385,35 @@ def test_job_info_json_to_proto():
         "error_type",
         "driver_agent_http_address",
         "driver_node_id",
+        "retry_policy",
     ]:
         assert not minimal_info_proto.HasField(unset_optional_field)
+
+
+def test_job_info_retry_policy_to_proto():
+    """retry_policy + attempt_number should round-trip into JobsAPIInfo."""
+    info = JobInfo(
+        status=JobStatus.RUNNING,
+        entrypoint="echo hi",
+        retry_policy={
+            "max_retries": 3,
+            "backoff_initial_delay_seconds": 5.0,
+            "backoff_max_delay_seconds": 50.0,
+            "backoff_multiplier": 2.0,
+            "retry_on": ["NON_ZERO_EXIT"],
+            "no_retry_on_exit_codes": [130],
+        },
+        attempt_number=2,
+    )
+    info_proto = Parse(json.dumps(info.to_json()), JobsAPIInfo())
+    assert info_proto.attempt_number == 2
+    assert info_proto.HasField("retry_policy")
+    assert info_proto.retry_policy.max_retries == 3
+    assert info_proto.retry_policy.backoff_initial_delay_seconds == 5.0
+    assert info_proto.retry_policy.backoff_max_delay_seconds == 50.0
+    assert info_proto.retry_policy.backoff_multiplier == 2.0
+    assert list(info_proto.retry_policy.retry_on) == ["NON_ZERO_EXIT"]
+    assert list(info_proto.retry_policy.no_retry_on_exit_codes) == [130]
 
 
 def test_get_all_jobs_filters_out_none_job_info():

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1654,5 +1654,121 @@ async def test_no_task_events_exported(shared_ray_instance, tmp_path):
         assert "JobSupervisor" not in t.name
 
 
+def _counter_script(count_file: str, fail_times: int, exit_code: int = 1) -> str:
+    """A shell entrypoint that fails its first ``fail_times`` runs, then succeeds.
+
+    A counter is persisted in ``count_file`` across in-place retries (the file
+    survives because the driver is re-execed within the same supervisor).
+    """
+    return (
+        f'n=$(cat "{count_file}" 2>/dev/null || echo 0); '
+        f'n=$((n + 1)); echo "$n" > "{count_file}"; '
+        f'if [ "$n" -le {fail_times} ]; then exit {exit_code}; fi'
+    )
+
+
+# A backoff that is effectively instant, to keep retry tests fast.
+_FAST_BACKOFF = {
+    "backoff_initial_delay_seconds": 0.1,
+    "backoff_max_delay_seconds": 0.1,
+    "backoff_multiplier": 1.0,
+}
+
+
+@pytest.mark.asyncio
+async def test_retry_policy_retries_to_success(job_manager, tmp_path):
+    """A driver that fails once is retried in place and eventually succeeds."""
+    count_file = os.path.join(tmp_path, "count")
+    job_id = await job_manager.submit_job(
+        entrypoint=_counter_script(count_file, fail_times=1),
+        retry_policy={"max_retries": 3, **_FAST_BACKOFF},
+    )
+
+    await async_wait_for_condition(
+        check_job_succeeded, job_manager=job_manager, job_id=job_id
+    )
+
+    info = await job_manager.get_job_info(job_id)
+    assert info.attempt_number == 1  # one retry happened
+    assert info.driver_exit_code == 0
+    with open(count_file) as f:
+        assert f.read().strip() == "2"  # ran twice total
+
+
+@pytest.mark.asyncio
+async def test_retry_policy_exhausts_retries(job_manager, tmp_path):
+    """A driver that always fails is retried up to max_retries, then FAILS."""
+    count_file = os.path.join(tmp_path, "count")
+    job_id = await job_manager.submit_job(
+        entrypoint=_counter_script(count_file, fail_times=999),
+        retry_policy={"max_retries": 2, **_FAST_BACKOFF},
+    )
+
+    await async_wait_for_condition(
+        check_job_failed,
+        job_manager=job_manager,
+        job_id=job_id,
+        expected_error_type=JobErrorType.JOB_ENTRYPOINT_COMMAND_ERROR,
+    )
+
+    info = await job_manager.get_job_info(job_id)
+    assert info.attempt_number == 2  # original + 2 retries
+    assert info.driver_exit_code == 1
+    with open(count_file) as f:
+        assert f.read().strip() == "3"  # ran three times total
+
+
+@pytest.mark.asyncio
+async def test_retry_policy_no_retry_on_exit_codes(job_manager, tmp_path):
+    """An exit code in no_retry_on_exit_codes fails immediately without retry."""
+    count_file = os.path.join(tmp_path, "count")
+    job_id = await job_manager.submit_job(
+        entrypoint=_counter_script(count_file, fail_times=999, exit_code=42),
+        retry_policy={
+            "max_retries": 3,
+            "no_retry_on_exit_codes": [42],
+            **_FAST_BACKOFF,
+        },
+    )
+
+    await async_wait_for_condition(
+        check_job_failed, job_manager=job_manager, job_id=job_id
+    )
+
+    info = await job_manager.get_job_info(job_id)
+    assert info.attempt_number == 0  # never retried
+    assert info.driver_exit_code == 42
+    with open(count_file) as f:
+        assert f.read().strip() == "1"  # ran only once
+
+
+@pytest.mark.asyncio
+async def test_retry_policy_stop_during_backoff(job_manager):
+    """Stopping a job while it is waiting in the retry backoff yields STOPPED."""
+    job_id = await job_manager.submit_job(
+        entrypoint="exit 1",
+        # Long backoff so the job stays in the RUNNING backoff window.
+        retry_policy={
+            "max_retries": 5,
+            "backoff_initial_delay_seconds": 100.0,
+            "backoff_max_delay_seconds": 100.0,
+            "backoff_multiplier": 1.0,
+        },
+    )
+
+    # Wait until the first attempt has failed and the job is backing off:
+    # status stays RUNNING and attempt_number has been bumped to 1.
+    async def _backing_off():
+        info = await job_manager.get_job_info(job_id)
+        return info.status == JobStatus.RUNNING and info.attempt_number == 1
+
+    await async_wait_for_condition(_backing_off)
+
+    assert job_manager.stop_job(job_id)
+    await async_wait_for_condition(
+        check_job_stopped, job_manager=job_manager, job_id=job_id
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -390,6 +390,23 @@ message GcsNodeAddressAndLiveness {
   NodeDeathInfo death_info = 6;
 }
 
+// In-place retry policy for a submitted job. Mirrors the flattened
+// RetryPolicy dataclass in dashboard/modules/job/common.py.
+message RetryPolicy {
+  // Maximum number of retries after the initial attempt. 0 disables retries.
+  optional int32 max_retries = 1;
+  // Delay before the first retry, in seconds.
+  optional double backoff_initial_delay_seconds = 2;
+  // Maximum delay between retries, in seconds.
+  optional double backoff_max_delay_seconds = 3;
+  // Multiplier applied to the delay after each retry.
+  optional double backoff_multiplier = 4;
+  // Conditions under which to retry (e.g. "NON_ZERO_EXIT", "DRIVER_OOM").
+  repeated string retry_on = 5;
+  // Driver exit codes that should never be retried.
+  repeated int32 no_retry_on_exit_codes = 6;
+}
+
 // Please keep this in sync with the definition of JobInfo in
 // dashboard/modules/job/common.py
 message JobsAPIInfo {
@@ -426,6 +443,10 @@ message JobsAPIInfo {
   optional int32 driver_exit_code = 14;
   // The amount of reservable memory resource in bytes for the entrypoint command.
   optional uint64 entrypoint_memory = 15;
+    // The in-place retry policy for the job, if configured.
+  optional RetryPolicy retry_policy = 16;
+  // The current driver attempt number (0 = original run, 1 = first retry, ...).
+  optional int32 attempt_number = 17;
 }
 
 message WorkerTableData {


### PR DESCRIPTION
## Description
Adds an opt-in, in-place **retry policy** to the Ray Job Submission API. On a retryable driver failure, the job is retried **on the same Ray cluster using the same `submission_id`** after an exponential backoff, instead of going straight to `FAILED`.

This is the Ray-core half of [ray-project/kuberay#4668](https://github.com/ray-project/kuberay/issues/4668): instead of recreating the RayCluster on every RayJob backoff retry, a job can be retried in place. Because the cluster (workers, object store, actors) stays alive across retries, only the driver is re-executed; head-node failure is out of scope and still requires a cluster restart.

## Public API

New optional `retry_policy` on the REST API and `JobSubmissionClient.submit_job`:

```python
client.submit_job(
    entrypoint="python train.py",
    retry_policy={
        "max_retries": 3,
        "backoff": {"initial_delay_seconds": 30, "max_delay_seconds": 600, "multiplier": 2.0},
        "retry_on": ["NON_ZERO_EXIT", "DRIVER_OOM"],
        "no_retry_on_exit_codes": [130],
    },
)
```

## Related issues
Closes #64104 
Related to https://github.com/ray-project/kuberay/issues/4668

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
