### PR TITLE
[ci] add pip-freeze artifact naming to RayImagePushContext

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -382,6 +382,7 @@ py_binary(
     srcs = ["push_ray_image.py"],
     exec_compatible_with = ["//bazel:py3"],
     deps = [
+        ":crane_lib",
         ":image_tags_lib",
         "//ci/ray_ci:ray_ci_lib",
         "//release:ray_release",

--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -400,6 +400,7 @@ py_test(
         "team:ci",
     ],
     deps = [
+        ":crane_lib",
         ":push_ray_image",
         ci_require("pytest"),
     ],

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -367,6 +367,15 @@ def main(
         if not _image_exists(src_ref):
             raise PushRayImageError(f"Source image not found in Wanda cache: {src_ref}")
 
+        # Re-emit the per-image pip freeze as a Buildkite artifact (cpu only).
+        # Downstream consumer: anyscale/product
+        # devprod/rayrelease/releaser.py:update_doc_with_latest_docker_dependencies.
+        # Runs regardless of dry_run: the shipped-deps record is independent of
+        # whether we push to Docker Hub, and PR builds (dry_run) are how we
+        # verify this artifact on CI.
+        if plat == "cpu":
+            _export_pip_freeze(src_ref, ctx)
+
         destination_tags = ctx.destination_tags()
         for tag in destination_tags:
             dest_ref = f"{ctx.docker_hub_repo}:{tag}"

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -1,10 +1,14 @@
 import logging
+import os
+import shutil
 import sys
+import tempfile
 from datetime import datetime
 from typing import List
 
 import click
 
+from ci.ray_ci.automation.crane_lib import call_crane_export
 from ci.ray_ci.automation.image_tags_lib import (
     ImageTagsError,
     copy_image,
@@ -34,6 +38,14 @@ logging.basicConfig(
     stream=sys.stdout,
 )
 logger = logging.getLogger(__name__)
+
+# rayci auto-uploads everything under /artifact-mount as Buildkite artifacts.
+# Mirrors the old ci/build/build-ray-docker.sh staging location so the artifact
+# filename/layout is unchanged for downstream consumers.
+ARTIFACT_MOUNT_IMAGE_INFO_DIR = "/artifact-mount/.image-info"
+# Path of the pip freeze inside the image filesystem (no leading slash in the
+# crane-exported tar). Written by ci/docker/ray-image.Dockerfile.
+PIP_FREEZE_PATH_IN_IMAGE = os.path.join("home", "ray", "pip-freeze.txt")
 
 
 class PushRayImageError(Exception):
@@ -201,6 +213,43 @@ def _copy_image(reference: str, destination: str, dry_run: bool = False) -> None
         copy_image(reference, destination, dry_run)
     except ImageTagsError as e:
         raise PushRayImageError(str(e))
+
+
+def _export_pip_freeze(src_ref: str, ctx: RayImagePushContext) -> str:
+    """
+    Export the image's pip-freeze.txt and stage it as a Buildkite artifact.
+
+    Uses `crane export` (no docker daemon) to pull the image filesystem, reads
+    PIP_FREEZE_PATH_IN_IMAGE out of it, and copies it under
+    ARTIFACT_MOUNT_IMAGE_INFO_DIR using ctx.pip_freeze_artifact_filename().
+
+    Runs independently of whether images are pushed (dry_run), so the shipped
+    dependencies record is produced even on PR/dry-run builds -- mirroring the
+    old ci/build/build-ray-docker.sh behavior.
+
+    Returns the staged file path.
+
+    Raises:
+        PushRayImageError: if the image has no pip-freeze.txt.
+    """
+    with tempfile.TemporaryDirectory() as export_dir:
+        logger.info(f"Exporting pip freeze from {src_ref}")
+        call_crane_export(src_ref, export_dir)
+
+        freeze_src = os.path.join(export_dir, PIP_FREEZE_PATH_IN_IMAGE)
+        if not os.path.exists(freeze_src):
+            raise PushRayImageError(
+                f"pip-freeze.txt not found in image {src_ref} "
+                f"at /{PIP_FREEZE_PATH_IN_IMAGE}"
+            )
+
+        os.makedirs(ARTIFACT_MOUNT_IMAGE_INFO_DIR, exist_ok=True)
+        dest = os.path.join(
+            ARTIFACT_MOUNT_IMAGE_INFO_DIR, ctx.pip_freeze_artifact_filename()
+        )
+        shutil.copyfile(freeze_src, dest)
+        logger.info(f"Staged pip freeze Buildkite artifact at {dest}")
+        return dest
 
 
 def _should_upload(pipeline_id: str, branch: str, rayci_schedule: str) -> bool:

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -371,10 +371,21 @@ def main(
         # Downstream consumer: anyscale/product
         # devprod/rayrelease/releaser.py:update_doc_with_latest_docker_dependencies.
         # Runs regardless of dry_run: the shipped-deps record is independent of
-        # whether we push to Docker Hub, and PR builds (dry_run) are how we
-        # verify this artifact on CI.
+        # whether we push to Docker Hub.
+        #
+        # Best-effort by design: this publish step is skip-on-premerge, so the
+        # path only ever runs in postmerge and cannot be validated pre-merge.
+        # A failure here must never break image publishing (the critical path),
+        # so swallow and log any error rather than propagating it.
         if plat == "cpu":
-            _export_pip_freeze(src_ref, ctx)
+            try:
+                _export_pip_freeze(src_ref, ctx)
+            except Exception as e:
+                logger.error(
+                    f"Failed to stage pip-freeze artifact for {src_ref}; "
+                    f"continuing without it: {e}",
+                    exc_info=True,
+                )
 
         destination_tags = ctx.destination_tags()
         for tag in destination_tags:

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -8,7 +8,7 @@ from typing import List
 
 import click
 
-from ci.ray_ci.automation.crane_lib import call_crane_export
+from ci.ray_ci.automation.crane_lib import CraneError, call_crane_export
 from ci.ray_ci.automation.image_tags_lib import (
     ImageTagsError,
     copy_image,
@@ -230,26 +230,33 @@ def _export_pip_freeze(src_ref: str, ctx: RayImagePushContext) -> str:
     Returns the staged file path.
 
     Raises:
-        PushRayImageError: if the image has no pip-freeze.txt.
+        PushRayImageError: if the image has no pip-freeze.txt, or if the crane
+            export / filesystem staging fails (CraneError / OSError are wrapped,
+            mirroring _copy_image's handling of ImageTagsError).
     """
-    with tempfile.TemporaryDirectory() as export_dir:
-        logger.info(f"Exporting pip freeze from {src_ref}")
-        call_crane_export(src_ref, export_dir)
+    try:
+        with tempfile.TemporaryDirectory() as export_dir:
+            logger.info(f"Exporting pip freeze from {src_ref}")
+            call_crane_export(src_ref, export_dir)
 
-        freeze_src = os.path.join(export_dir, PIP_FREEZE_PATH_IN_IMAGE)
-        if not os.path.exists(freeze_src):
-            raise PushRayImageError(
-                f"pip-freeze.txt not found in image {src_ref} "
-                f"at /{PIP_FREEZE_PATH_IN_IMAGE}"
+            freeze_src = os.path.join(export_dir, PIP_FREEZE_PATH_IN_IMAGE)
+            if not os.path.exists(freeze_src):
+                raise PushRayImageError(
+                    f"pip-freeze.txt not found in image {src_ref} "
+                    f"at /{PIP_FREEZE_PATH_IN_IMAGE}"
+                )
+
+            os.makedirs(ARTIFACT_MOUNT_IMAGE_INFO_DIR, exist_ok=True)
+            dest = os.path.join(
+                ARTIFACT_MOUNT_IMAGE_INFO_DIR, ctx.pip_freeze_artifact_filename()
             )
-
-        os.makedirs(ARTIFACT_MOUNT_IMAGE_INFO_DIR, exist_ok=True)
-        dest = os.path.join(
-            ARTIFACT_MOUNT_IMAGE_INFO_DIR, ctx.pip_freeze_artifact_filename()
-        )
-        shutil.copyfile(freeze_src, dest)
-        logger.info(f"Staged pip freeze Buildkite artifact at {dest}")
-        return dest
+            shutil.copyfile(freeze_src, dest)
+            logger.info(f"Staged pip freeze Buildkite artifact at {dest}")
+            return dest
+    except (CraneError, OSError) as e:
+        raise PushRayImageError(
+            f"Failed to export pip-freeze from {src_ref}: {e}"
+        ) from e
 
 
 def _should_upload(pipeline_id: str, branch: str, rayci_schedule: str) -> bool:

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -161,6 +161,34 @@ class RayImagePushContext:
         """Get platform suffixes (includes aliases like -gpu for GPU_PLATFORM)."""
         return get_platform_suffixes(self.platform, self.ray_type.value)
 
+    def pip_freeze_canonical_tag(self) -> str:
+        """
+        Canonical image tag used to name the pip-freeze Buildkite artifact.
+
+        Mirrors the old RayDockerContainer._get_image_tags(external=False)[0]
+        contract: the *internal* version tag (bare "<sha6>" on master/PR/other,
+        "<release_name>.<sha6>" on releases/* branches) -- NOT the external
+        "nightly.*" tag. Format: "<version><variation>-py<NN>-cpu<arch_suffix>".
+
+        This is the source-of-truth filename consumed by the anyscale/product
+        repo at devprod/rayrelease/releaser.py:
+        update_doc_with_latest_docker_dependencies. Keep the two in sync.
+        """
+        sha = self.commit[:6]
+        if self.branch and self.branch.startswith("releases/"):
+            version = f"{self.branch[len('releases/'):]}.{sha}"
+        else:
+            version = sha
+        py_tag = f"-py{self.python_version.replace('.', '')}"
+        return f"{version}{self._variation_suffix()}{py_tag}-cpu{self.arch_suffix}"
+
+    def pip_freeze_artifact_filename(self) -> str:
+        """Buildkite artifact basename: "<image_type>:<canonical_tag>_pip-freeze.txt"."""
+        return (
+            f"{self.ray_image.image_type}:"
+            f"{self.pip_freeze_canonical_tag()}_pip-freeze.txt"
+        )
+
 
 def _image_exists(tag: str) -> bool:
     """Check if a container image manifest exists using crane."""

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -643,6 +643,61 @@ class TestPipFreezeArtifact:
             == "ray-extra:2.56.0.d7951f-extra-py311-cpu-aarch64_pip-freeze.txt"
         )
 
+    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_export")
+    def test_export_pip_freeze_writes_artifact(self, mock_export, tmp_path):
+        import os
+
+        from ci.ray_ci.automation.push_ray_image import _export_pip_freeze
+
+        # Simulate crane export laying down the image filesystem.
+        def fake_export(src_ref, export_dir):
+            freeze = os.path.join(export_dir, "home", "ray", "pip-freeze.txt")
+            os.makedirs(os.path.dirname(freeze), exist_ok=True)
+            with open(freeze, "w") as f:
+                f.write("ray==2.56.0\nnumpy==1.26.4\n")
+
+        mock_export.side_effect = fake_export
+
+        artifact_dir = tmp_path / "image-info"
+        with mock.patch(
+            "ci.ray_ci.automation.push_ray_image.ARTIFACT_MOUNT_IMAGE_INFO_DIR",
+            str(artifact_dir),
+        ):
+            ctx = make_ctx(
+                ray_type=RayType.RAY,
+                python_version="3.10",
+                platform="cpu",
+                architecture=DEFAULT_ARCHITECTURE,
+                branch="releases/2.56.0",
+                commit="d7951f63abcd",
+            )
+            dest = _export_pip_freeze("work-repo:build123-ray-py3.10-cpu", ctx)
+
+        expected = artifact_dir / "ray:2.56.0.d7951f-py310-cpu_pip-freeze.txt"
+        assert dest == str(expected)
+        assert expected.read_text() == "ray==2.56.0\nnumpy==1.26.4\n"
+        mock_export.assert_called_once_with(
+            "work-repo:build123-ray-py3.10-cpu", mock.ANY
+        )
+
+    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_export")
+    def test_export_pip_freeze_missing_file_raises(self, mock_export, tmp_path):
+        from ci.ray_ci.automation.push_ray_image import (
+            PushRayImageError,
+            _export_pip_freeze,
+        )
+
+        # crane export "succeeds" but produces no pip-freeze.txt.
+        mock_export.side_effect = lambda src_ref, export_dir: None
+
+        with mock.patch(
+            "ci.ray_ci.automation.push_ray_image.ARTIFACT_MOUNT_IMAGE_INFO_DIR",
+            str(tmp_path / "image-info"),
+        ):
+            ctx = make_ctx(platform="cpu", branch="releases/2.56.0")
+            with pytest.raises(PushRayImageError, match="pip-freeze.txt not found"):
+                _export_pip_freeze("work-repo:tag", ctx)
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-vv", __file__]))

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -877,6 +877,64 @@ class TestPipFreezeArtifact:
         # ...but the pip-freeze artifact was still exported.
         assert mock_export.call_count == 1
 
+    @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
+    def test_main_export_failure_does_not_break_pipeline(
+        self,
+        mock_config,
+        mock_exists,
+        mock_copy,
+        mock_ecr_login,
+        mock_ci_init,
+        mock_export,
+    ):
+        # A failure while staging the pip-freeze artifact must NOT fail the
+        # publish step -- image pushes are the critical path, and this code
+        # path cannot be validated until it runs in postmerge.
+        from click.testing import CliRunner
+
+        from ci.ray_ci.automation.push_ray_image import main
+
+        pipeline_id = "test-postmerge-pipeline-id"
+        work_repo = "123456789.dkr.ecr.us-west-2.amazonaws.com/rayci-work"
+        mock_config.return_value = {"ci_pipeline_postmerge": [pipeline_id]}
+        mock_exists.return_value = True
+        mock_export.side_effect = RuntimeError("crane export blew up")
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "--python-version",
+                "3.10",
+                "--platform",
+                "cpu",
+                "--image-type",
+                "ray",
+                "--architecture",
+                "x86_64",
+                "--rayci-work-repo",
+                work_repo,
+                "--rayci-build-id",
+                "build123",
+                "--pipeline-id",
+                pipeline_id,
+                "--branch",
+                "releases/2.56.0",
+                "--commit",
+                "d7951f63abcd",
+            ],
+        )
+
+        # The export raised, but the publish step still succeeded...
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert mock_export.call_count == 1
+        # ...and image copying still happened.
+        mock_copy.assert_called()
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-vv", __file__]))

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -712,6 +712,26 @@ class TestPipFreezeArtifact:
             with pytest.raises(PushRayImageError, match="pip-freeze.txt not found"):
                 _export_pip_freeze("work-repo:tag", ctx)
 
+    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_export")
+    def test_export_pip_freeze_wraps_crane_error(self, mock_export, tmp_path):
+        from ci.ray_ci.automation.crane_lib import CraneError
+        from ci.ray_ci.automation.push_ray_image import (
+            PushRayImageError,
+            _export_pip_freeze,
+        )
+
+        # crane export itself fails -> wrapped as PushRayImageError (mirrors how
+        # _copy_image wraps ImageTagsError), not propagated as a raw CraneError.
+        mock_export.side_effect = CraneError("crane export failed (rc=1)")
+
+        with mock.patch(
+            "ci.ray_ci.automation.push_ray_image.ARTIFACT_MOUNT_IMAGE_INFO_DIR",
+            str(tmp_path / "image-info"),
+        ):
+            ctx = make_ctx(platform="cpu", branch="releases/2.56.0")
+            with pytest.raises(PushRayImageError, match="Failed to export pip-freeze"):
+                _export_pip_freeze("work-repo:tag", ctx)
+
     @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
     @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
     @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -581,5 +581,68 @@ class TestMultiplePlatforms:
         assert "Source image not found" in str(result.exception)
 
 
+class TestPipFreezeArtifact:
+    """Tests for pip-freeze canonical tag + Buildkite artifact filename."""
+
+    def test_release_branch_cpu_default_python(self):
+        ctx = make_ctx(
+            ray_type=RayType.RAY,
+            python_version="3.10",
+            platform="cpu",
+            architecture=DEFAULT_ARCHITECTURE,
+            branch="releases/2.56.0",
+            commit="d7951f63abcd",
+        )
+        assert ctx.pip_freeze_canonical_tag() == "2.56.0.d7951f-py310-cpu"
+        assert (
+            ctx.pip_freeze_artifact_filename()
+            == "ray:2.56.0.d7951f-py310-cpu_pip-freeze.txt"
+        )
+
+    def test_master_branch_uses_bare_sha(self):
+        ctx = make_ctx(
+            ray_type=RayType.RAY,
+            python_version="3.10",
+            platform="cpu",
+            architecture=DEFAULT_ARCHITECTURE,
+            branch="master",
+            commit="d7951f63abcd",
+        )
+        assert ctx.pip_freeze_canonical_tag() == "d7951f-py310-cpu"
+        assert (
+            ctx.pip_freeze_artifact_filename() == "ray:d7951f-py310-cpu_pip-freeze.txt"
+        )
+
+    def test_pr_branch_uses_bare_sha(self):
+        # PR / feature branch: not master, not releases/* -> bare sha (the form
+        # this change is verified against on the PR's own release-pipeline CI).
+        ctx = make_ctx(
+            ray_type=RayType.RAY,
+            python_version="3.10",
+            platform="cpu",
+            architecture=DEFAULT_ARCHITECTURE,
+            branch="ci-publish-step-pip-freeze-artifact",
+            commit="d7951f63abcd",
+        )
+        assert (
+            ctx.pip_freeze_artifact_filename() == "ray:d7951f-py310-cpu_pip-freeze.txt"
+        )
+
+    def test_extra_variation_and_aarch64_suffix(self):
+        ctx = make_ctx(
+            ray_type=RayType.RAY_EXTRA,
+            python_version="3.11",
+            platform="cpu",
+            architecture="aarch64",
+            branch="releases/2.56.0",
+            commit="d7951f63abcd",
+        )
+        assert ctx.pip_freeze_canonical_tag() == "2.56.0.d7951f-extra-py311-cpu-aarch64"
+        assert (
+            ctx.pip_freeze_artifact_filename()
+            == "ray-extra:2.56.0.d7951f-extra-py311-cpu-aarch64_pip-freeze.txt"
+        )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-vv", __file__]))

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -470,13 +470,20 @@ class TestMultiplePlatforms:
     POSTMERGE_PIPELINE_ID = "test-postmerge-pipeline-id"
     WORK_REPO = "123456789.dkr.ecr.us-west-2.amazonaws.com/rayci-work"
 
+    @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
     @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
     @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
     @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
     @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
     @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
     def test_multiple_platforms_processed(
-        self, mock_config, mock_exists, mock_copy, mock_ecr_login, mock_ci_init
+        self,
+        mock_config,
+        mock_exists,
+        mock_copy,
+        mock_ecr_login,
+        mock_ci_init,
+        mock_export,
     ):
         """Test that multiple platforms are each processed with correct source refs."""
         from click.testing import CliRunner
@@ -531,13 +538,20 @@ class TestMultiplePlatforms:
             for src, dest in copy_calls
         )
 
+    @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
     @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
     @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
     @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
     @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
     @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
     def test_multiple_platforms_fails_if_one_missing(
-        self, mock_config, mock_exists, mock_copy, mock_ecr_login, mock_ci_init
+        self,
+        mock_config,
+        mock_exists,
+        mock_copy,
+        mock_ecr_login,
+        mock_ci_init,
+        mock_export,
     ):
         """Test that processing fails if any platform's source image is missing."""
         from click.testing import CliRunner
@@ -697,6 +711,171 @@ class TestPipFreezeArtifact:
             ctx = make_ctx(platform="cpu", branch="releases/2.56.0")
             with pytest.raises(PushRayImageError, match="pip-freeze.txt not found"):
                 _export_pip_freeze("work-repo:tag", ctx)
+
+    @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
+    def test_main_exports_pip_freeze_for_cpu_only(
+        self,
+        mock_config,
+        mock_exists,
+        mock_copy,
+        mock_ecr_login,
+        mock_ci_init,
+        mock_export,
+    ):
+        from click.testing import CliRunner
+
+        from ci.ray_ci.automation.push_ray_image import main
+
+        pipeline_id = "test-postmerge-pipeline-id"
+        work_repo = "123456789.dkr.ecr.us-west-2.amazonaws.com/rayci-work"
+        mock_config.return_value = {"ci_pipeline_postmerge": [pipeline_id]}
+        mock_exists.return_value = True
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "--python-version",
+                "3.10",
+                "--platform",
+                "cpu",
+                "--platform",
+                "cu12.1.1-cudnn8",
+                "--image-type",
+                "ray",
+                "--architecture",
+                "x86_64",
+                "--rayci-work-repo",
+                work_repo,
+                "--rayci-build-id",
+                "build123",
+                "--pipeline-id",
+                pipeline_id,
+                "--branch",
+                "releases/2.56.0",
+                "--commit",
+                "d7951f63abcd",
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        # Exactly one export -- for the cpu platform, not the cuda one.
+        assert mock_export.call_count == 1
+        src_ref = mock_export.call_args[0][0]
+        assert "ray-py3.10-cpu" in src_ref
+
+    @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
+    def test_main_no_export_when_no_cpu_platform(
+        self,
+        mock_config,
+        mock_exists,
+        mock_copy,
+        mock_ecr_login,
+        mock_ci_init,
+        mock_export,
+    ):
+        from click.testing import CliRunner
+
+        from ci.ray_ci.automation.push_ray_image import main
+
+        pipeline_id = "test-postmerge-pipeline-id"
+        work_repo = "123456789.dkr.ecr.us-west-2.amazonaws.com/rayci-work"
+        mock_config.return_value = {"ci_pipeline_postmerge": [pipeline_id]}
+        mock_exists.return_value = True
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "--python-version",
+                "3.12",
+                "--platform",
+                "cu13.0.0-cudnn",
+                "--image-type",
+                "ray-llm",
+                "--architecture",
+                "x86_64",
+                "--rayci-work-repo",
+                work_repo,
+                "--rayci-build-id",
+                "build123",
+                "--pipeline-id",
+                pipeline_id,
+                "--branch",
+                "releases/2.56.0",
+                "--commit",
+                "d7951f63abcd",
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        mock_export.assert_not_called()
+
+    @mock.patch("ci.ray_ci.automation.push_ray_image._export_pip_freeze")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ci_init")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.ecr_docker_login")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._copy_image")
+    @mock.patch("ci.ray_ci.automation.push_ray_image._image_exists")
+    @mock.patch("ci.ray_ci.automation.push_ray_image.get_global_config")
+    def test_main_exports_even_in_dry_run(
+        self,
+        mock_config,
+        mock_exists,
+        mock_copy,
+        mock_ecr_login,
+        mock_ci_init,
+        mock_export,
+    ):
+        # Feature/PR branch -> _should_upload() is False -> dry_run=True.
+        # The pip-freeze export must STILL run; this is what makes the artifact
+        # verifiable on the PR's own release-pipeline CI build.
+        from click.testing import CliRunner
+
+        from ci.ray_ci.automation.push_ray_image import main
+
+        pipeline_id = "test-postmerge-pipeline-id"
+        work_repo = "123456789.dkr.ecr.us-west-2.amazonaws.com/rayci-work"
+        mock_config.return_value = {"ci_pipeline_postmerge": [pipeline_id]}
+        mock_exists.return_value = True
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "--python-version",
+                "3.10",
+                "--platform",
+                "cpu",
+                "--image-type",
+                "ray",
+                "--architecture",
+                "x86_64",
+                "--rayci-work-repo",
+                work_repo,
+                "--rayci-build-id",
+                "build123",
+                "--pipeline-id",
+                pipeline_id,
+                "--branch",
+                "ci-publish-step-pip-freeze-artifact",
+                "--commit",
+                "d7951f63abcd",
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        # Pushes were skipped (dry run)...
+        mock_copy.assert_called()
+        assert all(call.kwargs.get("dry_run") for call in mock_copy.call_args_list)
+        # ...but the pip-freeze artifact was still exported.
+        assert mock_export.call_count == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
The migration of ray image builds to wanda + the `:crane: publish` step
(`ci/ray_ci/automation/push_ray_image.py`) dropped the per-image
`pip-freeze.txt` Buildkite artifact that the old `:tapioca: build:` step
uploaded via `ci/build/build-ray-docker.sh`. That artifact is the source of
truth for a downstream tool that records the shipped Python dependencies of
each released image.

This PR re-emits it: for the cpu platform, the `:crane: publish` step now
`crane export`s the wanda source image, pulls `home/ray/pip-freeze.txt` out of
its filesystem, and stages it at
`/artifact-mount/.image-info/<image_type>:<canonical_tag>_pip-freeze.txt` — the
same name/layout the old step produced — so the downstream consumer keeps
working once it is repointed at the publish job.

## Related issues
None.

## Additional information
**Implementation**
- No docker daemon; reuses `crane_lib.call_crane_export`.
- The canonical tag is the internal version tag — bare `<sha6>` on master/PR,
  `<release>.<sha6>` on `releases/*` — matching the old
  `RayDockerContainer._get_canonical_tag()` contract the consumer reconstructs.
- The extraction runs regardless of `dry_run`, mirroring the old
  `build-ray-docker.sh`, which always staged the freeze.
- Staging is best-effort: `_export_pip_freeze` normalizes `CraneError`/`OSError`
  into `PushRayImageError` (mirroring `_copy_image`), and the call site in
  `main()` catches and logs any failure so it can never break image publishing
  (the critical path).

**Testing**
- `bazel test //ci/ray_ci/automation:test_push_ray_image` — full target passes,
  including new `TestPipFreezeArtifact` tests covering the canonical-tag rules
  (release / master / PR / `-extra` / `aarch64`), the `_export_pip_freeze`
  helper (success, missing-file error, and `CraneError` wrapping), and the
  `main()` wiring (cpu-only trigger, no-export without cpu, export-still-runs
  under `dry_run`, and export-failure-does-not-break-pipeline).

**Verification note**
This `push_ray_image` publish step is `skip-on-premerge`, so it runs only in the
**postmerge** pipeline (master / `releases/*`). It is not exercised by premerge
or by the `release` pipeline (which uses the separate `push_release_test_image`
binary for `ray-anyscale` images). End-to-end emission of the artifact is
therefore confirmed on the first postmerge build after merge; pre-merge coverage
is the unit tests above.