### PR TITLE
[data] write_lance(mode=CREATE) errors instead of silently overwriting

### DIFF
--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -31,6 +31,7 @@ from ray.data.datasource.datasink import Datasink
 
 if TYPE_CHECKING:
     import pandas as pd
+    from lance import LanceDataset
     from lance.fragment import FragmentMetadata
 
 
@@ -244,17 +245,55 @@ class _BaseLanceDatasink(Datasink):
     def supports_distributed_writes(self) -> bool:
         return True
 
+    def _open_dataset(self) -> "LanceDataset":
+        """Open the Lance dataset at ``self.uri``.
+
+        Raises whatever Lance raises if the dataset can't be opened (missing,
+        bad ``storage_options``, etc.). Opening natively honors
+        ``storage_options``/``storage_options_provider``.
+        """
+        import lance
+
+        return lance.LanceDataset(
+            self.uri,
+            storage_options=self.storage_options,
+            storage_options_provider=self.storage_options_provider,
+        )
+
+    def _dataset_exists(self) -> bool:
+        """Whether a Lance dataset already exists at ``self.uri``.
+
+        A *successful open* is the authoritative existence signal, and it honors
+        ``storage_options`` for every backend. We intentionally do not try to
+        classify failures (e.g. by matching Lance error strings, which drift
+        across versions): if the dataset can't be opened we report it as
+        not-existing and let the subsequent write surface any real error (such
+        as invalid ``storage_options``) with Lance's own message.
+        """
+        try:
+            self._open_dataset()
+            return True
+        except Exception:
+            return False
+
     def on_write_start(self, schema: Optional["pa.Schema"] = None) -> None:
         _check_import(self, module="lance", package="pylance")
 
-        import lance
-
-        if self.mode == SaveMode.APPEND:
-            ds = lance.LanceDataset(
-                self.uri,
-                storage_options=self.storage_options,
-                storage_options_provider=self.storage_options_provider,
-            )
+        if self.mode == SaveMode.CREATE:
+            # CREATE must not clobber an existing dataset. Users who want to
+            # replace existing data should use SaveMode.OVERWRITE. Namespace
+            # writes manage table creation separately (the table location is
+            # declared/created up front), so skip the check in that case.
+            if self.table_id is None and self._dataset_exists():
+                raise ValueError(
+                    f"Dataset at {self.uri} already exists. "
+                    "Use mode=SaveMode.OVERWRITE to replace it, or "
+                    "mode=SaveMode.APPEND to add to it."
+                )
+        elif self.mode == SaveMode.APPEND:
+            # APPEND needs the existing dataset's version/schema. Let Lance
+            # raise its own error (e.g. dataset not found) if it can't open.
+            ds = self._open_dataset()
             self.read_version = ds.version
             if self.schema is None:
                 self.schema = ds.schema

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -171,6 +171,42 @@ def test_lance_write(data_path):
 
 
 @pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
+def test_lance_write_create_errors_if_exists(data_path):
+    table_path = os.path.join(data_path, "my_table")
+    ds = ray.data.range(10)
+
+    # First CREATE succeeds on an empty destination.
+    ds.write_lance(table_path, mode=SaveMode.CREATE)
+    assert lance.dataset(table_path).count_rows() == 10
+
+    # A second CREATE must error instead of silently overwriting.
+    with pytest.raises(ValueError, match="already exists"):
+        ray.data.range(5).write_lance(table_path, mode=SaveMode.CREATE)
+
+    # Existing data is untouched.
+    assert lance.dataset(table_path).count_rows() == 10
+
+    # CREATE is also the default mode, so it must guard too.
+    with pytest.raises(ValueError, match="already exists"):
+        ray.data.range(5).write_lance(table_path)
+    assert lance.dataset(table_path).count_rows() == 10
+
+    # OVERWRITE replaces the existing data.
+    ray.data.range(5).write_lance(table_path, mode=SaveMode.OVERWRITE)
+    assert lance.dataset(table_path).count_rows() == 5
+
+
+@pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
+def test_lance_write_append_errors_if_missing(data_path):
+    table_path = os.path.join(data_path, "missing_table")
+    # APPEND surfaces Lance's own "not found" error. We don't pin the message,
+    # since it can change across Lance versions.
+    with pytest.raises((ValueError, OSError, FileNotFoundError)):
+        ray.data.range(5).write_lance(table_path, mode=SaveMode.APPEND)
+    assert not os.path.exists(table_path)
+
+
+@pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
 def test_lance_write_min_rows_per_file(data_path):
     schema = pa.schema([pa.field("id", pa.int64()), pa.field("str", pa.string())])
 

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -201,7 +201,12 @@ def test_lance_write_append_errors_if_missing(data_path):
     table_path = os.path.join(data_path, "missing_table")
     # APPEND surfaces Lance's own "not found" error. We don't pin the message,
     # since it can change across Lance versions.
-    with pytest.raises((ValueError, OSError, FileNotFoundError)):
+    expected_errors: tuple[type[Exception], ...] = (
+        ValueError,
+        OSError,
+        FileNotFoundError,
+    )
+    with pytest.raises(expected_errors):
         ray.data.range(5).write_lance(table_path, mode=SaveMode.APPEND)
     assert not os.path.exists(table_path)
 


### PR DESCRIPTION
SaveMode.CREATE is documented to "create new data and error if data already exists", but the Lance sink mapped both CREATE and OVERWRITE to lance.LanceOperation.Overwrite without any existence check, silently clobbering an existing dataset. This diverges from FileDatasink, which errors on CREATE when the destination already exists.

on_write_start now checks for an existing dataset and raises on CREATE, directing users to OVERWRITE/APPEND. APPEND likewise raises a clear error when the dataset is missing. The check is skipped for namespace-backed writes, which declare/create the table location up front.

Closes #64363
 
