### PR TITLE
[Data] Configure `memory` for `heterogeneous_memory_batch_inference`

### DIFF
--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -33,6 +33,7 @@ import numpy as np
 from benchmark import Benchmark
 
 import ray
+from ray.data import DataContext
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data.datasource import Datasink
 
@@ -91,12 +92,24 @@ def build_and_run_pipeline(
     cpu_batch_size: int,
     gpu_batch_size: int,
     gpu_concurrency: int,
+    set_memory: bool,
 ):
+    if set_memory:
+        # Setting `default_map_logical_memory_enabled` is a best practice, and we
+        # recommend it in our docs, but it isn't enabled by default.
+        DataContext.get_current().default_map_logical_memory_enabled = True
+        # These are the values from logs of the nightly test run.
+        gen_memory = 3175944192  # ~3 GB
+        cpu_memory = 2151890944  # ~2 GB
+    else:
+        gen_memory = None
+        cpu_memory = None
+
     ds = ray.data.range(num_rows)
 
-    ds = ds.map_batches(gen_data, batch_size=gen_batch_size)
+    ds = ds.map_batches(gen_data, batch_size=gen_batch_size, memory=gen_memory)
 
-    ds = ds.map_batches(cpu_process, batch_size=cpu_batch_size)
+    ds = ds.map_batches(cpu_process, batch_size=cpu_batch_size, memory=cpu_memory)
 
     ds = ds.map_batches(
         FakeGPUInference,
@@ -121,6 +134,7 @@ def main(args):
         cpu_batch_size=args.cpu_batch_size,
         gpu_batch_size=args.gpu_batch_size,
         gpu_concurrency=args.gpu_concurrency,
+        set_memory=args.set_memory,
     )
 
     return {
@@ -138,6 +152,14 @@ def parse_args():
     p.add_argument("--cpu-batch-size", type=int, default=1024)
     p.add_argument("--gpu-batch-size", type=int, default=256)
     p.add_argument("--gpu-concurrency", type=int, default=8)
+    p.add_argument(
+        "--set-memory",
+        action="store_true",
+        help=(
+            "Set per-operator memory requirements and enable logical memory "
+            "accounting. Otherwise, leave memory unset (None)."
+        ),
+    )
     return p.parse_args()
 
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -859,14 +859,16 @@
     byod:
       runtime_env:
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=0
-        - RAYTEST_FAIL_ON_DEAD_NODES=0
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
         - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: heterogeneous_memory_compute.yaml
 
   run:
     timeout: 3600
-    script: python heterogeneous_memory_batch_inference.py
+    # This release test uses large batch sizes. Since Ray Data requires memory hints
+    # for high-memory operations, we need to manually specify the memory.
+    script: python heterogeneous_memory_batch_inference.py --set-memory
 
 # 300 GB image classification parquet data up to 10 GPUs
 # 10 g4dn.12xlarge.


### PR DESCRIPTION
Ray Data can't prevent out-of-memory errors unless you specify hints for high-memory UDFs. Since the `heterogeneous_memory_batch_inference` release test uses large batch sizes that require multiple GiBs of heap memory, I'm adding `memory` hints in this PR.

There is room to optimize the memory use for these UDFs (in theory, they only need ~2 GiB rather than the ~4 GiB I observed), but I'm leaving that out of scope for now since I think there are higher priority improvements to make.