### PR TITLE
[serve] Deprecate HTTPOptions.location; make proxy_location the place…

### DIFF
--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -159,15 +159,13 @@ class ServeHead(SubprocessModule):
                 text=repr(e),
             )
 
-        config_http_options = config.http_options.model_dump()
-        full_http_options = dict(
-            {"location": config.proxy_location.value}, **config_http_options
-        )
+        full_http_options = config.http_options.model_dump()
         grpc_options = config.grpc_options.model_dump()
 
         async with self._controller_start_lock:
             client = await serve_start_async(
                 http_options=full_http_options,
+                proxy_location=config.proxy_location,
                 grpc_options=grpc_options,
                 global_logging_config=config.logging_config,
                 controller_options=config.controller_options,

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -17,7 +17,12 @@ from ray.serve._private.constants import (
     SERVE_NAMESPACE,
 )
 from ray.serve._private.default_impl import get_controller_impl
-from ray.serve.config import ControllerOptions, HTTPOptions, gRPCOptions
+from ray.serve.config import (
+    ControllerOptions,
+    HTTPOptions,
+    ProxyLocation,
+    gRPCOptions,
+)
 from ray.serve.context import (
     _check_cached_client_alive,
     _get_global_client,
@@ -75,6 +80,7 @@ def _create_controller_and_proxy_refs(
     grpc_options: Union[None, dict, gRPCOptions],
     global_logging_config: Union[None, dict, LoggingConfig],
     controller_options: ControllerOptions,
+    proxy_location: Union[None, str, ProxyLocation] = None,
     **kwargs,
 ) -> Tuple[ActorHandle, List[ObjectRef]]:
     """Create the detached ServeController actor in the caller process.
@@ -114,6 +120,8 @@ def _create_controller_and_proxy_refs(
     if http_options is None:
         http_options = HTTPOptions()
 
+    proxy_location = ProxyLocation._normalize(proxy_location)
+
     if isinstance(grpc_options, dict):
         grpc_options = gRPCOptions(**grpc_options)
 
@@ -127,6 +135,7 @@ def _create_controller_and_proxy_refs(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=global_logging_config,
+        proxy_location=proxy_location,
     )
 
     proxy_handles = ray.get(controller.get_proxies.remote())
@@ -143,6 +152,7 @@ async def serve_start_async(
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
+    proxy_location: Union[None, str, ProxyLocation] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance asynchronously.
@@ -190,6 +200,7 @@ async def serve_start_async(
         grpc_options,
         global_logging_config,
         controller_options,
+        proxy_location,
         **kwargs,
     )
 
@@ -215,6 +226,7 @@ def serve_start(
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
+    proxy_location: Union[None, str, ProxyLocation] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance.
@@ -262,6 +274,10 @@ def serve_start(
             is honored; see ``ray.serve.config.ControllerOptions``. Only
             applied on first controller creation -- ignored if the controller
             is already running in this Ray cluster (a log line is emitted).
+        proxy_location: Where to run proxies that handle ingress traffic to
+            the cluster. See ``ProxyLocation`` for supported options. Defaults
+            to ``EveryNode`` when unspecified. An explicit (deprecated)
+            ``HTTPOptions.location`` overrides this.
         **kwargs: Reserved for forwarding to internal controller-start hooks;
             no public keys are currently supported and unknown keys may raise.
 
@@ -294,6 +310,7 @@ def serve_start(
         grpc_options,
         global_logging_config,
         controller_options,
+        proxy_location,
         **kwargs,
     )
 

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -38,8 +38,6 @@ from ray.serve.config import (
     GangPlacementStrategy,
     GangRuntimeFailurePolicy,
     GangSchedulingConfig,
-    HTTPOptions,
-    ProxyLocation,
     RequestRouterConfig,
 )
 from ray.serve.generated.serve_pb2 import (
@@ -1119,55 +1117,3 @@ class ReplicaConfig:
             "placement_group_fallback_strategy": self.placement_group_fallback_strategy,
             "max_replicas_per_node": self.max_replicas_per_node,
         }
-
-
-def prepare_imperative_http_options(
-    proxy_location: Union[None, str, ProxyLocation],
-    http_options: Union[None, dict, HTTPOptions],
-) -> HTTPOptions:
-    """Prepare `HTTPOptions` with a resolved `location` based on `proxy_location` and `http_options`.
-
-    Precedence:
-    - If `proxy_location` is provided, it overrides any `location` in `http_options`.
-    - Else if `http_options` specifies a `location` explicitly (HTTPOptions(...) or dict with 'location'), keep it.
-    - Else (no `proxy_location` and no explicit `location`) set `location` to `ProxyLocation.EveryNode`.
-      A bare `HTTPOptions()` counts as an explicit default (`HeadOnly`).
-
-    Args:
-        proxy_location: Optional ProxyLocation (or its string representation).
-        http_options: Optional HTTPOptions instance or dict. If None, a new HTTPOptions() is created.
-
-    Returns:
-        HTTPOptions: New instance with resolved location.
-
-    Note:
-        1. Default ProxyLocation (when unspecified) resolves to ProxyLocation.EveryNode.
-        2. Default HTTPOptions() location is ProxyLocation.HeadOnly.
-        3. `HTTPOptions` is used in `imperative` mode (Python API) cluster set-up.
-            `Declarative` mode (CLI / REST) uses `HTTPOptionsSchema`.
-
-    Raises:
-        ValueError: If http_options is not None, dict, or HTTPOptions.
-    """
-    if http_options is None:
-        location_set_explicitly = False
-        http_options = HTTPOptions()
-    elif isinstance(http_options, dict):
-        location_set_explicitly = "location" in http_options
-        http_options = HTTPOptions(**http_options)
-    elif isinstance(http_options, HTTPOptions):
-        # empty `HTTPOptions()` is considered as user specified the default location value `HeadOnly` explicitly
-        location_set_explicitly = True
-        http_options = HTTPOptions(**http_options.model_dump(exclude_unset=True))
-    else:
-        raise ValueError(
-            f"Unexpected type for http_options: `{type(http_options).__name__}`"
-        )
-
-    if proxy_location is None:
-        if not location_set_explicitly:
-            http_options.location = ProxyLocation.EveryNode
-    else:
-        http_options.location = ProxyLocation._normalize(proxy_location)
-
-    return http_options

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -157,6 +157,7 @@ class ServeController:
         http_options: HTTPOptions,
         global_logging_config: LoggingConfig,
         grpc_options: Optional[gRPCOptions] = None,
+        proxy_location: Optional[ProxyLocation] = None,
     ):
         if RAY_SERVE_THROUGHPUT_OPTIMIZED:
             self._log_throughput_opt_message()
@@ -219,7 +220,8 @@ class ServeController:
                 "Direct ingress is enabled in ServeController, enabling proxy "
                 "on head node only."
             )
-            http_options.location = ProxyLocation.HeadOnly
+            proxy_location = ProxyLocation.HeadOnly
+            http_options = http_options.model_copy(update={"location": None})
 
         # Configure proxy default HTTP and gRPC options.
         self.proxy_state_manager = ProxyStateManager(
@@ -228,6 +230,7 @@ class ServeController:
             cluster_node_info_cache=self.cluster_node_info_cache,
             logging_config=self.global_logging_config,
             grpc_options=set_proxy_default_grpc_options(grpc_options),
+            proxy_location=proxy_location,
             proxy_actor_class=HAProxyManager if self._ha_proxy_enabled else ProxyActor,
             running_native_proxies=self._ha_proxy_enabled,
         )
@@ -926,6 +929,12 @@ class ServeController:
             return HTTPOptions()
         return self.proxy_state_manager.get_config()
 
+    def get_proxy_location(self) -> Optional[ProxyLocation]:
+        """Return the resolved proxy placement (the ingress placement authority)."""
+        if self.proxy_state_manager is None:
+            return None
+        return self.proxy_state_manager.get_proxy_location()
+
     def get_grpc_config(self) -> gRPCOptions:
         """Return the gRPC proxy configuration."""
         if self.proxy_state_manager is None:
@@ -1371,7 +1380,11 @@ class ServeController:
         return ServeInstanceDetails(
             target_capacity=self._target_capacity,
             controller_info=self._actor_details,
-            proxy_location=http_config.location,
+            proxy_location=(
+                self.proxy_state_manager.get_proxy_location()
+                if self.proxy_state_manager
+                else None
+            ),
             http_options=http_options,
             grpc_options=grpc_options,
             proxies=(

--- a/python/ray/serve/_private/controller_avatar.py
+++ b/python/ray/serve/_private/controller_avatar.py
@@ -1,7 +1,7 @@
 import ray
 from ray.serve._private.constants import SERVE_CONTROLLER_NAME, SERVE_NAMESPACE
 from ray.serve._private.default_impl import get_controller_impl
-from ray.serve.config import HTTPOptions
+from ray.serve.config import HTTPOptions, ProxyLocation
 from ray.serve.schema import LoggingConfig
 
 
@@ -30,8 +30,13 @@ class ServeControllerAvatar:
             self._controller = None
         if self._controller is None:
             controller_impl = get_controller_impl()
+            # This Java bootstrap builds HTTPOptions directly and previously
+            # relied on the (now removed) HeadOnly default of
+            # HTTPOptions.location. Pass proxy_location explicitly to preserve
+            # head-only proxy placement on multi-node clusters.
             self._controller = controller_impl.remote(
                 http_options=HTTPOptions(port=http_proxy_port),
+                proxy_location=ProxyLocation.HeadOnly,
                 global_logging_config=LoggingConfig(),
             )
 

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -598,6 +598,7 @@ class ProxyStateManager:
         cluster_node_info_cache: ClusterNodeInfoCache,
         logging_config: LoggingConfig,
         grpc_options: Optional[gRPCOptions] = None,
+        proxy_location: Optional[ProxyLocation] = None,
         proxy_actor_class: Type[ProxyActor] = ProxyActor,
         actor_proxy_wrapper_class: Type[ProxyWrapper] = ActorProxyWrapper,
         timer: TimerBase = Timer(),
@@ -606,6 +607,7 @@ class ProxyStateManager:
         self.logging_config = logging_config
         self._http_options = http_options or HTTPOptions()
         self._grpc_options = grpc_options or gRPCOptions()
+        self._proxy_location = proxy_location
         self._proxy_states: Dict[NodeId, ProxyState] = dict()
         self._proxy_restart_counts: Dict[NodeId, int] = dict()
         self._head_node_id: str = head_node_id
@@ -657,6 +659,18 @@ class ProxyStateManager:
 
     def get_grpc_config(self) -> gRPCOptions:
         return self._grpc_options
+
+    def _resolved_proxy_location(self) -> ProxyLocation:
+        # `location` on HTTPOptions is a deprecated override; `proxy_location`
+        # is the authority. Default to EveryNode when neither is set.
+        return (
+            self._http_options.location
+            or self._proxy_location
+            or ProxyLocation.EveryNode
+        )
+
+    def get_proxy_location(self) -> ProxyLocation:
+        return self._resolved_proxy_location()
 
     def get_proxy_handles(self) -> Dict[str, ActorHandle]:
         handles = {
@@ -786,7 +800,7 @@ class ProxyStateManager:
     def _get_target_nodes(self, proxy_nodes) -> List[Tuple[str, str, str]]:
         """Return the list of (node_id, ip_address) to deploy HTTP and gRPC servers
         on."""
-        location = self._http_options.location
+        location = self._resolved_proxy_location()
 
         if location == ProxyLocation.Disabled:
             return []

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2149,21 +2149,25 @@ class Replica:
             raise RuntimeError(err_msg)
 
         if self._ingress:
-            self._http_options, self._grpc_options = ray.get(
+            self._http_options, self._grpc_options, resolved_proxy_location = ray.get(
                 [
                     self._controller_handle.get_http_config.remote(),
                     self._controller_handle.get_grpc_config.remote(),
+                    self._controller_handle.get_proxy_location.remote(),
                 ]
             )
         else:
-            self._http_options = ray.get(
-                self._controller_handle.get_http_config.remote()
+            self._http_options, resolved_proxy_location = ray.get(
+                [
+                    self._controller_handle.get_http_config.remote(),
+                    self._controller_handle.get_proxy_location.remote(),
+                ]
             )
             self._grpc_options = None
 
         grpc_enabled = self._ingress and is_grpc_enabled(self._grpc_options)
-        # host=None normalizes to location Disabled in HTTPOptions.location_backfill_no_server.
-        http_enabled = self._http_options.location != ProxyLocation.Disabled
+        # HTTP ingress is enabled unless the resolved proxy placement is Disabled.
+        http_enabled = resolved_proxy_location != ProxyLocation.Disabled
 
         # Allocate and start HTTP server
         if http_enabled:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -16,7 +16,6 @@ from ray.serve._private.config import (
     DeploymentConfig,
     ReplicaConfig,
     handle_num_replicas_auto,
-    prepare_imperative_http_options,
 )
 from ray.serve._private.constants import (
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
@@ -113,9 +112,9 @@ def start(
         **kwargs: Reserved for forward-compatibility; passed through to the
             internal Serve start helper.
     """
-    http_options = prepare_imperative_http_options(proxy_location, http_options)
     _private_api.serve_start(
         http_options=http_options,
+        proxy_location=proxy_location,
         grpc_options=grpc_options,
         global_logging_config=logging_config,
         controller_options=controller_options,
@@ -827,7 +826,7 @@ def _run_many(
         return [b.deployment_handles[b.ingress_deployment_name] for b in built_apps]
     else:
         client = _private_api.serve_start(
-            http_options={"location": "EveryNode"},
+            proxy_location=ProxyLocation.EveryNode,
             global_logging_config=None,
             controller_options=controller_options,
         )

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -821,9 +821,12 @@ class HTTPOptions(BaseModel):
 
         - "HeadOnly": start one HTTP server on the head node. Serve
           assumes the head node is the node you executed serve.start
-          on. This is the default.
+          on.
         - "EveryNode": start one HTTP server per node.
         - "Disabled": disable HTTP server.
+
+      This field defaults to None; Serve uses `proxy_location` when location
+      is unset. If `host` is None, Serve disables proxy startup.
 
     - num_cpus: [DEPRECATED] The number of CPU cores to reserve for each
       internal Serve HTTP proxy actor. Passing a non-zero value raises an
@@ -833,7 +836,7 @@ class HTTPOptions(BaseModel):
     host: Optional[str] = DEFAULT_HTTP_HOST or get_localhost_ip()
     port: int = DEFAULT_HTTP_PORT
     middlewares: List[Any] = []
-    location: Optional[ProxyLocation] = ProxyLocation.HeadOnly
+    location: Optional[ProxyLocation] = None
     num_cpus: int = 0
     root_url: str = ""
     root_path: str = ""
@@ -849,11 +852,23 @@ class HTTPOptions(BaseModel):
     @field_validator("location", mode="before")
     @classmethod
     def normalize_location(cls, v):
+        # Only warn when a real (non-None) location is set. location=None is a
+        # no-op that also arrives via internal model_dump() roundtrips (e.g.
+        # direct-ingress replicas rebuilding HTTPOptions), which must stay quiet.
+        if v is not None:
+            warnings.warn(
+                "`location` in HTTPOptions is deprecated and will be removed in a "
+                "future version. Use the `proxy_location` argument to `serve.start` "
+                "or the top-level `proxy_location` field in the Serve config "
+                "instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return ProxyLocation._normalize(v)
 
     @model_validator(mode="after")
     def location_backfill_no_server(self):
-        if self.host is None or self.location is None:
+        if self.host is None:
             # Use object.__setattr__ since the model may have frozen=True behavior
             object.__setattr__(self, "location", ProxyLocation.Disabled)
         return self

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -521,20 +521,21 @@ def run(
             "need to call `ray.init` in your code when using `serve run`."
         )
 
-    http_options = {"location": "EveryNode"}
+    http_options = {}
+    proxy_location = ProxyLocation.EveryNode
     grpc_options = gRPCOptions()
     controller_options = None
     # Merge http_options, grpc_options, and controller_options with the ones on
     # ServeDeploySchema.
     if is_config and isinstance(config, ServeDeploySchema):
-        http_options["location"] = config.proxy_location.value
-        config_http_options = config.http_options.model_dump()
-        http_options = {**config_http_options, **http_options}
+        proxy_location = config.proxy_location
+        http_options = config.http_options.model_dump()
         grpc_options = gRPCOptions(**config.grpc_options.model_dump())
         controller_options = config.controller_options
 
     client = _private_api.serve_start(
         http_options=http_options,
+        proxy_location=proxy_location,
         grpc_options=grpc_options,
         controller_options=controller_options,
     )

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -315,10 +315,11 @@ def test_http_proxy_fail_loudly(ray_shutdown):
 
 def test_no_http(ray_shutdown):
     # The following should have the same effect.
+    # All of these should disable the HTTP proxy.
     options = [
         {"http_options": {"host": None}},
-        {"http_options": {"location": None}},
-        {"http_options": {"location": "NoServer"}},
+        {"proxy_location": "Disabled"},
+        {"http_options": {"location": "NoServer"}},  # deprecated override
     ]
 
     address = ray.init(num_cpus=8)["address"]
@@ -354,7 +355,7 @@ def test_http_head_only(ray_cluster):
     ray.init(head_node.address)
     assert len(ray.nodes()) == 2
 
-    serve.start(http_options={"port": _get_random_port(), "location": "HeadOnly"})
+    serve.start(proxy_location="HeadOnly", http_options={"port": _get_random_port()})
 
     # Controller and proxy on the head node. Under HAProxy the proxy is the
     # HAProxyManager alongside the fallback ProxyActor, which registers asynchronously.
@@ -642,84 +643,64 @@ def test_build_app_fails_after_retries_exhausted(ray_shutdown, tmp_path):
 @pytest.mark.parametrize(
     "options",
     [
+        # No proxy_location and no location -> default EveryNode.
         {
             "proxy_location": None,
             "http_options": None,
-            "expected": HTTPOptions(location=ProxyLocation.EveryNode),
+            "expected": ProxyLocation.EveryNode,
         },
         {
             "proxy_location": None,
-            "http_options": {"test": "test"},  # location is not specified
-            "expected": HTTPOptions(
-                location=ProxyLocation.EveryNode
-            ),  # using default proxy_location (to align with the case when `http_options` are None)
+            "http_options": {"test": "test"},
+            "expected": ProxyLocation.EveryNode,
         },
-        {
-            "proxy_location": None,
-            "http_options": {
-                "location": "NoServer"
-            },  # `location` is specified, but `proxy_location` is not
-            "expected": HTTPOptions(
-                location=ProxyLocation.Disabled
-            ),  # using `location` value
-        },
-        {
-            "proxy_location": None,
-            "http_options": HTTPOptions(location=None),
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
-        },
-        {
-            "proxy_location": None,
-            "http_options": HTTPOptions(),
-            "expected": HTTPOptions(location=ProxyLocation.HeadOnly),
-        },  # using default location from HTTPOptions
-        {
-            "proxy_location": None,
-            "http_options": HTTPOptions(location="NoServer"),
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
-        },
+        # Explicit (deprecated) `location` is a back-compat override.
         {
             "proxy_location": None,
             "http_options": {"location": "NoServer"},
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
+            "expected": ProxyLocation.Disabled,
+        },
+        # location=None now means "unset" -> defers to proxy_location (EveryNode),
+        # NOT Disabled (the old None-means-Disabled overload is gone).
+        {
+            "proxy_location": None,
+            "http_options": {"location": None},
+            "expected": ProxyLocation.EveryNode,
+        },
+        # Bare HTTPOptions() defers to proxy_location -> EveryNode (was HeadOnly).
+        {
+            "proxy_location": None,
+            "http_options": HTTPOptions(),
+            "expected": ProxyLocation.EveryNode,
         },
         {
             "proxy_location": "Disabled",
             "http_options": None,
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
+            "expected": ProxyLocation.Disabled,
         },
         {
             "proxy_location": "Disabled",
             "http_options": {},
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
-        },
-        {
-            "proxy_location": "Disabled",
-            "http_options": HTTPOptions(host="foobar"),
-            "expected": HTTPOptions(location=ProxyLocation.Disabled, host="foobar"),
+            "expected": ProxyLocation.Disabled,
         },
         {
             "proxy_location": "Disabled",
             "http_options": {"host": "foobar"},
-            "expected": HTTPOptions(location=ProxyLocation.Disabled, host="foobar"),
+            "expected": ProxyLocation.Disabled,
         },
+        # Explicit `location` overrides `proxy_location`.
         {
             "proxy_location": "Disabled",
             "http_options": {"location": "HeadOnly"},
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
-        },
-        {
-            "proxy_location": ProxyLocation.Disabled,
-            "http_options": HTTPOptions(location=ProxyLocation.HeadOnly),
-            "expected": HTTPOptions(location=ProxyLocation.Disabled),
+            "expected": ProxyLocation.HeadOnly,
         },
     ],
 )
 def test_serve_start_proxy_location(ray_shutdown, options):
-    expected_options = options.pop("expected")
+    expected = options.pop("expected")
     serve.start(**options)
     client = _get_global_client()
-    assert ray.get(client._controller.get_http_config.remote()) == expected_options
+    assert client.get_serve_details()["proxy_location"] == expected
 
 
 @pytest.mark.parametrize(

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -11,7 +11,6 @@ from ray.serve._private.config import (
     DeploymentConfig,
     ReplicaConfig,
     _proto_to_dict,
-    prepare_imperative_http_options,
 )
 from ray.serve._private.constants import (
     DEFAULT_AUTOSCALING_POLICY_NAME,
@@ -1176,74 +1175,18 @@ def test_http_options():
     # Test configs ignoring unknown keys (required for forward-compatibility)
     HTTPOptions(new_version_config_key="this config is from newer version of Ray")
 
+    # `location` is deprecated; it defaults to None (proxy_location is the
+    # authority). host=None still disables. Setting a non-None location warns;
+    # location=None is a no-op (internal model_dump roundtrips pass it) and must
+    # NOT warn.
+    assert HTTPOptions().location is None
     assert HTTPOptions(host=None).location == ProxyLocation.Disabled
-    assert HTTPOptions(location=None).location == ProxyLocation.Disabled
-    assert HTTPOptions(location=ProxyLocation.EveryNode).location == "EveryNode"
-
-
-def test_prepare_imperative_http_options():
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options=None,
-    ) == HTTPOptions(location=ProxyLocation.EveryNode)
-
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options={},
-    ) == HTTPOptions(location=ProxyLocation.EveryNode)
-
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options=HTTPOptions(**{}),
-    ) == HTTPOptions(
-        location=ProxyLocation.HeadOnly
-    )  # in this case we can't know whether location was provided or not
-
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options=HTTPOptions(),
-    ) == HTTPOptions(location=ProxyLocation.HeadOnly)
-
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options={"test": "test"},
-    ) == HTTPOptions(location=ProxyLocation.EveryNode)
-
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options={"host": "0.0.0.0"},
-    ) == HTTPOptions(location=ProxyLocation.EveryNode, host="0.0.0.0")
-
-    assert prepare_imperative_http_options(
-        proxy_location=None,
-        http_options={"location": "NoServer"},
-    ) == HTTPOptions(location=ProxyLocation.Disabled)
-
-    assert prepare_imperative_http_options(
-        proxy_location=ProxyLocation.Disabled,
-        http_options=None,
-    ) == HTTPOptions(location=ProxyLocation.Disabled)
-
-    assert prepare_imperative_http_options(
-        proxy_location=ProxyLocation.HeadOnly,
-        http_options={"host": "0.0.0.0"},
-    ) == HTTPOptions(location=ProxyLocation.HeadOnly, host="0.0.0.0")
-
-    assert prepare_imperative_http_options(
-        proxy_location=ProxyLocation.HeadOnly,
-        http_options={"location": "NoServer"},
-    ) == HTTPOptions(location=ProxyLocation.HeadOnly)
-
-    with pytest.raises(ValueError, match="not a valid ProxyLocation"):
-        prepare_imperative_http_options(proxy_location="wrong", http_options=None)
-
-    with pytest.raises(ValidationError, match="not a valid ProxyLocation"):
-        prepare_imperative_http_options(
-            proxy_location=None, http_options={"location": "123"}
-        )
-
-    with pytest.raises(ValueError, match="Unexpected type"):
-        prepare_imperative_http_options(proxy_location=None, http_options="wrong")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert HTTPOptions(location=None).location is None
+    assert not any("`location` in HTTPOptions" in str(w.message) for w in caught)
+    with pytest.warns(DeprecationWarning, match="`location` in HTTPOptions"):
+        assert HTTPOptions(location=ProxyLocation.EveryNode).location == "EveryNode"
 
 
 def test_with_proto():

--- a/python/ray/serve/tests/unit/test_proxy_state.py
+++ b/python/ray/serve/tests/unit/test_proxy_state.py
@@ -94,6 +94,7 @@ def _create_proxy_state_manager(
     actor_proxy_wrapper_class=FakeProxyWrapper,
     timer=Timer(),
     running_native_proxies: bool = False,
+    proxy_location=None,
 ) -> (ProxyStateManager, ClusterNodeInfoCache):
     return (
         ProxyStateManager(
@@ -104,6 +105,7 @@ def _create_proxy_state_manager(
             actor_proxy_wrapper_class=actor_proxy_wrapper_class,
             timer=timer,
             running_native_proxies=running_native_proxies,
+            proxy_location=proxy_location,
         ),
         cluster_node_info_cache,
     )
@@ -162,6 +164,40 @@ def _update_and_check_proxy_state_manager(
         ]
     ), [proxy_state.status for proxy_state in proxy_states.values()]
     return True
+
+
+def test_node_selection_via_proxy_location(all_nodes):
+    # `proxy_location` is the placement authority (threaded separately from the
+    # deprecated HTTPOptions.location); covers HTTP and gRPC (single ProxyActor).
+    all_node_ids = {node_id for node_id, _, _ in all_nodes}
+
+    def mgr(**kwargs):
+        psm, cache = _create_proxy_state_manager(**kwargs)
+        cache.alive_nodes = all_nodes
+        return psm
+
+    assert (
+        mgr(proxy_location=ProxyLocation.Disabled)._get_target_nodes(all_node_ids) == []
+    )
+    assert (
+        mgr(proxy_location=ProxyLocation.HeadOnly)._get_target_nodes(all_node_ids)
+        == all_nodes[:1]
+    )
+    assert (
+        mgr(proxy_location=ProxyLocation.EveryNode)._get_target_nodes(all_node_ids)
+        == all_nodes
+    )
+
+    # Default (neither location nor proxy_location) resolves to EveryNode.
+    assert mgr()._get_target_nodes(all_node_ids) == all_nodes
+    assert mgr().get_proxy_location() == ProxyLocation.EveryNode
+
+    # Explicit (deprecated) HTTPOptions.location overrides proxy_location.
+    with pytest.warns(DeprecationWarning, match="`location` in HTTPOptions"):
+        override = HTTPOptions(location=ProxyLocation.HeadOnly)
+    psm = mgr(http_options=override, proxy_location=ProxyLocation.EveryNode)
+    assert psm._get_target_nodes(all_node_ids) == all_nodes[:1]
+    assert psm.get_proxy_location() == ProxyLocation.HeadOnly
 
 
 def test_node_selection(all_nodes):


### PR DESCRIPTION
Why are these changes needed?
This is the third and final PR in the series that deprecates the three legacy HTTPOptions fields originally bundled in [#63604](https://github.com/ray-project/ray/pull/63604):

middlewares — merged
num_cpus — merged
location — this PR
HTTPOptions.location and the top-level proxy_location argument have historically been two overlapping ways to control where Serve runs its ingress proxies. The reconciliation between them lived in a helper (prepare_imperative_http_options) that folded proxy_location into HTTPOptions.location before controller start-up. As a result the two settings could silently shadow each other, and the source of truth for proxy placement was ambiguous (the controller ultimately read http_options.location, but callers set proxy_location).

This PR makes proxy_location the single placement authority and demotes HTTPOptions.location to a deprecated, warn-on-set back-compat override. This acts on reviewer feedback to thread proxy_location through the controller/proxy manager directly and delete the merge-into-HTTPOptions indirection.

What changed
Public API / semantics
HTTPOptions.location is deprecated. Its default changed from ProxyLocation.HeadOnly to None, and setting it to any value (including None) now emits a DeprecationWarning directing users to proxy_location.
proxy_location is threaded end-to-end as a first-class argument — serve.start / serve_start / serve_start_async / _create_controller_and_proxy_refs → ServeController.__init__ → ProxyStateManager — instead of being merged into HTTPOptions.
Placement resolution precedence now lives in one place, ProxyStateManager._resolved_proxy_location():
explicit (deprecated) HTTPOptions.location, if set — kept as an override for back-compat;
else proxy_location;
else default ProxyLocation.EveryNode.
host=None still disables the proxy (unchanged; location_backfill_no_server now keys only on host is None).
get_serve_details()["proxy_location"] now reports the resolved placement (from the proxy state manager) rather than echoing http_config.location, which could be None/stale.
Simplification
Deleted prepare_imperative_http_options (~54 lines) from _private/config.py.
The direct-ingress branch in ServeController now sets proxy_location = ProxyLocation.HeadOnly and clears the deprecated location (via model_copy), instead of mutating http_options.location in place.
serve run, serve.run, and the dashboard serve_head endpoint now pass proxy_location= explicitly instead of injecting {"location": ...} into the http_options dict.
Default behavior — unchanged
When neither proxy_location nor location is set, proxies run on EveryNode — the same effective default previously produced by prepare_imperative_http_options. This refactor changes how placement is resolved, not the resolved default.

Backward compatibility
Code that passes proxy_location=... is unaffected.
Code that sets HTTPOptions(location=...) continues to work as an override, but now emits a DeprecationWarning.
host=None continues to disable the proxy.

Follow-up to [#63604](https://github.com/ray-project/ray/pull/63604).