### PR TITLE
[ci][doc] Repair doc build cache production; skip incremental for structural PRs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -53,8 +53,8 @@ build:
       html:
         - |
           if [ "${READTHEDOCS_VERSION_TYPE:-}" = "external" ]; then
-            if git diff --no-renames --name-only --diff-filter=D origin/master...HEAD -- doc/source/ 2>/dev/null | grep -q .; then
-              echo "PR deletes or moves doc sources; the incremental cache can't prune their stale pages, so building clean (DOC-1314)."
+            if ! git diff --quiet --no-renames --diff-filter=D origin/master...HEAD -- doc/source/ 2>/dev/null; then
+              echo "PR deletes or moves doc sources; the incremental cache cannot prune their stale pages, so building clean (DOC-1314)."
               make -C doc rtd-fallback HTMLDIR="$READTHEDOCS_OUTPUT/html"
             else
               echo "PR build; attempting incremental build from the master doc cache."

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -41,18 +41,25 @@ build:
         fi
         echo "Doc-affecting files changed; building docs. Changed doc-relevant paths:"
         git diff --name-only origin/master...HEAD -- doc/ python/ray/ rllib/ .readthedocs.yaml
-    # Override the html build step. On PR (external) builds, restore the latest
-    # master build cache and build incrementally so only PR-changed files are
-    # rebuilt; fall back to a clean build (rtd-fallback) if the incremental build
-    # fails. On branch/tag builds (master, stable, release tags) always do a full
-    # clean build so the published output is never stale. Targets live in
-    # doc/Makefile (rtd, rtd-fallback, html).
+    # Override the html build step. On PR (external) builds, build incrementally
+    # from the latest master doc cache, falling back to a clean build
+    # (rtd-fallback) if it fails. PRs that delete or move doc sources skip the
+    # incremental path: the restored cache can't prune the stale pages/stubs they
+    # leave behind, and a clean rename wouldn't trip a warning to force the
+    # fallback. The prune-on-restore fix is tracked in DOC-1314. Branch/tag builds
+    # (master, stable, release tags) always do a full clean build so published
+    # output is never stale. Targets live in doc/Makefile (rtd, rtd-fallback, html).
     build:
       html:
         - |
           if [ "${READTHEDOCS_VERSION_TYPE:-}" = "external" ]; then
-            echo "PR build; attempting incremental build from the master doc cache."
-            make -C doc rtd HTMLDIR="$READTHEDOCS_OUTPUT/html" || make -C doc rtd-fallback HTMLDIR="$READTHEDOCS_OUTPUT/html"
+            if git diff --no-renames --name-only --diff-filter=D origin/master...HEAD -- doc/source/ 2>/dev/null | grep -q .; then
+              echo "PR deletes or moves doc sources; the incremental cache can't prune their stale pages, so building clean (DOC-1314)."
+              make -C doc rtd-fallback HTMLDIR="$READTHEDOCS_OUTPUT/html"
+            else
+              echo "PR build; attempting incremental build from the master doc cache."
+              make -C doc rtd HTMLDIR="$READTHEDOCS_OUTPUT/html" || make -C doc rtd-fallback HTMLDIR="$READTHEDOCS_OUTPUT/html"
+            fi
           else
             echo "Branch/tag build; running a full clean build."
             make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html"

--- a/ci/ray_ci/doc/build_cache.py
+++ b/ci/ray_ci/doc/build_cache.py
@@ -41,6 +41,8 @@ class BuildCache:
         self, environment_cache_file: str, python_executable: str = "python"
     ) -> None:
         """
+        TODO (elliot-barn): revert when upgrading bazel python toolchain
+        
         Strip build-environment-local dependencies from the Sphinx environment
         pickle so the artifacts can be reused as a global cache.
 

--- a/ci/ray_ci/doc/build_cache.py
+++ b/ci/ray_ci/doc/build_cache.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 import subprocess
 import sys
 import tempfile
@@ -11,6 +10,28 @@ ENVIRONMENT_PICKLE = "_build/doctrees/environment.pickle"
 
 _BUILD_CACHE_S3_BUCKET = "ray-ci-results"
 _BUILD_CACHE_PATH_PREFIX = "doc_build/"
+
+# Strips build-environment-local dependencies from the Sphinx environment pickle.
+# Run as a standalone script under the doc-build environment's Python (see
+# BuildCache._massage_cache) so the pickle is read by the same Sphinx that wrote
+# it; it intentionally imports only the standard library.
+_STRIP_LOCAL_DEPS_SCRIPT = """\
+import pickle
+import sys
+
+environment_cache_path = sys.argv[1]
+with open(environment_cache_path, "rb") as f:
+    environment_cache = pickle.load(f)
+
+for doc, dependencies in environment_cache.dependencies.items():
+    # site-packages paths are local to the build machine and would mark every
+    # doc that imports them as outdated when the cache is restored elsewhere.
+    for dependency in [d for d in dependencies if "site-packages" in d]:
+        environment_cache.dependencies[doc].remove(dependency)
+
+with open(environment_cache_path, "wb") as f:
+    pickle.dump(environment_cache, f, pickle.HIGHEST_PROTOCOL)
+"""
 
 
 class BuildCache:
@@ -38,25 +59,36 @@ class BuildCache:
 
         self._upload_cache(doc_tarball)
 
-    def _massage_cache(self, environment_cache_file: str) -> None:
+    def _massage_cache(
+        self, environment_cache_file: str, python_executable: str = "python"
+    ) -> None:
         """
-        Massage the build artifacts, remove the unnecessary files so that they can
-        be used as a global cache
+        Strip build-environment-local dependencies from the Sphinx environment
+        pickle so the artifacts can be reused as a global cache.
+
+        This must run under the doc-build environment's Python -- the same
+        interpreter that built the docs and wrote the pickle, not this script's
+        Bazel-pinned Python. A pickled Sphinx environment can only be loaded by a
+        matching Sphinx; loading a Sphinx 8.x pickle under an older Sphinx raises
+        e.g. ``ModuleNotFoundError: No module named 'sphinx.util._files'``. So we
+        shell out with PYTHONPATH unset, mirroring how _build() runs ``make html``.
+
+        Args:
+            environment_cache_file: Path to the environment pickle, relative to
+                the cache directory.
+            python_executable: Interpreter to run the massage with. Defaults to the
+                environment ``python``; tests override it with their own.
         """
         environment_cache_path = os.path.join(self._cache_dir, environment_cache_file)
-        environment_cache = None
-
-        with open(environment_cache_path, "rb") as f:
-            environment_cache = pickle.load(f)
-            for doc, dependencies in environment_cache.dependencies.items():
-                # Remove the site-packages dependencies because they are local to the
-                # build environment and cannot be used as a global cache
-                local_dependencies = [d for d in dependencies if "site-packages" in d]
-                for dependency in local_dependencies:
-                    environment_cache.dependencies[doc].remove(dependency)
-
-        with open(environment_cache_path, "wb+") as f:
-            pickle.dump(environment_cache, f, pickle.HIGHEST_PROTOCOL)
+        env = os.environ.copy()
+        # Unset PYTHONPATH so the environment Python (with the Sphinx that wrote
+        # the pickle) is used instead of the Bazel runfiles Python.
+        env["PYTHONPATH"] = ""
+        subprocess.run(
+            [python_executable, "-c", _STRIP_LOCAL_DEPS_SCRIPT, environment_cache_path],
+            env=env,
+            check=True,
+        )
 
     def _get_cache(self) -> Set[str]:
         """

--- a/ci/ray_ci/doc/build_cache.py
+++ b/ci/ray_ci/doc/build_cache.py
@@ -11,29 +11,6 @@ ENVIRONMENT_PICKLE = "_build/doctrees/environment.pickle"
 _BUILD_CACHE_S3_BUCKET = "ray-ci-results"
 _BUILD_CACHE_PATH_PREFIX = "doc_build/"
 
-# Strips build-environment-local dependencies from the Sphinx environment pickle.
-# Run as a standalone script under the doc-build environment's Python (see
-# BuildCache._massage_cache) so the pickle is read by the same Sphinx that wrote
-# it; it intentionally imports only the standard library.
-_STRIP_LOCAL_DEPS_SCRIPT = """\
-import pickle
-import sys
-
-environment_cache_path = sys.argv[1]
-with open(environment_cache_path, "rb") as f:
-    environment_cache = pickle.load(f)
-
-for doc, dependencies in environment_cache.dependencies.items():
-    # site-packages paths are local to the build machine and would mark every
-    # doc that imports them as outdated when the cache is restored elsewhere.
-    environment_cache.dependencies[doc] = type(dependencies)(
-        d for d in dependencies if "site-packages" not in d
-    )
-
-with open(environment_cache_path, "wb") as f:
-    pickle.dump(environment_cache, f, pickle.HIGHEST_PROTOCOL)
-"""
-
 
 class BuildCache:
     """
@@ -72,7 +49,8 @@ class BuildCache:
         Bazel-pinned Python. A pickled Sphinx environment can only be loaded by a
         matching Sphinx; loading a Sphinx 8.x pickle under an older Sphinx raises
         e.g. ``ModuleNotFoundError: No module named 'sphinx.util._files'``. So we
-        shell out with PYTHONPATH unset, mirroring how _build() runs ``make html``.
+        run massage_cache.py with PYTHONPATH unset, mirroring how _build() runs
+        ``make html``.
 
         Args:
             environment_cache_file: Path to the environment pickle, relative to
@@ -81,12 +59,15 @@ class BuildCache:
                 environment ``python``; tests override it with their own.
         """
         environment_cache_path = os.path.join(self._cache_dir, environment_cache_file)
+        massage_script = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "massage_cache.py"
+        )
         env = os.environ.copy()
         # Drop PYTHONPATH so the environment Python (with the Sphinx that wrote
         # the pickle) is used instead of the Bazel runfiles Python.
         env.pop("PYTHONPATH", None)
         subprocess.run(
-            [python_executable, "-c", _STRIP_LOCAL_DEPS_SCRIPT, environment_cache_path],
+            [python_executable, massage_script, environment_cache_path],
             env=env,
             check=True,
         )

--- a/ci/ray_ci/doc/build_cache.py
+++ b/ci/ray_ci/doc/build_cache.py
@@ -42,7 +42,6 @@ class BuildCache:
     ) -> None:
         """
         TODO (elliot-barn): revert when upgrading bazel python toolchain
-        
         Strip build-environment-local dependencies from the Sphinx environment
         pickle so the artifacts can be reused as a global cache.
 

--- a/ci/ray_ci/doc/build_cache.py
+++ b/ci/ray_ci/doc/build_cache.py
@@ -26,8 +26,9 @@ with open(environment_cache_path, "rb") as f:
 for doc, dependencies in environment_cache.dependencies.items():
     # site-packages paths are local to the build machine and would mark every
     # doc that imports them as outdated when the cache is restored elsewhere.
-    for dependency in [d for d in dependencies if "site-packages" in d]:
-        environment_cache.dependencies[doc].remove(dependency)
+    environment_cache.dependencies[doc] = type(dependencies)(
+        d for d in dependencies if "site-packages" not in d
+    )
 
 with open(environment_cache_path, "wb") as f:
     pickle.dump(environment_cache, f, pickle.HIGHEST_PROTOCOL)
@@ -81,9 +82,9 @@ class BuildCache:
         """
         environment_cache_path = os.path.join(self._cache_dir, environment_cache_file)
         env = os.environ.copy()
-        # Unset PYTHONPATH so the environment Python (with the Sphinx that wrote
+        # Drop PYTHONPATH so the environment Python (with the Sphinx that wrote
         # the pickle) is used instead of the Bazel runfiles Python.
-        env["PYTHONPATH"] = ""
+        env.pop("PYTHONPATH", None)
         subprocess.run(
             [python_executable, "-c", _STRIP_LOCAL_DEPS_SCRIPT, environment_cache_path],
             env=env,

--- a/ci/ray_ci/doc/massage_cache.py
+++ b/ci/ray_ci/doc/massage_cache.py
@@ -1,0 +1,34 @@
+"""Strip build-environment-local dependencies from a Sphinx environment pickle.
+
+Run this with the Python that built the docs (the doc-build image's interpreter),
+which is typically a newer Sphinx than ci/ray_ci's Bazel-pinned one. A pickled
+Sphinx environment can only be unpickled by a matching Sphinx; loading a Sphinx
+8.x pickle under an older Sphinx raises e.g. ``ModuleNotFoundError: No module
+named 'sphinx.util._files'``. This script imports only the standard library so
+any interpreter can run it (see ``BuildCache._massage_cache``).
+
+Usage:
+    python massage_cache.py <environment_pickle_path>
+"""
+
+import pickle
+import sys
+
+
+def strip_local_dependencies(environment_cache_path: str) -> None:
+    with open(environment_cache_path, "rb") as f:
+        environment_cache = pickle.load(f)
+
+    for doc, dependencies in environment_cache.dependencies.items():
+        # site-packages paths are local to the build machine and would mark every
+        # doc that imports them as outdated when the cache is restored elsewhere.
+        environment_cache.dependencies[doc] = type(dependencies)(
+            d for d in dependencies if "site-packages" not in d
+        )
+
+    with open(environment_cache_path, "wb") as f:
+        pickle.dump(environment_cache, f, pickle.HIGHEST_PROTOCOL)
+
+
+if __name__ == "__main__":
+    strip_local_dependencies(sys.argv[1])

--- a/ci/ray_ci/doc/test_build_cache.py
+++ b/ci/ray_ci/doc/test_build_cache.py
@@ -2,16 +2,12 @@ import os
 import pickle
 import sys
 import tempfile
+import types
 from unittest import mock
 
 import pytest
 
 from ci.ray_ci.doc.build_cache import BuildCache
-
-
-class FakeCache:
-    def __init__(self, dependencies):
-        self.dependencies = dependencies
 
 
 @mock.patch("subprocess.check_output")
@@ -34,8 +30,9 @@ def test_zip_cache():
 
 
 def test_massage_cache():
-    cache = FakeCache(
-        {
+    # SimpleNamespace (stdlib) so the subprocess interpreter can unpickle it.
+    cache = types.SimpleNamespace(
+        dependencies={
             "doc1": ["site-packages/dep1", "dep2"],
             "doc2": ["dep3", "site-packages/dep4"],
         }
@@ -46,7 +43,9 @@ def test_massage_cache():
             pickle.dump(cache, file)
 
         build_cache = BuildCache(temp_dir)
-        build_cache._massage_cache("env_cache.pkl")
+        # Production defaults to the doc-build image's `python`; run the massage
+        # with this test's interpreter instead.
+        build_cache._massage_cache("env_cache.pkl", python_executable=sys.executable)
 
         with open(cache_path, "rb") as file:
             cache = pickle.load(file)


### PR DESCRIPTION
## Description

Two related fixes that get the incremental Read the Docs build (DOC-1047, #64277) actually working.

### 1. Repair the cache producer (`ci/ray_ci/doc/`)

The postmerge `doc: build` step has crashed on every run since the Sphinx 8.2.3 upgrade (#64070), so **no doc build cache has been uploaded since Jun 23**. `make html` builds the docs with the docbuild image's Python (Sphinx 8.2.3) and writes `environment.pickle`, but `_massage_cache` then unpickled it in-process under Bazel's pinned Sphinx (6.2.1):

```
File ".../ci/ray_ci/doc/build_cache.py", line 50, in _massage_cache
    environment_cache = pickle.load(f)
ModuleNotFoundError: No module named 'sphinx.util._files'
```

(`sphinx.util._files` is new in Sphinx 8.x, so 6.2.1 can't load the pickle.) → upload crashes → no cache. Without a fresh cache, RtD only finds the last pre-upgrade (7.x) cache, rejects it as `build environment version not current`, and rebuilds cold every time — so the incremental path never engages.

**Fix:** run the pickle massage under the doc-build environment's Python (`PYTHONPATH` unset), mirroring how `_build()` runs `make html`, so the pickle is read by the same Sphinx that wrote it. Extracted into `ci/ray_ci/doc/massage_cache.py` (stdlib-only) per review.

### 2. Skip the incremental build for structural PRs (`.readthedocs.yaml`)

Incremental Sphinx doesn't delete output for sources removed/renamed in a PR, and the restored cache carries generated stubs — so a structural PR can leave stale pages in the preview. The fail-fast fallback only catches cases that emit a `-W` warning; a clean rename/delete (references updated) is silent. So if `git diff --diff-filter=D` finds any removed/moved source under `doc/source/`, route straight to the clean build (`rtd-fallback`). The proper prune-on-restore fix (so these PRs can *use* the cache) is tracked in **DOC-1314**.

## Related issues

Related to **[DOC-1047](https://anyscale1.atlassian.net/browse/DOC-1047)** (epic [DOC-1046](https://anyscale1.atlassian.net/browse/DOC-1046)); unblocks the incremental RtD builds added in #64277. Follow-up: **[DOC-1314](https://anyscale1.atlassian.net/browse/DOC-1314)**.

## Additional information

- `ci/ray_ci/doc:test_build_cache` passes (3/3); `test_massage_cache` exercises the real subprocess massage.
- The cache-upload path runs postmerge + master only, so change #1 is fully verifiable only after merge — expected: the next postmerge produces a Sphinx-8.2.3 cache that RtD then accepts.
- `.readthedocs.yaml` structural-detection uses `if ! git diff --quiet --no-renames --diff-filter=D … 2>/dev/null` — the same shape as the existing `post_checkout` step. An earlier `| grep` + `can't` version was silently dropped by RTD's job-script preprocessor (the build step logged `exit-code: None` and never ran), so the script now uses only constructs already proven in `post_checkout`, with no in-script apostrophes or pipes. Validated via YAML parse + `bash -n`.
- This bundles a `.readthedocs.yaml` (consumer) change with the `ci/` (producer) fix at the author's request; happy to split if a reviewer prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
