### PR TITLE
[serve][LLM] use model_id, not remote URI, as cache identifier in VLLMEngineConfig

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -8,7 +8,7 @@ from vllm.entrypoints.openai.cli_args import FrontendArgs
 
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.placement import PlacementGroupConfig
-from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig
+from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig, is_remote_path
 from ray.llm._internal.common.utils.import_utils import try_import
 from ray.llm._internal.serve.constants import (
     ALLOW_NEW_PLACEMENT_GROUPS_IN_DEPLOYMENT,
@@ -187,7 +187,18 @@ class VLLMEngineConfig(BaseModelExtended):
         if llm_config.model_loading_config.model_source is None:
             hf_model_id = llm_config.model_id
         elif isinstance(llm_config.model_loading_config.model_source, str):
-            hf_model_id = llm_config.model_loading_config.model_source
+            model_source = llm_config.model_loading_config.model_source
+            if is_remote_path(model_source):
+                # Remote URIs (s3://, gs://, …) are download addresses,
+                # not HuggingFace IDs.  Using the URI verbatim as
+                # hf_model_id propagates the scheme and slashes into the
+                # cache directory name (``models--s3:----bucket--…``).
+                # Use the user-supplied model_id as the identifier and
+                # treat the URI as a bucket mirror instead.
+                hf_model_id = llm_config.model_id
+                mirror_config = CloudMirrorConfig(bucket_uri=model_source)
+            else:
+                hf_model_id = model_source
         else:
             # If it's a CloudMirrorConfig (or subtype)
             mirror_config = llm_config.model_loading_config.model_source

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -178,6 +178,49 @@ class TestModelConfig:
         new_engine_config = llm_config.get_engine_config()
         assert new_engine_config is old_engine_config
 
+    def test_remote_model_source_uses_model_id_as_hf_model_id(self):
+        """A remote model_source must not leak its URI into hf_model_id.
+
+        Using the URI verbatim propagates the scheme and slashes into the HF
+        cache directory name (e.g. ``models--s3:----bucket--...``). The URI
+        should instead be carried by mirror_config while hf_model_id falls back
+        to the user-supplied model_id.
+        """
+        bucket_uri = "s3://my-bucket/my-model"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+                model_source=bucket_uri,
+            ),
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == "llm_model_id"
+        assert engine_config.mirror_config is not None
+        assert engine_config.mirror_config.bucket_uri == bucket_uri
+
+    def test_hf_model_source_used_as_hf_model_id(self):
+        """A plain HuggingFace model_source is used directly as hf_model_id."""
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+                model_source="facebook/opt-1.3b",
+            ),
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == "facebook/opt-1.3b"
+        assert engine_config.mirror_config is None
+
+    def test_no_model_source_falls_back_to_model_id(self):
+        """With no model_source, hf_model_id falls back to model_id."""
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+            ),
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == "llm_model_id"
+        assert engine_config.mirror_config is None
+
     def test_experimental_configs(self):
         """Test that `experimental_configs` can be used."""
         # Test with a valid dictionary can be used.


### PR DESCRIPTION
Reopens #63378 with the unit tests @kouroshHakha requested (the original was auto-closed by stalebot before I could follow up).

When `model_source` is a remote URI (`s3://`, `gs://`, …), `from_llm_config` used the URI verbatim as `hf_model_id`, which propagates the scheme and slashes into the HF cache directory name (`models--s3:----bucket--…`). This uses the user-supplied `model_id` as the identifier and carries the URI in `mirror_config` instead.

Adds `test_models.py` coverage for all three `model_source` cases (remote URI, HuggingFace id, and unset) via `LLMConfig.get_engine_config()`.