### PR TITLE
[core] Remove callbacks from `TaskToExecute` and make it a data class instead

### DIFF
--- a/src/ray/core_worker/task_execution/BUILD.bazel
+++ b/src/ray/core_worker/task_execution/BUILD.bazel
@@ -73,6 +73,8 @@ ray_cc_library(
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",
         "//src/ray/protobuf:common_cc_proto",
+        "//src/ray/protobuf:core_worker_cc_proto",
+        "//src/ray/raylet_rpc_client:raylet_client_interface",
         "//src/ray/rpc:rpc_callback_types",
     ],
 )

--- a/src/ray/core_worker/task_execution/common.cc
+++ b/src/ray/core_worker/task_execution/common.cc
@@ -21,43 +21,6 @@
 namespace ray {
 namespace core {
 
-TaskToExecute::TaskToExecute(
-    std::function<void(const TaskSpecification &)> execute_callback,
-    std::function<void(const TaskSpecification &, const Status &)> cancel_callback,
-    TaskSpecification task_spec)
-    : execute_callback_(std::move(execute_callback)),
-      cancel_callback_(std::move(cancel_callback)),
-      task_spec_(std::move(task_spec)),
-      pending_dependencies_(task_spec_.GetDependencies()) {}
-
-void TaskToExecute::Execute() { execute_callback_(task_spec_); }
-
-void TaskToExecute::Cancel(const Status &status) { cancel_callback_(task_spec_, status); }
-
-ray::TaskID TaskToExecute::TaskID() const { return task_spec_.TaskId(); }
-
-uint64_t TaskToExecute::AttemptNumber() const { return task_spec_.AttemptNumber(); }
-
-bool TaskToExecute::IsRetry() const { return task_spec_.IsRetry(); }
-
-const std::string &TaskToExecute::ConcurrencyGroupName() const {
-  return task_spec_.ConcurrencyGroupName();
-}
-
-ray::FunctionDescriptor TaskToExecute::FunctionDescriptor() const {
-  return task_spec_.FunctionDescriptor();
-}
-
-const std::vector<rpc::ObjectReference> &TaskToExecute::PendingDependencies() const {
-  return pending_dependencies_;
-};
-
-bool TaskToExecute::DependenciesResolved() const { return pending_dependencies_.empty(); }
-
-void TaskToExecute::MarkDependenciesResolved() { pending_dependencies_.clear(); }
-
-const TaskSpecification &TaskToExecute::TaskSpec() const { return task_spec_; }
-
 ActorTaskExecutionArgWaiter::ActorTaskExecutionArgWaiter(
     AsyncWaitForArgs async_wait_for_args)
     : async_wait_for_args_(async_wait_for_args) {}

--- a/src/ray/core_worker/task_execution/common.h
+++ b/src/ray/core_worker/task_execution/common.h
@@ -33,10 +33,7 @@ namespace ray {
 namespace core {
 
 /// Container holding a task queued for execution on this worker, along with the
-/// per-request state needed to execute it or reply that it was canceled. This is a
-/// pure data class; the actual execute/cancel logic lives in the execution queues
-/// (see ExecuteTaskCallback / CancelTaskCallback), which are given the queue-level
-/// callbacks at construction time.
+/// per-request state needed to execute it or reply that it was canceled.
 class TaskToExecute {
  public:
   TaskToExecute(TaskSpecification task_spec,
@@ -84,10 +81,7 @@ class TaskToExecute {
   rpc::SendReplyCallback send_reply_callback_;
 };
 
-// Queue-level callbacks invoked by the execution queues to run or reply-cancel a
-// queued task. These are set once when a queue is constructed (they are not per-task);
-// all per-task state travels with the TaskToExecute argument. `ExecuteTaskCallback`
-// takes a mutable reference because executing a task moves its resource_ids out.
+// Queue-level callbacks invoked to run a task or reply that it has been canceled.
 using ExecuteTaskCallback = std::function<void(TaskToExecute &)>;
 using CancelTaskCallback = std::function<void(const TaskToExecute &, const Status &)>;
 

--- a/src/ray/core_worker/task_execution/common.h
+++ b/src/ray/core_worker/task_execution/common.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -22,43 +23,69 @@
 #include "ray/common/id.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task_spec.h"
+#include "ray/raylet_rpc_client/raylet_client_interface.h"
 #include "ray/rpc/rpc_callback_types.h"
 #include "src/ray/protobuf/common.pb.h"
+#include "src/ray/protobuf/core_worker.pb.h"
 
 namespace ray {
 namespace core {
 
-/// Wraps the state and callbacks associated with a task queued for execution on this
-/// worker.
+/// Container holding a task queued for execution on this worker, along with the
+/// per-request state needed to execute it or reply that it was canceled. This is a
+/// pure data class; the actual execute/cancel logic lives in the execution queues
+/// (see ExecuteTaskCallback / CancelTaskCallback), which are given the queue-level
+/// callbacks at construction time.
 class TaskToExecute {
  public:
-  TaskToExecute(
-      std::function<void(const TaskSpecification &)> execute_callback,
-      std::function<void(const TaskSpecification &, const Status &)> cancel_callback,
-      TaskSpecification task_spec);
+  TaskToExecute(TaskSpecification task_spec,
+                std::optional<ResourceMappingType> resource_ids,
+                rpc::PushTaskReply *reply,
+                rpc::SendReplyCallback send_reply_callback)
+      : task_spec_(std::move(task_spec)),
+        pending_dependencies_(task_spec_.GetDependencies()),
+        resource_ids_(std::move(resource_ids)),
+        reply_(reply),
+        send_reply_callback_(std::move(send_reply_callback)) {}
 
-  void Execute();
-  void Cancel(const Status &status);
-  ray::TaskID TaskID() const;
-  uint64_t AttemptNumber() const;
-  bool IsRetry() const;
-  const std::string &ConcurrencyGroupName() const;
-  ray::FunctionDescriptor FunctionDescriptor() const;
-  bool DependenciesResolved() const;
-  void MarkDependenciesResolved();
-  const std::vector<rpc::ObjectReference> &PendingDependencies() const;
-  const TaskSpecification &TaskSpec() const;
+  ray::TaskID TaskID() const { return task_spec_.TaskId(); }
+  uint64_t AttemptNumber() const { return task_spec_.AttemptNumber(); }
+  bool IsRetry() const { return task_spec_.IsRetry(); }
+  const std::string &ConcurrencyGroupName() const {
+    return task_spec_.ConcurrencyGroupName();
+  }
+  ray::FunctionDescriptor FunctionDescriptor() const {
+    return task_spec_.FunctionDescriptor();
+  }
+  bool DependenciesResolved() const { return pending_dependencies_.empty(); }
+  void MarkDependenciesResolved() { pending_dependencies_.clear(); }
+  const std::vector<rpc::ObjectReference> &PendingDependencies() const {
+    return pending_dependencies_;
+  }
+  const TaskSpecification &TaskSpec() const { return task_spec_; }
+
+  // Per-request state used by the queue's execute / cancel callbacks. `resource_ids`
+  // is mutable because the execute path moves it into the task handler.
+  std::optional<ResourceMappingType> &resource_ids() { return resource_ids_; }
+  rpc::PushTaskReply *reply() const { return reply_; }
+  const rpc::SendReplyCallback &send_reply_callback() const {
+    return send_reply_callback_;
+  }
 
  private:
-  // Callbacks to execute the task or reply that it has been canceled and will not be
-  // executed.
-  // Only one invocation of these callbacks should ever be called.
-  std::function<void(const TaskSpecification &)> execute_callback_;
-  std::function<void(const TaskSpecification &, const Status &)> cancel_callback_;
-
   TaskSpecification task_spec_;
   std::vector<rpc::ObjectReference> pending_dependencies_;
+  std::optional<ResourceMappingType> resource_ids_;
+  rpc::PushTaskReply *reply_;
+  rpc::SendReplyCallback send_reply_callback_;
 };
+
+// Queue-level callbacks invoked by the execution queues to run or reply-cancel a
+// queued task. These are set once when a queue is constructed (they are not per-task);
+// all per-task state travels with the TaskToExecute argument. `ExecuteTaskCallback`
+// takes a mutable reference because executing a task moves its resource_ids out.
+using ExecuteTaskCallback = std::function<void(TaskToExecute &)>;
+using CancelTaskCallback = std::function<void(const TaskToExecute &, const Status &)>;
 
 // Container for metadata and outputs corresponding to a completed task execution.
 struct TaskExecutionResult {

--- a/src/ray/core_worker/task_execution/common.h
+++ b/src/ray/core_worker/task_execution/common.h
@@ -25,6 +25,7 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/raylet_rpc_client/raylet_client_interface.h"
 #include "ray/rpc/rpc_callback_types.h"
+#include "ray/util/logging.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/core_worker.pb.h"
 
@@ -46,7 +47,10 @@ class TaskToExecute {
         pending_dependencies_(task_spec_.GetDependencies()),
         resource_ids_(std::move(resource_ids)),
         reply_(reply),
-        send_reply_callback_(std::move(send_reply_callback)) {}
+        send_reply_callback_(std::move(send_reply_callback)) {
+    RAY_CHECK(reply_ != nullptr) << "reply must not be null.";
+    RAY_CHECK(send_reply_callback_ != nullptr) << "send_reply_callback must not be null.";
+  }
 
   ray::TaskID TaskID() const { return task_spec_.TaskId(); }
   uint64_t AttemptNumber() const { return task_spec_.AttemptNumber(); }

--- a/src/ray/core_worker/task_execution/normal_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/normal_task_execution_queue.cc
@@ -21,15 +21,13 @@
 namespace ray {
 namespace core {
 
-NormalTaskExecutionQueue::NormalTaskExecutionQueue(){};
-
 void NormalTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg) {
   absl::MutexLock lock(&mu_);
   Status status = Status::SchedulingCancelled(msg);
 
   while (!pending_normal_tasks_.empty()) {
     auto it = pending_normal_tasks_.begin();
-    it->Cancel(status);
+    cancel_task_(*it, status);
     pending_normal_tasks_.erase(it);
   }
 }
@@ -50,7 +48,7 @@ bool NormalTaskExecutionQueue::CancelTaskIfFound(TaskID task_id) {
        it != pending_normal_tasks_.rend();
        ++it) {
     if (it->TaskID() == task_id) {
-      it->Cancel(Status::OK());
+      cancel_task_(*it, Status::OK());
       pending_normal_tasks_.erase(std::next(it).base());
       return true;
     }
@@ -71,7 +69,7 @@ std::optional<TaskToExecute> NormalTaskExecutionQueue::TryPopQueuedTask() {
 
 void NormalTaskExecutionQueue::ExecuteQueuedTasks() {
   while (auto task = TryPopQueuedTask()) {
-    task->Execute();
+    execute_task_(*task);
   }
 }
 

--- a/src/ray/core_worker/task_execution/normal_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/normal_task_execution_queue.h
@@ -55,7 +55,7 @@ class NormalTaskExecutionQueue {
   // Get the next queued task to execute if available.
   std::optional<TaskToExecute> TryPopQueuedTask();
 
-  /// Callbacks used to execute / reply-cancel a queued task.
+  /// Callbacks used to execute a queued task or reply that it's canceled.
   ExecuteTaskCallback execute_task_;
   CancelTaskCallback cancel_task_;
 

--- a/src/ray/core_worker/task_execution/normal_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/normal_task_execution_queue.h
@@ -16,6 +16,7 @@
 
 #include <deque>
 #include <string>
+#include <utility>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
@@ -31,7 +32,9 @@ namespace core {
 /// constraints.
 class NormalTaskExecutionQueue {
  public:
-  NormalTaskExecutionQueue();
+  NormalTaskExecutionQueue(ExecuteTaskCallback execute_task,
+                           CancelTaskCallback cancel_task)
+      : execute_task_(std::move(execute_task)), cancel_task_(std::move(cancel_task)) {}
 
   void Stop();
 
@@ -51,6 +54,10 @@ class NormalTaskExecutionQueue {
 
   // Get the next queued task to execute if available.
   std::optional<TaskToExecute> TryPopQueuedTask();
+
+  /// Callbacks used to execute / reply-cancel a queued task.
+  ExecuteTaskCallback execute_task_;
+  CancelTaskCallback cancel_task_;
 
   /// Protects access to the dequeue below.
   mutable absl::Mutex mu_;

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -27,13 +27,17 @@ OrderedActorTaskExecutionQueue::OrderedActorTaskExecutionQueue(
     ActorTaskExecutionArgWaiterInterface &waiter,
     worker::TaskEventBuffer &task_event_buffer,
     std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
-    int64_t reorder_wait_seconds)
+    int64_t reorder_wait_seconds,
+    ExecuteTaskCallback execute_task,
+    CancelTaskCallback cancel_task)
     : task_execution_service_(task_execution_service),
       reorder_wait_seconds_(reorder_wait_seconds),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),
-      pool_manager_(std::move(pool_manager)) {}
+      pool_manager_(std::move(pool_manager)),
+      execute_task_(std::move(execute_task)),
+      cancel_task_(std::move(cancel_task)) {}
 
 void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg) {
   absl::MutexLock lock(&mu_);
@@ -44,7 +48,7 @@ void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg
     // Cancel queued ordered tasks.
     while (!group_state.pending_tasks.empty()) {
       auto head = group_state.pending_tasks.begin();
-      head->second.Cancel(status);
+      cancel_task_(head->second, status);
       pending_task_id_to_is_canceled.erase(head->second.TaskID());
       group_state.pending_tasks.erase(head);
     }
@@ -52,7 +56,7 @@ void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg
     // Cancel queued retry tasks.
     while (!group_state.pending_retry_tasks.empty()) {
       auto &req = group_state.pending_retry_tasks.front();
-      req.Cancel(status);
+      cancel_task_(req, status);
       pending_task_id_to_is_canceled.erase(req.TaskID());
       group_state.pending_retry_tasks.pop_front();
     }
@@ -183,7 +187,8 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
       auto head = group_state.pending_tasks.begin();
       RAY_LOG(ERROR) << "Cancelling stale RPC with seqno " << head->first << " < "
                      << group_state.next_seq_no << " in group '" << group_name << "'";
-      head->second.Cancel(
+      cancel_task_(
+          head->second,
           Status::Invalid("Task canceled due to stale sequence number. The client "
                           "intentionally discarded this task."));
       {
@@ -267,7 +272,7 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
             for (auto &[_, group_state_in] : group_states_) {
               while (!group_state_in.pending_tasks.empty()) {
                 auto head = group_state_in.pending_tasks.begin();
-                head->second.Cancel(invalid_status);
+                cancel_task_(head->second, invalid_status);
                 group_state_in.next_seq_no =
                     std::max(group_state_in.next_seq_no, head->first + 1);
                 {
@@ -312,10 +317,10 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
 
   // Accept can be very long, and we shouldn't hold a lock.
   if (is_canceled) {
-    request.Cancel(
-        Status::SchedulingCancelled("Task is canceled before it is scheduled."));
+    cancel_task_(request,
+                 Status::SchedulingCancelled("Task is canceled before it is scheduled."));
   } else {
-    request.Execute();
+    execute_task_(request);
   }
 
   absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -108,11 +108,11 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// If concurrent calls are allowed, holds the pools for executing these tasks.
   std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager_;
 
-  /// Callbacks used to execute / reply-cancel a queued task.
+  /// Callbacks used to execute a queued task or reply that it's canceled.
   ExecuteTaskCallback execute_task_;
   CancelTaskCallback cancel_task_;
 
-  /// Mutext to protect attributes used for thread safe APIs.
+  /// Mutex to protect attributes used for thread safe APIs.
   absl::Mutex mu_;
 
   /// A map of actor task IDs -> is_canceled

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -43,7 +43,9 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
       ActorTaskExecutionArgWaiterInterface &waiter,
       worker::TaskEventBuffer &task_event_buffer,
       std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager,
-      int64_t reorder_wait_seconds);
+      int64_t reorder_wait_seconds,
+      ExecuteTaskCallback execute_task,
+      CancelTaskCallback cancel_task);
 
   void Stop() override;
 
@@ -105,6 +107,10 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
 
   /// If concurrent calls are allowed, holds the pools for executing these tasks.
   std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager_;
+
+  /// Callbacks used to execute / reply-cancel a queued task.
+  ExecuteTaskCallback execute_task_;
+  CancelTaskCallback cancel_task_;
 
   /// Mutext to protect attributes used for thread safe APIs.
   absl::Mutex mu_;

--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -170,47 +170,15 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
     }
   }
 
-  auto execute_callback =
-      [this, reply, send_reply_callback, resource_ids = std::move(resource_ids)](
-          const TaskSpecification &t) mutable {
-        TaskExecutionResult result;
-        auto status = task_handler_(t,
-                                    std::move(resource_ids),
-                                    &result.return_objects,
-                                    &result.dynamic_return_objects,
-                                    &result.streaming_generator_returns,
-                                    reply->mutable_borrowed_refs(),
-                                    &result.is_retryable_error,
-                                    &result.actor_repr_name,
-                                    &result.application_error);
-
-        HandleTaskExecutionResult(status, t, result, send_reply_callback, reply);
-      };
-
-  auto cancel_callback = [this, reply, send_reply_callback](const TaskSpecification &t,
-                                                            const Status &status) {
-    if (t.IsActorTask()) {
-      // If task cancelation is due to worker shutdown, propagate that information
-      // to the submitter.
-      if (stopping_) {
-        reply->set_worker_exiting(true);
-        reply->set_was_cancelled_before_running(true);
-        send_reply_callback(Status::OK(), nullptr, nullptr);
-      } else {
-        send_reply_callback(status, nullptr, nullptr);
-      }
-    } else {
-      reply->set_was_cancelled_before_running(true);
-      send_reply_callback(status, nullptr, nullptr);
-    }
-  };
-
   if (task_spec.IsActorCreationTask()) {
     SetupActor(task_spec.IsAsyncioActor(),
                task_spec.MaxActorConcurrency(),
                task_spec.AllowOutOfOrderExecution());
     normal_task_execution_queue_->EnqueueTask(
-        TaskToExecute(execute_callback, cancel_callback, std::move(task_spec)));
+        TaskToExecute(std::move(task_spec),
+                      std::move(resource_ids),
+                      reply,
+                      std::move(send_reply_callback)));
   } else if (task_spec.IsActorTask()) {
     auto it = actor_task_execution_queues_.find(task_spec.CallerWorkerId());
     if (it == actor_task_execution_queues_.end()) {
@@ -227,7 +195,9 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                                  fiber_state_manager_,
                                  is_asyncio_,
                                  fiber_max_concurrency_,
-                                 concurrency_groups_))
+                                 concurrency_groups_,
+                                 execute_task_callback_,
+                                 cancel_task_callback_))
                        : std::unique_ptr<ActorTaskExecutionQueueInterface>(
                              std::make_unique<OrderedActorTaskExecutionQueue>(
                                  task_execution_service_,
@@ -235,16 +205,57 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                                  task_event_buffer_,
                                  pool_manager_,
                                  RayConfig::instance()
-                                     .actor_scheduling_queue_max_reorder_wait_seconds())))
+                                     .actor_scheduling_queue_max_reorder_wait_seconds(),
+                                 execute_task_callback_,
+                                 cancel_task_callback_)))
                .first;
     }
-    it->second->EnqueueTask(
-        request.sequence_number(),
-        request.client_processed_up_to(),
-        TaskToExecute(execute_callback, cancel_callback, std::move(task_spec)));
+    it->second->EnqueueTask(request.sequence_number(),
+                            request.client_processed_up_to(),
+                            TaskToExecute(std::move(task_spec),
+                                          std::move(resource_ids),
+                                          reply,
+                                          std::move(send_reply_callback)));
   } else {
     normal_task_execution_queue_->EnqueueTask(
-        TaskToExecute(execute_callback, cancel_callback, std::move(task_spec)));
+        TaskToExecute(std::move(task_spec),
+                      std::move(resource_ids),
+                      reply,
+                      std::move(send_reply_callback)));
+  }
+}
+
+void TaskReceiver::ExecuteTask(TaskToExecute &task) {
+  TaskExecutionResult result;
+  auto status = task_handler_(task.TaskSpec(),
+                              std::move(task.resource_ids()),
+                              &result.return_objects,
+                              &result.dynamic_return_objects,
+                              &result.streaming_generator_returns,
+                              task.reply()->mutable_borrowed_refs(),
+                              &result.is_retryable_error,
+                              &result.actor_repr_name,
+                              &result.application_error);
+
+  HandleTaskExecutionResult(
+      status, task.TaskSpec(), result, task.send_reply_callback(), task.reply());
+}
+
+void TaskReceiver::CancelTask(const TaskToExecute &task, const Status &status) {
+  const TaskSpecification &task_spec = task.TaskSpec();
+  if (task_spec.IsActorTask()) {
+    // If task cancelation is due to worker shutdown, propagate that information
+    // to the submitter.
+    if (stopping_) {
+      task.reply()->set_worker_exiting(true);
+      task.reply()->set_was_cancelled_before_running(true);
+      task.send_reply_callback()(Status::OK(), nullptr, nullptr);
+    } else {
+      task.send_reply_callback()(status, nullptr, nullptr);
+    }
+  } else {
+    task.reply()->set_was_cancelled_before_running(true);
+    task.send_reply_callback()(status, nullptr, nullptr);
   }
 }
 

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -64,7 +64,12 @@ class TaskReceiver {
         task_event_buffer_(task_event_buffer),
         waiter_(actor_task_execution_arg_waiter),
         initialize_thread_callback_(std::move(initialize_thread_callback)),
-        normal_task_execution_queue_(std::make_unique<NormalTaskExecutionQueue>()),
+        execute_task_callback_([this](TaskToExecute &task) { ExecuteTask(task); }),
+        cancel_task_callback_([this](const TaskToExecute &task, const Status &status) {
+          CancelTask(task, status);
+        }),
+        normal_task_execution_queue_(std::make_unique<NormalTaskExecutionQueue>(
+            execute_task_callback_, cancel_task_callback_)),
         pool_manager_(std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>()),
         fiber_state_manager_(nullptr) {}
 
@@ -111,6 +116,14 @@ class TaskReceiver {
                                  const rpc::SendReplyCallback &send_reply_callback,
                                  rpc::PushTaskReply *reply);
 
+  /// Execute a task that was queued for execution. Invoked by the execution queues via
+  /// `execute_task_callback_`. Reads all per-request state from `task`.
+  void ExecuteTask(TaskToExecute &task);
+
+  /// Reply that a queued task was canceled before it started executing. Invoked by the
+  /// execution queues via `cancel_task_callback_`. Reads per-request state from `task`.
+  void CancelTask(const TaskToExecute &task, const Status &status);
+
   // True once shutdown begins. Requests to execute new tasks will be rejected.
   std::atomic<bool> stopping_ = false;
 
@@ -127,6 +140,12 @@ class TaskReceiver {
 
   /// The language-specific callback function that initializes threads.
   std::function<std::function<void()>()> initialize_thread_callback_;
+
+  /// Queue-level callbacks passed to each execution queue at construction time. They
+  /// capture only `this` and read all per-request state from the TaskToExecute argument.
+  /// Declared before the queues so they are constructed first and outlive them.
+  ExecuteTaskCallback execute_task_callback_;
+  CancelTaskCallback cancel_task_callback_;
 
   /// Queue of actor tasks waiting to execute, keyed on the ID of the worker that
   /// submitted the task.

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -119,13 +119,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  int n_ok = 0;
-  int n_rej = 0;
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  int n_executed = 0;
+  int n_canceled = 0;
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id_1 = TaskID::FromRandom(job_id);
   TaskSpecification task_spec_without_dependency;
@@ -174,8 +176,8 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 2);
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_EQ(n_executed, 2);
+  ASSERT_EQ(n_canceled, 0);
 
   queue.Stop();
 }
@@ -189,13 +191,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestInOrder) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  int n_ok = 0;
-  int n_rej = 0;
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  int n_executed = 0;
+  int n_canceled = 0;
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   queue.EnqueueTask(0, -1, MakeTask(task_spec));
@@ -208,8 +212,8 @@ TEST(OrderedActorTaskExecutionQueueTest, TestInOrder) {
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 4);
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_EQ(n_executed, 4);
+  ASSERT_EQ(n_canceled, 0);
 
   queue.Stop();
 }
@@ -228,11 +232,12 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
   std::promise<void> running_started;
   std::promise<void> allow_finish;
   std::atomic<int> n_rejected{0};
-  auto fn_ok_blocking = [&running_started, &allow_finish](TaskToExecute &task) {
+  auto execute_task_blocking = [&running_started, &allow_finish](TaskToExecute &task) {
     running_started.set_value();
     allow_finish.get_future().wait();
   };
-  auto fn_rej_count = [&n_rejected](const TaskToExecute &task, const Status &status) {
+  auto cancel_task_count = [&n_rejected](const TaskToExecute &task,
+                                         const Status &status) {
     if (status.IsSchedulingCancelled()) {
       n_rejected.fetch_add(1);
     }
@@ -243,8 +248,8 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
                                        task_event_buffer,
                                        pool_manager,
                                        1,
-                                       fn_ok_blocking,
-                                       fn_rej_count);
+                                       execute_task_blocking,
+                                       cancel_task_count);
   TaskSpecification ts;
   ts.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   // Enqueue a running task and a queued task.
@@ -277,13 +282,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  std::atomic<int> n_ok(0);
-  std::atomic<int> n_rej(0);
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  std::atomic<int> n_executed(0);
+  std::atomic<int> n_canceled(0);
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec_without_dependency;
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   TaskSpecification task_spec_with_dependency;
@@ -297,13 +304,13 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
   queue.EnqueueTask(2, -1, MakeTask(task_spec_with_dependency));
   queue.EnqueueTask(3, -1, MakeTask(task_spec_with_dependency));
 
-  ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
+  ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
 
   waiter.Complete(0);
-  ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 2; }, 1000));
+  ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 2; }, 1000));
 
   waiter.Complete(2);
-  ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 2; }, 1000));
+  ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 2; }, 1000));
 
   waiter.Complete(1);
 
@@ -311,7 +318,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 4);
+  ASSERT_EQ(n_executed, 4);
 
   queue.Stop();
 }
@@ -326,13 +333,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  std::atomic<int> n_ok(0);
-  std::atomic<int> n_rej(0);
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  std::atomic<int> n_executed(0);
+  std::atomic<int> n_canceled(0);
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec_without_dependency;
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   TaskSpecification task_spec_with_dependency;
@@ -344,16 +353,16 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
   queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
   queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
 
-  ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
+  ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
   io_service.run();
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_EQ(n_canceled, 0);
   waiter.Complete(0);
 
   // Wait for all tasks to finish.
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 2);
+  ASSERT_EQ(n_executed, 2);
 
   queue.Stop();
 }
@@ -367,23 +376,25 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSeqWaitTimeout) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  std::atomic<int> n_ok(0);
-  std::atomic<int> n_rej(0);
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  std::atomic<int> n_executed(0);
+  std::atomic<int> n_canceled(0);
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   queue.EnqueueTask(2, -1, MakeTask(task_spec));
   queue.EnqueueTask(0, -1, MakeTask(task_spec));
   queue.EnqueueTask(3, -1, MakeTask(task_spec));
-  ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
+  ASSERT_EQ(n_canceled, 0);
   io_service.run();
-  ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
-  ASSERT_TRUE(WaitForCondition([&n_rej]() { return n_rej == 2; }, 1000));
+  ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
+  ASSERT_TRUE(WaitForCondition([&n_canceled]() { return n_canceled == 2; }, 1000));
   queue.EnqueueTask(4, -1, MakeTask(task_spec));
   queue.EnqueueTask(5, -1, MakeTask(task_spec));
 
@@ -391,8 +402,8 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSeqWaitTimeout) {
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 3);
-  ASSERT_EQ(n_rej, 2);
+  ASSERT_EQ(n_executed, 3);
+  ASSERT_EQ(n_canceled, 2);
 
   queue.Stop();
 }
@@ -406,13 +417,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSkipAlreadyProcessedByClient) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  std::atomic<int> n_ok(0);
-  std::atomic<int> n_rej(0);
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  std::atomic<int> n_executed(0);
+  std::atomic<int> n_canceled(0);
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   queue.EnqueueTask(2, 2, MakeTask(task_spec));
@@ -424,8 +437,8 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSkipAlreadyProcessedByClient) {
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 1);
-  ASSERT_EQ(n_rej, 2);
+  ASSERT_EQ(n_executed, 1);
+  ASSERT_EQ(n_canceled, 2);
 
   queue.Stop();
 }
@@ -462,16 +475,16 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
   std::vector<int64_t> accept_seq_nos;
   std::vector<int64_t> reject_seq_nos;
   std::atomic<int> n_accept = 0;
-  auto fn_ok = [&accept_seq_nos, &n_accept](TaskToExecute &task) {
+  auto execute_task = [&accept_seq_nos, &n_accept](TaskToExecute &task) {
     accept_seq_nos.push_back(task.TaskSpec().ConcurrencyGroupSequenceNumber());
     n_accept++;
   };
-  auto fn_rej = [&reject_seq_nos](const TaskToExecute &task, const Status &status) {
+  auto cancel_task = [&reject_seq_nos](const TaskToExecute &task, const Status &status) {
     reject_seq_nos.push_back(task.TaskSpec().ConcurrencyGroupSequenceNumber());
   };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 2, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 2, execute_task, cancel_task);
 
   // Submitting 0 with dep, 1, 3 (retry of 2), and 4 (with client_processed_up_to = 2 bc 2
   // failed to send), 6 (retry of 5) with dep.
@@ -519,15 +532,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
   // Track accepted tasks as (group_name, seq_no) pairs.
   std::vector<std::pair<std::string, int64_t>> accepted;
   std::atomic<int> n_accept = 0;
-  auto fn_ok = [&accepted, &n_accept](TaskToExecute &task) {
+  auto execute_task = [&accepted, &n_accept](TaskToExecute &task) {
     accepted.emplace_back(task.TaskSpec().ConcurrencyGroupName(),
                           task.TaskSpec().ConcurrencyGroupSequenceNumber());
     n_accept++;
   };
-  auto fn_rej = [](const TaskToExecute &, const Status &) { FAIL(); };
+  auto cancel_task = [](const TaskToExecute &, const Status &) { FAIL(); };
 
   OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 2, fn_ok, fn_rej);
+      io_service, waiter, task_event_buffer, pool_manager, 2, execute_task, cancel_task);
 
   auto make_task = [](const std::string &group, int64_t seq_no) {
     auto spec = CreateActorTaskSpec(seq_no);
@@ -578,10 +591,12 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  int n_ok = 0;
-  int n_rej = 0;
-  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  int n_executed = 0;
+  int n_canceled = 0;
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   UnorderedActorTaskExecutionQueue queue(io_service,
                                          waiter,
@@ -591,8 +606,8 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
                                          /*is_asyncio=*/false,
                                          /*fiber_max_concurrency=*/1,
                                          /*concurrency_groups=*/{},
-                                         fn_ok,
-                                         fn_rej);
+                                         execute_task,
+                                         cancel_task);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id_1 = TaskID::FromRandom(job_id);
   TaskSpecification task_spec_without_dependency;
@@ -641,8 +656,8 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto default_executor = pool_manager->GetDefaultExecutor();
   default_executor->Join();
 
-  ASSERT_EQ(n_ok, 2);
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_EQ(n_executed, 2);
+  ASSERT_EQ(n_canceled, 0);
 
   queue.Stop();
 }
@@ -657,11 +672,11 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
   std::promise<void> attempt_1_start_promise;
   std::promise<void> attempt_1_finish_promise;
   std::promise<void> attempt_2_start_promise;
-  int n_rej = 0;
+  int n_canceled = 0;
   // The per-attempt behavior is dispatched on the task's attempt number.
-  auto fn_ok = [&attempt_1_start_promise,
-                &attempt_1_finish_promise,
-                &attempt_2_start_promise](TaskToExecute &task) {
+  auto execute_task = [&attempt_1_start_promise,
+                       &attempt_1_finish_promise,
+                       &attempt_2_start_promise](TaskToExecute &task) {
     if (task.TaskSpec().AttemptNumber() == 1) {
       attempt_1_start_promise.set_value();
       attempt_1_finish_promise.get_future().wait();
@@ -669,7 +684,9 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
       attempt_2_start_promise.set_value();
     }
   };
-  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+  auto cancel_task = [&n_canceled](const TaskToExecute &task, const Status &status) {
+    n_canceled++;
+  };
 
   UnorderedActorTaskExecutionQueue queue(
       io_service,
@@ -682,8 +699,8 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
       /*is_asyncio=*/false,
       /*fiber_max_concurrency=*/1,
       /*concurrency_groups=*/{},
-      fn_ok,
-      fn_rej);
+      execute_task,
+      cancel_task);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id = TaskID::FromRandom(job_id);
 
@@ -710,7 +727,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
     io_service.poll();
   }
 
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_EQ(n_canceled, 0);
   auto no_leak = [&queue] {
     absl::MutexLock lock(&queue.mu_);
     return queue.queued_actor_tasks_.empty() &&
@@ -733,8 +750,8 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
   std::atomic<bool> attempt_4_cancelled = false;
   // Only attempt 1 ever executes; all other attempts are expected to be cancelled. The
   // per-attempt behavior is dispatched on the task's attempt number.
-  auto fn_ok = [&attempt_1_start_promise,
-                &attempt_1_finish_promise](TaskToExecute &task) {
+  auto execute_task = [&attempt_1_start_promise,
+                       &attempt_1_finish_promise](TaskToExecute &task) {
     if (task.TaskSpec().AttemptNumber() == 1) {
       attempt_1_start_promise.set_value();
       attempt_1_finish_promise.get_future().wait();
@@ -742,8 +759,8 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
       FAIL() << "Unexpected execution of attempt " << task.TaskSpec().AttemptNumber();
     }
   };
-  auto fn_rej = [&attempt_2_cancelled, &attempt_3_cancelled, &attempt_4_cancelled](
-                    const TaskToExecute &task, const Status &status) {
+  auto cancel_task = [&attempt_2_cancelled, &attempt_3_cancelled, &attempt_4_cancelled](
+                         const TaskToExecute &task, const Status &status) {
     ASSERT_TRUE(status.IsSchedulingCancelled());
     switch (task.TaskSpec().AttemptNumber()) {
     case 2:
@@ -771,8 +788,8 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
       /*is_asyncio=*/false,
       /*fiber_max_concurrency=*/1,
       /*concurrency_groups=*/{},
-      fn_ok,
-      fn_rej);
+      execute_task,
+      cancel_task);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id = TaskID::FromRandom(job_id);
 

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -94,6 +95,20 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
   NodeID GetNodeID() const override { return NodeID::Nil(); }
 };
 
+namespace {
+
+// Construct a TaskToExecute container for tests. The per-task execute/cancel behavior is
+// supplied to the queue at construction time (not per task), so the container only needs
+// to carry the task spec.
+TaskToExecute MakeTask(const TaskSpecification &task_spec) {
+  return TaskToExecute(task_spec,
+                       /*resource_ids=*/std::nullopt,
+                       /*reply=*/nullptr,
+                       /*send_reply_callback=*/nullptr);
+}
+
+}  // namespace
+
 TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   // Test task events are recorded.
   instrumented_io_context io_service;
@@ -104,14 +119,13 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
   int n_ok = 0;
   int n_rej = 0;
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id_1 = TaskID::FromRandom(job_id);
   TaskSpecification task_spec_without_dependency;
@@ -120,7 +134,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_without_dependency.GetMutableMessage().set_enable_task_events(true);
 
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec_without_dependency));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
   ASSERT_EQ(task_event_buffer.task_events.size(), 1UL);
   rpc::TaskEvents rpc_task_events;
   task_event_buffer.task_events[0]->ToRpcTaskEvents(&rpc_task_events);
@@ -140,7 +154,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(ObjectID::FromRandom().Binary());
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_spec_with_dependency));
+  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
   waiter.Complete(0);
   ASSERT_EQ(task_event_buffer.task_events.size(), 3UL);
   task_event_buffer.task_events[1]->ToRpcTaskEvents(&rpc_task_events);
@@ -175,20 +189,19 @@ TEST(OrderedActorTaskExecutionQueueTest, TestInOrder) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
   int n_ok = 0;
   int n_rej = 0;
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(2, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(3, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec));
+  queue.EnqueueTask(1, -1, MakeTask(task_spec));
+  queue.EnqueueTask(2, -1, MakeTask(task_spec));
+  queue.EnqueueTask(3, -1, MakeTask(task_spec));
   io_service.run();
 
   // Wait for all tasks to finish.
@@ -210,35 +223,39 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
-  // One running task that blocks until we signal.
+  // One running task that blocks until we signal. The queued task (with a dependency)
+  // stays queued and is cancelled by Stop().
   std::promise<void> running_started;
   std::promise<void> allow_finish;
-  auto fn_ok_blocking = [&running_started,
-                         &allow_finish](const TaskSpecification &task_spec) {
+  std::atomic<int> n_rejected{0};
+  auto fn_ok_blocking = [&running_started, &allow_finish](TaskToExecute &task) {
     running_started.set_value();
     allow_finish.get_future().wait();
   };
-  auto fn_rej = [](const TaskSpecification &task_spec, const Status &status) {};
-  TaskSpecification ts;
-  ts.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  // Enqueue a running task and a queued task.
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok_blocking, fn_rej, ts));
-  std::atomic<int> n_rejected{0};
-  auto fn_rej_count = [&n_rejected](const TaskSpecification &, const Status &status) {
+  auto fn_rej_count = [&n_rejected](const TaskToExecute &task, const Status &status) {
     if (status.IsSchedulingCancelled()) {
       n_rejected.fetch_add(1);
     }
   };
+
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       waiter,
+                                       task_event_buffer,
+                                       pool_manager,
+                                       1,
+                                       fn_ok_blocking,
+                                       fn_rej_count);
+  TaskSpecification ts;
+  ts.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  // Enqueue a running task and a queued task.
+  queue.EnqueueTask(0, -1, MakeTask(ts));
   // Make the queued task have a dependency so it stays queued and will be cancelled by
   // Stop().
   TaskSpecification ts_dep;
   ts_dep.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   ts_dep.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
       ObjectID::FromRandom().Binary());
-  queue.EnqueueTask(
-      1, -1, TaskToExecute([](const TaskSpecification &) {}, fn_rej_count, ts_dep));
+  queue.EnqueueTask(1, -1, MakeTask(ts_dep));
   io_service.poll();
   running_started.get_future().wait();
 
@@ -260,15 +277,13 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
 
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
   TaskSpecification task_spec_without_dependency;
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   TaskSpecification task_spec_with_dependency;
@@ -277,10 +292,10 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(obj.Binary());
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec_without_dependency));
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_spec_with_dependency));
-  queue.EnqueueTask(2, -1, TaskToExecute(fn_ok, fn_rej, task_spec_with_dependency));
-  queue.EnqueueTask(3, -1, TaskToExecute(fn_ok, fn_rej, task_spec_with_dependency));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
+  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
+  queue.EnqueueTask(2, -1, MakeTask(task_spec_with_dependency));
+  queue.EnqueueTask(3, -1, MakeTask(task_spec_with_dependency));
 
   ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
 
@@ -311,15 +326,13 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
 
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
   TaskSpecification task_spec_without_dependency;
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   TaskSpecification task_spec_with_dependency;
@@ -328,8 +341,8 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(obj.Binary());
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec_without_dependency));
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_spec_with_dependency));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
+  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
 
   ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
   io_service.run();
@@ -354,27 +367,25 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSeqWaitTimeout) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
 
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  queue.EnqueueTask(2, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(3, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
+  queue.EnqueueTask(2, -1, MakeTask(task_spec));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec));
+  queue.EnqueueTask(3, -1, MakeTask(task_spec));
   ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
   ASSERT_EQ(n_rej, 0);
   io_service.run();
   ASSERT_TRUE(WaitForCondition([&n_ok]() { return n_ok == 1; }, 1000));
   ASSERT_TRUE(WaitForCondition([&n_rej]() { return n_rej == 2; }, 1000));
-  queue.EnqueueTask(4, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(5, -1, TaskToExecute(fn_ok, fn_rej, task_spec));
+  queue.EnqueueTask(4, -1, MakeTask(task_spec));
+  queue.EnqueueTask(5, -1, MakeTask(task_spec));
 
   // Wait for all tasks to finish.
   auto default_executor = pool_manager->GetDefaultExecutor();
@@ -395,19 +406,18 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSkipAlreadyProcessedByClient) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 1);
   std::atomic<int> n_ok(0);
   std::atomic<int> n_rej(0);
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 1, fn_ok, fn_rej);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  queue.EnqueueTask(2, 2, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(3, 2, TaskToExecute(fn_ok, fn_rej, task_spec));
-  queue.EnqueueTask(1, 2, TaskToExecute(fn_ok, fn_rej, task_spec));
+  queue.EnqueueTask(2, 2, MakeTask(task_spec));
+  queue.EnqueueTask(3, 2, MakeTask(task_spec));
+  queue.EnqueueTask(1, 2, MakeTask(task_spec));
   io_service.run();
 
   // Wait for all tasks to finish.
@@ -449,19 +459,19 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 2);
   std::vector<int64_t> accept_seq_nos;
   std::vector<int64_t> reject_seq_nos;
   std::atomic<int> n_accept = 0;
-  auto fn_ok = [&accept_seq_nos, &n_accept](const TaskSpecification &task_spec) {
-    accept_seq_nos.push_back(task_spec.ConcurrencyGroupSequenceNumber());
+  auto fn_ok = [&accept_seq_nos, &n_accept](TaskToExecute &task) {
+    accept_seq_nos.push_back(task.TaskSpec().ConcurrencyGroupSequenceNumber());
     n_accept++;
   };
-  auto fn_rej = [&reject_seq_nos](const TaskSpecification &task_spec,
-                                  const Status &status) {
-    reject_seq_nos.push_back(task_spec.ConcurrencyGroupSequenceNumber());
+  auto fn_rej = [&reject_seq_nos](const TaskToExecute &task, const Status &status) {
+    reject_seq_nos.push_back(task.TaskSpec().ConcurrencyGroupSequenceNumber());
   };
+
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 2, fn_ok, fn_rej);
 
   // Submitting 0 with dep, 1, 3 (retry of 2), and 4 (with client_processed_up_to = 2 bc 2
   // failed to send), 6 (retry of 5) with dep.
@@ -469,15 +479,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
   // 3 (retry of 2) should get executed. Then, 4 should be executed. Then 6 (retry of 5)
   // once the dependency is fetched.
   auto task_spec_0 = CreateActorTaskSpec(0, /*is_retry=*/false, /*dependency=*/true);
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec_0));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec_0));
   auto task_spec_1 = CreateActorTaskSpec(1);
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_spec_1));
+  queue.EnqueueTask(1, -1, MakeTask(task_spec_1));
   auto task_spec_2_retry = CreateActorTaskSpec(3, /*is_retry=*/true);
-  queue.EnqueueTask(3, -1, TaskToExecute(fn_ok, fn_rej, task_spec_2_retry));
+  queue.EnqueueTask(3, -1, MakeTask(task_spec_2_retry));
   auto task_spec_4 = CreateActorTaskSpec(4);
-  queue.EnqueueTask(4, 2, TaskToExecute(fn_ok, fn_rej, task_spec_4));
+  queue.EnqueueTask(4, 2, MakeTask(task_spec_4));
   auto task_spec_5_retry = CreateActorTaskSpec(6, /*is_retry=*/true, /*dependency=*/true);
-  queue.EnqueueTask(6, -1, TaskToExecute(fn_ok, fn_rej, task_spec_5_retry));
+  queue.EnqueueTask(6, -1, MakeTask(task_spec_5_retry));
 
   io_service.run();
 
@@ -506,18 +516,18 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
-  OrderedActorTaskExecutionQueue queue(
-      io_service, waiter, task_event_buffer, pool_manager, 2);
-
   // Track accepted tasks as (group_name, seq_no) pairs.
   std::vector<std::pair<std::string, int64_t>> accepted;
   std::atomic<int> n_accept = 0;
-  auto fn_ok = [&accepted, &n_accept](const TaskSpecification &task_spec) {
-    accepted.emplace_back(task_spec.ConcurrencyGroupName(),
-                          task_spec.ConcurrencyGroupSequenceNumber());
+  auto fn_ok = [&accepted, &n_accept](TaskToExecute &task) {
+    accepted.emplace_back(task.TaskSpec().ConcurrencyGroupName(),
+                          task.TaskSpec().ConcurrencyGroupSequenceNumber());
     n_accept++;
   };
-  auto fn_rej = [](TaskSpecification, Status) { FAIL(); };
+  auto fn_rej = [](const TaskToExecute &, const Status &) { FAIL(); };
+
+  OrderedActorTaskExecutionQueue queue(
+      io_service, waiter, task_event_buffer, pool_manager, 2, fn_ok, fn_rej);
 
   auto make_task = [](const std::string &group, int64_t seq_no) {
     auto spec = CreateActorTaskSpec(seq_no);
@@ -532,9 +542,9 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
 
   // Sequence no 0 missing from group a, so that should block until 1 arrives.
   // Concurrency group b should be ready to go though.
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_a1));
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_b0));
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_b1));
+  queue.EnqueueTask(1, -1, MakeTask(task_a1));
+  queue.EnqueueTask(0, -1, MakeTask(task_b0));
+  queue.EnqueueTask(1, -1, MakeTask(task_b1));
 
   io_service.run_one();
   io_service.run_one();
@@ -542,7 +552,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
   ASSERT_EQ(n_accept, 2);
 
   // Now enqueue group "a" seq 0, which unblocks group "a".
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_a0));
+  queue.EnqueueTask(0, -1, MakeTask(task_a0));
   io_service.run_one();
   io_service.run_one();
   ASSERT_TRUE(WaitForCondition([&n_accept]() { return n_accept == 4; }, 1000));
@@ -568,6 +578,11 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
   auto pool_manager =
       std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
 
+  int n_ok = 0;
+  int n_rej = 0;
+  auto fn_ok = [&n_ok](TaskToExecute &task) { n_ok++; };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+
   UnorderedActorTaskExecutionQueue queue(io_service,
                                          waiter,
                                          task_event_buffer,
@@ -575,13 +590,9 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
                                          /*fiber_state_manager=*/nullptr,
                                          /*is_asyncio=*/false,
                                          /*fiber_max_concurrency=*/1,
-                                         /*concurrency_groups=*/{});
-  int n_ok = 0;
-  int n_rej = 0;
-  auto fn_ok = [&n_ok](const TaskSpecification &task_spec) { n_ok++; };
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
+                                         /*concurrency_groups=*/{},
+                                         fn_ok,
+                                         fn_rej);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id_1 = TaskID::FromRandom(job_id);
   TaskSpecification task_spec_without_dependency;
@@ -590,7 +601,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_without_dependency.GetMutableMessage().set_enable_task_events(true);
 
-  queue.EnqueueTask(0, -1, TaskToExecute(fn_ok, fn_rej, task_spec_without_dependency));
+  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
   ASSERT_EQ(task_event_buffer.task_events.size(), 1UL);
   rpc::TaskEvents rpc_task_events;
   task_event_buffer.task_events[0]->ToRpcTaskEvents(&rpc_task_events);
@@ -610,7 +621,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(ObjectID::FromRandom().Binary());
-  queue.EnqueueTask(1, -1, TaskToExecute(fn_ok, fn_rej, task_spec_with_dependency));
+  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
   waiter.Complete(0);
   ASSERT_EQ(task_event_buffer.task_events.size(), 3UL);
   task_event_buffer.task_events[1]->ToRpcTaskEvents(&rpc_task_events);
@@ -642,6 +653,24 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
   instrumented_io_context io_service;
   MockWaiter waiter;
   MockTaskEventBuffer task_event_buffer;
+
+  std::promise<void> attempt_1_start_promise;
+  std::promise<void> attempt_1_finish_promise;
+  std::promise<void> attempt_2_start_promise;
+  int n_rej = 0;
+  // The per-attempt behavior is dispatched on the task's attempt number.
+  auto fn_ok = [&attempt_1_start_promise,
+                &attempt_1_finish_promise,
+                &attempt_2_start_promise](TaskToExecute &task) {
+    if (task.TaskSpec().AttemptNumber() == 1) {
+      attempt_1_start_promise.set_value();
+      attempt_1_finish_promise.get_future().wait();
+    } else {
+      attempt_2_start_promise.set_value();
+    }
+  };
+  auto fn_rej = [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; };
+
   UnorderedActorTaskExecutionQueue queue(
       io_service,
       waiter,
@@ -652,36 +681,23 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
       /*fiber_state_manager=*/nullptr,
       /*is_asyncio=*/false,
       /*fiber_max_concurrency=*/1,
-      /*concurrency_groups=*/{});
+      /*concurrency_groups=*/{},
+      fn_ok,
+      fn_rej);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id = TaskID::FromRandom(job_id);
 
-  std::promise<void> attempt_1_start_promise;
-  std::promise<void> attempt_1_finish_promise;
-  auto fn_ok_1 = [&attempt_1_start_promise,
-                  &attempt_1_finish_promise](const TaskSpecification &task_spec) {
-    attempt_1_start_promise.set_value();
-    attempt_1_finish_promise.get_future().wait();
-  };
-  std::promise<void> attempt_2_start_promise;
-  auto fn_ok_2 = [&attempt_2_start_promise](const TaskSpecification &task_spec) {
-    attempt_2_start_promise.set_value();
-  };
-  int n_rej = 0;
-  auto fn_rej = [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-    n_rej++;
-  };
   TaskSpecification task_spec_1;
   task_spec_1.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_1.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_1.GetMutableMessage().set_attempt_number(1);
-  queue.EnqueueTask(-1, -1, TaskToExecute(fn_ok_1, fn_rej, task_spec_1));
+  queue.EnqueueTask(-1, -1, MakeTask(task_spec_1));
   attempt_1_start_promise.get_future().wait();
   TaskSpecification task_spec_2;
   task_spec_2.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_2.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_2.GetMutableMessage().set_attempt_number(2);
-  queue.EnqueueTask(-1, -1, TaskToExecute(fn_ok_2, fn_rej, task_spec_2));
+  queue.EnqueueTask(-1, -1, MakeTask(task_spec_2));
   io_service.poll();
   // Attempt 2 should only start after attempt 1 finishes.
   auto attempt_2_start_future = attempt_2_start_promise.get_future();
@@ -709,6 +725,41 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
   instrumented_io_context io_service;
   MockWaiter waiter;
   MockTaskEventBuffer task_event_buffer;
+
+  std::promise<void> attempt_1_start_promise;
+  std::promise<void> attempt_1_finish_promise;
+  std::atomic<bool> attempt_2_cancelled = false;
+  std::atomic<bool> attempt_3_cancelled = false;
+  std::atomic<bool> attempt_4_cancelled = false;
+  // Only attempt 1 ever executes; all other attempts are expected to be cancelled. The
+  // per-attempt behavior is dispatched on the task's attempt number.
+  auto fn_ok = [&attempt_1_start_promise,
+                &attempt_1_finish_promise](TaskToExecute &task) {
+    if (task.TaskSpec().AttemptNumber() == 1) {
+      attempt_1_start_promise.set_value();
+      attempt_1_finish_promise.get_future().wait();
+    } else {
+      FAIL() << "Unexpected execution of attempt " << task.TaskSpec().AttemptNumber();
+    }
+  };
+  auto fn_rej = [&attempt_2_cancelled, &attempt_3_cancelled, &attempt_4_cancelled](
+                    const TaskToExecute &task, const Status &status) {
+    ASSERT_TRUE(status.IsSchedulingCancelled());
+    switch (task.TaskSpec().AttemptNumber()) {
+    case 2:
+      attempt_2_cancelled.store(true);
+      break;
+    case 3:
+      attempt_3_cancelled.store(true);
+      break;
+    case 4:
+      attempt_4_cancelled.store(true);
+      break;
+    default:
+      FAIL() << "Unexpected cancellation of attempt " << task.TaskSpec().AttemptNumber();
+    }
+  };
+
   UnorderedActorTaskExecutionQueue queue(
       io_service,
       waiter,
@@ -719,69 +770,40 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
       /*fiber_state_manager=*/nullptr,
       /*is_asyncio=*/false,
       /*fiber_max_concurrency=*/1,
-      /*concurrency_groups=*/{});
+      /*concurrency_groups=*/{},
+      fn_ok,
+      fn_rej);
   JobID job_id = JobID::FromInt(1);
   TaskID task_id = TaskID::FromRandom(job_id);
 
-  std::promise<void> attempt_1_start_promise;
-  std::promise<void> attempt_1_finish_promise;
-  auto fn_ok_1 = [&attempt_1_start_promise,
-                  &attempt_1_finish_promise](const TaskSpecification &task_spec) {
-    attempt_1_start_promise.set_value();
-    attempt_1_finish_promise.get_future().wait();
-  };
-  auto fn_rej_1 = [](const TaskSpecification &task_spec, const Status &status) {
-    ASSERT_FALSE(true);
-  };
   TaskSpecification task_spec_1;
   task_spec_1.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_1.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_1.GetMutableMessage().set_attempt_number(1);
-  queue.EnqueueTask(-1, -1, TaskToExecute(fn_ok_1, fn_rej_1, task_spec_1));
+  queue.EnqueueTask(-1, -1, MakeTask(task_spec_1));
   attempt_1_start_promise.get_future().wait();
 
-  auto fn_ok_2 = [](const TaskSpecification &task_spec) { ASSERT_FALSE(true); };
-  std::atomic<bool> attempt_2_cancelled = false;
-  auto fn_rej_2 = [&attempt_2_cancelled](const TaskSpecification &task_spec,
-                                         const Status &status) {
-    ASSERT_TRUE(status.IsSchedulingCancelled());
-    attempt_2_cancelled.store(true);
-  };
   TaskSpecification task_spec_2;
   task_spec_2.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_2.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_2.GetMutableMessage().set_attempt_number(2);
-  queue.EnqueueTask(-1, -1, TaskToExecute(fn_ok_2, fn_rej_2, task_spec_2));
+  queue.EnqueueTask(-1, -1, MakeTask(task_spec_2));
 
-  auto fn_ok_4 = [](const TaskSpecification &task_spec) { ASSERT_FALSE(true); };
-  std::atomic<bool> attempt_4_cancelled = false;
-  auto fn_rej_4 = [&attempt_4_cancelled](const TaskSpecification &task_spec,
-                                         const Status &status) {
-    ASSERT_TRUE(status.IsSchedulingCancelled());
-    attempt_4_cancelled.store(true);
-  };
   // Adding attempt 4 should cancel the old attempt 2
   TaskSpecification task_spec_4;
   task_spec_4.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_4.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_4.GetMutableMessage().set_attempt_number(4);
-  queue.EnqueueTask(-1, -1, TaskToExecute(fn_ok_4, fn_rej_4, task_spec_4));
+  queue.EnqueueTask(-1, -1, MakeTask(task_spec_4));
   ASSERT_TRUE(attempt_2_cancelled.load());
 
-  auto fn_ok_3 = [](const TaskSpecification &task_spec) { ASSERT_FALSE(true); };
-  std::atomic<bool> attempt_3_cancelled = false;
-  auto fn_rej_3 = [&attempt_3_cancelled](const TaskSpecification &task_spec,
-                                         const Status &status) {
-    ASSERT_TRUE(status.IsSchedulingCancelled());
-    attempt_3_cancelled.store(true);
-  };
   // Attempt 3 should be cancelled immediately since there is attempt 4
   // in the queue.
   TaskSpecification task_spec_3;
   task_spec_3.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_3.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_3.GetMutableMessage().set_attempt_number(3);
-  queue.EnqueueTask(-1, -1, TaskToExecute(fn_ok_3, fn_rej_3, task_spec_3));
+  queue.EnqueueTask(-1, -1, MakeTask(task_spec_3));
   ASSERT_TRUE(attempt_3_cancelled.load());
 
   // Attempt 4 should be cancelled.

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -97,9 +97,8 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
 
 namespace {
 
-// Construct a TaskToExecute container for tests. The per-task execute/cancel behavior is
-// supplied to the queue at construction time (not per task), so the container only needs
-// to carry the task spec. The reply and send_reply_callback are dummy implementations
+// Construct a TaskToExecute container for tests. The reply and
+// send_reply_callback are dummy implementations
 // that are never inspected by the tests' queue-level callbacks.
 TaskToExecute MakeTaskToExecute(const TaskSpecification &task_spec) {
   static rpc::PushTaskReply dummy_reply;

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -99,12 +99,15 @@ namespace {
 
 // Construct a TaskToExecute container for tests. The per-task execute/cancel behavior is
 // supplied to the queue at construction time (not per task), so the container only needs
-// to carry the task spec.
-TaskToExecute MakeTask(const TaskSpecification &task_spec) {
-  return TaskToExecute(task_spec,
-                       /*resource_ids=*/std::nullopt,
-                       /*reply=*/nullptr,
-                       /*send_reply_callback=*/nullptr);
+// to carry the task spec. The reply and send_reply_callback are dummy implementations
+// that are never inspected by the tests' queue-level callbacks.
+TaskToExecute MakeTaskToExecute(const TaskSpecification &task_spec) {
+  static rpc::PushTaskReply dummy_reply;
+  return TaskToExecute(
+      task_spec,
+      /*resource_ids=*/std::nullopt,
+      &dummy_reply,
+      [](const Status &, std::function<void()>, std::function<void()>) {});
 }
 
 }  // namespace
@@ -136,7 +139,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_without_dependency.GetMutableMessage().set_enable_task_events(true);
 
-  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec_without_dependency));
   ASSERT_EQ(task_event_buffer.task_events.size(), 1UL);
   rpc::TaskEvents rpc_task_events;
   task_event_buffer.task_events[0]->ToRpcTaskEvents(&rpc_task_events);
@@ -156,7 +159,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestTaskEvents) {
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(ObjectID::FromRandom().Binary());
-  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_spec_with_dependency));
   waiter.Complete(0);
   ASSERT_EQ(task_event_buffer.task_events.size(), 3UL);
   task_event_buffer.task_events[1]->ToRpcTaskEvents(&rpc_task_events);
@@ -202,10 +205,10 @@ TEST(OrderedActorTaskExecutionQueueTest, TestInOrder) {
       io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  queue.EnqueueTask(0, -1, MakeTask(task_spec));
-  queue.EnqueueTask(1, -1, MakeTask(task_spec));
-  queue.EnqueueTask(2, -1, MakeTask(task_spec));
-  queue.EnqueueTask(3, -1, MakeTask(task_spec));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(2, -1, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(3, -1, MakeTaskToExecute(task_spec));
   io_service.run();
 
   // Wait for all tasks to finish.
@@ -253,14 +256,14 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
   TaskSpecification ts;
   ts.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   // Enqueue a running task and a queued task.
-  queue.EnqueueTask(0, -1, MakeTask(ts));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(ts));
   // Make the queued task have a dependency so it stays queued and will be cancelled by
   // Stop().
   TaskSpecification ts_dep;
   ts_dep.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   ts_dep.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
       ObjectID::FromRandom().Binary());
-  queue.EnqueueTask(1, -1, MakeTask(ts_dep));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(ts_dep));
   io_service.poll();
   running_started.get_future().wait();
 
@@ -299,10 +302,10 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(obj.Binary());
-  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
-  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
-  queue.EnqueueTask(2, -1, MakeTask(task_spec_with_dependency));
-  queue.EnqueueTask(3, -1, MakeTask(task_spec_with_dependency));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec_without_dependency));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_spec_with_dependency));
+  queue.EnqueueTask(2, -1, MakeTaskToExecute(task_spec_with_dependency));
+  queue.EnqueueTask(3, -1, MakeTaskToExecute(task_spec_with_dependency));
 
   ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
 
@@ -350,8 +353,8 @@ TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjectsNotSubjectToSeqTimeou
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(obj.Binary());
-  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
-  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec_without_dependency));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_spec_with_dependency));
 
   ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
   io_service.run();
@@ -387,16 +390,16 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSeqWaitTimeout) {
       io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  queue.EnqueueTask(2, -1, MakeTask(task_spec));
-  queue.EnqueueTask(0, -1, MakeTask(task_spec));
-  queue.EnqueueTask(3, -1, MakeTask(task_spec));
+  queue.EnqueueTask(2, -1, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(3, -1, MakeTaskToExecute(task_spec));
   ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
   ASSERT_EQ(n_canceled, 0);
   io_service.run();
   ASSERT_TRUE(WaitForCondition([&n_executed]() { return n_executed == 1; }, 1000));
   ASSERT_TRUE(WaitForCondition([&n_canceled]() { return n_canceled == 2; }, 1000));
-  queue.EnqueueTask(4, -1, MakeTask(task_spec));
-  queue.EnqueueTask(5, -1, MakeTask(task_spec));
+  queue.EnqueueTask(4, -1, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(5, -1, MakeTaskToExecute(task_spec));
 
   // Wait for all tasks to finish.
   auto default_executor = pool_manager->GetDefaultExecutor();
@@ -428,9 +431,9 @@ TEST(OrderedActorTaskExecutionQueueTest, TestSkipAlreadyProcessedByClient) {
       io_service, waiter, task_event_buffer, pool_manager, 1, execute_task, cancel_task);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  queue.EnqueueTask(2, 2, MakeTask(task_spec));
-  queue.EnqueueTask(3, 2, MakeTask(task_spec));
-  queue.EnqueueTask(1, 2, MakeTask(task_spec));
+  queue.EnqueueTask(2, 2, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(3, 2, MakeTaskToExecute(task_spec));
+  queue.EnqueueTask(1, 2, MakeTaskToExecute(task_spec));
   io_service.run();
 
   // Wait for all tasks to finish.
@@ -492,15 +495,15 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
   // 3 (retry of 2) should get executed. Then, 4 should be executed. Then 6 (retry of 5)
   // once the dependency is fetched.
   auto task_spec_0 = CreateActorTaskSpec(0, /*is_retry=*/false, /*dependency=*/true);
-  queue.EnqueueTask(0, -1, MakeTask(task_spec_0));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec_0));
   auto task_spec_1 = CreateActorTaskSpec(1);
-  queue.EnqueueTask(1, -1, MakeTask(task_spec_1));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_spec_1));
   auto task_spec_2_retry = CreateActorTaskSpec(3, /*is_retry=*/true);
-  queue.EnqueueTask(3, -1, MakeTask(task_spec_2_retry));
+  queue.EnqueueTask(3, -1, MakeTaskToExecute(task_spec_2_retry));
   auto task_spec_4 = CreateActorTaskSpec(4);
-  queue.EnqueueTask(4, 2, MakeTask(task_spec_4));
+  queue.EnqueueTask(4, 2, MakeTaskToExecute(task_spec_4));
   auto task_spec_5_retry = CreateActorTaskSpec(6, /*is_retry=*/true, /*dependency=*/true);
-  queue.EnqueueTask(6, -1, MakeTask(task_spec_5_retry));
+  queue.EnqueueTask(6, -1, MakeTaskToExecute(task_spec_5_retry));
 
   io_service.run();
 
@@ -555,9 +558,9 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
 
   // Sequence no 0 missing from group a, so that should block until 1 arrives.
   // Concurrency group b should be ready to go though.
-  queue.EnqueueTask(1, -1, MakeTask(task_a1));
-  queue.EnqueueTask(0, -1, MakeTask(task_b0));
-  queue.EnqueueTask(1, -1, MakeTask(task_b1));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_a1));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_b0));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_b1));
 
   io_service.run_one();
   io_service.run_one();
@@ -565,7 +568,7 @@ TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
   ASSERT_EQ(n_accept, 2);
 
   // Now enqueue group "a" seq 0, which unblocks group "a".
-  queue.EnqueueTask(0, -1, MakeTask(task_a0));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_a0));
   io_service.run_one();
   io_service.run_one();
   ASSERT_TRUE(WaitForCondition([&n_accept]() { return n_accept == 4; }, 1000));
@@ -616,7 +619,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
   task_spec_without_dependency.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_without_dependency.GetMutableMessage().set_enable_task_events(true);
 
-  queue.EnqueueTask(0, -1, MakeTask(task_spec_without_dependency));
+  queue.EnqueueTask(0, -1, MakeTaskToExecute(task_spec_without_dependency));
   ASSERT_EQ(task_event_buffer.task_events.size(), 1UL);
   rpc::TaskEvents rpc_task_events;
   task_event_buffer.task_events[0]->ToRpcTaskEvents(&rpc_task_events);
@@ -636,7 +639,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestTaskEvents) {
       .add_args()
       ->mutable_object_ref()
       ->set_object_id(ObjectID::FromRandom().Binary());
-  queue.EnqueueTask(1, -1, MakeTask(task_spec_with_dependency));
+  queue.EnqueueTask(1, -1, MakeTaskToExecute(task_spec_with_dependency));
   waiter.Complete(0);
   ASSERT_EQ(task_event_buffer.task_events.size(), 3UL);
   task_event_buffer.task_events[1]->ToRpcTaskEvents(&rpc_task_events);
@@ -708,13 +711,13 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttempts) {
   task_spec_1.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_1.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_1.GetMutableMessage().set_attempt_number(1);
-  queue.EnqueueTask(-1, -1, MakeTask(task_spec_1));
+  queue.EnqueueTask(-1, -1, MakeTaskToExecute(task_spec_1));
   attempt_1_start_promise.get_future().wait();
   TaskSpecification task_spec_2;
   task_spec_2.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_2.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_2.GetMutableMessage().set_attempt_number(2);
-  queue.EnqueueTask(-1, -1, MakeTask(task_spec_2));
+  queue.EnqueueTask(-1, -1, MakeTaskToExecute(task_spec_2));
   io_service.poll();
   // Attempt 2 should only start after attempt 1 finishes.
   auto attempt_2_start_future = attempt_2_start_promise.get_future();
@@ -797,21 +800,21 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
   task_spec_1.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_1.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_1.GetMutableMessage().set_attempt_number(1);
-  queue.EnqueueTask(-1, -1, MakeTask(task_spec_1));
+  queue.EnqueueTask(-1, -1, MakeTaskToExecute(task_spec_1));
   attempt_1_start_promise.get_future().wait();
 
   TaskSpecification task_spec_2;
   task_spec_2.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_2.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_2.GetMutableMessage().set_attempt_number(2);
-  queue.EnqueueTask(-1, -1, MakeTask(task_spec_2));
+  queue.EnqueueTask(-1, -1, MakeTaskToExecute(task_spec_2));
 
   // Adding attempt 4 should cancel the old attempt 2
   TaskSpecification task_spec_4;
   task_spec_4.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_4.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_4.GetMutableMessage().set_attempt_number(4);
-  queue.EnqueueTask(-1, -1, MakeTask(task_spec_4));
+  queue.EnqueueTask(-1, -1, MakeTaskToExecute(task_spec_4));
   ASSERT_TRUE(attempt_2_cancelled.load());
 
   // Attempt 3 should be cancelled immediately since there is attempt 4
@@ -820,7 +823,7 @@ TEST(UnorderedActorTaskExecutionQueueTest, TestSameTaskMultipleAttemptsCancellat
   task_spec_3.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
   task_spec_3.GetMutableMessage().set_task_id(task_id.Binary());
   task_spec_3.GetMutableMessage().set_attempt_number(3);
-  queue.EnqueueTask(-1, -1, MakeTask(task_spec_3));
+  queue.EnqueueTask(-1, -1, MakeTaskToExecute(task_spec_3));
   ASSERT_TRUE(attempt_3_cancelled.load());
 
   // Attempt 4 should be cancelled.

--- a/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
@@ -25,6 +25,23 @@
 namespace ray {
 namespace core {
 
+namespace {
+
+// Construct a TaskToExecute container for tests. The per-task execute/cancel behavior is
+// supplied to the queue at construction time (not per task), so the container only needs
+// to carry the task spec. The reply and send_reply_callback are dummy implementations
+// that are never inspected by the tests' queue-level callbacks.
+TaskToExecute MakeTaskToExecute(const TaskSpecification &task_spec) {
+  static rpc::PushTaskReply dummy_reply;
+  return TaskToExecute(
+      task_spec,
+      /*resource_ids=*/std::nullopt,
+      &dummy_reply,
+      [](const Status &, std::function<void()>, std::function<void()>) {});
+}
+
+}  // namespace
+
 TEST(NormalTaskExecutionQueueTest, TestCancelQueuedTask) {
   int n_executed = 0;
   int n_canceled = 0;
@@ -38,10 +55,7 @@ TEST(NormalTaskExecutionQueueTest, TestCancelQueuedTask) {
 
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::NORMAL_TASK);
-  TaskToExecute task = TaskToExecute(task_spec,
-                                     /*resource_ids=*/std::nullopt,
-                                     /*reply=*/nullptr,
-                                     /*send_reply_callback=*/nullptr);
+  TaskToExecute task = MakeTaskToExecute(task_spec);
 
   queue->EnqueueTask(task);
   queue->EnqueueTask(task);
@@ -70,10 +84,7 @@ TEST(NormalTaskExecutionQueueTest, StopCancelsQueuedTasks) {
 
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::NORMAL_TASK);
-  TaskToExecute task = TaskToExecute(task_spec,
-                                     /*resource_ids=*/std::nullopt,
-                                     /*reply=*/nullptr,
-                                     /*send_reply_callback=*/nullptr);
+  TaskToExecute task = MakeTaskToExecute(task_spec);
 
   // Enqueue several normal tasks but do not schedule them.
   queue->EnqueueTask(task);

--- a/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
@@ -26,13 +26,15 @@ namespace ray {
 namespace core {
 
 TEST(NormalTaskExecutionQueueTest, TestCancelQueuedTask) {
-  int n_ok = 0;
-  int n_rej = 0;
+  int n_executed = 0;
+  int n_canceled = 0;
 
   std::unique_ptr<NormalTaskExecutionQueue> queue =
       std::make_unique<NormalTaskExecutionQueue>(
-          [&n_ok](TaskToExecute &task) { n_ok++; },
-          [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; });
+          [&n_executed](TaskToExecute &task) { n_executed++; },
+          [&n_canceled](const TaskToExecute &task, const Status &status) {
+            n_canceled++;
+          });
 
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::NORMAL_TASK);
@@ -48,22 +50,22 @@ TEST(NormalTaskExecutionQueueTest, TestCancelQueuedTask) {
   queue->EnqueueTask(task);
   ASSERT_TRUE(queue->CancelTaskIfFound(TaskID::Nil()));
   queue->ExecuteQueuedTasks();
-  ASSERT_EQ(n_ok, 4);
-  ASSERT_EQ(n_rej, 1);
+  ASSERT_EQ(n_executed, 4);
+  ASSERT_EQ(n_canceled, 1);
 
   queue->Stop();
 }
 
 TEST(NormalTaskExecutionQueueTest, StopCancelsQueuedTasks) {
-  int n_ok = 0;
-  std::atomic<int> n_rej{0};
+  int n_executed = 0;
+  std::atomic<int> n_canceled{0};
 
   std::unique_ptr<NormalTaskExecutionQueue> queue =
       std::make_unique<NormalTaskExecutionQueue>(
-          [&n_ok](TaskToExecute &task) { n_ok++; },
-          [&n_rej](const TaskToExecute &task, const Status &status) {
+          [&n_executed](TaskToExecute &task) { n_executed++; },
+          [&n_canceled](const TaskToExecute &task, const Status &status) {
             ASSERT_TRUE(status.IsSchedulingCancelled());
-            n_rej.fetch_add(1);
+            n_canceled.fetch_add(1);
           });
 
   TaskSpecification task_spec;
@@ -81,8 +83,8 @@ TEST(NormalTaskExecutionQueueTest, StopCancelsQueuedTasks) {
   // Stopping should cancel all queued tasks without running them.
   queue->Stop();
 
-  ASSERT_EQ(n_ok, 0);
-  ASSERT_EQ(n_rej.load(), 3);
+  ASSERT_EQ(n_executed, 0);
+  ASSERT_EQ(n_canceled.load(), 3);
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 
 #include "gtest/gtest.h"
 #include "ray/common/status.h"
@@ -25,18 +26,20 @@ namespace ray {
 namespace core {
 
 TEST(NormalTaskExecutionQueueTest, TestCancelQueuedTask) {
-  std::unique_ptr<NormalTaskExecutionQueue> queue =
-      std::make_unique<NormalTaskExecutionQueue>();
-
   int n_ok = 0;
   int n_rej = 0;
 
+  std::unique_ptr<NormalTaskExecutionQueue> queue =
+      std::make_unique<NormalTaskExecutionQueue>(
+          [&n_ok](TaskToExecute &task) { n_ok++; },
+          [&n_rej](const TaskToExecute &task, const Status &status) { n_rej++; });
+
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::NORMAL_TASK);
-  TaskToExecute task = TaskToExecute(
-      [&n_ok](const TaskSpecification &task_spec) { n_ok++; },
-      [&n_rej](const TaskSpecification &task_spec, const Status &status) { n_rej++; },
-      task_spec);
+  TaskToExecute task = TaskToExecute(task_spec,
+                                     /*resource_ids=*/std::nullopt,
+                                     /*reply=*/nullptr,
+                                     /*send_reply_callback=*/nullptr);
 
   queue->EnqueueTask(task);
   queue->EnqueueTask(task);
@@ -52,21 +55,23 @@ TEST(NormalTaskExecutionQueueTest, TestCancelQueuedTask) {
 }
 
 TEST(NormalTaskExecutionQueueTest, StopCancelsQueuedTasks) {
-  std::unique_ptr<NormalTaskExecutionQueue> queue =
-      std::make_unique<NormalTaskExecutionQueue>();
-
   int n_ok = 0;
   std::atomic<int> n_rej{0};
 
+  std::unique_ptr<NormalTaskExecutionQueue> queue =
+      std::make_unique<NormalTaskExecutionQueue>(
+          [&n_ok](TaskToExecute &task) { n_ok++; },
+          [&n_rej](const TaskToExecute &task, const Status &status) {
+            ASSERT_TRUE(status.IsSchedulingCancelled());
+            n_rej.fetch_add(1);
+          });
+
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().set_type(TaskType::NORMAL_TASK);
-  TaskToExecute task =
-      TaskToExecute([&n_ok](const TaskSpecification &task_spec) { n_ok++; },
-                    [&n_rej](const TaskSpecification &task_spec, const Status &status) {
-                      ASSERT_TRUE(status.IsSchedulingCancelled());
-                      n_rej.fetch_add(1);
-                    },
-                    task_spec);
+  TaskToExecute task = TaskToExecute(task_spec,
+                                     /*resource_ids=*/std::nullopt,
+                                     /*reply=*/nullptr,
+                                     /*send_reply_callback=*/nullptr);
 
   // Enqueue several normal tasks but do not schedule them.
   queue->EnqueueTask(task);

--- a/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/normal_task_execution_queue_test.cc
@@ -27,9 +27,8 @@ namespace core {
 
 namespace {
 
-// Construct a TaskToExecute container for tests. The per-task execute/cancel behavior is
-// supplied to the queue at construction time (not per task), so the container only needs
-// to carry the task spec. The reply and send_reply_callback are dummy implementations
+// Construct a TaskToExecute container for tests. The reply and
+// send_reply_callback are dummy implementations
 // that are never inspected by the tests' queue-level callbacks.
 TaskToExecute MakeTaskToExecute(const TaskSpecification &task_spec) {
   static rpc::PushTaskReply dummy_reply;

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.cc
@@ -33,13 +33,17 @@ UnorderedActorTaskExecutionQueue::UnorderedActorTaskExecutionQueue(
     std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager,
     bool is_asyncio,
     int fiber_max_concurrency,
-    const std::vector<ConcurrencyGroup> &concurrency_groups)
+    const std::vector<ConcurrencyGroup> &concurrency_groups,
+    ExecuteTaskCallback execute_task,
+    CancelTaskCallback cancel_task)
     : task_execution_service_(task_execution_service),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),
       pool_manager_(pool_manager),
       fiber_state_manager_(fiber_state_manager),
+      execute_task_(std::move(execute_task)),
+      cancel_task_(std::move(cancel_task)),
       is_asyncio_(is_asyncio) {
   if (is_asyncio_) {
     std::stringstream ss;
@@ -60,7 +64,7 @@ void UnorderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &m
 
   while (!queued_actor_tasks_.empty()) {
     auto it = queued_actor_tasks_.begin();
-    it->second.Cancel(status);
+    cancel_task_(it->second, status);
     pending_task_id_to_is_canceled.erase(it->first);
     queued_actor_tasks_.erase(it);
   }
@@ -124,8 +128,9 @@ void UnorderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   }
 
   if (task_to_cancel.has_value()) {
-    task_to_cancel->Cancel(Status::SchedulingCancelled(
-        "In favor of the same task with larger attempt number"));
+    cancel_task_(*task_to_cancel,
+                 Status::SchedulingCancelled(
+                     "In favor of the same task with larger attempt number"));
   }
 }
 
@@ -220,10 +225,10 @@ void UnorderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
 
   // Accept can be very long, and we shouldn't hold a lock.
   if (is_canceled) {
-    request.Cancel(
-        Status::SchedulingCancelled("Task is canceled before it is scheduled."));
+    cancel_task_(request,
+                 Status::SchedulingCancelled("Task is canceled before it is scheduled."));
   } else {
-    request.Execute();
+    execute_task_(request);
   }
 
   std::optional<TaskToExecute> request_to_run;

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -47,7 +47,9 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
       std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager,
       bool is_asyncio,
       int fiber_max_concurrency,
-      const std::vector<ConcurrencyGroup> &concurrency_groups);
+      const std::vector<ConcurrencyGroup> &concurrency_groups,
+      ExecuteTaskCallback execute_task,
+      CancelTaskCallback cancel_task);
 
   void Stop() override;
 
@@ -82,6 +84,9 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
   /// Manage the running fiber states of actors in this worker. It works with
   /// python asyncio if this is an asyncio actor.
   std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager_;
+  /// Callbacks used to execute / reply-cancel a queued task.
+  ExecuteTaskCallback execute_task_;
+  CancelTaskCallback cancel_task_;
   /// Whether we should enqueue requests into asyncio pool. Setting this to true
   /// will instantiate all tasks as fibers that can be yielded.
   bool is_asyncio_ = false;

--- a/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/unordered_actor_task_execution_queue.h
@@ -84,7 +84,7 @@ class UnorderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface
   /// Manage the running fiber states of actors in this worker. It works with
   /// python asyncio if this is an asyncio actor.
   std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager_;
-  /// Callbacks used to execute / reply-cancel a queued task.
+  /// Callbacks used to execute a queued task or reply that it's canceled.
   ExecuteTaskCallback execute_task_;
   CancelTaskCallback cancel_task_;
   /// Whether we should enqueue requests into asyncio pool. Setting this to true


### PR DESCRIPTION
Trying to incrementally reduce the callback mania.

Previously we captured some dynamic fields to generate the `Execute` and `Cancel` callbacks in the task definition. This PR removes the last such capture and makes the `TaskToExecute` a data class instead.