### PR TITLE
[docs] Update AI chat widget display name to "Ray Docs"

### DIFF
--- a/doc/source/_templates/extrahead.html
+++ b/doc/source/_templates/extrahead.html
@@ -64,7 +64,7 @@ both in the usual template (layout.html) as well as (index.html). -->
   };
 </script>
 
-<!-- RunLLM Widget -->
+<!-- Herald Widget -->
 <script
   type="module"
   id="runllm-widget-script"
@@ -72,7 +72,7 @@ both in the usual template (layout.html) as well as (index.html). -->
   version="stable"
   crossorigin="anonymous"
   runllm-keyboard-shortcut="Mod+j"
-  runllm-name="Ray RunLLM Bot"
+  runllm-name="Ray Docs"
   runllm-position="BOTTOM_RIGHT"
   runllm-assistant-id="1003"
 ></script>


### PR DESCRIPTION
## What

The docs AI chat assistant vendor, RunLLM, has rebranded to Herald. This updates the user-facing pieces of the chat widget embedded on docs.ray.io:

- Renames the widget's display name from `Ray RunLLM Bot` to `Ray Docs` (the name shown in the chat widget header). This names the assistant after the documentation it serves rather than the vendor.
- Updates the surrounding HTML comment from `RunLLM Widget` to `Herald Widget`.

## What does not change

The widget still loads from `widget.runllm.com` using the existing `runllm-*` script attributes and `runllm-assistant-id`. The vendor's configuration namespace is unchanged by the rebrand, so only the display name and comment are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
