### PR TITLE
[core] Create event log files lazily to avoid stale/empty logs

### DIFF
--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -72,13 +72,27 @@ LogEventReporter::LogEventReporter(SourceTypeVariant source_type,
   file_name_ = "event_" + source_type_name +
                (add_pid_to_file ? "_" + std::to_string(getpid()) : "") + ".log";
 
-  std::string log_sink_key = GetReporterKey() + log_dir_ + file_name_;
-  log_sink_ = spdlog::get(log_sink_key);
+  // Store the sink key for lazy initialization.
+  // The log file will only be created on the first call to Report() or
+  // ReportExportEvent(), avoiding stale/empty log files at startup.
+  // See: https://github.com/ray-project/ray/issues/64153
+  log_sink_key_ = GetReporterKey() + log_dir_ + file_name_;
+  // Do NOT initialize log_sink_ here. It is lazily initialized in
+  // EnsureSinkInitialized(), which is called on the first write.
+}
+
+LogEventReporter::~LogEventReporter() { Flush(); }
+
+void LogEventReporter::EnsureSinkInitialized() {
+  if (log_sink_ != nullptr) {
+    return;
+  }
+  log_sink_ = spdlog::get(log_sink_key_);
   // If the file size is over {rotate_max_file_size_} MB, this file would be renamed
   // for example event_GCS.0.log, event_GCS.1.log, event_GCS.2.log ...
   // We allow to rotate for {rotate_max_file_num_} times.
   if (log_sink_ == nullptr) {
-    log_sink_ = spdlog::rotating_logger_mt(log_sink_key,
+    log_sink_ = spdlog::rotating_logger_mt(log_sink_key_,
                                            log_dir_ + file_name_,
                                            1048576 * rotate_max_file_size_,
                                            rotate_max_file_num_);
@@ -86,9 +100,13 @@ LogEventReporter::LogEventReporter(SourceTypeVariant source_type,
   log_sink_->set_pattern("%v");
 }
 
-LogEventReporter::~LogEventReporter() { Flush(); }
-
-void LogEventReporter::Flush() { log_sink_->flush(); }
+void LogEventReporter::Flush() {
+  // Guard against an uninitialized sink (no events were ever written,
+  // so no log file was created).
+  if (log_sink_ != nullptr) {
+    log_sink_->flush();
+  }
+}
 
 std::string LogEventReporter::replaceLineFeed(std::string message) {
   std::stringstream ss;
@@ -169,6 +187,8 @@ std::string LogEventReporter::ExportEventToString(const rpc::ExportEvent &export
 void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields) {
   RAY_CHECK(Event_SourceType_IsValid(event.source_type()));
   RAY_CHECK(Event_Severity_IsValid(event.severity()));
+  // Lazily create the log file on the first write.
+  EnsureSinkInitialized();
   std::string result = EventToString(event, custom_fields);
 
   log_sink_->info(result);
@@ -179,6 +199,8 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
 
 void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   RAY_CHECK(ExportEvent_SourceType_IsValid(export_event.source_type()));
+  // Lazily create the log file on the first write.
+  EnsureSinkInitialized();
   std::string result = ExportEventToString(export_event);
 
   log_sink_->info(result);

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -126,6 +126,11 @@ class LogEventReporter : public BaseEventReporter {
 
   virtual void Flush();
 
+  // Lazily initializes log_sink_ on the first write, so that no log file
+  // is created on disk unless at least one event is actually written.
+  // Fixes: https://github.com/ray-project/ray/issues/64153
+  void EnsureSinkInitialized();
+
   std::string GetReporterKey() override { return "log.event.reporter"; }
 
  protected:
@@ -136,6 +141,11 @@ class LogEventReporter : public BaseEventReporter {
 
   std::string file_name_;
 
+  // The key used to look up / register the spdlog logger. Stored to enable
+  // lazy initialization of log_sink_ in EnsureSinkInitialized().
+  std::string log_sink_key_;
+
+  // The underlying spdlog logger. nullptr until the first event is written.
   std::shared_ptr<spdlog::logger> log_sink_;
 };
 


### PR DESCRIPTION
## Why are these changes needed?
Fixes #64153
Ray currently creates several event log files eagerly at process startup,
even when they are never written to:
- `logs/events/event_CORE_WORKER_<pid>.log` — always empty
- `logs/events/event_GCS.log` — usually empty
- `logs/events/event_RAYLET.log` — usually empty
- `logs/export_events/*.log` — empty when new export framework is enabled
This creates unnecessary file clutter and wastes I/O on every Ray startup.
## What do these changes do?
Changes `LogEventReporter` in `src/ray/util/event.cc` to use lazy
initialization for the underlying log file. The log file is now only
created/opened on the **first call to `Report()`**, not in the constructor.
Key changes:
- Added `EnsureSinkInitialized()` private helper method
- Store `log_sink_key_` as a member variable for deferred initialization
- Modified `Flush()` to safely handle uninitialized sink
- All existing behavior is preserved when events are actually written
## Related issues/PRs
Closes #64153
## Checks
- [ ] I've signed off all commits with `git commit -s`
- [ ] I've run `scripts/format.sh` to lint the changes in Python
- [ ] I've run `clang-format` on C++ changes
- [ ] All existing tests pass locally
- [ ] Added/modified tests to cover the changes (if applicable)
