### PR TITLE
[runtime env] Expand working dir env vars in uv install options

### DIFF
--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 from asyncio import create_task, get_running_loop
@@ -18,6 +19,17 @@ from ray._private.runtime_env.utils import check_output_cmd
 from ray._private.utils import get_directory_size_bytes
 
 default_logger = logging.getLogger(__name__)
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _expand_runtime_env_vars(value: str, env: Dict[str, str]) -> str:
+    """Expand environment variables using the subprocess environment."""
+
+    def replace(match: re.Match) -> str:
+        env_var = match.group(1) or match.group(2)
+        return env.get(env_var, match.group(0))
+
+    return _ENV_VAR_PATTERN.sub(replace, value)
 
 
 def _get_uv_hash(uv_dict: Dict) -> str:
@@ -27,12 +39,24 @@ def _get_uv_hash(uv_dict: Dict) -> str:
     return hash_val
 
 
+def _has_env_var(value: str) -> bool:
+    return _ENV_VAR_PATTERN.search(value) is not None
+
+
 def get_uri(runtime_env: Dict) -> Optional[str]:
     """Return `"uv://<hashed_dependencies>"`, or None if no GC required."""
     uv = runtime_env.get("uv")
     if uv is not None:
         if isinstance(uv, dict):
-            uri = "uv://" + _get_uv_hash(uv_dict=uv)
+            hash_input = uv
+            uv_pip_install_options = uv.get("uv_pip_install_options") or []
+            if any(_has_env_var(option) for option in uv_pip_install_options):
+                hash_input = {
+                    "uv": uv,
+                    "env_vars": runtime_env.get("env_vars", {}),
+                    "working_dir": runtime_env.get("working_dir"),
+                }
+            uri = "uv://" + _get_uv_hash(uv_dict=hash_input)
         elif isinstance(uv, list):
             uri = "uv://" + _get_uv_hash(uv_dict=dict(packages=uv))
         else:
@@ -178,7 +202,9 @@ class UvProcessor:
 
         uv_opt_list = self._uv_config.get("uv_pip_install_options", ["--no-cache"])
         if uv_opt_list:
-            uv_install_cmd += uv_opt_list
+            uv_install_cmd += [
+                _expand_runtime_env_vars(option, pip_env) for option in uv_opt_list
+            ]
 
         logger.info("Installing python requirements to %s", virtualenv_path)
         await check_output_cmd(uv_install_cmd, logger=logger, cwd=cwd, env=pip_env)

--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -11,6 +11,7 @@ import sys
 from asyncio import create_task, get_running_loop
 from typing import Dict, List, Optional
 
+import ray._private.ray_constants as ray_constants
 from ray._common.utils import try_to_create_directory
 from ray._private.runtime_env import dependency_utils, virtualenv_utils
 from ray._private.runtime_env.packaging import Protocol, parse_uri
@@ -23,13 +24,22 @@ _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
 
 
 def _expand_runtime_env_vars(value: str, env: Dict[str, str]) -> str:
-    """Expand environment variables using the subprocess environment."""
+    """Expand environment variables using runtime-env controlled values."""
 
     def replace(match: re.Match) -> str:
         env_var = match.group(1) or match.group(2)
         return env.get(env_var, match.group(0))
 
     return _ENV_VAR_PATTERN.sub(replace, value)
+
+
+def _get_uv_install_option_env(env_vars: Dict[str, str]) -> Dict[str, str]:
+    """Return the bounded env context used for uv install option expansion."""
+    uv_install_option_env = dict(env_vars)
+    working_dir_env_var = ray_constants.RAY_RUNTIME_ENV_CREATE_WORKING_DIR_ENV_VAR
+    if working_dir_env_var in os.environ:
+        uv_install_option_env[working_dir_env_var] = os.environ[working_dir_env_var]
+    return uv_install_option_env
 
 
 def _get_uv_hash(uv_dict: Dict) -> str:
@@ -95,6 +105,9 @@ class UvProcessor:
         self._uv_config = self._runtime_env.uv_config()
         self._uv_env = os.environ.copy()
         self._uv_env.update(self._runtime_env.env_vars())
+        self._uv_install_option_env = _get_uv_install_option_env(
+            self._runtime_env.env_vars()
+        )
 
     async def _install_uv(
         self, path: str, cwd: str, pip_env: dict, logger: logging.Logger
@@ -203,7 +216,8 @@ class UvProcessor:
         uv_opt_list = self._uv_config.get("uv_pip_install_options", ["--no-cache"])
         if uv_opt_list:
             uv_install_cmd += [
-                _expand_runtime_env_vars(option, pip_env) for option in uv_opt_list
+                _expand_runtime_env_vars(option, self._uv_install_option_env)
+                for option in uv_opt_list
             ]
 
         logger.info("Installing python requirements to %s", virtualenv_path)

--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -53,7 +53,7 @@ def get_uri(runtime_env: Dict) -> Optional[str]:
             if any(_has_env_var(option) for option in uv_pip_install_options):
                 hash_input = {
                     "uv": uv,
-                    "env_vars": runtime_env.get("env_vars", {}),
+                    "env_vars": runtime_env.get("env_vars") or {},
                     "working_dir": runtime_env.get("working_dir"),
                 }
             uri = "uv://" + _get_uv_hash(uv_dict=hash_input)

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -250,7 +250,11 @@ def parse_and_validate_uv(uv: Union[str, List[str], Dict]) -> Optional[Dict]:
     # Deduplicate packages for package lists.
     result["packages"] = list(OrderedDict.fromkeys(result["packages"]))
 
-    if len(result["packages"]) == 0:
+    if len(result["packages"]) == 0 and result.get("uv_pip_install_options") in (
+        None,
+        [],
+        ["--no-cache"],
+    ):
         result = None
     logger.debug(f"Rewrote runtime_env `uv` field from {uv} to {result}.")
     return result

--- a/python/ray/tests/test_runtime_env_uv.py
+++ b/python/ray/tests/test_runtime_env_uv.py
@@ -111,6 +111,34 @@ def test_package_install_with_requirements(shutdown_only, tmp_working_dir):
     assert ray.get(f.remote()) == "2.32.3"
 
 
+def test_working_dir_applies_for_uv_pip_install_options(shutdown_only):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        working_dir = Path(tmp_dir)
+        with open(working_dir / "requirements.txt", "w") as f:
+            f.write("pip-install-test==0.5")
+
+        ray.init(
+            runtime_env={
+                "working_dir": str(working_dir),
+                "uv": {
+                    "packages": [],
+                    "uv_pip_install_options": [
+                        "--requirement="
+                        "${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/requirements.txt"
+                    ],
+                },
+            }
+        )
+
+        @ray.remote
+        def test_import():
+            import pip_install_test
+
+            return pip_install_test.__name__
+
+        assert ray.get(test_import.remote()) == "pip_install_test"
+
+
 # Install different versions of the same package across different tasks, used to check
 # uv cache doesn't break runtime env requirement.
 def test_package_install_with_different_versions(shutdown_only):

--- a/python/ray/tests/unit/test_runtime_env_uv.py
+++ b/python/ray/tests/unit/test_runtime_env_uv.py
@@ -7,11 +7,15 @@ from ray._private.runtime_env import uv
 
 
 class TestRuntimeEnv:
+    def __init__(self, uv_config=None, env_vars=None):
+        self._uv_config = uv_config or {"packages": ["requests"]}
+        self._env_vars = env_vars or {}
+
     def uv_config(self):
-        return {"packages": ["requests"]}
+        return self._uv_config
 
     def env_vars(self):
-        return {}
+        return self._env_vars
 
 
 @pytest.fixture
@@ -39,6 +43,67 @@ async def test_run(mock_install_uv, mock_install_uv_packages):
 
     uv_processor = uv.UvProcessor(target_dir=target_dir, runtime_env=runtime_env)
     await uv_processor._run()
+
+
+def test_expand_runtime_env_vars():
+    env = {"WORKING_DIR": "/tmp/ray/session/working_dir", "PACKAGE_INDEX": "test"}
+
+    assert (
+        uv._expand_runtime_env_vars(
+            "--requirements=${WORKING_DIR}/requirements.txt", env
+        )
+        == "--requirements=/tmp/ray/session/working_dir/requirements.txt"
+    )
+    assert uv._expand_runtime_env_vars("--index=$PACKAGE_INDEX", env) == "--index=test"
+    assert (
+        uv._expand_runtime_env_vars("--constraint=${UNKNOWN}/constraints.txt", env)
+        == "--constraint=${UNKNOWN}/constraints.txt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_uv_packages_expands_install_options(tmp_path):
+    working_dir = tmp_path / "working_dir"
+    target_dir = tmp_path / "uv_env"
+    exec_cwd = tmp_path / "exec_cwd"
+    working_dir.mkdir()
+    target_dir.mkdir()
+    exec_cwd.mkdir()
+
+    runtime_env = TestRuntimeEnv(
+        uv_config={
+            "packages": [],
+            "uv_pip_install_options": [
+                "--requirement=${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/requirements.txt",
+                "--constraint=$RAY_RUNTIME_ENV_CREATE_WORKING_DIR/constraints.txt",
+            ],
+        },
+        env_vars={"RAY_RUNTIME_ENV_CREATE_WORKING_DIR": str(working_dir)},
+    )
+    uv_processor = uv.UvProcessor(target_dir=str(target_dir), runtime_env=runtime_env)
+    captured_cmds = []
+
+    async def fake_check_output_cmd(cmd, **kwargs):
+        captured_cmds.append(cmd)
+        return ""
+
+    with patch.object(uv_processor, "_check_uv_existence", return_value=True), patch(
+        "ray._private.runtime_env.uv.check_output_cmd", fake_check_output_cmd
+    ):
+        await uv_processor._install_uv_packages(
+            str(target_dir),
+            [],
+            str(exec_cwd),
+            uv_processor._uv_env,
+            uv.default_logger,
+        )
+
+    assert len(captured_cmds) == 1
+    assert f"--requirement={working_dir}/requirements.txt" in captured_cmds[0]
+    assert f"--constraint={working_dir}/constraints.txt" in captured_cmds[0]
+    assert not any(
+        "RAY_RUNTIME_ENV_CREATE_WORKING_DIR" in arg for arg in captured_cmds[0]
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/unit/test_runtime_env_uv.py
+++ b/python/ray/tests/unit/test_runtime_env_uv.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from unittest.mock import patch
 
@@ -104,6 +105,49 @@ async def test_install_uv_packages_expands_install_options(tmp_path):
     assert not any(
         "RAY_RUNTIME_ENV_CREATE_WORKING_DIR" in arg for arg in captured_cmds[0]
     )
+
+
+@pytest.mark.asyncio
+async def test_install_uv_packages_does_not_expand_host_only_env_vars(tmp_path):
+    target_dir = tmp_path / "uv_env"
+    exec_cwd = tmp_path / "exec_cwd"
+    target_dir.mkdir()
+    exec_cwd.mkdir()
+
+    runtime_env = TestRuntimeEnv(
+        uv_config={
+            "packages": [],
+            "uv_pip_install_options": [
+                "--index-url=$HOST_ONLY_UV_INDEX",
+                "--constraint=$RUNTIME_ENV_CONSTRAINT",
+            ],
+        },
+        env_vars={"RUNTIME_ENV_CONSTRAINT": "constraints.txt"},
+    )
+    captured_cmds = []
+
+    async def fake_check_output_cmd(cmd, **kwargs):
+        captured_cmds.append(cmd)
+        return ""
+
+    with patch.dict(os.environ, {"HOST_ONLY_UV_INDEX": "https://example.com/simple"}):
+        uv_processor = uv.UvProcessor(
+            target_dir=str(target_dir), runtime_env=runtime_env
+        )
+        with patch.object(
+            uv_processor, "_check_uv_existence", return_value=True
+        ), patch("ray._private.runtime_env.uv.check_output_cmd", fake_check_output_cmd):
+            await uv_processor._install_uv_packages(
+                str(target_dir),
+                [],
+                str(exec_cwd),
+                uv_processor._uv_env,
+                uv.default_logger,
+            )
+
+    assert len(captured_cmds) == 1
+    assert "--index-url=$HOST_ONLY_UV_INDEX" in captured_cmds[0]
+    assert "--constraint=constraints.txt" in captured_cmds[0]
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/unit/test_runtime_env_validation.py
+++ b/python/ray/tests/unit/test_runtime_env_validation.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 from ray import job_config
-from ray._private.runtime_env import validation
+from ray._private.runtime_env import uv, validation
 from ray._private.runtime_env.pip import _get_pip_hash
 from ray._private.runtime_env.plugin_schema_manager import RuntimeEnvPluginSchemaManager
 from ray._private.runtime_env.validation import (
@@ -471,6 +471,65 @@ class TestValidateUV:
             "uv_pip_install_options": ["--no-cache"],
             "uv_version": "==0.4.30",
         }
+
+        # Empty packages are ignored unless custom uv install options may provide
+        # a dependency source such as a requirements file.
+        assert validation.parse_and_validate_uv({"packages": []}) is None
+        assert (
+            validation.parse_and_validate_uv(
+                {"packages": [], "uv_pip_install_options": []}
+            )
+            is None
+        )
+        result = validation.parse_and_validate_uv(
+            {
+                "packages": [],
+                "uv_pip_install_options": [
+                    "--requirement=${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/requirements.txt"
+                ],
+            }
+        )
+        assert result == {
+            "packages": [],
+            "uv_check": False,
+            "uv_pip_install_options": [
+                "--requirement=${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/requirements.txt"
+            ],
+        }
+
+    def test_uv_uri_includes_context_for_env_sensitive_options(self):
+        base_uv = {
+            "packages": [],
+            "uv_check": False,
+            "uv_pip_install_options": [
+                "--requirement=${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/requirements.txt"
+            ],
+        }
+        first_uri = uv.get_uri(
+            {
+                "working_dir": "gcs://first.zip",
+                "env_vars": {"CUSTOM_INDEX": "first"},
+                "uv": base_uv,
+            }
+        )
+        second_uri = uv.get_uri(
+            {
+                "working_dir": "gcs://second.zip",
+                "env_vars": {"CUSTOM_INDEX": "second"},
+                "uv": base_uv,
+            }
+        )
+        assert first_uri != second_uri
+
+    def test_uv_uri_unchanged_for_options_without_env_vars(self):
+        uv_config = {
+            "packages": ["requests"],
+            "uv_check": False,
+            "uv_pip_install_options": ["--no-cache"],
+        }
+        assert uv.get_uri({"working_dir": "gcs://first.zip", "uv": uv_config}) == (
+            uv.get_uri({"working_dir": "gcs://second.zip", "uv": uv_config})
+        )
 
 
 class TestValidatePip:

--- a/python/ray/tests/unit/test_runtime_env_validation.py
+++ b/python/ray/tests/unit/test_runtime_env_validation.py
@@ -521,6 +521,16 @@ class TestValidateUV:
         )
         assert first_uri != second_uri
 
+        assert uv.get_uri({"working_dir": "gcs://first.zip", "uv": base_uv}) == (
+            uv.get_uri(
+                {
+                    "working_dir": "gcs://first.zip",
+                    "env_vars": None,
+                    "uv": base_uv,
+                }
+            )
+        )
+
     def test_uv_uri_unchanged_for_options_without_env_vars(self):
         uv_config = {
             "packages": ["requests"],


### PR DESCRIPTION
## Why are these changes needed?

Fixes #59343.

Runtime env setup creates `working_dir` before other plugins and exposes the unpacked path through `RAY_RUNTIME_ENV_CREATE_WORKING_DIR`. `pip` and `conda` can use that variable to reference requirement files inside the working directory, but `uv_pip_install_options` were passed to `uv` as subprocess argv values without shell expansion.

This expands `$VAR` and `${VAR}` in `uv_pip_install_options` against the same environment passed to the `uv` subprocess, preserves unknown variables unchanged, and keeps UV cache keys distinct when env-sensitive options depend on `working_dir` or `env_vars`.

## Related issue number

Closes #59343

## Checks

- [x] `python3 -m py_compile python/ray/_private/runtime_env/uv.py python/ray/_private/runtime_env/validation.py python/ray/tests/unit/test_runtime_env_uv.py python/ray/tests/test_runtime_env_uv.py python/ray/tests/unit/test_runtime_env_validation.py`
- [x] `.venv/bin/python -m ruff check python/ray/_private/runtime_env/uv.py python/ray/_private/runtime_env/validation.py python/ray/tests/unit/test_runtime_env_uv.py python/ray/tests/test_runtime_env_uv.py python/ray/tests/unit/test_runtime_env_validation.py`
- [x] `.venv/bin/python -m black --check python/ray/_private/runtime_env/uv.py python/ray/_private/runtime_env/validation.py python/ray/tests/unit/test_runtime_env_uv.py python/ray/tests/test_runtime_env_uv.py python/ray/tests/unit/test_runtime_env_validation.py`
- [x] `git diff --check`
- [ ] `.venv/bin/python -m pytest ...` (blocked locally: this checkout has not built the compiled `ray._raylet` extension, and test conftest imports `ray`)
- [ ] `.venv/bin/pre-commit run --files ...` (blocked locally: hook env setup failed with SSL certificate verification errors while fetching dependencies)

Made with [Cursor](https://cursor.com)