### PR TITLE
Add perf metrics for 2.56.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 97.652736,
+    "_dashboard_memory_usage_mb": 105.664512,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.01,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3706\t1.57GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3138\t1.05GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6374\t0.83GiB\tpython distributed/test_many_actors.py\n3932\t0.2GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4413\t0.17GiB\tray::DashboardAgent\n3177\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1440\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4415\t0.09GiB\tray::RuntimeEnvAgent\n3849\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n6514\t0.08GiB\tray::DashboardTester.run",
-    "actors_per_second": 528.8023526342919,
+    "_peak_memory": 4.06,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3753\t1.56GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n6481\t0.81GiB\tpython distributed/test_many_actors.py\n3079\t0.7GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3953\t0.29GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4410\t0.16GiB\tray::DashboardAgent\n1382\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3367\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4412\t0.09GiB\tray::RuntimeEnvAgent\n3881\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n6622\t0.08GiB\tray::DashboardTester.run",
+    "actors_per_second": 543.8785742285336,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 528.8023526342919
+            "perf_metric_value": 543.8785742285336
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.635
+            "perf_metric_value": 8.979
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1983.793
+            "perf_metric_value": 1657.416
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3389.923
+            "perf_metric_value": 3448.611
         }
     ],
-    "time": 18.910657167434692
+    "time": 18.386456966400146
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 90.198016,
+    "_dashboard_memory_usage_mb": 104.574976,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.36,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3547\t0.6GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2994\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5416\t0.31GiB\taide --config=/etc/aide/aide.conf --update --after=report_url=file:/var/lib/aide/dailyaidecheck/arun\n4911\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3762\t0.17GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4243\t0.13GiB\tray::DashboardAgent\n3105\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1364\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3680\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5117\t0.09GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 10.13,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3559\t0.58GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2968\t0.37GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n9406\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3759\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4246\t0.15GiB\tray::DashboardAgent\n3145\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1349\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3687\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5552\t0.09GiB\tray::StateAPIGeneratorActor.start\n4248\t0.09GiB\tray::RuntimeEnvAgent",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 183.49078025658062
+            "perf_metric_value": 404.91633590598434
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.651
+            "perf_metric_value": 6.93
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 46.531
+            "perf_metric_value": 31.679
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 138.51
+            "perf_metric_value": 40.594
         }
     ],
-    "tasks_per_second": 183.49078025658062,
-    "time": 305.44986510276794,
+    "tasks_per_second": 404.91633590598434,
+    "time": 302.46964597702026,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 79.745024,
+    "_dashboard_memory_usage_mb": 74.715136,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.63,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3660\t0.83GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2982\t0.59GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5085\t0.35GiB\tpython distributed/test_many_pgs.py\n590\t0.22GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4371\t0.15GiB\tray::DashboardAgent\n3887\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1392\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3149\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4373\t0.09GiB\tray::RuntimeEnvAgent\n3791\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
+    "_peak_memory": 2.6,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1383\t3.81GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3730\t0.8GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3059\t0.65GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5041\t0.34GiB\tpython distributed/test_many_pgs.py\n597\t0.26GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4392\t0.14GiB\tray::DashboardAgent\n3932\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3370\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4394\t0.09GiB\tray::RuntimeEnvAgent\n3860\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 80.95254123918434
+            "perf_metric_value": 81.40547605262907
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.74
+            "perf_metric_value": 6.287
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 147.311
+            "perf_metric_value": 78.689
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1879.035
+            "perf_metric_value": 2390.781
         }
     ],
-    "pgs_per_second": 80.95254123918434,
-    "time": 12.352916717529297
+    "pgs_per_second": 81.40547605262907,
+    "time": 12.284185886383057
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 98.545664,
+    "_dashboard_memory_usage_mb": 106.504192,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.58,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3704\t2.15GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3925\t1.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n5053\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3139\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3928\t0.19GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4406\t0.13GiB\tray::DashboardAgent\n3143\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1448\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5268\t0.09GiB\tray::StateAPIGeneratorActor.start\n4408\t0.09GiB\tray::RuntimeEnvAgent",
+    "_peak_memory": 3.88,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3752\t1.1GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5081\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3957\t0.5GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3196\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3960\t0.16GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4414\t0.13GiB\tray::DashboardAgent\n1398\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3337\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3880\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5271\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 373.6653345877981
+            "perf_metric_value": 695.6022071314425
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.121
+            "perf_metric_value": 4.624
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 241.548
+            "perf_metric_value": 549.229
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1104.206
+            "perf_metric_value": 826.157
         }
     ],
-    "tasks_per_second": 373.6653345877981,
-    "time": 326.7619152069092,
+    "tasks_per_second": 695.6022071314425,
+    "time": 314.3760325908661,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.55.0"}
+{"release_version": "2.56.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8396.874033285541,
-        203.90199139819524
+        8342.568803508693,
+        409.43886660421316
     ],
     "1_1_actor_calls_concurrent": [
-        5678.956390335692,
-        50.71434424461075
+        5456.76183608015,
+        149.29467253197765
     ],
     "1_1_actor_calls_sync": [
-        1879.6455165405484,
-        25.108186673715778
+        1875.0279275238897,
+        49.40205766058054
     ],
     "1_1_async_actor_calls_async": [
-        4616.604004176862,
-        193.83565419000846
+        4674.834383534435,
+        232.57006597926497
     ],
     "1_1_async_actor_calls_sync": [
-        1417.1846351735794,
-        16.71205106233678
+        1394.4268791918364,
+        15.24206462330469
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2966.3149904468737,
-        176.1920125374007
+        3095.214627776353,
+        121.39660247574591
     ],
     "1_n_actor_calls_async": [
-        7370.550357182028,
-        122.44520396894765
+        7040.378512116067,
+        141.86458492326545
     ],
     "1_n_async_actor_calls_async": [
-        6907.905927393101,
-        85.84985868672779
+        6788.316704875271,
+        77.05220000176223
     ],
     "client__1_1_actor_calls_async": [
-        1066.5581344588645,
-        25.29295730544665
+        1057.5113866970246,
+        13.869553032268188
     ],
     "client__1_1_actor_calls_concurrent": [
-        1050.5473572391506,
-        78.9131834499914
+        1081.7307840702588,
+        19.359582107431898
     ],
     "client__1_1_actor_calls_sync": [
-        539.1188849292095,
-        13.207864650501818
+        546.5462754693076,
+        4.769363506758825
     ],
     "client__get_calls": [
-        1110.3815800718512,
-        46.94010981271201
+        1268.2621386289416,
+        18.098812220449094
     ],
     "client__put_calls": [
-        847.7132252307356,
-        9.482802711501769
+        895.6970682564656,
+        21.35291764881878
     ],
     "client__put_gigabytes": [
-        0.09852699612927329,
-        0.0011153895982075907
+        0.09907086001824938,
+        0.0006618851832748623
     ],
     "client__tasks_and_get_batch": [
-        0.9637211637507427,
-        0.022560513795709242
+        0.9872625245252546,
+        0.027137922752983233
     ],
     "client__tasks_and_put_batch": [
-        12087.25786385043,
-        175.63310455993135
+        12226.580116183099,
+        101.66892202557969
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12844.074948208083,
-        142.37580714319805
+        12736.988267796403,
+        82.08132189135176
     ],
     "multi_client_put_gigabytes": [
-        40.8627833341568,
-        2.480266729516992
+        33.19310764876294,
+        0.7078519327392999
     ],
     "multi_client_tasks_async": [
-        21137.109008698124,
-        1293.3274307575432
+        20764.825419627614,
+        2629.3497580957887
     ],
     "n_n_actor_calls_async": [
-        23481.256884763905,
-        892.8391276253976
+        23724.72845970961,
+        267.42069527657407
     ],
     "n_n_actor_calls_with_arg_async": [
-        3222.5114335686285,
-        29.534933551700966
+        9560.124425456765,
+        45.98251082693428
     ],
     "n_n_async_actor_calls_async": [
-        21566.207868367015,
-        636.2725036061306
+        21588.896745325528,
+        495.1457556369605
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10618.338081970585
+            "perf_metric_value": 13307.428346767498
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4632.275852502236
+            "perf_metric_value": 4638.961748423475
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12844.074948208083
+            "perf_metric_value": 12736.988267796403
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.831166033501425
+            "perf_metric_value": 6.9262999947537205
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.481786077048712
+            "perf_metric_value": 7.689211462260507
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 40.8627833341568
+            "perf_metric_value": 33.19310764876294
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.123293390343653
+            "perf_metric_value": 12.306253537383725
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.933826950268857
+            "perf_metric_value": 5.10474924198598
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 813.2443700905843
+            "perf_metric_value": 847.2523785992521
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7096.786888013178
+            "perf_metric_value": 7044.008888726476
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21137.109008698124
+            "perf_metric_value": 20764.825419627614
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1879.6455165405484
+            "perf_metric_value": 1875.0279275238897
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8396.874033285541
+            "perf_metric_value": 8342.568803508693
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5678.956390335692
+            "perf_metric_value": 5456.76183608015
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7370.550357182028
+            "perf_metric_value": 7040.378512116067
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23481.256884763905
+            "perf_metric_value": 23724.72845970961
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3222.5114335686285
+            "perf_metric_value": 9560.124425456765
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1417.1846351735794
+            "perf_metric_value": 1394.4268791918364
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4616.604004176862
+            "perf_metric_value": 4674.834383534435
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2966.3149904468737
+            "perf_metric_value": 3095.214627776353
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6907.905927393101
+            "perf_metric_value": 6788.316704875271
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21566.207868367015
+            "perf_metric_value": 21588.896745325528
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 657.0579674498558
+            "perf_metric_value": 650.9409444317282
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1110.3815800718512
+            "perf_metric_value": 1268.2621386289416
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 847.7132252307356
+            "perf_metric_value": 895.6970682564656
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.09852699612927329
+            "perf_metric_value": 0.09907086001824938
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12087.25786385043
+            "perf_metric_value": 12226.580116183099
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 539.1188849292095
+            "perf_metric_value": 546.5462754693076
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1066.5581344588645
+            "perf_metric_value": 1057.5113866970246
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1050.5473572391506
+            "perf_metric_value": 1081.7307840702588
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9637211637507427
+            "perf_metric_value": 0.9872625245252546
         }
     ],
     "placement_group_create/removal": [
-        657.0579674498558,
-        3.492779228356284
+        650.9409444317282,
+        3.4369842155053876
     ],
     "single_client_get_calls_Plasma_Store": [
-        10618.338081970585,
-        208.9811943036501
+        13307.428346767498,
+        124.19362621147212
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.123293390343653,
-        0.09539779266926034
+        12.306253537383725,
+        0.1292574303967555
     ],
     "single_client_put_calls_Plasma_Store": [
-        4632.275852502236,
-        36.084422332688135
+        4638.961748423475,
+        14.171431696132693
     ],
     "single_client_put_gigabytes": [
-        12.831166033501425,
-        9.770703025046103
+        6.9262999947537205,
+        4.926803289933447
     ],
     "single_client_tasks_and_get_batch": [
-        5.481786077048712,
-        2.8262175645089083
+        7.689211462260507,
+        0.43050221975482145
     ],
     "single_client_tasks_async": [
-        7096.786888013178,
-        236.50107313394884
+        7044.008888726476,
+        460.0339215170094
     ],
     "single_client_tasks_sync": [
-        813.2443700905843,
-        10.854662507708719
+        847.2523785992521,
+        4.09258394508908
     ],
     "single_client_wait_1k_refs": [
-        4.933826950268857,
-        0.16035857361821815
+        5.10474924198598,
+        0.17082054672729655
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.648311011999994,
+    "broadcast_time": 12.559787903,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.648311011999994
+            "perf_metric_value": 12.559787903
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 12.265755501000008,
-    "get_time": 15.200454125999997,
+    "args_time": 11.414861877,
+    "get_time": 15.554129597,
     "large_object_size": 107374182400,
-    "large_object_time": 24.263247010999976,
+    "large_object_time": 25.059670065000006,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.265755501000008
+            "perf_metric_value": 11.414861877
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.7088375179999957
+            "perf_metric_value": 3.651634725000008
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.200454125999997
+            "perf_metric_value": 15.554129597
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 140.07216235099997
+            "perf_metric_value": 113.14399953099999
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.263247010999976
+            "perf_metric_value": 25.059670065000006
         }
     ],
-    "queued_time": 140.07216235099997,
-    "returns_time": 3.7088375179999957,
+    "queued_time": 113.14399953099999,
+    "returns_time": 3.651634725000008,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 1.45254629611969,
-    "max_iteration_time": 5.837781667709351,
-    "min_iteration_time": 0.07228946685791016,
+    "avg_iteration_time": 1.0267318749427796,
+    "max_iteration_time": 4.054374694824219,
+    "min_iteration_time": 0.06292486190795898,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.45254629611969
+            "perf_metric_value": 1.0267318749427796
         }
     ],
-    "total_time": 145.25475406646729
+    "total_time": 102.67332315444946
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.620674133300781
+            "perf_metric_value": 7.522381067276001
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.162811255455017
+            "perf_metric_value": 13.57498586177826
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 37.03696446418762
+            "perf_metric_value": 36.382873344421384
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.1294972896575928
+            "perf_metric_value": 1.72922945022583
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2621.6581025123596
+            "perf_metric_value": 2306.0974526405334
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.6704279092079272
+            "perf_metric_value": 0.2940698300890875
         }
     ],
-    "stage_0_time": 8.620674133300781,
-    "stage_1_avg_iteration_time": 15.162811255455017,
-    "stage_1_max_iteration_time": 17.312448978424072,
-    "stage_1_min_iteration_time": 13.779070854187012,
-    "stage_1_time": 151.62816882133484,
-    "stage_2_avg_iteration_time": 37.03696446418762,
-    "stage_2_max_iteration_time": 41.41323781013489,
-    "stage_2_min_iteration_time": 35.700154542922974,
-    "stage_2_time": 185.1853449344635,
-    "stage_3_creation_time": 3.1294972896575928,
-    "stage_3_time": 2621.6581025123596,
-    "stage_4_spread": 0.6704279092079272
+    "stage_0_time": 7.522381067276001,
+    "stage_1_avg_iteration_time": 13.57498586177826,
+    "stage_1_max_iteration_time": 14.0574471950531,
+    "stage_1_min_iteration_time": 12.494763135910034,
+    "stage_1_time": 135.7499294281006,
+    "stage_2_avg_iteration_time": 36.382873344421384,
+    "stage_2_max_iteration_time": 37.604820013046265,
+    "stage_2_min_iteration_time": 35.432323932647705,
+    "stage_2_time": 181.91491556167603,
+    "stage_3_creation_time": 1.72922945022583,
+    "stage_3_time": 2306.0974526405334,
+    "stage_4_spread": 0.2940698300890875
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.6259311876874045,
-    "avg_pg_remove_time_ms": 1.7122211741741544,
+    "avg_pg_create_time_ms": 1.7084268978985828,
+    "avg_pg_remove_time_ms": 1.4966242087084354,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.6259311876874045
+            "perf_metric_value": 1.7084268978985828
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.7122211741741544
+            "perf_metric_value": 1.4966242087084354
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 46.02%: single_client_put_gigabytes (THROUGHPUT) regresses from 12.831166033501425 to 6.9262999947537205 in microbenchmark.json
REGRESSION 18.77%: multi_client_put_gigabytes (THROUGHPUT) regresses from 40.8627833341568 to 33.19310764876294 in microbenchmark.json
REGRESSION 4.48%: 1_n_actor_calls_async (THROUGHPUT) regresses from 7370.550357182028 to 7040.378512116067 in microbenchmark.json
REGRESSION 3.91%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5678.956390335692 to 5456.76183608015 in microbenchmark.json
REGRESSION 1.76%: multi_client_tasks_async (THROUGHPUT) regresses from 21137.109008698124 to 20764.825419627614 in microbenchmark.json
REGRESSION 1.73%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 6907.905927393101 to 6788.316704875271 in microbenchmark.json
REGRESSION 1.61%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1417.1846351735794 to 1394.4268791918364 in microbenchmark.json
REGRESSION 0.93%: placement_group_create/removal (THROUGHPUT) regresses from 657.0579674498558 to 650.9409444317282 in microbenchmark.json
REGRESSION 0.85%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1066.5581344588645 to 1057.5113866970246 in microbenchmark.json
REGRESSION 0.83%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12844.074948208083 to 12736.988267796403 in microbenchmark.json
REGRESSION 0.74%: single_client_tasks_async (THROUGHPUT) regresses from 7096.786888013178 to 7044.008888726476 in microbenchmark.json
REGRESSION 0.65%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8396.874033285541 to 8342.568803508693 in microbenchmark.json
REGRESSION 0.25%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1879.6455165405484 to 1875.0279275238897 in microbenchmark.json
REGRESSION 127.38%: dashboard_p95_latency_ms (LATENCY) regresses from 241.548 to 549.229 in benchmarks/many_tasks.json
REGRESSION 27.23%: dashboard_p99_latency_ms (LATENCY) regresses from 1879.035 to 2390.781 in benchmarks/many_pgs.json
REGRESSION 22.63%: dashboard_p50_latency_ms (LATENCY) regresses from 5.651 to 6.93 in benchmarks/many_nodes.json
REGRESSION 5.07%: avg_pg_create_time_ms (LATENCY) regresses from 1.6259311876874045 to 1.7084268978985828 in stress_tests/stress_test_placement_group.json
REGRESSION 3.28%: 107374182400_large_object_time (LATENCY) regresses from 24.263247010999976 to 25.059670065000006 in scalability/single_node.json
REGRESSION 2.33%: 10000_get_time (LATENCY) regresses from 15.200454125999997 to 15.554129597 in scalability/single_node.json
REGRESSION 1.73%: dashboard_p99_latency_ms (LATENCY) regresses from 3389.923 to 3448.611 in benchmarks/many_actors.json
```