### PR TITLE
[DO NOT MERGE] Test: trigger WinSock.h conflict on Windows

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -10,6 +10,9 @@ COPTS_TESTS = select({
     "@platforms//os:windows": [
         # TODO(mehrdadn): (How to) support dynamic linking?
         "-DRAY_STATIC",
+        # Prevent Windows.h from including WinSock.h, which conflicts with
+        # WinSock2.h used by Boost.Asio.
+        "-DWIN32_LEAN_AND_MEAN",
     ],
     "//conditions:default": [
         "-Wunused-result",

--- a/src/ray/core_worker/task_execution/thread_pool.h
+++ b/src/ray/core_worker/task_execution/thread_pool.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/chrono.hpp>


### PR DESCRIPTION
Include <Windows.h> before boost/asio to reproduce the WinSock.h / WinSock2.h header conflict on Windows builds.