### PR TITLE
[serve] Supply safe default request id header value in direct ingress

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2633,7 +2633,9 @@ class Replica:
         headers = dict(scope["headers"])
         request_id = (
             # RequestIdMiddleware populates the request ID in the headers if it isn't provided.
-            headers.get(SERVE_HTTP_REQUEST_ID_HEADER.encode("utf-8"), b"").decode("utf-8")
+            headers.get(SERVE_HTTP_REQUEST_ID_HEADER.encode("utf-8"), b"").decode(
+                "utf-8"
+            )
             or generate_request_id()
         )
         request_disconnect_disabled = parse_disconnect_disabled_header(headers)

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2632,7 +2632,8 @@ class Replica:
 
         headers = dict(scope["headers"])
         request_id = (
-            headers.get(SERVE_HTTP_REQUEST_ID_HEADER.encode("utf-8")).decode("utf-8")
+            # RequestIdMiddleware populates the request ID in the headers if it isn't provided.
+            headers.get(SERVE_HTTP_REQUEST_ID_HEADER.encode("utf-8"), b"").decode("utf-8")
             or generate_request_id()
         )
         request_disconnect_disabled = parse_disconnect_disabled_header(headers)


### PR DESCRIPTION
`x-request-id` http header is populated by `RequestIdMiddleware`, which is always added to the asgi app. This pr adds a comment describing that, and also defends the code with a safe default value if the header is ever removed/missing.