### PR TITLE
[serve][llm] Bridge SGLang metrics to Ray

### DIFF
--- a/doc/source/serve/llm/user-guides/observability.md
+++ b/doc/source/serve/llm/user-guides/observability.md
@@ -37,7 +37,7 @@ The dashboard includes visualizations for:
 
 ## Engine metrics
 
-All engine metrics, including vLLM, are available through the Ray metrics export endpoint and are queryable with Prometheus. See [vLLM metrics](https://docs.vllm.ai/en/stable/usage/metrics.html) for a complete list. The Serve LLM Grafana dashboard also visualizes these metrics.
+All engine metrics, including vLLM and SGLang, are available through the Ray metrics export endpoint and are queryable with Prometheus. See [vLLM metrics](https://docs.vllm.ai/en/stable/usage/metrics.html) and [SGLang production metrics](https://docs.sglang.ai/references/production_metrics.html) for engine-specific details. The Serve LLM Grafana dashboard also visualizes these metrics.
 
 Key engine metrics include:
 
@@ -46,6 +46,8 @@ Key engine metrics include:
 - **GPU cache utilization**: KV cache memory usage.
 - **Batch size**: Current and average batch sizes.
 - **Throughput**: Requests per second and tokens per second.
+
+For SGLang-backed deployments, `log_engine_metrics: true` also enables SGLang's scheduler, tokenizer, storage, radix cache, and expert-dispatch collectors and routes supported metrics through Ray's metrics export endpoint.
 
 ### Configure engine metrics
 
@@ -122,4 +124,3 @@ To opt out from usage data collection, see {ref}`Ray usage stats <ref-usage-stat
 - {ref}`collect-metrics` - Ray metrics collection guide
 - [vLLM metrics documentation](https://docs.vllm.ai/en/stable/usage/metrics.html)
 - {doc}`Troubleshooting <../troubleshooting>` - Common issues and solutions
-

--- a/doc/source/serve/llm/user-guides/sglang.md
+++ b/doc/source/serve/llm/user-guides/sglang.md
@@ -112,12 +112,26 @@ The `placement_group_strategy: "PACK"` fills GPUs on each node before moving to 
 RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_multinode_example:app
 ```
 
+## Metrics
+
+SGLang engine metrics are enabled by default through `log_engine_metrics: true`.
+Ray Serve LLM passes SGLang's scheduler, tokenizer, storage, radix cache, and expert-dispatch collectors through Ray's metrics export endpoint, so you can query them from the same Prometheus scrape target as other Ray metrics.
+
+Useful SGLang metric groups include:
+
+- Queue depth and running request counts.
+- TTFT, inter-token latency, and end-to-end request latency.
+- KV cache usage, cache hit rate, and evictable token counts.
+- Prefill, decode, and disaggregated serving queue metrics.
+- Expert-dispatch heatmap metrics for MoE deployments when enabled in SGLang.
+
+To turn off SGLang engine metrics for a deployment, set `log_engine_metrics: false` on the `LLMConfig`.
+
 ## Limitations
 
 The following SGLang features are available upstream but not yet integrated into Ray Serve LLM. Community contributions are welcome:
 
 - **Engine replicas:** Multiple engine replicas within a single deployment. See [ray-project/ray#62480](https://github.com/ray-project/ray/issues/62480).
-- **Observability:** Engine-level metrics (e.g. KV cache utilization, request queue depth).
 - **Prefill disaggregation:** Separating prefill and decode phases across different workers.
 - **Wide EP:** Wide expert parallelism for Mixture-of-Experts models.
 - **Elastic EP:** Fault-tolerant expert parallelism with dynamic rank health tracking.
@@ -133,4 +147,3 @@ SGLang's in-process engine overrides Python signal handlers on startup. The `SGL
 - [SGLang OpenAI compatibility](https://docs.sglang.ai/basic_usage/openai_api.html)
 - {doc}`../quick-start` - Basic LLM deployment examples
 - {doc}`cross-node-parallelism` - Cross-node parallelism with placement groups
-

--- a/python/ray/llm/_internal/serve/engines/sglang/metrics.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/metrics.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, Iterable, Mapping, Optional, Type
+
+
+DEFAULT_HISTOGRAM_BOUNDARIES = (0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10)
 
 
 def _to_tags(labels: Mapping[str, Any]) -> Dict[str, str]:
@@ -13,6 +17,14 @@ def _metric_name(name: str) -> str:
     # SGLang exposes prometheus series like "sglang:num_running_reqs".
     # Ray accepts this today but warns that ":" will be rejected later.
     return name.replace(":", "_")
+
+
+def _to_ray_histogram_boundaries(values: Iterable[Any]) -> tuple[float, ...]:
+    return tuple(
+        float(value)
+        for value in values
+        if isinstance(value, (int, float)) and value > 0 and math.isfinite(value)
+    )
 
 
 class _RayMetricChild:
@@ -106,9 +118,12 @@ class RayPrometheusHistogram(_RayPrometheusMetric):
         labelnames: Optional[Iterable[str]] = None,
         **kwargs: Any,
     ) -> None:
-        self._prometheus_buckets = tuple(
+        ray_boundaries = _to_ray_histogram_boundaries(
             kwargs.get("buckets", kwargs.get("boundaries", ()))
         )
+        if not ray_boundaries:
+            ray_boundaries = DEFAULT_HISTOGRAM_BOUNDARIES
+        self._ray_boundaries = ray_boundaries
         super().__init__(name, documentation, labelnames, **kwargs)
 
     def _build_metric(self, kwargs: Mapping[str, Any]) -> Any:
@@ -117,24 +132,17 @@ class RayPrometheusHistogram(_RayPrometheusMetric):
             from ray.util import metrics
 
             metric_cls = metrics.Histogram
-        boundaries = tuple(
-            value
-            for value in kwargs.get("buckets", kwargs.get("boundaries", ()))
-            if value > 0
-        )
-        if not boundaries:
-            boundaries = (0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10)
         return metric_cls(
             self._name,
             description=self._documentation,
-            boundaries=list(boundaries),
+            boundaries=list(self._ray_boundaries),
             tag_keys=self._labelnames,
         )
 
     def labels(self, *labelvalues: Any, **labelkwargs: Any) -> _RayMetricChild:
         child = super().labels(*labelvalues, **labelkwargs)
         child._buckets = [
-            _NoopAccumulator() for _ in range(len(self._prometheus_buckets) + 1)
+            _NoopAccumulator() for _ in range(len(self._ray_boundaries) + 1)
         ]
         return child
 
@@ -145,28 +153,6 @@ class RayPrometheusHistogram(_RayPrometheusMetric):
 
 class RayPrometheusSummary(RayPrometheusHistogram):
     pass
-
-
-def _build_tokenizer_collector_cls(tokenizer_collector_cls: Type[Any]) -> Type[Any]:
-    class RaySGLangTokenizerMetricsCollector(tokenizer_collector_cls):
-        _counter_cls = RayPrometheusCounter
-        _gauge_cls = RayPrometheusGauge
-        _histogram_cls = RayPrometheusHistogram
-        _summary_cls = RayPrometheusSummary
-
-        def observe_inter_token_latency(
-            self,
-            labels: Dict[str, str],
-            internval: float,
-            num_new_tokens: int,
-        ) -> None:
-            if num_new_tokens <= 0:
-                return
-            histogram = self.histogram_inter_token_latency.labels(**labels)
-            for _ in range(num_new_tokens):
-                histogram.observe(internval)
-
-    return RaySGLangTokenizerMetricsCollector
 
 
 def build_sglang_ray_stat_loggers() -> Dict[str, Type[Any]]:
@@ -195,6 +181,24 @@ def build_sglang_ray_stat_loggers() -> Dict[str, Type[Any]]:
         _histogram_cls = RayPrometheusHistogram
         _summary_cls = RayPrometheusSummary
 
+    class RaySGLangTokenizerMetricsCollector(TokenizerMetricsCollector):
+        _counter_cls = RayPrometheusCounter
+        _gauge_cls = RayPrometheusGauge
+        _histogram_cls = RayPrometheusHistogram
+        _summary_cls = RayPrometheusSummary
+
+        def observe_inter_token_latency(
+            self,
+            labels: Dict[str, str],
+            internval: float,
+            num_new_tokens: int,
+        ) -> None:
+            if num_new_tokens <= 0:
+                return
+            histogram = self.histogram_inter_token_latency.labels(**labels)
+            for _ in range(num_new_tokens):
+                histogram.observe(internval)
+
     class RaySGLangRadixCacheMetricsCollector(RadixCacheMetricsCollector):
         _counter_cls = RayPrometheusCounter
         _gauge_cls = RayPrometheusGauge
@@ -209,9 +213,7 @@ def build_sglang_ray_stat_loggers() -> Dict[str, Type[Any]]:
 
     return {
         STAT_LOGGER_ROLE_SCHEDULER: RaySGLangSchedulerMetricsCollector,
-        STAT_LOGGER_ROLE_TOKENIZER: _build_tokenizer_collector_cls(
-            TokenizerMetricsCollector
-        ),
+        STAT_LOGGER_ROLE_TOKENIZER: RaySGLangTokenizerMetricsCollector,
         STAT_LOGGER_ROLE_STORAGE: RaySGLangStorageMetricsCollector,
         STAT_LOGGER_ROLE_RADIX_CACHE: RaySGLangRadixCacheMetricsCollector,
         STAT_LOGGER_ROLE_EXPERT_DISPATCH: RaySGLangExpertDispatchCollector,

--- a/python/ray/llm/_internal/serve/engines/sglang/metrics.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/metrics.py
@@ -1,0 +1,228 @@
+"""Ray metrics bridge for SGLang's embedded engine collectors."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, Optional, Type
+
+
+def _to_tags(labels: Mapping[str, Any]) -> Dict[str, str]:
+    return {key: "" if value is None else str(value) for key, value in labels.items()}
+
+
+def _metric_name(name: str) -> str:
+    # SGLang exposes prometheus series like "sglang:num_running_reqs".
+    # Ray accepts this today but warns that ":" will be rejected later.
+    return name.replace(":", "_")
+
+
+class _RayMetricChild:
+    def __init__(
+        self,
+        metric: Any,
+        labels: Mapping[str, Any],
+        bucket_count: int = 1,
+    ):
+        self._metric = metric
+        self._labels = _to_tags(labels)
+        self._sum = _NoopAccumulator()
+        self._buckets = [_NoopAccumulator() for _ in range(bucket_count)]
+
+    def inc(self, value: float = 1.0) -> None:
+        self._metric.inc(value, tags=self._labels)
+
+    def set(self, value: Optional[float]) -> None:
+        self._metric.set(value, tags=self._labels)
+
+    def observe(self, value: float) -> None:
+        self._metric.observe(value, tags=self._labels)
+
+
+class _NoopAccumulator:
+    def inc(self, value: float = 1.0) -> None:
+        return
+
+
+class _RayPrometheusMetric:
+    _ray_metric_cls = None
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str = "",
+        labelnames: Optional[Iterable[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._name = _metric_name(name)
+        self._documentation = documentation
+        self._labelnames = tuple(labelnames or ())
+        self._metric = self._build_metric(kwargs)
+
+    def _build_metric(self, kwargs: Mapping[str, Any]) -> Any:
+        metric_cls = self._ray_metric_cls
+        if metric_cls is None:
+            from ray.util import metrics
+
+            metric_cls = self._default_ray_metric_cls(metrics)
+        return metric_cls(
+            self._name,
+            description=self._documentation,
+            tag_keys=self._labelnames,
+        )
+
+    @staticmethod
+    def _default_ray_metric_cls(metrics_module: Any) -> Type[Any]:
+        raise NotImplementedError
+
+    def labels(self, *labelvalues: Any, **labelkwargs: Any) -> _RayMetricChild:
+        if labelvalues:
+            if len(labelvalues) != len(self._labelnames):
+                raise ValueError(
+                    f"Expected {len(self._labelnames)} labels, got {len(labelvalues)}"
+                )
+            labels = dict(zip(self._labelnames, labelvalues))
+            labels.update(labelkwargs)
+        else:
+            labels = labelkwargs
+        return _RayMetricChild(self._metric, labels)
+
+
+class RayPrometheusCounter(_RayPrometheusMetric):
+    @staticmethod
+    def _default_ray_metric_cls(metrics_module: Any) -> Type[Any]:
+        return metrics_module.Counter
+
+
+class RayPrometheusGauge(_RayPrometheusMetric):
+    @staticmethod
+    def _default_ray_metric_cls(metrics_module: Any) -> Type[Any]:
+        return metrics_module.Gauge
+
+
+class RayPrometheusHistogram(_RayPrometheusMetric):
+    def __init__(
+        self,
+        name: str,
+        documentation: str = "",
+        labelnames: Optional[Iterable[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._prometheus_buckets = tuple(
+            kwargs.get("buckets", kwargs.get("boundaries", ()))
+        )
+        super().__init__(name, documentation, labelnames, **kwargs)
+
+    def _build_metric(self, kwargs: Mapping[str, Any]) -> Any:
+        metric_cls = self._ray_metric_cls
+        if metric_cls is None:
+            from ray.util import metrics
+
+            metric_cls = metrics.Histogram
+        boundaries = tuple(
+            value
+            for value in kwargs.get("buckets", kwargs.get("boundaries", ()))
+            if value > 0
+        )
+        if not boundaries:
+            boundaries = (0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10)
+        return metric_cls(
+            self._name,
+            description=self._documentation,
+            boundaries=list(boundaries),
+            tag_keys=self._labelnames,
+        )
+
+    def labels(self, *labelvalues: Any, **labelkwargs: Any) -> _RayMetricChild:
+        child = super().labels(*labelvalues, **labelkwargs)
+        child._buckets = [
+            _NoopAccumulator() for _ in range(len(self._prometheus_buckets) + 1)
+        ]
+        return child
+
+    @staticmethod
+    def _default_ray_metric_cls(metrics_module: Any) -> Type[Any]:
+        return metrics_module.Histogram
+
+
+class RayPrometheusSummary(RayPrometheusHistogram):
+    pass
+
+
+def _build_tokenizer_collector_cls(tokenizer_collector_cls: Type[Any]) -> Type[Any]:
+    class RaySGLangTokenizerMetricsCollector(tokenizer_collector_cls):
+        _counter_cls = RayPrometheusCounter
+        _gauge_cls = RayPrometheusGauge
+        _histogram_cls = RayPrometheusHistogram
+        _summary_cls = RayPrometheusSummary
+
+        def observe_inter_token_latency(
+            self,
+            labels: Dict[str, str],
+            internval: float,
+            num_new_tokens: int,
+        ) -> None:
+            if num_new_tokens <= 0:
+                return
+            histogram = self.histogram_inter_token_latency.labels(**labels)
+            for _ in range(num_new_tokens):
+                histogram.observe(internval)
+
+    return RaySGLangTokenizerMetricsCollector
+
+
+def build_sglang_ray_stat_loggers() -> Dict[str, Type[Any]]:
+    from sglang.srt.observability.metrics_collector import (
+        STAT_LOGGER_ROLE_EXPERT_DISPATCH,
+        STAT_LOGGER_ROLE_RADIX_CACHE,
+        STAT_LOGGER_ROLE_SCHEDULER,
+        STAT_LOGGER_ROLE_STORAGE,
+        STAT_LOGGER_ROLE_TOKENIZER,
+        ExpertDispatchCollector,
+        RadixCacheMetricsCollector,
+        SchedulerMetricsCollector,
+        StorageMetricsCollector,
+        TokenizerMetricsCollector,
+    )
+
+    class RaySGLangSchedulerMetricsCollector(SchedulerMetricsCollector):
+        _counter_cls = RayPrometheusCounter
+        _gauge_cls = RayPrometheusGauge
+        _histogram_cls = RayPrometheusHistogram
+        _summary_cls = RayPrometheusSummary
+
+    class RaySGLangStorageMetricsCollector(StorageMetricsCollector):
+        _counter_cls = RayPrometheusCounter
+        _gauge_cls = RayPrometheusGauge
+        _histogram_cls = RayPrometheusHistogram
+        _summary_cls = RayPrometheusSummary
+
+    class RaySGLangRadixCacheMetricsCollector(RadixCacheMetricsCollector):
+        _counter_cls = RayPrometheusCounter
+        _gauge_cls = RayPrometheusGauge
+        _histogram_cls = RayPrometheusHistogram
+        _summary_cls = RayPrometheusSummary
+
+    class RaySGLangExpertDispatchCollector(ExpertDispatchCollector):
+        _counter_cls = RayPrometheusCounter
+        _gauge_cls = RayPrometheusGauge
+        _histogram_cls = RayPrometheusHistogram
+        _summary_cls = RayPrometheusSummary
+
+    return {
+        STAT_LOGGER_ROLE_SCHEDULER: RaySGLangSchedulerMetricsCollector,
+        STAT_LOGGER_ROLE_TOKENIZER: _build_tokenizer_collector_cls(
+            TokenizerMetricsCollector
+        ),
+        STAT_LOGGER_ROLE_STORAGE: RaySGLangStorageMetricsCollector,
+        STAT_LOGGER_ROLE_RADIX_CACHE: RaySGLangRadixCacheMetricsCollector,
+        STAT_LOGGER_ROLE_EXPERT_DISPATCH: RaySGLangExpertDispatchCollector,
+    }
+
+
+def configure_sglang_engine_metrics(engine_kwargs: Dict[str, Any]) -> None:
+    """Enable SGLang metrics and route supported collectors through Ray metrics."""
+
+    engine_kwargs["enable_metrics"] = True
+    existing_loggers = engine_kwargs.get("stat_loggers") or {}
+    ray_loggers = build_sglang_ray_stat_loggers()
+    ray_loggers.update(existing_loggers)
+    engine_kwargs["stat_loggers"] = ray_loggers

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -51,8 +51,6 @@ class SGLangServer:
 
         self._llm_config = llm_config
         self.engine_kwargs = copy.deepcopy(llm_config.engine_kwargs)
-        if llm_config.log_engine_metrics:
-            configure_sglang_engine_metrics(self.engine_kwargs)
 
         try:
             import sglang
@@ -61,6 +59,9 @@ class SGLangServer:
                 "SGLang is not installed or failed to import. Please run "
                 "`pip install sglang[all]` to install required dependencies."
             ) from e
+
+        if llm_config.log_engine_metrics:
+            configure_sglang_engine_metrics(self.engine_kwargs)
 
         # TODO(issue-61108): remove this once sglang#18752 is merged and included
         # in the minimum supported SGLang version for this example.

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -41,13 +41,18 @@ from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import (
     _merge_replica_actor_and_child_actor_bundles,
 )
+from ray.llm._internal.serve.engines.sglang.metrics import (
+    configure_sglang_engine_metrics,
+)
 
 
 class SGLangServer:
     def __init__(self, llm_config: LLMConfig):
 
         self._llm_config = llm_config
-        self.engine_kwargs = llm_config.engine_kwargs
+        self.engine_kwargs = copy.deepcopy(llm_config.engine_kwargs)
+        if llm_config.log_engine_metrics:
+            configure_sglang_engine_metrics(self.engine_kwargs)
 
         try:
             import sglang

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_metrics.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_metrics.py
@@ -70,7 +70,7 @@ def test_ray_prometheus_gauge_and_histogram(monkeypatch):
     histogram = sglang_metrics.RayPrometheusHistogram(
         "sglang:queue_time_seconds",
         labelnames=("model_name",),
-        buckets=(0, 0.001, 0.01, 1),
+        buckets=(0, 0.001, 0.01, 1, float("inf")),
     )
     histogram_child = histogram.labels(model_name="llama")
     histogram_child.observe(0.25)
@@ -78,7 +78,20 @@ def test_ray_prometheus_gauge_and_histogram(monkeypatch):
     assert gauge._metric.records == [("set", 7, {"model_name": "llama"})]
     assert histogram._metric.boundaries == [0.001, 0.01, 1]
     assert histogram._metric.records == [("observe", 0.25, {"model_name": "llama"})]
-    assert len(histogram_child._buckets) == 5
+    assert len(histogram_child._buckets) == 4
+
+    default_histogram = sglang_metrics.RayPrometheusHistogram(
+        "sglang:default_latency_seconds",
+        labelnames=("model_name",),
+    )
+    default_child = default_histogram.labels(model_name="llama")
+
+    assert default_histogram._metric.boundaries == list(
+        sglang_metrics.DEFAULT_HISTOGRAM_BOUNDARIES
+    )
+    assert len(default_child._buckets) == len(
+        sglang_metrics.DEFAULT_HISTOGRAM_BOUNDARIES
+    ) + 1
 
 
 def test_configure_sglang_engine_metrics_preserves_user_stat_loggers(monkeypatch):

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_metrics.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_metrics.py
@@ -1,0 +1,98 @@
+from ray.llm._internal.serve.engines.sglang import metrics as sglang_metrics
+
+
+class _FakeCounter:
+    def __init__(self, name, description="", tag_keys=None):
+        self.name = name
+        self.description = description
+        self.tag_keys = tag_keys
+        self.records = []
+
+    def inc(self, value=1.0, tags=None):
+        self.records.append(("inc", value, tags))
+
+
+class _FakeGauge:
+    def __init__(self, name, description="", tag_keys=None):
+        self.name = name
+        self.description = description
+        self.tag_keys = tag_keys
+        self.records = []
+
+    def set(self, value, tags=None):
+        self.records.append(("set", value, tags))
+
+
+class _FakeHistogram:
+    def __init__(self, name, description="", boundaries=None, tag_keys=None):
+        self.name = name
+        self.description = description
+        self.boundaries = boundaries
+        self.tag_keys = tag_keys
+        self.records = []
+
+    def observe(self, value, tags=None):
+        self.records.append(("observe", value, tags))
+
+
+def test_ray_prometheus_counter_matches_prometheus_label_shape(monkeypatch):
+    monkeypatch.setattr(sglang_metrics.RayPrometheusCounter, "_ray_metric_cls", _FakeCounter)
+
+    counter = sglang_metrics.RayPrometheusCounter(
+        "sglang:num_requests_total",
+        "Total requests",
+        labelnames=("model_name", "tp_rank"),
+    )
+    counter.labels(model_name="llama", tp_rank=0).inc(3)
+
+    assert counter._metric.name == "sglang_num_requests_total"
+    assert counter._metric.tag_keys == ("model_name", "tp_rank")
+    assert counter._metric.records == [
+        ("inc", 3, {"model_name": "llama", "tp_rank": "0"})
+    ]
+
+
+def test_ray_prometheus_gauge_and_histogram(monkeypatch):
+    monkeypatch.setattr(sglang_metrics.RayPrometheusGauge, "_ray_metric_cls", _FakeGauge)
+    monkeypatch.setattr(
+        sglang_metrics.RayPrometheusHistogram,
+        "_ray_metric_cls",
+        _FakeHistogram,
+    )
+
+    gauge = sglang_metrics.RayPrometheusGauge(
+        "sglang:num_queue_reqs",
+        labelnames=("model_name",),
+        multiprocess_mode="mostrecent",
+    )
+    gauge.labels("llama").set(7)
+
+    histogram = sglang_metrics.RayPrometheusHistogram(
+        "sglang:queue_time_seconds",
+        labelnames=("model_name",),
+        buckets=(0, 0.001, 0.01, 1),
+    )
+    histogram_child = histogram.labels(model_name="llama")
+    histogram_child.observe(0.25)
+
+    assert gauge._metric.records == [("set", 7, {"model_name": "llama"})]
+    assert histogram._metric.boundaries == [0.001, 0.01, 1]
+    assert histogram._metric.records == [("observe", 0.25, {"model_name": "llama"})]
+    assert len(histogram_child._buckets) == 5
+
+
+def test_configure_sglang_engine_metrics_preserves_user_stat_loggers(monkeypatch):
+    user_tokenizer_logger = object()
+
+    monkeypatch.setattr(
+        sglang_metrics,
+        "build_sglang_ray_stat_loggers",
+        lambda: {"scheduler": object(), "tokenizer": object()},
+    )
+
+    engine_kwargs = {"stat_loggers": {"tokenizer": user_tokenizer_logger}}
+    sglang_metrics.configure_sglang_engine_metrics(engine_kwargs)
+
+    assert engine_kwargs["enable_metrics"] is True
+    assert "scheduler" in engine_kwargs["stat_loggers"]
+    assert engine_kwargs["stat_loggers"]["tokenizer"] is user_tokenizer_logger


### PR DESCRIPTION
## Description

This PR bridges SGLang engine metrics into Ray Serve LLM when `log_engine_metrics` is enabled.

Today the vLLM path installs a Ray-backed Prometheus stat logger, but the SGLang path only starts the in-process SGLang engine. That leaves SGLang scheduler, tokenizer, storage, radix cache, and expert-dispatch metrics out of Ray's metrics export endpoint.

This adds a small Ray metrics adapter for SGLang's embedded collector hooks:

- maps Prometheus-style `labels(...).inc/set/observe` calls onto `ray.util.metrics`
- enables `enable_metrics` for SGLang when `log_engine_metrics` is true
- registers Ray-backed collectors through SGLang `ServerArgs.stat_loggers`
- preserves user-provided `stat_loggers` overrides
- keeps weighted inter-token latency working through Ray histograms
- documents SGLang engine metrics in the Serve LLM docs

## Related issues

Related to #62931
Related to #62791
Related to #63585

## Additional information

Local validation:

- `python3 -m compileall -q python/ray/llm/_internal/serve/engines/sglang/metrics.py python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_metrics.py`
- `python3 -m ruff check python/ray/llm/_internal/serve/engines/sglang/metrics.py python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_metrics.py`
- `git diff --check`

I could not run the focused pytest locally because this checkout does not have Ray's compiled `_raylet` extension built.
