### PR TITLE
[Data] Extract remote args compatable in op fusion

### DIFF
--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -1,6 +1,6 @@
 import itertools
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from ray.data._internal.compute import (
     ActorPoolStrategy,
@@ -257,7 +257,7 @@ class FuseOperators(Rule):
             return False
 
         # Only fuse if the ops' remote arguments are compatible.
-        if not are_remote_args_compatible(up_logical_op, down_logical_op):
+        if not are_op_remote_args_compatible(up_logical_op, down_logical_op):
             return False
 
         if not self._can_merge_target_max_block_size(
@@ -726,8 +726,7 @@ class FuseOperators(Rule):
         return True
 
 
-@DeveloperAPI
-def are_remote_args_compatible(up_logical_op, down_logical_op) -> bool:
+def are_op_remote_args_compatible(up_logical_op, down_logical_op) -> bool:
     """Check whether two logical ops can be fused based on their Ray remote args.
 
     Two ops are compatible only if their ``ray_remote_args`` are mergeable and
@@ -742,8 +741,19 @@ def are_remote_args_compatible(up_logical_op, down_logical_op) -> bool:
         return False
 
     # Only fuse if the ops' remote arguments are compatible.
-    prev_args = _canonicalize(getattr(up_logical_op, "ray_remote_args", None) or {})
-    next_args = _canonicalize(getattr(down_logical_op, "ray_remote_args", None) or {})
+    return are_remote_args_compatible(
+        getattr(up_logical_op, "ray_remote_args", None) or {},
+        getattr(down_logical_op, "ray_remote_args", None) or {},
+    )
+
+
+@DeveloperAPI
+def are_remote_args_compatible(
+    prev_args: Dict[str, Any], next_args: Dict[str, Any]
+) -> bool:
+    """Check if Ray remote arguments are compatible for merging."""
+    prev_args = _canonicalize(prev_args)
+    next_args = _canonicalize(next_args)
     remote_args = next_args.copy()
     for key in INHERITABLE_REMOTE_ARGS:
         # NOTE: We only carry over inheritable value in case

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -1,6 +1,6 @@
 import itertools
 import logging
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from ray.data._internal.compute import (
     ActorPoolStrategy,
@@ -257,17 +257,7 @@ class FuseOperators(Rule):
             return False
 
         # Only fuse if the ops' remote arguments are compatible.
-        if not are_remote_args_compatible(
-            getattr(up_logical_op, "ray_remote_args", {}),
-            getattr(down_logical_op, "ray_remote_args", {}),
-        ):
-            return False
-
-        # Do not fuse if either op specifies a `ray_remote_args_fn`,
-        # since it is not known whether the generated args will be compatible.
-        if getattr(up_logical_op, "ray_remote_args_fn", None) or getattr(
-            down_logical_op, "ray_remote_args_fn", None
-        ):
+        if not are_remote_args_compatible(up_logical_op, down_logical_op):
             return False
 
         if not self._can_merge_target_max_block_size(
@@ -737,12 +727,23 @@ class FuseOperators(Rule):
 
 
 @DeveloperAPI
-def are_remote_args_compatible(
-    prev_args: Dict[str, Any], next_args: Dict[str, Any]
-) -> bool:
-    """Check if Ray remote arguments are compatible for merging."""
-    prev_args = _canonicalize(prev_args)
-    next_args = _canonicalize(next_args)
+def are_remote_args_compatible(up_logical_op, down_logical_op) -> bool:
+    """Check whether two logical ops can be fused based on their Ray remote args.
+
+    Two ops are compatible only if their ``ray_remote_args`` are mergeable and
+    neither op specifies a ``ray_remote_args_fn``, since the args it generates
+    are not known ahead of time.
+    """
+    # Do not fuse if either op specifies a `ray_remote_args_fn`,
+    # since it is not known whether the generated args will be compatible.
+    if getattr(up_logical_op, "ray_remote_args_fn", None) or getattr(
+        down_logical_op, "ray_remote_args_fn", None
+    ):
+        return False
+
+    # Only fuse if the ops' remote arguments are compatible.
+    prev_args = _canonicalize(getattr(up_logical_op, "ray_remote_args", None) or {})
+    next_args = _canonicalize(getattr(down_logical_op, "ray_remote_args", None) or {})
     remote_args = next_args.copy()
     for key in INHERITABLE_REMOTE_ARGS:
         # NOTE: We only carry over inheritable value in case

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -1,6 +1,6 @@
 import itertools
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ray.data._internal.compute import (
     ActorPoolStrategy,
@@ -726,7 +726,10 @@ class FuseOperators(Rule):
         return True
 
 
-def are_op_remote_args_compatible(up_logical_op, down_logical_op) -> bool:
+def are_op_remote_args_compatible(
+    up_logical_op: AbstractMap,
+    down_logical_op: Union[AbstractMap, AbstractAllToAll],
+) -> bool:
     """Check whether two logical ops can be fused based on their Ray remote args.
 
     Two ops are compatible only if their ``ray_remote_args`` are mergeable and
@@ -735,15 +738,16 @@ def are_op_remote_args_compatible(up_logical_op, down_logical_op) -> bool:
     """
     # Do not fuse if either op specifies a `ray_remote_args_fn`,
     # since it is not known whether the generated args will be compatible.
-    if getattr(up_logical_op, "ray_remote_args_fn", None) or getattr(
-        down_logical_op, "ray_remote_args_fn", None
+    # Only `AbstractMap` ops carry a `ray_remote_args_fn`.
+    if up_logical_op.ray_remote_args_fn or (
+        isinstance(down_logical_op, AbstractMap) and down_logical_op.ray_remote_args_fn
     ):
         return False
 
     # Only fuse if the ops' remote arguments are compatible.
     return are_remote_args_compatible(
-        getattr(up_logical_op, "ray_remote_args", None) or {},
-        getattr(down_logical_op, "ray_remote_args", None) or {},
+        up_logical_op.ray_remote_args,
+        down_logical_op.ray_remote_args,
     )
 
 

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -142,12 +142,12 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
     # This ensures with_column respects resource boundaries like map_batches does
     from ray.data._internal.logical.rules.operator_fusion import (
         FuseOperators,
-        are_remote_args_compatible,
+        are_op_remote_args_compatible,
     )
 
     # Check if remote args (num_cpus, num_gpus, etc.) are compatible and that
     # neither op specifies a `ray_remote_args_fn`.
-    if not are_remote_args_compatible(upstream_project, downstream_project):
+    if not are_op_remote_args_compatible(upstream_project, downstream_project):
         # Resources don't match - cannot fuse
         return downstream_project
 

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -145,17 +145,10 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
         are_remote_args_compatible,
     )
 
-    # Check if remote args (num_cpus, num_gpus, etc.) are compatible
-    if not are_remote_args_compatible(
-        upstream_project.ray_remote_args or {},
-        downstream_project.ray_remote_args or {},
-    ):
+    # Check if remote args (num_cpus, num_gpus, etc.) are compatible and that
+    # neither op specifies a `ray_remote_args_fn`.
+    if not are_remote_args_compatible(upstream_project, downstream_project):
         # Resources don't match - cannot fuse
-        return downstream_project
-
-    # Do not fuse if either op specifies a `ray_remote_args_fn`,
-    # since it is not known whether the generated args will be compatible.
-    if upstream_project.ray_remote_args_fn or downstream_project.ray_remote_args_fn:
         return downstream_project
 
     # Check if compute strategies are compatible


### PR DESCRIPTION
## Description
As title, extracts the inline logic that checks both ray_remote_args and ray_remote_args_fn into a reusable helper function are_op_remote_args_compatible in operator_fusion.py, and updates both operator_fusion.py and projection_pushdown.py to use this new helper.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
