### PR TITLE
[dashboard] Add a head-node-schedulable health endpoint (api/node_schedulable_healthz)

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -1023,6 +1023,33 @@ class ReportHead(SubprocessModule):
 
         return aiohttp.web.HTTPServiceUnavailable(reason="Health check failed")
 
+    @routes.get("/api/node_schedulable_healthz")
+    async def node_schedulable_health_check(
+        self, req: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        try:
+            head_node_id_hex = await dashboard_utils.get_head_node_id(self.gcs_client)
+            if head_node_id_hex is None:
+                return aiohttp.web.HTTPServiceUnavailable(
+                    reason="Head node id is not yet registered in GCS"
+                )
+            schedulable = await self._health_checker.check_head_node_schedulable(
+                NodeID.from_hex(head_node_id_hex)
+            )
+            if schedulable is True:
+                return aiohttp.web.Response(
+                    text="success",
+                    content_type="application/text",
+                )
+        except Exception as e:
+            return aiohttp.web.HTTPServiceUnavailable(
+                reason=f"Health check failed: {e}"
+            )
+
+        return aiohttp.web.HTTPServiceUnavailable(
+            reason="Head node not yet schedulable"
+        )
+
     @routes.get("/api/prometheus/sd")
     async def prometheus_service_discovery(self, req) -> aiohttp.web.Response:
         """

--- a/python/ray/dashboard/modules/reporter/tests/test_healthz.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_healthz.py
@@ -1,12 +1,16 @@
 import signal
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 import requests
 
 import ray._private.ray_constants as ray_constants
+from ray import NodeID
 from ray._common.network_utils import find_free_port
 from ray._common.test_utils import wait_for_condition
+from ray.core.generated.gcs_service_pb2 import GetAllTotalResourcesReply
+from ray.dashboard.modules.reporter.utils import HealthChecker
 from ray.tests.conftest import *  # noqa: F401 F403
 
 
@@ -115,6 +119,37 @@ def test_unified_healthz_worker_gcs_down(monkeypatch, ray_start_cluster):
 
     # Worker health check should still succeed.
     assert requests.get(uri).status_code == 200
+
+
+def _reply_with_node_ids(*node_ids: NodeID) -> GetAllTotalResourcesReply:
+    reply = GetAllTotalResourcesReply()
+    for node_id in node_ids:
+        reply.resources_list.add().node_id = node_id.binary()
+    return reply
+
+
+@pytest.mark.asyncio
+async def test_check_head_node_schedulable_not_in_view():
+    head_node_id = NodeID.from_random()
+    gcs_client = MagicMock()
+    gcs_client.get_all_total_resources.return_value = _reply_with_node_ids(
+        NodeID.from_random()
+    )
+    checker = HealthChecker(gcs_client)
+
+    assert await checker.check_head_node_schedulable(head_node_id) is False
+
+
+@pytest.mark.asyncio
+async def test_check_head_node_schedulable_in_view():
+    head_node_id = NodeID.from_random()
+    gcs_client = MagicMock()
+    gcs_client.get_all_total_resources.return_value = _reply_with_node_ids(
+        NodeID.from_random(), head_node_id
+    )
+    checker = HealthChecker(gcs_client)
+
+    assert await checker.check_head_node_schedulable(head_node_id) is True
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/reporter/utils.py
+++ b/python/ray/dashboard/modules/reporter/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Optional
 
 from ray._raylet import GcsClient, NodeID
@@ -17,3 +18,15 @@ class HealthChecker:
     async def check_gcs_liveness(self) -> bool:
         await self._gcs_client.async_check_alive([], 0.1)
         return True
+
+    async def check_head_node_schedulable(self, head_node_id: NodeID) -> bool:
+        if head_node_id is None:
+            return False
+        reply = await asyncio.get_running_loop().run_in_executor(
+            None, self._gcs_client.get_all_total_resources, 1.0
+        )
+        head_node_id_binary = head_node_id.binary()
+        return any(
+            resources.node_id == head_node_id_binary
+            for resources in reply.resources_list
+        )

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -522,6 +522,10 @@ cdef extern from "ray/gcs_rpc_client/accessor.h" nogil:
             int64_t timeout_ms,
             CGetAllResourceUsageReply &serialized_reply)
 
+        CRayStatus GetAllTotalResources(
+            int64_t timeout_ms,
+            CGetAllTotalResourcesReply &serialized_reply)
+
     cdef cppclass CInternalKVAccessor "ray::gcs::InternalKVAccessor":
         CRayStatus Keys(
             const c_string &ns,
@@ -752,6 +756,10 @@ cdef extern from "ray/pubsub/python_gcs_subscriber.h" namespace "ray::pubsub" no
 cdef extern from "ray/gcs_rpc_client/gcs_client.h" namespace "ray::gcs" nogil:
     unordered_map[c_string, c_string] PythonGetNodeLabels(
         const CGcsNodeInfo& node_info)
+
+cdef extern from "src/ray/protobuf/gcs_service.pb.h" nogil:
+    cdef cppclass CGetAllTotalResourcesReply "ray::rpc::GetAllTotalResourcesReply":
+        const c_string& SerializeAsString() const
 
 cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
     cdef enum CChannelType "ray::rpc::ChannelType":

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -20,10 +20,14 @@ from ray._common.utils import get_or_create_event_loop
 from typing import Dict, List, Sequence, Tuple
 from libcpp.utility cimport move
 import concurrent.futures
-from ray.core.generated.gcs_service_pb2 import GetAllResourceUsageReply
+from ray.core.generated.gcs_service_pb2 import (
+    GetAllResourceUsageReply,
+    GetAllTotalResourcesReply,
+)
 from ray.includes.common cimport (
     CGcsClient,
     CGetAllResourceUsageReply,
+    CGetAllTotalResourcesReply,
     ConnectOnSingletonIoContext,
     MultiItemPyCallback,
     OptionalItemPyCallback,
@@ -447,6 +451,23 @@ cdef class InnerGcsClient:
                 )
             serialized_reply = c_reply.SerializeAsString()
         ret = GetAllResourceUsageReply()
+        ret.ParseFromString(serialized_reply)
+        return ret
+
+    def get_all_total_resources(
+        self, timeout: Optional[int | float] = None
+    ) -> GetAllTotalResourcesReply:
+        cdef int64_t timeout_ms = round(1000 * timeout) if timeout else -1
+        cdef CGetAllTotalResourcesReply c_reply
+        cdef c_string serialized_reply
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                    self.inner.get()
+                    .NodeResources()
+                    .GetAllTotalResources(timeout_ms, c_reply)
+                )
+            serialized_reply = c_reply.SerializeAsString()
+        ret = GetAllTotalResourcesReply()
         ret.ParseFromString(serialized_reply)
         return ret
 

--- a/src/ray/gcs_rpc_client/accessor.cc
+++ b/src/ray/gcs_rpc_client/accessor.cc
@@ -553,6 +553,13 @@ Status NodeResourceInfoAccessor::GetAllResourceUsage(
       std::move(request), &reply, timeout_ms);
 }
 
+Status NodeResourceInfoAccessor::GetAllTotalResources(
+    int64_t timeout_ms, rpc::GetAllTotalResourcesReply &reply) {
+  rpc::GetAllTotalResourcesRequest request;
+  return client_impl_->GetGcsRpcClient().SyncGetAllTotalResources(
+      std::move(request), &reply, timeout_ms);
+}
+
 void TaskInfoAccessor::AsyncAddTaskEventData(std::unique_ptr<rpc::TaskEventData> data_ptr,
                                              rpc::StatusCallback callback) {
   rpc::AddTaskEventDataRequest request;

--- a/src/ray/gcs_rpc_client/accessor.h
+++ b/src/ray/gcs_rpc_client/accessor.h
@@ -343,6 +343,14 @@ class NodeResourceInfoAccessor {
   virtual Status GetAllResourceUsage(int64_t timeout_ms,
                                      rpc::GetAllResourceUsageReply &reply);
 
+  /// Get total resources of all nodes from GCS synchronously.
+  ///
+  /// \param timeout_ms -1 means infinite.
+  /// \param reply The total resources of all nodes in the resource view.
+  /// \return Status
+  virtual Status GetAllTotalResources(int64_t timeout_ms,
+                                      rpc::GetAllTotalResourcesReply &reply);
+
  private:
   GcsClient *client_impl_;
 


### PR DESCRIPTION
## Description

Adds a dashboard-head HTTP endpoint `GET /api/node_schedulable_healthz` that returns `success` once the head node is present in the GCS actor-scheduler resource view — i.e. once a hard `NodeAffinitySchedulingStrategy(head, soft=False)` actor (the default Ray Jobs driver/supervisor placement) can actually be placed on it.

Tooling that submits a head-pinned entrypoint can wait on this instead of `/api/gcs_healthz`. `gcs_healthz` only reflects GCS-process liveness and can be green before the head node enters the resource view, so the supervisor actor is transiently infeasible and the job fails (no `soft=False` fallback). Same class as #32167 / #35387; a liveness probe can't close it because liveness ≠ resource-view membership.

The signal already exists internally (`GcsResourceManager::HandleGetAllTotalResources` iterates the same `cluster_resource_manager_.GetResourceView()` that hard-affinity placement reads, head node included) but no Python `GcsClient` method or HTTP route surfaces it. This only surfaces it — no scheduler/resource-manager changes.

Layers: sync `NodeResourceInfoAccessor::GetAllTotalResources` (mirrors `GetAllResourceUsage`) → `GcsClient.get_all_total_resources` → `HealthChecker.check_head_node_schedulable` → the route. Unit tests cover not-in-view → 503 and in-view → 200/`success`.

## Related issues

Related to #64285 (design and analysis). Downstream consumer: ray-project/kuberay#4944.

## Additional information

Draft — authored without a Bazel build environment, so the C++/Cython layers are validated by CI's first build rather than locally.
