### PR TITLE
[core] fix test_streaming_generator_backpressure on windows

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -356,7 +356,6 @@ py_test_module_list(
         "test_streaming_generator_2.py",
         "test_streaming_generator_3.py",
         "test_streaming_generator_4.py",
-        "test_streaming_generator_backpressure.py",
         "test_task_metrics.py",
         "test_tempdir.py",
         "test_tls_auth.py",
@@ -365,6 +364,22 @@ py_test_module_list(
         "test_traceback.py",
         "test_worker_capping.py",
         "test_worker_state.py",
+    ],
+    tags = [
+        "exclusive",
+        "medium_size_python_tests_shard_1",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "large",
+    files = [
+        "test_streaming_generator_backpressure.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/tests/test_streaming_generator_backpressure.py
+++ b/python/ray/tests/test_streaming_generator_backpressure.py
@@ -2,6 +2,7 @@ import asyncio
 import gc
 import os
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -18,6 +19,20 @@ from ray.util.state import list_tasks
 def _list_tasks(**kwargs):
     """Same as ``list_tasks`` but pinned to this test's cluster. When several local Ray instances exist"""
     return list_tasks(address=ray.get_runtime_context().gcs_address, **kwargs)
+
+
+_WINDOWS_STATUS_ACCESS_VIOLATION = 0xC0000005
+
+
+def _run_driver_that_exits_ungracefully(driver):
+    try:
+        run_string_as_driver(driver)
+    except subprocess.CalledProcessError as exc:
+        if (
+            sys.platform != "win32"
+            or exc.returncode != _WINDOWS_STATUS_ACCESS_VIOLATION
+        ):
+            raise
 
 
 @pytest.mark.parametrize("actor", [False, True])
@@ -872,10 +887,11 @@ assert ray.get(a.ping.remote(), timeout=10) == "ok"
 os._exit(0)
 """
 
-    run_string_as_driver(driver)
+    _run_driver_that_exits_ungracefully(driver)
     a = ray.get_actor(actor_name, namespace=namespace)
     reporter = ray.get_actor(reporter_name, namespace=namespace)
     try:
+        assert ray.get(reporter.count.remote("first")) == 1
         g = a.gen.remote(reporter, "second", 2)
         wait_for_condition(
             lambda: ray.get(reporter.count.remote("second")) == 2,
@@ -941,10 +957,11 @@ wait_for_condition(lambda: ray.get(reporter.count.remote("first")) == 1, timeout
 os._exit(0)
 """
 
-    run_string_as_driver(driver)
+    _run_driver_that_exits_ungracefully(driver)
     a = ray.get_actor(actor_name, namespace=namespace)
     reporter = ray.get_actor(reporter_name, namespace=namespace)
     try:
+        assert ray.get(reporter.count.remote("first")) == 1
         assert ray.get(a.ping.remote(), timeout=_ACTOR_GEN_BP_WAIT_S) == "ok"
     finally:
         ray.kill(a)
@@ -1012,7 +1029,7 @@ wait_for_condition(lambda: ray.get(reporter.count.remote()) == 1, timeout=10)
 os._exit(0)
 """
 
-    run_string_as_driver(driver)
+    _run_driver_that_exits_ungracefully(driver)
     a = ray.get_actor(actor_name, namespace=namespace)
     reporter = ray.get_actor(reporter_name, namespace=namespace)
     try:


### PR DESCRIPTION
Ignore the WINDOWS_STATUS_ACCESS_VIOLATION exception on Windows to fix this test:

```
 ================================== FAILURES ===================================
 __________ test_actor_generator_backpressure_reclaim_on_owner_death ___________

 shutdown_only = None

     def test_actor_generator_backpressure_reclaim_on_owner_death(shutdown_only):
         namespace = "actor_generator_backpressure_owner_death"
         actor_name = f"actor_generator_backpressure_owner_death_actor_{os.getpid()}"
         reporter_name = f"actor_generator_backpressure_owner_death_reporter_{os.getpid()}"
         address = ray.init(num_cpus=2, namespace=namespace).address_info["address"]

         driver = f"""
     import os

     import ray
     from ray._common.test_utils import wait_for_condition

     ray.init(address="{address}", namespace="{namespace}")


     @ray.remote(name="{reporter_name}", lifetime="detached")
     class Reporter:
         def __init__(self):
             self.counts = {{}}

         def report(self, tag):
             self.counts[tag] = self.counts.get(tag, 0) + 1

         def count(self, tag):
             return self.counts.get(tag, 0)


     @ray.remote(
         name="{actor_name}",
         lifetime="detached",
         max_concurrency=1,
         _actor_generator_backpressure_num_objects=2,
     )
     class A:
         def gen(self, reporter, tag, count):
             for i in range(count):
                 ray.get(reporter.report.remote(tag))
                 yield i

         def ping(self):
             return "ok"


     reporter = Reporter.remote()
     a = A.remote()
     g = a.gen.remote(reporter, "first", 1)
     wait_for_condition(lambda: ray.get(reporter.count.remote("first")) == 1, timeout=10)
     assert ray.get(a.ping.remote(), timeout=10) == "ok"

     # Exit
     os._exit(0)
     """

 >       run_string_as_driver(driver)

 python\ray\tests\test_streaming_generator_backpressure.py:875:
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

 driver_script = '\nimport os\n\nimport ray\nfrom ray._common.test_utils import wait_for_condition\n\nray.init(address="192.168.247.108...count.remote("first")) == 1, timeout=10)\nassert ray.get(a.ping.remote(), timeout=10) == "ok"\n\n# Exit\nos._exit(0)\n'
 env = None, encode = 'utf-8'

     def run_string_as_driver(
         driver_script: str, env: Dict = None, encode: str = "utf-8"
     ) -> str:
         """Run a driver as a separate process.

         Args:
             driver_script: A string to run as a Python script.
             env: The environment variables for the driver.
             encode: The encoding to use for the driver script.

         Returns:
             The script's output.
         """
         proc = subprocess.Popen(
             [sys.executable, "-"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
         )
         with proc:
             output = proc.communicate(driver_script.encode(encoding=encode))[0]
             if proc.returncode:
                 print(decode(output, encode_type=encode))
                 logger.error(proc.stderr)
 >               raise subprocess.CalledProcessError(
                     proc.returncode, proc.args, output, proc.stderr
                 )
 E               subprocess.CalledProcessError: Command '['C:\\Miniconda3\\python.exe', '-']' returned non-zero exit status 3221225477.

 C:\rayci\python\ray\_common\test_utils.py:399: CalledProcessError
```

The extended timeout is also needed; otherwise, we could time out even before capturing the test output.

Update: The test now passes.

<img width="1541" height="617" alt="image" src="https://github.com/user-attachments/assets/09a4dc38-736b-4876-9bed-42acc505008c" />
