### PR TITLE
[core] runtime_env: cap parse_uri package name length to avoid ENAMETOOLONG

### DIFF
--- a/python/ray/_common/runtime_env_uri.py
+++ b/python/ray/_common/runtime_env_uri.py
@@ -94,12 +94,15 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
             # is preserved so is_zip_uri / is_jar_uri keep working. Compound
             # extensions (.tar.gz, .tar.bz2) are kept intact so archive-type
             # detection downstream still works.
-            if uri.path.endswith(".tar.gz"):
+            # netloc + path covers URIs where the filename has no path
+            # component (e.g., s3://package.zip puts "package.zip" in netloc).
+            raw = uri.netloc + uri.path
+            if raw.endswith(".tar.gz"):
                 suffix = ".tar.gz"
-            elif uri.path.endswith(".tar.bz2"):
+            elif raw.endswith(".tar.bz2"):
                 suffix = ".tar.bz2"
             else:
-                suffix = pathlib.Path(uri.path).suffix
+                suffix = pathlib.Path(raw).suffix
             digest = hashlib.sha1(pkg_uri.encode("utf-8")).hexdigest()
             package_name = f"{protocol.value}_{digest}{suffix}"
     else:

--- a/python/ray/_common/runtime_env_uri.py
+++ b/python/ray/_common/runtime_env_uri.py
@@ -2,7 +2,6 @@ import enum
 import hashlib
 import pathlib
 import urllib.parse
-from pathlib import Path
 from typing import Tuple
 from urllib.parse import urlparse
 
@@ -100,7 +99,7 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
             elif uri.path.endswith(".tar.bz2"):
                 suffix = ".tar.bz2"
             else:
-                suffix = Path(uri.path).suffix
+                suffix = pathlib.Path(uri.path).suffix
             digest = hashlib.sha1(pkg_uri.encode("utf-8")).hexdigest()
             package_name = f"{protocol.value}_{digest}{suffix}"
     else:

--- a/python/ray/_common/runtime_env_uri.py
+++ b/python/ray/_common/runtime_env_uri.py
@@ -1,6 +1,8 @@
 import enum
+import hashlib
 import pathlib
 import urllib.parse
+from pathlib import Path
 from typing import Tuple
 from urllib.parse import urlparse
 
@@ -62,8 +64,8 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
     Note that the output of this function is not for handling actual IO, it's
     only for setting up local directory folders by using package name as path.
 
-    >>> parse_uri("https://test.com/file.zip")
-    (<Protocol.HTTPS: 'https'>, 'https_test_com_file.zip')
+    >>> parse_uri("https://test.com/file.zip")  # doctest: +ELLIPSIS
+    (<Protocol.HTTPS: 'https'>, 'https_...zip')
 
     >>> parse_uri("https://test.com/file.whl")
     (<Protocol.HTTPS: 'https'>, 'file.whl')
@@ -88,30 +90,19 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
             # for more information.
             package_name = uri.path.split("/")[-1]
         else:
-            package_name = f"{protocol.value}_{uri.netloc}{uri.path}"
-
-            disallowed_chars = ["/", ":", "@", "+", " ", "(", ")"]
-            for disallowed_char in disallowed_chars:
-                package_name = package_name.replace(disallowed_char, "_")
-
-            # Preserve compound extensions like .tar.gz before replacing dots.
-            compound_ext = None
-            if package_name.endswith(".tar.gz"):
-                compound_ext = ".tar.gz"
-                package_name = package_name[: -len(".tar.gz")]
-            elif package_name.endswith(".tar.bz2"):
-                compound_ext = ".tar.bz2"
-                package_name = package_name[: -len(".tar.bz2")]
-
-            if compound_ext:
-                package_name = package_name.replace(".", "_")
-                package_name += compound_ext
+            # Hash the URI to produce a stable, NAME_MAX-safe local filename
+            # regardless of how long or deeply nested the URI is. The extension
+            # is preserved so is_zip_uri / is_jar_uri keep working. Compound
+            # extensions (.tar.gz, .tar.bz2) are kept intact so archive-type
+            # detection downstream still works.
+            if uri.path.endswith(".tar.gz"):
+                suffix = ".tar.gz"
+            elif uri.path.endswith(".tar.bz2"):
+                suffix = ".tar.bz2"
             else:
-                # Remove all periods except the last, which is part of the
-                # file extension.
-                package_name = package_name.replace(
-                    ".", "_", package_name.count(".") - 1
-                )
+                suffix = Path(uri.path).suffix
+            digest = hashlib.sha1(pkg_uri.encode("utf-8")).hexdigest()
+            package_name = f"{protocol.value}_{digest}{suffix}"
     else:
         package_name = uri.netloc
     return (protocol, package_name)

--- a/python/ray/_common/tests/test_runtime_env_uri.py
+++ b/python/ray/_common/tests/test_runtime_env_uri.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 
 import pytest
@@ -5,21 +6,48 @@ import pytest
 from ray._common.runtime_env_uri import Protocol, parse_uri
 
 
+def _sha1_hex(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()
+
+
 class TestParseUri:
     @pytest.mark.parametrize(
         "uri,protocol,package_name",
         [
+            # GCS stays in the netloc-only branch (unchanged behavior).
             ("gcs://file.zip", Protocol.GCS, "file.zip"),
-            ("s3://bucket/file.zip", Protocol.S3, "s3_bucket_file.zip"),
-            ("http://test.com/file.zip", Protocol.HTTP, "http_test_com_file.zip"),
-            ("https://test.com/file.zip", Protocol.HTTPS, "https_test_com_file.zip"),
-            ("gs://bucket/file.zip", Protocol.GS, "gs_bucket_file.zip"),
-            ("azure://container/file.zip", Protocol.AZURE, "azure_container_file.zip"),
+            # Remote (non-.whl) URIs are always hashed.
+            (
+                "s3://bucket/file.zip",
+                Protocol.S3,
+                f"s3_{_sha1_hex('s3://bucket/file.zip')}.zip",
+            ),
+            (
+                "http://test.com/file.zip",
+                Protocol.HTTP,
+                f"http_{_sha1_hex('http://test.com/file.zip')}.zip",
+            ),
+            (
+                "https://test.com/file.zip",
+                Protocol.HTTPS,
+                f"https_{_sha1_hex('https://test.com/file.zip')}.zip",
+            ),
+            (
+                "gs://bucket/file.zip",
+                Protocol.GS,
+                f"gs_{_sha1_hex('gs://bucket/file.zip')}.zip",
+            ),
+            (
+                "azure://container/file.zip",
+                Protocol.AZURE,
+                f"azure_{_sha1_hex('azure://container/file.zip')}.zip",
+            ),
             (
                 "abfss://container@account.dfs.core.windows.net/file.zip",
                 Protocol.ABFSS,
-                "abfss_container_account_dfs_core_windows_net_file.zip",
+                f"abfss_{_sha1_hex('abfss://container@account.dfs.core.windows.net/file.zip')}.zip",
             ),
+            # .whl URIs bypass the hash path (PEP 427 — names must round-trip).
             (
                 "https://test.com/package-0.0.1-py2.py3-none-any.whl?param=value",
                 Protocol.HTTPS,
@@ -40,17 +68,14 @@ class TestParseUri:
         [
             (
                 "https://username:PAT@github.com/repo/archive/commit_hash.zip",
-                "https_username_PAT_github_com_repo_archive_commit_hash.zip",
+                f"https_{_sha1_hex('https://username:PAT@github.com/repo/archive/commit_hash.zip')}.zip",
             ),
             (
                 (
                     "https://un:pwd@gitlab.com/user/repo/-/"
                     "archive/commit_hash/repo-commit_hash.zip"
                 ),
-                (
-                    "https_un_pwd_gitlab_com_user_repo_-_"
-                    "archive_commit_hash_repo-commit_hash.zip"
-                ),
+                f"https_{_sha1_hex('https://un:pwd@gitlab.com/user/repo/-/archive/commit_hash/repo-commit_hash.zip')}.zip",
             ),
         ],
     )
@@ -63,22 +88,22 @@ class TestParseUri:
             (
                 "https://username:PAT@github.com/repo/archive:2/commit_hash.zip",
                 Protocol.HTTPS,
-                "https_username_PAT_github_com_repo_archive_2_commit_hash.zip",
+                f"https_{_sha1_hex('https://username:PAT@github.com/repo/archive:2/commit_hash.zip')}.zip",
             ),
             (
                 "gs://fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.GS,
-                "gs_fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"gs_{_sha1_hex('gs://fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "s3://fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.S3,
-                "s3_fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"s3_{_sha1_hex('s3://fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "azure://fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.AZURE,
-                "azure_fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"azure_{_sha1_hex('azure://fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 (
@@ -86,20 +111,17 @@ class TestParseUri:
                     "2022-10-21T13:11:35+00:00/package.zip"
                 ),
                 Protocol.ABFSS,
-                (
-                    "abfss_container_account_dfs_core_windows_net_"
-                    "2022-10-21T13_11_35_00_00_package.zip"
-                ),
+                f"abfss_{_sha1_hex('abfss://container@account.dfs.core.windows.net/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "file:///fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.FILE,
-                "file__fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"file_{_sha1_hex('file:///fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "file:///fake/2022-10-21T13:11:35+00:00/(package).zip",
                 Protocol.FILE,
-                "file__fake_2022-10-21T13_11_35_00_00__package_.zip",
+                f"file_{_sha1_hex('file:///fake/2022-10-21T13:11:35+00:00/(package).zip')}.zip",
             ),
         ],
     )
@@ -156,6 +178,28 @@ class TestParseUri:
         protocol, package_name = parse_uri(gcs_uri)
         assert protocol == Protocol.GCS
         assert package_name == gcs_uri.split("/")[-1]
+
+    def test_parse_uri_remote_is_stable(self):
+        """Remote URIs must map deterministically to the same package_name;
+        otherwise concurrent workers would acquire different file locks for
+        the same package."""
+        uri = "s3://bucket/some/path/pkg.zip"
+        _, name_first = parse_uri(uri)
+        _, name_second = parse_uri(uri)
+        assert name_first == name_second
+
+    def test_parse_uri_remote_paths_are_unique(self):
+        """Distinct remote URIs must not collide on the same package_name."""
+        _, name_a = parse_uri("s3://bucket/a.zip")
+        _, name_b = parse_uri("s3://bucket/b.zip")
+        assert name_a != name_b
+
+    @pytest.mark.parametrize("ext", [".tar.gz", ".tar.bz2"])
+    def test_parse_uri_remote_preserves_compound_extension(self, ext):
+        """Compound extensions are kept intact so downstream archive-type
+        detection keeps working after the URI has been hashed."""
+        _, name = parse_uri(f"s3://bucket/package{ext}")
+        assert name.endswith(ext)
 
 
 def test_parse_uri_tar_gz():

--- a/python/ray/_common/tests/test_runtime_env_uri.py
+++ b/python/ray/_common/tests/test_runtime_env_uri.py
@@ -194,11 +194,18 @@ class TestParseUri:
         _, name_b = parse_uri("s3://bucket/b.zip")
         assert name_a != name_b
 
-    @pytest.mark.parametrize("ext", [".tar.gz", ".tar.bz2"])
-    def test_parse_uri_remote_preserves_compound_extension(self, ext):
-        """Compound extensions are kept intact so downstream archive-type
-        detection keeps working after the URI has been hashed."""
-        _, name = parse_uri(f"s3://bucket/package{ext}")
+    @pytest.mark.parametrize(
+        "uri_template",
+        [
+            "s3://bucket/package{ext}",  # extension in path
+            "s3://package{ext}",  # extension in netloc (no path component)
+        ],
+    )
+    @pytest.mark.parametrize("ext", [".zip", ".tar.gz", ".tar.bz2"])
+    def test_parse_uri_remote_preserves_extension(self, uri_template, ext):
+        """Extensions are kept intact after hashing, whether the filename
+        is in the path or the netloc."""
+        _, name = parse_uri(uri_template.format(ext=ext))
         assert name.endswith(ext)
 
 

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -1,3 +1,4 @@
+import hashlib
 import io
 import os
 import random
@@ -665,20 +666,44 @@ class TestUnzipPackage:
             assert Path(archive_path).is_file()
 
 
+def _sha1_hex(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()
+
+
 class TestParseUri:
     @pytest.mark.parametrize(
         "parsing_tuple",
         [
             ("gcs://file.zip", Protocol.GCS, "file.zip"),
-            ("s3://bucket/file.zip", Protocol.S3, "s3_bucket_file.zip"),
-            ("http://test.com/file.zip", Protocol.HTTP, "http_test_com_file.zip"),
-            ("https://test.com/file.zip", Protocol.HTTPS, "https_test_com_file.zip"),
-            ("gs://bucket/file.zip", Protocol.GS, "gs_bucket_file.zip"),
-            ("azure://container/file.zip", Protocol.AZURE, "azure_container_file.zip"),
+            (
+                "s3://bucket/file.zip",
+                Protocol.S3,
+                f"s3_{_sha1_hex('s3://bucket/file.zip')}.zip",
+            ),
+            (
+                "http://test.com/file.zip",
+                Protocol.HTTP,
+                f"http_{_sha1_hex('http://test.com/file.zip')}.zip",
+            ),
+            (
+                "https://test.com/file.zip",
+                Protocol.HTTPS,
+                f"https_{_sha1_hex('https://test.com/file.zip')}.zip",
+            ),
+            (
+                "gs://bucket/file.zip",
+                Protocol.GS,
+                f"gs_{_sha1_hex('gs://bucket/file.zip')}.zip",
+            ),
+            (
+                "azure://container/file.zip",
+                Protocol.AZURE,
+                f"azure_{_sha1_hex('azure://container/file.zip')}.zip",
+            ),
             (
                 "abfss://container@account.dfs.core.windows.net/file.zip",
                 Protocol.ABFSS,
-                "abfss_container_account_dfs_core_windows_net_file.zip",
+                f"abfss_{_sha1_hex('abfss://container@account.dfs.core.windows.net/file.zip')}.zip",
             ),
             (
                 "https://test.com/package-0.0.1-py2.py3-none-any.whl?param=value",
@@ -704,17 +729,14 @@ class TestParseUri:
         [
             (
                 "https://username:PAT@github.com/repo/archive/commit_hash.zip",
-                "https_username_PAT_github_com_repo_archive_commit_hash.zip",
+                f"https_{_sha1_hex('https://username:PAT@github.com/repo/archive/commit_hash.zip')}.zip",
             ),
             (
                 (
                     "https://un:pwd@gitlab.com/user/repo/-/"
                     "archive/commit_hash/repo-commit_hash.zip"
                 ),
-                (
-                    "https_un_pwd_gitlab_com_user_repo_-_"
-                    "archive_commit_hash_repo-commit_hash.zip"
-                ),
+                f"https_{_sha1_hex('https://un:pwd@gitlab.com/user/repo/-/archive/commit_hash/repo-commit_hash.zip')}.zip",
             ),
         ],
     )
@@ -730,37 +752,37 @@ class TestParseUri:
             (
                 "https://username:PAT@github.com/repo/archive:2/commit_hash.zip",
                 Protocol.HTTPS,
-                "https_username_PAT_github_com_repo_archive_2_commit_hash.zip",
+                f"https_{_sha1_hex('https://username:PAT@github.com/repo/archive:2/commit_hash.zip')}.zip",
             ),
             (
                 "gs://fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.GS,
-                "gs_fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"gs_{_sha1_hex('gs://fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "s3://fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.S3,
-                "s3_fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"s3_{_sha1_hex('s3://fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "azure://fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.AZURE,
-                "azure_fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"azure_{_sha1_hex('azure://fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "abfss://container@account.dfs.core.windows.net/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.ABFSS,
-                "abfss_container_account_dfs_core_windows_net_2022-10-21T13_11_35_00_00_package.zip",
+                f"abfss_{_sha1_hex('abfss://container@account.dfs.core.windows.net/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "file:///fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.FILE,
-                "file__fake_2022-10-21T13_11_35_00_00_package.zip",
+                f"file_{_sha1_hex('file:///fake/2022-10-21T13:11:35+00:00/package.zip')}.zip",
             ),
             (
                 "file:///fake/2022-10-21T13:11:35+00:00/(package).zip",
                 Protocol.FILE,
-                "file__fake_2022-10-21T13_11_35_00_00__package_.zip",
+                f"file_{_sha1_hex('file:///fake/2022-10-21T13:11:35+00:00/(package).zip')}.zip",
             ),
         ],
     )


### PR DESCRIPTION
Currently, we flatten remote runtime environment URIs to filenames with no length cap. On some systems, this can produce filenames that exceed the filesystem's 255-byte NAME_MAX. This change avoids the problem by using a hash for the filename (while preserving the file extension).