### PR TITLE
[core] fix flaky test_generator_oom

### DIFF
--- a/python/ray/tests/test_generators.py
+++ b/python/ray/tests/test_generators.py
@@ -36,6 +36,9 @@ def assert_no_leak():
     sys.platform != "linux" and sys.platform != "linux2",
     reason="This test requires Linux.",
 )
+# This test can spill many GiB to disk (the normal-return task may not OOM and
+# instead materializes all returns), so it needs a longer timeout.
+@pytest.mark.timeout(600)
 def test_generator_oom(ray_start_regular_shared):
     num_returns = 100
 


### PR DESCRIPTION
Fix this:
<img width="758" height="102" alt="image" src="https://github.com/user-attachments/assets/fe3a1be9-0235-442d-af9d-f4cdc26865af" />


The test took over 300 seconds, which exceeded the pytest default.

<img width="991" height="46" alt="image" src="https://github.com/user-attachments/assets/1ce95fbb-6ee8-4e31-aec9-450161c62210" />

