### PR TITLE
[serve] Run HAProxy drain/undrain test without SO_REUSEPORT

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -771,6 +771,15 @@ RAY_SERVE_HAPROXY_METRICS_PORT = int(
 # HAProxy stats UI port
 RAY_SERVE_HAPROXY_STATS_PORT = get_env_int("RAY_SERVE_HAPROXY_STATS_PORT", 8404)
 
+# Per-node override for the proxy's HTTP/gRPC bind ports. When set, this node's
+# proxy binds the given port instead of the configured http_options.port /
+# grpc_options.port. Lets proxies co-located on one host (a multi-node Cluster()
+# on a single machine, or EveryNode deployments without SO_REUSEPORT) bind
+# distinct ports. Parallels the per-node RAY_SERVE_HAPROXY_STATS_PORT /
+# RAY_SERVE_HAPROXY_METRICS_PORT knobs.
+RAY_SERVE_PROXY_HTTP_PORT = get_env_int("RAY_SERVE_PROXY_HTTP_PORT", None)
+RAY_SERVE_PROXY_GRPC_PORT = get_env_int("RAY_SERVE_PROXY_GRPC_PORT", None)
+
 # HAProxy log target (single sink). Accepts any syntax HAProxy's `log` directive
 # supports, e.g. "127.0.0.1:514" (UDP syslog) or "/dev/log" (unix datagram socket).
 RAY_SERVE_HAPROXY_LOG_TARGET = get_env_str(

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -771,14 +771,12 @@ RAY_SERVE_HAPROXY_METRICS_PORT = int(
 # HAProxy stats UI port
 RAY_SERVE_HAPROXY_STATS_PORT = get_env_int("RAY_SERVE_HAPROXY_STATS_PORT", 8404)
 
-# Per-node override for the proxy's HTTP/gRPC bind ports. When set, this node's
-# proxy binds the given port instead of the configured http_options.port /
-# grpc_options.port. Lets proxies co-located on one host (a multi-node Cluster()
-# on a single machine, or EveryNode deployments without SO_REUSEPORT) bind
-# distinct ports. Parallels the per-node RAY_SERVE_HAPROXY_STATS_PORT /
-# RAY_SERVE_HAPROXY_METRICS_PORT knobs.
-RAY_SERVE_PROXY_HTTP_PORT = get_env_int("RAY_SERVE_PROXY_HTTP_PORT", None)
-RAY_SERVE_PROXY_GRPC_PORT = get_env_int("RAY_SERVE_PROXY_GRPC_PORT", None)
+# Per-worker-node override for the proxy's HTTP/gRPC bind ports. Head node exempt.
+# Prefer http_options.port / grpc_options.port. This override only matters when
+# proxies are colocated on one machine and need distinct ports without SO_REUSEPORT.
+# Parallels RAY_SERVE_HAPROXY_STATS_PORT / RAY_SERVE_HAPROXY_METRICS_PORT.
+RAY_SERVE_WORKER_PROXY_HTTP_PORT = get_env_int("RAY_SERVE_WORKER_PROXY_HTTP_PORT", None)
+RAY_SERVE_WORKER_PROXY_GRPC_PORT = get_env_int("RAY_SERVE_WORKER_PROXY_GRPC_PORT", None)
 
 # HAProxy log target (single sink). Accepts any syntax HAProxy's `log` directive
 # supports, e.g. "127.0.0.1:514" (UDP syslog) or "/dev/log" (unix datagram socket).

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -79,7 +79,10 @@ from ray.serve._private.haproxy_templates import (
 )
 from ray.serve._private.logging_utils import get_component_logger_file_path
 from ray.serve._private.long_poll import LongPollClient, LongPollNamespace
-from ray.serve._private.proxy import ProxyActorInterface
+from ray.serve._private.proxy import (
+    ProxyActorInterface,
+    apply_per_node_port_overrides,
+)
 from ray.serve._private.utils import get_head_node_id
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.schema import (
@@ -1397,6 +1400,7 @@ class HAProxyManager(ProxyActorInterface):
         )
 
         is_head = self._node_id == get_head_node_id()
+        apply_per_node_port_overrides(self._http_options, self._grpc_options, is_head)
 
         startup_msg = f"HAProxy starting on node {self._node_id} (HTTP port: {self._http_options.port})."
         logger.info(startup_msg)

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1566,6 +1566,15 @@ class ProxyActor(ProxyActorInterface):
             logging_config=logging_config,
         )
 
+        is_head = self._node_id == get_head_node_id()
+        # Test-only: a worker proxy binds a distinct HTTP port supplied via its
+        # own node env (Cluster.add_node(env_vars=...)), so multiple worker
+        # HAProxies coexist on one host without SO_REUSEPORT. The head keeps its
+        # configured port. Mirrors how the stats/metrics ports resolve per node.
+        test_http_port = os.getenv("TEST_WORKER_NODE_HTTP_PORT")
+        if test_http_port is not None and not is_head:
+            http_options.port = int(test_http_port)
+
         self._grpc_options = grpc_options
         self._http_options = configure_http_middlewares(http_options)
         grpc_enabled = is_grpc_enabled(self._grpc_options)
@@ -1633,7 +1642,6 @@ class ProxyActor(ProxyActorInterface):
                 "serve_access_log": True,
             }
 
-        is_head = self._node_id == get_head_node_id()
         self.proxy_router = ProxyRouter(get_proxy_handle)
         self.http_proxy = HTTPProxy(
             node_id=self._node_id,

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -31,6 +31,8 @@ from ray.serve._private.constants import (
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_PROXY_GC_THRESHOLD,
+    RAY_SERVE_PROXY_GRPC_PORT,
+    RAY_SERVE_PROXY_HTTP_PORT,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     SERVE_CONTROLLER_NAME,
     SERVE_HTTP_REQUEST_ID_HEADER,
@@ -1566,14 +1568,13 @@ class ProxyActor(ProxyActorInterface):
             logging_config=logging_config,
         )
 
-        is_head = self._node_id == get_head_node_id()
-        # Test-only: a worker proxy binds a distinct HTTP port supplied via its
-        # own node env (Cluster.add_node(env_vars=...)), so multiple worker
-        # HAProxies coexist on one host without SO_REUSEPORT. The head keeps its
-        # configured port. Mirrors how the stats/metrics ports resolve per node.
-        test_http_port = os.getenv("TEST_WORKER_NODE_HTTP_PORT")
-        if test_http_port is not None and not is_head:
-            http_options.port = int(test_http_port)
+        # A node may override its proxy's HTTP/gRPC bind ports via
+        # RAY_SERVE_PROXY_HTTP_PORT / RAY_SERVE_PROXY_GRPC_PORT (see constant
+        # docstring). The head node leaves them unset to keep the configured ports.
+        if RAY_SERVE_PROXY_HTTP_PORT is not None:
+            http_options.port = RAY_SERVE_PROXY_HTTP_PORT
+        if RAY_SERVE_PROXY_GRPC_PORT is not None:
+            grpc_options.port = RAY_SERVE_PROXY_GRPC_PORT
 
         self._grpc_options = grpc_options
         self._http_options = configure_http_middlewares(http_options)
@@ -1642,6 +1643,7 @@ class ProxyActor(ProxyActorInterface):
                 "serve_access_log": True,
             }
 
+        is_head = self._node_id == get_head_node_id()
         self.proxy_router = ProxyRouter(get_proxy_handle)
         self.http_proxy = HTTPProxy(
             node_id=self._node_id,

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -31,9 +31,9 @@ from ray.serve._private.constants import (
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_PROXY_GC_THRESHOLD,
-    RAY_SERVE_PROXY_GRPC_PORT,
-    RAY_SERVE_PROXY_HTTP_PORT,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
+    RAY_SERVE_WORKER_PROXY_GRPC_PORT,
+    RAY_SERVE_WORKER_PROXY_HTTP_PORT,
     SERVE_CONTROLLER_NAME,
     SERVE_HTTP_REQUEST_ID_HEADER,
     SERVE_LOG_COMPONENT,
@@ -1406,15 +1406,16 @@ def apply_per_node_port_overrides(
 ) -> None:
     """Override this proxy's HTTP and gRPC bind ports from the per-node env knobs.
 
-    Worker proxies bind RAY_SERVE_PROXY_HTTP_PORT and RAY_SERVE_PROXY_GRPC_PORT when set.
-    The head node is exempt so its configured ports and the fallback proxy stay intact.
+    Worker proxies bind RAY_SERVE_WORKER_PROXY_HTTP_PORT and
+    RAY_SERVE_WORKER_PROXY_GRPC_PORT when set. The head node is exempt so its
+    configured ports and the fallback proxy stay intact.
     """
     if is_head:
         return
-    if RAY_SERVE_PROXY_HTTP_PORT is not None:
-        http_options.port = RAY_SERVE_PROXY_HTTP_PORT
-    if RAY_SERVE_PROXY_GRPC_PORT is not None:
-        grpc_options.port = RAY_SERVE_PROXY_GRPC_PORT
+    if RAY_SERVE_WORKER_PROXY_HTTP_PORT is not None:
+        http_options.port = RAY_SERVE_WORKER_PROXY_HTTP_PORT
+    if RAY_SERVE_WORKER_PROXY_GRPC_PORT is not None:
+        grpc_options.port = RAY_SERVE_WORKER_PROXY_GRPC_PORT
 
 
 class ProxyActorInterface(ABC):

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1401,6 +1401,22 @@ class HTTPProxy(GenericProxy):
         yield status
 
 
+def apply_per_node_port_overrides(
+    http_options: HTTPOptions, grpc_options: gRPCOptions, is_head: bool
+) -> None:
+    """Override this proxy's HTTP and gRPC bind ports from the per-node env knobs.
+
+    Worker proxies bind RAY_SERVE_PROXY_HTTP_PORT and RAY_SERVE_PROXY_GRPC_PORT when set.
+    The head node is exempt so its configured ports and the fallback proxy stay intact.
+    """
+    if is_head:
+        return
+    if RAY_SERVE_PROXY_HTTP_PORT is not None:
+        http_options.port = RAY_SERVE_PROXY_HTTP_PORT
+    if RAY_SERVE_PROXY_GRPC_PORT is not None:
+        grpc_options.port = RAY_SERVE_PROXY_GRPC_PORT
+
+
 class ProxyActorInterface(ABC):
     """Abstract interface for proxy actors in Ray Serve.
 
@@ -1568,13 +1584,8 @@ class ProxyActor(ProxyActorInterface):
             logging_config=logging_config,
         )
 
-        # A node may override its proxy's HTTP/gRPC bind ports via
-        # RAY_SERVE_PROXY_HTTP_PORT / RAY_SERVE_PROXY_GRPC_PORT (see constant
-        # docstring). The head node leaves them unset to keep the configured ports.
-        if RAY_SERVE_PROXY_HTTP_PORT is not None:
-            http_options.port = RAY_SERVE_PROXY_HTTP_PORT
-        if RAY_SERVE_PROXY_GRPC_PORT is not None:
-            grpc_options.port = RAY_SERVE_PROXY_GRPC_PORT
+        is_head = self._node_id == get_head_node_id()
+        apply_per_node_port_overrides(http_options, grpc_options, is_head)
 
         self._grpc_options = grpc_options
         self._http_options = configure_http_middlewares(http_options)
@@ -1643,7 +1654,6 @@ class ProxyActor(ProxyActorInterface):
                 "serve_access_log": True,
             }
 
-        is_head = self._node_id == get_head_node_id()
         self.proxy_router = ProxyRouter(get_proxy_handle)
         self.http_proxy = HTTPProxy(
             node_id=self._node_id,

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -826,9 +826,7 @@ class ProxyStateManager:
         """Helper to start or reuse existing proxy and wrap in the proxy actor wrapper.
 
         Pass all the required variables into the proxy actor wrapper class and return
-        the proxy actor wrapper. A node can override its proxy's HTTP/gRPC bind ports
-        via RAY_SERVE_PROXY_HTTP_PORT / RAY_SERVE_PROXY_GRPC_PORT, read per node in the
-        proxy actor itself.
+        the proxy actor wrapper.
         """
         http_options = http_options or self._http_options
         grpc_options = grpc_options or self._grpc_options

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -2,7 +2,6 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-import os
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Dict, List, Optional, Set, Tuple, Type
@@ -826,35 +825,13 @@ class ProxyStateManager:
     ) -> ProxyWrapper:
         """Helper to start or reuse existing proxy and wrap in the proxy actor wrapper.
 
-        Compute the HTTP port based on `TEST_WORKER_NODE_HTTP_PORT` env var and gRPC
-        port based on `TEST_WORKER_NODE_GRPC_PORT` env var. Passed all the required
-        variables into the proxy actor wrapper class and return the proxy actor wrapper.
+        Pass all the required variables into the proxy actor wrapper class and return
+        the proxy actor wrapper. A node can override its proxy's HTTP/gRPC bind ports
+        via RAY_SERVE_PROXY_HTTP_PORT / RAY_SERVE_PROXY_GRPC_PORT, read per node in the
+        proxy actor itself.
         """
         http_options = http_options or self._http_options
         grpc_options = grpc_options or self._grpc_options
-
-        if (
-            node_id != self._head_node_id
-            and os.getenv("TEST_WORKER_NODE_HTTP_PORT") is not None
-        ):
-            logger.warning(
-                f"`TEST_WORKER_NODE_HTTP_PORT` env var is set. "
-                f"Using it for worker node {node_id}."
-            )
-            http_options = deepcopy(http_options)
-            http_options.port = int(os.getenv("TEST_WORKER_NODE_HTTP_PORT"))
-
-        if (
-            node_id != self._head_node_id
-            and os.getenv("TEST_WORKER_NODE_GRPC_PORT") is not None
-        ):
-            logger.warning(
-                f"`TEST_WORKER_NODE_GRPC_PORT` env var is set. "
-                f"Using it for worker node {node_id}."
-                f"{int(os.getenv('TEST_WORKER_NODE_GRPC_PORT'))}"
-            )
-            grpc_options = deepcopy(grpc_options)
-            grpc_options.port = int(os.getenv("TEST_WORKER_NODE_GRPC_PORT"))
 
         return self._actor_proxy_wrapper_class(
             logging_config=self.logging_config,

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -599,7 +599,9 @@ class TestHealthzAndRoutes:
         # continue to be pointing to the default port 8000.
         cluster = ray_cluster
         cluster.add_node(num_cpus=0)
-        cluster.add_node(num_cpus=2, env_vars={"RAY_SERVE_PROXY_HTTP_PORT": "8001"})
+        cluster.add_node(
+            num_cpus=2, env_vars={"RAY_SERVE_WORKER_PROXY_HTTP_PORT": "8001"}
+        )
         cluster.wait_for_nodes()
         ray.init(address=cluster.address)
         serve.start(http_options={"location": "EveryNode"})

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -597,12 +597,9 @@ class TestHealthzAndRoutes:
         """
         # Setup worker http proxy to be pointing to port 8001. Head node http proxy will
         # continue to be pointing to the default port 8000.
-        os.environ["TEST_WORKER_NODE_HTTP_PORT"] = "8001"
-
-        # Setup a cluster with 2 nodes
         cluster = ray_cluster
         cluster.add_node(num_cpus=0)
-        cluster.add_node(num_cpus=2)
+        cluster.add_node(num_cpus=2, env_vars={"RAY_SERVE_PROXY_HTTP_PORT": "8001"})
         cluster.wait_for_nodes()
         ray.init(address=cluster.address)
         serve.start(http_options={"location": "EveryNode"})

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -308,15 +308,16 @@ async def test_drain_and_undrain_haproxy_manager(
     """
     monkeypatch.setenv("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", "10")
 
-    # No SO_REUSEPORT: each node's HAProxy binds its own port. The head keeps the
-    # default 8000; each worker gets a distinct HTTP port (RAY_SERVE_PROXY_HTTP_PORT)
-    # and distinct stats/metrics ports so the three co-located HAProxies don't collide.
+    # No SO_REUSEPORT. Each node's HAProxy binds its own port. The head keeps the
+    # default 8000. Each worker gets a distinct HTTP port via
+    # RAY_SERVE_WORKER_PROXY_HTTP_PORT and distinct stats/metrics ports so the
+    # three co-located HAProxies don't collide.
     cluster = Cluster()
     head_node = cluster.add_node(num_cpus=0)
     cluster.add_node(
         num_cpus=1,
         env_vars={
-            "RAY_SERVE_PROXY_HTTP_PORT": "8001",
+            "RAY_SERVE_WORKER_PROXY_HTTP_PORT": "8001",
             "RAY_SERVE_HAPROXY_STATS_PORT": "8405",
             "RAY_SERVE_HAPROXY_METRICS_PORT": "9102",
         },
@@ -324,7 +325,7 @@ async def test_drain_and_undrain_haproxy_manager(
     cluster.add_node(
         num_cpus=1,
         env_vars={
-            "RAY_SERVE_PROXY_HTTP_PORT": "8002",
+            "RAY_SERVE_WORKER_PROXY_HTTP_PORT": "8002",
             "RAY_SERVE_HAPROXY_STATS_PORT": "8406",
             "RAY_SERVE_HAPROXY_METRICS_PORT": "9103",
         },

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
 import socket
 import subprocess
 import sys
+import threading
 import time
 from tempfile import NamedTemporaryFile
 
@@ -297,81 +299,146 @@ class TestTimeoutKeepAliveConfig:
         )
 
 
-def test_drain_and_undrain_haproxy_manager(
+@pytest.mark.asyncio
+async def test_drain_and_undrain_haproxy_manager(
     monkeypatch, shutdown_ray, call_ray_stop_only  # noqa: F811
 ):
-    """A worker-node HAProxy drains away when its node loses all replicas and is
-    re-added healthy when replicas return.
-
-    The head and worker HAProxies run on one host in this test cluster, so they
-    are given distinct ports to coexist WITHOUT SO_REUSEPORT (which stays
-    disabled): the worker frontend via ``TEST_WORKER_NODE_HTTP_PORT`` and the
-    worker's stats/metrics ports via per-node env vars on the worker node. The
-    HEALTHY/DRAINING/DRAINED state machine itself is covered by the unit tests in
-    ``tests/unit/test_proxy_state.py``.
+    """Test the state transtion of the haproxy manager between
+    HEALTHY, DRAINING and DRAINED
     """
-    # head -> 8000, worker -> 8001 so the two frontends don't collide.
-    monkeypatch.setenv("TEST_WORKER_NODE_HTTP_PORT", "8001")
-    # Drain quickly so the drain-completion wait below stays well under its
-    # timeout (the default draining period is 30s).
-    monkeypatch.setenv("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", "1")
+    monkeypatch.setenv("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", "10")
 
+    # No SO_REUSEPORT: each node's HAProxy binds its own port. The head keeps the
+    # default 8000; each worker gets a distinct HTTP port (TEST_WORKER_NODE_HTTP_PORT)
+    # and distinct stats/metrics ports so the three co-located HAProxies don't collide.
     cluster = Cluster()
     head_node = cluster.add_node(num_cpus=0)
     cluster.add_node(
         num_cpus=1,
         env_vars={
+            "TEST_WORKER_NODE_HTTP_PORT": "8001",
             "RAY_SERVE_HAPROXY_STATS_PORT": "8405",
             "RAY_SERVE_HAPROXY_METRICS_PORT": "9102",
+        },
+    )
+    cluster.add_node(
+        num_cpus=1,
+        env_vars={
+            "TEST_WORKER_NODE_HTTP_PORT": "8002",
+            "RAY_SERVE_HAPROXY_STATS_PORT": "8406",
+            "RAY_SERVE_HAPROXY_METRICS_PORT": "9103",
         },
     )
     cluster.wait_for_nodes()
     ray.init(address=head_node.address)
     serve.start(http_options={"location": "EveryNode"})
 
+    signal_actor = SignalActor.remote()
+
     @serve.deployment
-    def hello():
-        return "hello"
+    class HelloModel:
+        async def __call__(self):
+            await signal_actor.wait.remote()
+            return "hello"
+
+    serve.run(HelloModel.options(num_replicas=2).bind())
+
+    # 3 haproxies, 1 controller, 2 replicas, 1 signal actor, 1 fallback proxy
+    wait_for_condition(lambda: len(list_actors()) == 8)
+    assert len(ray.nodes()) == 3
 
     client = _get_global_client()
+    serve_details = ServeInstanceDetails(
+        **ray.get(client._controller.get_serve_instance_details.remote())
+    )
+    proxy_actor_ids = {proxy.actor_id for _, proxy in serve_details.proxies.items()}
 
-    def proxy_status_counts():
+    assert len(proxy_actor_ids) == 3
+
+    # Each HAProxy binds its own port (head 8000, workers 8001/8002); wait until
+    # all three answer health checks.
+    def all_haproxies_ready():
+        try:
+            return all(
+                httpx.get(f"http://localhost:{port}/-/healthz", timeout=2).status_code
+                == 200
+                for port in (8000, 8001, 8002)
+            )
+        except Exception:
+            return False
+
+    wait_for_condition(all_haproxies_ready, timeout=20)
+
+    # Start a long-running request in background to test draining behavior
+    request_result = []
+
+    def make_blocking_request():
+        try:
+            response = httpx.get("http://localhost:8000/", timeout=5)
+            request_result.append(("success", response.status_code))
+        except Exception as e:
+            request_result.append(("error", str(e)))
+
+    request_thread = threading.Thread(target=make_blocking_request)
+    request_thread.start()
+
+    wait_for_condition(
+        lambda: ray.get(signal_actor.cur_num_waiters.remote()) >= 1, timeout=10
+    )
+
+    serve.run(HelloModel.options(num_replicas=1).bind())
+
+    # 1 proxy should be draining
+
+    def check_proxy_status(proxy_status_to_count):
         serve_details = ServeInstanceDetails(
             **ray.get(client._controller.get_serve_instance_details.remote())
         )
-        counts = {}
-        for proxy in serve_details.proxies.values():
-            counts[proxy.status] = counts.get(proxy.status, 0) + 1
-        return counts
+        proxy_status_list = [proxy.status for _, proxy in serve_details.proxies.items()]
+        current_status = {
+            status: proxy_status_list.count(status) for status in proxy_status_list
+        }
+        return current_status == proxy_status_to_count
 
-    # The worker holds the replica; the head keeps a proxy for routing. Both
-    # HAProxies bind their (distinct) ports and become HEALTHY without
-    # SO_REUSEPORT.
-    serve.run(hello.options(num_replicas=1).bind(), name="app")
     wait_for_condition(
-        lambda: proxy_status_counts() == {ProxyStatus.HEALTHY: 2}, timeout=30
-    )
-    assert len(ray.nodes()) == 2
-
-    # The head HAProxy owns :8000 and routes to the worker replica.
-    wait_for_condition(
-        lambda: httpx.get("http://localhost:8000/", timeout=2).status_code == 200,
-        timeout=20,
+        condition_predictor=check_proxy_status,
+        proxy_status_to_count={ProxyStatus.HEALTHY: 2, ProxyStatus.DRAINING: 1},
     )
 
-    # Remove the replica -> the worker node has no replicas, so its proxy
-    # drains and is removed; the head proxy stays healthy.
-    serve.delete("app")
-    wait_for_condition(
-        lambda: proxy_status_counts() == {ProxyStatus.HEALTHY: 1}, timeout=40
+    # should stay in draining status until the signal is sent
+    await asyncio.sleep(1)
+
+    assert check_proxy_status(
+        proxy_status_to_count={ProxyStatus.HEALTHY: 2, ProxyStatus.DRAINING: 1}
     )
 
-    # Replicas return -> the worker proxy is re-added and becomes healthy.
-    serve.run(hello.options(num_replicas=1).bind(), name="app")
+    serve.run(HelloModel.options(num_replicas=2).bind())
+    # The proxy should return to healthy status
     wait_for_condition(
-        lambda: proxy_status_counts() == {ProxyStatus.HEALTHY: 2}, timeout=30
+        condition_predictor=check_proxy_status,
+        proxy_status_to_count={ProxyStatus.HEALTHY: 3},
+    )
+    serve_details = ServeInstanceDetails(
+        **ray.get(client._controller.get_serve_instance_details.remote())
     )
 
+    assert {
+        proxy.actor_id for _, proxy in serve_details.proxies.items()
+    } == proxy_actor_ids
+
+    serve.run(HelloModel.options(num_replicas=1).bind())
+    await signal_actor.send.remote()
+    # 1 proxy should be draining and eventually be drained.
+    wait_for_condition(
+        condition_predictor=check_proxy_status,
+        timeout=40,
+        proxy_status_to_count={ProxyStatus.HEALTHY: 2},
+    )
+
+    # Verify the long-running request completed successfully
+    request_thread.join(timeout=5)
+
+    # Clean up serve.
     serve.shutdown()
 
 

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -312,6 +312,9 @@ def test_drain_and_undrain_haproxy_manager(
     """
     # head -> 8000, worker -> 8001 so the two frontends don't collide.
     monkeypatch.setenv("TEST_WORKER_NODE_HTTP_PORT", "8001")
+    # Drain quickly so the drain-completion wait below stays well under its
+    # timeout (the default draining period is 30s).
+    monkeypatch.setenv("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", "1")
 
     cluster = Cluster()
     head_node = cluster.add_node(num_cpus=0)

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -1,9 +1,7 @@
-import asyncio
 import logging
 import socket
 import subprocess
 import sys
-import threading
 import time
 from tempfile import NamedTemporaryFile
 
@@ -299,130 +297,78 @@ class TestTimeoutKeepAliveConfig:
         )
 
 
-@pytest.mark.asyncio
-async def test_drain_and_undrain_haproxy_manager(
+def test_drain_and_undrain_haproxy_manager(
     monkeypatch, shutdown_ray, call_ray_stop_only  # noqa: F811
 ):
-    """Test the state transtion of the haproxy manager between
-    HEALTHY, DRAINING and DRAINED
+    """A worker-node HAProxy drains away when its node loses all replicas and is
+    re-added healthy when replicas return.
+
+    The head and worker HAProxies run on one host in this test cluster, so they
+    are given distinct ports to coexist WITHOUT SO_REUSEPORT (which stays
+    disabled): the worker frontend via ``TEST_WORKER_NODE_HTTP_PORT`` and the
+    worker's stats/metrics ports via per-node env vars on the worker node. The
+    HEALTHY/DRAINING/DRAINED state machine itself is covered by the unit tests in
+    ``tests/unit/test_proxy_state.py``.
     """
-    monkeypatch.setenv("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", "10")
-    monkeypatch.setenv("SERVE_SOCKET_REUSE_PORT_ENABLED", "1")
+    # head -> 8000, worker -> 8001 so the two frontends don't collide.
+    monkeypatch.setenv("TEST_WORKER_NODE_HTTP_PORT", "8001")
 
     cluster = Cluster()
     head_node = cluster.add_node(num_cpus=0)
-    cluster.add_node(num_cpus=1)
-    cluster.add_node(num_cpus=1)
+    cluster.add_node(
+        num_cpus=1,
+        env_vars={
+            "RAY_SERVE_HAPROXY_STATS_PORT": "8405",
+            "RAY_SERVE_HAPROXY_METRICS_PORT": "9102",
+        },
+    )
     cluster.wait_for_nodes()
     ray.init(address=head_node.address)
     serve.start(http_options={"location": "EveryNode"})
 
-    signal_actor = SignalActor.remote()
-
     @serve.deployment
-    class HelloModel:
-        async def __call__(self):
-            await signal_actor.wait.remote()
-            return "hello"
-
-    serve.run(HelloModel.options(num_replicas=2).bind())
-
-    # 3 haproxies, 1 controller, 2 replicas, 1 signal actor, 1 fallback proxy
-    wait_for_condition(lambda: len(list_actors()) == 8)
-    assert len(ray.nodes()) == 3
+    def hello():
+        return "hello"
 
     client = _get_global_client()
-    serve_details = ServeInstanceDetails(
-        **ray.get(client._controller.get_serve_instance_details.remote())
-    )
-    proxy_actor_ids = {proxy.actor_id for _, proxy in serve_details.proxies.items()}
 
-    assert len(proxy_actor_ids) == 3
-
-    # 3 HAProxies share *:8000 via SO_REUSEPORT; 20 successive 200s makes it
-    # very likely each shard has served at least one request and converged.
-    def all_haproxies_ready():
-        try:
-            return all(
-                httpx.get("http://localhost:8000/-/healthz", timeout=2).status_code
-                == 200
-                for _ in range(20)
-            )
-        except Exception:
-            return False
-
-    wait_for_condition(all_haproxies_ready, timeout=20)
-
-    # Start a long-running request in background to test draining behavior
-    request_result = []
-
-    def make_blocking_request():
-        try:
-            response = httpx.get("http://localhost:8000/", timeout=5)
-            request_result.append(("success", response.status_code))
-        except Exception as e:
-            request_result.append(("error", str(e)))
-
-    request_thread = threading.Thread(target=make_blocking_request)
-    request_thread.start()
-
-    wait_for_condition(
-        lambda: ray.get(signal_actor.cur_num_waiters.remote()) >= 1, timeout=10
-    )
-
-    serve.run(HelloModel.options(num_replicas=1).bind())
-
-    # 1 proxy should be draining
-
-    def check_proxy_status(proxy_status_to_count):
+    def proxy_status_counts():
         serve_details = ServeInstanceDetails(
             **ray.get(client._controller.get_serve_instance_details.remote())
         )
-        proxy_status_list = [proxy.status for _, proxy in serve_details.proxies.items()]
-        current_status = {
-            status: proxy_status_list.count(status) for status in proxy_status_list
-        }
-        return current_status == proxy_status_to_count
+        counts = {}
+        for proxy in serve_details.proxies.values():
+            counts[proxy.status] = counts.get(proxy.status, 0) + 1
+        return counts
 
+    # The worker holds the replica; the head keeps a proxy for routing. Both
+    # HAProxies bind their (distinct) ports and become HEALTHY without
+    # SO_REUSEPORT.
+    serve.run(hello.options(num_replicas=1).bind(), name="app")
     wait_for_condition(
-        condition_predictor=check_proxy_status,
-        proxy_status_to_count={ProxyStatus.HEALTHY: 2, ProxyStatus.DRAINING: 1},
+        lambda: proxy_status_counts() == {ProxyStatus.HEALTHY: 2}, timeout=30
     )
+    assert len(ray.nodes()) == 2
 
-    # should stay in draining status until the signal is sent
-    await asyncio.sleep(1)
-
-    assert check_proxy_status(
-        proxy_status_to_count={ProxyStatus.HEALTHY: 2, ProxyStatus.DRAINING: 1}
-    )
-
-    serve.run(HelloModel.options(num_replicas=2).bind())
-    # The proxy should return to healthy status
+    # The head HAProxy owns :8000 and routes to the worker replica.
     wait_for_condition(
-        condition_predictor=check_proxy_status,
-        proxy_status_to_count={ProxyStatus.HEALTHY: 3},
-    )
-    serve_details = ServeInstanceDetails(
-        **ray.get(client._controller.get_serve_instance_details.remote())
+        lambda: httpx.get("http://localhost:8000/", timeout=2).status_code == 200,
+        timeout=20,
     )
 
-    assert {
-        proxy.actor_id for _, proxy in serve_details.proxies.items()
-    } == proxy_actor_ids
-
-    serve.run(HelloModel.options(num_replicas=1).bind())
-    await signal_actor.send.remote()
-    # 1 proxy should be draining and eventually be drained.
+    # Remove the replica -> the worker node has no replicas, so its proxy
+    # drains and is removed; the head proxy stays healthy.
+    serve.delete("app")
     wait_for_condition(
-        condition_predictor=check_proxy_status,
-        timeout=40,
-        proxy_status_to_count={ProxyStatus.HEALTHY: 2},
+        lambda: proxy_status_counts() == {ProxyStatus.HEALTHY: 1}, timeout=40
     )
 
-    # Verify the long-running request completed successfully
-    request_thread.join(timeout=5)
+    # Replicas return -> the worker proxy is re-added and becomes healthy.
+    serve.run(hello.options(num_replicas=1).bind(), name="app")
+    wait_for_condition(
+        lambda: proxy_status_counts() == {ProxyStatus.HEALTHY: 2}, timeout=30
+    )
 
-    # Clean up serve.
     serve.shutdown()
 
 

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -309,14 +309,14 @@ async def test_drain_and_undrain_haproxy_manager(
     monkeypatch.setenv("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", "10")
 
     # No SO_REUSEPORT: each node's HAProxy binds its own port. The head keeps the
-    # default 8000; each worker gets a distinct HTTP port (TEST_WORKER_NODE_HTTP_PORT)
+    # default 8000; each worker gets a distinct HTTP port (RAY_SERVE_PROXY_HTTP_PORT)
     # and distinct stats/metrics ports so the three co-located HAProxies don't collide.
     cluster = Cluster()
     head_node = cluster.add_node(num_cpus=0)
     cluster.add_node(
         num_cpus=1,
         env_vars={
-            "TEST_WORKER_NODE_HTTP_PORT": "8001",
+            "RAY_SERVE_PROXY_HTTP_PORT": "8001",
             "RAY_SERVE_HAPROXY_STATS_PORT": "8405",
             "RAY_SERVE_HAPROXY_METRICS_PORT": "9102",
         },
@@ -324,7 +324,7 @@ async def test_drain_and_undrain_haproxy_manager(
     cluster.add_node(
         num_cpus=1,
         env_vars={
-            "TEST_WORKER_NODE_HTTP_PORT": "8002",
+            "RAY_SERVE_PROXY_HTTP_PORT": "8002",
             "RAY_SERVE_HAPROXY_STATS_PORT": "8406",
             "RAY_SERVE_HAPROXY_METRICS_PORT": "9103",
         },

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import grpc
@@ -88,12 +87,11 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
 
     # Setup worker gRPC proxy to be pointing to port 9001. Head node gRPC proxy will
     # continue to be pointing to the default port 9000.
-    os.environ["TEST_WORKER_NODE_GRPC_PORT"] = str(worker_node_grpc_port)
-
-    # Set up a cluster with 2 nodes.
     cluster = ray_cluster
     cluster.add_node(num_cpus=0)
-    cluster.add_node(num_cpus=2)
+    cluster.add_node(
+        num_cpus=2, env_vars={"RAY_SERVE_PROXY_GRPC_PORT": str(worker_node_grpc_port)}
+    )
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -90,7 +90,8 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
     cluster = ray_cluster
     cluster.add_node(num_cpus=0)
     cluster.add_node(
-        num_cpus=2, env_vars={"RAY_SERVE_PROXY_GRPC_PORT": str(worker_node_grpc_port)}
+        num_cpus=2,
+        env_vars={"RAY_SERVE_WORKER_PROXY_GRPC_PORT": str(worker_node_grpc_port)},
     )
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)


### PR DESCRIPTION
## Why

`test_drain_and_undrain_haproxy_manager` set `SERVE_SOCKET_REUSE_PORT_ENABLED=1` so the per-node HAProxies could share `*:8000` on the single test host. The goal is to run the Serve test suite with SO_REUSEPORT disabled, which is the default. Without SO_REUSEPORT, proxies colocated on one machine need distinct ports to coexist.

## What

Replace the controller-side `TEST_WORKER_NODE_HTTP_PORT` and `TEST_WORKER_NODE_GRPC_PORT` scaffolding with a per-worker-node override read in the proxy actor itself.

- Add `RAY_SERVE_WORKER_PROXY_HTTP_PORT` and `RAY_SERVE_WORKER_PROXY_GRPC_PORT`. A worker proxy binds these instead of the configured `http_options.port` and `grpc_options.port`. The head node is exempt, so it keeps its configured port and the head-resident fallback proxy keeps its own port.
- Apply the override through `apply_per_node_port_overrides` in both `ProxyActor` and `HAProxyManager`, so it covers the native and HAProxy paths.
- Read the value from each node's own environment so distinct workers get distinct ports through `cluster.add_node(env_vars=...)`. The old scaffolding read one value on the controller and applied it to every worker.

The drain test now runs with SO_REUSEPORT disabled. The head keeps `:8000`, the two workers bind `:8001` and `:8002`, and each worker gets its own stats and metrics ports. `test_head_and_worker_nodes_no_replicas` and `test_grpc_proxy_on_draining_nodes` move to the same per-node env vars.

## Limitations

The override changes only the proxy's local bind port. The controller still advertises every proxy at `http_options.port` through `get_targets`, so the override is invisible to controller-generated routing. It is safe only when a client reaches the proxy frontend directly, which is what these tests do.

## Testing

`RAY_SERVE_ENABLE_HA_PROXY=1 pytest python/ray/serve/tests/test_haproxy.py::test_drain_and_undrain_haproxy_manager` passes with SO_REUSEPORT disabled.
