### PR TITLE
[serve] Add haproxy system metrics reporting

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1015,6 +1015,9 @@ if RAY_SERVE_ENABLE_HA_PROXY:
         )
     DEFAULT_HTTP_HOST = get_all_interfaces_ip()
 
+if RAY_SERVE_INGRESS_REQUEST_ROUTER_METRICS_ENABLED:
+    RAY_SERVE_HAPROXY_METRICS_ENABLED = True
+
 # Feature flag to aggregate metrics at the controller instead of the replicas or handles.
 RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER = get_env_bool(
     "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER", "0"

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -763,6 +763,17 @@ RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S = get_env_float_non_negative(
 # from the first coalesced controller broadcast to the HAProxy reload finishing.
 RAY_SERVE_HAPROXY_UPDATE_LATENCY_BUCKETS_S = [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30]
 
+# Controls whether HAProxy system metrics are reported. On by default.
+RAY_SERVE_HAPROXY_METRICS_ENABLED = get_env_bool(
+    "RAY_SERVE_HAPROXY_METRICS_ENABLED", "1"
+)
+
+# How often (seconds) each HAProxyManager samples and emits node-level HAProxy
+# observability gauges (process count and broadcasted-vs-reported target mismatch).
+RAY_SERVE_HAPROXY_METRICS_REPORT_INTERVAL_S = get_env_float_non_negative(
+    "RAY_SERVE_HAPROXY_METRICS_REPORT_INTERVAL_S", 10.0
+)
+
 # HAProxy metrics export port
 RAY_SERVE_HAPROXY_METRICS_PORT = int(
     os.environ.get("RAY_SERVE_HAPROXY_METRICS_PORT", "9101")

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -819,7 +819,7 @@ class HAProxyApi(ProxyApi):
             if entry.isdigit() and self._is_our_haproxy(int(entry))
         )
 
-    async def _compute_target_mismatch(self) -> int:
+    async def compute_target_mismatch(self) -> int:
         """Cardinality of the mismatch between the controller's broadcasted
         targets and the targets HAProxy actually reports in its stats.
 

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -50,7 +50,9 @@ from ray.serve._private.constants import (
     RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S,
     RAY_SERVE_HAPROXY_LOG_TARGET,
     RAY_SERVE_HAPROXY_MAXCONN,
+    RAY_SERVE_HAPROXY_METRICS_ENABLED,
     RAY_SERVE_HAPROXY_METRICS_PORT,
+    RAY_SERVE_HAPROXY_METRICS_REPORT_INTERVAL_S,
     RAY_SERVE_HAPROXY_METRICS_SOCKET_PATH,
     RAY_SERVE_HAPROXY_NBTHREAD,
     RAY_SERVE_HAPROXY_RETRIES,
@@ -88,6 +90,7 @@ from ray.serve.schema import (
     TargetGroup,
 )
 from ray.util import metrics
+
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -799,6 +802,47 @@ class HAProxyApi(ProxyApi):
         except OSError:
             return False
 
+    def count_haproxy_processes(self) -> int:
+        """Number of HAProxy processes on the node belonging to this manager.
+
+        Scans /proc for processes whose cmdline references our config file, so
+        the count spans the live worker, draining workers from prior reloads,
+        and any leaked/orphaned workers — making it a signal for process leaks.
+        Returns 0 on non-Linux / no-/proc platforms where /proc is unavailable.
+        """
+        try:
+            entries = os.listdir("/proc")
+        except OSError:
+            return 0
+        return sum(
+            1
+            for entry in entries
+            if entry.isdigit() and self._is_our_haproxy(int(entry))
+        )
+    
+    async def _compute_target_mismatch(self) -> int:
+        """Cardinality of the mismatch between the controller's broadcasted
+        targets and the targets HAProxy actually reports in its stats.
+
+        Broadcasted targets are the (backend, server) pairs the controller asked
+        this proxy to configure; reported targets are the (backend, server) pairs
+        present in HAProxy's live stats. The result is the symmetric difference,
+        so it counts both targets not yet applied to HAProxy and stale targets
+        HAProxy still reports.
+        """
+        expected = {
+            (backend_name, server.name)
+            for backend_name, backend_config in self.backend_configs.items()
+            for server in backend_config.servers
+        }
+        stats = await self._haproxy_api.get_all_stats()
+        reported = {
+            (backend_name, server_name)
+            for backend_name, servers in stats.items()
+            for server_name in servers
+        }
+        return len(expected ^ reported)
+
     def _retire_log_files(self, proc: asyncio.subprocess.Process) -> None:
         """Move an exited proc's std-stream logs into the bounded debug ring,
         deleting the oldest pair once the ring exceeds its cap. Only call this
@@ -1425,33 +1469,32 @@ class HAProxyManager(ProxyActorInterface):
             config_file_path=_per_node(RAY_SERVE_HAPROXY_CONFIG_FILE_LOC),
         )
 
-        # Start the metrics collector for the ingress request router. The
-        # collector owns its own dgram socket and transport lifecycle; we
-        # only hold a reference so we can close it on shutdown.
-        self._metrics_collector: Optional["HAProxyMetricsCollector"] = None
-        self._metrics_attach_task: Optional[asyncio.Task] = None
-        if self._haproxy.cfg.ingress_request_router_metrics_enabled:
+        if RAY_SERVE_HAPROXY_METRICS_ENABLED:
             from ray.serve._private.haproxy_metrics import HAProxyMetricsCollector
-
+            # The metrics collector owns all serve_haproxy_* metrics for this proxy.
+            # It is constructed if haproxy metrics are enabled. start() always begins
+            # node-level polling and, when ingress-request-router metrics are enabled,
+            # also binds the per-request dgram reader and returns its bind task (which
+            # ready() awaits to surface bind failures).
+            self._metrics_collector = HAProxyMetricsCollector(
+                haproxy_api=self._haproxy, node_id=self._node_id
+            )
+            self._metrics_attach_task: Optional[asyncio.Task] = None
             try:
-                os.makedirs(
-                    os.path.dirname(self._haproxy.cfg.metrics_socket_path),
-                    exist_ok=True,
-                )
-                self._metrics_collector = HAProxyMetricsCollector()
-                self._metrics_attach_task = self.event_loop.create_task(
-                    self._metrics_collector.bind_and_attach(
-                        self._haproxy.cfg.metrics_socket_path,
-                        loop=self.event_loop,
-                    )
+                self._metrics_attach_task = self._metrics_collector.start(
+                    self.event_loop,
+                    poll_interval_s=RAY_SERVE_HAPROXY_METRICS_REPORT_INTERVAL_S,
+                    enable_ingress_router_metrics=(
+                        self._haproxy.cfg.ingress_request_router_metrics_enabled
+                    ),
+                    metrics_socket_path=self._haproxy.cfg.metrics_socket_path,
                 )
             except Exception:
                 logger.exception(
-                    "Failed to construct ingress-request-router metrics "
-                    "collector; metrics will not be emitted. HAProxy will "
-                    "continue normally."
+                    "Failed to start the ingress-request-router datagram reader; "
+                    "per-request router metrics will not be emitted. Node-level "
+                    "metrics and HAProxy continue normally."
                 )
-                self._metrics_collector = None
 
         self._haproxy_start_task = self.event_loop.create_task(self._haproxy.start())
 
@@ -1493,13 +1536,13 @@ class HAProxyManager(ProxyActorInterface):
                 try:
                     await self._metrics_attach_task
                 except Exception:
+                    # Only the dgram reader failed. Leave the collector intact
+                    # so node-level gauges keep polling; the socket is left
+                    # unbound (bind_and_attach is safe to have failed).
                     logger.exception(
                         "Failed to bind/attach metrics dgram reader; "
-                        "metrics will not be drained."
+                        "per-request router metrics will not be drained."
                     )
-                    if self._metrics_collector is not None:
-                        self._metrics_collector.close()
-                        self._metrics_collector = None
         except Exception as e:
             logger.exception("Failed to start HAProxy.")
             raise e from None

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -801,21 +801,6 @@ class HAProxyApi(ProxyApi):
         except OSError:
             return False
 
-    @staticmethod
-    def _comm_is_haproxy(pid: int) -> bool:
-        """Whether `pid`'s process name is `haproxy`, read from /proc/<pid>/comm.
-
-        `comm` is a single short line (kernel-truncated to 15 chars, so the
-        7-char "haproxy" is never clipped), making it far cheaper to read than
-        the full cmdline. Used to skip the cmdline check for the many PIDs that
-        obviously aren't HAProxy. Returns False on any /proc read error.
-        """
-        try:
-            with open(f"/proc/{pid}/comm", "rb") as f:
-                return f.read().strip() == b"haproxy"
-        except OSError:
-            return False
-
     def count_haproxy_processes(self) -> int:
         """Number of HAProxy processes on the node belonging to this manager.
 
@@ -823,22 +808,18 @@ class HAProxyApi(ProxyApi):
         the count spans the live worker, draining workers from prior reloads,
         and any leaked/orphaned workers — making it a signal for process leaks.
         Returns 0 on non-Linux / no-/proc platforms where /proc is unavailable.
-
-        Pre-filters on the cheap /proc/<pid>/comm name so the more expensive
-        cmdline match in `_is_our_haproxy` runs only for the handful of PIDs
-        actually named "haproxy", not for every process on the node.
         """
         try:
             entries = os.listdir("/proc")
         except OSError:
             return 0
-        return sum(
-            1
+
+        processes = {
+            entry
             for entry in entries
-            if entry.isdigit()
-            and self._comm_is_haproxy(int(entry))
-            and self._is_our_haproxy(int(entry))
-        )
+            if entry.isdigit() and self._is_our_haproxy(int(entry))
+        }
+        return len(processes)
 
     async def compute_target_mismatch(self) -> int:
         """Cardinality of the mismatch between the controller's broadcasted

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -801,6 +801,21 @@ class HAProxyApi(ProxyApi):
         except OSError:
             return False
 
+    @staticmethod
+    def _comm_is_haproxy(pid: int) -> bool:
+        """Whether `pid`'s process name is `haproxy`, read from /proc/<pid>/comm.
+
+        `comm` is a single short line (kernel-truncated to 15 chars, so the
+        7-char "haproxy" is never clipped), making it far cheaper to read than
+        the full cmdline. Used to skip the cmdline check for the many PIDs that
+        obviously aren't HAProxy. Returns False on any /proc read error.
+        """
+        try:
+            with open(f"/proc/{pid}/comm", "rb") as f:
+                return f.read().strip() == b"haproxy"
+        except OSError:
+            return False
+
     def count_haproxy_processes(self) -> int:
         """Number of HAProxy processes on the node belonging to this manager.
 
@@ -808,6 +823,10 @@ class HAProxyApi(ProxyApi):
         the count spans the live worker, draining workers from prior reloads,
         and any leaked/orphaned workers — making it a signal for process leaks.
         Returns 0 on non-Linux / no-/proc platforms where /proc is unavailable.
+
+        Pre-filters on the cheap /proc/<pid>/comm name so the more expensive
+        cmdline match in `_is_our_haproxy` runs only for the handful of PIDs
+        actually named "haproxy", not for every process on the node.
         """
         try:
             entries = os.listdir("/proc")
@@ -816,7 +835,9 @@ class HAProxyApi(ProxyApi):
         return sum(
             1
             for entry in entries
-            if entry.isdigit() and self._is_our_haproxy(int(entry))
+            if entry.isdigit()
+            and self._comm_is_haproxy(int(entry))
+            and self._is_our_haproxy(int(entry))
         )
 
     async def compute_target_mismatch(self) -> int:

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -91,7 +91,6 @@ from ray.serve.schema import (
 )
 from ray.util import metrics
 
-
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
@@ -819,7 +818,7 @@ class HAProxyApi(ProxyApi):
             for entry in entries
             if entry.isdigit() and self._is_our_haproxy(int(entry))
         )
-    
+
     async def _compute_target_mismatch(self) -> int:
         """Cardinality of the mismatch between the controller's broadcasted
         targets and the targets HAProxy actually reports in its stats.
@@ -1471,6 +1470,7 @@ class HAProxyManager(ProxyActorInterface):
 
         if RAY_SERVE_HAPROXY_METRICS_ENABLED:
             from ray.serve._private.haproxy_metrics import HAProxyMetricsCollector
+
             # The metrics collector owns all serve_haproxy_* metrics for this proxy.
             # It is constructed if haproxy metrics are enabled. start() always begins
             # node-level polling and, when ingress-request-router metrics are enabled,

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -829,11 +829,16 @@ class HAProxyApi(ProxyApi):
         so it counts both targets not yet applied to HAProxy and stale targets
         HAProxy still reports.
         """
-        expected = {
-            (backend_name, server.name)
-            for backend_name, backend_config in self.backend_configs.items()
-            for server in backend_config.servers
-        }
+        expected = set()
+        for backend_name, backend_config in self.backend_configs.items():
+            for server in backend_config.servers:
+                expected.add((backend_name, server.name))
+            # The generated config also renders the fallback server as a real
+            # `server ... backup` line in the same backend, so it appears in
+            # get_all_stats; count it as expected or the gauge never converges
+            # to zero for backends that have a fallback.
+            if backend_config.fallback_server is not None:
+                expected.add((backend_name, backend_config.fallback_server.name))
         stats = await self.get_all_stats()
         reported = {
             (backend_name, server_name)

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -839,6 +839,12 @@ class HAProxyApi(ProxyApi):
             # to zero for backends that have a fallback.
             if backend_config.fallback_server is not None:
                 expected.add((backend_name, backend_config.fallback_server.name))
+
+        # Note that if an entire backend scaled down (when an app is removed),
+        # get_all_stats will filter out that entire backend, so there could be
+        # stale servers in that haproxy backend but not reported by this metric.
+        # This case is rare and not really something we worry about since requests
+        # shouldn't be hitting that backend or should return errors anyways.
         stats = await self.get_all_stats()
         reported = {
             (backend_name, server_name)

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1468,6 +1468,8 @@ class HAProxyManager(ProxyActorInterface):
             config_file_path=_per_node(RAY_SERVE_HAPROXY_CONFIG_FILE_LOC),
         )
 
+        self._metrics_collector = None
+        self._metrics_attach_task: Optional[asyncio.Task] = None
         if RAY_SERVE_HAPROXY_METRICS_ENABLED:
             from ray.serve._private.haproxy_metrics import HAProxyMetricsCollector
 
@@ -1479,7 +1481,6 @@ class HAProxyManager(ProxyActorInterface):
             self._metrics_collector = HAProxyMetricsCollector(
                 haproxy_api=self._haproxy, node_id=self._node_id
             )
-            self._metrics_attach_task: Optional[asyncio.Task] = None
             try:
                 self._metrics_attach_task = self._metrics_collector.start(
                     self.event_loop,

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -834,7 +834,7 @@ class HAProxyApi(ProxyApi):
             for backend_name, backend_config in self.backend_configs.items()
             for server in backend_config.servers
         }
-        stats = await self._haproxy_api.get_all_stats()
+        stats = await self.get_all_stats()
         reported = {
             (backend_name, server_name)
             for backend_name, servers in stats.items()

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -92,8 +92,7 @@ class HAProxyMetricsCollector:
         self._transport: Optional[asyncio.DatagramTransport] = None
         self._socket_path: Optional[str] = None
 
-        # Used by the node-level poll loop; optional so unit tests can drive
-        # the push-based parsing/recording without an HAProxyApi.
+        # Source for the node-level poll loop (process count + target mismatch).
         self._haproxy_api = haproxy_api
         self._node_id = node_id
         self._node_metrics_task: Optional[asyncio.Task] = None

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -12,10 +12,12 @@ import os
 import re
 import socket
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from ray.serve._private.haproxy import HAProxyApi
 from ray.util import metrics
+
+if TYPE_CHECKING:
+    from ray.serve._private.haproxy import HAProxyApi
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +88,7 @@ class HAProxyMetricsCollector:
 
     def __init__(
         self,
-        haproxy_api: HAProxyApi,
+        haproxy_api: "HAProxyApi",
         node_id: str,
     ) -> None:
         self._transport: Optional[asyncio.DatagramTransport] = None

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -12,9 +12,11 @@ import os
 import re
 import socket
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from ray.util import metrics
+from ray.serve._private.haproxy import HAProxyApi
+
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +52,21 @@ class ParsedMetrics:
 
 
 class HAProxyMetricsCollector:
-    """Owns the three ingress-request-router Counter / Histogram objects
-    and the dgram socket that feeds them.
+    """Owns every `serve_haproxy_*` metric for one proxy node.
 
-    Exposes `parse_line` and `record` for unit tests that want to
-    drive metrics without binding anything. `bind_and_attach` wires an
-    `AF_UNIX` dgram socket to the loop; `close` tears it down.
+    Two families of metrics live here:
+
+    - Per-request, push-based ingress-request-router metrics (Counters /
+      Histogram), fed by HAProxy datagrams. `parse_line` and `record` are
+      exposed for unit tests that want to drive these without binding
+      anything; `bind_and_attach` wires an `AF_UNIX` dgram socket to the
+      loop and `close` tears it down.
+    - Node-level, poll-based gauges (process count and broadcasted-vs-reported
+      target mismatch), sampled from an `HAProxyApi` on a periodic loop started
+      by `start_node_metrics_polling`.
+
+    The node-level gauges are always emitted; the datagram reader is only
+    bound when ingress-request-router metrics are enabled.
     """
 
     # Sub-millisecond to 1s, biased toward the expected sub-10ms range for
@@ -74,9 +85,19 @@ class HAProxyMetricsCollector:
         1000.0,
     ]
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        haproxy_api: HAProxyApi,
+        node_id: Optional[str] = None,
+    ) -> None:
         self._transport: Optional[asyncio.DatagramTransport] = None
         self._socket_path: Optional[str] = None
+
+        # Used by the node-level poll loop; optional so unit tests can drive
+        # the push-based parsing/recording without an HAProxyApi.
+        self._haproxy_api = haproxy_api
+        self._node_id = node_id
+        self._node_metrics_task: Optional[asyncio.Task] = None
 
         self.truncated_bodies_counter = metrics.Counter(
             "serve_haproxy_ingress_router_truncations",
@@ -132,6 +153,32 @@ class HAProxyMetricsCollector:
             tag_keys=("application",),
         )
 
+        # Node-level gauges, sampled by _report_node_metrics_forever.
+        self.process_count_gauge = metrics.Gauge(
+            "serve_haproxy_process_count",
+            description=(
+                "Number of HAProxy processes running on the node for this proxy, "
+                "spanning the live worker, draining workers from prior reloads, "
+                "and any leaked/orphaned workers. A value persistently above 1 "
+                "indicates HAProxy processes are not being reaped."
+            ),
+            tag_keys=("node_id",),
+        )
+        self.target_mismatch_gauge = metrics.Gauge(
+            "serve_haproxy_target_mismatch",
+            description=(
+                "Number of targets that differ between the controller's "
+                "broadcasted target set and the targets HAProxy actually reports "
+                "in its stats on this node (symmetric set difference). A non-zero "
+                "value means the HAProxy config has not yet converged to the "
+                "broadcasted targets."
+            ),
+            tag_keys=("node_id",),
+        )
+        if node_id is not None:
+            self.process_count_gauge.set_default_tags({"node_id": node_id})
+            self.target_mismatch_gauge.set_default_tags({"node_id": node_id})
+
     @staticmethod
     def parse_line(line: bytes) -> Optional[ParsedMetrics]:
         """Extract metric fields from one RFC 5424 log datagram.
@@ -176,10 +223,10 @@ class HAProxyMetricsCollector:
         """Update metrics from one parsed observation.
 
         Three disjoint cases:
-        - ``failed`` set: the Lua action set ``txn.ingress_request_router_failed``
+        - `failed` set: the Lua action set `txn.ingress_request_router_failed`
           and returned early. Bump the failures counter with the reason; no
           replica was pinned, so other metrics don't apply.
-        - ``via_router`` true: the Lua action successfully pinned a replica.
+        - `via_router` true: the Lua action successfully pinned a replica.
           Record latency, truncation, and replica-mismatch as applicable.
         - Neither: the request didn't go through the router path at all
           (no router-bearing app matched, or router state not yet pushed).
@@ -223,6 +270,60 @@ class HAProxyMetricsCollector:
                     "outcome": "failure" if parsed.failed else "success",
                 },
             )
+
+    async def _report_node_metrics_forever(self, interval_s: float) -> None:
+        """Background task to emit the node-level HAProxy observability gauges."""
+        consecutive_errors = 0
+        while True:
+            try:
+                await asyncio.sleep(interval_s)
+                self.process_count_gauge.set(
+                    self._haproxy_api.count_haproxy_processes()
+                )
+                self.target_mismatch_gauge.set(
+                    await self._haproxy_api._compute_target_mismatch()
+                )
+                consecutive_errors = 0
+            except Exception:
+                logger.exception("Unexpected error reporting HAProxy node metrics.")
+
+                # Exponential backoff starting at 1s and capping at 10s.
+                backoff_time_s = min(10, 2**consecutive_errors)
+                consecutive_errors += 1
+                await asyncio.sleep(backoff_time_s)
+
+    def start_node_metrics_polling(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        interval_s: float,
+    ) -> None:
+        """Start the periodic loop that emits the node-level gauges."""
+        if self._node_metrics_task is None:
+            self._node_metrics_task = loop.create_task(
+                self._report_node_metrics_forever(interval_s)
+            )
+
+    def start(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        poll_interval_s: float,
+        enable_ingress_router_metrics: bool,
+        metrics_socket_path: Optional[str] = None,
+    ) -> Optional[asyncio.Task]:
+        """Start all metric collection for this proxy node.
+
+        Always starts the node-level gauge poll loop. When
+        `enable_ingress_router_metrics` is set, also creates the dgram
+        socket directory and binds the per-request reader at
+        `metrics_socket_path`, returning the bind task so the caller can
+        await it (e.g. to surface bind failures at actor-readiness time).
+        Returns `None` when the dgram reader is disabled.
+        """
+        self.start_node_metrics_polling(loop, poll_interval_s)
+        if enable_ingress_router_metrics:
+            os.makedirs(os.path.dirname(metrics_socket_path), exist_ok=True)
+            return loop.create_task(self.bind_and_attach(metrics_socket_path, loop=loop))
 
     async def bind_and_attach(
         self,
@@ -268,12 +369,16 @@ class HAProxyMetricsCollector:
         self._transport = transport
 
     def close(self) -> None:
-        """Tear down the dgram transport and remove the socket file.
+        """Tear down the node-metrics loop, the dgram transport, and the
+        socket file.
 
         Safe to call multiple times; safe to call without ever having
-        bound. The metric Counter / Histogram objects survive close —
-        they are owned by Ray's metric registry, not this instance.
+        bound or started polling. The metric objects survive close — they
+        are owned by Ray's metric registry, not this instance.
         """
+        if self._node_metrics_task is not None:
+            self._node_metrics_task.cancel()
+            self._node_metrics_task = None
         if self._transport is not None:
             self._transport.close()
             self._transport = None

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -12,11 +12,10 @@ import os
 import re
 import socket
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
-from ray.util import metrics
 from ray.serve._private.haproxy import HAProxyApi
-
+from ray.util import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -323,7 +322,9 @@ class HAProxyMetricsCollector:
         self.start_node_metrics_polling(loop, poll_interval_s)
         if enable_ingress_router_metrics:
             os.makedirs(os.path.dirname(metrics_socket_path), exist_ok=True)
-            return loop.create_task(self.bind_and_attach(metrics_socket_path, loop=loop))
+            return loop.create_task(
+                self.bind_and_attach(metrics_socket_path, loop=loop)
+            )
 
     async def bind_and_attach(
         self,

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -87,7 +87,7 @@ class HAProxyMetricsCollector:
     def __init__(
         self,
         haproxy_api: HAProxyApi,
-        node_id: Optional[str] = None,
+        node_id: str,
     ) -> None:
         self._transport: Optional[asyncio.DatagramTransport] = None
         self._socket_path: Optional[str] = None
@@ -173,9 +173,8 @@ class HAProxyMetricsCollector:
             ),
             tag_keys=("node_id",),
         )
-        if node_id is not None:
-            self.process_count_gauge.set_default_tags({"node_id": node_id})
-            self.target_mismatch_gauge.set_default_tags({"node_id": node_id})
+        self.process_count_gauge.set_default_tags({"node_id": node_id})
+        self.target_mismatch_gauge.set_default_tags({"node_id": node_id})
 
     @staticmethod
     def parse_line(line: bytes) -> Optional[ParsedMetrics]:

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -14,10 +14,8 @@ import socket
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
+from ray.serve._private.haproxy import HAProxyApi
 from ray.util import metrics
-
-if TYPE_CHECKING:
-    from ray.serve._private.haproxy import HAProxyApi
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +86,7 @@ class HAProxyMetricsCollector:
 
     def __init__(
         self,
-        haproxy_api: "HAProxyApi",
+        haproxy_api: HAProxyApi,
         node_id: str,
     ) -> None:
         self._transport: Optional[asyncio.DatagramTransport] = None

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -276,9 +276,14 @@ class HAProxyMetricsCollector:
         while True:
             try:
                 await asyncio.sleep(interval_s)
-                self.process_count_gauge.set(
-                    self._haproxy_api.count_haproxy_processes()
+                # count_haproxy_processes does blocking /proc IO that scales
+                # with the node's process count; run it in a thread so the
+                # actor's event loop (health checks, reloads) isn't stalled.
+                loop = asyncio.get_running_loop()
+                count = await loop.run_in_executor(
+                    None, self._haproxy_api.count_haproxy_processes
                 )
+                self.process_count_gauge.set(count)
                 self.target_mismatch_gauge.set(
                     await self._haproxy_api.compute_target_mismatch()
                 )

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -12,7 +12,7 @@ import os
 import re
 import socket
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from ray.serve._private.haproxy import HAProxyApi
 from ray.util import metrics

--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -278,7 +278,7 @@ class HAProxyMetricsCollector:
                     self._haproxy_api.count_haproxy_processes()
                 )
                 self.target_mismatch_gauge.set(
-                    await self._haproxy_api._compute_target_mismatch()
+                    await self._haproxy_api.compute_target_mismatch()
                 )
                 consecutive_errors = 0
             except Exception:

--- a/python/ray/serve/tests/test_haproxy_metrics.py
+++ b/python/ray/serve/tests/test_haproxy_metrics.py
@@ -51,6 +51,11 @@ class _FakeHAProxyApi:
     def count_haproxy_processes(self) -> int:
         return 0
 
+    async def _compute_target_mismatch(self) -> int:
+        # Inert: the real symmetric-difference logic is covered by
+        # test_compute_target_mismatch against a real HAProxyApi.
+        return 0
+
 
 # ---------------------------------------------------------------------------
 # parse_line: pure parser tests
@@ -569,12 +574,22 @@ def _backend(name: str, server_names):
     ],
 )
 def test_compute_target_mismatch(broadcasted, reported, expected_mismatch) -> None:
-    api = _FakeHAProxyApi(
-        backend_configs={"http-app": _backend("http-app", broadcasted)},
-        stats={"http-app": {name: object() for name in reported}},
-    )
-    collector = HAProxyMetricsCollector(haproxy_api=api)
-    assert asyncio.run(collector._compute_target_mismatch()) == expected_mismatch
+    # _compute_target_mismatch lives on HAProxyApi (it reads backend_configs and
+    # get_all_stats), so exercise the real method with a stubbed stats source.
+    from ray.serve._private.haproxy import HAProxyApi, HAProxyConfig
+
+    with tempfile.TemporaryDirectory() as td:
+        api = HAProxyApi(
+            cfg=HAProxyConfig(socket_path=os.path.join(td, "admin.sock")),
+            backend_configs={"http-app": _backend("http-app", broadcasted)},
+            config_file_path=os.path.join(td, "haproxy.cfg"),
+        )
+
+        async def fake_get_all_stats():
+            return {"http-app": {name: object() for name in reported}}
+
+        api.get_all_stats = fake_get_all_stats
+        assert asyncio.run(api._compute_target_mismatch()) == expected_mismatch
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_haproxy_metrics.py
+++ b/python/ray/serve/tests/test_haproxy_metrics.py
@@ -34,6 +34,24 @@ def _line(sd_body: str) -> bytes:
     return f"{_SAMPLE_PREFIX}[serve@1 {sd_body}] - normal log message".encode()
 
 
+class _FakeHAProxyApi:
+    """Minimal HAProxyApi stand-in. Required by the collector constructor; the
+    push-metric tests pass it as an inert dummy, while the node-metrics tests
+    drive its backend_configs / stats."""
+
+    def __init__(
+        self, backend_configs: Optional[dict] = None, stats: Optional[dict] = None
+    ):
+        self.backend_configs = backend_configs or {}
+        self._stats = stats or {}
+
+    async def get_all_stats(self) -> dict:
+        return self._stats
+
+    def count_haproxy_processes(self) -> int:
+        return 0
+
+
 # ---------------------------------------------------------------------------
 # parse_line: pure parser tests
 # ---------------------------------------------------------------------------
@@ -185,7 +203,7 @@ def collector() -> HAProxyMetricsCollector:
     The collector's metric attributes are replaced post-init with
     `_RecordingMetric` so tests can assert against captured calls.
     """
-    c = HAProxyMetricsCollector()
+    c = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
     c.truncated_bodies_counter = _RecordingMetric()
     c.latency_histogram = _RecordingMetric()
     c.replica_mismatches_counter = _RecordingMetric()
@@ -455,7 +473,7 @@ async def test_bind_and_attach_receives_datagram_then_close_unlinks(
     """End-to-end on the asyncio path: bind a dgram socket, send a real
     syslog line to it from another socket, assert the metric was recorded,
     then close and verify the socket file is gone."""
-    collector = HAProxyMetricsCollector()
+    collector = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
     # Replace the metric objects so we can assert on them without depending
     # on Ray's Prometheus registry.
     collector.latency_histogram = _RecordingMetric()
@@ -498,7 +516,7 @@ async def test_bind_and_attach_receives_datagram_then_close_unlinks(
 @pytest.mark.asyncio
 async def test_close_is_idempotent_and_safe_without_bind() -> None:
     """close() should never raise -- pre-bind, post-bind, or called twice."""
-    collector = HAProxyMetricsCollector()
+    collector = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
     # never bound
     collector.close()
     collector.close()
@@ -511,12 +529,84 @@ async def test_bind_replaces_existing_socket_file(tmp_path) -> None:
     sock_path.write_bytes(b"")  # touch a stale file
     assert sock_path.exists()
 
-    collector = HAProxyMetricsCollector()
+    collector = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
     try:
         await collector.bind_and_attach(str(sock_path), loop=asyncio.get_event_loop())
         assert sock_path.exists()
     finally:
         collector.close()
+
+
+# ---------------------------------------------------------------------------
+# Node-level poll metrics: target mismatch
+# ---------------------------------------------------------------------------
+
+
+def _backend(name: str, server_names):
+    from ray.serve._private.haproxy import BackendConfig, ServerConfig
+
+    return BackendConfig(
+        name=name,
+        path_prefix="/",
+        servers=[
+            ServerConfig(name=s, host="127.0.0.1", port=9000 + i)
+            for i, s in enumerate(server_names)
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "broadcasted, reported, expected_mismatch",
+    [
+        # Fully converged: every broadcasted server is reported, nothing extra.
+        ({"s1", "s2"}, {"s1", "s2"}, 0),
+        # A broadcasted server hasn't been applied to HAProxy yet.
+        ({"s1", "s2", "s3"}, {"s1", "s2"}, 1),
+        # HAProxy still reports a stale server we no longer broadcast.
+        ({"s1", "s2"}, {"s1", "s2", "stale"}, 1),
+        # Divergence in both directions counts each side.
+        ({"s1", "s2"}, {"s1", "stale"}, 2),
+    ],
+)
+def test_compute_target_mismatch(broadcasted, reported, expected_mismatch) -> None:
+    api = _FakeHAProxyApi(
+        backend_configs={"http-app": _backend("http-app", broadcasted)},
+        stats={"http-app": {name: object() for name in reported}},
+    )
+    collector = HAProxyMetricsCollector(haproxy_api=api)
+    assert asyncio.run(collector._compute_target_mismatch()) == expected_mismatch
+
+
+@pytest.mark.asyncio
+async def test_start_polls_always_and_binds_only_when_enabled(tmp_path) -> None:
+    """start() always begins node polling; the dgram reader (and its task) is
+    only created when ingress-router metrics are enabled."""
+    api = _FakeHAProxyApi(backend_configs={}, stats={})
+    loop = asyncio.get_event_loop()
+
+    disabled = HAProxyMetricsCollector(haproxy_api=api)
+    attach_task = disabled.start(
+        loop, poll_interval_s=10.0, enable_ingress_router_metrics=False
+    )
+    assert attach_task is None
+    assert disabled._node_metrics_task is not None
+    disabled.close()
+
+    sock_path = tmp_path / "subdir" / "metrics.sock"
+    enabled = HAProxyMetricsCollector(haproxy_api=api)
+    attach_task = enabled.start(
+        loop,
+        poll_interval_s=10.0,
+        enable_ingress_router_metrics=True,
+        metrics_socket_path=str(sock_path),
+    )
+    try:
+        assert attach_task is not None
+        await attach_task  # bind completes; makedirs created the parent dir
+        assert sock_path.exists()
+        assert enabled._node_metrics_task is not None
+    finally:
+        enabled.close()
 
 
 # ---------------------------------------------------------------------------

--- a/python/ray/serve/tests/test_haproxy_metrics.py
+++ b/python/ray/serve/tests/test_haproxy_metrics.py
@@ -547,7 +547,7 @@ async def test_bind_replaces_existing_socket_file(tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _backend(name: str, server_names):
+def _backend(name: str, server_names, fallback: Optional[str] = None):
     from ray.serve._private.haproxy import BackendConfig, ServerConfig
 
     return BackendConfig(
@@ -557,6 +557,11 @@ def _backend(name: str, server_names):
             ServerConfig(name=s, host="127.0.0.1", port=9000 + i)
             for i, s in enumerate(server_names)
         ],
+        fallback_server=(
+            ServerConfig(name=fallback, host="127.0.0.1", port=8999)
+            if fallback is not None
+            else None
+        ),
     )
 
 
@@ -590,6 +595,29 @@ def test_compute_target_mismatch(broadcasted, reported, expected_mismatch) -> No
 
         api.get_all_stats = fake_get_all_stats
         assert asyncio.run(api._compute_target_mismatch()) == expected_mismatch
+
+
+def test_compute_target_mismatch_treats_fallback_server_as_expected() -> None:
+    """The generated config renders the fallback server as a real backup
+    `server` line, so HAProxy reports it in stats. It must count as expected,
+    or the gauge would never converge to zero for backends with a fallback."""
+    from ray.serve._private.haproxy import HAProxyApi, HAProxyConfig
+
+    with tempfile.TemporaryDirectory() as td:
+        api = HAProxyApi(
+            cfg=HAProxyConfig(socket_path=os.path.join(td, "admin.sock")),
+            backend_configs={
+                "http-app": _backend("http-app", {"s1", "s2"}, fallback="fb")
+            },
+            config_file_path=os.path.join(td, "haproxy.cfg"),
+        )
+
+        async def fake_get_all_stats():
+            # HAProxy reports the two servers plus the fallback backup server.
+            return {"http-app": {"s1": object(), "s2": object(), "fb": object()}}
+
+        api.get_all_stats = fake_get_all_stats
+        assert asyncio.run(api._compute_target_mismatch()) == 0
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_haproxy_metrics.py
+++ b/python/ray/serve/tests/test_haproxy_metrics.py
@@ -208,7 +208,7 @@ def collector() -> HAProxyMetricsCollector:
     The collector's metric attributes are replaced post-init with
     `_RecordingMetric` so tests can assert against captured calls.
     """
-    c = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
+    c = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi(), node_id="test-node")
     c.truncated_bodies_counter = _RecordingMetric()
     c.latency_histogram = _RecordingMetric()
     c.replica_mismatches_counter = _RecordingMetric()
@@ -478,7 +478,9 @@ async def test_bind_and_attach_receives_datagram_then_close_unlinks(
     """End-to-end on the asyncio path: bind a dgram socket, send a real
     syslog line to it from another socket, assert the metric was recorded,
     then close and verify the socket file is gone."""
-    collector = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
+    collector = HAProxyMetricsCollector(
+        haproxy_api=_FakeHAProxyApi(), node_id="test-node"
+    )
     # Replace the metric objects so we can assert on them without depending
     # on Ray's Prometheus registry.
     collector.latency_histogram = _RecordingMetric()
@@ -521,7 +523,9 @@ async def test_bind_and_attach_receives_datagram_then_close_unlinks(
 @pytest.mark.asyncio
 async def test_close_is_idempotent_and_safe_without_bind() -> None:
     """close() should never raise -- pre-bind, post-bind, or called twice."""
-    collector = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
+    collector = HAProxyMetricsCollector(
+        haproxy_api=_FakeHAProxyApi(), node_id="test-node"
+    )
     # never bound
     collector.close()
     collector.close()
@@ -534,7 +538,9 @@ async def test_bind_replaces_existing_socket_file(tmp_path) -> None:
     sock_path.write_bytes(b"")  # touch a stale file
     assert sock_path.exists()
 
-    collector = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi())
+    collector = HAProxyMetricsCollector(
+        haproxy_api=_FakeHAProxyApi(), node_id="test-node"
+    )
     try:
         await collector.bind_and_attach(str(sock_path), loop=asyncio.get_event_loop())
         assert sock_path.exists()
@@ -627,7 +633,7 @@ async def test_start_polls_always_and_binds_only_when_enabled(tmp_path) -> None:
     api = _FakeHAProxyApi(backend_configs={}, stats={})
     loop = asyncio.get_event_loop()
 
-    disabled = HAProxyMetricsCollector(haproxy_api=api)
+    disabled = HAProxyMetricsCollector(haproxy_api=api, node_id="test-node")
     attach_task = disabled.start(
         loop, poll_interval_s=10.0, enable_ingress_router_metrics=False
     )
@@ -636,7 +642,7 @@ async def test_start_polls_always_and_binds_only_when_enabled(tmp_path) -> None:
     disabled.close()
 
     sock_path = tmp_path / "subdir" / "metrics.sock"
-    enabled = HAProxyMetricsCollector(haproxy_api=api)
+    enabled = HAProxyMetricsCollector(haproxy_api=api, node_id="test-node")
     attach_task = enabled.start(
         loop,
         poll_interval_s=10.0,

--- a/python/ray/serve/tests/test_haproxy_metrics.py
+++ b/python/ray/serve/tests/test_haproxy_metrics.py
@@ -51,7 +51,7 @@ class _FakeHAProxyApi:
     def count_haproxy_processes(self) -> int:
         return 0
 
-    async def _compute_target_mismatch(self) -> int:
+    async def compute_target_mismatch(self) -> int:
         # Inert: the real symmetric-difference logic is covered by
         # test_compute_target_mismatch against a real HAProxyApi.
         return 0
@@ -585,7 +585,7 @@ def _backend(name: str, server_names, fallback: Optional[str] = None):
     ],
 )
 def test_compute_target_mismatch(broadcasted, reported, expected_mismatch) -> None:
-    # _compute_target_mismatch lives on HAProxyApi (it reads backend_configs and
+    # compute_target_mismatch lives on HAProxyApi (it reads backend_configs and
     # get_all_stats), so exercise the real method with a stubbed stats source.
     from ray.serve._private.haproxy import HAProxyApi, HAProxyConfig
 
@@ -600,7 +600,7 @@ def test_compute_target_mismatch(broadcasted, reported, expected_mismatch) -> No
             return {"http-app": {name: object() for name in reported}}
 
         api.get_all_stats = fake_get_all_stats
-        assert asyncio.run(api._compute_target_mismatch()) == expected_mismatch
+        assert asyncio.run(api.compute_target_mismatch()) == expected_mismatch
 
 
 def test_compute_target_mismatch_treats_fallback_server_as_expected() -> None:
@@ -623,7 +623,7 @@ def test_compute_target_mismatch_treats_fallback_server_as_expected() -> None:
             return {"http-app": {"s1": object(), "s2": object(), "fb": object()}}
 
         api.get_all_stats = fake_get_all_stats
-        assert asyncio.run(api._compute_target_mismatch()) == 0
+        assert asyncio.run(api.compute_target_mismatch()) == 0
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/unit/test_haproxy_process_manager.py
+++ b/python/ray/serve/tests/unit/test_haproxy_process_manager.py
@@ -137,5 +137,28 @@ class TestIsOurHaproxy:
         assert api._is_our_haproxy(2_000_000_000) is False
 
 
+class TestCountHaproxyProcesses:
+    """`count_haproxy_processes` scans /proc for processes whose cmdline carries
+    our config path, so the count spans live, draining, and leaked workers."""
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="/proc is Linux-only"
+    )
+    def test_counts_matching_processes(self, api):
+        # Point config_file_path at a real token in this process's cmdline so at
+        # least this process is counted.
+        with open(f"/proc/{os.getpid()}/cmdline", "rb") as f:
+            argv = [t for t in f.read().split(b"\0") if t]
+        api.config_file_path = argv[0].decode()
+        assert api.count_haproxy_processes() >= 1
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="/proc is Linux-only"
+    )
+    def test_returns_zero_when_no_match(self, api):
+        api.config_file_path = "/tmp/not-in-any-cmdline/haproxy.cfg"
+        assert api.count_haproxy_processes() == 0
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/tests/unit/test_haproxy_process_manager.py
+++ b/python/ray/serve/tests/unit/test_haproxy_process_manager.py
@@ -139,32 +139,18 @@ class TestIsOurHaproxy:
 
 class TestCountHaproxyProcesses:
     """`count_haproxy_processes` scans /proc for processes whose cmdline carries
-    our config path (gated by a cheap comm pre-filter), so the count spans live,
-    draining, and leaked workers."""
+    our config path, so the count spans live, draining, and leaked workers."""
 
     @pytest.mark.skipif(
         not sys.platform.startswith("linux"), reason="/proc is Linux-only"
     )
     def test_counts_matching_processes(self, api):
-        # Point config_file_path at a real token in this process's cmdline, and
-        # force the comm pre-filter to accept this pid (the test runner is
-        # python, not haproxy), so this process is counted.
+        # Point config_file_path at a real token in this process's cmdline so at
+        # least this process is counted.
         with open(f"/proc/{os.getpid()}/cmdline", "rb") as f:
             argv = [t for t in f.read().split(b"\0") if t]
         api.config_file_path = argv[0].decode()
-        api._comm_is_haproxy = lambda pid: pid == os.getpid()
         assert api.count_haproxy_processes() >= 1
-
-    @pytest.mark.skipif(
-        not sys.platform.startswith("linux"), reason="/proc is Linux-only"
-    )
-    def test_comm_filter_excludes_non_haproxy_processes(self, api):
-        # Even with a cmdline that matches, a process whose comm isn't "haproxy"
-        # is not counted -- the real test runner (python) is the live example.
-        with open(f"/proc/{os.getpid()}/cmdline", "rb") as f:
-            argv = [t for t in f.read().split(b"\0") if t]
-        api.config_file_path = argv[0].decode()
-        assert api.count_haproxy_processes() == 0
 
     @pytest.mark.skipif(
         not sys.platform.startswith("linux"), reason="/proc is Linux-only"
@@ -172,21 +158,6 @@ class TestCountHaproxyProcesses:
     def test_returns_zero_when_no_match(self, api):
         api.config_file_path = "/tmp/not-in-any-cmdline/haproxy.cfg"
         assert api.count_haproxy_processes() == 0
-
-
-class TestCommIsHaproxy:
-    """The cheap /proc/<pid>/comm pre-filter run before the cmdline match."""
-
-    @pytest.mark.skipif(
-        not sys.platform.startswith("linux"), reason="/proc is Linux-only"
-    )
-    def test_false_for_non_haproxy_process(self, api):
-        # The test runner is python, not haproxy.
-        assert api._comm_is_haproxy(os.getpid()) is False
-
-    def test_false_for_nonexistent_pid(self, api):
-        # Missing /proc entry (or any non-Linux platform) -> OSError -> False.
-        assert api._comm_is_haproxy(2_000_000_000) is False
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_haproxy_process_manager.py
+++ b/python/ray/serve/tests/unit/test_haproxy_process_manager.py
@@ -139,18 +139,32 @@ class TestIsOurHaproxy:
 
 class TestCountHaproxyProcesses:
     """`count_haproxy_processes` scans /proc for processes whose cmdline carries
-    our config path, so the count spans live, draining, and leaked workers."""
+    our config path (gated by a cheap comm pre-filter), so the count spans live,
+    draining, and leaked workers."""
 
     @pytest.mark.skipif(
         not sys.platform.startswith("linux"), reason="/proc is Linux-only"
     )
     def test_counts_matching_processes(self, api):
-        # Point config_file_path at a real token in this process's cmdline so at
-        # least this process is counted.
+        # Point config_file_path at a real token in this process's cmdline, and
+        # force the comm pre-filter to accept this pid (the test runner is
+        # python, not haproxy), so this process is counted.
         with open(f"/proc/{os.getpid()}/cmdline", "rb") as f:
             argv = [t for t in f.read().split(b"\0") if t]
         api.config_file_path = argv[0].decode()
+        api._comm_is_haproxy = lambda pid: pid == os.getpid()
         assert api.count_haproxy_processes() >= 1
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="/proc is Linux-only"
+    )
+    def test_comm_filter_excludes_non_haproxy_processes(self, api):
+        # Even with a cmdline that matches, a process whose comm isn't "haproxy"
+        # is not counted -- the real test runner (python) is the live example.
+        with open(f"/proc/{os.getpid()}/cmdline", "rb") as f:
+            argv = [t for t in f.read().split(b"\0") if t]
+        api.config_file_path = argv[0].decode()
+        assert api.count_haproxy_processes() == 0
 
     @pytest.mark.skipif(
         not sys.platform.startswith("linux"), reason="/proc is Linux-only"
@@ -158,6 +172,21 @@ class TestCountHaproxyProcesses:
     def test_returns_zero_when_no_match(self, api):
         api.config_file_path = "/tmp/not-in-any-cmdline/haproxy.cfg"
         assert api.count_haproxy_processes() == 0
+
+
+class TestCommIsHaproxy:
+    """The cheap /proc/<pid>/comm pre-filter run before the cmdline match."""
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="/proc is Linux-only"
+    )
+    def test_false_for_non_haproxy_process(self, api):
+        # The test runner is python, not haproxy.
+        assert api._comm_is_haproxy(os.getpid()) is False
+
+    def test_false_for_nonexistent_pid(self, api):
+        # Missing /proc entry (or any non-Linux platform) -> OSError -> False.
+        assert api._comm_is_haproxy(2_000_000_000) is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds two system-level metrics to haproxy monitoring:
1. The number of actual haproxy processes running per node
2. The server mismatch between what controller has told HAProxyManager and what HAProxy process actually reports