### PR TITLE
[core] Add PG + actor scheduling scalability benchmark for RL/post-training

### DIFF
--- a/release/benchmarks/distributed/many_nodes_tests/actor_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/actor_test.py
@@ -4,8 +4,14 @@ import math
 from time import sleep, perf_counter
 import json
 import ray
+import ray._common.test_utils
+import ray._private.test_utils as test_utils
 
 from dashboard_test import DashboardTestAtScale
+
+
+def no_resource_leaks():
+    return test_utils.no_resource_leaks_excluding_node_resources()
 
 
 def test_max_actors_launch(cpus_per_actor, total_actors):
@@ -88,13 +94,18 @@ def run_one(total_actors, cpus_per_actor, no_wait):
     )
     print(f"Through put: {throughput}")
 
-    return {
+    result = {
         "actor_launch_time": actor_launch_time,
         "actor_ready_time": actor_ready_time,
         "total_time": actor_launch_time + actor_ready_time,
         "num_actors": total_actors,
         "throughput": throughput,
     }
+
+    del actors
+    ray._common.test_utils.wait_for_condition(no_resource_leaks)
+
+    return result
 
 
 def main():

--- a/release/benchmarks/distributed/many_nodes_tests/compute_config_gce.yaml
+++ b/release/benchmarks/distributed/many_nodes_tests/compute_config_gce.yaml
@@ -21,5 +21,5 @@ head_node:
 worker_nodes:
   - instance_type: n2-standard-2
     min_nodes: 500
-    max_nodes: 2000
+    max_nodes: 10000
     market_type: ON_DEMAND

--- a/release/benchmarks/distributed/pg_topology/compute_rack_111.yaml
+++ b/release/benchmarks/distributed/pg_topology/compute_rack_111.yaml
@@ -1,25 +1,24 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
-
-# NFS needs to be disabled for this test, since the test spawns too many nodes
-# and may hit the limit on the # of clients.
 advanced_instance_config:
+  # Disable NFS: at this node count the shared mount hits its client limit.
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
         - Key: as-feature-disable-nfs-mount
           Value: "true"
-
   BlockDeviceMappings:
     - DeviceName: /dev/sda1
       Ebs:
         DeleteOnTermination: true
         VolumeSize: 30
-
 head_node:
   instance_type: m5.16xlarge
-
 worker_nodes:
-  - instance_type: m6i.large
-    min_nodes: 500
-    max_nodes: 10000
+{% for k in range(111) %}  - name: rack-{{k}}
+    instance_type: m6i.large
+    min_nodes: 18
+    max_nodes: 18
     market_type: ON_DEMAND
+    labels:
+      ray.io/gpu-domain: rack-{{k}}
+{% endfor %}

--- a/release/benchmarks/distributed/pg_topology/compute_rack_555.yaml
+++ b/release/benchmarks/distributed/pg_topology/compute_rack_555.yaml
@@ -1,25 +1,24 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
-
-# NFS needs to be disabled for this test, since the test spawns too many nodes
-# and may hit the limit on the # of clients.
 advanced_instance_config:
+  # Disable NFS: at this node count the shared mount hits its client limit.
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
         - Key: as-feature-disable-nfs-mount
           Value: "true"
-
   BlockDeviceMappings:
     - DeviceName: /dev/sda1
       Ebs:
         DeleteOnTermination: true
         VolumeSize: 30
-
 head_node:
   instance_type: m5.16xlarge
-
 worker_nodes:
-  - instance_type: m6i.large
-    min_nodes: 500
-    max_nodes: 10000
+{% for k in range(555) %}  - name: rack-{{k}}
+    instance_type: m6i.large
+    min_nodes: 18
+    max_nodes: 18
     market_type: ON_DEMAND
+    labels:
+      ray.io/gpu-domain: rack-{{k}}
+{% endfor %}

--- a/release/benchmarks/distributed/test_pg_actor_scalability.py
+++ b/release/benchmarks/distributed/test_pg_actor_scalability.py
@@ -1,0 +1,139 @@
+"""Times placement group creation and actor-into-PG scheduling throughput, at scale.
+
+Each bundle is a whole worker node; actors-per-node actors are scheduled into each.
+
+pg-per-node: one single-bundle PG per worker node.
+
+pg-per-rack: one PG per rack, one bundle per node in the rack.
+"""
+import argparse
+import time
+
+from many_nodes_tests.dashboard_test import DashboardTestAtScale
+
+import ray
+import ray._common.test_utils
+import ray._private.test_utils as test_utils
+import ray.autoscaler.sdk
+from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+RACK_LABEL = "ray.io/gpu-domain"
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--mode", choices=["pg-per-node", "pg-per-rack"], required=True)
+parser.add_argument("--node-counts", nargs="+", type=int, default=[])
+parser.add_argument("--actors-per-node", type=int, default=4)
+args, _ = parser.parse_known_args()
+
+
+def no_resource_leaks():
+    return test_utils.no_resource_leaks_excluding_node_resources()
+
+
+def worker_nodes():
+    head_node_id = ray.get_runtime_context().get_node_id()
+    nodes = [n for n in ray.nodes() if n["Alive"] and n["NodeID"] != head_node_id]
+    return nodes or [n for n in ray.nodes() if n["Alive"]]
+
+
+def total_cluster_cpus():
+    return int(sum(n["Resources"].get("CPU", 0) for n in ray.nodes() if n["Alive"]))
+
+
+def scale_up_to(num_nodes, cpu_per_node):
+    head_cpus = total_cluster_cpus() - len(worker_nodes()) * cpu_per_node
+    ray.autoscaler.sdk.request_resources(num_cpus=head_cpus + num_nodes * cpu_per_node)
+    while len(worker_nodes()) < num_nodes:
+        print(f"Waiting for {len(worker_nodes())}/{num_nodes} worker nodes")
+        time.sleep(5)
+
+
+def measure(num_pgs, bundles_per_pg, pg_kwargs, cpu_per_node):
+    @ray.remote(num_cpus=cpu_per_node / args.actors_per_node)
+    class Actor:
+        def ping(self):
+            return "pong"
+
+    start = time.time()
+    pgs = [placement_group(**pg_kwargs) for _ in range(num_pgs)]
+    ray.get([pg.ready() for pg in pgs])
+    pg_create_throughput = num_pgs / (time.time() - start)
+
+    start = time.time()
+    actors = [
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+        for pg in pgs
+        for _ in range(bundles_per_pg * args.actors_per_node)
+    ]
+    ray.get([a.ping.remote() for a in actors])
+    actor_throughput = len(actors) / (time.time() - start)
+
+    result = {
+        "mode": args.mode,
+        "num_pgs": num_pgs,
+        "bundles_per_pg": bundles_per_pg,
+        "num_actors": len(actors),
+        "pg_create_throughput": pg_create_throughput,
+        "actor_throughput": actor_throughput,
+    }
+    for pg in pgs:
+        remove_placement_group(pg)
+    ray._common.test_utils.wait_for_condition(no_resource_leaks)
+    return result
+
+
+def run_benchmark():
+    cpu_per_node = int(worker_nodes()[0]["Resources"]["CPU"])
+    bundle = {"CPU": cpu_per_node}
+    results = {}
+    if args.mode == "pg-per-node":
+        for n in sorted(args.node_counts):
+            scale_up_to(n, cpu_per_node)
+            results[f"pg_per_node_{n}"] = measure(
+                n, 1, dict(bundles=[bundle]), cpu_per_node
+            )
+    else:
+        workers = worker_nodes()
+        num_racks = len({n["Labels"][RACK_LABEL] for n in workers})
+        bundles_per_pg = len(workers) // num_racks
+        results[f"pg_per_rack_{num_racks}"] = measure(
+            num_racks,
+            bundles_per_pg,
+            dict(
+                bundles=[bundle] * bundles_per_pg,
+                topology_strategy={RACK_LABEL: "STRICT_PACK"},
+            ),
+            cpu_per_node,
+        )
+    return results
+
+
+addr = ray.init(address="auto")
+
+dashboard_test = DashboardTestAtScale(addr)
+
+results = run_benchmark()
+
+print(f"Result: {results}")
+perf_metrics = []
+for name, r in results.items():
+    perf_metrics.append(
+        {
+            "perf_metric_name": f"{name}_pg_create_throughput",
+            "perf_metric_value": r["pg_create_throughput"],
+            "perf_metric_type": "THROUGHPUT",
+        }
+    )
+    perf_metrics.append(
+        {
+            "perf_metric_name": f"{name}_actor_throughput",
+            "perf_metric_value": r["actor_throughput"],
+            "perf_metric_type": "THROUGHPUT",
+        }
+    )
+results["perf_metrics"] = perf_metrics
+dashboard_test.update_release_test_result(results)
+test_utils.safe_write_to_results_json(results)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3068,17 +3068,18 @@
   group: core-daily-test
   working_dir: benchmarks
 
-  frequency: nightly-3x
+  frequency: weekly
   team: core
   cluster:
     anyscale_sdk_2026: true
     cluster_compute: distributed/many_nodes_tests/compute_config.yaml
 
   run:
-    timeout: 3600
+    timeout: 10800
     # 2cpus per node x 1000 nodes / 0.2 cpus per actor = 10k
     # 2cpus per node x 2000 nodes / 0.2 cpus per actor = 20k
-    script: python distributed/many_nodes_tests/actor_test.py --no-wait --cpus-per-actor=0.2 --total-actors 10000 20000
+    # 2cpus per node x 10000 nodes / 0.2 cpus per actor = 100k
+    script: python distributed/many_nodes_tests/actor_test.py --no-wait --cpus-per-actor=0.2 --total-actors 10000 20000 100000
     wait_for_nodes:
       num_nodes: 500
 
@@ -3398,6 +3399,60 @@
     script: SMOKE_TEST=1 python distributed/test_many_pgs.py
     wait_for_nodes:
       num_nodes: 2
+
+
+- name: pg_per_node_scalability
+  python: "3.10"
+  group: core-scalability-test
+  working_dir: benchmarks
+
+  frequency: weekly
+  team: core
+  cluster:
+    anyscale_sdk_2026: true
+    cluster_compute: distributed/many_nodes_tests/compute_config.yaml
+
+  run:
+    timeout: 10800
+    script: python distributed/test_pg_actor_scalability.py --mode pg-per-node --node-counts 2000 10000
+    wait_for_nodes:
+      num_nodes: 500
+
+
+- name: pg_rack_aware_scalability
+  python: "3.10"
+  group: core-scalability-test
+  working_dir: benchmarks
+
+  frequency: weekly
+  team: core
+  cluster:
+    anyscale_sdk_2026: true
+    cluster_compute: distributed/pg_topology/compute_rack_111.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_pg_actor_scalability.py --mode pg-per-rack
+    wait_for_nodes:
+      num_nodes: 1998
+
+
+- name: pg_rack_aware_scalability_large
+  python: "3.10"
+  group: core-scalability-test
+  working_dir: benchmarks
+
+  frequency: weekly
+  team: core
+  cluster:
+    anyscale_sdk_2026: true
+    cluster_compute: distributed/pg_topology/compute_rack_555.yaml
+
+  run:
+    timeout: 7200
+    script: python distributed/test_pg_actor_scalability.py --mode pg-per-rack
+    wait_for_nodes:
+      num_nodes: 9990
 
 
 - name: many_nodes


### PR DESCRIPTION
## Description
This PR reviews all PG  and actor related release tests and adds a PG + actor scheduling scalability benchmark for RL/post-training. **If you only care about the new benchmark, just look at `release/benchmarks/distributed/test_pg_actor_scalability.py` and ignore the rest of the diff.**

The benchmark has two modes:
- `pg-per-node`: one single bundle PG per worker node. Each bundle is a whole worker node; `actors-per-node`(default 4) actors are scheduled into each.
- `pg-per-rack`: one PG per rack, one bundle per node in the rack. Each bundle is a whole worker node; `actors-per-node`(default 4) actors are scheduled into each.

Both modes run at 2,000 and 10k node settings, and report PG creation throughput and actor scheduling throughput separately.


## After this PR:


#### Pure Actor Scheduling Throughput release test
-  E2E scheduling quality
  - `test_many_actors.py`: 64 nodes, 156 actors/node, high density actor scheduling.
    - This should reflect the end to end overhead of placing an actor.
- whether throughput degrades as scale increases
  - `many_nodes_tests/actor_test.py`: 10 actors/node, tested at 1,000, 2,000, and 10k nodes.
      - This should surface the "stale resource view" issue or "GCS single thread bottleneck" and show how their impact grows as the number of nodes increases, basically, whether throughput degrades as scale increases.

#### Pure PG Scheduling release test
- E2E PG scheduling quality
  - Microbenchmark, 5 nodes:
      - `num_pgs ∈ [10, 100, 200, 400, 800, 1600]` (bundle=1), tests how scheduling scales with the number of PGs.
      - `num_bundles ∈ [1, 10, 20, 40]` (pgs=100), tests how scheduling scales with the number of bundles per PG.
  - `test_placement_group.py`: 5 nodes. 666 PGs / 3,330 bundles, measures the call latency of PG creation/deletion.
    - I actually feel like this test is quite meaningful now. not in its original intention, but its throughput will be impacted by the PG removal speed, which is a good and unique indicator.
- whether throughput degrades as scale increases
  - Large node scale PG throughput is tested in "PG + Actor among PG".

#### PG + Actor among PG release test
- The newly added `test_pg_actor_scalability.py`.
- `test_many_pgs.py`: 64 nodes. 1,000 small 3 bundle PGs (~25 PGs per node), then 3 actors packed into each PG. **This test should be deleted, as it doesn't make much sense here and could be replaced by the new test. Will do in a separate PR.**