### PR TITLE
[serve] Track actor fallback_strategy on DeploymentSchedulingInfo

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -286,6 +286,7 @@ class DeploymentSchedulingInfo:
     label_selector: Optional[Dict[str, str]] = None
     placement_group_bundles: Optional[List[RequestedResources]] = None
     bundle_label_selector: Optional[List[Dict[str, str]]] = None
+    fallback_strategy: Optional[List[Dict[str, Any]]] = None
     placement_group_strategy: Optional[str] = None
     max_replicas_per_node: Optional[int] = None
 
@@ -427,6 +428,9 @@ class DeploymentScheduler(ABC):
         info.label_selector = replica_config.ray_actor_options.get("label_selector")
         info.bundle_label_selector = (
             replica_config.placement_group_bundle_label_selector
+        )
+        info.fallback_strategy = replica_config.ray_actor_options.get(
+            "fallback_strategy"
         )
         info.max_replicas_per_node = replica_config.max_replicas_per_node
         if replica_config.placement_group_bundles:


### PR DESCRIPTION
## Why are these changes needed?

`DeploymentScheduler.on_deployment_deployed` records a deployment's scheduling constraints on `DeploymentSchedulingInfo` — including the actor `label_selector` and the placement-group `bundle_label_selector` — but it does not record the actor `fallback_strategy`. This adds a `fallback_strategy` field to `DeploymentSchedulingInfo` and populates it from `replica_config.ray_actor_options`, for parity with the other recorded scheduling options.

This makes the actor fallback strategy available to schedulers that reason over the per-deployment `DeploymentSchedulingInfo` rather than the per-replica `ReplicaSchedulingRequest`. The change is purely additive — one optional dataclass field plus its assignment in `on_deployment_deployed`. There is **no behavior change** in `DefaultDeploymentScheduler`, which builds placement candidates from the `ReplicaSchedulingRequest` (already carrying `fallback_strategy` in `actor_options`).

```python
# DeploymentSchedulingInfo
  bundle_label_selector: Optional[List[Dict[str, str]]] = None
+ fallback_strategy: Optional[List[Dict[str, Any]]] = None
  placement_group_strategy: Optional[str] = None

# DeploymentScheduler.on_deployment_deployed
  info.bundle_label_selector = replica_config.placement_group_bundle_label_selector
+ info.fallback_strategy = replica_config.ray_actor_options.get("fallback_strategy")
  info.max_replicas_per_node = replica_config.max_replicas_per_node
```

## Related issue number

N/A

## Checks

- [x] I've signed off every commit (`git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed — N/A (internal field, no API surface).
- [ ] I've made sure the tests are passing.
- [ ] Testing Strategy
  - [x] Unit tests
  - [ ] This PR is not tested :(