### PR TITLE
fix(core): improve error message when RAY_ADDRESS is set to HTTP address

### DIFF
--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -359,10 +359,21 @@ def _get_builder_from_address(address: Optional[str]) -> ClientBuilder:
             f"Module: {module_string} does not exist.\n"
             f"This module was parsed from Address: {address}"
         ) from e
-    assert "ClientBuilder" in dir(
-        module
-    ), f"Module: {module_string} does not have ClientBuilder."
-    return module.ClientBuilder(inner_address)
+    if "ClientBuilder" not in dir(module):
+        if module_string.startswith("http"):
+            raise ValueError(
+                f"Invalid Ray address: {address!r}. "
+                f"It looks like you set RAY_ADDRESS to an HTTP address "
+                f"(e.g. the API server address). "
+                f"To fix this, either:\n"
+                f"  1. Unset RAY_ADDRESS if you are running from a Ray node, or\n"
+                f"  2. Set RAY_ADDRESS to the GCS address instead "
+                f"(e.g. <head_node_ip>:6379)."
+            )
+        raise RuntimeError(
+            f"Module: {module_string} does not have ClientBuilder."
+        )
+    return module.ClientBuilder(inner_address) 
 
 
 @Deprecated

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -347,10 +347,21 @@ def _get_builder_from_address(address: Optional[str]) -> ClientBuilder:
     if address == "local":
         return _LocalClientBuilder("local")
     if address is None:
-        # NOTE: This is not placed in `Node::get_temp_dir_path`, because
-        # this file is accessed before the `Node` object is created.
         address = ray._private.services.canonicalize_bootstrap_address(address)
         return _LocalClientBuilder(address)
+    
+    # Check for HTTP/HTTPS address before attempting module import
+    if address and address.startswith(("http://", "https://")):
+        raise ValueError(
+            f"Invalid Ray address: {address!r}. "
+            f"It looks like you set RAY_ADDRESS to an HTTP address "
+            f"(e.g. the API server address). "
+            f"To fix this, either:\n"
+            f"  1. Unset RAY_ADDRESS if you are running from a Ray node, or\n"
+            f"  2. Set RAY_ADDRESS to the GCS address instead "
+            f"(e.g. <head_node_ip>:6379)."
+        )
+    
     module_string, inner_address = _split_address(address)
     try:
         module = importlib.import_module(module_string)
@@ -360,20 +371,10 @@ def _get_builder_from_address(address: Optional[str]) -> ClientBuilder:
             f"This module was parsed from Address: {address}"
         ) from e
     if "ClientBuilder" not in dir(module):
-        if module_string.startswith("http"):
-            raise ValueError(
-                f"Invalid Ray address: {address!r}. "
-                f"It looks like you set RAY_ADDRESS to an HTTP address "
-                f"(e.g. the API server address). "
-                f"To fix this, either:\n"
-                f"  1. Unset RAY_ADDRESS if you are running from a Ray node, or\n"
-                f"  2. Set RAY_ADDRESS to the GCS address instead "
-                f"(e.g. <head_node_ip>:6379)."
-            )
         raise RuntimeError(
             f"Module: {module_string} does not have ClientBuilder."
         )
-    return module.ClientBuilder(inner_address) 
+    return module.ClientBuilder(inner_address)
 
 
 @Deprecated

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -260,8 +260,7 @@ class ClientBuilder:
             self._remote_init_kwargs = kwargs
             unknown = ", ".join(kwargs)
             logger.info(
-                "Passing the following kwargs to ray.init() "
-                f"on the server: {unknown}"
+                f"Passing the following kwargs to ray.init() on the server: {unknown}"
             )
         return self
 
@@ -349,7 +348,7 @@ def _get_builder_from_address(address: Optional[str]) -> ClientBuilder:
     if address is None:
         address = ray._private.services.canonicalize_bootstrap_address(address)
         return _LocalClientBuilder(address)
-    
+
     # Check for HTTP/HTTPS address before attempting module import
     if address and address.startswith(("http://", "https://")):
         raise ValueError(
@@ -361,7 +360,7 @@ def _get_builder_from_address(address: Optional[str]) -> ClientBuilder:
             f"  2. Set RAY_ADDRESS to the GCS address instead "
             f"(e.g. <head_node_ip>:6379)."
         )
-    
+
     module_string, inner_address = _split_address(address)
     try:
         module = importlib.import_module(module_string)
@@ -371,9 +370,7 @@ def _get_builder_from_address(address: Optional[str]) -> ClientBuilder:
             f"This module was parsed from Address: {address}"
         ) from e
     if "ClientBuilder" not in dir(module):
-        raise RuntimeError(
-            f"Module: {module_string} does not have ClientBuilder."
-        )
+        raise RuntimeError(f"Module: {module_string} does not have ClientBuilder.")
     return module.ClientBuilder(inner_address)
 
 

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -243,9 +243,9 @@ def test_module_lacks_client_builder():
             ray.client("othermodule://")
         except RuntimeError as e:
             exception = e
-        assert exception is not None, (
-            "Module without ClientBuilder did not raise RuntimeError"
-        )
+        assert (
+            exception is not None
+        ), "Module without ClientBuilder did not raise RuntimeError"
         assert "does not have ClientBuilder" in str(exception)
 
 

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -243,9 +243,9 @@ def test_module_lacks_client_builder():
             ray.client("othermodule://")
         except RuntimeError as e:
             exception = e
-        assert (
-            exception is not None
-        ), "Module without ClientBuilder did not raise RuntimeError"
+        assert exception is not None, (
+            "Module without ClientBuilder did not raise RuntimeError"
+        )
         assert "does not have ClientBuilder" in str(exception)
 
 
@@ -368,11 +368,10 @@ def test_client_deprecation_warn():
 
     with warnings.catch_warnings(record=True) as w:
         ray.client().namespace("nmspc").env({"pip": ["requests"]}).connect()
-    expected = (
-        'ray.init(namespace="nmspc", runtime_env=<your_runtime_env>)'  # noqa E501
-    )
+    expected = 'ray.init(namespace="nmspc", runtime_env=<your_runtime_env>)'  # noqa E501
     assert any(
-        has_client_deprecation_warn(warning, expected) for warning in w  # noqa E501
+        has_client_deprecation_warn(warning, expected)
+        for warning in w  # noqa E501
     )
     ray.shutdown()
 
@@ -400,8 +399,9 @@ def test_client_deprecation_warn():
 
     # Test that passing namespace through env doesn't add namespace to the
     # replacement
-    with warnings.catch_warnings(record=True) as w, patch.dict(
-        os.environ, {"RAY_NAMESPACE": "aksdj"}
+    with (
+        warnings.catch_warnings(record=True) as w,
+        patch.dict(os.environ, {"RAY_NAMESPACE": "aksdj"}),
     ):
         with ray.client("localhost:50055").connect():
             pass
@@ -435,8 +435,9 @@ def test_client_deprecation_warn():
 
         # We don't expect namespace to appear in the warning message, since
         # it was configured through an env var
-        with warnings.catch_warnings(record=True) as w, patch.dict(
-            os.environ, {"RAY_NAMESPACE": "abcdef"}
+        with (
+            warnings.catch_warnings(record=True) as w,
+            patch.dict(os.environ, {"RAY_NAMESPACE": "abcdef"}),
         ):
             try:
                 ray.client("localhost:50055").env({"pip": ["requests"]}).connect()

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -241,14 +241,27 @@ def test_module_lacks_client_builder():
         exception = None
         try:
             ray.client("othermodule://")
-        except AssertionError as e:
+        except RuntimeError as e:
             exception = e
         assert (
             exception is not None
-        ), "Module without ClientBuilder did not raise AssertionError"
+        ), "Module without ClientBuilder did not raise RuntimeError"
         assert "does not have ClientBuilder" in str(exception)
 
 
+def test_http_address_error_message():
+    """Test that a helpful error is raised when RAY_ADDRESS is set to HTTP."""
+    exception = None
+    try:
+        ray.client("http://127.0.0.1:8265")
+    except ValueError as e:
+        exception = e
+
+    assert exception is not None, "HTTP address did not raise ValueError"
+    assert "RAY_ADDRESS" in str(exception)
+    assert "GCS address" in str(exception)
+
+    
 @pytest.mark.skipif(sys.platform == "win32", reason="RC Proxy is Flaky on Windows.")
 def test_disconnect(call_ray_stop_only, set_enable_auto_connect):
     subprocess.check_output(

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -249,19 +249,20 @@ def test_module_lacks_client_builder():
         assert "does not have ClientBuilder" in str(exception)
 
 
-def test_http_address_error_message():
-    """Test that a helpful error is raised when RAY_ADDRESS is set to HTTP."""
+@pytest.mark.parametrize("address", ["http://127.0.0.1:8265", "https://127.0.0.1:8265"])
+def test_http_address_error_message(address):
+    """Test that a helpful error is raised when RAY_ADDRESS is set to HTTP/HTTPS."""
     exception = None
     try:
-        ray.client("http://127.0.0.1:8265")
+        ray.client(address)
     except ValueError as e:
         exception = e
 
-    assert exception is not None, "HTTP address did not raise ValueError"
+    assert exception is not None, f"Address {address} did not raise ValueError"
     assert "RAY_ADDRESS" in str(exception)
     assert "GCS address" in str(exception)
 
-    
+
 @pytest.mark.skipif(sys.platform == "win32", reason="RC Proxy is Flaky on Windows.")
 def test_disconnect(call_ray_stop_only, set_enable_auto_connect):
     subprocess.check_output(

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -368,10 +368,11 @@ def test_client_deprecation_warn():
 
     with warnings.catch_warnings(record=True) as w:
         ray.client().namespace("nmspc").env({"pip": ["requests"]}).connect()
-    expected = 'ray.init(namespace="nmspc", runtime_env=<your_runtime_env>)'  # noqa E501
+    expected = (
+        'ray.init(namespace="nmspc", runtime_env=<your_runtime_env>)'  # noqa E501
+    )
     assert any(
-        has_client_deprecation_warn(warning, expected)
-        for warning in w  # noqa E501
+        has_client_deprecation_warn(warning, expected) for warning in w  # noqa E501
     )
     ray.shutdown()
 


### PR DESCRIPTION
## Description
When `RAY_ADDRESS` is set to an HTTP address (e.g. the API server address `http://127.0.0.1:8265`), the previous error message `Module: http does not have ClientBuilder` was confusing and unhelpful.

This PR replaces the `assert` statement with an explicit `ValueError` that clearly explains:
- What went wrong
- How to fix it (unset `RAY_ADDRESS` or switch to the GCS address)

## Related issues
Fixes #35010

## Additional information
- Modified `python/ray/client_builder.py`: replaced `assert` with conditional `ValueError` for HTTP addresses
- Updated `python/ray/tests/test_client_builder.py`: updated existing test to expect `RuntimeError` instead of `AssertionError`, added new test `test_http_address_error_message`