### PR TITLE
[Data] Make PandasBlock.size_bytes deterministic

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -632,8 +632,20 @@ class PandasBlockAccessor(TableBlockAccessor):
                 # Skip size calculation for empty columns
                 if sample_size == 0:
                     continue
-                # Following codes can also handel case that sample_size == total_size
-                sampled_data = self._table[column].sample(n=sample_size).values
+                if sample_size == total_size:
+                    # Sampling the whole column: read values directly to avoid the
+                    # permutation/copy overhead of .sample(). No randomness here, so
+                    # this is trivially deterministic.
+                    sampled_data = self._table[column].values
+                else:
+                    # Use a fixed random_state so size_bytes() is deterministic
+                    # across calls. Non-deterministic size estimation can cause
+                    # streaming generator tasks to produce different block counts
+                    # across replay attempts (e.g. lineage reconstruction), which
+                    # surfaces as a silent hang or silent data loss downstream.
+                    sampled_data = (
+                        self._table[column].sample(n=sample_size, random_state=0).values
+                    )
 
                 try:
                     if isinstance(sampled_data, TensorArray) and np.issubdtype(

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -457,6 +457,28 @@ class TestSizeBytes:
         )
         assert bytes_size == pytest.approx(true_size, rel=0.1), (bytes_size, true_size)
 
+    def test_deterministic_across_blocks(self):
+        """size_bytes() must return the same value for two blocks holding
+        identical data. Non-determinism here can cause a streaming generator
+        task to produce different block counts across replay attempts (e.g.
+        lineage reconstruction), since each attempt rebuilds the block and
+        re-estimates its size. That surfaces as a silent hang or silent data
+        loss downstream.
+        """
+        # Use enough rows to trigger sampling (sample_size < total_size), and
+        # vary the string lengths so a different sample yields a different
+        # estimate (this is what makes the non-deterministic case observable).
+        data = [f"str_{i}" for i in range(10_000)]
+        block1 = pd.DataFrame({"col": pd.Series(data, dtype="string")})
+        block2 = pd.DataFrame({"col": pd.Series(data, dtype="string")})
+
+        first = PandasBlockAccessor.for_block(block1).size_bytes()
+        second = PandasBlockAccessor.for_block(block2).size_bytes()
+
+        assert (
+            first == second
+        ), f"size_bytes() is non-deterministic: first={first}, second={second}"
+
 
 def test_iter_rows_with_na(ray_start_regular_shared):
     block = pd.DataFrame({"col": [pd.NA]})


### PR DESCRIPTION
## Description

`PandasBlockAccessor.size_bytes()` estimates string/object column sizes by sampling up to 200 rows via `pandas.DataFrame.sample(n=...)` without a seed, so two blocks holding identical data report different sizes. That estimate drives block splitting in streaming generators, so a re-executed task can emit a different number of objects than the original attempt — which leaves downstream consumers silently hanging or silently dropping data (the companion #64394 fails fast when that mismatch occurs). This PR fixes the sampling non-determinism by passing `random_state=0`, and skips sampling entirely when the column fits in the sample. User UDFs remain responsible for their own determinism.

**Symptom.** A streaming generator task re-executed for lineage reconstruction can leave the pipeline silently hanging or silently dropping data, with no error logged.

**Root cause.** `PandasBlockAccessor.size_bytes()` estimates string/object columns by sampling up to 200 rows via `pandas.DataFrame.sample(n=...)`. No seed is passed, so each call samples different rows and two blocks holding identical data report different sizes.

**How it turns into a bug.** That estimate drives block splitting:

1. `OutputBuffer.next()` calls `size_bytes()` to compute `target_num_rows`, so a task can split the same output into a different number of blocks each time it runs.
2. The first successful attempt pins the end-of-stream index to the object count it produced.
3. On re-execution, a different split produces a different object count:
   - **fewer** → downstream consumers block on indices that are never produced (silent hang);
   - **more** → the extras past the pinned end-of-stream index are dropped by `ObjectRefStream::InsertToStream` (silent data loss).

**Fix.** Pass `random_state=0` to `sample()`, and skip sampling when the column has fewer than `sample_size` rows. Identical input now always yields the same size estimate. This removes one Ray-internal source of streaming-generator object-count non-determinism; user UDFs remain responsible for their own determinism.

**Scope.** Only `PandasBlockAccessor.size_bytes()` is affected — the Arrow equivalent already uses `table.nbytes` and is deterministic. Pandas blocks are produced along several common paths:

- a UDF that returns a `pandas.DataFrame` (e.g. `map_batches(fn, batch_format="pandas")`), kept as a pandas block by `BlockAccessor.batch_to_block`;
- batches that Arrow cannot convert (object/ragged columns), which fall back to pandas blocks;
- `split_repartition` preserving a pandas input schema; and
- the built-in preprocessors (`encoder`, `vectorizer`, `imputer`).

On released branches these paths default to pandas, so the bug is broadly reachable. On `master`, #61733 added a default that converts many UDF outputs to Arrow, but the fallback and pandas-schema paths above still build pandas blocks.

## Related issues

None.

## Additional information

**Reproduction** (before this PR, the two printed sizes frequently differ):

```python
import pandas as pd
from ray.data._internal.pandas_block import PandasBlockAccessor

data = [f"str_{i}" for i in range(10_000)]
b1 = pd.DataFrame({"col": pd.Series(data, dtype="string")})
b2 = pd.DataFrame({"col": pd.Series(data, dtype="string")})

print(PandasBlockAccessor.for_block(b1).size_bytes())
print(PandasBlockAccessor.for_block(b2).size_bytes())
```

- **Test**: added `TestSizeBytes.test_deterministic_across_blocks`, asserting that two blocks holding identical data report the same `size_bytes()`.
