### PR TITLE
[Data] [Core] [3/n] Wire BlockRefCounter into Operators

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -24,6 +24,7 @@ from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import (
     ActorPoolInfo,
     AutoscalingActorPool,
 )
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
     ExecutionResources,
@@ -134,6 +135,8 @@ class DataOpTask(OpTask):
         self,
         task_index: int,
         streaming_gen: ObjectRefGenerator,
+        block_ref_counter: BlockRefCounter,
+        producer_id: str,
         output_ready_callback: Callable[[RefBundle], None] = lambda bundle: None,
         task_done_callback: TaskDoneCallbackType = lambda exc, worker_stats, driver_stats: None,
         block_ready_callback: Callable[
@@ -149,6 +152,9 @@ class DataOpTask(OpTask):
         Args:
             task_index: Index of the task. Used for callbacks.
             streaming_gen: The streaming generator of this task. It should yield blocks.
+            block_ref_counter: The centralized block reference counter. on_block_produced
+                is called for each block yielded by this task.
+            producer_id: The id of the operator that produces the blocks from this task.
             output_ready_callback: The callback to call when a new RefBundle is output
                 from the generator.
             task_done_callback: The callback to call when the task is done.
@@ -171,6 +177,8 @@ class DataOpTask(OpTask):
         self._block_ready_callback = block_ready_callback
         self._metadata_ready_callback = metadata_ready_callback
         self._operator_name = operator_name
+        self._block_ref_counter: BlockRefCounter = block_ref_counter
+        self._producer_id: str = producer_id
 
         # If the generator hasn't produced block metadata yet, or if the block metadata
         # object isn't available after we get a reference, we need store the pending
@@ -307,6 +315,9 @@ class DataOpTask(OpTask):
                 meta_with_schema_bytes
             )
             meta = meta_with_schema.metadata
+            self._block_ref_counter.on_block_produced(
+                self._pending_block_ref, meta.size_bytes or 0, self._producer_id
+            )
             self._output_ready_callback(
                 RefBundle(
                     [BlockEntry(self._pending_block_ref, meta)],
@@ -459,6 +470,7 @@ class PhysicalOperator(Operator):
         self._id = str(uuid.uuid4())
         # Initialize metrics after data_context is set
         self._metrics = OpRuntimeMetrics(self)
+        self._block_ref_counter: Optional[BlockRefCounter] = None
 
     def __reduce__(self):
         raise ValueError("Operator is not serializable.")
@@ -758,12 +770,21 @@ class PhysicalOperator(Operator):
         """
         return self._num_output_splits
 
-    def start(self, options: ExecutionOptions) -> None:
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional[BlockRefCounter] = None,
+    ) -> None:
         """Called by the executor when execution starts for an operator.
 
         Args:
             options: The global options used for the overall execution.
+            block_ref_counter: The executor-wide shared counter for tracking
+                object-store memory. If omitted, a fresh per-operator counter is used.
         """
+        self._block_ref_counter = (
+            block_ref_counter if block_ref_counter is not None else BlockRefCounter()
+        )
         self._started = True
 
     def can_add_input(self) -> bool:

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -135,7 +135,7 @@ class DataOpTask(OpTask):
         self,
         task_index: int,
         streaming_gen: ObjectRefGenerator,
-        block_ref_counter: Optional[BlockRefCounter],
+        block_ref_counter: BlockRefCounter,
         producer_id: str,
         output_ready_callback: Callable[[RefBundle], None] = lambda bundle: None,
         task_done_callback: TaskDoneCallbackType = lambda exc, worker_stats, driver_stats: None,
@@ -177,7 +177,7 @@ class DataOpTask(OpTask):
         self._block_ready_callback = block_ready_callback
         self._metadata_ready_callback = metadata_ready_callback
         self._operator_name = operator_name
-        self._block_ref_counter: Optional[BlockRefCounter] = block_ref_counter
+        self._block_ref_counter: BlockRefCounter = block_ref_counter
         self._producer_id: str = producer_id
 
         # If the generator hasn't produced block metadata yet, or if the block metadata
@@ -315,10 +315,9 @@ class DataOpTask(OpTask):
                 meta_with_schema_bytes
             )
             meta = meta_with_schema.metadata
-            if self._block_ref_counter is not None:
-                self._block_ref_counter.on_block_produced(
-                    self._pending_block_ref, meta.size_bytes or 0, self._producer_id
-                )
+            self._block_ref_counter.on_block_produced(
+                self._pending_block_ref, meta.size_bytes or 0, self._producer_id
+            )
             self._output_ready_callback(
                 RefBundle(
                     [BlockEntry(self._pending_block_ref, meta)],
@@ -774,7 +773,7 @@ class PhysicalOperator(Operator):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional[BlockRefCounter] = None,
+        block_ref_counter: BlockRefCounter,
     ) -> None:
         """Called by the executor when execution starts for an operator.
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -135,7 +135,7 @@ class DataOpTask(OpTask):
         self,
         task_index: int,
         streaming_gen: ObjectRefGenerator,
-        block_ref_counter: BlockRefCounter,
+        block_ref_counter: Optional[BlockRefCounter],
         producer_id: str,
         output_ready_callback: Callable[[RefBundle], None] = lambda bundle: None,
         task_done_callback: TaskDoneCallbackType = lambda exc, worker_stats, driver_stats: None,
@@ -177,7 +177,7 @@ class DataOpTask(OpTask):
         self._block_ready_callback = block_ready_callback
         self._metadata_ready_callback = metadata_ready_callback
         self._operator_name = operator_name
-        self._block_ref_counter: BlockRefCounter = block_ref_counter
+        self._block_ref_counter: Optional[BlockRefCounter] = block_ref_counter
         self._producer_id: str = producer_id
 
         # If the generator hasn't produced block metadata yet, or if the block metadata
@@ -315,9 +315,10 @@ class DataOpTask(OpTask):
                 meta_with_schema_bytes
             )
             meta = meta_with_schema.metadata
-            self._block_ref_counter.on_block_produced(
-                self._pending_block_ref, meta.size_bytes or 0, self._producer_id
-            )
+            if self._block_ref_counter is not None:
+                self._block_ref_counter.on_block_produced(
+                    self._pending_block_ref, meta.size_bytes or 0, self._producer_id
+                )
             self._output_ready_callback(
                 RefBundle(
                     [BlockEntry(self._pending_block_ref, meta)],
@@ -780,11 +781,9 @@ class PhysicalOperator(Operator):
         Args:
             options: The global options used for the overall execution.
             block_ref_counter: The executor-wide shared counter for tracking
-                object-store memory. If omitted, a fresh per-operator counter is used.
+                object-store memory.
         """
-        self._block_ref_counter = (
-            block_ref_counter if block_ref_counter is not None else BlockRefCounter()
-        )
+        self._block_ref_counter = block_ref_counter
         self._started = True
 
     def can_add_input(self) -> bool:

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -470,7 +470,6 @@ class PhysicalOperator(Operator):
         self._id = str(uuid.uuid4())
         # Initialize metrics after data_context is set
         self._metrics = OpRuntimeMetrics(self)
-        self._block_ref_counter: Optional[BlockRefCounter] = None
 
     def __reduce__(self):
         raise ValueError("Operator is not serializable.")

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -265,9 +265,9 @@ class ActorPoolMapOperator(MapOperator):
 
         return ray_actor_task_remote_args
 
-    def start(self, options: ExecutionOptions):
+    def start(self, options: ExecutionOptions, block_ref_counter=None):
         self._actor_locality_enabled = options.actor_locality_enabled
-        super().start(options)
+        super().start(options, block_ref_counter)
 
         self._actor_cls = ray.remote(**self._ray_remote_args)(self._map_worker_cls)
         self._actor_pool.scale(

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -270,7 +270,7 @@ class ActorPoolMapOperator(MapOperator):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ):
         self._actor_locality_enabled = options.actor_locality_enabled
         super().start(options, block_ref_counter)

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -23,6 +23,8 @@ from typing_extensions import override
 
 if TYPE_CHECKING:
     import pyarrow as pa
+
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 import ray
 from ray.actor import ActorHandle
 from ray.core.generated import gcs_pb2
@@ -265,7 +267,11 @@ class ActorPoolMapOperator(MapOperator):
 
         return ray_actor_task_remote_args
 
-    def start(self, options: ExecutionOptions, block_ref_counter=None):
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ):
         self._actor_locality_enabled = options.actor_locality_enabled
         super().start(options, block_ref_counter)
 

--- a/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
+++ b/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
@@ -53,6 +53,9 @@ class AggregateNumRows(PhysicalOperator):
             [BlockEntry(block_ref, metadata)], owns_blocks=True, schema=schema
         )
 
+        self._block_ref_counter.on_block_produced(
+            block_ref, metadata.size_bytes or 0, self.id
+        )
         self._has_outputted = True
         return bundle
 

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -183,8 +183,22 @@ class AllToAllOperator(
         )
         # NOTE: We don't account object store memory use from intermediate `bulk_fn`
         # outputs (e.g., map outputs for map-reduce).
-        output_buffer, self._stats = self._bulk_fn(self._input_buffer.to_list(), ctx)
+
+        # Snapshot input refs before calling bulk_fn. Some bulk_fns (e.g.
+        # randomize_blocks) forward input ObjectRefs unchanged to the output.
+        # We only call on_block_produced for genuinely new refs to avoid
+        # double-counting; forwarded refs stay attributed to their original producer.
+        input_bundles = self._input_buffer.to_list()
+        input_refs = {entry.ref for bundle in input_bundles for entry in bundle.blocks}
+        output_buffer, self._stats = self._bulk_fn(input_bundles, ctx)
         self._output_buffer = FIFOBundleQueue(output_buffer)
+
+        for bundle in output_buffer:
+            for entry in bundle.blocks:
+                if entry.ref not in input_refs:
+                    self._block_ref_counter.on_block_produced(
+                        entry.ref, entry.metadata.size_bytes or 0, self.id
+                    )
 
         while self._input_buffer.has_next():
             refs = self._input_buffer.get_next()

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -193,12 +193,13 @@ class AllToAllOperator(
         output_buffer, self._stats = self._bulk_fn(input_bundles, ctx)
         self._output_buffer = FIFOBundleQueue(output_buffer)
 
-        for bundle in output_buffer:
-            for entry in bundle.blocks:
-                if entry.ref not in input_refs:
-                    self._block_ref_counter.on_block_produced(
-                        entry.ref, entry.metadata.size_bytes or 0, self.id
-                    )
+        if self._block_ref_counter is not None:
+            for bundle in output_buffer:
+                for entry in bundle.blocks:
+                    if entry.ref not in input_refs:
+                        self._block_ref_counter.on_block_produced(
+                            entry.ref, entry.metadata.size_bytes or 0, self.id
+                        )
 
         while self._input_buffer.has_next():
             refs = self._input_buffer.get_next()

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -184,22 +184,15 @@ class AllToAllOperator(
         # NOTE: We don't account object store memory use from intermediate `bulk_fn`
         # outputs (e.g., map outputs for map-reduce).
 
-        # Snapshot input refs before calling bulk_fn. Some bulk_fns (e.g.
-        # randomize_blocks) forward input ObjectRefs unchanged to the output.
-        # We only call on_block_produced for genuinely new refs to avoid
-        # double-counting; forwarded refs stay attributed to their original producer.
         input_bundles = self._input_buffer.to_list()
-        input_refs = {entry.ref for bundle in input_bundles for entry in bundle.blocks}
         output_buffer, self._stats = self._bulk_fn(input_bundles, ctx)
         self._output_buffer = FIFOBundleQueue(output_buffer)
 
-        if self._block_ref_counter is not None:
-            for bundle in output_buffer:
-                for entry in bundle.blocks:
-                    if entry.ref not in input_refs:
-                        self._block_ref_counter.on_block_produced(
-                            entry.ref, entry.metadata.size_bytes or 0, self.id
-                        )
+        for bundle in output_buffer:
+            for entry in bundle.blocks:
+                self._block_ref_counter.on_block_produced(
+                    entry.ref, entry.metadata.size_bytes or 0, self.id
+                )
 
         while self._input_buffer.has_next():
             refs = self._input_buffer.get_next()

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -80,6 +80,7 @@ from ray.data.context import (
 )
 
 if typing.TYPE_CHECKING:
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
     from ray.data._internal.progress.base_progress import BaseProgressBar
 
 logger = logging.getLogger(__name__)
@@ -673,7 +674,11 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         self._reduce_bar = None
         self._reduce_metrics = OpRuntimeMetrics(self)
 
-    def start(self, options: ExecutionOptions, block_ref_counter=None) -> None:
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ) -> None:
         super().start(options, block_ref_counter)
 
     @property

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -677,7 +677,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ) -> None:
         super().start(options, block_ref_counter)
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -673,8 +673,8 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         self._reduce_bar = None
         self._reduce_metrics = OpRuntimeMetrics(self)
 
-    def start(self, options: ExecutionOptions) -> None:
-        super().start(options)
+    def start(self, options: ExecutionOptions, block_ref_counter=None) -> None:
+        super().start(options, block_ref_counter)
 
     @property
     def shuffle_name(self) -> str:
@@ -1196,6 +1196,8 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                     ExecutionResources.from_resource_dict(finalize_task_resource_bundle)
                 ),
                 operator_name=self.name,
+                block_ref_counter=self._block_ref_counter,
+                producer_id=self.id,
             )
             self._finalizing_tasks[partition_id] = data_task
 

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -45,7 +45,7 @@ class InputDataBuffer(PhysicalOperator):
         self._input_data_index = 0
         self.mark_execution_finished()
 
-    def start(self, options: ExecutionOptions) -> None:
+    def start(self, options: ExecutionOptions, block_ref_counter=None) -> None:
         if not self._is_input_initialized:
             self._input_data = self._input_data_factory(
                 self.target_max_block_size_override
@@ -57,7 +57,7 @@ class InputDataBuffer(PhysicalOperator):
         # so we record input metrics here
         for bundle in self._input_data:
             self._metrics.on_input_received(bundle)
-        super().start(options)
+        super().start(options, block_ref_counter)
 
     def has_next(self) -> bool:
         return self._input_data_index < len(self._input_data)

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -51,7 +51,7 @@ class InputDataBuffer(PhysicalOperator):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ) -> None:
         if not self._is_input_initialized:
             self._input_data = self._input_data_factory(

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -1,4 +1,7 @@
-from typing import Callable, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+if TYPE_CHECKING:
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
@@ -45,7 +48,11 @@ class InputDataBuffer(PhysicalOperator):
         self._input_data_index = 0
         self.mark_execution_finished()
 
-    def start(self, options: ExecutionOptions, block_ref_counter=None) -> None:
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ) -> None:
         if not self._is_input_initialized:
             self._input_data = self._input_data_factory(
                 self.target_max_block_size_override

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -81,6 +81,10 @@ class LimitOperator(OneToOneOperator):
                 )
                 out_blocks.append(block)
                 metadata = ray.get(metadata_ref)
+                # Slicing creates a new block; register it for memory tracking.
+                self._block_ref_counter.on_block_produced(
+                    block, metadata.size_bytes or 0, self.id
+                )
                 out_metadata.append(metadata)
                 self._output_blocks_stats.append(metadata.to_stats())
                 self._consumed_rows = self._limit

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -490,7 +490,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def start(
         self,
         options: "ExecutionOptions",
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ):
         super().start(options, block_ref_counter)
         # Create output queue with desired ordering semantics.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -485,8 +485,8 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         else:
             raise ValueError(f"Unsupported execution strategy {compute_strategy}")
 
-    def start(self, options: "ExecutionOptions"):
-        super().start(options)
+    def start(self, options: "ExecutionOptions", block_ref_counter=None):
+        super().start(options, block_ref_counter)
         # Create output queue with desired ordering semantics.
         if options.preserve_order:
             self._output_queue = ReorderingBundleQueue()
@@ -659,8 +659,12 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         data_task = DataOpTask(
             task_index,
             gen,
-            lambda output: _output_ready_callback(task_index, output),
-            functools.partial(_task_done_callback, task_index),
+            self._block_ref_counter,
+            self.id,
+            output_ready_callback=lambda output: _output_ready_callback(
+                task_index, output
+            ),
+            task_done_callback=functools.partial(_task_done_callback, task_index),
             operator_name=self.name,
         )
         self._metrics.on_task_submitted(

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -29,6 +29,8 @@ from ray.data._internal.util import GiB
 if TYPE_CHECKING:
     import pyarrow as pa
 
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
+
 import ray
 from ray import ObjectRef
 from ray._raylet import ObjectRefGenerator
@@ -485,7 +487,11 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         else:
             raise ValueError(f"Unsupported execution strategy {compute_strategy}")
 
-    def start(self, options: "ExecutionOptions", block_ref_counter=None):
+    def start(
+        self,
+        options: "ExecutionOptions",
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ):
         super().start(options, block_ref_counter)
         # Create output queue with desired ordering semantics.
         if options.preserve_order:

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -124,13 +124,13 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
         # The total number of rows is the same as the number of input rows.
         return self.input_dependencies[0].num_output_rows_total()
 
-    def start(self, options: ExecutionOptions) -> None:
+    def start(self, options: ExecutionOptions, block_ref_counter=None) -> None:
         if options.preserve_order:
             # If preserve_order is set, we need to ignore locality hints to ensure determinism.
             self._locality_hints = None
             self._max_buffer_size = 0
 
-        super().start(options)
+        super().start(options, block_ref_counter)
 
     def throttling_disabled(self) -> bool:
         """Disables resource-based throttling.

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -130,7 +130,7 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ) -> None:
         if options.preserve_order:
             # If preserve_order is set, we need to ignore locality hints to ensure determinism.

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -2,7 +2,10 @@ import logging
 import math
 import time
 from dataclasses import replace
-from typing import Any, Collection, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Collection, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 
 from typing_extensions import override
 
@@ -124,7 +127,11 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
         # The total number of rows is the same as the number of input rows.
         return self.input_dependencies[0].num_output_rows_total()
 
-    def start(self, options: ExecutionOptions, block_ref_counter=None) -> None:
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ) -> None:
         if options.preserve_order:
             # If preserve_order is set, we need to ignore locality hints to ensure determinism.
             self._locality_hints = None

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -210,6 +210,11 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
         for i, count in enumerate(allocation):
             bundles = self._split_from_buffer(count)
             for b in bundles:
+                # Splitting may create new blocks; register for memory tracking.
+                for entry in b.blocks:
+                    self._block_ref_counter.on_block_produced(
+                        entry.ref, entry.metadata.size_bytes or 0, self.id
+                    )
                 b = replace(b, output_split_idx=i)
                 self._output_queue.add(b)
                 self._metrics.on_output_queued(b)

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -210,11 +210,6 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
         for i, count in enumerate(allocation):
             bundles = self._split_from_buffer(count)
             for b in bundles:
-                # Splitting may create new blocks; register for memory tracking.
-                for entry in b.blocks:
-                    self._block_ref_counter.on_block_produced(
-                        entry.ref, entry.metadata.size_bytes or 0, self.id
-                    )
                 b = replace(b, output_split_idx=i)
                 self._output_queue.add(b)
                 self._metrics.on_output_queued(b)
@@ -335,7 +330,17 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
                 output.append(b)
                 acc += b.num_rows()
             else:
+                input_refs = {entry.ref for entry in b.blocks}
                 left, right = _split(b, nrow - acc, label_selector)
+                # Only register genuinely new blocks created by _split_block.
+                for part in (left, right):
+                    for entry in part.blocks:
+                        if entry.ref not in input_refs:
+                            self._block_ref_counter.on_block_produced(
+                                entry.ref,
+                                entry.metadata.size_bytes or 0,
+                                self.id,
+                            )
                 output.append(left)
                 acc += left.num_rows()
                 self._buffer.add(right)

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -235,10 +235,10 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         )
         refs.destroy_if_owned()
 
-        for entry in out_bundle.blocks:
-            self._block_ref_counter.on_block_produced(
-                entry.ref, entry.metadata.size_bytes or 0, self.id
-            )
+        # Empty partition creates a new block; register it for memory tracking.
+        self._block_ref_counter.on_block_produced(
+            out_bundle.blocks[0].ref, block_meta.size_bytes or 0, self.id
+        )
         self._num_reduce_tasks_submitted += 1
         self._output_queue.append(out_bundle)
         self._metrics.on_output_queued(out_bundle)

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -190,6 +190,8 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         data_task = DataOpTask(
             task_index=partition_id,
             streaming_gen=block_gen,
+            block_ref_counter=self._block_ref_counter,
+            producer_id=self.id,
             output_ready_callback=functools.partial(
                 self._handle_reduce_output_ready, partition_id
             ),

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -235,6 +235,10 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         )
         refs.destroy_if_owned()
 
+        for entry in out_bundle.blocks:
+            self._block_ref_counter.on_block_produced(
+                entry.ref, entry.metadata.size_bytes or 0, self.id
+            )
         self._num_reduce_tasks_submitted += 1
         self._output_queue.append(out_bundle)
         self._metrics.on_output_queued(out_bundle)

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -237,7 +237,9 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
 
         # Empty partition creates a new block; register it for memory tracking.
         self._block_ref_counter.on_block_produced(
-            out_bundle.blocks[0].ref, block_meta.size_bytes or 0, self.id
+            out_bundle.blocks[0].ref,  # pyrefly: ignore[bad-argument-type]
+            block_meta.size_bytes or 0,
+            self.id,
         )
         self._num_reduce_tasks_submitted += 1
         self._output_queue.append(out_bundle)

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -65,7 +65,7 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ):
         # Whether to preserve deterministic ordering of output blocks.
         # When True, blocks are emitted in round-robin order across inputs,

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -59,12 +59,12 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def _output_queues(self) -> List["BaseBundleQueue"]:
         return [self._output_buffer]
 
-    def start(self, options: ExecutionOptions):
+    def start(self, options: ExecutionOptions, block_ref_counter=None):
         # Whether to preserve deterministic ordering of output blocks.
         # When True, blocks are emitted in round-robin order across inputs,
         # ensuring the same input always produces the same output order.
         self._preserve_order = options.preserve_order
-        super().start(options)
+        super().start(options, block_ref_counter)
 
     def num_outputs_total(self) -> Optional[int]:
         num_outputs = 0

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -1,6 +1,9 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 
 from ray.data._internal.execution.bundle_queue import BaseBundleQueue, FIFOBundleQueue
 from ray.data._internal.execution.interfaces import (
@@ -59,7 +62,11 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def _output_queues(self) -> List["BaseBundleQueue"]:
         return [self._output_buffer]
 
-    def start(self, options: ExecutionOptions, block_ref_counter=None):
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ):
         # Whether to preserve deterministic ordering of output blocks.
         # When True, blocks are emitted in round-robin order across inputs,
         # ensuring the same input always produces the same output order.

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -122,8 +122,12 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
                 refs = input_buffer.get_next()
                 self._metrics.on_input_dequeued(refs, input_index=idx)
 
-        # Mark outputs as ready
+        # Zipping creates new blocks; register them for memory tracking.
         for ref in self._output_buffer:
+            for entry in ref.blocks:
+                self._block_ref_counter.on_block_produced(
+                    entry.ref, entry.metadata.size_bytes or 0, self.id
+                )
             self._metrics.on_output_queued(ref)
 
         super().all_inputs_done()

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional
 
 from ray._common.utils import env_bool, env_float
 from ray.data._internal.execution import create_resource_allocator
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
     ExecutionResources,
@@ -140,6 +141,8 @@ class ResourceManager:
         # operator's output usage.
         self._output_operator = terminal_operator_from_topology(topology)
 
+        self._block_ref_counter = BlockRefCounter()
+
         self._op_resource_allocator: Optional[
             "OpResourceAllocator"
         ] = create_resource_allocator(self, data_context)
@@ -170,6 +173,11 @@ class ResourceManager:
     def get_external_consumer_bytes(self) -> int:
         """Get the bytes buffered by external consumers."""
         return self._external_consumer_bytes
+
+    @property
+    def block_ref_counter(self) -> BlockRefCounter:
+        """The centralized block reference counter for this executor."""
+        return self._block_ref_counter
 
     def _estimate_object_store_memory_usage(
         self, op: "PhysicalOperator", state: "OpState"

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -109,6 +109,7 @@ class ResourceManager:
         options: ExecutionOptions,
         get_total_resources: Callable[[], ExecutionResources],
         data_context: DataContext,
+        block_ref_counter: BlockRefCounter,
     ):
         self._topology = topology
         self._options = options
@@ -141,7 +142,7 @@ class ResourceManager:
         # operator's output usage.
         self._output_operator = terminal_operator_from_topology(topology)
 
-        self._block_ref_counter = BlockRefCounter()
+        self._block_ref_counter = block_ref_counter
 
         self._op_resource_allocator: Optional[
             "OpResourceAllocator"
@@ -173,11 +174,6 @@ class ResourceManager:
     def get_external_consumer_bytes(self) -> int:
         """Get the bytes buffered by external consumers."""
         return self._external_consumer_bytes
-
-    @property
-    def block_ref_counter(self) -> BlockRefCounter:
-        """The centralized block reference counter for this executor."""
-        return self._block_ref_counter
 
     def _estimate_object_store_memory_usage(
         self, op: "PhysicalOperator", state: "OpState"

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -220,9 +220,11 @@ class StreamingExecutor(Executor, threading.Thread):
                 )
 
         # Setup the streaming DAG topology and start the runner thread.
-        self._topology = build_streaming_topology(dag, self._options)
-
         self._block_ref_counter = BlockRefCounter()
+        self._topology = build_streaming_topology(
+            dag, self._options, self._block_ref_counter
+        )
+
         self._resource_manager = ResourceManager(
             self._topology,
             self._options,
@@ -230,9 +232,6 @@ class StreamingExecutor(Executor, threading.Thread):
             self._data_context,
             self._block_ref_counter,
         )
-
-        for op in self._topology:
-            op.start(self._options, self._block_ref_counter)
 
         # Constructed once per executor (not per scheduling iteration) so the
         # guard's idle-detection state accumulates across scheduling iterations.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -14,6 +14,7 @@ from ray.data._internal.execution.backpressure_policy import (
     BackpressurePolicy,
     get_backpressure_policies,
 )
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.dataset_state import DatasetState
 from ray.data._internal.execution.execution_callback import ExecutionCallback
 from ray.data._internal.execution.interfaces import (
@@ -221,16 +222,17 @@ class StreamingExecutor(Executor, threading.Thread):
         # Setup the streaming DAG topology and start the runner thread.
         self._topology = build_streaming_topology(dag, self._options)
 
+        self._block_ref_counter = BlockRefCounter()
         self._resource_manager = ResourceManager(
             self._topology,
             self._options,
             lambda: self._cluster_autoscaler.get_total_resources(),
             self._data_context,
+            self._block_ref_counter,
         )
 
-        counter = self._resource_manager.block_ref_counter
         for op in self._topology:
-            op.start(self._options, counter)
+            op.start(self._options, self._block_ref_counter)
 
         # Constructed once per executor (not per scheduling iteration) so the
         # guard's idle-detection state accumulates across scheduling iterations.
@@ -349,7 +351,7 @@ class StreamingExecutor(Executor, threading.Thread):
             self._clear_topology_queues_post_shutdown(force, exception)
             # Queues have been drained; any remaining Ray Core callbacks that fire
             # after this point should be no-ops.
-            self._resource_manager.block_ref_counter.clear()
+            self._block_ref_counter.clear()
 
             min_ = round(timer.min(), 3)
             max_ = round(timer.max(), 3)

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -228,6 +228,10 @@ class StreamingExecutor(Executor, threading.Thread):
             self._data_context,
         )
 
+        counter = self._resource_manager.block_ref_counter
+        for op in self._topology:
+            op.start(self._options, counter)
+
         # Constructed once per executor (not per scheduling iteration) so the
         # guard's idle-detection state accumulates across scheduling iterations.
         self._output_backpressure_guard = OutputBackpressureGuard(
@@ -343,6 +347,9 @@ class StreamingExecutor(Executor, threading.Thread):
                 op.shutdown(timer, force=force)
 
             self._clear_topology_queues_post_shutdown(force, exception)
+            # Queues have been drained; any remaining Ray Core callbacks that fire
+            # after this point should be no-ops.
+            self._resource_manager.block_ref_counter.clear()
 
             min_ = round(timer.min(), 3)
             max_ = round(timer.max(), 3)

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import ray
 from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import ActorPoolInfo
 from ray.data._internal.execution.backpressure_policy import BackpressurePolicy
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.bundle_queue import (
     ThreadSafeBundleQueue,
     create_bundle_queue,
@@ -543,7 +544,9 @@ class OpState:
 
 
 def build_streaming_topology(
-    dag: PhysicalOperator, options: ExecutionOptions
+    dag: PhysicalOperator,
+    options: ExecutionOptions,
+    block_ref_counter: BlockRefCounter,
 ) -> Topology:
     """Instantiate the streaming operator state topology for the given DAG.
 
@@ -554,6 +557,8 @@ def build_streaming_topology(
     Args:
         dag: The operator DAG to instantiate.
         options: The execution options to use to start operators.
+        block_ref_counter: The executor-wide shared counter for tracking
+            object-store memory.
 
     Returns:
         The topology dict holding the streaming execution state.
@@ -575,6 +580,7 @@ def build_streaming_topology(
         # Create state.
         op_state = OpState(op, inqueues)
         topology[op] = op_state
+        op.start(options, block_ref_counter)
         return op_state
 
     setup_state(dag)

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -575,7 +575,6 @@ def build_streaming_topology(
         # Create state.
         op_state = OpState(op, inqueues)
         topology[op] = op_state
-        op.start(options)
         return op_state
 
     setup_state(dag)

--- a/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
+++ b/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
@@ -493,7 +493,7 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
     def start(
         self,
         options: ExecutionOptions,
-        block_ref_counter: Optional["BlockRefCounter"] = None,
+        block_ref_counter: "BlockRefCounter",
     ) -> None:
         super().start(options, block_ref_counter)
         self._rank_pool.start()

--- a/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
+++ b/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
@@ -40,7 +40,7 @@ from ray.data.block import Block, BlockAccessor, BlockStats, to_stats
 from ray.data.context import DataContext
 
 if typing.TYPE_CHECKING:
-
+    from ray.data._internal.execution.block_ref_counter import BlockRefCounter
     from ray.data._internal.execution.interfaces.physical_operator import ActorPoolInfo
     from ray.data._internal.progress.base_progress import BaseProgressBar
 
@@ -490,8 +490,12 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def start(self, options: ExecutionOptions) -> None:
-        super().start(options)
+    def start(
+        self,
+        options: ExecutionOptions,
+        block_ref_counter: Optional["BlockRefCounter"] = None,
+    ) -> None:
+        super().start(options, block_ref_counter)
         self._rank_pool.start()
 
     def _add_input_inner(self, bundle: RefBundle, input_index: int) -> None:
@@ -625,6 +629,8 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
             data_task = DataOpTask(
                 task_index=rank_idx,
                 streaming_gen=block_gen,
+                block_ref_counter=self._block_ref_counter,
+                producer_id=self.id,
                 output_ready_callback=_on_bundle_ready,
                 task_done_callback=functools.partial(
                     _on_extraction_done, rank=rank_idx

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private.internal_api import get_memory_info_reply, get_state_from_address
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
 )
@@ -46,6 +47,11 @@ def mock_all_to_all_op(input_op, name="MockAllToAll"):
     )
     op.start = MagicMock(side_effect=lambda _: None)
     return op
+
+
+def noop_counter():
+    """BlockRefCounter that works without a Ray cluster."""
+    return BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True)
 
 
 @pytest.fixture(scope="module")

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -45,7 +45,7 @@ def mock_all_to_all_op(input_op, name="MockAllToAll"):
         data_context=ray.data.DataContext.get_current(),
         name=name,
     )
-    op.start = MagicMock(side_effect=lambda _: None)
+    op.start = MagicMock(side_effect=lambda *_: None)
     return op
 
 

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -57,6 +57,7 @@ from ray.data.context import (
     DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
     DataContext,
 )
+from ray.data.tests.conftest import noop_counter
 from ray.data.tests.test_executor_resource_management import SMALL_STR
 from ray.data.tests.test_operators import _mul2_map_data_prcessor
 from ray.data.tests.util import (
@@ -1285,7 +1286,9 @@ def test_completed_when_downstream_op_has_finished_execution(ray_start_regular_s
     downstream_op = IdentityOperator(
         "Downstream", input_dependencies=[actor_pool_map_op], data_context=data_context
     )
-    topology = build_streaming_topology(downstream_op, ExecutionOptions())
+    topology = build_streaming_topology(
+        downstream_op, ExecutionOptions(), noop_counter()
+    )
 
     # SETUP: Add a bundle to the upstream operator's external output queue. This is
     # necessary to reproduce the bug where the actor pool operator wouldn't complete if

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -28,7 +28,6 @@ from ray.data._internal.actor_autoscaler.default_actor_autoscaler import (
     _estimate_total_available_task_slots,
 )
 from ray.data._internal.compute import ActorPoolStrategy
-from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.bundle_queue import HashLinkedQueue
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
@@ -966,7 +965,7 @@ def test_setting_initial_size_for_actor_pool():
         ray_remote_args={"num_cpus": 1},
     )
 
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     assert op._actor_pool.get_actor_info() == ActorPoolInfo(
         running=0,
@@ -1007,7 +1006,7 @@ def test_internal_input_queue_is_empty_after_early_completion(
     )
 
     # NOTE: This is blocking, until actor pool is fully started up
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     # Complete init sequence by completing pending metadata tasks (performed
     # by the executor)
     run_op_tasks_sync(op)
@@ -1064,7 +1063,7 @@ def test_actor_pool_input_queue_draining(
     )
 
     # NOTE: This is blocking, until actor pool is fully started up
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     # Finalize operator initialization sequence and make it schedulable
     run_op_tasks_sync(op, only_existing=True)
@@ -1522,7 +1521,7 @@ def test_actor_pool_map_operator_init(ray_start_regular_shared, data_context_ove
     )
 
     with pytest.raises(RayActorError, match=r"init_failed"):
-        op.start(ExecutionOptions(), BlockRefCounter())
+        op.start(ExecutionOptions(), noop_counter())
 
 
 @pytest.mark.parametrize(
@@ -1575,7 +1574,7 @@ def test_actor_pool_map_operator_should_add_input(
         ray_remote_args={"max_concurrency": max_concurrency},
     )
 
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     # Cannot add input until actor has started.
     assert not op.can_add_input()
@@ -1618,7 +1617,7 @@ def test_actor_pool_map_operator_num_active_tasks_and_completed(shutdown_only):
     actor_pool = op._actor_pool
 
     # Wait for the op to scale up to the min size.
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     run_op_tasks_sync(op)
     assert actor_pool.num_running_actors() == num_actors
     assert op.num_active_tasks() == 0

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -28,6 +28,7 @@ from ray.data._internal.actor_autoscaler.default_actor_autoscaler import (
     _estimate_total_available_task_slots,
 )
 from ray.data._internal.compute import ActorPoolStrategy
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.bundle_queue import HashLinkedQueue
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
@@ -964,7 +965,7 @@ def test_setting_initial_size_for_actor_pool():
         ray_remote_args={"num_cpus": 1},
     )
 
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     assert op._actor_pool.get_actor_info() == ActorPoolInfo(
         running=0,
@@ -1005,7 +1006,7 @@ def test_internal_input_queue_is_empty_after_early_completion(
     )
 
     # NOTE: This is blocking, until actor pool is fully started up
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     # Complete init sequence by completing pending metadata tasks (performed
     # by the executor)
     run_op_tasks_sync(op)
@@ -1062,7 +1063,7 @@ def test_actor_pool_input_queue_draining(
     )
 
     # NOTE: This is blocking, until actor pool is fully started up
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     # Finalize operator initialization sequence and make it schedulable
     run_op_tasks_sync(op, only_existing=True)
@@ -1518,7 +1519,7 @@ def test_actor_pool_map_operator_init(ray_start_regular_shared, data_context_ove
     )
 
     with pytest.raises(RayActorError, match=r"init_failed"):
-        op.start(ExecutionOptions())
+        op.start(ExecutionOptions(), BlockRefCounter())
 
 
 @pytest.mark.parametrize(
@@ -1571,7 +1572,7 @@ def test_actor_pool_map_operator_should_add_input(
         ray_remote_args={"max_concurrency": max_concurrency},
     )
 
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     # Cannot add input until actor has started.
     assert not op.can_add_input()
@@ -1614,7 +1615,7 @@ def test_actor_pool_map_operator_num_active_tasks_and_completed(shutdown_only):
     actor_pool = op._actor_pool
 
     # Wait for the op to scale up to the min size.
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     run_op_tasks_sync(op)
     assert actor_pool.num_running_actors() == num_actors
     assert op.num_active_tasks() == 0

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -5,7 +5,6 @@ import pytest
 import ray
 from ray.data._internal.actor_autoscaler import ActorPoolScalingRequest
 from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
-from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import ExecutionOptions, ExecutionResources
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
@@ -14,6 +13,7 @@ from ray.data._internal.execution.operators.output_splitter import OutputSplitte
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.conftest import noop_counter
 from ray.data.tests.test_operators import _mul2_map_data_prcessor
 from ray.data.tests.util import run_op_tasks_sync
 
@@ -209,7 +209,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
     )
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
@@ -254,7 +254,7 @@ def test_task_pool_resource_reporting_with_dynamic_remote_args(
         ray_remote_args={"num_cpus": 1},
         ray_remote_args_fn=lambda: {"memory": 500},
     )
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
 
@@ -281,7 +281,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
         compute_strategy=TaskPoolStrategy(),
         min_rows_per_bundle=3,
     )
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
@@ -341,7 +341,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     )
 
     # NOTE: This is blocking, until actors are fully started up
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     min_resource_usage, _ = op.min_max_resource_requirements()
     assert min_resource_usage == ExecutionResources(cpu=2, gpu=0, object_store_memory=0)
@@ -462,7 +462,7 @@ def test_actor_pool_resource_reporting_with_dynamic_remote_args(
     )
 
     # Blocking until actors are fully started
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     run_op_tasks_sync(op, only_existing=True)
 
     # Should reflect dynamic resources: 2 actors * (1 cpu, 500 memory)
@@ -492,7 +492,7 @@ def test_actor_pool_scheduling_with_bundling(
     )
 
     # NOTE: This is blocking, until actor pool is fully started up
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     min_resource_usage, _ = op.min_max_resource_requirements()
     assert min_resource_usage == ExecutionResources(cpu=2, gpu=0, object_store_memory=0)
@@ -642,7 +642,7 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
         make_ref_bundles([[SMALL_STR, SMALL_STR] for i in range(2)]),
     )  # Two two-row bundles
     op = LimitOperator(3, input_op, DataContext.get_current())
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
 
     assert op.current_logical_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0, memory=0
@@ -675,7 +675,7 @@ def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
         data_context=DataContext.get_current(),
         locality_hints=["0", "1"],
     )
-    op.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
+    op.start(ExecutionOptions(actor_locality_enabled=True), noop_counter())
 
     assert op.current_logical_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0, memory=0

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -5,6 +5,7 @@ import pytest
 import ray
 from ray.data._internal.actor_autoscaler import ActorPoolScalingRequest
 from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import ExecutionOptions, ExecutionResources
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
@@ -208,7 +209,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
     )
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
@@ -253,7 +254,7 @@ def test_task_pool_resource_reporting_with_dynamic_remote_args(
         ray_remote_args={"num_cpus": 1},
         ray_remote_args_fn=lambda: {"memory": 500},
     )
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
 
@@ -280,7 +281,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
         compute_strategy=TaskPoolStrategy(),
         min_rows_per_bundle=3,
     )
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
@@ -340,7 +341,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     )
 
     # NOTE: This is blocking, until actors are fully started up
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     min_resource_usage, _ = op.min_max_resource_requirements()
     assert min_resource_usage == ExecutionResources(cpu=2, gpu=0, object_store_memory=0)
@@ -461,7 +462,7 @@ def test_actor_pool_resource_reporting_with_dynamic_remote_args(
     )
 
     # Blocking until actors are fully started
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     run_op_tasks_sync(op, only_existing=True)
 
     # Should reflect dynamic resources: 2 actors * (1 cpu, 500 memory)
@@ -491,7 +492,7 @@ def test_actor_pool_scheduling_with_bundling(
     )
 
     # NOTE: This is blocking, until actor pool is fully started up
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     min_resource_usage, _ = op.min_max_resource_requirements()
     assert min_resource_usage == ExecutionResources(cpu=2, gpu=0, object_store_memory=0)
@@ -641,7 +642,7 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
         make_ref_bundles([[SMALL_STR, SMALL_STR] for i in range(2)]),
     )  # Two two-row bundles
     op = LimitOperator(3, input_op, DataContext.get_current())
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
 
     assert op.current_logical_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0, memory=0
@@ -674,7 +675,7 @@ def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
         data_context=DataContext.get_current(),
         locality_hints=["0", "1"],
     )
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    op.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
 
     assert op.current_logical_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0, memory=0

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -15,6 +15,7 @@ import ray
 import ray.data._internal.gpu_shuffle.hash_shuffle as hash_shuffle
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
+    ExecutionOptions,
     ExecutionResources,
     PhysicalOperator,
     RefBundle,
@@ -31,6 +32,7 @@ from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
 from ray.data._internal.util import explain_plan
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext, ShuffleStrategy
+from ray.data.tests.conftest import noop_counter
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -433,6 +435,7 @@ class TestGPUShuffleOperatorFinalization:
             )
         op._rank_pool._actors = mock_actors
         op._rank_pool._nranks = nranks
+        op.start(ExecutionOptions(), noop_counter())
         return op, mock_actors
 
     def test_finalization_not_started_until_inputs_complete(self):

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -15,7 +15,6 @@ import ray
 import ray.data._internal.gpu_shuffle.hash_shuffle as hash_shuffle
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
-    ExecutionOptions,
     ExecutionResources,
     PhysicalOperator,
     RefBundle,
@@ -435,7 +434,7 @@ class TestGPUShuffleOperatorFinalization:
             )
         op._rank_pool._actors = mock_actors
         op._rank_pool._nranks = nranks
-        op.start(ExecutionOptions(), noop_counter())
+        op._block_ref_counter = noop_counter()
         return op, mock_actors
 
     def test_finalization_not_started_until_inputs_complete(self):

--- a/python/ray/data/tests/test_limit_operator.py
+++ b/python/ray/data/tests/test_limit_operator.py
@@ -5,12 +5,14 @@ import pyarrow.parquet as pq
 import pytest
 
 import ray
+from ray.data._internal.execution.interfaces import ExecutionOptions
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.logical.optimizers import get_execution_plan
 from ray.data.context import DataContext
+from ray.data.tests.conftest import noop_counter
 from ray.data.tests.util import run_op_tasks_sync
 from ray.tests.conftest import *  # noqa
 
@@ -60,6 +62,9 @@ def test_limit_operator(ray_start_regular_shared):
         refs = make_ref_bundles([[i] * num_rows_per_block for i in range(num_refs)])
         input_op = InputDataBuffer(DataContext.get_current(), refs)
         limit_op = LimitOperator(limit, input_op, DataContext.get_current())
+        counter = noop_counter()
+        input_op.start(ExecutionOptions(), counter)
+        limit_op.start(ExecutionOptions(), counter)
         limit_op.mark_execution_finished = MagicMock(
             wraps=limit_op.mark_execution_finished
         )

--- a/python/ray/data/tests/test_map_operator.py
+++ b/python/ray/data/tests/test_map_operator.py
@@ -9,7 +9,6 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
-from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
 )
@@ -31,6 +30,7 @@ from ray.data.block import Block
 from ray.data.context import (
     DataContext,
 )
+from ray.data.tests.conftest import noop_counter
 from ray.data.tests.util import (
     _get_blocks,
     _mul2_transform,
@@ -76,7 +76,7 @@ def _run_map_operator_test(
     )
 
     # Feed data and block on exec.
-    op.start(ExecutionOptions(preserve_order=preserve_order), BlockRefCounter())
+    op.start(ExecutionOptions(preserve_order=preserve_order), noop_counter())
     if use_actors:
         # Wait for actors to be ready before adding inputs.
         run_op_tasks_sync(op, only_existing=True)
@@ -119,7 +119,7 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     # actor pool, which otherwise returns results in completion order).
     op.start(
         ExecutionOptions(actor_locality_enabled=True, preserve_order=True),
-        BlockRefCounter(),
+        noop_counter(),
     )
 
     if use_actors:
@@ -184,7 +184,7 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     options = ExecutionOptions()
     options.preserve_order = True
     options.actor_locality_enabled = True
-    op.start(options, BlockRefCounter())
+    op.start(options, noop_counter())
     # Wait for actors to be ready before adding inputs.
     run_op_tasks_sync(op, only_existing=True)
 
@@ -246,7 +246,7 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
     )
 
     # Feed data and block on exec.
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     if use_actors:
         # Wait for actors to be ready before adding inputs.
         run_op_tasks_sync(op, only_existing=True)
@@ -399,7 +399,7 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     )
 
     # Feed data and block on exec.
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     if use_actors:
         # Wait for the actor to start.
         run_op_tasks_sync(op)
@@ -447,7 +447,7 @@ def test_map_operator_shutdown(shutdown_only, use_actors):
     )
 
     # Start one task and then cancel.
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     if use_actors:
         # Wait for the actor to start.
         run_op_tasks_sync(op)
@@ -517,7 +517,7 @@ def test_map_kwargs(ray_start_regular_shared, use_actors):
         compute_strategy=compute_strategy,
     )
     op.add_map_task_kwargs_fn(lambda: kwargs)
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     if use_actors:
         # Wait for the actor to start.
         run_op_tasks_sync(op)
@@ -580,7 +580,7 @@ def test_map_estimated_num_output_bundles(
         min_rows_per_bundle=min_rows_per_bundle,
     )
 
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
@@ -625,7 +625,7 @@ def test_map_estimated_blocks_split():
     )
     op.set_additional_split_factor(2)
 
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
@@ -663,7 +663,7 @@ def test_operator_metrics():
         min_rows_per_bundle=MIN_ROWS_PER_BUNDLE,
     )
 
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     num_outputs_taken = 0
     bytes_outputs_taken = 0
     for i in range(len(inputs)):

--- a/python/ray/data/tests/test_map_operator.py
+++ b/python/ray/data/tests/test_map_operator.py
@@ -9,6 +9,7 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
 )
@@ -75,7 +76,7 @@ def _run_map_operator_test(
     )
 
     # Feed data and block on exec.
-    op.start(ExecutionOptions(preserve_order=preserve_order))
+    op.start(ExecutionOptions(preserve_order=preserve_order), BlockRefCounter())
     if use_actors:
         # Wait for actors to be ready before adding inputs.
         run_op_tasks_sync(op, only_existing=True)
@@ -116,7 +117,10 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     output = []
     # Use preserve_order so output order matches input order (required for
     # actor pool, which otherwise returns results in completion order).
-    op.start(ExecutionOptions(actor_locality_enabled=True, preserve_order=True))
+    op.start(
+        ExecutionOptions(actor_locality_enabled=True, preserve_order=True),
+        BlockRefCounter(),
+    )
 
     if use_actors:
         # Wait for actors to be ready before adding inputs.
@@ -180,7 +184,7 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     options = ExecutionOptions()
     options.preserve_order = True
     options.actor_locality_enabled = True
-    op.start(options)
+    op.start(options, BlockRefCounter())
     # Wait for actors to be ready before adding inputs.
     run_op_tasks_sync(op, only_existing=True)
 
@@ -242,7 +246,7 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
     )
 
     # Feed data and block on exec.
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     if use_actors:
         # Wait for actors to be ready before adding inputs.
         run_op_tasks_sync(op, only_existing=True)
@@ -395,7 +399,7 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     )
 
     # Feed data and block on exec.
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     if use_actors:
         # Wait for the actor to start.
         run_op_tasks_sync(op)
@@ -443,7 +447,7 @@ def test_map_operator_shutdown(shutdown_only, use_actors):
     )
 
     # Start one task and then cancel.
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     if use_actors:
         # Wait for the actor to start.
         run_op_tasks_sync(op)
@@ -513,7 +517,7 @@ def test_map_kwargs(ray_start_regular_shared, use_actors):
         compute_strategy=compute_strategy,
     )
     op.add_map_task_kwargs_fn(lambda: kwargs)
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     if use_actors:
         # Wait for the actor to start.
         run_op_tasks_sync(op)
@@ -576,7 +580,7 @@ def test_map_estimated_num_output_bundles(
         min_rows_per_bundle=min_rows_per_bundle,
     )
 
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
@@ -621,7 +625,7 @@ def test_map_estimated_blocks_split():
     )
     op.set_additional_split_factor(2)
 
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
@@ -659,7 +663,7 @@ def test_operator_metrics():
         min_rows_per_bundle=MIN_ROWS_PER_BUNDLE,
     )
 
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     num_outputs_taken = 0
     bytes_outputs_taken = 0
     for i in range(len(inputs)):

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import ray
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
     ExecutionOptions,
@@ -99,7 +100,7 @@ def test_all_to_all_operator():
         op.set_sub_progress_bar(name, pg)
 
     # Feed data.
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
@@ -145,7 +146,7 @@ def test_num_outputs_total():
 
     # Feed data and implement streaming exec.
     output = []
-    op1.start(ExecutionOptions(actor_locality_enabled=True))
+    op1.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
     while input_op.has_next():
         op1.add_input(input_op.get_next(), 0)
         while not op1.has_next():
@@ -182,8 +183,8 @@ def test_all_to_all_estimated_num_output_bundles():
         DataContext.get_current().target_max_block_size,
     )
 
-    op1.start(ExecutionOptions())
-    op2.start(ExecutionOptions())
+    op1.start(ExecutionOptions(), BlockRefCounter())
+    op2.start(ExecutionOptions(), BlockRefCounter())
     while input_op.has_next():
         op1.add_input(input_op.get_next(), 0)
     op1.all_inputs_done()

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -182,6 +182,8 @@ def test_all_to_all_estimated_num_output_bundles():
         DataContext.get_current().target_max_block_size,
     )
 
+    op1.start(ExecutionOptions())
+    op2.start(ExecutionOptions())
     while input_op.has_next():
         op1.add_input(input_op.get_next(), 0)
     op1.all_inputs_done()

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 import ray
-from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
     ExecutionOptions,
@@ -20,6 +19,7 @@ from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.progress.base_progress import NoopSubProgressBar
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
+from ray.data.tests.conftest import noop_counter
 from ray.data.tests.util import (
     _get_blocks,
     _mul2_transform,
@@ -100,7 +100,7 @@ def test_all_to_all_operator():
         op.set_sub_progress_bar(name, pg)
 
     # Feed data.
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
@@ -146,7 +146,7 @@ def test_num_outputs_total():
 
     # Feed data and implement streaming exec.
     output = []
-    op1.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
+    op1.start(ExecutionOptions(actor_locality_enabled=True), noop_counter())
     while input_op.has_next():
         op1.add_input(input_op.get_next(), 0)
         while not op1.has_next():
@@ -183,8 +183,8 @@ def test_all_to_all_estimated_num_output_bundles():
         DataContext.get_current().target_max_block_size,
     )
 
-    op1.start(ExecutionOptions(), BlockRefCounter())
-    op2.start(ExecutionOptions(), BlockRefCounter())
+    op1.start(ExecutionOptions(), noop_counter())
+    op2.start(ExecutionOptions(), noop_counter())
     while input_op.has_next():
         op1.add_input(input_op.get_next(), 0)
     op1.all_inputs_done()

--- a/python/ray/data/tests/test_output_splitter.py
+++ b/python/ray/data/tests/test_output_splitter.py
@@ -5,12 +5,12 @@ import random
 import pytest
 
 import ray
-from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import ExecutionOptions
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.context import DataContext
+from ray.data.tests.conftest import noop_counter
 from ray.tests.conftest import *  # noqa
 
 
@@ -36,7 +36,7 @@ def test_split_operator(ray_start_regular_shared, equal, chunk_size):
 
     # Feed data and implement streaming exec.
     output_splits = [[] for _ in range(num_splits)]
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     while input_op.has_next():
         for _ in range(num_add_input_blocks):
             if not input_op.has_next():
@@ -80,7 +80,7 @@ def test_split_operator_random(ray_start_regular_shared, equal, random_seed):
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(ExecutionOptions(), noop_counter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
@@ -125,7 +125,7 @@ def test_split_operator_locality_hints(ray_start_regular_shared):
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)
-    op.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
+    op.start(ExecutionOptions(actor_locality_enabled=True), noop_counter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
@@ -193,7 +193,7 @@ def test_split_operator_with_locality(ray_start_regular_shared, equal, random_se
     output_splits = [[] for _ in range(3)]
     yielded_incrementally = 0
 
-    op.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
+    op.start(ExecutionOptions(actor_locality_enabled=True), noop_counter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
 

--- a/python/ray/data/tests/test_output_splitter.py
+++ b/python/ray/data/tests/test_output_splitter.py
@@ -5,6 +5,7 @@ import random
 import pytest
 
 import ray
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import ExecutionOptions
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
@@ -35,7 +36,7 @@ def test_split_operator(ray_start_regular_shared, equal, chunk_size):
 
     # Feed data and implement streaming exec.
     output_splits = [[] for _ in range(num_splits)]
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     while input_op.has_next():
         for _ in range(num_add_input_blocks):
             if not input_op.has_next():
@@ -79,7 +80,7 @@ def test_split_operator_random(ray_start_regular_shared, equal, random_seed):
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
@@ -124,7 +125,7 @@ def test_split_operator_locality_hints(ray_start_regular_shared):
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    op.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
@@ -192,7 +193,7 @@ def test_split_operator_with_locality(ray_start_regular_shared, equal, random_se
     output_splits = [[] for _ in range(3)]
     yielded_incrementally = 0
 
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    op.start(ExecutionOptions(actor_locality_enabled=True), BlockRefCounter())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
 

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import ray
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
     ExecutionResources,
@@ -72,6 +73,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = op_internal_usage
@@ -237,6 +239,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -298,6 +301,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -333,6 +337,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -398,6 +403,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = {o1: 0, o2: 40, o3: 40}
@@ -475,6 +481,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = {o1: 0, o2: 40, o3: 40}
@@ -509,6 +516,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -572,6 +580,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3], 0)
@@ -620,6 +629,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3], 0)
@@ -663,6 +673,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2], 0)
@@ -709,6 +720,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2], 0)
@@ -780,6 +792,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3, o4, o5], 0)
@@ -836,6 +849,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3], 0)
@@ -924,6 +938,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys(ops, 0)
@@ -985,6 +1000,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = op_internal_usage
@@ -1082,6 +1098,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager.get_global_limits = MagicMock(

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -980,9 +980,6 @@ class TestReservationOpResourceAllocator:
                 return_value=(ExecutionResources.zero(), ExecutionResources.inf())
             )
 
-        o1.mark_execution_finished()
-        o2.mark_execution_finished()
-
         op_usages = {
             o1: ExecutionResources.zero(),
             o2: ExecutionResources(cpu=2, object_store_memory=50),
@@ -993,6 +990,9 @@ class TestReservationOpResourceAllocator:
         op_outputs_usages = dict.fromkeys([o1, o2, o3, o4], 0)
 
         topo = build_streaming_topology(o4, ExecutionOptions(), noop_counter())
+
+        o1.mark_execution_finished()
+        o2.mark_execution_finished()
 
         global_limits = ExecutionResources(cpu=10, object_store_memory=250)
 
@@ -1067,12 +1067,6 @@ class TestReservationOpResourceAllocator:
         o7 = InputDataBuffer(DataContext.get_current(), [])
         o8 = mock_join_op(o7, o6)
 
-        o1.mark_execution_finished()
-        o2.mark_execution_finished()
-        o4.mark_execution_finished()
-        o5.mark_execution_finished()
-        o7.mark_execution_finished()
-
         op_usages = {
             o1: ExecutionResources.zero(),
             o2: ExecutionResources(cpu=2, object_store_memory=150),
@@ -1087,6 +1081,12 @@ class TestReservationOpResourceAllocator:
         op_outputs_usages = dict.fromkeys([o1, o2, o3, o4, o5, o6, o7, o8], 0)
 
         topo = build_streaming_topology(o8, ExecutionOptions(), noop_counter())
+
+        o1.mark_execution_finished()
+        o2.mark_execution_finished()
+        o4.mark_execution_finished()
+        o5.mark_execution_finished()
+        o7.mark_execution_finished()
 
         global_limits = ExecutionResources.zero()
 

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -73,7 +73,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = op_internal_usage
@@ -239,7 +239,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -301,7 +301,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -337,7 +337,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -403,7 +403,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = {o1: 0, o2: 40, o3: 40}
@@ -481,7 +481,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = {o1: 0, o2: 40, o3: 40}
@@ -516,7 +516,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
@@ -580,7 +580,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3], 0)
@@ -629,7 +629,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3], 0)
@@ -673,7 +673,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2], 0)
@@ -720,7 +720,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2], 0)
@@ -792,7 +792,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3, o4, o5], 0)
@@ -849,7 +849,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys([o1, o2, o3], 0)
@@ -938,7 +938,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = dict.fromkeys(ops, 0)
@@ -1000,7 +1000,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = op_internal_usage
@@ -1098,7 +1098,7 @@ class TestReservationOpResourceAllocator:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager.get_global_limits = MagicMock(

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -21,6 +21,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.conftest import noop_counter
 from ray.data.tests.test_resource_manager import (
     mock_join_op,
     mock_map_op,
@@ -60,7 +61,7 @@ class TestReservationOpResourceAllocator:
         op_internal_usage = dict.fromkeys([o1, o2, o3, o4], 0)
         op_outputs_usages = dict.fromkeys([o1, o2, o3, o4], 0)
 
-        topo = build_streaming_topology(o4, ExecutionOptions())
+        topo = build_streaming_topology(o4, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources.zero()
 
@@ -232,7 +233,7 @@ class TestReservationOpResourceAllocator:
                 )
             )
 
-        topo = build_streaming_topology(o5, ExecutionOptions())
+        topo = build_streaming_topology(o5, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -294,7 +295,7 @@ class TestReservationOpResourceAllocator:
             )
         )
 
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -331,7 +332,7 @@ class TestReservationOpResourceAllocator:
                 ExecutionResources(cpu=1, object_store_memory=1),
             )
         )
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),
@@ -388,7 +389,7 @@ class TestReservationOpResourceAllocator:
             )
         )
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(cpu=20, object_store_memory=400)
 
@@ -466,7 +467,7 @@ class TestReservationOpResourceAllocator:
             )
         )
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(cpu=20, object_store_memory=400)
 
@@ -509,7 +510,7 @@ class TestReservationOpResourceAllocator:
         o1 = InputDataBuffer(DataContext.get_current(), input)
         o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2, DataContext.get_current())
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -566,7 +567,7 @@ class TestReservationOpResourceAllocator:
             return_value=(ExecutionResources(0, 1, 0), ExecutionResources.inf())
         )
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(gpu=4)
         op_usages = {
@@ -615,7 +616,7 @@ class TestReservationOpResourceAllocator:
             return_value=(ExecutionResources(0, 1, 0), ExecutionResources(0, 1, 0))
         )
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(gpu=4)
         op_usages = {
@@ -657,7 +658,7 @@ class TestReservationOpResourceAllocator:
             return_value=(ExecutionResources(0, 1, 0), ExecutionResources(0, 2, 0))
         )
 
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(gpu=1)
         op_usages = {
@@ -707,7 +708,7 @@ class TestReservationOpResourceAllocator:
             return_value=(ExecutionResources(0, 1, 0), ExecutionResources.inf())
         )
 
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(gpu=8)
         op_usages = {
@@ -771,7 +772,7 @@ class TestReservationOpResourceAllocator:
         )
         o5 = mock_map_op(o4, ray_remote_args={"num_cpus": 1}, name="Write")
 
-        topo = build_streaming_topology(o5, ExecutionOptions())
+        topo = build_streaming_topology(o5, ExecutionOptions(), noop_counter())
 
         # Cluster with 2 GPUs available
         global_limits = ExecutionResources(
@@ -835,7 +836,7 @@ class TestReservationOpResourceAllocator:
             return_value=(ExecutionResources(0, 1, 0), ExecutionResources.inf())
         )
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(gpu=8)
         op_usages = {
@@ -927,7 +928,7 @@ class TestReservationOpResourceAllocator:
             )
         )
 
-        topo = build_streaming_topology(write_op, ExecutionOptions())
+        topo = build_streaming_topology(write_op, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(cpu=8, gpu=8, object_store_memory=10_000_000)
         ops = [o1, read_op, infer1_op, infer2_op, write_op]
@@ -991,7 +992,7 @@ class TestReservationOpResourceAllocator:
         op_internal_usage = dict.fromkeys([o1, o2, o3, o4], 0)
         op_outputs_usages = dict.fromkeys([o1, o2, o3, o4], 0)
 
-        topo = build_streaming_topology(o4, ExecutionOptions())
+        topo = build_streaming_topology(o4, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources(cpu=10, object_store_memory=250)
 
@@ -1085,7 +1086,7 @@ class TestReservationOpResourceAllocator:
         op_internal_usage = dict.fromkeys([o1, o2, o3, o4, o5, o6, o7, o8], 0)
         op_outputs_usages = dict.fromkeys([o1, o2, o3, o4, o5, o6, o7, o8], 0)
 
-        topo = build_streaming_topology(o8, ExecutionOptions())
+        topo = build_streaming_topology(o8, ExecutionOptions(), noop_counter())
 
         global_limits = ExecutionResources.zero()
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -102,10 +102,6 @@ def mock_all_to_all_op(input_op, name="MockShuffle"):
         data_context=DataContext.get_current(),
         name=name,
     )
-    op.start(
-        ExecutionOptions(),
-        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
-    )
     return op
 
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -476,10 +476,10 @@ class TestResourceManager:
         o4 = mock_map_op(o3)
         o5 = mock_map_op(o4)
 
+        topo = build_streaming_topology(o5, ExecutionOptions(), noop_counter())
+
         o1.mark_execution_finished()
         o2.mark_execution_finished()
-
-        topo = build_streaming_topology(o5, ExecutionOptions(), noop_counter())
 
         op_usages = {
             o1: ExecutionResources.zero(),
@@ -533,13 +533,13 @@ class TestResourceManager:
         o7 = InputDataBuffer(DataContext.get_current(), [])
         o8 = mock_join_op(o7, o6)
 
+        topo = build_streaming_topology(o8, ExecutionOptions(), noop_counter())
+
         o1.mark_execution_finished()
         o2.mark_execution_finished()
         o4.mark_execution_finished()
         o5.mark_execution_finished()
         o7.mark_execution_finished()
-
-        topo = build_streaming_topology(o8, ExecutionOptions(), noop_counter())
 
         op_usages = {
             o1: ExecutionResources.zero(),
@@ -579,10 +579,11 @@ class TestResourceManager:
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
+
         o1.mark_execution_finished()
         o2.mark_execution_finished()
 
-        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 
 import ray
 from ray.data._internal.compute import ComputeStrategy
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import BlockEntry, PhysicalOperator
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
@@ -56,7 +57,7 @@ def mock_map_op(
         compute_strategy=compute_strategy,
         name=name,
     )
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     return op
 
 
@@ -101,7 +102,7 @@ def mock_all_to_all_op(input_op, name="MockShuffle"):
         data_context=DataContext.get_current(),
         name=name,
     )
-    op.start(ExecutionOptions())
+    op.start(ExecutionOptions(), BlockRefCounter())
     return op
 
 
@@ -119,6 +120,7 @@ def _resource_manager_for_limits_only_test(
         options,
         get_total_resources,
         DataContext.get_current(),
+        BlockRefCounter(),
     )
 
 
@@ -283,6 +285,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager._op_resource_allocator = None
         resource_manager.update_usages()
@@ -345,6 +348,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(return_value=ExecutionResources.zero()),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         ray.data.DataContext.get_current()._max_num_blocks_in_streaming_gen_buffer = 1
         ray.data.DataContext.get_current().target_max_block_size = 2
@@ -454,6 +458,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(return_value=ExecutionResources.zero()),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
 
         resource_manager.update_usages()
@@ -490,6 +495,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
 
@@ -552,6 +558,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
 
@@ -582,6 +589,7 @@ class TestResourceManager:
             ExecutionOptions(),
             lambda: cluster_resources,
             DataContext.get_current(),
+            BlockRefCounter(),
         )
 
         for op in [o1, o2, o3]:
@@ -650,6 +658,7 @@ class TestResourceManager:
             ExecutionOptions(),
             lambda: ExecutionResources(cpu=10, gpu=0, object_store_memory=1000),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         buf.current_logical_usage = MagicMock(return_value=ExecutionResources.zero())
         buf.running_logical_usage = MagicMock(return_value=ExecutionResources.zero())
@@ -681,6 +690,7 @@ class TestResourceManager:
             ExecutionOptions(),
             lambda: cluster_resources,
             DataContext.get_current(),
+            BlockRefCounter(),
         )
 
         for op in [o1, o2, o3]:
@@ -723,6 +733,7 @@ class TestResourceManager:
                 ExecutionOptions(),
                 MagicMock(return_value=ExecutionResources.zero()),
                 DataContext.get_current(),
+                BlockRefCounter(),
             )
 
     def test_topology_rejects_empty_topology(self, restore_data_context):
@@ -732,6 +743,7 @@ class TestResourceManager:
                 ExecutionOptions(),
                 MagicMock(return_value=ExecutionResources.zero()),
                 DataContext.get_current(),
+                BlockRefCounter(),
             )
 
     def test_topology_rejects_no_terminal_operator(self, restore_data_context):
@@ -749,6 +761,7 @@ class TestResourceManager:
                 ExecutionOptions(),
                 MagicMock(return_value=ExecutionResources.zero()),
                 DataContext.get_current(),
+                BlockRefCounter(),
             )
 
     def test_is_blocking_materializing_op(self, restore_data_context):
@@ -777,6 +790,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
 
         # Case 1: Shuffle operator itself is blocking materializing
@@ -807,6 +821,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
 
         # o5's downstream (o6, o7) has no blocking materializing ops
@@ -834,6 +849,7 @@ class TestResourceManager:
             options=options,
             get_total_resources=lambda: cluster_resources,
             data_context=DataContext.get_current(),
+            block_ref_counter=BlockRefCounter(),
         )
         resource_manager.update_usages()
 
@@ -866,6 +882,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -883,6 +900,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -910,6 +928,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -944,6 +963,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
         o3.num_active_tasks = MagicMock(return_value=0)
@@ -974,6 +994,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -1015,6 +1036,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
+            BlockRefCounter(),
         )
         assert not resource_manager.op_resource_allocator_enabled()
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -41,6 +41,7 @@ from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.block import TaskExecWorkerStats
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.conftest import noop_counter
 
 
 def mock_map_op(
@@ -56,10 +57,6 @@ def mock_map_op(
         ray_remote_args=ray_remote_args or {},
         compute_strategy=compute_strategy,
         name=name,
-    )
-    op.start(
-        ExecutionOptions(),
-        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
     )
     return op
 
@@ -228,7 +225,7 @@ class TestResourceManager:
         o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         # Mock different metrics that contribute to the resource usage.
         mock_cpu = {
@@ -348,7 +345,7 @@ class TestResourceManager:
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),
@@ -458,7 +455,7 @@ class TestResourceManager:
             internal=42, outputs=100
         )
 
-        topo = build_streaming_topology(override, ExecutionOptions())
+        topo = build_streaming_topology(override, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),
@@ -486,7 +483,7 @@ class TestResourceManager:
         o1.mark_execution_finished()
         o2.mark_execution_finished()
 
-        topo = build_streaming_topology(o5, ExecutionOptions())
+        topo = build_streaming_topology(o5, ExecutionOptions(), noop_counter())
 
         op_usages = {
             o1: ExecutionResources.zero(),
@@ -546,7 +543,7 @@ class TestResourceManager:
         o5.mark_execution_finished()
         o7.mark_execution_finished()
 
-        topo = build_streaming_topology(o8, ExecutionOptions())
+        topo = build_streaming_topology(o8, ExecutionOptions(), noop_counter())
 
         op_usages = {
             o1: ExecutionResources.zero(),
@@ -589,7 +586,7 @@ class TestResourceManager:
         o1.mark_execution_finished()
         o2.mark_execution_finished()
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),
@@ -658,7 +655,7 @@ class TestResourceManager:
         attach to that terminal sink instead of being dropped by the
         InputDataBuffer early return."""
         buf = InputDataBuffer(DataContext.get_current(), [])
-        topo = build_streaming_topology(buf, ExecutionOptions())
+        topo = build_streaming_topology(buf, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),
@@ -690,7 +687,7 @@ class TestResourceManager:
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
         resource_manager = ResourceManager(
             topo,
             ExecutionOptions(),
@@ -789,7 +786,7 @@ class TestResourceManager:
         o4 = mock_all_to_all_op(o3, name="Sort")
         o5 = mock_map_op(o4, name="Map2")
 
-        topo = build_streaming_topology(o5, ExecutionOptions())
+        topo = build_streaming_topology(o5, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -821,7 +818,7 @@ class TestResourceManager:
         o6 = LimitOperator(1, o5, DataContext.get_current())
         o7 = mock_map_op(o6, name="Map3")
 
-        topo2 = build_streaming_topology(o7, ExecutionOptions())
+        topo2 = build_streaming_topology(o7, ExecutionOptions(), noop_counter())
         resource_manager2 = ResourceManager(
             topo2,
             ExecutionOptions(),
@@ -847,7 +844,7 @@ class TestResourceManager:
             name="HighMemoryTask",
         )
 
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
         options = ExecutionOptions()
 
         resource_manager = ResourceManager(
@@ -883,7 +880,7 @@ class TestOutputBackpressureGuard:
         o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2, DataContext.get_current())
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -901,7 +898,7 @@ class TestOutputBackpressureGuard:
         # Add o4 operator - o2 is no longer terminal
         o4 = mock_map_op(o3)
 
-        topo = build_streaming_topology(o4, ExecutionOptions())
+        topo = build_streaming_topology(o4, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -929,7 +926,7 @@ class TestOutputBackpressureGuard:
         o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2, DataContext.get_current())
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -964,7 +961,7 @@ class TestOutputBackpressureGuard:
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -995,7 +992,7 @@ class TestOutputBackpressureGuard:
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,
@@ -1037,7 +1034,7 @@ class TestOutputBackpressureGuard:
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
-        topo = build_streaming_topology(o3, ExecutionOptions())
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
 
         resource_manager = ResourceManager(
             topo,

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -57,7 +57,10 @@ def mock_map_op(
         compute_strategy=compute_strategy,
         name=name,
     )
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(
+        ExecutionOptions(),
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+    )
     return op
 
 
@@ -102,7 +105,10 @@ def mock_all_to_all_op(input_op, name="MockShuffle"):
         data_context=DataContext.get_current(),
         name=name,
     )
-    op.start(ExecutionOptions(), BlockRefCounter())
+    op.start(
+        ExecutionOptions(),
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+    )
     return op
 
 
@@ -120,7 +126,7 @@ def _resource_manager_for_limits_only_test(
         options,
         get_total_resources,
         DataContext.get_current(),
-        BlockRefCounter(),
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
     )
 
 
@@ -285,7 +291,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager._op_resource_allocator = None
         resource_manager.update_usages()
@@ -348,7 +354,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(return_value=ExecutionResources.zero()),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         ray.data.DataContext.get_current()._max_num_blocks_in_streaming_gen_buffer = 1
         ray.data.DataContext.get_current().target_max_block_size = 2
@@ -458,7 +464,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(return_value=ExecutionResources.zero()),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
 
         resource_manager.update_usages()
@@ -495,7 +501,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
 
@@ -558,7 +564,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
 
@@ -589,7 +595,7 @@ class TestResourceManager:
             ExecutionOptions(),
             lambda: cluster_resources,
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
 
         for op in [o1, o2, o3]:
@@ -658,7 +664,7 @@ class TestResourceManager:
             ExecutionOptions(),
             lambda: ExecutionResources(cpu=10, gpu=0, object_store_memory=1000),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         buf.current_logical_usage = MagicMock(return_value=ExecutionResources.zero())
         buf.running_logical_usage = MagicMock(return_value=ExecutionResources.zero())
@@ -690,7 +696,7 @@ class TestResourceManager:
             ExecutionOptions(),
             lambda: cluster_resources,
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
 
         for op in [o1, o2, o3]:
@@ -733,7 +739,7 @@ class TestResourceManager:
                 ExecutionOptions(),
                 MagicMock(return_value=ExecutionResources.zero()),
                 DataContext.get_current(),
-                BlockRefCounter(),
+                BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
             )
 
     def test_topology_rejects_empty_topology(self, restore_data_context):
@@ -743,7 +749,7 @@ class TestResourceManager:
                 ExecutionOptions(),
                 MagicMock(return_value=ExecutionResources.zero()),
                 DataContext.get_current(),
-                BlockRefCounter(),
+                BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
             )
 
     def test_topology_rejects_no_terminal_operator(self, restore_data_context):
@@ -761,7 +767,7 @@ class TestResourceManager:
                 ExecutionOptions(),
                 MagicMock(return_value=ExecutionResources.zero()),
                 DataContext.get_current(),
-                BlockRefCounter(),
+                BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
             )
 
     def test_is_blocking_materializing_op(self, restore_data_context):
@@ -790,7 +796,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
 
         # Case 1: Shuffle operator itself is blocking materializing
@@ -821,7 +827,7 @@ class TestResourceManager:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
 
         # o5's downstream (o6, o7) has no blocking materializing ops
@@ -849,7 +855,9 @@ class TestResourceManager:
             options=options,
             get_total_resources=lambda: cluster_resources,
             data_context=DataContext.get_current(),
-            block_ref_counter=BlockRefCounter(),
+            block_ref_counter=BlockRefCounter(
+                add_object_out_of_scope_callback=lambda *_: True
+            ),
         )
         resource_manager.update_usages()
 
@@ -882,7 +890,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -900,7 +908,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -928,7 +936,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -963,7 +971,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
         o3.num_active_tasks = MagicMock(return_value=0)
@@ -994,7 +1002,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -1036,7 +1044,7 @@ class TestOutputBackpressureGuard:
             ExecutionOptions(),
             MagicMock(),
             DataContext.get_current(),
-            BlockRefCounter(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
         )
         assert not resource_manager.op_resource_allocator_enabled()
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -66,7 +66,7 @@ def mock_union_op(input_ops):
         DataContext.get_current(),
         *input_ops,
     )
-    op.start = MagicMock(side_effect=lambda _: None)
+    op.start = MagicMock(side_effect=lambda *_: None)
     return op
 
 
@@ -90,7 +90,7 @@ def mock_join_op(left_input_op, right_input_op):
             partition_size_hint=1,
         )
 
-    op.start = MagicMock(side_effect=lambda _: None)
+    op.start = MagicMock(side_effect=lambda *_: None)
     return op
 
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -534,6 +534,7 @@ def test_process_completed_tasks_unblocks_when_non_resource_budget_policy_zeros_
         ExecutionOptions(),
         MagicMock(),
         DataContext.get_current(),
+        BlockRefCounter(),
     )
     guard = OutputBackpressureGuard(topo, resource_manager)
 
@@ -754,6 +755,7 @@ def test_debug_dump_topology(ray_start_regular_shared):
         ExecutionOptions(),
         MagicMock(return_value=ExecutionResources.zero()),
         DataContext.get_current(),
+        BlockRefCounter(),
     )
     resource_manager.update_usages()
     # Just a sanity check to ensure it doesn't crash.
@@ -1392,13 +1394,6 @@ def ensure_block_metadata_stored_in_plasma(monkeypatch):
     monkeypatch.setenv("RAY_max_direct_call_object_size", 0)
 
 
-def _make_data_op_task(task_index, streaming_gen, **kwargs):
-    """Create a DataOpTask with a default BlockRefCounter and producer_id for tests."""
-    kwargs.setdefault("block_ref_counter", BlockRefCounter())
-    kwargs.setdefault("producer_id", "test_op")
-    return DataOpTask(task_index, streaming_gen, **kwargs)
-
-
 class TestDataOpTask:
     def test_on_data_ready_single_output(self, ray_start_regular_shared):
         streaming_gen = create_stub_streaming_gen(block_nbytes=[128 * MiB])
@@ -1406,8 +1401,12 @@ class TestDataOpTask:
         def verify_output(bundle):
             assert bundle.size_bytes() == pytest.approx(128 * MiB), bundle.size_bytes()
 
-        data_op_task = _make_data_op_task(
-            0, streaming_gen, output_ready_callback=verify_output
+        data_op_task = DataOpTask(
+            0,
+            streaming_gen,
+            BlockRefCounter(),
+            "test_op",
+            output_ready_callback=verify_output,
         )
 
         bytes_read = 0
@@ -1424,8 +1423,12 @@ class TestDataOpTask:
         def verify_output(bundle):
             assert bundle.size_bytes() == pytest.approx(128 * MiB), bundle.size_bytes()
 
-        data_op_task = _make_data_op_task(
-            0, streaming_gen, output_ready_callback=verify_output
+        data_op_task = DataOpTask(
+            0,
+            streaming_gen,
+            BlockRefCounter(),
+            "test_op",
+            output_ready_callback=verify_output,
         )
 
         bytes_read = 0
@@ -1447,9 +1450,11 @@ class TestDataOpTask:
             assert task_exec_stats is None
             assert task_exec_driver_stats is None
 
-        data_op_task = _make_data_op_task(
+        data_op_task = DataOpTask(
             0,
             streaming_gen,
+            BlockRefCounter(),
+            "test_op",
             task_done_callback=verify_exception,
         )
 
@@ -1460,11 +1465,17 @@ class TestDataOpTask:
 
     def test_operator_name_parameter(self, ray_start_regular_shared):
         streaming_gen = create_stub_streaming_gen(block_nbytes=[1])
-        task = _make_data_op_task(0, streaming_gen, operator_name="MapBatches(fn)")
+        task = DataOpTask(
+            0,
+            streaming_gen,
+            BlockRefCounter(),
+            "test_op",
+            operator_name="MapBatches(fn)",
+        )
         assert task._operator_name == "MapBatches(fn)"
 
         streaming_gen2 = create_stub_streaming_gen(block_nbytes=[1])
-        task_default = _make_data_op_task(1, streaming_gen2)
+        task_default = DataOpTask(1, streaming_gen2, BlockRefCounter(), "test_op")
         assert task_default._operator_name == "Unknown"
 
     @pytest.mark.parametrize(
@@ -1501,8 +1512,12 @@ class TestDataOpTask:
             new_worker_node = cluster.add_node(num_cpus=1)  # noqa: F841
             cluster.wait_for_nodes()
 
-        data_op_task = _make_data_op_task(
-            0, streaming_gen, **{preempt_on: remove_and_add_back_worker_node}
+        data_op_task = DataOpTask(
+            0,
+            streaming_gen,
+            BlockRefCounter(),
+            "test_op",
+            **{preempt_on: remove_and_add_back_worker_node},
         )
 
         # Run the task to completion.
@@ -1532,7 +1547,7 @@ class TestDataOpTask:
 
         # Create a streaming generator that produces a single 128 MiB output block.
         streaming_gen = create_stub_streaming_gen(block_nbytes=[128 * MiB])
-        data_op_task = _make_data_op_task(0, streaming_gen)
+        data_op_task = DataOpTask(0, streaming_gen, BlockRefCounter(), "test_op")
 
         # Wait for the block to be ready, then remove the worker node.
         ray.wait([streaming_gen], fetch_local=False)
@@ -1572,9 +1587,11 @@ class TestDataOpTask:
             captured_stats["task_exec_stats"] = task_exec_stats
             captured_stats["task_exec_driver_stats"] = task_exec_driver_stats
 
-        data_op_task = _make_data_op_task(
+        data_op_task = DataOpTask(
             0,
             streaming_gen,
+            BlockRefCounter(),
+            "test_op",
             task_done_callback=capture_done,
         )
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -23,6 +23,7 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.backpressure_policy.resource_budget_backpressure_policy import (
     ResourceBudgetBackpressurePolicy,
 )
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.execution_callback import ExecutionCallback
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
@@ -1391,6 +1392,13 @@ def ensure_block_metadata_stored_in_plasma(monkeypatch):
     monkeypatch.setenv("RAY_max_direct_call_object_size", 0)
 
 
+def _make_data_op_task(task_index, streaming_gen, **kwargs):
+    """Create a DataOpTask with a default BlockRefCounter and producer_id for tests."""
+    kwargs.setdefault("block_ref_counter", BlockRefCounter())
+    kwargs.setdefault("producer_id", "test_op")
+    return DataOpTask(task_index, streaming_gen, **kwargs)
+
+
 class TestDataOpTask:
     def test_on_data_ready_single_output(self, ray_start_regular_shared):
         streaming_gen = create_stub_streaming_gen(block_nbytes=[128 * MiB])
@@ -1398,7 +1406,9 @@ class TestDataOpTask:
         def verify_output(bundle):
             assert bundle.size_bytes() == pytest.approx(128 * MiB), bundle.size_bytes()
 
-        data_op_task = DataOpTask(0, streaming_gen, output_ready_callback=verify_output)
+        data_op_task = _make_data_op_task(
+            0, streaming_gen, output_ready_callback=verify_output
+        )
 
         bytes_read = 0
         while not data_op_task.has_finished:
@@ -1414,7 +1424,9 @@ class TestDataOpTask:
         def verify_output(bundle):
             assert bundle.size_bytes() == pytest.approx(128 * MiB), bundle.size_bytes()
 
-        data_op_task = DataOpTask(0, streaming_gen, output_ready_callback=verify_output)
+        data_op_task = _make_data_op_task(
+            0, streaming_gen, output_ready_callback=verify_output
+        )
 
         bytes_read = 0
         while not data_op_task.has_finished:
@@ -1435,7 +1447,7 @@ class TestDataOpTask:
             assert task_exec_stats is None
             assert task_exec_driver_stats is None
 
-        data_op_task = DataOpTask(
+        data_op_task = _make_data_op_task(
             0,
             streaming_gen,
             task_done_callback=verify_exception,
@@ -1448,11 +1460,11 @@ class TestDataOpTask:
 
     def test_operator_name_parameter(self, ray_start_regular_shared):
         streaming_gen = create_stub_streaming_gen(block_nbytes=[1])
-        task = DataOpTask(0, streaming_gen, operator_name="MapBatches(fn)")
+        task = _make_data_op_task(0, streaming_gen, operator_name="MapBatches(fn)")
         assert task._operator_name == "MapBatches(fn)"
 
         streaming_gen2 = create_stub_streaming_gen(block_nbytes=[1])
-        task_default = DataOpTask(1, streaming_gen2)
+        task_default = _make_data_op_task(1, streaming_gen2)
         assert task_default._operator_name == "Unknown"
 
     @pytest.mark.parametrize(
@@ -1489,7 +1501,7 @@ class TestDataOpTask:
             new_worker_node = cluster.add_node(num_cpus=1)  # noqa: F841
             cluster.wait_for_nodes()
 
-        data_op_task = DataOpTask(
+        data_op_task = _make_data_op_task(
             0, streaming_gen, **{preempt_on: remove_and_add_back_worker_node}
         )
 
@@ -1520,7 +1532,7 @@ class TestDataOpTask:
 
         # Create a streaming generator that produces a single 128 MiB output block.
         streaming_gen = create_stub_streaming_gen(block_nbytes=[128 * MiB])
-        data_op_task = DataOpTask(0, streaming_gen)
+        data_op_task = _make_data_op_task(0, streaming_gen)
 
         # Wait for the block to be ready, then remove the worker node.
         ray.wait([streaming_gen], fetch_local=False)
@@ -1560,7 +1572,7 @@ class TestDataOpTask:
             captured_stats["task_exec_stats"] = task_exec_stats
             captured_stats["task_exec_driver_stats"] = task_exec_driver_stats
 
-        data_op_task = DataOpTask(
+        data_op_task = _make_data_op_task(
             0,
             streaming_gen,
             task_done_callback=capture_done,

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -70,6 +70,7 @@ from ray.data._internal.util import MiB
 from ray.data.block import BlockAccessor, BlockMetadataWithSchema, TaskExecWorkerStats
 from ray.data.context import EXECUTION_CALLBACKS_ENV_VAR, DataContext
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.conftest import noop_counter
 
 
 def mock_resource_manager(
@@ -125,7 +126,7 @@ def test_build_streaming_topology(verbose_progress, ray_start_regular_shared):
         DataContext.get_current(),
     )
     topo = build_streaming_topology(
-        o3, ExecutionOptions(verbose_progress=verbose_progress)
+        o3, ExecutionOptions(verbose_progress=verbose_progress), noop_counter()
     )
     assert len(topo) == 3, topo
     assert o1 in topo, topo
@@ -155,7 +156,9 @@ def test_disallow_non_unique_operators(ray_start_regular_shared):
         DataContext.get_current(),
     )
     with pytest.raises(ValueError):
-        build_streaming_topology(o4, ExecutionOptions(verbose_progress=True))
+        build_streaming_topology(
+            o4, ExecutionOptions(verbose_progress=True), noop_counter()
+        )
 
 
 def _make_disabled_guard() -> MagicMock:
@@ -180,7 +183,9 @@ def test_process_completed_tasks(sleep_task_ref, ray_start_regular_shared):
         o1,
         DataContext.get_current(),
     )
-    topo = build_streaming_topology(o2, ExecutionOptions(verbose_progress=True))
+    topo = build_streaming_topology(
+        o2, ExecutionOptions(verbose_progress=True), noop_counter()
+    )
 
     # Test processing output bundles.
     assert len(topo[o1].output_queue) == 0, topo
@@ -229,7 +234,9 @@ def test_process_completed_tasks(sleep_task_ref, ray_start_regular_shared):
         o2,
         DataContext.get_current(),
     )
-    topo = build_streaming_topology(o3, ExecutionOptions(verbose_progress=True))
+    topo = build_streaming_topology(
+        o3, ExecutionOptions(verbose_progress=True), noop_counter()
+    )
 
     o3.mark_execution_finished()
     o2.mark_execution_finished = MagicMock()
@@ -254,7 +261,9 @@ def test_update_operator_states_drains_upstream(ray_start_regular_shared):
         o2,
         DataContext.get_current(),
     )
-    topo = build_streaming_topology(o3, ExecutionOptions(verbose_progress=True))
+    topo = build_streaming_topology(
+        o3, ExecutionOptions(verbose_progress=True), noop_counter()
+    )
 
     # First, populate the upstream output queues by processing some tasks
     process_completed_tasks(topo, [], 0, _make_disabled_guard())
@@ -299,7 +308,7 @@ def test_get_eligible_operators_to_run(ray_start_regular_shared):
         DataContext.get_current(),
         name="O3",
     )
-    topo = build_streaming_topology(o3, opts)
+    topo = build_streaming_topology(o3, opts, noop_counter())
 
     resource_manager = mock_resource_manager(
         global_limits=ExecutionResources.for_limits(1, 1, 1),
@@ -374,7 +383,7 @@ def test_backpressure_policy_tracking(ray_start_regular_shared):
         DataContext.get_current(),
         name="O2",
     )
-    topo = build_streaming_topology(o2, opts)
+    topo = build_streaming_topology(o2, opts, noop_counter())
 
     # Add input to o2's input queue so it becomes eligible
     topo[o1].output_queue.append(make_ref_bundle("dummy1"))
@@ -452,7 +461,7 @@ def test_output_backpressure_policy_tracking(ray_start_regular_shared):
         DataContext.get_current(),
         name="O2",
     )
-    topo = build_streaming_topology(o2, opts)
+    topo = build_streaming_topology(o2, opts, noop_counter())
 
     # Create mock backpressure policies for output limiting with name property
     class LimitingPolicy:
@@ -527,7 +536,7 @@ def test_process_completed_tasks_unblocks_when_non_resource_budget_policy_zeros_
         DataContext.get_current(),
         name="O2",
     )
-    topo = build_streaming_topology(o2, ExecutionOptions())
+    topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
 
     resource_manager = ResourceManager(
         topo,
@@ -576,7 +585,7 @@ def test_summary_str_backpressure_policies(ray_start_regular_shared):
         DataContext.get_current(),
         name="O2",
     )
-    topo = build_streaming_topology(o2, opts)
+    topo = build_streaming_topology(o2, opts, noop_counter())
 
     resource_manager = mock_resource_manager()
 
@@ -681,7 +690,7 @@ def test_select_ops_to_run(ray_start_regular_shared):
         # Case 1: Should pick the `o4` since it has throttling disabled
         _mock.return_value = [o1, o2, o3, o4]
 
-        topo = build_streaming_topology(o4, opts)
+        topo = build_streaming_topology(o4, opts, noop_counter())
 
         selected = select_operator_to_run(
             topo,
@@ -696,7 +705,7 @@ def test_select_ops_to_run(ray_start_regular_shared):
         # Case 2: Should pick the `o1` since it has lowest object store usage
         _mock.return_value = [o1, o2, o3]
 
-        topo = build_streaming_topology(o3, opts)
+        topo = build_streaming_topology(o3, opts, noop_counter())
 
         selected = select_operator_to_run(
             topo,
@@ -749,7 +758,7 @@ def test_debug_dump_topology(ray_start_regular_shared):
         o2,
         DataContext.get_current(),
     )
-    topo = build_streaming_topology(o3, opt)
+    topo = build_streaming_topology(o3, opt, noop_counter())
     resource_manager = ResourceManager(
         topo,
         ExecutionOptions(),
@@ -869,7 +878,7 @@ class GetOutputBlockingTest(unittest.TestCase):
         """num_waiting_consumers is incremented/decremented by get_output_blocking."""
         o1 = InputDataBuffer(ray.data.DataContext.get_current(), [])
         o2 = LimitOperator(1, o1, ray.data.DataContext.get_current())
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
         state = topo[o2]
 
         assert state.num_waiting_consumers == 0
@@ -903,7 +912,7 @@ class GetOutputBlockingTest(unittest.TestCase):
         For example, this happens for multiple streaming_split iterators."""
         o1 = InputDataBuffer(ray.data.DataContext.get_current(), [])
         o2 = LimitOperator(1, o1, ray.data.DataContext.get_current())
-        topo = build_streaming_topology(o2, ExecutionOptions())
+        topo = build_streaming_topology(o2, ExecutionOptions(), noop_counter())
         state = topo[o2]
 
         def blocking_consumer():
@@ -1230,7 +1239,9 @@ def test_create_topology_metadata():
     executor = StreamingExecutor(DataContext.get_current())
 
     # Initialize the topology on the executor
-    executor._topology = build_streaming_topology(o3, ExecutionOptions())
+    executor._topology = build_streaming_topology(
+        o3, ExecutionOptions(), noop_counter()
+    )
 
     # Call the _dump_dag_structure method
     op_to_id = {
@@ -1293,7 +1304,9 @@ def test_create_topology_metadata_with_sub_stages():
 
     # Create the executor and set up topology
     executor = StreamingExecutor(DataContext.get_current())
-    executor._topology = build_streaming_topology(o2, ExecutionOptions())
+    executor._topology = build_streaming_topology(
+        o2, ExecutionOptions(), noop_counter()
+    )
 
     # Get the DAG structure
     op_to_id = {

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -134,7 +134,7 @@ def test_does_not_double_count_usage_from_union():
         ExecutionOptions(),
         lambda: total_resources,
         DataContext.get_current(),
-        BlockRefCounter(),
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
     )
 
     # Create two 1-byte `RefBundle`s.
@@ -197,7 +197,7 @@ def test_per_input_inqueue_attribution_for_union():
         options,
         lambda: total_resources,
         DataContext.get_current(),
-        BlockRefCounter(),
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
     )
 
     # Create two 10-byte RefBundles with distinct block refs (simulates real execution

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -1,6 +1,7 @@
 import pytest
 
 import ray
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
     PhysicalOperator,
@@ -133,6 +134,7 @@ def test_does_not_double_count_usage_from_union():
         ExecutionOptions(),
         lambda: total_resources,
         DataContext.get_current(),
+        BlockRefCounter(),
     )
 
     # Create two 1-byte `RefBundle`s.
@@ -195,6 +197,7 @@ def test_per_input_inqueue_attribution_for_union():
         options,
         lambda: total_resources,
         DataContext.get_current(),
+        BlockRefCounter(),
     )
 
     # Create two 10-byte RefBundles with distinct block refs (simulates real execution

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -21,6 +21,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.conftest import noop_counter
 
 
 def test_physical_operator_tracks_output_dependencies():
@@ -125,7 +126,7 @@ def test_does_not_double_count_usage_from_union():
     input1 = PhysicalOperator("op1", [], DataContext.get_current())
     input2 = PhysicalOperator("op2", [], DataContext.get_current())
     union_op = UnionOperator(DataContext.get_current(), input1, input2)
-    topology = build_streaming_topology(union_op, ExecutionOptions())
+    topology = build_streaming_topology(union_op, ExecutionOptions(), noop_counter())
 
     # Create a resource manager.
     total_resources = ExecutionResources(cpu=0, object_store_memory=2)
@@ -188,7 +189,7 @@ def test_per_input_inqueue_attribution_for_union():
 
     options = ExecutionOptions()
     options.preserve_order = True
-    topology = build_streaming_topology(union_op, options)
+    topology = build_streaming_topology(union_op, options, noop_counter())
 
     # Create a resource manager.
     total_resources = ExecutionResources(cpu=0, object_store_memory=200)


### PR DESCRIPTION
## Description
Wires `BlockRefCounter` into every operator and the streaming executor. `ResourceManager` gains the counter as an attribute in this PR, but `_estimate_object_store_memory_usage` is **not changed** to keep the scheduling-visible change isolated.
## Implementation
**`physical_operator.py`.** `PhysicalOperator.start()` now accepts `block_ref_counter` (replaces `set_block_ref_counter()` used in prototype per review). `DataOpTask.on_data_ready` calls `on_block_produced` once both the block ref and its metadata are available.
**`base_physical_operator.py`.** `AllToAllOperator.all_inputs_done` skips `on_block_produced` for output refs that are unchanged from the input, avoiding double-counting when `bulk_fn` forwards refs unchanged (e.g. `randomize_blocks`).
**`streaming_executor_state.py` / `streaming_executor.py`.** Operators are no longer started inside `build_streaming_topology`. The executor starts them after `ResourceManager` is constructed so the shared counter can be passed in. `block_ref_counter.clear()` is called at shutdown after queues are drained.
**`resource_manager.py`.** Constructs `BlockRefCounter()` and exposes it via a `block_ref_counter` property.
## Tests
- **`test_operators.py`**: updated to remove `set_block_ref_counter` calls; adds `op.start(ExecutionOptions())` where missing.
- **`test_streaming_executor.py`**: `_make_data_op_task` helper supplies default `block_ref_counter` and `producer_id` so existing `DataOpTask` tests compile.
## Related issues
Depends on ray-project/ray#64157 (`BlockRefCounter` implementation).
Related to ray-project/ray#63601 (prototype), ray-project/ray#63074 (previous manual `BlockRefCounter`).
