### PR TITLE
[serve.llm] Set up KV-connector backend in mock engine for PD direct-streaming test

### DIFF
--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -31,6 +31,9 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
 )
 from ray.llm._internal.serve.core.engine.protocol import LLMEngine
 from ray.llm._internal.serve.core.protocol import RawRequestInfo
+from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+    DefaultConnectorBackend,
+)
 from ray.llm._internal.serve.utils.lora_serve_utils import LoraModelLoader
 from ray.serve.context import (
     _get_internal_replica_context,
@@ -51,14 +54,8 @@ class MockVLLMEngine(LLMEngine):
             llm_config: The llm configuration for this engine
         """
         self.llm_config = llm_config
-        # Mirror the real engine's setup_engine_backend() so the P/D orchestrator
-        # finds a KV-connector backend. Install the default backend since the real
-        # Nixl/LMCache setup() needs hardware the mock lacks.
+        # The mock skips engine init, where setup_engine_backend attaches this.
         if llm_config.engine_kwargs.get("kv_transfer_config"):
-            from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
-                DefaultConnectorBackend,
-            )
-
             llm_config._kv_connector_backend = DefaultConnectorBackend(llm_config)
         self.started = False
         self._current_lora_model: Dict[str, DiskMultiplexConfig] = {}

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -51,6 +51,15 @@ class MockVLLMEngine(LLMEngine):
             llm_config: The llm configuration for this engine
         """
         self.llm_config = llm_config
+        # Mirror the real engine's setup_engine_backend() so the P/D orchestrator
+        # finds a KV-connector backend. Install the default backend since the real
+        # Nixl/LMCache setup() needs hardware the mock lacks.
+        if llm_config.engine_kwargs.get("kv_transfer_config"):
+            from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+                DefaultConnectorBackend,
+            )
+
+            llm_config._kv_connector_backend = DefaultConnectorBackend(llm_config)
         self.started = False
         self._current_lora_model: Dict[str, DiskMultiplexConfig] = {}
         self._is_sleeping = False


### PR DESCRIPTION
## Why are these changes needed?

`test_pd_direct_streaming` is broken deterministically on master: every request returns 500. `PDDecodeServer._get_connector_backend()` asserts a KV-connector backend on its `LLMConfig`, and only `LLMConfig.setup_engine_backend()` populates it, which runs only during real vLLM engine init. The end-to-end test uses the mock engine, which skips that init, so `_kv_connector_backend` stays `None` and the decode server raises on every request.

This makes the mock engine install a default KV-connector backend when the config requests KV transfer, mirroring the real engine's `setup_engine_backend()`. The default backend is used because the real Nixl/LMCache `setup()` needs hardware the CPU test environment lacks. This matches the workaround the sibling unit test `test_prefill_decode_disagg.py` already applies by hand.

This is a test-infrastructure change only, in the mock engine under `ray/llm/tests`.

## Related issue number

Closes https://github.com/ray-project/ray/issues/64264.

After this fix, `test_pd_direct_streaming` reaches the request path. The only residual failure is the separate intermittent `unknown_replica_id` ingress-router race, tracked in https://github.com/ray-project/ray/issues/64265 and fixed by #64218.

## Checks

- [x] I've signed off every commit (DCO).
- [x] Verified locally against HAProxy 2.8: without this change every request 500s on the missing KV-connector backend. With it the 500 is gone and the test serves requests. The remaining `unknown_replica_id` failure is the separate race in #64265.
