### PR TITLE
[core] Fix test_state_api_scale

### DIFF
--- a/release/nightly_tests/stress_tests/test_state_api_scale.py
+++ b/release/nightly_tests/stress_tests/test_state_api_scale.py
@@ -151,7 +151,7 @@ def test_many_actors(num_actors: int):
     for _ in tqdm.trange(len(actors), desc="Destroying actors..."):
         _exitted, exiting_actors = ray.wait(exiting_actors)
 
-    invoke_state_api(
+    invoke_state_api_n(
         lambda res: len(res) == 0,
         list_actors,
         filters=[("state", "=", "ALIVE"), ("class_name", "=", actor_class_name)],


### PR DESCRIPTION
Issue: `test_many_actors` was failing in the release test. The test creates many actors and then destroys them using `ray.actor.exit_actor()`. It then checks the number of ALIVE actors using the state API. 

This is how the flow goes after the actor is killed. `exit_actor` kills the actor by raising an exception. This kills the worker, raylet detects it and then informs the GCS. The GCS then marks the actor dead on its end. The state API relies on the GCS data to tell the number of ALIVE actors. Since raylet detection, informing the GCS and then marking it dead might involve delay after `exit_actor`, state API may give wrong results for some time after killing the actor.

Fix: Use `invoke_state_api_n` instead of `invoke_state_api` since it retries the state API multiple times with a delay. Infact, the same function is used to check actor creation earlier in the same test. 

The release test is triggered in the PR and it passes.