### PR TITLE
[train][Preemption handling 3/n] Add public preemption API and controller PreemptingState

### DIFF
--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -149,6 +149,7 @@ Ray Train Utilities
     ~train.Checkpoint
     ~train.CheckpointUploadMode
     ~train.CheckpointConsistencyMode
+    ~train.PreemptionInfo
     ~train.TrainContext
     ~train.ValidationFn
     ~train.ValidationTaskConfig
@@ -163,6 +164,7 @@ Ray Train Utilities
     ~train.get_checkpoint
     ~train.get_context
     ~train.get_dataset_shard
+    ~train.preemption_info
     ~train.report
 
 **Collective**
@@ -195,6 +197,7 @@ Ray Train Errors
     :toctree: doc/
 
     ~train.ControllerError
+    ~train.PreemptionError
     ~train.WorkerGroupError
     ~train.TrainingFailedError
 

--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -149,10 +149,16 @@ Ray Train Utilities
     ~train.Checkpoint
     ~train.CheckpointUploadMode
     ~train.CheckpointConsistencyMode
-    ~train.PreemptionInfo
     ~train.TrainContext
     ~train.ValidationFn
     ~train.ValidationTaskConfig
+
+.. autosummary::
+    :nosignatures:
+    :template: autosummary/class_without_autosummary.rst
+    :toctree: doc/
+
+    ~train.PreemptionInfo
 
 **Functions**
 

--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -170,7 +170,7 @@ Ray Train Utilities
     ~train.get_checkpoint
     ~train.get_context
     ~train.get_dataset_shard
-    ~train.preemption_info
+    ~train.get_preemption_info
     ~train.report
 
 **Collective**

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -49,6 +49,7 @@ if is_v2_enabled():
     from ray.train.v2.api.context import TrainContext  # noqa: F811
     from ray.train.v2.api.exceptions import (  # noqa: F811
         ControllerError,
+        PreemptionError,
         TrainingFailedError,
         WorkerGroupError,
     )
@@ -119,6 +120,7 @@ if is_v2_enabled():
             "CheckpointConsistencyMode",
             "ControllerError",
             "LoggingConfig",
+            "PreemptionError",
             "PreemptionInfo",
             "ReportedCheckpoint",
             "ReportedCheckpointStatus",
@@ -136,6 +138,7 @@ if is_v2_enabled():
     CheckpointConsistencyMode.__module__ = "ray.train"
     ControllerError.__module__ = "ray.train"
     LoggingConfig.__module__ = "ray.train"
+    PreemptionError.__module__ = "ray.train"
     PreemptionInfo.__module__ = "ray.train"
     ReportedCheckpoint.__module__ = "ray.train"
     ReportedCheckpointStatus.__module__ = "ray.train"

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -35,6 +35,9 @@ if is_v2_enabled():
             "`ray.train.v2` requires the pydantic package, which is missing. "
             "Run the following command to fix this: `pip install pydantic`"
         ) from exc
+    from ray.train.v2._internal.execution.preemption import (  # noqa: F811
+        PreemptionInfo,
+    )
     from ray.train.v2.api.callback import UserCallback  # noqa: F811
     from ray.train.v2.api.config import (  # noqa: F811
         CheckpointConfig,
@@ -63,6 +66,7 @@ if is_v2_enabled():
         get_checkpoint,
         get_context,
         get_dataset_shard,
+        preemption_status,
         report,
     )
     from ray.train.v2.api.validation_config import (  # noqa: F811
@@ -115,6 +119,7 @@ if is_v2_enabled():
             "CheckpointConsistencyMode",
             "ControllerError",
             "LoggingConfig",
+            "PreemptionInfo",
             "ReportedCheckpoint",
             "ReportedCheckpointStatus",
             "UserCallback",
@@ -123,6 +128,7 @@ if is_v2_enabled():
             "ValidationFn",
             "ValidationTaskConfig",
             "get_all_reported_checkpoints",
+            "preemption_status",
         ]
     )
 
@@ -130,6 +136,7 @@ if is_v2_enabled():
     CheckpointConsistencyMode.__module__ = "ray.train"
     ControllerError.__module__ = "ray.train"
     LoggingConfig.__module__ = "ray.train"
+    PreemptionInfo.__module__ = "ray.train"
     ReportedCheckpoint.__module__ = "ray.train"
     ReportedCheckpointStatus.__module__ = "ray.train"
     UserCallback.__module__ = "ray.train"
@@ -138,6 +145,7 @@ if is_v2_enabled():
     ValidationFn.__module__ = "ray.train"
     ValidationTaskConfig.__module__ = "ray.train"
     get_all_reported_checkpoints.__module__ = "ray.train"
+    preemption_status.__module__ = "ray.train"
 
 
 # DO NOT ADD ANYTHING AFTER THIS LINE.

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -66,7 +66,7 @@ if is_v2_enabled():
         get_checkpoint,
         get_context,
         get_dataset_shard,
-        preemption_status,
+        preemption_info,
         report,
     )
     from ray.train.v2.api.validation_config import (  # noqa: F811
@@ -128,7 +128,7 @@ if is_v2_enabled():
             "ValidationFn",
             "ValidationTaskConfig",
             "get_all_reported_checkpoints",
-            "preemption_status",
+            "preemption_info",
         ]
     )
 
@@ -145,7 +145,7 @@ if is_v2_enabled():
     ValidationFn.__module__ = "ray.train"
     ValidationTaskConfig.__module__ = "ray.train"
     get_all_reported_checkpoints.__module__ = "ray.train"
-    preemption_status.__module__ = "ray.train"
+    preemption_info.__module__ = "ray.train"
 
 
 # DO NOT ADD ANYTHING AFTER THIS LINE.

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -35,9 +35,6 @@ if is_v2_enabled():
             "`ray.train.v2` requires the pydantic package, which is missing. "
             "Run the following command to fix this: `pip install pydantic`"
         ) from exc
-    from ray.train.v2._internal.execution.preemption import (  # noqa: F811
-        PreemptionInfo,
-    )
     from ray.train.v2.api.callback import UserCallback  # noqa: F811
     from ray.train.v2.api.config import (  # noqa: F811
         CheckpointConfig,
@@ -53,6 +50,7 @@ if is_v2_enabled():
         TrainingFailedError,
         WorkerGroupError,
     )
+    from ray.train.v2.api.preemption import PreemptionInfo  # noqa: F811
     from ray.train.v2.api.report_config import (  # noqa: F811
         CheckpointConsistencyMode,
         CheckpointUploadMode,

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -67,7 +67,7 @@ if is_v2_enabled():
         get_checkpoint,
         get_context,
         get_dataset_shard,
-        preemption_info,
+        get_preemption_info,
         report,
     )
     from ray.train.v2.api.validation_config import (  # noqa: F811
@@ -130,7 +130,7 @@ if is_v2_enabled():
             "ValidationFn",
             "ValidationTaskConfig",
             "get_all_reported_checkpoints",
-            "preemption_info",
+            "get_preemption_info",
         ]
     )
 
@@ -148,7 +148,7 @@ if is_v2_enabled():
     ValidationFn.__module__ = "ray.train"
     ValidationTaskConfig.__module__ = "ray.train"
     get_all_reported_checkpoints.__module__ = "ray.train"
-    preemption_info.__module__ = "ray.train"
+    get_preemption_info.__module__ = "ray.train"
 
 
 # DO NOT ADD ANYTHING AFTER THIS LINE.

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -561,22 +561,6 @@ py_test(
 )
 
 py_test(
-    name = "test_preemption_drain",
-    size = "large",
-    srcs = ["tests/test_preemption_drain.py"],
-    env = {"RAY_TRAIN_V2_ENABLED": "1"},
-    tags = [
-        "exclusive",
-        "team:ml",
-        "train_v2",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test(
     name = "test_result",
     size = "medium",
     srcs = ["tests/test_result.py"],

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -561,6 +561,22 @@ py_test(
 )
 
 py_test(
+    name = "test_preemption_drain",
+    size = "large",
+    srcs = ["tests/test_preemption_drain.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_result",
     size = "medium",
     srcs = ["tests/test_result.py"],

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -545,6 +545,22 @@ py_test(
 )
 
 py_test(
+    name = "test_preemption_fault_tolerance",
+    size = "medium",
+    srcs = ["tests/test_preemption_fault_tolerance.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_result",
     size = "medium",
     srcs = ["tests/test_result.py"],

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -164,8 +164,8 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
             pass
 
         elif isinstance(current_state, PreemptingState):
-            # Draining substate of RunningState; the run keeps reporting as
-            # running until it transitions to RestartingState.
+            # substate of RunningState; the run keeps reporting as
+            # running until it transitions to RestartingState or ShuttingDownState.
             pass
 
     def before_worker_group_start(self, worker_group_context: WorkerGroupContext):

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -15,6 +15,7 @@ from ray.train.v2._internal.execution.controller.state import (
     AbortedState,
     ErroredState,
     FinishedState,
+    PreemptingState,
     ReschedulingState,
     ResizingState,
     RestartingState,
@@ -160,6 +161,11 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
 
         elif isinstance(current_state, ShuttingDownState):
             # substate of RunningState
+            pass
+
+        elif isinstance(current_state, PreemptingState):
+            # Draining substate of RunningState; the run keeps reporting as
+            # running until it transitions to RestartingState.
             pass
 
     def before_worker_group_start(self, worker_group_context: WorkerGroupContext):

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -67,6 +67,12 @@ DEFAULT_ENABLE_PREEMPTION_WATCHER: bool = True
 PREEMPTION_POLL_INTERVAL_S_ENV_VAR = "RAY_TRAIN_PREEMPTION_POLL_INTERVAL_S"
 DEFAULT_PREEMPTION_POLL_INTERVAL_S: float = 5.0
 
+# Fallback grace window used by the controller while draining after a preemption
+# when Ray Core reports no deadline (deadline unknown). Sized to the shortest
+# common cloud reclaim notice (AWS spot gives ~120s) so we don't wait forever
+# for workers to exit before forcing a restart.
+DEFAULT_PREEMPTION_DEADLINE_S: float = 120.0
+
 # Environment variable to enable the print function patching.
 ENABLE_PRINT_PATCH_ENV_VAR = "RAY_TRAIN_ENABLE_PRINT_PATCH"
 DEFAULT_ENABLE_PRINT_PATCH = True

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -67,10 +67,9 @@ DEFAULT_ENABLE_PREEMPTION_WATCHER: bool = True
 PREEMPTION_POLL_INTERVAL_S_ENV_VAR = "RAY_TRAIN_PREEMPTION_POLL_INTERVAL_S"
 DEFAULT_PREEMPTION_POLL_INTERVAL_S: float = 5.0
 
-# Fallback grace window used by the controller while draining after a preemption
-# when Ray Core reports no deadline (deadline unknown). Sized to the shortest
-# common cloud reclaim notice (AWS spot gives ~120s) so we don't wait forever
-# for workers to exit before forcing a restart.
+# Fallback grace window the controller waits in PreemptingState when Ray Core
+# reports no reclaim deadline (deadline unknown). Only used as a default when
+# the deadline is unknown; a reported deadline is always respected as-is.
 DEFAULT_PREEMPTION_DEADLINE_S: float = 120.0
 
 # Environment variable to enable the print function patching.

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -55,6 +55,7 @@ from ray.train.v2._internal.execution.failure_handling import (
     FailureDecision,
     FailurePolicy,
 )
+from ray.train.v2._internal.execution.preemption import merge_preemption_info
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
@@ -652,20 +653,13 @@ class TrainController:
         elif isinstance(controller_state, RunningState):
             worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-            if worker_group_status.finished and not worker_group_status.errors:
-                self._return_value = worker_group_status.worker_statuses[0].return_value
-                return TrainControllerLoopIterationResult(
-                    run_attempt_id=self._get_run_attempt_id(),
-                    previous_state=controller_state,
-                    next_state=ShuttingDownState(
-                        next_state=FinishedState(),
-                    ),
-                )
-
             # A worker echoed a preemption signal: move to PreemptingState and
-            # let the worker group drain before restarting. Checked before the
-            # error branch so that workers killed by the preemption are counted
-            # against the preemption retry budget rather than `max_failures`.
+            # let the worker group drain before restarting. Checked before both
+            # the completion and error branches: a worker may react to the
+            # signal by checkpointing and returning (a clean exit) or be killed
+            # when its node is reclaimed (an error). Either way we want to drain
+            # and restart against the preemption retry budget, rather than
+            # finishing the run or charging it against `max_failures`.
             preemption_info = worker_group_status.get_preemption_info()
             if preemption_info is not None:
                 return TrainControllerLoopIterationResult(
@@ -674,6 +668,16 @@ class TrainController:
                     next_state=PreemptingState(
                         preemption_info=preemption_info,
                         detected_at_s=time_seconds(),
+                    ),
+                )
+
+            if worker_group_status.finished and not worker_group_status.errors:
+                self._return_value = worker_group_status.worker_statuses[0].return_value
+                return TrainControllerLoopIterationResult(
+                    run_attempt_id=self._get_run_attempt_id(),
+                    previous_state=controller_state,
+                    next_state=ShuttingDownState(
+                        next_state=FinishedState(),
                     ),
                 )
 
@@ -759,10 +763,16 @@ class TrainController:
         worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
         # Keep the preemption info current as additional nodes are drained.
-        preemption_info = (
-            worker_group_status.get_preemption_info()
-            or controller_state.preemption_info
-        )
+        # Merge rather than overwrite so a staggered preemption (or a node
+        # dropping out of the draining list once it's gone) doesn't erase
+        # earlier preempted nodes/ranks from the final PreemptionError.
+        new_preemption_info = worker_group_status.get_preemption_info()
+        if new_preemption_info is not None:
+            preemption_info = merge_preemption_info(
+                controller_state.preemption_info, new_preemption_info
+            )
+        else:
+            preemption_info = controller_state.preemption_info
         deadline_exceeded = self._is_preemption_deadline_exceeded(
             preemption_info, controller_state.detected_at_s
         )

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -14,6 +14,7 @@ from ray.train.v2._internal.constants import (
     DEFAULT_ENABLE_CONTROLLER_LOGGING,
     DEFAULT_ENABLE_PREEMPTION_WATCHER,
     DEFAULT_HEALTH_CHECK_INTERVAL_S,
+    DEFAULT_PREEMPTION_DEADLINE_S,
     ENABLE_CONTROLLER_STRUCTURED_LOGGING_ENV_VAR,
     ENABLE_PREEMPTION_WATCHER_ENV_VAR,
     HEALTH_CHECK_INTERVAL_S_ENV_VAR,
@@ -670,7 +671,10 @@ class TrainController:
                 return TrainControllerLoopIterationResult(
                     run_attempt_id=self._get_run_attempt_id(),
                     previous_state=controller_state,
-                    next_state=PreemptingState(preemption_info=preemption_info),
+                    next_state=PreemptingState(
+                        preemption_info=preemption_info,
+                        detected_at_s=time_seconds(),
+                    ),
                 )
 
             if worker_group_status.errors:
@@ -721,15 +725,19 @@ class TrainController:
     @staticmethod
     def _is_preemption_deadline_exceeded(
         preemption_info: "PreemptionInfo",
+        detected_at_s: float,
     ) -> bool:
         """Whether the preemption reclaim deadline has passed.
 
         `deadline_ms` mirrors Ray Core's draining deadline: an epoch timestamp
-        in milliseconds, or None when no deadline is known.
+        in milliseconds. Ray Core reports 0 (which the watcher maps to None)
+        when no deadline is known, in which case we cap the drain wait at
+        `DEFAULT_PREEMPTION_DEADLINE_S` from when the preemption was first
+        detected, so we never wait indefinitely for workers to exit.
         """
         deadline_ms = preemption_info.deadline_ms
         if deadline_ms is None:
-            return False
+            deadline_ms = (detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S) * 1000
         return time_seconds() * 1000 >= deadline_ms
 
     async def _handle_preempting_state(
@@ -738,11 +746,15 @@ class TrainController:
         """Wait for the worker group to drain after a preemption, then restart.
 
         Polls the worker group until either all workers have exited or the
-        preemption deadline elapses, whichever comes first, then synthesizes a
-        `PreemptionError` and routes it through the failure policy (which
-        consumes the separate `max_preemption_failures` budget). A RETRY
-        decision transitions to RestartingState, which tears down and recreates
-        the worker group on healthy nodes.
+        preemption deadline elapses (capped at `DEFAULT_PREEMPTION_DEADLINE_S`
+        when the deadline is unknown), whichever comes first. It then
+        synthesizes a `PreemptionError` and routes it through the failure
+        policy, which consumes the separate `max_preemption_failures` budget:
+        while that budget remains (it is unlimited by default), the decision is
+        RETRY and we transition to RestartingState, which tears down and
+        recreates the worker group on healthy nodes; once the budget is
+        exhausted the decision is RAISE and we transition to ShuttingDownState
+        followed by ErroredState.
         """
         worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
@@ -751,7 +763,9 @@ class TrainController:
             worker_group_status.get_preemption_info()
             or controller_state.preemption_info
         )
-        deadline_exceeded = self._is_preemption_deadline_exceeded(preemption_info)
+        deadline_exceeded = self._is_preemption_deadline_exceeded(
+            preemption_info, controller_state.detected_at_s
+        )
 
         # Stay in PreemptingState until the workers exit on their own or the
         # reclaim deadline passes.
@@ -759,13 +773,18 @@ class TrainController:
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
                 previous_state=controller_state,
-                next_state=PreemptingState(preemption_info=preemption_info),
+                next_state=PreemptingState(
+                    preemption_info=preemption_info,
+                    detected_at_s=controller_state.detected_at_s,
+                ),
             )
 
+        # True when the deadline forced teardown before every rank had exited.
+        drain_timed_out = deadline_exceeded and not worker_group_status.finished
         preemption_error = PreemptionError(
             preemption_info=preemption_info,
             worker_failures=worker_group_status.errors,
-            deadline_exceeded=deadline_exceeded,
+            drain_timed_out=drain_timed_out,
         )
         failure_decision = self._failure_policy.make_decision(
             training_failed_error=preemption_error,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -41,6 +41,7 @@ from ray.train.v2._internal.execution.controller.state import (
     ErroredState,
     FinishedState,
     InitializingState,
+    PreemptingState,
     ReschedulingState,
     ResizingState,
     RestartingState,
@@ -64,10 +65,15 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
 )
 from ray.train.v2._internal.logging import LoggingManager
-from ray.train.v2._internal.util import ObjectRefWrapper, time_monotonic
+from ray.train.v2._internal.util import (
+    ObjectRefWrapper,
+    time_monotonic,
+    time_seconds,
+)
 from ray.train.v2.api.callback import RayTrainCallback
 from ray.train.v2.api.exceptions import (
     ControllerError,
+    PreemptionError,
     TrainingFailedError,
 )
 from ray.train.v2.api.report_config import CheckpointConsistencyMode
@@ -75,6 +81,7 @@ from ray.train.v2.api.result import Result
 from ray.train.v2.api.validation_config import ValidationConfig
 
 if TYPE_CHECKING:
+    from ray.train.v2._internal.execution.preemption import PreemptionInfo
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint
 
 from ray.util.tpu import get_tpu_num_slices_for_workers
@@ -342,7 +349,7 @@ class TrainController:
         controller_state: TrainControllerState,
         training_failed_error: TrainingFailedError,
     ) -> TrainControllerState:
-        if isinstance(controller_state, RunningState):
+        if isinstance(controller_state, (RunningState, PreemptingState)):
             return RestartingState(training_failed_error=training_failed_error)
         elif isinstance(controller_state, SchedulingState):
             return ReschedulingState(training_failed_error=training_failed_error)
@@ -653,6 +660,19 @@ class TrainController:
                         next_state=FinishedState(),
                     ),
                 )
+
+            # A worker echoed a preemption signal: move to PreemptingState and
+            # let the worker group drain before restarting. Checked before the
+            # error branch so that workers killed by the preemption are counted
+            # against the preemption retry budget rather than `max_failures`.
+            preemption_info = worker_group_status.get_preemption_info()
+            if preemption_info is not None:
+                return TrainControllerLoopIterationResult(
+                    run_attempt_id=self._get_run_attempt_id(),
+                    previous_state=controller_state,
+                    next_state=PreemptingState(preemption_info=preemption_info),
+                )
+
             if worker_group_status.errors:
                 worker_group_error = worker_group_status.get_worker_group_error()
                 failure_decision = self._failure_policy.make_decision(
@@ -683,6 +703,8 @@ class TrainController:
                 previous_state=controller_state,
                 next_state=next_state,
             )
+        elif isinstance(controller_state, PreemptingState):
+            return await self._handle_preempting_state(controller_state)
         elif isinstance(controller_state, ResizingState):
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
@@ -695,6 +717,62 @@ class TrainController:
             return await self._shutdown()
         else:
             raise ValueError(f"Unexpected controller state: {controller_state}")
+
+    @staticmethod
+    def _is_preemption_deadline_exceeded(
+        preemption_info: "PreemptionInfo",
+    ) -> bool:
+        """Whether the preemption reclaim deadline has passed.
+
+        `deadline_ms` mirrors Ray Core's draining deadline: an epoch timestamp
+        in milliseconds, or None when no deadline is known.
+        """
+        deadline_ms = preemption_info.deadline_ms
+        if deadline_ms is None:
+            return False
+        return time_seconds() * 1000 >= deadline_ms
+
+    async def _handle_preempting_state(
+        self, controller_state: PreemptingState
+    ) -> TrainControllerLoopIterationResult:
+        """Wait for the worker group to drain after a preemption, then restart.
+
+        Polls the worker group until either all workers have exited or the
+        preemption deadline elapses, whichever comes first, then synthesizes a
+        `PreemptionError` and routes it through the failure policy (which
+        consumes the separate `max_preemption_failures` budget). A RETRY
+        decision transitions to RestartingState, which tears down and recreates
+        the worker group on healthy nodes.
+        """
+        worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
+
+        # Keep the preemption info current as additional nodes are drained.
+        preemption_info = (
+            worker_group_status.get_preemption_info()
+            or controller_state.preemption_info
+        )
+        deadline_exceeded = self._is_preemption_deadline_exceeded(preemption_info)
+
+        # Stay in PreemptingState until the workers exit on their own or the
+        # reclaim deadline passes.
+        if not worker_group_status.finished and not deadline_exceeded:
+            return TrainControllerLoopIterationResult(
+                run_attempt_id=self._get_run_attempt_id(),
+                previous_state=controller_state,
+                next_state=PreemptingState(preemption_info=preemption_info),
+            )
+
+        preemption_error = PreemptionError(
+            preemption_info=preemption_info,
+            worker_failures=worker_group_status.errors,
+            deadline_exceeded=deadline_exceeded,
+        )
+        failure_decision = self._failure_policy.make_decision(
+            training_failed_error=preemption_error,
+        )
+        return self._execute_failure_decision(
+            failure_decision, training_failed_error=preemption_error
+        )
 
     def _generate_run_attempt_id(self):
         self._run_attempt_id = uuid.uuid4().hex

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -672,6 +672,9 @@ class TrainController:
                 )
 
             if worker_group_status.finished and not worker_group_status.errors:
+                self._warn_if_finished_during_preemption(
+                    worker_group_status.get_preemption_info()
+                )
                 self._return_value = worker_group_status.worker_statuses[0].return_value
                 return TrainControllerLoopIterationResult(
                     run_attempt_id=self._get_run_attempt_id(),
@@ -741,6 +744,29 @@ class TrainController:
         """
         return worker_group_status.finished and not worker_group_status.errors
 
+    @staticmethod
+    def _warn_if_finished_during_preemption(
+        preemption_info: Optional["PreemptionInfo"],
+    ) -> None:
+        """Warn when a run finishes while a preemption signal is active.
+
+        A clean return always finishes the run, so a training function that
+        returns early after a just-in-time checkpoint -- expecting Ray Train to
+        restart it -- silently truncates training instead. Surface that loudly
+        so the misuse is caught at the moment it happens.
+        """
+        if preemption_info is None:
+            return
+        logger.warning(
+            "Training finished while a preemption was in progress "
+            f"(preempted_ranks={preemption_info.preempted_ranks}). If this was "
+            "intentional, ignore this warning. If you intended to resume after "
+            "the preemption instead, do not return from your training function "
+            "when `ray.train.get_preemption_info()` is set -- save a checkpoint "
+            "and continue training; Ray Train restarts and resumes the run when "
+            "the node is actually reclaimed."
+        )
+
     @classmethod
     def _preemption_to_drain(
         cls, worker_group_status: WorkerGroupPollStatus
@@ -800,6 +826,10 @@ class TrainController:
         # killed worker or a passed deadline fall through to the restart path
         # below.)
         if self._is_genuine_completion(worker_group_status):
+            self._warn_if_finished_during_preemption(
+                worker_group_status.get_preemption_info()
+                or controller_state.preemption_info
+            )
             self._return_value = worker_group_status.worker_statuses[0].return_value
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -798,14 +798,18 @@ class TrainController:
 
         Exits the drain on the first of:
         - Training is done (all ranks returned cleanly): the run finishes.
-        - A worker errors: routed through the failure policy, which charges the
-          preemption budget if a worker was killed by the reclaim
-          (`RayActorError.preempted`) and `max_failures` otherwise (e.g. a bug
-          in the training function while draining).
-        - The reclaim deadline elapses (capped at
-          `DEFAULT_PREEMPTION_DEADLINE_S` when unknown) with workers still
-          running: force a teardown via a `PreemptionError` with
-          `drain_timed_out=True`.
+        - A worker errors with something that is NOT a reclaim kill (e.g. a bug
+          in the training function while draining): routed through the normal
+          WorkerGroupError path, charged against `max_failures`.
+        - Every rank has exited (typically killed by the reclaim,
+          `RayActorError.preempted`) or the reclaim deadline elapses (capped at
+          `DEFAULT_PREEMPTION_DEADLINE_S` when unknown) with ranks still
+          running: a `PreemptionError` is routed through the failure policy,
+          charged against `max_preemption_failures`.
+
+        Reclaim kills of a subset of ranks do NOT end the drain: the healthy
+        ranks keep running (e.g. finishing emergency checkpoints) until every
+        rank has exited or the deadline passes.
 
         On RETRY the run transitions to RestartingState (fresh worker group on
         healthy nodes, resuming from the latest checkpoint); once the relevant
@@ -828,11 +832,15 @@ class TrainController:
                 ),
             )
 
-        # A worker errored while draining. The failure policy classifies it:
-        # a reclaim kill (RayActorError.preempted) is charged against the
-        # preemption budget, anything else (e.g. a bug in the training
-        # function's just-in-time checkpoint) against `max_failures`.
-        if worker_group_status.errors:
+        # Worker errors that are NOT reclaim kills (e.g. a bug in the training
+        # function's just-in-time checkpoint) are real failures: fail fast
+        # through the normal WorkerGroupError path so they are charged against
+        # `max_failures`, not the (unlimited-by-default) preemption budget.
+        # Reclaim kills are part of the drain and handled below.
+        if (
+            worker_group_status.errors
+            and not worker_group_status.has_preempted_worker()
+        ):
             worker_group_error = worker_group_status.get_worker_group_error()
             failure_decision = self._failure_policy.make_decision(
                 training_failed_error=worker_group_error,
@@ -841,9 +849,9 @@ class TrainController:
                 failure_decision, training_failed_error=worker_group_error
             )
 
-        # All workers are still running. Keep the preemption info current as
-        # additional nodes are drained: merge rather than overwrite so a
-        # staggered preemption doesn't erase earlier preempted nodes/ranks.
+        # Keep the preemption info current as additional nodes are drained:
+        # merge rather than overwrite so a staggered preemption doesn't erase
+        # earlier preempted nodes/ranks.
         new_preemption_info = worker_group_status.get_preemption_info()
         if new_preemption_info is not None:
             preemption_info = merge_preemption_info(
@@ -852,10 +860,17 @@ class TrainController:
         else:
             preemption_info = controller_state.preemption_info
 
-        # Stay in PreemptingState until the reclaim deadline passes.
-        if not self._is_preemption_deadline_exceeded(
+        # Stay in PreemptingState while ranks are still running and the reclaim
+        # deadline has not passed, even if some ranks were already killed by
+        # the reclaim -- the healthy ranks keep training/checkpointing.
+        # TODO(lehui): Decouple the worker group teardown from the node reclaim
+        # deadline (e.g. a configurable grace period and a survivor emergency
+        # checkpoint via a relaxed report() barrier) so healthy ranks can be
+        # held deliberately rather than until the cloud's deadline.
+        deadline_exceeded = self._is_preemption_deadline_exceeded(
             preemption_info, controller_state.detected_at_s
-        ):
+        )
+        if not worker_group_status.finished and not deadline_exceeded:
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
                 previous_state=controller_state,
@@ -865,10 +880,13 @@ class TrainController:
                 ),
             )
 
-        # The deadline passed with workers still running: force a teardown.
+        # The drain ended: every rank exited (reclaim kills carried in
+        # `worker_failures`) or the deadline forced a teardown with ranks still
+        # running (`drain_timed_out=True`).
         preemption_error = PreemptionError(
             preemption_info=preemption_info,
-            drain_timed_out=True,
+            worker_failures=worker_group_status.errors,
+            drain_timed_out=not worker_group_status.finished,
         )
         failure_decision = self._failure_policy.make_decision(
             training_failed_error=preemption_error,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -739,23 +739,15 @@ class TrainController:
         """Whether the preemption reclaim deadline has passed.
 
         `deadline_ms` mirrors Ray Core's draining deadline: an epoch timestamp
-        in milliseconds. Ray Core reports 0 (which the watcher maps to None)
-        when no deadline is known.
-
-        `DEFAULT_PREEMPTION_DEADLINE_S` (measured from when the preemption was
-        first detected) bounds the wait: it is the fallback when no deadline is
-        reported, and also a hard upper bound when one is -- so a reported (or,
-        after a staggered merge, a far-future) deadline can never keep us in
-        PreemptingState longer than the cap. Real cloud grace periods are short
-        (e.g. ~120s for AWS spot), so this only bites an anomalous or merged
-        far-future deadline.
+        in milliseconds, respected as-is (a staggered merge keeps the earliest
+        across all preempted nodes). Ray Core reports 0 (which the watcher maps
+        to None) when no deadline is known, in which case we fall back to
+        `DEFAULT_PREEMPTION_DEADLINE_S` from when the preemption was first
+        detected so we never wait indefinitely for the workers to exit.
         """
-        fallback_deadline_ms = (detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S) * 1000
         deadline_ms = preemption_info.deadline_ms
         if deadline_ms is None:
-            deadline_ms = fallback_deadline_ms
-        else:
-            deadline_ms = min(deadline_ms, fallback_deadline_ms)
+            deadline_ms = (detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S) * 1000
         return time_seconds() * 1000 >= deadline_ms
 
     async def _handle_preempting_state(
@@ -763,34 +755,17 @@ class TrainController:
     ) -> TrainControllerLoopIterationResult:
         """Wait out the preemption grace window, then restart or finish.
 
-        Terminology: Ray Core marks a preempted node as *draining* and reports
-        the cloud's *reclaim deadline* -- the time at which the node will be
-        taken away, killing the workers on it (such a death carries
-        `RayActorError.preempted`). While in PreemptingState, Ray Train keeps
-        the surviving workers running (e.g. to finish just-in-time checkpoints)
-        for as much of that grace window as possible.
-
-        Exits on the first of:
-        - Training is done (all ranks returned cleanly): the run finishes.
-        - A worker errors with something that is NOT a preemption-caused death
-          (e.g. a bug in the training function): routed through the normal
-          WorkerGroupError path, charged against `max_failures`.
-        - Every rank has exited, or the reclaim deadline passes (capped at
-          `DEFAULT_PREEMPTION_DEADLINE_S` when the cloud reports none) with
-          ranks still running: a `PreemptionError` is routed through the
-          failure policy, charged against `max_preemption_failures`.
-
-        A preemption-caused death of a subset of ranks does NOT end the wait:
-        the healthy ranks keep running until every rank has exited or the
-        deadline passes.
-
-        On RETRY the run transitions to RestartingState (fresh worker group on
-        healthy nodes, resuming from the latest checkpoint); once the relevant
-        budget is exhausted, to ShuttingDownState then ErroredState.
+        A preemption drains the affected nodes: Ray Core marks them draining and
+        (usually) reports a reclaim deadline. While draining, the healthy ranks
+        keep running so they can finish just-in-time checkpoints. Terminal
+        transitions are handled first -- training finished, a non-reclaim worker
+        error, or the drain completing (all ranks exited or the deadline
+        passed); otherwise the run stays in PreemptingState and keeps draining.
+        The failure policy decides retry-vs-raise for any resulting error.
         """
         worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-        # The workers returned cleanly (no errors) -> training is done.
+        # Training finished cleanly before the reclaim.
         if self._is_training_done(worker_group_status):
             self._return_value = worker_group_status.worker_statuses[0].return_value
             return TrainControllerLoopIterationResult(
@@ -801,17 +776,9 @@ class TrainController:
                 ),
             )
 
-        # Worker errors that are NOT preemption-caused deaths (e.g. a bug in
-        # the training function's just-in-time checkpoint) are real failures:
-        # fail fast through the normal WorkerGroupError path so they are
-        # charged against `max_failures`, not the (unlimited-by-default)
-        # preemption budget. If a preemption-caused death is present alongside
-        # other errors, the preemption wins the tie: when one rank dies, the
-        # surviving ranks routinely fail with collateral errors (collective
-        # aborts, connection resets), so treating any mixed poll as a worker
-        # failure would misclassify most real preemptions. A genuine bug that
-        # coincided with a preemption re-fires on the next attempt without a
-        # preemption present and is charged to `max_failures` then.
+        # A worker failed for a reason other than the reclaim -> fail fast
+        # rather than waiting out the drain. The failure policy classifies
+        # reclaim deaths vs. real failures.
         if (
             worker_group_status.errors
             and not worker_group_status.has_preempted_worker()
@@ -824,50 +791,43 @@ class TrainController:
                 failure_decision, training_failed_error=worker_group_error
             )
 
-        # Keep the preemption info current as additional nodes are preempted:
-        # merge rather than overwrite so a staggered preemption doesn't erase
-        # earlier preempted nodes/ranks.
+        # Merge staggered preemptions so the signal covers every drained node.
         new_preemption_info = worker_group_status.get_preemption_info()
-        if new_preemption_info is not None:
-            preemption_info = merge_preemption_info(
-                controller_state.preemption_info, new_preemption_info
-            )
-        else:
-            preemption_info = controller_state.preemption_info
+        preemption_info = (
+            merge_preemption_info(controller_state.preemption_info, new_preemption_info)
+            if new_preemption_info is not None
+            else controller_state.preemption_info
+        )
 
-        # Stay in PreemptingState while ranks are still running and the reclaim
-        # deadline has not passed, even if some ranks were already killed by
-        # the preemption -- the healthy ranks keep training/checkpointing.
-        # TODO(lehui): Decouple the worker group teardown from the node reclaim
-        # deadline (e.g. a configurable grace period and a survivor emergency
-        # checkpoint via a relaxed report() barrier) so healthy ranks can be
-        # held deliberately rather than until the cloud's deadline.
+        # Drain complete (all ranks exited, or the reclaim deadline passed) ->
+        # restart or raise via the preemption budget.
         deadline_exceeded = self._is_preemption_deadline_exceeded(
             preemption_info, controller_state.detected_at_s
         )
-        if not worker_group_status.finished and not deadline_exceeded:
-            return TrainControllerLoopIterationResult(
-                run_attempt_id=self._get_run_attempt_id(),
-                previous_state=controller_state,
-                next_state=PreemptingState(
-                    preemption_info=preemption_info,
-                    detected_at_s=controller_state.detected_at_s,
-                ),
+        if worker_group_status.finished or deadline_exceeded:
+            preemption_error = PreemptionError(
+                preemption_info=preemption_info,
+                drain_timed_out=not worker_group_status.finished,
+            )
+            failure_decision = self._failure_policy.make_decision(
+                training_failed_error=preemption_error,
+            )
+            return self._execute_failure_decision(
+                failure_decision, training_failed_error=preemption_error
             )
 
-        # The grace window is over: every rank exited (preemption-caused deaths
-        # carried in `worker_failures`) or the deadline forced a teardown with
-        # ranks still running (`drain_timed_out=True`).
-        preemption_error = PreemptionError(
-            preemption_info=preemption_info,
-            worker_failures=worker_group_status.errors,
-            drain_timed_out=not worker_group_status.finished,
-        )
-        failure_decision = self._failure_policy.make_decision(
-            training_failed_error=preemption_error,
-        )
-        return self._execute_failure_decision(
-            failure_decision, training_failed_error=preemption_error
+        # Otherwise keep draining: the healthy ranks keep training/checkpointing
+        # until every rank has exited or the deadline passes.
+        # TODO(lehui): decouple the teardown from the cloud's reclaim deadline
+        # (configurable grace period + survivor emergency checkpoint) so healthy
+        # ranks can be held deliberately rather than until the deadline.
+        return TrainControllerLoopIterationResult(
+            run_attempt_id=self._get_run_attempt_id(),
+            previous_state=controller_state,
+            next_state=PreemptingState(
+                preemption_info=preemption_info,
+                detected_at_s=controller_state.detected_at_s,
+            ),
         )
 
     def _generate_run_attempt_id(self):

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -653,7 +653,7 @@ class TrainController:
         elif isinstance(controller_state, RunningState):
             worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-            if self._is_training_done(worker_group_status):
+            if self._is_training_succeeded(worker_group_status):
                 self._return_value = worker_group_status.worker_statuses[0].return_value
                 return TrainControllerLoopIterationResult(
                     run_attempt_id=self._get_run_attempt_id(),
@@ -665,9 +665,6 @@ class TrainController:
 
             # A node hosting one of the workers is being preempted: move to
             # PreemptingState to wait out the grace window before restarting.
-            # Checked before the error branch so that a worker killed by the
-            # preemption is charged against `max_preemption_failures` rather
-            # than `max_failures`.
             preemption_info = worker_group_status.get_preemption_info()
             if preemption_info is not None:
                 return TrainControllerLoopIterationResult(
@@ -725,10 +722,10 @@ class TrainController:
             raise ValueError(f"Unexpected controller state: {controller_state}")
 
     @staticmethod
-    def _is_training_done(
+    def _is_training_succeeded(
         worker_group_status: WorkerGroupPollStatus,
     ) -> bool:
-        """Whether every rank exited cleanly (returned without error)."""
+        """Whether every rank exited successfully."""
         return worker_group_status.finished and not worker_group_status.errors
 
     @staticmethod
@@ -736,14 +733,12 @@ class TrainController:
         preemption_info: "PreemptionInfo",
         detected_at_s: float,
     ) -> bool:
-        """Whether the preemption reclaim deadline has passed.
+        """Whether the preemption deadline has passed.
 
-        `deadline_ms` mirrors Ray Core's draining deadline: an epoch timestamp
-        in milliseconds, respected as-is (a staggered merge keeps the earliest
-        across all preempted nodes). Ray Core reports 0 (which the watcher maps
-        to None) when no deadline is known, in which case we fall back to
-        `DEFAULT_PREEMPTION_DEADLINE_S` from when the preemption was first
-        detected so we never wait indefinitely for the workers to exit.
+        `deadline_ms` is when the preempted node will be taken away (epoch ms),
+        used as-is. When it is unknown (None), fall back to
+        `DEFAULT_PREEMPTION_DEADLINE_S` after the preemption was first detected
+        so we don't wait forever.
         """
         deadline_ms = preemption_info.deadline_ms
         if deadline_ms is None:
@@ -753,20 +748,10 @@ class TrainController:
     async def _handle_preempting_state(
         self, controller_state: PreemptingState
     ) -> TrainControllerLoopIterationResult:
-        """Wait out the preemption grace window, then restart or finish.
-
-        A preemption drains the affected nodes: Ray Core marks them draining and
-        (usually) reports a reclaim deadline. While draining, the healthy ranks
-        keep running so they can finish just-in-time checkpoints. Terminal
-        transitions are handled first -- training finished, a non-reclaim worker
-        error, or the drain completing (all ranks exited or the deadline
-        passed); otherwise the run stays in PreemptingState and keeps draining.
-        The failure policy decides retry-vs-raise for any resulting error.
-        """
         worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-        # Training finished cleanly before the reclaim.
-        if self._is_training_done(worker_group_status):
+        # Training finished successfully before the preemption.
+        if self._is_training_succeeded(worker_group_status):
             self._return_value = worker_group_status.worker_statuses[0].return_value
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
@@ -776,9 +761,7 @@ class TrainController:
                 ),
             )
 
-        # A worker failed for a reason other than the reclaim -> fail fast
-        # rather than waiting out the drain. The failure policy classifies
-        # reclaim deaths vs. real failures.
+        # A worker failed for a reason other than the preemption should fail fast.
         if (
             worker_group_status.errors
             and not worker_group_status.has_preempted_worker()
@@ -791,7 +774,7 @@ class TrainController:
                 failure_decision, training_failed_error=worker_group_error
             )
 
-        # Merge staggered preemptions so the signal covers every drained node.
+        # Merge any new preemption info so the info covers every preempted node.
         new_preemption_info = worker_group_status.get_preemption_info()
         preemption_info = (
             merge_preemption_info(controller_state.preemption_info, new_preemption_info)
@@ -799,8 +782,6 @@ class TrainController:
             else controller_state.preemption_info
         )
 
-        # Drain complete (all ranks exited, or the reclaim deadline passed) ->
-        # restart or raise via the preemption budget.
         deadline_exceeded = self._is_preemption_deadline_exceeded(
             preemption_info, controller_state.detected_at_s
         )
@@ -816,11 +797,8 @@ class TrainController:
                 failure_decision, training_failed_error=preemption_error
             )
 
-        # Otherwise keep draining: the healthy ranks keep training/checkpointing
-        # until every rank has exited or the deadline passes.
-        # TODO(lehui): decouple the teardown from the cloud's reclaim deadline
-        # (configurable grace period + survivor emergency checkpoint) so healthy
-        # ranks can be held deliberately rather than until the deadline.
+        # Otherwise the preemption is still in progress: keep the healthy ranks
+        # running until every rank exits or the deadline passes.
         return TrainControllerLoopIterationResult(
             run_attempt_id=self._get_run_attempt_id(),
             previous_state=controller_state,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -740,13 +740,22 @@ class TrainController:
 
         `deadline_ms` mirrors Ray Core's draining deadline: an epoch timestamp
         in milliseconds. Ray Core reports 0 (which the watcher maps to None)
-        when no deadline is known, in which case we cap the drain wait at
-        `DEFAULT_PREEMPTION_DEADLINE_S` from when the preemption was first
-        detected, so we never wait indefinitely for workers to exit.
+        when no deadline is known.
+
+        `DEFAULT_PREEMPTION_DEADLINE_S` (measured from when the preemption was
+        first detected) bounds the wait: it is the fallback when no deadline is
+        reported, and also a hard upper bound when one is -- so a reported (or,
+        after a staggered merge, a far-future) deadline can never keep us in
+        PreemptingState longer than the cap. Real cloud grace periods are short
+        (e.g. ~120s for AWS spot), so this only bites an anomalous or merged
+        far-future deadline.
         """
+        fallback_deadline_ms = (detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S) * 1000
         deadline_ms = preemption_info.deadline_ms
         if deadline_ms is None:
-            deadline_ms = (detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S) * 1000
+            deadline_ms = fallback_deadline_ms
+        else:
+            deadline_ms = min(deadline_ms, fallback_deadline_ms)
         return time_seconds() * 1000 >= deadline_ms
 
     async def _handle_preempting_state(

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -653,14 +653,14 @@ class TrainController:
         elif isinstance(controller_state, RunningState):
             worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-            # A worker echoed a preemption signal: move to PreemptingState and
-            # let the worker group drain before restarting. Checked before both
-            # the completion and error branches: a worker may react to the
-            # signal by checkpointing and returning (a clean exit) or be killed
-            # when its node is reclaimed (an error). Either way we want to drain
-            # and restart against the preemption retry budget, rather than
-            # finishing the run or charging it against `max_failures`.
-            preemption_info = worker_group_status.get_preemption_info()
+            # A preemption is in progress: move to PreemptingState and let the
+            # worker group drain before restarting. Checked before both the
+            # completion and error branches so that a worker killed when its
+            # node is reclaimed is charged against the preemption retry budget
+            # rather than `max_failures`. `_preemption_to_drain` returns None for
+            # a genuine completion (a clean return with no errors), letting it
+            # fall through to the finished branch below.
+            preemption_info = self._preemption_to_drain(worker_group_status)
             if preemption_info is not None:
                 return TrainControllerLoopIterationResult(
                     run_attempt_id=self._get_run_attempt_id(),
@@ -727,6 +727,36 @@ class TrainController:
             raise ValueError(f"Unexpected controller state: {controller_state}")
 
     @staticmethod
+    def _is_genuine_completion(
+        worker_group_status: WorkerGroupPollStatus,
+    ) -> bool:
+        """Whether a clean finish should be treated as a genuine completion.
+
+        True when every rank exited cleanly (returned without error). A run that
+        returns cleanly finishes regardless of any preemption signal -- the
+        training function is expected to react to a preemption by checkpointing
+        and continuing, and be restarted when its node is actually reclaimed (a
+        worker error) or the reclaim deadline elapses, not by returning early.
+        A killed worker (error) makes this False.
+        """
+        return worker_group_status.finished and not worker_group_status.errors
+
+    @classmethod
+    def _preemption_to_drain(
+        cls, worker_group_status: WorkerGroupPollStatus
+    ) -> Optional["PreemptionInfo"]:
+        """The preemption that should move the run into PreemptingState, if any.
+
+        Returns the echoed `PreemptionInfo` unless the poll is a genuine
+        completion (see `_is_genuine_completion`), in which case it returns None
+        so the caller lets the run finish normally.
+        """
+        preemption_info = worker_group_status.get_preemption_info()
+        if preemption_info is None or cls._is_genuine_completion(worker_group_status):
+            return None
+        return preemption_info
+
+    @staticmethod
     def _is_preemption_deadline_exceeded(
         preemption_info: "PreemptionInfo",
         detected_at_s: float,
@@ -759,8 +789,25 @@ class TrainController:
         recreates the worker group on healthy nodes; once the budget is
         exhausted the decision is RAISE and we transition to ShuttingDownState
         followed by ErroredState.
+
+        If instead the workers return cleanly (no errors) while draining, the run
+        is treated as a genuine completion and transitions to FinishedState --
+        the training function finished before its node was reclaimed.
         """
         worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
+
+        # The workers returned cleanly (no errors) -> genuine completion. (A
+        # killed worker or a passed deadline fall through to the restart path
+        # below.)
+        if self._is_genuine_completion(worker_group_status):
+            self._return_value = worker_group_status.worker_statuses[0].return_value
+            return TrainControllerLoopIterationResult(
+                run_attempt_id=self._get_run_attempt_id(),
+                previous_state=controller_state,
+                next_state=ShuttingDownState(
+                    next_state=FinishedState(),
+                ),
+            )
 
         # Keep the preemption info current as additional nodes are drained.
         # Merge rather than overwrite so a staggered preemption (or a node

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -657,9 +657,9 @@ class TrainController:
             # worker group drain before restarting. Checked before both the
             # completion and error branches so that a worker killed when its
             # node is reclaimed is charged against the preemption retry budget
-            # rather than `max_failures`. `_preemption_to_drain` returns None for
-            # a genuine completion (a clean return with no errors), letting it
-            # fall through to the finished branch below.
+            # rather than `max_failures`. `_preemption_to_drain` returns None
+            # when training is done, letting it fall through to the finished
+            # branch below.
             preemption_info = self._preemption_to_drain(worker_group_status)
             if preemption_info is not None:
                 return TrainControllerLoopIterationResult(
@@ -671,7 +671,7 @@ class TrainController:
                     ),
                 )
 
-            if worker_group_status.finished and not worker_group_status.errors:
+            if self._is_training_done(worker_group_status):
                 self._warn_if_finished_during_preemption(
                     worker_group_status.get_preemption_info()
                 )
@@ -730,18 +730,10 @@ class TrainController:
             raise ValueError(f"Unexpected controller state: {controller_state}")
 
     @staticmethod
-    def _is_genuine_completion(
+    def _is_training_done(
         worker_group_status: WorkerGroupPollStatus,
     ) -> bool:
-        """Whether a clean finish should be treated as a genuine completion.
-
-        True when every rank exited cleanly (returned without error). A run that
-        returns cleanly finishes regardless of any preemption signal -- the
-        training function is expected to react to a preemption by checkpointing
-        and continuing, and be restarted when its node is actually reclaimed (a
-        worker error) or the reclaim deadline elapses, not by returning early.
-        A killed worker (error) makes this False.
-        """
+        """Whether every rank exited cleanly (returned without error)."""
         return worker_group_status.finished and not worker_group_status.errors
 
     @staticmethod
@@ -767,18 +759,17 @@ class TrainController:
             "the node is actually reclaimed."
         )
 
-    @classmethod
     def _preemption_to_drain(
-        cls, worker_group_status: WorkerGroupPollStatus
+        self, worker_group_status: WorkerGroupPollStatus
     ) -> Optional["PreemptionInfo"]:
         """The preemption that should move the run into PreemptingState, if any.
 
-        Returns the echoed `PreemptionInfo` unless the poll is a genuine
-        completion (see `_is_genuine_completion`), in which case it returns None
-        so the caller lets the run finish normally.
+        Returns the active `PreemptionInfo` unless training is done (see
+        `_is_training_done`), in which case it returns None so the caller lets
+        the run finish normally.
         """
         preemption_info = worker_group_status.get_preemption_info()
-        if preemption_info is None or cls._is_genuine_completion(worker_group_status):
+        if preemption_info is None or self._is_training_done(worker_group_status):
             return None
         return preemption_info
 
@@ -803,29 +794,27 @@ class TrainController:
     async def _handle_preempting_state(
         self, controller_state: PreemptingState
     ) -> TrainControllerLoopIterationResult:
-        """Wait for the worker group to drain after a preemption, then restart.
+        """Wait for the worker group to drain after a preemption.
 
-        Polls the worker group until either all workers have exited or the
-        preemption deadline elapses (capped at `DEFAULT_PREEMPTION_DEADLINE_S`
-        when the deadline is unknown), whichever comes first. It then
-        synthesizes a `PreemptionError` and routes it through the failure
-        policy, which consumes the separate `max_preemption_failures` budget:
-        while that budget remains (it is unlimited by default), the decision is
-        RETRY and we transition to RestartingState, which tears down and
-        recreates the worker group on healthy nodes; once the budget is
-        exhausted the decision is RAISE and we transition to ShuttingDownState
-        followed by ErroredState.
+        Exits the drain on the first of:
+        - Training is done (all ranks returned cleanly): the run finishes.
+        - A worker errors: routed through the failure policy, which charges the
+          preemption budget if a worker was killed by the reclaim
+          (`RayActorError.preempted`) and `max_failures` otherwise (e.g. a bug
+          in the training function while draining).
+        - The reclaim deadline elapses (capped at
+          `DEFAULT_PREEMPTION_DEADLINE_S` when unknown) with workers still
+          running: force a teardown via a `PreemptionError` with
+          `drain_timed_out=True`.
 
-        If instead the workers return cleanly (no errors) while draining, the run
-        is treated as a genuine completion and transitions to FinishedState --
-        the training function finished before its node was reclaimed.
+        On RETRY the run transitions to RestartingState (fresh worker group on
+        healthy nodes, resuming from the latest checkpoint); once the relevant
+        budget is exhausted, to ShuttingDownState then ErroredState.
         """
         worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-        # The workers returned cleanly (no errors) -> genuine completion. (A
-        # killed worker or a passed deadline fall through to the restart path
-        # below.)
-        if self._is_genuine_completion(worker_group_status):
+        # The workers returned cleanly (no errors) -> training is done.
+        if self._is_training_done(worker_group_status):
             self._warn_if_finished_during_preemption(
                 worker_group_status.get_preemption_info()
                 or controller_state.preemption_info
@@ -839,10 +828,22 @@ class TrainController:
                 ),
             )
 
-        # Keep the preemption info current as additional nodes are drained.
-        # Merge rather than overwrite so a staggered preemption (or a node
-        # dropping out of the draining list once it's gone) doesn't erase
-        # earlier preempted nodes/ranks from the final PreemptionError.
+        # A worker errored while draining. The failure policy classifies it:
+        # a reclaim kill (RayActorError.preempted) is charged against the
+        # preemption budget, anything else (e.g. a bug in the training
+        # function's just-in-time checkpoint) against `max_failures`.
+        if worker_group_status.errors:
+            worker_group_error = worker_group_status.get_worker_group_error()
+            failure_decision = self._failure_policy.make_decision(
+                training_failed_error=worker_group_error,
+            )
+            return self._execute_failure_decision(
+                failure_decision, training_failed_error=worker_group_error
+            )
+
+        # All workers are still running. Keep the preemption info current as
+        # additional nodes are drained: merge rather than overwrite so a
+        # staggered preemption doesn't erase earlier preempted nodes/ranks.
         new_preemption_info = worker_group_status.get_preemption_info()
         if new_preemption_info is not None:
             preemption_info = merge_preemption_info(
@@ -850,13 +851,11 @@ class TrainController:
             )
         else:
             preemption_info = controller_state.preemption_info
-        deadline_exceeded = self._is_preemption_deadline_exceeded(
-            preemption_info, controller_state.detected_at_s
-        )
 
-        # Stay in PreemptingState until the workers exit on their own or the
-        # reclaim deadline passes.
-        if not worker_group_status.finished and not deadline_exceeded:
+        # Stay in PreemptingState until the reclaim deadline passes.
+        if not self._is_preemption_deadline_exceeded(
+            preemption_info, controller_state.detected_at_s
+        ):
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
                 previous_state=controller_state,
@@ -866,12 +865,10 @@ class TrainController:
                 ),
             )
 
-        # True when the deadline forced teardown before every rank had exited.
-        drain_timed_out = deadline_exceeded and not worker_group_status.finished
+        # The deadline passed with workers still running: force a teardown.
         preemption_error = PreemptionError(
             preemption_info=preemption_info,
-            worker_failures=worker_group_status.errors,
-            drain_timed_out=drain_timed_out,
+            drain_timed_out=True,
         )
         failure_decision = self._failure_policy.make_decision(
             training_failed_error=preemption_error,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -653,14 +653,22 @@ class TrainController:
         elif isinstance(controller_state, RunningState):
             worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
-            # A preemption is in progress: move to PreemptingState and let the
-            # worker group drain before restarting. Checked before both the
-            # completion and error branches so that a worker killed when its
-            # node is reclaimed is charged against the preemption retry budget
-            # rather than `max_failures`. `_preemption_to_drain` returns None
-            # when training is done, letting it fall through to the finished
-            # branch below.
-            preemption_info = self._preemption_to_drain(worker_group_status)
+            if self._is_training_done(worker_group_status):
+                self._return_value = worker_group_status.worker_statuses[0].return_value
+                return TrainControllerLoopIterationResult(
+                    run_attempt_id=self._get_run_attempt_id(),
+                    previous_state=controller_state,
+                    next_state=ShuttingDownState(
+                        next_state=FinishedState(),
+                    ),
+                )
+
+            # A node hosting one of the workers is being preempted: move to
+            # PreemptingState to wait out the grace window before restarting.
+            # Checked before the error branch so that a worker killed by the
+            # preemption is charged against `max_preemption_failures` rather
+            # than `max_failures`.
+            preemption_info = worker_group_status.get_preemption_info()
             if preemption_info is not None:
                 return TrainControllerLoopIterationResult(
                     run_attempt_id=self._get_run_attempt_id(),
@@ -668,19 +676,6 @@ class TrainController:
                     next_state=PreemptingState(
                         preemption_info=preemption_info,
                         detected_at_s=time_seconds(),
-                    ),
-                )
-
-            if self._is_training_done(worker_group_status):
-                self._warn_if_finished_during_preemption(
-                    worker_group_status.get_preemption_info()
-                )
-                self._return_value = worker_group_status.worker_statuses[0].return_value
-                return TrainControllerLoopIterationResult(
-                    run_attempt_id=self._get_run_attempt_id(),
-                    previous_state=controller_state,
-                    next_state=ShuttingDownState(
-                        next_state=FinishedState(),
                     ),
                 )
 
@@ -737,43 +732,6 @@ class TrainController:
         return worker_group_status.finished and not worker_group_status.errors
 
     @staticmethod
-    def _warn_if_finished_during_preemption(
-        preemption_info: Optional["PreemptionInfo"],
-    ) -> None:
-        """Warn when a run finishes while a preemption signal is active.
-
-        A clean return always finishes the run, so a training function that
-        returns early after a just-in-time checkpoint -- expecting Ray Train to
-        restart it -- silently truncates training instead. Surface that loudly
-        so the misuse is caught at the moment it happens.
-        """
-        if preemption_info is None:
-            return
-        logger.warning(
-            "Training finished while a preemption was in progress "
-            f"(preempted_ranks={preemption_info.preempted_ranks}). If this was "
-            "intentional, ignore this warning. If you intended to resume after "
-            "the preemption instead, do not return from your training function "
-            "when `ray.train.get_preemption_info()` is set -- save a checkpoint "
-            "and continue training; Ray Train restarts and resumes the run when "
-            "the node is actually reclaimed."
-        )
-
-    def _preemption_to_drain(
-        self, worker_group_status: WorkerGroupPollStatus
-    ) -> Optional["PreemptionInfo"]:
-        """The preemption that should move the run into PreemptingState, if any.
-
-        Returns the active `PreemptionInfo` unless training is done (see
-        `_is_training_done`), in which case it returns None so the caller lets
-        the run finish normally.
-        """
-        preemption_info = worker_group_status.get_preemption_info()
-        if preemption_info is None or self._is_training_done(worker_group_status):
-            return None
-        return preemption_info
-
-    @staticmethod
     def _is_preemption_deadline_exceeded(
         preemption_info: "PreemptionInfo",
         detected_at_s: float,
@@ -794,22 +752,28 @@ class TrainController:
     async def _handle_preempting_state(
         self, controller_state: PreemptingState
     ) -> TrainControllerLoopIterationResult:
-        """Wait for the worker group to drain after a preemption.
+        """Wait out the preemption grace window, then restart or finish.
 
-        Exits the drain on the first of:
+        Terminology: Ray Core marks a preempted node as *draining* and reports
+        the cloud's *reclaim deadline* -- the time at which the node will be
+        taken away, killing the workers on it (such a death carries
+        `RayActorError.preempted`). While in PreemptingState, Ray Train keeps
+        the surviving workers running (e.g. to finish just-in-time checkpoints)
+        for as much of that grace window as possible.
+
+        Exits on the first of:
         - Training is done (all ranks returned cleanly): the run finishes.
-        - A worker errors with something that is NOT a reclaim kill (e.g. a bug
-          in the training function while draining): routed through the normal
+        - A worker errors with something that is NOT a preemption-caused death
+          (e.g. a bug in the training function): routed through the normal
           WorkerGroupError path, charged against `max_failures`.
-        - Every rank has exited (typically killed by the reclaim,
-          `RayActorError.preempted`) or the reclaim deadline elapses (capped at
-          `DEFAULT_PREEMPTION_DEADLINE_S` when unknown) with ranks still
-          running: a `PreemptionError` is routed through the failure policy,
-          charged against `max_preemption_failures`.
+        - Every rank has exited, or the reclaim deadline passes (capped at
+          `DEFAULT_PREEMPTION_DEADLINE_S` when the cloud reports none) with
+          ranks still running: a `PreemptionError` is routed through the
+          failure policy, charged against `max_preemption_failures`.
 
-        Reclaim kills of a subset of ranks do NOT end the drain: the healthy
-        ranks keep running (e.g. finishing emergency checkpoints) until every
-        rank has exited or the deadline passes.
+        A preemption-caused death of a subset of ranks does NOT end the wait:
+        the healthy ranks keep running until every rank has exited or the
+        deadline passes.
 
         On RETRY the run transitions to RestartingState (fresh worker group on
         healthy nodes, resuming from the latest checkpoint); once the relevant
@@ -819,10 +783,6 @@ class TrainController:
 
         # The workers returned cleanly (no errors) -> training is done.
         if self._is_training_done(worker_group_status):
-            self._warn_if_finished_during_preemption(
-                worker_group_status.get_preemption_info()
-                or controller_state.preemption_info
-            )
             self._return_value = worker_group_status.worker_statuses[0].return_value
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
@@ -832,11 +792,17 @@ class TrainController:
                 ),
             )
 
-        # Worker errors that are NOT reclaim kills (e.g. a bug in the training
-        # function's just-in-time checkpoint) are real failures: fail fast
-        # through the normal WorkerGroupError path so they are charged against
-        # `max_failures`, not the (unlimited-by-default) preemption budget.
-        # Reclaim kills are part of the drain and handled below.
+        # Worker errors that are NOT preemption-caused deaths (e.g. a bug in
+        # the training function's just-in-time checkpoint) are real failures:
+        # fail fast through the normal WorkerGroupError path so they are
+        # charged against `max_failures`, not the (unlimited-by-default)
+        # preemption budget. If a preemption-caused death is present alongside
+        # other errors, the preemption wins the tie: when one rank dies, the
+        # surviving ranks routinely fail with collateral errors (collective
+        # aborts, connection resets), so treating any mixed poll as a worker
+        # failure would misclassify most real preemptions. A genuine bug that
+        # coincided with a preemption re-fires on the next attempt without a
+        # preemption present and is charged to `max_failures` then.
         if (
             worker_group_status.errors
             and not worker_group_status.has_preempted_worker()
@@ -849,7 +815,7 @@ class TrainController:
                 failure_decision, training_failed_error=worker_group_error
             )
 
-        # Keep the preemption info current as additional nodes are drained:
+        # Keep the preemption info current as additional nodes are preempted:
         # merge rather than overwrite so a staggered preemption doesn't erase
         # earlier preempted nodes/ranks.
         new_preemption_info = worker_group_status.get_preemption_info()
@@ -862,7 +828,7 @@ class TrainController:
 
         # Stay in PreemptingState while ranks are still running and the reclaim
         # deadline has not passed, even if some ranks were already killed by
-        # the reclaim -- the healthy ranks keep training/checkpointing.
+        # the preemption -- the healthy ranks keep training/checkpointing.
         # TODO(lehui): Decouple the worker group teardown from the node reclaim
         # deadline (e.g. a configurable grace period and a survivor emergency
         # checkpoint via a relaxed report() barrier) so healthy ranks can be
@@ -880,9 +846,9 @@ class TrainController:
                 ),
             )
 
-        # The drain ended: every rank exited (reclaim kills carried in
-        # `worker_failures`) or the deadline forced a teardown with ranks still
-        # running (`drain_timed_out=True`).
+        # The grace window is over: every rank exited (preemption-caused deaths
+        # carried in `worker_failures`) or the deadline forced a teardown with
+        # ranks still running (`drain_timed_out=True`).
         preemption_error = PreemptionError(
             preemption_info=preemption_info,
             worker_failures=worker_group_status.errors,

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -125,9 +125,13 @@ class PreemptingState(TrainControllerState):
     def __init__(
         self,
         preemption_info: "PreemptionInfo",
+        detected_at_s: float,
     ):
         super().__init__(state_type=TrainControllerStateType.PREEMPTING)
         self.preemption_info = preemption_info
+        # Wall-clock time (epoch seconds) when the preemption was first
+        # detected, used to bound the drain wait when no deadline is known.
+        self.detected_at_s = detected_at_s
 
 
 class RestartingState(TrainControllerState):

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -1,9 +1,13 @@
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
     ScalingDecision,
 )
 from ray.train.v2.api.exceptions import TrainingFailedError
+
+if TYPE_CHECKING:
+    from ray.train.v2._internal.execution.preemption import PreemptionInfo
 
 
 class TrainControllerStateType(Enum):
@@ -17,6 +21,9 @@ class TrainControllerStateType(Enum):
        RESCHEDULING: The train controller is in the process of rescheduling the worker
            group.
        RUNNING: The train controller is actively running training tasks.
+       PREEMPTING: A preemption was detected; the controller is waiting for the
+           worker group to drain (workers exit or the deadline elapses) before
+           restarting.
        RESTARTING: The train controller is in the process of recovering from an error.
        RESIZING: The train controller is in the process of resizing a running worker
            group.
@@ -39,6 +46,7 @@ class TrainControllerStateType(Enum):
     SCHEDULING = ("SCHEDULING", False, False)
     RESCHEDULING = ("RESCHEDULING", False, False)
     RUNNING = ("RUNNING", False, False)
+    PREEMPTING = ("PREEMPTING", False, False)
     RESTARTING = ("RESTARTING", False, True)
     RESIZING = ("RESIZING", False, True)
     SHUTTING_DOWN = ("SHUTTING_DOWN", False, False)
@@ -111,6 +119,15 @@ class RunningState(TrainControllerState):
     # For example, we may want to indicate if any health checks failed.
     def __init__(self):
         super().__init__(state_type=TrainControllerStateType.RUNNING)
+
+
+class PreemptingState(TrainControllerState):
+    def __init__(
+        self,
+        preemption_info: "PreemptionInfo",
+    ):
+        super().__init__(state_type=TrainControllerStateType.PREEMPTING)
+        self.preemption_info = preemption_info
 
 
 class RestartingState(TrainControllerState):

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -129,8 +129,6 @@ class PreemptingState(TrainControllerState):
     ):
         super().__init__(state_type=TrainControllerStateType.PREEMPTING)
         self.preemption_info = preemption_info
-        # Wall-clock time (epoch seconds) when the preemption was first
-        # detected, used to bound the drain wait when no deadline is known.
         self.detected_at_s = detected_at_s
 
 

--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -8,6 +8,7 @@ from ray.train.v2._internal.exceptions import (
 from ray.train.v2.api.config import FailureConfig
 from ray.train.v2.api.exceptions import (
     ControllerError,
+    PreemptionError,
     TrainingFailedError,
     WorkerGroupError,
 )
@@ -26,6 +27,7 @@ class DefaultFailurePolicy(FailurePolicy):
         super().__init__(failure_config)
         self._worker_group_failures = 0
         self._controller_failures = 0
+        self._preemption_failures = 0
 
     def _log_decision(
         self,
@@ -36,6 +38,8 @@ class DefaultFailurePolicy(FailurePolicy):
     ):
         if isinstance(training_failed_error, ControllerError):
             error_source = "controller"
+        elif isinstance(training_failed_error, PreemptionError):
+            error_source = "preemption"
         elif isinstance(training_failed_error, WorkerGroupError):
             error_source = "worker group"
         else:
@@ -54,7 +58,9 @@ class DefaultFailurePolicy(FailurePolicy):
         )
 
     def _is_retryable_error(self, training_failed_error: TrainingFailedError) -> bool:
-        if isinstance(training_failed_error, WorkerGroupError):
+        if isinstance(training_failed_error, PreemptionError):
+            return True
+        elif isinstance(training_failed_error, WorkerGroupError):
             return True
         elif isinstance(training_failed_error, ControllerError):
             return isinstance(
@@ -78,6 +84,14 @@ class DefaultFailurePolicy(FailurePolicy):
                 retry_limit = (
                     self.failure_config.controller_failure_limit
                     if self.failure_config.controller_failure_limit != -1
+                    else float("inf")
+                )
+            elif isinstance(training_failed_error, PreemptionError):
+                self._preemption_failures += 1
+                error_count = self._preemption_failures
+                retry_limit = (
+                    self.failure_config.max_preemption_failures
+                    if self.failure_config.max_preemption_failures != -1
                     else float("inf")
                 )
             elif isinstance(training_failed_error, WorkerGroupError):

--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -26,10 +26,15 @@ RETRYABLE_CONTROLLER_ERRORS = (
 def _is_preemption_failure(training_failed_error: TrainingFailedError) -> bool:
     """Whether a failure should be charged to the preemption retry budget.
 
-    True for a `PreemptionError` (raised by the controller while draining a
-    preemption) and for a `WorkerGroupError` in which a worker was killed by a
-    node reclaim (`RayActorError.preempted`), e.g. a preemption whose advance
-    signal was never observed.
+    True for a `PreemptionError` (raised by the controller after waiting out a
+    preemption) and for a `WorkerGroupError` in which any worker death was
+    caused by a preemption (`RayActorError.preempted`), e.g. a preemption whose
+    advance info was never observed. If a preemption-caused death appears
+    alongside other worker errors, the preemption wins: when one rank dies, the
+    surviving ranks routinely fail with collateral errors (collective aborts,
+    connection resets), so requiring *all* errors to be preemption-caused would
+    misclassify most real preemptions. A genuine bug re-fires on the next
+    attempt without a preemption and is charged to `max_failures` then.
     """
     if isinstance(training_failed_error, PreemptionError):
         return True

--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -1,9 +1,12 @@
 import logging
+from typing import Optional
 
 from .failure_policy import FailureDecision, FailurePolicy
+from ray.exceptions import RayActorError
 from ray.train.v2._internal.exceptions import (
     WorkerGroupStartupFailedError,
     WorkerGroupStartupTimeoutError,
+    WorkerHealthCheckFailedError,
 )
 from ray.train.v2.api.config import FailureConfig
 from ray.train.v2.api.exceptions import (
@@ -22,6 +25,33 @@ RETRYABLE_CONTROLLER_ERRORS = (
 )
 
 
+def _is_preempted_actor(error: Optional[Exception]) -> bool:
+    """Whether a worker error is a node-preemption-caused death.
+
+    A worker killed by a node reclaim surfaces as a WorkerHealthCheckFailedError
+    wrapping a RayActorError whose ``preempted`` flag is set.
+    """
+    if isinstance(error, WorkerHealthCheckFailedError):
+        error = error.health_check_failure
+    return isinstance(error, RayActorError) and error.preempted
+
+
+def _is_preemption_failure(training_failed_error: TrainingFailedError) -> bool:
+    """Whether a failure should be charged to the preemption retry budget.
+
+    True for a `PreemptionError` (raised by the controller while draining a
+    preemption) and for a `WorkerGroupError` in which a worker was killed by a
+    node reclaim (`RayActorError.preempted`), e.g. a preemption whose advance
+    signal was never observed.
+    """
+    if isinstance(training_failed_error, PreemptionError):
+        return True
+    return isinstance(training_failed_error, WorkerGroupError) and any(
+        _is_preempted_actor(error)
+        for error in training_failed_error.worker_failures.values()
+    )
+
+
 class DefaultFailurePolicy(FailurePolicy):
     def __init__(self, failure_config: FailureConfig):
         super().__init__(failure_config)
@@ -38,7 +68,7 @@ class DefaultFailurePolicy(FailurePolicy):
     ):
         if isinstance(training_failed_error, ControllerError):
             error_source = "controller"
-        elif isinstance(training_failed_error, PreemptionError):
+        elif _is_preemption_failure(training_failed_error):
             error_source = "preemption"
         elif isinstance(training_failed_error, WorkerGroupError):
             error_source = "worker group"
@@ -86,7 +116,7 @@ class DefaultFailurePolicy(FailurePolicy):
                     if self.failure_config.controller_failure_limit != -1
                     else float("inf")
                 )
-            elif isinstance(training_failed_error, PreemptionError):
+            elif _is_preemption_failure(training_failed_error):
                 self._preemption_failures += 1
                 error_count = self._preemption_failures
                 retry_limit = (

--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -1,13 +1,11 @@
 import logging
-from typing import Optional
 
 from .failure_policy import FailureDecision, FailurePolicy
-from ray.exceptions import RayActorError
 from ray.train.v2._internal.exceptions import (
     WorkerGroupStartupFailedError,
     WorkerGroupStartupTimeoutError,
-    WorkerHealthCheckFailedError,
 )
+from ray.train.v2._internal.execution.worker_group.poll import _is_preempted_actor
 from ray.train.v2.api.config import FailureConfig
 from ray.train.v2.api.exceptions import (
     ControllerError,
@@ -23,17 +21,6 @@ RETRYABLE_CONTROLLER_ERRORS = (
     WorkerGroupStartupFailedError,
     WorkerGroupStartupTimeoutError,
 )
-
-
-def _is_preempted_actor(error: Optional[Exception]) -> bool:
-    """Whether a worker error is a node-preemption-caused death.
-
-    A worker killed by a node reclaim surfaces as a WorkerHealthCheckFailedError
-    wrapping a RayActorError whose ``preempted`` flag is set.
-    """
-    if isinstance(error, WorkerHealthCheckFailedError):
-        error = error.health_check_failure
-    return isinstance(error, RayActorError) and error.preempted
 
 
 def _is_preemption_failure(training_failed_error: TrainingFailedError) -> bool:

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set
 import ray
 from ray.actor import ActorHandle
 from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_POLL_INTERVAL_S
+from ray.util.annotations import PublicAPI
 from ray.util.tpu import get_tpu_slice_name_from_node
 
 if TYPE_CHECKING:
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@PublicAPI(stability="alpha")
 @dataclass(frozen=True)
 class PreemptionInfo:
     """Information about an imminent preemption event.

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -43,6 +43,29 @@ class PreemptionInfo:
         )
 
 
+def merge_preemption_info(old: PreemptionInfo, new: PreemptionInfo) -> PreemptionInfo:
+    """Combine two preemption signals into one.
+
+    Used while the controller drains the worker group: in a staggered
+    preemption (nodes drained one after another, or a previously drained node
+    dropping out of Ray Core's draining list once it's gone) a later signal may
+    not include earlier preempted nodes. Union the ``preempted_node_to_ranks``
+    maps so we keep the full history, and keep the earliest known deadline.
+    """
+    merged_node_to_ranks: Dict[str, List[int]] = {
+        node: list(ranks) for node, ranks in old.preempted_node_to_ranks.items()
+    }
+    for node, ranks in new.preempted_node_to_ranks.items():
+        merged_node_to_ranks[node] = sorted(
+            set(merged_node_to_ranks.get(node, [])) | set(ranks)
+        )
+    deadlines = [d for d in (old.deadline_ms, new.deadline_ms) if d is not None]
+    return PreemptionInfo(
+        deadline_ms=min(deadlines) if deadlines else None,
+        preempted_node_to_ranks=merged_node_to_ranks,
+    )
+
+
 @dataclass
 class PreemptionContext:
     """Thread-shared preemption signal for one worker actor."""

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -23,8 +23,8 @@ class PreemptionInfo:
     Attributes:
         deadline_ms: Earliest preemption deadline (UNIX time in milliseconds)
             across all preempted nodes. ``None`` if no deadline was reported.
-        preempted_node_to_ranks: Map of preempted ``node_id`` to the worker ``world_rank``s affected when that node
-            is preempted.
+        preempted_node_to_ranks: Map of each preempted ``node_id`` to the
+            affected worker world ranks when that node is preempted.
     """
 
     deadline_ms: Optional[int]

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -17,14 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def merge_preemption_info(old: PreemptionInfo, new: PreemptionInfo) -> PreemptionInfo:
-    """Combine two preemption signals into one.
-
-    Used while the controller drains the worker group: in a staggered
-    preemption (nodes drained one after another, or a previously drained node
-    dropping out of Ray Core's draining list once it's gone) a later signal may
-    not include earlier preempted nodes. Union the ``preempted_node_to_ranks``
-    maps so we keep the full history, and keep the earliest known deadline.
-    """
+    """Combine two preemption signals into one."""
     ranks_by_node: Dict[str, Set[int]] = defaultdict(set)
     for info in (old, new):
         for node, ranks in info.preempted_node_to_ranks.items():
@@ -45,9 +38,7 @@ class PreemptionContext:
 
     Written by the worker actor's main thread (``mark_preempt``) and read from
     the training thread (``ray.train.get_preemption_info``) and the status
-    poll. No lock is needed: it is a single reference swapped atomically, and
-    ``PreemptionInfo`` is immutable. Reading it is informational (e.g. to save a
-    just-in-time checkpoint); it has no effect on control flow.
+    poll.
     """
 
     preemption_info: Optional[PreemptionInfo] = None

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -1,47 +1,18 @@
 import logging
 import threading
 from collections import defaultdict
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 import ray
 from ray.actor import ActorHandle
 from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_POLL_INTERVAL_S
-from ray.util.annotations import PublicAPI
+from ray.train.v2.api.preemption import PreemptionInfo
 from ray.util.tpu import get_tpu_slice_name_from_node
 
 if TYPE_CHECKING:
     from ray.train.v2._internal.worker import RayTrainWorker
 
 logger = logging.getLogger(__name__)
-
-
-@PublicAPI(stability="alpha")
-@dataclass(frozen=True)
-class PreemptionInfo:
-    """Information about an imminent preemption event.
-
-    Attributes:
-        deadline_ms: Earliest preemption deadline (UNIX time in milliseconds)
-            across all preempted nodes. ``None`` if no deadline was reported.
-        preempted_node_to_ranks: Map of each preempted ``node_id`` to the
-            affected worker world ranks when that node is preempted.
-    """
-
-    deadline_ms: Optional[int]
-    preempted_node_to_ranks: Dict[str, List[int]]
-
-    @property
-    def preempted_node_ids(self) -> List[str]:
-        """Preempted node IDs, sorted lexicographically."""
-        return sorted(self.preempted_node_to_ranks)
-
-    @property
-    def preempted_ranks(self) -> List[int]:
-        """All affected ranks across the preempted nodes, sorted ascending."""
-        return sorted(
-            {r for ranks in self.preempted_node_to_ranks.values() for r in ranks}
-        )
 
 
 def merge_preemption_info(old: PreemptionInfo, new: PreemptionInfo) -> PreemptionInfo:
@@ -67,28 +38,29 @@ def merge_preemption_info(old: PreemptionInfo, new: PreemptionInfo) -> Preemptio
     )
 
 
-@dataclass
 class PreemptionContext:
-    """Thread-shared preemption signal for one worker actor."""
+    """Holds the preemption info for one worker actor.
 
-    _preemption_info: Optional[PreemptionInfo] = field(default=None, init=False)
-    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    Written by the worker actor's main thread (``mark_preempt``) and read from
+    the training thread (``ray.train.get_preemption_info``) and the status
+    poll. No lock is needed: it is a single reference that is swapped
+    atomically, and ``PreemptionInfo`` is immutable.
+    """
+
+    def __init__(self):
+        self._preemption_info: Optional[PreemptionInfo] = None
 
     def set(self, info: PreemptionInfo) -> None:
-        with self._lock:
-            self._preemption_info = info
+        self._preemption_info = info
 
     def get(self) -> Optional[PreemptionInfo]:
-        """Return the current preemption signal, or ``None`` if none received.
+        """Return the current preemption info, or ``None`` if none received.
 
-        Reading the signal is informational: it lets the training function react
-        (e.g. save a just-in-time checkpoint and keep training) before its node
-        is reclaimed. It has no effect on control flow -- Ray Train restarts the
-        run when a node is actually reclaimed (or the reclaim deadline elapses),
-        and a run that returns cleanly finishes regardless of any signal.
+        Reading it is informational: it lets the training function react (e.g.
+        save a just-in-time checkpoint and keep training) before its node is
+        reclaimed. It has no effect on control flow.
         """
-        with self._lock:
-            return self._preemption_info
+        return self._preemption_info
 
 
 def _get_draining_nodes() -> Dict[str, int]:

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 import ray
@@ -38,29 +39,18 @@ def merge_preemption_info(old: PreemptionInfo, new: PreemptionInfo) -> Preemptio
     )
 
 
+@dataclass
 class PreemptionContext:
-    """Holds the preemption info for one worker actor.
+    """The preemption info for one worker actor, or ``None`` if not preempted.
 
     Written by the worker actor's main thread (``mark_preempt``) and read from
     the training thread (``ray.train.get_preemption_info``) and the status
-    poll. No lock is needed: it is a single reference that is swapped
-    atomically, and ``PreemptionInfo`` is immutable.
+    poll. No lock is needed: it is a single reference swapped atomically, and
+    ``PreemptionInfo`` is immutable. Reading it is informational (e.g. to save a
+    just-in-time checkpoint); it has no effect on control flow.
     """
 
-    def __init__(self):
-        self._preemption_info: Optional[PreemptionInfo] = None
-
-    def set(self, info: PreemptionInfo) -> None:
-        self._preemption_info = info
-
-    def get(self) -> Optional[PreemptionInfo]:
-        """Return the current preemption info, or ``None`` if none received.
-
-        Reading it is informational: it lets the training function react (e.g.
-        save a just-in-time checkpoint and keep training) before its node is
-        reclaimed. It has no effect on control flow.
-        """
-        return self._preemption_info
+    preemption_info: Optional[PreemptionInfo] = None
 
 
 def _get_draining_nodes() -> Dict[str, int]:

--- a/python/ray/train/v2/_internal/execution/preemption.py
+++ b/python/ray/train/v2/_internal/execution/preemption.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
@@ -52,17 +53,17 @@ def merge_preemption_info(old: PreemptionInfo, new: PreemptionInfo) -> Preemptio
     not include earlier preempted nodes. Union the ``preempted_node_to_ranks``
     maps so we keep the full history, and keep the earliest known deadline.
     """
-    merged_node_to_ranks: Dict[str, List[int]] = {
-        node: list(ranks) for node, ranks in old.preempted_node_to_ranks.items()
-    }
-    for node, ranks in new.preempted_node_to_ranks.items():
-        merged_node_to_ranks[node] = sorted(
-            set(merged_node_to_ranks.get(node, [])) | set(ranks)
-        )
+    ranks_by_node: Dict[str, Set[int]] = defaultdict(set)
+    for info in (old, new):
+        for node, ranks in info.preempted_node_to_ranks.items():
+            ranks_by_node[node].update(ranks)
+
     deadlines = [d for d in (old.deadline_ms, new.deadline_ms) if d is not None]
     return PreemptionInfo(
-        deadline_ms=min(deadlines) if deadlines else None,
-        preempted_node_to_ranks=merged_node_to_ranks,
+        deadline_ms=min(deadlines, default=None),
+        preempted_node_to_ranks={
+            node: sorted(ranks) for node, ranks in ranks_by_node.items()
+        },
     )
 
 
@@ -78,7 +79,14 @@ class PreemptionContext:
             self._preemption_info = info
 
     def get(self) -> Optional[PreemptionInfo]:
-        """Return the current preemption signal, or ``None`` if none received."""
+        """Return the current preemption signal, or ``None`` if none received.
+
+        Reading the signal is informational: it lets the training function react
+        (e.g. save a just-in-time checkpoint and keep training) before its node
+        is reclaimed. It has no effect on control flow -- Ray Train restarts the
+        run when a node is actually reclaimed (or the reclaim deadline elapses),
+        and a run that returns cleanly finishes regardless of any signal.
+        """
         with self._lock:
             return self._preemption_info
 

--- a/python/ray/train/v2/_internal/execution/train_fn_utils.py
+++ b/python/ray/train/v2/_internal/execution/train_fn_utils.py
@@ -122,7 +122,7 @@ class TrainFnUtils(ABC):
         pass
 
     @abstractmethod
-    def preemption_status(self) -> Optional["PreemptionInfo"]:
+    def preemption_info(self) -> Optional["PreemptionInfo"]:
         """Return the latest preemption signal for this worker, or None.
 
         Returns:
@@ -188,7 +188,7 @@ class DistributedTrainFnUtils(TrainFnUtils):
     def get_context(self) -> DistributedTrainContext:
         return DistributedTrainContext()
 
-    def preemption_status(self) -> Optional["PreemptionInfo"]:
+    def preemption_info(self) -> Optional["PreemptionInfo"]:
         return get_internal_train_context().preemption_context.get()
 
     def is_distributed(self) -> bool:
@@ -262,7 +262,7 @@ class LocalTrainFnUtils(TrainFnUtils):
     def get_context(self) -> LocalTrainContext:
         return self._context
 
-    def preemption_status(self) -> Optional["PreemptionInfo"]:
+    def preemption_info(self) -> Optional["PreemptionInfo"]:
         # Local mode runs in a single process with no preemption watcher.
         return None
 

--- a/python/ray/train/v2/_internal/execution/train_fn_utils.py
+++ b/python/ray/train/v2/_internal/execution/train_fn_utils.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from ray.data import DataIterator
     from ray.train import Checkpoint
+    from ray.train.v2._internal.execution.preemption import PreemptionInfo
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint
 
 
@@ -121,6 +122,16 @@ class TrainFnUtils(ABC):
         pass
 
     @abstractmethod
+    def preemption_status(self) -> Optional["PreemptionInfo"]:
+        """Return the latest preemption signal for this worker, or None.
+
+        Returns:
+            A PreemptionInfo if a preemption affecting this worker group has
+            been detected, otherwise None.
+        """
+        pass
+
+    @abstractmethod
     def is_distributed(self) -> bool:
         pass
 
@@ -176,6 +187,9 @@ class DistributedTrainFnUtils(TrainFnUtils):
 
     def get_context(self) -> DistributedTrainContext:
         return DistributedTrainContext()
+
+    def preemption_status(self) -> Optional["PreemptionInfo"]:
+        return get_internal_train_context().preemption_context.get()
 
     def is_distributed(self) -> bool:
         return True
@@ -247,6 +261,10 @@ class LocalTrainFnUtils(TrainFnUtils):
 
     def get_context(self) -> LocalTrainContext:
         return self._context
+
+    def preemption_status(self) -> Optional["PreemptionInfo"]:
+        # Local mode runs in a single process with no preemption watcher.
+        return None
 
     def is_distributed(self) -> bool:
         return False

--- a/python/ray/train/v2/_internal/execution/train_fn_utils.py
+++ b/python/ray/train/v2/_internal/execution/train_fn_utils.py
@@ -189,7 +189,7 @@ class DistributedTrainFnUtils(TrainFnUtils):
         return DistributedTrainContext()
 
     def get_preemption_info(self) -> Optional["PreemptionInfo"]:
-        return get_internal_train_context().preemption_context.get()
+        return get_internal_train_context().preemption_context.preemption_info
 
     def is_distributed(self) -> bool:
         return True

--- a/python/ray/train/v2/_internal/execution/train_fn_utils.py
+++ b/python/ray/train/v2/_internal/execution/train_fn_utils.py
@@ -122,7 +122,7 @@ class TrainFnUtils(ABC):
         pass
 
     @abstractmethod
-    def preemption_info(self) -> Optional["PreemptionInfo"]:
+    def get_preemption_info(self) -> Optional["PreemptionInfo"]:
         """Return the latest preemption signal for this worker, or None.
 
         Returns:
@@ -188,7 +188,7 @@ class DistributedTrainFnUtils(TrainFnUtils):
     def get_context(self) -> DistributedTrainContext:
         return DistributedTrainContext()
 
-    def preemption_info(self) -> Optional["PreemptionInfo"]:
+    def get_preemption_info(self) -> Optional["PreemptionInfo"]:
         return get_internal_train_context().preemption_context.get()
 
     def is_distributed(self) -> bool:
@@ -262,7 +262,7 @@ class LocalTrainFnUtils(TrainFnUtils):
     def get_context(self) -> LocalTrainContext:
         return self._context
 
-    def preemption_info(self) -> Optional["PreemptionInfo"]:
+    def get_preemption_info(self) -> Optional["PreemptionInfo"]:
         # Local mode runs in a single process with no preemption watcher.
         return None
 

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -85,6 +85,17 @@ class WorkerGroupPollStatus:
             worker_failures=self.errors,
         )
 
+    def get_preemption_info(self) -> Optional[PreemptionInfo]:
+        """Return the preemption signal echoed by any worker, or None.
+
+        The PreemptionWatcher fans the same PreemptionInfo out to every worker,
+        so any non-None echo reflects the current preemption; return the first.
+        """
+        for status in self.worker_statuses.values():
+            if status.preemption_info is not None:
+                return status.preemption_info
+        return None
+
     @property
     def finished(self) -> bool:
         return self.worker_statuses and all(

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set
 
 from ray._private.ray_logging import NUMBERS
+from ray.exceptions import RayActorError
 from ray.train.v2._internal.exceptions import (
     UserExceptionWithTraceback,
     WorkerHealthCheckFailedError,
@@ -14,6 +15,17 @@ from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.types import ObjectRef
 
 ERR_CHAR_LIMIT = 1000
+
+
+def _is_preempted_actor(error: Optional[Exception]) -> bool:
+    """Whether a worker error is a node-preemption-caused death.
+
+    A worker killed by a node reclaim surfaces as a WorkerHealthCheckFailedError
+    wrapping a RayActorError whose ``preempted`` flag is set.
+    """
+    if isinstance(error, WorkerHealthCheckFailedError):
+        error = error.health_check_failure
+    return isinstance(error, RayActorError) and error.preempted
 
 
 def _normalize_error_string(error_str: str) -> str:
@@ -97,6 +109,10 @@ class WorkerGroupPollStatus:
             if status.preemption_info is not None:
                 return status.preemption_info
         return None
+
+    def has_preempted_worker(self) -> bool:
+        """Whether any worker was killed by a node reclaim."""
+        return any(_is_preempted_actor(error) for error in self.errors.values())
 
     @property
     def finished(self) -> bool:

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -102,14 +102,6 @@ class WorkerGroupPollStatus:
 
         The PreemptionWatcher fans the same PreemptionInfo out to every worker,
         so any non-None echo reflects the current preemption; return the first.
-
-        The controller reads the info from the worker poll (rather than from
-        the watcher directly) so that it rides the existing status channel with
-        no extra RPC or watcher lifecycle coupling, and so that entering
-        PreemptingState implies the workers have actually received the info --
-        the training function and the controller always see the same thing.
-        A worker killed by a preemption before any info was delivered is
-        classified by the failure policy instead, via ``RayActorError.preempted``.
         """
         for status in self.worker_statuses.values():
             if status.preemption_info is not None:

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set
 
 from ray._private.ray_logging import NUMBERS
+from ray.exceptions import RayActorError
 from ray.train.v2._internal.exceptions import (
     UserExceptionWithTraceback,
     WorkerHealthCheckFailedError,
@@ -14,6 +15,22 @@ from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.types import ObjectRef
 
 ERR_CHAR_LIMIT = 1000
+
+# Sentinel node id used when a preemption is inferred from a worker's death
+# (RayActorError.preempted) rather than an advance drain signal, where the
+# preempted node id is not known.
+_UNKNOWN_PREEMPTED_NODE = "<unknown-preempted-node>"
+
+
+def _is_preemption_death(error: Optional[Exception]) -> bool:
+    """Whether a worker error is a node-preemption-caused death.
+
+    A worker killed by a node reclaim surfaces as a WorkerHealthCheckFailedError
+    wrapping a RayActorError whose ``preempted`` flag is set.
+    """
+    if isinstance(error, WorkerHealthCheckFailedError):
+        error = error.health_check_failure
+    return isinstance(error, RayActorError) and error.preempted
 
 
 def _normalize_error_string(error_str: str) -> str:
@@ -86,14 +103,28 @@ class WorkerGroupPollStatus:
         )
 
     def get_preemption_info(self) -> Optional[PreemptionInfo]:
-        """Return the preemption signal echoed by any worker, or None.
+        """Return the active preemption signal, or None.
 
-        The PreemptionWatcher fans the same PreemptionInfo out to every worker,
-        so any non-None echo reflects the current preemption; return the first.
+        Prefers the advance signal echoed by a worker (the PreemptionWatcher
+        fans the same PreemptionInfo out to every worker, so any non-None echo
+        reflects the current preemption). If there is no advance signal but a
+        worker was killed by a node reclaim -- detected via
+        ``RayActorError.preempted`` -- synthesize a PreemptionInfo for the
+        affected ranks so the reclaim is still charged to the preemption budget
+        rather than ``max_failures`` (the node id is unknown in this case).
         """
         for status in self.worker_statuses.values():
             if status.preemption_info is not None:
                 return status.preemption_info
+
+        preempted_ranks = sorted(
+            rank for rank, error in self.errors.items() if _is_preemption_death(error)
+        )
+        if preempted_ranks:
+            return PreemptionInfo(
+                deadline_ms=None,
+                preempted_node_to_ranks={_UNKNOWN_PREEMPTED_NODE: preempted_ranks},
+            )
         return None
 
     @property

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set
 
 from ray._private.ray_logging import NUMBERS
-from ray.exceptions import RayActorError
 from ray.train.v2._internal.exceptions import (
     UserExceptionWithTraceback,
     WorkerHealthCheckFailedError,
@@ -15,22 +14,6 @@ from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.types import ObjectRef
 
 ERR_CHAR_LIMIT = 1000
-
-# Sentinel node id used when a preemption is inferred from a worker's death
-# (RayActorError.preempted) rather than an advance drain signal, where the
-# preempted node id is not known.
-_UNKNOWN_PREEMPTED_NODE = "<unknown-preempted-node>"
-
-
-def _is_preemption_death(error: Optional[Exception]) -> bool:
-    """Whether a worker error is a node-preemption-caused death.
-
-    A worker killed by a node reclaim surfaces as a WorkerHealthCheckFailedError
-    wrapping a RayActorError whose ``preempted`` flag is set.
-    """
-    if isinstance(error, WorkerHealthCheckFailedError):
-        error = error.health_check_failure
-    return isinstance(error, RayActorError) and error.preempted
 
 
 def _normalize_error_string(error_str: str) -> str:
@@ -103,28 +86,16 @@ class WorkerGroupPollStatus:
         )
 
     def get_preemption_info(self) -> Optional[PreemptionInfo]:
-        """Return the active preemption signal, or None.
+        """Return the preemption signal echoed by any worker, or None.
 
-        Prefers the advance signal echoed by a worker (the PreemptionWatcher
-        fans the same PreemptionInfo out to every worker, so any non-None echo
-        reflects the current preemption). If there is no advance signal but a
-        worker was killed by a node reclaim -- detected via
-        ``RayActorError.preempted`` -- synthesize a PreemptionInfo for the
-        affected ranks so the reclaim is still charged to the preemption budget
-        rather than ``max_failures`` (the node id is unknown in this case).
+        The PreemptionWatcher fans the same PreemptionInfo out to every worker,
+        so any non-None echo reflects the current preemption; return the first.
+        A worker killed by a node reclaim with no advance signal is classified
+        by the failure policy instead, via ``RayActorError.preempted``.
         """
         for status in self.worker_statuses.values():
             if status.preemption_info is not None:
                 return status.preemption_info
-
-        preempted_ranks = sorted(
-            rank for rank, error in self.errors.items() if _is_preemption_death(error)
-        )
-        if preempted_ranks:
-            return PreemptionInfo(
-                deadline_ms=None,
-                preempted_node_to_ranks={_UNKNOWN_PREEMPTED_NODE: preempted_ranks},
-            )
         return None
 
     @property

--- a/python/ray/train/v2/_internal/execution/worker_group/poll.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/poll.py
@@ -98,12 +98,18 @@ class WorkerGroupPollStatus:
         )
 
     def get_preemption_info(self) -> Optional[PreemptionInfo]:
-        """Return the preemption signal echoed by any worker, or None.
+        """Return the preemption info echoed by any worker, or None.
 
         The PreemptionWatcher fans the same PreemptionInfo out to every worker,
         so any non-None echo reflects the current preemption; return the first.
-        A worker killed by a node reclaim with no advance signal is classified
-        by the failure policy instead, via ``RayActorError.preempted``.
+
+        The controller reads the info from the worker poll (rather than from
+        the watcher directly) so that it rides the existing status channel with
+        no extra RPC or watcher lifecycle coupling, and so that entering
+        PreemptingState implies the workers have actually received the info --
+        the training function and the controller always see the same thing.
+        A worker killed by a preemption before any info was delivered is
+        classified by the failure policy instead, via ``RayActorError.preempted``.
         """
         for status in self.worker_statuses.values():
             if status.preemption_info is not None:

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -192,7 +192,7 @@ class RayTrainWorker:
         """
         train_context = get_train_context()
         rank = train_context.get_world_rank()
-        train_context.preemption_context.set(info)
+        train_context.preemption_context.preemption_info = info
         logger.info(
             "Rank %d received preemption signal "
             "(this_worker_preempted=%s, preempted_ranks=%s, deadline_ms=%s).",
@@ -235,7 +235,7 @@ class RayTrainWorker:
             error=error,
             training_report=training_report,
             return_value=return_value,
-            preemption_info=train_context.preemption_context.get(),
+            preemption_info=train_context.preemption_context.preemption_info,
         )
 
     def clear_result_queue(self) -> bool:

--- a/python/ray/train/v2/_internal/util.py
+++ b/python/ray/train/v2/_internal/util.py
@@ -149,6 +149,16 @@ def time_monotonic():
     return time.monotonic()
 
 
+def time_seconds():
+    """Wall-clock time in seconds since the epoch.
+
+    Separate from `time_monotonic` because preemption deadlines from Ray Core
+    are epoch-based timestamps, not monotonic. Wrapped here so it can be mocked
+    in tests.
+    """
+    return time.time()
+
+
 def _copy_doc(copy_func):
     def wrapped(func):
         func.__doc__ = copy_func.__doc__

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -367,10 +367,16 @@ class FailureConfig(FailureConfigV1):
         controller_failure_limit: [DeveloperAPI] The maximum number of controller failures to tolerate.
             Setting to -1 will lead to infinite controller retries.
             Setting to 0 will disable controller retries. Defaults to -1.
+        max_preemption_failures: The maximum number of node-preemption interruptions
+            to recover from, counted separately from ``max_failures`` (which is
+            reserved for real failures). Will recover from the latest checkpoint
+            if present. Setting to -1 leads to infinite preemption retries;
+            setting to 0 disables them. Defaults to -1.
     """
 
     fail_fast: Union[bool, str] = _DEPRECATED
     controller_failure_limit: int = -1
+    max_preemption_failures: int = -1
 
     def __post_init__(self):
         if self.fail_fast != _DEPRECATED:

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -1,7 +1,10 @@
-from typing import Dict
+from typing import TYPE_CHECKING, Dict, Optional
 
 from ray.train.v2._internal.exceptions import RayTrainError
 from ray.util.annotations import PublicAPI
+
+if TYPE_CHECKING:
+    from ray.train.v2._internal.execution.preemption import PreemptionInfo
 
 
 @PublicAPI(stability="alpha")
@@ -47,3 +50,43 @@ class ControllerError(TrainingFailedError):
 
     def __reduce__(self):
         return (self.__class__, (self.controller_failure,))
+
+
+@PublicAPI(stability="alpha")
+class PreemptionError(TrainingFailedError):
+    """Exception raised when training is interrupted by node preemption.
+
+    Distinct from :class:`WorkerGroupError` so that a planned preemption
+    consumes a separate retry budget (``FailureConfig.max_preemption_failures``,
+    default -1 = unlimited) rather than ``max_failures``, which is reserved for
+    real failures (OOM, hardware faults, user-code bugs).
+
+    Args:
+        preemption_info: Details of the preemption (the affected node IDs and
+            ranks, and the reclaim deadline).
+        worker_failures: A mapping from worker rank to the exception observed on
+            that worker at teardown, if any.
+        deadline_exceeded: True if the worker group was torn down because the
+            preemption deadline elapsed before all workers exited.
+    """
+
+    def __init__(
+        self,
+        preemption_info: "PreemptionInfo",
+        worker_failures: Optional[Dict[int, Exception]] = None,
+        deadline_exceeded: bool = False,
+    ):
+        self.preemption_info = preemption_info
+        self.worker_failures = worker_failures or {}
+        self.deadline_exceeded = deadline_exceeded
+        super().__init__(
+            "Training was interrupted by node preemption "
+            f"(preempted_ranks={preemption_info.preempted_ranks}, "
+            f"deadline_exceeded={deadline_exceeded})."
+        )
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self.preemption_info, self.worker_failures, self.deadline_exceeded),
+        )

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -66,27 +66,29 @@ class PreemptionError(TrainingFailedError):
             ranks, and the reclaim deadline).
         worker_failures: A mapping from worker rank to the exception observed on
             that worker at teardown, if any.
-        deadline_exceeded: True if the worker group was torn down because the
-            preemption deadline elapsed before all workers exited.
+        drain_timed_out: True if the worker group was torn down because the
+            preemption deadline elapsed before all ranks had exited (i.e. the
+            drain did not complete in time), rather than all workers exiting
+            cleanly first.
     """
 
     def __init__(
         self,
         preemption_info: "PreemptionInfo",
         worker_failures: Optional[Dict[int, Exception]] = None,
-        deadline_exceeded: bool = False,
+        drain_timed_out: bool = False,
     ):
         self.preemption_info = preemption_info
         self.worker_failures = worker_failures or {}
-        self.deadline_exceeded = deadline_exceeded
+        self.drain_timed_out = drain_timed_out
         super().__init__(
             "Training was interrupted by node preemption "
             f"(preempted_ranks={preemption_info.preempted_ranks}, "
-            f"deadline_exceeded={deadline_exceeded})."
+            f"drain_timed_out={drain_timed_out})."
         )
 
     def __reduce__(self):
         return (
             self.__class__,
-            (self.preemption_info, self.worker_failures, self.deadline_exceeded),
+            (self.preemption_info, self.worker_failures, self.drain_timed_out),
         )

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 
 from ray.train.v2._internal.exceptions import RayTrainError
 from ray.util.annotations import PublicAPI
@@ -65,10 +65,6 @@ class PreemptionError(TrainingFailedError):
         preemption_info: Which nodes / world ranks were preempted and the
             reclaim deadline, for logging and debugging which preemption caused
             the restart.
-        worker_failures: Map of world rank to the exception that terminated that
-            worker (typically the preemption-caused actor death), so the
-            underlying errors are preserved for debugging rather than swallowed
-            by the retry.
         drain_timed_out: True when Ray Train stopped waiting because the reclaim
             deadline passed while workers were still running (and tore them down
             itself); False when every worker had already exited. Distinguishes
@@ -78,11 +74,9 @@ class PreemptionError(TrainingFailedError):
     def __init__(
         self,
         preemption_info: "PreemptionInfo",
-        worker_failures: Optional[Dict[int, Exception]] = None,
         drain_timed_out: bool = False,
     ):
         self.preemption_info = preemption_info
-        self.worker_failures = worker_failures or {}
         self.drain_timed_out = drain_timed_out
         super().__init__(
             "Training was interrupted by node preemption "
@@ -93,5 +87,5 @@ class PreemptionError(TrainingFailedError):
     def __reduce__(self):
         return (
             self.__class__,
-            (self.preemption_info, self.worker_failures, self.drain_timed_out),
+            (self.preemption_info, self.drain_timed_out),
         )

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -4,7 +4,7 @@ from ray.train.v2._internal.exceptions import RayTrainError
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
-    from ray.train.v2._internal.execution.preemption import PreemptionInfo
+    from ray.train.v2.api.preemption import PreemptionInfo
 
 
 @PublicAPI(stability="alpha")
@@ -62,14 +62,17 @@ class PreemptionError(TrainingFailedError):
     real failures (OOM, hardware faults, user-code bugs).
 
     Args:
-        preemption_info: Details of the preemption (the affected node IDs and
-            ranks, and the reclaim deadline).
-        worker_failures: A mapping from worker rank to the exception observed on
-            that worker at teardown, if any.
-        drain_timed_out: True if the worker group was torn down because the
-            preemption deadline elapsed before all ranks had exited (i.e. the
-            drain did not complete in time), rather than all workers exiting
-            cleanly first.
+        preemption_info: Which nodes / world ranks were preempted and the
+            reclaim deadline, for logging and debugging which preemption caused
+            the restart.
+        worker_failures: Map of world rank to the exception that terminated that
+            worker (typically the preemption-caused actor death), so the
+            underlying errors are preserved for debugging rather than swallowed
+            by the retry.
+        drain_timed_out: True when Ray Train stopped waiting because the reclaim
+            deadline passed while workers were still running (and tore them down
+            itself); False when every worker had already exited. Distinguishes
+            a forced teardown from an observed one when debugging.
     """
 
     def __init__(

--- a/python/ray/train/v2/api/preemption.py
+++ b/python/ray/train/v2/api/preemption.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="alpha")
+@dataclass(frozen=True)
+class PreemptionInfo:
+    """Information about an imminent preemption event.
+
+    Attributes:
+        deadline_ms: Earliest preemption deadline (UNIX time in milliseconds)
+            across all preempted nodes. ``None`` if no deadline was reported.
+        preempted_node_to_ranks: Map of each preempted ``node_id`` to the
+            affected worker world ranks when that node is preempted.
+    """
+
+    deadline_ms: Optional[int]
+    preempted_node_to_ranks: Dict[str, List[int]]
+
+    @property
+    def preempted_node_ids(self) -> List[str]:
+        """Preempted node IDs, sorted lexicographically."""
+        return sorted(self.preempted_node_to_ranks)
+
+    @property
+    def preempted_ranks(self) -> List[int]:
+        """All affected ranks across the preempted nodes, sorted ascending."""
+        return sorted(
+            {r for ranks in self.preempted_node_to_ranks.values() for r in ranks}
+        )

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -15,6 +15,7 @@ from ray.util.annotations import PublicAPI
 if TYPE_CHECKING:
     from ray.data import DataIterator
     from ray.train import Checkpoint
+    from ray.train.v2._internal.execution.preemption import PreemptionInfo
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint
 
 
@@ -142,6 +143,46 @@ def get_context() -> TrainContext:
     See the :class:`~ray.train.TrainContext` API reference to see available methods.
     """
     return get_train_fn_utils().get_context()
+
+
+@PublicAPI(stability="alpha")
+@requires_train_worker(raise_in_tune_session=True)
+def preemption_status() -> Optional["PreemptionInfo"]:
+    """Return the preemption signal for the current worker, or ``None``.
+
+    Ray Train surfaces the cloud's advance preemption notice (e.g. a spot/TPU
+    node drain) here so the training loop can react before the node is
+    reclaimed — for example, save a just-in-time checkpoint or run cleanup, then
+    exit cleanly. Returns ``None`` until a preemption affecting this worker
+    group is detected.
+
+    Example:
+
+        .. testcode::
+            :skipif: True
+
+            import ray.train
+
+            def train_func(config):
+                rank = ray.train.get_context().get_world_rank()
+                for step in range(config["total_steps"]):
+                    info = ray.train.preemption_status()
+                    if info is not None:
+                        if rank in info.preempted_ranks:
+                            # This worker's node is being reclaimed: clean up.
+                            ...
+                        else:
+                            # Survivor: save a just-in-time checkpoint.
+                            ray.train.report(metrics, checkpoint=checkpoint)
+                        return
+                    # ... normal training step ...
+
+    Returns:
+        A :class:`PreemptionInfo` describing the imminent preemption (which
+        node IDs / ranks are affected and the reclaim deadline), or ``None`` if
+        no preemption has been signaled.
+    """
+    return get_train_fn_utils().preemption_status()
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -147,7 +147,7 @@ def get_context() -> TrainContext:
 
 @PublicAPI(stability="alpha")
 @requires_train_worker(raise_in_tune_session=True)
-def preemption_status() -> Optional["PreemptionInfo"]:
+def preemption_info() -> Optional["PreemptionInfo"]:
     """Return the preemption signal for the current worker, or ``None``.
 
     Ray Train surfaces the cloud's advance preemption notice (e.g. a spot/TPU
@@ -166,7 +166,7 @@ def preemption_status() -> Optional["PreemptionInfo"]:
             def train_func(config):
                 rank = ray.train.get_context().get_world_rank()
                 for step in range(config["total_steps"]):
-                    info = ray.train.preemption_status()
+                    info = ray.train.preemption_info()
                     if info is not None:
                         if rank in info.preempted_ranks:
                             # This worker's node is being reclaimed: clean up.
@@ -182,7 +182,7 @@ def preemption_status() -> Optional["PreemptionInfo"]:
         node IDs / ranks are affected and the reclaim deadline), or ``None`` if
         no preemption has been signaled.
     """
-    return get_train_fn_utils().preemption_status()
+    return get_train_fn_utils().preemption_info()
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -15,7 +15,7 @@ from ray.util.annotations import PublicAPI
 if TYPE_CHECKING:
     from ray.data import DataIterator
     from ray.train import Checkpoint
-    from ray.train.v2._internal.execution.preemption import PreemptionInfo
+    from ray.train.v2.api.preemption import PreemptionInfo
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint
 
 
@@ -148,20 +148,15 @@ def get_context() -> TrainContext:
 @PublicAPI(stability="alpha")
 @requires_train_worker(raise_in_tune_session=True)
 def get_preemption_info() -> Optional["PreemptionInfo"]:
-    """Return the preemption signal for the current worker, or ``None``.
+    """Return the imminent preemption info for the current worker, or ``None``.
 
-    Ray Train surfaces the cloud's advance preemption notice (e.g. a spot/TPU
-    node drain) here so the training loop can react before the node is
-    reclaimed — for example, save a just-in-time checkpoint or run cleanup, then
-    exit cleanly. Returns ``None`` until a preemption affecting this worker
-    group is detected.
-
-    Reading the signal is informational. The recommended pattern is to save a
+    Returns ``None`` until a node hosting one of the workers is being preempted
+    (e.g. a spot instance reclaim). The recommended reaction is to save a
     just-in-time checkpoint and keep training: when the node is actually
-    reclaimed, Ray Train restarts and resumes the run from the latest checkpoint
-    (consuming the ``FailureConfig.max_preemption_failures`` budget). A run that
-    returns cleanly finishes regardless of any signal, so you do not need to
-    return early to trigger a restart.
+    preempted, Ray Train restarts the run and resumes it from the latest
+    checkpoint, retrying against ``FailureConfig.max_preemption_failures``.
+    A run that returns cleanly always finishes, whether or not a preemption
+    is in progress.
 
     Example:
 
@@ -173,17 +168,14 @@ def get_preemption_info() -> Optional["PreemptionInfo"]:
             def train_func(config):
                 for step in range(config["total_steps"]):
                     if ray.train.get_preemption_info() is not None:
-                        # Reclaim imminent: save a just-in-time checkpoint so the
-                        # restarted run resumes with minimal lost work. Keep
-                        # training -- Ray Train restarts you when the node is
-                        # actually reclaimed.
+                        # Save a just-in-time checkpoint and keep training.
                         ray.train.report(metrics, checkpoint=checkpoint)
                     # ... normal training step ...
 
     Returns:
-        A :class:`PreemptionInfo` describing the imminent preemption (which
-        node IDs / ranks are affected and the reclaim deadline), or ``None`` if
-        no preemption has been signaled.
+        A :class:`~ray.train.PreemptionInfo` with the affected node ids / world
+        ranks and the reclaim deadline, or ``None`` if no preemption has been
+        detected.
     """
     return get_train_fn_utils().get_preemption_info()
 

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -156,6 +156,13 @@ def get_preemption_info() -> Optional["PreemptionInfo"]:
     exit cleanly. Returns ``None`` until a preemption affecting this worker
     group is detected.
 
+    Reading the signal is informational. The recommended pattern is to save a
+    just-in-time checkpoint and keep training: when the node is actually
+    reclaimed, Ray Train restarts and resumes the run from the latest checkpoint
+    (consuming the ``FailureConfig.max_preemption_failures`` budget). A run that
+    returns cleanly finishes regardless of any signal, so you do not need to
+    return early to trigger a restart.
+
     Example:
 
         .. testcode::
@@ -164,17 +171,13 @@ def get_preemption_info() -> Optional["PreemptionInfo"]:
             import ray.train
 
             def train_func(config):
-                rank = ray.train.get_context().get_world_rank()
                 for step in range(config["total_steps"]):
-                    info = ray.train.get_preemption_info()
-                    if info is not None:
-                        if rank in info.preempted_ranks:
-                            # This worker's node is being reclaimed: clean up.
-                            ...
-                        else:
-                            # Survivor: save a just-in-time checkpoint.
-                            ray.train.report(metrics, checkpoint=checkpoint)
-                        return
+                    if ray.train.get_preemption_info() is not None:
+                        # Reclaim imminent: save a just-in-time checkpoint so the
+                        # restarted run resumes with minimal lost work. Keep
+                        # training -- Ray Train restarts you when the node is
+                        # actually reclaimed.
+                        ray.train.report(metrics, checkpoint=checkpoint)
                     # ... normal training step ...
 
     Returns:

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -147,7 +147,7 @@ def get_context() -> TrainContext:
 
 @PublicAPI(stability="alpha")
 @requires_train_worker(raise_in_tune_session=True)
-def preemption_info() -> Optional["PreemptionInfo"]:
+def get_preemption_info() -> Optional["PreemptionInfo"]:
     """Return the preemption signal for the current worker, or ``None``.
 
     Ray Train surfaces the cloud's advance preemption notice (e.g. a spot/TPU
@@ -166,7 +166,7 @@ def preemption_info() -> Optional["PreemptionInfo"]:
             def train_func(config):
                 rank = ray.train.get_context().get_world_rank()
                 for step in range(config["total_steps"]):
-                    info = ray.train.preemption_info()
+                    info = ray.train.get_preemption_info()
                     if info is not None:
                         if rank in info.preempted_ranks:
                             # This worker's node is being reclaimed: clean up.
@@ -182,7 +182,7 @@ def preemption_info() -> Optional["PreemptionInfo"]:
         node IDs / ranks are affected and the reclaim deadline), or ``None`` if
         no preemption has been signaled.
     """
-    return get_train_fn_utils().preemption_info()
+    return get_train_fn_utils().get_preemption_info()
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -168,9 +168,9 @@ def get_preemption_info() -> Optional["PreemptionInfo"]:
             def train_func(config):
                 for step in range(config["total_steps"]):
                     if ray.train.get_preemption_info() is not None:
-                        # Save a just-in-time checkpoint and keep training.
                         ray.train.report(metrics, checkpoint=checkpoint)
-                    # ... normal training step ...
+                    # ... normal training step (with your usual periodic
+                    # checkpointing) ...
 
     Returns:
         A :class:`~ray.train.PreemptionInfo` with the affected node ids / world

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -248,7 +248,7 @@ async def test_preemption_drain_then_restart():
 @pytest.mark.asyncio
 async def test_preemption_deadline_exceeded_and_raise():
     """If the reclaim deadline passes before workers exit, the controller stops
-    draining and surfaces a PreemptionError with deadline_exceeded=True."""
+    draining and surfaces a PreemptionError with drain_timed_out=True."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -276,7 +276,47 @@ async def test_preemption_deadline_exceeded_and_raise():
     state = controller.get_state()
     assert isinstance(state, ErroredState)
     assert isinstance(state.training_failed_error, PreemptionError)
-    assert state.training_failed_error.deadline_exceeded is True
+    assert state.training_failed_error.drain_timed_out is True
+
+
+def test_preemption_deadline_unknown_falls_back_to_default(monkeypatch):
+    """With no deadline reported, the drain wait is capped at the default grace
+    window measured from when the preemption was detected."""
+    import ray.train.v2._internal.execution.controller.controller as controller_module
+    from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_DEADLINE_S
+
+    info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
+    detected_at_s = 1000.0
+
+    # Before the fallback window elapses -> not exceeded.
+    monkeypatch.setattr(
+        controller_module,
+        "time_seconds",
+        lambda: detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S - 1,
+    )
+    assert not TrainController._is_preemption_deadline_exceeded(info, detected_at_s)
+
+    # After the fallback window elapses -> exceeded.
+    monkeypatch.setattr(
+        controller_module,
+        "time_seconds",
+        lambda: detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S + 1,
+    )
+    assert TrainController._is_preemption_deadline_exceeded(info, detected_at_s)
+
+
+def test_preemption_deadline_uses_reported_deadline(monkeypatch):
+    """A known deadline is honored regardless of when it was detected."""
+    import ray.train.v2._internal.execution.controller.controller as controller_module
+
+    # Deadline is 5s past epoch (5000ms).
+    info = PreemptionInfo(deadline_ms=5000, preempted_node_to_ranks={"node-a": [0]})
+
+    monkeypatch.setattr(controller_module, "time_seconds", lambda: 4.0)
+    assert not TrainController._is_preemption_deadline_exceeded(info, detected_at_s=0.0)
+
+    monkeypatch.setattr(controller_module, "time_seconds", lambda: 6.0)
+    assert TrainController._is_preemption_deadline_exceeded(info, detected_at_s=0.0)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -17,6 +17,7 @@ from ray.train.v2._internal.execution.controller.state import (
     ErroredState,
     FinishedState,
     InitializingState,
+    PreemptingState,
     ReschedulingState,
     ResizingState,
     RestartingState,
@@ -26,6 +27,7 @@ from ray.train.v2._internal.execution.controller.state import (
     TrainControllerState,
 )
 from ray.train.v2._internal.execution.failure_handling import FailureDecision
+from ray.train.v2._internal.execution.preemption import PreemptionInfo
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
@@ -35,7 +37,7 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerStatus,
 )
 from ray.train.v2.api.config import ScalingConfig
-from ray.train.v2.api.exceptions import ControllerError
+from ray.train.v2.api.exceptions import ControllerError, PreemptionError
 from ray.train.v2.tests.util import (
     DummyObjectRefWrapper,
     DummyWorkerGroup,
@@ -191,6 +193,90 @@ async def test_failure_handling():
     assert isinstance(controller.get_state(), ShuttingDownState)
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), ErroredState)
+
+
+async def _advance_to_running(controller, scaling_policy, num_workers):
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=num_workers, resources_per_worker={})
+    )
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), SchedulingState)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RunningState)
+
+
+@pytest.mark.asyncio
+async def test_preemption_drain_then_restart():
+    """A preemption signal moves Running -> Preempting; once workers drain, the
+    controller raises a PreemptionError through the failure policy and restarts."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group_before = controller.get_worker_group()
+
+    # A worker echoes a preemption signal (no deadline) -> PreemptingState.
+    info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
+    worker_group_before.preempt_worker(0, info)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # Workers still running and no deadline -> keep draining.
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # Once all workers exit, route through the failure policy and restart.
+    worker_group_before.finish_worker(0)
+    worker_group_before.finish_worker(1)
+    failure_policy.queue_decision(FailureDecision.RETRY)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RestartingState)
+    assert isinstance(controller.get_state().training_failed_error, PreemptionError)
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    # Full restart -> fresh worker group.
+    assert controller.get_worker_group() is not worker_group_before
+
+
+@pytest.mark.asyncio
+async def test_preemption_deadline_exceeded_and_raise():
+    """If the reclaim deadline passes before workers exit, the controller stops
+    draining and surfaces a PreemptionError with deadline_exceeded=True."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+
+    # Deadline of 1ms past epoch is always exceeded.
+    info = PreemptionInfo(deadline_ms=1, preempted_node_to_ranks={"node-a": [0, 1]})
+    controller.get_worker_group().preempt_worker(0, info)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # Deadline already passed even though workers are still running -> stop
+    # draining and raise.
+    failure_policy.queue_decision(FailureDecision.RAISE)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ShuttingDownState)
+    await controller._run_control_loop_iteration()
+    state = controller.get_state()
+    assert isinstance(state, ErroredState)
+    assert isinstance(state.training_failed_error, PreemptionError)
+    assert state.training_failed_error.deadline_exceeded is True
 
 
 @pytest.mark.parametrize(

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -246,6 +246,39 @@ async def test_preemption_drain_then_restart():
 
 
 @pytest.mark.asyncio
+async def test_preemption_takes_priority_over_clean_exit():
+    """If a worker reacts to preemption by checkpointing and returning (a clean
+    exit), the controller must still drain and restart, not finish the run."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    # Workers exit cleanly (no errors) but carry a preemption signal.
+    info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
+    worker_group.preempt_worker(0, info)
+    worker_group.finish_worker(0)
+    worker_group.finish_worker(1)
+    await controller._run_control_loop_iteration()
+    # Must NOT short-circuit to FinishedState.
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # Workers already exited -> next iteration drains and restarts.
+    failure_policy.queue_decision(FailureDecision.RETRY)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RestartingState)
+    assert isinstance(controller.get_state().training_failed_error, PreemptionError)
+
+
+@pytest.mark.asyncio
 async def test_preemption_deadline_exceeded_and_raise():
     """If the reclaim deadline passes before workers exit, the controller stops
     draining and surfaces a PreemptionError with drain_timed_out=True."""

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -535,6 +535,36 @@ def test_preemption_deadline_uses_reported_deadline(monkeypatch):
     assert TrainController._is_preemption_deadline_exceeded(info, detected_at_s=0.0)
 
 
+def test_preemption_deadline_caps_far_future_deadline(monkeypatch):
+    """A far-future reported deadline (e.g. from a staggered merge that dropped
+    an earlier no-deadline node's fallback) cannot extend the drain past the
+    default grace window measured from detection."""
+    import ray.train.v2._internal.execution.controller.controller as controller_module
+    from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_DEADLINE_S
+
+    detected_at_s = 1000.0
+    far_future_ms = (detected_at_s + 10 * DEFAULT_PREEMPTION_DEADLINE_S) * 1000
+    info = PreemptionInfo(
+        deadline_ms=int(far_future_ms), preempted_node_to_ranks={"node-a": [0]}
+    )
+
+    # Just before the cap -> not exceeded.
+    monkeypatch.setattr(
+        controller_module,
+        "time_seconds",
+        lambda: detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S - 1,
+    )
+    assert not TrainController._is_preemption_deadline_exceeded(info, detected_at_s)
+
+    # Past the cap but well before the reported deadline -> still exceeded.
+    monkeypatch.setattr(
+        controller_module,
+        "time_seconds",
+        lambda: detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S + 1,
+    )
+    assert TrainController._is_preemption_deadline_exceeded(info, detected_at_s)
+
+
 @pytest.mark.parametrize(
     "error_type", [WorkerGroupStartupFailedError, WorkerGroupStartupTimeoutError(2)]
 )

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -1,9 +1,8 @@
-from unittest.mock import create_autospec, patch
+from unittest.mock import create_autospec
 
 import pytest
 
 import ray
-import ray.train.v2._internal.execution.controller.controller as controller_module
 from ray.train.backend import Backend, BackendConfig
 from ray.train.v2._internal.constants import HEALTH_CHECK_INTERVAL_S_ENV_VAR
 from ray.train.v2._internal.exceptions import (
@@ -350,9 +349,8 @@ async def test_preemption_partial_kill_keeps_draining():
 @pytest.mark.asyncio
 async def test_preemption_clean_exit_finishes():
     """If the workers return cleanly, the run finishes rather than restarting,
-    even when a preemption signal is present -- the training function finished
-    before its node was reclaimed. A warning is logged so a training function
-    that returned early expecting a restart can catch the misuse."""
+    even when a preemption is in progress -- the training function finished
+    before its node was reclaimed."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -366,54 +364,17 @@ async def test_preemption_clean_exit_finishes():
     await _advance_to_running(controller, scaling_policy, num_workers=2)
     worker_group = controller.get_worker_group()
 
-    # A signal is present (echoed) but the workers return cleanly.
+    # A preemption is in progress (echoed) but the workers return cleanly.
     info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
     worker_group.preempt_worker(0, info)
     worker_group.finish_worker(0)
     worker_group.finish_worker(1)
-    with patch.object(controller_module.logger, "warning") as mock_warning:
-        await controller._run_control_loop_iteration()
+    await controller._run_control_loop_iteration()
 
     # Genuine completion: shut down toward FinishedState, not PreemptingState.
     state = controller.get_state()
     assert isinstance(state, ShuttingDownState)
     assert isinstance(state.next_state, FinishedState)
-    # The finished-during-preemption warning fired.
-    assert any(
-        "finished while a preemption was in progress" in str(call.args[0])
-        for call in mock_warning.call_args_list
-    )
-
-
-@pytest.mark.asyncio
-async def test_clean_exit_without_preemption_does_not_warn():
-    """A normal completion with no preemption signal finishes without the
-    finished-during-preemption warning."""
-    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
-    failure_policy = MockFailurePolicy(failure_config=None)
-    train_run_context = create_dummy_run_context()
-    controller = TrainController(
-        train_fn_ref=DummyObjectRefWrapper(lambda: None),
-        train_run_context=train_run_context,
-        scaling_policy=scaling_policy,
-        failure_policy=failure_policy,
-    )
-
-    await _advance_to_running(controller, scaling_policy, num_workers=2)
-    worker_group = controller.get_worker_group()
-
-    worker_group.finish_worker(0)
-    worker_group.finish_worker(1)
-    with patch.object(controller_module.logger, "warning") as mock_warning:
-        await controller._run_control_loop_iteration()
-
-    state = controller.get_state()
-    assert isinstance(state, ShuttingDownState)
-    assert isinstance(state.next_state, FinishedState)
-    assert not any(
-        "finished while a preemption was in progress" in str(call.args[0])
-        for call in mock_warning.call_args_list
-    )
 
 
 @pytest.mark.asyncio

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -38,7 +38,11 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerStatus,
 )
 from ray.train.v2.api.config import ScalingConfig
-from ray.train.v2.api.exceptions import ControllerError, PreemptionError
+from ray.train.v2.api.exceptions import (
+    ControllerError,
+    PreemptionError,
+    WorkerGroupError,
+)
 from ray.train.v2.tests.util import (
     DummyObjectRefWrapper,
     DummyWorkerGroup,
@@ -234,13 +238,15 @@ async def test_preemption_drain_then_restart():
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), PreemptingState)
 
-    # The reclaim kills the workers -> route through the failure policy, restart.
+    # The reclaim kills the workers -> route through the failure policy, which
+    # classifies the reclaim kill (RayActorError.preempted) against the
+    # preemption budget (see test_failure_policy.py), and restart.
     worker_group_before.preempt_kill_worker(0)
     worker_group_before.preempt_kill_worker(1)
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), RestartingState)
-    assert isinstance(controller.get_state().training_failed_error, PreemptionError)
+    assert isinstance(controller.get_state().training_failed_error, WorkerGroupError)
 
     await _advance_to_running(controller, scaling_policy, num_workers=2)
     # Full restart -> fresh worker group.
@@ -287,14 +293,12 @@ async def test_preemption_staggered_merges_while_draining():
     assert state.preemption_info.preempted_ranks == [0, 1]
     assert state.preemption_info.deadline_ms == far_future - 1000
 
-    # The reclaim kills the workers -> the PreemptionError carries the merged info.
+    # The reclaim kills the workers -> restart via the failure policy.
     worker_group.preempt_kill_worker(0)
     worker_group.preempt_kill_worker(1)
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
-    state = controller.get_state()
-    assert isinstance(state, RestartingState)
-    assert state.training_failed_error.preemption_info.preempted_ranks == [0, 1]
+    assert isinstance(controller.get_state(), RestartingState)
 
 
 @pytest.mark.asyncio
@@ -367,9 +371,10 @@ async def test_clean_exit_without_preemption_does_not_warn():
 
 
 @pytest.mark.asyncio
-async def test_preemption_worker_error_restarts():
-    """A worker killed by the reclaim (an error) is charged against the
-    preemption budget while a signal is active."""
+async def test_user_error_during_drain_is_worker_failure():
+    """A worker error that is NOT a reclaim kill (e.g. a bug in the training
+    function's just-in-time checkpoint) surfaces as a WorkerGroupError charged
+    against `max_failures`, even while a preemption is being drained."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -383,53 +388,55 @@ async def test_preemption_worker_error_restarts():
     await _advance_to_running(controller, scaling_policy, num_workers=2)
     worker_group = controller.get_worker_group()
 
-    # Signal present, and a worker is killed by the reclaim (a killed worker
-    # reports an error and is no longer running).
+    # Signal present -> PreemptingState.
     info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
     worker_group.preempt_worker(0, info)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # A worker fails with a plain user error (not a preempted actor death)
+    # while draining.
     worker_group.error_worker(0)
     worker_group.finish_worker(0)
-    await controller._run_control_loop_iteration()
-    # Routed to preemption handling (not the WorkerGroupError / max_failures path).
-    assert isinstance(controller.get_state(), PreemptingState)
-
     worker_group.finish_worker(1)
-    failure_policy.queue_decision(FailureDecision.RETRY)
-    await controller._run_control_loop_iteration()
-    assert isinstance(controller.get_state(), RestartingState)
-    assert isinstance(controller.get_state().training_failed_error, PreemptionError)
-
-
-@pytest.mark.asyncio
-async def test_preemption_detected_from_actor_error():
-    """A worker killed by a node reclaim (RayActorError.preempted) with no
-    advance echo is still charged to the preemption budget, not max_failures."""
-    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
-    failure_policy = MockFailurePolicy(failure_config=None)
-    train_run_context = create_dummy_run_context()
-    controller = TrainController(
-        train_fn_ref=DummyObjectRefWrapper(lambda: None),
-        train_run_context=train_run_context,
-        scaling_policy=scaling_policy,
-        failure_policy=failure_policy,
-    )
-
-    await _advance_to_running(controller, scaling_policy, num_workers=2)
-    worker_group = controller.get_worker_group()
-
-    # Worker 0 is killed by the reclaim (preempted actor error), no advance echo;
-    # worker 1 exits cleanly.
-    worker_group.preempt_kill_worker(0)
-    worker_group.finish_worker(1)
-    await controller._run_control_loop_iteration()
-    # Inferred from RayActorError.preempted -> preemption path, not WorkerGroupError.
-    assert isinstance(controller.get_state(), PreemptingState)
-
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
     state = controller.get_state()
     assert isinstance(state, RestartingState)
-    assert isinstance(state.training_failed_error, PreemptionError)
+    # Charged as a worker failure, not against the preemption budget.
+    assert isinstance(state.training_failed_error, WorkerGroupError)
+    assert not isinstance(state.training_failed_error, PreemptionError)
+
+
+@pytest.mark.asyncio
+async def test_preempted_death_without_signal_restarts_directly():
+    """A worker killed by a node reclaim (RayActorError.preempted) with no
+    advance signal restarts through the failure policy directly -- there is
+    nothing to drain, so the controller skips PreemptingState. The failure
+    policy charges the reclaim kill to the preemption budget (see
+    test_failure_policy.py)."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    # Worker 0 is killed by the reclaim (preempted actor error), no advance
+    # echo; worker 1 exits cleanly.
+    worker_group.preempt_kill_worker(0)
+    worker_group.finish_worker(1)
+    failure_policy.queue_decision(FailureDecision.RETRY)
+    await controller._run_control_loop_iteration()
+    state = controller.get_state()
+    assert isinstance(state, RestartingState)
+    assert isinstance(state.training_failed_error, WorkerGroupError)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -207,8 +207,9 @@ async def _advance_to_running(controller, scaling_policy, num_workers):
 
 @pytest.mark.asyncio
 async def test_preemption_drain_then_restart():
-    """A preemption signal moves Running -> Preempting; once workers drain, the
-    controller raises a PreemptionError through the failure policy and restarts."""
+    """A preemption signal moves Running -> Preempting and keeps draining while
+    workers run; when the reclaim kills them, a PreemptionError routes through
+    the failure policy to restart on a fresh worker group."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -232,9 +233,9 @@ async def test_preemption_drain_then_restart():
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), PreemptingState)
 
-    # Once all workers exit, route through the failure policy and restart.
-    worker_group_before.finish_worker(0)
-    worker_group_before.finish_worker(1)
+    # The reclaim kills the workers -> route through the failure policy, restart.
+    worker_group_before.preempt_kill_worker(0)
+    worker_group_before.preempt_kill_worker(1)
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), RestartingState)
@@ -246,9 +247,9 @@ async def test_preemption_drain_then_restart():
 
 
 @pytest.mark.asyncio
-async def test_preemption_takes_priority_over_clean_exit():
-    """If a worker reacts to preemption by checkpointing and returning (a clean
-    exit), the controller must still drain and restart, not finish the run."""
+async def test_preemption_staggered_merges_while_draining():
+    """A second preemption observed while draining is merged with the first, so
+    the final PreemptionError covers all affected nodes/ranks."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -262,16 +263,98 @@ async def test_preemption_takes_priority_over_clean_exit():
     await _advance_to_running(controller, scaling_policy, num_workers=2)
     worker_group = controller.get_worker_group()
 
-    # Workers exit cleanly (no errors) but carry a preemption signal.
+    # First preemption: node-a (rank 0) -> PreemptingState. Deadlines are epoch
+    # milliseconds; use far-future values so the drain doesn't time out.
+    far_future = 9_000_000_000_000
+    info_a = PreemptionInfo(
+        deadline_ms=far_future, preempted_node_to_ranks={"node-a": [0]}
+    )
+    worker_group.preempt_worker(0, info_a)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # While draining, a second node drains -> the echo now reports node-b
+    # (rank 1) with an earlier deadline. It should be merged with node-a.
+    info_b = PreemptionInfo(
+        deadline_ms=far_future - 1000, preempted_node_to_ranks={"node-b": [1]}
+    )
+    worker_group.preempt_worker(0, info_b)
+    await controller._run_control_loop_iteration()
+    state = controller.get_state()
+    assert isinstance(state, PreemptingState)
+    assert state.preemption_info.preempted_node_ids == ["node-a", "node-b"]
+    assert state.preemption_info.preempted_ranks == [0, 1]
+    assert state.preemption_info.deadline_ms == far_future - 1000
+
+    # The reclaim kills the workers -> the PreemptionError carries the merged info.
+    worker_group.preempt_kill_worker(0)
+    worker_group.preempt_kill_worker(1)
+    failure_policy.queue_decision(FailureDecision.RETRY)
+    await controller._run_control_loop_iteration()
+    state = controller.get_state()
+    assert isinstance(state, RestartingState)
+    assert state.training_failed_error.preemption_info.preempted_ranks == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_preemption_clean_exit_finishes():
+    """If the workers return cleanly, the run finishes rather than restarting,
+    even when a preemption signal is present -- the training function finished
+    before its node was reclaimed."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    # A signal is present (echoed) but the workers return cleanly.
     info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
     worker_group.preempt_worker(0, info)
     worker_group.finish_worker(0)
     worker_group.finish_worker(1)
     await controller._run_control_loop_iteration()
-    # Must NOT short-circuit to FinishedState.
+
+    # Genuine completion: shut down toward FinishedState, not PreemptingState.
+    state = controller.get_state()
+    assert isinstance(state, ShuttingDownState)
+    assert isinstance(state.next_state, FinishedState)
+
+
+@pytest.mark.asyncio
+async def test_preemption_worker_error_restarts():
+    """A worker killed by the reclaim (an error) is charged against the
+    preemption budget while a signal is active."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    # Signal present, and a worker is killed by the reclaim (a killed worker
+    # reports an error and is no longer running).
+    info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
+    worker_group.preempt_worker(0, info)
+    worker_group.error_worker(0)
+    worker_group.finish_worker(0)
+    await controller._run_control_loop_iteration()
+    # Routed to preemption handling (not the WorkerGroupError / max_failures path).
     assert isinstance(controller.get_state(), PreemptingState)
 
-    # Workers already exited -> next iteration drains and restarts.
+    worker_group.finish_worker(1)
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), RestartingState)
@@ -279,9 +362,49 @@ async def test_preemption_takes_priority_over_clean_exit():
 
 
 @pytest.mark.asyncio
-async def test_preemption_deadline_exceeded_and_raise():
-    """If the reclaim deadline passes before workers exit, the controller stops
-    draining and surfaces a PreemptionError with drain_timed_out=True."""
+async def test_preemption_detected_from_actor_error():
+    """A worker killed by a node reclaim (RayActorError.preempted) with no
+    advance echo is still charged to the preemption budget, not max_failures."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    # Worker 0 is killed by the reclaim (preempted actor error), no advance echo;
+    # worker 1 exits cleanly.
+    worker_group.preempt_kill_worker(0)
+    worker_group.finish_worker(1)
+    await controller._run_control_loop_iteration()
+    # Inferred from RayActorError.preempted -> preemption path, not WorkerGroupError.
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    failure_policy.queue_decision(FailureDecision.RETRY)
+    await controller._run_control_loop_iteration()
+    state = controller.get_state()
+    assert isinstance(state, RestartingState)
+    assert isinstance(state.training_failed_error, PreemptionError)
+
+
+@pytest.mark.parametrize(
+    "decision, expected_state",
+    [(FailureDecision.RETRY, RestartingState), (FailureDecision.RAISE, ErroredState)],
+)
+@pytest.mark.asyncio
+async def test_preemption_deadline_exceeded_routes_through_failure_policy(
+    decision, expected_state
+):
+    """The reclaim deadline only bounds how long we wait for workers to drain;
+    it does not by itself end the run. When it passes, we stop draining and route
+    the PreemptionError (with drain_timed_out=True) through the failure policy,
+    which RETRYs while the preemption budget remains and RAISEs once it's out."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -300,16 +423,23 @@ async def test_preemption_deadline_exceeded_and_raise():
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), PreemptingState)
 
-    # Deadline already passed even though workers are still running -> stop
-    # draining and raise.
-    failure_policy.queue_decision(FailureDecision.RAISE)
+    # Deadline already passed while workers are still running -> stop draining
+    # and let the failure policy decide (budget remaining -> RETRY, else RAISE).
+    failure_policy.queue_decision(decision)
     await controller._run_control_loop_iteration()
-    assert isinstance(controller.get_state(), ShuttingDownState)
-    await controller._run_control_loop_iteration()
-    state = controller.get_state()
-    assert isinstance(state, ErroredState)
-    assert isinstance(state.training_failed_error, PreemptionError)
-    assert state.training_failed_error.drain_timed_out is True
+
+    if expected_state is RestartingState:
+        state = controller.get_state()
+        assert isinstance(state, RestartingState)
+        assert isinstance(state.training_failed_error, PreemptionError)
+        assert state.training_failed_error.drain_timed_out is True
+    else:
+        assert isinstance(controller.get_state(), ShuttingDownState)
+        await controller._run_control_loop_iteration()
+        state = controller.get_state()
+        assert isinstance(state, ErroredState)
+        assert isinstance(state.training_failed_error, PreemptionError)
+        assert state.training_failed_error.drain_timed_out is True
 
 
 def test_preemption_deadline_unknown_falls_back_to_default(monkeypatch):

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -1,8 +1,9 @@
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, patch
 
 import pytest
 
 import ray
+import ray.train.v2._internal.execution.controller.controller as controller_module
 from ray.train.backend import Backend, BackendConfig
 from ray.train.v2._internal.constants import HEALTH_CHECK_INTERVAL_S_ENV_VAR
 from ray.train.v2._internal.exceptions import (
@@ -300,7 +301,8 @@ async def test_preemption_staggered_merges_while_draining():
 async def test_preemption_clean_exit_finishes():
     """If the workers return cleanly, the run finishes rather than restarting,
     even when a preemption signal is present -- the training function finished
-    before its node was reclaimed."""
+    before its node was reclaimed. A warning is logged so a training function
+    that returned early expecting a restart can catch the misuse."""
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = create_dummy_run_context()
@@ -319,12 +321,49 @@ async def test_preemption_clean_exit_finishes():
     worker_group.preempt_worker(0, info)
     worker_group.finish_worker(0)
     worker_group.finish_worker(1)
-    await controller._run_control_loop_iteration()
+    with patch.object(controller_module.logger, "warning") as mock_warning:
+        await controller._run_control_loop_iteration()
 
     # Genuine completion: shut down toward FinishedState, not PreemptingState.
     state = controller.get_state()
     assert isinstance(state, ShuttingDownState)
     assert isinstance(state.next_state, FinishedState)
+    # The finished-during-preemption warning fired.
+    assert any(
+        "finished while a preemption was in progress" in str(call.args[0])
+        for call in mock_warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_clean_exit_without_preemption_does_not_warn():
+    """A normal completion with no preemption signal finishes without the
+    finished-during-preemption warning."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    worker_group.finish_worker(0)
+    worker_group.finish_worker(1)
+    with patch.object(controller_module.logger, "warning") as mock_warning:
+        await controller._run_control_loop_iteration()
+
+    state = controller.get_state()
+    assert isinstance(state, ShuttingDownState)
+    assert isinstance(state.next_state, FinishedState)
+    assert not any(
+        "finished while a preemption was in progress" in str(call.args[0])
+        for call in mock_warning.call_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -247,7 +247,6 @@ async def test_preemption_drain_then_restart():
     error = controller.get_state().training_failed_error
     assert isinstance(error, PreemptionError)
     assert error.drain_timed_out is False
-    assert set(error.worker_failures) == {0, 1}
 
     await _advance_to_running(controller, scaling_policy, num_workers=2)
     # Full restart -> fresh worker group.
@@ -533,36 +532,6 @@ def test_preemption_deadline_uses_reported_deadline(monkeypatch):
 
     monkeypatch.setattr(controller_module, "time_seconds", lambda: 6.0)
     assert TrainController._is_preemption_deadline_exceeded(info, detected_at_s=0.0)
-
-
-def test_preemption_deadline_caps_far_future_deadline(monkeypatch):
-    """A far-future reported deadline (e.g. from a staggered merge that dropped
-    an earlier no-deadline node's fallback) cannot extend the drain past the
-    default grace window measured from detection."""
-    import ray.train.v2._internal.execution.controller.controller as controller_module
-    from ray.train.v2._internal.constants import DEFAULT_PREEMPTION_DEADLINE_S
-
-    detected_at_s = 1000.0
-    far_future_ms = (detected_at_s + 10 * DEFAULT_PREEMPTION_DEADLINE_S) * 1000
-    info = PreemptionInfo(
-        deadline_ms=int(far_future_ms), preempted_node_to_ranks={"node-a": [0]}
-    )
-
-    # Just before the cap -> not exceeded.
-    monkeypatch.setattr(
-        controller_module,
-        "time_seconds",
-        lambda: detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S - 1,
-    )
-    assert not TrainController._is_preemption_deadline_exceeded(info, detected_at_s)
-
-    # Past the cap but well before the reported deadline -> still exceeded.
-    monkeypatch.setattr(
-        controller_module,
-        "time_seconds",
-        lambda: detected_at_s + DEFAULT_PREEMPTION_DEADLINE_S + 1,
-    )
-    assert TrainController._is_preemption_deadline_exceeded(info, detected_at_s)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -238,15 +238,17 @@ async def test_preemption_drain_then_restart():
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), PreemptingState)
 
-    # The reclaim kills the workers -> route through the failure policy, which
-    # classifies the reclaim kill (RayActorError.preempted) against the
-    # preemption budget (see test_failure_policy.py), and restart.
+    # The reclaim kills all workers -> the drain is complete: a PreemptionError
+    # carrying the kill errors routes through the failure policy, and restart.
     worker_group_before.preempt_kill_worker(0)
     worker_group_before.preempt_kill_worker(1)
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), RestartingState)
-    assert isinstance(controller.get_state().training_failed_error, WorkerGroupError)
+    error = controller.get_state().training_failed_error
+    assert isinstance(error, PreemptionError)
+    assert error.drain_timed_out is False
+    assert set(error.worker_failures) == {0, 1}
 
     await _advance_to_running(controller, scaling_policy, num_workers=2)
     # Full restart -> fresh worker group.
@@ -293,12 +295,56 @@ async def test_preemption_staggered_merges_while_draining():
     assert state.preemption_info.preempted_ranks == [0, 1]
     assert state.preemption_info.deadline_ms == far_future - 1000
 
-    # The reclaim kills the workers -> restart via the failure policy.
+    # The reclaim kills the workers -> the PreemptionError carries the merged
+    # info from both staggered preemptions.
     worker_group.preempt_kill_worker(0)
     worker_group.preempt_kill_worker(1)
     failure_policy.queue_decision(FailureDecision.RETRY)
     await controller._run_control_loop_iteration()
-    assert isinstance(controller.get_state(), RestartingState)
+    state = controller.get_state()
+    assert isinstance(state, RestartingState)
+    assert isinstance(state.training_failed_error, PreemptionError)
+    assert state.training_failed_error.preemption_info.preempted_ranks == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_preemption_partial_kill_keeps_draining():
+    """A reclaim kill of a subset of ranks does not end the drain: the healthy
+    ranks keep running (e.g. finishing emergency checkpoints) until every rank
+    has exited or the deadline passes."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    train_run_context = create_dummy_run_context()
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=train_run_context,
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+
+    await _advance_to_running(controller, scaling_policy, num_workers=2)
+    worker_group = controller.get_worker_group()
+
+    # Signal (no deadline) -> PreemptingState.
+    info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"node-a": [0]})
+    worker_group.preempt_worker(0, info)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # Rank 0 is killed by the reclaim while rank 1 is still running: the drain
+    # continues so the healthy rank can keep training/checkpointing.
+    worker_group.preempt_kill_worker(0)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), PreemptingState)
+
+    # Once the remaining rank exits too, the drain completes and restarts.
+    worker_group.finish_worker(1)
+    failure_policy.queue_decision(FailureDecision.RETRY)
+    await controller._run_control_loop_iteration()
+    state = controller.get_state()
+    assert isinstance(state, RestartingState)
+    assert isinstance(state.training_failed_error, PreemptionError)
+    assert state.training_failed_error.drain_timed_out is False
 
 
 @pytest.mark.asyncio

--- a/python/ray/train/v2/tests/test_failure_policy.py
+++ b/python/ray/train/v2/tests/test_failure_policy.py
@@ -6,7 +6,20 @@ from ray.train.v2._internal.execution.failure_handling import (
     FailureDecision,
     create_failure_policy,
 )
-from ray.train.v2.api.exceptions import ControllerError, WorkerGroupError
+from ray.train.v2._internal.execution.preemption import PreemptionInfo
+from ray.train.v2.api.exceptions import (
+    ControllerError,
+    PreemptionError,
+    WorkerGroupError,
+)
+
+
+def _preemption_error():
+    return PreemptionError(
+        preemption_info=PreemptionInfo(
+            deadline_ms=None, preempted_node_to_ranks={"node-a": [0, 1]}
+        )
+    )
 
 
 def _controller_error(retryable):
@@ -95,6 +108,53 @@ def test_infinite_controller_failure_retry():
             policy.make_decision(training_failed_error=controller_error)
             == FailureDecision.RETRY
         )
+
+
+@pytest.mark.parametrize("max_preemption_failures", [0, 1, 10])
+def test_max_preemption_failures(max_preemption_failures):
+    policy = create_failure_policy(
+        FailureConfig(max_preemption_failures=max_preemption_failures)
+    )
+    for _ in range(max_preemption_failures):
+        assert (
+            policy.make_decision(training_failed_error=_preemption_error())
+            == FailureDecision.RETRY
+        )
+    assert (
+        policy.make_decision(training_failed_error=_preemption_error())
+        == FailureDecision.RAISE
+    )
+
+
+def test_infinite_preemption_retry_by_default():
+    # max_preemption_failures defaults to -1 (unlimited).
+    policy = create_failure_policy(FailureConfig())
+    for _ in range(10):
+        assert (
+            policy.make_decision(training_failed_error=_preemption_error())
+            == FailureDecision.RETRY
+        )
+
+
+def test_preemption_budget_is_separate_from_max_failures():
+    # Preemptions should not be charged against `max_failures`: with no worker
+    # failure budget, preemptions still retry while a real worker error raises.
+    policy = create_failure_policy(
+        FailureConfig(max_failures=0, max_preemption_failures=-1)
+    )
+    for _ in range(5):
+        assert (
+            policy.make_decision(training_failed_error=_preemption_error())
+            == FailureDecision.RETRY
+        )
+    assert (
+        policy.make_decision(
+            training_failed_error=_worker_group_error_from_errors(
+                [RuntimeError("boom")]
+            )
+        )
+        == FailureDecision.RAISE
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_failure_policy.py
+++ b/python/ray/train/v2/tests/test_failure_policy.py
@@ -1,7 +1,11 @@
 import pytest
 
+from ray.exceptions import RayActorError
 from ray.train import FailureConfig
-from ray.train.v2._internal.exceptions import WorkerGroupStartupTimeoutError
+from ray.train.v2._internal.exceptions import (
+    WorkerGroupStartupTimeoutError,
+    WorkerHealthCheckFailedError,
+)
 from ray.train.v2._internal.execution.failure_handling import (
     FailureDecision,
     create_failure_policy,
@@ -19,6 +23,19 @@ def _preemption_error():
         preemption_info=PreemptionInfo(
             deadline_ms=None, preempted_node_to_ranks={"node-a": [0, 1]}
         )
+    )
+
+
+def _preempted_death_worker_group_error():
+    """A worker group error where a worker was killed by a node reclaim."""
+    return WorkerGroupError(
+        "Worker group failed",
+        {
+            0: WorkerHealthCheckFailedError(
+                "worker died", failure=RayActorError(preempted=True)
+            ),
+            1: RuntimeError("collective communication aborted"),
+        },
     )
 
 
@@ -134,6 +151,44 @@ def test_infinite_preemption_retry_by_default():
             policy.make_decision(training_failed_error=_preemption_error())
             == FailureDecision.RETRY
         )
+
+
+@pytest.mark.parametrize("max_preemption_failures", [0, 1, 10])
+def test_preempted_worker_death_charged_to_preemption_budget(max_preemption_failures):
+    """A WorkerGroupError containing a reclaim kill (RayActorError.preempted) is
+    charged against max_preemption_failures, not max_failures."""
+    policy = create_failure_policy(
+        FailureConfig(max_failures=0, max_preemption_failures=max_preemption_failures)
+    )
+    for _ in range(max_preemption_failures):
+        assert (
+            policy.make_decision(
+                training_failed_error=_preempted_death_worker_group_error()
+            )
+            == FailureDecision.RETRY
+        )
+    assert (
+        policy.make_decision(
+            training_failed_error=_preempted_death_worker_group_error()
+        )
+        == FailureDecision.RAISE
+    )
+
+
+def test_non_preempted_actor_death_charged_to_max_failures():
+    """An actor death that was NOT caused by preemption stays on max_failures."""
+    policy = create_failure_policy(
+        FailureConfig(max_failures=0, max_preemption_failures=-1)
+    )
+    error = WorkerGroupError(
+        "Worker group failed",
+        {
+            0: WorkerHealthCheckFailedError(
+                "worker died", failure=RayActorError(preempted=False)
+            )
+        },
+    )
+    assert policy.make_decision(training_failed_error=error) == FailureDecision.RAISE
 
 
 def test_preemption_budget_is_separate_from_max_failures():

--- a/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
+++ b/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
@@ -1,4 +1,15 @@
-"""End-to-end preemption tests with a real ``DataParallelTrainer``."""
+"""End-to-end preemption tests with a real ``DataParallelTrainer``.
+
+Only the preemption info is mocked: the training function sets its own
+``PreemptionContext`` (byte-for-byte what ``RayTrainWorker.mark_preempt`` does
+when the ``PreemptionWatcher`` detects a node drain). Everything else -- the
+worker group, the controller state machine (RunningState -> PreemptingState),
+the failure policy, checkpoint resume -- is real. This keeps these tests fast
+and deterministic on a single node. Injecting the info directly (rather than
+mocking Ray Core's drain state) is deliberate: the PreemptionWatcher polls
+``get_draining_nodes`` inside its own actor process, so a driver-side mock
+cannot reach it; exercising a real GCS drain requires a multi-node cluster.
+"""
 
 import pytest
 
@@ -24,7 +35,7 @@ def ray_start_4_cpus():
 
 
 def test_preemption_clean_finish(tmp_path):
-    """A run that returns cleanly finishes even with an active preemption signal.
+    """A run that returns cleanly finishes even with an active preemption.
 
     ``max_preemption_failures=0`` and ``max_failures=0``: the run only succeeds
     if the clean return is treated as a completion, not a preemption restart.
@@ -36,13 +47,11 @@ def test_preemption_clean_finish(tmp_path):
         from ray.train.v2._internal.execution.context import get_train_context
         from ray.train.v2._internal.execution.preemption import PreemptionInfo
 
-        # Signal present the whole time; the UDF reads it but keeps training and
-        # returns normally.
-        get_train_context().preemption_context.set(
-            PreemptionInfo(
-                deadline_ms=None,
-                preempted_node_to_ranks={"mock-node": [0, 1]},
-            )
+        # Preemption in progress the whole time; the UDF reads it but keeps
+        # training and returns normally.
+        get_train_context().preemption_context.preemption_info = PreemptionInfo(
+            deadline_ms=None,
+            preempted_node_to_ranks={"mock-node": [0, 1]},
         )
         for step in range(2):
             assert ray.train.get_preemption_info() is not None
@@ -88,11 +97,9 @@ def test_preemption_deadline_restart_and_resume(tmp_path):
             # force-tears-us-down at the deadline.
             with create_dict_checkpoint({"step": 0}) as checkpoint:
                 ray.train.report({"step": 0}, checkpoint=checkpoint)
-            get_train_context().preemption_context.set(
-                PreemptionInfo(
-                    deadline_ms=1,  # epoch 1ms -> always in the past
-                    preempted_node_to_ranks={"mock-node": [0, 1]},
-                )
+            get_train_context().preemption_context.preemption_info = PreemptionInfo(
+                deadline_ms=1,  # epoch 1ms -> always in the past
+                preempted_node_to_ranks={"mock-node": [0, 1]},
             )
             time.sleep(60)  # interrupted by the forced teardown well before this
         else:
@@ -128,11 +135,9 @@ def test_preemption_budget_exhausted(tmp_path):
 
         # Every attempt is preempted with an already-passed deadline and keeps
         # running, so the controller force-tears-down each attempt.
-        get_train_context().preemption_context.set(
-            PreemptionInfo(
-                deadline_ms=1,  # epoch 1ms -> always in the past
-                preempted_node_to_ranks={"mock-node": [0, 1]},
-            )
+        get_train_context().preemption_context.preemption_info = PreemptionInfo(
+            deadline_ms=1,  # epoch 1ms -> always in the past
+            preempted_node_to_ranks={"mock-node": [0, 1]},
         )
         time.sleep(60)  # interrupted by the forced teardown well before this
 
@@ -149,7 +154,7 @@ def test_preemption_budget_exhausted(tmp_path):
 
 
 def test_user_error_with_signal_is_worker_failure(tmp_path):
-    """A training function bug while a preemption signal is active is still a
+    """A training function bug while a preemption is in progress is still a
     worker failure charged to ``max_failures`` -- it is not masked by the
     (unlimited-by-default) preemption budget."""
 
@@ -157,11 +162,9 @@ def test_user_error_with_signal_is_worker_failure(tmp_path):
         from ray.train.v2._internal.execution.context import get_train_context
         from ray.train.v2._internal.execution.preemption import PreemptionInfo
 
-        get_train_context().preemption_context.set(
-            PreemptionInfo(
-                deadline_ms=None,
-                preempted_node_to_ranks={"mock-node": [0, 1]},
-            )
+        get_train_context().preemption_context.preemption_info = PreemptionInfo(
+            deadline_ms=None,
+            preempted_node_to_ranks={"mock-node": [0, 1]},
         )
         raise RuntimeError("bug in jit checkpoint")
 

--- a/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
+++ b/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
@@ -1,21 +1,4 @@
-"""End-to-end preemption tests with a real ``DataParallelTrainer``.
-
-Only the preemption *signal* is mocked: the training function sets its own
-``PreemptionContext`` via ``get_train_context().preemption_context.set(...)``,
-which is byte-for-byte what ``RayTrainWorker.mark_preempt`` does when the
-``PreemptionWatcher`` detects a node drain. Everything else -- the worker group,
-the controller state machine (RunningState -> PreemptingState), the failure
-policy, checkpoint resume -- is real. This keeps these tests fast and
-deterministic on a single node; the nothing-mocked variant that drains a node
-through the real GCS ``DrainNode`` RPC on a multi-node cluster lives in
-test_preemption_drain.py.
-
-The controller restarts a run on an *actual* reclaim (a preempted worker death)
-or when the reclaim deadline elapses; a run that returns cleanly finishes
-regardless of any signal. A real preempted death can't be injected in-process,
-so the restart path is exercised here via the deadline (state-machine coverage
-of the death path lives in test_controller.py).
-"""
+"""End-to-end preemption tests with a real ``DataParallelTrainer``."""
 
 import pytest
 

--- a/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
+++ b/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
@@ -1,0 +1,130 @@
+"""End-to-end preemption tests with a real ``DataParallelTrainer``.
+
+Only the preemption *signal* is mocked: the training function sets its own
+``PreemptionContext`` via ``get_train_context().preemption_context.set(...)``,
+which is byte-for-byte what ``RayTrainWorker.mark_preempt`` does when the
+``PreemptionWatcher`` detects a node drain. Everything else -- the worker group,
+the controller state machine (RunningState -> PreemptingState), the failure
+policy, checkpoint resume -- is real.
+
+The controller restarts a run on an *actual* reclaim (a preempted worker death)
+or when the reclaim deadline elapses; a run that returns cleanly finishes
+regardless of any signal. A real preempted death can't be injected in-process,
+so the restart path is exercised here via the deadline (state-machine coverage
+of the death path lives in test_controller.py).
+"""
+
+import pytest
+
+import ray
+from ray.train import FailureConfig, RunConfig, ScalingConfig
+from ray.train.v2._internal.constants import is_v2_enabled
+from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
+
+assert is_v2_enabled()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ray_start_4_cpus():
+    ray.init(num_cpus=4)
+    yield
+    ray.shutdown()
+
+
+def test_preemption_clean_finish(tmp_path):
+    """A run that returns cleanly finishes even with an active preemption signal.
+
+    ``max_preemption_failures=0`` and ``max_failures=0``: the run only succeeds
+    if the clean return is treated as a completion, not a preemption restart.
+    """
+
+    def train_fn():
+        import ray.train
+        from ray.train.tests.util import create_dict_checkpoint
+        from ray.train.v2._internal.execution.context import get_train_context
+        from ray.train.v2._internal.execution.preemption import PreemptionInfo
+
+        # Signal present the whole time; the UDF reads it but keeps training and
+        # returns normally.
+        get_train_context().preemption_context.set(
+            PreemptionInfo(
+                deadline_ms=None,
+                preempted_node_to_ranks={"mock-node": [0, 1]},
+            )
+        )
+        for step in range(2):
+            assert ray.train.get_preemption_info() is not None
+            with create_dict_checkpoint({"step": step}) as checkpoint:
+                ray.train.report({"step": step}, checkpoint=checkpoint)
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(num_workers=2),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            failure_config=FailureConfig(max_failures=0, max_preemption_failures=0),
+        ),
+    )
+    result = trainer.fit()
+
+    assert result.error is None
+    assert result.metrics["step"] == 1
+
+
+def test_preemption_deadline_restart_and_resume(tmp_path):
+    """When the reclaim deadline elapses while workers are still running, the
+    controller tears them down and restarts, resuming from the last checkpoint.
+
+    ``max_failures=0`` is the key assertion: if the interruption were treated as
+    a generic worker error it would raise immediately. The run succeeding proves
+    it was classified as a preemption and retried against
+    ``max_preemption_failures``.
+    """
+
+    def train_fn():
+        import time
+
+        import ray.train
+        from ray.train.tests.util import create_dict_checkpoint, load_dict_checkpoint
+        from ray.train.v2._internal.execution.context import get_train_context
+        from ray.train.v2._internal.execution.preemption import PreemptionInfo
+
+        ckpt = ray.train.get_checkpoint()
+        if ckpt is None:
+            # First attempt: checkpoint, then signal a reclaim with an
+            # already-passed deadline and keep running so the controller
+            # force-tears-us-down at the deadline.
+            with create_dict_checkpoint({"step": 0}) as checkpoint:
+                ray.train.report({"step": 0}, checkpoint=checkpoint)
+            get_train_context().preemption_context.set(
+                PreemptionInfo(
+                    deadline_ms=1,  # epoch 1ms -> always in the past
+                    preempted_node_to_ranks={"mock-node": [0, 1]},
+                )
+            )
+            time.sleep(60)  # interrupted by the forced teardown well before this
+        else:
+            # Resumed attempt: finish.
+            step = load_dict_checkpoint(ckpt)["step"] + 1
+            with create_dict_checkpoint({"step": step}) as checkpoint:
+                ray.train.report({"step": step}, checkpoint=checkpoint)
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(num_workers=2),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            failure_config=FailureConfig(max_failures=0, max_preemption_failures=2),
+        ),
+    )
+    result = trainer.fit()
+
+    assert result.error is None
+    # Resumed from the step-0 checkpoint and ran to completion.
+    assert result.metrics["step"] == 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
+++ b/python/ray/train/v2/tests/test_preemption_fault_tolerance.py
@@ -5,7 +5,10 @@ Only the preemption *signal* is mocked: the training function sets its own
 which is byte-for-byte what ``RayTrainWorker.mark_preempt`` does when the
 ``PreemptionWatcher`` detects a node drain. Everything else -- the worker group,
 the controller state machine (RunningState -> PreemptingState), the failure
-policy, checkpoint resume -- is real.
+policy, checkpoint resume -- is real. This keeps these tests fast and
+deterministic on a single node; the nothing-mocked variant that drains a node
+through the real GCS ``DrainNode`` RPC on a multi-node cluster lives in
+test_preemption_drain.py.
 
 The controller restarts a run on an *actual* reclaim (a preempted worker death)
 or when the reclaim deadline elapses; a run that returns cleanly finishes
@@ -17,7 +20,13 @@ of the death path lives in test_controller.py).
 import pytest
 
 import ray
-from ray.train import FailureConfig, RunConfig, ScalingConfig
+from ray.train import (
+    FailureConfig,
+    PreemptionError,
+    RunConfig,
+    ScalingConfig,
+    WorkerGroupError,
+)
 from ray.train.v2._internal.constants import is_v2_enabled
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 
@@ -122,6 +131,67 @@ def test_preemption_deadline_restart_and_resume(tmp_path):
     assert result.error is None
     # Resumed from the step-0 checkpoint and ran to completion.
     assert result.metrics["step"] == 1
+
+
+def test_preemption_budget_exhausted(tmp_path):
+    """When preemption restarts exceed ``max_preemption_failures``, the run
+    raises a ``PreemptionError`` (not a generic worker error)."""
+
+    def train_fn():
+        import time
+
+        from ray.train.v2._internal.execution.context import get_train_context
+        from ray.train.v2._internal.execution.preemption import PreemptionInfo
+
+        # Every attempt is preempted with an already-passed deadline and keeps
+        # running, so the controller force-tears-down each attempt.
+        get_train_context().preemption_context.set(
+            PreemptionInfo(
+                deadline_ms=1,  # epoch 1ms -> always in the past
+                preempted_node_to_ranks={"mock-node": [0, 1]},
+            )
+        )
+        time.sleep(60)  # interrupted by the forced teardown well before this
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(num_workers=2),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            failure_config=FailureConfig(max_failures=0, max_preemption_failures=1),
+        ),
+    )
+    with pytest.raises(PreemptionError):
+        trainer.fit()
+
+
+def test_user_error_with_signal_is_worker_failure(tmp_path):
+    """A training function bug while a preemption signal is active is still a
+    worker failure charged to ``max_failures`` -- it is not masked by the
+    (unlimited-by-default) preemption budget."""
+
+    def train_fn():
+        from ray.train.v2._internal.execution.context import get_train_context
+        from ray.train.v2._internal.execution.preemption import PreemptionInfo
+
+        get_train_context().preemption_context.set(
+            PreemptionInfo(
+                deadline_ms=None,
+                preempted_node_to_ranks={"mock-node": [0, 1]},
+            )
+        )
+        raise RuntimeError("bug in jit checkpoint")
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(num_workers=2),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            failure_config=FailureConfig(max_failures=0, max_preemption_failures=-1),
+        ),
+    )
+    with pytest.raises(WorkerGroupError):
+        trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_preemption_watcher.py
+++ b/python/ray/train/v2/tests/test_preemption_watcher.py
@@ -6,7 +6,11 @@ import pytest
 
 import ray
 from ray.train.v2._internal.callbacks.preemption_callback import PreemptionCallback
-from ray.train.v2._internal.execution.preemption import PreemptionWatcher
+from ray.train.v2._internal.execution.preemption import (
+    PreemptionInfo,
+    PreemptionWatcher,
+    merge_preemption_info,
+)
 
 _PREEMPTION_MOD = "ray.train.v2._internal.execution.preemption"
 
@@ -215,6 +219,31 @@ class TestPreemptionCallbackTeardown:
 
         mock_kill.assert_called_once_with(watcher)
         assert callback._watcher is None
+
+
+def test_merge_preemption_info_unions_nodes_and_keeps_earliest_deadline():
+    a = PreemptionInfo(deadline_ms=5000, preempted_node_to_ranks={"n1": [0, 1]})
+    b = PreemptionInfo(deadline_ms=3000, preempted_node_to_ranks={"n2": [2]})
+    merged = merge_preemption_info(a, b)
+    assert merged.deadline_ms == 3000
+    assert merged.preempted_node_ids == ["n1", "n2"]
+    assert merged.preempted_ranks == [0, 1, 2]
+
+
+def test_merge_preemption_info_dedupes_overlapping_ranks():
+    a = PreemptionInfo(deadline_ms=5000, preempted_node_to_ranks={"n1": [0, 1]})
+    # Same node reappears with an additional rank; None deadline must not erase
+    # the known one.
+    b = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"n1": [1, 3]})
+    merged = merge_preemption_info(a, b)
+    assert merged.deadline_ms == 5000
+    assert merged.preempted_node_to_ranks == {"n1": [0, 1, 3]}
+
+
+def test_merge_preemption_info_both_deadlines_none():
+    a = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"n1": [0]})
+    b = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"n2": [1]})
+    assert merge_preemption_info(a, b).deadline_ms is None
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_preemption_watcher.py
+++ b/python/ray/train/v2/tests/test_preemption_watcher.py
@@ -253,11 +253,11 @@ def test_preemption_context_set_and_get():
     ctx = PreemptionContext()
 
     # No signal yet.
-    assert ctx.get() is None
+    assert ctx.preemption_info is None
 
     # After the watcher sets a signal, reads return it (purely informational).
-    ctx.set(info)
-    assert ctx.get() is info
+    ctx.preemption_info = info
+    assert ctx.preemption_info is info
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_preemption_watcher.py
+++ b/python/ray/train/v2/tests/test_preemption_watcher.py
@@ -7,6 +7,7 @@ import pytest
 import ray
 from ray.train.v2._internal.callbacks.preemption_callback import PreemptionCallback
 from ray.train.v2._internal.execution.preemption import (
+    PreemptionContext,
     PreemptionInfo,
     PreemptionWatcher,
     merge_preemption_info,
@@ -226,6 +227,7 @@ def test_merge_preemption_info_unions_nodes_and_keeps_earliest_deadline():
     b = PreemptionInfo(deadline_ms=3000, preempted_node_to_ranks={"n2": [2]})
     merged = merge_preemption_info(a, b)
     assert merged.deadline_ms == 3000
+    assert merged.preempted_node_to_ranks == {"n1": [0, 1], "n2": [2]}
     assert merged.preempted_node_ids == ["n1", "n2"]
     assert merged.preempted_ranks == [0, 1, 2]
 
@@ -244,6 +246,18 @@ def test_merge_preemption_info_both_deadlines_none():
     a = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"n1": [0]})
     b = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"n2": [1]})
     assert merge_preemption_info(a, b).deadline_ms is None
+
+
+def test_preemption_context_set_and_get():
+    info = PreemptionInfo(deadline_ms=None, preempted_node_to_ranks={"n1": [0]})
+    ctx = PreemptionContext()
+
+    # No signal yet.
+    assert ctx.get() is None
+
+    # After the watcher sets a signal, reads return it (purely informational).
+    ctx.set(info)
+    assert ctx.get() is info
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_worker.py
+++ b/python/ray/train/v2/tests/test_worker.py
@@ -95,7 +95,7 @@ def test_mark_preempt_stores_info(monkeypatch):
     info = PreemptionInfo(deadline_ms=30_000, preempted_node_to_ranks={"node-a": [0]})
     worker.mark_preempt(info)
 
-    assert get_train_context().preemption_context.get() is info
+    assert get_train_context().preemption_context.preemption_info is info
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_worker_group_poll_status.py
+++ b/python/ray/train/v2/tests/test_worker_group_poll_status.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ray.train.v2._internal.execution.preemption import PreemptionInfo
 from ray.train.v2._internal.execution.worker_group.poll import (
     ERR_CHAR_LIMIT,
     WorkerGroupPollStatus,
@@ -108,6 +109,27 @@ def test_failing_replica_group_indices_no_mapping():
     }
     poll_status = WorkerGroupPollStatus(worker_statuses=statuses)
     assert poll_status.failing_replica_group_indices == set()
+
+
+def test_get_preemption_info_none():
+    """No worker echoes a preemption signal."""
+    statuses = {
+        0: WorkerStatus(running=True),
+        1: WorkerStatus(running=True),
+    }
+    poll_status = WorkerGroupPollStatus(worker_statuses=statuses)
+    assert poll_status.get_preemption_info() is None
+
+
+def test_get_preemption_info_returns_echoed_signal():
+    """The first non-None echoed PreemptionInfo is returned."""
+    info = PreemptionInfo(deadline_ms=123, preempted_node_to_ranks={"node-a": [0]})
+    statuses = {
+        0: WorkerStatus(running=True, preemption_info=info),
+        1: WorkerStatus(running=True),
+    }
+    poll_status = WorkerGroupPollStatus(worker_statuses=statuses)
+    assert poll_status.get_preemption_info() is info
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_worker_group_poll_status.py
+++ b/python/ray/train/v2/tests/test_worker_group_poll_status.py
@@ -132,6 +132,51 @@ def test_get_preemption_info_returns_echoed_signal():
     assert poll_status.get_preemption_info() is info
 
 
+def test_get_preemption_info_from_preempted_actor_death():
+    """With no echo, a worker killed by preemption (RayActorError.preempted) is
+    still surfaced as a preemption; other deaths are not."""
+    from ray.exceptions import RayActorError
+    from ray.train.v2._internal.exceptions import WorkerHealthCheckFailedError
+
+    def _died(preempted):
+        return WorkerStatus(
+            running=False,
+            error=WorkerHealthCheckFailedError(
+                "died", failure=RayActorError(preempted=preempted)
+            ),
+        )
+
+    # Preempted death -> synthesized PreemptionInfo for that rank.
+    preempted = WorkerGroupPollStatus(
+        worker_statuses={0: _died(preempted=True), 1: WorkerStatus(running=False)}
+    )
+    info = preempted.get_preemption_info()
+    assert info is not None
+    assert info.preempted_ranks == [0]
+
+    # Non-preemption actor death -> not a preemption.
+    crashed = WorkerGroupPollStatus(
+        worker_statuses={0: _died(preempted=False), 1: WorkerStatus(running=False)}
+    )
+    assert crashed.get_preemption_info() is None
+
+    # A plain (non-actor) error -> not a preemption.
+    errored = WorkerGroupPollStatus(
+        worker_statuses={0: WorkerStatus(running=False, error=RuntimeError("boom"))}
+    )
+    assert errored.get_preemption_info() is None
+
+    # An echo still takes precedence over death inference.
+    echo = PreemptionInfo(deadline_ms=5, preempted_node_to_ranks={"node-a": [1]})
+    with_echo = WorkerGroupPollStatus(
+        worker_statuses={
+            0: _died(preempted=True),
+            1: WorkerStatus(running=False, preemption_info=echo),
+        }
+    )
+    assert with_echo.get_preemption_info() is echo
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_worker_group_poll_status.py
+++ b/python/ray/train/v2/tests/test_worker_group_poll_status.py
@@ -132,51 +132,6 @@ def test_get_preemption_info_returns_echoed_signal():
     assert poll_status.get_preemption_info() is info
 
 
-def test_get_preemption_info_from_preempted_actor_death():
-    """With no echo, a worker killed by preemption (RayActorError.preempted) is
-    still surfaced as a preemption; other deaths are not."""
-    from ray.exceptions import RayActorError
-    from ray.train.v2._internal.exceptions import WorkerHealthCheckFailedError
-
-    def _died(preempted):
-        return WorkerStatus(
-            running=False,
-            error=WorkerHealthCheckFailedError(
-                "died", failure=RayActorError(preempted=preempted)
-            ),
-        )
-
-    # Preempted death -> synthesized PreemptionInfo for that rank.
-    preempted = WorkerGroupPollStatus(
-        worker_statuses={0: _died(preempted=True), 1: WorkerStatus(running=False)}
-    )
-    info = preempted.get_preemption_info()
-    assert info is not None
-    assert info.preempted_ranks == [0]
-
-    # Non-preemption actor death -> not a preemption.
-    crashed = WorkerGroupPollStatus(
-        worker_statuses={0: _died(preempted=False), 1: WorkerStatus(running=False)}
-    )
-    assert crashed.get_preemption_info() is None
-
-    # A plain (non-actor) error -> not a preemption.
-    errored = WorkerGroupPollStatus(
-        worker_statuses={0: WorkerStatus(running=False, error=RuntimeError("boom"))}
-    )
-    assert errored.get_preemption_info() is None
-
-    # An echo still takes precedence over death inference.
-    echo = PreemptionInfo(deadline_ms=5, preempted_node_to_ranks={"node-a": [1]})
-    with_echo = WorkerGroupPollStatus(
-        worker_statuses={
-            0: _died(preempted=True),
-            1: WorkerStatus(running=False, preemption_info=echo),
-        }
-    )
-    assert with_echo.get_preemption_info() is echo
-
-
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -150,6 +150,10 @@ class DummyWorkerGroup(WorkerGroup):
         status = self._worker_statuses[worker_index]
         status.running = False
 
+    def preempt_worker(self, worker_index, preemption_info):
+        status = self._worker_statuses[worker_index]
+        status.preemption_info = preemption_info
+
     @classmethod
     def set_start_failure(cls, start_failure):
         cls._start_failure = start_failure

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -151,8 +151,24 @@ class DummyWorkerGroup(WorkerGroup):
         status.running = False
 
     def preempt_worker(self, worker_index, preemption_info):
+        """Simulate the watcher echoing a preemption signal to this worker."""
         status = self._worker_statuses[worker_index]
         status.preemption_info = preemption_info
+
+    def preempt_kill_worker(self, worker_index):
+        """Simulate a worker killed by a node reclaim with no advance echo.
+
+        The death surfaces as a WorkerHealthCheckFailedError wrapping a
+        RayActorError with preempted=True (see RayActorError.preempted).
+        """
+        from ray.exceptions import RayActorError
+        from ray.train.v2._internal.exceptions import WorkerHealthCheckFailedError
+
+        status = self._worker_statuses[worker_index]
+        status.running = False
+        status.error = WorkerHealthCheckFailedError(
+            f"Worker {worker_index} died", failure=RayActorError(preempted=True)
+        )
 
     @classmethod
     def set_start_failure(cls, start_failure):


### PR DESCRIPTION
## Description
This is stage 3 of preemption handling for Ray Train V2, stacked on top of stage 1 (#63807, watcher + observability) and stage 2 (#64099, worker-side fan-out). Stage 2 fans the preemption signal out to all workers; this stage
exposes it to user code and add the controller state to react to it.

1. add the public api: `ray.train.get_preemption_info()`, which returns the current `PreemptionInfo`
2. add `PreemptingState`, when an worker echoes a preemption signal in its poll status, controller transitions from `RunningState` -> `PreemptingState`.
3. in PreemptingState, controller will wait until  (a) all workers gone (b) reclaim deadline elapsed (`drain_timed_out`=True, force restart), (c) clean finish (run finish before the reclaim -> `Finished`.)
4. add `max_preemption_failures` in FailureConfig and `PreemptionError`.

### User behavior coverage
Note that currently, the deadline for preempting exit is the same as premption signal deadline or 120s if None.

| # | Situation | UDF behavior | preemption budget >= 0 | preemption budget < 0 |
|---|---|---|---|---|
| 1a | Ray Core draining signal arrives, then the reclaim kills **all** training workers (before or at the warned deadline) | Save a JIT checkpoint on the signal, keep training until killed | Enters `PreemptingState`; once every worker has exited → `PreemptionError(drain_timed_out=False)` → **restart + resume** | transfer into ShuttingDown and `ErroredState`; `fit()` raises `PreemptionError` |
| 1b | Ray Core draining signal arrives, Save a JIT checkpoint on the signal, keep training until killed **some** workers — others are still healthy | Healthy workers keep training and stuck at the next report barrier, util timeout | **Stays in `PreemptingState`** — the partial kill does *not* trigger an immediate restart; healthy workers get the rest of the grace window, until every worker exits (→ 1a) or the deadline passes (→ 2) | same as 1a / 2 |
| 2 |  Draining signal arrives but the reclaim is **late** — workers still alive at the warned deadline (or after 120s if the cloud gave no deadline) | Keep training | Enters `PreemptingState`; at the deadline Ray Train stops waiting → `PreemptionError(drain_timed_out=True)` → tears down the live workers itself → **restart + resume** | Run shuts down into `ErroredState`; `fit()` raises `PreemptionError` |
| 3 | Worker killed by a reclaim with **no warning ever observed** (no signal from Ray Core) | Nothing — there was no window to react | Skips `PreemptingState`; Ray Core tags the death (`RayActorError.preempted`), so the failure policy still charges it to the **preemption** budget → **restart + resume** | Run shuts down into `ErroredState`; raises `WorkerGroupError` carrying the preemption-tagged death |
| 4 | Training **finishes**  | Just `return`, as normal | The run **finishes** (`FinishedState`); **no budget consumed** (works even with `max_preemption_failures=0`);| — |
| 5 | A **bug in the training code** (e.g. the JIT-checkpoint part raises) while a warning is active or during the drain | e.g. user write a bug in jit checkpoint function | Fails fast: no `preempted` tag on the error → `WorkerGroupError` → charged to **`max_failures`**; the drain is not prolonged and the preemption budget never hides real bugs | retried/raised per `max_failures` |
| 6 | A **second node is warned** while the first is still draining (staggered preemption) | Nothing new — keep checkpointing | The signals are **merged** in `PreemptingState` (union of nodes/ranks, earliest deadline); exits via 1a/2 with the merged info in the error | same as 1a / 2 |


### Controller State transition graph for PreemptingState:
<img width="1340" height="1290" alt="3e915f722c3f4389dfa9e9d28fdcd207" src="https://github.com/user-attachments/assets/dfa5a19b-770c-42a4-b132-a41a75294781" />

## Related issues
part of #63968

## Additional information
tested with this script: https://gist.github.com/liulehui/2760cf896c4404f63827ba9e2664938b
this is the log:
```
RayTrainWorker pid=84119) [rank 1] PREEMPT signal: this=True preempting_ranks=[1] nodes=['2de6f67435d75ff6eb4045e628cbfd0fb0150ec1470b203d631b26da'] sec_left=14.7
(RayTrainWorker pid=84118) [rank 0] PREEMPT signal: this=False preempting_ranks=[1] nodes=['2de6f67435d75ff6eb4045e628cbfd0fb0150ec1470b203d631b26da'] sec_left=14.7
(RayTrainWorker pid=84119) [rank 1] starting fresh
(RayTrainWorker pid=84119) [rank 1] periodic checkpoint at step 0
(RayTrainWorker pid=84119) [rank 1] PREEMPT signal: this=True preempting_ranks=[1] nodes=['2de6f67435d75ff6eb4045e628cbfd0fb0150ec1470b203d631b26da'] sec_left=14.7
(RayTrainWorker pid=84118) [rank 0] EMERGENCY checkpoint at step 9
(RayTrainWorker pid=84118) [rank 0] EMERGENCY checkpoint at step 9
(RayTrainWorker pid=84119) Reporting training result 10: TrainingReport(checkpoint=None, metrics={'step': 9}, validation=False) from rank 1 [repeated 4x across cluster]
(TrainController pid=84105) [FailurePolicy] RETRY
(TrainController pid=84105)   Source: preemption
(TrainController pid=84105)   Error count: 1 (max allowed: 3)
(TrainController pid=84105) Error: Training was interrupted by node preemption (preempted_ranks=[1], drain_timed_out=False).
(TrainController pid=84105) ray.train.v2.api.exceptions.PreemptionError: Training was interrupted by node preemption (preempted_ranks=[1], drain_timed_out=False).
(TrainController pid=84105) Attempting to start training worker group of size 2 with the following resources: [{'worker_node': 1}] * 2
(raylet) /opt/homebrew/Caskroom/miniconda/base/envs/raytrain/lib/python3.12/site-packages/requests/__init__.py:86: RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).
(raylet)   warnings.warn(
(RayTrainWorker pid=84184) Setting up process group for: env:// [rank=0, world_size=2]
(RayTrainWorker pid=84184) [W625 15:57:53.256638000 ProcessGroupGloo.cpp:547] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
(TrainController pid=84105) Started training worker group of size 2: 
(TrainController pid=84105) - (ip=127.0.0.1, pid=84184) world_rank=0, local_rank=0, node_rank=0
(TrainController pid=84105) - (ip=127.0.0.1, pid=84183) world_rank=1, local_rank=1, node_rank=0
(RayTrainWorker pid=84184) [rank 0] RESUMED from step 9
(RayTrainWorker pid=84184) [rank 0] RESUMED from step 9
```