### PR TITLE
[core] skip crash simulations in test_streaming_generator_backpressure on windows

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -356,7 +356,6 @@ py_test_module_list(
         "test_streaming_generator_2.py",
         "test_streaming_generator_3.py",
         "test_streaming_generator_4.py",
-        "test_streaming_generator_backpressure.py",
         "test_task_metrics.py",
         "test_tempdir.py",
         "test_tls_auth.py",
@@ -369,6 +368,22 @@ py_test_module_list(
     tags = [
         "exclusive",
         "medium_size_python_tests_shard_1",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "large",
+    files = [
+        "test_streaming_generator_backpressure.py",
+    ],
+    tags = [
+        "exclusive",
+        "large_size_python_tests_shard_1",
         "team:core",
     ],
     deps = [

--- a/python/ray/tests/test_streaming_generator_backpressure.py
+++ b/python/ray/tests/test_streaming_generator_backpressure.py
@@ -819,6 +819,10 @@ def test_actor_generator_backpressure_zero_value_rejected(shutdown_only):
                 yield 0
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="This test uses os._exit(0), which can report an access violation on Windows.",
+)
 def test_actor_generator_backpressure_reclaim_on_owner_death(shutdown_only):
     namespace = "actor_generator_backpressure_owner_death"
     actor_name = f"actor_generator_backpressure_owner_death_actor_{os.getpid()}"
@@ -887,6 +891,10 @@ os._exit(0)
         ray.kill(reporter)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="This test uses os._exit(0), which can report an access violation on Windows.",
+)
 def test_actor_generator_backpressure_owner_death_unblocks_task_waiter(shutdown_only):
     namespace = "actor_generator_backpressure_owner_death_waiter"
     actor_name = f"actor_generator_backpressure_owner_death_waiter_actor_{os.getpid()}"
@@ -951,6 +959,10 @@ os._exit(0)
         ray.kill(reporter)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="This test uses os._exit(0), which can report an access violation on Windows.",
+)
 def test_actor_generator_backpressure_owner_death_skips_between_yield_work(
     shutdown_only,
 ):


### PR DESCRIPTION
There are currently 3 crash simulations in `test_streaming_generator_backpressure` that use `os._exit(0)` which could raise access violation exceptions on windows and cause test failures. So we skip them on windows.

The extended timeout is also needed; otherwise, we could time out even before capturing the test output.