### PR TITLE
[serve][test] Make test_cluster HAProxy-aware

### DIFF
--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -5,6 +5,7 @@
 //python/ray/serve/tests:test_cli
 //python/ray/serve/tests:test_cli_2
 //python/ray/serve/tests:test_cli_4
+//python/ray/serve/tests:test_cluster
 //python/ray/serve/tests:test_controller_recovery
 //python/ray/serve/tests:test_deploy
 //python/ray/serve/tests:test_deploy_2

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -64,6 +64,22 @@ STORAGE_ACTOR_NAME = "storage"
 PROMETHEUS_METRICS_TIMEOUT_S = 5
 
 
+def skip_if_haproxy(reason: str):
+    """Skip a test when the HAProxy ingress is enabled.
+
+    The HAProxy ingress runs as a separate premerge step with
+    RAY_SERVE_ENABLE_HA_PROXY=1. Some tests exercise behavior HAProxy does not
+    support yet (e.g. gRPC ingress) or that probes the native Serve proxy
+    directly. Mark those with this decorator instead of maintaining a separate
+    test allowlist. The test still runs in the non-HAProxy steps.
+    """
+    import pytest
+
+    return pytest.mark.skipif(
+        RAY_SERVE_ENABLE_HA_PROXY, reason=f"HAProxy ingress: {reason}"
+    )
+
+
 # Global variable that is fetched during controller recovery that
 # marks (simulates) which replicas have died since controller first
 # recovered a list of live replica names.

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -18,7 +18,11 @@ from ray.serve._private.constants import (
     SERVE_NAMESPACE,
 )
 from ray.serve._private.deployment_state import ReplicaStartupStatus
-from ray.serve._private.test_utils import check_deployment_status
+from ray.serve._private.test_utils import (
+    check_deployment_status,
+    expected_proxy_actors,
+    skip_if_haproxy,
+)
 from ray.serve._private.utils import calculate_remaining_timeout, get_head_node_id
 from ray.serve.config import GangSchedulingConfig
 from ray.serve.context import _get_global_client
@@ -526,6 +530,10 @@ def test_handle_prefers_replicas_on_same_node(ray_cluster):
     assert blocked_response.result() == outer_node_id
 
 
+# TODO: HAProxy's default ingress balances across all replicas with no
+# node-local preference. prefer-local routing could be wired under HAProxy via
+# the ingress_request_router use-server delegation, then this skip dropped.
+@skip_if_haproxy("balances across replicas without node-local preference")
 @pytest.mark.parametrize("set_flag", [True, False])
 def test_proxy_prefers_replicas_on_same_node(ray_cluster: Cluster, set_flag):
     """When the feature flag is turned on via env var, verify that http proxy routes to
@@ -630,9 +638,15 @@ class TestHealthzAndRoutes:
 
         wait_for_condition(check_replicas_on_worker_nodes)
 
-        # Ensure total actors of 2 proxies, 1 controller, and 2 replicas,
-        # and 2 nodes exist.
-        wait_for_condition(lambda: len(list_actors(address=cluster.address)) == 5)
+        # Total alive actors: EveryNode proxies on both nodes + 1 controller +
+        # 2 replicas. Under HAProxy each proxy node runs an HAProxyManager and
+        # the head node adds a fallback ProxyActor.
+        expected_num_actors = (
+            sum(expected_proxy_actors(num_proxy_nodes=2).values()) + 1 + 2
+        )
+        wait_for_condition(
+            lambda: len(list_actors(address=cluster.address)) == expected_num_actors
+        )
         assert len(ray.nodes()) == 2
 
         # Ensure `/-/healthz` and `/-/routes` return 200 and expected responses
@@ -660,15 +674,19 @@ class TestHealthzAndRoutes:
         assert httpx.get("http://127.0.0.1:8001/-/routes").status_code == 200
         assert httpx.get("http://127.0.0.1:8001/-/routes").text == '{"/":"default"}'
 
-        # Delete the deployment should bring the active actors down to 3 and drop
-        # replicas on all nodes.
+        # Deleting the deployment drops the replicas on all nodes. The proxies and
+        # controller stay alive (the worker proxy drains), so the count is the
+        # pre-delete total minus the 2 replicas.
         serve.delete(name=SERVE_DEFAULT_APP_NAME)
 
+        expected_num_actors_after_delete = (
+            sum(expected_proxy_actors(num_proxy_nodes=2).values()) + 1
+        )
         wait_for_condition(
             lambda: len(
                 list_actors(address=cluster.address, filters=[("STATE", "=", "ALIVE")])
             )
-            == 3,
+            == expected_num_actors_after_delete,
         )
 
         # Ensure head node `/-/healthz` and `/-/routes` continue to
@@ -681,18 +699,23 @@ class TestHealthzAndRoutes:
             expected_code=200,
             expected_text="success",
         )
-        assert httpx.get("http://127.0.0.1:8000/-/routes").status_code == 200
-        assert httpx.get("http://127.0.0.1:8000/-/routes").text == "{}"
+        wait_for_condition(
+            condition_predictor=check_request,
+            url="http://127.0.0.1:8000/-/routes",
+            expected_code=200,
+            expected_text="{}",
+        )
         wait_for_condition(
             condition_predictor=check_request,
             url="http://127.0.0.1:8001/-/healthz",
             expected_code=503,
             expected_text="This node is being drained.",
         )
-        assert httpx.get("http://127.0.0.1:8001/-/routes").status_code == 503
-        assert (
-            httpx.get("http://127.0.0.1:8001/-/routes").text
-            == "This node is being drained."
+        wait_for_condition(
+            condition_predictor=check_request,
+            url="http://127.0.0.1:8001/-/routes",
+            expected_code=503,
+            expected_text="This node is being drained.",
         )
 
 


### PR DESCRIPTION
## Why are these changes needed?

Running the full serve suite under HAProxy (#64210) surfaced benign failures in `test_cluster`. All pass natively.

`test_head_and_worker_nodes_no_replicas` hardcoded 5 alive actors. Under HAProxy each proxy node runs an HAProxyManager and the head node adds a fallback ProxyActor, so the count now derives from `expected_proxy_actors`. The post-delete `/-/routes` check polls instead of asserting once, because the route table clears through a config reload that lags replica teardown. `test_proxy_prefers_replicas_on_same_node` is skipped under HAProxy, whose default ingress balances across replicas with no node-local preference.

Adds a `skip_if_haproxy` helper to `test_utils` and enables `test_cluster` in the HAProxy allowlist.

This was split out of the original combined PR. The tracing changes are in #64550 and the replica-ranks change in #64551, so each PR covers one test file.

## Related issue number

Surfaced by #64210.

## Checks

- [x] I've signed off every commit (by using the -s flag).
- [x] I've made sure the tests are passing.
