### PR TITLE
[serve] Clean up leaked receive task when request times out in direct ingress mode

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2769,6 +2769,8 @@ class Replica:
                 raise asyncio.CancelledError
             else:
                 request_task.cancel()
+                if receive_task is not None:
+                    receive_task.cancel()
                 status_code_callback("408")
                 if not response_started:
                     msg = (
@@ -2777,6 +2779,19 @@ class Replica:
                     )
                     await send_http_response(msg, 408, send)
                 raise asyncio.CancelledError
+
+    def _get_inflight_direct_ingress_task_counts_for_testing(self) -> Dict[str, int]:
+        """Return counts of in-flight direct-ingress asyncio tasks. Used for testing."""
+        counts = {"request_tasks": 0, "receive_tasks": 0}
+        for task in asyncio.all_tasks(self._event_loop):
+            if task.done():
+                continue
+            name = getattr(getattr(task.get_coro(), "cr_code", None), "co_name", "")
+            if name == "call_asgi":
+                counts["request_tasks"] += 1
+            elif name == "_fetch_until_disconnect":
+                counts["receive_tasks"] += 1
+        return counts
 
 
 async def send_http_response(message, status_code, send):
@@ -2889,6 +2904,11 @@ class ReplicaActor:
 
     def list_outbound_deployments(self) -> Optional[List[DeploymentID]]:
         return self._replica_impl.list_outbound_deployments()
+
+    async def _get_inflight_direct_ingress_task_counts_for_testing(
+        self,
+    ) -> Dict[str, int]:
+        return self._replica_impl._get_inflight_direct_ingress_task_counts_for_testing()
 
     async def initialize_and_get_metadata(
         self,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2786,7 +2786,7 @@ class Replica:
         for task in asyncio.all_tasks(self._event_loop):
             if task.done():
                 continue
-            name = getattr(getattr(task.get_coro(), "cr_code", None), "co_name", "")
+            name = getattr(task.get_coro(), "__name__", "")
             if name == "call_asgi":
                 counts["request_tasks"] += 1
             elif name == "_fetch_until_disconnect":

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -32,6 +32,8 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
+    SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER,
+    SERVE_NAMESPACE,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.test_utils import (
@@ -2074,6 +2076,71 @@ def test_disconnect(_skip_if_ff_not_enabled, serve_instance):
 
     ray.get(running_signal.send.remote(clear=True))
     ray.get(cancelled_signal.send.remote(clear=True))
+
+
+def _get_replica_actor_handle(deployment_name: str, app_name: str) -> ActorHandle:
+    """Return the actor handle for the (single) replica of a deployment."""
+    for actor in ray.util.list_named_actors(all_namespaces=True):
+        if actor["namespace"] != SERVE_NAMESPACE:
+            continue
+        if f"{app_name}#{deployment_name}#" in actor["name"]:
+            return ray.get_actor(actor["name"], namespace=SERVE_NAMESPACE)
+    raise AssertionError(
+        f"No replica actor found for deployment '{deployment_name}' in app "
+        f"'{app_name}'."
+    )
+
+
+def test_tasks_cancelled_on_timeout(_skip_if_ff_not_enabled, serve_instance):
+    """Test that the async tasks are cancelled and cleaned up on timeout.
+
+    Beyond the 408 status code, this asserts that the per-request asyncio tasks
+    created by ``_direct_ingress_asgi`` (the request task and the disconnect-watcher
+    receive task) are actually cancelled and removed from the replica's event loop
+    after the timeout, rather than leaking (e.g. a receive task left parked on the
+    async queue).
+    """
+    name = "tasks-cancelled-on-timeout-deployment"
+
+    @serve.deployment(name=name)
+    class TasksCancelledOnTimeoutTest:
+        async def __call__(self):
+            await asyncio.sleep(10)
+            return "ok"
+
+    serve.run(TasksCancelledOnTimeoutTest.bind(), name=name)
+    http_url = get_application_url("HTTP", app_name=name)
+    headers = {SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER.encode("utf-8"): "1".encode("utf-8")}
+
+    replica = _get_replica_actor_handle(name, name)
+
+    def inflight_counts():
+        return ray.get(
+            replica._get_inflight_direct_ingress_task_counts_for_testing.remote()
+        )
+
+    # No direct-ingress request/receive tasks before we send anything.
+    assert inflight_counts() == {"request_tasks": 0, "receive_tasks": 0}
+
+    with ThreadPoolExecutor() as executor:
+        future = executor.submit(httpx.get, http_url, headers=headers)
+
+        # While the (slow) request is in flight, both the request task and the
+        # disconnect-watcher receive task should be present on the event loop.
+        wait_for_condition(
+            lambda: inflight_counts() == {"request_tasks": 1, "receive_tasks": 1},
+            timeout=10,
+        )
+
+        response = future.result()
+        assert response.status_code == 408
+
+    # After the timeout, both tasks must be cancelled and removed from the loop
+    # (not left pending / parked on the async queue).
+    wait_for_condition(
+        lambda: inflight_counts() == {"request_tasks": 0, "receive_tasks": 0},
+        timeout=10,
+    )
 
 
 def test_context_propagation(_skip_if_ff_not_enabled, serve_instance):

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2110,7 +2110,7 @@ def test_tasks_cancelled_on_timeout(_skip_if_ff_not_enabled, serve_instance):
 
     serve.run(TasksCancelledOnTimeoutTest.bind(), name=name)
     http_url = get_application_url("HTTP", app_name=name)
-    headers = {SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER.encode("utf-8"): "1".encode("utf-8")}
+    headers = {SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER: "1"}
 
     replica = _get_replica_actor_handle(name, name)
 


### PR DESCRIPTION
Before, the receive task would be left on the queue because it was never canceled in the request timeout path. This PR fixes that and adds a test for it.