### PR TITLE
[Data] Fix `iter_batches` (5/n): Finalize after reordering in the `preserve_order` case

### DIFF
--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -60,8 +60,9 @@ class BatchIterator:
         4. Then, in a threadpool consisting of `prefetch_batches` threads:
             a. Format the batches to the provided batch format.
             b. Apply the collate function.
-        5. Finalize each of the collated batches
-        6. Fetch outputs from the threadpool, maintaining order of the batches.
+        5. If preserve_order, restore the original batch order from the
+            threadpool output.
+        6. Finalize each of the (now ordered) collated batches.
 
     Args:
         ref_bundles: An iterator over RefBundles.
@@ -231,14 +232,16 @@ class BatchIterator:
         # Step 4: Format and collate the batches in a threadpool.
         batch_iter = self._format_batches(batch_iter)
 
-        # Step 5: Finalize the batches (e.g., move to GPU).
-        batch_iter = self._finalize_batches(batch_iter)
-
-        # Step 6 (optional): Restore the original order of the batches
+        # Step 5 (optional): Restore the original order of the batches
         # if preserve_order is True, in the case that the format/collate threadpool
         # shuffles around the batches non-deterministically.
+        # NOTE: This should happen before finalize_fn so the reorder buffer
+        # holds CPU batches rather than finalize_fn outputs (e.g., GPU tensors).
         if self._preserve_order:
             batch_iter = self._restore_original_batch_order(batch_iter)
+
+        # Step 6: Finalize the batches (e.g., move to GPU).
+        batch_iter = self._finalize_batches(batch_iter)
 
         yield from batch_iter
 

--- a/python/ray/data/tests/block_batching/test_iter_batches.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches.py
@@ -262,6 +262,45 @@ def test_iter_batches_preserve_order_flag(
         assert indices == list(range(num_blocks)), indices
 
 
+def test_finalize_fn_runs_after_restore_original_order(ray_start_regular_shared):
+    """When preserve_order=True, finalize_fn must run after the reorder
+    buffer so that the buffer holds CPU batches rather than finalize_fn
+    outputs (e.g., GPU tensors). Asserts finalize_fn sees batches in
+    monotonically increasing order even when the format/collate threadpool
+    completes them out of order."""
+
+    def collate_fn(batch):
+        # Variable per-batch cost so worker-completion order is arbitrary.
+        idx = int(batch["foo"][0])
+        time.sleep(0.05 * (idx % 4))
+        return batch
+
+    seen_by_finalize = []
+    seen_lock = threading.Lock()
+
+    def finalize_fn(batch):
+        idx = int(batch["foo"][0])
+        with seen_lock:
+            seen_by_finalize.append(idx)
+        return batch
+
+    num_blocks = 16
+    ref_bundles = ref_bundle_generator(num_blocks=num_blocks, num_rows=1)
+    list(
+        BatchIterator(
+            ref_bundles,
+            batch_size=1,
+            collate_fn=collate_fn,
+            finalize_fn=finalize_fn,
+            batch_format="pandas",
+            prefetch_batches=4,
+            preserve_order=True,
+        )
+    )
+
+    assert seen_by_finalize == list(range(num_blocks)), seen_by_finalize
+
+
 def _ref_bundles_with_size(
     num_blocks: int, num_rows: int, size_bytes_per_block: int
 ) -> Iterator[RefBundle]:

--- a/python/ray/data/tests/block_batching/test_iter_batches.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches.py
@@ -271,7 +271,7 @@ def test_finalize_fn_runs_after_restore_original_order(ray_start_regular_shared)
 
     def collate_fn(batch):
         # Variable per-batch cost so worker-completion order is arbitrary.
-        idx = int(batch["foo"][0])
+        idx = int(batch["foo"].iloc[0])
         time.sleep(0.05 * (idx % 4))
         return batch
 
@@ -279,7 +279,7 @@ def test_finalize_fn_runs_after_restore_original_order(ray_start_regular_shared)
     seen_lock = threading.Lock()
 
     def finalize_fn(batch):
-        idx = int(batch["foo"][0])
+        idx = int(batch["foo"].iloc[0])
         with seen_lock:
             seen_by_finalize.append(idx)
         return batch


### PR DESCRIPTION
## Motivation

When `preserve_order=True`, the pipeline runs `finalize_fn` *before*
`restore_original_order`. The reorder buffer therefore holds finalize_fn
outputs (e.g., GPU tensors) while it waits for the next-required
`batch_idx` to arrive — up to `num_workers - 1` extras on top of the
output queue, in-flight finalize, current step's activations/gradients, etc.

## Description

Swap the pipeline order so `finalize_fn` runs *after* the reorder buffer:
format/collate (threadpool, out-of-order) → restore_original_order → finalize_fn

The reorder buffer now holds collated CPU batches.
H2D copies happen in-order on an already-sequenced stream.

No throughput tradeoff: `finalize_batches` is a plain serial generator —
concurrency lives in the format/collate threadpool only.

Impact: Reduces GPU memory pressure by up to `prefetch_batches - 1`
finalized batches when preserve_order=True, since the reorder buffer
now holds CPU batches instead of `finalize_fn` outputs.
There's now always only 1 GPU batch in the prefetched output queue.

## Related PRs

This is a followup to https://github.com/ray-project/ray/pull/63792