### PR TITLE
[serve] Recover ingress request router pin-misses via the fallback proxy instead of 503

### DIFF
--- a/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
@@ -2,8 +2,6 @@
 Shared helpers for direct-streaming session-affinity tests.
 """
 
-import itertools
-
 import httpx
 import pytest
 
@@ -11,11 +9,7 @@ from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
 from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_SESSION_ID
-from ray.serve._private.test_utils import (
-    check_running,
-    get_application_url,
-    get_application_urls,
-)
+from ray.serve._private.test_utils import check_running, get_application_url
 from ray.serve.config import RequestRouterConfig
 
 CONSISTENT_HASH_ROUTER = (
@@ -45,60 +39,10 @@ def consistent_hash_deployment_config() -> dict:
 
 
 def run_app_through_haproxy(app, timeout_s: int = 60) -> str:
-    """Run ``app`` and return its (HAProxy) URL once HAProxy can route to every
-    data-plane replica.
-
-    ``ApplicationStatus.RUNNING`` only means the controller sees every replica
-    running. HAProxy reloads its data-plane server map asynchronously after
-    that, and the ingress request router learns the running replicas through a
-    separate long poll that usually runs ahead of the reload. In that window the
-    router can pin a replica HAProxy has not loaded yet, which HAProxy rejects
-    with a 503 ``unknown_replica_id``. Warm up until a request has reached every
-    replica so the test body never races the reload.
-    """
+    """Run ``app`` and return its (HAProxy) URL once all replicas are RUNNING."""
     serve.run(app)
     wait_for_condition(check_running, timeout=timeout_s)
-    base_url = get_application_url(use_localhost=True)
-    _wait_until_all_replicas_routable(base_url, timeout_s=timeout_s)
-    return base_url
-
-
-def _wait_until_all_replicas_routable(base_url: str, timeout_s: int = 60) -> None:
-    """Block until HAProxy routes successfully to every data-plane replica.
-
-    Probes distinct sessions so consistent hashing eventually covers every
-    replica. A 503 means HAProxy has not loaded that replica yet, so the probe
-    is retried under a fresh session until coverage is complete.
-    """
-    # One HTTP data-plane target per running replica of the ingress deployment.
-    expected_replicas = len(get_application_urls(use_localhost=True))
-    reached = set()
-    sessions = itertools.count()
-
-    def _all_replicas_reached() -> bool:
-        for _ in range(max(expected_replicas * 6, 40)):
-            resp = _chat_request(base_url, f"warmup-session-{next(sessions)}")
-            if resp.status_code == 200:
-                reached.add(resp.headers["x-replica-id"])
-            if len(reached) >= expected_replicas:
-                return True
-        return False
-
-    wait_for_condition(_all_replicas_reached, timeout=timeout_s)
-
-
-def _chat_request(base_url: str, session_id: str, model: str = "test-model"):
-    """POST a one-token chat request carrying ``session_id`` through HAProxy."""
-    return httpx.post(
-        f"{base_url}/v1/chat/completions",
-        json={
-            "model": model,
-            "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 1,
-        },
-        headers={SERVE_SESSION_ID: session_id},
-        timeout=30,
-    )
+    return get_application_url(use_localhost=True)
 
 
 def session_chat_response(base_url: str, session_id: str, model: str = "test-model"):
@@ -109,7 +53,16 @@ def session_chat_response(base_url: str, session_id: str, model: str = "test-mod
     replica from the ``x-replica-id`` header (and, for P/D, the prefill replica
     from ``kv_transfer_params.remote_engine_id``).
     """
-    resp = _chat_request(base_url, session_id, model)
+    resp = httpx.post(
+        f"{base_url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1,
+        },
+        headers={SERVE_SESSION_ID: session_id},
+        timeout=30,
+    )
     assert resp.status_code == 200, resp.text
     assert resp.headers["x-serve-session-id"] == session_id
     return resp

--- a/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/direct_streaming_utils.py
@@ -2,6 +2,8 @@
 Shared helpers for direct-streaming session-affinity tests.
 """
 
+import itertools
+
 import httpx
 import pytest
 
@@ -9,7 +11,11 @@ from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING
 from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY, SERVE_SESSION_ID
-from ray.serve._private.test_utils import check_running, get_application_url
+from ray.serve._private.test_utils import (
+    check_running,
+    get_application_url,
+    get_application_urls,
+)
 from ray.serve.config import RequestRouterConfig
 
 CONSISTENT_HASH_ROUTER = (
@@ -39,10 +45,60 @@ def consistent_hash_deployment_config() -> dict:
 
 
 def run_app_through_haproxy(app, timeout_s: int = 60) -> str:
-    """Run ``app`` and return its (HAProxy) URL once all replicas are RUNNING."""
+    """Run ``app`` and return its (HAProxy) URL once HAProxy can route to every
+    data-plane replica.
+
+    ``ApplicationStatus.RUNNING`` only means the controller sees every replica
+    running. HAProxy reloads its data-plane server map asynchronously after
+    that, and the ingress request router learns the running replicas through a
+    separate long poll that usually runs ahead of the reload. In that window the
+    router can pin a replica HAProxy has not loaded yet, which HAProxy rejects
+    with a 503 ``unknown_replica_id``. Warm up until a request has reached every
+    replica so the test body never races the reload.
+    """
     serve.run(app)
     wait_for_condition(check_running, timeout=timeout_s)
-    return get_application_url(use_localhost=True)
+    base_url = get_application_url(use_localhost=True)
+    _wait_until_all_replicas_routable(base_url, timeout_s=timeout_s)
+    return base_url
+
+
+def _wait_until_all_replicas_routable(base_url: str, timeout_s: int = 60) -> None:
+    """Block until HAProxy routes successfully to every data-plane replica.
+
+    Probes distinct sessions so consistent hashing eventually covers every
+    replica. A 503 means HAProxy has not loaded that replica yet, so the probe
+    is retried under a fresh session until coverage is complete.
+    """
+    # One HTTP data-plane target per running replica of the ingress deployment.
+    expected_replicas = len(get_application_urls(use_localhost=True))
+    reached = set()
+    sessions = itertools.count()
+
+    def _all_replicas_reached() -> bool:
+        for _ in range(max(expected_replicas * 6, 40)):
+            resp = _chat_request(base_url, f"warmup-session-{next(sessions)}")
+            if resp.status_code == 200:
+                reached.add(resp.headers["x-replica-id"])
+            if len(reached) >= expected_replicas:
+                return True
+        return False
+
+    wait_for_condition(_all_replicas_reached, timeout=timeout_s)
+
+
+def _chat_request(base_url: str, session_id: str, model: str = "test-model"):
+    """POST a one-token chat request carrying ``session_id`` through HAProxy."""
+    return httpx.post(
+        f"{base_url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1,
+        },
+        headers={SERVE_SESSION_ID: session_id},
+        timeout=30,
+    )
 
 
 def session_chat_response(base_url: str, session_id: str, model: str = "test-model"):
@@ -53,16 +109,7 @@ def session_chat_response(base_url: str, session_id: str, model: str = "test-mod
     replica from the ``x-replica-id`` header (and, for P/D, the prefill replica
     from ``kv_transfer_params.remote_engine_id``).
     """
-    resp = httpx.post(
-        f"{base_url}/v1/chat/completions",
-        json={
-            "model": model,
-            "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 1,
-        },
-        headers={SERVE_SESSION_ID: session_id},
-        timeout=30,
-    )
+    resp = _chat_request(base_url, session_id, model)
     assert resp.status_code == 200, resp.text
     assert resp.headers["x-serve-session-id"] == session_id
     return resp

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -117,8 +117,9 @@ class HAProxyMetricsCollector:
                 "'unparseable_replica_id' (router 200 but response body "
                 "did not contain a string replica_id), "
                 "'unknown_replica_id' (router returned a replica_id not "
-                "present in the current replica map). Each failure causes "
-                "HAProxy to return 503 to the client."
+                "present in the current replica map). All reasons return 503 "
+                "to the client except 'unknown_replica_id', which routes to the "
+                "fallback proxy when one is available (otherwise 503)."
             ),
             tag_keys=("application", "reason"),
         )

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -123,21 +123,23 @@ frontend http_frontend
     http-request wait-for-body time {{ ingress_request_router_timeout_s }}s if METH_POST has_ingress_request_router_app
     {%- endif %}
     http-request lua.route_via_ingress_request_router if METH_POST has_ingress_request_router_app
-    # Fail loudly when the Lua dispatch could not pin a replica, EXCEPT for
-    # `unknown_replica_id` (the router pinned a real replica HAProxy has not
-    # loaded yet, the brief membership gap after the app becomes RUNNING). That
-    # reason is recovered below by routing to the fallback Serve proxy. Must
-    # appear before the use_backend rules so other failures never fall through
-    # to the primary backend (a silent bypass of the configured router policy).
-    http-request return status 503 content-type text/plain lf-string "Ingress request router failed: %[var(txn.ingress_request_router_failed)]" hdr X-Serve-Reason %[var(txn.ingress_request_router_failed)] if { var(txn.ingress_request_router_failed) -m found } !{ var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
+    # A pin-miss is recoverable only if its app has a fallback proxy. Mark it
+    # per app so the 503 below fails loud for apps with none.
+    {%- for backend in backends %}
+    {%- if backend.ingress_request_router_servers and backend.fallback_server %}
+    http-request set-var(txn.ingress_request_router_recoverable) str(1) if { var(txn.ingress_request_router_app) -m str "{{ backend.name or 'unknown' }}" } { var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
+    {%- endif %}
+    {%- endfor %}
+    # 503 on any router failure except a recoverable pin-miss. Must precede the
+    # use_backend rules so failures never fall through to the primary backend.
+    http-request return status 503 content-type text/plain lf-string "Ingress request router failed: %[var(txn.ingress_request_router_failed)]" hdr X-Serve-Reason %[var(txn.ingress_request_router_failed)] if { var(txn.ingress_request_router_failed) -m found } !{ var(txn.ingress_request_router_recoverable) -m found }
     {%- endif %}
     # Static routing based on path prefixes in decreasing length then alphabetical order
 {%- for backend in backends %}
     {%- if has_ingress_request_router and backend.ingress_request_router_servers %}
     use_backend {{ backend.name or 'unknown' }}-via-ingress-request-router if is_{{ backend.name or 'unknown' }} { var(txn.via_ingress_request_router) -m found }
     {%- if backend.fallback_server %}
-    # Pin-miss recovery: route the unloaded-replica reason into the router
-    # backend too, where it selects the fallback Serve proxy.
+    # Pin-miss recovery: route into the router backend, which picks the fallback.
     use_backend {{ backend.name or 'unknown' }}-via-ingress-request-router if is_{{ backend.name or 'unknown' }} { var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
     {%- endif %}
     {%- endif %}
@@ -217,11 +219,8 @@ backend {{ backend.name or 'unknown' }}-via-ingress-request-router
     use-server {{ server.name }} if { var(txn.ingress_request_router_target) -m str "{{ server.name }}" }
     {%- endfor %}
     {%- if backend.fallback_server %}
-    # Pin-miss fallback: the router named a replica not yet in our server map
-    # (brief membership gap after the app becomes RUNNING). Hand the request to
-    # the fallback Serve proxy instead of 503ing; it re-pins via the same
-    # consistent-hash router. Other router failures still fail loud (see the
-    # frontend 503 rule).
+    # Pin-miss: route to the fallback Serve proxy, which re-pins via its own
+    # router. If it is DOWN, redispatch picks a primary replica instead.
     use-server {{ backend.fallback_server.name }} if { var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
     {%- endif %}
     # `track` allows us to mirror primary-backend health and avoid double-checking.

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -123,16 +123,23 @@ frontend http_frontend
     http-request wait-for-body time {{ ingress_request_router_timeout_s }}s if METH_POST has_ingress_request_router_app
     {%- endif %}
     http-request lua.route_via_ingress_request_router if METH_POST has_ingress_request_router_app
-    # Fail loudly when the Lua dispatch did not pick a replica. Must appear
-    # before the use_backend rules below so the request never falls back to
-    # the primary backend (which would be a silent bypass of the configured
-    # router policy).
-    http-request return status 503 content-type text/plain lf-string "Ingress request router failed: %[var(txn.ingress_request_router_failed)]" hdr X-Serve-Reason %[var(txn.ingress_request_router_failed)] if { var(txn.ingress_request_router_failed) -m found }
+    # Fail loudly when the Lua dispatch could not pin a replica, EXCEPT for
+    # `unknown_replica_id` (the router pinned a real replica HAProxy has not
+    # loaded yet, the brief membership gap after the app becomes RUNNING). That
+    # reason is recovered below by routing to the fallback Serve proxy. Must
+    # appear before the use_backend rules so other failures never fall through
+    # to the primary backend (a silent bypass of the configured router policy).
+    http-request return status 503 content-type text/plain lf-string "Ingress request router failed: %[var(txn.ingress_request_router_failed)]" hdr X-Serve-Reason %[var(txn.ingress_request_router_failed)] if { var(txn.ingress_request_router_failed) -m found } !{ var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
     {%- endif %}
     # Static routing based on path prefixes in decreasing length then alphabetical order
 {%- for backend in backends %}
     {%- if has_ingress_request_router and backend.ingress_request_router_servers %}
     use_backend {{ backend.name or 'unknown' }}-via-ingress-request-router if is_{{ backend.name or 'unknown' }} { var(txn.via_ingress_request_router) -m found }
+    {%- if backend.fallback_server %}
+    # Pin-miss recovery: route the unloaded-replica reason into the router
+    # backend too, where it selects the fallback Serve proxy.
+    use_backend {{ backend.name or 'unknown' }}-via-ingress-request-router if is_{{ backend.name or 'unknown' }} { var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
+    {%- endif %}
     {%- endif %}
     use_backend {{ backend.name or 'unknown' }} if is_{{ backend.name or 'unknown' }}
 {%- endfor %}
@@ -209,6 +216,14 @@ backend {{ backend.name or 'unknown' }}-via-ingress-request-router
     {%- for server in backend.servers %}
     use-server {{ server.name }} if { var(txn.ingress_request_router_target) -m str "{{ server.name }}" }
     {%- endfor %}
+    {%- if backend.fallback_server %}
+    # Pin-miss fallback: the router named a replica not yet in our server map
+    # (brief membership gap after the app becomes RUNNING). Hand the request to
+    # the fallback Serve proxy instead of 503ing; it re-pins via the same
+    # consistent-hash router. Other router failures still fail loud (see the
+    # frontend 503 rule).
+    use-server {{ backend.fallback_server.name }} if { var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
+    {%- endif %}
     # `track` allows us to mirror primary-backend health and avoid double-checking.
     {%- for server in backend.servers %}
     server {{ server.name }} {{ server.host }}:{{ server.port }} track {{ backend.name or 'unknown' }}/{{ server.name }}

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -220,7 +220,11 @@ backend {{ backend.name or 'unknown' }}-via-ingress-request-router
     {%- endfor %}
     {%- if backend.fallback_server %}
     # Pin-miss: route to the fallback Serve proxy, which re-pins via its own
-    # router. If it is DOWN, redispatch picks a primary replica instead.
+    # router. If the fallback is DOWN this use-server is skipped and the request
+    # load-balances onto a primary replica in this backend, so affinity lapses
+    # until the fallback's health check passes. That is plain selection-time
+    # fallthrough, not `option redispatch` (which only re-picks after a
+    # connection failure to an already-selected server).
     use-server {{ backend.fallback_server.name }} if { var(txn.ingress_request_router_failed) -m str "unknown_replica_id" }
     {%- endif %}
     # `track` allows us to mirror primary-backend health and avoid double-checking.

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -159,12 +159,9 @@ local function _route_via_ingress_request_router(txn, router, replica_map)
 
     local server_name = replica_map[replica_id]
     if not server_name then
-        -- Pin-miss: the router named a replica HAProxy has not loaded into its
-        -- server map yet (the brief membership gap after an app becomes
-        -- RUNNING, where the router's in-process view runs ahead of HAProxy's
-        -- config reload). Arm `failed` so the failures metric counts it by
-        -- reason; the frontend routes this specific reason to the fallback
-        -- Serve proxy instead of 503ing.
+        -- Pin-miss: router named a replica not in HAProxy's server map, a
+        -- transient gap between the router view and HAProxy's config snapshot.
+        -- Arm `failed`. The frontend recovers it via the fallback proxy.
         txn:set_var("txn.ingress_request_router_failed", "unknown_replica_id")
         return
     end
@@ -178,10 +175,9 @@ end
 -- rule fires instead of letting the request silently fall through to the
 -- primary backend. The product invariant is: requests to a router-bearing app
 -- are served via the router or fail; there is no quiet alternative path.
--- Exception: `unknown_replica_id` (the router pinned a real replica HAProxy
--- has not loaded yet) is recovered by the frontend through the fallback Serve
--- proxy rather than 503ed, because that path re-pins via the same router and
--- so does not bypass the routing policy. It is still counted as a failure.
+-- Exception: `unknown_replica_id` is recovered via the fallback proxy when the
+-- app has one, otherwise 503ed. The fallback re-pins via its own router so the
+-- policy is not bypassed. Still counted as a failure.
 -- Two silent returns are correct: (1) the request didn't target a
 -- router-bearing app (no txn var set, no app entry in our maps), and
 -- (2) the controller hasn't pushed router/replica state for this app yet.

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -177,7 +177,9 @@ end
 -- are served via the router or fail; there is no quiet alternative path.
 -- Exception: `unknown_replica_id` is recovered via the fallback proxy when the
 -- app has one, otherwise 503ed. The fallback re-pins via its own router so the
--- policy is not bypassed. Still counted as a failure.
+-- policy is not bypassed. While the fallback is DOWN the request load-balances
+-- onto a primary replica in the router backend instead of 503ing, so affinity
+-- lapses for that window. Still counted as a failure.
 -- Two silent returns are correct: (1) the request didn't target a
 -- router-bearing app (no txn var set, no app entry in our maps), and
 -- (2) the controller hasn't pushed router/replica state for this app yet.

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -159,6 +159,12 @@ local function _route_via_ingress_request_router(txn, router, replica_map)
 
     local server_name = replica_map[replica_id]
     if not server_name then
+        -- Pin-miss: the router named a replica HAProxy has not loaded into its
+        -- server map yet (the brief membership gap after an app becomes
+        -- RUNNING, where the router's in-process view runs ahead of HAProxy's
+        -- config reload). Arm `failed` so the failures metric counts it by
+        -- reason; the frontend routes this specific reason to the fallback
+        -- Serve proxy instead of 503ing.
         txn:set_var("txn.ingress_request_router_failed", "unknown_replica_id")
         return
     end
@@ -172,6 +178,10 @@ end
 -- rule fires instead of letting the request silently fall through to the
 -- primary backend. The product invariant is: requests to a router-bearing app
 -- are served via the router or fail; there is no quiet alternative path.
+-- Exception: `unknown_replica_id` (the router pinned a real replica HAProxy
+-- has not loaded yet) is recovered by the frontend through the fallback Serve
+-- proxy rather than 503ed, because that path re-pins via the same router and
+-- so does not bypass the routing policy. It is still counted as a failure.
 -- Two silent returns are correct: (1) the request didn't target a
 -- router-bearing app (no txn var set, no app entry in our maps), and
 -- (2) the controller hasn't pushed router/replica state for this app yet.

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -856,6 +856,61 @@ def _create_router_server(port: int, replica_id_to_return: str):
     return server, thread, captured
 
 
+async def _start_router_haproxy(
+    temp_dir, haproxy_port, stats_port, backend_configs, haproxy_api_cleanup
+):
+    """Build, start, and await readiness of an HAProxyApi for the ingress
+    request router e2e tests. These tests share this scaffold and differ only
+    in their backends, router behavior, and assertions."""
+    config = HAProxyConfig(
+        http_options=HTTPOptions(
+            host="127.0.0.1",
+            port=haproxy_port,
+            keep_alive_timeout_s=58,
+        ),
+        stats_port=stats_port,
+        socket_path=os.path.join(temp_dir, "admin.sock"),
+        has_received_routes=True,
+        has_received_servers=True,
+        health_check_path="/-/healthz",
+        health_check_inter="500ms",
+        health_check_rise=1,
+        health_check_fall=2,
+    )
+    api = HAProxyApi(
+        cfg=config,
+        backend_configs=backend_configs,
+        config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
+    )
+    haproxy_api_cleanup(api)
+    await api.start()
+    wait_for_condition(lambda: check_haproxy_ready(stats_port), timeout=10)
+    # Wait for primary-backend health checks to mark the replicas UP.
+    await async_wait_for_condition(
+        lambda: requests.get(
+            f"http://127.0.0.1:{haproxy_port}/-/healthz", timeout=2
+        ).status_code
+        == 200,
+        timeout=10,
+    )
+    return api
+
+
+def _shutdown_fake_servers(servers, threads):
+    """Signal uvicorn fake servers to exit and join their threads. Mirrors the
+    teardown each router test runs in its finally block."""
+    for srv in servers:
+        try:
+            srv.should_exit = True
+        except Exception:
+            pass
+    for thr in threads:
+        try:
+            thr.join(timeout=5)
+        except Exception:
+            pass
+
+
 @pytest.mark.asyncio
 async def test_ingress_request_router_end_to_end(haproxy_api_cleanup, monkeypatch):
     """Run actual HAProxy against a fake router + two replicas; verify a POST
@@ -886,22 +941,6 @@ async def test_ingress_request_router_end_to_end(haproxy_api_cleanup, monkeypatc
         )
 
         try:
-            config = HAProxyConfig(
-                http_options=HTTPOptions(
-                    host="127.0.0.1",
-                    port=haproxy_port,
-                    keep_alive_timeout_s=58,
-                ),
-                stats_port=stats_port,
-                socket_path=os.path.join(temp_dir, "admin.sock"),
-                has_received_routes=True,
-                has_received_servers=True,
-                health_check_path="/-/healthz",
-                health_check_inter="500ms",
-                health_check_rise=1,
-                health_check_fall=2,
-            )
-
             backend = BackendConfig(
                 name="llm",
                 path_prefix="/",
@@ -926,22 +965,12 @@ async def test_ingress_request_router_end_to_end(haproxy_api_cleanup, monkeypatc
                 ],
             )
 
-            api = HAProxyApi(
-                cfg=config,
-                backend_configs={"llm": backend},
-                config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
-            )
-            haproxy_api_cleanup(api)
-            await api.start()
-
-            wait_for_condition(lambda: check_haproxy_ready(stats_port), timeout=10)
-            # Wait for primary-backend health checks to mark both replicas UP.
-            await async_wait_for_condition(
-                lambda: requests.get(
-                    f"http://127.0.0.1:{haproxy_port}/-/healthz", timeout=2
-                ).status_code
-                == 200,
-                timeout=10,
+            await _start_router_haproxy(
+                temp_dir,
+                haproxy_port,
+                stats_port,
+                {"llm": backend},
+                haproxy_api_cleanup,
             )
 
             # POST goes through the router. Router returns B's actor name,
@@ -980,16 +1009,10 @@ async def test_ingress_request_router_end_to_end(haproxy_api_cleanup, monkeypatc
             ), "GET must not invoke /internal/route"
 
         finally:
-            for srv in (replica_a, replica_b, router):
-                try:
-                    srv.should_exit = True
-                except Exception:
-                    pass
-            for thr in (replica_a_thread, replica_b_thread, router_thread):
-                try:
-                    thr.join(timeout=5)
-                except Exception:
-                    pass
+            _shutdown_fake_servers(
+                (replica_a, replica_b, router),
+                (replica_a_thread, replica_b_thread, router_thread),
+            )
 
 
 def _create_broken_router_server(port: int, status_code: int = 500):
@@ -1051,22 +1074,6 @@ async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
         broken_router, broken_router_thread = _create_broken_router_server(router_port)
 
         try:
-            config = HAProxyConfig(
-                http_options=HTTPOptions(
-                    host="127.0.0.1",
-                    port=haproxy_port,
-                    keep_alive_timeout_s=58,
-                ),
-                stats_port=stats_port,
-                socket_path=os.path.join(temp_dir, "admin.sock"),
-                has_received_routes=True,
-                has_received_servers=True,
-                health_check_path="/-/healthz",
-                health_check_inter="500ms",
-                health_check_rise=1,
-                health_check_fall=2,
-            )
-
             backend = BackendConfig(
                 name="llm",
                 path_prefix="/",
@@ -1085,21 +1092,12 @@ async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
                 ],
             )
 
-            api = HAProxyApi(
-                cfg=config,
-                backend_configs={"llm": backend},
-                config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
-            )
-            haproxy_api_cleanup(api)
-            await api.start()
-
-            wait_for_condition(lambda: check_haproxy_ready(stats_port), timeout=10)
-            await async_wait_for_condition(
-                lambda: requests.get(
-                    f"http://127.0.0.1:{haproxy_port}/-/healthz", timeout=2
-                ).status_code
-                == 200,
-                timeout=10,
+            await _start_router_haproxy(
+                temp_dir,
+                haproxy_port,
+                stats_port,
+                {"llm": backend},
+                haproxy_api_cleanup,
             )
 
             # Every dispatch failure must surface as 5xx with a reason
@@ -1128,16 +1126,9 @@ async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
                 _backend_stot(stats_csv, "llm-via-ingress-request-router") == 0
             ), stats_csv
         finally:
-            for srv in (replica, broken_router):
-                try:
-                    srv.should_exit = True
-                except Exception:
-                    pass
-            for thr in (replica_thread, broken_router_thread):
-                try:
-                    thr.join(timeout=5)
-                except Exception:
-                    pass
+            _shutdown_fake_servers(
+                (replica, broken_router), (replica_thread, broken_router_thread)
+            )
 
 
 @pytest.mark.asyncio
@@ -1171,22 +1162,6 @@ async def test_pin_miss_falls_back_to_fallback_server(haproxy_api_cleanup):
         )
 
         try:
-            config = HAProxyConfig(
-                http_options=HTTPOptions(
-                    host="127.0.0.1",
-                    port=haproxy_port,
-                    keep_alive_timeout_s=58,
-                ),
-                stats_port=stats_port,
-                socket_path=os.path.join(temp_dir, "admin.sock"),
-                has_received_routes=True,
-                has_received_servers=True,
-                health_check_path="/-/healthz",
-                health_check_inter="500ms",
-                health_check_rise=1,
-                health_check_fall=2,
-            )
-
             backend = BackendConfig(
                 name="llm",
                 path_prefix="/",
@@ -1210,69 +1185,54 @@ async def test_pin_miss_falls_back_to_fallback_server(haproxy_api_cleanup):
                 ),
             )
 
-            api = HAProxyApi(
-                cfg=config,
-                backend_configs={"llm": backend},
-                config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
-            )
-            haproxy_api_cleanup(api)
-            await api.start()
-
-            wait_for_condition(lambda: check_haproxy_ready(stats_port), timeout=10)
-            await async_wait_for_condition(
-                lambda: requests.get(
-                    f"http://127.0.0.1:{haproxy_port}/-/healthz", timeout=2
-                ).status_code
-                == 200,
-                timeout=10,
+            await _start_router_haproxy(
+                temp_dir,
+                haproxy_port,
+                stats_port,
+                {"llm": backend},
+                haproxy_api_cleanup,
             )
 
             # The fallback is a `backup` server, so the /-/healthz wait above
-            # (satisfied by the primary replica alone) does not gate it. Poll a
-            # pin-miss POST until the fallback's health check marks it UP;
-            # before that, use-server is skipped and the request load-balances
-            # onto the primary replica.
-            def _pin_miss_reaches_fallback():
-                resp = requests.post(
-                    f"http://127.0.0.1:{haproxy_port}/predict",
-                    json={"prompt": "hi"},
-                    timeout=5,
-                )
-                return (
-                    resp.status_code == 200
-                    and resp.headers.get("x-replica-id") == "FALLBACK"
-                )
+            # (satisfied by the primary replica alone) does not gate it. Before
+            # its health check passes, a pin-miss use-server is skipped and the
+            # request load-balances onto the primary replica; once it passes,
+            # every pin-miss POST lands on the fallback proxy. Require several
+            # consecutive FALLBACK responses so a transient health-check flap
+            # during warmup retries here instead of failing an assertion.
+            def _pin_miss_consistently_reaches_fallback():
+                for _ in range(3):
+                    resp = requests.post(
+                        f"http://127.0.0.1:{haproxy_port}/predict",
+                        json={"prompt": "hi"},
+                        timeout=5,
+                    )
+                    if (
+                        resp.status_code != 200
+                        or resp.headers.get("x-replica-id") != "FALLBACK"
+                    ):
+                        return False
+                return True
 
-            await async_wait_for_condition(_pin_miss_reaches_fallback, timeout=10)
+            await async_wait_for_condition(
+                _pin_miss_consistently_reaches_fallback, timeout=10
+            )
 
-            # Once the fallback is UP, pin-miss routing is deterministic: every
-            # POST lands on the fallback proxy, served by "FALLBACK", never 503.
-            for _ in range(3):
-                resp = requests.post(
-                    f"http://127.0.0.1:{haproxy_port}/predict",
-                    json={"prompt": "hi"},
-                    timeout=5,
-                )
-                assert resp.status_code == 200, resp.text
-                assert resp.headers.get("x-replica-id") == "FALLBACK", resp.headers
-
-            # A pin-miss must never fall through to the plain primary backend
-            # (a silent router bypass); it always routes via the router backend.
+            # A pin-miss must route via the router backend, never through the
+            # plain primary backend (a silent router bypass). The router backend
+            # carries the fallback-served sessions; the plain backend stays 0.
             stats_csv = requests.get(
                 f"http://127.0.0.1:{stats_port}/stats;csv", timeout=5
             ).text
             assert _backend_stot(stats_csv, "llm") == 0, stats_csv
+            assert (
+                _backend_stot(stats_csv, "llm-via-ingress-request-router") >= 3
+            ), stats_csv
         finally:
-            for srv in (replica, fallback, router):
-                try:
-                    srv.should_exit = True
-                except Exception:
-                    pass
-            for thr in (replica_thread, fallback_thread, router_thread):
-                try:
-                    thr.join(timeout=5)
-                except Exception:
-                    pass
+            _shutdown_fake_servers(
+                (replica, fallback, router),
+                (replica_thread, fallback_thread, router_thread),
+            )
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -1227,8 +1227,26 @@ async def test_pin_miss_falls_back_to_fallback_server(haproxy_api_cleanup):
                 timeout=10,
             )
 
-            # The router pins an unknown replica, so every POST must land on the
-            # fallback proxy: 200, served by "FALLBACK", never 503.
+            # The fallback is a `backup` server, so the /-/healthz wait above
+            # (satisfied by the primary replica alone) does not gate it. Poll a
+            # pin-miss POST until the fallback's health check marks it UP;
+            # before that, use-server is skipped and the request load-balances
+            # onto the primary replica.
+            def _pin_miss_reaches_fallback():
+                resp = requests.post(
+                    f"http://127.0.0.1:{haproxy_port}/predict",
+                    json={"prompt": "hi"},
+                    timeout=5,
+                )
+                return (
+                    resp.status_code == 200
+                    and resp.headers.get("x-replica-id") == "FALLBACK"
+                )
+
+            await async_wait_for_condition(_pin_miss_reaches_fallback, timeout=10)
+
+            # Once the fallback is UP, pin-miss routing is deterministic: every
+            # POST lands on the fallback proxy, served by "FALLBACK", never 503.
             for _ in range(3):
                 resp = requests.post(
                     f"http://127.0.0.1:{haproxy_port}/predict",
@@ -1238,7 +1256,8 @@ async def test_pin_miss_falls_back_to_fallback_server(haproxy_api_cleanup):
                 assert resp.status_code == 200, resp.text
                 assert resp.headers.get("x-replica-id") == "FALLBACK", resp.headers
 
-            # The affinity-breaking primary backend must never be selected.
+            # A pin-miss must never fall through to the plain primary backend
+            # (a silent router bypass); it always routes via the router backend.
             stats_csv = requests.get(
                 f"http://127.0.0.1:{stats_port}/stats;csv", timeout=5
             ).text

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -1141,6 +1141,122 @@ async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
 
 
 @pytest.mark.asyncio
+async def test_pin_miss_falls_back_to_fallback_server(haproxy_api_cleanup):
+    """When the router pins a replica_id that is not in HAProxy's server map
+    (the brief membership gap right after an app becomes RUNNING, where the
+    router's in-process view runs ahead of HAProxy's config reload), HAProxy
+    must hand the request to the fallback Serve proxy instead of returning 503.
+    The primary backend must not be load-balanced into, since that would break
+    session affinity."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        haproxy_port = find_free_port()
+        stats_port = find_free_port()
+        replica_port = find_free_port()
+        fallback_port = find_free_port()
+        router_port = find_free_port()
+
+        actor_name = "SERVE_REPLICA::app#dep#aaa"
+        # The router names a replica that is NOT among the configured servers,
+        # simulating HAProxy lagging the router's freshly-updated view.
+        unknown_actor_name = "SERVE_REPLICA::app#dep#not_loaded_yet"
+
+        replica, replica_thread = _create_replica_server(
+            replica_port, replica_id_header="A"
+        )
+        fallback, fallback_thread = _create_replica_server(
+            fallback_port, replica_id_header="FALLBACK"
+        )
+        router, router_thread, _ = _create_router_server(
+            router_port, replica_id_to_return=unknown_actor_name
+        )
+
+        try:
+            config = HAProxyConfig(
+                http_options=HTTPOptions(
+                    host="127.0.0.1",
+                    port=haproxy_port,
+                    keep_alive_timeout_s=58,
+                ),
+                stats_port=stats_port,
+                socket_path=os.path.join(temp_dir, "admin.sock"),
+                has_received_routes=True,
+                has_received_servers=True,
+                health_check_path="/-/healthz",
+                health_check_inter="500ms",
+                health_check_rise=1,
+                health_check_fall=2,
+            )
+
+            backend = BackendConfig(
+                name="llm",
+                path_prefix="/",
+                app_name="llm",
+                health_check_path="/-/healthz",
+                servers=[
+                    ServerConfig(
+                        name="A",
+                        host="127.0.0.1",
+                        port=replica_port,
+                        replica_id=actor_name,
+                    ),
+                ],
+                ingress_request_router_servers=[
+                    ServerConfig(name="router", host="127.0.0.1", port=router_port),
+                ],
+                fallback_server=ServerConfig(
+                    name="fallback",
+                    host="127.0.0.1",
+                    port=fallback_port,
+                ),
+            )
+
+            api = HAProxyApi(
+                cfg=config,
+                backend_configs={"llm": backend},
+                config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
+            )
+            haproxy_api_cleanup(api)
+            await api.start()
+
+            wait_for_condition(lambda: check_haproxy_ready(stats_port), timeout=10)
+            await async_wait_for_condition(
+                lambda: requests.get(
+                    f"http://127.0.0.1:{haproxy_port}/-/healthz", timeout=2
+                ).status_code
+                == 200,
+                timeout=10,
+            )
+
+            # The router pins an unknown replica, so every POST must land on the
+            # fallback proxy: 200, served by "FALLBACK", never 503.
+            for _ in range(3):
+                resp = requests.post(
+                    f"http://127.0.0.1:{haproxy_port}/predict",
+                    json={"prompt": "hi"},
+                    timeout=5,
+                )
+                assert resp.status_code == 200, resp.text
+                assert resp.headers.get("x-replica-id") == "FALLBACK", resp.headers
+
+            # The affinity-breaking primary backend must never be selected.
+            stats_csv = requests.get(
+                f"http://127.0.0.1:{stats_port}/stats;csv", timeout=5
+            ).text
+            assert _backend_stot(stats_csv, "llm") == 0, stats_csv
+        finally:
+            for srv in (replica, fallback, router):
+                try:
+                    srv.should_exit = True
+                except Exception:
+                    pass
+            for thr in (replica_thread, fallback_thread, router_thread):
+                try:
+                    thr.join(timeout=5)
+                except Exception:
+                    pass
+
+
+@pytest.mark.asyncio
 async def test_graceful_reload(haproxy_api_cleanup):
     """Test that graceful reload preserves long-running connections."""
 


### PR DESCRIPTION
## Why are these changes needed?

With HAProxy ingress and direct streaming, the ingress request router pins a replica by name and HAProxy routes to it through its statically reloaded server map. Right after the replica set changes, the router's in-process view runs ahead of HAProxy's config reload, so it can name a replica HAProxy has not loaded yet. HAProxy returned a 503 `unknown_replica_id`. This is an intermittent failure in the direct-streaming session-affinity tests and a real client-facing error during the gap.

This routes `unknown_replica_id` to the fallback Serve proxy instead of 503ing. The fallback re-pins through its own router on the same consistent-hash ring, so affinity is preserved. A router app with no fallback still fails loud rather than silently using the primary backend, and other router failures still 503.

Reproduced and validated with `test_dp_direct_streaming` against HAProxy 2.8. The deterministic `test_pd_direct_streaming` failure is a separate KV-connector gap fixed in #64266.

## Related issue number

Closes https://github.com/ray-project/ray/issues/64265.

## Checks

- [x] I've signed off every commit (DCO).
- [x] Added `test_pin_miss_falls_back_to_fallback_server`. Lint clean.
