### PR TITLE
[Data] Fix type hints in `throughput_solver.py`

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/throughput_solver.py
+++ b/python/ray/data/_internal/cluster_autoscaler/throughput_solver.py
@@ -53,7 +53,7 @@ def compute_optimal_throughput(
     rates: Dict[T, float],
     resource_requirements: Dict[T, ExecutionResources],
     resource_limits: ExecutionResources,
-    concurrency_limits: Dict[T, int],
+    concurrency_limits: Dict[T, int | None],
 ) -> float:
     """Compute the optimal throughput for a pipeline.
 
@@ -111,11 +111,17 @@ def _max_throughput_from_resources(
 
 def _max_throughput_from_concurrency(
     rates: Dict[T, float],
-    concurrency_limits: Dict[T, int],
+    concurrency_limits: Dict[T, int | None],
 ) -> float:
     """Each operator's throughput is capped at rate * concurrency_limit."""
     assert rates, "Rates must be non-empty"
     assert (
         rates.keys() <= concurrency_limits.keys()
     ), "You must provide a concurrency limit for each operator with a rate."
-    return min(rates[op] * concurrency_limits[op] for op in rates)
+
+    # Convert `None` to float("inf") for operators with no concurrency limit
+    normalized_concurrency_limits: Dict[T, float] = {
+        op: limit if limit is not None else float("inf")
+        for op, limit in concurrency_limits.items()
+    }
+    return min(rates[op] * normalized_concurrency_limits[op] for op in rates)


### PR DESCRIPTION
Physical operators expose a `get_max_concurrency_limit` method that returns the maximum number of tasks or actor that operator can launch. Often, the method returns `None`.

Since operators often return `None`, I'm updating the utility functions in `throughput_solver.py` to also accept `None`. The motivation is to appease pyrefly.