### PR TITLE
[DO NOT MERGE][release] ray 2.56.0 windows image fix

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -42,8 +42,12 @@ steps:
       # RELEASE-BUILD OVERRIDE (DO NOT MERGE): stamp the wheels with the real 2.56.0
       # release commit, even though this branch's HEAD carries the windowsbuild fix.
       # build-wheel-windows.sh reads BUILDKITE_COMMIT for ray.__commit__; the env is
-      # forwarded into the container via _DOCKER_ENV. Drop this line for the clean PR.
+      # forwarded into the container via _DOCKER_ENV. Drop these lines for the clean PR.
+      # BUILDKITE_BRANCH routes the broker upload (copy_files.py key is
+      # {BUILDKITE_BRANCH}/{BUILDKITE_COMMIT}/{fn}) to the release prefix the PyPI
+      # upload reads from, so no post-hoc S3 copy is needed.
       - export BUILDKITE_COMMIT=637fd062205393b9e1929996bfe1d49bd3f8469d
+      - export BUILDKITE_BRANCH=releases/2.56.0
       - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
     matrix:

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -39,6 +39,11 @@ steps:
     job_env: WINDOWS
     instance_type: windows
     commands:
+      # RELEASE-BUILD OVERRIDE (DO NOT MERGE): stamp the wheels with the real 2.56.0
+      # release commit, even though this branch's HEAD carries the windowsbuild fix.
+      # build-wheel-windows.sh reads BUILDKITE_COMMIT for ray.__commit__; the env is
+      # forwarded into the container via _DOCKER_ENV. Drop this line for the clean PR.
+      - export BUILDKITE_COMMIT=637fd062205393b9e1929996bfe1d49bd3f8469d
       - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
     matrix:

--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -16,9 +16,9 @@ conda init
 # Conda 26.3.1 crashes on Windows when it tries to clean up a locked exe during
 # a build-variant swap. Preventing self-update avoids that code path.
 conda config --set auto_update_conda false
-conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3
+conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3 pyopenssl=23.2.0
 # Force CA trust stack to the newest versions available at build time.
-conda update -c conda-forge -q -y ca-certificates certifi
+conda update --freeze-installed -c conda-forge -q -y ca-certificates certifi
 
 # Install torch first, as some dependencies (e.g. torch-spline-conv) need torch to be
 # installed for their own install.


### PR DESCRIPTION
  Backport of #64034 to `releases/2.56.0`.

  The Windows base image build (`ci/ray_ci/windows/build_base.sh`) crashes during the
  `conda update -c conda-forge ca-certificates certifi` step:

      AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'

  `cryptography>=38`, which removed `_lib.X509_V_FLAG_CB_ISSUER_CHECK`. `pyopenssl` is not
  part of that transaction, so the stale py3.8-era `pyopenssl` is left behind and still
  references the removed attribute at import. The next conda invocation imports
  `requests -> urllib3.contrib.pyopenssl -> OpenSSL.crypto` and detonates before conda can
  run, failing the `windowsbuild` image build — which in turn cascades every Windows test
  and the Windows wheel jobs into `waiting_failed`.

  This is already fixed on `master` (#64034); the release branch never received it, so the
  2.56.0 postmerge build produced no Windows wheels.

  ## What's changed
  
  `ci/ray_ci/windows/build_base.sh` only:
  - Co-resolve `pyopenssl=23.2.0` in the *same* `conda install` transaction as the Python
    upgrade, so it stays compatible with the `cryptography` 38.x that gets installed.
  - Add `--freeze-installed` to the `ca-certificates`/`certifi` update so it can't perturb
    the just-resolved env.