### PR TITLE
[core][rdt] Support automatically merging nixl xfer descs in RDT

### DIFF
--- a/python/ray/experimental/rdt/nixl_tensor_transport.py
+++ b/python/ray/experimental/rdt/nixl_tensor_transport.py
@@ -1,10 +1,11 @@
 import logging
+import math
 import threading
 import time
 import traceback
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import ray
 from ray._private.ray_constants import (
@@ -247,7 +248,10 @@ class NixlTensorTransport(TensorTransportManager):
                     xfer_descs = self._allocate_pool_xfer_descs(rdt_object)
                 else:
                     self._add_tensor_descs(rdt_object)
-                    xfer_descs = nixl_agent.get_xfer_descs(rdt_object)
+                    merged_tuples = self._merge_xfer_descs(rdt_object)
+                    xfer_descs = nixl_agent.get_xfer_descs(
+                        merged_tuples, mem_type=device.type
+                    )
 
                 serialized_descs = nixl_agent.get_serialized_descs(xfer_descs)
                 agent_meta = nixl_agent.get_agent_metadata()
@@ -298,14 +302,6 @@ class NixlTensorTransport(TensorTransportManager):
         Returns:
             A NixlFetchRequest carrying the async transfer state.
         """
-        from ray.experimental.rdt.util import (
-            create_empty_tensors_from_metadata,
-        )
-
-        tensors = target_buffers or create_empty_tensors_from_metadata(
-            tensor_transport_metadata
-        )
-
         assert isinstance(tensor_transport_metadata, NixlTransportMetadata)
         assert isinstance(communicator_metadata, NixlCommunicatorMetadata)
 
@@ -317,19 +313,43 @@ class NixlTensorTransport(TensorTransportManager):
                 self._aborted_transfer_obj_ids.remove(obj_id)
                 raise RuntimeError(f"NIXL transfer aborted for object id: {obj_id}")
 
+        tensors = None
         remote_name = None
         xfer_handle = None
         added_tensor_descs = False
 
-        assert tensors
-
         try:
             nixl_agent = self.get_nixl_agent()
             remote_xfer_descs = nixl_agent.deserialize_descs(nixl_serialized_descs)
+
+            if target_buffers is not None:
+                tensors = target_buffers
+            else:
+                (
+                    tensors,
+                    merged_memory_regions,
+                ) = self._allocate_tensors_from_merged_xfer_descs(
+                    remote_xfer_descs,
+                    tensor_transport_metadata.tensor_meta,
+                    tensor_transport_metadata.tensor_device,
+                )
+
             # This creates a placeholder for the tensor in the tensor_desc_cache even though it doesn't have an object ref for caching purposes.
             self._add_tensor_descs(tensors)
             added_tensor_descs = True
-            local_xfer_descs = nixl_agent.get_xfer_descs(tensors)
+
+            if target_buffers is not None:
+                local_xfer_descs, remote_xfer_descs = self._find_common_xfer_descs(
+                    nixl_agent,
+                    tensors,
+                    remote_xfer_descs,
+                    tensor_transport_metadata.tensor_device,
+                )
+            else:
+                local_xfer_descs = nixl_agent.get_xfer_descs(
+                    merged_memory_regions,
+                    mem_type=tensor_transport_metadata.tensor_device,
+                )
 
             remote_name = tensor_transport_metadata.nixl_agent_name
             remote_agent_meta_version = (
@@ -653,7 +673,10 @@ class NixlTensorTransport(TensorTransportManager):
         }
         pool_tensor_views = pool.allocate_for_tensors(tensors)
         try:
-            xfer_descs = self._nixl_agent.get_xfer_descs(pool_tensor_views)
+            merged_memory_regions = self._merge_xfer_descs(pool_tensor_views)
+            xfer_descs = self._nixl_agent.get_xfer_descs(
+                merged_memory_regions, mem_type=pool_tensor_views[0].device.type
+            )
         except Exception:
             # Only free newly allocated blocks, not cache hits.
             new_tensors = [
@@ -664,3 +687,166 @@ class NixlTensorTransport(TensorTransportManager):
             raise
         self._add_pool_tensor_descs(tensors)
         return xfer_descs
+
+    @staticmethod
+    def _merge_xfer_descs(tensors: List["torch.Tensor"]):
+        """Merge consecutive tensors that are contiguous within one storage.
+
+        Two consecutive tensors are merged into one descriptor only when they
+        share the same underlying storage and the first ends exactly where the
+        next begins. Same-storage is required because each storage is registered
+        as a single NIXL memory region (one rkey) and a descriptor cannot span
+        two regions; merging adjacent runs lets us issue one RMA op per region
+        instead of one per tensor. The device id is not compared since sharing
+        one storage implies one device.
+
+        Args:
+            tensors: The tensors to potentially merge.
+
+        Returns:
+            A list of ``(addr, total_len, dev_id)`` tuples, one for each merged
+            memory region.
+        """
+        merged = []
+        last_storage = None
+        for t in tensors:
+            addr = t.data_ptr()
+            length = t.numel() * t.element_size()
+            storage = t.untyped_storage().data_ptr()
+            if (
+                merged
+                and storage == last_storage
+                and addr == merged[-1][0] + merged[-1][1]
+            ):
+                prev_addr, prev_len, prev_dev = merged[-1]
+                merged[-1] = (prev_addr, prev_len + length, prev_dev)
+            else:
+                merged.append((addr, length, max(t.get_device(), 0)))
+                last_storage = storage
+        return merged
+
+    def _allocate_tensors_from_merged_xfer_descs(
+        self,
+        remote_xfer_descs: Any,
+        tensor_meta: List[Tuple["torch.Size", "torch.dtype"]],
+        device: str,
+    ):
+        """Allocate one contiguous buffer per merged remote descriptor.
+
+        Each descriptor only carries its region's total byte size, so the merged
+        region byte size comes from the descriptor while the per-tensor
+        shapes/dtypes come from ``tensor_meta``. Each merged region is divided
+        back into tensor views based on the dimensions provided in tensor_meta.
+
+        Args:
+            remote_xfer_descs: The sender's merged xfer descriptors.
+            tensor_meta: Per-tensor ``(shape, dtype)``.
+            device: The device on which to allocate the receiving buffers.
+
+        Returns:
+            A ``(views, merged_memory_regions)`` tuple, where ``views`` are the
+            per-tensor output tensors in ``tensor_meta`` order and
+            ``merged_memory_regions`` is one ``(addr, total_len, dev_id)`` per
+            merged memory region (used to build the local xfer descriptors).
+        """
+        import torch
+
+        views: List["torch.Tensor"] = []
+        merged_memory_regions = []
+        tensor_meta_index = 0
+        num_tensors = len(tensor_meta)
+        for xfer_desc_index in range(remote_xfer_descs.descCount()):
+            memory_region_bytes = remote_xfer_descs[xfer_desc_index][1]
+            buf = torch.empty(memory_region_bytes, dtype=torch.uint8, device=device)
+            offset = 0
+            while offset < memory_region_bytes and tensor_meta_index < num_tensors:
+                shape, dtype = tensor_meta[tensor_meta_index]
+                nbytes = math.prod(shape) * dtype.itemsize
+                views.append(buf[offset : offset + nbytes].view(dtype).reshape(shape))
+                offset += nbytes
+                tensor_meta_index += 1
+            if offset != memory_region_bytes:
+                raise RuntimeError(
+                    "Failed to map a NIXL xfer descriptor back to tensors: "
+                    f"descriptor {xfer_desc_index} length {memory_region_bytes} "
+                    "does not align with tensor metadata."
+                )
+            merged_memory_regions.append(
+                (buf.data_ptr(), memory_region_bytes, max(buf.get_device(), 0))
+            )
+        return views, merged_memory_regions
+
+    def _find_common_xfer_descs(
+        self,
+        nixl_agent: Any,
+        tensors: List["torch.Tensor"],
+        remote_xfer_descs: Any,
+        remote_device: str,
+    ):
+        """Find matching local/remote xfer descriptors for caller-provided buffers.
+
+        The sender provides a list of merged remote xfer descriptors, where each
+        descriptor is one contiguous region within a single registered memory
+        region (non-adjacent regions stay as separate descriptors). The caller,
+        however, may provide tensors with an arbitrary layout whose merged
+        regions have a different number of registered memory regions. To minimize
+        the number of xfer descs while keeping the local and remote lists aligned,
+        we walk both merged lists and, for the side whose current region is
+        larger, split it into n descriptors to match the other side. This works
+        because the local and remote tensors have equal dimensions, so their
+        total byte size and tensor count is the same.
+
+        Args:
+            nixl_agent: The NIXL agent to use.
+            tensors: The tensors to potentially merge.
+            remote_xfer_descs: The sender's merged xfer descriptors.
+            remote_device: The device on which the sender's tensors are allocated.
+
+        Returns:
+            A tuple of ``(local_xfer_descs, remote_xfer_descs)``, where
+            ``local_xfer_descs`` are the local xfer descriptors and
+            ``remote_xfer_descs`` are the remote xfer descriptors.
+        """
+        local_merged_memory_regions = self._merge_xfer_descs(tensors)
+        remote_merged_memory_regions = [
+            remote_xfer_descs[d] for d in range(remote_xfer_descs.descCount())
+        ]
+
+        new_local_memory_regions = []
+        new_remote_memory_regions = []
+        local_index = remote_index = 0
+        l_offset = r_offset = 0
+        while local_index < len(local_merged_memory_regions) and remote_index < len(
+            remote_merged_memory_regions
+        ):
+            l_addr, l_len, l_device = local_merged_memory_regions[local_index]
+            r_addr, r_len, r_device = remote_merged_memory_regions[remote_index]
+            chunk = min(l_len - l_offset, r_len - r_offset)
+            new_local_memory_regions.append((l_addr + l_offset, chunk, l_device))
+            new_remote_memory_regions.append((r_addr + r_offset, chunk, r_device))
+            l_offset += chunk
+            r_offset += chunk
+            if l_offset == l_len:
+                local_index += 1
+                l_offset = 0
+            if r_offset == r_len:
+                remote_index += 1
+                r_offset = 0
+
+        if local_index != len(local_merged_memory_regions) or remote_index != len(
+            remote_merged_memory_regions
+        ):
+            raise RuntimeError(
+                "Caller-provided buffers do not match the sender's total "
+                "transfer size: local and remote descriptors cover different "
+                "byte counts."
+            )
+
+        local_device = tensors[0].device.type
+        local_xfer_descs = nixl_agent.get_xfer_descs(
+            new_local_memory_regions, mem_type=local_device
+        )
+        remote_xfer_descs = nixl_agent.get_xfer_descs(
+            new_remote_memory_regions, mem_type=remote_device
+        )
+        return local_xfer_descs, remote_xfer_descs

--- a/python/ray/tests/rdt/test_rdt_nixl.py
+++ b/python/ray/tests/rdt/test_rdt_nixl.py
@@ -717,5 +717,82 @@ def test_nixl_memory_pool_view_deduplication(ray_start_regular):
     assert not pool.has_block(base)
 
 
+def test_merge_xfer_descs():
+    """Test that contiguous memory regions are merged into a single xfer descriptor."""
+    from ray.experimental.rdt.nixl_tensor_transport import (
+        NixlTensorTransport,
+    )
+
+    merge_xfer_descs = NixlTensorTransport._merge_xfer_descs
+
+    # Adjacent views of one storage -> one merged descriptor.
+    base = torch.arange(12, dtype=torch.float32)
+    merged = merge_xfer_descs([base[0:4], base[4:8], base[8:12]])
+    assert len(merged) == 1
+    assert merged[0][1] == 12 * 4
+
+    # A gap between views of the same storage prevents merging.
+    merged = merge_xfer_descs([base[0:4], base[8:12]])
+    assert len(merged) == 2
+    assert [m[1] for m in merged] == [16, 16]
+
+    # Separate storages are never merged due to differing rkeys
+    seps = [torch.tensor([1.0, 2.0, 3.0]) for _ in range(3)]
+    merged = merge_xfer_descs(seps)
+    assert len(merged) == 3
+
+    # Two adjacent views then a separate tensor.
+    base2 = torch.arange(8, dtype=torch.float32)
+    merged = merge_xfer_descs([base2[0:4], base2[4:8], torch.tensor([9.0, 9.0])])
+    assert len(merged) == 2
+    assert merged[0][1] == 8 * 4
+    assert merged[1][1] == 2 * 4
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_nixl_get_into_buffers_mismatched_storage_blocks(ray_start_regular):
+    """Transfer when sender and receiver span a different number of torch storage blocks.
+
+    The sender's 3 tensors live in 2 registered regions (``base[0:4]`` and
+    ``base[4:8]`` share one storage and coalesce into a single region, while
+    ``[9, 9]`` is separate). The receiver provides 3 separate target buffers,
+    i.e. 3 regions.
+    """
+
+    @ray.remote(num_gpus=1, num_cpus=0)
+    class GPUTestActor:
+        def get_ref(self):
+            # base[0:4] + base[4:8] coalesce into one region; [9, 9] is a second
+            # region -> 3 tensors across 2 registered regions on the sender.
+            self.base = torch.arange(8, dtype=torch.float32).to("cuda")
+            self.tensor_list = [
+                self.base[0:4],
+                self.base[4:8],
+                torch.tensor([9.0, 9.0]).to("cuda"),
+            ]
+            return ray.put(self.tensor_list, _tensor_transport="nixl")
+
+        def get_with_separate_buffers(self, refs):
+            # 3 independent allocations -> 3 registered regions on the receiver.
+            targets = [
+                torch.empty(4, dtype=torch.float32, device="cuda"),
+                torch.empty(4, dtype=torch.float32, device="cuda"),
+                torch.empty(2, dtype=torch.float32, device="cuda"),
+            ]
+            set_target_for_ref(refs[0], targets)
+            tensors = ray.get(refs[0])
+            # Make sure we ray.get-ted into the provided buffers.
+            for new_tensor, target in zip(tensors, targets):
+                assert id(new_tensor) == id(target)
+            assert torch.equal(targets[0].cpu(), torch.tensor([0.0, 1.0, 2.0, 3.0]))
+            assert torch.equal(targets[1].cpu(), torch.tensor([4.0, 5.0, 6.0, 7.0]))
+            assert torch.equal(targets[2].cpu(), torch.tensor([9.0, 9.0]))
+            return True
+
+    src_actor, dst_actor = GPUTestActor.remote(), GPUTestActor.remote()
+    ref = ray.get(src_actor.get_ref.remote())
+    assert ray.get(dst_actor.get_with_separate_buffers.remote([ref]))
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
NIXL doesn't currently support merging transfer descriptors (nixlXferDlist) automatically when using get_xfer_descs.
This means that even if two tensor views belong to the same memory region (hence share rkeys) and are contiguous in memory, nixl will make two separate libibverbs calls to initiate the transfer rather than combining them into one. This greatly impacts the speed of the transfer, as transferring the same size tensor almost scales linearly in respect to the number of tensor views that cover the tensor.

For transferring a 2GB tensor on an A100 via NVLink intra-process: 
1k tensor views -> 17ms
10k tensor views -> 60ms
100k tensor views -> 1150ms

Hence to maximize the network bandwidth it's essential to minimize the number of xfer_descs as much as possible.

On the sender side in we merge the xfer_descs before serializing them and sending them to the receiver. On the receiver side, it allocates a tensor per merged xfer_desc and then partitions it according to tensor_meta which contains the actual pre-merged tensor info. The main nuance with the receiver side is the fact that the user can provide tensors via set_tensor_for_ref, and this means it can have an abitrary layout resulting in a different number of torch storage blocks the tensors belong to vs the sender side. In that case, for the tensor list with the smaller number of torch storage blocks backing the tensors, I'll further divide the xfer_descs to match the side with more storage blocks. 