### PR TITLE
[data] Avoid input dependencies when exporting args

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -106,6 +106,11 @@ class LogicalOperator(Operator, ABC):
         args["_name"] = self.name
         # Preserve legacy export shape even though output deps are no longer tracked.
         args["_output_dependencies"] = []
+        # Do not include input dependencies, since we only want to export this
+        # operator-specific args. Adding input_dependencies isn't wrong, but can
+        # lead to slow recursive calls with `sanitize_for_struct`, since logical
+        # operators are dataclasses.
+        args["_input_dependencies"] = []
         return args
 
     def infer_schema(self) -> Optional["Schema"]:


### PR DESCRIPTION
## Description
Context: https://github.com/ray-project/ray/issues/64293 caused logical operators to be frozen dataclasses. Dataclasses are handled specially in `sanitize_for_struct`, where we will _recursively_ search through each field. Each logical operator has a method called `_get_args` which returns all the fields of a logical operator. One of those fields is the `_input_dependencies` field that includes the dataclass logical operator. 

What's wrong: Ok after sharing this context, this is how an issue can occur for operators. In `create_topology_metadata`,  we loop through each operator, and call something along the lines of `sanitize_for_struct(op._get_args())`. `sanitize_for_struct` will recursively scan dataclass arguments. When it encounters a dataclass, like `_input_dependencies`, it will recursively look at the input operators, blowing up the chain of calls for `sanitize_for_struct`. 

Why is this bad for fused operators? This is really bad for fused operators, since we need we have a back pointer to the logical operators that created the physical operator (why we have backpointers is out of scope for this PR). So a fused map operator of length n, will have n-1 input dependencies, and each of those dependencies has n-2, and so forth, creating some crazy exponential call chain.

To fix this, I nullified the `_input_dependencies` argument, since the intent of the `_get_args` is to get the arguments just for that operator.

## Related issues
https://github.com/ray-project/ray/issues/64293

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
