### PR TITLE
[ci/doc] Generate API stubs without a full doc build; fail loudly

### DIFF
--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -122,12 +122,16 @@ api_annotations() {
 }
 
 api_policy_check() {
-  # install ray and compile doc to generate API files
-  echo "--- Build doc pages"
-  make -C doc/ html
-
   echo "--- Install Ray"
   _install_ray_no_deps
+
+  echo "--- Generate API doc stubs"
+  # The consistency check reads autosummary stub .rst files. Generate only those
+  # stubs instead of a full `make -C doc/ html` (which built the entire site just
+  # to produce them). This exits nonzero if generation produces nothing, so a
+  # broken autogen step fails here instead of silently. Stubs are generated after
+  # installing Ray so they reflect the checkout's source.
+  PYTHONPATH="$(pwd)${PYTHONPATH:+:$PYTHONPATH}" python doc/source/api_autogen.py
 
   echo "--- Check API/doc consistency"
   # Run via the image interpreter, not `bazel run`: the bazel target's @py_deps_py310

--- a/doc/source/api_autogen.py
+++ b/doc/source/api_autogen.py
@@ -1,0 +1,189 @@
+"""Standalone autosummary stub generation for the public API reference.
+
+The API-doc consistency check (``ci/ray_ci/doc``) reads autosummary stub
+``.rst`` files that are generated from the directives in :data:`AUTOGEN_FILES`
+-- for example the per-class method tables that the hand-written API pages
+``.. include::``. Historically those stubs were produced only as a side effect
+of a full ``make -C doc/ html`` (a hidden full-build dependency of every
+Python-touching premerge PR). This module generates just the stubs, so the
+check no longer needs the whole Sphinx render.
+
+It also closes the silent-failure gap: :func:`generate_api_stubs` raises when
+generation produces no files, instead of the old ``try/except`` in ``conf.py``
+that downgraded any failure to a warning -- a broken autogen step now fails the
+build loudly.
+
+``conf.py`` imports :data:`AUTOGEN_FILES`, :data:`AUTOSUMMARY_FILENAME_MAP`, and
+:func:`generate_api_stubs` from here, and importing this module registers the
+custom Jinja filters the autosummary templates use, so the render and the
+standalone path stay in lockstep. Run as a script, it generates the stubs and
+exits nonzero on failure.
+"""
+
+import os
+import sys
+from importlib import import_module
+
+from jinja2.filters import FILTERS
+from sphinx.ext.autosummary import generate
+from sphinx.util.inspect import safe_getattr
+
+DEFAULT_API_GROUP = "Others"
+
+# Source files whose autosummary directives drive stub generation. The
+# generated stubs are ``.. include::``'d by the hand-written API pages and read
+# by the API-doc consistency check, so this list is the single source of truth
+# shared with conf.py.
+AUTOGEN_FILES = [
+    "data/api/_autogen.rst",
+]
+
+# Override the output filenames autosummary generates for these objects.
+# `ray.serve.deployment` (the decorator) and `ray.serve.Deployment` (the class)
+# would otherwise write to filenames that collide on case-insensitive
+# filesystems, so the lowercase decorator is remapped to a distinct name.
+AUTOSUMMARY_FILENAME_MAP = {
+    "ray.serve.deployment": "ray.serve.deployment_decorator",
+    "ray.serve.Deployment": "ray.serve.Deployment",
+}
+
+
+def filter_out_undoc_class_members(member_name, class_name, module_name):
+    module = import_module(module_name)
+    cls = getattr(module, class_name)
+    if getattr(cls, member_name).__doc__:
+        return f"~{class_name}.{member_name}"
+    else:
+        return ""
+
+
+def has_public_constructor(class_name, module_name):
+    cls = getattr(import_module(module_name), class_name)
+    return _is_public_api(cls)
+
+
+def get_api_groups(method_names, class_name, module_name):
+    api_groups = set()
+    cls = getattr(import_module(module_name), class_name)
+    for method_name in method_names:
+        method = getattr(cls, method_name)
+        if _is_public_api(method):
+            api_groups.add(
+                safe_getattr(method, "_annotated_api_group", DEFAULT_API_GROUP)
+            )
+
+    return sorted(api_groups)
+
+
+def select_api_group(method_names, class_name, module_name, api_group):
+    cls = getattr(import_module(module_name), class_name)
+    return [
+        method_name
+        for method_name in method_names
+        if _is_public_api(getattr(cls, method_name))
+        and _is_api_group(getattr(cls, method_name), api_group)
+    ]
+
+
+def _is_public_api(obj):
+    api_type = safe_getattr(obj, "_annotated_type", None)
+    if not api_type:
+        return False
+    return api_type.value == "PublicAPI"
+
+
+def _is_api_group(obj, group):
+    return safe_getattr(obj, "_annotated_api_group", DEFAULT_API_GROUP) == group
+
+
+# Register the custom Jinja filters the autosummary templates (e.g.
+# _templates/autosummary/class_v2.rst) use. Importing this module -- from
+# conf.py or the standalone entry point below -- makes them available.
+FILTERS["filter_out_undoc_class_members"] = filter_out_undoc_class_members
+FILTERS["get_api_groups"] = get_api_groups
+FILTERS["select_api_group"] = select_api_group
+FILTERS["has_public_constructor"] = has_public_constructor
+
+
+def _build_standalone_app(srcdir):
+    """Build the minimal Sphinx stand-in that sphinx-autogen uses.
+
+    When generation is invoked outside a full build (no real Sphinx app), this
+    mirrors ``sphinx.ext.autosummary.generate.main``: a DummyApplication with
+    the documenters set up, the project's ``_templates`` directory on the
+    template path (so ``:template:`` references resolve), and the filename map.
+    """
+    import sphinx.locale
+    from sphinx.ext.autosummary.generate import DummyApplication, setup_documenters
+    from sphinx.util import logging as sphinx_logging
+
+    sphinx.locale.init_console()
+    app = DummyApplication(sphinx.locale.get_translator())
+    sphinx_logging.setup(app, sys.stdout, sys.stderr)
+    setup_documenters(app)
+    app.config.templates_path.append(os.path.join(srcdir, "_templates"))
+    app.config.autosummary_filename_map = AUTOSUMMARY_FILENAME_MAP
+    return app
+
+
+def generate_api_stubs(srcdir, app=None):
+    """Generate the autosummary stub files for :data:`AUTOGEN_FILES`.
+
+    Args:
+        srcdir: The Sphinx source directory (``doc/source``) that
+            :data:`AUTOGEN_FILES` are relative to.
+        app: A live Sphinx application when called from the render's
+            ``builder-inited`` hook; ``None`` when run standalone, in which case
+            a minimal stand-in is built.
+
+    Returns:
+        The list of generated stub file paths.
+
+    Raises:
+        RuntimeError: If generation produced no files. This is the loud failure
+            that replaces the previous silent ``try/except`` -- a broken
+            autosummary source or template should fail the build, not pass as an
+            empty fixture the consistency check then reads as "nothing to do".
+    """
+    from sphinx.ext.autodoc.mock import mock
+
+    from api_mock_imports import absent_mock_modules
+
+    sources = [os.path.join(srcdir, file) for file in AUTOGEN_FILES]
+    if app is None:
+        app = _build_standalone_app(srcdir)
+
+    # Mock only the genuinely-absent optional backends (vllm, sglang, ...), so a
+    # stub for a class whose module eagerly imports them generates instead of
+    # failing. NOT the full autodoc_mock_imports list: that mocks installed
+    # libraries too (e.g. pandas), and shadowing an installed library breaks the
+    # plain autosummary ``import ray.data`` here (autodoc tolerates it; this raw
+    # path does not). The Jinja filter functions above import_module() at
+    # generation time, so they run under the mock too. ray.* is never mocked.
+    with mock(absent_mock_modules()):
+        written = generate.generate_autosummary_docs(sources, app=app)
+
+    if not written:
+        raise RuntimeError(
+            "API stub generation produced no files for "
+            f"{AUTOGEN_FILES}; the autosummary sources or templates are likely "
+            "broken. The API-doc consistency check depends on these stubs."
+        )
+    return written
+
+
+def main(argv=None):
+    # The module lives in the Sphinx source directory, so its own directory is
+    # the srcdir the AUTOGEN_FILES are relative to.
+    srcdir = os.path.dirname(os.path.abspath(__file__))
+    try:
+        written = generate_api_stubs(srcdir)
+    except Exception as e:
+        print(f"[api_autogen] ERROR: {e}", file=sys.stderr)
+        return 1
+    print(f"[api_autogen] generated {len(written)} API stub file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,17 +6,11 @@ import re
 import sys
 from datetime import datetime
 from dataclasses import is_dataclass
-from importlib import import_module
 from typing import Any, Dict
 
 import sphinx
 from docutils import nodes
-from jinja2.filters import FILTERS
-from sphinx.ext.autosummary import generate
-from sphinx.util.inspect import safe_getattr
 from sphinx.util.matching import compile_matchers
-
-DEFAULT_API_GROUP = "Others"
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +24,14 @@ from custom_directives import (  # noqa
     pregenerate_example_rsts,
     generate_versions_json,
     collect_example_orphans,
+)
+
+# Importing api_autogen registers the custom autosummary Jinja filters and
+# exposes the shared stub-generation entry point (see doc/source/api_autogen.py).
+from api_autogen import (  # noqa: E402
+    AUTOGEN_FILES,
+    AUTOSUMMARY_FILENAME_MAP,
+    generate_api_stubs,
 )
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -306,9 +308,7 @@ language = "en"
 # autogen files are only used to auto-generate public API documentation.
 # They are not included in the toctree to avoid warnings such as documents not included
 # in any toctree.
-autogen_files = [
-    "data/api/_autogen.rst",
-]
+autogen_files = AUTOGEN_FILES
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -534,60 +534,6 @@ autodoc_member_order = "bysource"
 autodoc_typehints = "signature"
 
 
-def filter_out_undoc_class_members(member_name, class_name, module_name):
-    module = import_module(module_name)
-    cls = getattr(module, class_name)
-    if getattr(cls, member_name).__doc__:
-        return f"~{class_name}.{member_name}"
-    else:
-        return ""
-
-
-def has_public_constructor(class_name, module_name):
-    cls = getattr(import_module(module_name), class_name)
-    return _is_public_api(cls)
-
-
-def get_api_groups(method_names, class_name, module_name):
-    api_groups = set()
-    cls = getattr(import_module(module_name), class_name)
-    for method_name in method_names:
-        method = getattr(cls, method_name)
-        if _is_public_api(method):
-            api_groups.add(
-                safe_getattr(method, "_annotated_api_group", DEFAULT_API_GROUP)
-            )
-
-    return sorted(api_groups)
-
-
-def select_api_group(method_names, class_name, module_name, api_group):
-    cls = getattr(import_module(module_name), class_name)
-    return [
-        method_name
-        for method_name in method_names
-        if _is_public_api(getattr(cls, method_name))
-        and _is_api_group(getattr(cls, method_name), api_group)
-    ]
-
-
-def _is_public_api(obj):
-    api_type = safe_getattr(obj, "_annotated_type", None)
-    if not api_type:
-        return False
-    return api_type.value == "PublicAPI"
-
-
-def _is_api_group(obj, group):
-    return safe_getattr(obj, "_annotated_api_group", DEFAULT_API_GROUP) == group
-
-
-FILTERS["filter_out_undoc_class_members"] = filter_out_undoc_class_members
-FILTERS["get_api_groups"] = get_api_groups
-FILTERS["select_api_group"] = select_api_group
-FILTERS["has_public_constructor"] = has_public_constructor
-
-
 def add_custom_assets(
     app: sphinx.application.Sphinx,
     pagename: str,
@@ -644,15 +590,14 @@ def add_custom_assets(
 def _autogen_apis(app: sphinx.application.Sphinx):
     """
     Auto-generate public API documentation.
+
+    Delegates to the shared generate_api_stubs (see doc/source/api_autogen.py),
+    which raises if generation produces nothing. The failure is intentionally
+    not swallowed: the API-doc consistency check reads these stubs, so a broken
+    autogen step must fail the build instead of silently emitting an empty
+    fixture.
     """
-    try:
-        generate.generate_autosummary_docs(
-            [os.path.join(app.srcdir, file) for file in autogen_files],
-            app=app,
-        )
-    except Exception as e:
-        import warnings
-        warnings.warn(f"Skipping autogen due to: {e}")
+    generate_api_stubs(app.srcdir, app=app)
 
 
 def process_signature(app, what, name, obj, options, signature, return_annotation):
@@ -751,14 +696,7 @@ redoc = [
 
 redoc_uri = "https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"
 
-# Override the output filenames autosummary generates for these objects.
-# `ray.serve.deployment` (the decorator) and `ray.serve.Deployment` (the class)
-# would otherwise write to filenames that collide on case-insensitive
-# filesystems, so the lowercase decorator is remapped to a distinct name.
-autosummary_filename_map = {
-    "ray.serve.deployment": "ray.serve.deployment_decorator",
-    "ray.serve.Deployment": "ray.serve.Deployment",
-}
+autosummary_filename_map = AUTOSUMMARY_FILENAME_MAP
 
 # Mock out external dependencies here.
 
@@ -769,9 +707,9 @@ autosummary_filename_map = {
 # pyarrow are installed, so they are not mocked. tensorflow is also installed (a
 # direct requirements-doc entry), but importing it for real breaks the autodoc
 # import of ray.rllib.algorithms.algorithm at build time, so it stays mocked.
-# The mock list is shared with the API/doc consistency check (ci/ray_ci/doc)
-# via api_mock_imports.py so the check, which imports documented names directly
-# (bypassing Sphinx), applies the same mocks this render does. THIRD_PARTY_MOCK
+# The mock list is shared with api_autogen.py and the API/doc consistency check
+# (ci/ray_ci/doc) via api_mock_imports.py, so the standalone stub generator and
+# the check see the same API surface this render produces. THIRD_PARTY_MOCK
 # covers uninstalled third-party libraries; BUILD_ONLY_MOCK covers Ray's
 # compiled/generated modules, which are absent only in a source-checkout build.
 from api_mock_imports import BUILD_ONLY_MOCK_MODULES, THIRD_PARTY_MOCK_MODULES


### PR DESCRIPTION
## Why

The `doc: check API doc consistency` premerge step reads autosummary stub `.rst` files — the per-class method tables that the hand-written API pages `.. include::`. Those stubs are produced only as a side effect of `make -C doc/ html`, so **every Python-touching premerge PR pays for a full Sphinx render just to generate them**. Separately, the generation was wrapped in a `try/except` that downgraded any failure to a warning, so a broken autogen step silently produced an empty fixture the check then read as "nothing to do."

This PR extracts stub generation into a standalone entry point and makes it fail loudly, so the check runs against a faithfully generated stub set without the full render.

## What

Extracts the stub generation into `doc/source/api_autogen.py`, shared by the render and a standalone entry point:

- **`conf.py`** imports the autogen file list (`AUTOGEN_FILES`), the filename map, and the custom autosummary Jinja filters from the new module (importing it registers the filters), keeping the render and the standalone path in lockstep. No behavior change to the render except the loud failure below.
- **Fail loudly:** `generate_api_stubs()` raises when generation produces no files, and `conf.py` no longer swallows failures. A broken autogen step fails the build instead of emitting an empty fixture.
- **Decouple:** `lint.sh`'s `api_policy_check` runs `python doc/source/api_autogen.py` instead of `make -C doc/ html`, removing the full render from the premerge check while preserving the contract guarantee. Stubs are generated *after* installing Ray so they reflect the checkout's source.

The standalone path mirrors `sphinx-autogen` (a minimal `DummyApplication` with the project templates on the path), so it produces byte-identical stubs without the rest of the build. It applies the shared absent-backend mock from `doc/source/api_mock_imports.py` (introduced separately, see below), so the optional-dependency modules that the check imports are the same ones the generator sees.

## Relationship to #64808

The mock, whitelist, and doc-debt work that greened the check across all libraries — including `doc/source/api_mock_imports.py` and every `TEAM_API_CONFIGS` change — landed first in **#64808** and is now in `master`. This PR is rebased on top of it and **only consumes** the shared mock; it introduces none of that config. The diff here is exactly three files: `doc/source/api_autogen.py` (new), `doc/source/conf.py`, and `ci/lint/lint.sh`.

## Why data-only `AUTOGEN_FILES` is complete

`AUTOGEN_FILES` is `["data/api/_autogen.rst"]`, and that is the full set the check needs, not a partial one. The consistency check's doc-side reader (`ci/ray_ci/doc/autodoc.py`) parses `.. autosummary::` directives **directly from the checked-in source**, following only explicit `.. include::` and `.. toctree::` edges. It descends into a *generated* stub only where a tracked page includes one — and only the `data` API pages do that (`dataset.rst` etc. `.. include::` the generated `ray.data.Dataset.rst` method tables). The other teams list their APIs with `.. autosummary::` directives in tracked source, which the check reads without any generated file.

Two facts make this exact, independent of Ray version:

- Running the real `Autodoc` traversal against a clean checkout, the only generated files it follows are the three `data` class stubs — which this generator produces. core / train / tune / serve / rllib follow zero generated files.
- The method-table templates (`_templates/autosummary/class.rst`, `class_v2.rst`) emit only `.. autosummary::`, never `.. include::`/`.. toctree::`, so a generated stub never adds a new edge the traversal would follow.

So the stubs `make html` generated for the other teams were never read by the check; dropping them changes nothing it verifies. (A follow-up would only be needed if a non-data team later adopts the include-a-generated-method-stub pattern.)

## Verification

- **Rebase:** reduced to a single commit on current `master` (post-#64808). Final diff is the three files above, +217/−86.
- **Static (local):** all changed modules `py_compile`; `pre-commit` passes on the changed files (trailing-whitespace, end-of-file, shellcheck on `lint.sh`, semgrep — ruff/black skip `doc/source/**` by Ray's config).
- **Stub parity (local, earlier, against a matching Ray build):** the standalone script generated the same data stubs as the full render (82 files), the consistency check read them, and a genuine generation failure exited nonzero where the old code only warned.
- **Decisive gate:** the `doc: check API doc consistency` premerge job runs `python ci/ray_ci/doc/cmd_check_api_discrepancy.py <checkout> ALL` on the docbuild image. Confirming its result on this PR before leaving draft.

## Risk / coordination

`lint.sh` is a shared premerge surface and `conf.py` is the production render config. The functional change is the stub-generation source for the check (see the scope note above); the set of stubs the check actually reads is unchanged. Requesting doc-CI-owner review before this leaves draft.

AI assistance was used to author these changes; every changed line was reviewed by the submitter.

