### PR TITLE
[Core] Define WIN32_LEAN_AND_MEAN globally for Windows builds

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -10,6 +10,9 @@ COPTS_TESTS = select({
     "@platforms//os:windows": [
         # TODO(mehrdadn): (How to) support dynamic linking?
         "-DRAY_STATIC",
+        # Prevent Windows.h from including WinSock.h, which conflicts with
+        # WinSock2.h used by Boost.Asio.
+        "-DWIN32_LEAN_AND_MEAN",
     ],
     "//conditions:default": [
         "-Wunused-result",

--- a/cpp/include/ray/api/logging.h
+++ b/cpp/include/ray/api/logging.h
@@ -19,10 +19,10 @@
 
 #if defined(_WIN32)
 #ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
-                             // headers you need manually.
-                             // (https://stackoverflow.com/a/8294669)
-#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
+// This is a public header that may be compiled outside of Ray's build system,
+// so we cannot rely on the -DWIN32_LEAN_AND_MEAN compiler flag from ray.bzl.
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN  // Prevent Windows.h from including WinSock.h
 #endif
 #include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
 #endif

--- a/src/ray/common/metrics.h
+++ b/src/ray/common/metrics.h
@@ -15,10 +15,6 @@
 #pragma once
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN  // The macro ensures that windows.h will include winsock2.h
-                             // and not winsock.h. boost.asio (another dependency in the
-                             // codebase) is not compatible with winsock.h.
-                             // (https://stackoverflow.com/a/8294669).
 #include <winsock2.h>
 #endif  // #ifdef _WIN32
 

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -28,14 +28,7 @@
 #include "ray/util/logging.h"
 
 #ifdef _WIN32
-#ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
-                             // headers you need manually.
-                             // (https://stackoverflow.com/a/8294669)
-#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
-#endif
 #include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
-#endif
 #endif
 
 namespace ray {

--- a/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
+++ b/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
@@ -31,14 +31,7 @@
 #endif
 
 #ifdef _WIN32
-#ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
-                             // headers you need manually.
-                             // (https://stackoverflow.com/a/8294669)
-#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
-#endif
 #include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
-#endif
 #include <direct.h>   // For _mkdir on Windows
 #include <process.h>  // For _getpid on Windows
 #endif

--- a/src/ray/stats/tests/metric_exporter_grpc_test.cc
+++ b/src/ray/stats/tests/metric_exporter_grpc_test.cc
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #ifdef _WIN32
-// Prevent inclusion of winsock.h
-#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #endif

--- a/src/ray/util/compat.h
+++ b/src/ray/util/compat.h
@@ -60,15 +60,8 @@ mach_port_t pthread_mach_thread_np(pthread_t);
 #endif
 
 #ifdef _WIN32
+#include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
 #include <io.h>
-#ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
-                             // headers you need manually.
-                             // (https://stackoverflow.com/a/8294669)
-#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
-#endif                       // #ifndef WIN32_LEAN_AND_MEAN
-#include <Windows.h>         // Force inclusion of WinGDI here to resolve name conflict
-#endif                       // #ifndef _WINDOWS_
 #define MEMFD_TYPE_NON_UNIQUE HANDLE
 #define INVALID_FD NULL
 // https://docs.microsoft.com/en-us/windows/win32/winauto/32-bit-and-64-bit-interoperability

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -64,15 +64,8 @@
 #include "ray/util/macros.h"
 
 #if defined(_WIN32)
-#ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
-                             // headers you need manually.
-                             // (https://stackoverflow.com/a/8294669)
-#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
-#endif
 #include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
-#endif
-#ifdef ERROR  // Should be true unless someone else undef'd it already
+#ifdef ERROR          // Should be true unless someone else undef'd it already
 #undef ERROR  // Windows GDI defines this macro; make it a global enum so it doesn't
               // conflict with our code
 enum { ERROR = 0 };

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -17,9 +17,6 @@
 #include "ray/util/process_utils.h"
 
 #ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
-#endif
 #include <Windows.h>
 #include <Winternl.h>
 #include <process.h>

--- a/src/ray/util/process_utils.cc
+++ b/src/ray/util/process_utils.cc
@@ -15,9 +15,6 @@
 #include "ray/util/process_utils.h"
 
 #ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
-#endif
 #include <Windows.h>
 #include <Winternl.h>
 #else

--- a/src/ray/util/thread_utils.h
+++ b/src/ray/util/thread_utils.h
@@ -23,14 +23,7 @@
 #endif
 
 #ifdef _WIN32
-#ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
-                             // headers you need manually.
-                             // (https://stackoverflow.com/a/8294669)
-#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
-#endif
 #include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
-#endif
 #endif
 
 #include <string>


### PR DESCRIPTION
Compilation errors can happen if `Windows.h` gets included before `Boost.Asio` headers (this causes `WinSock.h`, which is included by `Windows.h`, to conflict with `WinSock2.h`, which is included by `Boost.Asio`).

The current solution is to define `WIN32_LEAN_AND_MEAN` in a bunch of files. However, this is a bit fragile (and I noticed a compilation error in #63765 caused by this).

Separately, I verified this in https://github.com/ray-project/ray/pull/64331/ (the first commit triggers the compilation error, the second resolves it by setting the global compiler flag).

The goal of this PR is to solve the compilation issue more globally.

This PR does two things
- Add `-DWIN32_LEAN_AND_MEAN` to the Windows compiler flags. This prevents Windows.h from including WinSock.h, which conflicts with the WinSock2.h required by Boost.Asio. It seems pretty normal to set this as a global compiler flag. We already do this for hiredis.
- Remove redundant include guards and definitions of `WIN32_LEAN_AND_MEAN` from files.

Note that we continue to define it in cpp/include/ray/api/logging.h because in theory that file can be consumed externally without the compiler flags.

Some details on what `WIN32_LEAN_AND_MEAN` excludes are in this post https://stackoverflow.com/questions/11040133/what-does-defining-win32-lean-and-mean-exclude-exactly