### PR TITLE
[data] Add logging support in WebDatasetDatasource for better observability

### DIFF
--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -4,6 +4,7 @@
 import fnmatch
 import io
 import json
+import logging
 import re
 import tarfile
 from functools import partial
@@ -17,6 +18,9 @@ from ray.data.datasource.file_based_datasource import FileBasedDatasource
 ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR = (
     "RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION"
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -135,7 +139,7 @@ def _tar_file_iterator(
     meta = meta or {}
     stream = tarfile.open(fileobj=fileobj, mode="r|*")
     if verbose_open:
-        print(f"start {meta}")
+        logger.info(f"start {meta}")
     for tarinfo in stream:
         fname = tarinfo.name
         if not tarinfo.isreg() or fname is None:
@@ -148,7 +152,7 @@ def _tar_file_iterator(
         result = dict(fname=fname, data=data)
         yield result
     if verbose_open:
-        print(f"done {meta}")
+        logger.info(f"done {meta}")
 
 
 def _group_by_keys(

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -329,7 +329,24 @@ def test_custom_decoder_bypasses_unsafe_guard(ray_start_2_cpus, tmp_path):
     assert rows[0]["pkl"] == {"key": "value"}
 
 
+def test_webdataset_verbose_open_logging(ray_start_2_cpus, tmp_path, capsys):
+    path = os.path.join(tmp_path, "bar_000000.tar")
+    with TarWriter(path) as tf:
+        for i in range(5):
+            tf.write(f"{i}.a", str(i).encode("utf-8"))
+    
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)], verbose_open=True)
+    samples = ds.take_all()
+    assert len(samples) == 5
+
+    # Check that start and done messages are logged to stderr
+    captured = capsys.readouterr()
+    assert "start" in captured.err or "start" in captured.out, captured.err
+    assert "done" in captured.err or "done" in captured.out, captured.err
+
+
 if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main(["-v", __file__]))
+


### PR DESCRIPTION
## Description

This PR replaces raw `print` statements in `WebDatasetDatasource` (`_tar_file_iterator`) with Python's standard `logging` module to support better observability and structured log aggregation.

Previously, stream progress updates ("start" and "done" messages) were written to standard output using raw `print`. This made it difficult for users to suppress progress output, adjust verbosity, or integrate with centralized logging setups. Replaying them with a standard module-level logger resolves these limitations.

A test case `test_webdataset_verbose_open_logging` was added to verify the logging behavior.

## Related issues

Fixes #64232

## Additional information

### Implementation Details
- Defined a logger in `webdataset_datasource.py`: `logger = logging.getLogger(__name__)`.
- Replaced `print(f"start {meta}")` and `print(f"done {meta}")` with `logger.info(...)`.
- Added `test_webdataset_verbose_open_logging` in `test_webdataset.py` using `capsys` to capture and verify log messages outputted to stderr by Ray's worker processes.
