### PR TITLE
[data] Add pyarrow-native implement of AggregateFn

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -567,7 +567,11 @@ class ArrowBlockAccessor(TableBlockAccessor):
             else:
                 ret = tables[0]
                 for table in tables[1:]:
-                    ret = ret.join(table, keys=keys, join_type="inner")
+                    if keys:
+                        ret = ret.join(table, keys=keys, join_type="inner")
+                    else:
+                        for col_name in table.column_names:
+                            ret = ret.append_column(col_name, table.column(col_name))
             return ret
         else:
             return super()._aggregate(sort_key, aggs)
@@ -580,6 +584,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
         aggs: Tuple["AggregateFn"],
         finalize: bool = True,
     ) -> Tuple[Block, "BlockMetadataWithSchema"]:
+        # Handle blocks of different types.
+        blocks = TableBlockAccessor.normalize_block_types(blocks)
+
         # Fall back to original way when not all aggregations support pyarrow kernel
         use_pyarrow_kernel = all(agg.support_pyarrow_kernel() for agg in aggs)
         if use_pyarrow_kernel:
@@ -608,18 +615,33 @@ class ArrowBlockAccessor(TableBlockAccessor):
                     column: column.removeprefix(name + "|") for column in need_columns
                 }
 
-                tables.append(
-                    agg.combine_and_finalize_pyarrow_kernel(
-                        combined.select(need_columns).rename_columns(columns_rename),
-                        keys,
-                    ).rename_columns({agg.name: name})
+                compacted_table = agg.combine_pyarrow_kernel(
+                    combined.select(need_columns).rename_columns(columns_rename),
+                    keys,
                 )
+
+                if finalize:
+                    tables.append(
+                        agg.finalize_pyarrow_kernel(compacted_table).rename_columns(
+                            {agg.name: name}
+                        )
+                    )
+                else:
+                    columns_rename = {
+                        column: name + "|" + column
+                        for column in set(compacted_table.column_names) - set(keys)
+                    }
+                    tables.append(compacted_table.rename_columns(columns_rename))
             if len(tables) == 1:
                 ret = tables[0]
             else:
                 ret = tables[0]
                 for table in tables[1:]:
-                    ret = ret.join(table, keys=keys, join_type="inner")
+                    if keys:
+                        ret = ret.join(table, keys=keys, join_type="inner")
+                    else:
+                        for col_name in table.column_names:
+                            ret = ret.append_column(col_name, table.column(col_name))
             return ret, BlockMetadataWithSchema.from_block(ret)
         else:
             return super()._combine_aggregated_blocks(blocks, sort_key, aggs, finalize)

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 import random
 from typing import (
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
     import pandas
 
     from ray.data._internal.planner.exchange.sort_task_spec import SortKey
+    from ray.data.aggregate import AggregateFn
 
 
 T = TypeVar("T")
@@ -538,6 +540,89 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         # Use PyArrow's built-in filter method
         return self._table.filter(mask)
+
+    def _aggregate(self, sort_key: "SortKey", aggs: Tuple["AggregateFn"]) -> Block:
+        # Fall back to original way when not all aggregations support pyarrow kernel
+        use_pyarrow_kernel = all(agg.support_pyarrow_kernel() for agg in aggs)
+        if use_pyarrow_kernel:
+            keys = sort_key.get_columns()
+            tables = []
+            count = collections.defaultdict(int)
+            for agg in aggs:
+                name = agg.name
+                # Check for conflicts with existing aggregation name.
+                if count[name] > 0:
+                    name = self._munge_conflict(name, count[name])
+                count[name] += 1
+                agg_table = agg.aggregate_block_pyarrow_kernel(self.to_block(), keys)
+                # Use aggregation name as column prefix to avoid duplicate column name
+                columns_rename = {
+                    column: name + "|" + column
+                    for column in set(agg_table.column_names) - set(keys)
+                }
+                tables.append(agg_table.rename_columns(columns_rename))
+
+            if len(tables) == 1:
+                ret = tables[0]
+            else:
+                ret = tables[0]
+                for table in tables[1:]:
+                    ret = ret.join(table, keys=keys, join_type="inner")
+            return ret
+        else:
+            return super()._aggregate(sort_key, aggs)
+
+    @classmethod
+    def _combine_aggregated_blocks(
+        cls,
+        blocks: List[Block],
+        sort_key: "SortKey",
+        aggs: Tuple["AggregateFn"],
+        finalize: bool = True,
+    ) -> Tuple[Block, "BlockMetadataWithSchema"]:
+        # Fall back to original way when not all aggregations support pyarrow kernel
+        use_pyarrow_kernel = all(agg.support_pyarrow_kernel() for agg in aggs)
+        if use_pyarrow_kernel:
+            keys = sort_key.get_columns()
+            combined = pyarrow.concat_tables(blocks) if len(blocks) > 1 else blocks[0]
+            tables = []
+
+            count = collections.defaultdict(int)
+
+            for agg in aggs:
+                name = agg.name
+                # Check for conflicts with existing aggregation name.
+                if count[name] > 0:
+                    name = TableBlockAccessor._munge_conflict(name, count[name])
+                count[name] += 1
+                # Retrieve only the columns needed for current aggregation
+                need_columns = [
+                    column
+                    for column in combined.column_names
+                    if column.startswith(name + "|")
+                ] + keys
+                # The aggregation is unaware of the actual prefix name that may
+                # be modified due to aggregation's name conflicts, so recover
+                # the column name by remove prefix
+                columns_rename = {
+                    column: column.removeprefix(name + "|") for column in need_columns
+                }
+
+                tables.append(
+                    agg.combine_and_finalize_pyarrow_kernel(
+                        combined.select(need_columns).rename_columns(columns_rename),
+                        keys,
+                    ).rename_columns({agg.name: name})
+                )
+            if len(tables) == 1:
+                ret = tables[0]
+            else:
+                ret = tables[0]
+                for table in tables[1:]:
+                    ret = ret.join(table, keys=keys, join_type="inner")
+            return ret, BlockMetadataWithSchema.from_block(ret)
+        else:
+            return super()._combine_aggregated_blocks(blocks, sort_key, aggs, finalize)
 
 
 def _iter_rows_from_batch_with_tensors(

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -542,9 +542,12 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return self._table.filter(mask)
 
     def _aggregate(self, sort_key: "SortKey", aggs: Tuple["AggregateFn"]) -> Block:
-        # Fall back to original way when not all aggregations support pyarrow kernel
+        # Fallback to original way when not all aggregations support pyarrow kernel
         use_pyarrow_kernel = all(agg.support_pyarrow_kernel() for agg in aggs)
         if use_pyarrow_kernel:
+            if self._table.num_rows == 0:
+                return ArrowBlockAccessor._empty_table()
+
             keys = sort_key.get_columns()
             tables = []
             count = collections.defaultdict(int)
@@ -584,12 +587,22 @@ class ArrowBlockAccessor(TableBlockAccessor):
         aggs: Tuple["AggregateFn"],
         finalize: bool = True,
     ) -> Tuple[Block, "BlockMetadataWithSchema"]:
-        # Handle blocks of different types.
-        blocks = TableBlockAccessor.normalize_block_types(blocks)
-
-        # Fall back to original way when not all aggregations support pyarrow kernel
+        # Fallback to original way when not all aggregations support pyarrow kernel
         use_pyarrow_kernel = all(agg.support_pyarrow_kernel() for agg in aggs)
         if use_pyarrow_kernel:
+            blocks = [
+                block
+                for block in blocks
+                if BlockAccessor.for_block(block).num_rows() > 0
+            ]
+
+            if not blocks:
+                ret = pyarrow_table_from_pydict({})
+                return ret, BlockMetadataWithSchema.from_block(ret)
+
+            # Handle blocks of different types.
+            blocks = TableBlockAccessor.normalize_block_types(blocks, BlockType.ARROW)
+
             keys = sort_key.get_columns()
             combined = pyarrow.concat_tables(blocks) if len(blocks) > 1 else blocks[0]
             tables = []
@@ -609,8 +622,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                     if column.startswith(name + "|")
                 ] + keys
                 # The aggregation is unaware of the actual prefix name that may
-                # be modified due to aggregation's name conflicts, so recover
-                # the column name by remove prefix
+                # be modified due to aggregation's name conflicts, so remove agg prefix
                 columns_rename = {
                     column: column.removeprefix(name + "|") for column in need_columns
                 }

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -343,6 +343,17 @@ class AggregateFnV2(AggregateFn, abc.ABC, Generic[AccumulatorType, AggOutputType
 
             SortKey(self._target_col_name).validate_schema(schema)
 
+    def support_pyarrow_kernel(self) -> bool:
+        return False
+
+    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        raise NotImplementedError
+
+    def combine_and_finalize_pyarrow_kernel(
+        self, block: Block, keys: List[str]
+    ) -> Block:
+        raise NotImplementedError
+
 
 def _agg_output_field(
     name: str,
@@ -456,6 +467,46 @@ class Count(AggregateFnV2[int, int]):
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return pa.field(self.name, pa.int64(), nullable=False)
+
+    def support_pyarrow_kernel(self) -> bool:
+        return True
+
+    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        if self._target_col_name is None:
+            aggregations = [
+                (
+                    [],
+                    "count_all",
+                    pc.CountOptions(mode="only_valid" if self._ignore_nulls else "all"),
+                )
+            ]
+        else:
+            aggregations = [
+                (
+                    self._target_col_name,
+                    "count",
+                    pc.CountOptions(mode="only_valid" if self._ignore_nulls else "all"),
+                )
+            ]
+
+        return table.group_by(keys).aggregate(aggregations)
+
+    def combine_and_finalize_pyarrow_kernel(
+        self, block: Block, keys: List[str]
+    ) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+        if self._target_col_name is None:
+            aggregations = [("count_all", "sum")]
+            columns_rename = {"count_all_sum": self.name}
+        else:
+            aggregations = [(self._target_col_name + "_count", "sum")]
+            columns_rename = {self._target_col_name + "_count_sum": self.name}
+
+        combined = table.group_by(keys).aggregate(aggregations)
+
+        return combined.rename_columns(columns_rename)
 
 
 @PublicAPI
@@ -645,6 +696,38 @@ class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return _agg_output_field(self.name, input_schema, self._target_col_name, pc.min)
 
+    def support_pyarrow_kernel(self) -> bool:
+        return True
+
+    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        aggregations = [
+            (
+                self._target_col_name,
+                "min",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            )
+        ]
+
+        return table.group_by(keys).aggregate(aggregations)
+
+    def combine_and_finalize_pyarrow_kernel(
+        self, block: Block, keys: List[str]
+    ) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+        aggregations = [
+            (
+                self._target_col_name + "_min",
+                "min",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            )
+        ]
+
+        combined = table.group_by(keys).aggregate(aggregations)
+
+        return combined.rename_columns({self._target_col_name + "_min_min": self.name})
+
 
 @PublicAPI
 class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType]):
@@ -710,6 +793,38 @@ class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return _agg_output_field(self.name, input_schema, self._target_col_name, pc.max)
+
+    def support_pyarrow_kernel(self) -> bool:
+        return True
+
+    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        aggregations = [
+            (
+                self._target_col_name,
+                "max",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            )
+        ]
+
+        return table.group_by(keys).aggregate(aggregations)
+
+    def combine_and_finalize_pyarrow_kernel(
+        self, block: Block, keys: List[str]
+    ) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+        aggregations = [
+            (
+                self._target_col_name + "_max",
+                "max",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            )
+        ]
+
+        combined = table.group_by(keys).aggregate(aggregations)
+
+        return combined.rename_columns({self._target_col_name + "_max_max": self.name})
 
 
 @PublicAPI
@@ -794,6 +909,57 @@ class Mean(AggregateFnV2[List[Union[int, float]], float]):
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return pa.field(self.name, pa.float64(), nullable=True)
+
+    def support_pyarrow_kernel(self) -> bool:
+        return True
+
+    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+        aggregations = [
+            (
+                self._target_col_name,
+                "sum",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            ),
+            (
+                self._target_col_name,
+                "count",
+                pc.CountOptions(mode="only_valid" if self._ignore_nulls else "all"),
+            ),
+        ]
+
+        return table.group_by(keys).aggregate(aggregations)
+
+    def combine_and_finalize_pyarrow_kernel(
+        self, block: Block, keys: List[str]
+    ) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        aggregations = [
+            (
+                self._target_col_name + "_sum",
+                "sum",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            ),
+            (
+                self._target_col_name + "_count",
+                "sum",
+                pc.ScalarAggregateOptions(skip_nulls=self._ignore_nulls),
+            ),
+        ]
+
+        combined = table.group_by(keys).aggregate(aggregations)
+
+        ret = combined.append_column(
+            self.name,
+            pc.divide(
+                pc.cast(combined[self._target_col_name + "_sum_sum"], pa.float64()),
+                pc.cast(combined[self._target_col_name + "_count_sum"], pa.float64()),
+            ),
+        ).drop_columns(
+            [self._target_col_name + "_sum_sum", self._target_col_name + "_count_sum"]
+        )
+        return ret
 
 
 @PublicAPI

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -349,9 +349,10 @@ class AggregateFnV2(AggregateFn, abc.ABC, Generic[AccumulatorType, AggOutputType
     def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
         raise NotImplementedError
 
-    def combine_and_finalize_pyarrow_kernel(
-        self, block: Block, keys: List[str]
-    ) -> Block:
+    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        raise NotImplementedError
+
+    def finalize_pyarrow_kernel(self, block: Block) -> Block:
         raise NotImplementedError
 
 
@@ -479,7 +480,6 @@ class Count(AggregateFnV2[int, int]):
                 (
                     [],
                     "count_all",
-                    pc.CountOptions(mode="only_valid" if self._ignore_nulls else "all"),
                 )
             ]
         else:
@@ -493,20 +493,29 @@ class Count(AggregateFnV2[int, int]):
 
         return table.group_by(keys).aggregate(aggregations)
 
-    def combine_and_finalize_pyarrow_kernel(
-        self, block: Block, keys: List[str]
-    ) -> Block:
+    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
         table = BlockAccessor.for_block(block).to_arrow()
         if self._target_col_name is None:
             aggregations = [("count_all", "sum")]
-            columns_rename = {"count_all_sum": self.name}
+            columns_rename = {"count_all_sum": "count_all"}
         else:
             aggregations = [(self._target_col_name + "_count", "sum")]
-            columns_rename = {self._target_col_name + "_count_sum": self.name}
+            columns_rename = {
+                self._target_col_name + "_count_sum": self._target_col_name + "_count"
+            }
 
         combined = table.group_by(keys).aggregate(aggregations)
 
         return combined.rename_columns(columns_rename)
+
+    def finalize_pyarrow_kernel(self, block: Block) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+        if self._target_col_name is None:
+            columns_rename = {"count_all": self.name}
+        else:
+            columns_rename = {self._target_col_name + "_count": self.name}
+
+        return table.rename_columns(columns_rename)
 
 
 @PublicAPI
@@ -712,9 +721,7 @@ class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
 
         return table.group_by(keys).aggregate(aggregations)
 
-    def combine_and_finalize_pyarrow_kernel(
-        self, block: Block, keys: List[str]
-    ) -> Block:
+    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
         table = BlockAccessor.for_block(block).to_arrow()
         aggregations = [
             (
@@ -726,7 +733,14 @@ class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
 
         combined = table.group_by(keys).aggregate(aggregations)
 
-        return combined.rename_columns({self._target_col_name + "_min_min": self.name})
+        return combined.rename_columns(
+            {self._target_col_name + "_min_min": self._target_col_name + "_min"}
+        )
+
+    def finalize_pyarrow_kernel(self, block: Block) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        return table.rename_columns({self._target_col_name + "_min": self.name})
 
 
 @PublicAPI
@@ -810,9 +824,7 @@ class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
 
         return table.group_by(keys).aggregate(aggregations)
 
-    def combine_and_finalize_pyarrow_kernel(
-        self, block: Block, keys: List[str]
-    ) -> Block:
+    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
         table = BlockAccessor.for_block(block).to_arrow()
         aggregations = [
             (
@@ -824,7 +836,14 @@ class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
 
         combined = table.group_by(keys).aggregate(aggregations)
 
-        return combined.rename_columns({self._target_col_name + "_max_max": self.name})
+        return combined.rename_columns(
+            {self._target_col_name + "_max_max": self._target_col_name + "_max"}
+        )
+
+    def finalize_pyarrow_kernel(self, block: Block) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        return table.rename_columns({self._target_col_name + "_max": self.name})
 
 
 @PublicAPI
@@ -930,9 +949,7 @@ class Mean(AggregateFnV2[List[Union[int, float]], float]):
 
         return table.group_by(keys).aggregate(aggregations)
 
-    def combine_and_finalize_pyarrow_kernel(
-        self, block: Block, keys: List[str]
-    ) -> Block:
+    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
         table = BlockAccessor.for_block(block).to_arrow()
 
         aggregations = [
@@ -950,14 +967,24 @@ class Mean(AggregateFnV2[List[Union[int, float]], float]):
 
         combined = table.group_by(keys).aggregate(aggregations)
 
-        ret = combined.append_column(
+        return combined.rename_columns(
+            {
+                self._target_col_name + "_sum_sum": self._target_col_name + "_sum",
+                self._target_col_name + "_count_sum": self._target_col_name + "_count",
+            }
+        )
+
+    def finalize_pyarrow_kernel(self, block: Block) -> Block:
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        ret = table.append_column(
             self.name,
             pc.divide(
-                pc.cast(combined[self._target_col_name + "_sum_sum"], pa.float64()),
-                pc.cast(combined[self._target_col_name + "_count_sum"], pa.float64()),
+                pc.cast(table[self._target_col_name + "_sum"], pa.float64()),
+                pc.cast(table[self._target_col_name + "_count"], pa.float64()),
             ),
         ).drop_columns(
-            [self._target_col_name + "_sum_sum", self._target_col_name + "_count_sum"]
+            [self._target_col_name + "_sum", self._target_col_name + "_count"]
         )
         return ret
 

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -162,6 +162,18 @@ class AggregateFn:
         """
         return None
 
+    def support_pyarrow_kernel(self) -> bool:
+        return False
+
+    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        raise NotImplementedError
+
+    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
+        raise NotImplementedError
+
+    def finalize_pyarrow_kernel(self, block: Block) -> Block:
+        raise NotImplementedError
+
 
 @PublicAPI(stability="alpha")
 class AggregateFnV2(AggregateFn, abc.ABC, Generic[AccumulatorType, AggOutputType]):
@@ -342,18 +354,6 @@ class AggregateFnV2(AggregateFn, abc.ABC, Generic[AccumulatorType, AggOutputType
             from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
             SortKey(self._target_col_name).validate_schema(schema)
-
-    def support_pyarrow_kernel(self) -> bool:
-        return False
-
-    def aggregate_block_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
-        raise NotImplementedError
-
-    def combine_pyarrow_kernel(self, block: Block, keys: List[str]) -> Block:
-        raise NotImplementedError
-
-    def finalize_pyarrow_kernel(self, block: Block) -> Block:
-        raise NotImplementedError
 
 
 def _agg_output_field(


### PR DESCRIPTION
## Description
Introduce pyarrow native aggregation to improve aggregate performance on specified case.  

## Additional information
Current, aggregate(group by key is not none) procedure is below:

- Map side 
    - Sort input block based on key
    - Determine the each group's boundaries
    - Partial aggregate group by group
- Reduce side
    - Use heap sort to sort the output of map
    - Combine group one by one

If a table contains many groups, aggregation performance will be very poor. This is because both map and reduce operations involve a lot of column-to-row transformations which are expensive.

We can use pyarrow groupby + aggregate to accelerate.

### For example:
`ds.groupby(key="id").max(on="value")` can be implement by
#### map side
`table.group_by("id").aggregate([("value", "max")])`
#### map output
```
pyarrow.Table
id: int64
value_max: int64
----
```
#### reduce side
`table.group_by("id").aggregate([("value_max", "max")])`
#### reduce output
```
pyarrow.Table
id: int64
value_max_max: int64
----
```