### PR TITLE
[dashboard] avoid configuring root logger on module import

### DIFF
--- a/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
+++ b/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
@@ -10,11 +10,6 @@ import requests
 
 from ray.dashboard.consts import PROMETHEUS_CONFIG_INPUT_PATH
 
-# Configure basic logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-
 FALLBACK_PROMETHEUS_VERSION = "2.48.1"
 DOWNLOAD_BLOCK_SIZE = 8192  # 8 KB
 TEST_MODE_ENV_VAR = "RAY_PROMETHEUS_DOWNLOAD_TEST_MODE"
@@ -176,6 +171,10 @@ def download_prometheus(os_type=None, architecture=None, prometheus_version=None
 
 
 def main():
+    # Configure logging only when this script is run directly
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     logging.warning("This script is not intended for production use.")
 
     downloaded, file_name = download_prometheus()


### PR DESCRIPTION
## Motivation
`install_and_start_prometheus.py` configured the root logger at import time via a module-level `logging.basicConfig()` call. Because the module is imported by `ray/scripts/scripts.py` (for `ray metrics launch-prometheus`) and by the metrics integration tests, this import-time side effect attached a handler to the root logger. Once the root logger has a handler, Ray's own `logging.basicConfig()` becomes a no-op, which corrupts the logging configuration of the whole Ray process and produces duplicated / incorrectly formatted container logs (seen in the Autoscaler). This PR removes the import-time side effect so imports stay side-effect free.

## Implementation Details
- File modified: `python/ray/dashboard/modules/metrics/install_and_start_prometheus.py`
- Moved the `logging.basicConfig(level=INFO, format="%(asctime)s - %(levelname)s - %(message)s")` call from module top level into the `main()` function, guarded with a comment noting it should only run when the script is executed directly.
- No behavioral change to the script's own output when run directly; the only change is *when* the root logger gets configured (now only at runtime via `main()`, never at import time).

## Verification
- [ ] `pre-commit run --all-files` passes on the modified file (ruff, black, pydoclint, semgrep, Ray import order, Ray docstyle all Passed).
- [ ] Import the module and assert the root logger has no handlers added by the import:
      `python -c "import logging; before=len(logging.getLogger().handlers); from ray.dashboard.modules.metrics import install_and_start_prometheus; after=len(logging.getLogger().handlers); assert before==after, (before, after)"`
- [ ] Run `ray metrics launch-prometheus` and confirm logs are emitted once with the expected Ray format (no duplication).
- [ ] Run the metrics integration tests: `python -m pytest python/ray/dashboard/modules/tests/test_metrics_integration.py`
