### PR TITLE
[Data] Disable write operators throttling

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -151,9 +151,7 @@ class ActorPoolMapOperator(MapOperator):
             default_logical_memory_enabled: If ``True``, the operator launches actors
                 with a default logical ``memory``. The method for choosing the
                 default is an implementation detail.
-            throttling_disabled: If ``True``, exempt this operator from object-store
-                resource reservation/throttling. Intended for terminal "drain"
-                operators (e.g. writes) whose object-store output is negligible.
+            throttling_disabled: If ``True``, exempt this operator from resource reservation/throttling.
         """
         super().__init__(
             map_transformer,

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -116,6 +116,7 @@ class ActorPoolMapOperator(MapOperator):
         target_max_block_size_override: Optional[int] = None,
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         default_logical_memory_enabled: bool = False,
+        throttling_disabled: bool = False,
     ):
         """Create an ActorPoolMapOperator instance.
 
@@ -150,6 +151,9 @@ class ActorPoolMapOperator(MapOperator):
             default_logical_memory_enabled: If ``True``, the operator launches actors
                 with a default logical ``memory``. The method for choosing the
                 default is an implementation detail.
+            throttling_disabled: If ``True``, exempt this operator from object-store
+                resource reservation/throttling. Intended for terminal "drain"
+                operators (e.g. writes) whose object-store output is negligible.
         """
         super().__init__(
             map_transformer,
@@ -165,6 +169,7 @@ class ActorPoolMapOperator(MapOperator):
             ray_remote_args,
             on_start,
             default_logical_memory_enabled,
+            throttling_disabled=throttling_disabled,
         )
 
         self._min_rows_per_bundle = min_rows_per_bundle

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -408,9 +408,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 scheduled on the same worker processes as this operator's. This flag
                 is useful to prevent side-effects from affecting other operators, like
                 large PyArrow memory allocations.
-            throttling_disabled: If ``True``, exempt this operator from object-store
-                resource reservation/throttling. Intended for terminal "drain"
-                operators (e.g. writes) whose object-store output is negligible.
+            throttling_disabled: If ``True``, exempt this operator from resource reservation/throttling.
 
         Returns:
             A ``MapOperator`` instance whose concrete subclass depends on the
@@ -761,10 +759,6 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         return self._supports_fusion
 
     def throttling_disabled(self) -> bool:
-        # Terminal "drain" operators (e.g. writes) emit negligible object-store
-        # output, so excluding them from resource reservation lets them run as fast
-        # as CPU allows instead of being gated on object-store budget. See
-        # ``ReservationOpResourceAllocator.is_op_eligible``.
         return self._throttling_disabled
 
     def num_active_tasks(self) -> int:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -205,6 +205,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         ray_remote_args: Optional[Dict[str, Any]],
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         default_logical_memory_enabled: bool = False,
+        throttling_disabled: bool = False,
     ):
         # NOTE: This constructor should not be called directly; use MapOperator.create()
         # instead.
@@ -228,6 +229,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
 
         self._map_transformer = map_transformer
         self._supports_fusion = supports_fusion
+        self._throttling_disabled = throttling_disabled
         self._map_task_kwargs = map_task_kwargs
         self._ray_remote_args = ray_remote_args
         self._ray_remote_args_fn = ray_remote_args_fn
@@ -365,6 +367,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         per_block_limit: Optional[int] = None,
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         isolate_workers: bool = False,
+        throttling_disabled: bool = False,
     ) -> "MapOperator":
         """Create a MapOperator.
 
@@ -405,6 +408,9 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 scheduled on the same worker processes as this operator's. This flag
                 is useful to prevent side-effects from affecting other operators, like
                 large PyArrow memory allocations.
+            throttling_disabled: If ``True``, exempt this operator from object-store
+                resource reservation/throttling. Intended for terminal "drain"
+                operators (e.g. writes) whose object-store output is negligible.
 
         Returns:
             A ``MapOperator`` instance whose concrete subclass depends on the
@@ -447,6 +453,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 on_start=on_start,
                 isolate_workers=isolate_workers,
                 default_logical_memory_enabled=data_context.default_map_logical_memory_enabled,
+                throttling_disabled=throttling_disabled,
             )
         elif isinstance(compute_strategy, ActorPoolStrategy):
             from ray.data._internal.execution.operators import (
@@ -475,6 +482,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 ray_remote_args=ray_remote_args,
                 on_start=on_start,
                 default_logical_memory_enabled=data_context.default_map_logical_memory_enabled,
+                throttling_disabled=throttling_disabled,
             )
         else:
             raise ValueError(f"Unsupported execution strategy {compute_strategy}")
@@ -751,6 +759,13 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
 
     def supports_fusion(self) -> bool:
         return self._supports_fusion
+
+    def throttling_disabled(self) -> bool:
+        # Terminal "drain" operators (e.g. writes) emit negligible object-store
+        # output, so excluding them from resource reservation lets them run as fast
+        # as CPU allows instead of being gated on object-store budget. See
+        # ``ReservationOpResourceAllocator.is_op_eligible``.
+        return self._throttling_disabled
 
     def num_active_tasks(self) -> int:
         # Override `num_active_tasks` to only include data tasks and exclude

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -46,6 +46,7 @@ class TaskPoolMapOperator(MapOperator):
         on_start: Optional[Callable[[Optional["pa.Schema"]], None]] = None,
         isolate_workers: bool = False,
         default_logical_memory_enabled: bool = False,
+        throttling_disabled: bool = False,
     ):
         """Create an TaskPoolMapOperator instance.
 
@@ -82,6 +83,9 @@ class TaskPoolMapOperator(MapOperator):
             default_logical_memory_enabled: If ``True``, the operator launches tasks
                 with a default logical ``memory``. The method for choosing the
                 default is an implementation detail.
+            throttling_disabled: If ``True``, exempt this operator from object-store
+                resource reservation/throttling. Intended for terminal "drain"
+                operators (e.g. writes) whose object-store output is negligible.
         """
         super().__init__(
             map_transformer,
@@ -97,6 +101,7 @@ class TaskPoolMapOperator(MapOperator):
             ray_remote_args,
             on_start,
             default_logical_memory_enabled,
+            throttling_disabled=throttling_disabled,
         )
 
         self._isolate_workers = isolate_workers

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -83,9 +83,7 @@ class TaskPoolMapOperator(MapOperator):
             default_logical_memory_enabled: If ``True``, the operator launches tasks
                 with a default logical ``memory``. The method for choosing the
                 default is an implementation detail.
-            throttling_disabled: If ``True``, exempt this operator from object-store
-                resource reservation/throttling. Intended for terminal "drain"
-                operators (e.g. writes) whose object-store output is negligible.
+            throttling_disabled: If ``True``, exempt this operator from resource reservation/throttling.
         """
         super().__init__(
             map_transformer,

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -146,6 +146,13 @@ def _plan_write_op_internal(
         min_rows_per_bundle=op.min_rows_per_bundled_input,
         compute_strategy=op.compute,
         on_start=on_start,
+        # Writes are a terminal drain: each task streams its input to external storage
+        # and emits only a tiny stats block to the object store. Throttling writes on
+        # the object-store reservation is counterproductive -- it keeps upstream
+        # outputs pinned in plasma longer because the write op can't drain them. Mark
+        # the write op as throttling-disabled so it is excluded from resource
+        # reservation and can run as fast as CPU/input availability allow.
+        throttling_disabled=True,
     )
 
     return map_op

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -148,10 +148,7 @@ def _plan_write_op_internal(
         on_start=on_start,
         # Writes are a terminal drain: each task streams its input to external storage
         # and emits only a tiny stats block to the object store. Throttling writes on
-        # the object-store reservation is counterproductive -- it keeps upstream
-        # outputs pinned in plasma longer because the write op can't drain them. Mark
-        # the write op as throttling-disabled so it is excluded from resource
-        # reservation and can run as fast as CPU/input availability allow.
+        # the object-store reservation is counterproductive.
         throttling_disabled=True,
     )
 


### PR DESCRIPTION
## Description
When write op's upstream is using a lot of object source (e.g. right after a shuffle reduce), there will be no budget for write tasks to run. But datasinks actually help relieve object store pressure, so we should disable throttle for it.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
