### PR TITLE
[Data][LLM][Doc] Document how to disable a pipeline stage

### DIFF
--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -498,6 +498,12 @@ Configure individual pipeline stages for fine-grained resource control:
 
 See :ref:`stage config classes <stage-configs-ref>` for all available fields.
 
+.. note::
+    To drop a stage from the pipeline, set it to ``False`` (for example,
+    ``detokenize_stage=False``) or pass ``"enabled": False``. The optional stages are
+    ``prepare_multimodal_stage``, ``chat_template_stage``, ``tokenize_stage``, and
+    ``detokenize_stage``; the vLLM engine stage always runs.
+
 LoRA adapters
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
Adds a note to the "Per-stage configuration" section of the Ray Data LLM guide showing that a pipeline stage is dropped by setting it to `False` (for example, `detokenize_stage=False`) or `"enabled": False`, and lists the toggleable stages.

## Why
The per-stage enable/disable switch wasn't documented, so dropping a stage (such as the separate detokenize stage) was effectively discoverable only by grepping the config fields.
