### PR TITLE
[Data] Export `from_blocks` from `ray.data`

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -154,6 +154,7 @@ __all__ = [
     "from_items",
     "from_arrow",
     "from_arrow_refs",
+    "from_blocks",
     "from_mars",
     "from_modin",
     "from_numpy",


### PR DESCRIPTION
## Description

`from_blocks` is a utility function that creates a dataset from the user-provided input blocks. It's useful for testing and reproduction scripts because it guarantees that the dataset starts with the exact given inputs without any unexpected changes. 

In this PR, I'm exporting it from the `ray.data` package so that linters don't complain. 

<img width="323" height="100" alt="image" src="https://github.com/user-attachments/assets/b63e3f73-f62e-4320-9a0d-95eca2486569" />

## Related issues

## Additional information
