### PR TITLE
[docs] Exclude doc/.claude/ from the RtD PR skip-guard

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,9 @@ build:
     # with a backslash-escape format string), avoid backslash escapes
     # in general, and keep shell comments out of this block so that
     # backticks/$() inside comments don't confuse the preprocessor.
+    # The runner also strips the surrounding single quotes from arguments,
+    # so use git's :! exclude shorthand rather than :(exclude): unquoted
+    # parentheses reach /bin/sh (dash) and abort the script with a syntax error.
     post_checkout:
       - |
         if [ "${READTHEDOCS_VERSION_TYPE:-}" != "external" ]; then
@@ -36,14 +39,14 @@ build:
           echo "Could not determine merge-base with origin/master; building docs to be safe."
           exit 0
         fi
-        if git diff --quiet origin/master...HEAD -- doc/ ':(exclude)doc/.claude/' python/ray/ rllib/ .readthedocs.yaml; then
+        if git diff --quiet origin/master...HEAD -- doc/ ':!doc/.claude/' python/ray/ rllib/ .readthedocs.yaml; then
           echo "No doc-affecting files changed in this PR; skipping Sphinx build."
           echo "Files changed in PR:"
           git diff --name-only origin/master...HEAD
           exit 183
         fi
         echo "Doc-affecting files changed; building docs. Changed doc-relevant paths:"
-        git diff --name-only origin/master...HEAD -- doc/ ':(exclude)doc/.claude/' python/ray/ rllib/ .readthedocs.yaml
+        git diff --name-only origin/master...HEAD -- doc/ ':!doc/.claude/' python/ray/ rllib/ .readthedocs.yaml
     # Override the html build step. On PR (external) builds, build incrementally
     # from the latest master doc cache, falling back to a clean build
     # (rtd-fallback) if it fails. PRs that delete or move doc sources skip the

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,9 @@ build:
     # files that affect documentation output. Reduces queue pressure on
     # the shared RTD build slots when several PRs are open at once.
     # Tag/branch builds (master, stable, etc.) always run.
+    # The guard matches doc/ but excludes doc/.claude/ (Claude Code skills
+    # and agent files), which never participate in the Sphinx build, so a
+    # PR that changes only those paths skips the build instead of running one.
     # See https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
     #
     # Some constructs are avoided deliberately because RTD's job runner
@@ -33,14 +36,14 @@ build:
           echo "Could not determine merge-base with origin/master; building docs to be safe."
           exit 0
         fi
-        if git diff --quiet origin/master...HEAD -- doc/ python/ray/ rllib/ .readthedocs.yaml; then
+        if git diff --quiet origin/master...HEAD -- doc/ ':(exclude)doc/.claude/' python/ray/ rllib/ .readthedocs.yaml; then
           echo "No doc-affecting files changed in this PR; skipping Sphinx build."
           echo "Files changed in PR:"
           git diff --name-only origin/master...HEAD
           exit 183
         fi
         echo "Doc-affecting files changed; building docs. Changed doc-relevant paths:"
-        git diff --name-only origin/master...HEAD -- doc/ python/ray/ rllib/ .readthedocs.yaml
+        git diff --name-only origin/master...HEAD -- doc/ ':(exclude)doc/.claude/' python/ray/ rllib/ .readthedocs.yaml
     # Override the html build step. On PR (external) builds, build incrementally
     # from the latest master doc cache, falling back to a clean build
     # (rtd-fallback) if it fails. PRs that delete or move doc sources skip the


### PR DESCRIPTION
## Description

The `post_checkout` skip-guard in `.readthedocs.yaml` (added in #64277) skips the RtD Sphinx build on PRs that touch no doc-affecting files. It keys on a coarse pathspec:

```
git diff --quiet origin/master...HEAD -- doc/ python/ray/ rllib/ .readthedocs.yaml
```

Because it matches all of `doc/`, a PR whose only changes are under `doc/.claude/` (Claude Code skills and agent files) counts as doc-affecting and runs a full Sphinx build — even though those files never participate in the build, which globs from `doc/source/`.

This surfaced on #64147 (the entire diff was under `doc/.claude/skills/**` plus `.pre-commit-config.yaml`), which should have been a no-op for RtD but ran a full build. While the doc build cache was unavailable (from the Sphinx 8.2.3 upgrade until #64414), that full build was a cold clean build that repeatedly timed out the RtD check. A correctly-scoped guard skips the build entirely and sidesteps the timeouts regardless of cache health.

This PR adds a `':(exclude)doc/.claude/'` git exclude pathspec to the guard's `git diff` and to the doc-affecting-paths echo just below it, so a PR touching only those paths skips the build. Both stay on single lines with no backslash escapes, so RtD's job-runner preprocessor (which silently drops scripts containing certain constructs) preserves the script.

Verified locally: a staged change under only `doc/.claude/` makes `git diff --quiet ...` return true (skip), while a change under `doc/source/` still returns false (build).

## Related issues

Related to #64277, #64414.

## Additional information

The excluded set is intentionally conservative — `doc/.claude/` is the clear build-irrelevant case today. A false skip would publish stale output, so other non-source paths were left in scope.
