### PR TITLE
[serve][test] Skip HTTPS proxy tests under HAProxy (HTTP-only ingress)

### DIFF
--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -31,6 +31,7 @@
 //python/ray/serve/tests:test_http_cancellation
 //python/ray/serve/tests:test_http_headers
 //python/ray/serve/tests:test_http_routes
+//python/ray/serve/tests:test_https_proxy
 //python/ray/serve/tests:test_list_outbound_deployments
 //python/ray/serve/tests:test_logging
 //python/ray/serve/tests:test_long_poll

--- a/python/ray/serve/tests/test_https_proxy.py
+++ b/python/ray/serve/tests/test_https_proxy.py
@@ -14,15 +14,15 @@ from ray._common.tls_utils import generate_self_signed_tls_certs
 from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY
 from ray.serve.config import HTTPOptions
 
-# HAProxy ingress does not terminate TLS: the HAProxy frontend binds plain HTTP
-# and health-checks replicas over plain HTTP, while direct-ingress replicas serve
-# HTTPS. The backends never pass the health check, the proxy never becomes ready,
-# and serve.run() blocks until timeout. Supporting HTTPS through HAProxy requires
-# plumbing TLS into the frontend bind and backend health checks (a feature, not a
-# test fix), so the HTTPS-serving tests are skipped under HAProxy.
+# HAProxy ingress intentionally does not terminate TLS (won't-do): the HAProxy
+# frontend serves plain HTTP only. HTTPS is served by direct-ingress mode, where
+# the replicas terminate TLS themselves, or by terminating TLS at a proxy in
+# front of HAProxy. So HTTPS/wss is not supported under HAProxy ingress, and
+# these HTTPS-serving tests are skipped there by design, not pending a feature.
 skip_https_under_haproxy = pytest.mark.skipif(
     RAY_SERVE_ENABLE_HA_PROXY,
-    reason="HAProxy ingress does not terminate TLS; HTTPS/wss is unsupported.",
+    reason="HTTPS/wss is not supported under HAProxy ingress by design "
+    "(HAProxy serves plain HTTP only; use direct-ingress mode for TLS).",
 )
 
 

--- a/python/ray/serve/tests/test_https_proxy.py
+++ b/python/ray/serve/tests/test_https_proxy.py
@@ -11,7 +11,19 @@ import websockets
 import ray
 from ray import serve
 from ray._common.tls_utils import generate_self_signed_tls_certs
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY
 from ray.serve.config import HTTPOptions
+
+# HAProxy ingress does not terminate TLS: the HAProxy frontend binds plain HTTP
+# and health-checks replicas over plain HTTP, while direct-ingress replicas serve
+# HTTPS. The backends never pass the health check, the proxy never becomes ready,
+# and serve.run() blocks until timeout. Supporting HTTPS through HAProxy requires
+# plumbing TLS into the frontend bind and backend health checks (a feature, not a
+# test fix), so the HTTPS-serving tests are skipped under HAProxy.
+skip_https_under_haproxy = pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason="HAProxy ingress does not terminate TLS; HTTPS/wss is unsupported.",
+)
 
 
 @pytest.fixture(scope="session")
@@ -69,6 +81,7 @@ def https_serve_instance(ssl_cert_and_key):
     ray.shutdown()
 
 
+@skip_https_under_haproxy
 class TestHTTPSProxy:
     def test_https_basic_deployment(self, https_serve_instance):
         """Test basic HTTPS deployment functionality."""
@@ -424,6 +437,7 @@ class TestHTTPSErrorHandling:
         assert options.ssl_certfile is None
 
 
+@skip_https_under_haproxy
 class TestHTTPSIntegration:
     def test_https_with_custom_port(self, ssl_cert_and_key):
         """Test HTTPS on custom port."""

--- a/python/ray/serve/tests/test_https_proxy.py
+++ b/python/ray/serve/tests/test_https_proxy.py
@@ -14,10 +14,8 @@ from ray._common.tls_utils import generate_self_signed_tls_certs
 from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY
 from ray.serve.config import HTTPOptions
 
-# HAProxy ingress serves plain HTTP and does not terminate TLS. TLS is handled
-# by direct-ingress mode, where the replicas terminate it, or by an upstream
-# TLS-terminating proxy. These tests drive HTTPS/wss through HAProxy, which is
-# not a path it serves, so skip them when HAProxy is enabled.
+# HAProxy ingress is HTTP-only and does not terminate TLS, so HTTPS and wss
+# requests can't pass through it. Skip these tests when HAProxy is enabled.
 skip_https_under_haproxy = pytest.mark.skipif(
     RAY_SERVE_ENABLE_HA_PROXY,
     reason="HAProxy ingress serves HTTP only; TLS is handled by direct ingress "

--- a/python/ray/serve/tests/test_https_proxy.py
+++ b/python/ray/serve/tests/test_https_proxy.py
@@ -14,15 +14,14 @@ from ray._common.tls_utils import generate_self_signed_tls_certs
 from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY
 from ray.serve.config import HTTPOptions
 
-# HAProxy ingress intentionally does not terminate TLS (won't-do): the HAProxy
-# frontend serves plain HTTP only. HTTPS is served by direct-ingress mode, where
-# the replicas terminate TLS themselves, or by terminating TLS at a proxy in
-# front of HAProxy. So HTTPS/wss is not supported under HAProxy ingress, and
-# these HTTPS-serving tests are skipped there by design, not pending a feature.
+# HAProxy ingress serves plain HTTP and does not terminate TLS. TLS is handled
+# by direct-ingress mode, where the replicas terminate it, or by an upstream
+# TLS-terminating proxy. These tests drive HTTPS/wss through HAProxy, which is
+# not a path it serves, so skip them when HAProxy is enabled.
 skip_https_under_haproxy = pytest.mark.skipif(
     RAY_SERVE_ENABLE_HA_PROXY,
-    reason="HTTPS/wss is not supported under HAProxy ingress by design "
-    "(HAProxy serves plain HTTP only; use direct-ingress mode for TLS).",
+    reason="HAProxy ingress serves HTTP only; TLS is handled by direct ingress "
+    "or an upstream proxy.",
 )
 
 


### PR DESCRIPTION
## Why

Under HAProxy ingress (`RAY_SERVE_ENABLE_HA_PROXY=1`), `test_https_websocket_with_fastapi` hangs until SIGKILL. The cause is not websockets. HAProxy ingress serves plain HTTP and does not terminate TLS. The frontend binds plain HTTP and health-checks replicas over plain HTTP, while direct-ingress replicas serve HTTPS, so backends never pass the health check, the proxy never becomes ready, and `serve.run()` blocks. The whole HTTPS-serving path is affected, not only the websocket test.

## Scope

HAProxy ingress is HTTP-only. TLS is terminated by direct-ingress mode (replicas terminate TLS) or by an upstream TLS-terminating proxy in front of HAProxy, so HTTPS is not a path HAProxy serves. Same shape as gRPC, which is served by direct-ingress mode rather than HAProxy.

## What

Skip the TLS-serving test classes (`TestHTTPSProxy`, `TestHTTPSIntegration`) under `RAY_SERVE_ENABLE_HA_PROXY`. The config-only validation classes (`TestSSLConfiguration`, `TestHTTPSErrorHandling`) still run.

Add `//python/ray/serve/tests:test_https_proxy` to the HAProxy CI allowlist (`ci/ray_ci/serve_hap_test_names.txt`) so the file runs under `RAY_SERVE_ENABLE_HA_PROXY=1`.

## Notes

- Unblocks the "run all serve tests under HAProxy" effort (#64210), where these tests otherwise hang.
- The allowlist is deleted wholesale by #64210. Until that lands, this entry runs the file under HAProxy on master, so the skips are exercised in CI rather than dormant.
