### PR TITLE
[serve] Eager load proxy imports

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -55,7 +55,6 @@ from ray.serve._private.controller_health_metrics_tracker import (
 )
 from ray.serve._private.default_impl import (
     create_cluster_node_info_cache,
-    get_proxy_actor_class,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_state import (
@@ -64,6 +63,7 @@ from ray.serve._private.deployment_state import (
 from ray.serve._private.endpoint_state import EndpointState
 from ray.serve._private.exceptions import ExternalScalerDisabledError
 from ray.serve._private.grpc_util import set_proxy_default_grpc_options
+from ray.serve._private.haproxy import HAProxyManager
 from ray.serve._private.http_util import (
     configure_http_options_with_defaults,
 )
@@ -74,6 +74,7 @@ from ray.serve._private.logging_utils import (
 )
 from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
 from ray.serve._private.node_port_manager import NodePortManager
+from ray.serve._private.proxy import ProxyActor
 from ray.serve._private.proxy_state import ProxyStateManager
 from ray.serve._private.storage.kv_store import RayInternalKVStore
 from ray.serve._private.usage import ServeUsageTag
@@ -225,7 +226,7 @@ class ServeController:
             cluster_node_info_cache=self.cluster_node_info_cache,
             logging_config=self.global_logging_config,
             grpc_options=set_proxy_default_grpc_options(grpc_options),
-            proxy_actor_class=get_proxy_actor_class(),
+            proxy_actor_class=HAProxyManager if self._ha_proxy_enabled else ProxyActor,
             running_native_proxies=self._ha_proxy_enabled,
         )
         # We modify the HTTP and gRPC options above, so delete them to avoid

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -12,13 +12,16 @@ from ray.serve._private.common import (
     CreatePlacementGroupRequest,
     DeploymentHandleSource,
     DeploymentID,
+    EndpointInfo,
     RequestMetadata,
     RequestProtocol,
 )
 from ray.serve._private.constants import (
     CONTROLLER_MAX_CONCURRENCY,
-    RAY_SERVE_ENABLE_HA_PROXY,
     RAY_SERVE_ENABLE_TASK_EVENTS,
+    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+    RAY_SERVE_PROXY_USE_GRPC,
+    RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     SERVE_CONTROLLER_NAME,
     SERVE_NAMESPACE,
 )
@@ -29,8 +32,6 @@ from ray.serve._private.deployment_scheduler import (
 from ray.serve._private.event_loop_monitoring import EventLoopMonitor
 from ray.serve._private.grpc_util import gRPCGenericServer
 from ray.serve._private.handle_options import DynamicHandleOptions, InitHandleOptions
-from ray.serve._private.haproxy import HAProxyManager
-from ray.serve._private.proxy import ProxyActor
 from ray.serve._private.router import CurrentLoopRouter, Router, SingletonThreadRouter
 from ray.serve._private.utils import (
     asyncio_grpc_exception_handler,
@@ -214,6 +215,33 @@ def add_grpc_address(grpc_server: gRPCGenericServer, server_address: str):
     grpc_server.add_insecure_port(server_address)
 
 
+def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
+    # NOTE(zcin): needs to be lazy import due to a circular dependency.
+    # We should not be importing from application_state in context.
+    from ray.serve.context import _get_global_client
+
+    client = _get_global_client()
+    handle = client.get_handle(endpoint.name, endpoint.app_name, check_exists=True)
+
+    # NOTE(zcin): It's possible that a handle is already initialized
+    # if a deployment with the same name and application name was
+    # deleted, then redeployed later. However this is not an issue since
+    # we initialize all handles with the same init options.
+    if not handle.is_initialized:
+        # NOTE(zcin): since the router is eagerly initialized here, the
+        # proxy will receive the replica set from the controller early.
+        handle._init(
+            _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+            _source=DeploymentHandleSource.PROXY,
+            _run_router_in_separate_loop=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
+        )
+
+    return handle.options(
+        stream=not info.app_is_cross_language,
+        _by_reference=not RAY_SERVE_PROXY_USE_GRPC,
+    )
+
+
 def get_controller_impl(controller_options: Optional[ControllerOptions] = None):
     """Build the Ray actor class for the Serve controller.
 
@@ -241,10 +269,3 @@ def get_controller_impl(controller_options: Optional[ControllerOptions] = None):
         actor_options["runtime_env"] = controller_options.runtime_env
 
     return ray.remote(**actor_options)(ServeController)
-
-
-def get_proxy_actor_class():
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        return HAProxyManager
-
-    return ProxyActor

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -33,6 +33,8 @@ from ray.serve._private.deployment_scheduler import (
 from ray.serve._private.event_loop_monitoring import EventLoopMonitor
 from ray.serve._private.grpc_util import gRPCGenericServer
 from ray.serve._private.handle_options import DynamicHandleOptions, InitHandleOptions
+from ray.serve._private.haproxy import HAProxyManager
+from ray.serve._private.proxy import ProxyActor
 from ray.serve._private.router import CurrentLoopRouter, Router, SingletonThreadRouter
 from ray.serve._private.utils import (
     asyncio_grpc_exception_handler,
@@ -273,13 +275,7 @@ def get_controller_impl(controller_options: Optional[ControllerOptions] = None):
 
 
 def get_proxy_actor_class():
-    # These imports are lazy to avoid circular imports
-
     if RAY_SERVE_ENABLE_HA_PROXY:
-        from ray.serve._private.haproxy import HAProxyManager
-
         return HAProxyManager
-    else:
-        from ray.serve._private.proxy import ProxyActor
 
-        return ProxyActor
+    return ProxyActor

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -12,7 +12,6 @@ from ray.serve._private.common import (
     CreatePlacementGroupRequest,
     DeploymentHandleSource,
     DeploymentID,
-    EndpointInfo,
     RequestMetadata,
     RequestProtocol,
 )
@@ -20,9 +19,6 @@ from ray.serve._private.constants import (
     CONTROLLER_MAX_CONCURRENCY,
     RAY_SERVE_ENABLE_HA_PROXY,
     RAY_SERVE_ENABLE_TASK_EVENTS,
-    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-    RAY_SERVE_PROXY_USE_GRPC,
-    RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     SERVE_CONTROLLER_NAME,
     SERVE_NAMESPACE,
 )
@@ -216,33 +212,6 @@ def create_router(
 def add_grpc_address(grpc_server: gRPCGenericServer, server_address: str):
     """Helper function to add an address to a gRPC server."""
     grpc_server.add_insecure_port(server_address)
-
-
-def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
-    # NOTE(zcin): needs to be lazy import due to a circular dependency.
-    # We should not be importing from application_state in context.
-    from ray.serve.context import _get_global_client
-
-    client = _get_global_client()
-    handle = client.get_handle(endpoint.name, endpoint.app_name, check_exists=True)
-
-    # NOTE(zcin): It's possible that a handle is already initialized
-    # if a deployment with the same name and application name was
-    # deleted, then redeployed later. However this is not an issue since
-    # we initialize all handles with the same init options.
-    if not handle.is_initialized:
-        # NOTE(zcin): since the router is eagerly initialized here, the
-        # proxy will receive the replica set from the controller early.
-        handle._init(
-            _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-            _source=DeploymentHandleSource.PROXY,
-            _run_router_in_separate_loop=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
-        )
-
-    return handle.options(
-        stream=not info.app_is_cross_language,
-        _by_reference=not RAY_SERVE_PROXY_USE_GRPC,
-    )
 
 
 def get_controller_impl(controller_options: Optional[ControllerOptions] = None):

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -18,6 +18,7 @@ import ray
 from ray._common.filters import CoreContextFilter
 from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import (
+    DeploymentHandleSource,
     DeploymentID,
     EndpointInfo,
     NodeId,
@@ -31,7 +32,10 @@ from ray.serve._private.constants import (
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_PROXY_GC_THRESHOLD,
+    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+    RAY_SERVE_PROXY_USE_GRPC,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
+    RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
     SERVE_HTTP_REQUEST_ID_HEADER,
@@ -43,7 +47,6 @@ from ray.serve._private.constants import (
     SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_NAMESPACE,
 )
-from ray.serve._private.default_impl import get_proxy_handle
 from ray.serve._private.event_loop_monitoring import EventLoopMonitor
 from ray.serve._private.grpc_util import (
     get_grpc_response_status,
@@ -101,6 +104,7 @@ from ray.serve._private.utils import (
     is_grpc_enabled,
 )
 from ray.serve.config import HTTPOptions, gRPCOptions
+from ray.serve.context import _get_global_client
 from ray.serve.generated.serve_pb2 import HealthzResponse, ListApplicationsResponse
 from ray.serve.handle import DeploymentHandle
 from ray.serve.schema import EncodingType, LoggingConfig
@@ -1715,7 +1719,7 @@ class ProxyActor(ProxyActorInterface):
             }
 
         is_head = self._node_id == get_head_node_id()
-        self.proxy_router = ProxyRouter(get_proxy_handle)
+        self.proxy_router = ProxyRouter(self.get_proxy_handle)
         self.http_proxy = HTTPProxy(
             node_id=self._node_id,
             node_ip_address=self._node_ip_address,
@@ -1781,6 +1785,28 @@ class ProxyActor(ProxyActorInterface):
             actor_id=ray.get_runtime_context().get_actor_id(),
         )
         self._event_loop_monitor.start(event_loop)
+    
+    def get_proxy_handle(self, endpoint: DeploymentID, info: EndpointInfo):
+        client = _get_global_client()
+        handle = client.get_handle(endpoint.name, endpoint.app_name, check_exists=True)
+
+        # NOTE(zcin): It's possible that a handle is already initialized
+        # if a deployment with the same name and application name was
+        # deleted, then redeployed later. However this is not an issue since
+        # we initialize all handles with the same init options.
+        if not handle.is_initialized:
+            # NOTE(zcin): since the router is eagerly initialized here, the
+            # proxy will receive the replica set from the controller early.
+            handle._init(
+                _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+                _source=DeploymentHandleSource.PROXY,
+                _run_router_in_separate_loop=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
+            )
+
+        return handle.options(
+            stream=not info.app_is_cross_language,
+            _by_reference=not RAY_SERVE_PROXY_USE_GRPC,
+        )
 
     def _update_routes_in_proxies(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         self.proxy_router.update_routes(endpoints)

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1785,7 +1785,7 @@ class ProxyActor(ProxyActorInterface):
             actor_id=ray.get_runtime_context().get_actor_id(),
         )
         self._event_loop_monitor.start(event_loop)
-    
+
     def get_proxy_handle(self, endpoint: DeploymentID, info: EndpointInfo):
         client = _get_global_client()
         handle = client.get_handle(endpoint.name, endpoint.app_name, check_exists=True)

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -18,7 +18,6 @@ import ray
 from ray._common.filters import CoreContextFilter
 from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import (
-    DeploymentHandleSource,
     DeploymentID,
     EndpointInfo,
     NodeId,
@@ -32,10 +31,7 @@ from ray.serve._private.constants import (
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_PROXY_GC_THRESHOLD,
-    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-    RAY_SERVE_PROXY_USE_GRPC,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
-    RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
     SERVE_HTTP_REQUEST_ID_HEADER,
@@ -47,6 +43,7 @@ from ray.serve._private.constants import (
     SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_NAMESPACE,
 )
+from ray.serve._private.default_impl import get_proxy_handle
 from ray.serve._private.event_loop_monitoring import EventLoopMonitor
 from ray.serve._private.grpc_util import (
     get_grpc_response_status,
@@ -104,7 +101,6 @@ from ray.serve._private.utils import (
     is_grpc_enabled,
 )
 from ray.serve.config import HTTPOptions, gRPCOptions
-from ray.serve.context import _get_global_client
 from ray.serve.generated.serve_pb2 import HealthzResponse, ListApplicationsResponse
 from ray.serve.handle import DeploymentHandle
 from ray.serve.schema import EncodingType, LoggingConfig
@@ -1719,7 +1715,7 @@ class ProxyActor(ProxyActorInterface):
             }
 
         is_head = self._node_id == get_head_node_id()
-        self.proxy_router = ProxyRouter(self.get_proxy_handle)
+        self.proxy_router = ProxyRouter(get_proxy_handle)
         self.http_proxy = HTTPProxy(
             node_id=self._node_id,
             node_ip_address=self._node_ip_address,
@@ -1785,28 +1781,6 @@ class ProxyActor(ProxyActorInterface):
             actor_id=ray.get_runtime_context().get_actor_id(),
         )
         self._event_loop_monitor.start(event_loop)
-
-    def get_proxy_handle(self, endpoint: DeploymentID, info: EndpointInfo):
-        client = _get_global_client()
-        handle = client.get_handle(endpoint.name, endpoint.app_name, check_exists=True)
-
-        # NOTE(zcin): It's possible that a handle is already initialized
-        # if a deployment with the same name and application name was
-        # deleted, then redeployed later. However this is not an issue since
-        # we initialize all handles with the same init options.
-        if not handle.is_initialized:
-            # NOTE(zcin): since the router is eagerly initialized here, the
-            # proxy will receive the replica set from the controller early.
-            handle._init(
-                _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-                _source=DeploymentHandleSource.PROXY,
-                _run_router_in_separate_loop=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
-            )
-
-        return handle.options(
-            stream=not info.app_is_cross_language,
-            _by_reference=not RAY_SERVE_PROXY_USE_GRPC,
-        )
 
     def _update_routes_in_proxies(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         self.proxy_router.update_routes(endpoints)


### PR DESCRIPTION
remove the helper in `default_impl.py` which lazily imports proxy modules and directly import the modules at top level in `controller.py`