### PR TITLE
[ci] Add credential-free redirect-validation premerge check

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -89,3 +89,21 @@ steps:
       - oss
       - skip-on-premerge
     soft_fail: true
+
+  # Credential-free PR-time gate for doc/redirects/*.yaml. Selected by the
+  # `doc_redirects` tag (see .buildkite/test.rules.txt), so a redirect-only PR runs
+  # only this step and skips docbuild, the API checks, linkcheck, and team doc tests.
+  # Runs in forge (no doc image), installs the pinned PyPI package, and uses no RtD
+  # token, so it's safe on fork PRs.
+  - label: ":book: doc: validate redirects"
+    key: doc_redirects
+    depends_on: forge
+    tags:
+      - oss
+      - doc_redirects
+    commands:
+      - pip install --no-cache-dir anyscale-rtd-redirects==0.2.0
+      # diff-file reads the base via `git show origin/master:<path>`; ensure the ref is present.
+      - git fetch -q origin master
+      - rtd-redirects validate doc/redirects/current.yaml
+      - rtd-redirects diff-file --file doc/redirects/current.yaml --base origin/master --head HEAD --repo .

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -103,7 +103,8 @@ steps:
       - doc_redirects
     commands:
       - pip install --no-cache-dir anyscale-rtd-redirects==0.2.0
-      # diff-file reads the base via `git show origin/master:<path>`; ensure the ref is present.
-      - git fetch -q origin master
+      # diff-file reads the base via `git show origin/<base>:<path>`, so resolve the
+      # PR's base branch (falling back to master for non-PR builds) and ensure it's present.
+      - git fetch -q origin "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
       - rtd-redirects validate doc/redirects/current.yaml
-      - rtd-redirects diff-file --file doc/redirects/current.yaml --base origin/master --head HEAD --repo .
+      - rtd-redirects diff-file --file doc/redirects/current.yaml --base "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}" --head HEAD --repo .

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -125,14 +125,18 @@ steps:
       - oss
       - doc_redirects
     commands:
-      - pip install --no-cache-dir anyscale-rtd-redirects==0.2.0
+      - uv tool install anyscale-rtd-redirects==0.2.0
       # The doc_redirects tag selects on doc/redirects/*.yaml, but the commands below
-      # name current.yaml: multiple files compose in the order given, which a shell glob
+      # name current.yaml: multiple files compose in the order given, which a glob
       # can't express. Fail closed if another redirect file appears, so it can't select
       # this step and then go unvalidated. To add one, name it in both commands below in
       # compose order, then update this guard.
+      #
+      # The guard recurses rather than globbing a single level, because the tag rule
+      # matches with fnmatch, whose `*` crosses `/`: doc/redirects/nested/foo.yaml
+      # selects this step, and a one-level glob wouldn't see it.
       - >
-        test "$$(ls doc/redirects/*.yaml)" = "doc/redirects/current.yaml" ||
+        test "$$(find doc/redirects -name '*.yaml')" = "doc/redirects/current.yaml" ||
         { echo "doc/redirects/ holds a .yaml file this check doesn't validate; see the comment in .buildkite/doc.rayci.yml"; exit 1; }
       # diff-file resolves the base with `git show <ref>:<path>`. Fetch the PR's base
       # branch (master on non-PR builds) and diff against FETCH_HEAD, the same pattern

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -110,3 +110,34 @@ steps:
       - oss
       - skip-on-premerge
     soft_fail: true
+
+  # Credential-free PR-time gate for doc/redirects/*.yaml, which nothing validated
+  # before: redirect YAML matched no tag rule, so a redirect-only PR triggered no
+  # documentation step at all. Selected by the `doc_redirects` tag (see
+  # .buildkite/test.rules.txt), which routes redirect YAML here and nowhere else, so
+  # this is the only step a redirect-only PR runs. It needs neither the doc image nor
+  # a compiled Ray: it runs in forge, installs the pinned PyPI package, and uses no
+  # RtD token, so it's safe on fork PRs.
+  - label: ":book: doc: validate redirects"
+    key: doc_redirects
+    depends_on: forge
+    tags:
+      - oss
+      - doc_redirects
+    commands:
+      - pip install --no-cache-dir anyscale-rtd-redirects==0.2.0
+      # The doc_redirects tag selects on doc/redirects/*.yaml, but the commands below
+      # name current.yaml: multiple files compose in the order given, which a shell glob
+      # can't express. Fail closed if another redirect file appears, so it can't select
+      # this step and then go unvalidated. To add one, name it in both commands below in
+      # compose order, then update this guard.
+      - >
+        test "$$(ls doc/redirects/*.yaml)" = "doc/redirects/current.yaml" ||
+        { echo "doc/redirects/ holds a .yaml file this check doesn't validate; see the comment in .buildkite/doc.rayci.yml"; exit 1; }
+      # diff-file resolves the base with `git show <ref>:<path>`. Fetch the PR's base
+      # branch (master on non-PR builds) and diff against FETCH_HEAD, the same pattern
+      # doc/test_no_new_rst.py uses: a clone with a restricted refspec may never create
+      # a local origin/<base>.
+      - git fetch -q origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+      - rtd-redirects validate doc/redirects/current.yaml
+      - rtd-redirects diff-file --file doc/redirects/current.yaml --base FETCH_HEAD --head HEAD --repo .

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -89,6 +89,9 @@ doc/example.ipynb: doc
 doc/requirements-doc.txt: doc
 python/deplocks/docs/docbuild_depset_py3.10.lock: doc python_dependencies
 ci/raydepsets/configs/docs.depsets.yaml: doc python_dependencies
+# Redirect YAML selects the dedicated lightweight check, NOT the broad `doc` tag,
+# so a redirect-only PR skips docbuild, API checks, and the per-team doc tests.
+doc/redirects/current.yaml: doc_redirects
 
 # === Release ===
 

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -176,7 +176,10 @@ doc/source/_ext/llms_txt.py: doc doc_api
 doc/source/custom_directives.py: doc doc_api
 doc/source/api_autogen.py: doc doc_api
 doc/source/api_mock_imports.py: doc doc_api
-.buildkite/doc.rayci.yml: doc doc_api
+# doc.rayci.yml declares the redirect-validation step as well as the two API
+# checks, so it emits doc_redirects on top of doc and doc_api. An edit to a step
+# definition has to be able to select the step it edits.
+.buildkite/doc.rayci.yml: doc doc_api doc_redirects
 # api_sidebar.py sits under doc/source/_ext/ but carries `tools` on top of the
 # dir rule's tags, because //ci/pipeline:test_doc_api_rules_sync is a ci_unit
 # target and ci_unit is selected by `tools`. This case is what keeps the drift
@@ -211,6 +214,11 @@ doc/source/llms_txt_summary.txt: doc
 doc/test_myst_doc.py: core_doc
 python/deplocks/docs/docbuild_depset_py3.11.lock: doc doc_api python_dependencies
 ci/raydepsets/configs/docs.depsets.yaml: doc doc_api python_dependencies
+# Redirect YAML selects the dedicated lightweight check and nothing else: no
+# docbuild, no API checks, no per-team doc tests. The README beside it is prose
+# and stays unrouted, which is what the second case locks in.
+doc/redirects/current.yaml: doc_redirects
+doc/redirects/README.md:
 
 # === Release ===
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -17,7 +17,7 @@
 ! python cpp core_cpp java workflow cgraphs_direct_transport dashboard
 ! ray_client runtime_env_container
 ! data dask serve ml tune train train_gpu llm rllib rllib_gpu rllib_directly
-! linux_wheels macos_wheels docker doc python_dependencies min_build tools windows
+! linux_wheels macos_wheels docker doc doc_redirects python_dependencies min_build tools windows
 ! release_tests spark_on_ray
 
 # NOTE: dstrodtman is leading effort to rework content in RST files, and wanted to shift
@@ -202,6 +202,15 @@ doc/requirements-doc.txt
 .vale/
 .buildkite/doc.rayci.yml
 @ doc
+;
+
+# Redirect YAML under doc/redirects/ gets a dedicated, credential-free premerge
+# check (rtd-redirects validate + diff-file) instead of the full doc build. It must
+# NOT emit the broad `doc` tag, which would pull in docbuild, the API
+# annotation/consistency checks, and the per-team doc tests. This rule must precede
+# the broad `doc/` pass rule below so a redirect-only PR selects `doc_redirects` alone.
+doc/redirects/*.yaml
+@ doc_redirects
 ;
 
 ci/docker/doctest.build.Dockerfile

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -17,7 +17,7 @@
 ! core_python cpp core_cpp java workflow cgraphs_direct_transport dashboard
 ! ray_client runtime_env_container
 ! data dask serve ml tune train train_gpu llm rllib rllib_gpu rllib_directly
-! linux_wheels macos_wheels docker doc doc_api python_dependencies min_build tools windows
+! linux_wheels macos_wheels docker doc doc_api doc_redirects python_dependencies min_build tools windows
 ! release_tests spark_on_ray rocksdb_tests redis_tests sandbox_tests
 ! core_doc data_doc ml_doc rllib_doc serve_doc
 
@@ -297,12 +297,35 @@ doc/source/api_mock_imports.py
 doc/source/custom_directives.py
 doc/source/_ext/
 doc/requirements-doc.txt
-# The doc pipeline definition declares the two API-consistency check steps. An
-# edit to those step definitions should exercise the steps it edits, so this
-# emits `doc_api` too. Without it, changing a check's command or image would
-# never run that check on the PR making the change.
-.buildkite/doc.rayci.yml
 @ doc doc_api
+;
+
+# The doc pipeline definition gets its own rule because it declares the redirect
+# step as well as the two API-consistency checks, so it needs a tag the machinery
+# block above must not emit: a conf.py edit shouldn't run the redirect check.
+#
+# An edit to a step definition should exercise the step it edits. Without
+# `doc_api`, changing a check's command or image would never run that check on
+# the PR making the change; without `doc_redirects`, the same holds for the
+# redirect step. `doc_redirects` also covers the `anyscale-rtd-redirects` version
+# pin, which lives in that step's commands, so a version bump re-runs the check.
+.buildkite/doc.rayci.yml
+@ doc doc_api doc_redirects
+;
+
+# Redirect YAML under doc/redirects/ gets a dedicated, credential-free premerge
+# check (rtd-redirects validate + diff-file). Today these files match no rule at
+# all: `.yaml` isn't covered by the leading prose-and-image skip, nor by the
+# `doc/*.py`/`doc/*.ipynb` catch-all further down, so they fall through to the
+# broad `doc/` pass rule and trigger nothing. This rule is purely additive.
+#
+# It emits `doc_redirects` alone, and deliberately not `doc` or `doc_api`. A
+# redirect edit can't change the documented API surface, and it doesn't need the
+# documentation build: the check parses the YAML and diffs it against the base
+# ref. Keep this rule ahead of the `doc/` pass rule at the bottom of the doc
+# section, or redirect YAML goes back to matching nothing.
+doc/redirects/*.yaml
+@ doc_redirects
 ;
 
 # Documentation validation infra, part 2 of 2: rendering and validation only.


### PR DESCRIPTION
## Why are these changes needed?

The YAML under `doc/redirects/` is the source of truth for the docs.ray.io Read the Docs redirect configuration, managed with [rtd-redirects](https://github.com/anyscale/rtd-redirects). Today a PR that edits only redirect YAML runs no check at all, so a malformed or unreachable redirect can merge unnoticed.

Nothing routes redirect YAML anywhere. `.yaml` isn't covered by the leading prose-and-image skip rule, nor by the `doc/*.py`/`doc/*.ipynb`/`doc/*/BUILD.bazel` catch-all, so it falls through to the broad `doc/` pass rule at the bottom of the doc section and emits no tag at all. Confirmed against the rule engine on master: `doc/redirects/current.yaml` emits `set()`.

This adds a lightweight, credential-free premerge gate for `doc/redirects/*.yaml` that validates the redirects and prints the redirect-level diff. The change is purely additive: it gives redirect YAML a check where it previously had none, and no other path's selection changes.

## What changed

- **`.buildkite/test.rules.txt`** — declare a `doc_redirects` test tag and route `doc/redirects/*.yaml` to it. The rule sits ahead of every `doc/` rule, which matters because the final `doc/` pass rule is what currently swallows these files.

  The rule emits `doc_redirects` alone, deliberately not `doc` or `doc_api`. A redirect edit can't change the documented API surface, and the check needs neither a rendered documentation build nor a compiled Ray: it parses the YAML and diffs it against the base ref.
- **`.buildkite/test.rules.txt`** — route `.buildkite/doc.rayci.yml` to `doc_redirects` as well, on its own rule rather than by extending the autodoc-machinery block, so a `conf.py` edit doesn't start running the redirect check. An edit to a step definition has to be able to select the step it edits, which is the same reason that file already emits `doc_api`. This also covers the `anyscale-rtd-redirects` version pin, which lives in the redirect step's commands, so a version bump re-runs the check.
- **`.buildkite/test.rules.test.txt`** — three cases: `doc/redirects/current.yaml: doc_redirects`, `doc/redirects/README.md:` asserting the prose beside it stays unrouted, and `.buildkite/doc.rayci.yml: doc doc_api doc_redirects`. The last one revises an assertion that already existed on master, since that file's tag set genuinely changes here.
- **`.buildkite/doc.rayci.yml`** — add a `forge`-based step (no doc image) that installs the pinned `anyscale-rtd-redirects==0.2.0` from PyPI and runs:
  ```
  rtd-redirects validate doc/redirects/current.yaml
  rtd-redirects diff-file --file doc/redirects/current.yaml --base FETCH_HEAD --head HEAD --repo .
  ```
  The step diffs against `FETCH_HEAD` after fetching the PR's base branch, rather than against `origin/<base>`: a clone with a restricted refspec may never create a local remote-tracking ref, and `doc/test_no_new_rst.py` already solves the same problem the same way. The base branch resolves at runtime from `$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}`, escaped so the shell expands it rather than Buildkite interpolating it at pipeline-upload time, matching the `$${...}` convention used across the other pipeline files.

  The step also fails closed if `doc/redirects/` grows a YAML file the commands don't name. The tag selects on a glob, but multiple redirect files compose in the order given and a shell glob can't express that order, so the guard forces the compose-order decision to be made explicitly instead of letting a new file select the step and then go unvalidated.

## Verification

Verified with Ray's rule parser (`ci/pipeline/determine_tests_to_run.py`), the same first-match-wins engine rayci uses:

- `check_rules()` parses clean, and all 126 cases in `test.rules.test.txt` replay green. That file is enforced by the `test-rules` CI step, and rayci asserts exact set equality, so a passing case proves the path emits exactly those tags and nothing else.
- A sweep of all 10,333 tracked files against master shows **exactly two deltas** — `doc/redirects/current.yaml` gaining `doc_redirects`, and `.buildkite/doc.rayci.yml` gaining it alongside its existing `doc doc_api` — and **zero tag losses** on any path. Every pre-existing assertion in `test.rules.test.txt` is preserved except the `doc.rayci.yml` one this PR deliberately revises.
- Ran the step's commands locally in a clean venv with `anyscale-rtd-redirects==0.2.0` against the current `doc/redirects/current.yaml`: `validate` reports 0 errors (49 chain warnings, informational), and `diff-file --base FETCH_HEAD` reports the redirect-level diff and exits 0 with no Read the Docs credentials.
- Exercised the drift guard both ways: it passes with only `current.yaml` present and exits non-zero when a second `doc/redirects/*.yaml` appears.

Because `.buildkite/doc.rayci.yml` now emits `doc_redirects`, **this PR selects the new step and runs it**. Replaying this PR's own changed files through the rule engine gives a tag union of `doc`, `doc_api`, `doc_redirects`, and `tools`, so the step's commands are exercised in CI here rather than only on some later PR that happens to edit redirect YAML. It runs against an unchanged `current.yaml`, so `diff-file` reports an empty redirect diff and exits 0, which is exactly the smoke test that catches a typo in the step definition.

## Update: rebased onto the doc-tag reorg

Rebased after #64775 and #64812 landed, which reorganized the doc tags: doc example tests moved to per-library `<lib>_doc` tags, and `doc` was split so the autodoc machinery emits `doc doc_api` while the rendering-only surface emits `doc`. This branch's four commits (one an upstream merge) are collapsed into one. Two conflicts in `test.rules.txt` (the tag declaration line, and the rule insertion point) and one in `test.rules.test.txt` (three expectations the reorg had since updated) were resolved in favor of master, then the `doc_redirects` rule and cases re-applied on top.

The rebase also invalidated this PR's original rationale, so the rule and step comments have been rewritten. The earlier framing was that `doc_redirects` keeps redirect YAML from pulling in docbuild, the API checks, and the per-team doc tests. That's no longer accurate on any of the three: the per-team tests are selected by `<lib>_doc`, the two API checks carry `doc_api` plus the library tags and no longer carry bare `doc`, and the only remaining step carrying bare `doc` is `doc: build`, which is `skip-on-premerge`. Since redirect YAML emits nothing at all on master, this rule was never preventing over-triggering. It's additive, and the comments now say so.

## Update: the step now selects itself

Cursor Bugbot caught that the redirect step wasn't reachable from an edit to its own definition: `.buildkite/doc.rayci.yml` emitted `doc doc_api` but never `doc_redirects`, so changing the redirect step's commands wouldn't have run the redirect step. That contradicted the rule's own stated reason for emitting `doc_api`, and this PR demonstrated the gap: its previous revision noted that the new step didn't execute here.

Fixed by giving `.buildkite/doc.rayci.yml` its own rule emitting `doc doc_api doc_redirects`. It's a separate rule rather than an extra tag on the autodoc-machinery block, because that block also covers `conf.py`, `api_autogen.py`, and `doc/source/_ext/`, and a `conf.py` edit has no business running the redirect check. The first attempt at this appended the tag to the shared block and the full-repo sweep caught it immediately: seven machinery files picked up `doc_redirects`.

AI assistance (Claude Code) was used to draft the CI step, the rebase conflict resolution, and this description. Every changed line was reviewed by hand, and the verification above was run as described. This isn't duplicating existing work: no other open PR adds redirect validation to premerge, and the `doc_redirects` tag doesn't exist on master.

## Update: uv, and a recursive fail-closed guard

Two review follow-ups.

**Install with `uv`** (Elliot's suggestion). `ci/docker/forge.Dockerfile` already installs uv to `/usr/local/bin` and uses it for the image's Python, so the step needs no extra setup. It's `uv tool install` rather than `uv pip install --system` for a PATH reason: the previous revision's premerge log shows `pip install` fell back to a user install, so the `rtd-redirects` entry point resolved from `~/.local/bin`. `uv tool install` writes executables to that same directory, so PATH resolution is unchanged. `uv pip install --system` would target the uv-managed interpreter and put the entry point in that env's `bin`, which isn't on PATH.

**The fail-closed guard now recurses.** Cursor Bugbot caught that the guard's single-level shell glob didn't cover a nested redirect file, and it was right. The rule engine matches with `fnmatch`, whose `*` crosses `/`, so `doc/redirects/nested/foo.yaml` emits `doc_redirects` and selects this step, while `ls doc/redirects/*.yaml` never saw it and the guard passed. Replacing the glob with `find` closes the gap. Exercised three ways locally: passes with only `current.yaml`, exits non-zero for a nested file and for a sibling file.

A `.yml` file stays out of scope. The tag rule matches `*.yaml` only, so `doc/redirects/current.yml` emits no tags and never selects the step, putting it beyond the guard's reach. That matches the pre-PR baseline for every redirect file rather than regressing anything, and `rtd-redirects` uses `.yaml`.

Re-verified after the change: rules parse clean and all 126 cases in `test.rules.test.txt` replay green (the rule files are untouched by this revision).

## Related issue number

N/A

## Checks

- [x] I've signed off every commit (`-s`), because all commits are squashed into one when merged.
- [x] I've run `scripts/format.sh` to lint the changes in this PR. (Via `pre-commit`; the applicable hooks pass.)
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(


