### PR TITLE
[docs][serve] Fix Serve LLM examples sidebar doc links 404

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,3 @@
-import html
 import io
 import json
 import logging
@@ -274,37 +273,6 @@ _TEMPLATE_COLLECTIONS = {
     },
 }
 
-_DEPLOYMENT_SERVE_LLM_COLLECTION = (
-    "_collections/serve/tutorials/deployment-serve-llm"
-)
-_DEPLOYMENT_SERVE_LLM_TUTORIALS = (
-    "small-size-llm",
-    "medium-size-llm",
-    "large-size-llm",
-    "vision-llm",
-    "reasoning-llm",
-    "hybrid-reasoning-llm",
-    "gpt-oss",
-)
-_DEPLOYMENT_SERVE_LLM_TUTORIAL_RE = "|".join(
-    re.escape(name) for name in _DEPLOYMENT_SERVE_LLM_TUTORIALS
-)
-_DEPLOYMENT_SERVE_LLM_DOC_URL_RE = re.compile(
-    "https://docs\\.ray\\.io/en/[^/]+/"
-    "serve/tutorials/deployment-serve-llm/"
-    f"(?:content/)?(?P<tutorial>{_DEPLOYMENT_SERVE_LLM_TUTORIAL_RE})"
-    "(?:/content)?/README\\.html"
-)
-_DEPLOYMENT_SERVE_LLM_LEGACY_REDIRECTS = {
-    legacy: f"{_DEPLOYMENT_SERVE_LLM_COLLECTION}/{tutorial}/README.html"
-    for tutorial in _DEPLOYMENT_SERVE_LLM_TUTORIALS
-    for legacy in (
-        f"serve/tutorials/deployment-serve-llm/{tutorial}/README.html",
-        f"serve/tutorials/deployment-serve-llm/content/{tutorial}/README.html",
-        f"serve/tutorials/deployment-serve-llm/content/{tutorial}/content/README.html",
-    )
-}
-
 
 def _resolve_template_url(name):
     """Fetch the build zip URL for a template from the channel API."""
@@ -361,56 +329,6 @@ def _fetch_and_extract_zip(config):
         # passes don't trip over a half-extracted archive.
         if target.is_dir():
             shutil.rmtree(target, ignore_errors=True)
-
-
-def _rewrite_deployment_serve_llm_links(source: str, docname: str) -> str:
-    relative_docname = docname.removeprefix(
-        f"{_DEPLOYMENT_SERVE_LLM_COLLECTION}/"
-    )
-    parent_depth = len(pathlib.PurePosixPath(relative_docname).parent.parts)
-    relative_prefix = "../" * parent_depth
-    return _DEPLOYMENT_SERVE_LLM_DOC_URL_RE.sub(
-        lambda match: f"{relative_prefix}{match.group('tutorial')}/README.md",
-        source,
-    )
-
-
-def _redirect_html(target_url: str) -> str:
-    escaped_target = html.escape(target_url, quote=True)
-    js_target = json.dumps(target_url)
-    return f"""<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>Redirecting...</title>
-  <link rel="canonical" href="{escaped_target}">
-  <meta http-equiv="refresh" content="0; url={escaped_target}">
-  <script>
-    window.location.replace({js_target} + window.location.hash);
-  </script>
-</head>
-<body>
-  <p>Redirecting to <a href="{escaped_target}">{escaped_target}</a>.</p>
-</body>
-</html>
-"""
-
-
-def write_legacy_template_redirects(app, exception):
-    if exception is not None or app.builder.format != "html":
-        return
-
-    outdir = pathlib.Path(app.outdir)
-    for legacy_path, target_path in _DEPLOYMENT_SERVE_LLM_LEGACY_REDIRECTS.items():
-        target_file = outdir / target_path
-        if not target_file.exists():
-            continue
-
-        redirect_file = outdir / legacy_path
-        redirect_file.parent.mkdir(parents=True, exist_ok=True)
-        relative_target = os.path.relpath(target_file, redirect_file.parent)
-        relative_target = relative_target.replace(os.sep, "/")
-        redirect_file.write_text(_redirect_html(relative_target), encoding="utf-8")
 
 
 collections = {
@@ -1050,17 +968,11 @@ def setup(app):
     # lines render as shell.
     _MAGIC_CODE_BLOCK_RE = re.compile(r"```python\n((?:#[^\n]*\n)*)([!%]\S)")
 
-    def fix_collections_markdown(app, docname, source):
+    def fix_collections_code_blocks(app, docname, source):
         if docname.startswith("_collections/"):
             source[0] = _MAGIC_CODE_BLOCK_RE.sub(r"```ipython3\n\1\2", source[0])
-        if (
-            docname.startswith(f"{_DEPLOYMENT_SERVE_LLM_COLLECTION}/")
-            and docname.endswith("/README")
-        ):
-            source[0] = _rewrite_deployment_serve_llm_links(source[0], docname)
 
-    app.connect('source-read', fix_collections_markdown)
-    app.connect("build-finished", write_legacy_template_redirects)
+    app.connect('source-read', fix_collections_code_blocks)
 
     app.add_config_value("ipython3_lexer_patterns", [], "env")
     app.add_config_value("ipython3_lexer_exclude_patterns", [], "env")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,3 +1,4 @@
+import html
 import io
 import json
 import logging
@@ -273,6 +274,37 @@ _TEMPLATE_COLLECTIONS = {
     },
 }
 
+_DEPLOYMENT_SERVE_LLM_COLLECTION = (
+    "_collections/serve/tutorials/deployment-serve-llm"
+)
+_DEPLOYMENT_SERVE_LLM_TUTORIALS = (
+    "small-size-llm",
+    "medium-size-llm",
+    "large-size-llm",
+    "vision-llm",
+    "reasoning-llm",
+    "hybrid-reasoning-llm",
+    "gpt-oss",
+)
+_DEPLOYMENT_SERVE_LLM_TUTORIAL_RE = "|".join(
+    re.escape(name) for name in _DEPLOYMENT_SERVE_LLM_TUTORIALS
+)
+_DEPLOYMENT_SERVE_LLM_DOC_URL_RE = re.compile(
+    "https://docs\\.ray\\.io/en/[^/]+/"
+    "serve/tutorials/deployment-serve-llm/"
+    f"(?:content/)?(?P<tutorial>{_DEPLOYMENT_SERVE_LLM_TUTORIAL_RE})"
+    "(?:/content)?/README\\.html"
+)
+_DEPLOYMENT_SERVE_LLM_LEGACY_REDIRECTS = {
+    legacy: f"{_DEPLOYMENT_SERVE_LLM_COLLECTION}/{tutorial}/README.html"
+    for tutorial in _DEPLOYMENT_SERVE_LLM_TUTORIALS
+    for legacy in (
+        f"serve/tutorials/deployment-serve-llm/{tutorial}/README.html",
+        f"serve/tutorials/deployment-serve-llm/content/{tutorial}/README.html",
+        f"serve/tutorials/deployment-serve-llm/content/{tutorial}/content/README.html",
+    )
+}
+
 
 def _resolve_template_url(name):
     """Fetch the build zip URL for a template from the channel API."""
@@ -329,6 +361,56 @@ def _fetch_and_extract_zip(config):
         # passes don't trip over a half-extracted archive.
         if target.is_dir():
             shutil.rmtree(target, ignore_errors=True)
+
+
+def _rewrite_deployment_serve_llm_links(source: str, docname: str) -> str:
+    relative_docname = docname.removeprefix(
+        f"{_DEPLOYMENT_SERVE_LLM_COLLECTION}/"
+    )
+    parent_depth = len(pathlib.PurePosixPath(relative_docname).parent.parts)
+    relative_prefix = "../" * parent_depth
+    return _DEPLOYMENT_SERVE_LLM_DOC_URL_RE.sub(
+        lambda match: f"{relative_prefix}{match.group('tutorial')}/README.md",
+        source,
+    )
+
+
+def _redirect_html(target_url: str) -> str:
+    escaped_target = html.escape(target_url, quote=True)
+    js_target = json.dumps(target_url)
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="{escaped_target}">
+  <meta http-equiv="refresh" content="0; url={escaped_target}">
+  <script>
+    window.location.replace({js_target} + window.location.hash);
+  </script>
+</head>
+<body>
+  <p>Redirecting to <a href="{escaped_target}">{escaped_target}</a>.</p>
+</body>
+</html>
+"""
+
+
+def write_legacy_template_redirects(app, exception):
+    if exception is not None or app.builder.format != "html":
+        return
+
+    outdir = pathlib.Path(app.outdir)
+    for legacy_path, target_path in _DEPLOYMENT_SERVE_LLM_LEGACY_REDIRECTS.items():
+        target_file = outdir / target_path
+        if not target_file.exists():
+            continue
+
+        redirect_file = outdir / legacy_path
+        redirect_file.parent.mkdir(parents=True, exist_ok=True)
+        relative_target = os.path.relpath(target_file, redirect_file.parent)
+        relative_target = relative_target.replace(os.sep, "/")
+        redirect_file.write_text(_redirect_html(relative_target), encoding="utf-8")
 
 
 collections = {
@@ -968,11 +1050,17 @@ def setup(app):
     # lines render as shell.
     _MAGIC_CODE_BLOCK_RE = re.compile(r"```python\n((?:#[^\n]*\n)*)([!%]\S)")
 
-    def fix_collections_code_blocks(app, docname, source):
+    def fix_collections_markdown(app, docname, source):
         if docname.startswith("_collections/"):
             source[0] = _MAGIC_CODE_BLOCK_RE.sub(r"```ipython3\n\1\2", source[0])
+        if (
+            docname.startswith(f"{_DEPLOYMENT_SERVE_LLM_COLLECTION}/")
+            and docname.endswith("/README")
+        ):
+            source[0] = _rewrite_deployment_serve_llm_links(source[0], docname)
 
-    app.connect('source-read', fix_collections_code_blocks)
+    app.connect('source-read', fix_collections_markdown)
+    app.connect("build-finished", write_legacy_template_redirects)
 
     app.add_config_value("ipython3_lexer_patterns", [], "env")
     app.add_config_value("ipython3_lexer_exclude_patterns", [], "env")

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -67,6 +67,31 @@ TRACKED_FILES = (
     .split("\n")
 )
 
+_LEGACY_COLLECTION_HREF_REWRITES = (
+    (
+        "serve/tutorials/deployment-serve-llm/content/",
+        "_collections/serve/tutorials/deployment-serve-llm/",
+    ),
+    (
+        "serve/tutorials/deployment-serve-llm/",
+        "_collections/serve/tutorials/deployment-serve-llm/",
+    ),
+)
+_DEPLOYMENT_SERVE_LLM_COLLECTION_PREFIX = (
+    "_collections/serve/tutorials/deployment-serve-llm/"
+)
+
+
+def canonicalize_collection_href(href: str) -> str:
+    """Map legacy in-tree template links to fetched _collections pages."""
+    for old_prefix, new_prefix in _LEGACY_COLLECTION_HREF_REWRITES:
+        if href.startswith(old_prefix):
+            href = new_prefix + href[len(old_prefix) :]
+            break
+    if href.startswith(_DEPLOYMENT_SERVE_LLM_COLLECTION_PREFIX):
+        href = href.replace("/content/README.html", "/README.html")
+    return href
+
 
 def feedback_form_url(project, page):
     """Create a URL for feedback on a particular page in a project."""
@@ -350,6 +375,7 @@ def preload_sidebar_nav(
 
     for a in soup.select("a"):
         absolute_href = re.sub(r"^(\.\.\/)*", "", a["href"])
+        absolute_href = canonicalize_collection_href(absolute_href)
         a["href"] = to_root_prefix + absolute_href
 
         if absolute_href == f"{pagename}.html":

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -67,29 +67,28 @@ TRACKED_FILES = (
     .split("\n")
 )
 
-_LEGACY_COLLECTION_HREF_REWRITES = (
-    (
-        "serve/tutorials/deployment-serve-llm/content/",
-        "_collections/serve/tutorials/deployment-serve-llm/",
-    ),
-    (
-        "serve/tutorials/deployment-serve-llm/",
-        "_collections/serve/tutorials/deployment-serve-llm/",
-    ),
-)
-_DEPLOYMENT_SERVE_LLM_COLLECTION_PREFIX = (
-    "_collections/serve/tutorials/deployment-serve-llm/"
-)
+_EXTERNAL_HREF_RE = re.compile(r"^[a-z][a-z0-9+.-]*:|^//", re.IGNORECASE)
 
 
-def canonicalize_collection_href(href: str) -> str:
-    """Map legacy in-tree template links to fetched _collections pages."""
-    for old_prefix, new_prefix in _LEGACY_COLLECTION_HREF_REWRITES:
-        if href.startswith(old_prefix):
-            href = new_prefix + href[len(old_prefix) :]
-            break
-    if href.startswith(_DEPLOYMENT_SERVE_LLM_COLLECTION_PREFIX):
-        href = href.replace("/content/README.html", "/README.html")
+def canonicalize_collection_href(
+    href: str, known_docs: Optional[Iterable[str]] = None
+) -> str:
+    """Map moved collection doc links to their generated _collections pages."""
+    if not known_docs or _EXTERNAL_HREF_RE.match(href) or href.startswith("#"):
+        return href
+
+    path, sep, fragment = href.partition("#")
+    if not path.endswith(".html"):
+        return href
+
+    docname = path[: -len(".html")]
+    if docname in known_docs or docname.startswith("_collections/"):
+        return href
+
+    collection_docname = f"_collections/{docname}"
+    if collection_docname in known_docs:
+        return f"{collection_docname}.html{sep}{fragment}"
+
     return href
 
 
@@ -275,6 +274,7 @@ def preload_sidebar_nav(
     pathto: Callable[[str], str],
     root_doc: str,
     pagename: str,
+    known_docs: Optional[Iterable[str]] = None,
 ) -> bs4.BeautifulSoup:
     """Return the navigation link structure in HTML.
 
@@ -303,6 +303,8 @@ def preload_sidebar_nav(
     ----------
     get_toctree : Callable[[Any], str]
         The function defined in context["toctree"] when html-page-context is triggered
+    known_docs : Optional[Iterable[str]]
+        Sphinx docnames known to the build environment.
 
     Returns
     -------
@@ -374,8 +376,12 @@ def preload_sidebar_nav(
         to_root_prefix = re.sub(f"{root_doc}.html", "", pathto(root_doc))
 
     for a in soup.select("a"):
-        absolute_href = re.sub(r"^(\.\.\/)*", "", a["href"])
-        absolute_href = canonicalize_collection_href(absolute_href)
+        href = a["href"]
+        if _EXTERNAL_HREF_RE.match(href):
+            continue
+
+        absolute_href = re.sub(r"^(\.\.\/)*", "", href)
+        absolute_href = canonicalize_collection_href(absolute_href, known_docs)
         a["href"] = to_root_prefix + absolute_href
 
         if absolute_href == f"{pagename}.html":
@@ -1157,6 +1163,7 @@ def setup_context(app, pagename, templatename, context, doctree):
         context["pathto"],
         context["root_doc"],
         pagename,
+        getattr(app.env, "found_docs", None),
     )
     context["render_header_nav_links"] = render_header_nav_links
     context["render_library_examples"] = render_library_examples


### PR DESCRIPTION
## Why?

Clicking Serve LLM example entries in the sidebar, such as `Serving LLMs -> Examples -> Deploy a medium-sized LLM`, opened the old `serve/tutorials/deployment-serve-llm/...` path and missed the real `_collections/...` page.

## Summary

Fix the cached sidebar link normalization for docs that moved into `sphinx_collections` output under `/_collections`.

- Resolve sidebar hrefs against Sphinx `found_docs`.
- Rewrite a stale sidebar href to `_collections/{docname}.html` only when that collection doc exists.
- Leave normal, external, already-correct, and anchor links unchanged.

## Root Cause

The tutorials should be preserved. The in-tree copies were removed after the collection move, but Ray's cached sidebar normalization did not account for moved collection docnames.

## Validation

- `python -m compileall -q doc/source/conf.py doc/source/custom_directives.py`
- `git diff --check -- doc/source/conf.py doc/source/custom_directives.py`
- Focused sidebar href resolver checks, including anchor preservation.
- Direct `preload_sidebar_nav` helper check in a temporary docs-helper environment.
