### PR TITLE
[serve] Preserve deployment actor class across config re-apply

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1900,13 +1900,23 @@ def override_deployment_info(
                         **request_router_config
                     )
 
+        # _serialized_actor_class is a PrivateAttr dropped by model_dump() above;
+        # carry it over so it survives the DeploymentConfig reconstruction.
+        serialized_actors = {
+            cfg.name: cfg._serialized_actor_class
+            for cfg in (info.deployment_config.deployment_actors or [])
+            if cfg._serialized_actor_class
+        }
+
         if (
             deployment_to_serialized_deployment_actors
             and deployment_name in deployment_to_serialized_deployment_actors
         ):
-            serialized_actors = deployment_to_serialized_deployment_actors[
+            serialized_actors |= deployment_to_serialized_deployment_actors[
                 deployment_name
             ]
+
+        if serialized_actors:
             actors_list = options.get(
                 "deployment_actors",
                 original_options.get("deployment_actors"),

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -2105,6 +2105,64 @@ class TestOverrideDeploymentInfo:
         assert actors[0]._serialized_actor_class == serialized_1
         assert actors[1]._serialized_actor_class == b""  # Not in map, stays empty
 
+    def test_override_deployment_info_preserves_serialized_actor_on_reapply(self):
+        """Re-applying a config (no build task / no serialized map) must keep the
+        already-serialized actor class.
+
+        On a config re-apply with an unchanged code version (e.g. controller
+        restart, or re-submitting the same config), ``override_deployment_info``
+        runs without ``deployment_to_serialized_deployment_actors``. Since
+        ``_serialized_actor_class`` is a Pydantic PrivateAttr dropped by
+        ``model_dump()``, the bytes must be carried over from the in-memory
+        config; otherwise ``get_actor_class()`` later fails with
+        ``EOFError: Ran out of input`` when the deployment actor is recreated.
+        """
+
+        class _ReapplyActor:
+            pass
+
+        serialized = cloudpickle.dumps(_ReapplyActor)
+        initial_info = DeploymentInfo(
+            route_prefix="/",
+            version="123",
+            deployment_config=DeploymentConfig(
+                num_replicas=1,
+                deployment_actors=[
+                    DeploymentActorConfig(
+                        name="counter",
+                        actor_class="test.module:_ReapplyActor",
+                        _serialized_actor_class=serialized,
+                        init_kwargs={"start": 0},
+                    ),
+                ],
+            ),
+            replica_config=ReplicaConfig.create(lambda x: x),
+            start_time_ms=0,
+            deployer_job_id="",
+        )
+
+        config = ServeApplicationSchema(
+            name="default",
+            import_path="test.import.path",
+            deployments=[
+                DeploymentSchema(
+                    name="A",
+                    num_replicas=2,
+                )
+            ],
+        )
+
+        updated_infos = override_deployment_info(
+            {"A": initial_info},
+            config,
+            deployment_to_serialized_deployment_actors=None,
+        )
+        actor_cfg = updated_infos["A"].deployment_config.deployment_actors[0]
+        assert actor_cfg._serialized_actor_class == serialized
+        # Must round-trip without EOFError.
+        assert actor_cfg.get_actor_class().__name__ == "_ReapplyActor"
+        assert updated_infos["A"].deployment_config.num_replicas == 2
+
 
 @patch(
     "ray.serve._private.application_state.get_app_code_version",


### PR DESCRIPTION
## Description

`DeploymentActorConfig._serialized_actor_class` (the cloudpickled deployment-scoped actor class) is a Pydantic `PrivateAttr`, which `model_dump()` does not emit. `override_deployment_info()` reconstructs the deployment config via `DeploymentConfig(**info.deployment_config.model_dump())`, so the bytes are lost unless re-injected from the `deployment_to_serialized_deployment_actors` map. That map is only present after a build task; the lightweight config-apply path (`ApplicationState.apply_app_config`, taken when the code version is unchanged) calls `override_deployment_info` without it.

The reconstructed `DeploymentActorConfig` then has `actor_class` as an import-path string and `_serialized_actor_class == b""`, and the constructor does not re-serialize for a string `actor_class`. `get_actor_class()` later fails with `EOFError: Ran out of input` when the controller (re)creates the actor — e.g. after a controller restart or a redundant config re-apply (common under KubeRay RayService reconciles when a worker pod/node is replaced).

This makes the re-injection lossless: it carries `_serialized_actor_class` over from the in-memory config (the source of truth on a re-apply where no build task ran), while still letting freshly-built bytes from the build task take precedence.

Verified against Ray 2.55.1: before the fix the re-apply path drops the bytes and `get_actor_class()` raises `EOFError`; after the fix the bytes survive and the class deserializes. Added a regression test (`test_override_deployment_info_preserves_serialized_actor_on_reapply`); the existing `test_override_deployment_info_deployment_actors_partial_match` still passes (actors with no in-memory bytes and no map entry remain `b""`).

## Related issues

Fixes #64373

## Additional information

Alternative considered: making `_serialized_actor_class` a non-private field so `model_dump()` round-trips it (and/or having `get_actor_class()` re-import from the `actor_class` string). That is more robust against future `model_dump()` round-trips but larger in blast radius — happy to switch if preferred.
