### PR TITLE
[serve] Reject custom request router on ingress deployment under HAProxy

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1951,10 +1951,8 @@ def override_deployment_info(
         ):
             deployment.route_prefix = app_route_prefix
 
-    # `build_app` rejects a custom ingress request router under HAProxy, but it
-    # only sees the code-defined config. A config override can introduce one
-    # here, so re-check the final ingress config. The check is skipped when an
-    # `ingress_request_router` is attached (HAProxy delegates routing back to it).
+    # build_app cannot see config overrides, so re-check the post-override
+    # ingress router here.
     if RAY_SERVE_ENABLE_HA_PROXY and not any(
         info.ingress_request_router for info in deployment_infos.values()
     ):

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -13,7 +13,11 @@ from ray import cloudpickle
 from ray._common.utils import import_attr, import_module_and_attr
 from ray.exceptions import RayTaskError, RuntimeEnvSetupError
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
-from ray.serve._private.build_app import BuiltApplication, build_app
+from ray.serve._private.build_app import (
+    CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR,
+    BuiltApplication,
+    build_app,
+)
 from ray.serve._private.common import (
     DeploymentID,
     DeploymentStatus,
@@ -26,6 +30,7 @@ from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     DEFAULT_AUTOSCALING_POLICY_NAME,
     DEFAULT_REQUEST_ROUTER_PATH,
+    RAY_SERVE_ENABLE_HA_PROXY,
     RAY_SERVE_ENABLE_TASK_EVENTS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     SERVE_LOGGER_NAME,
@@ -1945,5 +1950,17 @@ def override_deployment_info(
             and deployment.route_prefix is not None
         ):
             deployment.route_prefix = app_route_prefix
+
+    # `build_app` rejects a custom ingress request router under HAProxy, but it
+    # only sees the code-defined config. A config override can introduce one
+    # here, so re-check the final ingress config. The check is skipped when an
+    # `ingress_request_router` is attached (HAProxy delegates routing back to it).
+    if RAY_SERVE_ENABLE_HA_PROXY and not any(
+        info.ingress_request_router for info in deployment_infos.values()
+    ):
+        for info in deployment_infos.values():
+            request_router_config = info.deployment_config.request_router_config
+            if info.ingress and not request_router_config.is_default_request_router():
+                raise RayServeException(CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR)
 
     return deployment_infos

--- a/python/ray/serve/_private/build_app.py
+++ b/python/ray/serve/_private/build_app.py
@@ -5,11 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 
 from ray.dag.py_obj_scanner import _PyObjScanner
-from ray.serve._private.constants import (
-    DEFAULT_REQUEST_ROUTER_PATH,
-    RAY_SERVE_ENABLE_HA_PROXY,
-    SERVE_LOGGER_NAME,
-)
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_LOGGER_NAME
 from ray.serve._private.http_util import ASGIAppReplicaWrapper
 from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
@@ -101,16 +97,7 @@ class BuiltApplication:
 def _has_custom_request_router(deployment: Deployment) -> bool:
     """Whether the deployment configures a non-default request router class."""
     request_router_config = deployment._deployment_config.request_router_config
-    if request_router_config is None:
-        return False
-    request_router_class = request_router_config.request_router_class
-    # `RequestRouterConfig` normalizes a class to its import path on init, but
-    # fall back to normalizing here so a class object is compared correctly.
-    if not isinstance(request_router_class, str):
-        request_router_class = (
-            f"{request_router_class.__module__}.{request_router_class.__name__}"
-        )
-    return request_router_class != DEFAULT_REQUEST_ROUTER_PATH
+    return not request_router_config.is_default_request_router()
 
 
 def _make_deployment_handle_default(

--- a/python/ray/serve/_private/build_app.py
+++ b/python/ray/serve/_private/build_app.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 
 from ray.dag.py_obj_scanner import _PyObjScanner
-from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_LOGGER_NAME
+from ray.serve._private.constants import (
+    DEFAULT_REQUEST_ROUTER_PATH,
+    RAY_SERVE_ENABLE_HA_PROXY,
+    SERVE_LOGGER_NAME,
+)
 from ray.serve._private.http_util import ASGIAppReplicaWrapper
 from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
@@ -20,6 +24,15 @@ V = TypeVar("V")
 INGRESS_REQUEST_ROUTER_REQUIRES_HAPROXY_ERROR = (
     "`ingress_request_router` requires HAProxy. "
     "Set `RAY_SERVE_ENABLE_HA_PROXY=1` in the Ray controller's environment."
+)
+
+CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR = (
+    "A custom `request_router_config.request_router_class` is not supported on "
+    "the ingress deployment when HAProxy is enabled. HAProxy load-balances "
+    "ingress traffic with its own algorithm and bypasses the Serve request "
+    "router, so the custom router would be silently ignored. Remove the custom "
+    "`request_router_class` from the ingress deployment, or configure HAProxy's "
+    "load-balancing algorithm instead."
 )
 
 
@@ -85,6 +98,21 @@ class BuiltApplication:
             )
 
 
+def _has_custom_request_router(deployment: Deployment) -> bool:
+    """Whether the deployment configures a non-default request router class."""
+    request_router_config = deployment._deployment_config.request_router_config
+    if request_router_config is None:
+        return False
+    request_router_class = request_router_config.request_router_class
+    # `RequestRouterConfig` normalizes a class to its import path on init, but
+    # fall back to normalizing here so a class object is compared correctly.
+    if not isinstance(request_router_class, str):
+        request_router_class = (
+            f"{request_router_class.__module__}.{request_router_class.__name__}"
+        )
+    return request_router_class != DEFAULT_REQUEST_ROUTER_PATH
+
+
 def _make_deployment_handle_default(
     deployment: Deployment, app_name: str
 ) -> DeploymentHandle:
@@ -129,6 +157,18 @@ def build_app(
         )
     if ingress_request_router is not None and not RAY_SERVE_ENABLE_HA_PROXY:
         raise RayServeException(INGRESS_REQUEST_ROUTER_REQUIRES_HAPROXY_ERROR)
+
+    # Under HAProxy, ingress traffic is load-balanced by HAProxy and bypasses
+    # the ingress deployment's Serve request router, so a custom router there is
+    # silently ignored. Reject it unless an `ingress_request_router` is attached
+    # (the Serve LLM direct-streaming path), where HAProxy delegates replica
+    # selection back to that router.
+    if (
+        RAY_SERVE_ENABLE_HA_PROXY
+        and ingress_request_router is None
+        and _has_custom_request_router(app._bound_deployment)
+    ):
+        raise RayServeException(CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR)
 
     handles = IDDict()
     deployment_names = IDDict()

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -396,21 +396,8 @@ class RequestRouterConfig(BaseModel):
         self.request_router_class = request_router_path
 
     def is_default_request_router(self) -> bool:
-        """Whether request_router_class resolves to Serve's default router.
-
-        Compares import paths instead of importing, so a custom class missing on
-        the controller does not raise.
-        """
-        request_router_class = self.request_router_class
-        if not isinstance(request_router_class, str):
-            request_router_class = (
-                f"{request_router_class.__module__}.{request_router_class.__name__}"
-            )
-        default_cls = import_attr(DEFAULT_REQUEST_ROUTER_PATH)
-        return request_router_class in (
-            DEFAULT_REQUEST_ROUTER_PATH,
-            f"{default_cls.__module__}.{default_cls.__name__}",
-        )
+        """Whether the configured request router is Serve's default."""
+        return self.request_router_class == DEFAULT_REQUEST_ROUTER_PATH
 
     def get_request_router_class(self) -> Callable:
         """Deserialize the request router from cloudpickled bytes."""

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -395,6 +395,24 @@ class RequestRouterConfig(BaseModel):
         # Update the request_router_class field to be the string path
         self.request_router_class = request_router_path
 
+    def is_default_request_router(self) -> bool:
+        """Whether `request_router_class` is Serve's default request router.
+
+        Compares against the default's package and defining-module import paths
+        so an equivalent spelling is not treated as custom. Does not import the
+        configured class, which may be unavailable in the controller.
+        """
+        request_router_class = self.request_router_class
+        if not isinstance(request_router_class, str):
+            request_router_class = (
+                f"{request_router_class.__module__}.{request_router_class.__name__}"
+            )
+        default_cls = import_attr(DEFAULT_REQUEST_ROUTER_PATH)
+        return request_router_class in (
+            DEFAULT_REQUEST_ROUTER_PATH,
+            f"{default_cls.__module__}.{default_cls.__name__}",
+        )
+
     def get_request_router_class(self) -> Callable:
         """Deserialize the request router from cloudpickled bytes."""
         try:

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -396,11 +396,10 @@ class RequestRouterConfig(BaseModel):
         self.request_router_class = request_router_path
 
     def is_default_request_router(self) -> bool:
-        """Whether `request_router_class` is Serve's default request router.
+        """Whether request_router_class resolves to Serve's default router.
 
-        Compares against the default's package and defining-module import paths
-        so an equivalent spelling is not treated as custom. Does not import the
-        configured class, which may be unavailable in the controller.
+        Compares import paths instead of importing, so a custom class missing on
+        the controller does not raise.
         """
         request_router_class = self.request_router_class
         if not isinstance(request_router_class, str):

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -16,6 +16,7 @@ from ray.serve._private.api import call_user_app_builder_with_args_if_necessary
 from ray.serve._private.common import DeploymentID
 from ray.serve._private.constants import (
     DEFAULT_MAX_ONGOING_REQUESTS,
+    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve._private.request_router.common import (
@@ -1322,6 +1323,13 @@ def test_max_ongoing_requests_none(serve_instance):
     assert get_max_ongoing_requests() == 12
 
 
+@pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason=(
+        "Custom ingress request routers are currently only available with Ray "
+        "Serve LLM and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING."
+    ),
+)
 def test_deploy_app_with_custom_request_router(serve_instance):
     """Test deploying an app with a custom request router configured in the
     deployment decorator."""
@@ -1341,6 +1349,13 @@ class AppWithCustomRequestRouterAndKwargs:
         return "Hello, world!"
 
 
+@pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason=(
+        "Custom ingress request routers are currently only available with Ray "
+        "Serve LLM and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING."
+    ),
+)
 def test_custom_request_router_kwargs(serve_instance):
     """Check that custom kwargs can be passed to the request router."""
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -15,7 +15,10 @@ import ray
 from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.serve._private.common import DeploymentID, ReplicaState
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_HA_PROXY,
+    SERVE_DEFAULT_APP_NAME,
+)
 from ray.serve._private.test_utils import get_application_url
 from ray.serve.scripts import remove_ansi_escape_sequences
 from ray.util.state import list_actors
@@ -843,6 +846,13 @@ def test_deployment_contains_utils(serve_instance):
     )
 
 
+@pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason=(
+        "Custom ingress request routers are currently only available with Ray "
+        "Serve LLM and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING."
+    ),
+)
 def test_deploy_use_custom_request_router(serve_instance):
     """Test that the custom request router is initialized and used correctly."""
     config_file = os.path.join(

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -20,6 +20,7 @@ from ray._common.test_utils import (
 )
 from ray.actor import ActorHandle
 from ray.cluster_utils import Cluster
+from ray.serve._private.build_app import CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
 from ray.serve._private.constants import (
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     RAY_SERVE_DIRECT_INGRESS_MAX_HTTP_PORT,
@@ -30,8 +31,10 @@ from ray.serve._private.constants import (
 )
 from ray.serve._private.haproxy import HAProxyManager
 from ray.serve._private.test_utils import get_application_url
-from ray.serve.config import HTTPOptions
+from ray.serve.config import HTTPOptions, RequestRouterConfig
 from ray.serve.context import _get_global_client
+from ray.serve.exceptions import RayServeException
+from ray.serve.experimental.round_robin_router import RoundRobinRouter
 from ray.serve.schema import (
     ProxyStatus,
     ServeDeploySchema,
@@ -1135,6 +1138,61 @@ def test_default_host_is_all_interfaces(ray_shutdown):
             f"direct ingress port {conn.laddr.port} bound to {conn.laddr.ip!r}, "
             f"expected {expected!r}"
         )
+
+
+def test_serve_run_rejects_custom_ingress_request_router(ray_shutdown):
+    """serve.run rejects a custom router on the ingress under HAProxy."""
+    ray.init(num_cpus=8)
+    serve.start(http_options=dict(port=8003))
+
+    @serve.deployment(
+        request_router_config=RequestRouterConfig(request_router_class=RoundRobinRouter)
+    )
+    class Ingress:
+        async def __call__(self):
+            return "hi"
+
+    with pytest.raises(
+        RayServeException, match=CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
+    ):
+        serve.run(Ingress.bind())
+
+
+def test_deploy_config_rejects_custom_ingress_request_router(ray_shutdown):
+    """A config override that sets a custom router on the ingress fails to deploy
+    under HAProxy."""
+    ray.init(num_cpus=8)
+    serve.start(http_options=dict(port=8003))
+    client = _get_global_client()
+
+    module = "ray.serve.tests.test_config_files.use_custom_request_router"
+    config = ServeDeploySchema.model_validate(
+        {
+            "applications": [
+                {
+                    "name": "app",
+                    "import_path": f"{module}.app",
+                    "deployments": [
+                        {
+                            "name": "UniformRequestRouterApp",
+                            "request_router_config": {
+                                "request_router_class": f"{module}.UniformRequestRouter"
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    client.deploy_apps(config)
+
+    def deploy_failed():
+        status = serve.status().applications["app"]
+        assert status.status == "DEPLOY_FAILED"
+        assert CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR in status.message
+        return True
+
+    wait_for_condition(deploy_failed)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_telemetry_2.py
+++ b/python/ray/serve/tests/test_telemetry_2.py
@@ -7,6 +7,7 @@ import pytest
 from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.serve._private.common import DeploymentID
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY
 from ray.serve._private.request_router.common import (
     PendingRequest,
 )
@@ -155,6 +156,13 @@ def test_num_replicas_auto(manage_ray_with_telemetry, mode):
     )
 
 
+@pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason=(
+        "Custom ingress request routers are currently only available with Ray "
+        "Serve LLM and RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING."
+    ),
+)
 def test_custom_request_router_telemetry(manage_ray_with_telemetry):
     """Check that the custom request router telemetry is recorded."""
 

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -22,6 +22,7 @@ from ray.serve._private.application_state import (
     override_deployment_info,
 )
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
+from ray.serve._private.build_app import CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
     DeploymentHandleSource,
@@ -48,8 +49,10 @@ from ray.serve.config import (
     AutoscalingConfig,
     DeploymentActorConfig,
     GangSchedulingConfig,
+    RequestRouterConfig,
 )
 from ray.serve.exceptions import RayServeException
+from ray.serve.experimental.round_robin_router import RoundRobinRouter
 from ray.serve.generated.serve_pb2 import (
     ApplicationArgs as ApplicationArgsProto,
     ApplicationStatusInfo as ApplicationStatusInfoProto,
@@ -1526,6 +1529,49 @@ class TestOverrideDeploymentInfo:
         updated_info = updated_infos["A"]
         assert updated_info.route_prefix == "/bob"
         assert updated_info.version == "123"
+
+    @pytest.mark.parametrize("haproxy_enabled", [True, False])
+    def test_override_custom_ingress_request_router_under_haproxy(
+        self, monkeypatch, haproxy_enabled
+    ):
+        """A config override that sets a custom router on the ingress deployment
+        is rejected only under HAProxy. build_app validates the code-defined
+        config; this override path is where build_app cannot see the router."""
+        monkeypatch.setattr(
+            "ray.serve._private.application_state.RAY_SERVE_ENABLE_HA_PROXY",
+            haproxy_enabled,
+        )
+        info = DeploymentInfo(
+            route_prefix="/",
+            version="123",
+            deployment_config=DeploymentConfig(num_replicas=1),
+            replica_config=ReplicaConfig.create(lambda x: x),
+            start_time_ms=0,
+            deployer_job_id="",
+            ingress=True,
+        )
+        config = ServeApplicationSchema(
+            name="default",
+            import_path="test.import.path",
+            deployments=[
+                DeploymentSchema(
+                    name="A",
+                    request_router_config=RequestRouterConfig(
+                        request_router_class=RoundRobinRouter
+                    ),
+                )
+            ],
+        )
+
+        if haproxy_enabled:
+            with pytest.raises(
+                RayServeException, match=CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
+            ):
+                override_deployment_info({"A": info}, config)
+        else:
+            updated_infos = override_deployment_info({"A": info}, config)
+            router_config = updated_infos["A"].deployment_config.request_router_config
+            assert not router_config.is_default_request_router()
 
     def test_override_ray_actor_options_1(self, info):
         """Test runtime env specified in config at deployment level."""

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1434,6 +1434,19 @@ class TestOverrideDeploymentInfo:
             deployer_job_id="",
         )
 
+    @staticmethod
+    def _make_info(ingress=False, ingress_request_router=False):
+        return DeploymentInfo(
+            route_prefix="/" if ingress else None,
+            version="123",
+            deployment_config=DeploymentConfig(num_replicas=1),
+            replica_config=ReplicaConfig.create(lambda x: x),
+            start_time_ms=0,
+            deployer_job_id="",
+            ingress=ingress,
+            ingress_request_router=ingress_request_router,
+        )
+
     def test_override_deployment_config(self, info):
         config = ServeApplicationSchema(
             name="default",
@@ -1550,21 +1563,9 @@ class TestOverrideDeploymentInfo:
             haproxy_enabled,
         )
 
-        def make_info(ingress=False, ingress_request_router=False):
-            return DeploymentInfo(
-                route_prefix="/" if ingress else None,
-                version="123",
-                deployment_config=DeploymentConfig(num_replicas=1),
-                replica_config=ReplicaConfig.create(lambda x: x),
-                start_time_ms=0,
-                deployer_job_id="",
-                ingress=ingress,
-                ingress_request_router=ingress_request_router,
-            )
-
-        infos = {"Ingress": make_info(ingress=True)}
+        infos = {"Ingress": self._make_info(ingress=True)}
         if attach_ingress_request_router:
-            infos["Router"] = make_info(ingress_request_router=True)
+            infos["Router"] = self._make_info(ingress_request_router=True)
         config = ServeApplicationSchema(
             name="default",
             import_path="test.import.path",
@@ -1588,6 +1589,36 @@ class TestOverrideDeploymentInfo:
                 "Ingress"
             ].deployment_config.request_router_config
             assert not router_config.is_default_request_router()
+
+    def test_override_allows_custom_router_on_non_ingress_under_haproxy(
+        self, monkeypatch
+    ):
+        """The guard targets only the ingress, so a custom router on a downstream
+        deployment is honored under HAProxy."""
+        monkeypatch.setattr(
+            "ray.serve._private.application_state.RAY_SERVE_ENABLE_HA_PROXY", True
+        )
+        infos = {
+            "Ingress": self._make_info(ingress=True),
+            "Downstream": self._make_info(ingress=False),
+        }
+        config = ServeApplicationSchema(
+            name="default",
+            import_path="test.import.path",
+            deployments=[
+                DeploymentSchema(
+                    name="Downstream",
+                    request_router_config=RequestRouterConfig(
+                        request_router_class=RoundRobinRouter
+                    ),
+                )
+            ],
+        )
+
+        router_config = override_deployment_info(infos, config)[
+            "Downstream"
+        ].deployment_config.request_router_config
+        assert not router_config.is_default_request_router()
 
     def test_override_ray_actor_options_1(self, info):
         """Test runtime env specified in config at deployment level."""

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1530,31 +1530,47 @@ class TestOverrideDeploymentInfo:
         assert updated_info.route_prefix == "/bob"
         assert updated_info.version == "123"
 
-    @pytest.mark.parametrize("haproxy_enabled", [True, False])
+    @pytest.mark.parametrize(
+        "haproxy_enabled, attach_ingress_request_router, rejected",
+        [
+            # A custom router added by config override is rejected only under
+            # HAProxy, since build_app cannot see the override...
+            (True, False, True),
+            (False, False, False),
+            # ...unless an ingress request router is attached (direct streaming),
+            # where routing flows through the Serve router.
+            (True, True, False),
+        ],
+    )
     def test_override_custom_ingress_request_router_under_haproxy(
-        self, monkeypatch, haproxy_enabled
+        self, monkeypatch, haproxy_enabled, attach_ingress_request_router, rejected
     ):
-        """A custom router added by config override is rejected only under
-        HAProxy, since build_app cannot see the override."""
         monkeypatch.setattr(
             "ray.serve._private.application_state.RAY_SERVE_ENABLE_HA_PROXY",
             haproxy_enabled,
         )
-        info = DeploymentInfo(
-            route_prefix="/",
-            version="123",
-            deployment_config=DeploymentConfig(num_replicas=1),
-            replica_config=ReplicaConfig.create(lambda x: x),
-            start_time_ms=0,
-            deployer_job_id="",
-            ingress=True,
-        )
+
+        def make_info(ingress=False, ingress_request_router=False):
+            return DeploymentInfo(
+                route_prefix="/" if ingress else None,
+                version="123",
+                deployment_config=DeploymentConfig(num_replicas=1),
+                replica_config=ReplicaConfig.create(lambda x: x),
+                start_time_ms=0,
+                deployer_job_id="",
+                ingress=ingress,
+                ingress_request_router=ingress_request_router,
+            )
+
+        infos = {"Ingress": make_info(ingress=True)}
+        if attach_ingress_request_router:
+            infos["Router"] = make_info(ingress_request_router=True)
         config = ServeApplicationSchema(
             name="default",
             import_path="test.import.path",
             deployments=[
                 DeploymentSchema(
-                    name="A",
+                    name="Ingress",
                     request_router_config=RequestRouterConfig(
                         request_router_class=RoundRobinRouter
                     ),
@@ -1562,14 +1578,15 @@ class TestOverrideDeploymentInfo:
             ],
         )
 
-        if haproxy_enabled:
+        if rejected:
             with pytest.raises(
                 RayServeException, match=CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
             ):
-                override_deployment_info({"A": info}, config)
+                override_deployment_info(infos, config)
         else:
-            updated_infos = override_deployment_info({"A": info}, config)
-            router_config = updated_infos["A"].deployment_config.request_router_config
+            router_config = override_deployment_info(infos, config)[
+                "Ingress"
+            ].deployment_config.request_router_config
             assert not router_config.is_default_request_router()
 
     def test_override_ray_actor_options_1(self, info):

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1534,9 +1534,8 @@ class TestOverrideDeploymentInfo:
     def test_override_custom_ingress_request_router_under_haproxy(
         self, monkeypatch, haproxy_enabled
     ):
-        """A config override that sets a custom router on the ingress deployment
-        is rejected only under HAProxy. build_app validates the code-defined
-        config; this override path is where build_app cannot see the router."""
+        """A custom router added by config override is rejected only under
+        HAProxy, since build_app cannot see the override."""
         monkeypatch.setattr(
             "ray.serve._private.application_state.RAY_SERVE_ENABLE_HA_PROXY",
             haproxy_enabled,

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -679,22 +679,31 @@ def test_ingress_validation_excludes_ingress_request_router_fastapi_app(monkeypa
     client._check_ingress_deployments([built_app])
 
 
-@pytest.mark.parametrize("custom_router", [True, False])
-def test_build_app_haproxy_rejects_only_custom_ingress_request_router(
-    monkeypatch, custom_router
+@pytest.mark.parametrize(
+    "haproxy_enabled, request_router_class, rejected",
+    [
+        # A custom router on the ingress is rejected only under HAProxy, which
+        # load-balances ingress traffic and bypasses the Serve request router.
+        (True, RoundRobinRouter, True),
+        (False, RoundRobinRouter, False),
+        # The default router is not custom, including when passed as a class.
+        (True, None, False),
+        (True, PowerOfTwoChoicesRequestRouter, False),
+    ],
+)
+def test_build_app_rejects_only_custom_ingress_request_router_under_haproxy(
+    monkeypatch, haproxy_enabled, request_router_class, rejected
 ):
-    """Under HAProxy, a custom router on the ingress deployment is rejected.
-
-    HAProxy load-balances ingress traffic and bypasses the Serve request
-    router, so a custom router there would be silently ignored. The default
-    router builds without complaint.
-    """
-    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
+    """A custom ingress router is rejected only under HAProxy. The default
+    router and the no-HAProxy case build."""
+    monkeypatch.setattr(
+        "ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", haproxy_enabled
+    )
 
     options = {}
-    if custom_router:
+    if request_router_class is not None:
         options["request_router_config"] = RequestRouterConfig(
-            request_router_class=RoundRobinRouter
+            request_router_class=request_router_class
         )
 
     @serve.deployment
@@ -703,22 +712,20 @@ def test_build_app_haproxy_rejects_only_custom_ingress_request_router(
 
     app = Ingress.options(**options).bind()
 
-    if custom_router:
-        with pytest.raises(
-            RayServeException, match=CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
-        ):
-            build_app(
-                app,
-                name="default",
-                make_deployment_handle=FakeDeploymentHandle.from_deployment,
-            )
-    else:
-        built_app: BuiltApplication = build_app(
+    def build():
+        return build_app(
             app,
             name="default",
             make_deployment_handle=FakeDeploymentHandle.from_deployment,
         )
-        assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
+
+    if rejected:
+        with pytest.raises(
+            RayServeException, match=CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
+        ):
+            build()
+    else:
+        assert [deployment.name for deployment in build().deployments] == ["Ingress"]
 
 
 def test_build_app_allows_custom_ingress_request_router_in_direct_streaming(
@@ -752,48 +759,6 @@ def test_build_app_allows_custom_ingress_request_router_in_direct_streaming(
 
     assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
     assert built_app.ingress_request_router_deployment is not None
-
-
-def test_build_app_allows_custom_ingress_request_router_without_haproxy(monkeypatch):
-    """Without HAProxy the Serve proxy routes through the ingress deployment's
-    request router, so a custom router is honored and must be allowed."""
-    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", False)
-
-    @serve.deployment(
-        request_router_config=RequestRouterConfig(request_router_class=RoundRobinRouter)
-    )
-    class Ingress:
-        pass
-
-    built_app: BuiltApplication = build_app(
-        Ingress.bind(),
-        name="default",
-        make_deployment_handle=FakeDeploymentHandle.from_deployment,
-    )
-
-    assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
-
-
-def test_build_app_haproxy_allows_default_request_router_passed_as_class(monkeypatch):
-    """The default router passed as a class object is not custom and must build
-    under HAProxy."""
-    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
-
-    @serve.deployment(
-        request_router_config=RequestRouterConfig(
-            request_router_class=PowerOfTwoChoicesRequestRouter
-        )
-    )
-    class Ingress:
-        pass
-
-    built_app: BuiltApplication = build_app(
-        Ingress.bind(),
-        name="default",
-        make_deployment_handle=FakeDeploymentHandle.from_deployment,
-    )
-
-    assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -12,6 +12,7 @@ from ray.serve._private.build_app import (
 )
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import DeploymentID
+from ray.serve._private.request_router import PowerOfTwoChoicesRequestRouter
 from ray.serve.config import RequestRouterConfig
 from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
@@ -753,12 +754,35 @@ def test_build_app_allows_custom_ingress_request_router_in_direct_streaming(
     assert built_app.ingress_request_router_deployment is not None
 
 
-def test_build_app_allows_custom_ingress_request_router_without_haproxy():
+def test_build_app_allows_custom_ingress_request_router_without_haproxy(monkeypatch):
     """Without HAProxy the Serve proxy routes through the ingress deployment's
     request router, so a custom router is honored and must be allowed."""
+    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", False)
 
     @serve.deployment(
         request_router_config=RequestRouterConfig(request_router_class=RoundRobinRouter)
+    )
+    class Ingress:
+        pass
+
+    built_app: BuiltApplication = build_app(
+        Ingress.bind(),
+        name="default",
+        make_deployment_handle=FakeDeploymentHandle.from_deployment,
+    )
+
+    assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
+
+
+def test_build_app_haproxy_allows_default_request_router_passed_as_class(monkeypatch):
+    """The default router supplied as a class object (e.g. to set
+    `request_router_kwargs`) is not custom and must build under HAProxy."""
+    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
+
+    @serve.deployment(
+        request_router_config=RequestRouterConfig(
+            request_router_class=PowerOfTwoChoicesRequestRouter
+        )
     )
     class Ingress:
         pass

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -12,7 +12,6 @@ from ray.serve._private.build_app import (
 )
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import DeploymentID
-from ray.serve._private.request_router import PowerOfTwoChoicesRequestRouter
 from ray.serve.config import RequestRouterConfig
 from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
@@ -686,9 +685,8 @@ def test_ingress_validation_excludes_ingress_request_router_fastapi_app(monkeypa
         # load-balances ingress traffic and bypasses the Serve request router.
         (True, RoundRobinRouter, True),
         (False, RoundRobinRouter, False),
-        # The default router is not custom, including when passed as a class.
+        # The default router (left unset) is not custom.
         (True, None, False),
-        (True, PowerOfTwoChoicesRequestRouter, False),
     ],
 )
 def test_build_app_rejects_only_custom_ingress_request_router_under_haproxy(

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -761,5 +761,33 @@ def test_build_app_allows_custom_ingress_request_router_in_direct_streaming(
     assert built_app.ingress_request_router_deployment is not None
 
 
+def test_build_app_haproxy_allows_custom_router_on_non_ingress_deployment(monkeypatch):
+    """The guard targets only the ingress, so a custom router on a downstream
+    deployment is honored under HAProxy."""
+    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
+
+    @serve.deployment(
+        request_router_config=RequestRouterConfig(request_router_class=RoundRobinRouter)
+    )
+    class Downstream:
+        pass
+
+    @serve.deployment
+    class Ingress:
+        def __init__(self, child):
+            pass
+
+    built_app: BuiltApplication = build_app(
+        Ingress.bind(Downstream.bind()),
+        name="default",
+        make_deployment_handle=FakeDeploymentHandle.from_deployment,
+    )
+
+    assert {deployment.name for deployment in built_app.deployments} == {
+        "Ingress",
+        "Downstream",
+    }
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -775,8 +775,8 @@ def test_build_app_allows_custom_ingress_request_router_without_haproxy(monkeypa
 
 
 def test_build_app_haproxy_allows_default_request_router_passed_as_class(monkeypatch):
-    """The default router supplied as a class object (e.g. to set
-    `request_router_kwargs`) is not custom and must build under HAProxy."""
+    """The default router passed as a class object is not custom and must build
+    under HAProxy."""
     monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
 
     @serve.deployment(

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -5,10 +5,17 @@ import pytest
 from fastapi import FastAPI
 
 from ray import serve
-from ray.serve._private.build_app import BuiltApplication, build_app
+from ray.serve._private.build_app import (
+    CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR,
+    BuiltApplication,
+    build_app,
+)
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import DeploymentID
+from ray.serve.config import RequestRouterConfig
 from ray.serve.deployment import Application, Deployment
+from ray.serve.exceptions import RayServeException
+from ray.serve.experimental.round_robin_router import RoundRobinRouter
 from ray.serve.handle import DeploymentHandle
 
 
@@ -669,6 +676,100 @@ def test_ingress_validation_excludes_ingress_request_router_fastapi_app(monkeypa
 
     client = object.__new__(ServeControllerClient)
     client._check_ingress_deployments([built_app])
+
+
+@pytest.mark.parametrize("custom_router", [True, False])
+def test_build_app_haproxy_rejects_only_custom_ingress_request_router(
+    monkeypatch, custom_router
+):
+    """Under HAProxy, a custom router on the ingress deployment is rejected.
+
+    HAProxy load-balances ingress traffic and bypasses the Serve request
+    router, so a custom router there would be silently ignored. The default
+    router builds without complaint.
+    """
+    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
+
+    options = {}
+    if custom_router:
+        options["request_router_config"] = RequestRouterConfig(
+            request_router_class=RoundRobinRouter
+        )
+
+    @serve.deployment
+    class Ingress:
+        pass
+
+    app = Ingress.options(**options).bind()
+
+    if custom_router:
+        with pytest.raises(
+            RayServeException, match=CUSTOM_INGRESS_REQUEST_ROUTER_UNSUPPORTED_ERROR
+        ):
+            build_app(
+                app,
+                name="default",
+                make_deployment_handle=FakeDeploymentHandle.from_deployment,
+            )
+    else:
+        built_app: BuiltApplication = build_app(
+            app,
+            name="default",
+            make_deployment_handle=FakeDeploymentHandle.from_deployment,
+        )
+        assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
+
+
+def test_build_app_allows_custom_ingress_request_router_in_direct_streaming(
+    monkeypatch,
+):
+    """Direct streaming attaches an ingress_request_router that delegates replica
+    selection back to the ingress deployment's router, so a custom router is
+    allowed even under HAProxy."""
+    monkeypatch.setattr("ray.serve._private.build_app.RAY_SERVE_ENABLE_HA_PROXY", True)
+
+    @serve.deployment(
+        request_router_config=RequestRouterConfig(request_router_class=RoundRobinRouter)
+    )
+    class Ingress:
+        pass
+
+    @serve.deployment
+    class IngressRequestRouter:
+        pass
+
+    ingress_app = Ingress.bind()
+    app = ingress_app._with_ingress_request_router(
+        IngressRequestRouter.bind(server=ingress_app)
+    )
+
+    built_app: BuiltApplication = build_app(
+        app,
+        name="default",
+        make_deployment_handle=FakeDeploymentHandle.from_deployment,
+    )
+
+    assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
+    assert built_app.ingress_request_router_deployment is not None
+
+
+def test_build_app_allows_custom_ingress_request_router_without_haproxy():
+    """Without HAProxy the Serve proxy routes through the ingress deployment's
+    request router, so a custom router is honored and must be allowed."""
+
+    @serve.deployment(
+        request_router_config=RequestRouterConfig(request_router_class=RoundRobinRouter)
+    )
+    class Ingress:
+        pass
+
+    built_app: BuiltApplication = build_app(
+        Ingress.bind(),
+        name="default",
+        make_deployment_handle=FakeDeploymentHandle.from_deployment,
+    )
+
+    assert [deployment.name for deployment in built_app.deployments] == ["Ingress"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

When HAProxy is enabled, ingress traffic is load-balanced by HAProxy and bypasses the ingress deployment's Serve request router. A custom `request_router_config.request_router_class` on the ingress deployment is therefore silently ignored. The configured routing policy never takes effect.

## What

Reject a non-default `request_router_class` on the ingress deployment when HAProxy is enabled, raising `RayServeException`. The check runs at two layers so both the code-defined router and a router introduced by config override are caught:

- `build_app` validates the code-defined ingress router and fails fast on `serve.run`.
- `override_deployment_info` re-validates the ingress config after declarative config overrides are applied. `build_app` runs before the override and cannot see a router set through the config file.

Only the ingress deployment is checked. Downstream deployments route through Serve, so their custom routers are honored. `RequestRouterConfig.is_default_request_router` matches the configured class against the default's import path, so the default router is recognized whether left unset or passed as a class.

Serve LLM direct streaming is exempt. It attaches an `ingress_request_router` that HAProxy calls at `/internal/route` to delegate replica selection back to the Serve router, so a custom router is honored in that mode.

## Tests

`test_build_app.py` covers the build-time guard. Under HAProxy a custom ingress router is rejected and the default router builds, including when passed as a class. Direct streaming and the no-HAProxy case build. A custom router on a downstream deployment builds.

`test_application_state.py` covers the config-override backstop. A custom ingress router set through a config override is rejected under HAProxy, allowed without HAProxy, and allowed under direct streaming. A custom router on a downstream deployment is allowed.
