### PR TITLE
[Data] Skip unreliable CIFAR10 `from_torch` doctest

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -814,7 +814,10 @@ Ray Data interoperates with PyTorch and TensorFlow datasets.
 
         To convert a PyTorch dataset to a Ray Dataset, call :func:`~ray.data.from_torch`.
 
+        .. The mirror for CIFAR10 has historically been unreliable, so we skip the test.
+
         .. testcode::
+            :skipif: True
 
             import ray
             from torch.utils.data import Dataset


### PR DESCRIPTION
The `from_torch` example in the data loading docs downloads the CIFAR10 dataset, whose mirror has historically been unreliable. This causes intermittent doc build failures unrelated to any code change.

In this PR, I'm skipping that doctest so we don't block premerge.
<img width="1624" height="96" alt="image" src="https://github.com/user-attachments/assets/02259bf8-69f0-446d-b664-eafbb0b4af7a" />
