### PR TITLE
[data][ci][docs] skipping loading-data test

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -847,6 +847,7 @@ Ray Data interoperates with PyTorch and TensorFlow datasets.
             function with small datasets like MNIST or CIFAR.
 
         .. testcode::
+            :skipif: True
 
             import ray
             import tensorflow_datasets as tfds


### PR DESCRIPTION
Skipping last cifar dataset download in docs. CIFAR dataset download endpoint is not reliable and causes timeouts in CI

Postmerge run: https://buildkite.com/ray-project/postmerge/builds/18158/canvas
