### PR TITLE
[data] Skip arrow v23 tests on premerge

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -110,6 +110,7 @@ steps:
     tags:
       - python
       - data
+      - skip-on-premerge
     instance_type: medium
     parallelism: 8
     commands:
@@ -125,6 +126,7 @@ steps:
       - python
       - data
       - data_non_parallel
+      - skip-on-premerge
     instance_type: medium
     parallelism: 3
     commands:


### PR DESCRIPTION
To reduce CI redundancy, running only the oldest arrow version tests on premerge