### PR TITLE
[core][rdt] Deflake RDT NIXL tests

### DIFF
--- a/python/ray/experimental/rdt/rdt_manager.py
+++ b/python/ray/experimental/rdt/rdt_manager.py
@@ -901,6 +901,11 @@ class RDTManager:
 
         with self._lock:
             rdt_meta = self._managed_rdt_metadata.pop(object_id)
+        # TODO(#60434): Once the driver has some notion about where rdt args are stored, we can
+        # integrate __ray_free__ with the current free objects RPC and avoid having to call
+        # an actor task here.
+        if not ray.is_initialized():
+            return
         src_actor = rdt_meta.src_actor
         tensor_transport_backend = rdt_meta.tensor_transport_backend
         tensor_transport_meta = rdt_meta.tensor_transport_meta

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -654,9 +654,28 @@ py_test_module_list(
     files = [
         "rdt/test_rdt_ipc.py",
         "rdt/test_rdt_nccl.py",
-        "rdt/test_rdt_nixl.py",
         "test_gpu_provider_on_gpu.py",
         "test_gpu_tensor_zero_copy_serialization.py",
+    ],
+    tags = [
+        "custom_setup",
+        "exclusive",
+        "multi_gpu",
+        "no_windows",
+        "rdt",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "large",
+    env = {"RAY_PYTEST_USE_GPU": "1"},
+    files = [
+        "rdt/test_rdt_nixl.py",
     ],
     tags = [
         "custom_setup",


### PR DESCRIPTION
RDT NIXL tests were starting to become flaky in CI. Judging from the py-spy stacktrace: 
```
Thread 549917 (idle): "MainThread"
    pthread_cond_wait@@GLIBC_2.3.2 (libpthread-2.31.so)
    boost::condition_variable::wait (ray/_raylet.so)
    boost::thread::join_noexcept (ray/_raylet.so)
    ray::core::CoreWorkerShutdownExecutor::ExecuteGracefulShutdown (ray/_raylet.so)
    ray::core::ShutdownCoordinator::ExecuteGracefulShutdown (ray/_raylet.so)
    ray::core::ShutdownCoordinator::ExecuteShutdownSequence (ray/_raylet.so)
    ray::core::ShutdownCoordinator::RequestShutdown (ray/_raylet.so)
    ray::core::CoreWorker::Shutdown (ray/_raylet.so)
    ray::core::CoreWorkerProcessImpl::ShutdownDriver (ray/_raylet.so)
    ray::core::CoreWorkerProcess::Shutdown (ray/_raylet.so)
    shutdown_driver (ray/_raylet.so)
    shutdown (ray/_private/worker.py:2130)
    wrapper (ray/_private/worker.py:1170)
    wrapper (ray/_private/client_mode_hook.py:134)
    ...
Thread 561776 (idle): "Dummy-6"
    do_futex_wait.constprop.0 (libpthread-2.31.so)
    __new_sem_wait_slow.constprop.0 (libpthread-2.31.so)
    PyThread_acquire_lock_timed (python3.11)
    wrapper (ray/_private/worker.py:1169)
    init (ray/_private/worker.py:2026)
    wrapper (ray/_private/client_mode_hook.py:134)
    auto_init_ray (ray/_private/auto_init_hook.py:15)
    auto_init_wrapper (ray/_private/auto_init_hook.py:21)
    remote (ray/actor.py:1223)
    free_object_primary_copy (ray/experimental/rdt/rdt_manager.py:907)
    queue_or_free_object_primary_copy (ray/experimental/rdt/rdt_manager.py:895)
    _raylet_free_actor_object_callback (ray/_raylet.so)
   ...
```

It looks like the python main thread is waiting on joining the C++ io context thread while the C++ io context thread is deadlocked on the _connect_or_shutdown_lock in worker.py. The reason this can happen is that during the driver shutdown process, it frees all primary copies and waits for the io_context to finish what it's doing via calling .join() on it. In the non-rdt path this is fine, but in the rdt path because the object locations are invisible to C++ and in python heap, not plasma, no free object RPC will hit any actor owning RDT tensors. Hence we call an actor task to do this cleanup, but ray will automatically restart via the auto-init hook if it detects any .remote() task being triggered shutdown resulting in this deadlock. Since actor processes are usually cleaned up on driver shutdown anyway (except for detached actors, but we don't talk about those) it's fine to skip the free object actor task. 

NOTE: this fix is still a bit racy since it's possible that you could have triggered the shutdown path on the driver between the call to ray.is_initialized() and when we call the actor task, but it's pretty unlikely to happen and I'll do a bigger cleanup later once we lower more of RDT into C++. 

Also separate the rdt nixl tests into their own target and bumped it to large since it was around 250 seconds on each run. 