### PR TITLE
[doc] Soft-wrap prose in ray-contribute developer guides

### DIFF
--- a/doc/source/ray-contribute/agent-development.md
+++ b/doc/source/ray-contribute/agent-development.md
@@ -8,9 +8,7 @@ myst:
 
 # Using Agents for Development
 
-AI coding agents can accelerate development on the Ray codebase. This guide covers
-how the Ray project is configured for agent-assisted development and how to set up
-your local environment.
+AI coding agents can accelerate development on the Ray codebase. This guide covers how the Ray project is configured for agent-assisted development and how to set up your local environment.
 
 ```{contents}
 :local:
@@ -21,17 +19,14 @@ your local environment.
 
 ## Claude Code
 
-[Claude Code](https://code.claude.com) is an AI coding assistant that understands the Ray codebase
-through a hierarchy of instruction files, rules, and skills. For installation instructions, see the
-[official documentation](https://code.claude.com/docs).
+[Claude Code](https://code.claude.com) is an AI coding assistant that understands the Ray codebase through a hierarchy of instruction files, rules, and skills. For installation instructions, see the [official documentation](https://code.claude.com/docs).
 
 ### Project configuration
 
 The Ray repository includes shared Claude Code configuration that is version-controlled:
 
 - `.claude/CLAUDE.md` — root instructions loaded in every session
-- `<library>/.claude/CLAUDE.md` — library-specific instructions loaded on-demand
-  (e.g., `python/ray/data/.claude/CLAUDE.md`)
+- `<library>/.claude/CLAUDE.md` — library-specific instructions loaded on-demand (e.g., `python/ray/data/.claude/CLAUDE.md`)
 - `.claude/rules/` — coding rules scoped by file type
 - `.claude/skills/` — reusable workflows (rebuild, lint, fetch CI logs)
 - `.claude/agents/` — project-specific subagents
@@ -43,8 +38,7 @@ Personal configuration lives in files that are **not** version-controlled:
 
 ### Personal setup
 
-After installing Claude Code, create a `CLAUDE.local.md` file in the repository root
-with your environment-specific configuration:
+After installing Claude Code, create a `CLAUDE.local.md` file in the repository root with your environment-specific configuration:
 
 ```markdown
 ## My Environment
@@ -63,12 +57,9 @@ This file is gitignored and will not be committed.
 
 ### Cross-worktree setup
 
-If you use multiple git worktrees, `CLAUDE.local.md` only exists in the worktree where
-you created it. To automatically symlink it from your main checkout whenever a new
-worktree is created, set up a `post-checkout` git hook:
+If you use multiple git worktrees, `CLAUDE.local.md` only exists in the worktree where you created it. To automatically symlink it from your main checkout whenever a new worktree is created, set up a `post-checkout` git hook:
 
-1. From your main Ray checkout (not a worktree), create the hook file at
-   `$(git rev-parse --git-common-dir)/hooks/post-checkout` with the following contents:
+1. From your main Ray checkout (not a worktree), create the hook file at `$(git rev-parse --git-common-dir)/hooks/post-checkout` with the following contents:
 
    ```bash
    #!/bin/bash
@@ -86,8 +77,7 @@ worktree is created, set up a `post-checkout` git hook:
    chmod +x "$(git rev-parse --git-common-dir)/hooks/post-checkout"
    ```
 
-3. The hook fires automatically when you create a new worktree with
-   `git worktree add`. For existing worktrees, run the symlink manually:
+3. The hook fires automatically when you create a new worktree with `git worktree add`. For existing worktrees, run the symlink manually:
 
    ```bash
    ln -s /path/to/ray/CLAUDE.local.md CLAUDE.local.md
@@ -122,11 +112,9 @@ Shared skills available in every session:
 
 ### Adding team rules
 
-Each Ray library has a `.claude/rules/` directory where teams can add coding rules
-that apply when working on their files. To add a new rule:
+Each Ray library has a `.claude/rules/` directory where teams can add coding rules that apply when working on their files. To add a new rule:
 
-1. Create a `.md` file in your library's rules directory, e.g.,
-   `python/ray/data/.claude/rules/data-conventions.md`
+1. Create a `.md` file in your library's rules directory, e.g., `python/ray/data/.claude/rules/data-conventions.md`
 
 2. Add a `paths` frontmatter to scope it to your files:
 
@@ -139,16 +127,13 @@ that apply when working on their files. To add a new rule:
    - Prefer streaming execution over batch where possible
    ```
 
-Rules without `paths` frontmatter load unconditionally in every session.
-See the `README.md` in each rules directory for examples.
+Rules without `paths` frontmatter load unconditionally in every session. See the `README.md` in each rules directory for examples.
 
 ### Adding team skills
 
-Skills are reusable workflows that load on-demand when invoked with `/<skill-name>`.
-To add a new skill:
+Skills are reusable workflows that load on-demand when invoked with `/<skill-name>`. To add a new skill:
 
-1. Create a directory under your library's `.claude/skills/`, e.g.,
-   `python/ray/data/.claude/skills/debug-data/`
+1. Create a directory under your library's `.claude/skills/`, e.g., `python/ray/data/.claude/skills/debug-data/`
 
 2. Add a `SKILL.md` file with frontmatter:
 
@@ -165,5 +150,4 @@ To add a new skill:
    2. Look for common issues...
    ```
 
-Skills in a library's `.claude/skills/` directory are discovered when working in that
-library. Shared skills in `.claude/skills/` are available everywhere.
+Skills in a library's `.claude/skills/` directory are discovered when working in that library. Shared skills in `.claude/skills/` are available everywhere.

--- a/doc/source/ray-contribute/api-policy.md
+++ b/doc/source/ray-contribute/api-policy.md
@@ -8,26 +8,13 @@ myst:
 
 # API Policy
 
-Ray APIs refer to classes, class methods, or functions.
-When we declare an API, we promise our
-users that they can use these APIs to develop their
-apps without worrying about changes to these
-interfaces between different Ray releases. Declaring
-or deprecating an API has a significant impact on the
-community.  This document proposes simple policies to
-hold Ray contributors accountable to these promises
-and manage user expectations.
+Ray APIs refer to classes, class methods, or functions. When we declare an API, we promise our users that they can use these APIs to develop their apps without worrying about changes to these interfaces between different Ray releases. Declaring or deprecating an API has a significant impact on the community.  This document proposes simple policies to hold Ray contributors accountable to these promises and manage user expectations.
 
 For API exposure levels, see {ref}`API Stability <api-stability>`.
 
 ## API documentation policy
 
-Documentation is one of the main channels through which
-we expose our APIs to users. If we provide incorrect
-information, it can significantly impact the reliability
-and maintainability of our users' applications. Based on
-the API exposure level, here is the policy to ensure the
-accuracy of our information.
+Documentation is one of the main channels through which we expose our APIs to users. If we provide incorrect information, it can significantly impact the reliability and maintainability of our users' applications. Based on the API exposure level, here is the policy to ensure the accuracy of our information.
 
 ```{list-table} API Documentation Policy
 :widths: 20 16 16 16 16 16
@@ -61,9 +48,7 @@ accuracy of our information.
 
 ## API Lifecycle Policy
 
-Users have high expectations for certain exposure levels,
-so we need to be cautious when moving APIs between different
-levels. Here is the policy for managing the API exposure lifecycle.
+Users have high expectations for certain exposure levels, so we need to be cautious when moving APIs between different levels. Here is the policy for managing the API exposure lifecycle.
 
 ```{list-table} API Lifecycle Policy
 :widths: 20 16 16 16 16 16

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -6,28 +6,16 @@ myst:
 
 # CI Testing Workflow on PRs
 
-This guide helps contributors to understand the Continuous Integration (CI)
-workflow on a PR. Here CI stands for the automated testing of the codebase
-on the PR.
+This guide helps contributors to understand the Continuous Integration (CI) workflow on a PR. Here CI stands for the automated testing of the codebase on the PR.
 
 ## `microcheck`: default tests on your PR
 
-With every commit on your PR, by default, we'll run a set of tests
-called `microcheck`.
+With every commit on your PR, by default, we'll run a set of tests called `microcheck`.
 
-These tests are designed to be 90% accurate at catching bugs on your
-PR while running only 10% of the full test suite. As a result,
-microcheck typically finishes twice as fast and twice cheaper than
-the full test suite. Some of the notable features of microcheck are:
+These tests are designed to be 90% accurate at catching bugs on your PR while running only 10% of the full test suite. As a result, microcheck typically finishes twice as fast and twice cheaper than the full test suite. Some of the notable features of microcheck are:
 
-* If a new test is added or an existing test is modified in a pull
-  request, microcheck will ensure these tests are included.
-* You can manually add more tests to microcheck by including the following line
-  in the body of your git commit message:
-  `@microcheck TEST_TARGET01 TEST_TARGET02 ....`. This line must be in the
-  body of your message, starting from the second line or
-  below (the first line is the commit message title). For example, here
-  is how I manually add tests in my pull request:
+* If a new test is added or an existing test is modified in a pull request, microcheck will ensure these tests are included.
+* You can manually add more tests to microcheck by including the following line in the body of your git commit message: `@microcheck TEST_TARGET01 TEST_TARGET02 ....`. This line must be in the body of your message, starting from the second line or below (the first line is the commit message title). For example, here is how I manually add tests in my pull request:
 
   ```
   // git command to add commit message
@@ -41,18 +29,10 @@ the full test suite. Some of the notable features of microcheck are:
   Signed-off-by: can <can@anyscale.com>
   ```
 
-If microcheck passes, you'll see a green checkmark on your PR. If it
-fails, you'll see a red cross. In either case, you'll see a summary of
-the test run statuses in the github UI.
+If microcheck passes, you'll see a green checkmark on your PR. If it fails, you'll see a red cross. In either case, you'll see a summary of the test run statuses in the github UI.
 
 ## Additional tests at merge time
 
-In this workflow, to merge your PR, simply click on the Enable auto-merge
-button (or ask a committer to do so). This will trigger additional test
-cases, and the PR will merge automatically once they finish and pass.
+In this workflow, to merge your PR, simply click on the Enable auto-merge button (or ask a committer to do so). This will trigger additional test cases, and the PR will merge automatically once they finish and pass.
 
-Alternatively, you can also add a `go` label to manually trigger the full
-test suite on your PR (be mindful that this is less recommended but we
-understand you know best about the need of your PR). While we anticipate
-this will be rarely needed, if you do require it constantly, please let
-us know. We are continuously improving the effectiveness of microcheck.
+Alternatively, you can also add a `go` label to manually trigger the full test suite on your PR (be mindful that this is less recommended but we understand you know best about the need of your PR). While we anticipate this will be rarely needed, if you do require it constantly, please let us know. We are continuously improving the effectiveness of microcheck.

--- a/doc/source/ray-contribute/debugging.md
+++ b/doc/source/ray-contribute/debugging.md
@@ -10,8 +10,7 @@ This debugging guide is for contributors to the Ray project.
 
 ## Starting processes in a debugger
 
-When processes are crashing, it is often useful to start them in a debugger.
-Ray currently allows processes to be started in the following:
+When processes are crashing, it is often useful to start them in a debugger. Ray currently allows processes to be started in the following:
 
 - valgrind
 - the valgrind profiler
@@ -19,46 +18,30 @@ Ray currently allows processes to be started in the following:
 - gdb
 - tmux
 
-To use any of these tools, please make sure that you have them installed on
-your machine first (`gdb` and `valgrind` on MacOS are known to have issues).
-Then, you can launch a subset of ray processes by adding the environment
-variable `RAY_{PROCESS_NAME}_{DEBUGGER}=1`. For instance, if you wanted to
-start the raylet in `valgrind`, then you simply need to set the environment
-variable `RAY_RAYLET_VALGRIND=1`.
+To use any of these tools, please make sure that you have them installed on your machine first (`gdb` and `valgrind` on MacOS are known to have issues). Then, you can launch a subset of ray processes by adding the environment variable `RAY_{PROCESS_NAME}_{DEBUGGER}=1`. For instance, if you wanted to start the raylet in `valgrind`, then you simply need to set the environment variable `RAY_RAYLET_VALGRIND=1`.
 
-To start a process inside of `gdb`, the process must also be started inside of
-`tmux`. So if you want to start the raylet in `gdb`, you would start your
-Python script with the following:
+To start a process inside of `gdb`, the process must also be started inside of `tmux`. So if you want to start the raylet in `gdb`, you would start your Python script with the following:
 
 ```bash
 RAY_RAYLET_GDB=1 RAY_RAYLET_TMUX=1 python
 ```
 
-You can then list the `tmux` sessions with `tmux ls` and attach to the
-appropriate one.
+You can then list the `tmux` sessions with `tmux ls` and attach to the appropriate one.
 
-You can also get a core dump of the `raylet` process, which is especially
-useful when filing [issues](https://github.com/ray-project/ray/issues). The process to obtain a core dump is OS-specific,
-but usually involves running `ulimit -c unlimited` before starting Ray to
-allow core dump files to be written.
+You can also get a core dump of the `raylet` process, which is especially useful when filing [issues](https://github.com/ray-project/ray/issues). The process to obtain a core dump is OS-specific, but usually involves running `ulimit -c unlimited` before starting Ray to allow core dump files to be written.
 
 (backend-logging)=
 
 ## Backend logging
 
-The `raylet` process logs detailed information about events like task
-execution and object transfers between nodes. To set the logging level at
-runtime, you can set the `RAY_BACKEND_LOG_LEVEL` environment variable before
-starting Ray. For example, you can do:
+The `raylet` process logs detailed information about events like task execution and object transfers between nodes. To set the logging level at runtime, you can set the `RAY_BACKEND_LOG_LEVEL` environment variable before starting Ray. For example, you can do:
 
 ```shell
 export RAY_BACKEND_LOG_LEVEL=debug
 ray start
 ```
 
-This will print any `RAY_LOG(DEBUG)` lines in the source code to the
-`raylet.err` file, which you can find in {ref}`temp-dir-log-files`.
-If it worked, you should see as the first line in `raylet.err`:
+This will print any `RAY_LOG(DEBUG)` lines in the source code to the `raylet.err` file, which you can find in {ref}`temp-dir-log-files`. If it worked, you should see as the first line in `raylet.err`:
 
 ```shell
 logging.cc:270: Set ray log level from environment variable RAY_BACKEND_LOG_LEVEL to -1
@@ -73,12 +56,9 @@ logging.cc:270: Set ray log level from environment variable RAY_BACKEND_LOG_LEVE
 
 ## Backend event stats
 
-The `raylet` process also periodically dumps event stats to `debug_state.txt` and its log
-file if `RAY_event_stats=1` environment variable is set. To alter the interval at which
-Ray writes stats to log files, you can set `RAY_event_stats_print_interval_ms`.
+The `raylet` process also periodically dumps event stats to `debug_state.txt` and its log file if `RAY_event_stats=1` environment variable is set. To alter the interval at which Ray writes stats to log files, you can set `RAY_event_stats_print_interval_ms`.
 
-Event stats include ASIO event handlers, periodic timers, and RPC handlers. Here is a sample
-of what the event stats look like:
+Event stats include ASIO event handlers, periodic timers, and RPC handlers. Here is a sample of what the event stats look like:
 
 ```shell
 Event stats:
@@ -97,14 +77,10 @@ Handler stats:
 
 ## Callback latency injection
 
-Sometimes, bugs are caused by RPC issues, for example, due to the delay of some requests, the system goes to a deadlock.
-To debug and reproduce this kind of issue, we need to have a way to inject latency for the RPC request. To enable this,
-`RAY_testing_asio_delay_us` is introduced. If you'd like to make the callback of some RPC requests be executed after some time,
-you can do it with this variable. For example:
+Sometimes, bugs are caused by RPC issues, for example, due to the delay of some requests, the system goes to a deadlock. To debug and reproduce this kind of issue, we need to have a way to inject latency for the RPC request. To enable this, `RAY_testing_asio_delay_us` is introduced. If you'd like to make the callback of some RPC requests be executed after some time, you can do it with this variable. For example:
 
 ```shell
 RAY_testing_asio_delay_us="NodeManagerService.grpc_client.PrepareBundleResources=2000000:2000000" ray start --head
 ```
 
-The syntax for this is `RAY_testing_asio_delay_us="method1=min_us:max_us,method2=min_us:max_us"`. Entries are comma separated.
-There is a special method `*` which means all methods. It has a lower priority compared with other entries.
+The syntax for this is `RAY_testing_asio_delay_us="method1=min_us:max_us,method2=min_us:max_us"`. Entries are comma separated. There is a special method `*` which means all methods. It has a lower priority compared with other entries.

--- a/doc/source/ray-contribute/development.md
+++ b/doc/source/ray-contribute/development.md
@@ -30,8 +30,7 @@ Depending on your goal, you may not need all sections on this page:
 
 ### Fork the Ray repository
 
-Forking an open source repository is a best practice when looking to contribute, as it allows you to make and test changes without affecting the original project, ensuring a clean and organized collaboration process.
-You can propose changes to the main project by submitting a pull request to the main project's repository.
+Forking an open source repository is a best practice when looking to contribute, as it allows you to make and test changes without affecting the original project, ensuring a clean and organized collaboration process. You can propose changes to the main project by submitting a pull request to the main project's repository.
 
 1. Navigate to the [Ray GitHub repository](https://github.com/ray-project/ray).
 2. Follow these [GitHub instructions](https://docs.github.com/en/get-started/quickstart/fork-a-repo), and do the following:
@@ -154,8 +153,7 @@ Before you begin, make sure you have:
 - [Docker](https://docs.docker.com/get-docker/) installed
 :::
 
-To build a distributable manylinux `.whl`, use the `build-wheel.sh`
-script at the repository root.
+To build a distributable manylinux `.whl`, use the `build-wheel.sh` script at the repository root.
 
 ```bash
 # Build a manylinux wheel for the host architecture:
@@ -165,12 +163,9 @@ script at the repository root.
 ./build-wheel.sh 3.12 ./dist
 ```
 
-Run `./build-wheel.sh` without arguments to see supported Python versions and options.
-Regardless of host OS, the output is always a manylinux wheel (the same format used by CI
-and PyPI). Supported build hosts are Linux x86_64, Linux aarch64, and macOS ARM64.
+Run `./build-wheel.sh` without arguments to see supported Python versions and options. Regardless of host OS, the output is always a manylinux wheel (the same format used by CI and PyPI). Supported build hosts are Linux x86_64, Linux aarch64, and macOS ARM64.
 
-See `python/README-building-wheels.md` for additional options, including building
-manylinux wheels directly with Docker.
+See `python/README-building-wheels.md` for additional options, including building manylinux wheels directly with Docker.
 
 (build-ray-image)=
 
@@ -206,8 +201,7 @@ Run `./build-image.sh --help` to see available image types, Python versions, and
 ## Full source build
 
 :::{tip}
-If you already followed the instructions in {ref}`python-develop` and want to switch
-to the Full build, you need to first uninstall Ray (see {ref}`uninstallation steps <python-develop-uninstall>`).
+If you already followed the instructions in {ref}`python-develop` and want to switch to the Full build, you need to first uninstall Ray (see {ref}`uninstallation steps <python-develop-uninstall>`).
 :::
 
 ### Preparing to build Ray on Linux
@@ -292,8 +286,7 @@ pip install -r requirements.txt
 pip install -e . --verbose  # Add --user if you see a permission denied error.
 ```
 
-The `-e` means "editable", so changes you make to files in the Ray
-directory take effect without reinstalling the package.
+The `-e` means "editable", so changes you make to files in the Ray directory take effect without reinstalling the package.
 
 :::{warning}
 Don't run `python setup.py install` — Python copies files from the Ray directory to a packages directory (`/lib/python3.6/site-packages/ray`), so changes you make to files in the Ray directory won't have any effect.
@@ -347,11 +340,7 @@ ray/ci/env/install-bazel.sh
 
 3. Define an environment variable `BAZEL_SH` to point to `bash.exe`. If git for Windows was installed for all users, bash's path should be `C:\Program Files\Git\bin\bash.exe`. If git was installed for a single user, adjust the path accordingly.
 
-4. Install Bazel 7.5.0. Go to the Bazel 7.5.0 release page and download
-   `bazel-7.5.0-windows-x86_64.exe`. Copy the exe into the directory of your choice.
-   Define an environment variable `BAZEL_PATH` to the full exe path (example:
-   `set BAZEL_PATH=C:\bazel\bazel.exe`). Also add the Bazel directory to
-   `PATH` (example: `set PATH=%PATH%;C:\bazel`)
+4. Install Bazel 7.5.0. Go to the Bazel 7.5.0 release page and download `bazel-7.5.0-windows-x86_64.exe`. Copy the exe into the directory of your choice. Define an environment variable `BAZEL_PATH` to the full exe path (example: `set BAZEL_PATH=C:\bazel\bazel.exe`). Also add the Bazel directory to `PATH` (example: `set PATH=%PATH%;C:\bazel`)
 
 5. Download ray source code and build it.
 
@@ -369,61 +358,43 @@ pip install -e . --verbose
 You can tweak the build with the following environment variables (when running `pip install -e .` or `python setup.py install`):
 
 - `RAY_BUILD_CORE`: If set and equal to `1`, Ray builds the core parts. Defaults to `1`.
-- `RAY_INSTALL_JAVA`: If set and equal to `1`, Ray runs extra build steps
-  to build Java portions of the codebase
+- `RAY_INSTALL_JAVA`: If set and equal to `1`, Ray runs extra build steps to build Java portions of the codebase
 - `RAY_INSTALL_CPP`: If set and equal to `1`, Ray installs `ray-cpp`
-- `RAY_BUILD_REDIS`: If set and equal to `1`, Ray builds or fetches Redis binaries.
-  These binaries are only used for testing. Defaults to `1`.
-- `RAY_DISABLE_EXTRA_CPP`: If set and equal to `1`, a regular (non-`cpp`)
-  build won't provide some `cpp` interfaces
+- `RAY_BUILD_REDIS`: If set and equal to `1`, Ray builds or fetches Redis binaries. These binaries are only used for testing. Defaults to `1`.
+- `RAY_DISABLE_EXTRA_CPP`: If set and equal to `1`, a regular (non-`cpp`) build won't provide some `cpp` interfaces
 - `SKIP_BAZEL_BUILD`: If set and equal to `1`, Ray skips all Bazel build steps
-- `SKIP_THIRDPARTY_INSTALL_CONDA_FORGE`: If set, setup skips installation of
-  third-party packages required for build. This is active on conda-forge where
-  pip isn't used to create a build environment.
-- `RAY_DEBUG_BUILD`: Can be set to `debug`, `asan`, or `tsan`. Ray ignores
-  any other value
-- `BAZEL_ARGS`: If set, pass a space-separated set of arguments to Bazel. This can be useful
-  for restricting resource usage during builds, for example. See https://bazel.build/docs/user-manual
-  for more information about valid arguments.
+- `SKIP_THIRDPARTY_INSTALL_CONDA_FORGE`: If set, setup skips installation of third-party packages required for build. This is active on conda-forge where pip isn't used to create a build environment.
+- `RAY_DEBUG_BUILD`: Can be set to `debug`, `asan`, or `tsan`. Ray ignores any other value
+- `BAZEL_ARGS`: If set, pass a space-separated set of arguments to Bazel. This can be useful for restricting resource usage during builds, for example. See https://bazel.build/docs/user-manual for more information about valid arguments.
 - `IS_AUTOMATED_BUILD`: Used in conda-forge CI to tweak the build for the managed CI machines
-- `SRC_DIR`: Can be set to the root of the source checkout, defaults to
-  `None` which is `cwd()`
+- `SRC_DIR`: Can be set to the root of the source checkout, defaults to `None` which is `cwd()`
 - `BAZEL_SH`: used on Windows to find a `bash.exe`, see below
 - `BAZEL_PATH`: used on Windows to find `bazel.exe`, see below
 - `MINGW_DIR`: used on Windows to find `bazel.exe` if not found in `BAZEL_PATH`
 
 ### Fast, debug, and optimized builds
 
-By default, Ray builds with optimizations, which can take a long time and
-interfere with debugging. To perform fast, debug, or optimized builds,
-run the following (via `-c` `fastbuild`/`dbg`/`opt`, respectively):
+By default, Ray builds with optimizations, which can take a long time and interfere with debugging. To perform fast, debug, or optimized builds, run the following (via `-c` `fastbuild`/`dbg`/`opt`, respectively):
 
 ```shell
 bazel run -c fastbuild //:gen_ray_pkg
 ```
 
-This rebuilds Ray with the appropriate options (which might take a while).
-If you need to build all targets, use `bazel build //:all` instead of
-`bazel run //:gen_ray_pkg`.
+This rebuilds Ray with the appropriate options (which might take a while). If you need to build all targets, use `bazel build //:all` instead of `bazel run //:gen_ray_pkg`.
 
-To make this change permanent, you can add an option such as the following
-line to your user-level `~/.bazelrc` file (not to be confused with the
-workspace-level `.bazelrc` file):
+To make this change permanent, you can add an option such as the following line to your user-level `~/.bazelrc` file (not to be confused with the workspace-level `.bazelrc` file):
 
 ```shell
 build --compilation_mode=fastbuild
 ```
 
-If you do so, remember to revert this change, unless you want it to affect
-all of your development in the future.
+If you do so, remember to revert this change, unless you want it to affect all of your development in the future.
 
-Using `dbg` instead of `fastbuild` generates more debug information,
-which can make it easier to debug with a debugger like `gdb`.
+Using `dbg` instead of `fastbuild` generates more debug information, which can make it easier to debug with a debugger like `gdb`.
 
 ### Using a local repository for dependencies
 
-If you'd like to build Ray with custom dependencies (for example, with a
-different version of Cython), you can modify your `.bzl` file as follows:
+If you'd like to build Ray with custom dependencies (for example, with a different version of Cython), you can modify your `.bzl` file as follows:
 
 ```python
 http_archive(
@@ -436,11 +407,7 @@ http_archive(
 )
 ```
 
-This replaces the existing `http_archive` rule with one that references a
-sibling of your Ray directory (named `cython`) using the build file
-provided in the Ray repository (`bazel/BUILD.cython`).
-If the dependency already has a Bazel build file in it, you can use
-`native.local_repository` instead, and omit `build_file`.
+This replaces the existing `http_archive` rule with one that references a sibling of your Ray directory (named `cython`) using the build file provided in the Ray repository (`bazel/BUILD.cython`). If the dependency already has a Bazel build file in it, you can use `native.local_repository` instead, and omit `build_file`.
 
 To test switching back to the original rule, change `False` to `True`.
 
@@ -465,18 +432,14 @@ Requirement files for running Ray Data / ML library tests are under `python/requ
 
 ### Pre-commit hooks
 
-Ray uses pre-commit hooks with [the pre-commit python package](https://pre-commit.com/).
-The `.pre-commit-config.yaml` file configures all the linting and formatting checks.
-To start using `pre-commit`:
+Ray uses pre-commit hooks with [the pre-commit python package](https://pre-commit.com/). The `.pre-commit-config.yaml` file configures all the linting and formatting checks. To start using `pre-commit`:
 
 ```shell
 pip install pre-commit
 pre-commit install
 ```
 
-This installs pre-commit into the current environment and enables pre-commit checks every time
-you commit new code changes with git. To temporarily skip pre-commit checks, use the `-n` or
-`--no-verify` flag when committing:
+This installs pre-commit into the current environment and enables pre-commit checks every time you commit new code changes with git. To temporarily skip pre-commit checks, use the `-n` or `--no-verify` flag when committing:
 
 ```shell
 git commit -n
@@ -490,8 +453,7 @@ To learn more about building the docs refer to [Contributing to the Ray Document
 
 ## Troubleshooting
 
-If importing Ray (`python3 -c "import ray"`) in your development clone results
-in this error:
+If importing Ray (`python3 -c "import ray"`) in your development clone results in this error:
 
 ```python
 Traceback (most recent call last):

--- a/doc/source/ray-contribute/docs.md
+++ b/doc/source/ray-contribute/docs.md
@@ -6,16 +6,14 @@ myst:
 
 # Contributing to the Ray Documentation
 
-There are many ways to contribute to the Ray documentation, and we're always looking for new contributors.
-Even if you just want to fix a typo or expand on a section, please feel free to do so!
+There are many ways to contribute to the Ray documentation, and we're always looking for new contributors. Even if you just want to fix a typo or expand on a section, please feel free to do so!
 
 This document walks you through everything you need to do to get started.
 
 
 ## Editorial style
 
-We follow the [Google developer documentation style guide](https://developers.google.com/style).
-Here are some highlights:
+We follow the [Google developer documentation style guide](https://developers.google.com/style). Here are some highlights:
 
 * [Use present tense](https://developers.google.com/style/tense)
 * [Use second person](https://developers.google.com/style/person)
@@ -23,13 +21,11 @@ Here are some highlights:
 * [Use active voice](https://developers.google.com/style/voice)
 * [Use sentence case](https://developers.google.com/style/capitalization)
 
-The editorial style is enforced in CI by Vale. For more information, see
-[How to use Vale](vale).
+The editorial style is enforced in CI by Vale. For more information, see [How to use Vale](vale).
 
 ## Building the Ray documentation
 
-If you want to contribute to the Ray documentation, you need a way to build it.
-Don't install Ray in the environment you plan to use to build documentation. The requirements for the docs build system are generally not compatible with those you need to run Ray itself.
+If you want to contribute to the Ray documentation, you need a way to build it. Don't install Ray in the environment you plan to use to build documentation. The requirements for the docs build system are generally not compatible with those you need to run Ray itself.
 
 Follow these instructions to build the documentation:
 
@@ -83,8 +79,7 @@ This option is recommended if you need to make frequent uncomplicated and small 
 
 In this approach, Sphinx only builds the changes you made in your branch compared to your last pull from upstream master. The rest of doc is cached with pre-built doc pages from your last commit from upstream (for every new commit pushed to Ray, CI builds all the documentation pages from that commit and store them on S3 as cache).
 
-The build first traces your commit tree to find the latest commit that CI already cached on S3. 
-Once the build finds the commit, it fetches the corresponding cache from S3 and extracts it into the `doc/` directory. Simultaneously, CI tracks all the files that have changed from that commit to current `HEAD`, including any un-staged changes.
+The build first traces your commit tree to find the latest commit that CI already cached on S3. Once the build finds the commit, it fetches the corresponding cache from S3 and extracts it into the `doc/` directory. Simultaneously, CI tracks all the files that have changed from that commit to current `HEAD`, including any un-staged changes.
 
 Sphinx then rebuilds only the pages that your changes affect, leaving the rest untouched from the cache.
 
@@ -93,21 +88,15 @@ When build finishes, the doc page would automatically pop up on your browser. If
 For more complicated changes that involve adding or removing files, always use `make develop` first, then you can start using `make local` afterwards to iterate on the cache that `make develop` produces.
 
 #### 2. Full build from scratch
-In the full build option, Sphinx rebuilds all files in `doc/` directory, ignoring all cache and saved environment.
-Because of this behavior, you get a really clean build but it's much slower.
+In the full build option, Sphinx rebuilds all files in `doc/` directory, ignoring all cache and saved environment. Because of this behavior, you get a really clean build but it's much slower.
 
 ```shell
 make develop
 ```
 
-Find the documentation build in the `_build` directory.
-After the build finishes, you can simply open the `_build/html/index.html` file in your browser.
-It's considered good practice to check the output of your build to make sure everything is working as expected.
+Find the documentation build in the `_build` directory. After the build finishes, you can simply open the `_build/html/index.html` file in your browser. It's considered good practice to check the output of your build to make sure everything is working as expected.
 
-Before committing any changes, make sure you run the
-[linter](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting)
-with `pre-commit run` from the `doc` folder,
-to make sure your changes are formatted correctly.
+Before committing any changes, make sure you run the [linter](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting) with `pre-commit run` from the `doc` folder, to make sure your changes are formatted correctly.
 
 ### Code completion and other developer tooling
 
@@ -126,24 +115,15 @@ Esbonio also can be used with neovim - [see the lspconfig repository for install
 
 ## The basics of our build system
 
-The Ray documentation is built using the [`sphinx`](https://www.sphinx-doc.org/) build system.
-We're using the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/) for the documentation.
+The Ray documentation is built using the [`sphinx`](https://www.sphinx-doc.org/) build system. We're using the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/) for the documentation.
 
-We use [`myst-parser`](https://myst-parser.readthedocs.io/en/latest/) to allow you to write Ray documentation in either Sphinx's native
-[reStructuredText (rST)](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html) or in
-[Markedly Structured Text (MyST)](https://myst-parser.readthedocs.io/en/latest/).
-The two formats can be converted to each other, so the choice is up to you.
-Having said that, it's important to know that MyST is
-[common markdown compliant](https://myst-parser.readthedocs.io/en/latest/syntax/reference.html#commonmark-block-tokens). Past experience has shown that most developers are familiar with `md` syntax, so
-if you intend to add a new document, we recommend starting from an `.md` file.
+We use [`myst-parser`](https://myst-parser.readthedocs.io/en/latest/) to allow you to write Ray documentation in either Sphinx's native [reStructuredText (rST)](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html) or in [Markedly Structured Text (MyST)](https://myst-parser.readthedocs.io/en/latest/). The two formats can be converted to each other, so the choice is up to you. Having said that, it's important to know that MyST is [common markdown compliant](https://myst-parser.readthedocs.io/en/latest/syntax/reference.html#commonmark-block-tokens). Past experience has shown that most developers are familiar with `md` syntax, so if you intend to add a new document, we recommend starting from an `.md` file.
 
-The Ray documentation also fully supports executable formats like [Jupyter Notebooks](https://jupyter.org/).
-Many of our examples are notebooks with [MyST markdown cells](https://myst-nb.readthedocs.io/en/latest/index.html).
+The Ray documentation also fully supports executable formats like [Jupyter Notebooks](https://jupyter.org/). Many of our examples are notebooks with [MyST markdown cells](https://myst-nb.readthedocs.io/en/latest/index.html).
 
 ## What to contribute?
 
-If you take Ray Tune as an example, you can see that our documentation is made up of several types of documentation,
-all of which you can contribute to:
+If you take Ray Tune as an example, you can see that our documentation is made up of several types of documentation, all of which you can contribute to:
 
 - [a project landing page](https://docs.ray.io/en/latest/tune/index.html),
 - [a getting started guide](https://docs.ray.io/en/latest/tune/getting-started.html),
@@ -153,34 +133,20 @@ all of which you can contribute to:
 - [a detailed FAQ](https://docs.ray.io/en/latest/tune/faq.html),
 - [and API references](https://docs.ray.io/en/latest/tune/api/api.html).
 
-This structure is reflected in the
-[Ray documentation source code](https://github.com/ray-project/ray/tree/master/doc/source/tune) as well, so you
-should have no problem finding what you're looking for.
-All other Ray projects share a similar structure, but depending on the project there might be minor differences.
+This structure is reflected in the [Ray documentation source code](https://github.com/ray-project/ray/tree/master/doc/source/tune) as well, so you should have no problem finding what you're looking for. All other Ray projects share a similar structure, but depending on the project there might be minor differences.
 
-Each type of documentation listed above has its own purpose, but at the end our documentation
-comes down to _two types_ of documents:
+Each type of documentation listed above has its own purpose, but at the end our documentation comes down to _two types_ of documents:
 
-- Markup documents, written in MyST or rST. If you don't have a lot of (executable) code to contribute or
-  use more complex features such as
-  [tabbed content blocks](https://docs.ray.io/en/latest/ray-core/walkthrough.html#starting-ray), this is the right
-  choice. Most of the documents in Ray Tune are written in this way, for instance the
-  [key concepts](https://github.com/ray-project/ray/blob/master/doc/source/tune/key-concepts.rst) or
-  [API documentation](https://github.com/ray-project/ray/blob/master/doc/source/tune/api/api.rst).
-- Notebooks, written in `.ipynb` format. All Tune examples are written as notebooks. These notebooks render in
-  the browser like `.md` or `.rst` files, but have the added benefit that users can easily run the code themselves.
+- Markup documents, written in MyST or rST. If you don't have a lot of (executable) code to contribute or use more complex features such as [tabbed content blocks](https://docs.ray.io/en/latest/ray-core/walkthrough.html#starting-ray), this is the right choice. Most of the documents in Ray Tune are written in this way, for instance the [key concepts](https://github.com/ray-project/ray/blob/master/doc/source/tune/key-concepts.rst) or [API documentation](https://github.com/ray-project/ray/blob/master/doc/source/tune/api/api.rst).
+- Notebooks, written in `.ipynb` format. All Tune examples are written as notebooks. These notebooks render in the browser like `.md` or `.rst` files, but have the added benefit that users can easily run the code themselves.
 
 ## Fixing typos and improving explanations
 
-If you spot a typo in any document, or think that an explanation is not clear enough, please consider
-opening a pull request.
-In this scenario, just run the linter as described above and submit your pull request.
+If you spot a typo in any document, or think that an explanation is not clear enough, please consider opening a pull request. In this scenario, just run the linter as described above and submit your pull request.
 
 ## Adding API references
 
-We use [Sphinx's autodoc extension](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) to generate
-our API documentation from our source code.
-In case we're missing a reference to a function or class, please consider adding it to the respective document in question.
+We use [Sphinx's autodoc extension](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) to generate our API documentation from our source code. In case we're missing a reference to a function or class, please consider adding it to the respective document in question.
 
 For example, here's how you can add a function or class reference using `autofunction` and `autoclass`:
 
@@ -190,23 +156,15 @@ For example, here's how you can add a function or class reference using `autofun
 .. autoclass:: ray.tune.integration.keras.TuneReportCallback
 ```
 
-The above snippet was taken from the
-[Tune API documentation](https://github.com/ray-project/ray/blob/master/doc/source/tune/api/integration.rst),
-which you can look at for reference.
+The above snippet was taken from the [Tune API documentation](https://github.com/ray-project/ray/blob/master/doc/source/tune/api/integration.rst), which you can look at for reference.
 
-If you want to change the content of the API documentation, you will have to edit the respective function or class
-signatures directly in the source code.
-For example, in the above `autofunction` call, to change the API reference for `ray.tune.integration.docker.DockerSyncer`,
-you would have to [change the following source file](https://github.com/ray-project/ray/blob/7f1bacc7dc9caf6d0ec042e39499bbf1d9a7d065/python/ray/tune/integration/docker.py#L15-L38).
+If you want to change the content of the API documentation, you will have to edit the respective function or class signatures directly in the source code. For example, in the above `autofunction` call, to change the API reference for `ray.tune.integration.docker.DockerSyncer`, you would have to [change the following source file](https://github.com/ray-project/ray/blob/7f1bacc7dc9caf6d0ec042e39499bbf1d9a7d065/python/ray/tune/integration/docker.py#L15-L38).
 
 To show the usage of APIs, it is important to have small usage examples embedded in the API documentation. These should be self-contained and run out of the box, so a user can copy and paste them into a Python interpreter and play around with them (e.g., if applicable, they should point to example data). Users often rely on these examples to build their applications. To learn more about writing examples, read [How to write code snippets](writing-code-snippets).
 
 ## Adding code to an `.rST` or `.md` file
 
-Modifying text in an existing documentation file is easy, but you need to be careful when it comes to adding code.
-The reason is that we want to ensure every code snippet on our documentation is tested.
-This requires us to have a process for including and testing code snippets in documents. To learn how to write testable code
-snippets, read [How to write code snippets](writing-code-snippets).
+Modifying text in an existing documentation file is easy, but you need to be careful when it comes to adding code. The reason is that we want to ensure every code snippet on our documentation is tested. This requires us to have a process for including and testing code snippets in documents. To learn how to write testable code snippets, read [How to write code snippets](writing-code-snippets).
 
 ```python
 from ray import train
@@ -224,60 +182,25 @@ def trainable(config):  # Pass a "config" dictionary into your trainable.
         train.report({"score": score})  # Send the score to Tune.
 ```
 
-This code is imported by `literalinclude` from a file called `doc_code/key_concepts.py`.
-Every Python file in the `doc_code` directory will automatically get tested by our CI system,
-but make sure to run scripts that you change (or new scripts) locally first.
-You do not need to run the testing framework locally.
+This code is imported by `literalinclude` from a file called `doc_code/key_concepts.py`. Every Python file in the `doc_code` directory will automatically get tested by our CI system, but make sure to run scripts that you change (or new scripts) locally first. You do not need to run the testing framework locally.
 
-In rare situations, when you're adding _obvious_ pseudo-code to demonstrate a concept, it is ok to add it
-literally into your `.rST` or `.md` file, e.g. using a `.. code-cell:: python` directive.
-But if your code is supposed to run, it needs to be tested.
+In rare situations, when you're adding _obvious_ pseudo-code to demonstrate a concept, it is ok to add it literally into your `.rST` or `.md` file, e.g. using a `.. code-cell:: python` directive. But if your code is supposed to run, it needs to be tested.
 
 ## Creating a new document from scratch
 
-Sometimes you might want to add a completely new document to the Ray documentation, like adding a new
-user guide or a new example.
+Sometimes you might want to add a completely new document to the Ray documentation, like adding a new user guide or a new example.
 
-For this to work, you need to make sure to add the new document explicitly to a parent document's toctree,
-which determines the structure of the Ray documentation. See
-[the sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree)
-for more information.
+For this to work, you need to make sure to add the new document explicitly to a parent document's toctree, which determines the structure of the Ray documentation. See [the sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree) for more information.
 
-Depending on the type of document you're adding, you might also have to make changes to an existing overview
-page that curates the list of documents in question.
-For instance, for Ray Tune each user guide is added to the
-[user guide overview page](https://docs.ray.io/en/latest/tune/tutorials/overview.html) as a panel, and the same
-goes for [all Tune examples](https://docs.ray.io/en/latest/tune/examples/index.html).
-Always check the structure of the Ray sub-project whose documentation you're working on to see how to integrate
-it within the existing structure.
-In some cases you may be required to choose an image for the panel. Images are located in
-`doc/source/images`.
+Depending on the type of document you're adding, you might also have to make changes to an existing overview page that curates the list of documents in question. For instance, for Ray Tune each user guide is added to the [user guide overview page](https://docs.ray.io/en/latest/tune/tutorials/overview.html) as a panel, and the same goes for [all Tune examples](https://docs.ray.io/en/latest/tune/examples/index.html). Always check the structure of the Ray sub-project whose documentation you're working on to see how to integrate it within the existing structure. In some cases you may be required to choose an image for the panel. Images are located in `doc/source/images`.
 
 ## Creating a notebook example
 
-To add a new executable example to the Ray documentation, you can start from our
-[MyST notebook template](https://github.com/ray-project/ray/blob/master/doc/source/_templates/template.md) or
-[Jupyter notebook template](https://github.com/ray-project/ray/blob/master/doc/source/_templates/template.ipynb).
-You could also simply download the document you're reading right now (click on the respective download button at the
-top of this page to get the `.ipynb` file) and start modifying it.
-All the example notebooks in Ray Tune get automatically tested by our CI system, provided you place them in the
-[`examples` folder](https://github.com/ray-project/ray/tree/master/doc/source/tune/examples).
-If you have questions about how to test your notebook when contributing to other Ray sub-projects, please make
-sure to ask a question in [the Ray community Slack](https://www.ray.io/join-slack) or directly on GitHub,
-when opening your pull request.
+To add a new executable example to the Ray documentation, you can start from our [MyST notebook template](https://github.com/ray-project/ray/blob/master/doc/source/_templates/template.md) or [Jupyter notebook template](https://github.com/ray-project/ray/blob/master/doc/source/_templates/template.ipynb). You could also simply download the document you're reading right now (click on the respective download button at the top of this page to get the `.ipynb` file) and start modifying it. All the example notebooks in Ray Tune get automatically tested by our CI system, provided you place them in the [`examples` folder](https://github.com/ray-project/ray/tree/master/doc/source/tune/examples). If you have questions about how to test your notebook when contributing to other Ray sub-projects, please make sure to ask a question in [the Ray community Slack](https://www.ray.io/join-slack) or directly on GitHub, when opening your pull request.
 
-To work off of an existing example, you could also have a look at the
-[Ray Tune Hyperopt example (`.ipynb`)](https://github.com/ray-project/ray/blob/master/doc/source/tune/examples/hyperopt_example.ipynb)
-or the [Ray Serve guide for text classification (`.md`)](https://github.com/ray-project/ray/blob/master/doc/source/serve/tutorials/text-classification.md).
-We recommend that you start with an `.md` file and convert your file to an `.ipynb` notebook at the end of the process.
-We'll walk you through this process below.
+To work off of an existing example, you could also have a look at the [Ray Tune Hyperopt example (`.ipynb`)](https://github.com/ray-project/ray/blob/master/doc/source/tune/examples/hyperopt_example.ipynb) or the [Ray Serve guide for text classification (`.md`)](https://github.com/ray-project/ray/blob/master/doc/source/serve/tutorials/text-classification.md). We recommend that you start with an `.md` file and convert your file to an `.ipynb` notebook at the end of the process. We'll walk you through this process below.
 
-What makes these notebooks different from other documents is that they combine code and text in one document,
-and can be launched in the browser.
-We also make sure they are tested by our CI system, before we add them to our documentation.
-To make this work, notebooks need to define a _kernel specification_ to tell a notebook server how to interpret
-and run the code.
-For instance, here's the kernel specification of a Python notebook:
+What makes these notebooks different from other documents is that they combine code and text in one document, and can be launched in the browser. We also make sure they are tested by our CI system, before we add them to our documentation. To make this work, notebooks need to define a _kernel specification_ to tell a notebook server how to interpret and run the code. For instance, here's the kernel specification of a Python notebook:
 
 ```markdown
 ---
@@ -292,9 +215,7 @@ kernelspec:
 ---
 ```
 
-If you write a notebook in `.md` format, you need this YAML front matter at the top of the file.
-To add code to your notebook, you can use the `code-cell` directive.
-Here's an example:
+If you write a notebook in `.md` format, you need this YAML front matter at the top of the file. To add code to your notebook, you can use the `code-cell` directive. Here's an example:
 
 ````markdown
 ```python
@@ -341,14 +262,9 @@ checkpoint_path = train_ppo_model()
 
 ### Tags for your notebook
 
-What makes this work is the `:tags: [hide-cell]` directive in the `code-cell`.
-The reason we suggest starting with `.md` files is that it's much easier to add tags to them, as you've just seen.
-You can also add tags to `.ipynb` files, but you'll need to start a notebook server for that first, which may
-not want to do to contribute a piece of documentation.
+What makes this work is the `:tags: [hide-cell]` directive in the `code-cell`. The reason we suggest starting with `.md` files is that it's much easier to add tags to them, as you've just seen. You can also add tags to `.ipynb` files, but you'll need to start a notebook server for that first, which may not want to do to contribute a piece of documentation.
 
-Apart from `hide-cell`, you also have `hide-input` and `hide-output` tags that hide the input and output of a cell.
-Also, if you need code that gets executed in the notebook, but you don't want to show it in the documentation,
-you can use the `remove-cell`, `remove-input`, and `remove-output` tags in the same way.
+Apart from `hide-cell`, you also have `hide-input` and `hide-output` tags that hide the input and output of a cell. Also, if you need code that gets executed in the notebook, but you don't want to show it in the documentation, you can use the `remove-cell`, `remove-input`, and `remove-output` tags in the same way.
 
 ### Reference section labels
 
@@ -367,10 +283,7 @@ See {ref}`the thing that I labeled <my-label>` for more information.
 
 ### Testing notebooks
 
-Removing cells can be particularly interesting for compute-intensive notebooks.
-We want you to contribute notebooks that use _realistic_ values, not just toy examples.
-At the same time we want our notebooks to be tested by our CI system, and running them should not take too long.
-What you can do to address this is to have notebook cells with the parameters you want the users to see first:
+Removing cells can be particularly interesting for compute-intensive notebooks. We want you to contribute notebooks that use _realistic_ values, not just toy examples. At the same time we want our notebooks to be tested by our CI system, and running them should not take too long. What you can do to address this is to have notebook cells with the parameters you want the users to see first:
 
 ````markdown
 ```{code-cell} python3
@@ -386,8 +299,7 @@ num_workers = 8
 num_gpus = 2
 ```
 
-But then in your notebook you follow that up with a _removed_ cell that won't get rendered, but has much smaller
-values and make the notebook run faster:
+But then in your notebook you follow that up with a _removed_ cell that won't get rendered, but has much smaller values and make the notebook run faster:
 
 ````markdown
 ```{code-cell} python3
@@ -405,22 +317,16 @@ Once you're finished writing your example, you can convert it to an `.ipynb` not
 jupytext your-example.md --to ipynb
 ```
 
-In the same way, you can convert `.ipynb` notebooks to `.md` notebooks with `--to myst`.
-And if you want to convert your notebook to a Python file, e.g. to test if your whole script runs without errors,
-you can use `--to py` instead.
+In the same way, you can convert `.ipynb` notebooks to `.md` notebooks with `--to myst`. And if you want to convert your notebook to a Python file, e.g. to test if your whole script runs without errors, you can use `--to py` instead.
 
 (vale)=
 
 ## How to use Vale
 ### What is Vale?
 
-[Vale](https://vale.sh/) checks if your writing adheres to the
-[Google developer documentation style guide](https://developers.google.com/style).
-It's only enforced on the Ray Data documentation.
+[Vale](https://vale.sh/) checks if your writing adheres to the [Google developer documentation style guide](https://developers.google.com/style). It's only enforced on the Ray Data documentation.
 
-Vale catches typos and grammatical errors. It also enforces stylistic rules like
-“use contractions” and “use second person.” For the full list of rules, see the
-[configuration in the Ray repository](https://github.com/ray-project/ray/tree/master/.vale/styles/Google).
+Vale catches typos and grammatical errors. It also enforces stylistic rules like “use contractions” and “use second person.” For the full list of rules, see the [configuration in the Ray repository](https://github.com/ray-project/ray/tree/master/.vale/styles/Google).
 
 ### How do you run Vale?
 
@@ -440,8 +346,7 @@ Vale catches typos and grammatical errors. It also enforces stylistic rules like
 
     For more information on installation, see the [Vale documentation](https://vale.sh/docs/vale-cli/installation/).
 
-2. Install the Vale VS Code extension by following these
-[installation instructions](https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode).
+2. Install the Vale VS Code extension by following these [installation instructions](https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode).
 
 3. VS Code should show warnings in your code editor and in the “Problems” panel.
 
@@ -493,14 +398,11 @@ Vale catches typos and grammatical errors. It also enforces stylistic rules like
 
 To add custom terminology, complete the following steps:
 
-1. If it doesn’t already exist, create a directory for your team in
-`.vale/styles/Vocab`. For example, `.vale/styles/Vocab/Data`.
-2. If it doesn’t already exist, create a text file named `accept.txt`. For example,
-`.vale/styles/Vocab/Data/accept.txt`.
+1. If it doesn’t already exist, create a directory for your team in `.vale/styles/Vocab`. For example, `.vale/styles/Vocab/Data`.
+2. If it doesn’t already exist, create a text file named `accept.txt`. For example, `.vale/styles/Vocab/Data/accept.txt`.
 3. Add your term to `accept.txt`. Vale accepts Regex.
 
-For more information, see [Vocabularies](https://vale.sh/docs/topics/vocab/) in the Vale
-documentation.
+For more information, see [Vocabularies](https://vale.sh/docs/topics/vocab/) in the Vale documentation.
 
 ### How to handle false Google.WordList errors
 
@@ -525,5 +427,4 @@ If you run into a problem building the docs, following these steps can help isol
 
 ## Where to go from here?
 
-There are many other ways to contribute to Ray other than documentation.
-See {doc}`our contributor guide <getting-involved>` for more information.
+There are many other ways to contribute to Ray other than documentation. See {doc}`our contributor guide <getting-involved>` for more information.

--- a/doc/source/ray-contribute/fake-autoscaler.md
+++ b/doc/source/ray-contribute/fake-autoscaler.md
@@ -8,9 +8,7 @@ myst:
 
 # Testing Autoscaling Locally
 
-Testing autoscaling behavior is important for autoscaler development and the debugging of applications that depend
-on autoscaler behavior. You can run the autoscaler locally without needing to launch a real cluster with one of the
-following methods:
+Testing autoscaling behavior is important for autoscaler development and the debugging of applications that depend on autoscaler behavior. You can run the autoscaler locally without needing to launch a real cluster with one of the following methods:
 
 ## Using `RAY_FAKE_CLUSTER=1 ray start`
 
@@ -93,11 +91,9 @@ However, there are a few limitations:
 
 # Testing containerized multi nodes locally with Docker compose
 
-To go one step further and locally test a multi node setup where each node uses its own container (and thus
-has a separate filesystem, IP address, and Ray processes), you can use the `fake_multinode_docker` node provider.
+To go one step further and locally test a multi node setup where each node uses its own container (and thus has a separate filesystem, IP address, and Ray processes), you can use the `fake_multinode_docker` node provider.
 
-The setup is very similar to the {ref}`fake_multinode <fake-multinode>` provider. However, you need to start a monitoring process
-(`docker_monitor.py`) that takes care of running the `docker compose` command.
+The setup is very similar to the {ref}`fake_multinode <fake-multinode>` provider. However, you need to start a monitoring process (`docker_monitor.py`) that takes care of running the `docker compose` command.
 
 Prerequisites:
 
@@ -140,9 +136,7 @@ $ docker exec -it fake_docker_ffffffffffffffffffffffffffffffffffffffffffffffffff
 
 ## Using `ray.autoscaler._private.fake_multi_node.test_utils.DockerCluster`
 
-This utility is used to write tests that use multi node behavior. The `DockerCluster` class can
-be used to setup a Docker-compose cluster in a temporary directory, start the monitoring process,
-wait for the cluster to come up, connect to it, and update the configuration.
+This utility is used to write tests that use multi node behavior. The `DockerCluster` class can be used to setup a Docker-compose cluster in a temporary directory, start the monitoring process, wait for the cluster to come up, connect to it, and update the configuration.
 
 Please see the API documentation and example test cases on how to use this utility.
 
@@ -153,11 +147,9 @@ Please see the API documentation and example test cases on how to use this utili
 
 ## Features and Limitations of `fake_multinode_docker`
 
-The fake multinode docker node provider provides fully fledged nodes in their own containers. However,
-some limitations still remain:
+The fake multinode docker node provider provides fully fledged nodes in their own containers. However, some limitations still remain:
 
-1. Configurations for auth, setup, initialization, Ray start, file sync, and anything cloud-specific are not supported
-   (but might be in the future).
+1. Configurations for auth, setup, initialization, Ray start, file sync, and anything cloud-specific are not supported (but might be in the future).
 
 2. It's necessary to limit the number of nodes / node CPU / object store memory to avoid overloading your local machine.
 
@@ -167,50 +159,32 @@ some limitations still remain:
 
 The containers will mount two locations to host storage:
 
-- `/cluster/node`: This location (in the container) will point to `cluster_dir/nodes/<node_id>` (on the host).
-  This location is individual per node, but it can be used so that the host can examine contents stored in this directory.
-- `/cluster/shared`: This location (in the container) will point to `cluster_dir/shared` (on the host). This location
-  is shared across nodes and effectively acts as a shared filesystem (comparable to NFS).
+- `/cluster/node`: This location (in the container) will point to `cluster_dir/nodes/<node_id>` (on the host). This location is individual per node, but it can be used so that the host can examine contents stored in this directory.
+- `/cluster/shared`: This location (in the container) will point to `cluster_dir/shared` (on the host). This location is shared across nodes and effectively acts as a shared filesystem (comparable to NFS).
 
 ## Setting up in a Docker-in-Docker (dind) environment
 
-When setting up in a Docker-in-Docker (dind) environment (e.g. the Ray OSS Buildkite environment), some
-things have to be kept in mind. To make this clear, consider these concepts:
+When setting up in a Docker-in-Docker (dind) environment (e.g. the Ray OSS Buildkite environment), some things have to be kept in mind. To make this clear, consider these concepts:
 
 * The **host** is the not-containerized machine on which the code is executed (e.g. Buildkite runner)
-* The **outer container** is the container running directly on the **host**. In the Ray OSS Buildkite environment,
-  two containers are started - a *dind* network host and a container with the Ray source code and wheel in it.
+* The **outer container** is the container running directly on the **host**. In the Ray OSS Buildkite environment, two containers are started - a *dind* network host and a container with the Ray source code and wheel in it.
 * The **inner container** is a container started by the fake multinode docker node provider.
 
-The control plane for the multinode docker node provider lives in the outer container. However, `docker compose`
-commands are executed from the connected docker-in-docker network. In the Ray OSS Buildkite environment, this is
-the `dind-daemon` container running on the host docker. If you e.g. mounted `/var/run/docker.sock` from the
-host instead, it would be the host docker daemon. We will refer to both as the **host daemon** from now on.
+The control plane for the multinode docker node provider lives in the outer container. However, `docker compose` commands are executed from the connected docker-in-docker network. In the Ray OSS Buildkite environment, this is the `dind-daemon` container running on the host docker. If you e.g. mounted `/var/run/docker.sock` from the host instead, it would be the host docker daemon. We will refer to both as the **host daemon** from now on.
 
-The outer container modifies files that have to be mounted in the inner containers (and modified from there
-as well). This means that the host daemon also has to have access to these files.
+The outer container modifies files that have to be mounted in the inner containers (and modified from there as well). This means that the host daemon also has to have access to these files.
 
-Similarly, the inner containers expose ports - but because the containers are actually started by the host daemon,
-the ports are also only accessible on the host (or the dind container).
+Similarly, the inner containers expose ports - but because the containers are actually started by the host daemon, the ports are also only accessible on the host (or the dind container).
 
 For the Ray OSS Buildkite environment, we thus set some environment variables:
 
-* `RAY_TEMPDIR="/ray-mount"`. This environment variable defines where the temporary directory for the
-  cluster files should be created. This directory has to be accessible by the host, the outer container,
-  and the inner container. In the inner container, we can control the directory name.
+* `RAY_TEMPDIR="/ray-mount"`. This environment variable defines where the temporary directory for the cluster files should be created. This directory has to be accessible by the host, the outer container, and the inner container. In the inner container, we can control the directory name.
 
-* `RAY_HOSTDIR="/ray"`. In the case where the shared directory has a different name on the host, we can
-  rewrite the mount points dynamically. In this example, the outer container is started with `-v /ray:/ray-mount`
-  or similar, so the directory on the host is `/ray` and in the outer container `/ray-mount` (see `RAY_TEMPDIR`).
+* `RAY_HOSTDIR="/ray"`. In the case where the shared directory has a different name on the host, we can rewrite the mount points dynamically. In this example, the outer container is started with `-v /ray:/ray-mount` or similar, so the directory on the host is `/ray` and in the outer container `/ray-mount` (see `RAY_TEMPDIR`).
 
-* `RAY_TESTHOST="dind-daemon"` As the containers are started by the host daemon, we can't just connect to
-  `localhost`, as the ports are not exposed to the outer container. Thus, we can set the Ray host with this environment
-  variable.
+* `RAY_TESTHOST="dind-daemon"` As the containers are started by the host daemon, we can't just connect to `localhost`, as the ports are not exposed to the outer container. Thus, we can set the Ray host with this environment variable.
 
-Lastly, docker-compose obviously requires a docker image. The default docker image is `rayproject/ray:nightly`.
-The docker image requires `openssh-server` to be installed and enabled. In Buildkite we build a new image from
-`rayproject/ray:nightly-py38-cpu` to avoid installing this on the fly for every node (which is the default way).
-This base image is built in one of the previous build steps.
+Lastly, docker-compose obviously requires a docker image. The default docker image is `rayproject/ray:nightly`. The docker image requires `openssh-server` to be installed and enabled. In Buildkite we build a new image from `rayproject/ray:nightly-py38-cpu` to avoid installing this on the fly for every node (which is the default way). This base image is built in one of the previous build steps.
 
 Thus, we set
 
@@ -226,12 +200,10 @@ If you're doing local development on the fake multi node docker module, you can 
 
 * `FAKE_CLUSTER_DEV="auto"`
 
-this will mount the `ray/python/ray/autoscaler` directory to the started nodes. Please note that
-this is will probably not work in your docker-in-docker setup.
+this will mount the `ray/python/ray/autoscaler` directory to the started nodes. Please note that this is will probably not work in your docker-in-docker setup.
 
 If you want to specify which top-level Ray directories to mount, you can use:
 
 * `FAKE_CLUSTER_DEV_MODULES="autoscaler,tune"`
 
-This will mount both `ray/python/ray/autoscaler` and `ray/python/ray/tune` within the node containers. The
-list of modules should be comma separated and without spaces.
+This will mount both `ray/python/ray/autoscaler` and `ray/python/ray/tune` within the node containers. The list of modules should be comma separated and without spaces.

--- a/doc/source/ray-contribute/getting-involved.md
+++ b/doc/source/ray-contribute/getting-involved.md
@@ -26,13 +26,10 @@ profiling
 agent-development
 ```
 
-Ray is more than a framework for distributed applications but also an active community of developers,
-researchers, and folks that love machine learning.
+Ray is more than a framework for distributed applications but also an active community of developers, researchers, and folks that love machine learning.
 
 :::{tip}
-Ask questions on [our forum](https://discuss.ray.io/)! The
-community is extremely active in helping people succeed in building their
-Ray applications.
+Ask questions on [our forum](https://discuss.ray.io/)! The community is extremely active in helping people succeed in building their Ray applications.
 :::
 
 You can join (and Star!) us [on GitHub](https://github.com/ray-project/ray).
@@ -97,18 +94,11 @@ There are a couple steps to merge a contribution.
    git pull . upstream/master
    ```
 
-2. Make sure all existing [tests](#testing) and [linters](#lint-and-formatting) pass.
-   Run `setup_hooks.sh` to create a git hook that will run the linter before you push your changes.
-3. If introducing a new feature or patching a bug, be sure to add new test cases
-   in the relevant file in `ray/python/ray/tests/`.
-4. Document the code. Public functions need to be documented, and remember to provide an usage
-   example if applicable. See `doc/README.md` for instructions on editing and building public documentation.
-5. Address comments on your PR. During the review
-   process you may need to address merge conflicts with other changes. To resolve merge conflicts,
-   run `git pull . upstream/master` on your branch (please do not use rebase, as it is less
-   friendly to the GitHub review tool. All commits will be squashed on merge.)
-6. Reviewers will merge and approve the pull request; be sure to ping them if
-   the pull request is getting stale.
+2. Make sure all existing [tests](#testing) and [linters](#lint-and-formatting) pass. Run `setup_hooks.sh` to create a git hook that will run the linter before you push your changes.
+3. If introducing a new feature or patching a bug, be sure to add new test cases in the relevant file in `ray/python/ray/tests/`.
+4. Document the code. Public functions need to be documented, and remember to provide an usage example if applicable. See `doc/README.md` for instructions on editing and building public documentation.
+5. Address comments on your PR. During the review process you may need to address merge conflicts with other changes. To resolve merge conflicts, run `git pull . upstream/master` on your branch (please do not use rebase, as it is less friendly to the GitHub review tool. All commits will be squashed on merge.)
+6. Reviewers will merge and approve the pull request; be sure to ping them if the pull request is getting stale.
 
 ## PR Review Process
 
@@ -128,9 +118,7 @@ There are a couple steps to merge a contribution.
 
 ## Testing
 
-Even though we have hooks to run unit tests automatically for each pull request,
-we recommend you to run unit tests locally beforehand to reduce reviewers’
-burden and speedup review process.
+Even though we have hooks to run unit tests automatically for each pull request, we recommend you to run unit tests locally beforehand to reduce reviewers’ burden and speedup review process.
 
 If you are running tests for the first time, you can install the required dependencies with:
 
@@ -311,13 +299,9 @@ python setup.py check --restructuredtext --strict --metadata
 
 ## Understanding CI test jobs
 
-The Ray project automatically runs continuous integration (CI) tests once a PR
-is opened using [Buildkite](https://buildkite.com/ray-project/) with
-multiple CI test jobs.
+The Ray project automatically runs continuous integration (CI) tests once a PR is opened using [Buildkite](https://buildkite.com/ray-project/) with multiple CI test jobs.
 
-The [CI](https://github.com/ray-project/ray/tree/master/ci) test folder contains all integration test scripts and they
-invoke other test scripts via `pytest`, `bazel`-based test or other bash
-scripts. Some of the examples include:
+The [CI](https://github.com/ray-project/ray/tree/master/ci) test folder contains all integration test scripts and they invoke other test scripts via `pytest`, `bazel`-based test or other bash scripts. Some of the examples include:
 
 * Bazel test command:
     * `bazel test --build_tests_only //:all`
@@ -326,9 +310,7 @@ scripts. Some of the examples include:
     * `pytest python/ray/serve/tests`
     * `python python/ray/serve/examples/echo_full.py`
 
-If a CI build exception doesn't appear to be related to your change,
-please visit [this link](https://flakey-tests.ray.io/) to
-check recent tests known to be flaky.
+If a CI build exception doesn't appear to be related to your change, please visit [this link](https://flakey-tests.ray.io/) to check recent tests known to be flaky.
 
 ## API compatibility style guide
 
@@ -354,8 +336,7 @@ def tune_user_callback(model, score, **future_kwargs):
 
 ## Community Examples
 
-We're always looking for new example contributions! When contributing an example for a Ray library,
-include a link to your example in the `examples.yml` file for that library:
+We're always looking for new example contributions! When contributing an example for a Ray library, include a link to your example in the `examples.yml` file for that library:
 
 ```yaml
  - title: Serve a Java App
@@ -364,16 +345,11 @@ include a link to your example in the `examples.yml` file for that library:
    contributor: community
 ```
 
-Give your example a title, a skill level (`beginner`, `intermediate`, or `advanced`), and a
-link (relative links point to other documentation pages, but direct links starting with `http://`
-also work). Include the `contributor: community` metadata to ensure that the example is correctly
-labeled as a community example in the example gallery.
+Give your example a title, a skill level (`beginner`, `intermediate`, or `advanced`), and a link (relative links point to other documentation pages, but direct links starting with `http://` also work). Include the `contributor: community` metadata to ensure that the example is correctly labeled as a community example in the example gallery.
 
 ## Becoming a Committer
 
-Committers are experienced contributors who have demonstrated significant contributions
-to the Ray project over an extended period. Committers have additional responsibilities
-and privileges within the project.
+Committers are experienced contributors who have demonstrated significant contributions to the Ray project over an extended period. Committers have additional responsibilities and privileges within the project.
 
 **Eligibility Criteria**
 

--- a/doc/source/ray-contribute/involvement.md
+++ b/doc/source/ray-contribute/involvement.md
@@ -1,5 +1,4 @@
-Ray is more than a framework for distributed applications but also an active community of developers,
-researchers, and folks that love machine learning. Here's a list of tips for getting involved with the Ray community:
+Ray is more than a framework for distributed applications but also an active community of developers, researchers, and folks that love machine learning. Here's a list of tips for getting involved with the Ray community:
 
 - Join our [community Slack](https://www.ray.io/join-slack) to discuss Ray!
 - Star and follow us on [on GitHub](https://github.com/ray-project/ray).

--- a/doc/source/ray-contribute/profiling.md
+++ b/doc/source/ray-contribute/profiling.md
@@ -12,10 +12,7 @@ This guide helps contributors to the Ray project analyze Ray performance.
 
 ## Getting a stack trace of Ray C++ processes
 
-You can use the following GDB command to view the current stack trace of any
-running Ray process (e.g., raylet). This can be useful for debugging 100% CPU
-utilization or infinite loops (simply run the command a few times to see what
-the process is stuck on).
+You can use the following GDB command to view the current stack trace of any running Ray process (e.g., raylet). This can be useful for debugging 100% CPU utilization or infinite loops (simply run the command a few times to see what the process is stuck on).
 
 ```shell
 sudo gdb -batch -ex "thread apply all bt" -p <pid>
@@ -25,8 +22,7 @@ Note that you can find the pid of the raylet with `pgrep raylet`.
 
 ## Installation
 
-These instructions are for Ubuntu only. Attempts to get `pprof` to correctly
-symbolize on Mac OS have failed.
+These instructions are for Ubuntu only. Attempts to get `pprof` to correctly symbolize on Mac OS have failed.
 
 ```bash
 sudo apt-get install google-perftools libgoogle-perftools-dev
@@ -48,18 +44,13 @@ export PERFTOOLS_LOGFILE=/tmp/pprof.out
 export RAY_RAYLET_PERFTOOLS_PROFILER=1
 ```
 
-The file `/tmp/pprof.out` is empty until you let the binary run the
-target workload for a while and then `kill` it via `ray stop` or by
-letting the driver exit.
+The file `/tmp/pprof.out` is empty until you let the binary run the target workload for a while and then `kill` it via `ray stop` or by letting the driver exit.
 
-Note: Enabling `RAY_RAYLET_PERFTOOLS_PROFILER` allows profiling of the Raylet component.
-To profile other modules, use `RAY_{MODULE}_PERFTOOLS_PROFILER`,
-where `MODULE` represents the uppercase form of the process type, such as `GCS_SERVER`.
+Note: Enabling `RAY_RAYLET_PERFTOOLS_PROFILER` allows profiling of the Raylet component. To profile other modules, use `RAY_{MODULE}_PERFTOOLS_PROFILER`, where `MODULE` represents the uppercase form of the process type, such as `GCS_SERVER`.
 
 ### Visualizing the CPU profile
 
-You can visualize the output of `pprof` in different ways. Below, the output is a
-zoomable `.svg` image displaying the call graph annotated with hot paths.
+You can visualize the output of `pprof` in different ways. Below, the output is a zoomable `.svg` image displaying the call graph annotated with hot paths.
 
 ```bash
 # Use the appropriate path.
@@ -73,18 +64,15 @@ google-pprof -svg $RAYLET /tmp/pprof.out > /tmp/pprof.svg
 google-pprof -focus=epoll_wait -svg $RAYLET /tmp/pprof.out > /tmp/pprof.svg
 ```
 
-Below is a snapshot of an example SVG output, from the official
-documentation:
+Below is a snapshot of an example SVG output, from the official documentation:
 
 ![](http://goog-perftools.sourceforge.net/doc/pprof-test-big.gif)
 
 ## Memory profiling
 
-To run memory profiling on Ray core components, use [jemalloc](https://github.com/jemalloc/jemalloc).
-Ray supports environment variables that override `LD_PRELOAD` on core components.
+To run memory profiling on Ray core components, use [jemalloc](https://github.com/jemalloc/jemalloc). Ray supports environment variables that override `LD_PRELOAD` on core components.
 
-You can find the component name from `ray_constants.py`. For example, if you'd like to profile gcs_server,
-search `PROCESS_TYPE_GCS_SERVER` in `ray_constants.py`. You can see the value is `gcs_server`.
+You can find the component name from `ray_constants.py`. For example, if you'd like to profile gcs_server, search `PROCESS_TYPE_GCS_SERVER` in `ray_constants.py`. You can see the value is `gcs_server`.
 
 Users are supposed to provide 4 env vars for memory profiling.
 

--- a/doc/source/ray-contribute/stability.md
+++ b/doc/source/ray-contribute/stability.md
@@ -22,37 +22,25 @@ Ray's PublicAPI stability definitions are based off the [Google stability level 
 
 ## Alpha
 
-An *alpha* component undergoes rapid iteration with a known set of users who
-**must** be tolerant of change. The number of users **should** be a
-curated, manageable set, such that it is feasible to communicate with all
-of them individually.
+An *alpha* component undergoes rapid iteration with a known set of users who **must** be tolerant of change. The number of users **should** be a curated, manageable set, such that it is feasible to communicate with all of them individually.
 
-Breaking changes **must** be both allowed and expected in alpha components, and
-users **must** have no expectation of stability.
+Breaking changes **must** be both allowed and expected in alpha components, and users **must** have no expectation of stability.
 
 (api-stability-beta)=
 
 ## Beta
 
-A *beta* component **must** be considered complete and ready to be declared
-stable, subject to public testing.
+A *beta* component **must** be considered complete and ready to be declared stable, subject to public testing.
 
-Because users of beta components tend to have a lower tolerance of change, beta
-components **should** be as stable as possible; however, the beta component
-**must** be permitted to change over time. These changes **should** be minimal
-but **may** include backwards-incompatible changes to beta components.
+Because users of beta components tend to have a lower tolerance of change, beta components **should** be as stable as possible; however, the beta component **must** be permitted to change over time. These changes **should** be minimal but **may** include backwards-incompatible changes to beta components.
 
-Backwards-incompatible changes **must** be made only after a reasonable
-deprecation period to provide users with an opportunity to migrate their code.
+Backwards-incompatible changes **must** be made only after a reasonable deprecation period to provide users with an opportunity to migrate their code.
 
 (api-stability-stable)=
 
 ## Stable
 
-A *stable* component **must** be fully-supported over the lifetime of the major
-API version. Because users expect such stability from components marked stable,
-there **must** be no breaking changes to these components within a major version
-(excluding extraordinary circumstances).
+A *stable* component **must** be fully-supported over the lifetime of the major API version. Because users expect such stability from components marked stable, there **must** be no breaking changes to these components within a major version (excluding extraordinary circumstances).
 
 ### Docstrings
 

--- a/doc/source/ray-contribute/testing-tips.md
+++ b/doc/source/ray-contribute/testing-tips.md
@@ -6,8 +6,7 @@ myst:
 
 # Tips for testing Ray programs
 
-Ray programs can be a little tricky to test due to the nature of parallel programs.
-We've put together a list of tips and tricks for common testing practices for Ray programs.
+Ray programs can be a little tricky to test due to the nature of parallel programs. We've put together a list of tips and tricks for common testing practices for Ray programs.
 
 ```{contents}
 :local:
@@ -72,8 +71,7 @@ Depending on your application, there are certain cases where it may be unsafe to
 If writing an application for a cluster setting, you may want to mock a multi-node Ray cluster. This can be done with the `ray.cluster_utils.Cluster` utility.
 
 :::{note}
-On Windows, support for multi-node Ray clusters is currently experimental and untested.
-If you run into issues please file a report at <https://github.com/ray-project/ray/issues>.
+On Windows, support for multi-node Ray clusters is currently experimental and untested. If you run into issues please file a report at <https://github.com/ray-project/ray/issues>.
 :::
 
 ```{testcode}

--- a/doc/source/ray-contribute/whitepaper.md
+++ b/doc/source/ray-contribute/whitepaper.md
@@ -8,7 +8,6 @@ myst:
 
 # Architecture Whitepapers
 
-For an in-depth overview of Ray internals, check out the [Ray 2.0 Architecture whitepaper](https://docs.google.com/document/d/1tBw9A4j62ruI5omIJbMxly-la5w4q_TjyJgJL_jN2fI/preview).
-The previous v1.0 whitepaper can be found [here](https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview).
+For an in-depth overview of Ray internals, check out the [Ray 2.0 Architecture whitepaper](https://docs.google.com/document/d/1tBw9A4j62ruI5omIJbMxly-la5w4q_TjyJgJL_jN2fI/preview). The previous v1.0 whitepaper can be found [here](https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview).
 
 For more about the scalability and performance of the Ray dataplane, see the [Exoshuffle paper](https://arxiv.org/abs/2203.05072).

--- a/doc/source/ray-contribute/writing-code-snippets.md
+++ b/doc/source/ray-contribute/writing-code-snippets.md
@@ -8,16 +8,12 @@ myst:
 
 # How to write code snippets
 
-Users learn from example. So, whether you're writing a docstring or a user guide,
-include examples that illustrate the relevant APIs. Your examples should run
-out-of-the-box so that users can copy them and adapt them to their own needs.
+Users learn from example. So, whether you're writing a docstring or a user guide, include examples that illustrate the relevant APIs. Your examples should run out-of-the-box so that users can copy them and adapt them to their own needs.
 
 This page describes how to write code snippets so that they're tested in CI.
 
 :::{note}
-The examples in this guide use reStructuredText. If you're writing
-Markdown, use MyST syntax. To learn more, read the
-[MyST documentation](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html#directives-a-block-level-extension-point).
+The examples in this guide use reStructuredText. If you're writing Markdown, use MyST syntax. To learn more, read the [MyST documentation](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html#directives-a-block-level-extension-point).
 :::
 
 ## Types of examples
@@ -123,8 +119,7 @@ They're rendered like this:
 
 ## Which type of example should you write?
 
-There's no hard rule about which style you should use. Choose the style that best
-illustrates your API.
+There's no hard rule about which style you should use. Choose the style that best illustrates your API.
 
 :::{tip}
 If you're not sure which style to use, use *code-output-style*.
@@ -132,8 +127,7 @@ If you're not sure which style to use, use *code-output-style*.
 
 ### When to use *doctest-style*
 
-If you're writing a small example that emphasizes object representations, or if you
-want to print intermediate objects, use *doctest-style*.
+If you're writing a small example that emphasizes object representations, or if you want to print intermediate objects, use *doctest-style*.
 
 ```
 .. doctest::
@@ -196,8 +190,7 @@ If you're writing a longer example, or if object representations aren't relevant
 
 ### When to use *literalinclude*
 
-If you're writing an end-to-end examples and your examples doesn't contain outputs, use
-*literalinclude*.
+If you're writing an end-to-end examples and your examples doesn't contain outputs, use *literalinclude*.
 
 ## How to handle hard-to-test examples
 
@@ -250,8 +243,7 @@ To ignore an output altogether, write a *code-output-style* snippet. Don't use `
 
 ### Ignoring *code-output-style* outputs
 
-If parts of your output are long or non-deterministic, replace problematic sections
-with ellipses.
+If parts of your output are long or non-deterministic, replace problematic sections with ellipses.
 
 ```
 .. testcode::
@@ -265,8 +257,7 @@ with ellipses.
     Dataset(num_rows=..., schema=...)
 ```
 
-If your output is nondeterministic and you want to display a sample output, add
-`:options: +MOCK`.
+If your output is nondeterministic and you want to display a sample output, add `:options: +MOCK`.
 
 ```
 .. testcode::
@@ -280,8 +271,7 @@ If your output is nondeterministic and you want to display a sample output, add
     0.969461416250246
 ```
 
-If your output is hard to test and you don't want to display a sample output, exclude
-the `testoutput`.
+If your output is hard to test and you don't want to display a sample output, exclude the `testoutput`.
 
 ```
 .. testcode::
@@ -293,9 +283,7 @@ the `testoutput`.
 
 To configure Bazel to run an example with GPUs, complete the following steps:
 
-1. Open the corresponding `BUILD` file. If your example is in the `doc/` folder,
-   open `doc/BUILD`. If your example is in the `python/` folder, open a file like
-   `python/ray/train/BUILD`.
+1. Open the corresponding `BUILD` file. If your example is in the `doc/` folder, open `doc/BUILD`. If your example is in the `python/` folder, open a file like `python/ray/train/BUILD`.
 
 2. Locate the `doctest` rule. It looks like this:
 


### PR DESCRIPTION
## Description

Soft-wraps the prose in the `ray-contribute` developer guides: each paragraph and list item becomes a single line, leaving line wrapping to the editor and renderer. The recent RST-to-MyST conversion preserved the source's original hard line breaks, and this unwraps them.

This is intentionally a **whitespace-only** change, kept on its own so it doesn't mix with the style and grammar edits that follow.

Left untouched: fenced code blocks (including nested fences and the `{list-table}` / `{contents}` directives), `:::` admonitions and their options, MyST `(target)=` anchors, headings, block quotes, and YAML front matter. Only single newlines within a paragraph or list item are collapsed to spaces.

Verified the rendered output is unchanged: for every file the CommonMark-rendered HTML is identical before and after (after whitespace normalization), non-whitespace content is byte-for-byte identical, and MyST-specific constructs are left unchanged.

## Related issues

N/A.

## Additional information

14 files changed: every `.md` file under `doc/source/ray-contribute/` that contained hard-wrapped prose. `index.md` already had no hard-wrapped prose and is unchanged.
