### PR TITLE
[serve][test] Mark gRPC ingress tests skipped under HAProxy with accurate reason

### DIFF
--- a/python/ray/serve/tests/test_backpressure_grpc.py
+++ b/python/ray/serve/tests/test_backpressure_grpc.py
@@ -8,8 +8,17 @@ import ray
 from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray.serve._private.common import RequestProtocol
+from ray.serve._private.constants import RAY_SERVE_ENABLE_HA_PROXY
 from ray.serve._private.test_utils import get_application_url
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
+
+# gRPC ingress is served by direct-ingress mode, not by HAProxy (which fronts
+# HTTP only). These gRPC backpressure tests are not applicable under HAProxy
+# ingress; gRPC coverage lives in the direct-ingress test steps.
+pytestmark = pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason="gRPC ingress is served by direct-ingress mode, not HAProxy.",
+)
 
 
 def test_grpc_backpressure(serve_instance):

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -12,6 +12,7 @@ from ray import serve
 from ray._common.test_utils import SignalActor
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
+    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_NAMESPACE,
 )
 from ray.serve._private.test_utils import (
@@ -29,6 +30,15 @@ from ray.serve.config import gRPCOptions
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.grpc_util import RayServegRPCContext, gRPCInputStream
 from ray.serve.tests.test_config_files.grpc_deployment import g, g2
+
+# gRPC ingress is served by direct-ingress mode (each replica runs its own gRPC
+# server), not by HAProxy, which fronts HTTP only. These gRPC tests are not
+# applicable under HAProxy ingress; gRPC coverage lives in the direct-ingress
+# test steps (RAY_SERVE_ENABLE_DIRECT_INGRESS=1).
+pytestmark = pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason="gRPC ingress is served by direct-ingress mode, not HAProxy.",
+)
 
 
 def test_serving_grpc_requests(ray_cluster):


### PR DESCRIPTION
## Why

gRPC ingress in Serve is served by **direct-ingress mode** (each replica runs its own gRPC server, `RAY_SERVE_ENABLE_DIRECT_INGRESS=1`), not by HAProxy, which fronts HTTP only. So the dedicated gRPC ingress test modules are not applicable under HAProxy ingress, and that is by design, not a missing feature.

## What

Add a module-level `skipif(RAY_SERVE_ENABLE_HA_PROXY)` to `test_grpc.py` and `test_backpressure_grpc.py`, with a reason that states the design ("served by direct-ingress mode, not HAProxy") rather than implying gRPC-over-HAProxy is unfinished ("...not supported yet").

## Scope / notes

- Covers the two dedicated gRPC ingress test modules. gRPC sub-tests embedded in mixed HTTP/gRPC files (e.g. `test_proxy.py`, `test_metrics_2.py`, `test_cli_4.py`, `test_consistent_hash_router.py`) are handled where they live as part of the broader "run all serve tests under HAProxy" effort (#64210).
- These modules are not in the HAProxy whitelist on master, so the skip is dormant until the suite runs under HAProxy; it documents intent and takes effect under that effort.