### PR TITLE
fix(cli): prepend task_id in ray list tasks output

### DIFF
--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -192,6 +192,13 @@ def get_table_output(state_data: List, schema: StateSchema, detail: bool) -> str
         for col in cols:
             if col in keys:
                 headers.append(col.upper())
+                
+        # --- Fix UX Issue #30805: Prepend TASK_ID ---
+        if "TASK_ID" in headers:
+            headers.remove("TASK_ID")
+            headers.insert(0, "TASK_ID")
+        # ---------------------------------------------
+
         table.append([data[header.lower()] for header in headers])
     return f"""
 {header}


### PR DESCRIPTION
## Description
This PR addresses the UX issue where `task_id` is hidden down in the default table fields. Moving `task_id` to the first position significantly improves readability when users check task statuses via the CLI.

## Related issues
Fixes #30805

## Additional information
- Tested manually by ensuring the column order format logic properly updates the header list.
- Minimal risk as it only modifies the CLI display presentation layer.