### PR TITLE
[core] Fix flaky test_python_call_cpp.py

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -444,6 +444,10 @@ cc_binary(
 
 py_test_module_list(
     size = "medium",
+    data = [
+        "counter.so",
+        "plus.so",
+    ],
     extra_srcs = [],
     files = [
         "test_python_call_cpp.py",

--- a/cpp/test_python_call_cpp.py
+++ b/cpp/test_python_call_cpp.py
@@ -16,8 +16,14 @@ _CODE_SEARCH_PATH = [
 ]
 
 
-def test_cross_language_cpp():
+@pytest.fixture(scope="module", autouse=True)
+def ray_start():
     ray.init(job_config=ray.job_config.JobConfig(code_search_path=_CODE_SEARCH_PATH))
+    yield
+    ray.shutdown()
+
+
+def test_cross_language_cpp():
     obj = ray.cross_language.cpp_function("Plus1").remote(1)
     assert 2 == ray.get(obj)
 

--- a/cpp/test_python_call_cpp.py
+++ b/cpp/test_python_call_cpp.py
@@ -1,16 +1,23 @@
+import os
+
 import pytest
 
 import ray
 import ray.cluster_utils
 from ray.exceptions import CrossLanguageError, RayActorError
 
+# plus.so / counter.so are staged next to this file via the bazel
+# target's `data` attr; resolve them absolutely so the worker finds them
+# regardless of its cwd.
+_CODE_SEARCH_DIR = os.path.dirname(os.path.abspath(__file__))
+_CODE_SEARCH_PATH = [
+    os.path.join(_CODE_SEARCH_DIR, "plus.so"),
+    os.path.join(_CODE_SEARCH_DIR, "counter.so"),
+]
+
 
 def test_cross_language_cpp():
-    ray.init(
-        job_config=ray.job_config.JobConfig(
-            code_search_path=["../../plus.so:../../counter.so"]
-        )
-    )
+    ray.init(job_config=ray.job_config.JobConfig(code_search_path=_CODE_SEARCH_PATH))
     obj = ray.cross_language.cpp_function("Plus1").remote(1)
     assert 2 == ray.get(obj)
 


### PR DESCRIPTION
The test was failing because it was not able to find the plus.so and counter.so files. It was flaky because sometimes the .so files may be present because of another test cluster_mode_test that uses these .so files as well. 

Fix: Add the .so files in test_python_call_cpp dependencies. Also change relative paths to absolute paths in the test.

Triggered a buildkite: https://buildkite.com/ray-project/postmerge-macos/builds/13203/canvas, but it is taking a while to complete. Validated the fix locally on macos. Without the fix the test fails locally consistently. With the fix the test passes 