### PR TITLE
[Rllib] Fix `test_checkpointable`

### DIFF
--- a/rllib/utils/checkpoints.py
+++ b/rllib/utils/checkpoints.py
@@ -483,9 +483,8 @@ class Checkpointable(abc.ABC):
                     else:
                         ctor_kwargs[param_name] = val
 
-        # If the pickle file is from another python version, use provided
-        # args instead.
-        except (ValueError, AttributeError, ImportError):
+        # If the pickle file is from another python version, use provided args instead.
+        except (ValueError, AttributeError, ImportError, TypeError):
             logger.warning(
                 "Could not restore original class from checkpoint at '%s' "
                 "(possible version mismatch), falling back to %s.",


### PR DESCRIPTION
## Description
`linux://rllib:utils/tests/test_checkpointable` recently started failing. 
This PR fixes it through catching the TypeError which was removed in #63614 
