### PR TITLE
[serve] Deprecate HTTPOptions.num_cpus (raise on non-zero)

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -823,7 +823,8 @@ class HTTPOptions(BaseModel):
         - "Disabled": disable HTTP server.
 
     - num_cpus: [DEPRECATED] The number of CPU cores to reserve for each
-      internal Serve HTTP proxy actor.
+      internal Serve HTTP proxy actor. Passing a non-zero value raises an
+      error.
     """
 
     host: Optional[str] = DEFAULT_HTTP_HOST or get_localhost_ip()
@@ -875,11 +876,12 @@ class HTTPOptions(BaseModel):
 
     @field_validator("num_cpus")
     @classmethod
-    def warn_for_num_cpus(cls, v):
+    def raise_for_num_cpus_assignment(cls, v):
         if v:
-            warnings.warn(
-                "Passing `num_cpus` to HTTPOptions is deprecated and will be "
-                "removed in a future version."
+            raise ValueError(
+                "`num_cpus` in HTTPOptions has been removed. Serve no longer "
+                "supports configuring CPU reservations for HTTP proxy actors "
+                "via HTTPOptions."
             )
         return v
 

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -1161,6 +1161,12 @@ def test_http_options():
     HTTPOptions()
     HTTPOptions(host="8.8.8.8", middlewares=[object()])
 
+    # `num_cpus` is removed: a non-zero value raises; 0 (the old default) is
+    # a no-op so default construction is unaffected.
+    HTTPOptions(num_cpus=0)
+    with pytest.raises(ValueError, match="`num_cpus` in HTTPOptions"):
+        HTTPOptions(num_cpus=2)
+
     # Test configs ignoring unknown keys (required for forward-compatibility)
     HTTPOptions(new_version_config_key="this config is from newer version of Ray")
 


### PR DESCRIPTION
Escalate the long-standing HTTPOptions.num_cpus deprecation from a DeprecationWarning to an error: setting a non-zero num_cpus now raises ValueError. Zero (the existing default) remains a no-op, so default construction and internal config round-trips are unaffected.

Serve no longer supports reserving CPUs for HTTP proxy actors via HTTPOptions.

middlewares and location deprecations are handled in separate PRs.

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
