### PR TITLE
[core] Rename label_domain to topology strategy in scheduling policy

### DIFF
--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -583,17 +583,17 @@ child tasks and actors to the same placement group, specify ``PlacementGroupSche
 --------------------------------
 
 Within a :ref:`namespace <namespaces-guide>`, you can *name* a placement group.
-You can use the name of a placement group to retrieve the placement group from any job 
+You can use the name of a placement group to retrieve the placement group from any job
 in the Ray cluster, as long as the job is within the same namespace.
 This is useful if you can't directly pass the placement group handle to
 the actor or task that needs it, or if you are trying to
-access a placement group launched by another driver. 
+access a placement group launched by another driver.
 
-The placement group is destroyed when the original creation job completes if its 
+The placement group is destroyed when the original creation job completes if its
 lifetime isn't `detached`. You can avoid this by using a :ref:`detached placement group <placement-group-detached>`
 
-Note that this feature requires that you specify a 
-:ref:`namespace <namespaces-guide>` associated with it, or else you can't retrieve the 
+Note that this feature requires that you specify a
+:ref:`namespace <namespaces-guide>` associated with it, or else you can't retrieve the
 placement group across jobs.
 
 .. tab-set::
@@ -737,8 +737,8 @@ Ray reschedules Actors and tasks that use the bundle (reserved resources) based 
 .. warning::
 
   Topology strategy scheduling is an **alpha** feature. It's actively being iterated on and
-  the API surface may change. Ray currently only supports defining one topology label and 
-  one node level strategy (described below). For topology labels, Ray currently supports 
+  the API surface may change. Ray currently only supports defining one topology label and
+  one node level strategy (described below). For topology labels, Ray currently supports
   only ``STRICT_PACK``. Support for additional strategies and multi-level topologies is planned.
 
 Why topology strategy scheduling?
@@ -765,7 +765,7 @@ any domain and this becomes cumbersome if you have many GPU domains.
 
 Topology strategy scheduling currently solves this by letting you express a topology strategy for the placement
 group, which allows specifying a topology label within the cluster. Ray picks a value for this topology label
-that can satisfy all bundles (for example, a specific rack) and then applies your node-level strategy 
+that can satisfy all bundles (for example, a specific rack) and then applies your node-level strategy
 within that value.
 
 How it works
@@ -802,7 +802,7 @@ With this, Ray accomplishes the following:
 2. Selects a value for that label that can satisfy all bundles.
 3. Applies the node-level scheduling strategy within the selected value.
 
-Here is a following example to STRICT_SPREAD bundles across distinct nodes while still 
+Here is a following example to STRICT_SPREAD bundles across distinct nodes while still
 STRICT_PACKing them onto a single rack (``ray.io/gpu-domain`` is each rack's **topology label**):
 
 .. code-block:: python

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -731,18 +731,18 @@ Ray reschedules Actors and tasks that use the bundle (reserved resources) based 
 
 .. _pgroup-topology-strategy:
 
-[Alpha] Topology aware scheduling
----------------------------------
+[Alpha] Topology strategy scheduling
+------------------------------------
 
 .. warning::
 
-  Topology aware scheduling is an **alpha** feature. It's actively being iterated on and
+  Topology strategy scheduling is an **alpha** feature. It's actively being iterated on and
   the API surface may change. Ray currently only supports defining one topology label and 
   one node level strategy (described below). For topology labels, Ray currently supports 
   only ``STRICT_PACK``. Support for additional strategies and multi-level topologies is planned.
 
-Why topology aware scheduling?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why topology strategy scheduling?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The placement strategies above (PACK, STRICT_PACK, SPREAD, STRICT_SPREAD) operate purely on a
 per-node basis. For multi-node GPU domains such as GB200 or GB300 NVL racks where nodes share
@@ -763,7 +763,7 @@ fault tolerance. If all nodes in ``rack-1`` go down, the placement group can't a
 to a different rack. Furthermore, you have to manually specify a domain when you really just want
 any domain and this becomes cumbersome if you have many GPU domains.
 
-Topology aware scheduling currently solves this by letting you express a topology strategy for the placement 
+Topology strategy scheduling currently solves this by letting you express a topology strategy for the placement
 group, which allows specifying a topology label within the cluster. Ray picks a value for this topology label
 that can satisfy all bundles (for example, a specific rack) and then applies your node-level strategy 
 within that value.
@@ -771,7 +771,7 @@ within that value.
 How it works
 ~~~~~~~~~~~~
 
-Pass ``topology_strategy=`` to :func:`ray.util.placement_group` to enable topology-aware
+Pass ``topology_strategy=`` to :func:`ray.util.placement_group` to enable topology strategy
 placement. The argument is a dict that maps a label key to the placement strategy used at that level.
 
 Currently, ``topology_strategy`` is a dictionary that may contain up to two keys:
@@ -832,7 +832,7 @@ put the node-level strategy under ``ray.io/node-id`` in the same dict, as shown 
 Fault tolerance
 ~~~~~~~~~~~~~~~
 
-Topology aware scheduling improves on static label selectors by providing automatic
+Topology strategy scheduling improves on static label selectors by providing automatic
 fault tolerance at the topology-label level:
 
 - **Partial failure** (some nodes within the selected value of the topology label die):
@@ -851,7 +851,7 @@ fault tolerance at the topology-label level:
 Observability
 ~~~~~~~~~~~~~
 
-You can inspect topology-aware placement groups using the existing placement group
+You can inspect topology strategy placement groups using the existing placement group
 observability tools:
 
 - **Dashboard**: The placement group table shows a ``Topology`` column, which displays the
@@ -890,7 +890,7 @@ packs onto a single ``ray.io/gpu-domain``:
     - assignments:
         ray.io/gpu-domain: rack-2
 
-For placement groups that don't use topology-aware scheduling, ``topology_strategy`` and
+For placement groups that don't use a topology strategy, ``topology_strategy`` and
 ``topology_assignments`` are both empty lists. Both fields appear only when you pass
 ``--detail``.
 

--- a/python/ray/tests/test_topology_strategy.py
+++ b/python/ray/tests/test_topology_strategy.py
@@ -25,7 +25,7 @@ def assert_pg_nodes_label_value(cluster_nodes, pg, label, value):
 
 
 def test_topology_strategy_feasible_after_rack_kill(ray_start_cluster):
-    """Verify topology-aware rescheduling after total rack failure.
+    """Verify topology strategy rescheduling after total rack failure.
 
     Creates a PG on rack 1 (the only available rack at the time). After
     removing one rack 1 node, the PG enters RESCHEDULING but stays pinned to

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -165,7 +165,7 @@ def placement_group(
             This currently only works with STRICT_PACK pg.
         bundle_label_selector: A list of label selectors to apply to a
             placement group on a per-bundle level.
-        topology_strategy: Topology-aware placement. A dict mapping each
+        topology_strategy: Topology strategy placement. A dict mapping each
             topology label key to a placement strategy (e.g.,
             ``{"ray.io/gpu-domain": "STRICT_PACK"}``).
             Mutually exclusive with `strategy`.

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -567,7 +567,7 @@ class PlacementGroupState(StateSchema):
     #: The topology strategy for this placement group: a dict mapping each
     #: topology label key (e.g. "ray.io/gpu-domain") to a placement strategy
     #: (e.g. "STRICT_PACK"). Empty dict if the placement group does not use
-    #: topology-aware scheduling.
+    #: a topology strategy.
     #:
     #: NOTE: This field is experimental and may change in the future.
     topology_strategy: Optional[dict] = state_column(filterable=False, detail=True)

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -259,7 +259,7 @@ void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
       }
     }
 
-    // Populate locality_requirement if this PG uses topology-aware scheduling.
+    // Populate locality_requirement if this PG uses a topology strategy.
     const auto &topology_strategy = pg_data.topology_strategy();
     if (!topology_strategy.empty()) {
       const auto &[topology_label_key, _strategy] = *topology_strategy.begin();

--- a/src/ray/gcs/gcs_placement_group.h
+++ b/src/ray/gcs/gcs_placement_group.h
@@ -165,7 +165,7 @@ class GcsPlacementGroup {
   rpc::PlacementGroupStats *GetMutableStats();
 
   /// Get the non-node topology label keys (e.g. {"ray.io/gpu-domain"}), or
-  /// std::nullopt if this PG doesn't use topology-aware scheduling.
+  /// std::nullopt if this PG doesn't use a topology strategy.
   std::optional<std::vector<std::string>> GetTopologyStrategyKeys() const;
 
   /// Get the topology assignment value selected for `label_key` (e.g. the
@@ -176,8 +176,8 @@ class GcsPlacementGroup {
   void SetTopologyAssignment(const std::string &label_key,
                              const std::string &label_value);
 
-  /// Clear all topology assignments (used when every bundle of a topology-aware
-  /// PG becomes unplaced, so a fresh selection can be made).
+  /// Clear all topology assignments (used when every bundle of a topology
+  /// strategy PG becomes unplaced, so a fresh selection can be made).
   void ClearTopologyAssignments();
 
  private:

--- a/src/ray/gcs/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_placement_group_manager.cc
@@ -731,7 +731,7 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
             iter->second->GetPlacementGroupTableData(),
             {[this](Status status) { SchedulePendingPlacementGroups(); }, io_context_});
       } else if (iter->second->GetState() == rpc::PlacementGroupTableData::RESCHEDULING) {
-        // For topology-aware PGs that are stuck in the infeasible queue: if ALL
+        // For topology strategy PGs that are stuck in the infeasible queue: if ALL
         // bundles are now unplaced (total failure), move the PG back to the
         // pending queue so the scheduler can clear the stale topology
         // assignments and retry on a fresh selection. The manager here is just

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -57,7 +57,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
   const auto &bundles = placement_group->GetUnplacedBundles();
   const auto &strategy = placement_group->GetStrategy();
 
-  // For topology-aware PGs: if ALL bundles are unplaced (total failure), clear
+  // For topology strategy PGs: if ALL bundles are unplaced (total failure), clear
   // the topology assignments so new values can be selected. If only some bundles
   // are unplaced (partial failure), we attempt to reschedule onto the same
   // assignments.

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -105,10 +105,9 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
   RAY_CHECK(bundles.size() == selected_nodes.size());
 
-  // TODO(#64370) rename this to fit topology strategy
-  if (scheduling_result.selected_label_domain.has_value()) {
+  if (scheduling_result.selected_topology_assignment.has_value()) {
     const auto &[topology_label_key, topology_label_value] =
-        *scheduling_result.selected_label_domain;
+        *scheduling_result.selected_topology_assignment;
     placement_group->SetTopologyAssignment(topology_label_key, topology_label_value);
     RAY_LOG(INFO) << "Placement group " << placement_group->GetPlacementGroupID()
                   << " assigned to topology label " << topology_label_key << ": "

--- a/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
@@ -1434,7 +1434,7 @@ TEST_F(GcsAutoscalerStateManagerTest,
 
   const auto &req = requests.Get(0);
   ASSERT_EQ(req.bundle_selectors_size(), 1);
-  // Does not use topology-aware scheduling, so locality_requirement should not be set.
+  // Does not use a topology strategy, so locality_requirement should not be set.
   EXPECT_FALSE(req.bundle_selectors(0).has_locality_requirement());
 }
 

--- a/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
@@ -1415,7 +1415,7 @@ TEST_F(GcsAutoscalerStateManagerTest,
 }
 
 TEST_F(GcsAutoscalerStateManagerTest,
-       TestGetPendingGangResourceRequestsNoLocalityWithoutLabelDomainKey) {
+       TestGetPendingGangResourceRequestsNoLocalityWithoutTopologyStrategyKey) {
   rpc::PlacementGroupLoad load;
   auto *pg_data = load.add_placement_group_data();
   pg_data->set_state(rpc::PlacementGroupTableData::PENDING);
@@ -1434,7 +1434,7 @@ TEST_F(GcsAutoscalerStateManagerTest,
 
   const auto &req = requests.Get(0);
   ASSERT_EQ(req.bundle_selectors_size(), 1);
-  // Does not use label-domain scheduling, so locality_requirement should not be set.
+  // Does not use topology-aware scheduling, so locality_requirement should not be set.
   EXPECT_FALSE(req.bundle_selectors(0).has_locality_requirement());
 }
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -686,7 +686,7 @@ message PlacementGroupTableData {
   map<string, string> topology_assignments = 17;
   // Topology strategy that applies to this PG. Mirrors
   // PlacementGroupSpec.topology_strategy. Empty if the PG does not use
-  // topology-aware scheduling.
+  // a topology strategy.
   map<string, PlacementStrategy> topology_strategy = 18;
 }
 

--- a/src/ray/raylet/scheduling/BUILD.bazel
+++ b/src/ray/raylet/scheduling/BUILD.bazel
@@ -219,9 +219,9 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "label_domain_bundle_scheduling_policy",
-    srcs = ["policy/label_domain_bundle_scheduling_policy.cc"],
-    hdrs = ["policy/label_domain_bundle_scheduling_policy.h"],
+    name = "topology_bundle_scheduling_policy",
+    srcs = ["policy/topology_bundle_scheduling_policy.cc"],
+    hdrs = ["policy/topology_bundle_scheduling_policy.h"],
     deps = [
         ":cluster_resource_manager",
         ":scheduling_policy",
@@ -237,11 +237,11 @@ ray_cc_library(
         ":bundle_scheduling_policy",
         ":cluster_resource_manager",
         ":hybrid_scheduling_policy",
-        ":label_domain_bundle_scheduling_policy",
         ":node_affinity_scheduling_policy",
         ":node_label_scheduling_policy",
         ":random_scheduling_policy",
         ":spread_scheduling_policy",
+        ":topology_bundle_scheduling_policy",
     ],
 )
 

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
@@ -47,21 +47,21 @@ SchedulingResult CompositeBundleSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
     SchedulingOptions options,
     absl::flat_hash_set<scheduling::NodeID> candidate_nodes) {
-  if (options.label_domain_scheduling_strategy_ != LabelDomainSchedulingStrategy::NONE) {
+  if (options.topology_scheduling_strategy_ != TopologySchedulingStrategy::NONE) {
     NodeScheduleFn node_schedule_fn =
         [this](const std::vector<const ResourceRequest *> &reqs,
                SchedulingOptions opts,
                absl::flat_hash_set<scheduling::NodeID> nodes) {
-          opts.label_domain_scheduling_strategy_ = LabelDomainSchedulingStrategy::NONE;
+          opts.topology_scheduling_strategy_ = TopologySchedulingStrategy::NONE;
           return this->Schedule(reqs, std::move(opts), std::move(nodes));
         };
-    switch (options.label_domain_scheduling_strategy_) {
-    case LabelDomainSchedulingStrategy::STRICT_PACK:
-      return label_domain_strict_pack_policy_.Schedule(
+    switch (options.topology_scheduling_strategy_) {
+    case TopologySchedulingStrategy::STRICT_PACK:
+      return topology_strict_pack_policy_.Schedule(
           resource_request_list, options, std::move(candidate_nodes), node_schedule_fn);
     default:
-      RAY_LOG(FATAL) << "Unsupported label domain scheduling strategy: "
-                     << static_cast<int>(options.label_domain_scheduling_strategy_);
+      RAY_LOG(FATAL) << "Unsupported topology scheduling strategy: "
+                     << static_cast<int>(options.topology_scheduling_strategy_);
     }
     UNREACHABLE;
   }

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
@@ -20,11 +20,11 @@
 #include "ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/bundle_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/hybrid_scheduling_policy.h"
-#include "ray/raylet/scheduling/policy/label_domain_bundle_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/node_affinity_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/node_label_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/random_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/spread_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
@@ -74,7 +74,7 @@ class CompositeBundleSchedulingPolicy : public IBundleSchedulingPolicy {
         bundle_spread_policy_(cluster_resource_manager),
         bundle_strict_spread_policy_(cluster_resource_manager),
         bundle_strict_pack_policy_(cluster_resource_manager),
-        label_domain_strict_pack_policy_(cluster_resource_manager) {}
+        topology_strict_pack_policy_(cluster_resource_manager) {}
 
   SchedulingResult Schedule(
       const std::vector<const ResourceRequest *> &resource_request_list,
@@ -86,7 +86,7 @@ class CompositeBundleSchedulingPolicy : public IBundleSchedulingPolicy {
   BundleSpreadSchedulingPolicy bundle_spread_policy_;
   BundleStrictSpreadSchedulingPolicy bundle_strict_spread_policy_;
   BundleStrictPackSchedulingPolicy bundle_strict_pack_policy_;
-  LabelDomainStrictPackSchedulingPolicy label_domain_strict_pack_policy_;
+  TopologyStrictPackSchedulingPolicy topology_strict_pack_policy_;
 };
 
 }  // namespace raylet_scheduling_policy

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -43,9 +43,9 @@ enum class SchedulingType {
   NODE_LABEL = 9,
 };
 
-// Label-domain-level scheduling strategies for placement groups.
+// Topology-level scheduling strategies for placement groups.
 // Only STRICT_PACK is supported for now.
-enum class LabelDomainSchedulingStrategy {
+enum class TopologySchedulingStrategy {
   NONE = 0,
   STRICT_PACK = 1,
 };
@@ -78,7 +78,7 @@ struct SchedulingOptions {
                              avoid_local_node,
                              require_node_available,
                              RayConfig::instance().scheduler_avoid_gpu_nodes(),
-                             /*target_label_domain*/ std::nullopt,
+                             /*target_topology_assignment*/ std::nullopt,
                              /*scheduling_context*/ nullptr,
                              preferred_node_id);
   }
@@ -115,7 +115,7 @@ struct SchedulingOptions {
         /*avoid_local_node*/ false,
         /*require_node_available*/ true,
         /*avoid_gpu_nodes*/ RayConfig::instance().scheduler_avoid_gpu_nodes(),
-        /*target_label_domain*/ std::nullopt,
+        /*target_topology_assignment*/ std::nullopt,
         std::move(scheduling_context));
   }
 
@@ -129,7 +129,7 @@ struct SchedulingOptions {
         /*avoid_local_node*/ false,
         /*require_node_available*/ true,
         /*avoid_gpu_nodes*/ RayConfig::instance().scheduler_avoid_gpu_nodes(),
-        /*target_label_domain*/ std::nullopt,
+        /*target_topology_assignment*/ std::nullopt,
         std::move(scheduling_context));
   }
   /*
@@ -139,38 +139,38 @@ struct SchedulingOptions {
   // construct option for soft pack scheduling policy.
   static SchedulingOptions BundlePack(
       std::optional<std::pair<std::string, std::optional<std::string>>>
-          target_label_domain = std::nullopt) {
+          target_topology_assignment = std::nullopt) {
     return SchedulingOptions(SchedulingType::BUNDLE_PACK,
                              /*spread_threshold*/ 0,
                              /*avoid_local_node*/ false,
                              /*require_node_available*/ true,
                              /*avoid_gpu_nodes*/ false,
-                             std::move(target_label_domain));
+                             std::move(target_topology_assignment));
   }
 
   // construct option for strict spread scheduling policy.
   static SchedulingOptions BundleSpread(
       std::optional<std::pair<std::string, std::optional<std::string>>>
-          target_label_domain = std::nullopt) {
+          target_topology_assignment = std::nullopt) {
     return SchedulingOptions(SchedulingType::BUNDLE_SPREAD,
                              /*spread_threshold*/ 0,
                              /*avoid_local_node*/ false,
                              /*require_node_available*/ true,
                              /*avoid_gpu_nodes*/ false,
-                             std::move(target_label_domain));
+                             std::move(target_topology_assignment));
   }
 
   // construct option for strict pack scheduling policy.
   static SchedulingOptions BundleStrictPack(
       scheduling::NodeID soft_target_node_id = scheduling::NodeID::Nil(),
       std::optional<std::pair<std::string, std::optional<std::string>>>
-          target_label_domain = std::nullopt) {
+          target_topology_assignment = std::nullopt) {
     SchedulingOptions options(SchedulingType::BUNDLE_STRICT_PACK,
                               /*spread_threshold*/ 0,
                               /*avoid_local_node*/ false,
                               /*require_node_available*/ true,
                               /*avoid_gpu_nodes*/ false,
-                              std::move(target_label_domain));
+                              std::move(target_topology_assignment));
     options.bundle_strict_pack_soft_target_node_id_ = soft_target_node_id;
     return options;
   }
@@ -179,13 +179,13 @@ struct SchedulingOptions {
   static SchedulingOptions BundleStrictSpread(
       std::unique_ptr<SchedulingContext> scheduling_context = nullptr,
       std::optional<std::pair<std::string, std::optional<std::string>>>
-          target_label_domain = std::nullopt) {
+          target_topology_assignment = std::nullopt) {
     return SchedulingOptions(SchedulingType::BUNDLE_STRICT_SPREAD,
                              /*spread_threshold*/ 0,
                              /*avoid_local_node*/ false,
                              /*require_node_available*/ true,
                              /*avoid_gpu_nodes*/ false,
-                             std::move(target_label_domain),
+                             std::move(target_topology_assignment),
                              std::move(scheduling_context));
   }
 
@@ -194,15 +194,15 @@ struct SchedulingOptions {
   bool avoid_local_node_;
   bool require_node_available_;
   bool avoid_gpu_nodes_;
-  // The scheduling strategy for the label domain level.
-  // Set to NONE to disable label domain level scheduling.
-  LabelDomainSchedulingStrategy label_domain_scheduling_strategy_ =
-      LabelDomainSchedulingStrategy::NONE;
-  // The label domain target for label-domain-aware scheduling.
+  // The scheduling strategy for the topology level.
+  // Set to NONE to disable topology-aware scheduling.
+  TopologySchedulingStrategy topology_scheduling_strategy_ =
+      TopologySchedulingStrategy::NONE;
+  // The topology target for topology-aware scheduling.
   // first: the node label key used to partition nodes into groups.
-  // second: if set, constrains scheduling to this domain value
+  // second: if set, constrains scheduling to this topology value
   //   (bundle rescheduling). If nullopt, a new group is selected.
-  std::pair<std::string, std::optional<std::string>> target_label_domain_;
+  std::pair<std::string, std::optional<std::string>> target_topology_assignment_;
   // ID of the target node where bundles should be placed
   // iff the target node has enough available resources.
   // Otherwise, the bundles can be placed elsewhere.
@@ -227,7 +227,7 @@ struct SchedulingOptions {
       bool require_node_available,
       bool avoid_gpu_nodes,
       std::optional<std::pair<std::string, std::optional<std::string>>>
-          target_label_domain = std::nullopt,
+          target_topology_assignment = std::nullopt,
       std::shared_ptr<SchedulingContext> scheduling_context = nullptr,
       const std::string &preferred_node_id = std::string(),
       int32_t schedule_top_k_absolute = RayConfig::instance().scheduler_top_k_absolute(),
@@ -237,12 +237,13 @@ struct SchedulingOptions {
         avoid_local_node_(avoid_local_node),
         require_node_available_(require_node_available),
         avoid_gpu_nodes_(avoid_gpu_nodes),
-        label_domain_scheduling_strategy_(target_label_domain.has_value()
-                                              ? LabelDomainSchedulingStrategy::STRICT_PACK
-                                              : LabelDomainSchedulingStrategy::NONE),
-        target_label_domain_(target_label_domain.has_value()
-                                 ? std::move(*target_label_domain)
-                                 : std::pair<std::string, std::optional<std::string>>{}),
+        topology_scheduling_strategy_(target_topology_assignment.has_value()
+                                          ? TopologySchedulingStrategy::STRICT_PACK
+                                          : TopologySchedulingStrategy::NONE),
+        target_topology_assignment_(
+            target_topology_assignment.has_value()
+                ? std::move(*target_topology_assignment)
+                : std::pair<std::string, std::optional<std::string>>{}),
         scheduling_context_(std::move(scheduling_context)),
         preferred_node_id_(preferred_node_id),
         schedule_top_k_absolute_(schedule_top_k_absolute),

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -195,10 +195,10 @@ struct SchedulingOptions {
   bool require_node_available_;
   bool avoid_gpu_nodes_;
   // The scheduling strategy for the topology level.
-  // Set to NONE to disable topology-aware scheduling.
+  // Set to NONE to disable the topology strategy.
   TopologySchedulingStrategy topology_scheduling_strategy_ =
       TopologySchedulingStrategy::NONE;
-  // The topology target for topology-aware scheduling.
+  // The topology target for topology strategy scheduling.
   // first: the node label key used to partition nodes into groups.
   // second: if set, constrains scheduling to this topology value
   //   (bundle rescheduling). If nullopt, a new group is selected.

--- a/src/ray/raylet/scheduling/policy/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy.h
@@ -81,14 +81,14 @@ struct SchedulingResult {
   SchedulingResultStatus status;
   // The nodes successfully scheduled.
   std::vector<scheduling::NodeID> selected_nodes;
-  // The label domain selected during placement group scheduling.
-  // The key is the label domain key (e.g. "ray.io/gpu-domain"),
-  // the value is the label domain value (e.g. "rack-1").
+  // The topology assignment selected during placement group scheduling.
+  // The key is the topology label key (e.g. "ray.io/gpu-domain"),
+  // the value is the topology label value (e.g. "rack-1").
   // We have one pair per placement group for now because we only support
   // STRICT_PACK scheduling strategy. To support other strategies, this data
   // structure will need to be extended.
-  // TODO(#61777): Extend to support multiple tiers of label-domain scheduling.
-  std::optional<std::pair<std::string, std::string>> selected_label_domain;
+  // TODO(#61777): Extend to support multiple tiers of topology-aware scheduling.
+  std::optional<std::pair<std::string, std::string>> selected_topology_assignment;
 };
 
 using NodeScheduleFn =

--- a/src/ray/raylet/scheduling/policy/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy.h
@@ -87,7 +87,7 @@ struct SchedulingResult {
   // We have one pair per placement group for now because we only support
   // STRICT_PACK scheduling strategy. To support other strategies, this data
   // structure will need to be extended.
-  // TODO(#61777): Extend to support multiple tiers of topology-aware scheduling.
+  // TODO(#61777): Extend to support multiple tiers of topology strategy scheduling.
   std::optional<std::pair<std::string, std::string>> selected_topology_assignment;
 };
 

--- a/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
@@ -62,7 +62,7 @@ class HybridSchedulingPolicyTest : public ::testing::Test {
                              avoid_local_node,
                              require_node_available,
                              avoid_gpu_nodes,
-                             /*target_label_domain*/ std::nullopt,
+                             /*target_topology_assignment*/ std::nullopt,
                              /*scheduling_context*/ nullptr,
                              /*preferred_node*/ "",
                              schedule_top_k_absolute,

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -777,9 +777,9 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
 
   SchedulingResult result_2 =
       topology_policy.Schedule(req_list_2,
-                                   options,
-                                   GetCandidateNodes(*cluster_resource_manager),
-                                   node_schedule_fn);
+                               options,
+                               GetCandidateNodes(*cluster_resource_manager),
+                               node_schedule_fn);
 
   ASSERT_TRUE(result_2.status.IsSuccess());
   ASSERT_TRUE(result_2.selected_topology_assignment.has_value());

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -70,7 +70,7 @@ class SchedulingPolicyTest : public ::testing::Test {
                              avoid_local_node,
                              require_node_available,
                              avoid_gpu_nodes,
-                             /*target_label_domain*/ std::nullopt,
+                             /*target_topology_assignment*/ std::nullopt,
                              /*scheduling_context*/ nullptr,
                              /*preferred node*/ "",
                              schedule_top_k_absolute,
@@ -735,7 +735,7 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
       ResourceMapToResourceRequest({{"CPU", 2}, {"GPU", 4}}, false);
   std::vector<const ResourceRequest *> req_list(15, &bundle_req);
 
-  LabelDomainStrictPackSchedulingPolicy label_domain_policy(*cluster_resource_manager);
+  TopologyStrictPackSchedulingPolicy topology_policy(*cluster_resource_manager);
   SchedulingOptions options = SchedulingOptions::BundlePack(
       std::make_pair(kDomainLabelKey, std::optional<std::string>(std::nullopt)));
 
@@ -748,13 +748,13 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
   };
 
   // Schedule should return SUCCESS with 15 nodes all from rack-1
-  SchedulingResult result_1 = label_domain_policy.Schedule(
+  SchedulingResult result_1 = topology_policy.Schedule(
       req_list, options, GetCandidateNodes(*cluster_resource_manager), node_schedule_fn);
 
   ASSERT_TRUE(result_1.status.IsSuccess());
-  ASSERT_TRUE(result_1.selected_label_domain.has_value());
-  ASSERT_EQ(result_1.selected_label_domain->first, kDomainLabelKey);
-  ASSERT_EQ(result_1.selected_label_domain->second, "rack-1");
+  ASSERT_TRUE(result_1.selected_topology_assignment.has_value());
+  ASSERT_EQ(result_1.selected_topology_assignment->first, kDomainLabelKey);
+  ASSERT_EQ(result_1.selected_topology_assignment->second, "rack-1");
   ASSERT_EQ(result_1.selected_nodes.size(), 15);
 
   for (const scheduling::NodeID &node_id : result_1.selected_nodes) {
@@ -763,7 +763,7 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
     absl::flat_hash_map<std::string, std::string>::const_iterator it =
         node_resources.labels.find(kDomainLabelKey);
     ASSERT_NE(it, node_resources.labels.end());
-    ASSERT_EQ(it->second, result_1.selected_label_domain->second);
+    ASSERT_EQ(it->second, result_1.selected_topology_assignment->second);
   }
 
   // Subtract the resources from the selected nodes
@@ -776,15 +776,15 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
   std::vector<const ResourceRequest *> req_list_2(3, &bundle_req);
 
   SchedulingResult result_2 =
-      label_domain_policy.Schedule(req_list_2,
+      topology_policy.Schedule(req_list_2,
                                    options,
                                    GetCandidateNodes(*cluster_resource_manager),
                                    node_schedule_fn);
 
   ASSERT_TRUE(result_2.status.IsSuccess());
-  ASSERT_TRUE(result_2.selected_label_domain.has_value());
-  ASSERT_EQ(result_2.selected_label_domain->first, kDomainLabelKey);
-  ASSERT_EQ(result_2.selected_label_domain->second, "rack-1");
+  ASSERT_TRUE(result_2.selected_topology_assignment.has_value());
+  ASSERT_EQ(result_2.selected_topology_assignment->first, kDomainLabelKey);
+  ASSERT_EQ(result_2.selected_topology_assignment->second, "rack-1");
   ASSERT_EQ(result_2.selected_nodes.size(), 3);
 
   for (const scheduling::NodeID &node_id : result_2.selected_nodes) {
@@ -793,7 +793,7 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
     absl::flat_hash_map<std::string, std::string>::const_iterator it =
         node_resources.labels.find(kDomainLabelKey);
     ASSERT_NE(it, node_resources.labels.end());
-    ASSERT_EQ(it->second, result_2.selected_label_domain->second);
+    ASSERT_EQ(it->second, result_2.selected_topology_assignment->second);
   }
 
   // Verify the remaining 3 bundles uses nodes that weren't fully consumed by the first 15
@@ -830,7 +830,7 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingInfeasibleTest) {
       ResourceMapToResourceRequest({{"CPU", 2}, {"GPU", 4}}, false);
   std::vector<const ResourceRequest *> req_list(16, &bundle_req);
 
-  LabelDomainStrictPackSchedulingPolicy label_domain_policy(*cluster_resource_manager);
+  TopologyStrictPackSchedulingPolicy topology_policy(*cluster_resource_manager);
   SchedulingOptions options = SchedulingOptions::BundlePack(
       std::make_pair(kDomainLabelKey, std::optional<std::string>(std::nullopt)));
 
@@ -842,11 +842,11 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingInfeasibleTest) {
     return bundle_pack_policy.Schedule(reqs, opts, std::move(nodes));
   };
 
-  SchedulingResult result = label_domain_policy.Schedule(
+  SchedulingResult result = topology_policy.Schedule(
       req_list, options, GetCandidateNodes(*cluster_resource_manager), node_schedule_fn);
 
   ASSERT_TRUE(result.status.IsInfeasible());
-  ASSERT_FALSE(result.selected_label_domain.has_value());
+  ASSERT_FALSE(result.selected_topology_assignment.has_value());
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/scheduling/policy/label_domain_bundle_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
 
-bool LabelDomainSchedulingPolicyInterface::IsRequestFeasible(
+bool TopologySchedulingPolicyInterface::IsRequestFeasible(
     const std::vector<const ResourceRequest *> &resource_request_list,
     const absl::flat_hash_set<scheduling::NodeID> &candidate_nodes) const {
   // Check that each bundle is individually feasible on at least one node.
@@ -52,21 +52,21 @@ bool LabelDomainSchedulingPolicyInterface::IsRequestFeasible(
   return true;
 }
 
-SchedulingResult LabelDomainStrictPackSchedulingPolicy::Schedule(
+SchedulingResult TopologyStrictPackSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
     const SchedulingOptions &options,
     absl::flat_hash_set<scheduling::NodeID> candidate_nodes,
     NodeScheduleFn node_schedule_fn) {
   RAY_CHECK(!resource_request_list.empty());
 
-  const std::string &label_key = options.target_label_domain_.first;
+  const std::string &label_key = options.target_topology_assignment_.first;
   RAY_CHECK(!label_key.empty());
 
-  // If a target label domain value is specified (partial failure rescheduling),
-  // prune to only nodes in that domain and use the node-level scheduling callback to
+  // If a target topology value is specified (partial failure rescheduling),
+  // prune to only nodes with that value and use the node-level scheduling callback to
   // schedule the bundles.
-  if (options.target_label_domain_.second.has_value()) {
-    const std::string &target = *options.target_label_domain_.second;
+  if (options.target_topology_assignment_.second.has_value()) {
+    const std::string &target = *options.target_topology_assignment_.second;
     for (auto it = candidate_nodes.begin(); it != candidate_nodes.end();) {
       const auto &labels = cluster_resource_manager_.GetNodeLabels(*it);
       auto label_it = labels.find(label_key);
@@ -77,44 +77,47 @@ SchedulingResult LabelDomainStrictPackSchedulingPolicy::Schedule(
       }
     }
     if (!IsRequestFeasible(resource_request_list, candidate_nodes)) {
-      RAY_LOG(DEBUG) << "Target label domain '" << target
+      RAY_LOG(DEBUG) << "Target topology value '" << target
                      << "' has insufficient resources; infeasible.";
       return SchedulingResult::Infeasible();
     }
     SchedulingResult result =
         node_schedule_fn(resource_request_list, options, std::move(candidate_nodes));
     if (result.status.IsSuccess()) {
-      result.selected_label_domain = std::make_pair(label_key, std::string(target));
+      result.selected_topology_assignment =
+          std::make_pair(label_key, std::string(target));
     }
     return result;
   }
 
-  // Group candidate nodes by their label domain.
-  absl::flat_hash_map<std::string, absl::flat_hash_set<scheduling::NodeID>> domain_groups;
+  // Group candidate nodes by their topology value.
+  absl::flat_hash_map<std::string, absl::flat_hash_set<scheduling::NodeID>>
+      topology_groups;
   for (const auto &node_id : candidate_nodes) {
     const auto &labels = cluster_resource_manager_.GetNodeLabels(node_id);
     auto it = labels.find(label_key);
     if (it != labels.end() && !it->second.empty()) {
-      domain_groups[it->second].insert(node_id);
+      topology_groups[it->second].insert(node_id);
     }
   }
 
-  if (domain_groups.empty()) {
+  if (topology_groups.empty()) {
     RAY_LOG(DEBUG) << "No candidate nodes have a " << label_key
-                   << " label; label domain scheduling infeasible.";
+                   << " label; topology-aware scheduling infeasible.";
     return SchedulingResult::Infeasible();
   }
 
-  // Try each feasible domain: call node-level scheduling and return on first success.
+  // Try each feasible group: call node-level scheduling and return on first success.
   bool all_infeasible = true;
-  for (auto &[domain_id, domain_nodes] : domain_groups) {
-    if (!IsRequestFeasible(resource_request_list, domain_nodes)) {
+  for (auto &[topology_value, topology_nodes] : topology_groups) {
+    if (!IsRequestFeasible(resource_request_list, topology_nodes)) {
       continue;
     }
     SchedulingResult result =
-        node_schedule_fn(resource_request_list, options, std::move(domain_nodes));
+        node_schedule_fn(resource_request_list, options, std::move(topology_nodes));
     if (result.status.IsSuccess()) {
-      result.selected_label_domain = std::make_pair(label_key, std::move(domain_id));
+      result.selected_topology_assignment =
+          std::make_pair(label_key, std::move(topology_value));
       return result;
     }
     if (!result.status.IsInfeasible()) {
@@ -123,10 +126,10 @@ SchedulingResult LabelDomainStrictPackSchedulingPolicy::Schedule(
   }
 
   if (all_infeasible) {
-    RAY_LOG(DEBUG) << "No label domain has sufficient total resources; infeasible.";
+    RAY_LOG(DEBUG) << "No topology value has sufficient total resources; infeasible.";
     return SchedulingResult::Infeasible();
   } else {
-    RAY_LOG(DEBUG) << "No label domain has sufficient available resources; failed";
+    RAY_LOG(DEBUG) << "No topology value has sufficient available resources; failed";
     return SchedulingResult::Failed();
   }
 }

--- a/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.cc
@@ -116,8 +116,7 @@ SchedulingResult TopologyStrictPackSchedulingPolicy::Schedule(
     SchedulingResult result =
         node_schedule_fn(resource_request_list, options, std::move(topology_nodes));
     if (result.status.IsSuccess()) {
-      result.selected_topology_assignment =
-          std::make_pair(label_key, topology_value);
+      result.selected_topology_assignment = std::make_pair(label_key, topology_value);
       return result;
     }
     if (!result.status.IsInfeasible()) {

--- a/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.cc
@@ -103,7 +103,7 @@ SchedulingResult TopologyStrictPackSchedulingPolicy::Schedule(
 
   if (topology_groups.empty()) {
     RAY_LOG(DEBUG) << "No candidate nodes have a " << label_key
-                   << " label; topology-aware scheduling infeasible.";
+                   << " label; topology strategy scheduling infeasible.";
     return SchedulingResult::Infeasible();
   }
 
@@ -117,7 +117,7 @@ SchedulingResult TopologyStrictPackSchedulingPolicy::Schedule(
         node_schedule_fn(resource_request_list, options, std::move(topology_nodes));
     if (result.status.IsSuccess()) {
       result.selected_topology_assignment =
-          std::make_pair(label_key, std::move(topology_value));
+          std::make_pair(label_key, topology_value);
       return result;
     }
     if (!result.status.IsInfeasible()) {

--- a/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h
@@ -26,7 +26,7 @@ namespace raylet_scheduling_policy {
 /**
  * @brief Abstract base class for topology-level scheduling policies.
  *
- * @details Topology-aware scheduling partitions the cluster's candidate nodes
+ * @details Topology strategy scheduling partitions the cluster's candidate nodes
  * into groups by an arbitrary node label key (e.g. "ray.io/gpu-domain") and
  * selects which groups can feasibly host a placement group's bundles. It then
  * delegates to a node-level scheduling policy to schedule the bundles within

--- a/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h
@@ -86,8 +86,7 @@ class TopologySchedulingPolicyInterface {
  *
  * @details Ensures that each bundle is placed on a node with the same topology value.
  */
-class TopologyStrictPackSchedulingPolicy
-    : public TopologySchedulingPolicyInterface {
+class TopologyStrictPackSchedulingPolicy : public TopologySchedulingPolicyInterface {
  public:
   using TopologySchedulingPolicyInterface::TopologySchedulingPolicyInterface;
   SchedulingResult Schedule(

--- a/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/topology_bundle_scheduling_policy.h
@@ -24,36 +24,35 @@ namespace ray {
 namespace raylet_scheduling_policy {
 
 /**
- * @brief Abstract base class for label-domain-level scheduling policies.
+ * @brief Abstract base class for topology-level scheduling policies.
  *
- * @details Label-domain scheduling partitions the cluster's candidate nodes
+ * @details Topology-aware scheduling partitions the cluster's candidate nodes
  * into groups by an arbitrary node label key (e.g. "ray.io/gpu-domain") and
  * selects which groups can feasibly host a placement group's bundles. It then
  * delegates to a node-level scheduling policy to schedule the bundles within
  * the selected groups.
  */
-// TODO(#64370) rename this to fit topology strategy
-class LabelDomainSchedulingPolicyInterface {
+class TopologySchedulingPolicyInterface {
  public:
-  explicit LabelDomainSchedulingPolicyInterface(
+  explicit TopologySchedulingPolicyInterface(
       ClusterResourceManager &cluster_resource_manager)
       : cluster_resource_manager_(cluster_resource_manager) {}
-  virtual ~LabelDomainSchedulingPolicyInterface() = default;
+  virtual ~TopologySchedulingPolicyInterface() = default;
 
   /**
-   * @brief Partitions candidate nodes by label domain, then for each feasible
-   * domain invokes the node-level scheduling callback. Returns the first
+   * @brief Partitions candidate nodes by topology value, then for each feasible
+   * group invokes the node-level scheduling callback. Returns the first
    * successful result.
    *
    * @param resource_request_list The resource/label requirements for each
    * bundle in the placement group.
-   * @param options Scheduling options that contains which label domain key to group by.
-   *   If the label domain value is specified, scheduling is constrained to that specific
-   * domain (bundle rescheduling).
+   * @param options Scheduling options that contains which topology label key to group by.
+   *   If the topology value is specified, scheduling is constrained to that specific
+   * value (bundle rescheduling).
    * @param candidate_nodes All available candidate nodes to consider.
    * @param node_schedule_fn Callback that performs node-level bundle scheduling
    *   on a set of candidate nodes.
-   * @return A LabelDomainFilterResult with the feasible candidate groups, or
+   * @return A SchedulingResult with the feasible candidate groups, or
    *   an INFEASIBLE / FAILED status if no group qualifies.
    */
   virtual SchedulingResult Schedule(
@@ -83,14 +82,14 @@ class LabelDomainSchedulingPolicyInterface {
 };
 
 /**
- * @brief Strict-pack label-domain scheduling policy.
+ * @brief Strict-pack topology scheduling policy.
  *
- * @details Ensures that each bundle is placed on a node in the same label domain value.
+ * @details Ensures that each bundle is placed on a node with the same topology value.
  */
-class LabelDomainStrictPackSchedulingPolicy
-    : public LabelDomainSchedulingPolicyInterface {
+class TopologyStrictPackSchedulingPolicy
+    : public TopologySchedulingPolicyInterface {
  public:
-  using LabelDomainSchedulingPolicyInterface::LabelDomainSchedulingPolicyInterface;
+  using TopologySchedulingPolicyInterface::TopologySchedulingPolicyInterface;
   SchedulingResult Schedule(
       const std::vector<const ResourceRequest *> &resource_request_list,
       const SchedulingOptions &options,


### PR DESCRIPTION
The placement-group topology API was migrated to the topology_strategy naming convention everywhere except the raylet scheduling-policy layer, which still used the old label_domain naming.

Rename the remaining label_domain/LabelDomain identifiers to match the topology convention already used in the proto, GCS, and Python layers:

- LabelDomainSchedulingStrategy -> TopologySchedulingStrategy
- LabelDomain{,StrictPack}SchedulingPolicy{Interface} -> Topology...
- target_label_domain_ -> target_topology_assignment_
- selected_label_domain -> selected_topology_assignment
- label_domain_scheduling_strategy_ -> topology_scheduling_strategy_
- label_domain_bundle_scheduling_policy.{cc,h} -> topology_bundle_...

Pure rename; no behavior change.  
Closes #64370
 