### PR TITLE
[serve] Gate HAProxy startup readiness on admin-socket health, not the process exit code

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -954,12 +954,7 @@ class HAProxyApi(ProxyApi):
                 # immediately if the process dies in the meantime.
                 await asyncio.wait({proc_exited}, timeout=min(remaining, 0.5))
         finally:
-            if not proc_exited.done():
-                proc_exited.cancel()
-                try:
-                    await proc_exited
-                except asyncio.CancelledError:
-                    pass
+            proc_exited.cancel()
 
         raise RuntimeError(
             f"HAProxy (pid={proc.pid}) did not take over the admin socket within "

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -915,28 +915,51 @@ class HAProxyApi(ProxyApi):
         proc: asyncio.subprocess.Process,
         timeout_s: int = RAY_SERVE_HAPROXY_STARTUP_TIMEOUT_S,
     ) -> None:
-        start_time = time.time()
+        """Block until ``proc`` is the HAProxy worker answering the admin socket.
 
-        # TODO: update this to use health checks
-        while time.time() - start_time < timeout_s:
-            if proc.returncode is not None:
-                # Both streams were redirected to files at spawn; tail them.
-                stderr_text = _tail_file(proc._stderr_path)
-                stdout_text = _tail_file(proc._stdout_path)
-                output = stderr_text or stdout_text
+        Readiness comes from HAProxy's built-in runtime status. ``show info``
+        reports the live worker pid and we wait for it to equal ``proc.pid``.
+        During a reload the socket answers through the displaced worker until
+        ``proc`` rebinds it, so a socket-only check could call a dead spawn
+        ready and strand its ``-sf`` target.
 
-                raise RuntimeError(
-                    f"HAProxy crashed during startup: {output or f'exit code {proc.returncode}'}"
-                )
+        A crash is surfaced the moment ``proc`` exits by awaiting
+        ``proc.wait()`` instead of busy-polling its exit code, so startup fails
+        fast with the spawn's stderr.
+        """
+        # Resolves as soon as the process exits. Cancelled after a successful
+        # takeover so no pending wait is left behind.
+        proc_exited = asyncio.ensure_future(proc.wait())
+        deadline = time.time() + timeout_s
+        try:
+            while True:
+                if proc_exited.done():
+                    # Both streams were redirected to files at spawn, so tail them.
+                    stderr_text = _tail_file(proc._stderr_path)
+                    stdout_text = _tail_file(proc._stdout_path)
+                    output = stderr_text or stdout_text
+                    raise RuntimeError(
+                        f"HAProxy crashed during startup: "
+                        f"{output or f'exit code {proc.returncode}'}"
+                    )
 
-            # The socket path answers through its previous owner until the
-            # new process rebinds it, so require the answer to come from
-            # `proc` itself. Otherwise a spawn that dies before taking over is
-            # declared ready and its -sf target is stranded forever.
-            if await self._get_running_pid() == proc.pid:
-                return
+                if await self._get_running_pid() == proc.pid:
+                    return
 
-            await asyncio.sleep(0.5)
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+
+                # Re-probe the runtime status after a bounded interval but wake
+                # immediately if the process dies in the meantime.
+                await asyncio.wait({proc_exited}, timeout=min(remaining, 0.5))
+        finally:
+            if not proc_exited.done():
+                proc_exited.cancel()
+                try:
+                    await proc_exited
+                except asyncio.CancelledError:
+                    pass
 
         raise RuntimeError(
             f"HAProxy (pid={proc.pid}) did not take over the admin socket within "

--- a/python/ray/serve/tests/unit/test_haproxy_process_manager.py
+++ b/python/ray/serve/tests/unit/test_haproxy_process_manager.py
@@ -30,6 +30,12 @@ class FakeProc:
         self._stdout_path = stdout_path
         self._stderr_path = stderr_path
 
+    async def wait(self) -> int:
+        """Resolve once the process has an exit code, mirroring Process.wait."""
+        while self.returncode is None:
+            await asyncio.sleep(0.01)
+        return self.returncode
+
 
 @pytest.fixture
 def api(tmp_path) -> HAProxyApi:
@@ -87,6 +93,29 @@ class TestWaitForHapAvailability:
 
         with pytest.raises(RuntimeError, match="crashed during startup"):
             asyncio.run(api._wait_for_hap_availability(proc, timeout_s=1))
+
+    def test_detects_crash_during_wait(self, api, tmp_path):
+        """A spawn that dies mid-wait is caught via proc.wait, so the crash is
+        reported instead of waiting out the full timeout."""
+        stdout, stderr = _make_stream_files(tmp_path, "died mid-startup")
+        proc = FakeProc(pid=222, stdout_path=stdout, stderr_path=stderr)
+
+        # The spawn is alive for the first probe then exits; the answering pid
+        # never matches, so only proc.wait can end the wait early.
+        probes = {"n": 0}
+
+        async def fake_send(cmd: str) -> str:
+            assert cmd == "show info"
+            probes["n"] += 1
+            if probes["n"] == 1:
+                proc.returncode = 1
+            return "Name: HAProxy\nPid: 111\n"
+
+        api._send_socket_command = fake_send
+
+        with pytest.raises(RuntimeError, match="crashed during startup") as exc_info:
+            asyncio.run(api._wait_for_hap_availability(proc, timeout_s=5))
+        assert "died mid-startup" in str(exc_info.value)
 
 
 class TestGetRunningPid:


### PR DESCRIPTION
## What

The HAProxy startup wait already gated readiness on HAProxy's own runtime status. `_wait_for_hap_availability` waits for the admin socket to report the freshly spawned worker's pid as the live one via `show info`. On top of that it polled `proc.returncode` on every iteration to fail fast if the spawn crashed.

This removes that process-exit-code poll. A crashed spawn is now detected event-driven by awaiting `proc.wait()`, so readiness is gated on HAProxy's health and the OS process is only watched for a fast crash signal.

The pid match is kept deliberately. During a reload the admin socket answers through the displaced worker until the new process rebinds it, so requiring the answering pid to be the spawn avoids declaring a dead spawn ready and stranding its `-sf` target.

Behavior change: a startup or reload crash is reported immediately with the spawn's stderr instead of after up to one poll interval.

Resolves the `# TODO: update this to use health checks` in the startup wait.

## Related issue number

N/A

## Checks

Run against the branch with `RAY_SERVE_ENABLE_HA_PROXY=1`:

- `python/ray/serve/tests/unit/test_haproxy_process_manager.py`, adds `test_detects_crash_during_wait`
- `python/ray/serve/tests/unit/test_haproxy_binary.py`
- `python/ray/serve/tests/test_haproxy_api.py` real-subprocess start and reload paths