### PR TITLE
[core][taskEvents out of GCS][1/n] Implement RayTaskEventRecorder

### DIFF
--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -202,6 +202,25 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "ray_event_recorder_base",
+    srcs = [
+        "ray_event_recorder_base.cc",
+    ],
+    hdrs = [
+        "ray_event_recorder_base.h",
+    ],
+    deps = [
+        ":metric_interface",
+        ":ray_event_recorder_interface",
+        "//src/ray/asio:periodical_runner_interface",
+        "//src/ray/common:ray_config",
+        "//src/ray/rpc:event_aggregator_client",
+        "//src/ray/util:graceful_shutdown",
+        "//src/ray/util:logging",
+    ],
+)
+
+ray_cc_library(
     name = "ray_event_recorder",
     srcs = [
         "ray_event_recorder.cc",
@@ -212,12 +231,10 @@ ray_cc_library(
     deps = [
         ":metric_interface",
         ":ray_event",
-        ":ray_event_recorder_interface",
-        "//src/ray/asio:periodical_runner_interface",
+        ":ray_event_recorder_base",
         "//src/ray/common:ray_config",
         "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
         "//src/ray/rpc:event_aggregator_client",
-        "//src/ray/util:graceful_shutdown",
         "//src/ray/util:logging",
         "@boost//:circular_buffer",
     ],

--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -214,9 +214,11 @@ ray_cc_library(
         ":ray_event_recorder_interface",
         "//src/ray/asio:periodical_runner_interface",
         "//src/ray/common:ray_config",
+        "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
         "//src/ray/rpc:event_aggregator_client",
         "//src/ray/util:graceful_shutdown",
         "//src/ray/util:logging",
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 
@@ -237,6 +239,37 @@ ray_cc_library(
         "//src/ray/rpc:event_aggregator_client",
         "//src/ray/util:logging",
         "@boost//:circular_buffer",
+    ],
+)
+
+ray_cc_library(
+    name = "task_ray_event_interface",
+    hdrs = [
+        "task_ray_event_interface.h",
+    ],
+)
+
+ray_cc_library(
+    name = "ray_task_event_recorder",
+    srcs = [
+        "ray_task_event_recorder.cc",
+    ],
+    hdrs = [
+        "ray_task_event_recorder.h",
+    ],
+    deps = [
+        ":metric_interface",
+        ":ray_event",
+        ":ray_event_recorder_base",
+        ":task_ray_event_interface",
+        "//src/ray/common:id",
+        "//src/ray/common:ray_config",
+        "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
+        "//src/ray/rpc:event_aggregator_client",
+        "//src/ray/util:logging",
+        "@boost//:circular_buffer",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/src/ray/observability/ray_event_recorder.cc
+++ b/src/ray/observability/ray_event_recorder.cc
@@ -50,61 +50,16 @@ void RayEventRecorder::ExportEvents() {
            "once previous export completes.";
     return;
   }
-  rpc::events::AddEventsRequest request;
-  rpc::events::RayEventsData ray_event_data;
-  // group the event in the buffer_ by their entity id and type; then for each group,
-  // merge the events into a single event. maintain the order of the events in the buffer.
-  std::list<std::unique_ptr<RayEventInterface>> grouped_events;
-  absl::flat_hash_map<RayEventKey,
-                      std::list<std::unique_ptr<RayEventInterface>>::iterator>
-      event_key_to_iterator;
+  // Drain the buffer and hand the events to the shared group/serialize/send path.
+  std::list<std::unique_ptr<RayEventInterface>> events;
   for (auto &event : buffer_) {
-    if (!event->SupportsMerge()) {
-      // Non-mergeable events (e.g. those sent from Python) are sent individually.
-      grouped_events.push_back(std::move(event));
-      continue;
-    }
-    auto key = std::make_pair(event->GetEntityId(), event->GetEventType());
-    auto [it, inserted] = event_key_to_iterator.try_emplace(key);
-    if (inserted) {
-      grouped_events.push_back(std::move(event));
-      event_key_to_iterator[key] = std::prev(grouped_events.end());
-    } else {
-      (*it->second)->Merge(std::move(*event));
-    }
+    events.push_back(std::move(event));
   }
-  for (auto &event : grouped_events) {
-    auto ray_event_or = std::move(*event).Serialize();
-    if (ray_event_or.has_error()) {
-      // TODO: Add a metric to track the number of events skipped due to
-      // serialization failure.
-      RAY_LOG(ERROR) << "Skipping event that failed to serialize: "
-                     << ray_event_or.message();
-      continue;
-    }
-    rpc::events::RayEvent ray_event = std::move(ray_event_or.value());
-    // Set node_id centrally for all events
-    ray_event.set_node_id(node_id_.Binary());
-    *ray_event_data.mutable_events()->Add() = std::move(ray_event);
-  }
-  *request.mutable_events_data() = std::move(ray_event_data);
   buffer_.clear();
 
-  grpc_in_progress_ = true;
-  event_aggregator_client_.AddEvents(
-      request, [this](Status status, rpc::events::AddEventsReply reply) {
-        if (!status.ok()) {
-          // TODO(#56391): Add a metric to track the number of failed events. Also
-          // add logic for error recovery.
-          RAY_LOG(ERROR) << "Failed to record ray event: " << status.ToString();
-        }
-        // Signal under mutex to avoid lost wakeup race condition
-        {
-          absl::MutexLock grpc_lock(&grpc_completion_mutex_);
-          grpc_in_progress_ = false;
-          grpc_completion_cv_.Signal();
-        }
-      });
+  rpc::events::AddEventsRequest request;
+  GroupAndSerializeEvents(std::move(events), request.mutable_events_data());
+  SendRequest(std::move(request));
 }
 
 void RayEventRecorder::AddEvents(

--- a/src/ray/observability/ray_event_recorder.cc
+++ b/src/ray/observability/ray_event_recorder.cc
@@ -15,7 +15,6 @@
 #include "ray/observability/ray_event_recorder.h"
 
 #include "ray/common/ray_config.h"
-#include "ray/util/graceful_shutdown.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/public/events_base_event.pb.h"
 
@@ -29,71 +28,13 @@ RayEventRecorder::RayEventRecorder(
     std::string_view metric_source,
     ray::observability::MetricInterface &dropped_events_counter,
     const NodeID &node_id)
-    : event_aggregator_client_(event_aggregator_client),
-      periodical_runner_(std::move(periodical_runner)),
-      max_buffer_size_(max_buffer_size),
-      metric_source_(metric_source),
-      buffer_(max_buffer_size),
-      dropped_events_counter_(dropped_events_counter),
-      node_id_(node_id) {}
-
-void RayEventRecorder::StartExportingEvents() {
-  absl::MutexLock lock(&mutex_);
-  if (!RayConfig::instance().enable_ray_event()) {
-    RAY_LOG(INFO) << "Ray event recording is disabled. Skipping start exporting events.";
-    return;
-  }
-  if (exporting_started_) {
-    return;
-  }
-  exporting_started_ = true;
-  periodical_runner_->RunFnPeriodically(
-      [this]() { ExportEvents(); },
-      RayConfig::instance().ray_events_report_interval_ms(),
-      "RayEventRecorder.ExportEvents");
-}
-
-void RayEventRecorder::StopExportingEvents() {
-  {
-    absl::MutexLock lock(&mutex_);
-    if (!enabled_) {
-      return;
-    }
-    // Set enabled_ to false early to prevent new events from being added during shutdown.
-    // This prevents event loss from events added after ExportEvents() clears the buffer.
-    enabled_ = false;
-  }
-  RAY_LOG(INFO) << "Stopping RayEventRecorder and flushing remaining events.";
-
-  auto flush_timeout_ms = RayConfig::instance().task_events_shutdown_flush_timeout_ms();
-
-  // Local handler implementing GracefulShutdownHandler interface.
-  class ShutdownHandler : public GracefulShutdownHandler {
-   public:
-    explicit ShutdownHandler(RayEventRecorder *recorder) : recorder_(recorder) {}
-
-    bool WaitUntilIdle(absl::Duration timeout) override {
-      absl::MutexLock lock(&recorder_->grpc_completion_mutex_);
-      auto deadline = absl::Now() + timeout;
-      while (recorder_->grpc_in_progress_) {
-        if (recorder_->grpc_completion_cv_.WaitWithDeadline(
-                &recorder_->grpc_completion_mutex_, deadline)) {
-          return false;  // Timeout
-        }
-      }
-      return true;
-    }
-
-    void Flush() override { recorder_->ExportEvents(); }
-
-   private:
-    RayEventRecorder *recorder_;
-  };
-
-  ShutdownHandler handler(this);
-  GracefulShutdownWithFlush(
-      handler, absl::Milliseconds(flush_timeout_ms), "RayEventRecorder");
-}
+    : RayEventRecorderBase(event_aggregator_client,
+                           std::move(periodical_runner),
+                           max_buffer_size,
+                           metric_source,
+                           dropped_events_counter,
+                           node_id),
+      buffer_(max_buffer_size) {}
 
 void RayEventRecorder::ExportEvents() {
   absl::MutexLock lock(&mutex_);

--- a/src/ray/observability/ray_event_recorder.h
+++ b/src/ray/observability/ray_event_recorder.h
@@ -17,7 +17,6 @@
 #include <boost/circular_buffer.hpp>
 #include <memory>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 #include "ray/observability/ray_event_recorder_base.h"
@@ -46,8 +45,6 @@ class RayEventRecorder : public RayEventRecorderBase {
   void AddEvents(std::vector<std::unique_ptr<RayEventInterface>> &&data_list) override;
 
  private:
-  using RayEventKey = std::pair<std::string, rpc::events::RayEvent::EventType>;
-
   void ExportEvents() override;
 
   // Bounded queue to store events before sending to the event aggregator.

--- a/src/ray/observability/ray_event_recorder.h
+++ b/src/ray/observability/ray_event_recorder.h
@@ -15,13 +15,12 @@
 #pragma once
 
 #include <boost/circular_buffer.hpp>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <vector>
 
-#include "absl/synchronization/mutex.h"
-#include "ray/asio/periodical_runner_interface.h"
-#include "ray/observability/metric_interface.h"
-#include "ray/observability/ray_event_interface.h"
-#include "ray/observability/ray_event_recorder_interface.h"
-#include "ray/rpc/event_aggregator_client.h"
+#include "ray/observability/ray_event_recorder_base.h"
 
 namespace ray {
 namespace observability {
@@ -33,7 +32,7 @@ namespace observability {
 // aggregator periodically.
 //
 // This class is thread safe.
-class RayEventRecorder : public RayEventRecorderInterface {
+class RayEventRecorder : public RayEventRecorderBase {
  public:
   RayEventRecorder(rpc::EventAggregatorClient &event_aggregator_client,
                    std::shared_ptr<PeriodicalRunnerInterface> periodical_runner,
@@ -42,15 +41,6 @@ class RayEventRecorder : public RayEventRecorderInterface {
                    ray::observability::MetricInterface &dropped_events_counter,
                    const NodeID &node_id);
 
-  // Start exporting events to the event aggregator by periodically sending events to
-  // the event aggregator. This should be called only once. Subsequent calls will be
-  // ignored.
-  void StartExportingEvents() override;
-
-  // Stop exporting events and perform a final flush to ensure all buffered events
-  // are sent before shutdown. This should be called during graceful shutdown.
-  void StopExportingEvents() override;
-
   // Add a vector of data to the internal buffer. Data in the buffer will be sent to
   // the event aggregator periodically.
   void AddEvents(std::vector<std::unique_ptr<RayEventInterface>> &&data_list) override;
@@ -58,36 +48,12 @@ class RayEventRecorder : public RayEventRecorderInterface {
  private:
   using RayEventKey = std::pair<std::string, rpc::events::RayEvent::EventType>;
 
-  rpc::EventAggregatorClient &event_aggregator_client_;
-  std::shared_ptr<PeriodicalRunnerInterface> periodical_runner_;
-  // Lock for thread safety when modifying the buffer.
-  absl::Mutex mutex_;
+  void ExportEvents() override;
 
-  // Maximum number of events to store in the buffer (configurable at runtime)
-  size_t max_buffer_size_;
-  std::string_view metric_source_;
   // Bounded queue to store events before sending to the event aggregator.
   // When the queue is full, old events are dropped to make room for new ones.
   boost::circular_buffer<std::unique_ptr<RayEventInterface>> buffer_
       ABSL_GUARDED_BY(mutex_);
-  ray::observability::MetricInterface &dropped_events_counter_;
-  // Flag to track if exporting has been started
-  bool exporting_started_ ABSL_GUARDED_BY(mutex_) = false;
-  // Flag to track if the recorder is enabled and accepting new events.
-  // Set to false during shutdown to prevent event loss.
-  bool enabled_ ABSL_GUARDED_BY(mutex_) = true;
-  // Node ID to be set on all events
-  const NodeID node_id_;
-
-  // Flag to track if there's an in-flight gRPC call
-  std::atomic<bool> grpc_in_progress_ = false;
-  // Mutex and condition variable for waiting on gRPC completion during shutdown
-  absl::Mutex grpc_completion_mutex_;
-  absl::CondVar grpc_completion_cv_;
-
-  // Export events to the event aggregator. This is called periodically by the
-  // PeriodicalRunner.
-  void ExportEvents();
 };
 
 }  // namespace observability

--- a/src/ray/observability/ray_event_recorder_base.cc
+++ b/src/ray/observability/ray_event_recorder_base.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/observability/ray_event_recorder_base.cc
+++ b/src/ray/observability/ray_event_recorder_base.cc
@@ -14,9 +14,14 @@
 
 #include "ray/observability/ray_event_recorder_base.h"
 
+#include <iterator>
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
 #include "ray/common/ray_config.h"
 #include "ray/util/graceful_shutdown.h"
 #include "ray/util/logging.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
 
 namespace ray {
 namespace observability {
@@ -91,6 +96,65 @@ void RayEventRecorderBase::StopExportingEvents() {
   ShutdownHandler handler(this);
   GracefulShutdownWithFlush(
       handler, absl::Milliseconds(flush_timeout_ms), "RayEventRecorder");
+}
+
+void RayEventRecorderBase::GroupAndSerializeEvents(
+    std::list<std::unique_ptr<RayEventInterface>> &&events,
+    rpc::events::RayEventsData *data) const {
+  using RayEventKey = std::pair<std::string, rpc::events::RayEvent::EventType>;
+  // group the events by their entity id and type; then for each group, merge the events
+  // into a single event. maintain the order of the events.
+  std::list<std::unique_ptr<RayEventInterface>> grouped_events;
+  absl::flat_hash_map<RayEventKey,
+                      std::list<std::unique_ptr<RayEventInterface>>::iterator>
+      event_key_to_iterator;
+  for (auto &event : events) {
+    if (!event->SupportsMerge()) {
+      // Non-mergeable events (e.g. those sent from Python) are sent individually.
+      grouped_events.push_back(std::move(event));
+      continue;
+    }
+    auto key = std::make_pair(event->GetEntityId(), event->GetEventType());
+    auto [it, inserted] = event_key_to_iterator.try_emplace(key);
+    if (inserted) {
+      grouped_events.push_back(std::move(event));
+      event_key_to_iterator[key] = std::prev(grouped_events.end());
+    } else {
+      (*it->second)->Merge(std::move(*event));
+    }
+  }
+  for (auto &event : grouped_events) {
+    auto ray_event_or = std::move(*event).Serialize();
+    if (ray_event_or.has_error()) {
+      // TODO: Add a metric to track the number of events skipped due to
+      // serialization failure.
+      RAY_LOG(ERROR) << "Skipping event that failed to serialize: "
+                     << ray_event_or.message();
+      continue;
+    }
+    rpc::events::RayEvent ray_event = std::move(ray_event_or.value());
+    // Set node_id centrally for all events
+    ray_event.set_node_id(node_id_.Binary());
+    *data->mutable_events()->Add() = std::move(ray_event);
+  }
+}
+
+void RayEventRecorderBase::SendRequest(rpc::events::AddEventsRequest &&request) {
+  grpc_in_progress_ = true;
+  event_aggregator_client_.AddEvents(
+      request, [this](Status status, rpc::events::AddEventsReply reply) {
+        if (!status.ok()) {
+          // TODO(#56391): Add a metric to track the number of failed events. Also
+          // add logic for error recovery.
+          RAY_LOG(ERROR) << "Failed to record ray event: " << status.ToString();
+        }
+        // Signal under mutex to avoid lost wakeup race condition
+        {
+          absl::MutexLock grpc_lock(&grpc_completion_mutex_);
+          grpc_in_progress_ = false;
+          grpc_completion_cv_.Signal();
+        }
+      });
 }
 
 }  // namespace observability

--- a/src/ray/observability/ray_event_recorder_base.cc
+++ b/src/ray/observability/ray_event_recorder_base.cc
@@ -1,0 +1,97 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/ray_event_recorder_base.h"
+
+#include "ray/common/ray_config.h"
+#include "ray/util/graceful_shutdown.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace observability {
+
+RayEventRecorderBase::RayEventRecorderBase(
+    rpc::EventAggregatorClient &event_aggregator_client,
+    std::shared_ptr<PeriodicalRunnerInterface> periodical_runner,
+    size_t max_buffer_size,
+    std::string_view metric_source,
+    ray::observability::MetricInterface &dropped_events_counter,
+    const NodeID &node_id)
+    : event_aggregator_client_(event_aggregator_client),
+      periodical_runner_(std::move(periodical_runner)),
+      max_buffer_size_(max_buffer_size),
+      metric_source_(metric_source),
+      dropped_events_counter_(dropped_events_counter),
+      node_id_(node_id) {}
+
+void RayEventRecorderBase::StartExportingEvents() {
+  absl::MutexLock lock(&mutex_);
+  if (!RayConfig::instance().enable_ray_event()) {
+    RAY_LOG(INFO) << "Ray event recording is disabled. Skipping start exporting events.";
+    return;
+  }
+  if (exporting_started_) {
+    return;
+  }
+  exporting_started_ = true;
+  periodical_runner_->RunFnPeriodically(
+      [this]() { ExportEvents(); },
+      RayConfig::instance().ray_events_report_interval_ms(),
+      "RayEventRecorder.ExportEvents");
+}
+
+void RayEventRecorderBase::StopExportingEvents() {
+  {
+    absl::MutexLock lock(&mutex_);
+    if (!enabled_) {
+      return;
+    }
+    // Set enabled_ to false early to prevent new events from being added during shutdown.
+    // This prevents event loss from events added after ExportEvents() clears the buffer.
+    enabled_ = false;
+  }
+  RAY_LOG(INFO) << "Stopping RayEventRecorder and flushing remaining events.";
+
+  auto flush_timeout_ms = RayConfig::instance().task_events_shutdown_flush_timeout_ms();
+
+  // Local handler implementing GracefulShutdownHandler interface.
+  class ShutdownHandler : public GracefulShutdownHandler {
+   public:
+    explicit ShutdownHandler(RayEventRecorderBase *recorder) : recorder_(recorder) {}
+
+    bool WaitUntilIdle(absl::Duration timeout) override {
+      absl::MutexLock lock(&recorder_->grpc_completion_mutex_);
+      auto deadline = absl::Now() + timeout;
+      while (recorder_->grpc_in_progress_) {
+        if (recorder_->grpc_completion_cv_.WaitWithDeadline(
+                &recorder_->grpc_completion_mutex_, deadline)) {
+          return false;  // Timeout
+        }
+      }
+      return true;
+    }
+
+    void Flush() override { recorder_->ExportEvents(); }
+
+   private:
+    RayEventRecorderBase *recorder_;
+  };
+
+  ShutdownHandler handler(this);
+  GracefulShutdownWithFlush(
+      handler, absl::Milliseconds(flush_timeout_ms), "RayEventRecorder");
+}
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/ray_event_recorder_base.h
+++ b/src/ray/observability/ray_event_recorder_base.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/observability/ray_event_recorder_base.h
+++ b/src/ray/observability/ray_event_recorder_base.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <atomic>
+#include <list>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -55,6 +56,18 @@ class RayEventRecorderBase : public RayEventRecorderInterface {
   // Export events to the event aggregator. This is called periodically by the
   // PeriodicalRunner.
   virtual void ExportEvents() = 0;
+
+  // Group mergeable events by (entity_id, event_type), merge each group,
+  // serialize all events, and append the results to `data`.
+  // Non-mergeable events are serialized individually; events that fail to serialize
+  // are skipped. Shared by the ExportEvents implementations of all subclasses.
+  void GroupAndSerializeEvents(std::list<std::unique_ptr<RayEventInterface>> &&events,
+                               rpc::events::RayEventsData *data) const;
+
+  // Send a populated request to the event aggregator, tracking the in-flight
+  // gRPC so shutdown can drain. Sets grpc_in_progress_; the completion callback resets
+  // it. Call while holding mutex_.
+  void SendRequest(rpc::events::AddEventsRequest &&request);
 
   rpc::EventAggregatorClient &event_aggregator_client_;
   std::shared_ptr<PeriodicalRunnerInterface> periodical_runner_;

--- a/src/ray/observability/ray_event_recorder_base.h
+++ b/src/ray/observability/ray_event_recorder_base.h
@@ -1,0 +1,84 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "absl/synchronization/mutex.h"
+#include "ray/asio/periodical_runner_interface.h"
+#include "ray/observability/metric_interface.h"
+#include "ray/observability/ray_event_interface.h"
+#include "ray/observability/ray_event_recorder_interface.h"
+#include "ray/rpc/event_aggregator_client.h"
+
+namespace ray {
+namespace observability {
+
+// Base for RayEventRecorderInterface implementations: owns the export-loop and
+// gRPC-drain machinery shared by all recorders. Subclasses own the buffer
+// and implement AddEvents and ExportEvents.
+// This class is thread safe.
+class RayEventRecorderBase : public RayEventRecorderInterface {
+ public:
+  // Start exporting events to the event aggregator by periodically sending events to
+  // the event aggregator. This should be called only once. Subsequent calls will be
+  // ignored.
+  void StartExportingEvents() override;
+
+  // Stop exporting events and perform a final flush to ensure all buffered events
+  // are sent before shutdown. This should be called during graceful shutdown.
+  void StopExportingEvents() override;
+
+ protected:
+  RayEventRecorderBase(rpc::EventAggregatorClient &event_aggregator_client,
+                       std::shared_ptr<PeriodicalRunnerInterface> periodical_runner,
+                       size_t max_buffer_size,
+                       std::string_view metric_source,
+                       ray::observability::MetricInterface &dropped_events_counter,
+                       const NodeID &node_id);
+
+  // Export events to the event aggregator. This is called periodically by the
+  // PeriodicalRunner.
+  virtual void ExportEvents() = 0;
+
+  rpc::EventAggregatorClient &event_aggregator_client_;
+  std::shared_ptr<PeriodicalRunnerInterface> periodical_runner_;
+  // Lock for thread safety when modifying the buffer.
+  absl::Mutex mutex_;
+
+  // Maximum number of events to store in the buffer (configurable at runtime)
+  size_t max_buffer_size_;
+  std::string_view metric_source_;
+  ray::observability::MetricInterface &dropped_events_counter_;
+  // Flag to track if exporting has been started
+  bool exporting_started_ ABSL_GUARDED_BY(mutex_) = false;
+  // Flag to track if the recorder is enabled and accepting new events.
+  // Set to false during shutdown to prevent event loss.
+  bool enabled_ ABSL_GUARDED_BY(mutex_) = true;
+  // Node ID to be set on all events
+  const NodeID node_id_;
+
+  // Flag to track if there's an in-flight gRPC call
+  std::atomic<bool> grpc_in_progress_ = false;
+  // Mutex and condition variable for waiting on gRPC completion during shutdown
+  absl::Mutex grpc_completion_mutex_;
+  absl::CondVar grpc_completion_cv_;
+};
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/ray_task_event_recorder.cc
+++ b/src/ray/observability/ray_task_event_recorder.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/observability/ray_task_event_recorder.cc
+++ b/src/ray/observability/ray_task_event_recorder.cc
@@ -1,0 +1,207 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/ray_task_event_recorder.h"
+
+#include <list>
+#include <string>
+#include <utility>
+
+#include "ray/common/id.h"
+#include "ray/common/ray_config.h"
+#include "ray/util/logging.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
+
+namespace ray {
+namespace observability {
+
+RayTaskEventRecorder::RayTaskEventRecorder(
+    rpc::EventAggregatorClient &event_aggregator_client,
+    std::shared_ptr<PeriodicalRunnerInterface> periodical_runner,
+    size_t max_buffer_size,
+    std::string_view metric_source,
+    ray::observability::MetricInterface &dropped_events_counter,
+    const NodeID &node_id)
+    : RayEventRecorderBase(event_aggregator_client,
+                           std::move(periodical_runner),
+                           max_buffer_size,
+                           metric_source,
+                           dropped_events_counter,
+                           node_id),
+      status_events_(max_buffer_size) {}
+
+TaskAttemptId RayTaskEventRecorder::GetTaskAttemptOrDie(
+    const std::unique_ptr<RayEventInterface> &event) {
+  auto *task_event = dynamic_cast<TaskRayEventInterface *>(event.get());
+  RAY_CHECK(task_event != nullptr)
+      << "RayTaskEventRecorder received an event that is not a TaskRayEventInterface.";
+  return task_event->GetTaskAttempt();
+}
+
+void RayTaskEventRecorder::RecordDropped(size_t count) {
+  if (count == 0) {
+    return;
+  }
+  dropped_events_counter_.Record(count, {{"Source", std::string(metric_source_)}});
+}
+
+void RayTaskEventRecorder::AddEvents(
+    std::vector<std::unique_ptr<RayEventInterface>> &&data_list) {
+  absl::MutexLock lock(&mutex_);
+  if (!enabled_) {
+    return;
+  }
+  if (!RayConfig::instance().enable_ray_event()) {
+    return;
+  }
+  for (auto &event : data_list) {
+    TaskAttemptId attempt = GetTaskAttemptOrDie(event);
+    if (event->GetEventType() == rpc::events::RayEvent::TASK_PROFILE_EVENT) {
+      AddProfileEvent(std::move(event), attempt);
+    } else {
+      AddStatusEvent(std::move(event), attempt);
+    }
+  }
+}
+
+void RayTaskEventRecorder::AddStatusEvent(std::unique_ptr<RayEventInterface> event,
+                                          const TaskAttemptId &attempt) {
+  if (dropped_task_attempts_unreported_.count(attempt) != 0u) {
+    // This task attempt has already been dropped, so drop this event too.
+    RecordDropped(1);
+    return;
+  }
+  if (status_events_.full()) {
+    // The ring is full: pushing will evict the oldest event, so record its attempt as
+    // dropped before it is overwritten.
+    TaskAttemptId evicted = GetTaskAttemptOrDie(status_events_.front());
+    dropped_task_attempts_unreported_.insert(evicted);
+    RecordDropped(1);
+    RAY_LOG_EVERY_N(WARNING, 100000)
+        << "[RayTaskEventRecorder] Dropping task status events for task: "
+        << TaskID::FromBinary(evicted.first)
+        << ", set a higher value for "
+           "RAY_task_events_max_num_status_events_buffer_on_worker("
+        << RayConfig::instance().task_events_max_num_status_events_buffer_on_worker()
+        << ") to avoid this.";
+  }
+  status_events_.push_back(std::move(event));
+}
+
+void RayTaskEventRecorder::AddProfileEvent(std::unique_ptr<RayEventInterface> event,
+                                           const TaskAttemptId &attempt) {
+  auto profile_events_itr = profile_events_.find(attempt);
+  if (profile_events_itr == profile_events_.end()) {
+    auto inserted = profile_events_.insert(
+        {attempt, std::vector<std::unique_ptr<RayEventInterface>>()});
+    RAY_CHECK(inserted.second);
+    profile_events_itr = inserted.first;
+  }
+
+  auto max_num_profile_event_per_task =
+      RayConfig::instance().task_events_max_num_profile_events_per_task();
+  auto max_profile_events_stored =
+      RayConfig::instance().task_events_max_num_profile_events_buffer_on_worker();
+
+  // If we store too many per task or too many per kind of event, we drop the new event.
+  if ((max_num_profile_event_per_task >= 0 &&
+       profile_events_itr->second.size() >=
+           static_cast<size_t>(max_num_profile_event_per_task)) ||
+      num_profile_events_buffered_ >= max_profile_events_stored) {
+    RecordDropped(1);
+    // Data loss. We are dropping the newly reported profile event.
+    // This will likely happen on a driver task since the driver has a fixed placeholder
+    // driver task id and it could generate large number of profile events when submitting
+    // many tasks.
+    RAY_LOG_EVERY_N(WARNING, 100000)
+        << "[RayTaskEventRecorder] Dropping profiling events for task: "
+        << TaskID::FromBinary(attempt.first)
+        << ", set a higher value for RAY_task_events_max_num_profile_events_per_task("
+        << max_num_profile_event_per_task
+        << "), or RAY_task_events_max_num_profile_events_buffer_on_worker ("
+        << max_profile_events_stored << ") to avoid this.";
+    return;
+  }
+
+  num_profile_events_buffered_++;
+  profile_events_itr->second.push_back(std::move(event));
+}
+
+void RayTaskEventRecorder::ExportEvents() {
+  absl::MutexLock lock(&mutex_);
+  if (status_events_.empty() && profile_events_.empty() &&
+      dropped_task_attempts_unreported_.empty()) {
+    return;
+  }
+  // Skip if there's already an in-flight gRPC call to avoid overlapping requests.
+  if (grpc_in_progress_) {
+    RAY_LOG_EVERY_N_OR_DEBUG(WARNING, 100)
+        << "Previous RayTaskEventRecorder export in progress: new events will be "
+           "exported once previous export completes.";
+    return;
+  }
+
+  // TODO(karticam): Unlike TaskEventBufferImpl::FlushEvents, which sends a bounded batch
+  // per flush, this drains the entire buffer so one export can potentially be a large
+  // gRPC. This will be bounded once batching lands in the RayEventRecorder export path
+  // (PR #60045).
+
+  absl::flat_hash_set<TaskAttemptId> dropped_to_send =
+      std::move(dropped_task_attempts_unreported_);
+  dropped_task_attempts_unreported_.clear();
+
+  // Collect events to export, skipping any whose attempt was dropped
+  std::list<std::unique_ptr<RayEventInterface>> events;
+  size_t num_skipped = 0;
+  for (auto &event : status_events_) {
+    if (dropped_to_send.contains(GetTaskAttemptOrDie(event))) {
+      num_skipped++;
+      continue;
+    }
+    events.push_back(std::move(event));
+  }
+  status_events_.clear();
+  for (auto &[attempt, profile_vec] : profile_events_) {
+    if (dropped_to_send.contains(attempt)) {
+      num_skipped += profile_vec.size();
+      continue;
+    }
+    for (auto &event : profile_vec) {
+      events.push_back(std::move(event));
+    }
+  }
+  profile_events_.clear();
+  num_profile_events_buffered_ = 0;
+  RecordDropped(num_skipped);
+
+  rpc::events::AddEventsRequest request;
+  rpc::events::RayEventsData *data = request.mutable_events_data();
+  GroupAndSerializeEvents(std::move(events), data);
+
+  rpc::events::TaskEventsMetadata *metadata = data->mutable_task_events_metadata();
+  for (const auto &attempt : dropped_to_send) {
+    rpc::TaskAttempt *rpc_attempt = metadata->add_dropped_task_attempts();
+    rpc_attempt->set_task_id(attempt.first);
+    rpc_attempt->set_attempt_number(attempt.second);
+  }
+
+  if (data->events_size() == 0 && metadata->dropped_task_attempts_size() == 0) {
+    return;
+  }
+
+  SendRequest(std::move(request));
+}
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/ray_task_event_recorder.h
+++ b/src/ray/observability/ray_task_event_recorder.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/observability/ray_task_event_recorder.h
+++ b/src/ray/observability/ray_task_event_recorder.h
@@ -1,0 +1,96 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <boost/circular_buffer.hpp>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ray/observability/ray_event_recorder_base.h"
+#include "ray/observability/task_ray_event_interface.h"
+
+namespace ray {
+namespace observability {
+
+// RayTaskEventRecorder is the task-event-specific RayEventRecorderInterface impl. Unlike
+// the generic RayEventRecorder (a single FIFO drop-oldest buffer), it preserves the
+// drop semantics of the legacy task event buffer (see core_worker/task_event_buffer):
+//
+//   - Status events (definition + lifecycle) live in a bounded ring. On overflow the
+//     evicted event's task attempt is recorded as dropped, and later events for
+//     an already-dropped attempt are dropped too. Dropped attempts are reported
+//     via RayEventsData.task_events_metadata.dropped_task_attempts. For a task attempt,
+//     either all events are sent out or none is sent out.
+//   - Profile events are stored per attempt with a per-task cap and a global cap; on
+//     overflow the newest profile event is dropped (counted as a dropped-event metric)
+//     Dropped profile events are not reported. They are metric only.
+//
+// Events passed to AddEvents must implement TaskRayEventInterface.
+//
+// This class is thread safe.
+class RayTaskEventRecorder : public RayEventRecorderBase {
+ public:
+  RayTaskEventRecorder(rpc::EventAggregatorClient &event_aggregator_client,
+                       std::shared_ptr<PeriodicalRunnerInterface> periodical_runner,
+                       size_t max_buffer_size,
+                       std::string_view metric_source,
+                       ray::observability::MetricInterface &dropped_events_counter,
+                       const NodeID &node_id);
+
+  // Add a vector of task events to the internal buffers. Each event must implement
+  // TaskRayEventInterface.
+  void AddEvents(std::vector<std::unique_ptr<RayEventInterface>> &&data_list) override;
+
+ private:
+  void ExportEvents() override;
+
+  // Add a status (definition / lifecycle) event to the bounded ring. On overflow the
+  // oldest event is evicted and its attempt added to dropped_task_attempts_unreported_;
+  // an event whose attempt was already dropped is dropped.
+  void AddStatusEvent(std::unique_ptr<RayEventInterface> event,
+                      const TaskAttemptId &attempt) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  // Add a profile event to the per-attempt store, dropping the newest on a per-task or
+  // global cap overflow.
+  void AddProfileEvent(std::unique_ptr<RayEventInterface> event,
+                       const TaskAttemptId &attempt)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  // Read the task attempt of an event; the event must implement TaskRayEventInterface.
+  static TaskAttemptId GetTaskAttemptOrDie(
+      const std::unique_ptr<RayEventInterface> &event);
+
+  // Record `count` dropped events to the metric.
+  void RecordDropped(size_t count) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  // Bounded ring of status events (definition + lifecycle). On overflow the oldest is
+  // evicted and its attempt is recorded in dropped_task_attempts_unreported_.
+  boost::circular_buffer<std::unique_ptr<RayEventInterface>> status_events_
+      ABSL_GUARDED_BY(mutex_);
+  // Task attempts whose status events were dropped and not yet reported.
+  absl::flat_hash_set<TaskAttemptId> dropped_task_attempts_unreported_
+      ABSL_GUARDED_BY(mutex_);
+  // Profile events keyed by task attempt; capped per attempt and globally (drop-newest).
+  absl::flat_hash_map<TaskAttemptId, std::vector<std::unique_ptr<RayEventInterface>>>
+      profile_events_ ABSL_GUARDED_BY(mutex_);
+  // Total profile events buffered across all attempts (for the global cap).
+  size_t num_profile_events_buffered_ ABSL_GUARDED_BY(mutex_) = 0;
+};
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/ray_task_event_recorder.h
+++ b/src/ray/observability/ray_task_event_recorder.h
@@ -28,8 +28,8 @@ namespace ray {
 namespace observability {
 
 // RayTaskEventRecorder is the task-event-specific RayEventRecorderInterface impl. Unlike
-// the generic RayEventRecorder (a single FIFO drop-oldest buffer), it preserves the
-// drop semantics of the legacy task event buffer (see core_worker/task_event_buffer):
+// the generic RayEventRecorder (a single FIFO drop-oldest buffer), it applies
+// per-task-attempt drop semantics:
 //
 //   - Status events (definition + lifecycle) live in a bounded ring. On overflow the
 //     evicted event's task attempt is recorded as dropped, and later events for
@@ -37,8 +37,8 @@ namespace observability {
 //     via RayEventsData.task_events_metadata.dropped_task_attempts. For a task attempt,
 //     either all events are sent out or none is sent out.
 //   - Profile events are stored per attempt with a per-task cap and a global cap; on
-//     overflow the newest profile event is dropped (counted as a dropped-event metric)
-//     Dropped profile events are not reported. They are metric only.
+//     overflow the newest profile event is dropped (counted as a dropped-event metric).
+//     Dropped profile events are not reported — metric only.
 //
 // Events passed to AddEvents must implement TaskRayEventInterface.
 //

--- a/src/ray/observability/task_ray_event_interface.h
+++ b/src/ray/observability/task_ray_event_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/observability/task_ray_event_interface.h
+++ b/src/ray/observability/task_ray_event_interface.h
@@ -1,0 +1,41 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace ray {
+namespace observability {
+
+// Identifies the task attempt an event belongs to: (task_id binary, attempt_number).
+// Used as the buffer / drop-tracking key in RayTaskEventRecorder.
+using TaskAttemptId = std::pair<std::string, int32_t>;
+
+// Mix-in implemented by the task-event wrappers (definition / lifecycle / profile) so
+// RayTaskEventRecorder can read the (task_id, attempt) an event belongs to. Kept separate
+// from RayEventInterface so the generic recorder stays free of task-specific concepts;
+// RayTaskEventRecorder dynamic_casts the events it receives to this interface.
+class TaskRayEventInterface {
+ public:
+  virtual ~TaskRayEventInterface() = default;
+
+  // The task attempt this event belongs to.
+  virtual TaskAttemptId GetTaskAttempt() const = 0;
+};
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/tests/BUILD.bazel
+++ b/src/ray/observability/tests/BUILD.bazel
@@ -46,6 +46,7 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/asio:periodical_runner",
+        "//src/ray/common:id",
         "//src/ray/observability:fake_metric",
         "//src/ray/observability:ray_task_event_recorder",
         "//src/ray/observability:task_ray_event_interface",

--- a/src/ray/observability/tests/BUILD.bazel
+++ b/src/ray/observability/tests/BUILD.bazel
@@ -40,6 +40,20 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "ray_task_event_recorder_test",
+    size = "small",
+    srcs = ["ray_task_event_recorder_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/asio:periodical_runner",
+        "//src/ray/observability:fake_metric",
+        "//src/ray/observability:ray_task_event_recorder",
+        "//src/ray/observability:task_ray_event_interface",
+        "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
+    ],
+)
+
+ray_cc_test(
     name = "python_event_interface_test",
     size = "small",
     srcs = ["python_event_interface_test.cc"],

--- a/src/ray/observability/tests/ray_task_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_task_event_recorder_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/observability/tests/ray_task_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_task_event_recorder_test.cc
@@ -23,6 +23,7 @@
 #include "gtest/gtest.h"
 #include "ray/asio/instrumented_io_context.h"
 #include "ray/asio/periodical_runner.h"
+#include "ray/common/id.h"
 #include "ray/common/ray_config.h"
 #include "ray/observability/fake_metric.h"
 #include "ray/observability/task_ray_event_interface.h"
@@ -65,14 +66,26 @@ class FakeAggregatorClient : public rpc::EventAggregatorClient {
   absl::Mutex mutex_;
 };
 
-// Minimal task event: carries a task attempt + event type, and serializes to a RayEvent
-// whose `message` encodes "task_id:attempt" so tests can identify exported events.
+// A valid 24-byte TaskID binary derived from a human label. The recorder's drop-warning
+// path calls TaskID::FromBinary(attempt.first), which CHECK-fails unless the id is
+// exactly TaskID::Size() (24) bytes — so test task ids must be full size, not short
+// strings.
+std::string Tid(const std::string &label) {
+  std::string binary = label;
+  binary.resize(TaskID::Size(), '_');
+  return binary;
+}
+
+// Minimal task event: carries a task attempt + event type. The task attempt uses a valid
+// 24-byte task-id binary (derived from `label` via Tid); the serialized RayEvent's
+// `message` uses the human `label` ("label:attempt") so tests can identify exported
+// events.
 class FakeTaskRayEvent : public RayEventInterface, public TaskRayEventInterface {
  public:
-  FakeTaskRayEvent(std::string task_id,
+  FakeTaskRayEvent(const std::string &label,
                    int32_t attempt,
                    rpc::events::RayEvent::EventType type)
-      : task_id_(std::move(task_id)), attempt_(attempt), type_(type) {}
+      : task_id_(Tid(label)), label_(label), attempt_(attempt), type_(type) {}
 
   std::string GetEntityId() const override { return task_id_ + std::to_string(attempt_); }
 
@@ -82,7 +95,7 @@ class FakeTaskRayEvent : public RayEventInterface, public TaskRayEventInterface 
       override {
     rpc::events::RayEvent event;
     event.set_event_type(type_);
-    event.set_message(task_id_ + ":" + std::to_string(attempt_));
+    event.set_message(label_ + ":" + std::to_string(attempt_));
     return event;
   }
 
@@ -94,6 +107,7 @@ class FakeTaskRayEvent : public RayEventInterface, public TaskRayEventInterface 
 
  private:
   std::string task_id_;
+  std::string label_;
   int32_t attempt_;
   rpc::events::RayEvent::EventType type_;
 };
@@ -201,8 +215,8 @@ TEST_F(RayTaskEventRecorderTest, TestStatusRingOverflowReportsDroppedAttempts) {
     dropped_ids.push_back(attempt.task_id());
     EXPECT_EQ(attempt.attempt_number(), 0);
   }
-  EXPECT_EQ(std::count(dropped_ids.begin(), dropped_ids.end(), "task1"), 1);
-  EXPECT_EQ(std::count(dropped_ids.begin(), dropped_ids.end(), "task2"), 1);
+  EXPECT_EQ(std::count(dropped_ids.begin(), dropped_ids.end(), Tid("task1")), 1);
+  EXPECT_EQ(std::count(dropped_ids.begin(), dropped_ids.end(), Tid("task2")), 1);
 }
 
 // Once an attempt is dropped, later events for it are dropped on add (sticky).
@@ -227,7 +241,7 @@ TEST_F(RayTaskEventRecorderTest, TestStickyDropForDroppedAttempt) {
   }
   auto dropped = fake_client_->GetDroppedAttempts();
   ASSERT_EQ(dropped.size(), 1);
-  EXPECT_EQ(dropped[0].task_id(), "task1");
+  EXPECT_EQ(dropped[0].task_id(), Tid("task1"));
 }
 
 // All-or-none per attempt: a buffered event whose attempt was dropped (via eviction of an
@@ -252,7 +266,7 @@ TEST_F(RayTaskEventRecorderTest, TestAllOrNoneSkipsBufferedEventForDroppedAttemp
   }
   auto dropped = fake_client_->GetDroppedAttempts();
   ASSERT_EQ(dropped.size(), 1);
-  EXPECT_EQ(dropped[0].task_id(), "task1");
+  EXPECT_EQ(dropped[0].task_id(), Tid("task1"));
 }
 
 // A flush with only dropped attempts and no surviving events still sends the metadata
@@ -279,7 +293,7 @@ TEST_F(RayTaskEventRecorderTest, TestMetadataOnlySendForFullyDroppedAttempt) {
   EXPECT_TRUE(client.GetRecordedEvents().empty());
   auto dropped = client.GetDroppedAttempts();
   ASSERT_EQ(dropped.size(), 1);
-  EXPECT_EQ(dropped[0].task_id(), "task1");
+  EXPECT_EQ(dropped[0].task_id(), Tid("task1"));
 }
 
 // Profile events beyond the per-task cap are dropped (newest), and not reported in-band.

--- a/src/ray/observability/tests/ray_task_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_task_event_recorder_test.cc
@@ -1,0 +1,342 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/ray_task_event_recorder.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ray/asio/instrumented_io_context.h"
+#include "ray/asio/periodical_runner.h"
+#include "ray/common/ray_config.h"
+#include "ray/observability/fake_metric.h"
+#include "ray/observability/task_ray_event_interface.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
+
+namespace ray {
+namespace observability {
+
+// Aggregator client fake that records both the exported events and the dropped task
+// attempts reported in the request metadata.
+class FakeAggregatorClient : public rpc::EventAggregatorClient {
+ public:
+  void AddEvents(
+      const rpc::events::AddEventsRequest &request,
+      const rpc::ClientCallback<rpc::events::AddEventsReply> &callback) override {
+    absl::MutexLock lock(&mutex_);
+    for (const auto &event : request.events_data().events()) {
+      recorded_events_.push_back(event);
+    }
+    for (const auto &attempt :
+         request.events_data().task_events_metadata().dropped_task_attempts()) {
+      dropped_attempts_.push_back(attempt);
+    }
+    callback(Status::OK(), rpc::events::AddEventsReply{});
+  }
+
+  std::vector<rpc::events::RayEvent> GetRecordedEvents() {
+    absl::MutexLock lock(&mutex_);
+    return recorded_events_;
+  }
+
+  std::vector<rpc::TaskAttempt> GetDroppedAttempts() {
+    absl::MutexLock lock(&mutex_);
+    return dropped_attempts_;
+  }
+
+ private:
+  std::vector<rpc::events::RayEvent> recorded_events_ ABSL_GUARDED_BY(mutex_);
+  std::vector<rpc::TaskAttempt> dropped_attempts_ ABSL_GUARDED_BY(mutex_);
+  absl::Mutex mutex_;
+};
+
+// Minimal task event: carries a task attempt + event type, and serializes to a RayEvent
+// whose `message` encodes "task_id:attempt" so tests can identify exported events.
+class FakeTaskRayEvent : public RayEventInterface, public TaskRayEventInterface {
+ public:
+  FakeTaskRayEvent(std::string task_id,
+                   int32_t attempt,
+                   rpc::events::RayEvent::EventType type)
+      : task_id_(std::move(task_id)), attempt_(attempt), type_(type) {}
+
+  std::string GetEntityId() const override { return task_id_ + std::to_string(attempt_); }
+
+  void Merge(RayEventInterface &&other) override {}
+
+  ray::StatusSetOr<ray::rpc::events::RayEvent, ray::StatusT::Invalid> Serialize() &&
+      override {
+    rpc::events::RayEvent event;
+    event.set_event_type(type_);
+    event.set_message(task_id_ + ":" + std::to_string(attempt_));
+    return event;
+  }
+
+  rpc::events::RayEvent::EventType GetEventType() const override { return type_; }
+
+  bool SupportsMerge() const override { return true; }
+
+  TaskAttemptId GetTaskAttempt() const override { return {task_id_, attempt_}; }
+
+ private:
+  std::string task_id_;
+  int32_t attempt_;
+  rpc::events::RayEvent::EventType type_;
+};
+
+class RayTaskEventRecorderTest : public ::testing::Test {
+ public:
+  RayTaskEventRecorderTest() {
+    fake_client_ = std::make_unique<FakeAggregatorClient>();
+    fake_dropped_counter_ = std::make_unique<FakeCounter>();
+    node_id_ = NodeID::FromRandom();
+    recorder_ =
+        std::make_unique<RayTaskEventRecorder>(*fake_client_,
+                                               PeriodicalRunner::Create(io_service_),
+                                               max_buffer_size_,
+                                               "core_worker",
+                                               *fake_dropped_counter_,
+                                               node_id_);
+  }
+
+  std::unique_ptr<RayEventInterface> StatusEvent(const std::string &task_id,
+                                                 int32_t attempt) {
+    return std::make_unique<FakeTaskRayEvent>(
+        task_id, attempt, rpc::events::RayEvent::TASK_LIFECYCLE_EVENT);
+  }
+
+  std::unique_ptr<RayEventInterface> ProfileEvent(const std::string &task_id,
+                                                  int32_t attempt) {
+    return std::make_unique<FakeTaskRayEvent>(
+        task_id, attempt, rpc::events::RayEvent::TASK_PROFILE_EVENT);
+  }
+
+  void AddOne(std::unique_ptr<RayEventInterface> event) {
+    AddOneTo(*recorder_, std::move(event));
+  }
+
+  void AddOneTo(RayTaskEventRecorder &recorder,
+                std::unique_ptr<RayEventInterface> event) {
+    std::vector<std::unique_ptr<RayEventInterface>> events;
+    events.push_back(std::move(event));
+    recorder.AddEvents(std::move(events));
+  }
+
+  // Sum of all dropped-event metric values across tag sets.
+  size_t TotalDropped() {
+    size_t total = 0;
+    for (const auto &[tags, value] : fake_dropped_counter_->GetTagToValue()) {
+      total += value;
+    }
+    return total;
+  }
+
+  instrumented_io_context io_service_;
+  std::unique_ptr<FakeAggregatorClient> fake_client_;
+  std::unique_ptr<FakeCounter> fake_dropped_counter_;
+  std::unique_ptr<RayTaskEventRecorder> recorder_;
+  size_t max_buffer_size_ = 3;
+  NodeID node_id_;
+};
+
+// Status events within capacity are all exported, with node_id stamped, no drops.
+TEST_F(RayTaskEventRecorderTest, TestStatusEventsExported) {
+  RayConfig::instance().initialize(R"({"enable_ray_event": true})");
+  recorder_->StartExportingEvents();
+
+  AddOne(StatusEvent("task1", 0));
+  AddOne(StatusEvent("task2", 0));
+  AddOne(StatusEvent("task3", 0));
+  io_service_.run_one();
+
+  auto recorded = fake_client_->GetRecordedEvents();
+  ASSERT_EQ(recorded.size(), 3);
+  for (const auto &event : recorded) {
+    EXPECT_EQ(event.node_id(), node_id_.Binary());
+  }
+  EXPECT_TRUE(fake_client_->GetDroppedAttempts().empty());
+  EXPECT_EQ(TotalDropped(), 0);
+}
+
+// Overflowing the status ring reports the evicted attempts as dropped and does not
+// export their events.
+TEST_F(RayTaskEventRecorderTest, TestStatusRingOverflowReportsDroppedAttempts) {
+  RayConfig::instance().initialize(R"({"enable_ray_event": true})");
+  recorder_->StartExportingEvents();
+
+  // Capacity is 3; adding 5 distinct attempts evicts the two oldest (task1, task2).
+  for (int i = 1; i <= 5; i++) {
+    AddOne(StatusEvent("task" + std::to_string(i), 0));
+  }
+  io_service_.run_one();
+
+  auto recorded = fake_client_->GetRecordedEvents();
+  ASSERT_EQ(recorded.size(), 3);
+  std::vector<std::string> messages;
+  for (const auto &event : recorded) {
+    messages.push_back(event.message());
+  }
+  // task1 and task2 were evicted; task3..task5 survive.
+  EXPECT_EQ(std::count(messages.begin(), messages.end(), "task1:0"), 0);
+  EXPECT_EQ(std::count(messages.begin(), messages.end(), "task2:0"), 0);
+
+  auto dropped = fake_client_->GetDroppedAttempts();
+  ASSERT_EQ(dropped.size(), 2);
+  std::vector<std::string> dropped_ids;
+  for (const auto &attempt : dropped) {
+    dropped_ids.push_back(attempt.task_id());
+    EXPECT_EQ(attempt.attempt_number(), 0);
+  }
+  EXPECT_EQ(std::count(dropped_ids.begin(), dropped_ids.end(), "task1"), 1);
+  EXPECT_EQ(std::count(dropped_ids.begin(), dropped_ids.end(), "task2"), 1);
+}
+
+// Once an attempt is dropped, later events for it are dropped on add (sticky).
+TEST_F(RayTaskEventRecorderTest, TestStickyDropForDroppedAttempt) {
+  RayConfig::instance().initialize(R"({"enable_ray_event": true})");
+  recorder_->StartExportingEvents();
+
+  // Fill the ring, then evict task1 by adding task4.
+  AddOne(StatusEvent("task1", 0));
+  AddOne(StatusEvent("task2", 0));
+  AddOne(StatusEvent("task3", 0));
+  AddOne(StatusEvent("task4", 0));  // evicts task1 -> task1 dropped (sticky)
+  // A new event for the dropped attempt task1 is dropped on add.
+  AddOne(StatusEvent("task1", 0));
+  io_service_.run_one();
+
+  auto recorded = fake_client_->GetRecordedEvents();
+  // Only task2, task3, task4 are exported; both task1 events are gone.
+  ASSERT_EQ(recorded.size(), 3);
+  for (const auto &event : recorded) {
+    EXPECT_NE(event.message(), "task1:0");
+  }
+  auto dropped = fake_client_->GetDroppedAttempts();
+  ASSERT_EQ(dropped.size(), 1);
+  EXPECT_EQ(dropped[0].task_id(), "task1");
+}
+
+// All-or-none per attempt: a buffered event whose attempt was dropped (via eviction of an
+// earlier event of the same attempt) is skipped on export, and the attempt is reported.
+TEST_F(RayTaskEventRecorderTest, TestAllOrNoneSkipsBufferedEventForDroppedAttempt) {
+  RayConfig::instance().initialize(R"({"enable_ray_event": true})");
+  recorder_->StartExportingEvents();
+
+  // Two events for task1 fill 2 of 3 slots; task2 fills the ring.
+  AddOne(StatusEvent("task1", 0));  // task1 event #1 (front)
+  AddOne(StatusEvent("task1", 0));  // task1 event #2
+  AddOne(StatusEvent("task2", 0));  // ring full: [t1#1, t1#2, t2]
+  // task3 evicts the front (task1 event #1) -> task1 dropped, but task1 event #2 remains.
+  AddOne(StatusEvent("task3", 0));
+  io_service_.run_one();
+
+  auto recorded = fake_client_->GetRecordedEvents();
+  // task1's remaining buffered event is skipped; only task2 and task3 are exported.
+  ASSERT_EQ(recorded.size(), 2);
+  for (const auto &event : recorded) {
+    EXPECT_NE(event.message(), "task1:0");
+  }
+  auto dropped = fake_client_->GetDroppedAttempts();
+  ASSERT_EQ(dropped.size(), 1);
+  EXPECT_EQ(dropped[0].task_id(), "task1");
+}
+
+// A flush with only dropped attempts and no surviving events still sends the metadata
+// (events_size()==0 but dropped_task_attempts>0), exercising the has_aggregator_payload
+// guard's "send anyway" branch.
+TEST_F(RayTaskEventRecorderTest, TestMetadataOnlySendForFullyDroppedAttempt) {
+  RayConfig::instance().initialize(R"({"enable_ray_event": true})");
+  FakeAggregatorClient client;
+  FakeCounter counter;
+  RayTaskEventRecorder recorder(client,
+                                PeriodicalRunner::Create(io_service_),
+                                /*max_buffer_size=*/1,
+                                "core_worker",
+                                counter,
+                                node_id_);
+  recorder.StartExportingEvents();
+
+  // Capacity 1: the second task1 event evicts the first, flagging task1 as dropped; the
+  // survivor (also task1) is then skipped on export, leaving only the metadata.
+  AddOneTo(recorder, StatusEvent("task1", 0));
+  AddOneTo(recorder, StatusEvent("task1", 0));
+  io_service_.run_one();
+
+  EXPECT_TRUE(client.GetRecordedEvents().empty());
+  auto dropped = client.GetDroppedAttempts();
+  ASSERT_EQ(dropped.size(), 1);
+  EXPECT_EQ(dropped[0].task_id(), "task1");
+}
+
+// Profile events beyond the per-task cap are dropped (newest), and not reported in-band.
+TEST_F(RayTaskEventRecorderTest, TestProfilePerTaskCap) {
+  RayConfig::instance().initialize(
+      R"({"enable_ray_event": true,
+          "task_events_max_num_profile_events_per_task": 2,
+          "task_events_max_num_profile_events_buffer_on_worker": 1000})");
+  recorder_->StartExportingEvents();
+
+  // 5 profile events for the same attempt; only 2 are kept, 3 dropped.
+  for (int i = 0; i < 5; i++) {
+    AddOne(ProfileEvent("task1", 0));
+  }
+  io_service_.run_one();
+
+  // The 2 kept profile events merge (same entity_id + type) into a single RayEvent.
+  auto recorded = fake_client_->GetRecordedEvents();
+  ASSERT_EQ(recorded.size(), 1);
+  EXPECT_EQ(recorded[0].event_type(), rpc::events::RayEvent::TASK_PROFILE_EVENT);
+  EXPECT_EQ(TotalDropped(), 3);
+  // Profile drops are metric-only; they are not reported as dropped attempts.
+  EXPECT_TRUE(fake_client_->GetDroppedAttempts().empty());
+}
+
+// Profile events beyond the global cap are dropped (newest), across attempts.
+TEST_F(RayTaskEventRecorderTest, TestProfileGlobalCap) {
+  RayConfig::instance().initialize(
+      R"({"enable_ray_event": true,
+          "task_events_max_num_profile_events_per_task": 1000,
+          "task_events_max_num_profile_events_buffer_on_worker": 2})");
+  recorder_->StartExportingEvents();
+
+  // 4 profile events across distinct attempts; only the first 2 are kept.
+  AddOne(ProfileEvent("task1", 0));
+  AddOne(ProfileEvent("task2", 0));
+  AddOne(ProfileEvent("task3", 0));
+  AddOne(ProfileEvent("task4", 0));
+  io_service_.run_one();
+
+  auto recorded = fake_client_->GetRecordedEvents();
+  ASSERT_EQ(recorded.size(), 2);
+  EXPECT_EQ(TotalDropped(), 2);
+  EXPECT_TRUE(fake_client_->GetDroppedAttempts().empty());
+}
+
+// When ray events are disabled, nothing is buffered or exported.
+TEST_F(RayTaskEventRecorderTest, TestDisabled) {
+  RayConfig::instance().initialize(R"({"enable_ray_event": false})");
+  recorder_->StartExportingEvents();
+
+  AddOne(StatusEvent("task1", 0));
+  io_service_.run_one();
+
+  EXPECT_TRUE(fake_client_->GetRecordedEvents().empty());
+  EXPECT_TRUE(fake_client_->GetDroppedAttempts().empty());
+}
+
+}  // namespace observability
+}  // namespace ray


### PR DESCRIPTION
We want to move away from `task_event_buffer` for sending events to aggregator agent in `core_worker`. This is because of an existing bug where this route can lead to events getting dropped until aggregator agent is up and running. 

`RayEventRecorder` has this bug fixed and therefore we should use that instead of `task_event_buffer`. While I was doing that migration, I realized that `task_event_buffer` does special handling of task events that `RayEventRecorder` doesn't provide right now. 

For this, this PR introduces a separate `RayTaskEventRecorder` for task events. The differences between `RayEventRecorder` and `task_event_buffer` are: 
1. Current `RayEventRecorder` doesn't emit dropped  task events metadata to aggregator agent. We need this data to reach the GCS (via the aggregator agent) for observabillity purposes. `RayTaskEventRecorder` sends the dropped task events to aggregator agent.
2. `task_event_buffer` has the logic that either all events for a task attempt will be flushed or none will be flushed. Unlike 'RayEventRecorder`, `RayTaskEventRecorder` adds this logic to event addition and export.  