### PR TITLE
[Docs] Fix metric cardinality default comments

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -571,12 +571,12 @@ RAY_ENABLE_PYTHON_RAY_EVENT_TYPES = frozenset(
 # manually set the py_executable in your runtime environment hook.
 RAY_ENABLE_UV_RUN_RUNTIME_ENV = env_bool("RAY_ENABLE_UV_RUN_RUNTIME_ENV", True)
 
-# Prometheus metric cardinality level setting, either "legacy" or "recommended".
+# Prometheus metric cardinality level setting: "legacy", "recommended", or "low".
 #
-# Legacy: report all metrics to prometheus with the set of labels that are reported by
-#   the component, including WorkerId, (task or actor) Name, etc. This is the default.
-# Recommended: report only the node level metrics to prometheus. This means that the
-#   WorkerId will be removed from all metrics.
+# Legacy: report all metrics to Prometheus with the set of labels that are reported by
+#   the component, including WorkerId, (task or actor) Name, etc.
+# Recommended: report metrics to Prometheus with high-cardinality labels removed.
+#   Currently, WorkerId will be removed from all metrics. This is the default.
 # Low: Same as recommended, but also drop the Name label for tasks and actors.
 RAY_METRIC_CARDINALITY_LEVEL = os.environ.get(
     "RAY_metric_cardinality_level", "recommended"

--- a/python/ray/_private/telemetry/metric_cardinality.py
+++ b/python/ray/_private/telemetry/metric_cardinality.py
@@ -27,7 +27,7 @@ class MetricCardinality(str, Enum):
 
     - LEGACY: Keep all labels. This was the default behavior before `recommended`.
     - RECOMMENDED: Drop high cardinality labels. The set of high cardinality labels
-    are determined internally by Ray and not exposed to users. This is the default
+    is determined internally by Ray and not exposed to users. This is the default
     behavior. Currently, this includes the following labels: WorkerId
     - LOW: Same as RECOMMENDED, but also drop the Name label for tasks and actors.
     """

--- a/python/ray/_private/telemetry/metric_cardinality.py
+++ b/python/ray/_private/telemetry/metric_cardinality.py
@@ -21,14 +21,14 @@ _HIGH_CARDINALITY_LABELS: Dict[str, List[str]] = {}
 
 class MetricCardinality(str, Enum):
     """Cardinality level configuration for all Ray metrics (ray_tasks, ray_actors,
-    etc.). This configurtion is used to determine whether to globally drop high
+    etc.). This configuration is used to determine whether to globally drop high
     cardinality labels. This is important for high scale clusters that might consist
-    thousands of workers, millions of tasks.
+    of thousands of workers and millions of tasks.
 
-    - LEGACY: Keep all labels. This is the default behavior.
+    - LEGACY: Keep all labels. This was the default behavior before `recommended`.
     - RECOMMENDED: Drop high cardinality labels. The set of high cardinality labels
-    are determined internally by Ray and not exposed to users. Currently, this includes
-    the following labels: WorkerId
+    are determined internally by Ray and not exposed to users. This is the default
+    behavior. Currently, this includes the following labels: WorkerId
     - LOW: Same as RECOMMENDED, but also drop the Name label for tasks and actors.
     """
 


### PR DESCRIPTION
## Why are these changes needed?

`RAY_metric_cardinality_level` now defaults to `recommended`, but some inline comments still described `legacy` as the default behavior. This PR updates those comments to match the actual default value and documents `low` as a valid option.

## Related issue number

N/A

## Checks

- [x] Ran `pre-commit run --files python/ray/_private/ray_constants.py python/ray/_private/telemetry/metric_cardinality.py`
