### PR TITLE
[ci] Fix PR number parsing in get_contributors for cherry-picks and edge cases

### DIFF
--- a/ci/ray_ci/automation/get_contributors.py
+++ b/ci/ray_ci/automation/get_contributors.py
@@ -1,22 +1,29 @@
 import os
+import re
 import sys
 from collections import defaultdict
 from subprocess import check_output
+from typing import List
 
 import click
 from tqdm import tqdm
 
 from ray_release.github_client import GitHubClient, GitHubException
 
+# Matches a well-formed "(#<digits>)" reference. Compiled once at module scope
+# because _find_pr_numbers may run a thousand or more times per invocation.
+_PR_NUMBER_RE = re.compile(r"\(#(\d+)\)")
 
-def _find_pr_number(line: str) -> str:
-    start = line.find("(#")
-    if start < 0:
-        return ""
-    end = line.find(")", start + 2)
-    if end < 0:
-        return ""
-    return line[start + 2 : end]
+
+def _find_pr_numbers(line: str) -> List[int]:
+    # A commit title may carry several "(#<digits>)" references: a fixed issue,
+    # a reverted PR, or an original PR plus its cherry-pick/backport PR (e.g.
+    # "...in MiB (#63932) (#64042)"). The text alone cannot tell an issue from a
+    # PR, nor an original from a backport, so we return every well-formed
+    # candidate in title order and let the caller resolve which are real PRs via
+    # the GitHub API. Truncated text like "(#6..." is ignored because it has no
+    # closing ")".
+    return [int(n) for n in _PR_NUMBER_RE.findall(line)]
 
 
 @click.command()
@@ -85,12 +92,13 @@ def run(access_token, prev_release_commit, curr_release_commit):
             for commit_msg in commit_msgs:
                 file.write("{}\n".format(commit_msg))
 
-    # Query Github API to get the list of contributors
-    pr_numbers = []
-    for line in lines:
-        pr_number = _find_pr_number(line)
-        if pr_number:
-            pr_numbers.append(int(pr_number))
+    # Query Github API to get the list of contributors. A commit may reference
+    # several numbers (e.g. an original PR plus its backport); we collect every
+    # candidate so that both the original author and the backporter are credited
+    # and a cherry-pick never silently drops the original author. Numbers that
+    # are actually issues (or deleted PRs) resolve to a 404 below and are
+    # skipped, so we cannot pre-filter them from the text.
+    pr_numbers = sorted({num for line in lines for num in _find_pr_numbers(line)})
 
     # Sort the PR numbers
     print("PR numbers", pr_numbers)
@@ -99,11 +107,27 @@ def run(access_token, prev_release_commit, curr_release_commit):
     client = GitHubClient(access_token)
     ray_repo = client.get_repo("ray-project/ray")
     logins = set()
+    # A 404 is expected for numbers that are actually issues rather than PRs.
+    # We still collect them so the script acknowledges every number it could
+    # not resolve, in case GitHub's behavior (issue numbers 404, PR numbers
+    # never do) changes and a real PR silently stops being credited.
+    not_found_numbers = []
     for num in tqdm(pr_numbers):
         try:
             logins.add(ray_repo.get_pull(num).user.login)
         except GitHubException as e:
-            print(e)
+            if getattr(e, "status", None) == 404:
+                not_found_numbers.append(num)
+            else:
+                print(e)
+
+    if not_found_numbers:
+        print()
+        print(
+            "The following numbers did not resolve to a PR (expected for issue "
+            "references; investigate if any of these are known PRs):"
+        )
+        print(not_found_numbers)
 
     print()
     print("Here's the list of contributors")

--- a/ci/ray_ci/automation/get_contributors.py
+++ b/ci/ray_ci/automation/get_contributors.py
@@ -11,19 +11,20 @@ from tqdm import tqdm
 from ray_release.github_client import GitHubClient, GitHubException
 
 # Matches a well-formed "(#<digits>)" reference. Compiled once at module scope
-# because _find_pr_numbers may run a thousand or more times per invocation.
+# since the same pattern is reused across every invocation of the script.
 _PR_NUMBER_RE = re.compile(r"\(#(\d+)\)")
 
 
-def _find_pr_numbers(line: str) -> List[int]:
-    # A commit title may carry several "(#<digits>)" references: a fixed issue,
-    # a reverted PR, or an original PR plus its cherry-pick/backport PR (e.g.
-    # "...in MiB (#63932) (#64042)"). The text alone cannot tell an issue from a
-    # PR, nor an original from a backport, so we return every well-formed
-    # candidate in title order and let the caller resolve which are real PRs via
-    # the GitHub API. Truncated text like "(#6..." is ignored because it has no
-    # closing ")".
-    return [int(n) for n in _PR_NUMBER_RE.findall(line)]
+def _find_pr_numbers(text: str) -> List[int]:
+    # A single commit title may carry several "(#<digits>)" references: a fixed
+    # issue, a reverted PR, or an original PR plus its cherry-pick/backport PR
+    # (e.g. "...in MiB (#63932) (#64042)"). The text alone cannot tell an issue
+    # from a PR, nor an original from a backport, so we return every well-formed
+    # candidate in order and let the caller resolve which are real PRs via the
+    # GitHub API. Truncated text like "(#6..." is ignored because it has no
+    # closing ")". `text` may be a single title or the whole multi-line git-log
+    # blob; re.findall scans across newlines either way.
+    return [int(n) for n in _PR_NUMBER_RE.findall(text)]
 
 
 @click.command()
@@ -98,6 +99,12 @@ def run(access_token, prev_release_commit, curr_release_commit):
     # and a cherry-pick never silently drops the original author. Numbers that
     # are actually issues (or deleted PRs) resolve to a 404 below and are
     # skipped, so we cannot pre-filter them from the text.
+    #
+    # Trade-off: because we keep every reference, a commit that mentions another
+    # PR in prose -- most commonly a revert like 'Revert "[X] foo (#500)" (#600)'
+    # -- also credits the author of that referenced PR (#500), even though their
+    # change is not in this release. We accept this over-crediting in exchange
+    # for never missing a real contributor.
     pr_numbers = sorted(set(_find_pr_numbers(commits)))
 
     # Sort the PR numbers
@@ -112,6 +119,11 @@ def run(access_token, prev_release_commit, curr_release_commit):
     # not resolve, in case GitHub's behavior (issue numbers 404, PR numbers
     # never do) changes and a real PR silently stops being credited.
     not_found_numbers = []
+    # Any other error (rate limit 403, 5xx, network) means we could not look up
+    # that PR's author. Dropping it silently would omit a real contributor from
+    # a release announcement, so we collect these and fail loudly at the end
+    # instead of printing a complete-looking list and exiting 0.
+    errored_numbers = []
     for num in tqdm(pr_numbers):
         try:
             logins.add(ray_repo.get_pull(num).user.login)
@@ -120,6 +132,7 @@ def run(access_token, prev_release_commit, curr_release_commit):
                 not_found_numbers.append(num)
             else:
                 print(e)
+                errored_numbers.append(num)
 
     if not_found_numbers:
         print()
@@ -136,6 +149,14 @@ def run(access_token, prev_release_commit, curr_release_commit):
     print("@" + ", @".join(logins))
     print()
     print("=" * 10)
+
+    if errored_numbers:
+        raise click.ClickException(
+            "Could not fetch the author for the following PR numbers due to "
+            f"GitHub API errors (see logs above): {errored_numbers}. The "
+            "contributor list above is INCOMPLETE; re-run after resolving the "
+            "errors (e.g. wait out rate limits) before using it."
+        )
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/get_contributors.py
+++ b/ci/ray_ci/automation/get_contributors.py
@@ -98,7 +98,7 @@ def run(access_token, prev_release_commit, curr_release_commit):
     # and a cherry-pick never silently drops the original author. Numbers that
     # are actually issues (or deleted PRs) resolve to a 404 below and are
     # skipped, so we cannot pre-filter them from the text.
-    pr_numbers = sorted({num for line in lines for num in _find_pr_numbers(line)})
+    pr_numbers = sorted(set(_find_pr_numbers(commits)))
 
     # Sort the PR numbers
     print("PR numbers", pr_numbers)

--- a/ci/ray_ci/automation/test_get_contributors.py
+++ b/ci/ray_ci/automation/test_get_contributors.py
@@ -5,7 +5,7 @@ import pytest
 import responses
 from click.testing import CliRunner
 
-from ci.ray_ci.automation.get_contributors import _find_pr_number, run
+from ci.ray_ci.automation.get_contributors import _find_pr_numbers, run
 
 BASE = "https://api.github.com"
 REPO = "ray-project/ray"
@@ -15,6 +15,15 @@ _COMMIT_LOG = "\n".join(
         "[core] Fix scheduler bug (#100)",
         "[serve] Add new endpoint (#101)",
         "No category commit (#102)",
+        "",
+    ]
+)
+
+# A cherry-pick carries the original PR followed by the backport PR. Both
+# authors should be credited.
+_COMMIT_LOG_CHERRY_PICK = "\n".join(
+    [
+        "[Core] Compute per component memory usage in MiB (#63932) (#64042)",
         "",
     ]
 )
@@ -30,28 +39,62 @@ _COMMIT_LOG_NO_PRS = "\n".join(
 
 
 # ---------------------------------------------------------------------------
-# _find_pr_number
+# _find_pr_numbers
 # ---------------------------------------------------------------------------
 
 
-def test_find_pr_number_standard_format():
-    assert _find_pr_number("[fix] Fix crash in serve (#12345)") == "12345"
+def test_find_pr_numbers_standard_format():
+    assert _find_pr_numbers("[fix] Fix crash in serve (#12345)") == [12345]
 
 
-def test_find_pr_number_no_pr():
-    assert _find_pr_number("[fix] Fix crash in serve") == ""
+def test_find_pr_numbers_no_pr():
+    assert _find_pr_numbers("[fix] Fix crash in serve") == []
 
 
-def test_find_pr_number_empty_string():
-    assert _find_pr_number("") == ""
+def test_find_pr_numbers_empty_string():
+    assert _find_pr_numbers("") == []
 
 
-def test_find_pr_number_unclosed_paren():
-    assert _find_pr_number("[fix] Fix crash (#12345") == ""
+def test_find_pr_numbers_unclosed_paren():
+    assert _find_pr_numbers("[fix] Fix crash (#12345") == []
 
 
-def test_find_pr_number_at_start_of_line():
-    assert _find_pr_number("(#99)") == "99"
+def test_find_pr_numbers_at_start_of_line():
+    assert _find_pr_numbers("(#99)") == [99]
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # Reverted-PR title where the inner reference is truncated by git's
+        # subject elision: only the trailing well-formed token is captured.
+        (
+            'Revert "[Data] Remove safe_round from ExecutionResources hot path '
+            "(#6... (#64309)",
+            [64309],
+        ),
+        # Two references: a fixed GitHub issue (#63729) followed by the merging
+        # PR (#63733). Both candidates are returned in title order; the API
+        # resolves which are real PRs (the issue number 404s).
+        (
+            "[dashboard] Guard against zero num_cpus in k8s_utils.cpu_percent "
+            "(#63729) (#63733)",
+            [63729, 63733],
+        ),
+        # Cherry-picked commit: original PR first, then the backport PR. Both
+        # are returned so both authors can be credited.
+        (
+            "[Core] Compute per component memory usage in MiB (#63932) (#64042)",
+            [63932, 64042],
+        ),
+        # Truncated reference only — no well-formed "(#<digits>)" token.
+        ("[Data] Some very long title that got cut off (#6...", []),
+        # Non-digit content between "(#" and ")" must not match.
+        ("[fix] Mention the (#hashtag) in the title", []),
+    ],
+)
+def test_find_pr_numbers_edge_cases(line, expected):
+    assert _find_pr_numbers(line) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +186,90 @@ def test_run_skips_failed_pr_lookups():
     assert result.exit_code == 0, result.output
     assert "bob" in result.output
     assert "carol" in result.output
+
+
+@responses.activate
+def test_run_credits_both_authors_of_cherry_pick():
+    # Original PR author and backport PR author must both be credited.
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/63932",
+        json={"number": 63932, "user": {"login": "original_author"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/64042",
+        json={"number": 64042, "user": {"login": "backporter"}},
+    )
+
+    with (
+        mock.patch(
+            "ci.ray_ci.automation.get_contributors.check_output",
+            return_value=_COMMIT_LOG_CHERRY_PICK.encode(),
+        ),
+        mock.patch.dict("os.environ", {"BUILD_WORKSPACE_DIRECTORY": "/fake/repo"}),
+    ):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "original_author" in result.output
+    assert "backporter" in result.output
+
+
+@responses.activate
+def test_run_skips_issue_reference_but_keeps_pr():
+    # "(#63729) (#63733)": 63729 is a fixed issue (404), 63733 is the PR.
+    # The issue 404 must not prevent the PR author from being credited.
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/63729",
+        json={"message": "Not Found"},
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/63733",
+        json={"number": 63733, "user": {"login": "dave"}},
+    )
+
+    commit_log = (
+        "[dashboard] Guard against zero num_cpus in k8s_utils.cpu_percent "
+        "(#63729) (#63733)\n"
+    )
+    with (
+        mock.patch(
+            "ci.ray_ci.automation.get_contributors.check_output",
+            return_value=commit_log.encode(),
+        ),
+        mock.patch.dict("os.environ", {"BUILD_WORKSPACE_DIRECTORY": "/fake/repo"}),
+    ):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "dave" in result.output
+    # The unresolved issue number is acknowledged in the output rather than
+    # silently dropped.
+    assert "63729" in result.output
 
 
 def test_run_writes_commits_file_with_categories():

--- a/ci/ray_ci/automation/test_get_contributors.py
+++ b/ci/ray_ci/automation/test_get_contributors.py
@@ -287,6 +287,51 @@ def test_run_skips_issue_reference_but_keeps_pr():
     assert "63729" in result.output
 
 
+@responses.activate
+def test_run_fails_loudly_on_non_404_error():
+    # A non-404 error (e.g. rate limit / 5xx) means a real PR author could not
+    # be fetched. The run must fail rather than print a complete-looking list.
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/100",
+        json={"number": 100, "user": {"login": "alice"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/101",
+        json={"message": "rate limited"},
+        status=403,
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/102",
+        json={"number": 102, "user": {"login": "carol"}},
+    )
+
+    with (
+        mock.patch(
+            "ci.ray_ci.automation.get_contributors.check_output",
+            return_value=_COMMIT_LOG.encode(),
+        ),
+        mock.patch.dict("os.environ", {"BUILD_WORKSPACE_DIRECTORY": "/fake/repo"}),
+    ):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+
+    # Non-zero exit signals the incomplete list, and the failing number is named.
+    assert result.exit_code != 0
+    assert "101" in result.output
+
+
 def test_run_writes_commits_file_with_categories():
     with (
         mock.patch(

--- a/ci/ray_ci/automation/test_get_contributors.py
+++ b/ci/ray_ci/automation/test_get_contributors.py
@@ -63,6 +63,21 @@ def test_find_pr_numbers_at_start_of_line():
     assert _find_pr_numbers("(#99)") == [99]
 
 
+def test_find_pr_numbers_multiple_titles_in_one_blob():
+    # `run` passes the entire multi-line `git log` output at once; every
+    # reference across all lines must be found, in order, including both
+    # references of a cherry-pick and ignoring titles with no PR.
+    blob = "\n".join(
+        [
+            "[core] Fix scheduler bug (#100)",
+            "[data] No PR reference here",
+            "[Core] Compute per component memory usage in MiB (#63932) (#64042)",
+            "[serve] Add new endpoint (#101)",
+        ]
+    )
+    assert _find_pr_numbers(blob) == [100, 63932, 64042, 101]
+
+
 @pytest.mark.parametrize(
     "line,expected",
     [


### PR DESCRIPTION
## Description

The `get_contributors` release-notes script extracts PR numbers from commit subjects to look up contributor logins. The old `_find_pr_number` helper grabbed all text between `(#` and the first `)`, which produced wrong results for several real commit titles:

- A truncated revert like `Revert "... hot path (#6... (#64309)` yielded `6... (#64309` instead of `64309`.
- A title carrying a fixed-issue reference followed by the merging PR, e.g. `... cpu_percent (#63729) (#63733)`, yielded the issue number `63729` instead of the PR `63733`.
- **Cherry-picks** such as `... in MiB (#63932) (#64042)` (original PR + backport PR) credited only one number, silently dropping the original author.

This PR replaces it with `_find_pr_numbers`, which:

- Matches only well-formed `(#<digits>)` tokens using a module-level compiled regex (the helper runs up to thousands of times per invocation).
- Returns **every** candidate in title order. The commit text alone cannot tell an issue from a PR or an original from a backport, so `run` queries all candidates via the GitHub API and credits each one that resolves as a real PR. A cherry-pick now credits both the original author and the backporter.
- Treats a `404` as expected (the number is an issue, not a PR) and collects those numbers, printing them at the end. This way, if GitHub's behavior ever changes and a real PR starts returning `404`, the dropped numbers are surfaced rather than silently lost.

## Related issues

N/A

## Additional information

Unit tests cover the parsing edge cases (truncated revert, issue+PR, cherry-pick, non-digit parentheticals) and the CLI behavior (both cherry-pick authors credited; an issue `404` does not drop the real PR author and is reported in the output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)