### PR TITLE
docs(core): improve NIXL RDT tuning guide

### DIFF
--- a/doc/source/ray-core/direct-transport/direct-transport.rst
+++ b/doc/source/ray-core/direct-transport/direct-transport.rst
@@ -211,16 +211,28 @@ Usage with NIXL (CPUs or NVIDIA GPUs)
 Installation
 ^^^^^^^^^^^^
 First, install NIXL with a plain ``pip install nixl``.
-For maximum performance, run the `install_gdrcopy.sh <https://github.com/ray-project/ray/blob/master/doc/tools/install_gdrcopy.sh>`__ script (e.g., ``install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "12.8" "x64"``). You can find available OS versions `here <https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2012.8/>`__. 
+For maximum performance, run the `install_gdrcopy.sh <https://github.com/ray-project/ray/blob/master/doc/tools/install_gdrcopy.sh>`__ script (e.g., ``install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "12.8" "x64"``). You can find available OS versions `here <https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2012.8/>`__.
 
 When Ray selects the ``UCX`` backend (see :ref:`NIXL backend selection <nixl-backend-selection>` below), set these UCX environment variables to either let UCX choose the right transport from all options, or so that you can set your preferred transport option yourself. These variables apply only to the ``UCX`` backend and have no effect when Ray runs the ``LIBFABRIC`` backend.
-
 
 .. code-block:: bash
 
    # Example UCX configuration, adjust according to your environment
    $ export UCX_TLS=all  # or specify specific transports like "rc,ud,sm,^cuda_ipc" ..etc
    $ export UCX_NET_DEVICES=all  # or specify network devices like "mlx5_0:1,mlx5_1:1"
+
+For RDMA and GPU transfers, also verify that the host and container are configured
+for memory registration:
+
+* Set the locked-memory limit high enough for your workload, commonly
+  ``ulimit -l unlimited``.
+* Load the ``nvidia-peermem`` kernel module when using GPUDirect RDMA.
+* Install and load GDRCopy (``gdrdrv``) for lower-latency GPU memory access.
+* Use IOMMU passthrough mode when IOMMU is enabled.
+* Avoid container memory or cgroup settings that prevent memory pinning.
+
+When debugging the ``UCX`` backend or UCX-related registration failures, set
+``UCX_LOG_LEVEL=debug`` before starting Ray workers.
 
 On the ``LIBFABRIC`` backend, use libfabric environment variables instead, such as ``FI_PROVIDER=efa`` to pin the provider and ``FI_LOG_LEVEL=Debug`` for diagnostics. See the `NIXL libfabric plugin documentation <https://github.com/ai-dynamo/nixl/blob/main/src/plugins/libfabric/README.md>`__ for additional configuration and troubleshooting.
 
@@ -275,6 +287,112 @@ You can also use NIXL to retrieve the result from references created by :func:`r
    :end-before: __nixl_put__and_get_end__
 
 
+NIXL performance tuning
+^^^^^^^^^^^^^^^^^^^^^^^
+
+NIXL memory registration can be expensive, especially when a workload repeatedly
+returns the same large tensor storage or many views of the same storage. By
+default, Ray registers memory when it creates NIXL RDT metadata for an
+``ObjectRef`` and deregisters that memory after the ``ObjectRef`` is garbage
+collected. This is convenient, but repeated register/deregister cycles can
+dominate small or frequent transfers.
+
+Use these APIs to reduce memory registration overhead:
+
+* :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>`:
+  Pre-register a long-lived tensor storage and keep it registered for the
+  lifetime of the worker process, or until you call
+  :func:`ray.experimental.deregister_nixl_memory <ray.experimental.deregister_nixl_memory>`.
+  This is best for model weights, cache blocks, or other tensors that are
+  returned many times.
+* :func:`ray.experimental.register_nixl_memory_pool <ray.experimental.register_nixl_memory_pool>`:
+  Allocate one CPU or GPU memory pool and register it once with NIXL. Ray copies
+  eligible tensors into pool-backed views for RDT transfers, avoiding repeated
+  registration of each tensor allocation.
+
+Pre-register reused tensors
+"""""""""""""""""""""""""""
+
+Call :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>`
+inside the actor that owns the tensor. Registering the full tensor storage also
+covers views into that storage, so repeated transfers of rows, shards, or slices
+can reuse one registration.
+
+.. literalinclude:: ../doc_code/direct_transport_nixl.py
+   :language: python
+   :start-after: __nixl_register_memory_start__
+   :end-before: __nixl_register_memory_end__
+
+Use this pattern when:
+
+* The same tensor storage is transferred repeatedly.
+* The tensor is long-lived relative to the RDT ``ObjectRef`` instances created
+  from it.
+* The tensor memory footprint is predictable enough to keep registered.
+
+Call :func:`ray.experimental.deregister_nixl_memory <ray.experimental.deregister_nixl_memory>`
+when the actor no longer needs the persistent registration. Live ``ObjectRef``
+instances that still reference the tensor keep their own registration references
+until they go out of scope.
+
+Use a memory pool for many transient tensors
+""""""""""""""""""""""""""""""""""""""""""""
+
+Call :func:`ray.experimental.register_nixl_memory_pool <ray.experimental.register_nixl_memory_pool>`
+once per worker process to pre-allocate and register a pool. The pool can be on
+CPU or CUDA, but Ray only uses it for tensors on the same device as the pool and
+for tensors that were not already pre-registered with
+:func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>`.
+
+.. literalinclude:: ../doc_code/direct_transport_nixl.py
+   :language: python
+   :start-after: __nixl_memory_pool_start__
+   :end-before: __nixl_memory_pool_end__
+
+The memory pool is useful when a producer creates many short-lived tensors with
+similar lifetimes. Within one RDT object, tensors that share the same underlying
+PyTorch storage, including views, share one pool allocation. Across calls, the
+same storage can reuse its pool slot while it remains tracked by Ray.
+
+Size the pool for the maximum live NIXL RDT data produced by the actor, not just
+for one transfer. The pool allocates space based on the entire underlying
+storage size of each tensor, so returning small views of large tensors can
+quickly exhaust the pool unless those views are cloned first to reclaim unused
+storage. If the pool is too small, Ray raises ``NixlOutOfMemoryError``. Increase
+the pool size or reduce the number of simultaneously live RDT ``ObjectRef``
+instances.
+
+Common NIXL anti-patterns
+"""""""""""""""""""""""""
+
+Avoid these patterns when tuning NIXL RDT workloads:
+
+* Returning many views of the same large storage without pre-registering the
+  base tensor or using a memory pool. Registering the base storage once is
+  usually cheaper than registering and deregistering the same storage repeatedly.
+* Creating a new CUDA tensor for every small message. Batch small tensors into
+  fewer RDT objects when possible, or use a memory pool sized for the expected
+  live working set.
+* Keeping unnecessary RDT ``ObjectRef`` instances alive. Registrations and pool
+  blocks are released only after the corresponding refs go out of scope and Ray
+  finishes dependent tasks.
+* Mutating tensor storage after creating an RDT ref when receivers expect
+  snapshot semantics. RDT objects are mutable references. Clone before
+  ``ray.put`` or before returning from an RDT method if the producer will mutate
+  the storage before consumers finish.
+* Registering memory too broadly. Persistent registrations improve repeated
+  transfers, but they also keep pinned or GPU memory registered. Deregister
+  tensors that are no longer reused.
+* Mixing CPU and CUDA tensors in one RDT object. All tensors in an RDT object
+  must have the same device type.
+* Returning non-contiguous tensor views. NIXL RDT requires tensors in the RDT
+  object to be contiguous.
+
+Profile before and after changing registrations. The best configuration depends
+on tensor sizes, view counts, transfer frequency, number of live refs, and the
+NIXL backend and transport configuration selected for the cluster.
+
+
 Summary
 -------
 
@@ -282,7 +400,11 @@ RDT allows Ray to store and pass objects directly between Ray actors, using acce
 Here are the main points to keep in mind:
 
 * If using a collective-based tensor transport (Gloo or NCCL), a collective group must be created ahead of time. NIXL just requires all involved actors to have NIXL installed.
-* Unlike objects in the Ray object store, RDT objects are *mutable*, meaning that Ray only holds a reference, not a copy, to the stored tensor(s). 
+* For NIXL, use :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>`
+  or :func:`ray.experimental.register_nixl_memory_pool <ray.experimental.register_nixl_memory_pool>`
+  to reduce repeated memory registration overhead in workloads that reuse tensor
+  storage or create many short-lived tensors.
+* Unlike objects in the Ray object store, RDT objects are *mutable*, meaning that Ray only holds a reference, not a copy, to the stored tensor(s).
 * Otherwise, actors can be used as normal.
 
 For a full list of limitations, see the :ref:`limitations <limitations>` section.

--- a/doc/source/ray-core/direct-transport/direct-transport.rst
+++ b/doc/source/ray-core/direct-transport/direct-transport.rst
@@ -214,16 +214,25 @@ Usage with NIXL (CPUs or NVIDIA GPUs)
 Installation
 ^^^^^^^^^^^^
 First, install NIXL with a plain ``pip install nixl``.
-For maximum performance, run the `install_gdrcopy.sh <https://github.com/ray-project/ray/blob/master/doc/tools/install_gdrcopy.sh>`__ script (e.g., ``install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "12.8" "x64"``). You can find available OS versions `here <https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2012.8/>`__. 
+For maximum performance, run the `install_gdrcopy.sh <https://github.com/ray-project/ray/blob/master/doc/tools/install_gdrcopy.sh>`__ script (for example, ``install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "12.8" "x64"``). You can find available OS versions `here <https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2012.8/>`__.
 
 When Ray selects the ``UCX`` backend (see :ref:`NIXL backend selection <nixl-backend-selection>` below), set these UCX environment variables to either let UCX choose the right transport from all options, or so that you can set your preferred transport option yourself. These variables apply only to the ``UCX`` backend and have no effect when Ray runs the ``LIBFABRIC`` backend.
-
 
 .. code-block:: bash
 
    # Example UCX configuration, adjust according to your environment
    $ export UCX_TLS=all  # or specify specific transports like "rc,ud,sm,^cuda_ipc" ..etc
    $ export UCX_NET_DEVICES=all  # or specify network devices like "mlx5_0:1,mlx5_1:1"
+
+For RDMA and GPU transfers, also verify that the host and container are configured for memory registration:
+
+* Set the locked-memory limit high enough for your workload, commonly ``ulimit -l unlimited``.
+* Load the ``nvidia-peermem`` kernel module when using GPUDirect RDMA.
+* Install and load GDRCopy (``gdrdrv``) for lower-latency GPU memory access.
+* Use IOMMU passthrough mode when IOMMU is enabled.
+* Avoid container memory or cgroup settings that prevent memory pinning.
+
+When debugging the ``UCX`` backend or UCX-related registration failures, set ``UCX_LOG_LEVEL=debug`` before starting Ray workers.
 
 On the ``LIBFABRIC`` backend, use libfabric environment variables instead, such as ``FI_PROVIDER=efa`` to pin the provider and ``FI_LOG_LEVEL=Debug`` for diagnostics. See the `NIXL libfabric plugin documentation <https://github.com/ai-dynamo/nixl/blob/main/src/plugins/libfabric/README.md>`__ for additional configuration and troubleshooting.
 
@@ -278,6 +287,64 @@ You can also use NIXL to retrieve the result from references created by :func:`r
    :end-before: __nixl_put__and_get_end__
 
 
+NIXL performance tuning
+^^^^^^^^^^^^^^^^^^^^^^^
+
+NIXL memory registration can be expensive, especially when a workload repeatedly returns the same large tensor storage or many views of the same storage. By default, Ray registers memory when it creates NIXL RDT metadata for an ``ObjectRef`` and deregisters that memory after the ``ObjectRef`` is garbage collected. This is convenient, but repeated register and deregister cycles can dominate small or frequent transfers.
+
+Use these APIs to reduce memory registration overhead:
+
+* :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>`: Pre-register a long-lived tensor storage and keep it registered for the lifetime of the worker process, or until you call :func:`ray.experimental.deregister_nixl_memory <ray.experimental.deregister_nixl_memory>`. This is best for model weights, cache blocks, or other tensors that are returned many times.
+* :func:`ray.experimental.register_nixl_memory_pool <ray.experimental.register_nixl_memory_pool>`: Allocate one CPU or GPU memory pool and register it once with NIXL. Ray copies eligible tensors into pool-backed views for RDT transfers, avoiding repeated registration of each tensor allocation.
+
+Pre-register reused tensors
+"""""""""""""""""""""""""""
+
+Call :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>` inside the actor that owns the tensor. Registering the full tensor storage also covers views into that storage, so repeated transfers of rows, shards, or slices can reuse one registration.
+
+.. literalinclude:: ../doc_code/direct_transport_nixl.py
+   :language: python
+   :start-after: __nixl_register_memory_start__
+   :end-before: __nixl_register_memory_end__
+
+Use this pattern when:
+
+* The same tensor storage is transferred repeatedly.
+* The tensor is long-lived relative to the RDT ``ObjectRef`` instances created from it.
+* The tensor memory footprint is predictable enough to keep registered.
+
+Call :func:`ray.experimental.deregister_nixl_memory <ray.experimental.deregister_nixl_memory>` when the actor no longer needs the persistent registration. Live ``ObjectRef`` instances that still reference the tensor keep their own registration references until they go out of scope.
+
+Use a memory pool for many transient tensors
+""""""""""""""""""""""""""""""""""""""""""""
+
+Call :func:`ray.experimental.register_nixl_memory_pool <ray.experimental.register_nixl_memory_pool>` once per worker process to pre-allocate and register a pool. The pool can be on CPU or CUDA, but Ray only uses it for tensors on the same device as the pool and for tensors that were not already pre-registered with :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>`.
+
+.. literalinclude:: ../doc_code/direct_transport_nixl.py
+   :language: python
+   :start-after: __nixl_memory_pool_start__
+   :end-before: __nixl_memory_pool_end__
+
+The memory pool is useful when a producer creates many short-lived tensors with similar lifetimes. Within one RDT object, tensors that share the same underlying PyTorch storage, including views, share one pool allocation. Across calls, the same storage can reuse its pool slot while it remains tracked by Ray.
+
+Size the pool for the maximum live NIXL RDT data produced by the actor, not just for one transfer. The pool allocates space based on the entire underlying storage size of each tensor, so returning small views of large tensors can quickly exhaust the pool unless those views are cloned first to reclaim unused storage. If the pool is too small, Ray raises ``NixlOutOfMemoryError``. Increase the pool size or reduce the number of simultaneously live RDT ``ObjectRef`` instances.
+
+Common NIXL anti-patterns
+"""""""""""""""""""""""""
+
+Avoid these patterns when tuning NIXL RDT workloads:
+
+* Returning many views of the same large storage without pre-registering the base tensor or using a memory pool. Registering the base storage once is usually cheaper than registering and deregistering the same storage repeatedly.
+* Creating a new CUDA tensor for every small message. Batch small tensors into fewer RDT objects when possible, or use a memory pool sized for the expected live working set.
+* Keeping unnecessary RDT ``ObjectRef`` instances alive. Registrations and pool blocks are released only after the corresponding refs go out of scope and Ray finishes dependent tasks.
+* Mutating tensor storage after creating an RDT ref when receivers expect snapshot semantics. RDT objects are mutable references. Clone before ``ray.put`` or before returning from an RDT method if the producer mutates the storage before consumers finish.
+* Registering memory too broadly. Persistent registrations improve repeated transfers, but they also keep pinned or GPU memory registered. Deregister tensors that are no longer reused.
+* Mixing CPU and CUDA tensors in one RDT object. All tensors in an RDT object must have the same device type.
+* Returning non-contiguous tensor views. NIXL RDT requires tensors in the RDT object to be contiguous.
+
+Profile before and after changing registrations. The best configuration depends on tensor sizes, view counts, transfer frequency, number of live refs, and the NIXL backend and transport configuration selected for the cluster.
+
+
 Summary
 -------
 
@@ -285,7 +352,8 @@ RDT allows Ray to store and pass objects directly between Ray actors, using acce
 Here are the main points to keep in mind:
 
 * If using a collective-based tensor transport (Gloo or NCCL), a collective group must be created ahead of time. NIXL just requires all involved actors to have NIXL installed.
-* Unlike objects in the Ray object store, RDT objects are *mutable*, meaning that Ray only holds a reference, not a copy, to the stored tensor(s). 
+* For NIXL, use :func:`ray.experimental.register_nixl_memory <ray.experimental.register_nixl_memory>` or :func:`ray.experimental.register_nixl_memory_pool <ray.experimental.register_nixl_memory_pool>` to reduce repeated memory registration overhead in workloads that reuse tensor storage or create many short-lived tensors.
+* Unlike objects in the Ray object store, RDT objects are *mutable*, meaning that Ray only holds a reference, not a copy, to the stored tensor(s).
 * Otherwise, actors can be used as normal.
 
 For a full list of limitations, see the :ref:`limitations <limitations>` section.

--- a/doc/source/ray-core/doc_code/direct_transport_nixl.py
+++ b/doc/source/ray-core/doc_code/direct_transport_nixl.py
@@ -58,6 +58,58 @@ print(ray.get(ref1))
 # __nixl_put__and_get_end__
 
 
+# __nixl_register_memory_start__
+import torch
+import ray
+from ray.experimental import deregister_nixl_memory, register_nixl_memory
+
+
+@ray.remote(num_gpus=1, enable_tensor_transport=True)
+class Trainer:
+    def __init__(self):
+        self.weight = torch.randn(1000, 1000, device="cuda")
+        register_nixl_memory(self.weight)
+
+    def get_weight_ref(self):
+        return ray.put(self.weight, _tensor_transport="nixl")
+
+    def get_weight_shard_refs(self):
+        return ray.put([self.weight[i] for i in range(1000)], _tensor_transport="nixl")
+
+    def close(self):
+        deregister_nixl_memory(self.weight)
+
+
+trainer = Trainer.remote()
+weight_ref = trainer.get_weight_ref.remote()
+ray.get(weight_ref)
+ray.get(trainer.close.remote())
+# __nixl_register_memory_end__
+
+
+# __nixl_memory_pool_start__
+import torch
+import ray
+from ray.experimental import register_nixl_memory_pool
+
+
+@ray.remote(num_gpus=1, enable_tensor_transport=True)
+class PoolActor:
+    def __init__(self):
+        register_nixl_memory_pool(1024 * 1024 * 1024, torch.device("cuda"))
+
+    @ray.method(tensor_transport="nixl")
+    def make_batch(self):
+        tensor = torch.randn(1024, 1024, device="cuda")
+        return {"full": tensor, "first_half": tensor[:512]}
+
+
+producer = PoolActor.remote()
+batch_ref = producer.make_batch.remote()
+ray.get(batch_ref)
+# __nixl_memory_pool_end__
+
+
 # __nixl_limitations_start__
 @ray.remote(num_gpus=1)
 class Actor:


### PR DESCRIPTION
## Description
This PR improves the Ray Direct Transport NIXL documentation with configuration and performance tuning guidance.

It adds:
- UCX, GDRCopy, RDMA, and memory registration setup notes for NIXL users.
- Guidance on reducing NIXL memory registration overhead with `register_nixl_memory`, `deregister_nixl_memory`, and `register_nixl_memory_pool`.
- Usage examples for pre-registering reused tensor storage and using a NIXL memory pool.
- Common NIXL RDT anti-patterns around tensor views, small transfers, long-lived refs, mutation semantics, mixed devices, and non-contiguous tensors.

## Related issues
Fixes #62600

## Additional information
This is a docs-only change.

Validation:
- `python -m py_compile doc\source\ray-core\doc_code\direct_transport_nixl.py`
- `git diff --check`