### PR TITLE
[Serve][LLM] Fix metrics middleware crash on FastAPI >= 0.137 _IncludedRouter

### DIFF
--- a/python/ray/llm/_internal/serve/observability/metrics/middleware.py
+++ b/python/ray/llm/_internal/serve/observability/metrics/middleware.py
@@ -7,6 +7,14 @@ from starlette.requests import Request
 from starlette.routing import Match
 from starlette.types import Message
 
+try:
+    # FastAPI >= 0.137.2 exposes a public helper that flattens routes added via
+    # include_router() (nested under _IncludedRouter on 0.137) into matchable
+    # route contexts. Older versions lack it; see _flatten_routes().
+    from fastapi.routing import iter_route_contexts
+except ImportError:
+    iter_route_contexts = None
+
 from ray.llm._internal.serve.core.ingress.middleware import (
     get_request_id,
     get_user_id,
@@ -114,6 +122,27 @@ class MeasureHTTPRequestMetricsMiddleware:
                 )
 
 
+def _flatten_routes(routes):
+    """Yield matchable routes, flattening FastAPI 0.137+ included routers.
+
+    FastAPI 0.137 nests routes added via ``include_router()`` under
+    ``_IncludedRouter`` tree nodes that expose no ``path`` attribute, so iterating
+    ``app.routes`` and reading ``route.path`` raises ``AttributeError``. FastAPI
+    >= 0.137.2 provides the public ``iter_route_contexts()`` to flatten them into
+    route contexts (each exposing ``matches()`` and the templated ``path``); on
+    0.137.0/0.137.1 fall back to the private ``effective_route_contexts()``, and on
+    FastAPI < 0.137 the routes are already matchable as-is.
+    """
+    if iter_route_contexts is not None:
+        yield from iter_route_contexts(routes)
+        return
+    for route in routes:
+        if hasattr(route, "effective_route_contexts"):
+            yield from route.effective_route_contexts()
+        else:
+            yield route
+
+
 def _get_route_details(scope: dict) -> str:
     """
     Function to retrieve Starlette route from scope.
@@ -128,7 +157,7 @@ def _get_route_details(scope: dict) -> str:
     app = scope["app"]
     route = None
 
-    for starlette_route in app.routes:
+    for starlette_route in _flatten_routes(app.routes):
         match, _ = starlette_route.matches(scope)
         if match == Match.FULL:
             route = starlette_route.path

--- a/python/ray/llm/tests/serve/cpu/observability/test_metrics_middleware.py
+++ b/python/ray/llm/tests/serve/cpu/observability/test_metrics_middleware.py
@@ -1,20 +1,128 @@
 import sys
+from types import SimpleNamespace
 
 import pytest
 from fastapi import APIRouter, FastAPI
+from starlette.routing import Match
 
+from ray.llm._internal.serve.observability.metrics import middleware
 from ray.llm._internal.serve.observability.metrics.middleware import (
+    _flatten_routes,
     _get_route_details,
 )
 
 
-def _build_app() -> FastAPI:
-    """FastAPI app with a top-level route and routes added via include_router().
+class _FakeRouteContext:
+    """Stand-in for a FastAPI route context: ``matches()`` + templated ``path``."""
 
-    FastAPI 0.137 wraps the included routes in ``_IncludedRouter`` nodes that have
-    no ``path`` attribute, which used to make ``_get_route_details`` raise
-    ``AttributeError``.
+    def __init__(self, path: str, match: Match = Match.FULL):
+        self.path = path
+        self._match = match
+
+    def matches(self, scope: dict):
+        return self._match, {}
+
+
+class _FakeIncludedRouter:
+    """Stand-in for ``fastapi.routing._IncludedRouter`` (FastAPI 0.137+).
+
+    Like the real node it exposes ``effective_route_contexts()`` and crucially has
+    no ``path`` attribute, so reading ``route.path`` on it raises ``AttributeError``
+    (the regression this middleware works around).
     """
+
+    def __init__(self, contexts):
+        self._contexts = list(contexts)
+
+    def effective_route_contexts(self):
+        return list(self._contexts)
+
+
+def _http_scope(app, method: str, path: str) -> dict:
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+        "app": app,
+        "path_params": {},
+        "root_path": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Version-independent coverage of the FastAPI 0.137+ _IncludedRouter handling.
+#
+# The LLM test lockfile pins fastapi==0.133.0, where include_router() flattens
+# routes directly (no _IncludedRouter), so a real FastAPI app cannot exercise
+# the flattening branches in CI. These tests inject the 0.137 route shape and
+# pin ``iter_route_contexts`` so every branch of _flatten_routes runs regardless
+# of the installed FastAPI version.
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_routes_expands_included_router_via_fallback(monkeypatch):
+    # FastAPI 0.137.0/0.137.1: no public helper, fall back to the private
+    # effective_route_contexts() on the _IncludedRouter node.
+    monkeypatch.setattr(middleware, "iter_route_contexts", None)
+
+    item_ctx = _FakeRouteContext("/api/items/{item_id}")
+    included = _FakeIncludedRouter([item_ctx])
+    plain = _FakeRouteContext("/health")
+
+    assert list(_flatten_routes([included, plain])) == [item_ctx, plain]
+
+
+def test_flatten_routes_uses_public_iter_route_contexts_when_available(monkeypatch):
+    # FastAPI >= 0.137.2: delegate to the public iter_route_contexts() helper.
+    flattened = [object(), object()]
+    seen = {}
+
+    def fake_iter_route_contexts(routes):
+        seen["routes"] = routes
+        yield from flattened
+
+    monkeypatch.setattr(middleware, "iter_route_contexts", fake_iter_route_contexts)
+
+    routes = [object()]
+    assert list(_flatten_routes(routes)) == flattened
+    assert seen["routes"] is routes
+
+
+@pytest.mark.parametrize("match", [Match.FULL, Match.PARTIAL])
+def test_get_route_details_resolves_included_router_path(monkeypatch, match):
+    # An included route (full or partial match) must resolve to its templated
+    # path instead of raising AttributeError on the _IncludedRouter node.
+    monkeypatch.setattr(middleware, "iter_route_contexts", None)
+
+    included = _FakeIncludedRouter([_FakeRouteContext("/api/items/{item_id}", match)])
+    app = SimpleNamespace(routes=[included])
+
+    assert (
+        _get_route_details(_http_scope(app, "GET", "/api/items/123"))
+        == "/api/items/{item_id}"
+    )
+
+
+def test_get_route_details_returns_none_when_no_route_matches(monkeypatch):
+    monkeypatch.setattr(middleware, "iter_route_contexts", None)
+
+    included = _FakeIncludedRouter(
+        [_FakeRouteContext("/api/items/{item_id}", Match.NONE)]
+    )
+    app = SimpleNamespace(routes=[included])
+
+    assert _get_route_details(_http_scope(app, "GET", "/nope")) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration check against a real FastAPI app on the installed version. On
+# FastAPI < 0.137 this exercises the plain-route path; on >= 0.137 it also
+# covers the real _IncludedRouter flattening end to end.
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
     app = FastAPI()
 
     @app.get("/health")
@@ -31,40 +139,22 @@ def _build_app() -> FastAPI:
     return app
 
 
-def _http_scope(app: FastAPI, method: str, path: str) -> dict:
-    return {
-        "type": "http",
-        "method": method,
-        "path": path,
-        "headers": [],
-        "app": app,
-        "path_params": {},
-        "root_path": "",
-    }
-
-
 @pytest.mark.parametrize(
     ("method", "path", "expected"),
     [
-        # Routes added via include_router() must resolve to their templated path
-        # rather than raising AttributeError on FastAPI >= 0.137 (_IncludedRouter).
         ("GET", "/api/items/123", "/api/items/{item_id}"),
-        # A partial match (path matches, method does not) must also be handled.
         ("OPTIONS", "/api/items/123", "/api/items/{item_id}"),
-        # Top-level routes keep resolving as before.
         ("GET", "/health", "/health"),
     ],
 )
-def test_get_route_details_resolves_templated_path(method, path, expected):
+def test_get_route_details_real_app(method, path, expected):
     app = _build_app()
-    scope = _http_scope(app, method, path)
-    assert _get_route_details(scope) == expected
+    assert _get_route_details(_http_scope(app, method, path)) == expected
 
 
-def test_get_route_details_returns_none_when_no_route_matches():
+def test_get_route_details_real_app_no_match():
     app = _build_app()
-    scope = _http_scope(app, "GET", "/does-not-exist")
-    assert _get_route_details(scope) is None
+    assert _get_route_details(_http_scope(app, "GET", "/does-not-exist")) is None
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/observability/test_metrics_middleware.py
+++ b/python/ray/llm/tests/serve/cpu/observability/test_metrics_middleware.py
@@ -1,0 +1,71 @@
+import sys
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from ray.llm._internal.serve.observability.metrics.middleware import (
+    _get_route_details,
+)
+
+
+def _build_app() -> FastAPI:
+    """FastAPI app with a top-level route and routes added via include_router().
+
+    FastAPI 0.137 wraps the included routes in ``_IncludedRouter`` nodes that have
+    no ``path`` attribute, which used to make ``_get_route_details`` raise
+    ``AttributeError``.
+    """
+    app = FastAPI()
+
+    @app.get("/health")
+    def health() -> str:
+        return "ok"
+
+    router = APIRouter()
+
+    @router.get("/items/{item_id}")
+    def get_item(item_id: str) -> str:
+        return item_id
+
+    app.include_router(router, prefix="/api")
+    return app
+
+
+def _http_scope(app: FastAPI, method: str, path: str) -> dict:
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+        "app": app,
+        "path_params": {},
+        "root_path": "",
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected"),
+    [
+        # Routes added via include_router() must resolve to their templated path
+        # rather than raising AttributeError on FastAPI >= 0.137 (_IncludedRouter).
+        ("GET", "/api/items/123", "/api/items/{item_id}"),
+        # A partial match (path matches, method does not) must also be handled.
+        ("OPTIONS", "/api/items/123", "/api/items/{item_id}"),
+        # Top-level routes keep resolving as before.
+        ("GET", "/health", "/health"),
+    ],
+)
+def test_get_route_details_resolves_templated_path(method, path, expected):
+    app = _build_app()
+    scope = _http_scope(app, method, path)
+    assert _get_route_details(scope) == expected
+
+
+def test_get_route_details_returns_none_when_no_route_matches():
+    app = _build_app()
+    scope = _http_scope(app, "GET", "/does-not-exist")
+    assert _get_route_details(scope) is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
FastAPI 0.137 wraps routes added via `include_router()` in `_IncludedRouter` objects that have no `path` attribute. The Serve LLM metrics middleware's `_get_route_details()` read `route.path` unconditionally while walking `app.routes`, so every request to an included route raised `AttributeError: '_IncludedRouter' object has no attribute 'path'` and returned HTTP 500.

This flattens the routes before matching via a `_flatten_routes()` helper — FastAPI's public `iter_route_contexts()` on >= 0.137.2, falling back to the private `effective_route_contexts()` on 0.137.0/0.137.1 and to plain routes on older FastAPI. It fixes the crash and recovers the real templated route name (e.g. `/api/items/{item_id}`) for the metric handler tag. Adds a unit test.

## Related issues
Closes #64245

## Additional information
Verified the fix resolves the crash and returns the templated path on FastAPI 0.137.2 (public path), 0.137.0/0.137.1 (private fallback), and pre-0.137 (plain routes).