### PR TITLE
[docs] Add examples.yml header instructions

### DIFF
--- a/doc/source/data/examples.yml
+++ b/doc/source/data/examples.yml
@@ -1,3 +1,9 @@
+# This file is used to auto-generate the Examples Gallery page.
+# Do not edit the generated examples.rst page directly.
+# To request formatting changes to the generated page, file an issue with the Ray docs team.
+# To reference the generated page, use examples.html.
+# When adding a new example, include the skill level and framework, if applicable.
+
 text: Below are examples for using Ray Data for batch inference workloads or large-scale data processing with a variety of frameworks and use cases.
 columns_to_show:
   - frameworks

--- a/doc/source/serve/examples.yml
+++ b/doc/source/serve/examples.yml
@@ -1,3 +1,9 @@
+# This file is used to auto-generate the Examples Gallery page.
+# Do not edit the generated examples.rst page directly.
+# To request formatting changes to the generated page, file an issue with the Ray docs team.
+# To reference the generated page, use examples.html.
+# When adding a new example, include the skill level and framework, if applicable.
+
 text: Below are tutorials for exploring Ray Serve capabilities and learning how to integrate different modeling frameworks.
 groupby: related_technology
 examples:

--- a/doc/source/train/examples.yml
+++ b/doc/source/train/examples.yml
@@ -1,3 +1,9 @@
+# This file is used to auto-generate the Examples Gallery page.
+# Do not edit the generated examples.rst page directly.
+# To request formatting changes to the generated page, file an issue with the Ray docs team.
+# To reference the generated page, use examples.html.
+# When adding a new example, include the skill level and framework, if applicable.
+
 text: Below are examples for using Ray Train with a variety of frameworks and use cases. Ray Train makes it easy to scale out each of these examples to a large cluster of GPUs.
 columns_to_show:
   - frameworks


### PR DESCRIPTION
## Description

This PR closes #44388 by adding header comments to the `examples.yml` files used to generate the Examples Gallery pages.

The comments clarify that:

* the generated `examples.rst` pages should not be edited directly;
* formatting changes to the generated pages should be requested through a docs issue;
* generated pages should be referenced with `examples.html`;
* new examples should include skill level and framework information when applicable.

## Related issues

Closes #44388

## Additional information

This is a docs-only change. No runtime code was modified.

Checks:

* Verified that only the three requested `examples.yml` files were changed.
* Ran `git diff --check`.
* Checked the files with PyYAML.
