### PR TITLE
[serve] Support root_path in the HAProxy ingress

### DIFF
--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -53,6 +53,7 @@
 //python/ray/serve/tests:test_request_timeout
 //python/ray/serve/tests:test_serve_with_tracing
 //python/ray/serve/tests:test_shutdown
+//python/ray/serve/tests:test_standalone
 //python/ray/serve/tests:test_standalone_2
 //python/ray/serve/tests:test_streaming_response
 //python/ray/serve/tests:test_target_capacity

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -603,6 +603,14 @@ class HAProxyConfig:
         return self.http_options.port
 
     @property
+    def root_path(self) -> str:
+        """Global root_path prefix, normalized without a trailing slash.
+
+        Empty when unset so the config template omits root_path handling.
+        """
+        return (self.http_options.root_path or "").rstrip("/")
+
+    @property
     def timeout_http_keep_alive_s(self) -> int:
         return self.http_options.keep_alive_timeout_s
 
@@ -648,8 +656,6 @@ class HAProxyConfig:
             routes_message=routes_message,
             routes_content_type="application/json" if healthy else "text/plain",
         )
-
-    # TODO: support custom root_path and https
 
 
 class ProxyApi(ABC):

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -94,6 +94,13 @@ frontend http_frontend
     log {{ metrics_socket_path }} len 8192 format rfc5424 local1 info
     log-format-sd "%{+Q,+E}o [serve@1 app=%[var(txn.ingress_request_router_app)] intended=%[var(txn.ingress_request_router_target)] actual=%s router_latency_us=%[var(txn.ingress_request_router_latency_us)] body_truncated_full_length=%[var(txn.ingress_request_router_truncated_full_length)] via_router=%[var(txn.via_ingress_request_router)] failed=%[var(txn.ingress_request_router_failed)]]"
     {%- endif %}
+    {%- if config.root_path %}
+    # Strip the configured global root_path so the health/routes endpoints, the
+    # per-backend path ACLs, and the path forwarded to replicas are all
+    # root_path-agnostic. Mirrors the native Serve proxy, which mounts the app
+    # under root_path. Paths outside root_path are left unchanged.
+    http-request set-path %[path,regsub(^{{ config.root_path }}(/.*)?$,\\1)]
+    {%- endif %}
 {{ healthz_rules|safe }}
     # Routes endpoint
     acl routes path -i /-/routes

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -98,8 +98,10 @@ frontend http_frontend
     # Strip the configured global root_path so the health/routes endpoints, the
     # per-backend path ACLs, and the path forwarded to replicas are all
     # root_path-agnostic. Mirrors the native Serve proxy, which mounts the app
-    # under root_path. Paths outside root_path are left unchanged.
-    http-request set-path %[path,regsub(^{{ config.root_path }}(/.*)?$,\\1)]
+    # under root_path. An exact root_path match becomes "/", and paths outside
+    # root_path are left unchanged.
+    http-request set-path / if { path {{ config.root_path }} }
+    http-request set-path %[path,regsub(^{{ config.root_path }}/,/)] if { path_beg {{ config.root_path }}/ }
     {%- endif %}
 {{ healthz_rules|safe }}
     # Routes endpoint

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -167,7 +167,12 @@ from ray.serve._private.utils import (
     parse_import_path,
 )
 from ray.serve._private.version import DeploymentVersion
-from ray.serve.config import AutoscalingConfig, HTTPOptions, gRPCOptions
+from ray.serve.config import (
+    AutoscalingConfig,
+    HTTPOptions,
+    ProxyLocation,
+    gRPCOptions,
+)
 from ray.serve.context import _get_in_flight_requests
 from ray.serve.deployment import Deployment
 from ray.serve.exceptions import (
@@ -2153,32 +2158,36 @@ class Replica:
             self._grpc_options = None
 
         grpc_enabled = self._ingress and is_grpc_enabled(self._grpc_options)
+        # host=None normalizes to location Disabled in HTTPOptions.location_backfill_no_server.
+        http_enabled = self._http_options.location != ProxyLocation.Disabled
 
         # Allocate and start HTTP server
-        async def start_http_server(port):
-            options = configure_http_middlewares(
-                configure_http_options_with_defaults(
-                    HTTPOptions(**{**self._http_options.model_dump(), "port": port})
+        if http_enabled:
+
+            async def start_http_server(port):
+                options = configure_http_middlewares(
+                    configure_http_options_with_defaults(
+                        HTTPOptions(**{**self._http_options.model_dump(), "port": port})
+                    )
                 )
-            )
 
-            return await start_asgi_http_server(
-                self._direct_ingress_asgi,
-                options,
-                event_loop=self._event_loop,
-                enable_so_reuseport=False,
-            )
+                return await start_asgi_http_server(
+                    self._direct_ingress_asgi,
+                    options,
+                    event_loop=self._event_loop,
+                    enable_so_reuseport=False,
+                )
 
-        (
-            self._http_port,
             (
-                self._direct_ingress_http_server_task,
-                self._direct_ingress_http_server,
-            ),
-        ) = await allocate_and_start_server(
-            start_server_fn=start_http_server,
-            protocol=RequestProtocol.HTTP,
-        )
+                self._http_port,
+                (
+                    self._direct_ingress_http_server_task,
+                    self._direct_ingress_http_server,
+                ),
+            ) = await allocate_and_start_server(
+                start_server_fn=start_http_server,
+                protocol=RequestProtocol.HTTP,
+            )
 
         # Allocate and start gRPC server for ingress replicas if enabled.
         # Ingress request router replicas only need HTTP for /internal/route.
@@ -2207,10 +2216,13 @@ class Replica:
                 protocol=RequestProtocol.GRPC,
             )
 
-        logger.info(
-            f"Started HTTP server on port {self._http_port}"
-            + (f" and gRPC server on port {self._grpc_port}" if grpc_enabled else "")
-        )
+        started = []
+        if http_enabled:
+            started.append(f"HTTP server on port {self._http_port}")
+        if grpc_enabled:
+            started.append(f"gRPC server on port {self._grpc_port}")
+        if started:
+            logger.info(f"Started {' and '.join(started)}")
 
     @contextmanager
     def _tracing_context(self, request_metadata: RequestMetadata):

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -19,6 +19,7 @@ from ray._common.test_utils import run_string_as_driver, wait_for_condition
 from ray._raylet import GcsClient
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
     SERVE_PROXY_NAME,
@@ -255,6 +256,12 @@ def test_multiple_routers(ray_cluster):
     ray.get(block_until_http_ready.remote("http://127.0.0.1:8005/-/routes"))
 
 
+@pytest.mark.skipif(
+    RAY_SERVE_ENABLE_HA_PROXY,
+    reason="HAProxy ingress: user HTTP middleware runs on the replica, but the "
+    "/-/routes endpoint is served by HAProxy, so middleware-injected headers "
+    "are absent there.",
+)
 def test_middleware(ray_shutdown):
     from starlette.middleware import Middleware
     from starlette.middleware.cors import CORSMiddleware
@@ -363,10 +370,22 @@ def test_http_head_only(ray_cluster):
 
     serve.start(http_options={"port": _get_random_port(), "location": "HeadOnly"})
 
-    # Only the controller and head node proxy should be started, both on the head node.
-    actors = list_actors(address=head_node.address)
-    assert len(actors) == 2
-    assert all([actor.node_id == head_node.node_id for actor in actors])
+    # The controller and head-node proxy should be started, all on the head node.
+    # Under HAProxy the head node also runs the HAProxyManager alongside the
+    # fallback ProxyActor, so three actors instead of two. The fallback proxy
+    # registers asynchronously, so wait for the expected set rather than
+    # asserting an immediate count.
+    expected_num_actors = 3 if RAY_SERVE_ENABLE_HA_PROXY else 2
+
+    def check_head_only_actors():
+        actors = list_actors(
+            address=head_node.address, filters=[("state", "=", "ALIVE")]
+        )
+        assert len(actors) == expected_num_actors
+        assert all(actor.node_id == head_node.node_id for actor in actors)
+        return True
+
+    wait_for_condition(check_head_only_actors)
 
 
 def test_instance_in_non_anonymous_namespace(ray_shutdown):

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -370,18 +370,17 @@ def test_http_head_only(ray_cluster):
 
     serve.start(http_options={"port": _get_random_port(), "location": "HeadOnly"})
 
-    # The controller and head-node proxy should be started, all on the head node.
-    # Under HAProxy the head node also runs the HAProxyManager alongside the
-    # fallback ProxyActor, so three actors instead of two. The fallback proxy
-    # registers asynchronously, so wait for the expected set rather than
-    # asserting an immediate count.
-    expected_num_actors = 3 if RAY_SERVE_ENABLE_HA_PROXY else 2
+    # Controller and proxy on the head node. HAProxy adds the HAProxyManager
+    # alongside the fallback ProxyActor, which registers asynchronously.
+    expected_classes = {"ServeController", "ProxyActor"}
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        expected_classes.add("HAProxyManager")
 
     def check_head_only_actors():
         actors = list_actors(
             address=head_node.address, filters=[("state", "=", "ALIVE")]
         )
-        assert len(actors) == expected_num_actors
+        assert {actor.class_name for actor in actors} == expected_classes
         assert all(actor.node_id == head_node.node_id for actor in actors)
         return True
 


### PR DESCRIPTION
## What

Implement `root_path` for the HAProxy ingress and run `test_standalone.py` under HAProxy.

`HAProxyConfig.root_path` exposes the normalized `http_options.root_path`. When it is set, the frontend strips it from the request path with `http-request set-path` before the health and routes rules, the per-backend path ACLs, and forwarding to replicas. This matches the native Serve proxy, which mounts the app under `root_path`. Paths outside `root_path` are left unchanged.

## Test changes

`test_http_head_only`: under HAProxy the head node runs the HAProxyManager alongside the fallback ProxyActor, so the expected actor count is 3 rather than 2. The fallback proxy registers asynchronously, so the test waits for the expected set.

`test_middleware`: skipped under HAProxy. User HTTP middleware runs on the replica, but the `/-/routes` endpoint is served by HAProxy, so middleware-injected headers are absent there.

`test_standalone` is added to the HAProxy CI allowlist so the file runs under HAProxy.

## Verification

`root_path` config generation is verified by rendering the config template. The end-to-end paths `test_http_root_path` and `test_no_http` run in the HAProxy CI step via the allowlist addition.
