### PR TITLE
[Draft] [Data] Add node-local sharded Parquet reads and writes

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -2201,6 +2201,20 @@ py_test(
 )
 
 py_test(
+    name = "test_node_sharded_read",
+    size = "medium",
+    srcs = ["tests/test_node_sharded_read.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_random_api",
     size = "small",
     srcs = ["tests/test_random_api.py"],

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -64,7 +64,9 @@ from ray.data.datasource.path_util import (
     _resolve_paths_and_filesystem,
 )
 from ray.data.expressions import BinaryExpr, Expr, Operation
+from ray.util.annotations import DeveloperAPI
 from ray.util.debug import log_once
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
     import pyarrow
@@ -711,9 +713,9 @@ class ParquetDatasource(Datasource):
             partition_columns_selected=False,
             partition_schema=pa.schema([]),
             partitioning=None,
-            projection_map={col: col for col in columns}
-            if columns is not None
-            else None,
+            projection_map=(
+                {col: col for col in columns} if columns is not None else None
+            ),
             to_batch_kwargs=to_batch_kwargs,
             _block_udf=_block_udf,
             shuffle=shuffle,
@@ -2125,3 +2127,205 @@ def _infer_data_and_partition_columns(
         partition_columns = []
 
     return data_columns, partition_columns
+
+
+def _read_node_local_parquet(
+    paths: Union[str, List[str]],
+    *,
+    columns: Optional[List[str]],
+    partitioning: Optional[Partitioning],
+    include_paths: bool,
+    schema: Optional["pyarrow.Schema"],
+    to_batch_kwargs: Dict[str, Any],
+    file_extensions: Optional[List[str]],
+    filesystem: Optional["pyarrow.fs.FileSystem"],
+) -> Iterator["pyarrow.Table"]:
+    """Read this node's *local* view of ``paths`` and yield Arrow tables.
+
+    This runs inside a node-pinned read task (see
+    :class:`_NodeShardedParquetDatasource`). All listing and reading happen here,
+    on the node, against the node's local filesystem -- the driver never lists
+    these files. This deliberately avoids :class:`ParquetDatasource`'s sampling
+    path, which launches nested ``SPREAD``-scheduled tasks that could land on a
+    different node and fail to see this node's local files.
+    """
+    # Resolve the path against the node-local filesystem (plain paths resolve to a
+    # LocalFileSystem here), then expand directories into concrete Parquet file
+    # paths -- mirroring ``ParquetDatasource.__init__``. This listing happens on
+    # the node, so each node sees its own shard. ``get_parquet_dataset`` expects
+    # file paths, not a directory, so the expansion must happen first.
+    resolved_paths, filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+    filesystem = RetryingPyFileSystem.wrap(
+        filesystem, retryable_errors=DataContext.get_current().retried_io_errors
+    )
+    listed_files = _list_files(
+        resolved_paths,
+        filesystem,
+        partition_filter=None,
+        file_extensions=file_extensions,
+    )
+    if not listed_files:
+        return
+    file_paths = [file_path for file_path, _ in listed_files]
+
+    pq_ds = get_parquet_dataset(
+        file_paths,
+        filesystem=filesystem,
+        schema=schema,
+        # Inspect all fragments so the on-node schema reflects local files.
+        inspect_num_fragments=None,
+        dataset_kwargs={"partitioning": None},
+    )
+    fragments = list(pq_ds.fragments)
+    if not fragments:
+        return
+
+    data_columns, partition_columns = None, None
+    if columns is not None:
+        data_columns, partition_columns = _infer_data_and_partition_columns(
+            columns, fragments[0], partitioning
+        )
+
+    pq_fragments = [_ParquetFragment(fragment, None) for fragment in fragments]
+    yield from read_fragments(
+        block_udf=None,
+        to_batches_kwargs=to_batch_kwargs or {},
+        data_columns=data_columns,
+        partition_columns=partition_columns,
+        schema=schema if schema is not None else pq_ds.schema,
+        fragments=pq_fragments,
+        include_paths=include_paths,
+        include_row_hash=False,
+        partitioning=partitioning,
+    )
+
+
+@DeveloperAPI
+class _NodeShardedParquetDatasource(Datasource):
+    """Reads node-local Parquet shards, one read task pinned per node.
+
+    Every node in the cluster is expected to hold a *different* subset of the
+    dataset under the *same* ``paths`` on its local disk (the "convention-based"
+    sharding layout, e.g. ``/mnt/nvme/dataset`` populated differently on each
+    node). This datasource emits exactly one read task per target node, pins it
+    to that node via a :class:`NodeAffinitySchedulingStrategy`, and reads that
+    node's *local* view of ``paths`` from within the task. Listing is deferred to
+    the node, so the driver never needs (and must not assume) a global view of
+    the files.
+
+    Because each read task runs on its node, the blocks it produces land in that
+    node's local object store. A downstream consumer pinned to the same node --
+    e.g. a Ray Train worker via ``streaming_split(..., locality_hints=...)`` --
+    therefore reads its shard without any cross-node transfer.
+    """
+
+    def __init__(
+        self,
+        paths: Union[str, List[str]],
+        *,
+        nodes: Optional[List[str]] = None,
+        soft: bool = False,
+        columns: Optional[List[str]] = None,
+        partitioning: Optional[Partitioning] = None,
+        include_paths: bool = False,
+        schema: Optional["pyarrow.Schema"] = None,
+        to_batch_kwargs: Optional[Dict[str, Any]] = None,
+        file_extensions: Optional[List[str]] = None,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ):
+        super().__init__()
+        _check_pyarrow_version()
+        self._paths = paths
+        self._nodes = nodes
+        self._soft = soft
+        self._columns = columns
+        self._partitioning = partitioning
+        self._include_paths = include_paths
+        self._schema = schema
+        self._to_batch_kwargs = to_batch_kwargs or {}
+        self._file_extensions = file_extensions
+        self._filesystem = filesystem
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        # The shards live on the nodes, not the driver, so we can't size them
+        # without a (forbidden) driver-side listing.
+        return None
+
+    def _resolve_target_nodes(self) -> List[str]:
+        if self._nodes is not None:
+            if not self._nodes:
+                raise ValueError("`nodes` must be a non-empty list of node IDs.")
+            return list(self._nodes)
+
+        node_ids = [
+            node["NodeID"]
+            for node in ray.nodes()
+            if node.get("Alive") and node.get("Resources", {}).get("CPU", 0) > 0
+        ]
+        if not node_ids:
+            raise ValueError(
+                "No alive nodes with CPU resources were found to schedule "
+                "node-sharded reads on."
+            )
+        return node_ids
+
+    def get_read_tasks(
+        self,
+        parallelism: int,
+        per_task_row_limit: Optional[int] = None,
+        data_context: Optional["DataContext"] = None,
+    ) -> List[ReadTask]:
+        node_ids = self._resolve_target_nodes()
+
+        # Capture read options for the closures (avoid capturing `self`, which
+        # would bloat the serialized task).
+        paths = self._paths
+        columns = self._columns
+        partitioning = self._partitioning
+        include_paths = self._include_paths
+        schema = self._schema
+        to_batch_kwargs = self._to_batch_kwargs
+        file_extensions = self._file_extensions
+        filesystem = self._filesystem
+
+        read_tasks = []
+        for node_id in node_ids:
+            scheduling_strategy = NodeAffinitySchedulingStrategy(
+                node_id, soft=self._soft
+            )
+
+            def read_fn(node_id=node_id):
+                return _read_node_local_parquet(
+                    paths,
+                    columns=columns,
+                    partitioning=partitioning,
+                    include_paths=include_paths,
+                    schema=schema,
+                    to_batch_kwargs=to_batch_kwargs,
+                    file_extensions=file_extensions,
+                    filesystem=filesystem,
+                )
+
+            metadata = BlockMetadata(
+                num_rows=None,
+                size_bytes=None,
+                input_files=None,
+                exec_stats=None,
+            )
+            read_tasks.append(
+                ReadTask(
+                    read_fn,
+                    metadata,
+                    ray_remote_args={"scheduling_strategy": scheduling_strategy},
+                    per_task_row_limit=per_task_row_limit,
+                )
+            )
+
+        return read_tasks
+
+    def get_name(self) -> str:
+        return "NodeShardedParquet"
+
+    @property
+    def supports_distributed_reads(self) -> bool:
+        return True

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -1,7 +1,7 @@
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import ray
 from .common import NodeIdStr
@@ -85,6 +85,13 @@ class RefBundle:
     # This attribute is used by the split() operator to assign bundles to logical
     # output splits. It is otherwise None.
     output_split_idx: Optional[int] = None
+
+    # Optional per-task ``ray.remote`` args (e.g. a ``scheduling_strategy``) that
+    # the consuming map operator applies to the task launched for this bundle,
+    # overriding the operator's defaults. This is how a read task can be pinned to
+    # a specific node (see ``ReadTask.ray_remote_args`` and ``plan_read_op``).
+    # ``None`` for the vast majority of bundles, which use operator-level args.
+    task_ray_remote_args: Optional[Dict[str, Any]] = None
 
     # Object metadata (size, locations, spilling status)
     _cached_object_meta: Optional[Dict[ObjectRef, "_ObjectMetadata"]] = None
@@ -326,6 +333,7 @@ class RefBundle:
             schema=self.schema,
             owns_blocks=False,
             slices=tuple(consumed_slices) if consumed_slices else None,
+            task_ray_remote_args=self.task_ray_remote_args,
         )
 
         remaining_bundle = RefBundle(
@@ -333,6 +341,7 @@ class RefBundle:
             schema=self.schema,
             owns_blocks=False,
             slices=tuple(remaining_slices) if remaining_slices else None,
+            task_ray_remote_args=self.task_ray_remote_args,
         )
 
         return sliced_bundle, remaining_bundle
@@ -366,11 +375,27 @@ class RefBundle:
         owns_blocks = all(bundle.owns_blocks for bundle in bundles)
         # TODO: Reconcile the schemas rather than taking the first non-empty schema.
         schema = _take_first_non_empty_schema(bundle.schema for bundle in bundles)
+        # Per-task remote args (e.g. a node-affinity scheduling strategy) only make
+        # sense if every bundle being merged agrees on them; merging bundles pinned
+        # to different nodes would silently drop a placement constraint. Such bundles
+        # must not be combined, so require them to match and carry the value through.
+        task_args = [
+            bundle.task_ray_remote_args
+            for bundle in bundles
+            if bundle.task_ray_remote_args is not None
+        ]
+        merged_task_ray_remote_args = task_args[0] if task_args else None
+        assert all(args == merged_task_ray_remote_args for args in task_args), (
+            "Cannot merge RefBundles with differing task_ray_remote_args: "
+            f"{task_args}. Bundles pinned to different placements must not be "
+            "bundled together (e.g. node-sharded reads with min_rows_per_bundle set)."
+        )
         return cls(
             blocks=tuple(merged_blocks),
             schema=schema,
             owns_blocks=owns_blocks,
             slices=merged_slices,
+            task_ray_remote_args=merged_task_ray_remote_args,
         )
 
     def __eq__(self, other: "RefBundle"):

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -563,9 +563,9 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         if "scheduling_strategy" not in ray_remote_args:
             ctx = self.data_context
             if input_bundle and input_bundle.size_bytes() > ctx.large_args_threshold:
-                ray_remote_args[
-                    "scheduling_strategy"
-                ] = ctx.scheduling_strategy_large_args
+                ray_remote_args["scheduling_strategy"] = (
+                    ctx.scheduling_strategy_large_args
+                )
                 # Takes precedence over small args case. This is to let users know
                 # when the large args case is being triggered.
                 self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)
@@ -574,6 +574,18 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                 # Only save to metrics if we haven't already done so.
                 if "scheduling_strategy" not in self._remote_args_for_metrics:
                     self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)
+        # Apply any per-task remote args carried by this bundle (e.g. a node-affinity
+        # scheduling strategy set by a datasource to pin a read task to the node that
+        # holds its shard). These take precedence over the operator-level args and the
+        # defaults above -- including the framework's default `scheduling_strategy`
+        # (SPREAD), which is otherwise baked into `self._ray_remote_args` and would
+        # mask the per-task placement. Only bundles that carry these args (e.g.
+        # node-sharded reads) are affected; all other bundles are unchanged.
+        per_task_args = (
+            input_bundle.task_ray_remote_args if input_bundle is not None else None
+        )
+        if per_task_args:
+            ray_remote_args.update(per_task_args)
         ray_remote_args = merge_label_selector(
             ray_remote_args, self.data_context.execution_options.label_selector
         )

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -101,6 +101,10 @@ def plan_read_op(
                 # be reconstructed.
                 owns_blocks=False,
                 schema=None,
+                # Carry any per-task remote args (e.g. a node-affinity scheduling
+                # strategy) so the read MapOperator pins this task as the
+                # datasource requested. ``None`` for ordinary reads.
+                task_ray_remote_args=read_task.ray_remote_args,
             )
             ret.append(ref_bundle)
         return ret

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -355,7 +355,7 @@ def _resolve_custom_scheme(path: str) -> str:
 
 
 def _normalize_paths_to_strings(
-    paths: Union[str, pathlib.Path, List[Union[str, pathlib.Path]]]
+    paths: Union[str, pathlib.Path, List[Union[str, pathlib.Path]]],
 ) -> List[str]:
     """Normalize path input to a list of strings.
 
@@ -392,6 +392,55 @@ def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
             f"but found mixed {paths}"
         )
     return num == len(paths)
+
+
+def _ensure_node_local_target(
+    paths: Union[str, List[str]],
+    filesystem: Optional["pyarrow.fs.FileSystem"],
+    *,
+    operation: str,
+) -> None:
+    """Raise ``ValueError`` if ``paths``/``filesystem`` aren't node-local.
+
+    ``shard_by_node`` reads/writes each node's *local* disk, so the target must
+    be a local filesystem. Remote/shared storage (S3, GCS, HDFS, ...) is
+    rejected: on shared storage every node would hit the *same physical*
+    directory, which duplicates reads and races writes (data loss on
+    ``OVERWRITE``). Local ``OVERWRITE`` is fine -- each node overwrites its own
+    directory -- so this targets the storage, not the mode.
+
+    NOTE: a network filesystem mounted locally (e.g. NFS) looks like a real
+    local disk here and is NOT detected; the caller is responsible for ensuring
+    the path is genuinely node-local in that case.
+
+    Args:
+        paths: The path(s) to validate.
+        filesystem: An optional explicit pyarrow filesystem.
+        operation: Verb phrase for the error message, e.g. ``"reads from"``.
+    """
+    import pyarrow.fs as pafs
+
+    if filesystem is not None:
+        fs = filesystem
+        if isinstance(fs, RetryingPyFileSystem):
+            fs = fs.unwrap()
+        if not isinstance(fs, pafs.LocalFileSystem):
+            raise ValueError(
+                f"`shard_by_node=True` {operation} each node's local disk, so it "
+                f"requires node-local storage, but got a non-local filesystem "
+                f"{type(fs).__name__!r}."
+            )
+        return
+
+    for path in _normalize_paths_to_strings(paths):
+        scheme = urllib.parse.urlparse(path).scheme
+        if scheme not in ("", "file"):
+            raise ValueError(
+                f"`shard_by_node=True` {operation} each node's local disk, so it "
+                f"requires node-local paths, but got scheme {scheme!r} in "
+                f"{path!r}. Remote/shared storage (e.g. S3, GCS, HDFS) isn't "
+                f"supported."
+            )
 
 
 def _truncated_repr(obj: Any) -> str:
@@ -530,8 +579,7 @@ def _consumption_api(
 
 
 @overload
-def ConsumptionAPI(obj: F) -> F:
-    ...
+def ConsumptionAPI(obj: F) -> F: ...
 
 
 @overload
@@ -541,8 +589,7 @@ def ConsumptionAPI(
     datasource_metadata: Optional[str] = None,
     extra_condition: Optional[str] = None,
     delegate: Optional[str] = None,
-) -> Callable[[F], F]:
-    ...
+) -> Callable[[F], F]: ...
 
 
 def ConsumptionAPI(*args, **kwargs):
@@ -576,8 +623,7 @@ def _all_to_all_api() -> Callable[[F], F]:
 
 
 @overload
-def AllToAllAPI(obj: F) -> F:
-    ...
+def AllToAllAPI(obj: F) -> F: ...
 
 
 def AllToAllAPI(*args, **kwargs):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4297,6 +4297,8 @@ class Dataset:
         concurrency: Optional[int] = None,
         num_rows_per_file: Optional[int] = None,
         mode: SaveMode = SaveMode.APPEND,
+        shard_by_node: bool = False,
+        nodes: Optional[List[str]] = None,
         **arrow_parquet_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to parquet files under the provided ``path``.
@@ -4379,6 +4381,23 @@ class Dataset:
                 "ignore", "append". Defaults to "append".
                 NOTE: This method isn't atomic. "Overwrite" first deletes all the data
                 before writing to `path`.
+            shard_by_node: If ``True``, materialize the dataset and shard it across
+                the cluster's nodes: the rows are split into one roughly-balanced
+                shard per target node, and each shard is written -- pinned to its
+                node via a ``NodeAffinitySchedulingStrategy`` -- to ``path`` on
+                that node's local disk. No rows are dropped. This is the inverse
+                of ``read_parquet(path, shard_by_node=True)``: write shards onto
+                node-local NVMe here, then read them back with node locality
+                (e.g. for Ray Train). Because each node writes to its own local
+                ``path``, ``mode`` applies per node (no cross-node conflict) --
+                ``SaveMode.OVERWRITE`` refreshes each node's own directory. The
+                target must be node-local: remote/shared storage (S3, GCS, HDFS)
+                is rejected, since every node would write to the same physical
+                directory. Can't be combined with a user-provided
+                ``ray_remote_args["scheduling_strategy"]``.
+            nodes: Optional explicit list of node IDs (hex strings as returned by
+                ``ray.nodes()[i]["NodeID"]``) to shard across when ``shard_by_node``
+                is ``True``. Defaults to all alive nodes with CPU resources.
             **arrow_parquet_args: Options to pass to
                 `pyarrow.parquet.ParquetWriter() <https:/\
                     /arrow.apache.org/docs/python/generated/\
@@ -4410,6 +4429,25 @@ class Dataset:
             max_rows_per_file=max_rows_per_file,
         )
 
+        if shard_by_node:
+            self._write_parquet_sharded_by_node(
+                path,
+                nodes=nodes,
+                partition_cols=partition_cols,
+                arrow_parquet_args_fn=arrow_parquet_args_fn,
+                arrow_parquet_args=arrow_parquet_args,
+                min_rows_per_file=effective_min_rows,
+                max_rows_per_file=effective_max_rows,
+                filesystem=filesystem,
+                try_create_dir=try_create_dir,
+                arrow_open_stream_args=arrow_open_stream_args,
+                filename_provider=filename_provider,
+                mode=mode,
+                ray_remote_args=ray_remote_args,
+                concurrency=concurrency,
+            )
+            return
+
         datasink = ParquetDatasink(
             path,
             partition_cols=partition_cols,
@@ -4429,6 +4467,106 @@ class Dataset:
             ray_remote_args=ray_remote_args,
             concurrency=concurrency,
         )
+
+    def _write_parquet_sharded_by_node(
+        self,
+        path: str,
+        *,
+        nodes: Optional[List[str]],
+        partition_cols: Optional[List[str]],
+        arrow_parquet_args_fn: Callable[[], Dict[str, Any]],
+        arrow_parquet_args: Dict[str, Any],
+        min_rows_per_file: Optional[int],
+        max_rows_per_file: Optional[int],
+        filesystem: Optional["pyarrow.fs.FileSystem"],
+        try_create_dir: bool,
+        arrow_open_stream_args: Optional[Dict[str, Any]],
+        filename_provider: Optional[FilenameProvider],
+        mode: SaveMode,
+        ray_remote_args: Optional[Dict[str, Any]],
+        concurrency: Optional[int],
+    ) -> None:
+        """Materialize this dataset and write one node-local shard per node.
+
+        See ``write_parquet(..., shard_by_node=True)``. The dataset is
+        materialized once, split into one roughly-balanced shard per target node
+        (no rows dropped), and each shard is written with its write tasks pinned
+        to its node, so the files land on that node's local disk.
+        """
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+        if ray_remote_args and "scheduling_strategy" in ray_remote_args:
+            raise ValueError(
+                "`shard_by_node=True` pins each shard's write tasks to a node via "
+                "a `scheduling_strategy`, so it can't be combined with a "
+                "`ray_remote_args['scheduling_strategy']`."
+            )
+
+        # Node-local sharding only makes sense on node-local storage. On shared
+        # storage (S3/NFS) every node writes to the *same physical* directory, so
+        # shards pile up together and -- with OVERWRITE -- race-delete each other
+        # (data loss). Reject shared/remote targets; local OVERWRITE is fine
+        # because each node overwrites only its own directory.
+        from ray.data._internal.util import _ensure_node_local_target
+
+        _ensure_node_local_target(path, filesystem, operation="writes to")
+
+        if nodes is not None:
+            if not nodes:
+                raise ValueError("`nodes` must be a non-empty list of node IDs.")
+            node_ids = list(nodes)
+        else:
+            node_ids = [
+                node["NodeID"]
+                for node in ray.nodes()
+                if node.get("Alive") and node.get("Resources", {}).get("CPU", 0) > 0
+            ]
+            if not node_ids:
+                raise ValueError(
+                    "No alive nodes with CPU resources were found to shard the "
+                    "write across."
+                )
+
+        # Materialize once, then split by row count so every row is written
+        # exactly once (``split(equal=True)`` would drop the remainder).
+        materialized = self.materialize()
+        num_nodes = len(node_ids)
+        if num_nodes == 1:
+            shards = [materialized]
+        else:
+            total_rows = materialized.count()
+            rows_per_shard = total_rows // num_nodes
+            # ``n - 1`` split indices produce ``n`` shards; the last shard absorbs
+            # the remainder. With fewer rows than nodes some trailing shards are
+            # empty.
+            split_indices = [rows_per_shard * i for i in range(1, num_nodes)]
+            shards = materialized.split_at_indices(split_indices)
+
+        for node_id, shard in zip(node_ids, shards):
+            shard_remote_args = dict(ray_remote_args or {})
+            shard_remote_args["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
+                node_id, soft=False
+            )
+            datasink = ParquetDatasink(
+                path,
+                partition_cols=partition_cols,
+                arrow_parquet_args_fn=arrow_parquet_args_fn,
+                arrow_parquet_args=arrow_parquet_args,
+                min_rows_per_file=min_rows_per_file,
+                max_rows_per_file=max_rows_per_file,
+                filesystem=filesystem,
+                try_create_dir=try_create_dir,
+                open_stream_args=arrow_open_stream_args,
+                filename_provider=filename_provider,
+                # Distinct uuid per shard so per-node filenames never coincide.
+                dataset_uuid=shard._uuid,
+                mode=mode,
+            )
+            shard.write_datasink(
+                datasink,
+                ray_remote_args=shard_remote_args,
+                concurrency=concurrency,
+            )
 
     @ConsumptionAPI
     @PublicAPI(api_group=IOC_API_GROUP)
@@ -5880,9 +6018,9 @@ class Dataset:
                     "on the driver's node."
                 )
             label_selector = ray_remote_args.get("label_selector", {})
-            label_selector[
-                ray._raylet.RAY_NODE_ID_KEY
-            ] = ray.get_runtime_context().get_node_id()
+            label_selector[ray._raylet.RAY_NODE_ID_KEY] = (
+                ray.get_runtime_context().get_node_id()
+            )
             ray_remote_args["label_selector"] = label_selector
             ray_remote_args.pop("scheduling_strategy", None)
 
@@ -6901,9 +7039,9 @@ class Dataset:
         import pyarrow as pa
 
         ref_bundle: RefBundle = self._execute()
-        block_refs: List[
-            ObjectRef["pyarrow.Table"]
-        ] = _ref_bundles_iterator_to_block_refs_list([ref_bundle])
+        block_refs: List[ObjectRef["pyarrow.Table"]] = (
+            _ref_bundles_iterator_to_block_refs_list([ref_bundle])
+        )
         # Schema is safe to call since we have already triggered execution with
         # self._execute(), which will cache the schema
         schema = self.schema(fetch_if_missing=True)

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 
 import numpy as np
 
@@ -356,15 +356,29 @@ class ReadTask(Callable[[], Iterable[Block]]):
         metadata: BlockMetadata,
         schema: Optional["Schema"] = None,
         per_task_row_limit: Optional[int] = None,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         self._metadata = metadata
         self._read_fn = read_fn
         self._schema = schema
         self._per_task_row_limit = per_task_row_limit
+        self._ray_remote_args = ray_remote_args
 
     @property
     def metadata(self) -> BlockMetadata:
         return self._metadata
+
+    @property
+    def ray_remote_args(self) -> Optional[Dict[str, Any]]:
+        """Per-task ``ray.remote`` args (e.g. a ``scheduling_strategy``).
+
+        When set, these args are applied only to the task that executes this
+        read, overriding the read operator's defaults. This is how a datasource
+        pins an individual read task to a specific node (for example, reading a
+        shard that lives on a particular node's local disk via a
+        ``NodeAffinitySchedulingStrategy``).
+        """
+        return self._ray_remote_args
 
     # TODO(justin): We want to remove schema from `ReadTask` later on
     @property

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -83,6 +83,7 @@ from ray.data._internal.stats import DatasetStats
 from ray.data._internal.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.util import (
     _autodetect_parallelism,
+    _ensure_node_local_target,
     get_compute_strategy_for_read_api,
     get_table_block_metadata_schema,
     merge_resources_to_ray_remote_args,
@@ -404,9 +405,9 @@ def _resolve_read_remote_args(
         ray_remote_args = {}
     if not datasource.supports_distributed_reads:
         label_selector = ray_remote_args.get("label_selector", {})
-        label_selector[
-            ray._raylet.RAY_NODE_ID_KEY
-        ] = ray.get_runtime_context().get_node_id()
+        label_selector[ray._raylet.RAY_NODE_ID_KEY] = (
+            ray.get_runtime_context().get_node_id()
+        )
         ray_remote_args["label_selector"] = label_selector
         ray_remote_args.pop("scheduling_strategy", None)
     if (
@@ -1144,6 +1145,8 @@ def read_parquet(
     file_extensions: Optional[List[str]] = ParquetDatasource._FILE_EXTENSIONS,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
+    shard_by_node: bool = False,
+    nodes: Optional[List[str]] = None,
     **arrow_parquet_args,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from parquet files.
@@ -1281,6 +1284,25 @@ def read_parquet(
             By default, the number of output blocks is dynamically decided based on
             input data size and available resources. You shouldn't manually set this
             value in most cases.
+        shard_by_node: If ``True``, read node-local shards: each node in the
+            cluster is assumed to hold a *different* subset of the dataset under
+            the *same* ``paths`` on its local disk (e.g. ``/mnt/nvme/dataset``
+            populated differently on every node). Ray Data emits one read task
+            per target node, pins it to that node, and reads that node's local
+            view of ``paths`` -- listing and reading happen on the node, so the
+            blocks land in that node's object store and aren't copied across the
+            network at read time. This is intended for data pre-sharded onto
+            node-local NVMe drives and consumed with node locality (e.g. Ray
+            Train via ``streaming_split`` locality hints). When set, the shards
+            should be roughly balanced across nodes. The target must be
+            node-local: remote/shared storage (S3, GCS, HDFS) is rejected, since
+            every node would then read the same physical files. Not compatible
+            with ``partition_filter``, ``shuffle``, ``include_row_hash``,
+            ``tensor_column_schema``, or a user-provided
+            ``ray_remote_args["scheduling_strategy"]``.
+        nodes: Optional explicit list of node IDs (hex strings as returned by
+            ``ray.nodes()[i]["NodeID"]``) to shard across when ``shard_by_node``
+            is ``True``. Defaults to all alive nodes with CPU resources.
         **arrow_parquet_args: Other parquet read options to pass to PyArrow. For the full
             set of arguments, see the `PyArrow API <https://arrow.apache.org/docs/\
                 python/generated/pyarrow.dataset.Scanner.html\
@@ -1323,6 +1345,29 @@ def read_parquet(
     dataset_kwargs = arrow_parquet_args.pop("dataset_kwargs", None)
     _block_udf = arrow_parquet_args.pop("_block_udf", None)
     schema = arrow_parquet_args.pop("schema", None)
+
+    if shard_by_node:
+        return _read_parquet_node_sharded(
+            paths,
+            columns=columns,
+            partitioning=partitioning,
+            include_paths=include_paths,
+            include_row_hash=include_row_hash,
+            schema=schema,
+            partition_filter=partition_filter,
+            shuffle=shuffle,
+            filesystem=filesystem,
+            ray_remote_args=ray_remote_args,
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            memory=memory,
+            concurrency=concurrency,
+            override_num_blocks=override_num_blocks,
+            nodes=nodes,
+            to_batch_kwargs=arrow_parquet_args,
+            block_udf=_block_udf,
+            file_extensions=file_extensions,
+        )
 
     ctx = DataContext.get_current()
     if ctx.use_datasource_v2:
@@ -1446,6 +1491,84 @@ def read_parquet(
         ray_remote_args=ray_remote_args,
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,
+    )
+
+
+def _read_parquet_node_sharded(
+    paths: Union[str, List[str]],
+    *,
+    columns: Optional[List[str]],
+    partitioning: Optional[Partitioning],
+    include_paths: bool,
+    include_row_hash: bool,
+    schema: Optional["pyarrow.Schema"],
+    partition_filter: Optional[PathPartitionFilter],
+    shuffle: Optional[Union[Literal["files"], FileShuffleConfig]],
+    filesystem: Optional["pyarrow.fs.FileSystem"],
+    ray_remote_args: Optional[Dict[str, Any]],
+    num_cpus: Optional[float],
+    num_gpus: Optional[float],
+    memory: Optional[float],
+    concurrency: Optional[int],
+    override_num_blocks: Optional[int],
+    nodes: Optional[List[str]],
+    to_batch_kwargs: Dict[str, Any],
+    block_udf: Optional[Callable[[Block], Block]],
+    file_extensions: Optional[List[str]],
+) -> Dataset:
+    """Read Parquet shards pinned to the nodes that hold them on local disk.
+
+    See ``read_parquet(..., shard_by_node=True)``. Validates the unsupported
+    option combinations, then dispatches to ``_NodeShardedParquetDatasource``.
+    """
+    from ray.data._internal.datasource.parquet_datasource import (
+        _NodeShardedParquetDatasource,
+    )
+
+    # Node-local sharding pins each read task to a node via a
+    # NodeAffinitySchedulingStrategy. Options that conflict with that or that the
+    # on-node reader doesn't yet support are rejected explicitly rather than
+    # silently ignored.
+    if ray_remote_args and "scheduling_strategy" in ray_remote_args:
+        raise ValueError(
+            "`shard_by_node=True` sets a per-task `scheduling_strategy` to pin "
+            "each read to its node, so it can't be combined with a "
+            "`ray_remote_args['scheduling_strategy']`."
+        )
+    # Node-local sharding only makes sense on node-local storage: on shared
+    # storage every node would read the same physical files (duplicated data).
+    _ensure_node_local_target(paths, filesystem, operation="reads from")
+    if partition_filter is not None:
+        raise ValueError("`shard_by_node=True` doesn't support `partition_filter`.")
+    if shuffle is not None:
+        raise ValueError("`shard_by_node=True` doesn't support `shuffle`.")
+    if include_row_hash:
+        raise ValueError("`shard_by_node=True` doesn't support `include_row_hash`.")
+    if block_udf is not None:
+        # `tensor_column_schema` folds into `_block_udf`.
+        raise ValueError("`shard_by_node=True` doesn't support `tensor_column_schema`.")
+
+    datasource = _NodeShardedParquetDatasource(
+        paths,
+        nodes=nodes,
+        columns=columns,
+        partitioning=partitioning,
+        include_paths=include_paths,
+        schema=schema,
+        to_batch_kwargs=to_batch_kwargs,
+        file_extensions=file_extensions,
+        filesystem=filesystem,
+    )
+    return read_datasource(
+        datasource,
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        memory=memory,
+        # One read task per node; never split or coalesce them, otherwise a task
+        # could be unpinned from the node holding its shard.
+        override_num_blocks=override_num_blocks,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
     )
 
 

--- a/python/ray/data/tests/test_node_sharded_read.py
+++ b/python/ray/data/tests/test_node_sharded_read.py
@@ -1,0 +1,263 @@
+import os
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+import ray
+from ray.data._internal.datasource.parquet_datasource import (
+    _NodeShardedParquetDatasource,
+)
+from ray.data.block import BlockMetadata
+from ray.data.datasource.datasource import Datasource, ReadTask
+from ray.data.tests.conftest import *  # noqa
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+def _alive_cpu_node_ids():
+    return [
+        node["NodeID"]
+        for node in ray.nodes()
+        if node.get("Alive") and node.get("Resources", {}).get("CPU", 0) > 0
+    ]
+
+
+class _PerNodePinnedDatasource(Datasource):
+    """Emits one read task per node, each pinned to its node. Each block records
+    both the node it was *asked* to run on and the node it *actually* ran on, so
+    a test can assert the per-task affinity was honored."""
+
+    def __init__(self, node_ids):
+        super().__init__()
+        self._node_ids = node_ids
+
+    def estimate_inmemory_data_size(self):
+        return None
+
+    def get_read_tasks(self, parallelism, per_task_row_limit=None, data_context=None):
+        read_tasks = []
+        for node_id in self._node_ids:
+            scheduling_strategy = NodeAffinitySchedulingStrategy(node_id, soft=False)
+
+            def read_fn(node_id=node_id):
+                actual = ray.get_runtime_context().get_node_id()
+                return [pa.table({"assigned_node": [node_id], "actual_node": [actual]})]
+
+            metadata = BlockMetadata(
+                num_rows=1, size_bytes=None, input_files=None, exec_stats=None
+            )
+            read_tasks.append(
+                ReadTask(
+                    read_fn,
+                    metadata,
+                    ray_remote_args={"scheduling_strategy": scheduling_strategy},
+                )
+            )
+        return read_tasks
+
+
+def test_per_read_task_node_affinity(ray_start_cluster):
+    """Layer 1: a read task carrying a per-task NodeAffinity scheduling strategy
+    actually runs on the node it was pinned to."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+
+    ray.shutdown()
+    ray.init(cluster.address)
+
+    node_ids = _alive_cpu_node_ids()
+    assert len(node_ids) >= 2
+
+    rows = ray.data.read_datasource(_PerNodePinnedDatasource(node_ids)).take_all()
+
+    # Each task ran on exactly the node it was pinned to...
+    for row in rows:
+        assert row["actual_node"] == row["assigned_node"]
+    # ...and every node got exactly its own pinned task.
+    assert {row["assigned_node"] for row in rows} == set(node_ids)
+
+
+def _write_parquet_shard(data_path, shard_idx, num_rows=10):
+    os.makedirs(data_path, exist_ok=True)
+    start = shard_idx * num_rows
+    df = pd.DataFrame({"id": list(range(start, start + num_rows))})
+    df.to_parquet(os.path.join(data_path, f"shard_{shard_idx}.parquet"))
+
+
+def test_read_parquet_shard_by_node(ray_start_cluster, tmp_path):
+    """``read_parquet(shard_by_node=True)`` emits one read task per node, pinned
+    to that node, and reads that node's local view of the path.
+
+    NOTE: On a single-machine test cluster all "nodes" share one filesystem, so
+    every node sees the same files (the shards aren't physically distinct). We
+    therefore assert one-task-per-node distribution (via stats) and read success,
+    not a disjoint row split (which requires truly separate disks per node).
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+
+    ray.shutdown()
+    ray.init(cluster.address)
+
+    data_path = os.path.join(str(tmp_path), "dataset")
+    for shard_idx in range(4):
+        _write_parquet_shard(data_path, shard_idx)
+
+    node_ids = _alive_cpu_node_ids()
+    num_nodes = len(node_ids)
+    assert num_nodes >= 2
+
+    ds = ray.data.read_parquet(data_path, shard_by_node=True).materialize()
+
+    # Exactly one read task per node => the read ran across all `num_nodes` nodes.
+    stats = ds.stats()
+    assert f"; {num_nodes} n" in stats, stats
+    # Reading succeeded and returned data (shared FS => each node read all files).
+    assert ds.count() > 0
+
+
+def test_read_parquet_shard_by_node_honors_file_extensions(ray_start_cluster, tmp_path):
+    """file_extensions is threaded through to the on-node listing (not ignored):
+    a non-matching extension yields no files, hence an empty dataset."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+
+    ray.shutdown()
+    ray.init(cluster.address)
+
+    data_path = os.path.join(str(tmp_path), "dataset")
+    for shard_idx in range(2):
+        _write_parquet_shard(data_path, shard_idx)
+
+    # The shards are *.parquet; restricting to a bogus extension must read nothing,
+    # proving the parameter is honored rather than silently replaced with the
+    # default ["parquet"].
+    ds = ray.data.read_parquet(
+        data_path, shard_by_node=True, file_extensions=["doesnotexist"]
+    )
+    assert ds.count() == 0
+
+
+@pytest.mark.parametrize("remote_path", ["s3://bucket/dataset", "gs://bucket/dataset"])
+def test_read_parquet_shard_by_node_rejects_remote_storage(
+    ray_start_regular_shared, remote_path
+):
+    # Raises on the driver from the path scheme, before any remote I/O.
+    with pytest.raises(ValueError, match="node-local"):
+        ray.data.read_parquet(remote_path, shard_by_node=True)
+
+
+def test_read_parquet_shard_by_node_explicit_nodes(ray_start_cluster, tmp_path):
+    """An explicit `nodes=` list restricts sharding to those nodes only."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+
+    ray.shutdown()
+    ray.init(cluster.address)
+
+    data_path = os.path.join(str(tmp_path), "dataset")
+    for shard_idx in range(3):
+        _write_parquet_shard(data_path, shard_idx)
+
+    target_nodes = _alive_cpu_node_ids()[:2]
+
+    ds = ray.data.read_parquet(
+        data_path, shard_by_node=True, nodes=target_nodes
+    ).materialize()
+
+    # Read ran on exactly the 2 requested nodes, not all 3.
+    stats = ds.stats()
+    assert "; 2 n" in stats, stats
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        (
+            {"ray_remote_args": {"scheduling_strategy": "SPREAD"}},
+            "scheduling_strategy",
+        ),
+        ({"shuffle": "files"}, "shuffle"),
+        ({"include_row_hash": True}, "include_row_hash"),
+        ({"tensor_column_schema": {"x": (None, (1,))}}, "tensor_column_schema"),
+    ],
+)
+def test_shard_by_node_rejects_unsupported_options(
+    ray_start_regular_shared, tmp_path, kwargs, match
+):
+    data_path = os.path.join(str(tmp_path), "dataset")
+    _write_parquet_shard(data_path, 0)
+
+    with pytest.raises(ValueError, match=match):
+        ray.data.read_parquet(data_path, shard_by_node=True, **kwargs)
+
+
+def test_write_parquet_shard_by_node_roundtrip(ray_start_cluster, tmp_path):
+    """``write_parquet(shard_by_node=True)`` shards the dataset across nodes (one
+    node-pinned write per node, no rows dropped). On a single-machine cluster the
+    shards land in the same directory, so a plain read-back reconstructs the full,
+    disjoint dataset."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+
+    ray.shutdown()
+    ray.init(cluster.address)
+
+    num_rows = 100
+    ds = ray.data.range(num_rows)
+
+    out_path = os.path.join(str(tmp_path), "sharded")
+    ds.write_parquet(out_path, shard_by_node=True)
+
+    read_back = ray.data.read_parquet(out_path)
+    ids = sorted(row["id"] for row in read_back.take_all())
+    # Every row written exactly once, none dropped or duplicated.
+    assert ids == list(range(num_rows))
+
+
+def test_write_parquet_shard_by_node_rejects_scheduling_strategy(
+    ray_start_regular_shared, tmp_path
+):
+    out_path = os.path.join(str(tmp_path), "sharded")
+    with pytest.raises(ValueError, match="scheduling_strategy"):
+        ray.data.range(10).write_parquet(
+            out_path,
+            shard_by_node=True,
+            ray_remote_args={"scheduling_strategy": "SPREAD"},
+        )
+
+
+@pytest.mark.parametrize("remote_path", ["s3://bucket/out", "gs://bucket/out"])
+def test_write_parquet_shard_by_node_rejects_remote_storage(
+    ray_start_regular_shared, remote_path
+):
+    # Raises on the driver from the path scheme, before materialize/remote I/O.
+    with pytest.raises(ValueError, match="node-local"):
+        ray.data.range(10).write_parquet(remote_path, shard_by_node=True)
+
+
+def test_node_sharded_datasource_resolves_all_nodes(ray_start_regular_shared, tmp_path):
+    data_path = os.path.join(str(tmp_path), "dataset")
+    _write_parquet_shard(data_path, 0)
+
+    datasource = _NodeShardedParquetDatasource(data_path)
+    read_tasks = datasource.get_read_tasks(parallelism=1)
+
+    # One task per alive CPU node, each pinned to a node.
+    assert len(read_tasks) == len(_alive_cpu_node_ids())
+    for read_task in read_tasks:
+        strategy = read_task.ray_remote_args["scheduling_strategy"]
+        assert isinstance(strategy, NodeAffinitySchedulingStrategy)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

Experimental PoC adding support for reading and writing Ray Data datasets sharded across node-local storage.

In this mode, each node has a local path such as `/mnt/data/dataset`, but the contents differ per node. The union of those per-node local directories forms the dataset. Read/write tasks are pinned to the node that owns the corresponding local shard, avoiding reads through shared storage, object stores, or cross-node transfers.

Looking for feedback on the approach, API shape, and whether this approach has a place in Ray Data.

## Motivation

Ray Data currently assumes a shared-global storage model: every node sees the same bytes at the same path, whether via S3/GCS/HDFS or a shared POSIX filesystem such as Lustre/FSx.

That works well for shared storage, but it does not support datasets staged onto node-local disks such as NVMe instance store, EBS volumes, local SSD, or tmpfs. This can be a large performance improvement since for training workloads where the dataset fits in aggregate local disk capacity, node-local sharding can avoid repeated network reads across epochs and jobs. Data can thus be staged once, then read locally at device throughput (an order of magnitude faster than over-the-network). It also keeps produced blocks in the local object store of the node that read them, which can align with Ray Train locality hints.

## Feedback requested

- Is `shard_by_node=True` the right API shape? (maybe `node_local_shards` is a better name)
- Should this live in Ray Data, or outside as a custom datasource?
- Is one read/write task per node the right abstraction?
- Are the unsupported option guards reasonable?
- Is the per-task `ray_remote_args` mechanism acceptable, or should scheduling be handled differently?

## API

Read:

```python
ds = ray.data.read_parquet("/mnt/data/dataset", shard_by_node=True)
```

Write:

```python
ds.write_parquet("/mnt/data/dataset", shard_by_node=True)
```
New public options:
```
read_parquet(..., shard_by_node: bool = False, nodes: Optional[List[str]] = None)
Dataset.write_parquet(..., shard_by_node: bool = False, nodes: Optional[List[str]] = None)
```

## Behaviour

When shard_by_node=True:
* reads emit one read task per target node
* each task is pinned using NodeAffinitySchedulingStrategy
* listing happens on the worker node, not on the driver
* each node reads only its local view of the path
* writes split the dataset by row count and write one shard per node
* no rows are dropped

## Implementation notes

This PR adds a reusable per-task node-affinity mechanism:
* ReadTask gains an optional ray_remote_args field;
* RefBundle.task_ray_remote_args carries those args through bundle operations;
* plan_read_op stamps per-task scheduling args;
* MapOperator._get_dynamic_ray_remote_args applies them with precedence over the operator default scheduling strategy.

The Parquet implementation uses _NodeShardedParquetDatasource, which creates one node-pinned read task per node and defers listing/reading to that node.

This intentionally avoids ParquetDatasource encoding-ratio sampling, because those sampling tasks are scheduled independently and may run on a node that cannot see the relevant local files.

Guard rails / unsupported options:
* shard_by_node=True rejects remote/object storage URI schemes such as S3, GCS, and HDFS. Node-local sharding only makes sense for local paths; shared storage would cause duplicate reads or racing writes.
* The following options are rejected explicitly rather than silently ignored:
  * shuffle
  * partition_filter
  * include_row_hash
  * tensor_column_schema
  * user-provided scheduling_strategy

read_parquet still honors file_extensions on the node-local path.

## Caveat

A shared filesystem mounted as a local POSIX path, such as Lustre or FSx for Lustre, cannot be distinguished from genuine node-local storage by path inspection. Users must ensure the path is genuinely node-local and has distinct per-node contents.

## Testing
This is a PoC and would need real significant testing before merge. 
Added python/ray/data/tests/test_node_sharded_read.py with coverage for:
* per-task node-affinity placement;
* one-task-per-node Parquet reads;
* explicit nodes=;
* write/read round trip;
* scheduling-precedence behavior;
* remote-storage rejection;
* file_extensions;
* unsupported option guards.
