### PR TITLE
[autoscaler] Ignore profile output in captured SSH commands

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -44,6 +44,9 @@ MAX_HOME_RETRIES = 3
 HOME_RETRY_DELAY_S = 5
 
 _config = {"use_login_shells": True, "silent_rsync": True}
+_OUTPUT_MARKER_TOKEN_LENGTH = 16
+_OUTPUT_START_MARKER_PREFIX = "__ray_command_output_start_"
+_OUTPUT_END_MARKER_PREFIX = "__ray_command_output_end_"
 
 
 def is_rsync_silent():
@@ -111,6 +114,57 @@ def _with_interactive(cmd):
         f"export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ({cmd})"
     )
     return ["bash", "--login", "-c", "-i", quote(force_interactive)]
+
+
+def _with_output_markers(cmd: str) -> str:
+    marker_token = hashlib.sha256(cmd.encode()).hexdigest()[
+        :_OUTPUT_MARKER_TOKEN_LENGTH
+    ]
+    start_marker = f"{_OUTPUT_START_MARKER_PREFIX}{marker_token}__"
+    end_marker = f"{_OUTPUT_END_MARKER_PREFIX}{marker_token}__"
+    return (
+        "__ray_command_status=0; "
+        f"printf '%s\\n' {start_marker}; "
+        f"({cmd}) || __ray_command_status=$?; "
+        f"printf '\\n%s\\n' {end_marker}; "
+        "exit $__ray_command_status"
+    )
+
+
+def _extract_output_between_markers(output: bytes) -> bytes:
+    start_prefix = _OUTPUT_START_MARKER_PREFIX.encode()
+    end_prefix = _OUTPUT_END_MARKER_PREFIX.encode()
+
+    start = output.find(start_prefix)
+    if start == -1:
+        return output
+
+    start_marker_end = start + len(start_prefix) + _OUTPUT_MARKER_TOKEN_LENGTH + 2
+    start_marker = output[start:start_marker_end]
+    if not start_marker.endswith(b"__"):
+        return output
+
+    marker_token = start_marker[
+        len(start_prefix) : len(start_prefix) + _OUTPUT_MARKER_TOKEN_LENGTH
+    ]
+    end_marker = end_prefix + marker_token + b"__"
+
+    start += len(start_marker)
+    if output[start : start + 2] == b"\r\n":
+        start += 2
+    elif output[start : start + 1] == b"\n":
+        start += 1
+
+    end = output.find(end_marker, start)
+    if end == -1:
+        return output
+
+    payload = output[start:end]
+    if payload.endswith(b"\r\n"):
+        payload = payload[:-2]
+    elif payload.endswith(b"\n"):
+        payload = payload[:-1]
+    return payload
 
 
 class SSHOptions:
@@ -295,7 +349,8 @@ class SSHCommandRunner(CommandRunnerInterface):
                     use_login_shells=is_using_login_shells(),
                 )
             else:
-                return self.process_runner.check_output(final_cmd)
+                output = self.process_runner.check_output(final_cmd)
+                return _extract_output_between_markers(output)
         except subprocess.CalledProcessError as e:
             joined_cmd = " ".join(final_cmd)
             if not is_using_login_shells():
@@ -378,6 +433,8 @@ class SSHCommandRunner(CommandRunnerInterface):
         if cmd:
             if environment_variables:
                 cmd = _with_environment_variables(cmd, environment_variables)
+            if with_output:
+                cmd = _with_output_markers(cmd)
             if is_using_login_shells():
                 final_cmd += _with_interactive(cmd)
             else:

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -139,9 +139,10 @@ def _extract_output_between_markers(output: bytes) -> bytes:
     if start == -1:
         return output
 
-    start_marker_end = start + len(start_prefix) + _OUTPUT_MARKER_TOKEN_LENGTH + 2
+    expected_marker_len = len(start_prefix) + _OUTPUT_MARKER_TOKEN_LENGTH + 2
+    start_marker_end = start + expected_marker_len
     start_marker = output[start:start_marker_end]
-    if not start_marker.endswith(b"__"):
+    if len(start_marker) != expected_marker_len or not start_marker.endswith(b"__"):
         return output
 
     marker_token = start_marker[

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -5,6 +5,9 @@ from getpass import getuser
 import pytest
 
 from ray.autoscaler._private.command_runner import (
+    _OUTPUT_END_MARKER_PREFIX,
+    _OUTPUT_MARKER_TOKEN_LENGTH,
+    _OUTPUT_START_MARKER_PREFIX,
     DockerCommandRunner,
     SSHCommandRunner,
     _with_environment_variables,
@@ -122,6 +125,45 @@ def test_ssh_command_runner():
     for x, y in zip(process_runner.calls[0], expected):
         assert x == y
     process_runner.assert_has_call("1.2.3.4", exact=expected)
+
+
+def test_ssh_command_runner_with_output_ignores_profile_output():
+    process_runner = MockProcessRunner()
+    provider = MockProvider()
+    provider.create_node({}, {}, 1)
+    cmd_runner = SSHCommandRunner(
+        log_prefix="prefix",
+        node_id="0",
+        provider=provider,
+        auth_config=auth_config,
+        cluster_name="cluster",
+        process_runner=process_runner,
+        use_internal_ip=False,
+    )
+
+    marker_token = hashlib.sha256("echo hello".encode()).hexdigest()[
+        :_OUTPUT_MARKER_TOKEN_LENGTH
+    ]
+    start_marker = f"{_OUTPUT_START_MARKER_PREFIX}{marker_token}__"
+    end_marker = f"{_OUTPUT_END_MARKER_PREFIX}{marker_token}__"
+
+    process_runner.respond_to_call(
+        "echo hello",
+        [
+            "\n".join(
+                [
+                    "profile script banner",
+                    start_marker,
+                    "hello",
+                    end_marker,
+                    "profile script footer",
+                ]
+            )
+        ],
+    )
+
+    assert cmd_runner.run("echo hello", with_output=True) == b"hello"
+    process_runner.assert_has_call("1.2.3.4", pattern=start_marker)
 
 
 def test_docker_command_runner():


### PR DESCRIPTION
## Why are these changes needed?

Fixes #62045.

Autoscaler SSH inspection commands capture stdout and parse it for values such as Docker inspect JSON. When a remote login/profile script prints a banner or other text to stdout, that extra output can pollute the captured result and make parsing brittle.

This wraps captured SSH commands with Ray-specific stdout markers and strips anything outside the marker range before returning the command output. The command exit status is preserved, and commands without markers fall back to the previous behavior.

## Related issue number

Closes #62045

## Checks

- [x] `python3 -m py_compile python/ray/autoscaler/_private/command_runner.py python/ray/tests/test_command_runner.py`
- [x] `.venv/bin/python -m ruff check python/ray/autoscaler/_private/command_runner.py python/ray/tests/test_command_runner.py`
- [x] `.venv/bin/python -m black --check python/ray/autoscaler/_private/command_runner.py python/ray/tests/test_command_runner.py`
- [x] `git diff --check`
- [ ] `PYTHONPATH=python .venv/bin/python -m pytest python/ray/tests/test_command_runner.py -q` (blocked locally: this checkout has not built the compiled `ray._raylet` extension)

Made with [Cursor](https://cursor.com)