### PR TITLE
fix(autoscaler): skip instances with unknown type in metrics_reporter…

### DIFF
--- a/python/ray/autoscaler/v2/metrics_reporter.py
+++ b/python/ray/autoscaler/v2/metrics_reporter.py
@@ -84,6 +84,114 @@ class AutoscalerMetricsReporter:
                 resource_map[resource_name] += resource_value * count
 
         for instance in instances:
+            # Skip instances whose type is no longer in node_type_configs
+            # (e.g. after a worker group is deleted), to avoid KeyError.
+            if instance.instance_type not in node_type_configs:
+                continue
+            if InstanceUtil.is_ray_pending(instance.status):
+                _add_resources(
+                    pending_resources, node_type_configs, instance.instance_type, 1
+                )
+            elif InstanceUtil.is_ray_running(instance.status):
+                _add_resources(
+                    cluster_resources, node_type_configs, instance.instance_type, 1
+                )
+
+        for resource_name, resource_value in pending_resources.items():
+            self._prom_metrics.pending_resources.labels(
+                SessionName=self._prom_metrics.session_name, resource=resource_name
+            ).set(resource_value)
+
+        for resource_name, resource_value in cluster_resources.items():
+            self._prom_metrics.cluster_resources.labels(
+                SessionName=self._prom_metrics.session_name, resource=resource_name
+            ).set(resource_value)
+from collections import defaultdict
+from typing import Dict, List
+
+from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
+from ray.autoscaler.v2.instance_manager.common import InstanceUtil
+from ray.autoscaler.v2.instance_manager.config import NodeTypeConfig
+from ray.autoscaler.v2.schema import NodeType
+from ray.core.generated.instance_manager_pb2 import Instance as IMInstance
+
+
+class AutoscalerMetricsReporter:
+    def __init__(self, prom_metrics: AutoscalerPrometheusMetrics) -> None:
+        self._prom_metrics = prom_metrics
+
+    def inc_stopped_nodes(self, count: int) -> None:
+        self._prom_metrics.stopped_nodes.inc(count)
+
+    def report_instances(
+        self,
+        instances: List[IMInstance],
+        node_type_configs: Dict[NodeType, NodeTypeConfig],
+    ):
+        """
+        Record autoscaler metrics for:
+            - pending_nodes: Nodes that are launching/pending ray start
+            - active_nodes: Active nodes (nodes running ray)
+            - recently_failed_nodes: Nodes that are being terminated.
+        """
+        # map of instance type to a dict of status to count.
+        status_count_by_type: Dict[NodeType, Dict[str, int]] = {}
+        # initialize the status count by type.
+        for instance_type in node_type_configs.keys():
+            status_count_by_type[instance_type] = {
+                "pending": 0,
+                "running": 0,
+                "terminating": 0,
+                "terminated": 0,
+            }
+
+        for instance in instances:
+            # Skip instances whose type is no longer in node_type_configs
+            # (e.g. after a worker group is deleted), to avoid KeyError.
+            if instance.instance_type not in status_count_by_type:
+                continue
+            if InstanceUtil.is_ray_pending(instance.status):
+                status_count_by_type[instance.instance_type]["pending"] += 1
+            elif InstanceUtil.is_ray_running(instance.status):
+                status_count_by_type[instance.instance_type]["running"] += 1
+            elif instance.status == IMInstance.TERMINATING:
+                status_count_by_type[instance.instance_type]["terminating"] += 1
+            elif instance.status == IMInstance.TERMINATED:
+                status_count_by_type[instance.instance_type]["terminated"] += 1
+
+        for instance_type, status_count in status_count_by_type.items():
+            self._prom_metrics.pending_nodes.labels(
+                SessionName=self._prom_metrics.session_name, NodeType=instance_type
+            ).set(status_count["pending"])
+
+            self._prom_metrics.active_nodes.labels(
+                SessionName=self._prom_metrics.session_name, NodeType=instance_type
+            ).set(status_count["running"])
+
+            self._prom_metrics.recently_failed_nodes.labels(
+                SessionName=self._prom_metrics.session_name, NodeType=instance_type
+            ).set(status_count["terminating"])
+
+    def report_resources(
+        self,
+        instances: List[IMInstance],
+        node_type_configs: Dict[NodeType, NodeTypeConfig],
+    ):
+        """
+        Record autoscaler metrics for:
+            - pending_resources: Pending resources
+            - cluster_resources: Cluster resources (resources running on the cluster)
+        """
+        # pending resources.
+        pending_resources = defaultdict(float)
+        cluster_resources = defaultdict(float)
+
+        def _add_resources(resource_map, node_type_configs, node_type, count):
+            node_resources = node_type_configs[node_type].resources
+            for resource_name, resource_value in node_resources.items():
+                resource_map[resource_name] += resource_value * count
+
+        for instance in instances:
             if InstanceUtil.is_ray_pending(instance.status):
                 _add_resources(
                     pending_resources, node_type_configs, instance.instance_type, 1

--- a/python/ray/autoscaler/v2/metrics_reporter.py
+++ b/python/ray/autoscaler/v2/metrics_reporter.py
@@ -38,6 +38,10 @@ class AutoscalerMetricsReporter:
             }
 
         for instance in instances:
+            # Skip instances whose type is no longer in node_type_configs
+            # (e.g. after a worker group is deleted), to avoid KeyError.
+            if instance.instance_type not in status_count_by_type:
+                continue
             if InstanceUtil.is_ray_pending(instance.status):
                 status_count_by_type[instance.instance_type]["pending"] += 1
             elif InstanceUtil.is_ray_running(instance.status):


### PR DESCRIPTION
## Description

Fixes a `KeyError` in `AutoscalerMetricsReporter.report_instances()` that occurs when an instance's `instance_type` is not present in `node_type_configs` — for example, after a worker group is deleted while historical instances still reference it.

**Root cause:** `status_count_by_type` is pre-populated only for types in `node_type_configs.keys()`. If an instance has a type that was removed (deleted worker group), accessing `status_count_by_type[instance.instance_type]` raises a `KeyError`.

**Fix:** Add a `continue` guard before the status update block to skip any instance whose type is not in the tracking dict:

```python
if instance.instance_type not in status_count_by_type:
    continue
```

## Related issues

Fixes #64177

## Additional information

- File: `python/ray/autoscaler/v2/metrics_reporter.py`
- The fix is minimal and safe — instances from deleted worker groups are irrelevant to current metrics anyway.