### PR TITLE
[core] Fix scheduling_test_many_0s_tasks_many_nodes release test

### DIFF
--- a/release/benchmarks/scheduling.yaml
+++ b/release/benchmarks/scheduling.yaml
@@ -1,9 +1,9 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
-    instance_type: m5.4xlarge
+    instance_type: m5.8xlarge
     resources:
-      # Assume the node has 64 CPU instead of 16.
+      # Assume the node has 64 CPU instead of 32.
       # This should be fine since each task has little
       # computation in scheduling tests.
       CPU: 64

--- a/release/benchmarks/scheduling.yaml
+++ b/release/benchmarks/scheduling.yaml
@@ -1,9 +1,9 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
-    instance_type: m5.8xlarge
+    instance_type: m5.4xlarge
     resources:
-      # Assume the node has 64 CPU instead of 32.
+      # Assume the node has 64 CPU instead of 16.
       # This should be fine since each task has little
       # computation in scheduling tests.
       CPU: 64

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -631,7 +631,7 @@ RAY_CONFIG(int64_t, io_context_monitor_probe_interval_ms, 1000)
 
 /// If a probe has been outstanding longer than this, the io_context is marked
 /// unhealthy.
-RAY_CONFIG(int64_t, io_context_monitor_healthy_deadline_ms, 5000)
+RAY_CONFIG(int64_t, io_context_monitor_healthy_deadline_ms, 30000)
 
 /// Sliding window over which the max probe latency is tracked and exported. The
 /// Prometheus metrics scrape interval is usually 15s; we exceed it so that the


### PR DESCRIPTION
 Release test scheduling_test_many_0s_tasks_many_nodes was failing due to this error: 
```
 ray.exceptions.ActorDiedError: The actor died unexpectedly before finishing this task.
        class_name: SimpleActor
        actor_id: add27d584c6b18bf725ef9f903000000
        pid: 2645
        namespace: b340b99a-3273-4ff3-a093-fcfedceb0080
        ip: 10.0.235.31
The actor is dead because its owner has died. Owner Id: 03000000ffffffffffffffffffffffffffffffffffffffffffffffff Owner Ip address: 10.0.250.212 Owner worker exit type: SYSTEM_ERROR Worker exit detail: Owner's node has crashed.
```

As per investigation by @rueian, raylet was not able to connect to GCS which resulted in the actor getting killed. GCS CPU usage was showing around ~90%.
Therefore, we are increasing the head node compute. 
