### PR TITLE
[serve] Fix flaky test_deploy_2 (autoscaling ceil boundary + bad-pip timeout)

### DIFF
--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -238,7 +238,7 @@ def test_deploy_bad_pip_package_deployment(serve_instance):
         assert "No matching distribution found for does_not_exist" in deployment_message
         return True
 
-    wait_for_condition(check_fail, timeout=20)
+    wait_for_condition(check_fail, timeout=60)
 
 
 def test_deploy_same_deployment_name_different_app(serve_instance):
@@ -346,6 +346,10 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
                 "metrics_interval_s": 1,
                 "upscale_delay_s": 1,
                 "look_back_period_s": 2,
+                # Shrink from the 600s default so the transient extra replica
+                # (metric reading fractionally over target) downscales back
+                # within the test's wait window.
+                "downscale_delay_s": 4,
             },
             graceful_shutdown_timeout_s=1,
         )
@@ -356,6 +360,10 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
                 "metrics_interval_s": 1,
                 "upscale_delay_s": 1,
                 "look_back_period_s": 2,
+                # Shrink from the 600s default so the transient extra replica
+                # (metric reading fractionally over target) downscales back
+                # within the test's wait window.
+                "downscale_delay_s": 4,
             },
             graceful_shutdown_timeout_s=1,
         )(A)
@@ -378,9 +386,9 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
         # Overrided by `autoscaling_config`
         "metrics_interval_s": 1.0,
         "upscale_delay_s": 1.0,
+        "downscale_delay_s": 4.0,
         # Untouched defaults
         "look_back_period_s": 2.0,
-        "downscale_delay_s": 600.0,
         "downscale_to_zero_delay_s": None,
         "upscale_smoothing_factor": None,
         "downscale_smoothing_factor": None,


### PR DESCRIPTION
## Why

`linux://python/ray/serve/tests:test_deploy_2` is flaky on postmerge (builds 18330 / 18314 / 18226). It never times out at the Bazel level (medium, p99 ~100s) and always passes on retry, so it is an intermittent race. Two distinct tests flake.

### 1. `test_num_replicas_auto_basic` (3 of the 4 observed failures)

The test asserts an EXACT replica count at a `ceil()` rounding boundary. On the last loop iteration there are 6 blocking requests with `target_ongoing_requests=2`, and the autoscaler's desired replicas reduce to `ceil(total_num_requests / 2)` (`autoscaling_policy.py` `_core_replica_queue_length_policy` + `_apply_scaling_factors`). `total_num_requests` is a time-weighted average of the merged running (replica) and queued (handle) request gauges (`autoscaling_state.py`), so it jitters slightly around the true value of 6.0. When it reads above 6.0, `ceil(x/2)=4`, the deployment scales 2 -> 4 and never sits at exactly 3, so `check_num_replicas_eq(target=3)` times out after 30s.

Controller log evidence, failing run vs the passing sibling param in the same job:

| run | measured ongoing requests | scaled |
| --- | --- | --- |
| 18314 `[False]` FAIL | 6.07 | 2 -> 4 |
| 18226 direct-ingress `[False]` FAIL | 6.15 | 2 -> 4 |
| 18226 HAProxy `[True]` FAIL | 6.04 | 2 -> 4 |
| passing siblings | 5.93 / 6.00 / 5.94 | 2 -> 3 |

This is a test bug, not an autoscaler bug: requesting 4 replicas when it measures 6.07 ongoing against target 2 is correct behavior.

### 2. `test_deploy_bad_pip_package_deployment` (1 of the 4)

`wait_for_condition(check_fail, timeout=20)` timed out with the app still `DEPLOYING`. The bad-pip runtime env setup did not fail and propagate `DEPLOY_FAILED` within 20s under CI load. This progression is monotonic, so it just needs more time.

## What

- `test_num_replicas_auto_basic`: shrink `downscale_delay_s` from the 600s default to 4s so the transient extra replica collapses back to the expected count within the 30s wait, keeping the exact-equality assertion. The `autoscaling_config` assertion is updated to match. (Increasing the timeout alone does not work: downscaling from 4 back to 3 is gated by `downscale_delay_s`, which defaults to 600s and exceeds the medium Bazel cap.)
- `test_deploy_bad_pip_package_deployment`: bump the wait from 20s to 60s.
