### PR TITLE
[ci] Hold CUDA packages in GPU base image to stop cuda-compat churn

### DIFF
--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -31,7 +31,7 @@ apt-get update -qq
 # container's effective CUDA driver version (via cuda-compat forward-compat),
 # which can flip on NCCL's cuMem host path and break multi-GPU collectives on
 # non-P2P GPUs (CUDA error 217). See NVIDIA/nccl#1838.
-apt-mark hold $(dpkg-query -W -f='${Package}\n' 'cuda-*' 2>/dev/null) 2>/dev/null || true
+dpkg-query -W -f='${Package}\n' 'cuda-*' 2>/dev/null | xargs -r apt-mark hold || true
 apt-get upgrade -qq
 apt-get install -y -qq \
     curl python-is-python3 git build-essential \

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -23,7 +23,16 @@ RUN <<EOF
 
 set -euo pipefail
 
-apt-get update -qq && apt-get upgrade -qq
+apt-get update -qq
+# Pin CUDA packages before upgrading. The base image ships a consistent CUDA
+# toolkit, but a blanket 'apt-get upgrade' pulls whatever cuda-compat / toolkit
+# version NVIDIA's mutable apt index currently advertises. That (a) 404s
+# transiently mid-rebuild when NVIDIA rotates a .deb, and (b) churns the
+# container's effective CUDA driver version (via cuda-compat forward-compat),
+# which can flip on NCCL's cuMem host path and break multi-GPU collectives on
+# non-P2P GPUs (CUDA error 217). See NVIDIA/nccl#1838.
+apt-mark hold $(dpkg-query -W -f='${Package}\n' 'cuda-*' 2>/dev/null) 2>/dev/null || true
+apt-get upgrade -qq
 apt-get install -y -qq \
     curl python-is-python3 git build-essential \
     sudo zip unzip unrar apt-utils dialog tzdata wget rsync \


### PR DESCRIPTION
The blanket `apt-get upgrade` pulls whatever cuda-compat/toolkit version NVIDIA's mutable apt index advertises, which causes transient .deb 404s on rebuilds and churns the container's effective CUDA driver (triggering an NCCL cuMem peer-access failure on non-P2P GPUs, CUDA 217 / NVIDIA/nccl#1838). `apt-mark hold` the cuda-* packages so the base image's toolkit is preserved.


postmerge build: https://buildkite.com/ray-project/postmerge/builds/18135/canvas