### PR TITLE
[core] Move `TaskReceiver::SetupActor` out of `HandleTaskExecutionResult`

### DIFF
--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -27,11 +27,12 @@
 namespace ray {
 namespace core {
 
-void HandleTaskExecutionResult(Status status,
-                               const TaskSpecification &task_spec,
-                               const TaskExecutionResult &result,
-                               const rpc::SendReplyCallback &send_reply_callback,
-                               rpc::PushTaskReply *reply) {
+void TaskReceiver::HandleTaskExecutionResult(
+    Status status,
+    const TaskSpecification &task_spec,
+    const TaskExecutionResult &result,
+    const rpc::SendReplyCallback &send_reply_callback,
+    rpc::PushTaskReply *reply) {
   reply->set_is_retryable_error(result.is_retryable_error);
   reply->set_is_application_error(!result.application_error.empty());
   std::string task_execution_error;

--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -27,12 +27,11 @@
 namespace ray {
 namespace core {
 
-void HandleTaskExecutionResult(
-    Status status,
-    const TaskSpecification &task_spec,
-    const TaskExecutionResult &result,
-    const rpc::SendReplyCallback &send_reply_callback,
-    rpc::PushTaskReply *reply) {
+void HandleTaskExecutionResult(Status status,
+                               const TaskSpecification &task_spec,
+                               const TaskExecutionResult &result,
+                               const rpc::SendReplyCallback &send_reply_callback,
+                               rpc::PushTaskReply *reply) {
   reply->set_is_retryable_error(result.is_retryable_error);
   reply->set_is_application_error(!result.application_error.empty());
   std::string task_execution_error;

--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -27,7 +27,7 @@
 namespace ray {
 namespace core {
 
-void TaskReceiver::HandleTaskExecutionResult(
+void HandleTaskExecutionResult(
     Status status,
     const TaskSpecification &task_spec,
     const TaskExecutionResult &result,
@@ -95,16 +95,6 @@ void TaskReceiver::HandleTaskExecutionResult(
     }
 
     if (task_spec.IsActorCreationTask()) {
-      concurrency_groups_ = task_spec.ConcurrencyGroups();
-      if (is_asyncio_) {
-        fiber_state_manager_ = std::make_shared<ConcurrencyGroupManager<FiberState>>(
-            concurrency_groups_, fiber_max_concurrency_, initialize_thread_callback_);
-      } else {
-        const int default_max_concurrency = task_spec.MaxActorConcurrency();
-        pool_manager_ = std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
-            concurrency_groups_, default_max_concurrency, initialize_thread_callback_);
-      }
-
       if (status.IsCreationTaskError()) {
         RAY_LOG(WARNING) << "Actor creation task finished with errors, task_id: "
                          << task_spec.TaskId()
@@ -206,9 +196,7 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
   };
 
   if (task_spec.IsActorCreationTask()) {
-    SetupActor(task_spec.IsAsyncioActor(),
-               task_spec.MaxActorConcurrency(),
-               task_spec.AllowOutOfOrderExecution());
+    SetupActor(task_spec);
     normal_task_execution_queue_->EnqueueTask(
         TaskToExecute(execute_callback, cancel_callback, std::move(task_spec)));
   } else if (task_spec.IsActorTask()) {
@@ -272,18 +260,27 @@ bool TaskReceiver::CancelQueuedNormalTask(TaskID task_id) {
   return normal_task_execution_queue_->CancelTaskIfFound(task_id);
 }
 
-void TaskReceiver::SetupActor(bool is_asyncio,
-                              int fiber_max_concurrency,
-                              bool allow_out_of_order_execution) {
+void TaskReceiver::SetupActor(const TaskSpecification &task_spec) {
   RAY_CHECK(fiber_max_concurrency_ == 0)
       << "SetupActor should only be called at most once.";
+
   // Note: It's possible to have allow_out_of_order_execution as false but max_concurrency
   // > 1, from the C++ / Java API's.
-  RAY_CHECK(is_asyncio ? allow_out_of_order_execution : true)
+  RAY_CHECK(task_spec.IsAsyncioActor() ? task_spec.AllowOutOfOrderExecution() : true)
       << "allow_out_of_order_execution must be true if is_asyncio is true";
-  is_asyncio_ = is_asyncio;
-  fiber_max_concurrency_ = fiber_max_concurrency;
-  allow_out_of_order_execution_ = allow_out_of_order_execution;
+  is_asyncio_ = task_spec.IsAsyncioActor();
+  fiber_max_concurrency_ = task_spec.MaxActorConcurrency();
+  allow_out_of_order_execution_ = task_spec.AllowOutOfOrderExecution();
+
+  concurrency_groups_ = task_spec.ConcurrencyGroups();
+  if (is_asyncio_) {
+    fiber_state_manager_ = std::make_shared<ConcurrencyGroupManager<FiberState>>(
+        concurrency_groups_, fiber_max_concurrency_, initialize_thread_callback_);
+  } else {
+    const int default_max_concurrency = task_spec.MaxActorConcurrency();
+    pool_manager_ = std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
+        concurrency_groups_, default_max_concurrency, initialize_thread_callback_);
+  }
 }
 
 void TaskReceiver::Stop() {

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -105,12 +105,11 @@ class TaskReceiver {
 
   /// Populate `reply` from a completed task execution's `status` and `result`, then
   /// invoke `send_reply_callback`.
-  static void HandleTaskExecutionResult(
-      Status status,
-      const TaskSpecification &task_spec,
-      const TaskExecutionResult &result,
-      const rpc::SendReplyCallback &send_reply_callback,
-      rpc::PushTaskReply *reply);
+  static void HandleTaskExecutionResult(Status status,
+                                        const TaskSpecification &task_spec,
+                                        const TaskExecutionResult &result,
+                                        const rpc::SendReplyCallback &send_reply_callback,
+                                        rpc::PushTaskReply *reply);
 
   // True once shutdown begins. Requests to execute new tasks will be rejected.
   std::atomic<bool> stopping_ = false;

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -40,6 +40,12 @@ namespace core {
 using RepeatedObjectRefCount =
     ::google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount>;
 
+void HandleTaskExecutionResult(Status status,
+                               const TaskSpecification &task_spec,
+                               const TaskExecutionResult &result,
+                               const rpc::SendReplyCallback &send_reply_callback,
+                               rpc::PushTaskReply *reply);
+
 class TaskReceiver {
  public:
   using TaskHandler = std::function<Status(
@@ -101,15 +107,7 @@ class TaskReceiver {
  private:
   /// Set up the configs for an actor.
   /// This should be called once for the actor creation task.
-  void SetupActor(bool is_asyncio,
-                  int fiber_max_concurrency,
-                  bool allow_out_of_order_execution);
-
-  void HandleTaskExecutionResult(Status status,
-                                 const TaskSpecification &task_spec,
-                                 const TaskExecutionResult &result,
-                                 const rpc::SendReplyCallback &send_reply_callback,
-                                 rpc::PushTaskReply *reply);
+  void SetupActor(const TaskSpecification &task_spec);
 
   // True once shutdown begins. Requests to execute new tasks will be rejected.
   std::atomic<bool> stopping_ = false;

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -40,12 +40,6 @@ namespace core {
 using RepeatedObjectRefCount =
     ::google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount>;
 
-void HandleTaskExecutionResult(Status status,
-                               const TaskSpecification &task_spec,
-                               const TaskExecutionResult &result,
-                               const rpc::SendReplyCallback &send_reply_callback,
-                               rpc::PushTaskReply *reply);
-
 class TaskReceiver {
  public:
   using TaskHandler = std::function<Status(
@@ -108,6 +102,15 @@ class TaskReceiver {
   /// Set up the configs for an actor.
   /// This should be called once for the actor creation task.
   void SetupActor(const TaskSpecification &task_spec);
+
+  /// Populate `reply` from a completed task execution's `status` and `result`, then
+  /// invoke `send_reply_callback`.
+  static void HandleTaskExecutionResult(
+      Status status,
+      const TaskSpecification &task_spec,
+      const TaskExecutionResult &result,
+      const rpc::SendReplyCallback &send_reply_callback,
+      rpc::PushTaskReply *reply);
 
   // True once shutdown begins. Requests to execute new tasks will be rejected.
   std::atomic<bool> stopping_ = false;


### PR DESCRIPTION
There is no need to delay this logic until after the creation task executes. This simplifies the model because `HandleTaskExecutionResult` is now stateless - it doesn't modify the fields of the `TaskReceiver`.