### PR TITLE
[Data] Lower constant at which high memory issue detector emits warnings

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -87,6 +87,50 @@ from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
 
+SAFE_DEFAULT_LOGICAL_MEMORY_PER_CPU: Final[int] = int(
+    4
+    * GiB
+    * (
+        1
+        - DEFAULT_SYSTEM_RESERVED_MEMORY_PROPORTION
+        - DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
+    )
+)
+"""A safe default logical memory to request for map tasks and actors per logical CPU.
+
+Ray Data aims to guarantee that if you set each UDF's logical memory to at least
+the heap memory that UDF needs, the system won't oversubscribe tasks and actors.
+
+The problem is that if you set logical memory for some UDFs but not others, the
+unspecified ones fall back to 0 and the system oversubscribes anyway.
+
+To avoid that, we can default to ~2.57 GiB per CPU core. Here's where that magic number
+comes from: We want to pick the largest logical memory (so it's safe) that won't
+decrease concurrency (so we don't regress performance). Hyperscaler nodes usually
+have 4 GiB per CPU core, and Ray Core sets logical memory to physical memory minus
+30% for the object store and 10% for system-reserved memory. So, in the typical
+case, you end up with 4 GiB * 60% = ~2.57 GiB GiB of logical memory per core, and
+that's the highest you can go before you start decreasing concurrency.
+
+We use this heuristic over more sophisticated alternatives because a constant
+default is easy to reason about.
+"""
+
+
+def get_safe_default_logical_memory(ray_remote_args: Dict[str, Any]) -> int:
+    """Return a safe default logical memory (in bytes) for the given remote args."""
+    num_cpus = ray_remote_args.get("num_cpus")
+    if not num_cpus:
+        # If the map tasks or actors don't require logical CPUs, just assume it
+        # requires one logical CPU for the purpose of computing a default value.
+        default_memory = math.ceil(SAFE_DEFAULT_LOGICAL_MEMORY_PER_CPU)
+    else:
+        default_memory = math.ceil(SAFE_DEFAULT_LOGICAL_MEMORY_PER_CPU * num_cpus)
+
+    assert isinstance(default_memory, int), default_memory
+    assert default_memory > 0, default_memory
+    return default_memory
+
 
 @ray.remote(num_cpus=0)
 def _get_arrow_schema_from_block(block: Block) -> "pa.Schema":
@@ -161,35 +205,6 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     Warn if the size of the map UDF exceeds this threshold.
     """
 
-    DEFAULT_LOGICAL_MEMORY_PER_CPU: Final[int] = int(
-        4
-        * GiB
-        * (
-            1
-            - DEFAULT_SYSTEM_RESERVED_MEMORY_PROPORTION
-            - DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
-        )
-    )
-    """Default logical memory to request for map tasks and actors per logical CPU.
-
-    Ray Data aims to guarantee that if you set each UDF's logical memory to at least
-    the heap memory that UDF needs, the system won't oversubscribe tasks and actors.
-
-    The problem is that if you set logical memory for some UDFs but not others, the
-    unspecified ones fall back to 0 and the system oversubscribes anyway.
-
-    To avoid that, we default to ~2.57 GiB per CPU core. Here's where that magic number
-    comes from: We want to pick the largest logical memory (so it's safe) that won't
-    decrease concurrency (so we don't regress performance). Hyperscaler nodes usually
-    have 4 GiB per CPU core, and Ray Core sets logical memory to physical memory minus
-    30% for the object store and 10% for system-reserved memory. So, in the typical
-    case, you end up with 4 GiB * 60% = ~2.57 GiB GiB of logical memory per core, and
-    that's the highest you can go before you start decreasing concurrency.
-
-    We use this heuristic over more sophisticated alternatives because a constant
-    default is easy to reason about.
-    """
-
     def __init__(
         self,
         map_transformer: MapTransformer,
@@ -220,10 +235,10 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         # Configure a default logical memory to improve memory safety when the user has
         # specified memory for some UDFs but not others.
         if default_logical_memory_enabled:
-            self._set_default_logical_memory(ray_remote_args)
+            default_memory = get_safe_default_logical_memory(ray_remote_args)
+            ray_remote_args.setdefault("memory", default_memory)
             logger.debug(
-                f"Operator {name!r} set default logical memory to "
-                f"{ray_remote_args.get('memory')}"
+                f"Operator {name!r} set default logical memory to {default_memory}"
             )
 
         self._map_transformer = map_transformer
@@ -264,19 +279,6 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         # (e.g., schema evolution for Iceberg writes via on_write_start).
         self._on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = on_start
         self._on_start_called = False
-
-    def _set_default_logical_memory(self, ray_remote_args: Dict[str, Any]) -> None:
-        num_cpus = ray_remote_args.get("num_cpus")
-        if not num_cpus:
-            # If the map tasks or actors don't require logical CPUs, just assume it
-            # requires one logical CPU for the purpose of computing a default value.
-            default_memory = math.ceil(self.DEFAULT_LOGICAL_MEMORY_PER_CPU)
-        else:
-            default_memory = math.ceil(self.DEFAULT_LOGICAL_MEMORY_PER_CPU * num_cpus)
-
-        assert isinstance(default_memory, int), default_memory
-        assert default_memory > 0, default_memory
-        ray_remote_args.setdefault("memory", default_memory)
 
     @functools.cached_property
     def _map_transformer_ref(self) -> ObjectRef[MapTransformer]:

--- a/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
@@ -2,7 +2,10 @@ import textwrap
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List
 
-from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_operator import (
+    MapOperator,
+    get_safe_default_logical_memory,
+)
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.issue_detection.issue_detector import (
     Issue,
@@ -37,10 +40,6 @@ class HighMemoryIssueDetectorConfig:
 
 
 class HighMemoryIssueDetector(IssueDetector):
-    # Many nodes have a 4 GiB : 1 core ratio, but this isn't always the case (e.g., for
-    # high memory nodes).
-    _MEMORY_PER_CORE_ESTIMATE = 4 * 1024**3
-
     def __init__(
         self,
         dataset_id: str,
@@ -86,12 +85,11 @@ class HighMemoryIssueDetector(IssueDetector):
                 continue
 
             remote_args = op._get_dynamic_ray_remote_args()
-            num_cpus_per_task = remote_args.get("num_cpus", 1)
-            max_memory_per_task = self._MEMORY_PER_CORE_ESTIMATE * num_cpus_per_task
+            safe_memory_per_task = get_safe_default_logical_memory(remote_args)
 
             if (
                 op.metrics.average_max_uss_per_task > self._initial_memory_requests[op]
-                and op.metrics.average_max_uss_per_task >= max_memory_per_task
+                and op.metrics.average_max_uss_per_task >= safe_memory_per_task
             ):
                 message = HIGH_MEMORY_PERIODIC_WARNING.format(
                     op_name=op.name,

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -29,6 +29,7 @@ from ray.data._internal.issue_detection.detectors.hanging_detector import (
 from ray.data._internal.issue_detection.detectors.high_memory_detector import (
     HighMemoryIssueDetector,
 )
+from ray.data._internal.util import GiB
 from ray.data.block import BlockMetadata, TaskExecWorkerStats
 from ray.data.context import DataContext
 from ray.tests.conftest import *  # noqa
@@ -205,12 +206,12 @@ class TestHangingExecutionIssueDetector:
     "configured_memory, actual_memory, should_return_issue",
     [
         # User has appropriately configured memory, so no issue.
-        (4 * 1024**3, 4 * 1024**3, False),
+        (8 * GiB, 8 * GiB, False),
         # User hasn't configured memory correctly and memory use is high, so issue.
-        (None, 4 * 1024**3, True),
-        (1, 4 * 1024**3, True),
+        (None, 8 * GiB, True),
+        (1 * GiB, 8 * GiB, True),
         # User hasn't configured memory correctly but memory use is low, so no issue.
-        (None, 4 * 1024**3 - 1, False),
+        (None, 1 * GiB, False),
     ],
 )
 def test_high_memory_detection(


### PR DESCRIPTION
## Description

A long time ago, we added an "issue detector" that emits warnings when UDFs use more than 4 GiB USS per logical CPU. The rationale is that nodes typically have 4 GiB of physical memory per core, and if you use more than that you'll likely encounter OOMs.

Recently, I added `default_map_logical_memory_enabled` flag in https://github.com/ray-project/ray/pull/63814. If enabled, it causes tasks to default to a slightly different constant of ~2.6 GiB USS per logical CPU.

In this PR, I'm unifying the issue detector and default map memory to use the 2.6 GiB USS constant. My motivation is to avoid duplicate and divergent code paths for similar logic. Also, the 4 GiB was too permissive, because it doesn't account for memory from object store and system.

## Related issues

* https://github.com/ray-project/ray/pull/63814
* https://github.com/ray-project/ray/pull/55155
