### PR TITLE
[Data] remove shuffle streaming reduce

### DIFF
--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -48,14 +48,8 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         data_context: Runtime configuration.
         num_partitions: Total number of output partitions.  Must match the
             value used by the paired `ShuffleMapOp`.
-        reduce_fn: Function called once per partition (in blocking mode)
-            or incrementally (in streaming mode) to combine input shards
-            into output blocks.
-        streaming_reduce: If True, `reduce_fn` is called whenever a
-            partition's accumulator reaches `target_max_block_size`.  If
-            False, wait for all shards before calling once (required for
-            sort or stateful aggregation).  Forced to False when
-            `disallow_block_splitting=True`.
+        reduce_fn: Function called once per partition, with the full shard
+            list, to combine input shards into output blocks.
         disallow_block_splitting: If True, output blocks are emitted as-is
             without being reshaped to `target_max_block_size` — required
             for hash-shuffle's "partition = block" contract.
@@ -80,7 +74,6 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         *,
         num_partitions: int,
         reduce_fn: ReduceFn,
-        streaming_reduce: bool = True,
         disallow_block_splitting: bool = False,
         reduce_cpus: Optional[float] = None,
         name: str = "ShuffleReduce",
@@ -97,9 +90,6 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         self._num_partitions: int = num_partitions
         self._reduce_fn: ReduceFn = reduce_fn
         self._disallow_block_splitting: bool = disallow_block_splitting
-        # Block-splitting disallowed → reducer must see entire partition
-        # before emitting, so force blocking mode regardless of the flag.
-        self._streaming_reduce: bool = streaming_reduce and not disallow_block_splitting
 
         # -- Reduce task config & tracking -----------------------------------
         self._shuffle_reduce_task_num_cpus: float = (
@@ -190,7 +180,6 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             partition_id,
             self._reduce_fn,
             target_max_block_size,
-            self._streaming_reduce,
             self.data_context.hash_shuffle_reduce_batch_size,
             self.data_context.hash_shuffle_reduce_get_timeout_s,
             self._fused_output_map_transformer,

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
@@ -215,7 +215,6 @@ def _shuffle_reduce_task(
     partition_id: int,
     reduce_fn: ReduceFn,
     target_max_block_size: Optional[int],
-    streaming: bool,
     batch_size: int,
     get_timeout_s: float,
     map_transformer: Optional["MapTransformer"],
@@ -224,22 +223,17 @@ def _shuffle_reduce_task(
 ) -> Generator[Union[Block, bytes], None, None]:
     """Reduce stage: fetch one partition's shards and run reduce_fn over them.
 
-    With streaming=True, reduce_fn is called each time the accumulated input
-    passes target_max_block_size and its output is reshaped to that size via a
-    BlockOutputBuffer; this bounds peak input memory but requires reduce_fn to
-    produce valid output from partial input.  With streaming=False, all shards
-    are accumulated and reduce_fn is called once, use this when it needs the
-    whole partition (sort, aggregate).
+    All of the partition's shards are accumulated and reduce_fn is called once
+    over the full list; its output is reshaped to target_max_block_size via a
+    BlockOutputBuffer (a no-op passthrough when target_max_block_size is None).
 
     Args:
         shard_refs: ObjectRefs to this partition's IPC shards from every mapper.
             May contain None for mappers that produced no rows here.
         partition_id: Partition this reducer owns.
         reduce_fn: User-supplied reduce callable.
-        target_max_block_size: Output block size, and the streaming flush
-            threshold.  None emits blocks as-is (no reshaping, no streaming
-            flush) -- the "partition = block" contract.
-        streaming: Flush incrementally (True) or accumulate then reduce (False).
+        target_max_block_size: Output block size.  None emits blocks as-is
+            (no reshaping).
         batch_size: Number of shard refs to ray.get() at a time.
         get_timeout_s: Timeout for batch ray.get().
         map_transformer: Fused downstream map applied to reduce output (or None).
@@ -250,8 +244,6 @@ def _shuffle_reduce_task(
     """
     start_time_s = time.perf_counter()
 
-    accum_tables: List[pa.Table] = []
-    accum_bytes: int = 0
     output_buffer: Optional[BlockOutputBuffer] = None
 
     def _yield_with_stats(block: Block):
@@ -285,10 +277,9 @@ def _shuffle_reduce_task(
             yield from output_buffer.iter_ready_blocks()
 
     def _reduce_output_blocks():
-        nonlocal accum_tables, accum_bytes
-        # Step 1: fetch shard refs in batches, decompress, accumulate.  In
-        # streaming mode, when the accumulator reaches target_max_block_size,
-        # flush through reduce_fn and yield any ready output blocks.
+        # Step 1: fetch shard refs in batches, decompress, accumulate the whole
+        # partition.
+        accum_tables: List[pa.Table] = []
         num_batches = math.ceil(len(shard_refs) / batch_size) if batch_size else 0
         for batch_index, batch_start in enumerate(
             range(0, len(shard_refs), batch_size)
@@ -308,24 +299,12 @@ def _shuffle_reduce_task(
                 if table is None:
                     continue
                 accum_tables.append(table)
-                accum_bytes += table.nbytes
 
-                if (
-                    streaming
-                    and target_max_block_size is not None
-                    and accum_bytes >= target_max_block_size
-                ):
-                    tables, accum_tables = accum_tables, []
-                    accum_bytes = 0
-                    yield from _flush(tables)
-
-        # Step 2: drain remaining shards through reduce_fn.  This is the only
-        # reduce_fn call in blocking mode, and the tail-flush in streaming mode.
+        # Step 2: run reduce_fn once over the full partition.
         if accum_tables:
             yield from _flush(accum_tables)
 
-        # Step 3: if reduce_fn ran at least once, finalize the buffer to flush
-        # any partial block.
+        # Step 3: finalize the buffer to flush any partial block.
         if output_buffer is not None:
             output_buffer.finalize()
             yield from output_buffer.iter_ready_blocks()

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -388,7 +388,6 @@ class FuseOperators(Rule):
             up_op.data_context,
             num_partitions=up_op._num_partitions,
             reduce_fn=up_op._reduce_fn,
-            streaming_reduce=up_op._streaming_reduce,
             disallow_block_splitting=up_op._disallow_block_splitting,
             reduce_cpus=up_op._shuffle_reduce_task_num_cpus,
             name=name,

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -100,7 +100,6 @@ def _plan_hash_shuffle_repartition(
         data_context,
         num_partitions=target_num_partitions,
         reduce_fn=reduce_fn,
-        streaming_reduce=False,
         disallow_block_splitting=True,
         name=(
             f"HashShuffleReduce(keys={tuple(key_list)}, "


### PR DESCRIPTION
## Description
Most APIs won't use streaming reduce, and repartition in particular can't — it need to maintain the "one partition = one block", so it always runs the reducer in blocking mode (`disallow_block_splitting=True`). On top of that, keeping the streaming-reduce path around makes it harder to implement other APIs (join) that all require the full partition before reducing.

So we're removing the streaming_reduce flag and its incremental-flush logic now. The reduce is unconditionally "accumulate the partition → reduce once → finalize". The disallow_block_splitting / target_max_block_size axis is kept — it's independent and still useful.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
