### PR TITLE
[Data] DataSourceV2: row-group-aware Parquet chunking

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -360,3 +360,9 @@ python/ray/data/tests/datasource/test_kafka.py
 python/ray/data/_internal/gpu_shuffle/rapidsmpf_backend.py
 python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
 python/ray/data/_internal/execution/bundle_queue/base.py
+python/ray/data/_internal/datasource_v2/tests/test_file_partitioners.py
+python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+python/ray/data/tests/datasource/test_read_parquet_v2.py
+python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
+python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+python/ray/data/tests/unit/datasource_v2/test_list_files_op.py

--- a/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
@@ -7,8 +7,10 @@ reader carry the per-chunk metadata through to the read task.
 """
 
 import abc
+import logging
 import math
 from typing import (
+    TYPE_CHECKING,
     Iterable,
     Optional,
     Tuple,
@@ -19,8 +21,13 @@ from typing import (
     get_type_hints,
 )
 
-from ray.data._internal.util import GiB, MiB, infer_compression
+from ray.data._internal.util import MiB, infer_compression
 from ray.util.annotations import DeveloperAPI
+
+if TYPE_CHECKING:
+    from pyarrow.fs import FileSystem
+
+logger = logging.getLogger(__name__)
 
 
 class ChunkMetadata(TypedDict):
@@ -57,13 +64,14 @@ class LineDelimitedFileChunkMetadata(ChunkMetadata):
 class ParquetFileChunkMetadata(ChunkMetadata):
     """Metadata for Parquet file chunks.
 
-    For a parquet file, the chunks are based on the total size of the file, not on the
-    underlying row groups. We will split a file into potentially many chunks of the
-    target chunk size. This may correspond to 0, 1, or more row groups per chunk.
+    A chunk is an explicit, half-open range of consecutive row groups
+    ``[row_group_start, row_group_end)`` within a single file, computed at
+    listing time from the file's footer. The reader slices the fragment to
+    exactly this range — no estimation or read-time reconciliation.
     """
 
-    chunk_idx: int
-    total_num_chunks: int
+    row_group_start: int  # inclusive
+    row_group_end: int  # exclusive
 
 
 @DeveloperAPI
@@ -78,15 +86,27 @@ class FileChunker(abc.ABC):
     - Parquet files can be chunked by row groups
     """
 
+    # Whether ``generate_chunk_metadatas`` performs file I/O (e.g. reading a
+    # Parquet footer). When True, the indexer fans chunking across its thread
+    # pool so the per-file reads parallelize even for a single input
+    # directory. When False, the indexer chunks inline (no thread hand-off).
+    reads_file_metadata: bool = False
+
     @abc.abstractmethod
     def generate_chunk_metadatas(
-        self, path: str, file_size: int
+        self,
+        path: str,
+        file_size: int,
+        filesystem: Optional["FileSystem"] = None,
     ) -> Iterable[Tuple[Optional[ChunkMetadata], int]]:
         """Generate metadata for file chunks.
 
         Args:
             path: The file path being chunked.
             file_size: The total size in bytes of the file to be chunked.
+            filesystem: PyArrow filesystem used to read per-file metadata
+                (e.g. the Parquet footer). Ignored by chunkers that do not
+                read file metadata.
 
         Returns:
             An iterable of tuples containing (metadata, chunk_size) where metadata
@@ -110,7 +130,10 @@ class WholeFileChunker(FileChunker):
     """
 
     def generate_chunk_metadatas(
-        self, path: str, file_size: int
+        self,
+        path: str,
+        file_size: int,
+        filesystem: Optional["FileSystem"] = None,
     ) -> Iterable[Tuple[Optional[ChunkMetadata], int]]:
         yield None, file_size
 
@@ -127,7 +150,10 @@ class LineDelimitedFileChunker(FileChunker):
     _CHUNK_BYTE_SIZE = 256 * MiB  # 256 MiB
 
     def generate_chunk_metadatas(
-        self, path: str, file_size: int
+        self,
+        path: str,
+        file_size: int,
+        filesystem: Optional["FileSystem"] = None,
     ) -> Iterable[Tuple[Optional[ChunkMetadata], int]]:
         compression = infer_compression(path)
         if compression is not None:
@@ -152,58 +178,104 @@ class LineDelimitedFileChunker(FileChunker):
 class ParquetFileChunker(FileChunker):
     """File chunker for Parquet files.
 
-    This chunker splits Parquet files into an estimated number of chunks. We do not
-    fetch the metadata for the file, so we may overestimate the number of chunks
-    compared to the actual number of underlying row groups. The partitioner creates
-    groupings based on these estimates, and the reader fetches the metadata and
-    ensures that all row groups are read / any overestimated row groups are ignored.
+    Reads each file's footer at listing time and chunks on **true row-group
+    boundaries**: consecutive row groups are bundled into a chunk until the
+    bundle's on-disk size reaches ``target_chunk_size`` (always at least one
+    row group per chunk). Each chunk carries an explicit half-open row-group
+    range, so the reader slices to exactly those row groups with no
+    estimation or read-time reconciliation, and the listing stage never
+    produces empty read tasks.
+
+    The row group is Parquet's atomic read unit, so a chunk can never be
+    smaller than a single row group. With the default target (which falls
+    back to ``DataContext.target_min_block_size``), a file's row groups map
+    1:1 to chunks unless they are smaller than the target, in which case
+    consecutive small row groups are bundled to avoid an excessive number of
+    tiny chunks.
     """
 
-    # Chosen so that we can effectively chunk files but will not result in OOMs if
-    # the compression ratio is high.
-    #
-    # If the compression ratio is high and this chunk size is large, we end up with
-    # larger chunks than we need and reading can OOM. Reducing the chunk size gives
-    # better memory performance by reading a smaller fraction of row groups at a time.
-    #
-    # We also want to keep this large enough such that we do not end up reading too
-    # much data if we underestimate the number of chunks. If row groups are larger
-    # than the chunk size and we place many of them in the same read task, the total
-    # amount of data read might be larger than expected. By increasing the chunk
-    # size we are less likely to put many such row groups in the same task.
-    _DEFAULT_TARGET_CHUNK_SIZE = 1 * GiB
+    # Hard fallback used only when neither an explicit target nor the
+    # DataContext size knobs are set.
+    _FALLBACK_TARGET_CHUNK_SIZE = 1 * MiB
+
+    # Footer reads are file I/O — let the indexer parallelize them.
+    reads_file_metadata: bool = True
 
     def __init__(self, target_chunk_size: Optional[int] = None):
         from ray.data.context import DataContext
 
         ctx = DataContext.get_current()
-        if target_chunk_size is not None:
-            self._target_chunk_size = target_chunk_size
-        elif ctx.parquet_chunker_target_chunk_size is not None:
-            self._target_chunk_size = ctx.parquet_chunker_target_chunk_size
-        else:
-            self._target_chunk_size = self._DEFAULT_TARGET_CHUNK_SIZE
+        self._target_chunk_size = (
+            target_chunk_size
+            or ctx.parquet_chunker_target_chunk_size
+            or ctx.target_min_block_size
+            or self._FALLBACK_TARGET_CHUNK_SIZE
+        )
 
     def generate_chunk_metadatas(
-        self, path: str, file_size: int
+        self,
+        path: str,
+        file_size: int,
+        filesystem: Optional["FileSystem"] = None,
     ) -> Iterable[Tuple[Optional[ChunkMetadata], int]]:
-        if file_size <= self._target_chunk_size:
-            # Do not chunk if the file is smaller than the target chunk size; when
-            # we read the file, this prevents additional metadata fetching since we
-            # want to read the entire file.
+        import pyarrow.parquet as pq
+
+        try:
+            # Reads only the Parquet footer (file metadata), not data.
+            metadata = pq.read_metadata(path, filesystem=filesystem)
+        except Exception as e:
+            # Corrupt / unreadable footer (or a non-Parquet file that slipped
+            # through). Fall back to a single whole-file chunk so the file is
+            # still read rather than dropped.
+            logger.debug(
+                "Could not read Parquet footer for chunking (%s): %s; "
+                "falling back to a whole-file chunk.",
+                path,
+                e,
+            )
             yield None, file_size
             return
 
-        num_chunks = math.ceil(file_size / self._target_chunk_size)
-        for i in range(num_chunks):
-            chunk_start = self._target_chunk_size * i
-            chunk_end = min(self._target_chunk_size * (i + 1), file_size)
-            chunk_size = chunk_end - chunk_start
-            yield (
-                create_chunk_metadata(
-                    ParquetFileChunkMetadata,
-                    chunk_idx=i,
-                    total_num_chunks=num_chunks,
-                ),
-                chunk_size,
+        num_row_groups = metadata.num_row_groups
+        if num_row_groups == 0:
+            yield None, file_size
+            return
+
+        # Greedily bundle consecutive row groups until the running on-disk
+        # size reaches the target. Always emit at least one row group per
+        # chunk (the atomic read unit).
+        start = 0
+        running_size = 0
+        for rg_idx in range(num_row_groups):
+            rg_meta = metadata.row_group(rg_idx)
+            # On-disk (compressed) row-group size. ``RowGroupMetaData`` exposes
+            # only the *uncompressed* ``total_byte_size``; the on-disk size lives
+            # on each ``ColumnChunkMetaData``, so sum the per-column compressed
+            # sizes. Keeping chunk sizes in on-disk units matches the manifest's
+            # ``file_sizes`` and the ``×encoding_ratio`` in-memory estimator.
+            rg_size = sum(
+                rg_meta.column(c).total_compressed_size
+                for c in range(rg_meta.num_columns)
             )
+            if running_size > 0 and running_size + rg_size > self._target_chunk_size:
+                yield (
+                    create_chunk_metadata(
+                        ParquetFileChunkMetadata,
+                        row_group_start=start,
+                        row_group_end=rg_idx,
+                    ),
+                    running_size,
+                )
+                start = rg_idx
+                running_size = 0
+            running_size += rg_size
+
+        # Flush the final bundle.
+        yield (
+            create_chunk_metadata(
+                ParquetFileChunkMetadata,
+                row_group_start=start,
+                row_group_end=num_row_groups,
+            ),
+            running_size,
+        )

--- a/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
@@ -205,12 +205,17 @@ class ParquetFileChunker(FileChunker):
         from ray.data.context import DataContext
 
         ctx = DataContext.get_current()
-        self._target_chunk_size = (
-            target_chunk_size
-            or ctx.parquet_chunker_target_chunk_size
-            or ctx.target_min_block_size
-            or self._FALLBACK_TARGET_CHUNK_SIZE
-        )
+        # Resolve with explicit ``is not None`` checks rather than ``or`` so an
+        # explicit ``0`` (e.g. to force one row group per chunk) isn't treated as
+        # "unset" and silently overridden by a falsy-coalescing fallback.
+        if target_chunk_size is not None:
+            self._target_chunk_size = target_chunk_size
+        elif ctx.parquet_chunker_target_chunk_size is not None:
+            self._target_chunk_size = ctx.parquet_chunker_target_chunk_size
+        elif ctx.target_min_block_size is not None:
+            self._target_chunk_size = ctx.target_min_block_size
+        else:
+            self._target_chunk_size = self._FALLBACK_TARGET_CHUNK_SIZE
 
     def generate_chunk_metadatas(
         self,

--- a/python/ray/data/_internal/datasource_v2/chunkers/parquet_file_chunking_utils.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/parquet_file_chunking_utils.py
@@ -1,9 +1,11 @@
 """Parquet file-level chunking helpers for DataSourceV2.
 
-Maps planner chunk metadata (``ParquetFileChunkMetadata``) to row-group
-ranges and PyArrow ``ParquetFileFragment`` subsets for parallel reads.
+Maps planner chunk metadata (``ParquetFileChunkMetadata``) to PyArrow
+``ParquetFileFragment`` subsets for parallel reads. Chunk metadata carries
+an explicit half-open row-group range computed at listing time from the
+file's footer, so no estimation or reconciliation is needed here.
 """
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import pyarrow.dataset as pds
 
@@ -12,96 +14,30 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
 )
 
 
-def _calculate_row_group_range(
-    chunk_idx: int, total_num_chunks: int, total_row_groups: int
-) -> Optional[Tuple[int, int]]:
-    """Compute the half-open row-group range for a given chunk.
-
-    Distributes row groups as evenly as possible across chunks. If row groups
-    don't divide evenly, earlier chunks get the extra row groups.
-
-    Example:
-        - 10 row groups, 3 chunks -> [0:4), [4:7), [7:10)
-        - 11 row groups, 3 chunks -> [0:4), [4:8), [8:11)
-
-    Args:
-        chunk_idx: Index of the current chunk (0-based).
-        total_num_chunks: Total number of chunks.
-        total_row_groups: Total number of row groups to distribute.
-
-    Returns:
-        Tuple ``(start_row_group, end_row_group)`` where ``end`` is exclusive,
-        or ``None`` if ``chunk_idx`` falls beyond the actual number of row
-        groups (i.e. the planner over-estimated the chunk count).
-    """
-    assert (
-        total_row_groups >= 0
-    ), f"total_row_groups must be non-negative, got {total_row_groups}"
-    assert (
-        total_num_chunks > 0
-    ), f"total_num_chunks must be positive, got {total_num_chunks}"
-    assert (
-        chunk_idx < total_num_chunks
-    ), f"chunk_idx must be less than total_num_chunks, got {chunk_idx} and {total_num_chunks}"
-    assert chunk_idx >= 0, f"chunk_idx must be non-negative, got {chunk_idx}"
-
-    # Handle the case where ``chunk_idx`` exceeds the actual number of chunks
-    # needed. This happens when the planner overestimated the number of chunks
-    # (the chunker doesn't fetch metadata).
-    if chunk_idx >= total_row_groups:
-        return None
-
-    base_row_groups_per_chunk = total_row_groups // total_num_chunks
-    remainder = total_row_groups % total_num_chunks
-
-    # Chunks 0 through (remainder-1) get one extra row group.
-    if chunk_idx < remainder:
-        row_groups_in_this_chunk = base_row_groups_per_chunk + 1
-        start = chunk_idx * row_groups_in_this_chunk
-    else:
-        row_groups_in_this_chunk = base_row_groups_per_chunk
-        start = (
-            remainder * (base_row_groups_per_chunk + 1)
-            + (chunk_idx - remainder) * base_row_groups_per_chunk
-        )
-
-    end = start + row_groups_in_this_chunk
-
-    assert (
-        0 <= start <= end <= total_row_groups
-    ), f"Invalid range [{start}, {end}) for {total_row_groups} row groups"
-
-    return start, end
-
-
 def _fragments_from_chunk_metadata(
     fragment: pds.ParquetFileFragment,
     chunk_metadata: ParquetFileChunkMetadata,
 ) -> List[Tuple[pds.ParquetFileFragment, int]]:
-    """Slice ``fragment`` into per-row-group sub-fragments per chunk metadata.
+    """Slice ``fragment`` into per-row-group sub-fragments for the chunk's range.
 
+    The chunk carries an explicit ``[row_group_start, row_group_end)`` range.
     Returns one ``(ParquetFileFragment, file_row_offset)`` pair per row group
-    covered by the chunk, where ``file_row_offset`` is the sum of ``num_rows``
-    across all row groups that precede the sub-fragment in the underlying
-    file. Callers seed per-fragment hashing offsets with this value so
-    sub-fragments of the same file don't collide on ``(path, 0, n)``.
+    in that range, where ``file_row_offset`` is the sum of ``num_rows`` across
+    all row groups that precede the sub-fragment in the underlying file.
+    Callers seed per-fragment hashing offsets with this value so sub-fragments
+    of the same file don't collide on ``(path, 0, n)``.
 
-    Returns an empty list when the chunk index falls beyond the file's actual
-    row-group count (the planner over-estimated; we silently drop the slice).
+    The range is defensively clamped to the file's actual row-group count;
+    since ranges are computed from the same footer the reader sees, the clamp
+    is a no-op in practice and never drops real row groups.
     """
-    chunk_idx = chunk_metadata["chunk_idx"]
-    total_num_chunks = chunk_metadata["total_num_chunks"]
+    start = chunk_metadata["row_group_start"]
+    end = chunk_metadata["row_group_end"]
     metadata = fragment.metadata
     total_row_groups = metadata.num_row_groups
 
-    row_group_range = _calculate_row_group_range(
-        chunk_idx, total_num_chunks, total_row_groups
-    )
-
-    if row_group_range is None:
-        return []
-
-    start, end = row_group_range
+    start = min(start, total_row_groups)
+    end = min(end, total_row_groups)
 
     file_row_offset = sum(metadata.row_group(i).num_rows for i in range(start))
     sub_fragments: List[Tuple[pds.ParquetFileFragment, int]] = []

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Iterable, Iterator, List, Optional
+from typing import Iterable, Iterator, List, Optional, Tuple
 
 from pyarrow.fs import FileSystem
 
@@ -122,9 +122,12 @@ class NonSamplingFileIndexer(FileIndexer):
             else self._get_file_info_iterator_sequential(paths, filesystem)
         )
 
-        yield from self._process_file_infos_to_manifests(
-            file_info_iterator, pruners or []
-        )
+        # Stage pipeline: list → prune (cheap, inline) → chunk (may read
+        # per-file metadata) → batch into manifests. Pruning runs *before*
+        # chunking so we never read a footer for a file we'd discard.
+        pruned = self._filter_file_infos(file_info_iterator, pruners or [])
+        chunk_records = self._generate_chunk_records(pruned, filesystem, preserve_order)
+        yield from self._batch_chunk_records_to_manifests(chunk_records)
 
     def _get_file_info_iterator_sequential(
         self,
@@ -176,50 +179,84 @@ class NonSamplingFileIndexer(FileIndexer):
             buffer_size=self._queue_size_per_thread,
         )
 
-    def _process_file_infos_to_manifests(
+    def _filter_file_infos(
         self,
         file_infos: Iterable[FileInfo],
         pruners: List[FilePruner],
+    ) -> Iterator[FileInfo]:
+        """Drop zero-size and pruned files before any per-file metadata read."""
+        for file_info in file_infos:
+            if file_info.size is None or file_info.size == 0:
+                logger.warning(f"Skipping zero-size file: {file_info.path!r}")
+                continue
+            if not all(pruner.should_include(file_info.path) for pruner in pruners):
+                continue
+            yield file_info
+
+    def _generate_chunk_records(
+        self,
+        file_infos: Iterable[FileInfo],
+        filesystem: "FileSystem",
+        preserve_order: bool,
+    ) -> Iterator[Tuple[str, int, Optional[ChunkMetadata]]]:
+        """Drive the chunker per file, yielding ``(path, chunk_size, metadata)``.
+
+        When the chunker reads per-file metadata (e.g. ``ParquetFileChunker``
+        reading footers), fan the work across the indexer's thread pool so the
+        I/O parallelizes even for a single input directory — ``make_async_gen``
+        over the *discovered files*, not the input paths. Chunkers that don't
+        read metadata (whole-file / line-delimited) are driven inline to avoid
+        a pointless thread hand-off.
+        """
+        chunker = self._file_chunker
+
+        def chunk(
+            infos: Iterator[FileInfo],
+        ) -> Iterator[Tuple[str, int, Optional[ChunkMetadata]]]:
+            for fi in infos:
+                for chunk_metadata, chunk_size in chunker.generate_chunk_metadatas(
+                    fi.path, fi.size, filesystem
+                ):
+                    yield fi.path, chunk_size, chunk_metadata
+
+        if chunker.reads_file_metadata and self._num_workers > 1:
+            yield from make_async_gen(
+                base_iterator=file_infos,
+                fn=chunk,
+                preserve_ordering=preserve_order,
+                num_workers=self._num_workers,
+                buffer_size=self._queue_size_per_thread,
+            )
+        else:
+            yield from chunk(iter(file_infos))
+
+    def _batch_chunk_records_to_manifests(
+        self,
+        chunk_records: Iterable[Tuple[str, int, Optional[ChunkMetadata]]],
     ) -> Iterable[FileManifest]:
+        """Batch chunk records into ``FileManifest`` blocks of bounded size."""
         running_paths: List[str] = []
         running_file_sizes: List[int] = []
         running_chunk_metadatas: List[Optional[ChunkMetadata]] = []
         manifests_count = 0
         chunks_count = 0
 
-        for file_info in file_infos:
-            path, file_size = file_info.path, file_info.size
+        for path, chunk_size, chunk_metadata in chunk_records:
+            running_paths.append(path)
+            running_file_sizes.append(chunk_size)
+            running_chunk_metadatas.append(chunk_metadata)
+            chunks_count += 1
 
-            if file_size is None or file_size == 0:
-                logger.warning(f"Skipping zero-size file: {path!r}")
-                continue
-
-            if not all(pruner.should_include(path) for pruner in pruners):
-                continue
-
-            # Drive the chunker once per file; emit one manifest row per chunk.
-            # ``chunk_metadata`` is ``None`` for whole-file chunks (default
-            # ``WholeFileChunker`` behavior and ``ParquetFileChunker`` for files
-            # smaller than the target chunk size).
-            for (
-                chunk_metadata,
-                chunk_size,
-            ) in self._file_chunker.generate_chunk_metadatas(path, file_size):
-                running_paths.append(path)
-                running_file_sizes.append(chunk_size)
-                running_chunk_metadatas.append(chunk_metadata)
-                chunks_count += 1
-
-                if len(running_paths) >= self._max_paths_per_output:
-                    manifests_count += 1
-                    yield FileManifest.construct_manifest(
-                        running_paths,
-                        running_file_sizes,
-                        running_chunk_metadatas,
-                    )
-                    running_paths = []
-                    running_file_sizes = []
-                    running_chunk_metadatas = []
+            if len(running_paths) >= self._max_paths_per_output:
+                manifests_count += 1
+                yield FileManifest.construct_manifest(
+                    running_paths,
+                    running_file_sizes,
+                    running_chunk_metadatas,
+                )
+                running_paths = []
+                running_file_sizes = []
+                running_chunk_metadatas = []
 
         if running_paths:
             manifests_count += 1

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -210,27 +210,42 @@ class NonSamplingFileIndexer(FileIndexer):
         """
         chunker = self._file_chunker
 
-        def chunk(
-            infos: Iterator[FileInfo],
-        ) -> Iterator[Tuple[str, int, Optional[ChunkMetadata]]]:
-            for fi in infos:
+        def chunk_file(
+            fi: FileInfo,
+        ) -> List[Tuple[str, int, Optional[ChunkMetadata]]]:
+            return [
+                (fi.path, chunk_size, chunk_metadata)
                 for chunk_metadata, chunk_size in chunker.generate_chunk_metadatas(
                     fi.path, fi.size, filesystem
-                ):
-                    yield fi.path, chunk_size, chunk_metadata
+                )
+            ]
 
         if chunker.reads_file_metadata and self._num_workers > 1:
-            yield from make_async_gen(
+            # Fan per-file footer reads across the thread pool. ``make_async_gen``
+            # only preserves ordering for a 1:1 map (one output per input item), so
+            # emit ONE record list per file and flatten here. Yielding chunk rows
+            # individually would let its round-robin merge interleave chunks from
+            # the files processed concurrently -- breaking per-file contiguity and
+            # discovery order under ``preserve_order=True``.
+            def chunk_files(
+                infos: Iterator[FileInfo],
+            ) -> Iterator[List[Tuple[str, int, Optional[ChunkMetadata]]]]:
+                for fi in infos:
+                    yield chunk_file(fi)
+
+            for records in make_async_gen(
                 # ``iter(...)`` so a non-iterator iterable (e.g. a list from a
                 # test or subclass) is still consumed correctly by the helper.
                 base_iterator=iter(file_infos),
-                fn=chunk,
+                fn=chunk_files,
                 preserve_ordering=preserve_order,
                 num_workers=self._num_workers,
                 buffer_size=self._queue_size_per_thread,
-            )
+            ):
+                yield from records
         else:
-            yield from chunk(iter(file_infos))
+            for fi in file_infos:
+                yield from chunk_file(fi)
 
     def _batch_chunk_records_to_manifests(
         self,

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -221,7 +221,9 @@ class NonSamplingFileIndexer(FileIndexer):
 
         if chunker.reads_file_metadata and self._num_workers > 1:
             yield from make_async_gen(
-                base_iterator=file_infos,
+                # ``iter(...)`` so a non-iterator iterable (e.g. a list from a
+                # test or subclass) is still consumed correctly by the helper.
+                base_iterator=iter(file_infos),
                 fn=chunk,
                 preserve_ordering=preserve_order,
                 num_workers=self._num_workers,

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -9,7 +9,6 @@ import os
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-import pytest
 
 from ray.data._internal.datasource_v2.chunkers.file_chunker import (
     ParquetFileChunker,
@@ -18,7 +17,6 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
     create_chunk_metadata,
 )
 from ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils import (
-    _calculate_row_group_range,
     _fragments_from_chunk_metadata,
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
@@ -230,53 +228,6 @@ def test_datasource_accepts_custom_chunker(tmp_path):
     assert indexer.file_chunker is custom
 
 
-@pytest.mark.parametrize(
-    "total_row_groups,total_num_chunks,expected_ranges",
-    [
-        # Even distribution.
-        (10, 2, [(0, 5), (5, 10)]),
-        (12, 3, [(0, 4), (4, 8), (8, 12)]),
-        (20, 4, [(0, 5), (5, 10), (10, 15), (15, 20)]),
-        # Uneven distribution: earlier chunks get extra row groups.
-        (10, 3, [(0, 4), (4, 7), (7, 10)]),
-        (11, 3, [(0, 4), (4, 8), (8, 11)]),
-        (13, 4, [(0, 4), (4, 7), (7, 10), (10, 13)]),
-        # Edge cases — over-estimated chunk counts must produce ``None``.
-        (1, 1, [(0, 1)]),
-        (1, 2, [(0, 1), None]),
-        (0, 1, [None]),
-        (5, 10, [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)] + [None] * 5),
-    ],
-)
-def test_calculate_row_group_range_distribution(
-    total_row_groups, total_num_chunks, expected_ranges
-):
-    """Row-group distribution across chunks is even and covers everything."""
-    for chunk_idx in range(total_num_chunks):
-        result = _calculate_row_group_range(
-            chunk_idx, total_num_chunks, total_row_groups
-        )
-        expected = (
-            expected_ranges[chunk_idx] if chunk_idx < len(expected_ranges) else None
-        )
-        assert (
-            result == expected
-        ), f"Chunk {chunk_idx}: expected {expected}, got {result}"
-
-    # No gaps, no overlaps, every row group covered exactly once.
-    covered = set()
-    for chunk_idx in range(total_num_chunks):
-        result = _calculate_row_group_range(
-            chunk_idx, total_num_chunks, total_row_groups
-        )
-        if result is not None:
-            start, end = result
-            chunk_rows = set(range(start, end))
-            assert not (covered & chunk_rows)
-            covered.update(chunk_rows)
-    assert covered == set(range(total_row_groups))
-
-
 def _write_multi_row_group_parquet(path, num_rows: int, row_group_size: int):
     table = pa.table({"id": list(range(num_rows))})
     pq.write_table(table, path, row_group_size=row_group_size)
@@ -284,7 +235,7 @@ def _write_multi_row_group_parquet(path, num_rows: int, row_group_size: int):
 
 
 def test_fragments_from_chunk_metadata_subsets_by_row_group(tmp_path):
-    """``_fragments_from_chunk_metadata`` slices a file fragment per chunk."""
+    """``_fragments_from_chunk_metadata`` slices a fragment to the explicit range."""
     import pyarrow.dataset as pds
 
     file_path = str(tmp_path / "multi.parquet")
@@ -295,24 +246,21 @@ def test_fragments_from_chunk_metadata_subsets_by_row_group(tmp_path):
     (fragment,) = dataset.get_fragments()
     assert fragment.metadata.num_row_groups == 100
 
-    # 100 row groups split into 4 chunks -> 25 row groups each.
+    # Explicit range [25, 50) → 25 row groups, starting row offset 250.
     chunk_md = create_chunk_metadata(
-        ParquetFileChunkMetadata, chunk_idx=1, total_num_chunks=4
+        ParquetFileChunkMetadata, row_group_start=25, row_group_end=50
     )
     sub_fragments = _fragments_from_chunk_metadata(fragment, chunk_md)
     assert len(sub_fragments) == 25
-    # chunk_idx=1, 25 rows/chunk * 10 rows/row_group = starting offset 250.
-    expected_offset = 250
+    expected_offset = 250  # 25 row groups × 10 rows each precede the range.
     for sub, offset in sub_fragments:
         assert len(sub.row_groups) == 1
         assert offset == expected_offset
         expected_offset += sub.metadata.row_group(sub.row_groups[0].id).num_rows
 
 
-def test_fragments_from_chunk_metadata_returns_empty_for_out_of_range_chunk(
-    tmp_path,
-):
-    """Over-estimated chunk indices fall off the end → no sub-fragments."""
+def test_fragments_from_chunk_metadata_clamps_range_beyond_row_groups(tmp_path):
+    """A range beyond the file's actual row-group count is clamped (no crash)."""
     import pyarrow.dataset as pds
 
     file_path = str(tmp_path / "single.parquet")
@@ -321,12 +269,21 @@ def test_fragments_from_chunk_metadata_returns_empty_for_out_of_range_chunk(
 
     dataset = pds.dataset(file_path, format="parquet")
     (fragment,) = dataset.get_fragments()
+    assert fragment.metadata.num_row_groups == 1
 
-    # chunk_idx=4 with 5 chunks but only 1 row group → no sub-fragments.
+    # Fully out-of-range [5, 6) → clamped to [1, 1) → no sub-fragments.
     chunk_md = create_chunk_metadata(
-        ParquetFileChunkMetadata, chunk_idx=4, total_num_chunks=5
+        ParquetFileChunkMetadata, row_group_start=5, row_group_end=6
     )
     assert _fragments_from_chunk_metadata(fragment, chunk_md) == []
+
+    # Partially out-of-range [0, 9) → clamped to [0, 1) → the one real row group.
+    chunk_md = create_chunk_metadata(
+        ParquetFileChunkMetadata, row_group_start=0, row_group_end=9
+    )
+    sub_fragments = _fragments_from_chunk_metadata(fragment, chunk_md)
+    assert len(sub_fragments) == 1
+    assert sub_fragments[0][1] == 0  # row offset
 
 
 def _read_via_reader(reader, manifest):
@@ -346,7 +303,8 @@ def test_parquet_file_reader_reads_chunked_manifest(tmp_path):
     whole_tables = _read_via_reader(reader_whole, whole_manifest)
     whole_rows = pa.concat_tables(whole_tables).column("id").to_pylist()
 
-    chunker = ParquetFileChunker(target_chunk_size=1024)
+    # target_chunk_size=1 forces one chunk per row group.
+    chunker = ParquetFileChunker(target_chunk_size=1)
     chunks = list(chunker.generate_chunk_metadatas(file_path, file_size))
     assert len(chunks) > 1, "test setup expects ParquetFileChunker to chunk"
 
@@ -378,7 +336,7 @@ def test_parquet_file_reader_chunked_row_hashes_are_unique(tmp_path):
     _write_multi_row_group_parquet(file_path, num_rows=expected_rows, row_group_size=20)
     file_size = os.path.getsize(file_path)
 
-    chunker = ParquetFileChunker(target_chunk_size=1024)
+    chunker = ParquetFileChunker(target_chunk_size=1)
     chunks = list(chunker.generate_chunk_metadatas(file_path, file_size))
     assert len(chunks) > 1, "test setup expects ParquetFileChunker to chunk"
 
@@ -399,23 +357,23 @@ def test_parquet_file_reader_chunked_row_hashes_are_unique(tmp_path):
 
 
 def test_parquet_file_reader_handles_out_of_range_chunks(tmp_path):
-    """Out-of-range chunk metadata is silently dropped — no exception, no rows."""
+    """Defensively clamped out-of-range chunk metadata yields no rows, no crash.
+
+    The chunker never emits out-of-range ranges (they're computed from the
+    same footer the reader sees), but a hand-constructed range beyond the
+    file's row groups must be handled gracefully.
+    """
     file_path = str(tmp_path / "tiny.parquet")
+    # 5 rows, single row group.
     _write_multi_row_group_parquet(file_path, num_rows=5, row_group_size=5)
-
     file_size = os.path.getsize(file_path)
-    # ``ParquetFileChunker`` over-estimates here; keep only the over-estimated
-    # tail (chunk_idx >= 1) to assert the reader yields no tables.
-    chunker = ParquetFileChunker(target_chunk_size=128)
-    chunks = list(chunker.generate_chunk_metadatas(file_path, file_size))
-    assert len(chunks) > 1
 
-    paths = [file_path] * (len(chunks) - 1)
-    out_of_range_metadatas = [md for md, _ in chunks[1:]]
-    sizes = [sz for _, sz in chunks[1:]]
-    manifest = FileManifest.construct_manifest(paths, sizes, out_of_range_metadatas)
+    # Explicit range entirely beyond the file's one row group.
+    out_of_range = create_chunk_metadata(
+        ParquetFileChunkMetadata, row_group_start=3, row_group_end=4
+    )
+    manifest = FileManifest.construct_manifest([file_path], [file_size], [out_of_range])
 
     reader = ParquetFileReader()
     tables = list(reader.read(manifest))
-    # All sub-fragments are out-of-range -> 0 tables emitted.
     assert sum(t.num_rows for t in tables) == 0

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -537,10 +537,12 @@ class DataContext:
             driver-side first-file sampling for schema inference,
             ``ParquetScanner`` / ``ParquetFileReader``). Defaults to False — V1
             remains the production path while V2 bakes.
-        parquet_chunker_target_chunk_size: Target chunk size in bytes used by
-            ``ParquetFileChunker`` when splitting large Parquet files into
-            multiple read tasks. When ``None``, the chunker's built-in default
-            (currently 1 GiB) is used.
+        parquet_chunker_target_chunk_size: Target on-disk bytes per chunk used
+            by ``ParquetFileChunker``. The chunker reads each file's footer at
+            listing time and bundles consecutive row groups until their on-disk
+            size reaches this target (always at least one row group per chunk),
+            so normal-sized row groups map roughly 1:1 to chunks. When ``None``,
+            falls back to ``target_min_block_size``.
         enable_tensor_extension_casting: Whether to automatically cast NumPy ndarray
             columns in Pandas DataFrames to tensor extension columns.
         arrow_fixed_shape_tensor_format: The tensor format to use for fixed-shape tensors.
@@ -802,8 +804,9 @@ class DataContext:
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     use_datasource_v2: bool = DEFAULT_USE_DATASOURCE_V2
-    # Target chunk size in bytes for ``ParquetFileChunker``. When ``None``, the
-    # chunker uses its built-in default (currently 1 GiB).
+    # Target on-disk bytes per chunk for ``ParquetFileChunker`` (bundles
+    # consecutive row groups up to this size, >= 1 row group). When ``None``,
+    # falls back to ``target_min_block_size``.
     parquet_chunker_target_chunk_size: Optional[
         int
     ] = DEFAULT_PARQUET_CHUNKER_TARGET_CHUNK_SIZE

--- a/python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
@@ -1,6 +1,9 @@
 """Unit tests for ``FileChunker`` implementations in DataSourceV2."""
+from pathlib import Path
 from typing import cast
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from ray.data._internal.datasource_v2.chunkers.file_chunker import (
@@ -14,25 +17,38 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
 )
 
 
+def _write_parquet_with_row_groups(
+    path: str, num_row_groups: int, rows_per_group: int = 10
+) -> int:
+    """Write a Parquet file with exactly ``num_row_groups`` row groups.
+
+    Returns the on-disk file size in bytes.
+    """
+    n = num_row_groups * rows_per_group
+    table = pa.table({"a": list(range(n))})
+    pq.write_table(table, path, row_group_size=rows_per_group)
+    return Path(path).stat().st_size
+
+
 class TestCreateChunkMetadata:
     def test_validates_missing_keys(self):
         with pytest.raises(ValueError, match="Missing required keys"):
-            create_chunk_metadata(ParquetFileChunkMetadata, chunk_idx=0)
+            create_chunk_metadata(ParquetFileChunkMetadata, row_group_start=0)
 
     def test_validates_unexpected_keys(self):
         with pytest.raises(ValueError, match="Unexpected keys"):
             create_chunk_metadata(
                 ParquetFileChunkMetadata,
-                chunk_idx=0,
-                total_num_chunks=1,
+                row_group_start=0,
+                row_group_end=1,
                 extra_field="boom",
             )
 
     def test_returns_dict_with_keys(self):
         md = create_chunk_metadata(
-            ParquetFileChunkMetadata, chunk_idx=2, total_num_chunks=5
+            ParquetFileChunkMetadata, row_group_start=2, row_group_end=5
         )
-        assert md == {"chunk_idx": 2, "total_num_chunks": 5}
+        assert md == {"row_group_start": 2, "row_group_end": 5}
 
 
 class TestWholeFileChunker:
@@ -40,6 +56,9 @@ class TestWholeFileChunker:
         chunker = WholeFileChunker()
         chunks = list(chunker.generate_chunk_metadatas("foo.bin", 12345))
         assert chunks == [(None, 12345)]
+
+    def test_does_not_read_metadata(self):
+        assert WholeFileChunker.reads_file_metadata is False
 
 
 class TestLineDelimitedFileChunker:
@@ -62,55 +81,84 @@ class TestLineDelimitedFileChunker:
         chunks = list(chunker.generate_chunk_metadatas("data.jsonl.gz", 1024))
         assert chunks == [(None, 1024)]
 
+    def test_does_not_read_metadata(self):
+        assert LineDelimitedFileChunker.reads_file_metadata is False
+
 
 class TestParquetFileChunker:
-    def test_small_file_yields_whole(self):
-        chunker = ParquetFileChunker(target_chunk_size=256 * 1024 * 1024)
-        chunks = list(
-            chunker.generate_chunk_metadatas("data.parquet", 100 * 1024 * 1024)
+    def test_reads_file_metadata_flag(self):
+        assert ParquetFileChunker.reads_file_metadata is True
+
+    def test_one_chunk_per_row_group_when_target_below_rg_size(self, tmp_path):
+        """target < row-group size → K=1, one chunk per row group."""
+        p = str(tmp_path / "d.parquet")
+        size = _write_parquet_with_row_groups(p, num_row_groups=5)
+        chunker = ParquetFileChunker(target_chunk_size=1)
+        chunks = list(chunker.generate_chunk_metadatas(p, size))
+        ranges = [(m["row_group_start"], m["row_group_end"]) for m, _ in chunks]
+        assert ranges == [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
+
+    def test_bundles_all_row_groups_when_target_large(self, tmp_path):
+        """target ≫ file size → all row groups in one chunk."""
+        p = str(tmp_path / "d.parquet")
+        size = _write_parquet_with_row_groups(p, num_row_groups=5)
+        chunker = ParquetFileChunker(target_chunk_size=10 * 1024**3)
+        chunks = list(chunker.generate_chunk_metadatas(p, size))
+        ranges = [(m["row_group_start"], m["row_group_end"]) for m, _ in chunks]
+        assert ranges == [(0, 5)]
+
+    def test_chunk_size_equals_summed_row_group_bytes(self, tmp_path):
+        p = str(tmp_path / "d.parquet")
+        size = _write_parquet_with_row_groups(p, num_row_groups=4)
+        chunker = ParquetFileChunker(target_chunk_size=1)
+        chunks = list(chunker.generate_chunk_metadatas(p, size))
+        md = pq.read_metadata(p)
+        expected_total = sum(
+            md.row_group(i).column(c).total_compressed_size
+            for i in range(md.num_row_groups)
+            for c in range(md.row_group(i).num_columns)
         )
-        assert chunks == [(None, 100 * 1024 * 1024)]
+        assert sum(sz for _, sz in chunks) == expected_total
 
-    def test_at_target_yields_whole(self):
-        chunker = ParquetFileChunker(target_chunk_size=256 * 1024 * 1024)
-        chunks = list(
-            chunker.generate_chunk_metadatas("data.parquet", 256 * 1024 * 1024)
-        )
-        assert chunks == [(None, 256 * 1024 * 1024)]
+    def test_ranges_are_contiguous_and_cover_all_row_groups(self, tmp_path):
+        """Bundled ranges partition [0, num_row_groups) with no gaps/overlap."""
+        p = str(tmp_path / "d.parquet")
+        # Many small row groups + a moderate target → some bundling.
+        size = _write_parquet_with_row_groups(p, num_row_groups=12, rows_per_group=5)
+        n = pq.read_metadata(p).num_row_groups
+        chunker = ParquetFileChunker(target_chunk_size=2_000)
+        chunks = list(chunker.generate_chunk_metadatas(p, size))
+        ranges = [(m["row_group_start"], m["row_group_end"]) for m, _ in chunks]
+        # Contiguous, starts at 0, ends at n, each non-empty.
+        assert ranges[0][0] == 0
+        assert ranges[-1][1] == n
+        for (_, prev_end), (next_start, _) in zip(ranges, ranges[1:]):
+            assert prev_end == next_start
+        assert all(start < end for start, end in ranges)
 
-    @pytest.mark.parametrize(
-        "file_size,expected_num_chunks",
-        [
-            (257 * 1024 * 1024, 2),
-            (300 * 1024 * 1024, 2),
-            (512 * 1024 * 1024, 2),
-            (600 * 1024 * 1024, 3),
-            (1024 * 1024 * 1024, 4),
-        ],
-    )
-    def test_large_files_produce_chunks(self, file_size, expected_num_chunks):
-        target_chunk_size = 256 * 1024 * 1024
-        chunker = ParquetFileChunker(target_chunk_size=target_chunk_size)
-        chunks = list(chunker.generate_chunk_metadatas("data.parquet", file_size))
-        assert len(chunks) == expected_num_chunks
-        total_size = 0
-        for i, (md, chunk_size) in enumerate(chunks):
-            assert isinstance(md, dict)
-            assert md["chunk_idx"] == i
-            assert md["total_num_chunks"] == expected_num_chunks
-            if i < expected_num_chunks - 1:
-                assert chunk_size == target_chunk_size
-            else:
-                assert chunk_size == file_size - target_chunk_size * i
-            total_size += chunk_size
-        assert total_size == file_size
+    def test_corrupt_footer_falls_back_to_whole_file(self, tmp_path):
+        p = str(tmp_path / "bad.parquet")
+        Path(p).write_bytes(b"this is not a parquet file")
+        chunker = ParquetFileChunker(target_chunk_size=1)
+        chunks = list(chunker.generate_chunk_metadatas(p, 26))
+        assert chunks == [(None, 26)]
 
-    def test_default_target_chunk_size_from_context(self, restore_data_context):
+    def test_default_target_falls_back_to_target_min_block_size(
+        self, restore_data_context
+    ):
+        from ray.data.context import DataContext
+
+        ctx = DataContext.get_current()
+        ctx.parquet_chunker_target_chunk_size = None
+        ctx.target_min_block_size = 7777
+        chunker = ParquetFileChunker()
+        assert chunker._target_chunk_size == 7777
+
+    def test_ctx_knob_used_when_set(self, restore_data_context):
         from ray.data.context import DataContext
 
         DataContext.get_current().parquet_chunker_target_chunk_size = 1024
-        chunker = ParquetFileChunker()
-        assert chunker._target_chunk_size == 1024
+        assert ParquetFileChunker()._target_chunk_size == 1024
 
     def test_ctor_arg_takes_precedence_over_context(self, restore_data_context):
         from ray.data.context import DataContext
@@ -123,14 +171,14 @@ class TestParquetFileChunker:
 def test_chunk_metadata_subclasses_are_typeddicts():
     # Ensures the subclasses don't accidentally inherit unrelated keys.
     pmd: ChunkMetadata = create_chunk_metadata(
-        ParquetFileChunkMetadata, chunk_idx=0, total_num_chunks=1
+        ParquetFileChunkMetadata, row_group_start=0, row_group_end=1
     )
     lmd: ChunkMetadata = create_chunk_metadata(
         LineDelimitedFileChunkMetadata,
         chunk_byte_start_idx=0,
         chunk_byte_end_idx=10,
     )
-    assert set(pmd.keys()) == {"chunk_idx", "total_num_chunks"}
+    assert set(pmd.keys()) == {"row_group_start", "row_group_end"}
     assert set(lmd.keys()) == {"chunk_byte_start_idx", "chunk_byte_end_idx"}
 
 

--- a/python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
@@ -89,23 +89,25 @@ class TestParquetFileChunker:
     def test_reads_file_metadata_flag(self):
         assert ParquetFileChunker.reads_file_metadata is True
 
-    def test_one_chunk_per_row_group_when_target_below_rg_size(self, tmp_path):
-        """target < row-group size → K=1, one chunk per row group."""
+    @pytest.mark.parametrize(
+        "target_chunk_size, expected_ranges",
+        [
+            # target < row-group size → K=1, one chunk per row group.
+            (1, [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]),
+            # target ≫ file size → all row groups bundled into one chunk.
+            (10 * 1024**3, [(0, 5)]),
+        ],
+        ids=["target_below_rg_size", "target_above_file_size"],
+    )
+    def test_row_group_bundling_by_target(
+        self, tmp_path, target_chunk_size, expected_ranges
+    ):
         p = str(tmp_path / "d.parquet")
         size = _write_parquet_with_row_groups(p, num_row_groups=5)
-        chunker = ParquetFileChunker(target_chunk_size=1)
+        chunker = ParquetFileChunker(target_chunk_size=target_chunk_size)
         chunks = list(chunker.generate_chunk_metadatas(p, size))
         ranges = [(m["row_group_start"], m["row_group_end"]) for m, _ in chunks]
-        assert ranges == [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
-
-    def test_bundles_all_row_groups_when_target_large(self, tmp_path):
-        """target ≫ file size → all row groups in one chunk."""
-        p = str(tmp_path / "d.parquet")
-        size = _write_parquet_with_row_groups(p, num_row_groups=5)
-        chunker = ParquetFileChunker(target_chunk_size=10 * 1024**3)
-        chunks = list(chunker.generate_chunk_metadatas(p, size))
-        ranges = [(m["row_group_start"], m["row_group_end"]) for m, _ in chunks]
-        assert ranges == [(0, 5)]
+        assert ranges == expected_ranges
 
     def test_chunk_size_equals_summed_row_group_bytes(self, tmp_path):
         p = str(tmp_path / "d.parquet")
@@ -143,29 +145,31 @@ class TestParquetFileChunker:
         chunks = list(chunker.generate_chunk_metadatas(p, 26))
         assert chunks == [(None, 26)]
 
-    def test_default_target_falls_back_to_target_min_block_size(
-        self, restore_data_context
+    @pytest.mark.parametrize(
+        "ctor_arg, ctx_chunk_size, ctx_min_block, expected",
+        [
+            # ctor arg wins over the context knobs.
+            (2048, 1024, 7777, 2048),
+            # An explicit 0 is honored (resolved with ``is not None``, not
+            # ``or``), so it isn't silently treated as "unset" and overridden.
+            (0, 1024, 7777, 0),
+            # ctx chunk-size knob used when there's no ctor arg.
+            (None, 1024, 7777, 1024),
+            # Falls back to target_min_block_size when the chunk-size knob is unset.
+            (None, None, 7777, 7777),
+        ],
+        ids=["ctor_arg", "ctor_arg_zero", "ctx_knob", "fallback_min_block"],
+    )
+    def test_target_chunk_size_resolution(
+        self, restore_data_context, ctor_arg, ctx_chunk_size, ctx_min_block, expected
     ):
         from ray.data.context import DataContext
 
         ctx = DataContext.get_current()
-        ctx.parquet_chunker_target_chunk_size = None
-        ctx.target_min_block_size = 7777
-        chunker = ParquetFileChunker()
-        assert chunker._target_chunk_size == 7777
-
-    def test_ctx_knob_used_when_set(self, restore_data_context):
-        from ray.data.context import DataContext
-
-        DataContext.get_current().parquet_chunker_target_chunk_size = 1024
-        assert ParquetFileChunker()._target_chunk_size == 1024
-
-    def test_ctor_arg_takes_precedence_over_context(self, restore_data_context):
-        from ray.data.context import DataContext
-
-        DataContext.get_current().parquet_chunker_target_chunk_size = 1024
-        chunker = ParquetFileChunker(target_chunk_size=2048)
-        assert chunker._target_chunk_size == 2048
+        ctx.parquet_chunker_target_chunk_size = ctx_chunk_size
+        ctx.target_min_block_size = ctx_min_block
+        chunker = ParquetFileChunker(target_chunk_size=ctor_arg)
+        assert chunker._target_chunk_size == expected
 
 
 def test_chunk_metadata_subclasses_are_typeddicts():

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -1,6 +1,7 @@
 import os
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from pyarrow.fs import LocalFileSystem
 
@@ -229,10 +230,13 @@ class TestFileChunkerIntegration:
         assert list(manifest.file_chunk_metadatas) == [None]
         assert list(manifest.file_sizes) == [100]
 
-    def test_parquet_chunker_splits_large_file_into_many_chunks(self, tmp_path):
-        # Write a "Parquet" file by name only — the chunker doesn't open it.
-        (tmp_path / "big.parquet").write_bytes(b"x" * 10_000)
-        chunker = ParquetFileChunker(target_chunk_size=1024)
+    def test_parquet_chunker_splits_file_on_row_group_boundaries(self, tmp_path):
+        # A real Parquet file with 8 row groups; the chunker reads the footer
+        # at listing time and (target < row-group size) emits one chunk per
+        # row group with an explicit half-open range.
+        table = pa.table({"a": list(range(80))})
+        pq.write_table(table, str(tmp_path / "big.parquet"), row_group_size=10)
+        chunker = ParquetFileChunker(target_chunk_size=1)
         indexer = NonSamplingFileIndexer(
             ignore_missing_paths=False,
             num_workers=1,
@@ -245,12 +249,36 @@ class TestFileChunkerIntegration:
             for path, size, md in zip(m.paths, m.file_sizes, m.file_chunk_metadatas):
                 rows.append((str(path), int(size), md))
 
-        # 10000 bytes / 1024 target chunk size -> 10 chunks (ceil).
-        assert len(rows) == 10
-        for i, (_, _, md) in enumerate(rows):
-            assert md is not None
-            assert md["chunk_idx"] == i
-            assert md["total_num_chunks"] == 10
+        # 8 row groups → 8 chunks, contiguous half-open ranges.
+        assert len(rows) == 8
+        ranges = [(md["row_group_start"], md["row_group_end"]) for _, _, md in rows]
+        assert ranges == [(i, i + 1) for i in range(8)]
+
+    def test_parquet_chunker_parallel_footer_reads(self, tmp_path):
+        # With num_workers > 1 the chunker's footer reads fan across the
+        # thread pool (reads_file_metadata=True). Verify correctness is
+        # unaffected: every file's row groups are represented exactly once.
+        for f in range(4):
+            table = pa.table({"a": list(range(30))})
+            pq.write_table(table, str(tmp_path / f"f{f}.parquet"), row_group_size=10)
+        chunker = ParquetFileChunker(target_chunk_size=1)
+        indexer = NonSamplingFileIndexer(
+            ignore_missing_paths=False,
+            num_workers=4,
+            file_chunker=chunker,
+        )
+        fs = LocalFileSystem()
+        manifests = list(indexer.list_files(pa.array([str(tmp_path)]), filesystem=fs))
+        per_path_ranges = {}
+        for m in manifests:
+            for path, _, md in zip(m.paths, m.file_sizes, m.file_chunk_metadatas):
+                per_path_ranges.setdefault(str(path), []).append(
+                    (md["row_group_start"], md["row_group_end"])
+                )
+        # 4 files × 3 row groups each.
+        assert len(per_path_ranges) == 4
+        for ranges in per_path_ranges.values():
+            assert sorted(ranges) == [(0, 1), (1, 2), (2, 3)]
 
     def test_line_delimited_chunker_byte_ranges(self, tmp_path):
         (tmp_path / "a.jsonl").write_bytes(b"x" * 10_000)

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -6,14 +6,30 @@ import pytest
 from pyarrow.fs import LocalFileSystem
 
 from ray.data._internal.datasource_v2.chunkers.file_chunker import (
+    FileChunker,
     LineDelimitedFileChunker,
     ParquetFileChunker,
     WholeFileChunker,
 )
 from ray.data._internal.datasource_v2.listing.file_indexer import (
+    FileInfo,
     NonSamplingFileIndexer,
 )
 from ray.data._internal.datasource_v2.listing.file_pruners import FileExtensionPruner
+
+
+class _CountingChunker(FileChunker):
+    """Fake chunker that emits a fixed number of chunks per file and reports it
+    reads metadata, so the indexer takes the threaded fan-out path."""
+
+    reads_file_metadata = True
+
+    def __init__(self, chunks_per_file: int):
+        self._chunks_per_file = chunks_per_file
+
+    def generate_chunk_metadatas(self, path, file_size, filesystem=None):
+        for i in range(self._chunks_per_file):
+            yield {"chunk_index": i}, file_size
 
 
 def _list_all(indexer, paths, **kwargs):
@@ -301,6 +317,33 @@ class TestFileChunkerIntegration:
         # Byte ranges must tile the file exactly.
         assert rows[0][2]["chunk_byte_start_idx"] == 0
         assert rows[-1][2]["chunk_byte_end_idx"] == 10_000
+
+    def test_parallel_chunking_preserves_discovery_order(self):
+        """Regression: with num_workers>1 and preserve_order, a multi-chunk-per-
+        file chunker's records stay grouped per file in discovery order.
+
+        ``make_async_gen`` only preserves order for a 1:1 map, so the indexer
+        must emit one record list per file (not yield chunk rows individually) --
+        otherwise its round-robin merge interleaves chunks across the files
+        processed concurrently, e.g. f0,f1,f2,f3,f0,f1,... instead of f0,f0,f0,...
+        """
+        chunker = _CountingChunker(chunks_per_file=3)
+        indexer = NonSamplingFileIndexer(
+            ignore_missing_paths=False, num_workers=4, file_chunker=chunker
+        )
+        file_infos = [FileInfo(path=f"f{i}.parquet", size=100 + i) for i in range(8)]
+        records = list(
+            indexer._generate_chunk_records(
+                file_infos, filesystem=None, preserve_order=True
+            )
+        )
+        # 8 files x 3 chunks each, contiguous per file in discovery order.
+        assert [path for path, _, _ in records] == [
+            f"f{i}.parquet" for i in range(8) for _ in range(3)
+        ]
+        assert [md["chunk_index"] for _, _, md in records] == [
+            i for _ in range(8) for i in range(3)
+        ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces the byte-estimate-and-reconcile Parquet chunker with one that reads the footer at listing time and chunks on true row-group boundaries.

Why
---
The Parquet read's atomic unit is the row group (PyArrow fragments are row-group-granular). The previous chunker estimated chunk count from ``ceil(file_size / target_chunk_size)`` and reconciled the guess to real row groups at read time. When the estimate diverged from the layout it produced empty read tasks and redundant footer reads — and misbehaved badly for large (128-512 MB) enterprise row groups, where a small target emitted hundreds of chunks for a file with 1-2 row groups.

What
----
- ``ParquetFileChunker.generate_chunk_metadatas`` now reads each file's footer (``pq.read_metadata``) and greedily bundles consecutive row groups until their on-disk size reaches ``target_chunk_size`` (always
  >= 1 row group per chunk). Each chunk carries an explicit half-open
  ``{row_group_start, row_group_end}`` range. Corrupt/unreadable footer or zero row groups falls back to a single whole-file chunk.
- ``FileChunker`` gains a ``filesystem`` param on ``generate_chunk_metadatas`` and a ``reads_file_metadata`` flag.
- ``NonSamplingFileIndexer`` threads the filesystem to the chunker and, when the chunker reads metadata, fans the footer reads across its thread pool over the *discovered files* (``make_async_gen``), so reads parallelize even for a single input directory. Pruning runs before chunking so footers are never read for files that would be discarded.
- ``_fragments_from_chunk_metadata`` consumes the explicit range directly (defensive clamp to the file's actual row-group count); ``_calculate_row_group_range`` and the over-estimate→reconcile step are deleted.
- The chunker's default target falls back to ``DataContext.target_min_block_size`` so normal-sized row groups map ~1:1 to chunks.

Replaces the interim adaptive byte-estimate path: removes ``read_api._compute_adaptive_parquet_chunk_size`` and the ``ParquetDatasourceV2._get_file_indexer(target_chunk_size_override=...)`` kwarg. F1 (num_buckets), F2 (partitioner), F4 (batch sizing), F5 (output block sizing) are unchanged.

Tests
-----
- ``test_file_chunker.py``: footer-based bundling (K=1 when target < row-group size; bundle-all when target large), contiguous covering ranges, chunk_size == summed row-group bytes, corrupt-footer whole-file fallback, target resolution / precedence, ``reads_file_metadata`` flags.
- ``test_parquet_datasource_v2.py``: ``_fragments_from_chunk_metadata`` explicit-range slicing + defensive clamp; reader round-trips chunked manifests; deleted ``_calculate_row_group_range`` tests.
- ``test_file_indexer.py``: row-group-boundary splitting; parallel footer reads across workers.
- ``test_read_api_parallelism.py``: removed the deleted adaptive/override cases; kept F1/F4/F5 coverage.

Known limitation: a single-row-group file is still one read task (the inherent Parquet floor; sub-row-group reads are out of scope). Footer reads at listing scale with file count, parallelized across the indexer thread pool; read-time footer-read elimination (metadata caching) is a tracked follow-up.