### PR TITLE
[serve] deflake test grpc for haproxy

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import string
 import time
 from abc import ABC, abstractmethod
@@ -906,6 +907,23 @@ class HAProxyApi(ProxyApi):
             self._retire_log_files(p)
         self._old_procs = still_alive
 
+    def _soft_stop_old_procs(self) -> None:
+        """Send SIGUSR1 to displaced workers so they close their listeners and
+        drain.
+
+        HAProxy's `-sf` flag already requests this, but its delivery can be
+        lost, so the manager sends the signal itself where it is reliable.
+        """
+        self._prune_old_procs()
+        for proc in self._old_procs:
+            if not self._is_our_haproxy(proc.pid):
+                continue
+            try:
+                # This is a no-op if the worker is already draining
+                os.kill(proc.pid, signal.SIGUSR1)
+            except OSError:
+                pass
+
     def _is_our_haproxy(self, pid: int) -> bool:
         """Whether `pid` is currently one of our haproxy workers.
 
@@ -1077,6 +1095,12 @@ class HAProxyApi(ProxyApi):
             # Track for shutdown cleanup; pruned at the next reload.
             if old_proc is not None:
                 self._old_procs.append(old_proc)
+
+            # `-sf` only re-signals stranded workers on the next reload, and
+            # there is none after the final one. Re-send SIGUSR1 directly so a
+            # worker left serving stale config stops now instead of racing the
+            # client's next request.
+            self._soft_stop_old_procs()
 
             logger.info(
                 "Successfully performed graceful HAProxy reload with process restart."

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -1,6 +1,8 @@
 import asyncio
+import collections
 import logging
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -2563,6 +2565,30 @@ async def test_is_drained_waits_for_old_procs():
     # Old worker has exited -> drained.
     manager._haproxy.has_alive_old_procs = mock.Mock(return_value=False)
     assert await manager.is_drained() is True
+
+
+def test_soft_stop_old_procs_signals_live_workers():
+    """_soft_stop_old_procs re-delivers SIGUSR1 to our live displaced workers,
+    healing a worker whose `-sf` signal was lost, and skips exited procs and a
+    pid that is no longer one of ours (recycled)."""
+    api = HAProxyApi.__new__(HAProxyApi)
+
+    alive_ours = mock.Mock(pid=111, returncode=None)
+    exited = mock.Mock(pid=222, returncode=0)
+    alive_recycled = mock.Mock(pid=333, returncode=None)
+    api._old_procs = [alive_ours, exited, alive_recycled]
+    api._retired_logs = collections.deque()
+    api._max_retained_logs = 10
+
+    # 333's pid was recycled onto an unrelated process.
+    api._is_our_haproxy = lambda pid: pid != 333
+
+    with mock.patch("ray.serve._private.haproxy.os.kill") as mock_kill:
+        api._soft_stop_old_procs()
+
+    # Only the live worker that is still ours is signaled; the exited one is
+    # pruned and the recycled pid is left alone.
+    mock_kill.assert_called_once_with(111, signal.SIGUSR1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Requests were still being sent to the old haproxy because the new worker may fail to send the termination signal if it stops early. This PR directly sends the termination signal to the old processes during reload.