### PR TITLE
[ci] apt-get update before installing MuJoCo deps

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -277,6 +277,7 @@ install_pip_packages() {
     requirements_files+=("${WORKSPACE_DIR}/python/requirements/ml/rllib-test-requirements.txt")
 
     # Install MuJoCo.
+    sudo apt-get update
     sudo apt-get install -y libosmesa6-dev libgl1 libglfw3 patchelf
     wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
     mkdir -p /root/.mujoco


### PR DESCRIPTION
The base ML image build fails when installing libosmesa6/mesa packages because the apt index cached in the image is stale: Ubuntu's jammy-updates pocket rolled mesa to a newer point release and pruned the old .deb from the archive pool, so the fetch 404s:

    E: Failed to fetch .../libosmesa6_23.2.1-1ubuntu3.1~22.04.3_amd64.deb
       404  Not Found

Add `apt-get update` before the install so the index always resolves to the current package versions.