### PR TITLE
[Core] Drain node on SIGTERM before shutting down `ray start --block`

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -44,6 +44,7 @@ from ray._raylet import (
     get_session_key_from_storage,
     wait_for_persisted_port,
 )
+from ray.core.generated import autoscaler_pb2
 from ray.core.generated.gcs_pb2 import GcsNodeInfo
 from ray.core.generated.gcs_service_pb2 import GetAllNodeInfoRequest
 
@@ -623,11 +624,123 @@ class Node:
         # Register the handler to be called if we get a SIGTERM.
         # In this case, we want to exit with an error code (1) after
         # cleaning up child processes.
+        # `sigterm_received` guards against re-entrancy: a second SIGTERM that
+        # arrives while we are draining must not restart the drain wait.
+        sigterm_received = False
+
         def sigterm_handler(signum, frame):
+            nonlocal sigterm_received
+            if sigterm_received:
+                return
+            sigterm_received = True
+            # Mark the node as draining and give drain-aware components (e.g.
+            # Ray Serve proxies) a chance to stop accepting traffic and finish
+            # in-flight requests before we tear down local processes. Draining is
+            # best-effort: a failure here (e.g. SIGTERM arriving mid-startup,
+            # before the node is fully initialized) must never prevent local
+            # process cleanup.
+            try:
+                self._drain_node_before_shutdown()
+            except Exception:
+                logger.exception(
+                    "Error while draining node on SIGTERM; proceeding with shutdown."
+                )
             self.kill_all_processes(check_alive=False, allow_graceful=True)
             sys.exit(1)
 
         ray._private.utils.set_sigterm_handler(sigterm_handler)
+
+    def _drain_node_before_shutdown(self):
+        """Mark the local node as draining and wait before killing processes.
+
+        Invoked from the SIGTERM handler. Without this, receiving SIGTERM (e.g.
+        when `ray start --block` is PID 1 and Kubernetes deletes the pod during
+        a RayService upgrade) immediately kills the raylet and local Serve
+        replicas while old proxies are still routing to them, returning HTTP
+        500s. Marking the node as draining lets the Serve controller quiesce the
+        local proxy before its replicas disappear.
+
+        Controlled by ``RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S`` (seconds); a
+        value <= 0 disables draining and preserves immediate teardown.
+        """
+        timeout_s = ray_constants.RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S
+        if timeout_s <= 0:
+            return
+        # `_node_id` is assigned partway through Node.__init__, after the
+        # shutdown hooks are registered; if SIGTERM arrives before then there is
+        # nothing to drain (and the attribute may not exist yet).
+        if not getattr(self, "_node_id", None):
+            return
+        # The raylet is started later in Node.__init__ (after the shutdown hooks
+        # and the node id). If SIGTERM arrives before it exists there is no local
+        # node to drain, and nothing whose exit we could poll for -- so skip
+        # rather than sleep out the whole timeout.
+        if ray_constants.PROCESS_TYPE_RAYLET not in getattr(self, "all_processes", {}):
+            return
+
+        # One budget for the whole drain phase (GCS drain RPC + the poll below):
+        # compute the deadline up front so a slow RPC eats into the poll window
+        # instead of adding to it -- the total wait cannot exceed timeout_s.
+        deadline = time.monotonic() + timeout_s
+        logger.info(
+            "Node %s received SIGTERM. Draining for up to %s seconds before "
+            "shutting down local processes.",
+            self._node_id,
+            timeout_s,
+        )
+        try:
+            deadline_timestamp_ms = int(time.time() * 1000) + int(timeout_s * 1000)
+            # NOTE: drain_node expects the node id as a hex string (it decodes
+            # via FromHex); passing binary yields a nil id that the GCS silently
+            # accepts without ever draining the raylet.
+            is_accepted, rejection_message = self.get_gcs_client().drain_node(
+                self._node_id,
+                autoscaler_pb2.DrainNodeReason.DRAIN_NODE_REASON_PREEMPTION,
+                "Node received SIGTERM; draining before shutdown.",
+                deadline_timestamp_ms,
+                # Bound the RPC so a hung or unreachable GCS can't block the
+                # SIGTERM handler indefinitely and delay teardown; draining is
+                # best-effort and must never prevent shutdown.
+                timeout=timeout_s,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to mark the local node as draining on SIGTERM; "
+                "proceeding with immediate shutdown."
+            )
+            return
+
+        if not is_accepted:
+            # PREEMPTION drains are non-rejectable, so this is unexpected, but
+            # don't block shutdown on it.
+            logger.warning(
+                "Drain request for the local node was rejected (%s); "
+                "proceeding with immediate shutdown.",
+                rejection_message,
+            )
+            return
+
+        # Wait for the node to finish draining, using the timeout only as an
+        # upper bound. Once the node is draining AND idle -- all worker leases
+        # returned, i.e. Serve has quiesced the local proxy and migrated its
+        # replicas -- the raylet self-terminates, so we poll for the raylet
+        # process exiting. Whoever sent SIGTERM (e.g. Kubernetes) will SIGKILL
+        # us if we exceed the pod's termination grace period.
+        poll_interval_s = ray_constants.RAY_GRACEFUL_SHUTDOWN_POLL_INTERVAL_S
+        while time.monotonic() < deadline:
+            if any(
+                process_type == ray_constants.PROCESS_TYPE_RAYLET
+                for process_type, _ in self.dead_processes()
+            ):
+                logger.info("Local node finished draining; shutting down.")
+                return
+            time.sleep(min(poll_interval_s, max(0.0, deadline - time.monotonic())))
+        logger.warning(
+            "Node %s did not finish draining within %s seconds; aborting and "
+            "shutting down local processes ungracefully.",
+            self._node_id,
+            timeout_s,
+        )
 
     def _init_temp(self, node_to_connect_info: Optional[GcsNodeInfo]):
         # Create a dictionary to store temp file index.

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -29,6 +29,27 @@ RAY_LOG_TO_DRIVER = env_bool("RAY_LOG_TO_DRIVER", True)
 # Filter level under which events will be filtered out, i.e. not printing to driver
 RAY_LOG_TO_DRIVER_EVENT_LEVEL = os.environ.get("RAY_LOG_TO_DRIVER_EVENT_LEVEL", "INFO")
 
+# When `ray start --block` (which becomes PID 1 in a container) receives
+# SIGTERM, the number of seconds to mark the local node as draining and wait
+# before tearing down local processes. This gives drain-aware components (e.g.
+# Ray Serve proxies) time to stop accepting new traffic and finish in-flight
+# requests before the raylet and replicas are killed, avoiding HTTP 500s during
+# RayService upgrades (https://github.com/ray-project/ray/issues/64181).
+# Defaults to 30s; cluster managers (e.g. KubeRay) tune it, typically to just
+# under the pod termination grace period. 0 disables draining (immediate teardown).
+RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S = env_float(
+    "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S", 30.0
+)
+
+# How often (seconds) the SIGTERM drain wait polls for the node having finished
+# draining (the raylet self-terminating once it is draining AND idle) before
+# falling back to RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S as an upper bound. Floored
+# at a small positive value so a misconfigured 0 (or negative) can never turn the
+# wait into a 100% busy-wait.
+RAY_GRACEFUL_SHUTDOWN_POLL_INTERVAL_S = max(
+    env_float("RAY_GRACEFUL_SHUTDOWN_POLL_INTERVAL_S", 0.5), 0.001
+)
+
 # Internal kv keys for storing monitor debug status.
 DEBUG_AUTOSCALING_ERROR = "__autoscaling_error"
 DEBUG_AUTOSCALING_STATUS = "__autoscaling_status"

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -638,7 +638,8 @@ cdef class InnerGcsClient:
             node_id: c_string,
             reason: int32_t,
             reason_message: c_string,
-            deadline_timestamp_ms: int64_t):
+            deadline_timestamp_ms: int64_t,
+            timeout: Optional[int | float] = None):
         """Send a DrainNode request to GCS to gracefully terminate a node.
 
         Used by the `ray drain-node` CLI command and by autoscaler v2's
@@ -654,6 +655,10 @@ cdef class InnerGcsClient:
             deadline_timestamp_ms: Timestamp (ms) when the node will be
                 force-killed. Used as a hint so workloads can drain
                 before the deadline.
+            timeout: Optional RPC timeout in seconds. ``None`` (the default)
+                uses an unlimited gRPC deadline; latency-sensitive callers
+                (e.g. draining on SIGTERM before shutdown) should bound this
+                so a hung or unreachable GCS cannot block indefinitely.
 
         Returns:
             Tuple of (is_accepted, rejection_reason_message). When
@@ -661,7 +666,7 @@ cdef class InnerGcsClient:
             why the raylet rejected the request.
         """
         cdef:
-            int64_t timeout_ms = -1
+            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             c_bool is_accepted = False
             c_string rejection_reason_message
         with nogil:

--- a/python/ray/tests/test_draining.py
+++ b/python/ray/tests/test_draining.py
@@ -1,10 +1,13 @@
+import signal
 import sys
 import time
 from collections import Counter
+from unittest import mock
 
 import pytest
 
 import ray
+import ray._private.node as ray_node
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray._raylet import GcsClient
 from ray.core.generated import autoscaler_pb2, common_pb2
@@ -680,6 +683,237 @@ def test_leases_rescheduling_during_draining(ray_start_cluster):
     # The task should be rescheduled on another node.
     worker2 = cluster.add_node(num_cpus=1)
     assert ray.get(obj_ref) == worker2.node_id
+
+
+class _FakeNode:
+    """Minimal stand-in for Node to exercise _drain_node_before_shutdown."""
+
+    def __init__(self, node_id, gcs_client, dead_processes):
+        self._node_id = node_id
+        self._gcs_client = gcs_client
+        self.dead_processes = dead_processes
+        self.all_processes = {ray_node.ray_constants.PROCESS_TYPE_RAYLET: [object()]}
+
+    def get_gcs_client(self):
+        return self._gcs_client
+
+
+def _run_drain(
+    monkeypatch,
+    *,
+    timeout_s,
+    node_id,
+    drain_return=(True, ""),
+    drain_side_effect=None,
+    raylet_dead_after_polls=None,
+    poll_interval=0.5,
+):
+    """Invoke Node._drain_node_before_shutdown against a fake clock + raylet.
+
+    Returns (gcs_client_mock, sleep_durations, poll_count). A fake monotonic
+    clock advances only when the code sleeps, so waits are deterministic.
+    ``raylet_dead_after_polls=k`` makes dead_processes() report the raylet gone
+    (self-terminated after draining) on its k-th call.
+    """
+    monkeypatch.setattr(
+        ray_node.ray_constants, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S", timeout_s
+    )
+    monkeypatch.setattr(
+        ray_node.ray_constants, "RAY_GRACEFUL_SHUTDOWN_POLL_INTERVAL_S", poll_interval
+    )
+
+    clock = {"t": 1000.0}
+    sleeps = []
+
+    def fake_sleep(s):
+        sleeps.append(s)
+        clock["t"] += s
+
+    monkeypatch.setattr(ray_node.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(ray_node.time, "sleep", fake_sleep)
+
+    gcs = mock.MagicMock()
+    if drain_side_effect is not None:
+        gcs.drain_node.side_effect = drain_side_effect
+    else:
+        gcs.drain_node.return_value = drain_return
+
+    polls = {"n": 0}
+
+    def dead_processes():
+        polls["n"] += 1
+        if (
+            raylet_dead_after_polls is not None
+            and polls["n"] >= raylet_dead_after_polls
+        ):
+            return [(ray_node.ray_constants.PROCESS_TYPE_RAYLET, object())]
+        return []
+
+    fake = _FakeNode(node_id, gcs, dead_processes)
+    ray_node.Node._drain_node_before_shutdown(fake)
+    return gcs, sleeps, polls["n"]
+
+
+def test_drain_marks_node_draining_then_polls(monkeypatch):
+    node_id = ray.NodeID.from_random().hex()
+    before_ms = int(time.time() * 1000)
+    gcs, sleeps, polls = _run_drain(
+        monkeypatch, timeout_s=5.0, node_id=node_id, raylet_dead_after_polls=None
+    )
+    after_ms = int(time.time() * 1000)
+
+    gcs.drain_node.assert_called_once()
+    args = gcs.drain_node.call_args.args
+    # drain_node takes the *hex* node id (it decodes via FromHex); passing binary
+    # yields a nil id that the GCS silently accepts without draining the raylet.
+    assert args[0] == node_id
+    assert args[1] == autoscaler_pb2.DrainNodeReason.DRAIN_NODE_REASON_PREEMPTION
+    assert before_ms + 5000 <= args[3] <= after_ms + 5000
+    # The drain RPC must be bounded so a hung/unreachable GCS can't block the
+    # SIGTERM handler and delay teardown.
+    assert gcs.drain_node.call_args.kwargs["timeout"] == 5.0
+    # Raylet never exits -> we poll and wait up to (not beyond) the cap.
+    assert polls > 1
+    assert sum(sleeps) == pytest.approx(5.0)
+
+
+def test_drain_exits_early_when_raylet_self_terminates(monkeypatch):
+    node_id = ray.NodeID.from_random().hex()
+    gcs, sleeps, polls = _run_drain(
+        monkeypatch, timeout_s=30.0, node_id=node_id, raylet_dead_after_polls=3
+    )
+    gcs.drain_node.assert_called_once()
+    # Raylet self-terminates (draining+idle) by the 3rd poll -> stop, not 30s.
+    assert polls == 3
+    assert sum(sleeps) == pytest.approx(1.0)
+    assert sum(sleeps) < 30.0
+
+
+def test_drain_disabled_when_timeout_non_positive(monkeypatch):
+    node_id = ray.NodeID.from_random().hex()
+    gcs, sleeps, polls = _run_drain(monkeypatch, timeout_s=0.0, node_id=node_id)
+    gcs.drain_node.assert_not_called()
+    assert sleeps == []
+    assert polls == 0
+
+
+def test_drain_failure_does_not_block_shutdown(monkeypatch):
+    node_id = ray.NodeID.from_random().hex()
+    gcs, sleeps, polls = _run_drain(
+        monkeypatch,
+        timeout_s=5.0,
+        node_id=node_id,
+        drain_side_effect=RuntimeError("gcs unreachable"),
+    )
+    gcs.drain_node.assert_called_once()
+    assert sleeps == []
+    assert polls == 0
+
+
+def test_drain_rejected_skips_wait(monkeypatch):
+    node_id = ray.NodeID.from_random().hex()
+    gcs, sleeps, polls = _run_drain(
+        monkeypatch, timeout_s=5.0, node_id=node_id, drain_return=(False, "rejected")
+    )
+    gcs.drain_node.assert_called_once()
+    assert sleeps == []
+    assert polls == 0
+
+
+def test_sigterm_handler_drains_then_kills(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "ray._private.utils.set_sigterm_handler",
+        lambda handler: captured.__setitem__("handler", handler),
+    )
+    monkeypatch.setattr(ray_node.atexit, "register", lambda *a, **k: None)
+
+    calls = []
+    fake = mock.MagicMock()
+    fake._drain_node_before_shutdown.side_effect = lambda: calls.append("drain")
+    fake.kill_all_processes.side_effect = lambda **kw: calls.append("kill")
+
+    ray_node.Node._register_shutdown_hooks(fake)
+    handler = captured["handler"]
+
+    with pytest.raises(SystemExit):
+        handler(signal.SIGTERM, None)
+    assert calls == ["drain", "kill"]
+    fake.kill_all_processes.assert_called_once_with(
+        check_alive=False, allow_graceful=True
+    )
+
+    calls.clear()
+    handler(signal.SIGTERM, None)
+    assert calls == []
+
+
+def test_drain_skipped_when_node_id_unset(monkeypatch):
+    # SIGTERM can arrive mid-Node.__init__, before _node_id is assigned (the
+    # shutdown hooks are registered first). The drain must be skipped rather
+    # than raise AttributeError, so teardown can still proceed.
+    monkeypatch.setattr(
+        ray_node.ray_constants, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S", 30.0
+    )
+    gcs = mock.MagicMock()
+
+    class _NodeWithoutId:
+        def get_gcs_client(self):
+            return gcs
+
+        def dead_processes(self):
+            return []
+
+    # Returns without raising and without attempting a drain.
+    ray_node.Node._drain_node_before_shutdown(_NodeWithoutId())
+    gcs.drain_node.assert_not_called()
+
+
+def test_sigterm_handler_shuts_down_even_if_drain_raises(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "ray._private.utils.set_sigterm_handler",
+        lambda handler: captured.__setitem__("handler", handler),
+    )
+    monkeypatch.setattr(ray_node.atexit, "register", lambda *a, **k: None)
+
+    fake = mock.MagicMock()
+    fake._drain_node_before_shutdown.side_effect = RuntimeError("boom")
+
+    ray_node.Node._register_shutdown_hooks(fake)
+    with pytest.raises(SystemExit):
+        captured["handler"](signal.SIGTERM, None)
+    # Drain raised, but local processes were still torn down.
+    fake.kill_all_processes.assert_called_once_with(
+        check_alive=False, allow_graceful=True
+    )
+
+
+def test_drain_skipped_when_no_local_raylet(monkeypatch):
+    # SIGTERM can arrive during Node.__init__ after _node_id is set but before
+    # the raylet is started. With no local raylet there is nothing to drain and
+    # nothing whose exit to poll for, so the handler must return immediately
+    # rather than sleep out the whole timeout.
+    monkeypatch.setattr(
+        ray_node.ray_constants, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S", 30.0
+    )
+    slept = []
+    monkeypatch.setattr(ray_node.time, "sleep", lambda s: slept.append(s))
+    gcs = mock.MagicMock()
+
+    class _NodeNoRaylet:
+        _node_id = ray.NodeID.from_random().hex()
+        all_processes = {}  # raylet not started yet
+
+        def get_gcs_client(self):
+            return gcs
+
+        def dead_processes(self):
+            return []
+
+    ray_node.Node._drain_node_before_shutdown(_NodeNoRaylet())
+    gcs.drain_node.assert_not_called()
+    assert slept == []
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -144,7 +144,10 @@ def test_calling_start_ray_head(call_ray_stop_only):
     del os.environ["RAY_REDIS_ADDRESS"]
 
     # Test --block. Killing a child process should cause the command to exit.
-    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", "0"])
+    blocked = subprocess.Popen(
+        ["ray", "start", "--head", "--block", "--port", "0"],
+        env={**os.environ, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S": "0"},
+    )
 
     blocked.poll()
     assert blocked.returncode is None
@@ -182,7 +185,10 @@ for i in range(0, 5):
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
 
     # Test --block. Killing the command should clean up all child processes.
-    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", "0"])
+    blocked = subprocess.Popen(
+        ["ray", "start", "--head", "--block", "--port", "0"],
+        env={**os.environ, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S": "0"},
+    )
     blocked.poll()
     assert blocked.returncode is None
 
@@ -199,6 +205,54 @@ for i in range(0, 5):
     wait_for_children_of_pid_to_exit(blocked.pid, timeout=30)
     blocked.wait()
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
+
+
+def test_graceful_shutdown_drains_node_on_sigterm(
+    call_ray_stop_only, monkeypatch, tmp_path
+):
+    # Opt-in graceful drain on SIGTERM (#64181): with
+    # RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S set, SIGTERM to a `ray start --block`
+    # node marks the node draining and waits for it to finish before tearing
+    # down, instead of killing the raylet within ~1s. We assert on the drain log
+    # markers, which only appear when the option is enabled.
+    import signal
+    import time
+
+    monkeypatch.setenv("RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S", "8")
+    monkeypatch.setenv("RAY_GRACEFUL_SHUTDOWN_POLL_INTERVAL_S", "0.5")
+
+    log_path = tmp_path / "ray_start.log"
+    with open(log_path, "w") as out:
+        blocked = subprocess.Popen(
+            ["ray", "start", "--head", "--block", "--include-dashboard", "false"],
+            stdout=out,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            # Wait for the runtime to come up.
+            deadline = time.time() + 30
+            while time.time() < deadline and blocked.poll() is None:
+                if "Ray runtime started" in log_path.read_text():
+                    break
+                time.sleep(0.5)
+            assert "Ray runtime started" in log_path.read_text(), log_path.read_text()
+
+            # SIGTERM the supervisor, as Kubernetes would to PID 1.
+            blocked.send_signal(signal.SIGTERM)
+            blocked.wait(timeout=30)
+
+            # The node drained before teardown (these markers are absent when the
+            # option is off, which tears the raylet down within ~1s).
+            log = log_path.read_text()
+            assert "received SIGTERM. Draining for up to 8" in log, log[-2000:]
+            assert (
+                "Local node finished draining" in log
+                or "did not finish draining within" in log
+            ), log[-2000:]
+        finally:
+            if blocked.poll() is None:
+                blocked.kill()
+                blocked.wait()
 
 
 def test_ray_start_non_head(call_ray_stop_only, monkeypatch):

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -96,6 +96,7 @@ def test_ray_init_existing_instance_via_blocked_ray_start():
     """Run a blocked ray start command and check that ray.init() connects to it."""
     blocked_start_cmd = subprocess.Popen(
         ["ray", "start", "--head", "--block", "--num-cpus", "1999"],
+        env={**os.environ, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S": "0"},
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -260,7 +260,9 @@ def test_non_default_ports_visible_on_init(shutdown_only):
         cmd += ["--" + port_name, str(port)]
 
     print(" ".join(cmd))
-    proc = subprocess.Popen(cmd)
+    proc = subprocess.Popen(
+        cmd, env={**os.environ, "RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S": "0"}
+    )
 
     # From the connected node
     def verify():


### PR DESCRIPTION
## Why are these changes needed?

Fixes a regression between Ray 2.32 and 2.33 that causes bursts of HTTP 500s
during RayService zero-downtime upgrades.

### Root cause

KubeRay launches the container as `bash -c "...; ray start ... --block"`.

- **2.32:** bash stays PID 1. A non-interactive bash does not forward SIGTERM,
  and the kernel suppresses PID-1 default signal actions, so the SIGTERM that
  Kubernetes sends on pod deletion is effectively swallowed. Ray keeps running
  until the grace-period SIGKILL, and traffic drains off the node naturally.
- **2.33+:** bash's last-command `exec` optimization replaces the shell, making
  `ray start` (Python) PID 1. SIGTERM now reaches `ray start`'s handler, which
  calls `kill_all_processes` → SIGTERMs the raylet with a 1s grace before
  SIGKILL. Local Serve replicas are torn down immediately while old proxies
  still route to them → HTTP 500s.

### Fix

Add an **opt-in** graceful drain on SIGTERM for `ray start --block`, gated by
`RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S` (seconds; **default `0` = disabled,
shutdown behavior unchanged**). KubeRay sets it on RayService nodes.

When enabled, before `kill_all_processes` the SIGTERM handler:

1. Marks the local node draining in the GCS via `drain_node` (reason
   `PREEMPTION`, with a deadline). This reuses the exact mechanism autoscaler v2
   already uses to terminate nodes — no new raylet- or GCS-side behavior.
2. Drain-aware components (Ray Serve) observe the draining node and quiesce the
   local proxy + migrate replicas. As leases are returned the node becomes
   draining **and** idle, at which point the raylet self-terminates.
3. Polls for the raylet process to exit (`dead_processes()`), capped by the
   timeout, then proceeds with teardown.

### Safety / correctness

- **Best-effort, never blocks shutdown:** the drain is wrapped in `try/except`,
  and the `drain_node` RPC is given a bounded timeout so a hung or unreachable
  GCS cannot stall the handler. It is skipped entirely when there is no local
  node id yet or no raylet in `all_processes` (SIGTERM can arrive mid
  `Node.__init__`, before the id is set or the raylet is started).
- **Hex node id:** `drain_node` is passed the node id as a hex string — it
  decodes via `FromHex`; a binary id yields a nil id that the GCS silently
  accepts as an "unknown node" without actually draining.
- **Scope:** only `ray start --block` is affected. `ray.init()` uses
  `shutdown_at_exit=False` (the handler is never installed) and `ray stop`
  kills the raylet directly.
- **Double-bounded:** worst case is the drain timeout, itself bounded by the
  pod's termination grace period (Kubernetes SIGKILLs at the deadline anyway).

### Testing

- `test_draining.py`: mock-based unit tests (fake clock) — marks draining then
  polls to the cap, early-exits when the raylet self-terminates, disabled when
  timeout ≤ 0, drain failure/rejection do not block shutdown, the RPC is
  bounded, and the no-node-id / no-raylet guards are covered.
- `test_multi_node_3.py::test_graceful_shutdown_drains_node_on_sigterm`:
  integration test of the drain-enabled path (`ray start --head --block`,
  SIGTERM, assert the drain and finished-draining log lines).
- The fast-teardown tests that SIGTERM a `ray start --block` supervisor
  (`test_calling_start_ray_head`, `test_ray_init`, `test_ray_init_2`) pin
  `RAY_GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S=0` to keep asserting immediate teardown.

## Related issue number

Fixes #64181