### PR TITLE
[Data] Fix flaky test_streaming_split_stats

### DIFF
--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -553,15 +553,40 @@ def test_streaming_split_stats(ray_start_regular_shared, restore_data_context):
     it = ds.map_batches(dummy_map_batches).streaming_split(1)[0]
     list(it.iter_batches())
     stats = it.stats()
-    extra_metrics_1 = STANDARD_EXTRA_METRICS_TASK_BACKPRESSURE  # .replace(
-    #     "'obj_store_mem_used': A", "'obj_store_mem_used': Z"
-    # )
     extra_metrics_2 = gen_expected_metrics(
         is_map=False,
         extra_metrics=["'num_output_N': N", "'output_splitter_overhead_time': N"],
     )
+    # The task_output_backpressure_time* metrics are wall-clock timers for output
+    # backpressure on the running MapBatches operator. Whether (and for how long)
+    # it blocks is a timing race against the single, slower streaming-split
+    # consumer, so the value is genuinely nondeterministic across runs (sometimes
+    # 0, usually positive). We therefore deliberately do NOT assert these three
+    # values: both the expected and the produced stats collapse them to a
+    # sentinel. Everything else -- including task_submission_backpressure_time --
+    # stays strictly checked. Only the running operator's (first) occurrence is
+    # collapsed; the idle split operator's timers remain strictly asserted as 0.
+    not_asserted = "<varies>"
+    backpressure_keys = (
+        "average_task_output_backpressure_time_s",
+        "task_output_backpressure_time",
+        "task_output_backpressure_time_s",
+    )
+    extra_metrics_1 = STANDARD_EXTRA_METRICS_TASK_BACKPRESSURE
+    for key in backpressure_keys:
+        extra_metrics_1 = extra_metrics_1.replace(
+            f"'{key}': Z", f"'{key}': {not_asserted}"
+        )
+    produced = canonicalize(stats)
+    for key in backpressure_keys:
+        # count=1 collapses only the first (running MapBatches operator)
+        # occurrence; the \b stops the "N" token from matching the "N" in an idle
+        # operator's "None".
+        produced = re.sub(
+            rf"('{key}': )(?:N|Z)\b", rf"\g<1>{not_asserted}", produced, count=1
+        )
     assert (
-        canonicalize(stats)
+        produced
         == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total


### PR DESCRIPTION
## Why

`test_streaming_split_stats` is flaky. The `task_output_backpressure_time*` metrics on the running `MapBatches` operator are wall-clock timers for output backpressure, which is a timing race against the single, slower `streaming_split(1)` consumer. The value is genuinely nondeterministic across runs (sometimes `0`, usually positive), but the test hardcoded it to zero (`Z`), so it only passed on the occasional fast run (~1/5 locally; also seen failing in CI).

Empirically, output backpressure is the *normal* state for this pipeline (nonzero ~every run), so the hardcoded `Z` was the less-representative outcome. There is no deterministic value to assert for a wall-clock timer, so the honest fix is to stop asserting its magnitude rather than force a value.

## What

Scoped, test-only change inside `test_streaming_split_stats`:

- Mark just the three timer values (`average_task_output_backpressure_time_s`, `task_output_backpressure_time`, `task_output_backpressure_time_s`) as **not-asserted** (a `<varies>` sentinel applied to both the expected and produced stats) — but **only for the running `MapBatches` operator** (first occurrence).
- Everything else stays strictly checked:
  - `task_submission_backpressure_time` remains `N`.
  - The idle `split` operator's backpressure timers remain strictly asserted as `0`.
  - All other fields and all other tests are untouched (no change to `canonicalize()` or `gen_expected_metrics()`).

This mirrors the existing precedent for `obj_store_mem_used` (collapsed to `A` because it's "zero or positive depending on the run").

## Verification

- `test_streaming_split_stats`: **10/10 pass** (was 1/5).
- `test_dataset__repr__`, `test_dataset_stats_basic`: still pass (strict, unchanged).
- `pre-commit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)