### PR TITLE
[doc] Don't mock installed numpy/pyarrow in autodoc_mock_imports

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1028,6 +1028,13 @@ autosummary_filename_map = {
 
 # Mock out external dependencies here.
 
+# Prefer not to mock libraries that are actually installed in the docs build
+# environment (doc/requirements-doc.lock.txt). Mocking an installed library
+# shadows the real module: an eager import in a documented class body then hits
+# the mock and aborts the whole package import as a misleading error. numpy and
+# pyarrow are installed, so they are not mocked. tensorflow is also installed (a
+# direct requirements-doc entry), but importing it for real breaks the autodoc
+# import of ray.rllib.algorithms.algorithm at build time, so it stays mocked.
 autodoc_mock_imports = [
     "aiohttp",
     "async_timeout",
@@ -1052,10 +1059,7 @@ autodoc_mock_imports = [
     "lightgbm_ray",
     "mlflow",
     "nevergrad",
-    "numpy",
     "pandas",
-    "pyarrow",
-    "pyarrow.compute",
     "pytorch_lightning",
     "scipy",
     "setproctitle",


### PR DESCRIPTION
## Why

`autodoc_mock_imports` in `doc/source/conf.py` mocks `numpy` and `pyarrow`, but both are installed in the docs build environment (`doc/requirements-doc.lock.txt`; `pyarrow` is a direct `requirements-doc.txt` entry and `numpy` is foundational to the installed stack).

Mocking a library that's actually installed shadows the real module. An eager import in a documented class body then hits the mock instead of the real library and aborts the whole package import, surfacing as a misleading decoy error. This is the failure class fixed in #63821 (the `read_lerobot` break), where a mocked-but-needed library broke an unrelated import.

## What

Remove `numpy`, `pyarrow`, and `pyarrow.compute` from `autodoc_mock_imports` so autodoc introspects the real, installed modules. Libraries genuinely absent from the docs lock stay mocked. A comment records the mock-iff-absent policy so the entries aren't re-added.

`tensorflow` is also installed (a direct `requirements-doc` entry) but is intentionally left mocked: importing it for real breaks the autodoc import of `ray.rllib.algorithms.algorithm` at build time. The comment notes this.

## Checks

Built the full docs in a faithful Linux environment: the pinned `python/deplocks/docs/docbuild_depset_py3.11.lock` installed in a container, run with the same `python -m sphinx ... -W` command (warnings as errors) the RtD config uses. The build completes green — `build succeeded.` with zero Sphinx warnings; removing the three entries introduces none.
