### PR TITLE
[doc] Add notebook tests for the lightweight Ray Core examples

### DIFF
--- a/doc/source/ray-core/examples/BUILD.bazel
+++ b/doc/source/ray-core/examples/BUILD.bazel
@@ -1,7 +1,32 @@
+load("//bazel:python.bzl", "py_test_run_all_notebooks")
+
 filegroup(
     name = "core_examples",
     srcs = glob(["*.ipynb"]),
     visibility = ["//doc:__subpackages__"]
+)
+
+# --------------------------------------------------------------------
+# Test the lightweight, CPU-only Ray Core example notebooks. The
+# excluded notebooks need GPU, long-running training, or live network
+# access and aren't runnable in the standard CPU CI job.
+# --------------------------------------------------------------------
+
+py_test_run_all_notebooks(
+    size = "large",
+    include = ["*.ipynb"],
+    exclude = [
+        "batch_prediction.ipynb",  # Requires GPU (num_gpus=1) and torch.
+        "plot_hyperparameter.ipynb",  # Model-training loop.
+        "plot_parameter_server.ipynb",  # Torch training loop; slow/non-deterministic.
+        "plot_pong_example.ipynb",  # Long-running RL (Pong) training.
+        "web_crawler.ipynb",  # Makes live network requests.
+    ],
+    data = ["//doc/source/ray-core/examples:core_examples"],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
## Why

The `doc/source/ray-core/examples` notebooks have no execution-test coverage. Ray Data, Train, Tune, and LLM examples all wire `py_test_run_all_notebooks`, but Ray Core does not — so nothing runs these notebooks in CI and they can break silently.

## What

Adds a `py_test_run_all_notebooks` target for `ray-core/examples` covering the lightweight, CPU-only intro notebooks: `gentle_walkthrough`, `map_reduce`, and `highly_parallel` (verified to import only `ray` plus the standard library — no GPU, torch, or network use).

The remaining notebooks are excluded with reasons:
- `batch_prediction` — requires GPU (`num_gpus=1`) and torch
- `plot_pong_example` — long-running RL (Pong) training
- `plot_parameter_server` — torch training loop, slow/non-deterministic
- `plot_hyperparameter` — model-training loop
- `web_crawler` — makes live network requests

These can be wired separately on GPU / appropriate runners. This establishes baseline coverage for the Ray Core examples that are safe in the standard CPU CI job; premerge CI confirms the included set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
