### PR TITLE
[doc] Add a guide for running the API consistency check locally

### DIFF
--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -38,3 +38,44 @@ If microcheck passes, you'll see a green checkmark on your PR. If it fails, you'
 If you're a committer, add the `go` label to your PR once it's ready, then merge after the full suite passes. Clicking **Enable auto-merge** does both in one step: it adds the `go` label and merges the PR automatically once the suite passes. Pushing a new commit disables auto-merge, so re-enable it afterward. When you review an external contributor's PR, add the `go` label for them, since they can't add it themselves.
 
 If you're an external contributor, adding the `go` label and enabling auto-merge both require write access, so a committer runs the full suite and merges when your PR is ready.
+
+## Running the API consistency check locally
+
+The `doc: check API doc consistency` premerge step runs the `api_policy_check` function in `ci/lint/lint.sh`, which does three things: installs Ray from your checkout with `--no-deps`, generates the autosummary stub `.rst` files with `doc/source/api_autogen.py`, then runs `ci/ray_ci/doc/cmd_check_api_discrepancy.py`. The checker compares each team's documented API surface against the annotated (`@PublicAPI`/`@DeveloperAPI`/`@Deprecated`) surface in the code, importing Ray's own symbols for real. So it needs an environment where Ray installs and imports, which is the opposite of the docs *build* environment, which deliberately doesn't install Ray (see [Building the Ray documentation](docs.md#building-the-ray-documentation)).
+
+The optional third-party backends that some surfaces pull in at import time don't have to be installed. Examples include the vLLM and SGLang stack behind `ray.data.llm` and `ray.serve.llm`, and the deep-learning backends behind `ray.train`, `ray.tune`, and `ray.rllib`. The check mocks whichever of them are absent, reading the list from `doc/source/api_mock_imports.py`, the same source of truth the docs build uses for `autodoc_mock_imports`. It mocks only the absent ones, because shadowing an installed library breaks the plain `import` the walk relies on.
+
+### The faithful environment: the docbuild image
+
+CI runs this check inside the `docbuild` image (`ci/docker/doc.build.Dockerfile`). The image doesn't pip-install Ray. It stages the prebuilt `ray-core` and `ray-dashboard` artifacts into `/opt/ray-build` on top of the `oss-ci-base_build` base image, then installs the docs dependency lock (`python/deplocks/docs/docbuild_depset_py3.11.lock`), which is where Sphinx and Jinja2 come from. At step time `lint.sh` unpacks those artifacts and runs `pip install -e "python[all]" --no-deps`, so the walked surface is your checkout's source over prebuilt compiled extensions.
+
+The base image supplies `python/requirements.txt`, so a few of the libraries the walk imports are real rather than mocked, `pandas` most notably. The heavy deep-learning backends aren't installed even in CI: `torch`, `transformers`, and `tensorflow` are all mocked there too. Because the lock pins Linux wheels, the only fully faithful local reproduction is the Linux docbuild image through Docker, or a CI run on your branch.
+
+### A lightweight local approximation
+
+For quick iteration on the checker itself, a Python 3.11 virtual environment with a nightly Ray wheel and Sphinx is usually enough. Sphinx isn't a Ray dependency, and both halves of the step need it: the checker imports `sphinx.ext.autodoc.mock` and the stub generator imports `sphinx.ext.autosummary`. You generally don't need to install the mocked backends by hand. Install one for real only when you want the check to walk that library's true surface instead of a mock.
+
+```bash
+uv venv --python 3.11 ~/.virtualenvs/ray-apiref
+# The wheel URL below is macOS arm64 / Python 3.11. Adjust it for your OS, architecture, and Python version.
+uv pip install --python ~/.virtualenvs/ray-apiref/bin/python \
+  sphinx \
+  "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl"
+# Link your checkout's Python files over the wheel so the check walks your local @PublicAPI changes, not the wheel's:
+~/.virtualenvs/ray-apiref/bin/python python/ray/setup-dev.py --yes
+
+# Generate the autosummary stubs the check reads, as CI does in the same step:
+PYTHONPATH="$(pwd)" ~/.virtualenvs/ray-apiref/bin/python doc/source/api_autogen.py
+
+# Run the check against your checkout (PYTHONPATH so the checker imports from your tree):
+PYTHONPATH="$(pwd)" ~/.virtualenvs/ray-apiref/bin/python \
+  ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
+```
+
+Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.
+
+A bare Ray wheel doesn't pull in `pandas`, so locally the check mocks it where CI walks it for real. Install `pandas` in the virtual environment when you're checking the `data` team.
+
+```{warning}
+`setup-dev.py` links your checkout's Python packages over the wheel, so the walked `@PublicAPI` surface reflects your local changes. The rest of the wheel (compiled extensions and generated code) is still the nightly build, cut at a different commit than your checkout, so treat a clean local run as a fast iteration signal rather than a definitive result. For sign-off, rely on the CI run in the docbuild image.
+```

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -57,19 +57,20 @@ For quick iteration on the checker itself, a Python 3.11 virtual environment wit
 
 ```bash
 uv venv --python 3.11 ~/.virtualenvs/ray-apiref
+source ~/.virtualenvs/ray-apiref/bin/activate
+
 # The wheel URL below is macOS arm64 / Python 3.11. Adjust it for your OS, architecture, and Python version.
-uv pip install --python ~/.virtualenvs/ray-apiref/bin/python \
-  sphinx \
+uv pip install sphinx \
   "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl"
+
 # Link your checkout's Python files over the wheel so the check walks your local @PublicAPI changes, not the wheel's:
-~/.virtualenvs/ray-apiref/bin/python python/ray/setup-dev.py --yes
+python python/ray/setup-dev.py --yes
 
 # Generate the autosummary stubs the check reads, as CI does in the same step:
-PYTHONPATH="$(pwd)" ~/.virtualenvs/ray-apiref/bin/python doc/source/api_autogen.py
+PYTHONPATH="$(pwd)" python doc/source/api_autogen.py
 
 # Run the check against your checkout (PYTHONPATH so the checker imports from your tree):
-PYTHONPATH="$(pwd)" ~/.virtualenvs/ray-apiref/bin/python \
-  ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
+PYTHONPATH="$(pwd)" python ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
 ```
 
 Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -38,3 +38,34 @@ If microcheck passes, you'll see a green checkmark on your PR. If it fails, you'
 If you're a committer, add the `go` label to your PR once it's ready, then merge after the full suite passes. Clicking **Enable auto-merge** does both in one step: it adds the `go` label and merges the PR automatically once the suite passes. Pushing a new commit disables auto-merge, so re-enable it afterward. When you review an external contributor's PR, add the `go` label for them, since they can't add it themselves.
 
 If you're an external contributor, adding the `go` label and enabling auto-merge both require write access, so a committer runs the full suite and merges when your PR is ready.
+
+## Running the API consistency check locally
+
+The `doc: check API doc consistency` premerge step (the `api_policy_check` function in `ci/lint/lint.sh`) runs `ci/ray_ci/doc/cmd_check_api_discrepancy.py`, which compares each team's documented API surface against the annotated (`@PublicAPI`/`@DeveloperAPI`/`@Deprecated`) surface in the code. It imports Ray's own symbols for real, so it needs an environment where Ray installs and imports. This is the opposite of the docs *build* environment, which deliberately doesn't install Ray (see [Building the Ray documentation](docs.md)). The optional third-party backends that some surfaces pull in at import time (for example the vLLM and SGLang stack behind `ray.data.llm` and `ray.serve.llm`, or the deep-learning backends behind `ray.train`, `ray.tune`, and `ray.rllib`) don't have to be installed: the check mocks any that are absent, reading the list from `doc/source/api_mock_imports.py`, the same source of truth the docs build uses for `autodoc_mock_imports`.
+
+### The faithful environment: the docbuild image
+
+CI runs this check inside the `docbuild` image (`ci/docker/doc.build.Dockerfile`). The image builds on the prebuilt `ray-core` and `oss-ci-base_build` base images, which supply Ray and the real ML libraries the walk imports (for example `pandas`, `torch`, and `transformers`), then installs the docs dependency lock (`python/deplocks/docs/docbuild_depset_py<version>.lock`) on top. Because the real libraries come from the base images and the lock is pinned to Linux wheels, the only fully faithful local reproduction is the Linux docbuild image (via Docker) or a CI run on your branch.
+
+### A lightweight local approximation
+
+For quick iteration on the checker itself, a Python 3.11 virtual environment with a nightly Ray wheel is usually enough. Because the check mocks the absent optional backends, you generally don't need to install `pandas`, `torch`, `transformers`, and the rest by hand. Install a backend for real only when you want the check to walk that library's true surface rather than a mock.
+
+```bash
+uv venv --python 3.11 ~/.virtualenvs/ray-apiref
+# The wheel URL below is macOS arm64 / Python 3.11. Adjust it for your OS, architecture, and Python version.
+uv pip install --python ~/.virtualenvs/ray-apiref/bin/python \
+  "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl"
+# Link your checkout's Python files over the wheel so the check walks your local @PublicAPI changes, not the wheel's:
+~/.virtualenvs/ray-apiref/bin/python python/ray/setup-dev.py --yes
+
+# Run the check against your checkout (PYTHONPATH so the checker imports from your tree):
+PYTHONPATH="$(pwd)" ~/.virtualenvs/ray-apiref/bin/python \
+  ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
+```
+
+Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) or omit the argument to check all of them.
+
+```{warning}
+`setup-dev.py` links your checkout's Python packages over the wheel, so the walked `@PublicAPI` surface reflects your local changes. The rest of the wheel (compiled extensions and generated code) is still the nightly build, cut at a different commit than your checkout, so treat a clean local run as a fast iteration signal rather than a definitive result. For sign-off, rely on the CI run in the docbuild image.
+```


### PR DESCRIPTION
## Why are these changes needed?

The API doc consistency check (the `api_policy_check` function in `ci/lint/lint.sh`, which runs `ci/ray_ci/doc/cmd_check_api_discrepancy.py`) introspects the **live** `@PublicAPI` surface, so it needs an environment where Ray and the libraries it checks import for real. That's the opposite of the docs *build* environment, which deliberately doesn't install Ray, so no existing contributor doc covered how to run this check locally.

This adds a **"Running the API consistency check locally"** section to `doc/source/ray-contribute/ci.md`:

- What the premerge step actually does: install Ray `--no-deps`, generate the autosummary stubs with `doc/source/api_autogen.py`, then run the checker.
- How the mocking works, and that it mocks only the *absent* optional backends (`doc/source/api_mock_imports.py`), so it can't shadow an installed library the walk needs.
- The faithful environment (the `docbuild` image), including which libraries are real there (`pandas`) versus mocked even in CI (`torch`, `transformers`, `tensorflow`), and why the docs lock alone isn't a complete env.
- A lightweight local approximation: a `uv` venv, a nightly wheel, `setup-dev.py`, and Sphinx (which the Ray wheel doesn't bring but both the checker and the stub generator import).
- The single-team vs. full-pass difference: `core` ordering and the cross-team unwalked-subpackage guard only apply on the full run.
- Warnings about nightly-wheel vs. checkout version skew, and about `pandas` being mocked locally where CI walks it for real.

Docs-only change (single file).

## Related issue number

N/A, contributor-docs improvement.

## Checks

- [x] I've signed off every commit (DCO).
- [x] Docs-only; `doc/source/ray-contribute/ci.md`.
- [x] Verified every claim against `upstream/master` (`lint.sh`, `cmd_check_api_discrepancy.py`, `api_autogen.py`, `api_mock_imports.py`, `doc.build.Dockerfile`, `doc.rayci.yml`, and the docs deplock).

Note: `ci/lint/check-documentation-style.sh` scopes Vale to `doc/source/data` and `doc/source/ray-overview/examples`, so this file isn't Vale-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
