### PR TITLE
[data] Fix parquet sampling hang on permanent OSError (#57278)

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -1823,7 +1823,9 @@ def _fetch_file_infos(
     futures = []
 
     # Retry in case of transient errors during sampling.
-    task_options = {"retry_exceptions": [OSError]}
+    # Cap retries to avoid hanging indefinitely on permanent errors
+    # (e.g., permission denied, invalid credentials).
+    task_options = {"retry_exceptions": [OSError], "max_retries": 3}
     ctx = DataContext.get_current()
     if local_scheduling:
         task_options["label_selector"] = local_scheduling
@@ -1846,8 +1848,18 @@ def _fetch_file_infos(
         )
 
     sample_bar = ProgressBar("Parquet dataset sampling", len(futures), unit="file")
-    file_infos = sample_bar.fetch_until_complete(futures)
-    sample_bar.close()
+    try:
+        file_infos = sample_bar.fetch_until_complete(futures)
+    except ray.exceptions.RayTaskError as e:
+        logger.warning(
+            "Parquet dataset sampling failed. "
+            "If this is a credentials or permissions issue, "
+            "check your cloud storage access configuration. "
+            f"Underlying error: {e.cause}"
+        )
+        raise
+    finally:
+        sample_bar.close()
 
     return file_infos
 

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -3253,6 +3253,30 @@ def test_read_parquet_nested_fallback_skipped_when_only_flat_columns_selected(
         mock_safe.assert_not_called()
 
 
+def test_parquet_sampling_fails_on_permanent_error(ray_start_regular_shared, tmp_path):
+    """Test that parquet sampling does not hang on permanent OSError (e.g.,
+    permission denied). Instead, it should fail with a clear error after
+    limited retries. Regression test for #57278."""
+    from unittest.mock import patch
+
+    # Write a valid parquet file so that fragment discovery succeeds.
+    table = pa.table({"col": [1, 2, 3]})
+    pq.write_table(table, os.path.join(tmp_path, "data.parquet"))
+
+    # Patch the remote sampling function to always raise PermissionError
+    # (a subclass of OSError), simulating invalid credentials.
+    original_fn = (
+        "ray.data._internal.datasource.parquet_datasource._fetch_parquet_file_info"
+    )
+
+    def _raise_permission_error(*args, **kwargs):
+        raise PermissionError("Access Denied: invalid credentials")
+
+    with patch(original_fn, new=_raise_permission_error):
+        with pytest.raises(Exception, match="Access Denied"):
+            ray.data.read_parquet(str(tmp_path)).materialize()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description
Caps Parquet metadata sampling retries to 3 (from infinite) and logs a clear
warning with the underlying error before re-raising, so jobs fail fast with
an actionable message instead of hanging indefinitely when cloud storage credentials or permissions are invalid.

Revives the approach from #63185 (originally by @f0rest9999), which fixed the same issue but went stale and was auto-closed for inactivity.

## Related issues
Fixes #57278

## Additional information
- Retained the original regression test
  (`test_parquet_sampling_fails_on_permanent_error`); confirmed it still passes