### PR TITLE
[ci] Add CODEOWNERS protection for critical build and CI config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,12 +105,12 @@
 # ==== Build and CI ====
 
 # Bazel.
-#/BUILD.bazel @ray-project/ray-core @ray-project/ray-ci
-#/WORKSPACE @ray-project/ray-core @ray-project/ray-ci
-#/bazel/ @ray-project/ray-core @ray-project/ray-ci
+/BUILD.bazel @ray-project/ray-core @ray-project/ray-ci
+/WORKSPACE @ray-project/ray-core @ray-project/ray-ci
+/bazel/ @ray-project/ray-core @ray-project/ray-ci
 
-# CI scripts.
-#/ci/ @ray-project/ray-core @ray-project/ray-ci
+# CI scripts. More specific /ci/ rules below override this catch-all.
+/ci/ @ray-project/ray-core @ray-project/ray-ci
 
 # CI
 /ci/docker @ray-project/ray-ci
@@ -123,7 +123,21 @@
 # Buildkite pipeline management
 .buildkite/hooks @ray-project/ray-ci
 
+# Buildkite pipeline definitions and the change-detection rules that decide
+# what CI runs for every PR. Editing these changes what runs for everyone.
+/.buildkite/*.rayci.yml @ray-project/ray-ci
+/.buildkite/test.rules.txt @ray-project/ray-ci
+/.buildkite/always.rules.txt @ray-project/ray-ci
+
+# Compiled dependency lockfile. Gates the build and test environment.
+/python/requirements_compiled.txt @ray-project/ray-ci
+
+# Read the Docs build configuration. ray-docs owns the docs build; ray-ci
+# co-owns, and ray-docs-reviewers is a silent fallback for backup approval.
+/.readthedocs.yaml @ray-project/ray-docs @ray-project/ray-ci @ray-project/ray-docs-reviewers
+
 /release/ray_release @ray-project/ray-ci
+/release/release_tests.yaml @ray-project/ray-ci
 
 # Allow people to add BYOD post-installation shell scripts
 # on their own.


### PR DESCRIPTION
## Summary

Several critical CI and build configuration files have no `CODEOWNERS` entry today, so changes to them can merge without review from the team that owns CI behavior. This adds protection for those surfaces.

What this covers:

- **Bazel / build:** uncomments the pre-existing but disabled `/BUILD.bazel`, `/WORKSPACE`, `/bazel/`, and `/ci/` rules — `@ray-project/ray-core` + `@ray-project/ray-ci`.
- **Buildkite pipelines + change-detection rules:** `.buildkite/*.rayci.yml`, `.buildkite/test.rules.txt`, `.buildkite/always.rules.txt` — `@ray-project/ray-ci`. Editing the rules files changes what CI runs for *every* PR, so these especially warrant required review.
- **Build / test environment:** `python/requirements_compiled.txt` and `release/release_tests.yaml` — `@ray-project/ray-ci`.
- **Docs build config:** `.readthedocs.yaml` — `@ray-project/ray-docs` as primary (it's the docs build config), with `@ray-project/ray-ci` co-owning and `@ray-project/ray-docs-reviewers` as a silent backup approver. The doctest-adjacent configs above stay `ray-ci`-owned.

The more-specific `/ci/docker`, `/ci/ray_ci`, etc. rules below the `/ci/` catch-all continue to take precedence, since CODEOWNERS uses last-match-wins.

## Notes for reviewers

- This increases the required-review load on `@ray-project/ray-ci` for core build files that were previously left commented out. **Opening as a draft** so the CI owners (REEf) can confirm this is the coverage they want before it's enabled.
- Companion to #64445 (documentation-path ownership). This PR is scoped to CI/build config and edits a disjoint region of the file, so the two shouldn't conflict.
