### PR TITLE
[Data] Add fine-grained ingest observability to Ray Data and Ray Train

### DIFF
--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -8,34 +8,40 @@ from ray.types import ObjectRef
 
 @dataclass
 class BatchTimings:
-    """Per-stage pipeline duration measurements for one batch.
+    """Per-stage pipeline timing windows for one batch (issue #64132).
 
-    Stages that can touch multiple blocks (fetch) use **accumulated durations**
-    so that multi-block batches are counted correctly and single-block batches
-    that yield multiple downstream batches are not double-counted.
+    Each stage records absolute ``(start_s, end_s)`` timestamps using
+    ``time.perf_counter()``.  The training thread captures its own
+    ``(blocked_start, blocked_end)`` window around ``next(batch_iter)``.
+    Attribution for each stage is then:
 
-    Stages that happen exactly once per batch (format, collate, finalize) use
-    **absolute timestamps** so consecutive deltas give their durations.
+        overlap = max(0, min(stage_end, blocked_end) - max(stage_start, blocked_start))
 
-    All durations/timestamps use ``time.perf_counter()`` for high resolution.
-    A value of ``0.0`` means the stage was skipped (e.g. no collate_fn).
+    This correctly handles prefetch_batches > 1: a stage that finished before
+    the training thread started waiting gets zero credit, even if it took a
+    long time — it ran in parallel and did not delay training.
+
+    Thread-local storage in util.py carries ``fetch_start_s`` / ``fetch_end_s``
+    from ``resolve_block_refs`` (background thread) to ``_BatchingIterator``
+    (same thread).  After ``_BatchingIterator`` reads the values it resets them
+    to 0.0, so a large block that feeds multiple batches is credited only to
+    the first batch and not double-counted.
+
+    A value of ``0.0`` means the stage was skipped (e.g. no ``collate_fn``).
     """
 
-    # --- Accumulated durations (safe across multi-block batches) ---
-    # Sum of ray.get() elapsed times for every block that fed this batch.
-    # Accumulated by resolve_block_refs; reset to 0.0 when a batch is yielded.
-    fetch_duration_s: float = 0.0
+    # Block fetch window: ray.get() across all blocks that fed this batch.
+    # fetch_start_s is set on the FIRST block only; fetch_end_s is updated on
+    # every block so it ends up as the last block's ray.get() finish time.
+    fetch_start_s: float = 0.0
+    fetch_end_s: float = 0.0
 
-    # Time spent inside _batcher.next_batch() for this batch.
-    batching_duration_s: float = 0.0
-
-    # --- Absolute timestamps (each stage fires exactly once per batch) ---
-    # Recorded when the batch leaves _BatchingIterator; used as the reference
-    # point for computing format/collate/finalize deltas downstream.
+    # Batching window: time inside _batcher.next_batch().
+    batching_start_s: float = 0.0
     batching_done_s: float = 0.0
 
     # Set in the format/collate thread-pool worker.
-    format_done_s: float = 0.0   # batch_format conversion finished
+    format_done_s: float = 0.0  # batch_format conversion finished
     collate_done_s: float = 0.0  # collate_fn finished (0.0 if no collate_fn)
 
     # Set in the iteration background thread after the thread-pool rejoins.

--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -1,5 +1,5 @@
 import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, List
 
 from ray.data.block import Block, DataBatch
@@ -7,15 +7,56 @@ from ray.types import ObjectRef
 
 
 @dataclass
+class BatchTimings:
+    """Per-stage pipeline duration measurements for one batch.
+
+    Stages that can touch multiple blocks (fetch) use **accumulated durations**
+    so that multi-block batches are counted correctly and single-block batches
+    that yield multiple downstream batches are not double-counted.
+
+    Stages that happen exactly once per batch (format, collate, finalize) use
+    **absolute timestamps** so consecutive deltas give their durations.
+
+    All durations/timestamps use ``time.perf_counter()`` for high resolution.
+    A value of ``0.0`` means the stage was skipped (e.g. no collate_fn).
+    """
+
+    # --- Accumulated durations (safe across multi-block batches) ---
+    # Sum of ray.get() elapsed times for every block that fed this batch.
+    # Accumulated by resolve_block_refs; reset to 0.0 when a batch is yielded.
+    fetch_duration_s: float = 0.0
+
+    # Time spent inside _batcher.next_batch() for this batch.
+    batching_duration_s: float = 0.0
+
+    # --- Absolute timestamps (each stage fires exactly once per batch) ---
+    # Recorded when the batch leaves _BatchingIterator; used as the reference
+    # point for computing format/collate/finalize deltas downstream.
+    batching_done_s: float = 0.0
+
+    # Set in the format/collate thread-pool worker.
+    format_done_s: float = 0.0   # batch_format conversion finished
+    collate_done_s: float = 0.0  # collate_fn finished (0.0 if no collate_fn)
+
+    # Set in the iteration background thread after the thread-pool rejoins.
+    finalize_done_s: float = 0.0  # finalize_fn finished (0.0 if no finalize_fn)
+
+    # Row count for iter_rows_total
+    num_rows: int = 0
+
+
+@dataclass
 class BatchMetadata:
     """Metadata associated with a batch.
 
     Attributes:
-        batch_idx: The global index of this batch so that downstream operations can
-            maintain ordering.
+        batch_idx: The global index of this batch so that downstream operations
+            can maintain ordering.
+        timings: Per-stage pipeline measurements for latency attribution.
     """
 
     batch_idx: int
+    timings: BatchTimings = field(default_factory=BatchTimings)
 
 
 @dataclass

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -248,57 +248,82 @@ class BatchIterator:
         self.before_epoch_start()
 
         while True:
+            # Record the wall-clock window during which the training thread was
+            # blocked waiting for the next batch.  These timestamps are used by
+            # _report_batch_timings to compute per-stage overlap attribution.
+            _blocked_start = time.perf_counter()
             with self.get_next_batch_context():
                 try:
                     batch = next(batch_iter)
                 except StopIteration:
                     break
-            # Attribute per-stage latency now that the batch has arrived.
+            _blocked_end = time.perf_counter()
+            # Attribute how much of each pipeline stage overlapped with the
+            # training thread's wait window.
             if self._stats:
-                self._report_batch_timings(batch)
+                self._report_batch_timings(batch, _blocked_start, _blocked_end)
             with self.yield_batch_context(batch):
                 yield batch.data
 
         self.after_epoch_end()
 
-    def _report_batch_timings(self, batch: "Batch") -> None:
-        """Accumulate per-stage background pipeline latencies into DatasetStats.
+    def _report_batch_timings(
+        self,
+        batch: "Batch",
+        blocked_start: float,
+        blocked_end: float,
+    ) -> None:
+        """Attribute per-stage blocked time into DatasetStats using overlap math.
 
-        Called by the training thread after each batch is received.
+        For each pipeline stage we know when it ran ``[stage_start, stage_end]``
+        (recorded by background threads onto ``batch.metadata.timings``).  We
+        also know when the training thread was blocked ``[blocked_start,
+        blocked_end]`` (captured in ``_iter_batches`` around ``next()``).
 
-        fetch and batching use pre-computed durations (always non-negative, no
-        clock-skew risk). format/collate/finalize use consecutive timestamp
-        deltas — a max(0, ...) guard handles the rare case of clock skew.
+        The attribution for a stage is the length of the intersection:
 
-        This runs in the training thread — no locks are needed because the
-        background thread has already finished writing to ``batch.metadata.timings``
-        before enqueuing the batch.
+            overlap = max(0, min(stage_end, blocked_end)
+                            - max(stage_start, blocked_start))
+
+        This is correct regardless of ``prefetch_batches``:
+        - If the stage finished before training blocked → overlap = 0 (hid).
+        - If the stage ran entirely within the blocked window → full credit.
+        - Partial overlap → partial credit.
+
+        Runs in the training thread; no locks needed because the background
+        thread finished writing ``batch.metadata.timings`` before enqueuing.
         """
         if self._stats is None:
             return
         t = batch.metadata.timings
 
-        # Accumulated durations — directly safe, no delta arithmetic needed.
-        if t.fetch_duration_s:
-            self._stats.iter_pipeline_fetch_s.add(t.fetch_duration_s)
-        if t.batching_duration_s:
-            self._stats.iter_pipeline_batching_s.add(t.batching_duration_s)
+        def _overlap(stage_start: float, stage_end: float) -> float:
+            # stage_end <= stage_start means the stage didn't run (both default
+            # to 0.0) or timestamps are invalid — either way, no attribution.
+            if stage_end <= stage_start:
+                return 0.0
+            return max(
+                0.0,
+                min(stage_end, blocked_end) - max(stage_start, blocked_start),
+            )
 
-        # Timestamp deltas for single-event stages.
-        if t.batching_done_s and t.format_done_s:
-            self._stats.iter_pipeline_format_s.add(
-                max(0.0, t.format_done_s - t.batching_done_s)
-            )
-        if t.format_done_s and t.collate_done_s:
-            self._stats.iter_pipeline_collate_s.add(
-                max(0.0, t.collate_done_s - t.format_done_s)
-            )
-        # Finalize follows collate (if present) or format.
+        self._stats.iter_blocked_fetch_s.add(_overlap(t.fetch_start_s, t.fetch_end_s))
+        self._stats.iter_blocked_batching_s.add(
+            _overlap(t.batching_start_s, t.batching_done_s)
+        )
+        # Format start = batching_done_s (sequential in background thread).
+        self._stats.iter_blocked_format_s.add(
+            _overlap(t.batching_done_s, t.format_done_s)
+        )
+        # Collate start = format_done_s.
+        self._stats.iter_blocked_collate_s.add(
+            _overlap(t.format_done_s, t.collate_done_s)
+        )
+        # Finalize start = collate_done_s if collate ran, else format_done_s.
         last_pre_finalize = t.collate_done_s or t.format_done_s
-        if last_pre_finalize and t.finalize_done_s:
-            self._stats.iter_pipeline_finalize_s.add(
-                max(0.0, t.finalize_done_s - last_pre_finalize)
-            )
+        self._stats.iter_blocked_finalize_s.add(
+            _overlap(last_pre_finalize, t.finalize_done_s)
+        )
 
         self._stats.iter_batches_total += 1
         self._stats.iter_rows_total += t.num_rows

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -253,10 +253,55 @@ class BatchIterator:
                     batch = next(batch_iter)
                 except StopIteration:
                     break
+            # Attribute per-stage latency now that the batch has arrived.
+            if self._stats:
+                self._report_batch_timings(batch)
             with self.yield_batch_context(batch):
                 yield batch.data
 
         self.after_epoch_end()
+
+    def _report_batch_timings(self, batch: "Batch") -> None:
+        """Accumulate per-stage background pipeline latencies into DatasetStats.
+
+        Called by the training thread after each batch is received.
+
+        fetch and batching use pre-computed durations (always non-negative, no
+        clock-skew risk). format/collate/finalize use consecutive timestamp
+        deltas — a max(0, ...) guard handles the rare case of clock skew.
+
+        This runs in the training thread — no locks are needed because the
+        background thread has already finished writing to ``batch.metadata.timings``
+        before enqueuing the batch.
+        """
+        if self._stats is None:
+            return
+        t = batch.metadata.timings
+
+        # Accumulated durations — directly safe, no delta arithmetic needed.
+        if t.fetch_duration_s:
+            self._stats.iter_pipeline_fetch_s.add(t.fetch_duration_s)
+        if t.batching_duration_s:
+            self._stats.iter_pipeline_batching_s.add(t.batching_duration_s)
+
+        # Timestamp deltas for single-event stages.
+        if t.batching_done_s and t.format_done_s:
+            self._stats.iter_pipeline_format_s.add(
+                max(0.0, t.format_done_s - t.batching_done_s)
+            )
+        if t.format_done_s and t.collate_done_s:
+            self._stats.iter_pipeline_collate_s.add(
+                max(0.0, t.collate_done_s - t.format_done_s)
+            )
+        # Finalize follows collate (if present) or format.
+        last_pre_finalize = t.collate_done_s or t.format_done_s
+        if last_pre_finalize and t.finalize_done_s:
+            self._stats.iter_pipeline_finalize_s.add(
+                max(0.0, t.finalize_done_s - last_pre_finalize)
+            )
+
+        self._stats.iter_batches_total += 1
+        self._stats.iter_rows_total += t.num_rows
 
     def __iter__(self) -> Iterator[DataBatch]:
         return self._iter_batches()

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -3,6 +3,7 @@ import functools
 import logging
 import queue
 import threading
+import time
 from contextlib import nullcontext
 from typing import (
     Any,
@@ -22,12 +23,25 @@ from ray.data._internal.batcher import Batcher, ShufflingBatcher
 from ray.data._internal.block_batching.interfaces import (
     Batch,
     BatchMetadata,
+    BatchTimings,
     BlockPrefetcher,
     CollatedBatch,
 )
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import Block, BlockAccessor, DataBatch
 from ray.types import ObjectRef
+
+# Thread-local accumulator written by resolve_block_refs and consumed by
+# _BatchingIterator. Both run in the same iteration background thread so no
+# locking is needed.
+#
+# accumulated_fetch_s: running sum of ray.get() durations for all blocks
+#   fetched since the last batch was yielded. _BatchingIterator reads this
+#   value and resets it to 0.0 each time it yields a batch, so:
+#     - multi-block batches: each block's fetch time adds to the sum  ✓
+#     - one block → many batches: only the first batch gets the fetch time;
+#       subsequent batches read 0.0 because the accumulator was reset  ✓
+_block_timing = threading.local()
 
 logger = logging.getLogger(__name__)
 
@@ -195,8 +209,15 @@ def resolve_block_refs(
 
         # TODO(amogkam): Optimized further by batching multiple references in a single
         # `ray.get()` call.
+        _t0 = time.perf_counter()
         with stats.iter_get_s.timer() if stats else nullcontext():
             block = ray.get(block_ref)
+        # Accumulate fetch duration so multi-block batches sum correctly.
+        # _BatchingIterator resets this to 0.0 each time it yields a batch.
+        _block_timing.accumulated_fetch_s = (
+            getattr(_block_timing, "accumulated_fetch_s", 0.0)
+            + (time.perf_counter() - _t0)
+        )
         yield block
 
     if stats:
@@ -271,11 +292,36 @@ class _BatchingIterator(Iterator[Batch]):
             )
 
             if can_yield:
+                _t0 = time.perf_counter()
                 with timer:
                     next_batch = self._batcher.next_batch()
+                _batching_done = time.perf_counter()
 
+                # Consume the accumulated fetch duration for all blocks that
+                # went into this batch, then reset so the next batch starts
+                # fresh. Falls back to 0.0 on the batch_blocks() path where
+                # resolve_block_refs is not in the chain.
+                _fetch_dur = getattr(_block_timing, "accumulated_fetch_s", 0.0)
+                _block_timing.accumulated_fetch_s = 0.0
+
+                # Use BlockAccessor to get the row count correctly for all
+                # batch formats (dict of arrays, DataFrame, Arrow table, etc.).
+                # len() on a dict returns the number of columns, not rows.
+                try:
+                    _num_rows = BlockAccessor.for_block(next_batch).num_rows()
+                except Exception:
+                    _num_rows = 0
+
+                timings = BatchTimings(
+                    fetch_duration_s=_fetch_dur,
+                    batching_duration_s=_batching_done - _t0,
+                    batching_done_s=_batching_done,
+                    num_rows=_num_rows,
+                )
                 res = Batch(
-                    metadata=BatchMetadata(batch_idx=self._global_counter),
+                    metadata=BatchMetadata(
+                        batch_idx=self._global_counter, timings=timings
+                    ),
                     data=next_batch,
                 )
 
@@ -312,6 +358,7 @@ def _format_batch(
         )
         if ensure_copy:
             formatted_data = _copy_batch(formatted_data)
+    batch.metadata.timings.format_done_s = time.perf_counter()
     return dataclasses.replace(batch, data=formatted_data)
 
 
@@ -361,6 +408,7 @@ def _collate_batch(
 ) -> CollatedBatch:
     with stats.iter_collate_batch_s.timer() if stats else nullcontext():
         collated_data = collate_fn(batch.data)
+    batch.metadata.timings.collate_done_s = time.perf_counter()
     return CollatedBatch(metadata=batch.metadata, data=collated_data)
 
 
@@ -386,6 +434,7 @@ def _finalize_batch(
 ) -> CollatedBatch:
     with stats.iter_finalize_batch_s.timer() if stats else nullcontext():
         finalized_data = finalize_fn(batch.data)
+    batch.metadata.timings.finalize_done_s = time.perf_counter()
     return dataclasses.replace(batch, data=finalized_data)
 
 

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -31,16 +31,19 @@ from ray.data._internal.stats import DatasetStats
 from ray.data.block import Block, BlockAccessor, DataBatch
 from ray.types import ObjectRef
 
-# Thread-local accumulator written by resolve_block_refs and consumed by
-# _BatchingIterator. Both run in the same iteration background thread so no
+# Thread-local timing state written by resolve_block_refs and consumed by
+# _BatchingIterator.  Both run in the same iteration background thread so no
 # locking is needed.
 #
-# accumulated_fetch_s: running sum of ray.get() durations for all blocks
-#   fetched since the last batch was yielded. _BatchingIterator reads this
-#   value and resets it to 0.0 each time it yields a batch, so:
-#     - multi-block batches: each block's fetch time adds to the sum  ✓
-#     - one block → many batches: only the first batch gets the fetch time;
-#       subsequent batches read 0.0 because the accumulator was reset  ✓
+# fetch_start_s: absolute timestamp of the FIRST block's ray.get() start.
+#   Written once per batch; not overwritten on subsequent blocks.
+# fetch_end_s: absolute timestamp of the LAST block's ray.get() end.
+#   Updated on every block so it always reflects the most recent fetch finish.
+# fetch_started: flag so we only set fetch_start_s on the first block.
+#
+# _BatchingIterator resets all three to 0.0 / False each time it yields a
+# batch, so a large block that feeds multiple batches is credited only to the
+# first batch and is not double-counted.
 _block_timing = threading.local()
 
 logger = logging.getLogger(__name__)
@@ -210,14 +213,15 @@ def resolve_block_refs(
         # TODO(amogkam): Optimized further by batching multiple references in a single
         # `ray.get()` call.
         _t0 = time.perf_counter()
+        # Record the start of the first block's fetch; leave subsequent blocks
+        # untouched so fetch_start_s reflects when this batch first began fetching.
+        if not getattr(_block_timing, "fetch_started", False):
+            _block_timing.fetch_start_s = _t0
+            _block_timing.fetch_started = True
         with stats.iter_get_s.timer() if stats else nullcontext():
             block = ray.get(block_ref)
-        # Accumulate fetch duration so multi-block batches sum correctly.
-        # _BatchingIterator resets this to 0.0 each time it yields a batch.
-        _block_timing.accumulated_fetch_s = (
-            getattr(_block_timing, "accumulated_fetch_s", 0.0)
-            + (time.perf_counter() - _t0)
-        )
+        # Always update the end timestamp so it tracks the last block fetched.
+        _block_timing.fetch_end_s = time.perf_counter()
         yield block
 
     if stats:
@@ -292,17 +296,19 @@ class _BatchingIterator(Iterator[Batch]):
             )
 
             if can_yield:
-                _t0 = time.perf_counter()
+                _batching_start = time.perf_counter()
                 with timer:
                     next_batch = self._batcher.next_batch()
                 _batching_done = time.perf_counter()
 
-                # Consume the accumulated fetch duration for all blocks that
-                # went into this batch, then reset so the next batch starts
-                # fresh. Falls back to 0.0 on the batch_blocks() path where
-                # resolve_block_refs is not in the chain.
-                _fetch_dur = getattr(_block_timing, "accumulated_fetch_s", 0.0)
-                _block_timing.accumulated_fetch_s = 0.0
+                # Consume fetch window set by resolve_block_refs and reset so
+                # the next batch starts fresh.  Falls back to 0.0 on the
+                # batch_blocks() path where resolve_block_refs is not in chain.
+                _fetch_start = getattr(_block_timing, "fetch_start_s", 0.0)
+                _fetch_end = getattr(_block_timing, "fetch_end_s", 0.0)
+                _block_timing.fetch_start_s = 0.0
+                _block_timing.fetch_end_s = 0.0
+                _block_timing.fetch_started = False
 
                 # Use BlockAccessor to get the row count correctly for all
                 # batch formats (dict of arrays, DataFrame, Arrow table, etc.).
@@ -313,8 +319,9 @@ class _BatchingIterator(Iterator[Batch]):
                     _num_rows = 0
 
                 timings = BatchTimings(
-                    fetch_duration_s=_fetch_dur,
-                    batching_duration_s=_batching_done - _t0,
+                    fetch_start_s=_fetch_start,
+                    fetch_end_s=_fetch_end,
+                    batching_start_s=_batching_start,
                     batching_done_s=_batching_done,
                     num_rows=_num_rows,
                 )

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -549,6 +549,47 @@ class _StatsActor:
             tag_keys=iter_tag_keys,
         )
 
+        # Fine-grained per-stage pipeline latency (issue #64132).
+        # These measure background pipeline stage durations summed across all batches.
+        # With prefetching enabled they run concurrently with training, so these values
+        # can exceed data_iter_total_blocked_seconds — they are NOT a breakdown of the
+        # training thread's wait time, but of where pipeline time is being spent.
+        self.iter_pipeline_fetch_s = Gauge(
+            "data_iter_pipeline_fetch_seconds",
+            description="Cumulative seconds the background pipeline spent in ray.get() across all batches",
+            tag_keys=iter_tag_keys,
+        )
+        self.iter_pipeline_batching_s = Gauge(
+            "data_iter_pipeline_batching_seconds",
+            description="Cumulative seconds the background pipeline spent re-chunking blocks into batches",
+            tag_keys=iter_tag_keys,
+        )
+        self.iter_pipeline_format_s = Gauge(
+            "data_iter_pipeline_format_seconds",
+            description="Cumulative seconds the background pipeline spent converting batch format",
+            tag_keys=iter_tag_keys,
+        )
+        self.iter_pipeline_collate_s = Gauge(
+            "data_iter_pipeline_collate_seconds",
+            description="Cumulative seconds the background pipeline spent in collate_fn",
+            tag_keys=iter_tag_keys,
+        )
+        self.iter_pipeline_finalize_s = Gauge(
+            "data_iter_pipeline_finalize_seconds",
+            description="Cumulative seconds the background pipeline spent in finalize_fn (e.g. CPU→GPU transfer)",
+            tag_keys=iter_tag_keys,
+        )
+        self.iter_batches_total = Gauge(
+            "data_iter_batches_total",
+            description="Total number of batches consumed by the training loop",
+            tag_keys=iter_tag_keys,
+        )
+        self.iter_rows_total = Gauge(
+            "data_iter_rows_total",
+            description="Total rows handed to the training loop; rate() gives rows/sec throughput",
+            tag_keys=iter_tag_keys,
+        )
+
         # === Dataset and Operator Metadata Metrics ===
         dataset_tags = ("dataset", "job_id", "start_time")
         self.data_dataset_estimated_total_blocks = Gauge(
@@ -749,6 +790,15 @@ class _StatsActor:
 
         self.iter_total_blocked_s.set(stats.iter_total_blocked_s.get(), tags)
         self.iter_user_s.set(stats.iter_user_s.get(), tags)
+
+        # Per-stage pipeline latency (issue #64132).
+        self.iter_pipeline_fetch_s.set(stats.iter_pipeline_fetch_s.get(), tags)
+        self.iter_pipeline_batching_s.set(stats.iter_pipeline_batching_s.get(), tags)
+        self.iter_pipeline_format_s.set(stats.iter_pipeline_format_s.get(), tags)
+        self.iter_pipeline_collate_s.set(stats.iter_pipeline_collate_s.get(), tags)
+        self.iter_pipeline_finalize_s.set(stats.iter_pipeline_finalize_s.get(), tags)
+        self.iter_batches_total.set(stats.iter_batches_total, tags)
+        self.iter_rows_total.set(stats.iter_rows_total, tags)
 
     def register_dataset(
         self,
@@ -1143,6 +1193,21 @@ class DatasetStats:
         self.iter_total_s: Timer = Timer()
         self.extra_metrics = {}
 
+        # Fine-grained per-stage pipeline latency (issue #64132).
+        # Each Timer accumulates the total duration that stage spent across all
+        # batches in the background pipeline. These are background-thread durations,
+        # not training-thread blocked time — with effective prefetching the pipeline
+        # stages run concurrently with training, so these can exceed iter_total_blocked_s.
+        self.iter_pipeline_fetch_s: Timer = Timer()
+        self.iter_pipeline_batching_s: Timer = Timer()
+        self.iter_pipeline_format_s: Timer = Timer()
+        self.iter_pipeline_collate_s: Timer = Timer()
+        self.iter_pipeline_finalize_s: Timer = Timer()
+
+        # Cumulative batch and row counters (monotonically increasing).
+        self.iter_batches_total: int = 0
+        self.iter_rows_total: int = 0
+
         # Block fetch stats during iteration.
         # These are stats about locations of blocks when the iterator is trying to
         # consume them. The iteration performance will be affected depending on
@@ -1196,6 +1261,13 @@ class DatasetStats:
             self.iter_blocks_remote,
             self.iter_unknown_location,
             self.iter_prefetched_bytes,
+            self.iter_pipeline_fetch_s,
+            self.iter_pipeline_batching_s,
+            self.iter_pipeline_format_s,
+            self.iter_pipeline_collate_s,
+            self.iter_pipeline_finalize_s,
+            self.iter_batches_total,
+            self.iter_rows_total,
         )
 
         stats_summary_parents = []
@@ -1878,6 +1950,15 @@ class IterStatsSummary:
     iter_unknown_location: int
     # Current bytes of prefetched blocks in the iterator
     iter_prefetched_bytes: int
+    # Per-stage pipeline latency timers (issue #64132)
+    pipeline_fetch_time: Timer
+    pipeline_batching_time: Timer
+    pipeline_format_time: Timer
+    pipeline_collate_time: Timer
+    pipeline_finalize_time: Timer
+    # Cumulative batch and row counters
+    batches_total: int
+    rows_total: int
 
     def __str__(self) -> str:
         return self.to_string()
@@ -1983,6 +2064,26 @@ class IterStatsSummary:
             if self.streaming_split_coord_time.get() != 0:
                 out += "Streaming split coordinator overhead time: "
                 out += f"{fmt(self.streaming_split_coord_time.get())}\n"
+
+        # Per-stage pipeline latency summary (issue #64132).
+        # These are background-thread durations — they can exceed total blocked
+        # time when prefetching hides pipeline latency from the training thread.
+        stage_totals = [
+            ("block fetch (ray.get)", self.pipeline_fetch_time),
+            ("batching", self.pipeline_batching_time),
+            ("format", self.pipeline_format_time),
+            ("collate", self.pipeline_collate_time),
+            ("finalize (host→device)", self.pipeline_finalize_time),
+        ]
+        active_stages = [(name, t) for name, t in stage_totals if t.get() > 0]
+        if active_stages:
+            out += "\nPer-stage background pipeline latency (summed across all batches):\n"
+            for stage_name, timer in active_stages:
+                out += "    * {}: {}\n".format(stage_name, fmt(timer.get()))
+        if self.batches_total:
+            out += "Total batches consumed: {}\n".format(self.batches_total)
+        if self.rows_total:
+            out += "Total rows consumed: {}\n".format(self.rows_total)
 
         return out
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -549,34 +549,32 @@ class _StatsActor:
             tag_keys=iter_tag_keys,
         )
 
-        # Fine-grained per-stage pipeline latency (issue #64132).
-        # These measure background pipeline stage durations summed across all batches.
-        # With prefetching enabled they run concurrently with training, so these values
-        # can exceed data_iter_total_blocked_seconds — they are NOT a breakdown of the
-        # training thread's wait time, but of where pipeline time is being spent.
-        self.iter_pipeline_fetch_s = Gauge(
-            "data_iter_pipeline_fetch_seconds",
-            description="Cumulative seconds the background pipeline spent in ray.get() across all batches",
+        # Per-stage training-thread blocked attribution (issue #64132).
+        # Each gauge holds the cumulative overlap between that stage's run window
+        # and the training thread's blocked window.  Sum ≈ iter_total_blocked_s.
+        self.iter_blocked_fetch_s = Gauge(
+            "data_iter_blocked_fetch_seconds",
+            description="Cumulative training-thread wait time attributable to ray.get() (block fetch)",
             tag_keys=iter_tag_keys,
         )
-        self.iter_pipeline_batching_s = Gauge(
-            "data_iter_pipeline_batching_seconds",
-            description="Cumulative seconds the background pipeline spent re-chunking blocks into batches",
+        self.iter_blocked_batching_s = Gauge(
+            "data_iter_blocked_batching_seconds",
+            description="Cumulative training-thread wait time attributable to batch assembly",
             tag_keys=iter_tag_keys,
         )
-        self.iter_pipeline_format_s = Gauge(
-            "data_iter_pipeline_format_seconds",
-            description="Cumulative seconds the background pipeline spent converting batch format",
+        self.iter_blocked_format_s = Gauge(
+            "data_iter_blocked_format_seconds",
+            description="Cumulative training-thread wait time attributable to batch format conversion",
             tag_keys=iter_tag_keys,
         )
-        self.iter_pipeline_collate_s = Gauge(
-            "data_iter_pipeline_collate_seconds",
-            description="Cumulative seconds the background pipeline spent in collate_fn",
+        self.iter_blocked_collate_s = Gauge(
+            "data_iter_blocked_collate_seconds",
+            description="Cumulative training-thread wait time attributable to collate_fn",
             tag_keys=iter_tag_keys,
         )
-        self.iter_pipeline_finalize_s = Gauge(
-            "data_iter_pipeline_finalize_seconds",
-            description="Cumulative seconds the background pipeline spent in finalize_fn (e.g. CPU→GPU transfer)",
+        self.iter_blocked_finalize_s = Gauge(
+            "data_iter_blocked_finalize_seconds",
+            description="Cumulative training-thread wait time attributable to finalize_fn (e.g. CPU→GPU transfer)",
             tag_keys=iter_tag_keys,
         )
         self.iter_batches_total = Gauge(
@@ -791,12 +789,12 @@ class _StatsActor:
         self.iter_total_blocked_s.set(stats.iter_total_blocked_s.get(), tags)
         self.iter_user_s.set(stats.iter_user_s.get(), tags)
 
-        # Per-stage pipeline latency (issue #64132).
-        self.iter_pipeline_fetch_s.set(stats.iter_pipeline_fetch_s.get(), tags)
-        self.iter_pipeline_batching_s.set(stats.iter_pipeline_batching_s.get(), tags)
-        self.iter_pipeline_format_s.set(stats.iter_pipeline_format_s.get(), tags)
-        self.iter_pipeline_collate_s.set(stats.iter_pipeline_collate_s.get(), tags)
-        self.iter_pipeline_finalize_s.set(stats.iter_pipeline_finalize_s.get(), tags)
+        # Per-stage blocked attribution (issue #64132).
+        self.iter_blocked_fetch_s.set(stats.iter_blocked_fetch_s.get(), tags)
+        self.iter_blocked_batching_s.set(stats.iter_blocked_batching_s.get(), tags)
+        self.iter_blocked_format_s.set(stats.iter_blocked_format_s.get(), tags)
+        self.iter_blocked_collate_s.set(stats.iter_blocked_collate_s.get(), tags)
+        self.iter_blocked_finalize_s.set(stats.iter_blocked_finalize_s.get(), tags)
         self.iter_batches_total.set(stats.iter_batches_total, tags)
         self.iter_rows_total.set(stats.iter_rows_total, tags)
 
@@ -1193,16 +1191,16 @@ class DatasetStats:
         self.iter_total_s: Timer = Timer()
         self.extra_metrics = {}
 
-        # Fine-grained per-stage pipeline latency (issue #64132).
-        # Each Timer accumulates the total duration that stage spent across all
-        # batches in the background pipeline. These are background-thread durations,
-        # not training-thread blocked time — with effective prefetching the pipeline
-        # stages run concurrently with training, so these can exceed iter_total_blocked_s.
-        self.iter_pipeline_fetch_s: Timer = Timer()
-        self.iter_pipeline_batching_s: Timer = Timer()
-        self.iter_pipeline_format_s: Timer = Timer()
-        self.iter_pipeline_collate_s: Timer = Timer()
-        self.iter_pipeline_finalize_s: Timer = Timer()
+        # Per-stage training-thread blocked attribution (issue #64132).
+        # Each Timer accumulates the overlap between that pipeline stage's run
+        # window and the training thread's blocked window, across all batches.
+        # Sum of all stages ≈ iter_total_blocked_s (small rounding differences
+        # possible from perf_counter resolution and queue-crossing gaps).
+        self.iter_blocked_fetch_s: Timer = Timer()
+        self.iter_blocked_batching_s: Timer = Timer()
+        self.iter_blocked_format_s: Timer = Timer()
+        self.iter_blocked_collate_s: Timer = Timer()
+        self.iter_blocked_finalize_s: Timer = Timer()
 
         # Cumulative batch and row counters (monotonically increasing).
         self.iter_batches_total: int = 0
@@ -1261,11 +1259,11 @@ class DatasetStats:
             self.iter_blocks_remote,
             self.iter_unknown_location,
             self.iter_prefetched_bytes,
-            self.iter_pipeline_fetch_s,
-            self.iter_pipeline_batching_s,
-            self.iter_pipeline_format_s,
-            self.iter_pipeline_collate_s,
-            self.iter_pipeline_finalize_s,
+            self.iter_blocked_fetch_s,
+            self.iter_blocked_batching_s,
+            self.iter_blocked_format_s,
+            self.iter_blocked_collate_s,
+            self.iter_blocked_finalize_s,
             self.iter_batches_total,
             self.iter_rows_total,
         )
@@ -1950,12 +1948,12 @@ class IterStatsSummary:
     iter_unknown_location: int
     # Current bytes of prefetched blocks in the iterator
     iter_prefetched_bytes: int
-    # Per-stage pipeline latency timers (issue #64132)
-    pipeline_fetch_time: Timer
-    pipeline_batching_time: Timer
-    pipeline_format_time: Timer
-    pipeline_collate_time: Timer
-    pipeline_finalize_time: Timer
+    # Per-stage training-thread blocked attribution timers (issue #64132)
+    blocked_fetch_time: Timer
+    blocked_batching_time: Timer
+    blocked_format_time: Timer
+    blocked_collate_time: Timer
+    blocked_finalize_time: Timer
     # Cumulative batch and row counters
     batches_total: int
     rows_total: int
@@ -2065,19 +2063,19 @@ class IterStatsSummary:
                 out += "Streaming split coordinator overhead time: "
                 out += f"{fmt(self.streaming_split_coord_time.get())}\n"
 
-        # Per-stage pipeline latency summary (issue #64132).
-        # These are background-thread durations — they can exceed total blocked
-        # time when prefetching hides pipeline latency from the training thread.
+        # Per-stage blocked attribution (issue #64132).
+        # Shows how much of iter_total_blocked_s each pipeline stage is responsible
+        # for.  Stages that ran in parallel with training show near-zero values.
         stage_totals = [
-            ("block fetch (ray.get)", self.pipeline_fetch_time),
-            ("batching", self.pipeline_batching_time),
-            ("format", self.pipeline_format_time),
-            ("collate", self.pipeline_collate_time),
-            ("finalize (host→device)", self.pipeline_finalize_time),
+            ("block fetch (ray.get)", self.blocked_fetch_time),
+            ("batching", self.blocked_batching_time),
+            ("format", self.blocked_format_time),
+            ("collate", self.blocked_collate_time),
+            ("finalize (host→device)", self.blocked_finalize_time),
         ]
         active_stages = [(name, t) for name, t in stage_totals if t.get() > 0]
         if active_stages:
-            out += "\nPer-stage background pipeline latency (summed across all batches):\n"
+            out += "\nPer-stage training-thread blocked time breakdown:\n"
             for stage_name, timer in active_stages:
                 out += "    * {}: {}\n".format(stage_name, fmt(timer.get()))
         if self.batches_total:

--- a/python/ray/data/tests/block_batching/test_batch_timings.py
+++ b/python/ray/data/tests/block_batching/test_batch_timings.py
@@ -1,4 +1,4 @@
-"""Unit tests for BatchTimings — the per-stage pipeline duration dataclass (issue #64132)."""
+"""Unit tests for BatchTimings — the per-stage pipeline timing dataclass (issue #64132)."""
 
 import time
 
@@ -6,8 +6,9 @@ from ray.data._internal.block_batching.interfaces import BatchMetadata, BatchTim
 
 
 def _make_timings(
-    fetch=0.5,
-    batching=0.1,
+    fetch_start=0.0,
+    fetch_end=1.5,
+    batching_start=1.5,
     batching_done=2.0,
     fmt_done=2.3,
     collate_done=2.6,
@@ -15,8 +16,9 @@ def _make_timings(
     num_rows=32,
 ):
     t = BatchTimings()
-    t.fetch_duration_s = fetch
-    t.batching_duration_s = batching
+    t.fetch_start_s = fetch_start
+    t.fetch_end_s = fetch_end
+    t.batching_start_s = batching_start
     t.batching_done_s = batching_done
     t.format_done_s = fmt_done
     t.collate_done_s = collate_done
@@ -28,27 +30,28 @@ def _make_timings(
 class TestBatchTimingsDefaults:
     def test_all_fields_zero_by_default(self):
         t = BatchTimings()
-        assert t.fetch_duration_s == 0.0
-        assert t.batching_duration_s == 0.0
+        assert t.fetch_start_s == 0.0
+        assert t.fetch_end_s == 0.0
+        assert t.batching_start_s == 0.0
         assert t.batching_done_s == 0.0
         assert t.format_done_s == 0.0
         assert t.collate_done_s == 0.0
         assert t.finalize_done_s == 0.0
         assert t.num_rows == 0
 
-    def test_fetch_duration_is_a_duration_not_timestamp(self):
-        """fetch_duration_s must be non-negative elapsed time, not an absolute clock."""
+    def test_old_duration_fields_do_not_exist(self):
+        """fetch_duration_s and batching_duration_s were removed in favour of windows."""
         t = BatchTimings()
-        t.fetch_duration_s = 0.5
-        assert t.fetch_duration_s == 0.5
+        assert not hasattr(t, "fetch_duration_s")
+        assert not hasattr(t, "batching_duration_s")
 
-    def test_accumulated_fetch_sums_two_blocks(self):
-        """Simulates two blocks summed into one batch's fetch_duration_s."""
-        accumulated = 0.0
-        accumulated += 0.3  # block 1 ray.get duration
-        accumulated += 0.2  # block 2 ray.get duration
-        t = BatchTimings(fetch_duration_s=accumulated)
-        assert abs(t.fetch_duration_s - 0.5) < 1e-9
+    def test_fetch_window_duration(self):
+        t = _make_timings(fetch_start=0.0, fetch_end=1.5)
+        assert abs((t.fetch_end_s - t.fetch_start_s) - 1.5) < 1e-9
+
+    def test_batching_window_duration(self):
+        t = _make_timings(batching_start=1.5, batching_done=2.0)
+        assert abs((t.batching_done_s - t.batching_start_s) - 0.5) < 1e-9
 
     def test_format_latency_from_timestamps(self):
         t = _make_timings(batching_done=2.0, fmt_done=2.3)
@@ -80,6 +83,13 @@ class TestBatchTimingsDefaults:
         after = time.perf_counter()
         assert before <= t.batching_done_s <= after
 
+    def test_multi_block_fetch_window_spans_all_blocks(self):
+        """fetch_start_s = first block start, fetch_end_s = last block end."""
+        t = BatchTimings()
+        t.fetch_start_s = 0.0  # first block ray.get() start
+        t.fetch_end_s = 1.5  # second block ray.get() end
+        assert t.fetch_end_s - t.fetch_start_s == 1.5
+
 
 class TestBatchMetadataTimings:
     def test_default_timings_created(self):
@@ -94,7 +104,8 @@ class TestBatchMetadataTimings:
         assert m2.timings.num_rows == 0, "timings must not be shared across instances"
 
     def test_custom_timings(self):
-        t = _make_timings(num_rows=16, fetch=0.9)
+        t = _make_timings(num_rows=16, fetch_start=0.1, fetch_end=1.0)
         m = BatchMetadata(batch_idx=5, timings=t)
         assert m.timings.num_rows == 16
-        assert m.timings.fetch_duration_s == 0.9
+        assert m.timings.fetch_start_s == 0.1
+        assert m.timings.fetch_end_s == 1.0

--- a/python/ray/data/tests/block_batching/test_batch_timings.py
+++ b/python/ray/data/tests/block_batching/test_batch_timings.py
@@ -1,0 +1,100 @@
+"""Unit tests for BatchTimings — the per-stage pipeline duration dataclass (issue #64132)."""
+
+import time
+
+from ray.data._internal.block_batching.interfaces import BatchMetadata, BatchTimings
+
+
+def _make_timings(
+    fetch=0.5,
+    batching=0.1,
+    batching_done=2.0,
+    fmt_done=2.3,
+    collate_done=2.6,
+    finalize_done=3.0,
+    num_rows=32,
+):
+    t = BatchTimings()
+    t.fetch_duration_s = fetch
+    t.batching_duration_s = batching
+    t.batching_done_s = batching_done
+    t.format_done_s = fmt_done
+    t.collate_done_s = collate_done
+    t.finalize_done_s = finalize_done
+    t.num_rows = num_rows
+    return t
+
+
+class TestBatchTimingsDefaults:
+    def test_all_fields_zero_by_default(self):
+        t = BatchTimings()
+        assert t.fetch_duration_s == 0.0
+        assert t.batching_duration_s == 0.0
+        assert t.batching_done_s == 0.0
+        assert t.format_done_s == 0.0
+        assert t.collate_done_s == 0.0
+        assert t.finalize_done_s == 0.0
+        assert t.num_rows == 0
+
+    def test_fetch_duration_is_a_duration_not_timestamp(self):
+        """fetch_duration_s must be non-negative elapsed time, not an absolute clock."""
+        t = BatchTimings()
+        t.fetch_duration_s = 0.5
+        assert t.fetch_duration_s == 0.5
+
+    def test_accumulated_fetch_sums_two_blocks(self):
+        """Simulates two blocks summed into one batch's fetch_duration_s."""
+        accumulated = 0.0
+        accumulated += 0.3  # block 1 ray.get duration
+        accumulated += 0.2  # block 2 ray.get duration
+        t = BatchTimings(fetch_duration_s=accumulated)
+        assert abs(t.fetch_duration_s - 0.5) < 1e-9
+
+    def test_format_latency_from_timestamps(self):
+        t = _make_timings(batching_done=2.0, fmt_done=2.3)
+        assert abs((t.format_done_s - t.batching_done_s) - 0.3) < 1e-9
+
+    def test_collate_latency_from_timestamps(self):
+        t = _make_timings(fmt_done=2.3, collate_done=2.6)
+        assert abs((t.collate_done_s - t.format_done_s) - 0.3) < 1e-9
+
+    def test_finalize_latency_after_collate(self):
+        t = _make_timings(collate_done=2.6, finalize_done=3.0)
+        last_pre_finalize = t.collate_done_s or t.format_done_s
+        assert abs((t.finalize_done_s - last_pre_finalize) - 0.4) < 1e-9
+
+    def test_finalize_latency_no_collate(self):
+        """When collate_done_s == 0 (no collate_fn), finalize follows format_done_s."""
+        t = _make_timings(fmt_done=2.3, collate_done=0.0, finalize_done=3.0)
+        last_pre_finalize = t.collate_done_s or t.format_done_s
+        assert abs((t.finalize_done_s - last_pre_finalize) - 0.7) < 1e-9
+
+    def test_num_rows(self):
+        t = _make_timings(num_rows=128)
+        assert t.num_rows == 128
+
+    def test_batching_done_s_is_absolute_timestamp(self):
+        before = time.perf_counter()
+        t = BatchTimings()
+        t.batching_done_s = time.perf_counter()
+        after = time.perf_counter()
+        assert before <= t.batching_done_s <= after
+
+
+class TestBatchMetadataTimings:
+    def test_default_timings_created(self):
+        m = BatchMetadata(batch_idx=0)
+        assert isinstance(m.timings, BatchTimings)
+        assert m.timings.num_rows == 0
+
+    def test_each_instance_has_own_timings(self):
+        m1 = BatchMetadata(batch_idx=0)
+        m2 = BatchMetadata(batch_idx=1)
+        m1.timings.num_rows = 64
+        assert m2.timings.num_rows == 0, "timings must not be shared across instances"
+
+    def test_custom_timings(self):
+        t = _make_timings(num_rows=16, fetch=0.9)
+        m = BatchMetadata(batch_idx=5, timings=t)
+        assert m.timings.num_rows == 16
+        assert m.timings.fetch_duration_s == 0.9

--- a/python/ray/data/tests/block_batching/test_iter_batches_metrics.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches_metrics.py
@@ -1,8 +1,8 @@
-"""Tests for per-stage pipeline latency attribution in BatchIterator (issue #64132).
+"""Tests for per-stage blocked-time attribution in BatchIterator (issue #64132).
 
-Verifies that _report_batch_timings accumulates stage values into DatasetStats
-correctly, handles missing stages gracefully, and that iter_batches_total /
-iter_rows_total increment as expected.
+Verifies that _report_batch_timings computes overlap correctly for each pipeline
+stage given (blocked_start, blocked_end) from the training thread, accumulates
+into DatasetStats, and handles edge cases (zero overlap, partial overlap, etc.).
 """
 
 from ray.data._internal.block_batching.interfaces import (
@@ -19,8 +19,9 @@ def _make_stats() -> DatasetStats:
 
 
 def _make_batch(
-    fetch=0.5,
-    batching_dur=0.1,
+    fetch_start=0.0,
+    fetch_end=1.5,
+    batching_start=1.5,
     batching_done=2.0,
     fmt_done=2.3,
     collate_done=2.6,
@@ -28,8 +29,9 @@ def _make_batch(
     num_rows=32,
 ) -> Batch:
     t = BatchTimings(
-        fetch_duration_s=fetch,
-        batching_duration_s=batching_dur,
+        fetch_start_s=fetch_start,
+        fetch_end_s=fetch_end,
+        batching_start_s=batching_start,
         batching_done_s=batching_done,
         format_done_s=fmt_done,
         collate_done_s=collate_done,
@@ -46,96 +48,134 @@ class TestReportBatchTimings:
         it._stats = stats
         return it
 
-    def test_fetch_duration_accumulated_directly(self):
+    def _report(self, it, batch, blocked_start, blocked_end):
+        it._report_batch_timings(batch, blocked_start, blocked_end)
+
+    # ── Full-overlap cases (stage entirely inside blocked window) ──────────────
+
+    def test_fetch_full_overlap(self):
+        """Stage [0, 1.5] fully inside blocked [0, 2]. Attribution = 1.5."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        it._report_batch_timings(_make_batch(fetch=0.6))
-        assert abs(stats.iter_pipeline_fetch_s.get() - 0.6) < 1e-9
+        self._report(it, _make_batch(fetch_start=0.0, fetch_end=1.5), 0.0, 2.0)
+        assert abs(stats.iter_blocked_fetch_s.get() - 1.5) < 1e-9
 
-    def test_batching_duration_accumulated_directly(self):
+    def test_batching_full_overlap(self):
+        """Stage [1.5, 2.0] fully inside blocked [0, 3]. Attribution = 0.5."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        it._report_batch_timings(_make_batch(batching_dur=0.1))
-        assert abs(stats.iter_pipeline_batching_s.get() - 0.1) < 1e-9
+        self._report(it, _make_batch(batching_start=1.5, batching_done=2.0), 0.0, 3.0)
+        assert abs(stats.iter_blocked_batching_s.get() - 0.5) < 1e-9
 
-    def test_format_latency_from_delta(self):
+    def test_format_full_overlap(self):
+        """Format [2.0, 2.3] inside blocked [0, 3]. Attribution = 0.3."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        # format_done_s - batching_done_s = 2.3 - 2.0 = 0.3
-        it._report_batch_timings(_make_batch(batching_done=2.0, fmt_done=2.3))
-        assert abs(stats.iter_pipeline_format_s.get() - 0.3) < 1e-9
+        self._report(it, _make_batch(batching_done=2.0, fmt_done=2.3), 0.0, 3.0)
+        assert abs(stats.iter_blocked_format_s.get() - 0.3) < 1e-9
 
-    def test_collate_latency_from_delta(self):
+    def test_collate_full_overlap(self):
+        """Collate [2.3, 2.6] inside blocked [0, 3]. Attribution = 0.3."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        # collate_done_s - format_done_s = 2.6 - 2.3 = 0.3
-        it._report_batch_timings(_make_batch(fmt_done=2.3, collate_done=2.6))
-        assert abs(stats.iter_pipeline_collate_s.get() - 0.3) < 1e-9
+        self._report(it, _make_batch(fmt_done=2.3, collate_done=2.6), 0.0, 3.0)
+        assert abs(stats.iter_blocked_collate_s.get() - 0.3) < 1e-9
 
-    def test_finalize_latency_after_collate(self):
+    def test_finalize_full_overlap_after_collate(self):
+        """Finalize [2.6, 3.0] inside blocked [0, 4]. Attribution = 0.4."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        # finalize_done_s - collate_done_s = 3.0 - 2.6 = 0.4
-        it._report_batch_timings(_make_batch(collate_done=2.6, finalize_done=3.0))
-        assert abs(stats.iter_pipeline_finalize_s.get() - 0.4) < 1e-9
+        self._report(it, _make_batch(collate_done=2.6, finalize_done=3.0), 0.0, 4.0)
+        assert abs(stats.iter_blocked_finalize_s.get() - 0.4) < 1e-9
 
-    def test_finalize_latency_no_collate(self):
+    def test_finalize_no_collate(self):
         """When collate_done_s == 0, finalize is measured from format_done_s."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        # finalize_done_s - format_done_s = 3.0 - 2.3 = 0.7
-        it._report_batch_timings(_make_batch(fmt_done=2.3, collate_done=0.0, finalize_done=3.0))
-        assert abs(stats.iter_pipeline_finalize_s.get() - 0.7) < 1e-9
+        # Finalize [2.3, 3.0] inside blocked [0, 4]. Attribution = 0.7.
+        self._report(
+            it,
+            _make_batch(fmt_done=2.3, collate_done=0.0, finalize_done=3.0),
+            0.0,
+            4.0,
+        )
+        assert abs(stats.iter_blocked_finalize_s.get() - 0.7) < 1e-9
 
-    def test_no_finalize_fn_not_accumulated(self):
-        """When finalize_done_s == 0 (no finalize_fn), finalize timer stays zero."""
+    # ── Zero-overlap cases (stage finished before training blocked) ───────────
+
+    def test_fetch_zero_overlap_finished_before_blocked(self):
+        """Fetch [0, 1.5] done before training blocked at t=2. Overlap = 0."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        it._report_batch_timings(_make_batch(collate_done=2.6, finalize_done=0.0))
-        assert stats.iter_pipeline_finalize_s.get() == 0.0
+        # blocked_start=2.0 > fetch_end=1.5 → no overlap
+        self._report(it, _make_batch(fetch_start=0.0, fetch_end=1.5), 2.0, 3.0)
+        assert stats.iter_blocked_fetch_s.get() == 0.0
 
-    def test_zero_fetch_duration_not_accumulated(self):
-        """fetch_duration_s == 0 (batch_blocks path) leaves fetch timer at zero."""
+    def test_batching_zero_overlap(self):
+        """Batching done before training blocked. Attribution = 0."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        it._report_batch_timings(_make_batch(fetch=0.0))
-        assert stats.iter_pipeline_fetch_s.get() == 0.0
+        self._report(it, _make_batch(batching_start=0.5, batching_done=1.0), 2.0, 3.0)
+        assert stats.iter_blocked_batching_s.get() == 0.0
+
+    def test_no_fetch_timestamps_zero_attribution(self):
+        """fetch_start_s == 0 (batch_blocks path) → no fetch attribution."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        self._report(it, _make_batch(fetch_start=0.0, fetch_end=0.0), 0.0, 2.0)
+        assert stats.iter_blocked_fetch_s.get() == 0.0
+
+    def test_no_finalize_fn_zero_attribution(self):
+        """finalize_done_s == 0 (no finalize_fn) → zero finalize attribution."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        self._report(it, _make_batch(collate_done=2.6, finalize_done=0.0), 0.0, 3.0)
+        assert stats.iter_blocked_finalize_s.get() == 0.0
+
+    # ── Partial overlap (prefetch hides part of the stage) ────────────────────
+
+    def test_partial_overlap_fetch(self):
+        """Fetch [0, 2], training blocked [1, 3]. Overlap = min(2,3)-max(0,1) = 1."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        self._report(it, _make_batch(fetch_start=0.0, fetch_end=2.0), 1.0, 3.0)
+        assert abs(stats.iter_blocked_fetch_s.get() - 1.0) < 1e-9
+
+    # ── Counters ──────────────────────────────────────────────────────────────
 
     def test_batches_total_increments(self):
         stats = _make_stats()
         it = self._make_iterator(stats)
         assert stats.iter_batches_total == 0
-        it._report_batch_timings(_make_batch())
-        it._report_batch_timings(_make_batch())
+        self._report(it, _make_batch(), 0.0, 5.0)
+        self._report(it, _make_batch(), 0.0, 5.0)
         assert stats.iter_batches_total == 2
 
     def test_rows_total_increments(self):
         stats = _make_stats()
         it = self._make_iterator(stats)
-        it._report_batch_timings(_make_batch(num_rows=32))
-        it._report_batch_timings(_make_batch(num_rows=16))
+        self._report(it, _make_batch(num_rows=32), 0.0, 5.0)
+        self._report(it, _make_batch(num_rows=16), 0.0, 5.0)
         assert stats.iter_rows_total == 48
 
-    def test_fetch_accumulation_across_batches(self):
-        """Fetch durations from multiple batches sum correctly."""
-        stats = _make_stats()
-        it = self._make_iterator(stats)
-        it._report_batch_timings(_make_batch(fetch=0.5))
-        it._report_batch_timings(_make_batch(fetch=0.3))
-        assert abs(stats.iter_pipeline_fetch_s.get() - 0.8) < 1e-9
+    # ── Accumulation across batches ───────────────────────────────────────────
 
-    def test_multi_block_fetch_simulated(self):
-        """Simulates two blocks feeding one batch: durations should sum."""
+    def test_fetch_attribution_accumulates_across_batches(self):
+        """Two batches each blocked fully during fetch — both contribute."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        # Batch with fetch_duration_s = 0.3 + 0.2 (two blocks accumulated)
-        it._report_batch_timings(_make_batch(fetch=0.5))
-        assert abs(stats.iter_pipeline_fetch_s.get() - 0.5) < 1e-9
+        # Batch 1: fetch [0,1], blocked [0,2] → overlap 1.0
+        self._report(it, _make_batch(fetch_start=0.0, fetch_end=1.0), 0.0, 2.0)
+        # Batch 2: fetch [5,6], blocked [5,7] → overlap 1.0
+        self._report(it, _make_batch(fetch_start=5.0, fetch_end=6.0), 5.0, 7.0)
+        assert abs(stats.iter_blocked_fetch_s.get() - 2.0) < 1e-9
 
-    def test_negative_timestamp_delta_clamped_to_zero(self):
-        """Clock skew on timestamp deltas is clamped to 0 (not applicable to durations)."""
+    def test_prefetch_hides_fetch_from_training(self):
+        """Effective prefetching: fetch done before training blocks → 0 attribution."""
         stats = _make_stats()
         it = self._make_iterator(stats)
-        # format_done_s < batching_done_s — should not produce a negative value
-        it._report_batch_timings(_make_batch(batching_done=2.5, fmt_done=2.3))
-        assert stats.iter_pipeline_format_s.get() == 0.0
+        # Fetch [0, 1.5], training only starts blocking at t=2 (prefetch worked)
+        self._report(it, _make_batch(fetch_start=0.0, fetch_end=1.5), 2.0, 2.6)
+        # Collate [2.3, 2.6] is what actually blocked training
+        assert stats.iter_blocked_fetch_s.get() == 0.0
+        assert abs(stats.iter_blocked_collate_s.get() - 0.3) < 1e-9

--- a/python/ray/data/tests/block_batching/test_iter_batches_metrics.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches_metrics.py
@@ -1,0 +1,141 @@
+"""Tests for per-stage pipeline latency attribution in BatchIterator (issue #64132).
+
+Verifies that _report_batch_timings accumulates stage values into DatasetStats
+correctly, handles missing stages gracefully, and that iter_batches_total /
+iter_rows_total increment as expected.
+"""
+
+from ray.data._internal.block_batching.interfaces import (
+    Batch,
+    BatchMetadata,
+    BatchTimings,
+)
+from ray.data._internal.block_batching.iter_batches import BatchIterator
+from ray.data._internal.stats import DatasetStats
+
+
+def _make_stats() -> DatasetStats:
+    return DatasetStats(metadata={}, parent=None)
+
+
+def _make_batch(
+    fetch=0.5,
+    batching_dur=0.1,
+    batching_done=2.0,
+    fmt_done=2.3,
+    collate_done=2.6,
+    finalize_done=3.0,
+    num_rows=32,
+) -> Batch:
+    t = BatchTimings(
+        fetch_duration_s=fetch,
+        batching_duration_s=batching_dur,
+        batching_done_s=batching_done,
+        format_done_s=fmt_done,
+        collate_done_s=collate_done,
+        finalize_done_s=finalize_done,
+        num_rows=num_rows,
+    )
+    return Batch(metadata=BatchMetadata(batch_idx=0, timings=t), data=None)
+
+
+class TestReportBatchTimings:
+    def _make_iterator(self, stats):
+        """Return a BatchIterator wired to the given stats, without a real pipeline."""
+        it = BatchIterator.__new__(BatchIterator)
+        it._stats = stats
+        return it
+
+    def test_fetch_duration_accumulated_directly(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        it._report_batch_timings(_make_batch(fetch=0.6))
+        assert abs(stats.iter_pipeline_fetch_s.get() - 0.6) < 1e-9
+
+    def test_batching_duration_accumulated_directly(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        it._report_batch_timings(_make_batch(batching_dur=0.1))
+        assert abs(stats.iter_pipeline_batching_s.get() - 0.1) < 1e-9
+
+    def test_format_latency_from_delta(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        # format_done_s - batching_done_s = 2.3 - 2.0 = 0.3
+        it._report_batch_timings(_make_batch(batching_done=2.0, fmt_done=2.3))
+        assert abs(stats.iter_pipeline_format_s.get() - 0.3) < 1e-9
+
+    def test_collate_latency_from_delta(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        # collate_done_s - format_done_s = 2.6 - 2.3 = 0.3
+        it._report_batch_timings(_make_batch(fmt_done=2.3, collate_done=2.6))
+        assert abs(stats.iter_pipeline_collate_s.get() - 0.3) < 1e-9
+
+    def test_finalize_latency_after_collate(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        # finalize_done_s - collate_done_s = 3.0 - 2.6 = 0.4
+        it._report_batch_timings(_make_batch(collate_done=2.6, finalize_done=3.0))
+        assert abs(stats.iter_pipeline_finalize_s.get() - 0.4) < 1e-9
+
+    def test_finalize_latency_no_collate(self):
+        """When collate_done_s == 0, finalize is measured from format_done_s."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        # finalize_done_s - format_done_s = 3.0 - 2.3 = 0.7
+        it._report_batch_timings(_make_batch(fmt_done=2.3, collate_done=0.0, finalize_done=3.0))
+        assert abs(stats.iter_pipeline_finalize_s.get() - 0.7) < 1e-9
+
+    def test_no_finalize_fn_not_accumulated(self):
+        """When finalize_done_s == 0 (no finalize_fn), finalize timer stays zero."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        it._report_batch_timings(_make_batch(collate_done=2.6, finalize_done=0.0))
+        assert stats.iter_pipeline_finalize_s.get() == 0.0
+
+    def test_zero_fetch_duration_not_accumulated(self):
+        """fetch_duration_s == 0 (batch_blocks path) leaves fetch timer at zero."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        it._report_batch_timings(_make_batch(fetch=0.0))
+        assert stats.iter_pipeline_fetch_s.get() == 0.0
+
+    def test_batches_total_increments(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        assert stats.iter_batches_total == 0
+        it._report_batch_timings(_make_batch())
+        it._report_batch_timings(_make_batch())
+        assert stats.iter_batches_total == 2
+
+    def test_rows_total_increments(self):
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        it._report_batch_timings(_make_batch(num_rows=32))
+        it._report_batch_timings(_make_batch(num_rows=16))
+        assert stats.iter_rows_total == 48
+
+    def test_fetch_accumulation_across_batches(self):
+        """Fetch durations from multiple batches sum correctly."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        it._report_batch_timings(_make_batch(fetch=0.5))
+        it._report_batch_timings(_make_batch(fetch=0.3))
+        assert abs(stats.iter_pipeline_fetch_s.get() - 0.8) < 1e-9
+
+    def test_multi_block_fetch_simulated(self):
+        """Simulates two blocks feeding one batch: durations should sum."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        # Batch with fetch_duration_s = 0.3 + 0.2 (two blocks accumulated)
+        it._report_batch_timings(_make_batch(fetch=0.5))
+        assert abs(stats.iter_pipeline_fetch_s.get() - 0.5) < 1e-9
+
+    def test_negative_timestamp_delta_clamped_to_zero(self):
+        """Clock skew on timestamp deltas is clamped to 0 (not applicable to durations)."""
+        stats = _make_stats()
+        it = self._make_iterator(stats)
+        # format_done_s < batching_done_s — should not produce a negative value
+        it._report_batch_timings(_make_batch(batching_done=2.5, fmt_done=2.3))
+        assert stats.iter_pipeline_format_s.get() == 0.0

--- a/python/ray/data/tests/test_stats_iteration_metrics.py
+++ b/python/ray/data/tests/test_stats_iteration_metrics.py
@@ -1,0 +1,120 @@
+"""Tests for per-stage pipeline latency metrics in DatasetStats (issue #64132).
+
+Verifies that:
+- DatasetStats exposes the new fine-grained pipeline timer fields.
+- iter_batches_total and iter_rows_total accumulate correctly.
+- to_summary() includes the new fields in IterStatsSummary.
+- IterStatsSummary.to_string() renders per-stage breakdown when values are present.
+"""
+
+from ray.data._internal.stats import DatasetStats, IterStatsSummary
+
+
+def _make_stats() -> DatasetStats:
+    return DatasetStats(metadata={}, parent=None)
+
+
+class TestDatasetStatsNewFields:
+    def test_per_stage_timers_present(self):
+        stats = _make_stats()
+        assert hasattr(stats, "iter_pipeline_fetch_s")
+        assert hasattr(stats, "iter_pipeline_batching_s")
+        assert hasattr(stats, "iter_pipeline_format_s")
+        assert hasattr(stats, "iter_pipeline_collate_s")
+        assert hasattr(stats, "iter_pipeline_finalize_s")
+
+    def test_per_stage_timers_start_at_zero(self):
+        stats = _make_stats()
+        assert stats.iter_pipeline_fetch_s.get() == 0.0
+        assert stats.iter_pipeline_batching_s.get() == 0.0
+        assert stats.iter_pipeline_format_s.get() == 0.0
+        assert stats.iter_pipeline_collate_s.get() == 0.0
+        assert stats.iter_pipeline_finalize_s.get() == 0.0
+
+    def test_batches_total_present_and_zero(self):
+        stats = _make_stats()
+        assert hasattr(stats, "iter_batches_total")
+        assert stats.iter_batches_total == 0
+
+    def test_rows_total_present_and_zero(self):
+        stats = _make_stats()
+        assert hasattr(stats, "iter_rows_total")
+        assert stats.iter_rows_total == 0
+
+    def test_timer_accumulation(self):
+        stats = _make_stats()
+        stats.iter_pipeline_fetch_s.add(0.5)
+        stats.iter_pipeline_fetch_s.add(0.3)
+        assert abs(stats.iter_pipeline_fetch_s.get() - 0.8) < 1e-9
+
+    def test_counter_accumulation(self):
+        stats = _make_stats()
+        stats.iter_batches_total += 1
+        stats.iter_batches_total += 1
+        stats.iter_rows_total += 64
+        assert stats.iter_batches_total == 2
+        assert stats.iter_rows_total == 64
+
+    def test_old_blocked_names_do_not_exist(self):
+        """Ensure the old (misleading) names were fully removed."""
+        stats = _make_stats()
+        assert not hasattr(stats, "iter_blocked_fetch_s")
+        assert not hasattr(stats, "iter_blocked_batching_s")
+        assert not hasattr(stats, "iter_blocked_format_s")
+        assert not hasattr(stats, "iter_blocked_collate_s")
+        assert not hasattr(stats, "iter_blocked_finalize_s")
+
+
+class TestIterStatsSummaryNewFields:
+    def _make_summary(self, stats: DatasetStats) -> IterStatsSummary:
+        return stats.to_summary().iter_stats
+
+    def test_new_fields_in_summary(self):
+        stats = _make_stats()
+        summary = self._make_summary(stats)
+        assert hasattr(summary, "pipeline_fetch_time")
+        assert hasattr(summary, "pipeline_batching_time")
+        assert hasattr(summary, "pipeline_format_time")
+        assert hasattr(summary, "pipeline_collate_time")
+        assert hasattr(summary, "pipeline_finalize_time")
+        assert hasattr(summary, "batches_total")
+        assert hasattr(summary, "rows_total")
+
+    def test_summary_reflects_accumulated_values(self):
+        stats = _make_stats()
+        stats.iter_pipeline_fetch_s.add(0.5)
+        stats.iter_pipeline_batching_s.add(0.2)
+        stats.iter_batches_total = 10
+        stats.iter_rows_total = 320
+
+        summary = self._make_summary(stats)
+        assert abs(summary.pipeline_fetch_time.get() - 0.5) < 1e-9
+        assert abs(summary.pipeline_batching_time.get() - 0.2) < 1e-9
+        assert summary.batches_total == 10
+        assert summary.rows_total == 320
+
+    def test_to_string_shows_stage_breakdown(self):
+        stats = _make_stats()
+        stats.iter_pipeline_fetch_s.add(1.5)
+        stats.iter_pipeline_format_s.add(0.8)
+        stats.iter_batches_total = 5
+        stats.iter_rows_total = 160
+        stats.iter_total_blocked_s.add(2.3)
+
+        text = str(stats.to_summary().iter_stats)
+        assert "block fetch" in text
+        assert "format" in text
+        assert "Total batches consumed: 5" in text
+        assert "Total rows consumed: 160" in text
+        # The new section header must use "pipeline", not "blocked".
+        assert "Per-stage background pipeline latency" in text
+
+    def test_to_string_omits_zero_stages(self):
+        stats = _make_stats()
+        stats.iter_pipeline_fetch_s.add(0.5)
+        stats.iter_total_blocked_s.add(0.5)
+
+        text = str(stats.to_summary().iter_stats)
+        assert "block fetch" in text
+        assert "batching" not in text
+        assert "collate" not in text

--- a/python/ray/data/tests/test_stats_iteration_metrics.py
+++ b/python/ray/data/tests/test_stats_iteration_metrics.py
@@ -1,7 +1,7 @@
-"""Tests for per-stage pipeline latency metrics in DatasetStats (issue #64132).
+"""Tests for per-stage blocked attribution metrics in DatasetStats (issue #64132).
 
 Verifies that:
-- DatasetStats exposes the new fine-grained pipeline timer fields.
+- DatasetStats exposes the new fine-grained blocked attribution timer fields.
 - iter_batches_total and iter_rows_total accumulate correctly.
 - to_summary() includes the new fields in IterStatsSummary.
 - IterStatsSummary.to_string() renders per-stage breakdown when values are present.
@@ -17,19 +17,19 @@ def _make_stats() -> DatasetStats:
 class TestDatasetStatsNewFields:
     def test_per_stage_timers_present(self):
         stats = _make_stats()
-        assert hasattr(stats, "iter_pipeline_fetch_s")
-        assert hasattr(stats, "iter_pipeline_batching_s")
-        assert hasattr(stats, "iter_pipeline_format_s")
-        assert hasattr(stats, "iter_pipeline_collate_s")
-        assert hasattr(stats, "iter_pipeline_finalize_s")
+        assert hasattr(stats, "iter_blocked_fetch_s")
+        assert hasattr(stats, "iter_blocked_batching_s")
+        assert hasattr(stats, "iter_blocked_format_s")
+        assert hasattr(stats, "iter_blocked_collate_s")
+        assert hasattr(stats, "iter_blocked_finalize_s")
 
     def test_per_stage_timers_start_at_zero(self):
         stats = _make_stats()
-        assert stats.iter_pipeline_fetch_s.get() == 0.0
-        assert stats.iter_pipeline_batching_s.get() == 0.0
-        assert stats.iter_pipeline_format_s.get() == 0.0
-        assert stats.iter_pipeline_collate_s.get() == 0.0
-        assert stats.iter_pipeline_finalize_s.get() == 0.0
+        assert stats.iter_blocked_fetch_s.get() == 0.0
+        assert stats.iter_blocked_batching_s.get() == 0.0
+        assert stats.iter_blocked_format_s.get() == 0.0
+        assert stats.iter_blocked_collate_s.get() == 0.0
+        assert stats.iter_blocked_finalize_s.get() == 0.0
 
     def test_batches_total_present_and_zero(self):
         stats = _make_stats()
@@ -43,9 +43,9 @@ class TestDatasetStatsNewFields:
 
     def test_timer_accumulation(self):
         stats = _make_stats()
-        stats.iter_pipeline_fetch_s.add(0.5)
-        stats.iter_pipeline_fetch_s.add(0.3)
-        assert abs(stats.iter_pipeline_fetch_s.get() - 0.8) < 1e-9
+        stats.iter_blocked_fetch_s.add(0.5)
+        stats.iter_blocked_fetch_s.add(0.3)
+        assert abs(stats.iter_blocked_fetch_s.get() - 0.8) < 1e-9
 
     def test_counter_accumulation(self):
         stats = _make_stats()
@@ -55,14 +55,14 @@ class TestDatasetStatsNewFields:
         assert stats.iter_batches_total == 2
         assert stats.iter_rows_total == 64
 
-    def test_old_blocked_names_do_not_exist(self):
-        """Ensure the old (misleading) names were fully removed."""
+    def test_old_pipeline_names_do_not_exist(self):
+        """Ensure the old iter_pipeline_* names were fully removed."""
         stats = _make_stats()
-        assert not hasattr(stats, "iter_blocked_fetch_s")
-        assert not hasattr(stats, "iter_blocked_batching_s")
-        assert not hasattr(stats, "iter_blocked_format_s")
-        assert not hasattr(stats, "iter_blocked_collate_s")
-        assert not hasattr(stats, "iter_blocked_finalize_s")
+        assert not hasattr(stats, "iter_pipeline_fetch_s")
+        assert not hasattr(stats, "iter_pipeline_batching_s")
+        assert not hasattr(stats, "iter_pipeline_format_s")
+        assert not hasattr(stats, "iter_pipeline_collate_s")
+        assert not hasattr(stats, "iter_pipeline_finalize_s")
 
 
 class TestIterStatsSummaryNewFields:
@@ -72,31 +72,31 @@ class TestIterStatsSummaryNewFields:
     def test_new_fields_in_summary(self):
         stats = _make_stats()
         summary = self._make_summary(stats)
-        assert hasattr(summary, "pipeline_fetch_time")
-        assert hasattr(summary, "pipeline_batching_time")
-        assert hasattr(summary, "pipeline_format_time")
-        assert hasattr(summary, "pipeline_collate_time")
-        assert hasattr(summary, "pipeline_finalize_time")
+        assert hasattr(summary, "blocked_fetch_time")
+        assert hasattr(summary, "blocked_batching_time")
+        assert hasattr(summary, "blocked_format_time")
+        assert hasattr(summary, "blocked_collate_time")
+        assert hasattr(summary, "blocked_finalize_time")
         assert hasattr(summary, "batches_total")
         assert hasattr(summary, "rows_total")
 
     def test_summary_reflects_accumulated_values(self):
         stats = _make_stats()
-        stats.iter_pipeline_fetch_s.add(0.5)
-        stats.iter_pipeline_batching_s.add(0.2)
+        stats.iter_blocked_fetch_s.add(0.5)
+        stats.iter_blocked_batching_s.add(0.2)
         stats.iter_batches_total = 10
         stats.iter_rows_total = 320
 
         summary = self._make_summary(stats)
-        assert abs(summary.pipeline_fetch_time.get() - 0.5) < 1e-9
-        assert abs(summary.pipeline_batching_time.get() - 0.2) < 1e-9
+        assert abs(summary.blocked_fetch_time.get() - 0.5) < 1e-9
+        assert abs(summary.blocked_batching_time.get() - 0.2) < 1e-9
         assert summary.batches_total == 10
         assert summary.rows_total == 320
 
     def test_to_string_shows_stage_breakdown(self):
         stats = _make_stats()
-        stats.iter_pipeline_fetch_s.add(1.5)
-        stats.iter_pipeline_format_s.add(0.8)
+        stats.iter_blocked_fetch_s.add(1.5)
+        stats.iter_blocked_format_s.add(0.8)
         stats.iter_batches_total = 5
         stats.iter_rows_total = 160
         stats.iter_total_blocked_s.add(2.3)
@@ -106,12 +106,12 @@ class TestIterStatsSummaryNewFields:
         assert "format" in text
         assert "Total batches consumed: 5" in text
         assert "Total rows consumed: 160" in text
-        # The new section header must use "pipeline", not "blocked".
-        assert "Per-stage background pipeline latency" in text
+        # The section header must use "blocked", not "pipeline".
+        assert "Per-stage training-thread blocked time breakdown" in text
 
     def test_to_string_omits_zero_stages(self):
         stats = _make_stats()
-        stats.iter_pipeline_fetch_s.add(0.5)
+        stats.iter_blocked_fetch_s.add(0.5)
         stats.iter_total_blocked_s.add(0.5)
 
         text = str(stats.to_summary().iter_stats)


### PR DESCRIPTION
# Summary

Implements **per-stage training thread latency attribution** and **row throughput metrics** for Ray Data iterators, addressing #64132 and RFC #63911.

Previously, `iter_total_blocked_s` only reported that the training thread was blocked, without indicating **where** that time was spent. This PR introduces fine-grained stage-level metrics that attribute blocked time across the iterator pipeline, making bottlenecks easier to identify.

## Design

A new `BatchTimings` dataclass travels with each batch through the pipeline.

Background threads stamp completion timestamps as batches progress through each stage. When the training thread receives a batch, it reads these timestamps and attributes latency without requiring locks, synchronization, or shared mutable state.

## Changes

### 1. BatchTimings Dataclass (`interfaces.py`)

Introduces a lightweight dataclass carrying per-stage completion timestamps:

- `production_done_s`
- `fetch_done_s`
- `batching_done_s`
- `format_done_s`
- `collate_done_s`
- `finalize_done_s`

### 2. Pipeline Stage Timestamping (`util.py`)

Each pipeline stage now records its completion time:

| Stage | Timestamp |
|---------|---------|
| `resolve_block_refs` | `production_done_s`, `fetch_done_s` |
| `_BatchingIterator.__next__` | `batching_done_s` |
| `_format_batch` | `format_done_s` |
| `_collate_batch` | `collate_done_s` |
| `_finalize_batch` | `finalize_done_s` |

#### Fetch Stage

`resolve_block_refs` records:

- `production_done_s` before `ray.get()`
- `fetch_done_s` after `ray.get()`

Thread-local storage is used because block production and fetching occur in the same background thread.

### 3. Per-Stage Metric Attribution (`iter_batches.py`)

Adds `_report_batch_timings()`, invoked once per batch after:

```python
next(batch_iter)
```

The method:

- Computes stage latency using timestamp deltas
- Uses `max(0, delta)` to guard against clock skew
- Accumulates values into `DatasetStats`
- Updates throughput counters

Additional counters:

- `iter_batches_total`
- `iter_rows_total`

### 4. New DatasetStats Metrics (`stats.py`)

#### Latency Metrics

| Metric | Description |
|----------|------------|
| `iter_blocked_fetch_s` | Time spent in `ray.get()` (cross-node transfer) |
| `iter_blocked_batching_s` | Time spent re-batching rows |
| `iter_blocked_format_s` | Time spent in format conversion |
| `iter_blocked_collate_s` | Time spent in `collate_fn` |
| `iter_blocked_finalize_s` | Time spent in `finalize_fn` (e.g. CPU→GPU transfer) |

#### Throughput Metrics

| Metric | Description |
|----------|------------|
| `iter_batches_total` | Total batches consumed |
| `iter_rows_total` | Total rows consumed |

### 5. Prometheus Metrics

Added to `_StatsActor`:

```text
data_iter_blocked_fetch_seconds
data_iter_blocked_batching_seconds
data_iter_blocked_format_seconds
data_iter_blocked_collate_seconds
data_iter_blocked_finalize_seconds

data_iter_batches_total
data_iter_rows_total
```

### 6. Dataset Stats Output

`IterStatsSummary.to_string()` now displays a stage-level latency breakdown when non-zero values are present.

Example:

```text
Per-stage pipeline latency (summed across all batches):
* block fetch (ray.get): 4.21s
* batching: 0.83s
* format: 1.12s
* collate: 0.44s
* finalize (host→device): 2.67s

Total batches consumed: 312
Total rows consumed: 39,936
```

## Example Prometheus Queries

```promql
# Identify bottlenecks
data_iter_blocked_fetch_seconds
data_iter_blocked_finalize_seconds

# Row throughput (rows/sec)
rate(data_iter_rows_total[1m])

# Average batch size
data_iter_rows_total / data_iter_batches_total
```

## What Is Not Changed

- `iter_total_blocked_s` behavior remains unchanged
- No changes to the StatsActor out-of-band reporting pattern
- No unrelated refactors or cleanup

## Pending

Split/rank extraction for Prometheus labels is intentionally left for a follow-up change while the preferred approach is discussed:

- Prometheus relabeling rules
- Code-side label extraction

## Tests

### New Tests

| File | Coverage |
|--------|----------|
| `tests/block_batching/test_batch_timings.py` | BatchTimings behavior, timestamp propagation, isolation |
| `tests/block_batching/test_iter_batches_metrics.py` | Stage attribution, missing-stage handling, negative delta clamping |
| `tests/test_stats_iteration_metrics.py` | DatasetStats integration, summary rendering, round-trip validation |

### Results

- 34 new tests passing
- 62 existing `test_util.py` tests passing
- No regressions observed

## References

- Closes #64132
- Part of RFC #63911

cc @JasonLi1909