### PR TITLE
[Train] Use user-defined train function name in training thread name and error stack traces

### DIFF
--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -4,7 +4,7 @@ import queue
 import socket
 import sys
 from dataclasses import dataclass
-from functools import cached_property
+from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypeVar, Union
 
 import ray
@@ -144,6 +144,7 @@ class RayTrainWorker:
             logger.error(f"Error deserializing the training function: {e}")
             raise
 
+        @wraps(train_fn)
         def train_fn_with_final_checkpoint_flush():
             result = train_fn()
             get_train_context().checkpoint_upload_threadpool.shutdown()

--- a/python/ray/train/v2/tests/test_worker.py
+++ b/python/ray/train/v2/tests/test_worker.py
@@ -70,6 +70,51 @@ def test_worker_finished_after_all_threads_finish(monkeypatch, created_nested_th
         assert queue_contents == ["main"]
 
 
+def test_training_thread_name_matches_user_fn(monkeypatch):
+    """The training thread should be named after the user's training function.
+
+    `run_train_fn` wraps the user function in an internal
+    `train_fn_with_final_checkpoint_flush` closure before handing it to the
+    `ThreadRunner`, which names the thread after the callable it runs. Without
+    `functools.wraps`, the thread (and therefore any stack trace produced from
+    the user function) would be labeled with the internal wrapper name instead
+    of the user function name, making errors harder to trace.
+    """
+    # Disable this to avoid TypeError from logging MagicMock
+    monkeypatch.setenv(ENABLE_WORKER_STRUCTURED_LOGGING_ENV_VAR, False)
+
+    worker = RayTrainWorker()
+    worker.init_train_context(
+        train_run_context=create_autospec(TrainRunContext, instance=True),
+        distributed_context=DistributedContext(
+            world_rank=0,
+            world_size=1,
+            local_rank=0,
+            local_world_size=1,
+            node_rank=0,
+        ),
+        synchronization_actor=create_autospec(ActorHandle, instance=True),
+        storage_context=create_autospec(StorageContext, instance=True),
+        worker_callbacks=[],
+        controller_actor=create_autospec(ActorHandle, instance=True),
+    )
+
+    def my_custom_train_fn():
+        pass
+
+    train_fn_ref = create_autospec(ObjectRefWrapper, instance=True)
+    train_fn_ref.get.return_value = my_custom_train_fn
+    worker.run_train_fn(train_fn_ref)
+
+    # The training thread is created synchronously inside `run_train_fn`, so its
+    # name is already set by the time the call returns -- there is no need to
+    # wait for the training function to run or finish.
+    training_thread = (
+        get_train_context().execution_context.training_thread_runner._thread
+    )
+    assert training_thread.name == "TrainingThread(my_custom_train_fn)"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description
When a user's training function raises an exception, the training thread (and the resulting stack trace) is named after Ray's internal wrapper `train_fn_with_final_checkpoint_flush` instead of the user-defined function.

The root cause is in `RayTrainWorker.run_train_fn`: the user's training function is wrapped by an inner `train_fn_with_final_checkpoint_flush` , and this wrapper is what gets handed to `ThreadRunner`. `ThreadRunner` names the training thread via `get_callable_name(target)`, so it reads the wrapper's `__name__` and produces
`TrainingThread(train_fn_with_final_checkpoint_flush)`. We apply `functools.wraps(train_fn)` to the inner wrapper so it inherits the user function's `__name__`. This is similar to how `construct_train_func` preserves the user's name on `train_fn` via `functools.wraps`.

## Related issues
Fixes TRAIN-744 on Jira

## Testing
Added a unit test `test_training_thread_name_matches_user_fn` in `python/ray/train/v2/tests/test_worker.py`. It runs `RayTrainWorker.run_train_fn` with a user function named `my_custom_train_fn` and asserts the launched training thread is named `TrainingThread(my_custom_train_fn)` (rather than `TrainingThread(train_fn_with_final_checkpoint_flush)`). Without the `functools.wraps` fix this assertion fails, so the test guards the fix.

## Reproduction
Repro script and before/after logs: https://gist.github.com/avigyabb/626151d1b05526f38b221198f6858c65

The script uses Ray's real `ThreadRunner` and `get_callable_name` and rebuilds the exact wrapper from `worker.py`, toggling `@functools.wraps` to show both states in a single run (no cluster required). It also has an `--e2e` mode that drives the real `DataParallelTrainer`.

Results (`thread_name_before_after.log`):

| | Thread / stack-trace name |
| --- | --- |
| **Before fix** | `TrainingThread(train_fn_with_final_checkpoint_flush)` |
| **After fix** | `TrainingThread(train_fn_per_worker)` |

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
