### PR TITLE
[doc] Add notebook test for the Tune PBT-visualization example

### DIFF
--- a/doc/source/tune/examples/BUILD.bazel
+++ b/doc/source/tune/examples/BUILD.bazel
@@ -6,6 +6,14 @@ filegroup(
     visibility = ["//doc:__subpackages__"],
 )
 
+# pbt_visualization lives in a subdirectory and imports a local helper module
+# (pbt_visualization_utils.py), so its whole directory is needed as test data.
+filegroup(
+    name = "pbt_visualization_files",
+    srcs = glob(["pbt_visualization/**"]),
+    visibility = ["//doc:__subpackages__"],
+)
+
 # --------------------------------------------------------------------
 # Test all doc/source/tune/examples notebooks.
 # --------------------------------------------------------------------
@@ -40,6 +48,21 @@ py_test_run_all_notebooks(
     tags = [
         "exclusive",
         "gpu",
+        "team:ml",
+    ],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+)
+
+# The non-recursive "*.ipynb" glob above skips the pbt_visualization
+# subdirectory. It's CPU-only and runs a small PBT experiment, like the other
+# Tune notebook tests, so wire it here with its directory as data.
+py_test_run_all_notebooks(
+    size = "large",
+    include = ["pbt_visualization/*.ipynb"],
+    data = ["//doc/source/tune/examples:pbt_visualization_files"],
+    exclude = [],
+    tags = [
+        "exclusive",
         "team:ml",
     ],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},


### PR DESCRIPTION
## Why

`doc/source/tune/examples/pbt_visualization/pbt_visualization.ipynb` has no test coverage. The `tune/examples` notebook test globs `*.ipynb` **non-recursively**, so this subdirectory notebook is silently skipped. It's a CPU-only example that runs a small PBT experiment — the same class as the other Tune notebook tests that are already wired.

## What

Wires a `py_test_run_all_notebooks` target for the `pbt_visualization` subdirectory, plus a filegroup that includes the whole directory so the notebook's local helper module (`pbt_visualization_utils.py`) is available at test time.

Premerge CI validates the data dependency and runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
