### PR TITLE
[serve] Add metrics to direct ingress grpc unary-unary path

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -800,6 +800,10 @@ class RequestMetadata:
 
     _http_method: str = ""
 
+    # Full gRPC service method (e.g. "/pkg.Service/Method") for direct-ingress gRPC
+    # requests. Mirrors the proxy's `method` metric tag (`gRPCProxyRequest.method`).
+    _grpc_service_method: str = ""
+
     # The client address in "host:port" format, if available.
     _client: str = ""
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -834,6 +834,10 @@ class RequestMetadata:
     def is_grpc_request(self) -> bool:
         return self._request_protocol == RequestProtocol.GRPC
 
+    @property
+    def protocol(self) -> RequestProtocol:
+        return self._request_protocol
+
 
 class StreamingHTTPRequest:
     """Sent from the HTTP proxy to replicas on the streaming codepath."""

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -459,6 +459,11 @@ class GenericProxy(ABC):
                 self._ongoing_requests_end()
 
         latency_ms = (time.time() - start_time) * 1000.0
+        status_code = (
+            status.code.name
+            if self.protocol == RequestProtocol.GRPC
+            else str(status.code)
+        )
         if response_handler_info.should_record_access_log:
             request_context = ray.serve.context._get_serve_request_context()
             self._access_log_context[SERVE_LOG_ROUTE] = request_context.route
@@ -467,7 +472,7 @@ class GenericProxy(ABC):
                 access_log_msg(
                     method=proxy_request.method,
                     route=request_context.route,
-                    status=str(status.code),
+                    status=status_code,
                     latency_ms=latency_ms,
                     client=format_client_address(proxy_request.client),
                 ),
@@ -478,7 +483,7 @@ class GenericProxy(ABC):
             route=response_handler_info.metadata.route,
             method=proxy_request.method,
             application=response_handler_info.metadata.application_name,
-            status_code=str(status.code),
+            status_code=status_code,
             latency_ms=latency_ms,
             is_error=status.is_error,
             deployment_name=response_handler_info.metadata.deployment_name,

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -69,7 +69,6 @@ from ray.serve._private.logging_utils import (
     get_component_logger_file_path,
 )
 from ray.serve._private.long_poll import LongPollClient, LongPollNamespace
-from ray.serve._private.proxy_metrics import ProxyMetrics
 from ray.serve._private.proxy_request_response import (
     ASGIProxyRequest,
     HandlerMetadata,
@@ -82,6 +81,7 @@ from ray.serve._private.proxy_request_response import (
 )
 from ray.serve._private.proxy_response_generator import ProxyResponseGenerator
 from ray.serve._private.proxy_router import ProxyRouter
+from ray.serve._private.request_ingress_metrics import RequestIngressMetrics
 from ray.serve._private.tracing_utils import (
     is_span_recording,
     set_http_span_attributes,
@@ -161,7 +161,7 @@ class GenericProxy(ABC):
 
         self.proxy_router = proxy_router
 
-        self._proxy_metrics = ProxyMetrics(
+        self._proxy_metrics = RequestIngressMetrics(
             self.protocol,
             source="proxy",
             node_id=node_id,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -565,7 +565,9 @@ class ReplicaMetricsManager:
             for request_tags, count in self._cached_deployment_request_error_counter[
                 protocol
             ].items():
-                metrics.deployment_request_error_counter.inc(count, tags=dict(request_tags))
+                metrics.deployment_request_error_counter.inc(
+                    count, tags=dict(request_tags)
+                )
 
             for latency_tags, latencies in self._cached_ingress_processing_latencies[
                 protocol
@@ -686,9 +688,11 @@ class ReplicaMetricsManager:
             if self._autoscaling_config:
                 self.start_metrics_pusher()
 
-    def _change_num_ongoing_requests(self, request_metadata: RequestMetadata, delta: int) -> None:
+    def _change_num_ongoing_requests(
+        self, request_metadata: RequestMetadata, delta: int
+    ) -> None:
         self._num_ongoing_requests += delta
-        
+
         protocol = request_metadata.protocol
 
         if self._is_direct_ingress and request_metadata.is_direct_ingress:
@@ -1058,7 +1062,6 @@ class Replica:
             autoscaling_config=self._deployment_config.autoscaling_config,
             ingress=ingress,
             max_ongoing_requests=self._deployment_config.max_ongoing_requests,
-
         )
 
         # Start event loop monitoring for the replica's main event loop.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2349,9 +2349,9 @@ class Replica:
                 deployment_name=self._deployment_id.name,
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=not healthy,
-                status_code=str(
+                status_code=(
                     grpc.StatusCode.OK if healthy else grpc.StatusCode.UNAVAILABLE
-                ),
+                ).name,
             )
             return HealthzResponse(message=message).SerializeToString()
 
@@ -2372,9 +2372,9 @@ class Replica:
                 deployment_name=self._deployment_id.name,
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=not healthy,
-                status_code=str(
+                status_code=(
                     grpc.StatusCode.OK if healthy else grpc.StatusCode.UNAVAILABLE
-                ),
+                ).name,
             )
             return ListApplicationsResponse(
                 application_names=application_names
@@ -2406,7 +2406,7 @@ class Replica:
                 deployment_name="",
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=True,
-                status_code=str(grpc.StatusCode.NOT_FOUND),
+                status_code=grpc.StatusCode.NOT_FOUND.name,
             )
             return b""
 
@@ -2485,7 +2485,7 @@ class Replica:
                 finally:
                     # Record the status code for both success and error paths so
                     # ingress metrics are emitted for successful gRPC requests.
-                    status_code_callback(str(status.code))
+                    status_code_callback(status.code.name)
                     set_grpc_code_and_details(context, status)
 
                 return result.SerializeToString()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2350,9 +2350,7 @@ class Replica:
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=not healthy,
                 status_code=str(
-                    grpc.StatusCode.OK
-                    if healthy
-                    else grpc.StatusCode.UNAVAILABLE
+                    grpc.StatusCode.OK if healthy else grpc.StatusCode.UNAVAILABLE
                 ),
             )
             return HealthzResponse(message=message).SerializeToString()
@@ -2375,9 +2373,7 @@ class Replica:
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=not healthy,
                 status_code=str(
-                    grpc.StatusCode.OK
-                    if healthy
-                    else grpc.StatusCode.UNAVAILABLE
+                    grpc.StatusCode.OK if healthy else grpc.StatusCode.UNAVAILABLE
                 ),
             )
             return ListApplicationsResponse(
@@ -2387,6 +2383,33 @@ class Replica:
         c = RayServegRPCContext(context)
         request_id = c.request_id() or generate_request_id()
         c.set_trailing_metadata([("request_id", request_id)])
+
+        # If the request targets a different application, return NOT_FOUND.
+        # If no application is specified, serve this replica's app.
+        requested_app = c.application()
+        if requested_app and requested_app != self._deployment_id.app_name:
+            status = ResponseStatus(
+                code=grpc.StatusCode.NOT_FOUND,
+                message=(
+                    f"Application '{requested_app}' not found. Ping "
+                    "/ray.serve.RayServeAPIService/ListApplications for available "
+                    "applications."
+                ),
+                is_error=True,
+            )
+            set_grpc_code_and_details(context, status)
+            self._metrics_manager.record_ingress_request_metrics(
+                protocol=RequestProtocol.GRPC,
+                method=service_method,
+                route="",
+                app_name="",
+                deployment_name="",
+                latency_ms=(time.time() - start_time) * 1000.0,
+                is_error=True,
+                status_code=str(grpc.StatusCode.NOT_FOUND),
+            )
+            return b""
+
         request_metadata = RequestMetadata(
             request_id=request_id,
             internal_request_id=generate_request_id(),
@@ -2606,12 +2629,25 @@ class Replica:
         # matches and downstream user code dispatches.
         route_prefix = self._route_prefix or ""
         if not route.startswith(route_prefix):
+            status_code = 404
             for msg in convert_object_to_asgi_messages(
                 f"Path '{route}' not found. "
                 "Ping http://.../-/routes for available routes.",
-                status_code=404,
+                status_code=status_code,
             ):
                 await send(msg)
+
+            latency_ms = (time.time() - start_time) * 1000.0
+            self._metrics_manager.record_ingress_request_metrics(
+                protocol=RequestProtocol.HTTP,
+                method=method,
+                route="",
+                app_name="",
+                deployment_name="",
+                latency_ms=latency_ms,
+                is_error=True,
+                status_code=str(status_code),
+            )
             return
 
         headers = dict(scope["headers"])

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -795,7 +795,7 @@ class ReplicaMetricsManager:
         *,
         route: str,
         latency_ms: float,
-        was_error: bool,
+        is_error: bool,
         exception_type: Optional[str] = None,
     ):
         """Records per-request metrics."""
@@ -805,14 +805,14 @@ class ReplicaMetricsManager:
 
         if self._cached_metrics_enabled:
             self._cached_latencies[route].append(latency_ms)
-            if was_error:
+            if is_error:
                 exc_type = exception_type or "Unknown"
                 self._cached_error_counter[(route, exc_type)] += 1
             else:
                 self._cached_request_counter[route] += 1
         else:
             self._processing_latency_tracker.observe(latency_ms, tags={"route": route})
-            if was_error:
+            if is_error:
                 exc_type = exception_type or "Unknown"
                 self._error_counter.inc(
                     tags={"route": route, "exception_type": exc_type}
@@ -829,7 +829,7 @@ class ReplicaMetricsManager:
         app_name: str,
         deployment_name: str,
         latency_ms: float,
-        was_error: bool,
+        is_error: bool,
         status_code: str,
     ):
         """Record per-request metrics."""
@@ -852,7 +852,7 @@ class ReplicaMetricsManager:
             self._cached_ingress_processing_latencies[protocol][
                 frozenset(request_tags.items())
             ].append(latency_ms)
-            if was_error:
+            if is_error:
                 request_error_tags = RequestIngressMetrics.request_error_tags(
                     route=route,
                     method=method,
@@ -879,7 +879,7 @@ class ReplicaMetricsManager:
                 application=app_name,
                 status_code=status_code,
                 latency_ms=latency_ms,
-                is_error=was_error,
+                is_error=is_error,
                 deployment_name=deployment_name,
             )
 
@@ -1355,7 +1355,7 @@ class Replica:
         request_metadata: RequestMetadata,
     ):
         http_method = request_metadata._http_method
-        http_route = request_metadata.route
+        route = request_metadata.route
         call_method = request_metadata.call_method
         if user_exception is None:
             status_str = "OK"
@@ -1367,12 +1367,12 @@ class Replica:
         # Mutating self._access_log_context is not thread safe, but since this
         # is only called from the same thread, it is safe. Mutating the same object
         # because creating a new dict is expensive.
-        self._access_log_context[SERVE_LOG_ROUTE] = http_route
+        self._access_log_context[SERVE_LOG_ROUTE] = route
         self._access_log_context[SERVE_LOG_REQUEST_ID] = request_metadata.request_id
         logger.info(
             access_log_msg(
                 method=http_method or "CALL",
-                route=http_route if self._ingress and http_route else call_method,
+                route=route if self._ingress and route else call_method,
                 # Prefer the HTTP status code if it was populated.
                 status=status_code or status_str,
                 latency_ms=latency_ms,
@@ -1384,9 +1384,9 @@ class Replica:
             type(user_exception).__name__ if user_exception is not None else None
         )
         self._metrics_manager.record_request_metrics(
-            route=http_route,
+            route=route,
             latency_ms=latency_ms,
-            was_error=user_exception is not None,
+            is_error=user_exception is not None,
             exception_type=exception_type,
         )
 
@@ -1409,14 +1409,25 @@ class Replica:
 
         # Record ingress metrics for direct ingress requests
         if request_metadata.is_direct_ingress and status_code is not None:
+            if request_metadata.is_grpc_request:
+                protocol = RequestProtocol.GRPC
+                # Match the proxy's `method` tag (the full gRPC service method).
+                # gRPC status codes are names (e.g. "OK", "UNAVAILABLE"); anything
+                # other than OK is an error, mirroring ResponseStatus.is_error.
+                method = request_metadata._grpc_service_method
+                is_error = status_code != grpc.StatusCode.OK.name
+            else:
+                protocol = RequestProtocol.HTTP
+                method = request_metadata._http_method
+                is_error = status_code.startswith(("4", "5"))
             self._metrics_manager.record_ingress_request_metrics(
-                protocol=RequestProtocol.HTTP,
-                method=request_metadata._http_method,
-                route=self._route_prefix,
+                protocol=protocol,
+                method=method,
+                route=route,
                 app_name=self._deployment_id.app_name,
                 deployment_name=self._deployment_id.name,
                 latency_ms=latency_ms,
-                was_error=status_code.startswith(("4", "5")),
+                is_error=is_error,
                 status_code=status_code,
             )
 
@@ -1455,7 +1466,7 @@ class Replica:
                 scope, request_metadata, request.receive_asgi_messages
             )
 
-            request_metadata._http_method = scope.get("method", "WS")
+            request_metadata._http_method = scope.get("method", "WS").upper()
 
             request_args = (scope, receive)
         elif request_metadata.is_grpc_request:
@@ -2300,12 +2311,23 @@ class Replica:
         request_proto: Any,
         context: grpc._cython.cygrpc._ServicerContext,
     ) -> bytes:
+        start_time = time.time()
         if service_method == "/ray.serve.RayServeAPIService/Healthz":
             healthy, message = await self._dataplane_health_check()
             context.set_code(
                 grpc.StatusCode.OK if healthy else grpc.StatusCode.UNAVAILABLE
             )
             context.set_details(message)
+            self._metrics_manager.record_ingress_request_metrics(
+                protocol=RequestProtocol.GRPC,
+                method=service_method,
+                route=self._deployment_id.app_name,
+                app_name=self._deployment_id.app_name,
+                deployment_name=self._deployment_id.name,
+                latency_ms=(time.time() - start_time) * 1000.0,
+                is_error=not healthy,
+                status_code=grpc.StatusCode.OK.name if healthy else grpc.StatusCode.UNAVAILABLE.name,
+            )
             return HealthzResponse(message=message).SerializeToString()
 
         if service_method == "/ray.serve.RayServeAPIService/ListApplications":
@@ -2317,6 +2339,16 @@ class Replica:
             context.set_details(message)
             # ListApplications returns only the app name the replica is serving.
             application_names = [self._deployment_id.app_name]
+            self._metrics_manager.record_ingress_request_metrics(
+                protocol=RequestProtocol.GRPC,
+                method=service_method,
+                route=self._deployment_id.app_name,
+                app_name=self._deployment_id.app_name,
+                deployment_name=self._deployment_id.name,
+                latency_ms=(time.time() - start_time) * 1000.0,
+                is_error=not healthy,
+                status_code=grpc.StatusCode.OK.name if healthy else grpc.StatusCode.UNAVAILABLE.name,
+            )
             return ListApplicationsResponse(
                 application_names=application_names
             ).SerializeToString()
@@ -2328,6 +2360,7 @@ class Replica:
             request_id=request_id,
             internal_request_id=generate_request_id(),
             call_method=service_method.split("/")[-1],
+            _grpc_service_method=service_method,
             _request_protocol=RequestProtocol.GRPC,
             grpc_context=c,
             app_name=self._deployment_id.app_name,
@@ -2394,9 +2427,11 @@ class Replica:
                         self._grpc_options.request_timeout_s,
                         request_metadata.request_id,
                     )
-                    status_code_callback(status.code.name)
                     raise e
                 finally:
+                    # Record the status code for both success and error paths so
+                    # ingress metrics are emitted for successful gRPC requests.
+                    status_code_callback(status.code.name)
                     set_grpc_code_and_details(context, status)
 
                 return result.SerializeToString()
@@ -2528,7 +2563,7 @@ class Replica:
                 app_name=self._deployment_id.app_name,
                 deployment_name=self._deployment_id.name,
                 latency_ms=latency_ms,
-                was_error=not healthy,
+                is_error=not healthy,
                 status_code=str(status_code),
             )
             return
@@ -2572,7 +2607,7 @@ class Replica:
             is_streaming=True,
             _request_protocol=RequestProtocol.HTTP,
             tracing_context=self.get_asgi_tracing_context(scope["headers"]),
-            _http_method=scope.get("method", "WS"),
+            _http_method=scope.get("method", "WS").upper(),
             is_direct_ingress=True,
             _client=format_client_address(scope.get("client")),
         )

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -353,7 +353,6 @@ class ReplicaMetricsManager:
         autoscaling_config: Optional[AutoscalingConfig],
         ingress: bool,
         max_ongoing_requests: int,
-        grpc_enabled: bool,
     ):
         self._replica_id = replica_id
         self._deployment_id = replica_id.deployment_id
@@ -381,10 +380,6 @@ class ReplicaMetricsManager:
         # If the interval is set to 0, eagerly sets all metrics.
         self._cached_metrics_enabled = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS != 0
         self._cached_metrics_interval_s = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS / 1000
-
-        self._ingress_protocols = [RequestProtocol.HTTP]
-        if grpc_enabled:
-            self._ingress_protocols.append(RequestProtocol.GRPC)
 
         # Request counter (only set on replica startup).
         self._restart_counter = metrics.Counter(
@@ -495,17 +490,13 @@ class ReplicaMetricsManager:
             # logic as those collected by the proxy (see RequestIngressMetrics). When
             # direct ingress is enabled traffic bypasses the proxy, so a given
             # request is recorded by exactly one of the two.
-            node_id = ray.get_runtime_context().get_node_id()
-            node_ip_address = ray.util.get_node_ip_address()
+            self._ingress_node_id = ray.get_runtime_context().get_node_id()
+            self._ingress_node_ip_address = ray.util.get_node_ip_address()
 
-            for protocol in self._ingress_protocols:
-                self._ingress_metrics[protocol] = RequestIngressMetrics(
-                    protocol,
-                    source="ingress",
-                    node_id=node_id,
-                    node_ip_address=node_ip_address,
-                )
-                self._ingress_ongoing_requests[protocol] = 0
+            # gRPC ingress metrics are allocated lazily via
+            # `enable_grpc_ingress_metrics()` once the gRPC config has been fetched from
+            # the controller, which is not available at construction time.
+            self._add_ingress_metrics(RequestProtocol.HTTP)
 
             if self._cached_metrics_enabled:
                 # Mapping from protocol -> {request_tags -> value}.
@@ -525,6 +516,29 @@ class ReplicaMetricsManager:
     @property
     def _is_direct_ingress(self) -> bool:
         return self._ingress and RAY_SERVE_ENABLE_DIRECT_INGRESS
+
+    def _add_ingress_metrics(self, protocol: RequestProtocol):
+        """Allocate metric objects and ongoing-request counter for a protocol."""
+        self._ingress_metrics[protocol] = RequestIngressMetrics(
+            protocol,
+            source="ingress",
+            node_id=self._ingress_node_id,
+            node_ip_address=self._ingress_node_ip_address,
+        )
+        self._ingress_ongoing_requests[protocol] = 0
+
+    def enable_grpc_ingress_metrics(self):
+        """Allocate gRPC ingress metrics for a direct-ingress replica.
+
+        gRPC config is fetched from the controller after this manager is
+        constructed, so gRPC ingress metrics are allocated here (from the replica's
+        server-start path) rather than in `__init__`.
+        """
+        if not self._is_direct_ingress:
+            return
+
+        if RequestProtocol.GRPC not in self._ingress_metrics:
+            self._add_ingress_metrics(RequestProtocol.GRPC)
 
     def _report_cached_metrics(self):
         for route, count in self._cached_request_counter.items():
@@ -549,23 +563,27 @@ class ReplicaMetricsManager:
         if not self._is_direct_ingress:
             return
 
-        for protocol in self._ingress_protocols:
-            metrics = self._ingress_metrics[protocol]
-            metrics.set_num_ongoing_requests(self._ingress_ongoing_requests[protocol])
+        for protocol in self._ingress_metrics:
+            protocol_metrics = self._ingress_metrics[protocol]
+            protocol_metrics.set_num_ongoing_requests(
+                self._ingress_ongoing_requests[protocol]
+            )
             for request_tags, count in self._cached_ingress_request_counter[
                 protocol
             ].items():
-                metrics.request_counter.inc(count, tags=dict(request_tags))
+                protocol_metrics.request_counter.inc(count, tags=dict(request_tags))
 
             for request_tags, count in self._cached_ingress_request_error_counter[
                 protocol
             ].items():
-                metrics.request_error_counter.inc(count, tags=dict(request_tags))
+                protocol_metrics.request_error_counter.inc(
+                    count, tags=dict(request_tags)
+                )
 
             for request_tags, count in self._cached_deployment_request_error_counter[
                 protocol
             ].items():
-                metrics.deployment_request_error_counter.inc(
+                protocol_metrics.deployment_request_error_counter.inc(
                     count, tags=dict(request_tags)
                 )
 
@@ -573,7 +591,7 @@ class ReplicaMetricsManager:
                 protocol
             ].items():
                 for latency_ms in latencies:
-                    metrics.processing_latency_tracker.observe(
+                    protocol_metrics.processing_latency_tracker.observe(
                         latency_ms, tags=dict(latency_tags)
                     )
 
@@ -695,7 +713,11 @@ class ReplicaMetricsManager:
 
         protocol = request_metadata.protocol
 
-        if self._is_direct_ingress and request_metadata.is_direct_ingress:
+        if (
+            self._is_direct_ingress
+            and request_metadata.is_direct_ingress
+            and protocol in self._ingress_metrics
+        ):
             self._ingress_ongoing_requests[protocol] += delta
 
         if not self._cached_metrics_enabled:
@@ -704,7 +726,7 @@ class ReplicaMetricsManager:
             if (
                 self._is_direct_ingress
                 and request_metadata.is_direct_ingress
-                and protocol in self._ingress_protocols
+                and protocol in self._ingress_metrics
             ):
                 self._ingress_metrics[protocol].set_num_ongoing_requests(
                     self._ingress_ongoing_requests[protocol]
@@ -2073,6 +2095,7 @@ class Replica:
         # Allocate and start gRPC server for ingress replicas if enabled.
         # Ingress request router replicas only need HTTP for /internal/route.
         if grpc_enabled:
+            self._metrics_manager.enable_grpc_ingress_metrics()
 
             async def start_grpc_server_fn(port):
                 options = gRPCOptions(
@@ -2326,7 +2349,11 @@ class Replica:
                 deployment_name=self._deployment_id.name,
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=not healthy,
-                status_code=grpc.StatusCode.OK.name if healthy else grpc.StatusCode.UNAVAILABLE.name,
+                status_code=str(
+                    grpc.StatusCode.OK
+                    if healthy
+                    else grpc.StatusCode.UNAVAILABLE
+                ),
             )
             return HealthzResponse(message=message).SerializeToString()
 
@@ -2347,7 +2374,11 @@ class Replica:
                 deployment_name=self._deployment_id.name,
                 latency_ms=(time.time() - start_time) * 1000.0,
                 is_error=not healthy,
-                status_code=grpc.StatusCode.OK.name if healthy else grpc.StatusCode.UNAVAILABLE.name,
+                status_code=str(
+                    grpc.StatusCode.OK
+                    if healthy
+                    else grpc.StatusCode.UNAVAILABLE
+                ),
             )
             return ListApplicationsResponse(
                 application_names=application_names
@@ -2431,7 +2462,7 @@ class Replica:
                 finally:
                     # Record the status code for both success and error paths so
                     # ingress metrics are emitted for successful gRPC requests.
-                    status_code_callback(status.code.name)
+                    status_code_callback(str(status.code))
                     set_grpc_code_and_details(context, status)
 
                 return result.SerializeToString()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -131,9 +131,9 @@ from ray.serve._private.logging_utils import (
     get_component_logger_file_path,
 )
 from ray.serve._private.metrics_utils import InMemoryMetricsStore, MetricsPusher
-from ray.serve._private.proxy_metrics import ProxyMetrics
 from ray.serve._private.proxy_request_response import ResponseStatus, gRPCStreamingType
 from ray.serve._private.replica_response_generator import ReplicaResponseGenerator
+from ray.serve._private.request_ingress_metrics import RequestIngressMetrics
 from ray.serve._private.rolling_window import (
     RollingWindowAccumulator,
     RollingWindowMax,
@@ -353,6 +353,7 @@ class ReplicaMetricsManager:
         autoscaling_config: Optional[AutoscalingConfig],
         ingress: bool,
         max_ongoing_requests: int,
+        grpc_enabled: bool,
     ):
         self._replica_id = replica_id
         self._deployment_id = replica_id.deployment_id
@@ -380,6 +381,10 @@ class ReplicaMetricsManager:
         # If the interval is set to 0, eagerly sets all metrics.
         self._cached_metrics_enabled = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS != 0
         self._cached_metrics_interval_s = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS / 1000
+
+        self._ingress_protocols = [RequestProtocol.HTTP]
+        if grpc_enabled:
+            self._ingress_protocols.append(RequestProtocol.GRPC)
 
         # Request counter (only set on replica startup).
         self._restart_counter = metrics.Counter(
@@ -482,22 +487,28 @@ class ReplicaMetricsManager:
 
         self.set_autoscaling_config(autoscaling_config)
 
+        # Only populated if direct ingress is enabled.
+        self._ingress_metrics: Dict[RequestProtocol, RequestIngressMetrics] = {}
+        self._ingress_ongoing_requests: Dict[RequestProtocol, int] = {}
         if self._is_direct_ingress:
             # These ingress metrics share the same names, tag keys, and emission
-            # logic as those collected by the proxy (see ProxyMetrics). When
+            # logic as those collected by the proxy (see RequestIngressMetrics). When
             # direct ingress is enabled traffic bypasses the proxy, so a given
             # request is recorded by exactly one of the two.
             node_id = ray.get_runtime_context().get_node_id()
             node_ip_address = ray.util.get_node_ip_address()
-            self._ingress_http_metrics = ProxyMetrics(
-                RequestProtocol.HTTP,
-                source="ingress",
-                node_id=node_id,
-                node_ip_address=node_ip_address,
-            )
-            self._ingress_ongoing_http_requests = 0
+
+            for protocol in self._ingress_protocols:
+                self._ingress_metrics[protocol] = RequestIngressMetrics(
+                    protocol,
+                    source="ingress",
+                    node_id=node_id,
+                    node_ip_address=node_ip_address,
+                )
+                self._ingress_ongoing_requests[protocol] = 0
 
             if self._cached_metrics_enabled:
+                # Mapping from protocol -> {request_tags -> value}.
                 self._cached_ingress_request_counter = defaultdict(
                     lambda: defaultdict(int)
                 )
@@ -538,45 +549,29 @@ class ReplicaMetricsManager:
         if not self._is_direct_ingress:
             return
 
-        for protocol in [RequestProtocol.HTTP]:
-            if protocol == RequestProtocol.HTTP:
-                ingress_request_counter = self._ingress_http_metrics.request_counter
-                ingress_request_error_counter = (
-                    self._ingress_http_metrics.request_error_counter
-                )
-                deployment_request_error_counter = (
-                    self._ingress_http_metrics.deployment_request_error_counter
-                )
-                ingress_processing_latencies = (
-                    self._ingress_http_metrics.processing_latency_tracker
-                )
-                self._ingress_http_metrics.set_num_ongoing_requests(
-                    self._ingress_ongoing_http_requests
-                )
-            else:
-                # TODO(alexyang): Add metrics for gRPC.
-                continue
-
+        for protocol in self._ingress_protocols:
+            metrics = self._ingress_metrics[protocol]
+            metrics.set_num_ongoing_requests(self._ingress_ongoing_requests[protocol])
             for request_tags, count in self._cached_ingress_request_counter[
                 protocol
             ].items():
-                ingress_request_counter.inc(count, tags=dict(request_tags))
+                metrics.request_counter.inc(count, tags=dict(request_tags))
 
             for request_tags, count in self._cached_ingress_request_error_counter[
                 protocol
             ].items():
-                ingress_request_error_counter.inc(count, tags=dict(request_tags))
+                metrics.request_error_counter.inc(count, tags=dict(request_tags))
 
             for request_tags, count in self._cached_deployment_request_error_counter[
                 protocol
             ].items():
-                deployment_request_error_counter.inc(count, tags=dict(request_tags))
+                metrics.deployment_request_error_counter.inc(count, tags=dict(request_tags))
 
             for latency_tags, latencies in self._cached_ingress_processing_latencies[
                 protocol
             ].items():
                 for latency_ms in latencies:
-                    ingress_processing_latencies.observe(
+                    metrics.processing_latency_tracker.observe(
                         latency_ms, tags=dict(latency_tags)
                     )
 
@@ -691,35 +686,31 @@ class ReplicaMetricsManager:
             if self._autoscaling_config:
                 self.start_metrics_pusher()
 
-    def inc_num_ongoing_requests(self, request_metadata: RequestMetadata) -> int:
-        self._num_ongoing_requests += 1
+    def _change_num_ongoing_requests(self, request_metadata: RequestMetadata, delta: int) -> None:
+        self._num_ongoing_requests += delta
+        
+        protocol = request_metadata.protocol
 
         if self._is_direct_ingress and request_metadata.is_direct_ingress:
-            self._ingress_ongoing_http_requests += 1
+            self._ingress_ongoing_requests[protocol] += delta
 
         if not self._cached_metrics_enabled:
             self._num_ongoing_requests_gauge.set(self._num_ongoing_requests)
 
-            if self._is_direct_ingress and request_metadata.is_direct_ingress:
-                if request_metadata.is_http_request:
-                    self._ingress_http_metrics.set_num_ongoing_requests(
-                        self._ingress_ongoing_http_requests
-                    )
+            if (
+                self._is_direct_ingress
+                and request_metadata.is_direct_ingress
+                and protocol in self._ingress_protocols
+            ):
+                self._ingress_metrics[protocol].set_num_ongoing_requests(
+                    self._ingress_ongoing_requests[protocol]
+                )
 
-    def dec_num_ongoing_requests(self, request_metadata: RequestMetadata) -> int:
-        self._num_ongoing_requests -= 1
+    def inc_num_ongoing_requests(self, request_metadata: RequestMetadata) -> None:
+        self._change_num_ongoing_requests(request_metadata, 1)
 
-        if self._is_direct_ingress and request_metadata.is_direct_ingress:
-            self._ingress_ongoing_http_requests -= 1
-
-        if not self._cached_metrics_enabled:
-            self._num_ongoing_requests_gauge.set(self._num_ongoing_requests)
-
-            if self._is_direct_ingress and request_metadata.is_direct_ingress:
-                if request_metadata.is_http_request:
-                    self._ingress_http_metrics.set_num_ongoing_requests(
-                        self._ingress_ongoing_http_requests
-                    )
+    def dec_num_ongoing_requests(self, request_metadata: RequestMetadata) -> None:
+        self._change_num_ongoing_requests(request_metadata, -1)
 
     def get_num_ongoing_requests(self) -> int:
         """Get current total queue length of requests for this replica."""
@@ -841,15 +832,11 @@ class ReplicaMetricsManager:
         if not self._is_direct_ingress:
             return
 
-        if protocol != RequestProtocol.HTTP:
-            # TODO(alexyang): Add metrics for gRPC.
-            return
-
         if self._cached_metrics_enabled:
             # Cached path: accumulate per-tag-set counts/latencies keyed by the same
             # canonical tag schemas used by the direct emit path, and flush them in
             # `_report_cached_metrics`.
-            request_tags = ProxyMetrics.request_tags(
+            request_tags = RequestIngressMetrics.request_tags(
                 route=route,
                 method=method,
                 application=app_name,
@@ -862,13 +849,13 @@ class ReplicaMetricsManager:
                 frozenset(request_tags.items())
             ].append(latency_ms)
             if was_error:
-                request_error_tags = ProxyMetrics.request_error_tags(
+                request_error_tags = RequestIngressMetrics.request_error_tags(
                     route=route,
                     method=method,
                     application=app_name,
                     status_code=status_code,
                 )
-                deployment_error_tags = ProxyMetrics.deployment_error_tags(
+                deployment_error_tags = RequestIngressMetrics.deployment_error_tags(
                     route=route,
                     method=method,
                     application=app_name,
@@ -882,7 +869,7 @@ class ReplicaMetricsManager:
                     frozenset(deployment_error_tags.items())
                 ] += 1
         else:
-            self._ingress_http_metrics.record_request(
+            self._ingress_metrics[protocol].record_request(
                 route=route,
                 method=method,
                 application=app_name,
@@ -1071,6 +1058,7 @@ class Replica:
             autoscaling_config=self._deployment_config.autoscaling_config,
             ingress=ingress,
             max_ongoing_requests=self._deployment_config.max_ongoing_requests,
+
         )
 
         # Start event loop monitoring for the replica's main event loop.
@@ -1416,7 +1404,7 @@ class Replica:
             if user_exception is not None:
                 set_span_exception(user_exception, escaped=False)
 
-        # Record ingress metrics for direct ingress HTTP requests
+        # Record ingress metrics for direct ingress requests
         if request_metadata.is_direct_ingress and status_code is not None:
             self._metrics_manager.record_ingress_request_metrics(
                 protocol=RequestProtocol.HTTP,

--- a/python/ray/serve/_private/request_ingress_metrics.py
+++ b/python/ray/serve/_private/request_ingress_metrics.py
@@ -5,7 +5,7 @@ from ray.serve._private.constants import REQUEST_LATENCY_BUCKETS_MS
 from ray.util import metrics
 
 
-class ProxyMetrics:
+class RequestIngressMetrics:
     """E2E request metrics shared by the proxies and direct-ingress replicas.
 
     Defines and emits the standard ``serve_num_{protocol}_requests`` family of

--- a/python/ray/serve/grpc_util.py
+++ b/python/ray/serve/grpc_util.py
@@ -156,6 +156,14 @@ class RayServegRPCContext:
         """
         return self._invocation_metadata_dict.get("request_id")
 
+    def application(self) -> Optional[str]:
+        """Accesses the target application name for the RPC, if provided.
+
+        Returns:
+          The application name from the request metadata, or None if not set.
+        """
+        return self._invocation_metadata_dict.get("application")
+
     def traceparent(self) -> Optional[str]:
         """Accesses the traceparent for the RPC.
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -288,14 +288,8 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
             elif "serve_num_deployment_grpc_error_requests" in metrics:
                 # gRPC pinged "B" once
                 if do_assert:
-                    assert (
-                        'error_code="NOT_FOUND"' in metrics
-                        and "1.0" in metrics
-                    )
-                if (
-                    'error_code="NOT_FOUND"' not in metrics
-                    or "1.0" not in metrics
-                ):
+                    assert 'error_code="NOT_FOUND"' in metrics and "1.0" in metrics
+                if 'error_code="NOT_FOUND"' not in metrics or "1.0" not in metrics:
                     return False
         return True
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -394,13 +394,23 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
 
 def test_proxy_metrics_fields_not_found(metrics_start_shutdown):
     """Tests the proxy metrics' fields' behavior for not found."""
+
+    @serve.deployment()
+    def f(*args):
+        return "Hi"
+
+    app_name = "app"
+    serve.run(f.bind(), name=app_name, route_prefix="/app")
+
     # Should generate 404 responses
-    broken_url = "http://127.0.0.1:8000/fake_route"
+    app_url = get_application_url("HTTP", app_name=app_name, exclude_route_prefix=True)
+    broken_url = f"{app_url}/fake_route"
     _ = httpx.get(broken_url).text
     print("Sent requests to broken URL.")
 
     # Ping gRPC proxy for not existing application.
-    channel = grpc.insecure_channel("127.0.0.1:9000")
+    grpc_url = get_application_url("gRPC", app_name=app_name)
+    channel = grpc.insecure_channel(grpc_url)
     fake_app_name = "fake-app"
     ping_grpc_call_method(channel=channel, app_name=fake_app_name, test_not_found=True)
 
@@ -746,10 +756,8 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     serve.run(WebSocketServer.bind())
 
-    websocket_url = get_application_url(is_websocket=True)
-
     # Regular disconnect (1000) is not an error.
-    with connect(websocket_url) as ws:
+    with connect("ws://localhost:8000/") as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("1000")
             ws.recv()
@@ -761,7 +769,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
     )
 
     # Goaway disconnect (1001) is not an error.
-    with connect(websocket_url) as ws:
+    with connect("ws://localhost:8000/") as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("1001")
             ws.recv()
@@ -773,7 +781,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
     )
 
     # Other codes are errors.
-    with connect(websocket_url) as ws:
+    with connect("ws://localhost:8000/") as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("1011")
             ws.recv()
@@ -785,7 +793,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
     )
 
     # Other codes are errors.
-    with connect(websocket_url) as ws:
+    with connect("ws://localhost:8000/") as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("3000")
             ws.recv()

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -445,7 +445,7 @@ def test_proxy_metrics_fields_not_found(metrics_start_shutdown):
     assert num_requests[0]["route"] == ""
     assert num_requests[0]["method"] == "/ray.serve.UserDefinedService/__call__"
     assert num_requests[0]["application"] == ""
-    assert num_requests[0]["status_code"] == str(grpc.StatusCode.NOT_FOUND)
+    assert num_requests[0]["status_code"] == grpc.StatusCode.NOT_FOUND.name
     print("serve_num_grpc_requests working as expected.")
 
     num_errors = get_metric_dictionaries("ray_serve_num_http_error_requests_total")
@@ -458,7 +458,7 @@ def test_proxy_metrics_fields_not_found(metrics_start_shutdown):
     num_errors = get_metric_dictionaries("ray_serve_num_grpc_error_requests_total")
     assert len(num_errors) == 1
     assert num_errors[0]["route"] == ""
-    assert num_errors[0]["error_code"] == str(grpc.StatusCode.NOT_FOUND)
+    assert num_errors[0]["error_code"] == grpc.StatusCode.NOT_FOUND.name
     assert num_errors[0]["method"] == "/ray.serve.UserDefinedService/__call__"
     print("serve_num_grpc_error_requests working as expected.")
 
@@ -507,7 +507,7 @@ def test_proxy_timeout_metrics(metrics_start_shutdown):
     num_errors = get_metric_dictionaries("ray_serve_num_grpc_error_requests_total")
     assert len(num_errors) == 1
     assert num_errors[0]["route"] == "status_code_timeout"
-    assert num_errors[0]["error_code"] == str(grpc.StatusCode.DEADLINE_EXCEEDED)
+    assert num_errors[0]["error_code"] == grpc.StatusCode.DEADLINE_EXCEEDED.name
     assert num_errors[0]["method"] == "/ray.serve.UserDefinedService/__call__"
     assert num_errors[0]["application"] == "status_code_timeout"
 
@@ -595,7 +595,7 @@ def test_proxy_disconnect_grpc_metrics(metrics_start_shutdown):
     num_errors = get_metric_dictionaries("ray_serve_num_grpc_error_requests_total")
     assert len(num_errors) == 1
     assert num_errors[0]["route"] == "disconnect"
-    assert num_errors[0]["error_code"] == str(grpc.StatusCode.CANCELLED)
+    assert num_errors[0]["error_code"] == grpc.StatusCode.CANCELLED.name
     assert num_errors[0]["method"] == "/ray.serve.UserDefinedService/__call__"
     assert num_errors[0]["application"] == "disconnect"
 
@@ -638,7 +638,7 @@ def test_proxy_metrics_fields_internal_error(metrics_start_shutdown):
     )
     assert len(num_deployment_errors) == 1
     assert num_deployment_errors[0]["deployment"] == "f"
-    assert num_deployment_errors[0]["error_code"] == str(grpc.StatusCode.INTERNAL)
+    assert num_deployment_errors[0]["error_code"] == grpc.StatusCode.INTERNAL.name
     assert (
         num_deployment_errors[0]["method"] == "/ray.serve.UserDefinedService/__call__"
     )
@@ -658,7 +658,7 @@ def test_proxy_metrics_fields_internal_error(metrics_start_shutdown):
     assert latency_metrics[0]["method"] == "/ray.serve.UserDefinedService/__call__"
     assert latency_metrics[0]["route"] == real_app_name
     assert latency_metrics[0]["application"] == real_app_name
-    assert latency_metrics[0]["status_code"] == str(grpc.StatusCode.INTERNAL)
+    assert latency_metrics[0]["status_code"] == grpc.StatusCode.INTERNAL.name
     print("serve_grpc_request_latency_ms_sum working as expected.")
 
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -27,6 +27,7 @@ from ray._common.test_utils import (
 )
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
+    RAY_SERVE_ENABLE_HA_PROXY,
 )
 from ray.serve._private.test_utils import (
     PROMETHEUS_METRICS_TIMEOUT_S,
@@ -230,12 +231,23 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
                 return False
         return True
 
+    # Create a dummy app so that there is a replica to hit for direct ingress tests.
+    @serve.deployment()
+    def f(*args):
+        return "Hi"
+
+    app_name = "app"
+    serve.run(f.bind(), name=app_name, route_prefix="/app")
+    serve.run(f.bind(), name="app2", route_prefix="/app2")
+
     # Trigger HTTP 404 error
-    httpx.get("http://127.0.0.1:8000/B/")
-    httpx.get("http://127.0.0.1:8000/B/")
+    http_url = get_application_url("HTTP", app_name=app_name, exclude_route_prefix=True)
+    httpx.get(f"{http_url}/B/")
+    httpx.get(f"{http_url}/B/")
 
     # Ping gPRC proxy
-    channel = grpc.insecure_channel("127.0.0.1:9000")
+    grpc_url = get_application_url("gRPC", app_name=app_name)
+    channel = grpc.insecure_channel(grpc_url)
     ping_grpc_call_method(channel=channel, app_name="foo", test_not_found=True)
 
     # Ensure all expected metrics are present.
@@ -295,6 +307,10 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
 
 
 def test_proxy_metrics_internal_error(metrics_start_shutdown):
+    # This test kills the replica process so metrics are not emitted.
+    if RAY_SERVE_ENABLE_DIRECT_INGRESS and not RAY_SERVE_ENABLE_HA_PROXY:
+        pytest.skip()
+
     # NOTE: These metrics should be documented at
     # https://docs.ray.io/en/latest/serve/monitoring.html#metrics
     # Any updates here should be reflected there too.
@@ -395,12 +411,14 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
 def test_proxy_metrics_fields_not_found(metrics_start_shutdown):
     """Tests the proxy metrics' fields' behavior for not found."""
 
+    # Create dummy apps so that there is a replica to hit for direct ingress tests.
     @serve.deployment()
     def f(*args):
         return "Hi"
 
     app_name = "app"
     serve.run(f.bind(), name=app_name, route_prefix="/app")
+    serve.run(f.bind(), name="app2", route_prefix="/app2")
 
     # Should generate 404 responses
     app_url = get_application_url("HTTP", app_name=app_name, exclude_route_prefix=True)
@@ -648,7 +666,7 @@ def test_proxy_metrics_fields_internal_error(metrics_start_shutdown):
 def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     """Verify that 2xx and 3xx status codes aren't errors, others are."""
     # TODO(eicherseiji): Remove skip when HAProxy is open-sourced.
-    if RAY_SERVE_ENABLE_DIRECT_INGRESS:
+    if RAY_SERVE_ENABLE_HA_PROXY:
         pytest.skip()
 
     def check_request_count_metrics(

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -117,7 +117,7 @@ def test_serve_metrics_for_successful_connection(metrics_start_shutdown):
     [handle.remote(http_url) for _ in range(10)]
 
     # Ping gPRC proxy
-    grpc_url = "localhost:9000"
+    grpc_url = get_application_url("gRPC", app_name=app_name)
     channel = grpc.insecure_channel(grpc_url)
     wait_for_condition(
         ping_grpc_list_applications, channel=channel, app_names=[app_name]
@@ -235,7 +235,7 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
     httpx.get("http://127.0.0.1:8000/B/")
 
     # Ping gPRC proxy
-    channel = grpc.insecure_channel("localhost:9000")
+    channel = grpc.insecure_channel("127.0.0.1:9000")
     ping_grpc_call_method(channel=channel, app_name="foo", test_not_found=True)
 
     # Ensure all expected metrics are present.
@@ -334,9 +334,11 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
     app_name = "app"
     serve.run(A.bind(), name=app_name)
 
-    httpx.get("http://localhost:8000", timeout=None)
-    httpx.get("http://localhost:8000", timeout=None)
-    channel = grpc.insecure_channel("localhost:9000")
+    http_url = get_application_url("HTTP", app_name=app_name)
+    _ = httpx.get(http_url, timeout=None)
+    _ = httpx.get(http_url, timeout=None)
+    grpc_url = get_application_url("gRPC", app_name=app_name)
+    channel = grpc.insecure_channel(grpc_url)
     with pytest.raises(grpc.RpcError):
         ping_grpc_call_method(channel=channel, app_name=app_name)
 
@@ -462,7 +464,8 @@ def test_proxy_timeout_metrics(metrics_start_shutdown):
     ray.get(signal.send.remote(clear=True))
 
     # make grpc call
-    channel = grpc.insecure_channel("localhost:9000")
+    grpc_url = get_application_url("gRPC", app_name="status_code_timeout")
+    channel = grpc.insecure_channel(grpc_url)
     with pytest.raises(grpc.RpcError):
         ping_grpc_call_method(channel=channel, app_name="status_code_timeout")
 
@@ -535,7 +538,8 @@ def test_proxy_disconnect_grpc_metrics(metrics_start_shutdown):
     )
 
     # make grpc call
-    channel = grpc.insecure_channel("localhost:9000")
+    grpc_url = get_application_url("gRPC", app_name="disconnect")
+    channel = grpc.insecure_channel(grpc_url)
     stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
     request = serve_pb2.UserDefinedMessage(name="foo", num=30, foo="bar")
     metadata = (("application", "disconnect"),)
@@ -586,7 +590,8 @@ def test_proxy_metrics_fields_internal_error(metrics_start_shutdown):
     print("Sent requests to correct URL.")
 
     # Ping gPRC proxy for broken app
-    channel = grpc.insecure_channel("localhost:9000")
+    grpc_url = get_application_url("gRPC", app_name=real_app_name)
+    channel = grpc.insecure_channel(grpc_url)
     with pytest.raises(grpc.RpcError):
         ping_grpc_call_method(channel=channel, app_name=real_app_name)
 
@@ -741,8 +746,10 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     serve.run(WebSocketServer.bind())
 
+    websocket_url = get_application_url(is_websocket=True)
+
     # Regular disconnect (1000) is not an error.
-    with connect("ws://localhost:8000/") as ws:
+    with connect(websocket_url) as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("1000")
             ws.recv()
@@ -754,7 +761,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
     )
 
     # Goaway disconnect (1001) is not an error.
-    with connect("ws://localhost:8000/") as ws:
+    with connect(websocket_url) as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("1001")
             ws.recv()
@@ -766,7 +773,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
     )
 
     # Other codes are errors.
-    with connect("ws://localhost:8000/") as ws:
+    with connect(websocket_url) as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("1011")
             ws.recv()
@@ -778,7 +785,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
     )
 
     # Other codes are errors.
-    with connect("ws://localhost:8000/") as ws:
+    with connect(websocket_url) as ws:
         with pytest.raises(ConnectionClosed):
             ws.send("3000")
             ws.recv()
@@ -1177,7 +1184,7 @@ def test_proxy_metrics_with_route_patterns(metrics_start_shutdown, use_factory_p
     serve.run(APIServer.bind(), name="api_app", route_prefix="/api")
 
     # Make requests to different route patterns with various parameter values
-    base_url = "http://localhost:8000/api"
+    base_url = get_application_url("HTTP", app_name="api_app")
     assert httpx.get(f"{base_url}/").status_code == 200
     assert httpx.get(f"{base_url}/users/123").status_code == 200
     assert httpx.get(f"{base_url}/users/456").status_code == 200
@@ -1537,10 +1544,12 @@ def test_max_processing_latency_metric(metrics_start_shutdown):
 
     stop_sending = threading.Event()
 
+    http_url = get_application_url("HTTP", app_name=app_name)
+
     def _send_requests_forever(route: str):
         while not stop_sending.is_set():
             try:
-                httpx.get(f"http://localhost:8000/api{route}", timeout=5)
+                httpx.get(f"{http_url}{route}", timeout=5)
             except Exception:
                 pass
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -289,11 +289,11 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
                 # gRPC pinged "B" once
                 if do_assert:
                     assert (
-                        'error_code="StatusCode.NOT_FOUND"' in metrics
+                        'error_code="NOT_FOUND"' in metrics
                         and "1.0" in metrics
                     )
                 if (
-                    'error_code="StatusCode.NOT_FOUND"' not in metrics
+                    'error_code="NOT_FOUND"' not in metrics
                     or "1.0" not in metrics
                 ):
                     return False


### PR DESCRIPTION
Main content in this PR is adding metrics to the grpc direct ingress path (these are the same ingress metrics in the http path and proxy path). This is done by reusing the existing metrics helper (which was renamed from `ProxyMetrics` to `RequestIngressMetrics`) in the `direct_ingress_unary_unary` method.

Some additional metrics changes:
* the method tag for HTTP metrics is always uppercased now
* needed to always set the grpc status code in the status callback (before it was only on errors)
* emit metrics for `NOT_FOUND` http and grpc requests (when the request is routed incorrectly)

Testing:
* the tests are constrained to `test_metrics.py`
* changed almost all call sites to use `get_application_url` instead of hardcoded `localhost:8000/9000`. Only remaining ones are websocket test, which is unrelated to the fixes in this PR, and a test that checks for request_router metrics, which doesn't exist in direct ingress case.