### PR TITLE
[serve] Adjust release test frequency

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1563,7 +1563,7 @@
   group: Serve tests
   working_dir: serve_tests
 
-  frequency: nightly
+  frequency: weekly
   team: serve
 
   cluster:
@@ -1632,7 +1632,7 @@
   group: Serve tests
   working_dir: serve_tests
 
-  frequency: nightly
+  frequency: weekly
   team: serve
 
   cluster:
@@ -1757,7 +1757,7 @@
   group: Serve tests
   working_dir: serve_tests
 
-  frequency: nightly
+  frequency: weekly
   team: serve
 
   cluster:


### PR DESCRIPTION
## Description
These tests are too expensive.
- `serve_controller_benchmark_haproxy.aws`
- `pytest_serve_router_benchmark.aws.supply_constraint`
- `pytest_serve_router_benchmark.aws.standard`
- `1k_noop_replica`

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
