### PR TITLE
[Data] Bump test_iceberg bazel size to medium to fix CI timeout

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1358,7 +1358,7 @@ py_test(
 
 py_test(
     name = "test_iceberg",
-    size = "small",
+    size = "medium",
     srcs = ["tests/datasource/test_iceberg.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
`//python/ray/data:test_iceberg` was failing in CI as a bazel TIMEOUT (`TIMEOUT in 2 out of 2 in 60.2s`), not a test failure. All 54 tests pass (`54 passed in 52.81s`), but the binary's total wall-clock — interpreter startup + heavy imports (ray/pyarrow/pandas/pyiceberg) + the ~53s pytest phase + teardown — exceeds the 60s "small" budget. The suite has grown past that budget (notably the distributed-upsert tests added in #63482), and the slower `arrow v23 py3.12` job tips it over consistently.

Bump the target from `size = "small"` (60s) to `size = "medium"` (300s), which is already the dominant size for data test targets and gives ample headroom while fast environments still finish in ~53s.