### PR TITLE
[Data] Enable memory-safety best practices in video object detection benchmark

### DIFF
--- a/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
@@ -86,12 +86,21 @@ def crop_image(row):
 
 
 def run_pipeline():
+    # These are best practices we recommend to avoid OOMs, though they're opt-in and
+    # not enabled by default.
+    ray.data.DataContext.isolate_read_workers = True
+    ray.data.DataContext.default_map_logical_memory_enabled = True
+
     ds = ray.data.read_videos(INPUT_PATH)
     ds = ds.map(resize_frame)
     ds = ds.map_batches(
         ExtractImageFeatures,
         batch_size=BATCH_SIZE,
         num_gpus=1.0,
+        # Ray Data can't prevent OOMs if you don't set `memory` for high-memory UDFs
+        # like this one. We chose this value because it was the max USS we observed in
+        # previous nightly test runs.
+        memory=3_529_273_344,  # ~3.5 GB
     )
     ds = ds.flat_map(explode_features)
     ds = ds.map(crop_image)


### PR DESCRIPTION
## Description

The video object detection benchmark previously ran with the default Ray Data settings, which don't guard against the OOMs we want this benchmark to be resilient to. This enables the memory-safety best practices we recommend to users so the benchmark exercises (and validates) them.

Specifically, it:

- Sets `isolate_read_workers = True` so other operators' tasks don't get co-scheduled with read workers.
- Sets `default_map_logical_memory_enabled = True` so the system reserves logical memory for map UDFs by default.
- Sets `memory=3_529_273_344` (~3.5 GB) on the high-memory `ExtractImageFeatures` UDF. Ray Data can't prevent OOMs unless `memory` is specified for high-memory UDFs; this value is the max USS observed in previous nightly runs.

These are opt-in settings (not enabled by default), so they only affect this benchmark.

## Related issues

## Additional information