### PR TITLE
[serve][test] Make proxy actor-set assertions HAProxy-aware

### DIFF
--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -51,6 +51,8 @@
 //python/ray/serve/tests:test_replica_sync_methods_with_run_sync_in_threadpool
 //python/ray/serve/tests:test_request_timeout
 //python/ray/serve/tests:test_serve_with_tracing
+//python/ray/serve/tests:test_shutdown
+//python/ray/serve/tests:test_standalone_2
 //python/ray/serve/tests:test_streaming_response
 //python/ray/serve/tests:test_target_capacity
 //python/ray/serve/tests:test_task_processor

--- a/python/ray/serve/tests/test_shutdown.py
+++ b/python/ray/serve/tests/test_shutdown.py
@@ -9,6 +9,7 @@ from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray._raylet import GcsClient
 from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_CONTROLLER_NAME,
     SERVE_DEPLOYMENT_ACTOR_PREFIX,
     SERVE_NAMESPACE,
@@ -133,6 +134,10 @@ def test_single_app_shutdown_actors(ray_shutdown):
         "ProxyActor",
         "ServeReplica:app:f",
     }
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
+        # fallback ProxyActor also remains.
+        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(
@@ -174,6 +179,10 @@ async def test_single_app_shutdown_actors_async(ray_shutdown):
         "ProxyActor",
         "ServeReplica:app:f",
     }
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
+        # fallback ProxyActor also remains.
+        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(
@@ -216,6 +225,10 @@ def test_multi_app_shutdown_actors(ray_shutdown):
         "ServeReplica:app1:f",
         "ServeReplica:app2:f",
     }
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
+        # fallback ProxyActor also remains.
+        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(
@@ -259,6 +272,10 @@ async def test_multi_app_shutdown_actors_async(ray_shutdown):
         "ServeReplica:app1:f",
         "ServeReplica:app2:f",
     }
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
+        # fallback ProxyActor also remains.
+        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(

--- a/python/ray/serve/tests/test_shutdown.py
+++ b/python/ray/serve/tests/test_shutdown.py
@@ -21,6 +21,14 @@ from ray.serve.config import DeploymentActorConfig
 from ray.util.state import list_actors
 
 
+def _expected_proxy_classes():
+    """Proxy actor class names expected ALIVE while a Serve app is running."""
+    # Under HAProxy the per-node HAProxyManager joins the head-node fallback ProxyActor.
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        return {"ProxyActor", "HAProxyManager"}
+    return {"ProxyActor"}
+
+
 def test_shutdown(ray_shutdown):
     ray.init(num_cpus=8)
     serve.start(http_options=dict(port=8003))
@@ -131,13 +139,9 @@ def test_single_app_shutdown_actors(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        "ProxyActor",
+        *_expected_proxy_classes(),
         "ServeReplica:app:f",
     }
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
-        # fallback ProxyActor also remains.
-        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(
@@ -176,13 +180,9 @@ async def test_single_app_shutdown_actors_async(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        "ProxyActor",
+        *_expected_proxy_classes(),
         "ServeReplica:app:f",
     }
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
-        # fallback ProxyActor also remains.
-        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(
@@ -221,14 +221,10 @@ def test_multi_app_shutdown_actors(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        "ProxyActor",
+        *_expected_proxy_classes(),
         "ServeReplica:app1:f",
         "ServeReplica:app2:f",
     }
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
-        # fallback ProxyActor also remains.
-        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(
@@ -268,14 +264,10 @@ async def test_multi_app_shutdown_actors_async(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        "ProxyActor",
+        *_expected_proxy_classes(),
         "ServeReplica:app1:f",
         "ServeReplica:app2:f",
     }
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        # Under HAProxy the per-node proxy is HAProxyManager; the head-node
-        # fallback ProxyActor also remains.
-        actor_names.add("HAProxyManager")
 
     def check_alive():
         actors = list_actors(

--- a/python/ray/serve/tests/test_standalone_2.py
+++ b/python/ray/serve/tests/test_standalone_2.py
@@ -11,7 +11,11 @@ import ray.actor
 from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.exceptions import RayActorError
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
+from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_HA_PROXY,
+    SERVE_DEFAULT_APP_NAME,
+    SERVE_NAMESPACE,
+)
 from ray.serve.context import _get_global_client
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
@@ -104,7 +108,10 @@ def test_serve_namespace(shutdown_ray_and_serve, ray_namespace):
             filters=[("state", "=", "ALIVE")],
         )
 
-        assert len(actors) == 3
+        # Under HAProxy the per-node proxy is HAProxyManager plus a head-node
+        # fallback ProxyActor, so there is one more actor than the native case
+        # (controller + proxy + replica).
+        assert len(actors) == (4 if RAY_SERVE_ENABLE_HA_PROXY else 3)
 
         # All actors should be in the SERVE_NAMESPACE, so none of these calls
         # should throw an error.

--- a/python/ray/serve/tests/test_standalone_2.py
+++ b/python/ray/serve/tests/test_standalone_2.py
@@ -103,18 +103,27 @@ def test_serve_namespace(shutdown_ray_and_serve, ray_namespace):
 
         serve.run(f.bind())
 
+        proxy_classes = {"ProxyActor"}
+        if RAY_SERVE_ENABLE_HA_PROXY:
+            # Under HAProxy the per-node HAProxyManager joins the fallback ProxyActor.
+            proxy_classes.add("HAProxyManager")
+        expected_actors = {"ServeController", *proxy_classes, "ServeReplica:default:f"}
+
+        def check_serve_actors():
+            actors = list_actors(
+                address=ray_context.address_info["address"],
+                filters=[("state", "=", "ALIVE")],
+            )
+            return {actor["class_name"] for actor in actors} == expected_actors
+
+        wait_for_condition(check_serve_actors)
+
+        # All actors should be in the SERVE_NAMESPACE, so none of these calls
+        # should throw an error.
         actors = list_actors(
             address=ray_context.address_info["address"],
             filters=[("state", "=", "ALIVE")],
         )
-
-        # Under HAProxy the per-node proxy is HAProxyManager plus a head-node
-        # fallback ProxyActor, so there is one more actor than the native case
-        # (controller + proxy + replica).
-        assert len(actors) == (4 if RAY_SERVE_ENABLE_HA_PROXY else 3)
-
-        # All actors should be in the SERVE_NAMESPACE, so none of these calls
-        # should throw an error.
         for actor in actors:
             ray.get_actor(name=actor["name"], namespace=SERVE_NAMESPACE)
 


### PR DESCRIPTION
## Why

Several tests assert the exact set or count of ALIVE actors and hard-code the native `ProxyActor`. Under HAProxy ingress the per-node proxy is `HAProxyManager` plus a head-node fallback `ProxyActor`, so those assertions fail. The cleanup behavior under test is mode-independent. Only the expected actor set differs.

## What

1. Make the actor-set assertions mode-aware via `RAY_SERVE_ENABLE_HA_PROXY`. In `test_shutdown.py` the four `test_{single,multi}_app_shutdown_actors{,_async}` tests add `HAProxyManager` to the expected ALIVE set under HAProxy. In `test_standalone_2.py::test_serve_namespace` the expected set gains `HAProxyManager`, so 4 actors under HAProxy versus 3 natively. The HAProxy set matches the existing copies in `test_haproxy.py`: `{ServeController, HAProxyManager, ProxyActor, ServeReplica:...}`.

2. Dedup and harden. `test_shutdown.py` builds the expected proxy classes from one `_expected_proxy_classes()` helper instead of four copied `if` blocks. `test_serve_namespace` now waits on the expected class-name set with `wait_for_condition` instead of an immediate `len(actors) == N` count, so it tolerates GCS actor-state propagation latency under HAProxy and names the offending actor on failure.

3. Run both files under HAProxy CI. Add `//python/ray/serve/tests:test_shutdown` and `//python/ray/serve/tests:test_standalone_2` to `ci/ray_ci/serve_hap_test_names.txt`, so the HAProxy pass exercises the new assertions on master instead of leaving them dormant until #64210.

## Notes

- The remaining tests in both files are mode-independent, so running the whole files under HAProxy is safe. `test_shutdown` and `test_shutdown_async` look up the proxy by name, which resolves to `HAProxyManager` because the per-node proxy keeps the `SERVE_PROXY_NAME` name regardless of class. `test_update_num_replicas` and `test_controller_recover_and_delete` assert delta-based actor counts where the constant proxy actors cancel. The rest assert `serve.status()` application counts or driver log output.
- Follow-up under #64210: the now-redundant single-app shutdown copies in `test_haproxy.py` can be deleted once these consolidated versions run under HAProxy. #64210 also deletes `serve_hap_test_names.txt` wholesale, so these allowlist entries disappear cleanly.
