### PR TITLE
[Core] Fail-fast on streaming generator replay object-count mismatch

### DIFF
--- a/doc/source/ray-core/api/exceptions.rst
+++ b/doc/source/ray-core/api/exceptions.rst
@@ -32,6 +32,7 @@ Exceptions
     ray.exceptions.ObjectReconstructionFailedError
     ray.exceptions.RayChannelError
     ray.exceptions.RayChannelTimeoutError
+    ray.exceptions.StreamingGeneratorReplayInconsistentError
     ray.exceptions.RayCgraphCapacityExceeded
     ray.exceptions.RayDirectTransportError
     ray.exceptions.RuntimeEnvSetupError

--- a/python/ray/_private/custom_types.py
+++ b/python/ray/_private/custom_types.py
@@ -120,6 +120,7 @@ ERROR_TYPE = [
     "OBJECT_UNRECONSTRUCTABLE_TASK_CANCELLED",
     "OBJECT_UNRECONSTRUCTABLE_LINEAGE_DISABLED",
     "WORKER_STARTUP_FAILED",
+    "STREAMING_GENERATOR_REPLAY_INCONSISTENT",
 ]
 # The Language enum is used in the export API so it is public
 # and any modifications must be backward compatible.

--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -46,6 +46,7 @@ from ray.exceptions import (
     RayTaskError,
     ReferenceCountingAssertionError,
     RuntimeEnvSetupError,
+    StreamingGeneratorReplayInconsistentError,
     TaskCancelledError,
     TaskPlacementGroupRemoved,
     TaskUnschedulableError,
@@ -531,6 +532,13 @@ class SerializationContext:
                 return ActorUnschedulableError(error_info.error_message)
             elif error_type == ErrorType.Value("END_OF_STREAMING_GENERATOR"):
                 return ObjectRefStreamEndOfStreamError()
+            elif error_type == ErrorType.Value(
+                "STREAMING_GENERATOR_REPLAY_INCONSISTENT"
+            ):
+                error_info = self._deserialize_error_info(data, metadata_fields)
+                return StreamingGeneratorReplayInconsistentError(
+                    error_info.error_message
+                )
             elif error_type == ErrorType.Value("ACTOR_UNAVAILABLE"):
                 error_info = self._deserialize_error_info(data, metadata_fields)
                 if error_info.HasField("actor_unavailable_error"):

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -985,6 +985,20 @@ class ObjectRefStreamEndOfStreamError(RayError):
     pass
 
 
+@PublicAPI
+class StreamingGeneratorReplayInconsistentError(RaySystemError):
+    """Raised when a streaming generator task's replay produces a different
+    number of objects than the first successful attempt.
+
+    This indicates the generator output is non-deterministic. The task is
+    failed fast to prevent downstream consumers from hanging (when fewer
+    objects are produced) or silently dropping data (when more objects are
+    produced).
+    """
+
+    pass
+
+
 @DeveloperAPI
 class OufOfBandObjectRefSerializationException(RayError):
     """Raised when an `ray.ObjectRef` is out of band serialized by

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -837,5 +837,47 @@ def test_inspect_func_serialization_prints_qualname():
     ), f"Expected inner closure qualname in output, got:\n{output}"
 
 
+def test_streaming_generator_replay_inconsistent_error_deserialization(monkeypatch):
+    """The STREAMING_GENERATOR_REPLAY_INCONSISTENT error type must deserialize
+    to StreamingGeneratorReplayInconsistentError carrying the C++-side
+    error_message, not fall through to the generic
+    RaySystemError("Unrecognized error type ...").
+    """
+    from ray._private.serialization import SerializationContext
+    from ray.core.generated.common_pb2 import ErrorType, RayErrorInfo
+    from ray.exceptions import (
+        RaySystemError,
+        StreamingGeneratorReplayInconsistentError,
+    )
+
+    # Bypass __init__ — it registers reducers that expect a connected worker.
+    # _deserialize_object only needs _deserialize_error_info for this branch.
+    ctx = SerializationContext.__new__(SerializationContext)
+
+    expected_message = (
+        "Streaming generator task abc123 was re-executed and produced 2 "
+        "objects, expected 3. The generator output is non-deterministic."
+    )
+    fake_error_info = RayErrorInfo()
+    fake_error_info.error_message = expected_message
+    fake_error_info.error_type = ErrorType.STREAMING_GENERATOR_REPLAY_INCONSISTENT
+    monkeypatch.setattr(
+        ctx, "_deserialize_error_info", lambda data, fields: fake_error_info
+    )
+
+    metadata = str(ErrorType.Value("STREAMING_GENERATOR_REPLAY_INCONSISTENT")).encode()
+
+    result = ctx._deserialize_object(
+        data=b"",  # content irrelevant — _deserialize_error_info is mocked
+        metadata=metadata,
+        object_ref=None,
+        out_of_band_tensors=None,
+    )
+
+    assert isinstance(result, StreamingGeneratorReplayInconsistentError)
+    assert isinstance(result, RaySystemError)  # inheritance sanity
+    assert expected_message in str(result)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_4.py
+++ b/python/ray/tests/test_streaming_generator_4.py
@@ -408,5 +408,80 @@ def test_cancel(shutdown_only, use_asyncio):
         pass
 
 
+def test_streaming_generator_replay_inconsistent_fails_fast(ray_start_cluster):
+    """
+    A streaming generator whose object count differs across attempts must fail
+    fast on replay with StreamingGeneratorReplayInconsistentError, instead of
+    hanging downstream consumers on objects that will never be produced.
+
+    Setup:
+    1. Head + worker node. A detached actor on the head tracks the attempt
+       number across cluster changes.
+    2. Generator runs on the worker; first attempt yields 3 objects (pins EOF
+       to 3); the replay yields only 2.
+    3. Kill the worker (drops the produced objects); add a fresh worker.
+    4. ray.get on the original refs forces lineage reconstruction; the replay's
+       object count mismatches the pinned EOF, and the task fails fast.
+    """
+    from ray.exceptions import StreamingGeneratorReplayInconsistentError
+
+    cluster = ray_start_cluster
+    cluster.add_node(
+        num_cpus=0,
+        resources={"head": 1},
+        _system_config=RECONSTRUCTION_CONFIG,
+        enable_object_reconstruction=True,
+    )
+    ray.init(address=cluster.address)
+    worker = cluster.add_node(num_cpus=1, resources={"worker": 1})
+    cluster.wait_for_nodes()
+
+    # Detached actor survives worker death, so the replay sees a different
+    # attempt number and yields a different object count.
+    @ray.remote(num_cpus=0, resources={"head": 0.01})
+    class AttemptCounter:
+        def __init__(self) -> None:
+            self.n = 0
+
+        def next(self) -> int:
+            self.n += 1
+            return self.n
+
+    AttemptCounter.options(name="counter", lifetime="detached").remote()
+
+    @ray.remote(num_returns="streaming", resources={"worker": 1}, max_retries=-1)
+    def gen():
+        attempt = ray.get(ray.get_actor("counter").next.remote())
+        # First attempt yields 3 objects → EOF pinned to 3. Replay yields 2 →
+        # mismatch is what this test exercises.
+        num_objects = 3 if attempt == 1 else 2
+        for i in range(num_objects):
+            # Large enough to exceed max_direct_call_object_size (100 bytes)
+            # so the objects live in the object store and are lost with the
+            # worker node, forcing reconstruction.
+            yield np.zeros(1024, dtype=np.uint8) + i
+
+    gen_ref = gen.remote()
+    refs = list(gen_ref)
+    assert len(refs) == 3
+
+    # Drop the generator handle and kill the producing node so the objects are
+    # lost; the next ray.get has to replay the task on a fresh worker.
+    del gen_ref
+    cluster.remove_node(worker, allow_graceful=False)
+    cluster.add_node(num_cpus=1, resources={"worker": 1})
+    cluster.wait_for_nodes()
+
+    # Reading any original ref forces reconstruction; the replay's object count
+    # doesn't match the pinned EOF, so the task fails fast with our new error
+    # instead of hanging on the third (never-produced) object.
+    with pytest.raises(
+        StreamingGeneratorReplayInconsistentError,
+        match=r"produced 2 objects, expected 3",
+    ):
+        for ref in refs:
+            ray.get(ref)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -940,6 +940,77 @@ void TaskManager::MarkEndOfStream(const ObjectID &generator_id,
   }
 }
 
+bool TaskManager::FailStreamingGeneratorReplayIfInconsistent(
+    const TaskID &task_id, const rpc::PushTaskReply &reply) {
+  ObjectID generator_id;
+  int64_t expected_count = 0;
+  int64_t actual_count = 0;
+  {
+    absl::MutexLock lock(&mu_);
+    auto it = submissible_tasks_.find(task_id);
+    if (it == submissible_tasks_.end() || !it->second.spec_.IsStreamingGenerator()) {
+      return false;
+    }
+    // Only a replay can be inconsistent: the first successful execution defines
+    // the expected object count, so there is nothing to compare against yet.
+    if (it->second.num_successful_executions_ == 0) {
+      return false;
+    }
+    expected_count = it->second.spec_.NumStreamingGeneratorReturns();
+    actual_count = reply.streaming_generator_return_ids_size();
+    // NumStreamingGeneratorReturns is only recorded when the first successful
+    // attempt yielded > 0 objects (see CompletePendingTask), so expected_count
+    // == 0 means the count is unknown; we cannot detect drift from it.
+    if (expected_count == 0 || expected_count == actual_count) {
+      return false;
+    }
+    // Defensive: a well-formed streaming generator reply always carries the
+    // generator id in return_objects(0), but guard against a malformed reply.
+    if (reply.return_objects_size() == 0) {
+      return false;
+    }
+    generator_id = ObjectID::FromBinary(reply.return_objects(0).object_id());
+  }
+  FailStreamingGeneratorReplayInconsistency(
+      task_id, generator_id, expected_count, actual_count);
+  return true;
+}
+
+void TaskManager::FailStreamingGeneratorReplayInconsistency(const TaskID &task_id,
+                                                            const ObjectID &generator_id,
+                                                            int64_t expected_count,
+                                                            int64_t actual_count) {
+  const std::string error_message = absl::StrCat(
+      "Streaming generator task ",
+      task_id.Hex(),
+      " was re-executed and produced ",
+      actual_count,
+      " objects, expected ",
+      expected_count,
+      ". The generator output is non-deterministic, which can hang downstream "
+      "consumers (when fewer objects are produced) or silently truncate their "
+      "input (when more objects are produced).");
+
+  RAY_LOG(ERROR).WithField(task_id).WithField(generator_id)
+      << error_message
+      << " Failing the task instead of leaving the pipeline stuck or silently "
+         "dropping data.";
+
+  rpc::RayErrorInfo error_info;
+  error_info.set_error_message(error_message);
+  // Set the error type explicitly: FailPendingTask forwards this RayErrorInfo
+  // as-is to the task status event, where an unset error_type would default to
+  // WORKER_DIED instead of the actual cause.
+  error_info.set_error_type(rpc::ErrorType::STREAMING_GENERATOR_REPLAY_INCONSISTENT);
+  Status status = Status::Invalid(error_message);
+  FailOrRetryPendingTask(task_id,
+                         rpc::ErrorType::STREAMING_GENERATOR_REPLAY_INCONSISTENT,
+                         &status,
+                         &error_info,
+                         /*mark_task_object_failed=*/true,
+                         /*fail_immediately=*/true);
+}
+
 bool TaskManager::HandleReportGeneratorItemReturns(
     const rpc::ReportGeneratorItemReturnsRequest &request,
     const ExecutionSignalCallback &execution_signal_callback,
@@ -1092,6 +1163,17 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
                                       const rpc::Address &worker_addr,
                                       bool is_application_error) {
   RAY_LOG(DEBUG) << "Completing task " << task_id;
+
+  // Detect a streaming generator replay that produced a different number of
+  // objects than the first attempt, and fail before any return object is
+  // written to the store below — otherwise downstream consumers could observe
+  // the inconsistent objects before the failure propagates. Skipped on
+  // application-error completions, which already route through the failure
+  // path.
+  if (!is_application_error &&
+      FailStreamingGeneratorReplayIfInconsistent(task_id, reply)) {
+    return;
+  }
 
   bool first_execution = false;
   const auto store_in_plasma_ids =

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -964,12 +964,9 @@ bool TaskManager::FailStreamingGeneratorReplayIfInconsistent(
     if (expected_count == 0 || expected_count == actual_count) {
       return false;
     }
-    // Defensive: a well-formed streaming generator reply always carries the
-    // generator id in return_objects(0), but guard against a malformed reply.
-    if (reply.return_objects_size() == 0) {
-      return false;
-    }
-    generator_id = ObjectID::FromBinary(reply.return_objects(0).object_id());
+    // Use the pinned task spec, so malformed replies without return_objects
+    // still fail fast on the object-count mismatch.
+    generator_id = it->second.spec_.ReturnId(0);
   }
   FailStreamingGeneratorReplayInconsistency(
       task_id, generator_id, expected_count, actual_count);

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -819,6 +819,41 @@ class TaskManager : public TaskManagerInterface {
   void MarkEndOfStream(const ObjectID &generator_id, int64_t end_of_stream_index)
       ABSL_LOCKS_EXCLUDED(object_ref_stream_ops_mu_) ABSL_LOCKS_EXCLUDED(mu_);
 
+  /// Detect whether a streaming generator replay produced a different number
+  /// of objects than the first successful attempt, and if so, fail the task.
+  /// Returns true when inconsistency was detected and the task was failed
+  /// (caller must not run normal completion logic in that case). Must run
+  /// early in CompletePendingTask: before any return object is written to the
+  /// store (so downstream consumers cannot observe the inconsistent objects)
+  /// and before SetTaskStatus(FINISHED) (FailPendingTask RAY_CHECKs
+  /// IsPending()). Whether this is a replay is determined internally from the
+  /// task's successful-execution count. The caller must skip this check on
+  /// application-error completions, which already route through the failure
+  /// path.
+  bool FailStreamingGeneratorReplayIfInconsistent(const TaskID &task_id,
+                                                  const rpc::PushTaskReply &reply)
+      ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Fail a streaming generator task whose replay produced a different number
+  /// of objects than the first successful attempt. Two failure modes:
+  /// - fewer objects: downstream consumers block on indices that will never
+  ///   be produced (silent hang).
+  /// - more objects: extras beyond the pinned EOF are silently dropped by
+  ///   ObjectRefStream::InsertToStream (silent data loss).
+  /// Failing the task (rather than only marking object refs) propagates the
+  /// failure through lineage to downstream tasks that haven't run yet.
+  ///
+  /// \param task_id The streaming generator task id.
+  /// \param generator_id The generator ObjectID (for logging context).
+  /// \param expected_count Number of objects reported by the first successful
+  ///   attempt (recorded on the task spec).
+  /// \param actual_count Number of objects reported by the replay attempt.
+  void FailStreamingGeneratorReplayInconsistency(const TaskID &task_id,
+                                                 const ObjectID &generator_id,
+                                                 int64_t expected_count,
+                                                 int64_t actual_count)
+      ABSL_LOCKS_EXCLUDED(mu_);
+
   /// See TemporarilyOwnGeneratorReturnRefIfNeeded for a docstring.
   bool TemporarilyOwnGeneratorReturnRefIfNeededInternal(const ObjectID &object_id,
                                                         const ObjectID &generator_id)

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -2530,6 +2530,38 @@ TEST_F(TaskManagerTest, TestStreamingGeneratorReplayMoreObjectsFailsLoudly) {
   // surfaces the problem to downstream tasks that haven't run yet.
 }
 
+TEST_F(TaskManagerTest, TestStreamingGeneratorReplayMismatchWithEmptyReturnsFails) {
+  std::vector<rpc::TaskStatus> recorded_statuses;
+  RecordTaskStatuses(&recorded_statuses);
+
+  rpc::Address caller_address;
+  auto spec =
+      CreateTaskHelper(1, {}, /*dynamic_returns=*/true, /*streaming_generator=*/true);
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/1);
+
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/2,
+                               /*set_in_plasma=*/true);
+
+  std::vector<ObjectID> resubmitted_task_deps;
+  ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
+
+  rpc::PushTaskReply malformed_reply;
+  auto return_id_proto = malformed_reply.add_streaming_generator_return_ids();
+  return_id_proto->set_object_id(spec.ReturnId(1).Binary());
+  return_id_proto->set_is_plasma_object(true);
+
+  manager_.CompletePendingTask(spec.TaskId(),
+                               malformed_reply,
+                               caller_address,
+                               /*is_application_error=*/false);
+
+  ASSERT_THAT(recorded_statuses, ::testing::Contains(rpc::TaskStatus::FAILED));
+  ASSERT_EQ(manager_.NumPendingTasks(), 0);
+  ASSERT_EQ(num_retries_, 1);
+}
+
 // Sanity: a replay that produces the same number of objects as the first
 // successful attempt must NOT trip the inconsistency path. Guards against
 // false positives.

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -252,6 +252,32 @@ class TaskManagerTest : public ::testing::Test {
     manager_.CompletePendingTask(spec.TaskId(), reply, caller_address, false);
   }
 
+  // Records every task status passed to the task event buffer into `out` so a
+  // test can assert whether the task ended up FAILED vs FINISHED. Call once at
+  // the start of a test, before any status event is emitted.
+  void RecordTaskStatuses(std::vector<rpc::TaskStatus> *out) {
+    EXPECT_CALL(*task_event_buffer_mock_,
+                RecordTaskStatusEventIfNeeded(::testing::_,
+                                              ::testing::_,
+                                              ::testing::_,
+                                              ::testing::_,
+                                              ::testing::_,
+                                              ::testing::_,
+                                              ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [out](const TaskID &,
+                  const JobID &,
+                  int32_t,
+                  const TaskSpecification &,
+                  rpc::TaskStatus status,
+                  bool,
+                  std::optional<const worker::TaskStatusEvent::TaskStateUpdate>) {
+              out->push_back(status);
+              return false;
+            });
+  }
+
   bool lineage_pinning_enabled_;
   bool did_queue_generator_resubmit_ = false;
   rpc::Address addr_;
@@ -2345,6 +2371,236 @@ TEST_F(TaskManagerTest, TestObjectRefStreamIndexDiscarded) {
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(obj_id, ObjectID::Nil());
   CompletePendingStreamingTask(spec, caller_address, 1);
+}
+
+// Regression test: a streaming generator whose replay produces fewer objects
+// than the first successful attempt must fail the task (not just mark
+// individual object refs) with rpc::ErrorType::STREAMING_GENERATOR_REPLAY_INCONSISTENT.
+// Without the fix, downstream consumers block on indices that will never be
+// produced (silent hang). Failing the task propagates the failure through
+// lineage to downstream consumers that may have already processed objects
+// from the first successful attempt (streaming generators are consumed
+// pipelined, so by replay time those consumers have already run).
+TEST_F(TaskManagerTest, TestStreamingGeneratorReplayFewerObjectsFailsLoudly) {
+  std::vector<rpc::TaskStatus> recorded_statuses;
+  RecordTaskStatuses(&recorded_statuses);
+
+  rpc::Address caller_address;
+  auto spec =
+      CreateTaskHelper(1, {}, /*dynamic_returns=*/true, /*streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/1);
+
+  // attempt 0: yield 3 objects in plasma.
+  for (int64_t i = 0; i < 3; i++) {
+    auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    auto data = GenerateRandomBuffer();
+    auto req = GetIntermediateTaskReturn(/*idx=*/i,
+                                         /*finished=*/false,
+                                         generator_id,
+                                         /*dynamic_return_id=*/obj_id,
+                                         data,
+                                         /*set_in_plasma=*/true);
+    ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
+        req, /*execution_signal_callback=*/[](Status) {}));
+  }
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/3,
+                               /*set_in_plasma=*/true);
+
+  // Simulate lineage reconstruction triggering a replay.
+  std::vector<ObjectID> resubmitted_task_deps;
+  ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
+
+  // attempt 1: yield only 2 objects. The third (index 2) is missing - this is
+  // the partial replay we are testing.
+  for (int64_t i = 0; i < 2; i++) {
+    auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    auto data = GenerateRandomBuffer();
+    auto req = GetIntermediateTaskReturn(/*idx=*/i,
+                                         /*finished=*/false,
+                                         generator_id,
+                                         /*dynamic_return_id=*/obj_id,
+                                         data,
+                                         /*set_in_plasma=*/true);
+    manager_.HandleReportGeneratorItemReturns(
+        req, /*execution_signal_callback=*/[](Status) {});
+  }
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/2,
+                               /*set_in_plasma=*/true);
+
+  // The replay must mark the task FAILED. This is the assertion that actually
+  // proves the fix ran: a same-object-count replay records FINISHED here
+  // instead.
+  ASSERT_THAT(recorded_statuses, ::testing::Contains(rpc::TaskStatus::FAILED));
+
+  // The task must be FAILED. FailPendingTask erases it from
+  // submissible_tasks_, so NumPendingTasks drops back to 0.
+  ASSERT_EQ(manager_.NumPendingTasks(), 0);
+
+  // Non-determinism is not a transient failure - fail_immediately=true must
+  // prevent a retry. num_retries_ reflects only the lineage-reconstruction
+  // Resubmit we triggered explicitly above.
+  ASSERT_EQ(num_retries_, 1);
+
+  // Object-level error markers are best-effort: MarkTaskReturnObjectsFailed
+  // (invoked from FailPendingTask) tries to write STREAMING_GENERATOR_REPLAY_INCONSISTENT
+  // to each return ref in the expected range, but MemoryStore::Put is a no-op
+  // on existing entries (sentinels from attempt 0) and is skipped entirely
+  // when the reference counter no longer tracks the object (e.g. after node
+  // death cleared the sentinel). The core guarantee is the task-level FAILED
+  // status asserted above, which propagates through lineage to downstream
+  // consumers. We do not assert on individual object markers here.
+}
+
+// When a replay returns MORE objects than the first successful attempt, the
+// extra objects (indices >= expected_count) are silently dropped by
+// ObjectRefStream::InsertToStream because the stream EOF is pinned to the
+// expected count. The consumer stops at the expected EOF and never sees the
+// extras, which means the consumer's logical data stream may be silently
+// truncated or have inconsistent block boundaries. The fix fails the task so
+// the failure propagates through lineage to downstream consumers.
+TEST_F(TaskManagerTest, TestStreamingGeneratorReplayMoreObjectsFailsLoudly) {
+  std::vector<rpc::TaskStatus> recorded_statuses;
+  RecordTaskStatuses(&recorded_statuses);
+
+  rpc::Address caller_address;
+  auto spec =
+      CreateTaskHelper(1, {}, /*dynamic_returns=*/true, /*streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/1);
+
+  // attempt 0: yield 2 objects.
+  for (int64_t i = 0; i < 2; i++) {
+    auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    auto data = GenerateRandomBuffer();
+    auto req = GetIntermediateTaskReturn(/*idx=*/i,
+                                         /*finished=*/false,
+                                         generator_id,
+                                         /*dynamic_return_id=*/obj_id,
+                                         data,
+                                         /*set_in_plasma=*/true);
+    ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
+        req, /*execution_signal_callback=*/[](Status) {}));
+  }
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/2,
+                               /*set_in_plasma=*/true);
+
+  std::vector<ObjectID> resubmitted_task_deps;
+  ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
+
+  // attempt 1: yield 3 objects (one more than the first successful attempt).
+  // The third object (index 2) is silently dropped by InsertToStream because
+  // it exceeds the EOF pinned to 2 by the first execution.
+  for (int64_t i = 0; i < 3; i++) {
+    auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    auto data = GenerateRandomBuffer();
+    auto req = GetIntermediateTaskReturn(/*idx=*/i,
+                                         /*finished=*/false,
+                                         generator_id,
+                                         /*dynamic_return_id=*/obj_id,
+                                         data,
+                                         /*set_in_plasma=*/true);
+    manager_.HandleReportGeneratorItemReturns(
+        req, /*execution_signal_callback=*/[](Status) {});
+  }
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/3,
+                               /*set_in_plasma=*/true);
+
+  // The task must be FAILED.
+  ASSERT_THAT(recorded_statuses, ::testing::Contains(rpc::TaskStatus::FAILED));
+  ASSERT_EQ(manager_.NumPendingTasks(), 0);
+  ASSERT_EQ(num_retries_, 1);
+
+  // The core guarantee of the fail-task approach is that the task is FAILED
+  // (asserted above), which propagates through lineage to downstream
+  // consumers. Object-level error markers are best-effort: indices 0/1
+  // already hold OBJECT_IN_PLASMA sentinels from the replay's
+  // HandleTaskReturn, and MarkTaskReturnObjectsFailed's Put is a no-op on
+  // them (MemoryStore::Put does not overwrite existing entries). In
+  // production, consumers that already fetched from plasma will get the
+  // (potentially inconsistent) data; the task-level FAILED status is what
+  // surfaces the problem to downstream tasks that haven't run yet.
+}
+
+// Sanity: a replay that produces the same number of objects as the first
+// successful attempt must NOT trip the inconsistency path. Guards against
+// false positives.
+TEST_F(TaskManagerTest, TestStreamingGeneratorReplaySameObjectsSucceeds) {
+  std::vector<rpc::TaskStatus> recorded_statuses;
+  RecordTaskStatuses(&recorded_statuses);
+
+  rpc::Address caller_address;
+  auto spec =
+      CreateTaskHelper(1, {}, /*dynamic_returns=*/true, /*streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/1);
+
+  for (int64_t i = 0; i < 2; i++) {
+    auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    auto data = GenerateRandomBuffer();
+    auto req = GetIntermediateTaskReturn(/*idx=*/i,
+                                         /*finished=*/false,
+                                         generator_id,
+                                         /*dynamic_return_id=*/obj_id,
+                                         data,
+                                         /*set_in_plasma=*/true);
+    ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
+        req, /*execution_signal_callback=*/[](Status) {}));
+  }
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/2,
+                               /*set_in_plasma=*/true);
+
+  std::vector<ObjectID> resubmitted_task_deps;
+  ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
+
+  for (int64_t i = 0; i < 2; i++) {
+    auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    auto data = GenerateRandomBuffer();
+    auto req = GetIntermediateTaskReturn(/*idx=*/i,
+                                         /*finished=*/false,
+                                         generator_id,
+                                         /*dynamic_return_id=*/obj_id,
+                                         data,
+                                         /*set_in_plasma=*/true);
+    manager_.HandleReportGeneratorItemReturns(
+        req, /*execution_signal_callback=*/[](Status) {});
+  }
+  CompletePendingStreamingTask(spec,
+                               caller_address,
+                               /*num_streaming_generator_returns=*/2,
+                               /*set_in_plasma=*/true);
+
+  // No object should hold a STREAMING_GENERATOR_REPLAY_INCONSISTENT marker
+  // when the replay object count matches the first successful attempt.
+  WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
+  for (int64_t i = 0; i < 2; i++) {
+    const auto obj_id = ObjectID::FromIndex(spec.TaskId(), /*index=*/2 + i);
+    std::vector<std::shared_ptr<RayObject>> results;
+    RAY_CHECK_OK(store_->Get({obj_id}, 1, /*timeout_ms=*/0, ctx, &results));
+    ASSERT_EQ(results.size(), 1);
+    rpc::ErrorType stored_error = rpc::ErrorType::OBJECT_LOST;
+    if (results[0]->IsException(&stored_error)) {
+      ASSERT_NE(stored_error, rpc::ErrorType::STREAMING_GENERATOR_REPLAY_INCONSISTENT);
+    }
+  }
+
+  // The task must NOT be failed - it should complete normally (FINISHED and
+  // erased from submissible_tasks_ as non-retryable).
+  ASSERT_THAT(recorded_statuses, ::testing::Contains(rpc::TaskStatus::FINISHED));
+  ASSERT_THAT(recorded_statuses,
+              ::testing::Not(::testing::Contains(rpc::TaskStatus::FAILED)));
+  ASSERT_EQ(manager_.NumPendingTasks(), 0);
+  ASSERT_EQ(num_retries_, 1);
 }
 
 TEST_F(TaskManagerTest, TestObjectRefStreamReadIgnoredWhenNothingWritten) {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -278,6 +278,10 @@ enum ErrorType {
   OBJECT_UNRECONSTRUCTABLE_LINEAGE_DISABLED = 32;
   // Indicates that the worker failed to startup after multiple retry attempts.
   WORKER_STARTUP_FAILED = 33;
+  // A streaming generator task was replayed (e.g. for lineage
+  // reconstruction) and produced a different number of objects than the
+  // first successful attempt, indicating non-deterministic generator output.
+  STREAMING_GENERATOR_REPLAY_INCONSISTENT = 34;
 }
 
 // The user error information.


### PR DESCRIPTION
## Description

When a streaming generator task's replay emits a different number of objects than the original successful attempt, downstream consumers break — fewer objects leaves the pipeline silently hanging (the scenario we hit in production), and more objects silently drops data past the pinned end-of-stream index (theoretical). Nothing detects this mismatch today. This PR fails the task fast with a new `STREAMING_GENERATOR_REPLAY_INCONSISTENT` error so the failure propagates through lineage to downstream consumers instead. The underlying object-count non-determinism is not fixed here; #64393 removes one Ray-internal source, and a future opt-in `rows_per_block` parameter would let users with unstable UDFs make the count deterministic.

**Symptom.** We hit this on an elastic-resource pipeline (worker pods can be preempted at any time) running `read_parquet → tokenize → predict → write_parquet`. The job occasionally hung: one last `predict` task sat in `PENDING_ARGS_AVAIL` for 5h+ with no error logged, blocked on object 12 from an upstream `tokenize` task that was never produced.

**Root cause.** A worker preemption had triggered lineage reconstruction of that `tokenize` task — but the replay produced only 11 objects instead of the original 12, so object 12 was never created.

We added logging in production to confirm this is systematic, not a one-off. For the same task, two attempts received identical input (`in_rows`/`in_bytes` equal) and produced an identical *row* count, yet emitted a different number of objects (one per output block):

```
Task 377d5b47   in_rows=8,510   in_bytes=332,299,291   (identical across attempts)
  attempt 1 (pid=428):  out_blocks=3   out_rows=8,510   out_bytes=1,947,213,121
  attempt 2 (pid=652):  out_blocks=4   out_rows=8,510   out_bytes=1,520,930,614
  → out_blocks 3 → 4; out_bytes estimate drifted ~22% (228KB/row → 179KB/row)

Task 5668fd1c   in_rows=9,330   in_bytes=383,047,785    (identical across attempts)
  attempt 1 (pid=307):    out_blocks=5   out_rows=9,330   out_bytes=2,284,886,568
  attempt 2 (pid=12772):  out_blocks=4   out_rows=9,330   out_bytes=2,388,146,403
  → out_blocks 5 → 4; out_bytes estimate drifted ~4.5% (245KB/row → 256KB/row)
```

`out_rows` is identical across attempts but `out_blocks` is not — a replay genuinely produces a different object count.

A task's object count is non-deterministic: block boundaries drift across attempts (see *Why the object count drifts* below), so a replay can emit fewer or more objects than the original successful attempt. Downstream consumers were created against the original count:

- **fewer** → the consumer blocks on stream indices that are never produced (the scenario we hit);
- **more** → the extras past the pinned end-of-stream index are silently dropped by `ObjectRefStream::InsertToStream`.

Why this goes undetected: the first successful execution pins the stream's end-of-stream index (EOF), `MarkEndOfStream` early-returns afterward so EOF can never move, and `CompletePendingTask` only re-checks replays that fail with an application error — a normally-completing replay with a different count falls through unhandled.

**Why the object count drifts.** A streaming generator yields one object per *output block*, and `OutputBuffer.next()` cuts a new block once accumulated rows reach `target_num_rows` — a value derived from `size_bytes()`. The object count therefore tracks the running size estimate rather than the input, so anything that changes that estimate or the data across attempts shifts the boundaries and changes the count:

- a non-deterministic `size_bytes()` estimate (e.g. `PandasBlock.size_bytes` sampling without a fixed seed — addressed in [Data] Make PandasBlock.size_bytes deterministic #64393);
- a UDF whose output is unstable across runs — the same input produces slightly different results across attempts (nondeterministic ordering, floating-point jitter, or wall-clock/random-dependent content), shifting the block boundaries.

**Fix.** This PR surfaces the mismatch loudly: detect it in `CompletePendingTask` and fail the task with a new `STREAMING_GENERATOR_REPLAY_INCONSISTENT` error type, so the failure propagates through lineage to downstream tasks instead of leaving the pipeline stuck or dropping data silently. The behavior change is strictly hang/silent-loss → explicit error; no caller relies on the old silent behavior.

**Implementation notes.**

- Detection runs in a new `FailStreamingGeneratorReplayIfInconsistent` helper called early in `CompletePendingTask` — *before* any return object is written to the store (so downstream consumers can't observe the inconsistent objects before the failure propagates) and *before* `SetTaskStatus(FINISHED)` (`FailPendingTask` `RAY_CHECK`s `IsPending()`).
- `expected_count` comes from `spec.NumStreamingGeneratorReturns()` (recorded on the first successful attempt); `actual_count` is `reply.streaming_generator_return_ids_size()`.
- Both the fewer- and more-objects cases fail the task: either way the stream is already inconsistent with what downstream consumers were created against.
- Known limitation: a first attempt that yields *zero* objects does not record a count, so a replay yielding a non-zero count is not flagged. This cannot hang (the stream's EOF is pinned to 0, so consumers finish immediately); detecting it would require tracking "count recorded" separately and is left out of scope here.

## Related issues

None.

## Additional information

**Tests.** Adds C++ unit tests in `task_manager_test.cc` that drive `CompletePendingTask` with controlled object counts — the deterministic repro of the bug:

- fewer objects on replay → task fails with `STREAMING_GENERATOR_REPLAY_INCONSISTENT`;
- more objects on replay → task fails with the same error;
- same count → completes normally (no false positive).

**End-to-end illustration.** Requires a dev build (`PYTHONPATH=$(pwd)/python python repro.py`). Without the fix, hangs on `refs[2]`; with the fix, fails fast with `produced 2 objects, expected 3`.

```python
import numpy as np
import ray
from ray.cluster_utils import Cluster

cluster = Cluster()
cluster.add_node(
    num_cpus=0,
    resources={"head": 1},
    _system_config={"max_direct_call_object_size": 100},
    enable_object_reconstruction=True,
)
ray.init(address=cluster.address)
worker = cluster.add_node(num_cpus=1, resources={"worker": 1})
cluster.wait_for_nodes()


@ray.remote(num_cpus=0, resources={"head": 0.01})
class AttemptCounter:
    def __init__(self):
        self.n = 0

    def next(self):
        self.n += 1
        return self.n


AttemptCounter.options(name="counter", lifetime="detached").remote()


@ray.remote(num_returns="streaming", resources={"worker": 1}, max_retries=-1)
def gen():
    attempt = ray.get(ray.get_actor("counter").next.remote())
    num_objects = 3 if attempt == 1 else 2
    for i in range(num_objects):
        yield np.zeros(1024, dtype=np.uint8) + i


gen_ref = gen.remote()
refs = list(gen_ref)
print(f"first attempt produced {len(refs)} objects")

del gen_ref
cluster.remove_node(worker, allow_graceful=False)
cluster.add_node(num_cpus=1, resources={"worker": 1})
cluster.wait_for_nodes()

for i, ref in enumerate(refs):
    print(f"ray.get(refs[{i}])...", end=" ")
    val = ray.get(ref, timeout=30)
    print(f"ok, shape={val.shape}")
```
