### PR TITLE
[dashboard] Diagnose dashboard-agent event-loop stalls

### DIFF
--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -28,6 +28,10 @@ from ray._raylet import (
     GcsClient,
     persist_port,
 )
+from ray.dashboard.event_loop_monitor import (
+    EVENT_LOOP_MONITOR_ENABLED,
+    EventLoopMonitor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +86,8 @@ class DashboardAgent:
         self.server = None
         # http_server is None in minimal.
         self.http_server = None
+        # Event-loop stall monitor, started in run() for non-minimal agents.
+        self._event_loop_monitor = None
 
         # Used by the agent and sub-modules.
         self.gcs_client = GcsClient(
@@ -210,6 +216,13 @@ class DashboardAgent:
         if self.server:
             await self.server.start()
 
+        # Watch this agent's event loop for stalls; it also serves job
+        # submission and metric/event export. Minimal agents run neither; set
+        # RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED=0 to disable.
+        if not self.minimal and EVENT_LOOP_MONITOR_ENABLED:
+            self._event_loop_monitor = EventLoopMonitor()
+            self._event_loop_monitor.start()
+
         modules = self._load_modules()
 
         launch_http_server = True
@@ -285,7 +298,11 @@ class DashboardAgent:
 
             tasks.append(wait_forever())
 
-        await asyncio.gather(*tasks)
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            if self._event_loop_monitor is not None:
+                self._event_loop_monitor.stop()
 
         if self.http_server:
             await self.http_server.cleanup()

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -216,13 +216,6 @@ class DashboardAgent:
         if self.server:
             await self.server.start()
 
-        # Watch this agent's event loop for stalls; it also serves job
-        # submission and metric/event export. Minimal agents run neither; set
-        # RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED=0 to disable.
-        if not self.minimal and EVENT_LOOP_MONITOR_ENABLED:
-            self._event_loop_monitor = EventLoopMonitor()
-            self._event_loop_monitor.start()
-
         modules = self._load_modules()
 
         launch_http_server = True
@@ -297,6 +290,16 @@ class DashboardAgent:
                     await asyncio.sleep(3600)
 
             tasks.append(wait_forever())
+
+        # Watch the serving event loop for stalls while the module tasks run;
+        # this loop also handles job submission and metric/event export.
+        # Started here (not during startup) so slow module loading isn't misread
+        # as a stall, and kept adjacent to the try/finally so stop() always
+        # runs. Not started for minimal agents; opt in elsewhere with
+        # RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED=1.
+        if not self.minimal and EVENT_LOOP_MONITOR_ENABLED:
+            self._event_loop_monitor = EventLoopMonitor()
+            self._event_loop_monitor.start()
 
         try:
             await asyncio.gather(*tasks)

--- a/python/ray/dashboard/event_loop_monitor.py
+++ b/python/ray/dashboard/event_loop_monitor.py
@@ -1,0 +1,151 @@
+"""Diagnostics for a stalled dashboard-agent asyncio event loop.
+
+The dashboard agent runs a single asyncio loop that serves metric ingestion,
+event aggregation, and the ``POST /api/jobs/`` submit handler, so a stall in
+that loop hangs job submission while the dashboard head stays healthy on its
+own loop.
+
+``EventLoopMonitor`` watches the loop two ways:
+
+* It observes loop lag (via :func:`enable_monitor_loop_lag`) and logs the lag
+  and pending-task count when lag is high.
+* A daemon thread watches a heartbeat the loop refreshes and dumps every
+  thread's stack via :mod:`faulthandler` when the heartbeat goes stale,
+  capturing the frame the loop thread is blocked in.
+
+The stack-dump watchdog runs on its own thread on purpose: a fully blocked loop
+cannot run an asyncio callback or fire an asyncio timeout, so an in-loop monitor
+would be wedged too. It is read-only and never cancels or restarts anything.
+"""
+
+import asyncio
+import faulthandler
+import logging
+import sys
+import threading
+import time
+from typing import Optional
+
+from ray._common.utils import get_or_create_event_loop
+from ray._private.async_utils import enable_monitor_loop_lag
+from ray._private.ray_constants import env_bool, env_float
+
+logger = logging.getLogger(__name__)
+
+
+# On by default for non-minimal agents; set
+# RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED=0 to disable.
+EVENT_LOOP_MONITOR_ENABLED = env_bool("RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED", True)
+# How often the loop-lag monitor samples (and the loop refreshes its heartbeat).
+_SAMPLE_INTERVAL_S = env_float("RAY_DASHBOARD_AGENT_LOOP_MONITOR_INTERVAL_S", 0.25)
+# Log a warning when observed loop lag exceeds this.
+_LAG_WARN_THRESHOLD_S = env_float("RAY_DASHBOARD_AGENT_LOOP_LAG_WARN_THRESHOLD_S", 1.0)
+# Dump all thread stacks once the loop has been blocked continuously this long.
+_STALL_DUMP_THRESHOLD_S = env_float(
+    "RAY_DASHBOARD_AGENT_LOOP_STALL_DUMP_THRESHOLD_S", 10.0
+)
+# Minimum gap between successive dumps so a long stall does not spam the log.
+_DUMP_COOLDOWN_S = env_float("RAY_DASHBOARD_AGENT_LOOP_DUMP_COOLDOWN_S", 60.0)
+
+
+class EventLoopMonitor:
+    """Watches the dashboard-agent event loop for stalls."""
+
+    def __init__(
+        self,
+        component: str = "dashboard_agent",
+        *,
+        sample_interval_s: float = _SAMPLE_INTERVAL_S,
+        lag_warn_threshold_s: float = _LAG_WARN_THRESHOLD_S,
+        stall_dump_threshold_s: float = _STALL_DUMP_THRESHOLD_S,
+        dump_cooldown_s: float = _DUMP_COOLDOWN_S,
+    ):
+        self._component = component
+        self._sample_interval_s = sample_interval_s
+        self._lag_warn_threshold_s = lag_warn_threshold_s
+        self._stall_dump_threshold_s = stall_dump_threshold_s
+        self._dump_cooldown_s = dump_cooldown_s
+
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        # Last time the loop proved it was alive (monotonic seconds). Written by
+        # the loop, read by the watchdog thread; a bare float access is atomic
+        # under CPython, so no lock is needed.
+        self._last_beat = time.monotonic()
+        self._last_dump = 0.0
+        self._stop = threading.Event()
+        self._watchdog: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Start the monitor. Must be called from within the agent's loop."""
+        self._loop = get_or_create_event_loop()
+        # Start the stall clock at activation, not at construction time.
+        self._last_beat = time.monotonic()
+
+        enable_monitor_loop_lag(
+            self._on_lag, interval_s=self._sample_interval_s, loop=self._loop
+        )
+
+        self._watchdog = threading.Thread(
+            target=self._watchdog_loop,
+            name="dashboard_agent_loop_watchdog",
+            daemon=True,
+        )
+        self._watchdog.start()
+        logger.info(
+            "[EventLoopMonitor] watching %s event loop "
+            "(lag_warn=%.1fs, stall_dump=%.1fs)",
+            self._component,
+            self._lag_warn_threshold_s,
+            self._stall_dump_threshold_s,
+        )
+
+    def _on_lag(self, lag_s: float) -> None:
+        # Runs on the loop, so reaching here proves the loop is alive.
+        self._last_beat = time.monotonic()
+        if lag_s >= self._lag_warn_threshold_s:
+            try:
+                pending = len(asyncio.all_tasks(self._loop))
+            except Exception:
+                pending = -1
+            logger.warning(
+                "[EventLoopMonitor] %s event loop lag %.3fs (pending_tasks=%d); "
+                "job submission and metric/event export run on this loop.",
+                self._component,
+                lag_s,
+                pending,
+            )
+
+    def _watchdog_loop(self) -> None:
+        while not self._stop.wait(self._sample_interval_s):
+            # If the loop is gone (shutdown/tests), stop rather than fire on a
+            # heartbeat that will never advance again.
+            if self._loop is not None and self._loop.is_closed():
+                break
+            stalled_for = time.monotonic() - self._last_beat
+            if stalled_for < self._stall_dump_threshold_s:
+                continue
+            now = time.monotonic()
+            if now - self._last_dump < self._dump_cooldown_s:
+                continue
+            self._last_dump = now
+            self._dump_stacks(stalled_for)
+
+    def _dump_stacks(self, stalled_for: float) -> None:
+        logger.warning(
+            "[EventLoopMonitor] %s event loop blocked for ~%.1fs (threshold "
+            "%.1fs); dumping all thread stacks.",
+            self._component,
+            stalled_for,
+            self._stall_dump_threshold_s,
+        )
+        # faulthandler writes Python frames for every thread, including the
+        # blocked loop thread, to stderr, which the agent redirects to its log.
+        try:
+            faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        except Exception:
+            logger.exception("[EventLoopMonitor] failed to dump thread stacks")
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._watchdog is not None and self._watchdog.is_alive():
+            self._watchdog.join(timeout=1.0)

--- a/python/ray/dashboard/event_loop_monitor.py
+++ b/python/ray/dashboard/event_loop_monitor.py
@@ -5,13 +5,17 @@ event aggregation, and the ``POST /api/jobs/`` submit handler, so a stall in
 that loop hangs job submission while the dashboard head stays healthy on its
 own loop.
 
-``EventLoopMonitor`` watches the loop two ways:
+``EventLoopMonitor`` watches the loop three ways:
 
 * It observes loop lag (via :func:`enable_monitor_loop_lag`) and logs the lag
   and pending-task count when lag is high.
 * A daemon thread watches a heartbeat the loop refreshes and dumps every
   thread's stack via :mod:`faulthandler` when the heartbeat goes stale,
   capturing the frame the loop thread is blocked in.
+* On demand, it dumps every thread's stack when the process receives a signal
+  (``SIGUSR2`` by default), so an operator -- or an external watchdog that
+  detected the hang from outside the process -- can capture the blocked frame
+  immediately, without waiting for the stall threshold.
 
 The stack-dump watchdog runs on its own thread on purpose: a fully blocked loop
 cannot run an asyncio callback or fire an asyncio timeout, so an in-loop monitor
@@ -21,6 +25,8 @@ would be wedged too. It is read-only and never cancels or restarts anything.
 import asyncio
 import faulthandler
 import logging
+import os
+import signal
 import sys
 import threading
 import time
@@ -33,9 +39,9 @@ from ray._private.ray_constants import env_bool, env_float
 logger = logging.getLogger(__name__)
 
 
-# On by default for non-minimal agents; set
-# RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED=0 to disable.
-EVENT_LOOP_MONITOR_ENABLED = env_bool("RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED", True)
+# Diagnostic-only instrumentation; off by default. Opt in with
+# RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED=1.
+EVENT_LOOP_MONITOR_ENABLED = env_bool("RAY_DASHBOARD_AGENT_LOOP_MONITOR_ENABLED", False)
 # How often the loop-lag monitor samples (and the loop refreshes its heartbeat).
 _SAMPLE_INTERVAL_S = env_float("RAY_DASHBOARD_AGENT_LOOP_MONITOR_INTERVAL_S", 0.25)
 # Log a warning when observed loop lag exceeds this.
@@ -46,6 +52,13 @@ _STALL_DUMP_THRESHOLD_S = env_float(
 )
 # Minimum gap between successive dumps so a long stall does not spam the log.
 _DUMP_COOLDOWN_S = env_float("RAY_DASHBOARD_AGENT_LOOP_DUMP_COOLDOWN_S", 60.0)
+# Signal that triggers an immediate all-thread stack dump on demand. Defaults
+# to SIGUSR2, which is unused elsewhere in Ray (Tune already claims SIGUSR1).
+# Set RAY_DASHBOARD_AGENT_LOOP_DUMP_SIGNAL to another signal name, or to an
+# empty value to disable the handler.
+_DUMP_SIGNAL_NAME = os.environ.get(
+    "RAY_DASHBOARD_AGENT_LOOP_DUMP_SIGNAL", "SIGUSR2"
+).strip()
 
 
 class EventLoopMonitor:
@@ -74,6 +87,8 @@ class EventLoopMonitor:
         self._last_dump = 0.0
         self._stop = threading.Event()
         self._watchdog: Optional[threading.Thread] = None
+        # Signal number the on-demand dump handler is registered on, if any.
+        self._dump_signum: Optional[int] = None
 
     def start(self) -> None:
         """Start the monitor. Must be called from within the agent's loop."""
@@ -91,6 +106,7 @@ class EventLoopMonitor:
             daemon=True,
         )
         self._watchdog.start()
+        self._register_dump_signal()
         logger.info(
             "[EventLoopMonitor] watching %s event loop "
             "(lag_warn=%.1fs, stall_dump=%.1fs)",
@@ -145,7 +161,59 @@ class EventLoopMonitor:
         except Exception:
             logger.exception("[EventLoopMonitor] failed to dump thread stacks")
 
+    def _register_dump_signal(self) -> None:
+        """Install an on-demand stack-dump handler on the configured signal.
+
+        Uses :func:`faulthandler.register`, whose C-level handler still fires
+        when the loop thread is hard-blocked holding the GIL -- exactly the
+        case the watchdog exists for -- so an external caller can force a dump
+        at will. ``chain=False`` because ``SIGUSR2``'s default action is to
+        kill the process, which must not happen here.
+
+        Signal handlers can only be registered on the main thread; if the loop
+        runs elsewhere this logs and skips rather than failing start-up.
+        """
+        if not _DUMP_SIGNAL_NAME:
+            return
+        signum = getattr(signal, _DUMP_SIGNAL_NAME, None)
+        if signum is None:
+            # e.g. SIGUSR2 does not exist on Windows.
+            logger.debug(
+                "[EventLoopMonitor] signal %r unavailable; "
+                "on-demand stack dump disabled.",
+                _DUMP_SIGNAL_NAME,
+            )
+            return
+        try:
+            faulthandler.register(
+                signum, file=sys.stderr, all_threads=True, chain=False
+            )
+        except (ValueError, RuntimeError) as e:
+            logger.warning(
+                "[EventLoopMonitor] could not register %s dump handler "
+                "(must run on the main thread): %s",
+                _DUMP_SIGNAL_NAME,
+                e,
+            )
+            return
+        self._dump_signum = signum
+        logger.info(
+            "[EventLoopMonitor] send %s to pid %d to dump all thread stacks.",
+            _DUMP_SIGNAL_NAME,
+            os.getpid(),
+        )
+
+    def _unregister_dump_signal(self) -> None:
+        if self._dump_signum is None:
+            return
+        try:
+            faulthandler.unregister(self._dump_signum)
+        except Exception:
+            logger.exception("[EventLoopMonitor] failed to unregister dump signal")
+        self._dump_signum = None
+
     def stop(self) -> None:
         self._stop.set()
+        self._unregister_dump_signal()
         if self._watchdog is not None and self._watchdog.is_alive():
             self._watchdog.join(timeout=1.0)

--- a/python/ray/dashboard/tests/test_event_loop_monitor.py
+++ b/python/ray/dashboard/tests/test_event_loop_monitor.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+import sys
+import threading
+import time
+
+import pytest
+
+from ray.dashboard.event_loop_monitor import EventLoopMonitor
+
+
+def test_on_lag_warns_and_refreshes_heartbeat(caplog):
+    """Lag above the threshold logs a warning and refreshes the heartbeat."""
+    monitor = EventLoopMonitor(lag_warn_threshold_s=1.0)
+    monitor._loop = asyncio.new_event_loop()
+    try:
+        monitor._last_beat = 0.0  # pretend stale
+        with caplog.at_level(logging.WARNING):
+            monitor._on_lag(2.0)
+        assert monitor._last_beat > 0.0  # heartbeat refreshed
+        assert any("event loop lag" in r.getMessage().lower() for r in caplog.records)
+    finally:
+        monitor._loop.close()
+
+
+def test_on_lag_below_threshold_is_quiet_but_still_beats(caplog):
+    monitor = EventLoopMonitor(lag_warn_threshold_s=5.0)
+    monitor._loop = asyncio.new_event_loop()
+    try:
+        monitor._last_beat = 0.0
+        with caplog.at_level(logging.WARNING):
+            monitor._on_lag(0.1)
+        assert monitor._last_beat > 0.0
+        assert not any(
+            "event loop lag" in r.getMessage().lower() for r in caplog.records
+        )
+    finally:
+        monitor._loop.close()
+
+
+def test_watchdog_dumps_when_loop_heartbeat_is_stale(monkeypatch):
+    """A stale heartbeat (loop blocked) triggers an out-of-loop stack dump."""
+    monitor = EventLoopMonitor(
+        sample_interval_s=0.01,
+        stall_dump_threshold_s=0.02,
+        dump_cooldown_s=0.0,
+    )
+    monitor._loop = asyncio.new_event_loop()
+    dumped = threading.Event()
+    monkeypatch.setattr(monitor, "_dump_stacks", lambda stalled_for: dumped.set())
+    # Heartbeat never refreshed -> the watchdog must observe a stall and dump.
+    monitor._last_beat = time.monotonic() - 1.0
+    monitor._watchdog = threading.Thread(target=monitor._watchdog_loop, daemon=True)
+    monitor._watchdog.start()
+    try:
+        assert dumped.wait(timeout=2.0), "watchdog did not dump on a stalled heartbeat"
+    finally:
+        monitor.stop()
+        monitor._loop.close()
+
+
+def test_watchdog_quiet_when_loop_is_healthy(monkeypatch):
+    monitor = EventLoopMonitor(
+        sample_interval_s=0.01,
+        stall_dump_threshold_s=0.5,
+        dump_cooldown_s=0.0,
+    )
+    monitor._loop = asyncio.new_event_loop()
+    dumped = threading.Event()
+    monkeypatch.setattr(monitor, "_dump_stacks", lambda stalled_for: dumped.set())
+    monitor._watchdog = threading.Thread(target=monitor._watchdog_loop, daemon=True)
+    monitor._watchdog.start()
+    try:
+        # Keep beating: heartbeat never gets older than the threshold.
+        for _ in range(20):
+            monitor._last_beat = time.monotonic()
+            time.sleep(0.02)
+        assert not dumped.is_set(), "watchdog dumped while the loop was healthy"
+    finally:
+        monitor.stop()
+        monitor._loop.close()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))

--- a/python/ray/dashboard/tests/test_event_loop_monitor.py
+++ b/python/ray/dashboard/tests/test_event_loop_monitor.py
@@ -1,5 +1,7 @@
 import asyncio
+import faulthandler
 import logging
+import signal
 import sys
 import threading
 import time
@@ -79,6 +81,37 @@ def test_watchdog_quiet_when_loop_is_healthy(monkeypatch):
     finally:
         monitor.stop()
         monitor._loop.close()
+
+
+def test_dump_signal_registers_and_unregisters(monkeypatch):
+    """start() arms the on-demand dump signal; stop() disarms it."""
+    if not hasattr(signal, "SIGUSR2"):
+        pytest.skip("SIGUSR2 is not available on this platform")
+
+    registered = {}
+    monkeypatch.setattr(
+        faulthandler,
+        "register",
+        lambda signum, **kwargs: registered.update(signum=signum, **kwargs),
+    )
+    monkeypatch.setattr(
+        faulthandler,
+        "unregister",
+        lambda signum: registered.update(unregistered=signum),
+    )
+
+    monitor = EventLoopMonitor()
+    monitor._register_dump_signal()
+    assert registered["signum"] == signal.SIGUSR2
+    assert registered["all_threads"] is True
+    # chain=False so the dump does not fall through to SIGUSR2's default
+    # action, which would terminate the agent.
+    assert registered["chain"] is False
+    assert monitor._dump_signum == signal.SIGUSR2
+
+    monitor._unregister_dump_signal()
+    assert registered["unregistered"] == signal.SIGUSR2
+    assert monitor._dump_signum is None
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/tests/test_event_loop_monitor.py
+++ b/python/ray/dashboard/tests/test_event_loop_monitor.py
@@ -5,37 +5,61 @@ import signal
 import sys
 import threading
 import time
+from contextlib import contextmanager
 
 import pytest
 
+from ray.dashboard import event_loop_monitor
 from ray.dashboard.event_loop_monitor import EventLoopMonitor
 
 
-def test_on_lag_warns_and_refreshes_heartbeat(caplog):
+# pytest's ``caplog`` attaches to the root logger, but Ray sets
+# ``propagate=False`` on the "ray" logger, so records emitted by
+# ``ray.dashboard.*`` never reach the root handler under the dashboard test
+# harness (they still show on stderr). Attach a handler to the module logger
+# directly so capture is independent of propagation.
+@contextmanager
+def capture_records(logger, level=logging.WARNING):
+    records = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _ListHandler()
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    try:
+        yield records
+    finally:
+        logger.setLevel(prev_level)
+        logger.removeHandler(handler)
+
+
+def test_on_lag_warns_and_refreshes_heartbeat():
     """Lag above the threshold logs a warning and refreshes the heartbeat."""
     monitor = EventLoopMonitor(lag_warn_threshold_s=1.0)
     monitor._loop = asyncio.new_event_loop()
     try:
         monitor._last_beat = 0.0  # pretend stale
-        with caplog.at_level(logging.WARNING):
+        with capture_records(event_loop_monitor.logger) as records:
             monitor._on_lag(2.0)
         assert monitor._last_beat > 0.0  # heartbeat refreshed
-        assert any("event loop lag" in r.getMessage().lower() for r in caplog.records)
+        assert any("event loop lag" in r.getMessage().lower() for r in records)
     finally:
         monitor._loop.close()
 
 
-def test_on_lag_below_threshold_is_quiet_but_still_beats(caplog):
+def test_on_lag_below_threshold_is_quiet_but_still_beats():
     monitor = EventLoopMonitor(lag_warn_threshold_s=5.0)
     monitor._loop = asyncio.new_event_loop()
     try:
         monitor._last_beat = 0.0
-        with caplog.at_level(logging.WARNING):
+        with capture_records(event_loop_monitor.logger) as records:
             monitor._on_lag(0.1)
         assert monitor._last_beat > 0.0
-        assert not any(
-            "event loop lag" in r.getMessage().lower() for r in caplog.records
-        )
+        assert not any("event loop lag" in r.getMessage().lower() for r in records)
     finally:
         monitor._loop.close()
 


### PR DESCRIPTION
## Description

The dashboard agent runs a single asyncio event loop that serves metric ingestion, event aggregation, and the `POST /api/jobs/` submit handler. When that loop stalls, job submission hangs even though the dashboard head stays healthy on its own loop, and the blocking call does not surface in any log because the agent simply goes silent.

This adds read-only diagnostics to the dashboard agent to identify what blocks the loop:

- **Loop-lag logging** — reuses `enable_monitor_loop_lag` (the same primitive the dashboard head already uses) to observe loop lag and log the lag and pending-task count when lag exceeds a threshold.
- **Off-loop stack dump** — a daemon thread watches a heartbeat the loop refreshes and, when it goes stale, dumps every thread's stack via `faulthandler`, capturing the frame the loop thread is blocked in. It runs on its own thread on purpose: a fully blocked loop cannot run an asyncio callback or fire an asyncio timeout, so an in-loop monitor would be wedged too and never dump.

Diagnostics only — nothing here cancels, restarts, or changes submission behavior. The monitor starts for non-minimal agents in `DashboardAgent.run()`.

## Related issues

<!-- none -->

## Additional information

Thresholds are env-tunable (defaults):
- `RAY_DASHBOARD_AGENT_LOOP_MONITOR_INTERVAL_S` (0.25)
- `RAY_DASHBOARD_AGENT_LOOP_LAG_WARN_THRESHOLD_S` (1.0)
- `RAY_DASHBOARD_AGENT_LOOP_STALL_DUMP_THRESHOLD_S` (10.0)
- `RAY_DASHBOARD_AGENT_LOOP_DUMP_COOLDOWN_S` (60.0)

Unit tests: `python/ray/dashboard/tests/test_event_loop_monitor.py` (auto-included by the dashboard `py_test_run_all_subdirectory` target).

<img width="1704" height="885" alt="Screenshot 2026-07-04 at 7 02 21 PM" src="https://github.com/user-attachments/assets/36581ddb-2157-4e87-a398-d4943d765485" />

