### PR TITLE
[Data] Increase timeout for `test_context_propagation`

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -379,7 +379,7 @@ py_test(
 
 py_test(
     name = "test_context_propagation",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_context_propagation.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
## Description

`test_context_propagation` runs close to its 60s timeout (`Stats over 2 runs: max = 60.2s, min = 53.2s, avg = 56.7s, dev = 3.5s`), so it intermittently times out. This bumps the Bazel test `size` from `small` (60s timeout) to `medium` (300s timeout) to give it more headroom.

<img width="1609" height="85" alt="image" src="https://github.com/user-attachments/assets/754f638d-d660-4f2d-8889-c63e0319f8cb" />


## Related issues

## Additional information