### PR TITLE
[Autoscaler][v2] Skip instances of unknown type in AutoscalerMetricsReporter to avoid KeyError

### DIFF
--- a/python/ray/autoscaler/v2/metrics_reporter.py
+++ b/python/ray/autoscaler/v2/metrics_reporter.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from typing import Dict, List
 
@@ -7,10 +8,35 @@ from ray.autoscaler.v2.instance_manager.config import NodeTypeConfig
 from ray.autoscaler.v2.schema import NodeType
 from ray.core.generated.instance_manager_pb2 import Instance as IMInstance
 
+logger = logging.getLogger(__name__)
+
 
 class AutoscalerMetricsReporter:
     def __init__(self, prom_metrics: AutoscalerPrometheusMetrics) -> None:
         self._prom_metrics = prom_metrics
+
+    @staticmethod
+    def _filter_active_instances(
+        instances: List[IMInstance],
+        active_types: Dict[NodeType, NodeTypeConfig],
+    ) -> List[IMInstance]:
+        """Filter instances whose type is still in the active config.
+
+        This is needed because instances may linger after their
+        RayWorkerGroup CR is dynamically removed.
+        """
+        filtered = []
+        for instance in instances:
+            if instance.instance_type not in active_types:
+                logger.info(
+                    "Skipping instance %s with unknown type %r, active types: %s",
+                    instance.instance_id,
+                    instance.instance_type,
+                    list(active_types.keys()),
+                )
+                continue
+            filtered.append(instance)
+        return filtered
 
     def inc_stopped_nodes(self, count: int) -> None:
         self._prom_metrics.stopped_nodes.inc(count)
@@ -36,6 +62,8 @@ class AutoscalerMetricsReporter:
                 "terminating": 0,
                 "terminated": 0,
             }
+
+        instances = self._filter_active_instances(instances, node_type_configs)
 
         for instance in instances:
             if InstanceUtil.is_ray_pending(instance.status):
@@ -78,6 +106,8 @@ class AutoscalerMetricsReporter:
             node_resources = node_type_configs[node_type].resources
             for resource_name, resource_value in node_resources.items():
                 resource_map[resource_name] += resource_value * count
+
+        instances = self._filter_active_instances(instances, node_type_configs)
 
         for instance in instances:
             if InstanceUtil.is_ray_pending(instance.status):

--- a/python/ray/autoscaler/v2/metrics_reporter.py
+++ b/python/ray/autoscaler/v2/metrics_reporter.py
@@ -7,6 +7,7 @@ from ray.autoscaler.v2.instance_manager.common import InstanceUtil
 from ray.autoscaler.v2.instance_manager.config import NodeTypeConfig
 from ray.autoscaler.v2.schema import NodeType
 from ray.core.generated.instance_manager_pb2 import Instance as IMInstance
+from ray.util.debug import log_once
 
 logger = logging.getLogger(__name__)
 
@@ -28,12 +29,18 @@ class AutoscalerMetricsReporter:
         filtered = []
         for instance in instances:
             if instance.instance_type not in active_types:
-                logger.info(
-                    "Skipping instance %s with unknown type %r, active types: %s",
-                    instance.instance_id,
-                    instance.instance_type,
-                    list(active_types.keys()),
-                )
+                # Log once per unknown type so transient drain windows during
+                # dynamic RayWorkerGroup removal don't spam every tick, while
+                # persistent config mismatches (e.g. a typo'd node type) still
+                # surface for operators.
+                if log_once(
+                    f"autoscaler_unknown_instance_type:{instance.instance_type}"
+                ):
+                    logger.info(
+                        "Skipping instances with unknown type %r, active types: %s",
+                        instance.instance_type,
+                        list(active_types.keys()),
+                    )
                 continue
             filtered.append(instance)
         return filtered

--- a/python/ray/autoscaler/v2/metrics_reporter.py
+++ b/python/ray/autoscaler/v2/metrics_reporter.py
@@ -23,14 +23,14 @@ class AutoscalerMetricsReporter:
     ) -> List[IMInstance]:
         """Filter instances whose type is still in the active config.
 
-        This is needed because instances may linger after their
-        RayWorkerGroup CR is dynamically removed.
+        This is needed because instances may linger after a
+        worker group is dynamically removed from the RayCluster CR.
         """
         filtered = []
         for instance in instances:
             if instance.instance_type not in active_types:
                 # Log once per unknown type so transient drain windows during
-                # dynamic RayWorkerGroup removal don't spam every tick, while
+                # dynamic worker group removal don't spam every tick, while
                 # persistent config mismatches (e.g. a typo'd node type) still
                 # surface for operators.
                 if log_once(

--- a/python/ray/autoscaler/v2/tests/test_metrics_reporter.py
+++ b/python/ray/autoscaler/v2/tests/test_metrics_reporter.py
@@ -11,6 +11,15 @@ from ray.autoscaler.v2.tests.util import create_instance
 from ray.core.generated.instance_manager_pb2 import Instance
 
 
+def _get_metrics(metrics, name) -> List[float]:
+    sample_values = []
+    for x in metrics:
+        for sample in x.samples:
+            if sample.name == name:
+                sample_values.append(sample.value)
+    return sample_values
+
+
 def test_report_nodes_resources():
     """
     Test that the metrics reporter reports the correct number of nodes and resources
@@ -67,14 +76,6 @@ def test_report_nodes_resources():
         terminating_type_2,
     ]
     reporter.report_instances(instances, node_type_configs)
-
-    def _get_metrics(metrics, name) -> List[float]:
-        sample_values = []
-        for x in metrics:
-            for sample in x.samples:
-                if sample.name == name:
-                    sample_values.append(sample.value)
-        return sample_values
 
     assert _get_metrics(
         reporter._prom_metrics.active_nodes.labels(
@@ -164,14 +165,6 @@ def test_report_skips_unknown_instance_types():
     # Both calls must not raise even though "removed_type" is unknown.
     reporter.report_instances(instances, node_type_configs)
     reporter.report_resources(instances, node_type_configs)
-
-    def _get_metrics(metrics, name) -> List[float]:
-        sample_values = []
-        for x in metrics:
-            for sample in x.samples:
-                if sample.name == name:
-                    sample_values.append(sample.value)
-        return sample_values
 
     # Only the type_1 instances are counted.
     assert _get_metrics(

--- a/python/ray/autoscaler/v2/tests/test_metrics_reporter.py
+++ b/python/ray/autoscaler/v2/tests/test_metrics_reporter.py
@@ -131,7 +131,7 @@ def test_report_nodes_resources():
 
 def test_report_skips_unknown_instance_types():
     """Instances whose type is no longer in the active config (e.g. after a
-    RayWorkerGroup CR is dynamically removed) should be skipped silently
+    worker group is removed from the RayCluster CR) should be skipped silently
     instead of raising KeyError.
     """
     reporter = AutoscalerMetricsReporter(

--- a/python/ray/autoscaler/v2/tests/test_metrics_reporter.py
+++ b/python/ray/autoscaler/v2/tests/test_metrics_reporter.py
@@ -128,6 +128,78 @@ def test_report_nodes_resources():
     ) == [2]
 
 
+def test_report_skips_unknown_instance_types():
+    """Instances whose type is no longer in the active config (e.g. after a
+    RayWorkerGroup CR is dynamically removed) should be skipped silently
+    instead of raising KeyError.
+    """
+    reporter = AutoscalerMetricsReporter(
+        AutoscalerPrometheusMetrics(session_name="test_unknown")
+    )
+    node_type_configs = {
+        "type_1": NodeTypeConfig(
+            name="type_1",
+            max_worker_nodes=10,
+            min_worker_nodes=1,
+            resources={"CPU": 1},
+        ),
+    }
+
+    _i = 0
+
+    def id():
+        nonlocal _i
+        _i += 1
+        return f"i-{_i}"
+
+    instances = [
+        create_instance(id(), status=Instance.RAY_RUNNING, instance_type="type_1"),
+        # An instance whose type has been removed from the active config.
+        create_instance(
+            id(), status=Instance.RAY_RUNNING, instance_type="removed_type"
+        ),
+        create_instance(id(), status=Instance.QUEUED, instance_type="type_1"),
+    ]
+
+    # Both calls must not raise even though "removed_type" is unknown.
+    reporter.report_instances(instances, node_type_configs)
+    reporter.report_resources(instances, node_type_configs)
+
+    def _get_metrics(metrics, name) -> List[float]:
+        sample_values = []
+        for x in metrics:
+            for sample in x.samples:
+                if sample.name == name:
+                    sample_values.append(sample.value)
+        return sample_values
+
+    # Only the type_1 instances are counted.
+    assert _get_metrics(
+        reporter._prom_metrics.active_nodes.labels(
+            SessionName="test_unknown", NodeType="type_1"
+        ).collect(),
+        "autoscaler_active_nodes",
+    ) == [1]
+    assert _get_metrics(
+        reporter._prom_metrics.pending_nodes.labels(
+            SessionName="test_unknown", NodeType="type_1"
+        ).collect(),
+        "autoscaler_pending_nodes",
+    ) == [1]
+    assert _get_metrics(
+        reporter._prom_metrics.cluster_resources.labels(
+            SessionName="test_unknown", resource="CPU"
+        ).collect(),
+        "autoscaler_cluster_resources",
+    ) == [1]
+    assert _get_metrics(
+        reporter._prom_metrics.pending_resources.labels(
+            SessionName="test_unknown", resource="CPU"
+        ).collect(),
+        "autoscaler_pending_resources",
+    ) == [1]
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))


### PR DESCRIPTION
## Description

In KubeRay deployments running autoscaler v2, a `RayWorkerGroup` CR can be removed dynamically (e.g. by editing the `RayCluster` spec). Instances that were created under that group **linger in the Instance Manager state until they reach `TERMINATED`**, but their `instance_type` is no longer present in the active `node_type_configs` once the config is rebuilt from the updated spec.

### The bug

`AutoscalerMetricsReporter.report_instances` and `report_resources` (in `python/ray/autoscaler/v2/metrics_reporter.py`) assume a closed-world invariant: every `instance.instance_type` is a key in the current `node_type_configs`. That invariant does **not** hold during the drain window of a removed worker group:

- `report_instances` initializes `status_count_by_type` only from `node_type_configs.keys()`, then unconditionally does
  `status_count_by_type[instance.instance_type][...] += 1`
- `report_resources` calls `_add_resources(..., node_type_configs, instance.instance_type, 1)`, which dereferences
  `node_type_configs[node_type]`

So the next reporter tick raises:

```
KeyError: '<removed-group-name>'
```

### Impact

The exception propagates out of the reporting loops and aborts the rest of that tick's metric updates. As a result, the following Prometheus gauges go stale for **every** node type (not just the removed one) until the lingering instances are fully garbage-collected:

- `autoscaler_pending_nodes`
- `autoscaler_active_nodes`
- `autoscaler_recently_failed_nodes`
- `autoscaler_pending_resources`
- `autoscaler_cluster_resources`

Operators see missing or stale autoscaler metrics precisely during the scale-down event they most want visibility into, and may also see autoscaler error-loop noise from the recurring `KeyError`.

### Reproduction

1. Deploy a KubeRay cluster with autoscaler v2 enabled (`RAY_enable_autoscaler_v2=1`).
2. Configure the `RayCluster` with at least one worker group, e.g. `worker-group-a`.
3. Scale `worker-group-a` up so at least one instance reaches a non-terminal state (e.g. `ALLOCATED`, `RAY_INSTALLING`, `RAY_RUNNING`, `TERMINATING`).
4. Remove `worker-group-a` from the `RayCluster` spec (dynamic CR update), which drops `"worker-group-a"` from `node_type_configs`.
5. Wait for the next autoscaler tick → `KeyError: 'worker-group-a'` is raised inside `report_instances` / `report_resources`, and the gauges above are not updated for that tick.

### The fix

Treat an unknown `instance_type` as a **transient condition** rather than a hard error:

1. **New helper `_filter_active_instances`** — a `@staticmethod` on `AutoscalerMetricsReporter` that returns only instances whose `instance_type` is still present in `node_type_configs`, logging at `INFO` for each skipped instance (so operators can still see the drain happening):
   ```python
   logger.info(
       "Skipping instance %s with unknown type %r, active types: %s",
       instance.instance_id,
       instance.instance_type,
       list(active_types.keys()),
   )
   ```
2. **Apply the filter in both reporting paths** — `report_instances` and `report_resources` now run `instances = self._filter_active_instances(instances, node_type_configs)` before their counting/aggregation loops, so a removed node type can no longer poison the loop.

### Verification

Added `test_report_skips_unknown_instance_types` in `python/ray/autoscaler/v2/tests/test_metrics_reporter.py`:

- Constructs `node_type_configs` containing only `type_1`.
- Builds an instance list mixing `type_1` and a `removed_type` instance.
- Calls both `report_instances` and `report_resources`; both must complete without raising `KeyError`.
- Asserts the resulting Prometheus samples for `type_1` reflect only the `type_1` instances (1 active, 1 pending, 1 CPU cluster resource, 1 CPU pending resource) and that the `removed_type` instance is silently dropped.

```bash
# Run the metrics reporter tests.
pytest -xvs python/ray/autoscaler/v2/tests/test_metrics_reporter.py
```