### PR TITLE
format RuntimeEnvState.creation_time_ms as duration

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -582,6 +582,12 @@ def test_humanify():
     assert Humanify.duration(timestamp) == "18 days, 15:13:20"
 
 
+def test_runtime_env_state_humanify_creation_time_ms():
+    state = {"creation_time_ms": 36639}
+    RuntimeEnvState.humanify(state)
+    assert state["creation_time_ms"] == "0:00:36.639000"
+
+
 def is_hex(val):
     try:
         int_val = int(val, 16)

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -918,7 +918,7 @@ class RuntimeEnvState(StateSchema):
     #: The latency of creating the runtime environment.
     #: Available if the runtime env is successfully created.
     creation_time_ms: Optional[float] = state_column(
-        filterable=False, format_fn=Humanify.timestamp
+        filterable=False, format_fn=Humanify.duration
     )
     #: The node id of this runtime environment.
     node_id: str = state_column(filterable=True)


### PR DESCRIPTION
This field is a latency instead of a timestamp according to https://github.com/ray-project/ray/blob/93ae36773b2c5b729a92347e5c5433071c6ada2c/src/ray/protobuf/runtime_env_common.proto#L31-L32

The bug is confirmed in
```
ray list runtime-envs --detail
...
    success: true
    creation_time_ms: '1969-12-31 16:00:36.639000'
    node_id: 963acd73e9d350496153a0a0dd971892d21c299269bf2fafec04b4e3
```

https://ray.slack.com/archives/C055H5GH3MY/p1781792140812189?thread_ts=1781633663.932849&cid=C055H5GH3MY
