### PR TITLE
[serve] Fix serve tests broken by protobuf 7

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -71,13 +71,17 @@ def _needs_pickle(deployment_language: DeploymentLanguage, is_cross_language: bo
         return False
 
 
-def _field_is_repeated(field: FieldDescriptor) -> bool:
-    # protobuf>=7 removed the deprecated FieldDescriptor.label in favor of the
-    # is_repeated property; fall back to label for older protobuf that lacks it.
-    is_repeated = getattr(field, "is_repeated", None)
-    if is_repeated is not None:
-        return bool(is_repeated)
-    return field.label == FieldDescriptor.LABEL_REPEATED
+# protobuf>=7 removed the deprecated FieldDescriptor.label in favor of the
+# is_repeated property; detect once at import and bind the right check.
+if hasattr(FieldDescriptor, "is_repeated"):
+
+    def _field_is_repeated(field: FieldDescriptor) -> bool:
+        return bool(field.is_repeated)
+
+else:
+
+    def _field_is_repeated(field: FieldDescriptor) -> bool:
+        return field.label == FieldDescriptor.LABEL_REPEATED
 
 
 def _proto_to_dict(proto: Message) -> Dict:

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -71,6 +71,15 @@ def _needs_pickle(deployment_language: DeploymentLanguage, is_cross_language: bo
         return False
 
 
+def _field_is_repeated(field: FieldDescriptor) -> bool:
+    # protobuf>=7 removed the deprecated FieldDescriptor.label in favor of the
+    # is_repeated property; fall back to label for older protobuf that lacks it.
+    is_repeated = getattr(field, "is_repeated", None)
+    if is_repeated is not None:
+        return bool(is_repeated)
+    return field.label == FieldDescriptor.LABEL_REPEATED
+
+
 def _proto_to_dict(proto: Message) -> Dict:
     """Recursively convert a protobuf into a Python dictionary.
 
@@ -82,7 +91,7 @@ def _proto_to_dict(proto: Message) -> Dict:
     # Fill data with non-empty fields.
     for field, value in proto.ListFields():
         # Handle repeated fields
-        if field.label == FieldDescriptor.LABEL_REPEATED:
+        if _field_is_repeated(field):
             # if we dont do this block the repeated field will be a list of
             # `google.protobuf.internal.containers.RepeatedScalarFieldContainer
             # Explicitly convert to list


### PR DESCRIPTION
## Description
protobuf 7's `upb` backend removed the deprecated `FieldDescriptor.label`, breaking `_proto_to_dict` (`AttributeError` in `deploy_applications`). Switch to `is_repeated`, falling back to label for older protobuf. Fixes `test_get_application_urls*` in the serve minimal CI step.

Broken run: https://buildkite.com/ray-project/postmerge/builds/18256/table?jid=019f0065-8bdf-4bfa-8172-9a26d41dd71b&tab=output

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
