### PR TITLE
[Docs] Update KubeRay Serve High Throughput guide to Ray 2.56

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-serve-high-throughput.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-serve-high-throughput.md
@@ -25,7 +25,7 @@ The following example demonstrates how to deploy Qwen 3.5 on four replicas
 with NVIDIA L4 GPUs using KubeRay on Google Kubernetes Engine (GKE) with [this
 sample RayService](https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.high-throughput-llm.yaml).
 
-A corresponding sample for high-performance serving with [Gemma 4 E2B with NVIDIA B200s is also available here](ray-service.high-throughput-gemma4.yaml).
+A corresponding sample for high-performance serving with [Gemma 4 E2B with NVIDIA B200s is also available here](https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.high-throughput-gemma4.yaml).
 
 ### 1. Configure the environment
 
@@ -133,7 +133,8 @@ Using the {ref}`Ray kubectl plugin <kubectl-plugin>` or `kubectl port-forward`
 to establish a connection to the Ray head:
 
 ```
-CLUSTER=$(kubectl get raycluster -o jsonpath='{.items[0].metadata.name}') kubectl ray session $CLUSTER
+CLUSTER=$(kubectl get raycluster -o jsonpath='{.items[0].metadata.name}')
+kubectl ray session $CLUSTER
 ```
 
 Now, use the Ray CLI to check for HAProxy. Alternatively, navigate to the Ray

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-serve-high-throughput.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-serve-high-throughput.md
@@ -6,27 +6,26 @@ Take advantage of major upgrades to Ray Serve, delivering online inference with
 
 ## Prerequisites
 
-- Ray 2.55 or later
+- Ray 2.56 or later
 
 ## Enabling high throughput mode
 
 
-With Ray 2.55 and later, high throughput config options are available for Ray
-Serve by setting  the environment variables `RAY_SERVE_ENABLE_HA_PROXY` and
-`RAY_SERVE_THROUGHPUT_OPTIMIZED`.
+With Ray 2.56 and later, high throughput config options are available for Ray
+Serve by setting the following environment variables:
 
-With the new proxy enabled, each Ray pod's proxy ingress (serving on port 8000
-by default) is now HAProxy ingress, a highly optimized, battle-tested
-open-source load balancer written in C.
-
-The throughput optimized variable enables multiple high throughput serving optimizations, including direct gRPC data-plane communications
-between Ray Serve replicas, improving the performance of inter-deployment
-traffic.
+- `RAY_SERVE_ENABLE_HA_PROXY=1`: Enables HAProxy ingress for each Ray pod's proxy ingress (serving on port 8000 by default), which is a highly optimized, battle-tested open-source load balancer written in C.
+- `RAY_SERVE_THROUGHPUT_OPTIMIZED=1`: Enables multiple high throughput serving optimizations, including direct gRPC data-plane communications between Ray Serve replicas, improving the performance of inter-deployment traffic.
+- `RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1`: Enables direct streaming, allowing requests and responses to stream directly to the backend server instead of passing through an ingress.
+- `VLLM_USE_RAY_V2_EXECUTOR_BACKEND=1`: Configures vLLM to use the Ray V2 executor backend.
 
 ## Example: Serving Qwen on GKE
 
 The following example demonstrates how to deploy Qwen 3.5 on four replicas
-with NVIDIA L4 GPUs using KubeRay on Google Kubernetes Engine (GKE).
+with NVIDIA L4 GPUs using KubeRay on Google Kubernetes Engine (GKE) with [this
+sample RayService](https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.high-throughput-llm.yaml).
+
+A corresponding sample for high-performance serving with [Gemma 4 E2B with NVIDIA B200s is also available here](ray-service.high-throughput-gemma4.yaml).
 
 ### 1. Configure the environment
 
@@ -86,9 +85,8 @@ Deploy the example high-throughput LLM service:
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.high-throughput-llm.yaml
 ```
 
-To enable these optimizations on your own Ray Service, add the environment
-variables `RAY_SERVE_ENABLE_HA_PROXY` and `RAY_SERVE_THROUGHPUT_OPTIMIZED` to
-both the head and worker group specifications:
+To enable these optimizations on your own Ray Service, add these environment
+variables to both the head and worker group specifications:
 
 ```yaml
 apiVersion: ray.io/v1
@@ -108,6 +106,10 @@ spec:
                   value: "1"
                 - name: RAY_SERVE_THROUGHPUT_OPTIMIZED
                   value: "1"
+                - name: RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
+                  value: "1"
+                - name: VLLM_USE_RAY_V2_EXECUTOR_BACKEND
+                  value: "1"
     workerGroupSpecs:
       - template:
           spec:
@@ -118,6 +120,10 @@ spec:
                     value: "1"
                   - name: RAY_SERVE_THROUGHPUT_OPTIMIZED
                     value: "1"
+                  - name: RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
+                    value: "1"
+                  - name: VLLM_USE_RAY_V2_EXECUTOR_BACKEND
+                    value: "1"
 ```
 
 
@@ -127,8 +133,7 @@ Using the {ref}`Ray kubectl plugin <kubectl-plugin>` or `kubectl port-forward`
 to establish a connection to the Ray head:
 
 ```
-CLUSTER=$(kubectl get raycluster -o jsonpath='{.items[0].metadata.name}')
-kubectl ray session $CLUSTER
+CLUSTER=$(kubectl get raycluster -o jsonpath='{.items[0].metadata.name}') kubectl ray session $CLUSTER
 ```
 
 Now, use the Ray CLI to check for HAProxy. Alternatively, navigate to the Ray
@@ -155,7 +160,7 @@ than 250, and bursty traffic.
 
 Performance gains scale with the size of the deployment. The more replicas your
 RayService is using, the greater the performance improvement compared to
-versions preceding 2.55.
+versions preceding 2.56.
 
 ## Next steps
 


### PR DESCRIPTION


## Description

Update the document to use Ray 2.56 as prerequisite and add new environment variables:
- RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
- VLLM_USE_RAY_V2_EXECUTOR_BACKEND

## Related issues
N/A
