### PR TITLE
[serve] Reject object store memory replica actor option

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -855,6 +855,13 @@ class ReplicaConfig:
             "fallback_strategy",
         }
 
+        if "object_store_memory" in self.ray_actor_options:
+            raise ValueError(
+                "Specifying 'object_store_memory' in ray_actor_options is not "
+                "allowed. Object store memory is a node-level resource and "
+                "cannot be requested for Serve replica actors."
+            )
+
         for option in self.ray_actor_options:
             if option not in allowed_ray_actor_options:
                 raise ValueError(

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -499,6 +499,11 @@ class TestReplicaConfig:
             ReplicaConfig.create(Class, ray_actor_options={"memory": -1})
         with pytest.raises(TypeError):
             ReplicaConfig.create(Class, ray_actor_options={"resources": []})
+        with pytest.raises(
+            ValueError,
+            match="Object store memory is a node-level resource",
+        ):
+            ReplicaConfig.create(Class, ray_actor_options={"object_store_memory": 100})
 
         disallowed_ray_actor_options = {
             "max_concurrency",


### PR DESCRIPTION
## Summary
- Reject `object_store_memory` in Serve `ray_actor_options` with a clear `ValueError`.
- Add regression coverage for `ReplicaConfig` validation.

Fixes #45780.

## Test plan
- `python3 -m py_compile python/ray/serve/_private/config.py python/ray/serve/tests/unit/test_config.py`
- `.venv/bin/python -m black --check python/ray/serve/_private/config.py python/ray/serve/tests/unit/test_config.py`
- `git diff --check`
- Attempted `.venv/bin/python -m pytest python/ray/serve/tests/unit/test_config.py -k ray_actor_options_validation`, but local checkout cannot import `ray._raylet` because Ray is not built.
- Attempted Bazel target discovery, but Bazel could not download external dependencies in this sandbox (`rules_java` download blocked).
- Attempted `.venv/bin/python -m pre_commit run --files ...`, but hook environment install failed due local pip SSL certificate verification while fetching `setuptools`.

Made with [Cursor](https://cursor.com)