### PR TITLE
[core] Fix raylet drain reading stale object store memory usage

### DIFF
--- a/python/ray/tests/test_draining.py
+++ b/python/ray/tests/test_draining.py
@@ -123,18 +123,15 @@ def test_idle_drain_rejected_while_holding_pinned_object(ray_start_cluster):
         is_accepted, _ = gcs_client.drain_node(
             worker_node_id,
             autoscaler_pb2.DrainNodeReason.Value("DRAIN_NODE_REASON_IDLE_TERMINATION"),
-            "regression: idle drain while object pinned",
+            "idle drain while node holds a referenced object",
             2**63 - 1,
         )
         return is_accepted
 
-    # Keep attempting an idle drain across the window where the worker lease is returned
-    # (CPU + NODE_WORKERS go idle). Once that happens, the pinned, still-referenced object
-    # is the only thing keeping the node non-idle, so EVERY attempt must still be
-    # rejected. Without the fix, the stale object-store-idle signal lets one attempt
-    # succeed and the worker is drained.
-    for _ in range(30):
-        assert not drain_idle(), "idle drain accepted while a pinned object was held"
+    # Make idle drain requests during the window where worker lease is returned (CPU +
+    # worker footprint go idle). The object held by the node should prevent it from draining.
+    for _ in range(10):
+        assert not drain_idle(), "idle drain accepted while the node held an object"
         time.sleep(0.5)
 
     # The worker survived and the object is still retrievable.

--- a/python/ray/tests/test_draining.py
+++ b/python/ray/tests/test_draining.py
@@ -87,6 +87,61 @@ def test_idle_termination(ray_start_cluster):
     assert is_accepted
 
 
+def test_idle_drain_rejected_while_holding_pinned_object(ray_start_cluster):
+    # Tests that a node is not drained if it's holding a pinned object
+    #
+    # The resource-sync period is widened so the object-store-memory idle signal is NOT
+    # refreshed between pinning the object and the drain request. The raylet must refresh
+    # it at the drain decision regardless; without that, the cached signal is stale and
+    # the drain is wrongly accepted once CPU/lease go idle.
+    cluster = ray_start_cluster
+    cluster.add_node(
+        num_cpus=0,
+        resources={"head": 1},
+        _system_config={"raylet_report_resources_period_milliseconds": 120000},
+    )
+    ray.init(address=cluster.address)
+    worker_node = cluster.add_node(num_cpus=1, resources={"worker": 1})
+    cluster.wait_for_nodes()
+    worker_node_id = worker_node.node_id
+
+    gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
+
+    # >100 KiB so the return is stored in the worker's plasma (in_plasma), not inlined
+    # into the owner's reply.
+    @ray.remote(num_cpus=1, max_retries=0)
+    def make_object():
+        return b"x" * (10 * 1024 * 1024)
+
+    # Runs on the worker (head has 0 CPU). Keep the ref but do NOT fetch it, so the only
+    # copy stays pinned in the worker's plasma.
+    ref = make_object.remote()
+    ready, _ = ray.wait([ref], num_returns=1, timeout=60, fetch_local=False)
+    assert ready
+
+    def drain_idle():
+        is_accepted, _ = gcs_client.drain_node(
+            worker_node_id,
+            autoscaler_pb2.DrainNodeReason.Value("DRAIN_NODE_REASON_IDLE_TERMINATION"),
+            "regression: idle drain while object pinned",
+            2**63 - 1,
+        )
+        return is_accepted
+
+    # Keep attempting an idle drain across the window where the worker lease is returned
+    # (CPU + NODE_WORKERS go idle). Once that happens, the pinned, still-referenced object
+    # is the only thing keeping the node non-idle, so EVERY attempt must still be
+    # rejected. Without the fix, the stale object-store-idle signal lets one attempt
+    # succeed and the worker is drained.
+    for _ in range(30):
+        assert not drain_idle(), "idle drain accepted while a pinned object was held"
+        time.sleep(0.5)
+
+    # The worker survived and the object is still retrievable.
+    assert worker_node_id in {node["NodeID"] for node in ray.nodes() if node["Alive"]}
+    assert len(ray.get(ref)) == 10 * 1024 * 1024
+
+
 def test_preemption(ray_start_cluster):
     cluster = ray_start_cluster
     head_node = cluster.add_node(resources={"head": 1})

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2255,7 +2255,7 @@ void NodeManager::HandleDrainRaylet(rpc::DrainRayletRequest request,
   if (request.reason() ==
       rpc::autoscaler::DrainNodeReason::DRAIN_NODE_REASON_IDLE_TERMINATION) {
     const bool is_idle =
-        cluster_resource_scheduler_.GetLocalResourceManager().IsLocalNodeIdle();
+        cluster_resource_scheduler_.GetLocalResourceManager().IsLocalNodeIdleForDrain();
     if (is_idle) {
       cluster_resource_scheduler_.GetLocalResourceManager().SetLocalNodeDraining(request);
       reply->set_is_accepted(true);

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -79,7 +79,7 @@ std::string LocalResourceManager::DebugString(void) const {
   std::stringstream buffer;
   buffer << local_resources_.DebugString();
   buffer << " is_draining: " << IsLocalNodeDraining();
-  buffer << " is_idle: " << IsLocalNodeIdle();
+  buffer << " is_idle: " << WasLastRecordedNodeStateIdle();
   return buffer.str();
 }
 
@@ -445,7 +445,7 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
 }
 
 void LocalResourceManager::OnResourceOrStateChanged() {
-  if (IsLocalNodeDraining() && IsLocalNodeIdle()) {
+  if (IsLocalNodeDraining() && WasLastRecordedNodeStateIdle()) {
     RAY_LOG(INFO) << "The node is drained, continue to shut down raylet...";
     rpc::NodeDeathInfo node_death_info = DeathInfoFromDrainRequest();
     shutdown_raylet_gracefully_(std::move(node_death_info));

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -167,7 +167,8 @@ class LocalResourceManager : public syncer::ReporterInterface {
   ///
   /// This might not be reflective of the node's current state since Object Store
   /// usage is refreshed at periodic intervals. Therefore, this might be giving a
-  /// stale view of object store memory.
+  /// stale view of object store memory. Other resources (WorkFootprints and Resources)
+  /// are updated eagerly on allocation/release.
   bool WasLastRecordedNodeStateIdle() const {
     return GetResourceIdleTime() != absl::nullopt;
   }

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -165,6 +165,16 @@ class LocalResourceManager : public syncer::ReporterInterface {
 
   bool IsLocalNodeIdle() const { return GetResourceIdleTime() != absl::nullopt; }
 
+  /// Returns whether the local node is idle for an idle-termination drain decision.
+  ///
+  /// Refreshes the object store memory usage. This is needed since pinning/unpinning
+  /// doesn't update the usage eagerly and if not refreshed here, might lead to reading
+  /// a stale value, draining a node with an object's primary copy.
+  bool IsLocalNodeIdleForDrain() {
+    UpdateAvailableObjectStoreMemResource();
+    return IsLocalNodeIdle();
+  }
+
   /// Change the local node to the draining state.
   /// After that, no new tasks can be scheduled onto the local node.
   void SetLocalNodeDraining(const rpc::DrainRayletRequest &drain_request);

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -163,7 +163,14 @@ class LocalResourceManager : public syncer::ReporterInterface {
   /// Record the metrics.
   void RecordMetrics() const;
 
-  bool IsLocalNodeIdle() const { return GetResourceIdleTime() != absl::nullopt; }
+  /// Whether the local node is idle as of the most recently synced resource state.
+  ///
+  /// This might not be reflective of the node's current state since Object Store
+  /// usage is refreshed at periodic intervals. Therefore, this might be giving a
+  /// stale view of object store memory.
+  bool WasLastRecordedNodeStateIdle() const {
+    return GetResourceIdleTime() != absl::nullopt;
+  }
 
   /// Returns whether the local node is idle for an idle-termination drain decision.
   ///
@@ -172,7 +179,7 @@ class LocalResourceManager : public syncer::ReporterInterface {
   /// a stale value, draining a node with an object's primary copy.
   bool IsLocalNodeIdleForDrain() {
     UpdateAvailableObjectStoreMemResource();
-    return IsLocalNodeIdle();
+    return WasLastRecordedNodeStateIdle();
   }
 
   /// Change the local node to the draining state.

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -1307,7 +1307,7 @@ TEST_F(ClusterLeaseManagerTest, TestIdleNode) {
       false,
       std::vector<internal::ReplyCallback>{internal::ReplyCallback(callback, &reply)});
   pool_.TriggerCallbacks();
-  ASSERT_TRUE(scheduler_->GetLocalResourceManager().IsLocalNodeIdle());
+  ASSERT_TRUE(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle());
   ASSERT_FALSE(callback_occurred);
   ASSERT_EQ(leased_workers_.size(), 0);
 
@@ -1318,7 +1318,7 @@ TEST_F(ClusterLeaseManagerTest, TestIdleNode) {
 
   ASSERT_TRUE(callback_occurred);
   ASSERT_EQ(leased_workers_.size(), 1);
-  ASSERT_FALSE(scheduler_->GetLocalResourceManager().IsLocalNodeIdle());
+  ASSERT_FALSE(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle());
   ASSERT_EQ(node_info_calls_, 0);
 }
 

--- a/src/ray/raylet/scheduling/tests/local_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/local_lease_manager_test.cc
@@ -541,7 +541,7 @@ TEST_F(LocalLeaseManagerTest, TestNoLeakOnImpossibleInfeasibleLease) {
   auto lease2 = CreateLease({{kCPU_ResourceLabel, 3}}, "f2", args);
 
   // The node is idle initially.
-  ASSERT_EQ(scheduler_->GetLocalResourceManager().IsLocalNodeIdle(), true);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle(), true);
   EXPECT_CALL(object_manager_, Pull(_, _, _))
       .WillOnce(::testing::Return(1))
       .WillOnce(::testing::Return(2));
@@ -568,7 +568,7 @@ TEST_F(LocalLeaseManagerTest, TestNoLeakOnImpossibleInfeasibleLease) {
       std::vector<internal::ReplyCallback>{internal::ReplyCallback(callback, &reply2)},
       internal::WorkStatus::WAITING));
   // The node is no longer idle as it is pulling objects.
-  ASSERT_EQ(scheduler_->GetLocalResourceManager().IsLocalNodeIdle(), false);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle(), false);
 
   // Node no longer has cpu.
   scheduler_->GetLocalResourceManager().DeleteLocalResource(
@@ -586,7 +586,7 @@ TEST_F(LocalLeaseManagerTest, TestNoLeakOnImpossibleInfeasibleLease) {
   ASSERT_EQ(num_callbacks_called, 2);
   ASSERT_EQ(local_lease_manager_->GetLeasesToGrant().size(), 0);
   // The node is idle again as the leases are cancelled.
-  ASSERT_EQ(scheduler_->GetLocalResourceManager().IsLocalNodeIdle(), true);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle(), true);
 }
 
 TEST_F(LocalLeaseManagerTest, TestNodeBusyWhenPullingTaskArguments) {
@@ -598,7 +598,7 @@ TEST_F(LocalLeaseManagerTest, TestNodeBusyWhenPullingTaskArguments) {
   std::shared_ptr<MockWorker> worker =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 0, clock_);
   pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
-  ASSERT_EQ(scheduler_->GetLocalResourceManager().IsLocalNodeIdle(), true);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle(), true);
   ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 3);
 
   // A lease that requires 3 CPUs and pulling task arguments is submitted to this
@@ -620,14 +620,14 @@ TEST_F(LocalLeaseManagerTest, TestNodeBusyWhenPullingTaskArguments) {
       std::vector<internal::ReplyCallback>{
           internal::ReplyCallback(empty_callback, &reply)},
       internal::WorkStatus::WAITING));
-  ASSERT_EQ(scheduler_->GetLocalResourceManager().IsLocalNodeIdle(), false);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle(), false);
   ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 3);
 
   // Simulate arg becoming local. The node is still node idle but because it is now
   // doing work (3 CPUs are now used).
   local_lease_manager_->LeasesUnblocked({lease.GetLeaseSpecification().LeaseId()});
   pool_.TriggerCallbacks();
-  ASSERT_EQ(scheduler_->GetLocalResourceManager().IsLocalNodeIdle(), false);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().WasLastRecordedNodeStateIdle(), false);
   ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 0);
 }
 

--- a/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
@@ -75,7 +75,7 @@ class LocalResourceManagerTest : public ::testing::Test {
 
   // Asserts that the node is idle and returns the idle time.
   absl::Time AssertIdleAndGetTime() {
-    EXPECT_TRUE(manager->IsLocalNodeIdle());
+    EXPECT_TRUE(manager->WasLastRecordedNodeStateIdle());
     auto idle_time = manager->GetResourceIdleTime();
     EXPECT_TRUE(idle_time.has_value());
     return idle_time.value();
@@ -83,7 +83,7 @@ class LocalResourceManagerTest : public ::testing::Test {
 
   // Asserts that the node is busy (not idle).
   void AssertBusy() {
-    EXPECT_FALSE(manager->IsLocalNodeIdle());
+    EXPECT_FALSE(manager->WasLastRecordedNodeStateIdle());
     EXPECT_FALSE(manager->GetResourceIdleTime().has_value());
   }
 

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -59,6 +59,7 @@ using ::testing::Return;
 namespace {
 
 constexpr double kTestTotalCpuResource = 10.0;
+constexpr double kTestObjectStoreMemory = 1024 * 1024 * 1024;  // 1 GiB
 
 class FakeLocalObjectManager : public LocalObjectManagerInterface {
  public:
@@ -100,7 +101,10 @@ class FakeLocalObjectManager : public LocalObjectManagerInterface {
 
   std::string GetLocalSpilledObjectURL(const ObjectID &object_id) override { return ""; }
 
-  int64_t GetPrimaryBytes() const override { return 0; }
+  int64_t GetPrimaryBytes() const override { return primary_bytes_; }
+
+  // Settable by tests to simulate pinned primary object copies on the node.
+  int64_t primary_bytes_ = 0;
 
   bool HasLocallySpilledObjects() const override { return false; }
 
@@ -320,8 +324,10 @@ class NodeManagerTest : public ::testing::Test {
     NodeManagerConfig node_manager_config{};
     node_manager_config.maximum_startup_concurrency = 1;
     node_manager_config.store_socket_name = "test_store_socket";
-    node_manager_config.resource_config = ResourceSet(
-        absl::flat_hash_map<std::string, double>{{"CPU", kTestTotalCpuResource}});
+    node_manager_config.resource_config =
+        ResourceSet(absl::flat_hash_map<std::string, double>{
+            {"CPU", kTestTotalCpuResource},
+            {"object_store_memory", kTestObjectStoreMemory}});
     // Set non-zero ports to skip waiting for agents reporting ports back.
     // we don't actually start the agents in this test.
     node_manager_config.metrics_agent_port = 44386;
@@ -353,7 +359,7 @@ class NodeManagerTest : public ::testing::Test {
     objects_pending_deletion_ = std::make_shared<absl::flat_hash_set<ObjectID>>();
 
     local_object_manager_ =
-        std::make_unique<FakeLocalObjectManager>(objects_pending_deletion_);
+        std::make_shared<FakeLocalObjectManager>(objects_pending_deletion_);
 
     lease_dependency_manager_ = std::make_unique<LeaseDependencyManager>(
         *mock_object_manager_, fake_task_by_state_counter_);
@@ -478,7 +484,7 @@ class NodeManagerTest : public ::testing::Test {
   std::unique_ptr<LocalLeaseManager> local_lease_manager_;
   std::unique_ptr<ClusterLeaseManager> cluster_lease_manager_;
   std::unique_ptr<PlacementGroupResourceManager> placement_group_resource_manager_;
-  std::shared_ptr<LocalObjectManagerInterface> local_object_manager_;
+  std::shared_ptr<FakeLocalObjectManager> local_object_manager_;
   std::unique_ptr<LeaseDependencyManager> lease_dependency_manager_;
   std::unique_ptr<gcs::MockGcsClient> mock_gcs_client_ =
       std::make_unique<gcs::MockGcsClient>();
@@ -1449,6 +1455,37 @@ TEST_P(NodeManagerDeathTest, TestGcsPublishesSelfDead) {
 INSTANTIATE_TEST_SUITE_P(NodeManagerDeathVariations,
                          NodeManagerDeathTest,
                          testing::Bool());
+
+TEST_F(NodeManagerTest, TestHandleDrainRayletRejectsIdleDrainWithPinnedObject) {
+  // Tests that a node that holds a primary copy rejects a drain.
+  local_object_manager_->primary_bytes_ = 1;
+
+  rpc::DrainRayletRequest request;
+  request.set_reason(
+      rpc::autoscaler::DrainNodeReason::DRAIN_NODE_REASON_IDLE_TERMINATION);
+  request.set_reason_message("idle for long enough");
+  request.set_deadline_timestamp_ms(std::numeric_limits<int64_t>::max());
+
+  rpc::DrainRayletReply reply;
+  node_manager_->HandleDrainRaylet(
+      request, &reply, [](Status s, std::function<void()>, std::function<void()>) {
+        ASSERT_TRUE(s.ok());
+      });
+  ASSERT_FALSE(reply.is_accepted());
+  ASSERT_FALSE(
+      cluster_resource_scheduler_->GetLocalResourceManager().IsLocalNodeDraining());
+
+  // With no pinned primary copies, the same idle drain is accepted.
+  local_object_manager_->primary_bytes_ = 0;
+  rpc::DrainRayletReply reply2;
+  node_manager_->HandleDrainRaylet(
+      request, &reply2, [](Status s, std::function<void()>, std::function<void()>) {
+        ASSERT_TRUE(s.ok());
+      });
+  ASSERT_TRUE(reply2.is_accepted());
+  ASSERT_TRUE(
+      cluster_resource_scheduler_->GetLocalResourceManager().IsLocalNodeDraining());
+}
 
 class DrainRayletIdempotencyTest
     : public NodeManagerTest,


### PR DESCRIPTION
HandleRayletDrain checks if the node is idle before actually draining the node. One of the checks to decide whether node is idle or not is object store memory usage which is updated by the function `LocalResourceManager::UpdateAvailableObjectStoreMemResource`. This function is triggered periodically in the ray syncer mechanism. This could lead to the object store idleness metric having a stale value, which results in the node draining even if there object store is not actually free. 

Fix: Refresh the object store metric again before deciding the node idleness. 