### PR TITLE
[docs] point examples at canonical viskit and fairseq sources

### DIFF
--- a/doc/source/ray-core/examples/lm/preprocess.sh
+++ b/doc/source/ray-core/examples/lm/preprocess.sh
@@ -11,7 +11,7 @@ unzip wikitext-103-raw-v1.zip
 mkdir -p gpt2_bpe
 wget -O gpt2_bpe/encoder.json https://dl.fbaipublicfiles.com/fairseq/gpt2_bpe/encoder.json
 wget -O gpt2_bpe/vocab.bpe https://dl.fbaipublicfiles.com/fairseq/gpt2_bpe/vocab.bpe
-wget https://raw.githubusercontent.com/pytorch/fairseq/master/examples/roberta/multiprocessing_bpe_encoder.py
+wget https://raw.githubusercontent.com/facebookresearch/fairseq/master/examples/roberta/multiprocessing_bpe_encoder.py
 for SPLIT in train valid test; do \
     python multiprocessing_bpe_encoder.py \
         --encoder-json gpt2_bpe/encoder.json \

--- a/doc/source/tune/api/logging.rst
+++ b/doc/source/tune/api/logging.rst
@@ -117,8 +117,8 @@ To use VisKit (you may have to install some dependencies), run:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/rll/rllab.git
-    $ python rllab/rllab/viskit/frontend.py ~/ray_results/my_experiment
+    $ git clone https://github.com/vitchyr/viskit.git
+    $ python viskit/viskit/frontend.py ~/ray_results/my_experiment
 
 The non-relevant metrics (like timing stats) can be disabled on the left to show only the
 relevant ones (like accuracy, loss, etc.).


### PR DESCRIPTION
## Description

Two documentation examples fetch third-party source at runtime from legacy upstream locations. Both still resolve today, but point at outdated homes; this updates them to the canonical, maintained sources. No behavior change.

- **`doc/source/tune/api/logging.rst`** (Viskit) — the code block clones the `rll/rllab` monorepo to run Viskit, even though the surrounding prose already links the standalone [vitchyr/viskit](https://github.com/vitchyr/viskit) project. Clone Viskit directly and run `viskit/viskit/frontend.py`.
- **`doc/source/ray-core/examples/lm/preprocess.sh`** (fairseq) — `wget`s the RoBERTa BPE encoder from the legacy `pytorch/fairseq` org (fairseq's pre-2018 location). Repoint to `facebookresearch/fairseq`, the canonical repo.

Both new URLs were verified to return HTTP 200 and serve the same content.

## Related issues

N/A.

## Additional information

Docs-only change; touches only `doc`-tagged files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
