### PR TITLE
[data][doc] Document 2 datasets in 1 cluster usage

### DIFF
--- a/.vale/styles/config/vocabularies/Data/accept.txt
+++ b/.vale/styles/config/vocabularies/Data/accept.txt
@@ -5,6 +5,7 @@ autoscaler
 conda
 Dask
 [Dd]ata('s)?
+[Dd]ataset('s)?
 [Dd]atasource(s)?
 [Dd]eserializable
 [Dd]iscretizer(s)?
@@ -22,6 +23,8 @@ LLM(s)?
 MCAP
 Modin
 [Mm]ultiget(s)?
+[Mm]ultitenancy
+[Ss]ubcluster(s)?
 ndarray(s)?
 NLP
 [Oo]mni

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -464,6 +464,7 @@ py_test_run_all_subdirectory(
     include = ["source/train/doc_code/*.py"],
     exclude = [
         "source/train/doc_code/hvd_trainer.py",  # CI do not have Horovod
+        "source/train/doc_code/asynchronous_validation.py",  # pseudocode snippets, not runnable
     ],
     extra_srcs = [],
     tags = [

--- a/doc/source/data/concurrent-dataset-execution.md
+++ b/doc/source/data/concurrent-dataset-execution.md
@@ -4,9 +4,9 @@
 
 When two or more Ray Data Datasets share a single Ray cluster, they compete
 for the same pool of nodes by default. That competition can cause unwanted
-contention — one Dataset's reads can starve another's GPU stage, autoscaling
-decisions get muddled, and runtime becomes a function of whatever else
-happens to be running.
+contention — one Dataset's reads can starve a second Dataset's GPU stage,
+autoscaling decisions get muddled, and runtime becomes a function of
+whatever else happens to be running.
 
 Ray Data lets you assign each Dataset to its own **subcluster** — a labeled
 subset of nodes that only that Dataset uses. Subclusters give you smooth,
@@ -120,8 +120,8 @@ When the Datasets are wired into a `TorchTrainer` (or any
 `DataParallelTrainer`), `ray.train.DataConfig` is the more ergonomic entry
 point — it takes a per-dataset `ExecutionOptions` map. See
 {ref}`train-validating-checkpoints` for the full pattern, including how to
-set the training-side selector via `DataConfig` and the validation-side
-selector inside your `validation_fn`.
+set the training-side selector through `DataConfig` and the
+validation-side selector inside your `validation_fn`.
 
 ## API reference
 

--- a/doc/source/data/concurrent-dataset-execution.md
+++ b/doc/source/data/concurrent-dataset-execution.md
@@ -1,0 +1,132 @@
+(data_concurrent_execution)=
+
+# Run multiple Datasets in one cluster
+
+When two or more Ray Data Datasets share a single Ray cluster, they compete
+for the same pool of nodes by default. That competition can cause unwanted
+contention — one Dataset's reads can starve another's GPU stage, autoscaling
+decisions get muddled, and runtime becomes a function of whatever else
+happens to be running.
+
+Ray Data lets you assign each Dataset to its own **subcluster** — a labeled
+subset of nodes that only that Dataset uses. Subclusters give you smooth,
+predictable execution for concurrent Datasets and a natural way to express
+"this Dataset runs here, that one runs there."
+
+Common use cases:
+
+- **Asynchronous validation during training.** A training Dataset feeds the
+  trainer; a validation Dataset feeds a separate validation task on
+  different hardware. See {ref}`train-validating-checkpoints` for the Ray
+  Train integration.
+- **Multitenancy on a shared workspace.** Several Datasets — different
+  users, different pipelines, or different stages of one workflow — share
+  one Anyscale workspace and don't disturb each other.
+
+## How it works
+
+Each Dataset carries an `ExecutionOptions.label_selector` (a
+`Dict[str, str]`) that Ray Data attaches to every task and actor the Dataset
+launches. The autoscaling coordinator buckets nodes by the value at the
+reserved label key `"ray-subcluster"` and only places a Dataset's work on
+nodes whose label matches.
+
+## Configuration
+
+There are two steps.
+
+### 1. Label your worker nodes
+
+In your Anyscale [compute config](https://docs.anyscale.com/reference/compute-config-api/),
+add a `labels` block to each worker pool. Use the reserved key
+`ray-subcluster` to mark which subcluster each pool belongs to.
+
+```yaml
+worker_nodes:
+  - name: train-workers
+    instance_type: g5.xlarge
+    min_nodes: 2
+    max_nodes: 4
+    labels:
+      ray-subcluster: training
+  - name: validation-workers
+    instance_type: g4dn.xlarge
+    min_nodes: 0
+    max_nodes: 2
+    labels:
+      ray-subcluster: validation
+```
+
+Subcluster values are arbitrary strings (`"training"`, `"validation"`,
+`"tenant_a"`, `"team-blue"`, etc.) — pick whatever makes sense for your
+workload.
+
+### 2. Tag each Dataset with a `label_selector`
+
+Set the selector on the **global** `DataContext` *before* creating the
+Dataset:
+
+```python
+import ray
+
+# Set the global DataContext first.
+ctx = ray.data.DataContext.get_current()
+ctx.execution_options.label_selector = {"ray-subcluster": "tenant_a"}
+
+# Now create the Dataset. ``Dataset.context`` is a deep copy of the global
+# ``DataContext`` taken at construction time, so it inherits the selector
+# automatically — you don't need to also set ``dataset.context``.
+dataset = ray.data.read_parquet("s3://my-bucket/tenant_a/")
+```
+
+:::{important}
+Set the global `DataContext` selector *before* creating the Dataset, not
+after. Tasks Ray Data spawns during construction (for example, the parquet
+read tasks that infer the schema) read the global context directly, so
+setting `dataset.context.execution_options.label_selector` after the fact
+doesn't retroactively re-route them.
+:::
+
+If you have more than one Dataset in the same driver, set the global
+context to each Dataset's subcluster *just before* you create that Dataset.
+
+## Example: two Datasets, two subclusters
+
+```python
+import ray
+import threading
+
+ctx = ray.data.DataContext.get_current()
+
+# Tenant A: subcluster "tenant_a".
+ctx.execution_options.label_selector = {"ray-subcluster": "tenant_a"}
+ds_a = ray.data.read_parquet("s3://my-bucket/tenant_a/")
+
+# Tenant B: subcluster "tenant_b". Set the global context again
+# right before creating ds_b.
+ctx.execution_options.label_selector = {"ray-subcluster": "tenant_b"}
+ds_b = ray.data.read_parquet("s3://my-bucket/tenant_b/")
+
+# Run them concurrently. ds_a's tasks only land on
+# ray-subcluster=tenant_a nodes; ds_b's only on
+# ray-subcluster=tenant_b nodes.
+threading.Thread(target=lambda: ds_a.materialize()).start()
+threading.Thread(target=lambda: ds_b.materialize()).start()
+```
+
+## Ray Train integration
+
+When the Datasets are wired into a `TorchTrainer` (or any
+`DataParallelTrainer`), `ray.train.DataConfig` is the more ergonomic entry
+point — it takes a per-dataset `ExecutionOptions` map. See
+{ref}`train-validating-checkpoints` for the full pattern, including how to
+set the training-side selector via `DataConfig` and the validation-side
+selector inside your `validation_fn`.
+
+## API reference
+
+- {class}`ray.data.ExecutionOptions` — see the `label_selector` parameter.
+- {class}`ray.data.DataContext` — the per-process Ray Data configuration
+  the `execution_options` live on.
+- {class}`ray.train.DataConfig` — accepts a `Dict[str, ExecutionOptions]`
+  so each Train dataset can carry its own selector.

--- a/doc/source/data/concurrent-dataset-execution.md
+++ b/doc/source/data/concurrent-dataset-execution.md
@@ -63,32 +63,36 @@ workload.
 
 ### 2. Tag each Dataset with a `label_selector`
 
-Set the selector on the **global** `DataContext` *before* creating the
-Dataset:
+Copy the current `DataContext`, set the selector on the copy, and apply
+the copy temporarily with the `DataContext.current()` context manager.
+Construct your Dataset inside the `with` block:
 
 ```python
 import ray
 
-# Set the global DataContext first.
-ctx = ray.data.DataContext.get_current()
+ctx = ray.data.DataContext.get_current().copy()
 ctx.execution_options.label_selector = {"ray-subcluster": "tenant_a"}
 
-# Now create the Dataset. ``Dataset.context`` is a deep copy of the global
-# ``DataContext`` taken at construction time, so it inherits the selector
-# automatically — you don't need to also set ``dataset.context``.
-dataset = ray.data.read_parquet("s3://my-bucket/tenant_a/")
+with ray.data.DataContext.current(ctx):
+    # Tasks launched during construction (reads, schema inference) read
+    # the temporary context. ``Dataset.context`` is a deep copy of the
+    # current context, so the new Dataset keeps the selector after the
+    # ``with`` block exits.
+    dataset = ray.data.read_parquet("s3://my-bucket/tenant_a/")
 ```
 
 :::{important}
-Set the global `DataContext` selector *before* creating the Dataset, not
-after. Tasks Ray Data spawns during construction (for example, the parquet
-read tasks that infer the schema) read the global context directly, so
-setting `dataset.context.execution_options.label_selector` after the fact
-doesn't retroactively re-route them.
-:::
+Mutating `ray.data.DataContext.get_current()` in place permanently
+affects every subsequent Dataset in the same driver process. Use the
+`DataContext.current()` context manager so each Dataset's selector is
+scoped to its own construction block.
 
-If you have more than one Dataset in the same driver, set the global
-context to each Dataset's subcluster *just before* you create that Dataset.
+Also: set the selector *before* creating the Dataset, not after. Tasks
+Ray Data spawns during construction (for example, the parquet read tasks
+that infer the schema) read the current context, so setting
+`dataset.context.execution_options.label_selector` after the fact doesn't
+retroactively re-route them.
+:::
 
 ## Example: two Datasets, two subclusters
 
@@ -96,18 +100,20 @@ context to each Dataset's subcluster *just before* you create that Dataset.
 import ray
 import threading
 
-ctx = ray.data.DataContext.get_current()
 
-# Tenant A: subcluster "tenant_a".
-ctx.execution_options.label_selector = {"ray-subcluster": "tenant_a"}
-ds_a = ray.data.read_parquet("s3://my-bucket/tenant_a/")
+def make_dataset(subcluster: str, path: str) -> ray.data.Dataset:
+    ctx = ray.data.DataContext.get_current().copy()
+    ctx.execution_options.label_selector = {"ray-subcluster": subcluster}
+    with ray.data.DataContext.current(ctx):
+        return ray.data.read_parquet(path)
 
-# Tenant B: subcluster "tenant_b". Set the global context again
-# right before creating ds_b.
-ctx.execution_options.label_selector = {"ray-subcluster": "tenant_b"}
-ds_b = ray.data.read_parquet("s3://my-bucket/tenant_b/")
 
-# Run them concurrently. ds_a's tasks only land on
+# Construct each Dataset in the main thread so the temporary contexts
+# don't race on the process-global ``_default_context``.
+ds_a = make_dataset("tenant_a", "s3://my-bucket/tenant_a/")
+ds_b = make_dataset("tenant_b", "s3://my-bucket/tenant_b/")
+
+# Then run them concurrently. ds_a's tasks only land on
 # ray-subcluster=tenant_a nodes; ds_b's only on
 # ray-subcluster=tenant_b nodes.
 threading.Thread(target=lambda: ds_a.materialize()).start()

--- a/doc/source/data/concurrent-dataset-execution.md
+++ b/doc/source/data/concurrent-dataset-execution.md
@@ -2,34 +2,18 @@
 
 # Run multiple Datasets in one cluster
 
-When two or more Ray Data Datasets share a single Ray cluster, they compete
-for the same pool of nodes by default. That competition can cause unwanted
-contention — one Dataset's reads can starve a second Dataset's GPU stage,
-autoscaling decisions get muddled, and runtime becomes a function of
-whatever else happens to be running.
+When two or more Ray Data Datasets share a single Ray cluster, they compete for the same pool of nodes by default. That competition can cause unwanted contention — one Dataset's reads can starve a second Dataset's GPU stage, autoscaling decisions get muddled, and runtime becomes a function of whatever else happens to be running.
 
-Ray Data lets you assign each Dataset to its own **subcluster** — a labeled
-subset of nodes that only that Dataset uses. Subclusters give you smooth,
-predictable execution for concurrent Datasets and a natural way to express
-"this Dataset runs here, that one runs there."
+Ray Data lets you assign each Dataset to its own **subcluster** — a labeled subset of nodes that only that Dataset uses. Subclusters give you smooth, predictable execution for concurrent Datasets and a natural way to express "this Dataset runs here, that one runs there."
 
 Common use cases:
 
-- **Asynchronous validation during training.** A training Dataset feeds the
-  trainer; a validation Dataset feeds a separate validation task on
-  different hardware. See {ref}`train-validating-checkpoints` for the Ray
-  Train integration.
-- **Multitenancy on a shared workspace.** Several Datasets — different
-  users, different pipelines, or different stages of one workflow — share
-  one Anyscale workspace and don't disturb each other.
+- **Asynchronous validation during training.** A training Dataset feeds the trainer. A validation Dataset feeds a separate validation task on different hardware. See {ref}`train-validating-checkpoints` for the Ray Train integration.
+- **Multitenancy on a shared workspace.** Several Datasets — different users, different pipelines, or different stages of one workflow — share one Anyscale workspace and don't disturb each other.
 
 ## How it works
 
-Each Dataset carries an `ExecutionOptions.label_selector` (a
-`Dict[str, str]`) that Ray Data attaches to every task and actor the Dataset
-launches. The autoscaling coordinator buckets nodes by the value at the
-reserved label key `"ray-subcluster"` and only places a Dataset's work on
-nodes whose label matches.
+Each Dataset carries an `ExecutionOptions.label_selector` (a `Dict[str, str]`) that Ray Data attaches to every task and actor the Dataset launches. The autoscaling coordinator buckets nodes by the value at the reserved label key `"ray-subcluster"` and only places a Dataset's work on nodes whose label matches.
 
 ## Configuration
 
@@ -37,9 +21,7 @@ There are two steps.
 
 ### 1. Label your worker nodes
 
-In your Anyscale [compute config](https://docs.anyscale.com/reference/compute-config-api/),
-add a `labels` block to each worker pool. Use the reserved key
-`ray-subcluster` to mark which subcluster each pool belongs to.
+In your Anyscale [compute config](https://docs.anyscale.com/reference/compute-config-api/), add a `labels` block to each worker pool. Use the reserved key `ray-subcluster` to mark which subcluster each pool belongs to.
 
 ```yaml
 worker_nodes:
@@ -57,15 +39,11 @@ worker_nodes:
       ray-subcluster: validation
 ```
 
-Subcluster values are arbitrary strings (`"training"`, `"validation"`,
-`"tenant_a"`, `"team-blue"`, etc.) — pick whatever makes sense for your
-workload.
+Subcluster values are arbitrary strings (`"training"`, `"validation"`, `"tenant_a"`, `"team-blue"`) — pick whatever makes sense for your workload.
 
 ### 2. Tag each Dataset with a `label_selector`
 
-Copy the current `DataContext`, set the selector on the copy, and apply
-the copy temporarily with the `DataContext.current()` context manager.
-Construct your Dataset inside the `with` block:
+Copy the current `DataContext`, set the selector on the copy, and apply the copy temporarily with the `DataContext.current()` context manager. Construct your Dataset inside the `with` block:
 
 ```python
 import ray
@@ -82,16 +60,9 @@ with ray.data.DataContext.current(ctx):
 ```
 
 :::{important}
-Mutating `ray.data.DataContext.get_current()` in place permanently
-affects every subsequent Dataset in the same driver process. Use the
-`DataContext.current()` context manager so each Dataset's selector is
-scoped to its own construction block.
+Mutating `ray.data.DataContext.get_current()` in place permanently affects every subsequent Dataset in the same driver process. Use the `DataContext.current()` context manager to scope each Dataset's selector to its own construction block.
 
-Also: set the selector *before* creating the Dataset, not after. Tasks
-Ray Data spawns during construction (for example, the parquet read tasks
-that infer the schema) read the current context, so setting
-`dataset.context.execution_options.label_selector` after the fact doesn't
-retroactively re-route them.
+Set the selector *before* creating the Dataset, not after. Tasks Ray Data spawns during construction (for example, the parquet read tasks that infer the schema) read the current context, so setting `dataset.context.execution_options.label_selector` after the fact doesn't retroactively re-route them.
 :::
 
 ## Example: two Datasets, two subclusters
@@ -122,17 +93,10 @@ threading.Thread(target=lambda: ds_b.materialize()).start()
 
 ## Ray Train integration
 
-When the Datasets are wired into a `TorchTrainer` (or any
-`DataParallelTrainer`), `ray.train.DataConfig` is the more ergonomic entry
-point — it takes a per-dataset `ExecutionOptions` map. See
-{ref}`train-validating-checkpoints` for the full pattern, including how to
-set the training-side selector through `DataConfig` and the
-validation-side selector inside your `validation_fn`.
+When you wire the Datasets into a `TorchTrainer` (or any `DataParallelTrainer`), `ray.train.DataConfig` is the more ergonomic entry point — it takes a per-dataset `ExecutionOptions` map. See {ref}`train-validating-checkpoints` for the full pattern, including how to set the training-side selector through `DataConfig` and the validation-side selector inside your `validation_fn`.
 
 ## API reference
 
 - {class}`ray.data.ExecutionOptions` — see the `label_selector` parameter.
-- {class}`ray.data.DataContext` — the per-process Ray Data configuration
-  the `execution_options` live on.
-- {class}`ray.train.DataConfig` — accepts a `Dict[str, ExecutionOptions]`
-  so each Train dataset can carry its own selector.
+- {class}`ray.data.DataContext` — the per-process Ray Data configuration the `execution_options` live on.
+- {class}`ray.train.DataConfig` — accepts a `Dict[str, ExecutionOptions]` so each Train dataset can carry its own selector.

--- a/doc/source/data/user-guide.rst
+++ b/doc/source/data/user-guide.rst
@@ -29,6 +29,7 @@ shows you how to achieve several tasks.
     how-to-avoid-ooms
     monitoring-your-workload
     execution-configurations
+    concurrent-dataset-execution
     batch_inference
     performance-tips
     scaling-collation-functions

--- a/doc/source/train/doc_code/asynchronous_validation.py
+++ b/doc/source/train/doc_code/asynchronous_validation.py
@@ -107,15 +107,21 @@ class Predictor:
         return {"res": (pred.argmax(1) == label).cpu().numpy()}
 
 
+# Construct ``validation_dataset`` under a DataContext copy pinned to the
+# "validation" subcluster. ``Dataset.context`` is a deep copy of the
+# current context taken at construction, so the selector is baked in and
+# every downstream operator (including the ``map_batches`` below) inherits
+# it — no in-function mutation needed. See
+# https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+ctx = ray.data.DataContext.get_current().copy()
+ctx.execution_options.label_selector = {"ray-subcluster": "validation"}
+with ray.data.DataContext.current(ctx):
+    validation_dataset = ray.data.read_parquet(...)
+
+
 def validation_fn(checkpoint: ray.train.Checkpoint) -> dict:
     # Set name to avoid confusion; default name is "Dataset"
     validation_dataset.set_name("validation")
-    # Pin to the "validation" subcluster. map_batches doesn't use
-    # DataConfig, so set the selector on ds.context directly. See
-    # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
-    validation_dataset.context.execution_options.label_selector = {
-        "ray-subcluster": "validation"
-    }
     eval_res = validation_dataset.map_batches(
         Predictor,
         batch_size=128,
@@ -164,13 +170,15 @@ def train_func(config: dict) -> None:
 
 
 def run_trainer() -> ray.train.Result:
-    # Pin reads to the "training" subcluster by setting the global before
-    # constructing the Dataset. See
-    # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
-    ray.data.DataContext.get_current().execution_options.label_selector = {
-        "ray-subcluster": "training"
-    }
-    train_dataset = ray.data.read_parquet(...)
+    # Pin reads to the "training" subcluster by applying a copy of the
+    # DataContext via the DataContext.current() context manager. The copy
+    # is scoped to the `with` block; mutating the global DataContext
+    # directly would permanently affect every subsequent Dataset in this
+    # driver. See https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+    ctx = ray.data.DataContext.get_current().copy()
+    ctx.execution_options.label_selector = {"ray-subcluster": "training"}
+    with ray.data.DataContext.current(ctx):
+        train_dataset = ray.data.read_parquet(...)
 
     trainer = ray.train.torch.TorchTrainer(
         train_func,

--- a/doc/source/train/doc_code/asynchronous_validation.py
+++ b/doc/source/train/doc_code/asynchronous_validation.py
@@ -32,6 +32,7 @@ import torchmetrics
 from torch.nn import CrossEntropyLoss
 
 import ray.train.torch
+from ray.data import ExecutionOptions
 
 
 def eval_only_train_fn(config_dict: dict) -> dict:
@@ -72,6 +73,16 @@ def validation_fn(checkpoint: ray.train.Checkpoint, train_run_name: str, epoch: 
         ),
         # Use weaker GPUs for validation
         datasets={"validation": validation_dataset},
+        # Pin validation to the "validation" subcluster so it runs on the
+        # validation-labeled nodes and doesn't compete with training for
+        # resources. See https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+        dataset_config=ray.train.DataConfig(
+            execution_options={
+                "validation": ExecutionOptions(
+                    label_selector={"ray-subcluster": "validation"}
+                ),
+            },
+        ),
     )
     result = trainer.fit()
     # return_value holds the value returned by train function of worker 0
@@ -79,6 +90,9 @@ def validation_fn(checkpoint: ray.train.Checkpoint, train_run_name: str, epoch: 
 # __validation_fn_torch_trainer_end__
 
 # __validation_fn_map_batches_start__
+import ray.data
+
+
 class Predictor:
     def __init__(self, checkpoint: ray.train.Checkpoint):
         self.model = ...
@@ -97,6 +111,15 @@ class Predictor:
 def validation_fn(checkpoint: ray.train.Checkpoint) -> dict:
     # Set name to avoid confusion; default name is "Dataset"
     validation_dataset.set_name("validation")
+    # Pin validation to the "validation" subcluster. The map_batches path
+    # doesn't go through ``DataConfig``, so set the selector on the
+    # already-constructed Dataset's execution options. Operators read this
+    # at task-submission time, so all chained tasks (including the
+    # ``Predictor`` actors below) land on validation-labeled nodes. See
+    # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+    validation_dataset.context.execution_options.label_selector = {
+        "ray-subcluster": "validation"
+    }
     eval_res = validation_dataset.map_batches(
         Predictor,
         batch_size=128,
@@ -113,6 +136,7 @@ def validation_fn(checkpoint: ray.train.Checkpoint) -> dict:
 # __validation_fn_report_start__
 import tempfile
 
+from ray.data import ExecutionOptions
 from ray.train import ValidationConfig, ValidationTaskConfig
 
 
@@ -144,12 +168,35 @@ def train_func(config: dict) -> None:
 
 
 def run_trainer() -> ray.train.Result:
+    # Set the global ``DataContext`` to the "training" subcluster BEFORE
+    # creating the training Dataset so reads/schema-inference tasks land
+    # on training nodes. ``Dataset.context`` is a deep copy of the global
+    # taken at construction, so this single setting also propagates to
+    # every operator the Dataset later launches. See
+    # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+    ray.data.DataContext.get_current().execution_options.label_selector = {
+        "ray-subcluster": "training"
+    }
     train_dataset = ray.data.read_parquet(...)
+
     trainer = ray.train.torch.TorchTrainer(
         train_func,
         validation_config=ValidationConfig(fn=validation_fn),
         # Pass training dataset in datasets arg to split it across training workers
         datasets={"train": train_dataset},
+        # ``DataConfig.execution_options`` overrides the Dataset's
+        # ``execution_options`` at training start, so re-specify the
+        # label_selector here to keep per-worker ingest pinned to the
+        # "training" subcluster. The validation_fn separately pins its own
+        # Dataset to the "validation" subcluster, so the two never compete.
+        dataset_config=ray.train.DataConfig(
+            datasets_to_split=["train"],
+            execution_options={
+                "train": ExecutionOptions(
+                    label_selector={"ray-subcluster": "training"}
+                ),
+            },
+        ),
         scaling_config=ray.train.ScalingConfig(
             num_workers=2,
             use_gpu=True,

--- a/doc/source/train/doc_code/asynchronous_validation.py
+++ b/doc/source/train/doc_code/asynchronous_validation.py
@@ -170,11 +170,11 @@ def train_func(config: dict) -> None:
 
 
 def run_trainer() -> ray.train.Result:
-    # Pin reads to the "training" subcluster by applying a copy of the
-    # DataContext via the DataContext.current() context manager. The copy
-    # is scoped to the `with` block; mutating the global DataContext
-    # directly would permanently affect every subsequent Dataset in this
-    # driver. See https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+    # 1) Construction-time tasks (parquet schema inference, file listing)
+    # read the current DataContext. Pin them to "training" with a copy of
+    # the DataContext applied via the DataContext.current() context
+    # manager — scoped to the `with` block so it doesn't leak. See
+    # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
     ctx = ray.data.DataContext.get_current().copy()
     ctx.execution_options.label_selector = {"ray-subcluster": "training"}
     with ray.data.DataContext.current(ctx):
@@ -185,8 +185,10 @@ def run_trainer() -> ray.train.Result:
         validation_config=ValidationConfig(fn=validation_fn),
         # Pass training dataset in datasets arg to split it across training workers
         datasets={"train": train_dataset},
-        # DataConfig.execution_options overrides ds.context at training
-        # start, so re-pin per-worker ingest to "training" here.
+        # 2) DataConfig.execution_options REPLACES ds.context.execution_options
+        # wholesale at training start, dropping anything not re-specified
+        # (including label_selector). Restate the selector here so per-worker
+        # ingest stays pinned to "training".
         dataset_config=ray.train.DataConfig(
             datasets_to_split=["train"],
             execution_options={

--- a/doc/source/train/doc_code/asynchronous_validation.py
+++ b/doc/source/train/doc_code/asynchronous_validation.py
@@ -73,9 +73,8 @@ def validation_fn(checkpoint: ray.train.Checkpoint, train_run_name: str, epoch: 
         ),
         # Use weaker GPUs for validation
         datasets={"validation": validation_dataset},
-        # Pin validation to the "validation" subcluster so it runs on the
-        # validation-labeled nodes and doesn't compete with training for
-        # resources. See https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
+        # Pin to the "validation" subcluster so it doesn't compete with
+        # training. See https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
         dataset_config=ray.train.DataConfig(
             execution_options={
                 "validation": ExecutionOptions(
@@ -111,11 +110,8 @@ class Predictor:
 def validation_fn(checkpoint: ray.train.Checkpoint) -> dict:
     # Set name to avoid confusion; default name is "Dataset"
     validation_dataset.set_name("validation")
-    # Pin validation to the "validation" subcluster. The map_batches path
-    # doesn't go through ``DataConfig``, so set the selector on the
-    # already-constructed Dataset's execution options. Operators read this
-    # at task-submission time, so all chained tasks (including the
-    # ``Predictor`` actors below) land on validation-labeled nodes. See
+    # Pin to the "validation" subcluster. map_batches doesn't use
+    # DataConfig, so set the selector on ds.context directly. See
     # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
     validation_dataset.context.execution_options.label_selector = {
         "ray-subcluster": "validation"
@@ -168,11 +164,8 @@ def train_func(config: dict) -> None:
 
 
 def run_trainer() -> ray.train.Result:
-    # Set the global ``DataContext`` to the "training" subcluster BEFORE
-    # creating the training Dataset so reads/schema-inference tasks land
-    # on training nodes. ``Dataset.context`` is a deep copy of the global
-    # taken at construction, so this single setting also propagates to
-    # every operator the Dataset later launches. See
+    # Pin reads to the "training" subcluster by setting the global before
+    # constructing the Dataset. See
     # https://docs.ray.io/en/latest/data/concurrent-dataset-execution.html.
     ray.data.DataContext.get_current().execution_options.label_selector = {
         "ray-subcluster": "training"
@@ -184,11 +177,8 @@ def run_trainer() -> ray.train.Result:
         validation_config=ValidationConfig(fn=validation_fn),
         # Pass training dataset in datasets arg to split it across training workers
         datasets={"train": train_dataset},
-        # ``DataConfig.execution_options`` overrides the Dataset's
-        # ``execution_options`` at training start, so re-specify the
-        # label_selector here to keep per-worker ingest pinned to the
-        # "training" subcluster. The validation_fn separately pins its own
-        # Dataset to the "validation" subcluster, so the two never compete.
+        # DataConfig.execution_options overrides ds.context at training
+        # start, so re-pin per-worker ingest to "training" here.
         dataset_config=ray.train.DataConfig(
             datasets_to_split=["train"],
             execution_options={

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -146,6 +146,72 @@ calculate average accuracy on a validation set. To learn more about how to use
     :start-after: __validation_fn_map_batches_start__
     :end-before: __validation_fn_map_batches_end__
 
+Isolating training and validation with subclusters
+---------------------------------------------------
+
+When training and validation run concurrently on the same Ray cluster,
+they compete for the same nodes by default. To give each phase its own
+slice of the cluster — for example, A100s for training and A10Gs for
+validation — label your worker pools with a ``ray-subcluster`` value and
+pin each Dataset to its subcluster. See :ref:`data_concurrent_execution`
+for the background and compute-config setup.
+
+The pattern differs slightly between the ``TorchTrainer`` validation_fn
+and the ``map_batches`` validation_fn, because only the former goes
+through ``ray.train.DataConfig``.
+
+**TorchTrainer validation_fn.** Set the validation Dataset's selector via
+the sub-trainer's ``dataset_config``:
+
+.. literalinclude:: ../doc_code/asynchronous_validation.py
+    :language: python
+    :start-after: __validation_fn_torch_trainer_start__
+    :end-before: __validation_fn_torch_trainer_end__
+
+**map_batches validation_fn.** The ``map_batches`` path doesn't take a
+``DataConfig``, so set the selector directly on the Dataset's execution
+options inside the validation function:
+
+.. literalinclude:: ../doc_code/asynchronous_validation.py
+    :language: python
+    :start-after: __validation_fn_map_batches_start__
+    :end-before: __validation_fn_map_batches_end__
+
+**Training-side configuration.** Set the training Dataset's selector on
+the global ``ray.data.DataContext`` before constructing the Dataset (so
+reads/schema-inference tasks land on training nodes), and re-specify it
+in the trainer's ``dataset_config`` because ``DataConfig.execution_options``
+overrides the Dataset's options at training start:
+
+.. literalinclude:: ../doc_code/asynchronous_validation.py
+    :language: python
+    :start-after: __validation_fn_report_start__
+    :end-before: __validation_fn_report_end__
+
+.. note::
+
+    For *interleaved* validation — where you reuse the training workers
+    to validate on a separate "validation" Dataset inside the same
+    ``TorchTrainer`` — pass both Datasets to ``datasets={...}`` and give
+    both an entry in ``DataConfig.execution_options`` so they're each
+    scoped to their own subcluster:
+
+    .. code-block:: python
+
+        from ray.data import ExecutionOptions
+
+        dataset_config = ray.train.DataConfig(
+            datasets_to_split=["train", "validation"],
+            execution_options={
+                "train": ExecutionOptions(
+                    label_selector={"ray-subcluster": "training"}
+                ),
+                "validation": ExecutionOptions(
+                    label_selector={"ray-subcluster": "validation"}
+                ),
+            },
+        )
+
 Tuning asynchronous validation
 ------------------------------
 

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -197,23 +197,32 @@ Dataset at construction — every downstream operator inherits it:
         eval_res = validation_dataset.map_batches(...)
         ...
 
-**Training-side configuration.** Apply a copy of the ``DataContext``
-with the ``DataContext.current()`` context manager when constructing the
-training Dataset (so reads/schema-inference tasks land on training nodes),
-and re-specify the selector in the trainer's ``dataset_config`` because
-``DataConfig.execution_options`` overrides the Dataset's options at
-training start:
+**Training-side configuration.** A Train pipeline needs the selector
+specified in two places — they cover different phases and are not
+redundant:
+
+1. **At Dataset construction**, via the ``DataContext.current()`` context
+   manager, so construction-time tasks (parquet schema inference, file
+   listing) land on training nodes.
+2. **In the trainer's** ``dataset_config``, because Train wholesale
+   replaces ``ds.context.execution_options`` with ``DataConfig``'s
+   per-dataset entry at training start. Anything not restated in
+   ``DataConfig.execution_options`` — ``label_selector`` included — is
+   dropped, so per-worker ingest would lose its pinning.
 
 .. code-block:: python
 
     from ray.data import ExecutionOptions
 
     def run_trainer() -> ray.train.Result:
+        # (1) Pin construction-time tasks.
         ctx = ray.data.DataContext.get_current().copy()
         ctx.execution_options.label_selector = {"ray-subcluster": "training"}
         with ray.data.DataContext.current(ctx):
             train_dataset = ray.data.read_parquet(...)
 
+        # (2) Pin per-worker ingest — Train replaces ds.context options
+        # wholesale, so the selector must be restated here.
         trainer = ray.train.torch.TorchTrainer(
             ...,
             datasets={"train": train_dataset},

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -92,7 +92,7 @@ The ``validation_fn`` above runs in a single Ray task, but you can improve its p
 even more Ray tasks or actors. The Ray team recommends doing this with one of the following approaches:
 
 * Creating a :class:`ray.train.torch.TorchTrainer` that only does validation, not training.
-* (Experimental) Using :func:`ray.data.Dataset.map_batches` to calculate metrics on a validation set.
+* Using :func:`ray.data.Dataset.map_batches` to calculate metrics on a validation set.
 
 Choose an approach
 ~~~~~~~~~~~~~~~~~~
@@ -134,8 +134,8 @@ loss on a validation set. Note the following about this example:
     :start-after: __validation_fn_torch_trainer_start__
     :end-before: __validation_fn_torch_trainer_end__
 
-(Experimental) Example: validation with Ray Data map_batches
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Example: validation with Ray Data map_batches
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following is a ``validation_fn`` that uses :func:`ray.data.Dataset.map_batches` to
 calculate average accuracy on a validation set. To learn more about how to use
@@ -160,22 +160,39 @@ The pattern differs slightly between the ``TorchTrainer`` validation_fn
 and the ``map_batches`` validation_fn, because only the former goes
 through ``ray.train.DataConfig``.
 
-**TorchTrainer validation_fn.** Set the validation Dataset's selector via
-the sub-trainer's ``dataset_config``:
+**TorchTrainer validation_fn.** Set the validation Dataset's selector
+through the sub-trainer's ``dataset_config``:
 
-.. literalinclude:: ../doc_code/asynchronous_validation.py
-    :language: python
-    :start-after: __validation_fn_torch_trainer_start__
-    :end-before: __validation_fn_torch_trainer_end__
+.. code-block:: python
+
+    from ray.data import ExecutionOptions
+
+    def validation_fn(checkpoint, ...) -> dict:
+        trainer = ray.train.torch.TorchTrainer(
+            ...,
+            datasets={"validation": validation_dataset},
+            dataset_config=ray.train.DataConfig(
+                execution_options={
+                    "validation": ExecutionOptions(
+                        label_selector={"ray-subcluster": "validation"}
+                    ),
+                },
+            ),
+        )
+        ...
 
 **map_batches validation_fn.** The ``map_batches`` path doesn't take a
 ``DataConfig``, so set the selector directly on the Dataset's execution
 options inside the validation function:
 
-.. literalinclude:: ../doc_code/asynchronous_validation.py
-    :language: python
-    :start-after: __validation_fn_map_batches_start__
-    :end-before: __validation_fn_map_batches_end__
+.. code-block:: python
+
+    def validation_fn(checkpoint) -> dict:
+        validation_dataset.context.execution_options.label_selector = {
+            "ray-subcluster": "validation"
+        }
+        eval_res = validation_dataset.map_batches(...)
+        ...
 
 **Training-side configuration.** Set the training Dataset's selector on
 the global ``ray.data.DataContext`` before constructing the Dataset (so
@@ -183,10 +200,29 @@ reads/schema-inference tasks land on training nodes), and re-specify it
 in the trainer's ``dataset_config`` because ``DataConfig.execution_options``
 overrides the Dataset's options at training start:
 
-.. literalinclude:: ../doc_code/asynchronous_validation.py
-    :language: python
-    :start-after: __validation_fn_report_start__
-    :end-before: __validation_fn_report_end__
+.. code-block:: python
+
+    from ray.data import ExecutionOptions
+
+    def run_trainer() -> ray.train.Result:
+        ray.data.DataContext.get_current().execution_options.label_selector = {
+            "ray-subcluster": "training"
+        }
+        train_dataset = ray.data.read_parquet(...)
+
+        trainer = ray.train.torch.TorchTrainer(
+            ...,
+            datasets={"train": train_dataset},
+            dataset_config=ray.train.DataConfig(
+                datasets_to_split=["train"],
+                execution_options={
+                    "train": ExecutionOptions(
+                        label_selector={"ray-subcluster": "training"}
+                    ),
+                },
+            ),
+        )
+        ...
 
 .. note::
 

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -66,12 +66,12 @@ because the validation task always runs on cpu; for a more realistic example, se
     access them from shared storage later as explained in :ref:`train-checkpointing`.
 
 Next, register your ``validation_fn`` with your trainer by settings its ``validation_config`` argument to a
-:class:`ray.train.v2.api.report_config.ValidationConfig` object that contains your ``validation_fn``
+:class:`~ray.train.v2.api.report_config.ValidationConfig` object that contains your ``validation_fn``
 and any default keyword arguments you want to pass to your ``validation_fn``.
 
 Next, within your rank 0 worker's training loop, call :func:`ray.train.report` with ``validation``
 set to True, which will call your ``validation_fn`` with the default keyword arguments you passed to the trainer.
-Alternatively, you can set ``validation`` to a :class:`ray.train.v2.api.report_config.ValidationTaskConfig` object
+Alternatively, you can set ``validation`` to a :class:`~ray.train.v2.api.report_config.ValidationTaskConfig` object
 that contains keyword arguments that will override matching keyword arguments you passed to the trainer. If
 ``validation`` is False, Ray Train will not run validation.
 
@@ -294,7 +294,7 @@ Checkpoint metrics lifecycle
 During the training loop the following happens to your checkpoints and metrics :
 
 1. You report a checkpoint with some initial metrics, such as training loss, as well as a
-   :class:`ray.train.v2.api.report_config.ValidationTaskConfig` object that contains the keyword
+   :class:`~ray.train.v2.api.report_config.ValidationTaskConfig` object that contains the keyword
    arguments to pass to the ``validation_fn``.
 2. Ray Train asynchronously runs your ``validation_fn`` with that checkpoint and configuration.
 3. When that validation task completes, Ray Train associates the metrics returned by your ``validation_fn``

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -182,33 +182,37 @@ through the sub-trainer's ``dataset_config``:
         ...
 
 **map_batches validation_fn.** The ``map_batches`` path doesn't take a
-``DataConfig``, so set the selector directly on the Dataset's execution
-options inside the validation function:
+``DataConfig``. Construct ``validation_dataset`` under a
+``DataContext.current()`` block so the selector is baked into the
+Dataset at construction — every downstream operator inherits it:
 
 .. code-block:: python
 
+    ctx = ray.data.DataContext.get_current().copy()
+    ctx.execution_options.label_selector = {"ray-subcluster": "validation"}
+    with ray.data.DataContext.current(ctx):
+        validation_dataset = ray.data.read_parquet(...)
+
     def validation_fn(checkpoint) -> dict:
-        validation_dataset.context.execution_options.label_selector = {
-            "ray-subcluster": "validation"
-        }
         eval_res = validation_dataset.map_batches(...)
         ...
 
-**Training-side configuration.** Set the training Dataset's selector on
-the global ``ray.data.DataContext`` before constructing the Dataset (so
-reads/schema-inference tasks land on training nodes), and re-specify it
-in the trainer's ``dataset_config`` because ``DataConfig.execution_options``
-overrides the Dataset's options at training start:
+**Training-side configuration.** Apply a copy of the ``DataContext``
+with the ``DataContext.current()`` context manager when constructing the
+training Dataset (so reads/schema-inference tasks land on training nodes),
+and re-specify the selector in the trainer's ``dataset_config`` because
+``DataConfig.execution_options`` overrides the Dataset's options at
+training start:
 
 .. code-block:: python
 
     from ray.data import ExecutionOptions
 
     def run_trainer() -> ray.train.Result:
-        ray.data.DataContext.get_current().execution_options.label_selector = {
-            "ray-subcluster": "training"
-        }
-        train_dataset = ray.data.read_parquet(...)
+        ctx = ray.data.DataContext.get_current().copy()
+        ctx.execution_options.label_selector = {"ray-subcluster": "training"}
+        with ray.data.DataContext.current(ctx):
+            train_dataset = ray.data.read_parquet(...)
 
         trainer = ray.train.torch.TorchTrainer(
             ...,


### PR DESCRIPTION
# Summary

Document how to run 2 datasets in 1 cluster for various use cases including training + validation.

We actually need to set this in two places for async validation:
1) We recommend creating the dataset in a copy of the current data context that contains the label selector. This scopes creation-time tasks like `read_parquet` to the cluster
2) (only applies to ray train; ray data doesn't need this) we also need to set the `DataConfig` because Ray Train overrides the Dataset's options at training start. Maybe we can make this more ergonomic in a future PR.