### PR TITLE
[core] fix: normalize the cmdline field in StatsPayload schema

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -123,7 +123,6 @@ if PYDANTIC_INSTALLED:
         def _normalize_cmdline(cls, value):
             return [] if value is None else value
 
-
     # Note: The actual data structure uses tuples for some fields, not structured objects
     # These are type aliases to document the tuple structure
     MemoryUsage = Tuple[

--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple
 from ray._common.pydantic_compat import PYDANTIC_INSTALLED, BaseModel
 
 if PYDANTIC_INSTALLED:
+    from pydantic import field_validator
 
     # TODO(aguo): Use these pydantic models in the dashboard API as well.
     class ProcessGPUInfo(BaseModel):
@@ -117,6 +118,12 @@ if PYDANTIC_INSTALLED:
         gpuMemoryUsage: Optional[int] = None  # in MB, added by _get_workers
         gpuUtilization: Optional[int] = None  # percentage, added by _get_workers
 
+        @field_validator("cmdline", mode="before")
+        @classmethod
+        def _normalize_cmdline(cls, value):
+            return [] if value is None else value
+
+
     # Note: The actual data structure uses tuples for some fields, not structured objects
     # These are type aliases to document the tuple structure
     MemoryUsage = Tuple[
@@ -182,6 +189,11 @@ if PYDANTIC_INSTALLED:
         networkSpeed: NetworkSpeed  # (sendSpeed, receiveSpeed) in bytes/sec
         cmdline: List[str]  # deprecated field from raylet
         gcs: Optional[ProcessInfo] = None  # only present on head node
+
+        @field_validator("cmdline", mode="before")
+        @classmethod
+        def _normalize_cmdline(cls, value):
+            return [] if value is None else value
 
 else:
     StatsPayload = None

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -466,6 +466,30 @@ def test_report_stats(tmp_path):
     assert isinstance(stats_payload, str)
 
 
+def test_generate_stats_payload_normalizes_none_process_cmdline(tmp_path):
+    dashboard_agent = MagicMock()
+    dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
+    raylet_client = MagicMock()
+    agent = ReporterAgent(dashboard_agent, raylet_client)
+
+    stats = copy.deepcopy(STATS_TEMPLATE)
+    stats["workers"][0]["cmdline"] = None
+    stats["raylet"]["cmdline"] = None
+    stats["agent"]["cmdline"] = None
+    stats["gcs"]["cmdline"] = None
+    stats["cmdline"] = None
+
+    stats_payload = json.loads(agent._generate_stats_payload(stats))
+
+    assert stats_payload["workers"][0]["cmdline"] == []
+    assert stats_payload["raylet"]["cmdline"] == []
+    assert stats_payload["agent"]["cmdline"] == []
+    assert stats_payload["gcs"]["cmdline"] == []
+    assert stats_payload["cmdline"] == []
+
+
 def test_report_stats_gpu(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -468,6 +468,7 @@ def test_report_stats(tmp_path):
 
 def test_generate_stats_payload_normalizes_none_process_cmdline(tmp_path):
     from ray._common.pydantic_compat import PYDANTIC_INSTALLED
+
     if not PYDANTIC_INSTALLED:
         pytest.skip("Pydantic is not installed")
 

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -467,6 +467,10 @@ def test_report_stats(tmp_path):
 
 
 def test_generate_stats_payload_normalizes_none_process_cmdline(tmp_path):
+    from ray._common.pydantic_compat import PYDANTIC_INSTALLED
+    if not PYDANTIC_INSTALLED:
+        pytest.skip("Pydantic is not installed")
+
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
     dashboard_agent.session_dir = str(tmp_path)


### PR DESCRIPTION
## Description
Fix this:
```
2026-06-19 23:17:11,662	ERROR reporter_agent.py:1983 -- Error publishing node physical stats.
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/reporter/reporter_agent.py", line 1971, in _run_loop
    json_payload = await loop.run_in_executor(
  File "/home/ray/anaconda3/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/reporter/reporter_agent.py", line 1992, in _run_in_executor
    return asyncio.run(
  File "/home/ray/anaconda3/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/ray/anaconda3/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/reporter/reporter_agent.py", line 2039, in _async_compose_stats_payload
    return self._generate_stats_payload(stats)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/reporter/reporter_agent.py", line 2076, in _generate_stats_payload
    parsed_stats = StatsPayload.parse_obj(stats_dict)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/pydantic/main.py", line 1370, in parse_obj
    return cls.model_validate(obj)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for StatsPayload
workers.70.cmdline
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/list_type

```

The root cause is that `psutil.Process.as_dict()` returns None for any attribute whose getter raises AccessDenied/ZombieProcess (psutil's default ad_value is None). So a worker's cmdline can come back as None, but the StatsPayload schema (cmdline: List[str]) rejects.

