### PR TITLE
[core] increase the timeout for test_job_manager

### DIFF
--- a/python/ray/dashboard/BUILD.bazel
+++ b/python/ray/dashboard/BUILD.bazel
@@ -65,6 +65,7 @@ py_test(
 py_test(
     name = "test_job_manager",
     size = "large",
+    timeout = "eternal",
     srcs = ["modules/job/tests/test_job_manager.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
Recent test failures have shown that the test reaches the 900s timeout. Increase it, and we will consider splitting the test later.

Recent failures:
<img width="1150" height="50" alt="image" src="https://github.com/user-attachments/assets/d1eb37dd-7965-4ef4-92dd-e80054bdc191" />
<img width="1199" height="49" alt="image" src="https://github.com/user-attachments/assets/b1e0cc6f-8003-451b-955b-3eb1d125d7c4" />
<img width="1161" height="46" alt="image" src="https://github.com/user-attachments/assets/43235786-ba20-4b0b-b432-3965a8862fdc" />
<img width="1243" height="48" alt="image" src="https://github.com/user-attachments/assets/4ea2f1b1-6d13-4047-b7f7-f65ae8215621" />
<img width="1316" height="43" alt="image" src="https://github.com/user-attachments/assets/c4aec1a6-5694-476b-8f02-eba853a9c7ea" />
<img width="1216" height="46" alt="image" src="https://github.com/user-attachments/assets/3a45fec9-0bf1-4535-8aeb-9934e086b86c" />
<img width="1235" height="46" alt="image" src="https://github.com/user-attachments/assets/79692aec-d660-4af0-bc34-d635eac73cbc" />
<img width="1184" height="42" alt="image" src="https://github.com/user-attachments/assets/b66f3a68-23ab-4913-b82a-ed50ae4bffea" />
<img width="1315" height="47" alt="image" src="https://github.com/user-attachments/assets/20ab3aa6-6fcf-408c-b078-811252c741ac" />
<img width="1224" height="46" alt="image" src="https://github.com/user-attachments/assets/c6fb82b1-c542-46e0-9238-ac978374e52e" />


Update:

A successful run took over 1000s
<img width="1020" height="69" alt="image" src="https://github.com/user-attachments/assets/d33c1444-eb01-4ce4-b485-9c122e6baa1f" />

