### PR TITLE
[Train] Update `Result.from_path` to be read-only

### DIFF
--- a/python/ray/train/v2/_internal/execution/storage.py
+++ b/python/ray/train/v2/_internal/execution/storage.py
@@ -468,6 +468,11 @@ class StorageContext:
         Returns:
             Checkpoint: A Checkpoint pointing to the persisted checkpoint location.
         """
+        if self.read_only:
+            raise RuntimeError(
+                "Cannot perform write/validation operations as the StorageContext is read-only."
+            )
+
         # TODO(justinvyu): Fix this cyclical import.
         from ray.train import Checkpoint
 

--- a/python/ray/train/v2/_internal/execution/storage.py
+++ b/python/ray/train/v2/_internal/execution/storage.py
@@ -394,6 +394,7 @@ class StorageContext:
         storage_path: Union[str, os.PathLike],
         experiment_dir_name: str,
         storage_filesystem: Optional[pyarrow.fs.FileSystem] = None,
+        read_only: bool = False,
     ):
         self.custom_fs_provided = storage_filesystem is not None
 
@@ -406,8 +407,10 @@ class StorageContext:
         )
         self.storage_fs_path = Path(self.storage_fs_path).as_posix()
 
-        self._create_validation_file()
-        self._check_validation_file()
+        self.read_only = read_only
+        if not self.read_only:
+            self._create_validation_file()
+            self._check_validation_file()
 
     def __str__(self):
         return (

--- a/python/ray/train/v2/api/result.py
+++ b/python/ray/train/v2/api/result.py
@@ -93,6 +93,7 @@ class Result(ResultV1):
             storage_path=storage_path,
             experiment_dir_name=experiment_dir_name,
             storage_filesystem=fs,
+            read_only=True,
         )
 
         # Validate that the checkpoint manager snapshot file exists

--- a/python/ray/train/v2/tests/test_result.py
+++ b/python/ray/train/v2/tests/test_result.py
@@ -1,3 +1,4 @@
+import stat
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
@@ -12,6 +13,7 @@ from ray.train.tests.util import create_dict_checkpoint, load_dict_checkpoint
 from ray.train.torch import TorchTrainer
 from ray.train.v2._internal.constants import CHECKPOINT_MANAGER_SNAPSHOT_FILENAME
 from ray.train.v2._internal.execution.storage import StorageContext
+from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.train.v2.api.result import Result
 
@@ -277,6 +279,55 @@ def test_result_restore(
 
     with pytest.raises(RuntimeError, match="Invalid metric name.*"):
         result.get_best_checkpoint(metric="invalid_metric", mode="max")
+
+
+def test_result_from_path_read_only_storage(
+    ray_start_4_cpus,
+    tmp_path,
+):
+    """Reproduces https://github.com/ray-project/ray/issues/64305.
+
+    If checkpoints live on write-once / read-only storage, check that
+    ``Result.from_path`` / ``get_best_checkpoint`` are read-only operations.
+    """
+
+    def train_fn():
+        with create_dict_checkpoint({"iter": 1}) as ckpt:
+            ray.train.report({"epoch": 1}, ckpt)
+        with create_dict_checkpoint({"iter": 2}) as ckpt:
+            ray.train.report({"epoch": 2}, ckpt)
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        run_config=RunConfig(
+            name="test_read_only_storage",
+            storage_path=str(tmp_path),
+        ),
+    )
+    trainer.fit()
+
+    # Strip write permissions from the experiment directory, so that any new write fails.
+    no_write_mask = ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+    experiment_dir = Path(tmp_path) / "test_read_only_storage"
+    assert experiment_dir.exists()
+    original_modes = {
+        path: stat.S_IMODE(path.stat().st_mode)
+        for path in [experiment_dir, *experiment_dir.rglob("*")]
+    }
+    for path in original_modes:
+        path.chmod(original_modes[path] & no_write_mask)
+
+    try:
+        # Reading the best checkpoint must not require write access.
+        result = Result.from_path(str(experiment_dir))
+        assert result.checkpoint
+        assert len(result.best_checkpoints) == 2
+
+        best_ckpt = result.get_best_checkpoint(metric="epoch", mode="max")
+        assert load_dict_checkpoint(best_ckpt)["iter"] == 2
+    finally:
+        for path, mode in original_modes.items():
+            path.chmod(mode)
 
 
 def test_result_from_path_validation(


### PR DESCRIPTION
## Description
In Ray Train V2, `ray.train.Result.from_path()` (and therefore `get_best_checkpoint()`) requires write access to the checkpoint storage location, even though it is a read-only operation. For `Result.from_path`, as its a read-only operation, when creating the `StorageContext` we can skip writing the validation file

## Related issues
Fixes https://github.com/ray-project/ray/issues/64305
