### PR TITLE
[DO NOT MERGE] Bisect: multitenancy test at 73f6edeb9b~1 (before safe_round)

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -40,6 +40,7 @@ def create_cluster_autoscaler(
     execution_id: str,
 ) -> ClusterAutoscaler:
     resource_limits = data_context.execution_options.resource_limits
+    label_selector = data_context.execution_options.label_selector
     cluster_autoscaler_version = os.environ.get(
         CLUSTER_AUTOSCALER_ENV_KEY, DEFAULT_CLUSTER_AUTOSCALER_VERSION
     )
@@ -50,6 +51,7 @@ def create_cluster_autoscaler(
             resource_manager,
             execution_id=execution_id,
             resource_limits=resource_limits,
+            label_selector=label_selector,
         )
 
     elif cluster_autoscaler_version == ClusterAutoscalerVersion.V1:

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -19,6 +19,13 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 logger = logging.getLogger(__name__)
 
 HEAD_NODE_RESOURCE_LABEL = "node:__internal_head__"
+# Label key the cluster autoscaler uses to bucket nodes by subcluster.
+# Hardcoded so all components agree without per-Dataset configuration.
+SUBCLUSTER_LABEL_KEY = "__subcluster__"
+# Sentinel for "no subcluster" — used as both a node-label fallback and
+# the bucket key for unlabeled nodes in ``_cluster_node_resources``.
+DEFAULT_SUBCLUSTER: Optional[str] = None
+
 
 RAY_DATA_AUTOSCALING_COORDINATOR_LOG_TRACEBACK = env_bool(
     "RAY_DATA_AUTOSCALING_COORDINATOR_LOG_TRACEBACK", True
@@ -71,8 +78,12 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         self,
         requester_id: str,
         autoscaling_coordinator_actor=None,  # For testing only: injects an actor instead of using the shared named singleton.
+        subcluster_selector: Optional[Dict[str, str]] = None,
     ):
         self._requester_id = requester_id
+        # Label selector keyed by ``SUBCLUSTER_LABEL_KEY`` pinning this
+        # requester to a single subcluster.
+        self._subcluster_selector = subcluster_selector
         self._cached_allocated_resources: List[ResourceDict] = []
         # In-flight get_allocated_resources ref, or None if no request is pending.
         self._pending_allocated_resources: Optional[ray.ObjectRef] = None
@@ -83,7 +94,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
 
     @functools.cached_property
     def _autoscaling_coordinator(self):
-        # Create the coordinator actor lazily rather than eagerly in the constructor.
+        # Lazy: avoids creating the actor in __init__.
         return get_or_create_autoscaling_coordinator()
 
     def request_resources(
@@ -105,6 +116,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
             request_remaining=request_remaining,
             priority=priority,
             label_selectors=label_selectors,
+            subcluster_selector=self._subcluster_selector,
         )
 
     def cancel_request(self) -> None:
@@ -190,7 +202,11 @@ class _AutoscalingCoordinatorActor:
         self._get_cluster_nodes = get_cluster_nodes
 
         self._ongoing_reqs: Dict[str, OngoingRequest] = {}
-        self._cluster_node_resources: List[ResourceDict] = []
+        # Map from requester id to its subcluster selector.
+        self._subcluster_selectors: Dict[str, Optional[Dict[str, str]]] = {}
+        # Node resources bucketed by their ``SUBCLUSTER_LABEL_KEY`` value.
+        # Nodes without the key fall under ``DEFAULT_SUBCLUSTER``.
+        self._cluster_node_resources: Dict[Optional[str], List[ResourceDict]] = {}
         # Lock for thread-safe access to shared state from the background
         self._lock = threading.Lock()
         self._update_cluster_node_resources()
@@ -223,12 +239,15 @@ class _AutoscalingCoordinatorActor:
         request_remaining: bool = False,
         priority: ResourceRequestPriority = ResourceRequestPriority.MEDIUM,
         label_selectors: Optional[List[Dict[str, str]]] = None,
+        subcluster_selector: Optional[Dict[str, str]] = None,
     ) -> None:
         logger.debug(
-            "Received request from %s: %s (label_selectors=%s).",
+            "Received request from %s: %s "
+            "(label_selectors=%s, subcluster_selector=%s).",
             requester_id,
             resources,
             label_selectors,
+            subcluster_selector,
         )
         if label_selectors is None:
             label_selectors = [{} for _ in resources]
@@ -237,6 +256,20 @@ class _AutoscalingCoordinatorActor:
                 f"label_selectors length ({len(label_selectors)}) must match "
                 f"resources length ({len(resources)})."
             )
+        if subcluster_selector and label_selectors:
+            req_subcluster = subcluster_selector.get(SUBCLUSTER_LABEL_KEY)
+            for i, sel in enumerate(label_selectors):
+                bundle_subcluster = sel.get(SUBCLUSTER_LABEL_KEY)
+                if (
+                    bundle_subcluster is not None
+                    and bundle_subcluster != req_subcluster
+                ):
+                    raise ValueError(
+                        f"Bundle {i} label_selector targets subcluster "
+                        f"{bundle_subcluster!r}, but requester is registered to "
+                        f"{req_subcluster!r}. Per-bundle cross-subcluster "
+                        f"allocation is not supported."
+                    )
         with self._lock:
             now = self._get_current_time()
             request_updated = False
@@ -248,6 +281,15 @@ class _AutoscalingCoordinatorActor:
                     )
                 if priority.value != old_req.priority:
                     raise ValueError("Cannot change priority of an ongoing request.")
+                if (
+                    requester_id in self._subcluster_selectors
+                    and self._subcluster_selectors[requester_id] != subcluster_selector
+                ):
+                    raise ValueError(
+                        "Cannot change subcluster_selector of an ongoing request "
+                        f"from {self._subcluster_selectors[requester_id]!r} to "
+                        f"{subcluster_selector!r}."
+                    )
 
                 request_updated = (
                     resources != old_req.requested_resources
@@ -267,6 +309,9 @@ class _AutoscalingCoordinatorActor:
                     expiration_time=now + expire_after_s,
                     allocated_resources=[],
                 )
+            # Write subcluster after all validations so a rejected call
+            # never leaves the registry on a new subcluster.
+            self._subcluster_selectors[requester_id] = subcluster_selector
             if request_updated:
                 # If the request has updated, immediately send
                 # a new request and reallocate resources.
@@ -282,25 +327,38 @@ class _AutoscalingCoordinatorActor:
             if requester_id not in self._ongoing_reqs:
                 return
             del self._ongoing_reqs[requester_id]
+            self._subcluster_selectors.pop(requester_id, None)
             self._merge_and_send_requests()
             self._reallocate_resources()
 
     def _purge_expired_requests(self):
         now = self._get_current_time()
-        self._ongoing_reqs = {
+        live = {
             requester_id: req
             for requester_id, req in self._ongoing_reqs.items()
             if req.expiration_time > now
         }
+        for expired_id in self._ongoing_reqs.keys() - live.keys():
+            self._subcluster_selectors.pop(expired_id, None)
+        self._ongoing_reqs = live
 
     def _merge_and_send_requests(self):
-        """Merge requests and send them to Ray Autoscaler."""
+        """Merge requests and send them to Ray Autoscaler.
+
+        Each bundle's forwarded selector is the union of its per-bundle
+        ``requested_label_selectors`` entry and the requester's
+        ``subcluster_selector``. The subcluster pin wins on key conflict,
+        so the autoscaler always sees the correct subcluster regardless
+        of what the per-bundle selectors contain.
+        """
         self._purge_expired_requests()
         merged_req: List[ResourceDict] = []
         merged_selectors: List[Dict[str, str]] = []
-        for req in self._ongoing_reqs.values():
+        for requester_id, req in self._ongoing_reqs.items():
             merged_req.extend(req.requested_resources)
-            merged_selectors.extend(req.requested_label_selectors)
+            subcluster_selector = self._subcluster_selectors.get(requester_id) or {}
+            for per_bundle in req.requested_label_selectors:
+                merged_selectors.append({**per_bundle, **subcluster_selector})
         if any(merged_selectors):
             self._send_resources_request(merged_req, label_selectors=merged_selectors)
         else:
@@ -324,7 +382,7 @@ class _AutoscalingCoordinatorActor:
         return True
 
     def _update_cluster_node_resources(self) -> bool:
-        """Update cluster's total resources. Return True if changed."""
+        """Update cluster resources bucketed by subcluster. Return True if changed."""
 
         def _is_node_eligible(node):
             # Exclude dead nodes.
@@ -341,47 +399,69 @@ class _AutoscalingCoordinatorActor:
 
         nodes = list(filter(_is_node_eligible, self._get_cluster_nodes()))
         nodes = sorted(nodes, key=lambda node: node.get("NodeID", ""))
-        cluster_node_resources = [node["Resources"] for node in nodes]
+        cluster_node_resources: Dict[Optional[str], List[ResourceDict]] = {}
+        for node in nodes:
+            # Safeguard against case where the value of Labels is None.
+            labels = node.get("Labels") or {}
+            subcluster = labels.get(SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER)
+            cluster_node_resources.setdefault(subcluster, []).append(node["Resources"])
         if cluster_node_resources == self._cluster_node_resources:
             return False
-        else:
-            logger.debug("Cluster resources updated: %s.", cluster_node_resources)
-            self._cluster_node_resources = cluster_node_resources
-            return True
+        logger.debug("Cluster resources updated: %s.", cluster_node_resources)
+        self._cluster_node_resources = cluster_node_resources
+        return True
 
     def _reallocate_resources(self):
-        """Reallocate cluster resources."""
+        """Reallocate cluster resources.
+
+        Each requester's subcluster comes from its ``subcluster_selector``.
+        A requester without one is eligible only for the ``None`` bucket.
+        """
         now = self._get_current_time()
-        cluster_node_resources = copy.deepcopy(self._cluster_node_resources)
-        ongoing_reqs = sorted(
-            [req for req in self._ongoing_reqs.values() if req.expiration_time >= now]
+        cluster_node_resources: Dict[Optional[str], List[ResourceDict]] = copy.deepcopy(
+            self._cluster_node_resources
         )
-        # Allocate resources to ongoing requests.
-        # TODO(hchen): Optimize the following triple loop.
-        for ongoing_req in ongoing_reqs:
-            ongoing_req.allocated_resources = []
-            for req in ongoing_req.requested_resources:
-                for node_resource in cluster_node_resources:
-                    if self._maybe_subtract_resources(node_resource, req):
-                        ongoing_req.allocated_resources.append(req)
-                        break
-        # Allocate remaining resources.
-        # NOTE: to handle the case where multiple datasets are running concurrently,
-        # we divide remaining resources equally to all requesters with `request_remaining=True`.
-        remaining_resource_requesters = [
-            req for req in ongoing_reqs if req.request_remaining
+        live_items = [
+            (req_id, req)
+            for req_id, req in self._ongoing_reqs.items()
+            if req.expiration_time >= now
         ]
-        num_remaining_requesters = len(remaining_resource_requesters)
-        if num_remaining_requesters > 0:
-            for node_resource in cluster_node_resources:
-                # Divide remaining resources equally among requesters.
-                # NOTE: Integer division may leave some resources unallocated.
-                divided_resource = {
-                    k: v // num_remaining_requesters for k, v in node_resource.items()
-                }
-                for ongoing_req in remaining_resource_requesters:
-                    if any(v > 0 for v in divided_resource.values()):
-                        ongoing_req.allocated_resources.append(divided_resource)
+        live_items.sort(key=lambda item: item[1])
+
+        def _subcluster_of(requester_id: str) -> Optional[str]:
+            selector = self._subcluster_selectors.get(requester_id)
+            return (selector or {}).get(SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER)
+
+        # TODO(hchen): Optimize the following triple loop.
+        for requester_id, ongoing_req in live_items:
+            ongoing_req.allocated_resources = []
+            subcluster = _subcluster_of(requester_id)
+            for bundle in ongoing_req.requested_resources:
+                for node_resource in cluster_node_resources.get(subcluster, []):
+                    if self._maybe_subtract_resources(node_resource, bundle):
+                        ongoing_req.allocated_resources.append(bundle)
+                        break
+
+        # Allocate remaining resources. Multiple concurrent requesters in
+        # the same subcluster split that subcluster's leftovers equally.
+        remaining_items = [
+            (req_id, req) for req_id, req in live_items if req.request_remaining
+        ]
+        for subcluster, node_resources in cluster_node_resources.items():
+            eligible = [
+                req
+                for req_id, req in remaining_items
+                if _subcluster_of(req_id) == subcluster
+            ]
+            if not eligible:
+                continue
+            for node_resource in node_resources:
+                # Integer division may leave some resources unallocated.
+                divided = {k: v // len(eligible) for k, v in node_resource.items()}
+                if not any(v > 0 for v in divided.values()):
+                    continue
+                for r in eligible:
+                    r.allocated_resources.append(divided)
 
         if logger.isEnabledFor(logging.DEBUG):
             msg = "Allocated resources:\n"

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 HEAD_NODE_RESOURCE_LABEL = "node:__internal_head__"
 # Label key the cluster autoscaler uses to bucket nodes by subcluster.
 # Hardcoded so all components agree without per-Dataset configuration.
-SUBCLUSTER_LABEL_KEY = "__subcluster__"
+SUBCLUSTER_LABEL_KEY = "subcluster"
 # Sentinel for "no subcluster" — used as both a node-label fallback and
 # the bucket key for unlabeled nodes in ``_cluster_node_resources``.
 DEFAULT_SUBCLUSTER: Optional[str] = None

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 import ray
 from .base_autoscaling_coordinator import AutoscalingCoordinator, ResourceDict
 from .default_autoscaling_coordinator import (
+    DEFAULT_SUBCLUSTER,
+    SUBCLUSTER_LABEL_KEY,
     DefaultAutoscalingCoordinator,
 )
 from .resource_utilization_gauge import (
@@ -69,8 +71,27 @@ class _NodeResourceSpec:
         return {"CPU": self.cpu, "GPU": self.gpu, "memory": self.mem}
 
 
-def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
-    """Get the unique node resource specs and their count in the cluster."""
+def _get_node_resource_spec_and_count(
+    subcluster: Optional[str] = DEFAULT_SUBCLUSTER,
+) -> Dict[_NodeResourceSpec, int]:
+    """Get the unique node resource specs and their count in the cluster,
+    scoped to a single subcluster.
+
+    ``subcluster`` is the value at ``SUBCLUSTER_LABEL_KEY`` to match
+    against. The default ``DEFAULT_SUBCLUSTER`` (None) selects nodes with
+    no subcluster label.
+
+    Quirk: the returned dict also contains a ``node_type: 0`` (ex: `"m5.xlarge": 0`) entry for every
+    node type registered in ``cluster_config.node_group_configs`` that
+    isn't included in this subcluster. ``get_cluster_config()``
+    reports node types but not labels, so the only way to know a
+    shape's subcluster is to inspect live nodes. Harmless: for example,
+    if m5.xlarge nodes only exist in the training subcluster, the validation
+    dataset will emit pending-bundle scale-up demand for foo nodes
+    stamped with the validation label, which the autoscaler can never
+    satisfy.
+    TODO: get labels from cluster config so the catalog can be filtered.
+    """
     nodes_resource_spec_count = defaultdict(int)
 
     cluster_config = ray._private.state.state.get_cluster_config()
@@ -84,11 +105,16 @@ def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
             )
             nodes_resource_spec_count[node_resource_spec] = 0
 
-    # Filter out the head node.
+    # Filter out the head node and nodes outside the requester's subcluster.
     node_resources = [
         node["Resources"]
         for node in ray.nodes()
-        if node["Alive"] and "node:__internal_head__" not in node["Resources"]
+        if (
+            node["Alive"]
+            and "node:__internal_head__" not in node["Resources"]
+            and (node.get("Labels") or {}).get(SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER)
+            == subcluster
+        )
     ]
 
     for r in node_resources:
@@ -162,10 +188,9 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         min_gap_between_autoscaling_requests_s: float = MIN_GAP_BETWEEN_AUTOSCALING_REQUESTS,  # noqa: E501
         low_util_request_release_delay_s: float = DEFAULT_LOW_UTIL_REQUEST_RELEASE_DELAY_S,  # noqa: E501
         autoscaling_coordinator: Optional[AutoscalingCoordinator] = None,
-        get_node_counts: Callable[[], Dict[_NodeResourceSpec, int]] = (
-            _get_node_resource_spec_and_count
-        ),
+        get_node_counts: Optional[Callable[[], Dict[_NodeResourceSpec, int]]] = None,
         get_time: Callable[[], float] = time.time,
+        label_selector: Optional[Dict[str, str]] = None,
     ):
         assert cluster_scaling_up_delta > 0
         assert cluster_util_avg_window_s > 0
@@ -180,6 +205,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             )
 
         self._resource_limits = resource_limits
+        self._label_selector = label_selector or {}
         self._resource_utilization_calculator = resource_utilization_calculator
         # Threshold of cluster utilization to trigger scaling up.
         self._cluster_scaling_up_util_threshold = cluster_scaling_up_util_threshold
@@ -200,9 +226,20 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._requester_id = f"data-{execution_id}"
         if autoscaling_coordinator is None:
             autoscaling_coordinator = DefaultAutoscalingCoordinator(
-                requester_id=self._requester_id
+                requester_id=self._requester_id,
+                subcluster_selector=label_selector,
             )
         self._autoscaling_coordinator = autoscaling_coordinator
+        if get_node_counts is None:
+            # Scope node-shape/count discovery to this requester's subcluster
+            # so try_trigger_scaling doesn't pull node shapes / counts from
+            # other subclusters into ``active_bundles`` / ``pending_bundles``.
+            subcluster = self._label_selector.get(
+                SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER
+            )
+            get_node_counts = lambda: _get_node_resource_spec_and_count(  # noqa: E731
+                subcluster=subcluster
+            )
         self._get_node_counts = get_node_counts
         self._get_time = get_time
         self._autoscaling_enabled = is_autoscaling_enabled()

--- a/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
@@ -51,6 +51,7 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
         request_remaining: bool = False,
         priority: ResourceRequestPriority = ResourceRequestPriority.MEDIUM,
         label_selectors: Optional[List[Dict[str, str]]] = None,
+        subcluster_selector: Optional[Dict[str, str]] = None,
     ) -> None:
         if priority != ResourceRequestPriority.MEDIUM:
             raise NotImplementedError(

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -316,7 +316,7 @@ class ExecutionOptions:
             aggregator actors) carries this label selector in its remote args,
             constraining placement to nodes whose labels satisfy the selector.
             Used to scope a Dataset to a labeled subset of the cluster (e.g.
-            ``{"subcluster": "training"}``). Operator-level ``label_selector``
+            ``{"__subcluster__": "training"}``). Operator-level ``label_selector``
             entries in ``ray_remote_args`` take precedence on key conflicts so
             existing node-pin selectors are preserved.
     """

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -507,7 +507,7 @@ def test_fractional_bundles_are_forwarded_unchanged():
 
 
 def test_label_selectors_are_forwarded_to_sdk():
-    """Test that label selectors are forwarded to the autoscaler SDK."""
+    """Per-bundle label_selectors are forwarded as ``bundle_label_selectors``."""
     mock_send = Mock()
     coord = _AutoscalingCoordinatorActor(
         get_current_time=lambda: 0,
@@ -527,6 +527,37 @@ def test_label_selectors_are_forwarded_to_sdk():
     )
 
 
+def test_sdk_forwarding_merges_subcluster_into_each_bundle():
+    """Forwarded bundles union the per-bundle selector with the
+    requester's subcluster."""
+    mock_send = Mock()
+    coord = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=mock_send,
+        get_cluster_nodes=lambda: CLUSTER_NODES_WITHOUT_HEAD,
+    )
+
+    coord.request_resources(
+        requester_id="r",
+        resources=[{"CPU": 1}, {"CPU": 1}],
+        label_selectors=[
+            # Non-subcluster key preserved alongside the subcluster.
+            {"node_id": "n1"},
+            # Empty per-bundle entry — should still receive the subcluster.
+            {},
+        ],
+        subcluster_selector={"__subcluster__": "training"},
+        expire_after_s=10,
+    )
+    mock_send.assert_called_once_with(
+        [{"CPU": 1}, {"CPU": 1}],
+        label_selectors=[
+            {"node_id": "n1", "__subcluster__": "training"},
+            {"__subcluster__": "training"},
+        ],
+    )
+
+
 def test_label_selectors_length_mismatch_raises():
     coord = _AutoscalingCoordinatorActor(
         get_current_time=lambda: 0,
@@ -540,6 +571,52 @@ def test_label_selectors_length_mismatch_raises():
             label_selectors=[{"a": "b"}],
             expire_after_s=10,
         )
+
+
+def test_request_rejects_per_bundle_cross_subcluster():
+    """Per-bundle subcluster values that disagree with the requester's
+    ``subcluster_selector`` raise."""
+    coord = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=Mock(),
+        get_cluster_nodes=lambda: CLUSTER_NODES_WITHOUT_HEAD,
+    )
+    with pytest.raises(ValueError, match="cross-subcluster"):
+        coord.request_resources(
+            requester_id="r",
+            resources=[{"CPU": 1}, {"CPU": 1}],
+            label_selectors=[
+                {"__subcluster__": "training"},
+                {"__subcluster__": "validation"},
+            ],
+            subcluster_selector={"__subcluster__": "training"},
+            expire_after_s=10,
+        )
+
+
+def test_request_rejects_changing_subcluster_selector():
+    """A requester's ``subcluster_selector`` can't change between calls;
+    the rejected call must also leave the registry untouched."""
+    coord = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=Mock(),
+        get_cluster_nodes=lambda: CLUSTER_NODES_WITHOUT_HEAD,
+    )
+    coord.request_resources(
+        requester_id="r",
+        resources=[{"CPU": 1}],
+        subcluster_selector={"__subcluster__": "training"},
+        expire_after_s=10,
+    )
+    with pytest.raises(ValueError, match="Cannot change subcluster_selector"):
+        coord.request_resources(
+            requester_id="r",
+            resources=[{"CPU": 1}],
+            subcluster_selector={"__subcluster__": "validation"},
+            expire_after_s=10,
+        )
+    # Registry must be unchanged after the rejected call.
+    assert coord._subcluster_selectors["r"] == {"__subcluster__": "training"}
 
 
 def test_label_selector_change_triggers_resend():
@@ -566,6 +643,281 @@ def test_label_selector_change_triggers_resend():
     )
     assert mock_send.call_count == 2
     mock_send.assert_called_with([{"CPU": 1}], label_selectors=[{"zone": "b"}])
+
+
+LABELED_CLUSTER_NODES = [
+    {
+        "NodeID": "n-train-1",
+        "Resources": {"CPU": 8, "object_store_memory": 1000},
+        "Labels": {"__subcluster__": "training"},
+        "Alive": True,
+    },
+    {
+        "NodeID": "n-train-2",
+        "Resources": {"CPU": 8, "object_store_memory": 1000},
+        "Labels": {"__subcluster__": "training"},
+        "Alive": True,
+    },
+    {
+        "NodeID": "n-val-1",
+        "Resources": {"CPU": 4, "object_store_memory": 500},
+        "Labels": {"__subcluster__": "validation"},
+        "Alive": True,
+    },
+    {
+        "NodeID": "n-default-1",
+        "Resources": {"CPU": 2, "object_store_memory": 200},
+        "Labels": {},
+        "Alive": True,
+    },
+]
+
+
+def _make_coordinator(nodes):
+    return _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=Mock(),
+        get_cluster_nodes=lambda: nodes,
+    )
+
+
+def test_label_selector_disjoint_requesters_dont_cross_talk():
+    coord = _make_coordinator(LABELED_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="train",
+        resources=[{"CPU": 4}],
+        subcluster_selector={"__subcluster__": "training"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+    coord.request_resources(
+        requester_id="val",
+        resources=[{"CPU": 4}],
+        subcluster_selector={"__subcluster__": "validation"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+
+    train = coord.get_allocated_resources("train")
+    val = coord.get_allocated_resources("val")
+    assert {"CPU": 4} in train and {"CPU": 4} in val
+    # Training bucket: 2 x 8 - 4 explicit = 12 leftover, all to train.
+    assert sum(a["CPU"] for a in train if a != {"CPU": 4}) == 12
+    # Validation bucket: 4 - 4 explicit = 0 leftover.
+    assert sum(a["CPU"] for a in val if a != {"CPU": 4}) == 0
+
+
+def test_unlabeled_requester_only_sees_none_bucket():
+    """An unlabeled requester is only eligible for nodes in the ``None``
+    bucket (no subcluster label). It must not get explicit allocations or
+    leftover share from any labeled subcluster, even when it has
+    ``request_remaining=True``."""
+    coord = _make_coordinator(LABELED_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="anon",
+        resources=[{"CPU": 1}],
+        # No label_selector -> effective subcluster = None -> only the
+        # default-labeled node (2 CPU).
+        expire_after_s=10,
+        request_remaining=True,
+    )
+
+    alloc = coord.get_allocated_resources("anon")
+    total_cpu = sum(a["CPU"] for a in alloc)
+    assert total_cpu == 2, (
+        f"unlabeled requester should only see the 2-CPU None bucket; got "
+        f"{total_cpu} (alloc={alloc})"
+    )
+
+
+def test_labeled_and_unlabeled_requesters_are_isolated():
+    coord = _make_coordinator(LABELED_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="train",
+        resources=[{"CPU": 1}],
+        subcluster_selector={"__subcluster__": "training"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+    coord.request_resources(
+        requester_id="anon",
+        resources=[{"CPU": 1}],
+        expire_after_s=10,
+        request_remaining=True,
+    )
+
+    train_total = sum(a["CPU"] for a in coord.get_allocated_resources("train"))
+    anon_total = sum(a["CPU"] for a in coord.get_allocated_resources("anon"))
+    # Training bucket: 2 x 8 = 16 CPU; anon gets none of it.
+    assert train_total == 16
+    # Default bucket: 1 x 2 = 2 CPU; train gets none of it.
+    assert anon_total == 2
+
+
+def test_label_selector_unmatched_yields_no_allocation():
+    """A requester whose subcluster has no matching nodes gets no
+    allocation this tick."""
+    coord = _make_coordinator(LABELED_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="ghost",
+        resources=[{"CPU": 1}],
+        subcluster_selector={"__subcluster__": "nonexistent"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+    assert coord.get_allocated_resources("ghost") == []
+
+
+def test_label_selector_partial_fit_when_demand_exceeds_capacity():
+    """When demand exceeds capacity in the matching bucket, only the
+    bundles that fit get allocated this tick."""
+    coord = _make_coordinator(LABELED_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="val",
+        resources=[{"CPU": 3}, {"CPU": 3}, {"CPU": 3}],
+        subcluster_selector={"__subcluster__": "validation"},
+        expire_after_s=10,
+    )
+    # Validation has one 4-CPU node; only the first 3-CPU bundle fits.
+    assert coord.get_allocated_resources("val") == [{"CPU": 3}]
+
+
+def test_full_tick_exercises_update_merge_reallocate():
+    """A `_tick()` call runs update -> merge_and_forward -> reallocate, so
+    a mid-stream node-list change is picked up after the next tick."""
+    nodes = [
+        {
+            "NodeID": "n1",
+            "Resources": {"CPU": 4},
+            "Labels": {"__subcluster__": "training"},
+            "Alive": True,
+        },
+    ]
+    mock_send = Mock()
+    coord = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=mock_send,
+        get_cluster_nodes=lambda: nodes,
+    )
+    coord.request_resources(
+        requester_id="train",
+        resources=[{"CPU": 1}],
+        subcluster_selector={"__subcluster__": "training"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+    # Before the join: only 4 CPU in the training bucket; 1 used explicitly,
+    # 3 leftover go to train.
+    train_total = sum(a["CPU"] for a in coord.get_allocated_resources("train"))
+    assert train_total == 4
+
+    # A new training node joins the cluster.
+    nodes.append(
+        {
+            "NodeID": "n2",
+            "Resources": {"CPU": 8},
+            "Labels": {"__subcluster__": "training"},
+            "Alive": True,
+        }
+    )
+    # Without a tick, the coordinator still sees the old snapshot.
+    coord._tick()
+    train_total = sum(a["CPU"] for a in coord.get_allocated_resources("train"))
+    # Now: 4 + 8 = 12 total; 1 explicit + 11 leftover.
+    assert train_total == 12
+
+
+def test_labeled_requester_with_empty_resources_stays_pinned():
+    """A labeled requester with empty resources + request_remaining=True is
+    eligible only for leftovers from its own subcluster."""
+    coord = _make_coordinator(LABELED_CLUSTER_NODES)
+
+    # Idle "train" requester: no bundles, still affiliated with training
+    # via the requester-wide ``label_selector``.
+    coord.request_resources(
+        requester_id="train_idle",
+        resources=[],
+        subcluster_selector={"__subcluster__": "training"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+    # Active "val" requester: asks for 2 CPU on validation. After explicit
+    # allocation, validation has 2 CPU of leftover.
+    coord.request_resources(
+        requester_id="val_active",
+        resources=[{"CPU": 2}],
+        subcluster_selector={"__subcluster__": "validation"},
+        expire_after_s=10,
+        request_remaining=True,
+    )
+
+    train_idle_alloc = coord.get_allocated_resources("train_idle")
+    val_active_alloc = coord.get_allocated_resources("val_active")
+
+    # Training bucket: 2 x 8 = 16 CPU, all leftover, all to train_idle.
+    train_idle_cpu = sum(a.get("CPU", 0) for a in train_idle_alloc)
+    assert train_idle_cpu == 16, (
+        f"train_idle should get exactly 16 CPU from training only, got "
+        f"{train_idle_cpu} (alloc={train_idle_alloc})"
+    )
+    # Validation bucket: 4 - 2 explicit = 2 leftover, all to val_active.
+    # Total = 2 explicit + 2 leftover = 4.
+    val_active_cpu = sum(a["CPU"] for a in val_active_alloc)
+    assert val_active_cpu == 4, (
+        f"val_active should get 2 explicit + 2 leftover = 4 CPU, got "
+        f"{val_active_cpu} (alloc={val_active_alloc})"
+    )
+
+
+def test_proxy_forwards_label_selector_from_init():
+    """``DefaultAutoscalingCoordinator`` forwards the ``label_selector``
+    it was constructed with on every request, so the actor can store the
+    requester's subcluster affiliation."""
+    mock_actor = Mock()
+    proxy = DefaultAutoscalingCoordinator(
+        requester_id="r",
+        autoscaling_coordinator_actor=mock_actor,
+        subcluster_selector={"__subcluster__": "training"},
+    )
+    proxy.request_resources(resources=[{"CPU": 1}, {"CPU": 2}], expire_after_s=10)
+    kwargs = mock_actor.request_resources.remote.call_args.kwargs
+    assert kwargs["subcluster_selector"] == {"__subcluster__": "training"}
+
+
+def test_proxy_forwards_label_selector_on_empty_resources():
+    """The proxy carries its ``label_selector`` even on the empty /
+    registration path, so the actor keeps the requester pinned to its
+    subcluster for remaining-resources eligibility."""
+    mock_actor = Mock()
+    proxy = DefaultAutoscalingCoordinator(
+        requester_id="r",
+        autoscaling_coordinator_actor=mock_actor,
+        subcluster_selector={"__subcluster__": "training"},
+    )
+    proxy.request_resources(resources=[], expire_after_s=10, request_remaining=True)
+    kwargs = mock_actor.request_resources.remote.call_args.kwargs
+    assert kwargs["resources"] == []
+    assert kwargs["subcluster_selector"] == {"__subcluster__": "training"}
+
+
+def test_proxy_passes_caller_label_selectors_through():
+    """If the caller passes per-bundle ``label_selectors``, the proxy
+    forwards them as-is (used by callers that want per-bundle
+    constraints beyond subcluster, e.g. node pins)."""
+    mock_actor = Mock()
+    proxy = DefaultAutoscalingCoordinator(
+        requester_id="r",
+        autoscaling_coordinator_actor=mock_actor,
+        subcluster_selector={"__subcluster__": "training"},
+    )
+    proxy.request_resources(
+        resources=[{"CPU": 1}],
+        label_selectors=[{"node_id": "n1"}],
+        expire_after_s=10,
+    )
+    kwargs = mock_actor.request_resources.remote.call_args.kwargs
+    assert kwargs["label_selectors"] == [{"node_id": "n1"}]
+    assert kwargs["subcluster_selector"] == {"__subcluster__": "training"}
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -1,10 +1,12 @@
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 import ray
 from ray.core.generated import autoscaler_pb2
+from ray.data._internal import cluster_autoscaler as ca_pkg
+from ray.data._internal.cluster_autoscaler import create_cluster_autoscaler
 from ray.data._internal.cluster_autoscaler.default_cluster_autoscaler_v2 import (
     DefaultClusterAutoscalerV2,
     _get_node_resource_spec_and_count,
@@ -125,6 +127,48 @@ class TestClusterAutoscaling:
             ),
         ):
             assert _get_node_resource_spec_and_count() == expected
+
+    def test_get_node_resource_spec_and_count_filters_by_subcluster(self):
+        """Only nodes whose ``__subcluster__`` label matches contribute to
+        the counts. Prevents ``try_trigger_scaling`` from pulling shapes
+        and counts from foreign subclusters into a labeled requester's
+        active / pending bundles."""
+        node_table = [
+            {
+                "Resources": self._node_type1,
+                "Labels": {"__subcluster__": "training"},
+                "Alive": True,
+            },
+            {
+                "Resources": self._node_type1,
+                "Labels": {"__subcluster__": "training"},
+                "Alive": True,
+            },
+            {
+                "Resources": self._node_type2,
+                "Labels": {"__subcluster__": "validation"},
+                "Alive": True,
+            },
+            {
+                "Resources": self._node_type3,
+                "Labels": {},
+                "Alive": True,
+            },
+        ]
+        with (
+            patch("ray.nodes", return_value=node_table),
+            patch(
+                "ray._private.state.state.get_cluster_config",
+                return_value=None,
+            ),
+        ):
+            assert _get_node_resource_spec_and_count(subcluster="training") == {
+                _NodeResourceSpec.of(
+                    cpu=self._node_type1["CPU"],
+                    gpu=self._node_type1.get("GPU", 0),
+                    mem=self._node_type1["memory"],
+                ): 2,
+            }
 
     @pytest.mark.parametrize("cpu_util", [0.5, 0.75])
     @pytest.mark.parametrize("gpu_util", [0.5, 0.75])
@@ -730,6 +774,57 @@ class TestClusterAutoscaling:
         scaling_records = [r for r in caplog.records if "Requesting" in r.message]
         assert len(scaling_records) == 1
         assert scaling_records[0].levelno == logging.DEBUG
+
+
+def test_v2_autoscaler_passes_label_selector_to_coordinator(monkeypatch):
+    """``DefaultClusterAutoscalerV2`` forwards the DataContext's
+    ``label_selector`` to the ``DefaultAutoscalingCoordinator`` it
+    constructs."""
+    from ray.data._internal.cluster_autoscaler import default_cluster_autoscaler_v2
+
+    captured = {}
+
+    class _StubProxy:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def request_resources(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        default_cluster_autoscaler_v2, "DefaultAutoscalingCoordinator", _StubProxy
+    )
+    with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=False):
+        DefaultClusterAutoscalerV2(
+            resource_manager=Mock(),
+            execution_id="exec-1",
+            label_selector={"__subcluster__": "training"},
+        )
+    assert captured["subcluster_selector"] == {"__subcluster__": "training"}
+
+
+def test_create_cluster_autoscaler_forwards_label_selector(monkeypatch):
+    """The factory reads ``label_selector`` from ``execution_options`` and
+    forwards it to ``DefaultClusterAutoscalerV2``."""
+    captured = {}
+
+    class _StubV2:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(ca_pkg, "DefaultClusterAutoscalerV2", _StubV2)
+
+    data_context = Mock()
+    data_context.execution_options.resource_limits = Mock()
+    data_context.execution_options.label_selector = {"__subcluster__": "training"}
+
+    create_cluster_autoscaler(
+        topology=Mock(),
+        resource_manager=Mock(),
+        data_context=data_context,
+        execution_id="exec-1",
+    )
+    assert captured["label_selector"] == {"__subcluster__": "training"}
 
 
 if __name__ == "__main__":

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -28,6 +28,7 @@ Cluster (heterogeneous_memory_compute.yaml):
 
 import argparse
 import time
+from typing import Optional
 
 import numpy as np
 from benchmark import Benchmark
@@ -91,8 +92,22 @@ def build_and_run_pipeline(
     cpu_batch_size: int,
     gpu_batch_size: int,
     gpu_concurrency: int,
+    subcluster: Optional[str] = None,
 ):
+    if subcluster is not None:
+        # Set on the process-global DataContext first: some operator paths
+        # read via DataContext.get_current() at task-submission time, which
+        # is thread-local in places, so the per-Dataset setting alone isn't
+        # sufficient when callers run on a non-driver thread.
+        ray.data.DataContext.get_current().execution_options.label_selector = {
+            "subcluster": subcluster
+        }
+
     ds = ray.data.range(num_rows)
+
+    if subcluster is not None:
+        # Also pin on the Dataset's own context so chained ops inherit it.
+        ds.context.execution_options.label_selector = {"subcluster": subcluster}
 
     ds = ds.map_batches(gen_data, batch_size=gen_batch_size)
 
@@ -107,6 +122,14 @@ def build_and_run_pipeline(
     )
 
     ds.write_datasink(NullDatasink())
+
+    # Tag each tenant's per-stage breakdown so multi-run logs (multiple
+    # threads writing to stdout) stay attributable.
+    tag = subcluster if subcluster is not None else "no-subcluster"
+    print(
+        f"\n===== ds.stats() [tenant={tag}] =====\n{ds.stats()}\n===== end stats =====\n",
+        flush=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference_multitenancy.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference_multitenancy.py
@@ -1,0 +1,265 @@
+"""
+Heterogeneous Memory Batch Inference — Multitenancy Variant
+
+Runs two copies of `heterogeneous_memory_batch_inference` concurrently on a
+single Ray cluster, each pinned to its own labeled subcluster via Ray Data
+`label_selector`. Reports two properties of the subcluster scheduling
+work:
+
+1. Isolation: wall-clock time for the two tenants running concurrently is
+   close to the time for a single tenant running alone on its half of the
+   cluster. Departure from that indicates cross-subcluster interference.
+2. Placement: no task from a labeled pipeline ran on the wrong subcluster's
+   nodes, and no operator task escaped to the unlabeled head node.
+
+Cluster (heterogeneous_memory_compute_multitenancy.yaml):
+  - 1 head node, unlabeled.
+  - 10 CPU + 2 GPU workers per tenant, each pool labeled
+    `subcluster: tenant_a` or `subcluster: tenant_b`.
+
+Sequence:
+  1. Solo baseline run as tenant_a -> T_single
+  2. Concurrent run as tenant_a + tenant_b (two threads) -> per-tenant
+     wall times; multi wall is the max of the two.
+  3. Print solo vs. multi timing and overhead ratio.
+  4. Sweep `list_tasks` against `list_nodes`, print any placement
+     mismatches.
+  5. After metrics have been written, raise if either runtime or
+     placement failed.
+"""
+
+import argparse
+import os
+import threading
+import time
+from typing import Dict, List
+
+import heterogeneous_memory_batch_inference as hmbi
+from benchmark import Benchmark, benchmark_py_modules
+from heterogeneous_memory_batch_inference import build_and_run_pipeline
+
+import ray
+from ray.util.state import list_actors, list_nodes, list_tasks
+
+
+SUBCLUSTERS = ("tenant_a", "tenant_b")
+
+# Max acceptable concurrent-vs-solo overhead before we flag a regression.
+MAX_OVERHEAD = 0.15
+
+# Operator-name prefixes set by Ray Data on tasks for this pipeline:
+#   ray.data.range -> "Read*", map_batches(...) -> "MapBatches(...)",
+#   write_datasink(...) -> "Write*". Exhaustive for this pipeline; extend
+#   if the pipeline ever adds shuffles / aggregates / repartitions.
+DATA_TASK_NAME_PREFIXES = ("MapBatches(", "Read", "Write")
+
+# Upper bound on tasks fetched via list_tasks. We print the scanned count
+# so the operator can spot truncation. Going above this limit gives
+# RayStateApiException. When I ran this release test I saw 16081 tasks.
+LIST_TASKS_LIMIT = 20_000
+
+
+def run_pipeline(subcluster: str, args: argparse.Namespace) -> None:
+    build_and_run_pipeline(
+        num_rows=args.num_rows,
+        gen_batch_size=args.gen_batch_size,
+        cpu_batch_size=args.cpu_batch_size,
+        gpu_batch_size=args.gpu_batch_size,
+        gpu_concurrency=args.gpu_concurrency,
+        subcluster=subcluster,
+    )
+
+
+def run_solo(args: argparse.Namespace) -> float:
+    start = time.perf_counter()
+    run_pipeline("tenant_a", args)
+    return time.perf_counter() - start
+
+
+def run_concurrent(args: argparse.Namespace) -> Dict[str, float]:
+    """Run both tenants on threads concurrently; return per-tenant wall-time."""
+    per_tenant: Dict[str, float] = {}
+
+    def _run(sc: str) -> None:
+        t0 = time.perf_counter()
+        run_pipeline(sc, args)
+        per_tenant[sc] = time.perf_counter() - t0
+
+    threads = [
+        threading.Thread(target=_run, args=(sc,), name=f"pipeline-{sc}")
+        for sc in SUBCLUSTERS
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return per_tenant
+
+
+def verify_placement() -> dict:
+    """Sweep the state API; print any subcluster leaks or head escapes.
+
+    Collects mismatch details into the returned dict so the caller can
+    raise after metrics have been written.
+    """
+    nodes = list_nodes(detail=True, limit=1000)
+    node_subcluster = {n.node_id: (n.labels or {}).get("subcluster") for n in nodes}
+
+    # For actor methods (e.g. ``MapWorker(...).submit``), TaskState.label_selector
+    # is None — the placement constraint lives on the actor's creation, not on
+    # each method call. Walk back to ActorState.label_selector for those.
+    actor_label_selector = {
+        a.actor_id: a.label_selector or {}
+        for a in list_actors(detail=True, limit=LIST_TASKS_LIMIT)
+    }
+
+    def _selector_for(t) -> Dict[str, str]:
+        if t.label_selector:
+            return t.label_selector
+        if t.actor_id and t.actor_id in actor_label_selector:
+            return actor_label_selector[t.actor_id]
+        return {}
+
+    bad_on_labeled = []  # task on labeled node with mismatching selector
+    bad_on_head = []  # dataset-shaped task that escaped to head / unlabeled node
+    tasks_on_labeled = 0
+    tasks_on_head = 0
+    total_tasks = 0
+
+    for t in list_tasks(detail=True, limit=LIST_TASKS_LIMIT):
+        total_tasks += 1
+        node_sc = node_subcluster.get(t.node_id)
+        if node_sc in SUBCLUSTERS:
+            tasks_on_labeled += 1
+            want = _selector_for(t).get("subcluster")
+            if want != node_sc:
+                bad_on_labeled.append(
+                    (t.task_id, t.name, t.func_or_class_name, want, node_sc)
+                )
+        else:
+            tasks_on_head += 1
+            if t.name and any(t.name.startswith(p) for p in DATA_TASK_NAME_PREFIXES):
+                bad_on_head.append((t.task_id, t.name))
+
+    print(
+        f"Placement: scanned {total_tasks} tasks "
+        f"(limit={LIST_TASKS_LIMIT}; if equal, results may be truncated). "
+        f"{tasks_on_labeled} on labeled nodes, {tasks_on_head} on head/unlabeled."
+    )
+
+    if bad_on_labeled:
+        print(
+            f"Subcluster mismatches on labeled nodes " f"(total {len(bad_on_labeled)}):"
+        )
+        for row in bad_on_labeled:
+            print(f"  {row}")
+    else:
+        print("No subcluster mismatches on labeled nodes.")
+
+    if bad_on_head:
+        print(
+            f"Dataset tasks escaped to head/unlabeled nodes "
+            f"(total {len(bad_on_head)}):"
+        )
+        for row in bad_on_head:
+            print(f"  {row}")
+    else:
+        print("No dataset tasks escaped to head/unlabeled nodes.")
+
+    return {
+        "tasks_scanned": total_tasks,
+        "tasks_on_labeled_nodes": tasks_on_labeled,
+        "tasks_on_head_or_unlabeled": tasks_on_head,
+        "subcluster_mismatches": len(bad_on_labeled),
+        "head_escapes": len(bad_on_head),
+        "list_tasks_limit": LIST_TASKS_LIMIT,
+    }
+
+
+def main(args: argparse.Namespace) -> dict:
+    """Returns the benchmark dict. Errors are recorded under "_errors" so
+    metrics can be written first; the caller raises after write_result."""
+    errors: List[str] = []
+
+    solo_time = run_solo(args)
+    per_tenant = run_concurrent(args)
+    multi_time = max(per_tenant.values()) if per_tenant else float("nan")
+    overhead_ratio = multi_time / solo_time if solo_time > 0 else float("inf")
+    per_tenant_str = ", ".join(
+        f"{sc}={per_tenant.get(sc, float('nan')):.2f}s" for sc in SUBCLUSTERS
+    )
+    print(
+        f"Solo: {solo_time:.2f}s; Multi: {multi_time:.2f}s "
+        f"[{per_tenant_str}]; overhead ratio: {overhead_ratio:.3f}"
+    )
+    if overhead_ratio > 1 + MAX_OVERHEAD:
+        errors.append(
+            f"Multi-tenant overhead {overhead_ratio:.3f}x exceeds budget "
+            f"{1 + MAX_OVERHEAD:.3f}x (solo={solo_time:.2f}s, "
+            f"multi={multi_time:.2f}s)."
+        )
+
+    placement_metrics = verify_placement()
+    if placement_metrics["subcluster_mismatches"]:
+        errors.append(
+            f"{placement_metrics['subcluster_mismatches']} task(s) ran on a "
+            "node with the wrong subcluster label."
+        )
+    if placement_metrics["head_escapes"]:
+        errors.append(
+            f"{placement_metrics['head_escapes']} dataset task(s) escaped "
+            "to head/unlabeled nodes."
+        )
+
+    result = {
+        "solo_runtime_s": solo_time,
+        "multi_runtime_s": multi_time,
+        "overhead_ratio": overhead_ratio,
+        "num_rows": int(args.num_rows),
+        "gpu_concurrency": int(args.gpu_concurrency),
+    }
+    for sc in SUBCLUSTERS:
+        if sc in per_tenant:
+            result[f"multi_runtime_s_{sc}"] = per_tenant[sc]
+    result.update(placement_metrics)
+    if errors:
+        result["_errors"] = errors
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Heterogeneous memory batch inference multitenancy benchmark"
+    )
+    p.add_argument("--num-rows", type=int, default=400_000)
+    p.add_argument("--gen-batch-size", type=int, default=1024)
+    p.add_argument("--cpu-batch-size", type=int, default=1024)
+    p.add_argument("--gpu-batch-size", type=int, default=256)
+    p.add_argument("--gpu-concurrency", type=int, default=8)
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    name = "heterogeneous-memory-batch-inference-multitenancy"
+    # Ship both benchmark.py and heterogeneous_memory_batch_inference.py to
+    # workers: when this script is run as ``__main__``, the UDF classes
+    # (FakeGPUInference, etc.) live in the imported
+    # ``heterogeneous_memory_batch_inference`` module, so cloudpickle
+    # serializes them by reference and each worker needs to import the
+    # module to deserialize.
+    ray.init(
+        runtime_env={
+            "py_modules": benchmark_py_modules() + [os.path.abspath(hmbi.__file__)],
+        }
+    )
+    benchmark = Benchmark()
+    benchmark.run_fn(name, main, args)
+    benchmark.write_result()
+
+    # Raise after metrics have been written so the dashboard still records
+    # the failed run (matches the sort_benchmark.py "print then raise"
+    # convention).
+    errors = benchmark.result.get(name, {}).get("_errors", [])
+    if errors:
+        raise AssertionError("; ".join(errors))

--- a/release/nightly_tests/dataset/heterogeneous_memory_compute_multitenancy.yaml
+++ b/release/nightly_tests/dataset/heterogeneous_memory_compute_multitenancy.yaml
@@ -1,0 +1,54 @@
+# Multitenancy variant of heterogeneous_memory_compute.yaml.
+# Each tenant gets a full mirror of the original cluster's CPU+GPU pools,
+# pinned to its subcluster via Ray node labels. The two tenants share the
+# same Ray cluster but should run as if isolated.
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    instance_type: m5.2xlarge
+
+worker_nodes:
+    # tenant_a CPU pool — mirrors the original CPU pool.
+    - name: cpu-tenant-a
+      instance_type: m5.2xlarge
+      min_nodes: 10
+      max_nodes: 10
+      market_type: ON_DEMAND
+      labels:
+        subcluster: tenant_a
+
+    # tenant_b CPU pool — mirrors the original CPU pool.
+    - name: cpu-tenant-b
+      instance_type: m5.2xlarge
+      min_nodes: 10
+      max_nodes: 10
+      market_type: ON_DEMAND
+      labels:
+        subcluster: tenant_b
+
+    # tenant_a "GPU" pool (logical GPUs, no CPUs).
+    - name: gpu-tenant-a
+      instance_type: r5.4xlarge
+      min_nodes: 2
+      max_nodes: 2
+      market_type: ON_DEMAND
+      resources:
+        CPU: 0
+        GPU: 4
+      labels:
+        subcluster: tenant_a
+
+    # tenant_b "GPU" pool (logical GPUs, no CPUs).
+    - name: gpu-tenant-b
+      instance_type: r5.4xlarge
+      min_nodes: 2
+      max_nodes: 2
+      market_type: ON_DEMAND
+      resources:
+        CPU: 0
+        GPU: 4
+      labels:
+        subcluster: tenant_b

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -869,6 +869,30 @@
     timeout: 3600
     script: python heterogeneous_memory_batch_inference.py
 
+# Multitenancy variant: runs two copies of the heterogeneous_memory pipeline
+# concurrently on a single cluster, each pinned to its own subcluster via
+# label_selector. Asserts isolation (no runtime regression vs. solo) and
+# placement (no task crossed subcluster boundaries).
+- name: heterogeneous_memory_batch_inference_multitenancy
+  python: "3.10"
+  frequency: nightly
+  group: data-batch-inference
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=0
+        - RAYTEST_FAIL_ON_DEAD_NODES=0
+        - RAY_MAX_LIMIT_FROM_API_SERVER=20000
+        - RAY_MAX_LIMIT_FROM_DATA_SOURCE=20000
+    cluster_compute: heterogeneous_memory_compute_multitenancy.yaml
+
+  run:
+    timeout: 7200
+    script: python heterogeneous_memory_batch_inference_multitenancy.py
+
 # 300 GB image classification parquet data up to 10 GPUs
 # 10 g4dn.12xlarge.
 - name: "image_classification_{{scaling}}"


### PR DESCRIPTION
Multitenancy release test on master @ `73f6edeb9b~1` (just before #63680 'Remove safe_round from ExecutionResources hot path') with PR #63375 cherry-picked on top. Pin/PASS decides whether #63680 caused the regression.