### PR TITLE
[docs] Re-add docs team to CODEOWNERS for documentation paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,9 @@
 # ==== Documentation ====
 
 # Authors responsible for documentation infrastructure and layout.
-/doc/ @ray-project/ray-docs
-/doc/source/use-cases.rst @pcmoritz
+# ray-ci co-owns doc CI/build config; ray-docs-reviewers is a silent fallback
+# (notifications disabled) so docs leads can unblock docs-required reviews.
+/doc/ @ray-project/ray-docs @ray-project/ray-ci @ray-project/ray-docs-reviewers
 
 # ==== Ray core ====
 
@@ -25,10 +26,10 @@
 # C++ worker
 /cpp/ @SongGuyang @raulchen @kfstorm @ray-project/ray-core
 
-/doc/source/cluster/ @ray-project/ray-core
-/doc/source/ray-core/ @ray-project/ray-core
+/doc/source/cluster/ @ray-project/ray-core @ray-project/ray-docs
+/doc/source/ray-core/ @ray-project/ray-core @ray-project/ray-docs
 
-/doc/source/cluster/kubernetes/ @andrewsykim @ray-project/ray-core
+/doc/source/cluster/kubernetes/ @andrewsykim @ray-project/ray-core @ray-project/ray-docs
 
 # Public protobuf files.
 /src/ray/protobuf/public/ @edoakes @dayshah @MengjinYan
@@ -48,21 +49,21 @@
 
 # Ray data.
 /python/ray/data/ @ray-project/ray-data
-/doc/source/data/ @ray-project/ray-data
+/doc/source/data/ @ray-project/ray-data @ray-project/ray-docs
 /python/ray/dashboard/modules/data/ @ray-project/ray-data
 /python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py @ray-project/ray-data
 
 # RLlib.
 /rllib/ @ray-project/ray-rllib
-/doc/source/rllib/ @ray-project/ray-rllib
+/doc/source/rllib/ @ray-project/ray-rllib @ray-project/ray-docs
 
 # Ray Tune
 /python/ray/tune/ @ray-project/ray-tune
-/doc/source/tune/ @ray-project/ray-tune
+/doc/source/tune/ @ray-project/ray-tune @ray-project/ray-docs
 
 # Ray Train
 /python/ray/train/ @ray-project/ray-train
-/doc/source/train/ @ray-project/ray-train
+/doc/source/train/ @ray-project/ray-train @ray-project/ray-docs
 
 # Ray AIR
 /python/ray/air/ @ray-project/ray-train
@@ -72,7 +73,7 @@
 /java/serve/ @ray-project/ray-serve
 /src/ray/protobuf/serve.proto @ray-project/ray-serve
 /python/ray/dashboard/modules/serve/ @ray-project/ray-serve
-/doc/source/serve/ @ray-project/ray-serve
+/doc/source/serve/ @ray-project/ray-serve @ray-project/ray-docs
 
 # LLM
 /python/ray/llm/ @ray-project/ray-llm
@@ -80,9 +81,9 @@
 /python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py @ray-project/ray-llm
 /python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json @ray-project/ray-llm
 /python/ray/serve/llm/ @ray-project/ray-llm
-/doc/source/serve/llm/ @ray-project/ray-llm
-/doc/source/data/working-with-llms.rst @ray-project/ray-llm
-/doc/source/data/doc_code/working-with-llms/ @ray-project/ray-llm
+/doc/source/serve/llm/ @ray-project/ray-llm @ray-project/ray-docs
+/doc/source/data/working-with-llms.rst @ray-project/ray-llm @ray-project/ray-docs
+/doc/source/data/doc_code/working-with-llms/ @ray-project/ray-llm @ray-project/ray-docs
 
 # LLM dependencies
 /python/requirements/llm/llm-requirements.txt @ray-project/ray-llm


### PR DESCRIPTION
## What

Re-add `@ray-project/ray-docs` as a co-owner on the per-library documentation subtrees in `.github/CODEOWNERS`, and extend the `/doc/` catchall with `@ray-project/ray-ci` and a new silent `@ray-project/ray-docs-reviewers` fallback.

## Why

CODEOWNERS resolves by last-matching rule, so the per-library doc rules (`/doc/source/data/`, `/doc/source/rllib/`, etc.) currently override the `/doc/ @ray-project/ray-docs` catchall. As a result the docs team isn't in the required-review path for most files under `doc/`. The docs team co-owned these subtrees until ~6 months ago; the entries were removed then to reduce review noise during a low-bandwidth period.

This restores the docs team to the review path so it receives a review request on documentation changes (change-frequency visibility) and can help unblock doc-heavy PRs. Because any one listed owner's approval satisfies GitHub, this does **not** block library teams from approving their own doc changes — it adds visibility and optional review, not a required docs gate.

## Changes

- `@ray-project/ray-docs` added as a co-owner on the doc subtrees: `cluster/`, `ray-core/`, `cluster/kubernetes/`, `data/`, `rllib/`, `tune/`, `train/`, `serve/`, `serve/llm/`, and the two LLM data paths.
- `/doc/` catchall extended with `@ray-project/ray-ci` (doc CI/build config) and `@ray-project/ray-docs-reviewers` (a notifications-disabled backup-reviewer team that can silently unblock a docs-required review without paging members on routine PRs).
- Dropped the stale `/doc/source/use-cases.rst` rule: that file now lives at `doc/source/ray-overview/use-cases.rst`, so the old path matched nothing.

## Prerequisite before merge

Draft pending GitHub team and permission setup:

- `@ray-project/ray-docs-reviewers` must be granted **write** access to this repository, or CODEOWNERS validation reports it as an unknown owner. This PR will show that validation error on the catchall line until the access grant lands.
- The team's membership and notifications-disabled setting are being configured separately.

Opening as a draft now to serve as the reference for the desired CODEOWNERS state alongside the in-flight permissions changes.
