### PR TITLE
[serve][test] Centralize HAProxy-aware actor assertions in a shared test_utils helper

### DIFF
--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -54,6 +54,7 @@
 //python/ray/serve/tests:test_serve_with_tracing
 //python/ray/serve/tests:test_shutdown
 //python/ray/serve/tests:test_standalone_2
+//python/ray/serve/tests:test_standalone_3
 //python/ray/serve/tests:test_streaming_response
 //python/ray/serve/tests:test_target_capacity
 //python/ray/serve/tests:test_task_processor

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -34,6 +34,7 @@ from ray.serve._private.common import (
     RunningReplicaInfo,
 )
 from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
 )
@@ -819,6 +820,26 @@ def get_num_alive_replicas(
         ]
     )
     return len(actors)
+
+
+def expected_proxy_actors(num_proxy_nodes: int = 1) -> Dict[str, int]:
+    """Proxy actors expected ALIVE by class name for the given number of proxy nodes.
+
+    Natively each proxy node runs one ProxyActor. Under HAProxy each proxy node runs an
+    HAProxyManager and the head node also runs a single fallback ProxyActor. Set-based
+    callers can take the keys, count-based callers use the counts directly.
+    """
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        return {"HAProxyManager": num_proxy_nodes, "ProxyActor": 1}
+    return {"ProxyActor": num_proxy_nodes}
+
+
+def alive_actor_counts() -> Dict[str, int]:
+    """Count of ALIVE actors by class name in the current Ray session."""
+    counts: Dict[str, int] = {}
+    for actor in list_actors(filters=[("STATE", "=", "ALIVE")]):
+        counts[actor["class_name"]] = counts.get(actor["class_name"], 0) + 1
+    return counts
 
 
 def check_num_replicas_gte(

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -30,7 +30,10 @@ from ray.serve._private.constants import (
     SERVE_SESSION_ID,
 )
 from ray.serve._private.haproxy import HAProxyManager
-from ray.serve._private.test_utils import get_application_url
+from ray.serve._private.test_utils import (
+    expected_proxy_actors,
+    get_application_url,
+)
 from ray.serve.config import HTTPOptions, RequestRouterConfig
 from ray.serve.context import _get_global_client
 from ray.serve.exceptions import RayServeException
@@ -123,8 +126,7 @@ def test_single_app_shutdown_actors(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        "HAProxyManager",
-        "ProxyActor",
+        *expected_proxy_actors(),
         "ServeReplica:app:f",
     }
 
@@ -165,8 +167,7 @@ async def test_single_app_shutdown_actors_async(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        "HAProxyManager",
-        "ProxyActor",
+        *expected_proxy_actors(),
         "ServeReplica:app:f",
     }
 
@@ -347,8 +348,10 @@ async def test_drain_and_undrain_haproxy_manager(
 
     serve.run(HelloModel.options(num_replicas=2).bind())
 
-    # 3 haproxies, 1 controller, 2 replicas, 1 signal actor, 1 fallback proxy
-    wait_for_condition(lambda: len(list_actors()) == 8)
+    # 1 controller, 2 replicas, 1 signal actor, plus the proxy actors for 3 nodes
+    # (3 HAProxyManagers and the head fallback ProxyActor under HAProxy).
+    expected_total = 1 + 2 + 1 + sum(expected_proxy_actors(num_proxy_nodes=3).values())
+    wait_for_condition(lambda: len(list_actors()) == expected_total)
     assert len(ray.nodes()) == 3
 
     client = _get_global_client()

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -31,6 +31,7 @@ from ray.serve._private.constants import (
 )
 from ray.serve._private.haproxy import HAProxyManager
 from ray.serve._private.test_utils import (
+    alive_actor_counts,
     expected_proxy_actors,
     get_application_url,
 )
@@ -348,10 +349,13 @@ async def test_drain_and_undrain_haproxy_manager(
 
     serve.run(HelloModel.options(num_replicas=2).bind())
 
-    # 1 controller, 2 replicas, 1 signal actor, plus the proxy actors for 3 nodes
-    # (3 HAProxyManagers and the head fallback ProxyActor under HAProxy).
-    expected_total = 1 + 2 + 1 + sum(expected_proxy_actors(num_proxy_nodes=3).values())
-    wait_for_condition(lambda: len(list_actors()) == expected_total)
+    expected_actors = {
+        "ServeController": 1,
+        **expected_proxy_actors(num_proxy_nodes=3),
+        "ServeReplica:default:HelloModel": 2,
+        "SignalActor": 1,
+    }
+    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
     assert len(ray.nodes()) == 3
 
     client = _get_global_client()

--- a/python/ray/serve/tests/test_metrics_haproxy.py
+++ b/python/ray/serve/tests/test_metrics_haproxy.py
@@ -38,7 +38,11 @@ from ray._common.test_utils import (
 from ray._common.utils import reset_ray_address
 from ray.serve import HTTPOptions
 from ray.serve._private.long_poll import LongPollHost, UpdatedObject
-from ray.serve._private.test_utils import get_application_url, get_metric_dictionaries
+from ray.serve._private.test_utils import (
+    expected_proxy_actors,
+    get_application_url,
+    get_metric_dictionaries,
+)
 from ray.serve._private.utils import block_until_http_ready
 from ray.serve.tests.conftest import (
     TEST_METRICS_EXPORT_PORT,
@@ -1051,7 +1055,7 @@ def test_actor_summary(serve_instance):
     actors = list_actors(filters=[("state", "=", "ALIVE")])
     class_names = {actor["class_name"] for actor in actors}
     assert class_names.issuperset(
-        {"ServeController", "HAProxyManager", "ServeReplica:app:f"}
+        {"ServeController", *expected_proxy_actors(), "ServeReplica:app:f"}
     )
 
 

--- a/python/ray/serve/tests/test_shutdown.py
+++ b/python/ray/serve/tests/test_shutdown.py
@@ -9,24 +9,16 @@ from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray._raylet import GcsClient
 from ray.serve._private.constants import (
-    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_CONTROLLER_NAME,
     SERVE_DEPLOYMENT_ACTOR_PREFIX,
     SERVE_NAMESPACE,
     SERVE_PROXY_NAME,
 )
 from ray.serve._private.default_impl import create_cluster_node_info_cache
+from ray.serve._private.test_utils import expected_proxy_actors
 from ray.serve._private.utils import format_actor_name
 from ray.serve.config import DeploymentActorConfig
 from ray.util.state import list_actors
-
-
-def _expected_proxy_classes():
-    """Proxy actor class names expected ALIVE while a Serve app is running."""
-    # Under HAProxy the per-node HAProxyManager joins the head-node fallback ProxyActor.
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        return {"ProxyActor", "HAProxyManager"}
-    return {"ProxyActor"}
 
 
 def test_shutdown(ray_shutdown):
@@ -139,7 +131,7 @@ def test_single_app_shutdown_actors(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        *_expected_proxy_classes(),
+        *expected_proxy_actors(),
         "ServeReplica:app:f",
     }
 
@@ -180,7 +172,7 @@ async def test_single_app_shutdown_actors_async(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        *_expected_proxy_classes(),
+        *expected_proxy_actors(),
         "ServeReplica:app:f",
     }
 
@@ -221,7 +213,7 @@ def test_multi_app_shutdown_actors(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        *_expected_proxy_classes(),
+        *expected_proxy_actors(),
         "ServeReplica:app1:f",
         "ServeReplica:app2:f",
     }
@@ -264,7 +256,7 @@ async def test_multi_app_shutdown_actors_async(ray_shutdown):
 
     actor_names = {
         "ServeController",
-        *_expected_proxy_classes(),
+        *expected_proxy_actors(),
         "ServeReplica:app1:f",
         "ServeReplica:app2:f",
     }

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -26,6 +26,7 @@ from ray.serve._private.constants import (
 )
 from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.http_util import set_socket_reuse_port
+from ray.serve._private.test_utils import expected_proxy_actors
 from ray.serve._private.utils import block_until_http_ready, format_actor_name
 from ray.serve.config import (
     ControllerOptions,
@@ -370,11 +371,9 @@ def test_http_head_only(ray_cluster):
 
     serve.start(http_options={"port": _get_random_port(), "location": "HeadOnly"})
 
-    # Controller and proxy on the head node. HAProxy adds the HAProxyManager
-    # alongside the fallback ProxyActor, which registers asynchronously.
-    expected_classes = {"ServeController", "ProxyActor"}
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        expected_classes.add("HAProxyManager")
+    # Controller and proxy on the head node. Under HAProxy the proxy is the
+    # HAProxyManager alongside the fallback ProxyActor, which registers asynchronously.
+    expected_classes = {"ServeController", *expected_proxy_actors()}
 
     def check_head_only_actors():
         actors = list_actors(

--- a/python/ray/serve/tests/test_standalone_2.py
+++ b/python/ray/serve/tests/test_standalone_2.py
@@ -12,10 +12,10 @@ from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.exceptions import RayActorError
 from ray.serve._private.constants import (
-    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
 )
+from ray.serve._private.test_utils import expected_proxy_actors
 from ray.serve.context import _get_global_client
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
@@ -103,11 +103,11 @@ def test_serve_namespace(shutdown_ray_and_serve, ray_namespace):
 
         serve.run(f.bind())
 
-        proxy_classes = {"ProxyActor"}
-        if RAY_SERVE_ENABLE_HA_PROXY:
-            # Under HAProxy the per-node HAProxyManager joins the fallback ProxyActor.
-            proxy_classes.add("HAProxyManager")
-        expected_actors = {"ServeController", *proxy_classes, "ServeReplica:default:f"}
+        expected_actors = {
+            "ServeController",
+            *expected_proxy_actors(),
+            "ServeReplica:default:f",
+        }
 
         def check_serve_actors():
             actors = list_actors(

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -13,7 +13,11 @@ from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray.cluster_utils import AutoscalingCluster, Cluster
 from ray.exceptions import RayActorError
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_LOGGER_NAME
+from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_HA_PROXY,
+    SERVE_DEFAULT_APP_NAME,
+    SERVE_LOGGER_NAME,
+)
 from ray.serve._private.logging_utils import get_serve_logs_dir
 from ray.serve._private.test_utils import SharedCounter
 from ray.serve._private.utils import get_head_node_id
@@ -23,11 +27,21 @@ from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
 
 
-# Some tests are not possible to run if proxy is not available on every node.
-# We skip them if proxy is not available.
-def is_proxy_on_every_node() -> bool:
-    client = _get_global_client()
-    return client._http_config.location == "EveryNode"
+def _expected_proxy_classes():
+    """Proxy actor class names expected ALIVE while a Serve app is running.
+
+    Under HAProxy the per-node HAProxyManager joins the head-node fallback ProxyActor.
+    """
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        return {"ProxyActor", "HAProxyManager"}
+    return {"ProxyActor"}
+
+
+def _alive_actor_classes() -> set:
+    """Class names of all ALIVE actors in the current Ray session."""
+    return {
+        actor["class_name"] for actor in list_actors(filters=[("STATE", "=", "ALIVE")])
+    }
 
 
 @pytest.fixture
@@ -283,18 +297,22 @@ def test_autoscaler_shutdown_node_http_everynode(
 
     serve.run(A.bind(), name="app_f")
 
-    # If proxy is on every node, total actors are 2 proxies, 1 controller, 2 replicas.
-    # Otherwise, total actors are 1 proxy, 1 controller, 2 replicas.
-    expected_actors = 5 if is_proxy_on_every_node() else 4
-    wait_for_condition(lambda: len(list_actors()) == expected_actors)
-    assert len(ray.nodes()) == 2
+    # The second replica needs more CPU than the head node has free, so the autoscaler
+    # brings up the worker node (and its EveryNode proxy) to schedule it.
+    wait_for_condition(lambda: len(ray.nodes()) == 2)
+    wait_for_condition(
+        lambda: _alive_actor_classes()
+        == {"ServeController", *_expected_proxy_classes(), "ServeReplica:app_f:A"}
+    )
 
     # Stop all deployment replicas.
     serve.delete("app_f")
 
-    # The http proxy on worker node should exit as well.
+    # The worker node and its proxy exit, leaving the controller and the head-node
+    # proxy actor(s).
     wait_for_condition(
-        lambda: len(list_actors(filters=[("STATE", "=", "ALIVE")])) == 2,
+        lambda: _alive_actor_classes()
+        == {"ServeController", *_expected_proxy_classes()},
     )
 
     client = _get_global_client()
@@ -360,10 +378,14 @@ def test_controller_shutdown_gracefully(
     model = HelloModel.bind()
     serve.run(target=model)
 
-    # If proxy is on every node, total actors are 2 proxies, 1 controller, and 2 replicas
-    # Otherwise, total actors are 1 proxy, 1 controller, and 2 replicas
-    expected_actors = 5 if is_proxy_on_every_node() else 4
-    wait_for_condition(lambda: len(list_actors()) == expected_actors)
+    wait_for_condition(
+        lambda: _alive_actor_classes()
+        == {
+            "ServeController",
+            *_expected_proxy_classes(),
+            f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel",
+        }
+    )
     assert len(ray.nodes()) == 2
 
     # Call `graceful_shutdown()` on the controller, so it will start shutdown.
@@ -421,11 +443,14 @@ def test_client_shutdown_gracefully_when_timeout(
     model = HelloModel.bind()
     serve.run(target=model)
 
-    # Check expected actors based on mode
-    # If proxy is on every node, total actors are 2 proxies, 1 controller, and 2 replicas
-    # Otherwise, total actors are 1 proxy, 1 controller, and 2 replicas
-    expected_actors = 5 if is_proxy_on_every_node() else 4
-    wait_for_condition(lambda: len(list_actors()) == expected_actors)
+    wait_for_condition(
+        lambda: _alive_actor_classes()
+        == {
+            "ServeController",
+            *_expected_proxy_classes(),
+            f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel",
+        }
+    )
     assert len(ray.nodes()) == 2
 
     # Ensure client times out if the controller does not shutdown within timeout.

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -2,7 +2,6 @@ import logging
 import os
 import subprocess
 import sys
-from collections import Counter
 from contextlib import contextmanager
 
 import httpx
@@ -14,40 +13,18 @@ from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray.cluster_utils import AutoscalingCluster, Cluster
 from ray.exceptions import RayActorError
-from ray.serve._private.constants import (
-    RAY_SERVE_ENABLE_HA_PROXY,
-    SERVE_DEFAULT_APP_NAME,
-    SERVE_LOGGER_NAME,
-)
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_LOGGER_NAME
 from ray.serve._private.logging_utils import get_serve_logs_dir
-from ray.serve._private.test_utils import SharedCounter
+from ray.serve._private.test_utils import (
+    SharedCounter,
+    alive_actor_counts,
+    expected_proxy_actors,
+)
 from ray.serve._private.utils import get_head_node_id
 from ray.serve.context import _get_global_client
 from ray.serve.schema import ProxyStatus, ServeInstanceDetails
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
-
-
-def _expected_alive_actors(num_proxy_nodes: int, replica_counts: dict) -> dict:
-    """Expected count of each ALIVE actor class while a Serve app is running.
-
-    Each proxy node runs one proxy actor. Natively that is a ProxyActor. Under HAProxy
-    it is an HAProxyManager and the head node also runs a single fallback ProxyActor.
-    """
-    expected = {"ServeController": 1, **replica_counts}
-    if RAY_SERVE_ENABLE_HA_PROXY:
-        expected["HAProxyManager"] = num_proxy_nodes
-        expected["ProxyActor"] = 1
-    else:
-        expected["ProxyActor"] = num_proxy_nodes
-    return expected
-
-
-def _alive_actor_counts() -> Counter:
-    """Count of ALIVE actors by class name in the current Ray session."""
-    return Counter(
-        actor["class_name"] for actor in list_actors(filters=[("STATE", "=", "ALIVE")])
-    )
 
 
 @pytest.fixture
@@ -305,18 +282,20 @@ def test_autoscaler_shutdown_node_http_everynode(
 
     # The second replica needs more CPU than the head node has free, so the autoscaler
     # brings up the worker node. Requiring two proxies waits for that node to join.
-    expected_actors = _expected_alive_actors(
-        num_proxy_nodes=2, replica_counts={"ServeReplica:app_f:A": 2}
-    )
-    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
+    expected_actors = {
+        "ServeController": 1,
+        **expected_proxy_actors(num_proxy_nodes=2),
+        "ServeReplica:app_f:A": 2,
+    }
+    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
     assert len(ray.nodes()) == 2
 
     # Stop all deployment replicas.
     serve.delete("app_f")
 
     # The worker node and its proxy exit, leaving only the head-node proxy.
-    expected_actors = _expected_alive_actors(num_proxy_nodes=1, replica_counts={})
-    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
+    expected_actors = {"ServeController": 1, **expected_proxy_actors(num_proxy_nodes=1)}
+    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
 
     client = _get_global_client()
 
@@ -381,11 +360,12 @@ def test_controller_shutdown_gracefully(
     model = HelloModel.bind()
     serve.run(target=model)
 
-    expected_actors = _expected_alive_actors(
-        num_proxy_nodes=2,
-        replica_counts={f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2},
-    )
-    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
+    expected_actors = {
+        "ServeController": 1,
+        **expected_proxy_actors(num_proxy_nodes=2),
+        f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2,
+    }
+    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
     assert len(ray.nodes()) == 2
 
     # Call `graceful_shutdown()` on the controller, so it will start shutdown.
@@ -443,11 +423,12 @@ def test_client_shutdown_gracefully_when_timeout(
     model = HelloModel.bind()
     serve.run(target=model)
 
-    expected_actors = _expected_alive_actors(
-        num_proxy_nodes=2,
-        replica_counts={f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2},
-    )
-    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
+    expected_actors = {
+        "ServeController": 1,
+        **expected_proxy_actors(num_proxy_nodes=2),
+        f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2,
+    }
+    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
     assert len(ray.nodes()) == 2
 
     # Ensure client times out if the controller does not shutdown within timeout.

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections import Counter
 from contextlib import contextmanager
 
 import httpx
@@ -27,21 +28,26 @@ from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
 
 
-def _expected_proxy_classes():
-    """Proxy actor class names expected ALIVE while a Serve app is running.
+def _expected_alive_actors(num_proxy_nodes: int, replica_counts: dict) -> dict:
+    """Expected count of each ALIVE actor class while a Serve app is running.
 
-    Under HAProxy the per-node HAProxyManager joins the head-node fallback ProxyActor.
+    Each proxy node runs one proxy actor. Natively that is a ProxyActor. Under HAProxy
+    it is an HAProxyManager and the head node also runs a single fallback ProxyActor.
     """
+    expected = {"ServeController": 1, **replica_counts}
     if RAY_SERVE_ENABLE_HA_PROXY:
-        return {"ProxyActor", "HAProxyManager"}
-    return {"ProxyActor"}
+        expected["HAProxyManager"] = num_proxy_nodes
+        expected["ProxyActor"] = 1
+    else:
+        expected["ProxyActor"] = num_proxy_nodes
+    return expected
 
 
-def _alive_actor_classes() -> set:
-    """Class names of all ALIVE actors in the current Ray session."""
-    return {
+def _alive_actor_counts() -> Counter:
+    """Count of ALIVE actors by class name in the current Ray session."""
+    return Counter(
         actor["class_name"] for actor in list_actors(filters=[("STATE", "=", "ALIVE")])
-    }
+    )
 
 
 @pytest.fixture
@@ -298,22 +304,19 @@ def test_autoscaler_shutdown_node_http_everynode(
     serve.run(A.bind(), name="app_f")
 
     # The second replica needs more CPU than the head node has free, so the autoscaler
-    # brings up the worker node (and its EveryNode proxy) to schedule it.
-    wait_for_condition(lambda: len(ray.nodes()) == 2)
-    wait_for_condition(
-        lambda: _alive_actor_classes()
-        == {"ServeController", *_expected_proxy_classes(), "ServeReplica:app_f:A"}
+    # brings up the worker node. Requiring two proxies waits for that node to join.
+    expected_actors = _expected_alive_actors(
+        num_proxy_nodes=2, replica_counts={"ServeReplica:app_f:A": 2}
     )
+    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
+    assert len(ray.nodes()) == 2
 
     # Stop all deployment replicas.
     serve.delete("app_f")
 
-    # The worker node and its proxy exit, leaving the controller and the head-node
-    # proxy actor(s).
-    wait_for_condition(
-        lambda: _alive_actor_classes()
-        == {"ServeController", *_expected_proxy_classes()},
-    )
+    # The worker node and its proxy exit, leaving only the head-node proxy.
+    expected_actors = _expected_alive_actors(num_proxy_nodes=1, replica_counts={})
+    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
 
     client = _get_global_client()
 
@@ -378,14 +381,11 @@ def test_controller_shutdown_gracefully(
     model = HelloModel.bind()
     serve.run(target=model)
 
-    wait_for_condition(
-        lambda: _alive_actor_classes()
-        == {
-            "ServeController",
-            *_expected_proxy_classes(),
-            f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel",
-        }
+    expected_actors = _expected_alive_actors(
+        num_proxy_nodes=2,
+        replica_counts={f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2},
     )
+    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
     assert len(ray.nodes()) == 2
 
     # Call `graceful_shutdown()` on the controller, so it will start shutdown.
@@ -443,14 +443,11 @@ def test_client_shutdown_gracefully_when_timeout(
     model = HelloModel.bind()
     serve.run(target=model)
 
-    wait_for_condition(
-        lambda: _alive_actor_classes()
-        == {
-            "ServeController",
-            *_expected_proxy_classes(),
-            f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel",
-        }
+    expected_actors = _expected_alive_actors(
+        num_proxy_nodes=2,
+        replica_counts={f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2},
     )
+    wait_for_condition(lambda: _alive_actor_counts() == expected_actors)
     assert len(ray.nodes()) == 2
 
     # Ensure client times out if the controller does not shutdown within timeout.


### PR DESCRIPTION
## Description

The expected proxy-actor set under HAProxy was re-encoded across several serve test files. Under HAProxy the per-node proxy is an HAProxyManager and the head node adds a fallback ProxyActor, so each file carried its own copy of that rule in a slightly different shape, and they drifted.

This PR adds one source of truth and switches every consumer to it:

- Adds expected_proxy_actors and alive_actor_counts to serve test_utils. expected_proxy_actors returns the proxy actors by class for a given number of proxy nodes: a ProxyActor per node natively, or an HAProxyManager per node plus one head fallback ProxyActor under HAProxy.
- Migrates test_shutdown, test_standalone, test_standalone_2, test_haproxy, and test_metrics_haproxy onto the helper. test_shutdown drops its local _expected_proxy_classes helper.
- Fixes test_standalone_3, the original motivation. Two hard-coded actor counts never matched under HAProxy and timed out. They now assert per-class counts via the helper. The first wait gates full readiness, the second waits for the worker-node proxy to exit after scaledown.
- Adds test_standalone_3 to ci/ray_ci/serve_hap_test_names.txt so the HAProxy pass runs the file on master.

The behavior under test is mode-independent. Only the expected actor set differs.

## Related issues

Follows #64262, which made test_shutdown and test_standalone_2 HAProxy-aware, and #64295, which did the same for test_standalone. This consolidates their per-file copies into one helper.

## Additional information

- These tests run under RAY_SERVE_ENABLE_HA_PROXY=1 in CI.
- Premerge build #68564 surfaced the test_standalone_3 failures this fixes.
- The allowlist in serve_hap_test_names.txt is removed wholesale in #64210.
