### PR TITLE
[doc] rtd: walk origin/master (not shallow HEAD) to find the doc cache

### DIFF
--- a/doc/load_doc_cache.py
+++ b/doc/load_doc_cache.py
@@ -17,17 +17,27 @@ def _build_cache_url(commit: str):
 
 
 def find_latest_master_commit():
-    """Find latest commit that was pushed to origin/master that is also on local env."""
-    latest_commits = (
+    """Find the latest origin/master commit that has a build cache uploaded.
+
+    Walk origin/master, not HEAD. Read the Docs checks out PRs with a shallow
+    ``git clone --depth 1``, so HEAD's history is grafted -- a plain ``git log``
+    then sees ~1 commit and never reaches a cached master commit. post_checkout
+    in .readthedocs.yaml deepens origin/master (``git fetch --depth=500 origin
+    master``), so that ref has real history to probe. Fall back to HEAD when
+    origin/master is unavailable (e.g. a local checkout without that
+    remote-tracking ref).
+    """
+    try:
         subprocess.check_output(
-            [
-                "git",
-                "log",
-                "-n",
-                "100",
-                "--format=%H",
-            ]
+            ["git", "rev-parse", "--verify", "origin/master"],
+            stderr=subprocess.DEVNULL,
         )
+        ref = "origin/master"
+    except subprocess.CalledProcessError:
+        ref = "HEAD"
+
+    latest_commits = (
+        subprocess.check_output(["git", "log", "-n", "100", "--format=%H", ref])
         .strip()
         .decode("utf-8")
         .split("\n")

--- a/doc/load_doc_cache.py
+++ b/doc/load_doc_cache.py
@@ -27,14 +27,15 @@ def find_latest_master_commit():
     origin/master is unavailable (e.g. a local checkout without that
     remote-tracking ref).
     """
-    try:
-        subprocess.check_output(
+    has_origin_master = (
+        subprocess.run(
             ["git", "rev-parse", "--verify", "origin/master"],
+            stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-        )
-        ref = "origin/master"
-    except subprocess.CalledProcessError:
-        ref = "HEAD"
+        ).returncode
+        == 0
+    )
+    ref = "origin/master" if has_origin_master else "HEAD"
 
     latest_commits = (
         subprocess.check_output(["git", "log", "-n", "100", "--format=%H", ref])


### PR DESCRIPTION
## Description

Fixes the **consumer** side of the incremental Read the Docs build. `find_latest_master_commit()` never finds the doc cache, so every PR preview falls through to a full cold build — chronically near the RtD time limit, and timing out when the full build runs slow.

### Root cause

`find_latest_master_commit()` (`doc/load_doc_cache.py`) ran `git log` with **no ref** — i.e. against `HEAD`. But Read the Docs checks out PRs with `git clone --depth 1`, so `HEAD`'s history is grafted: the walk sees ~1 commit and never probes a real master commit. `post_checkout` deepens `origin/master` to 500 commits, but the consumer looked at `HEAD`, not `origin/master` — the two never meet. So `load_doc_cache.py` always raises `No cache found for latest master commit`, `make rtd` fails, and `|| make rtd-fallback` does a full `git clean` + cold Sphinx build (~3,967 sources) on every build.

This is independent of the producer: even after #64414 repaired cache production (caches are flowing again — e.g. `0c1f570a8bf1`, `5612883ea63f` serve 200 today), the consumer still couldn't reach them. It also explains why *merging master didn't help* affected PRs — the shallow graft means `git log HEAD` never reaches a merged-in cached commit either.

### Fix

Walk `origin/master` — the ref `post_checkout` already deepened — instead of `HEAD`. Falls back to `HEAD` when `origin/master` isn't available (e.g. a local checkout without that remote-tracking ref), and the existing `|| make rtd-fallback` still covers a genuine cache miss.

### Verified

Ran the modified `find_latest_master_commit()` against the live cache: it returns `0c1f570a8bf1` (a real cached master commit) where the old `HEAD` walk returned nothing usable. `ruff` + `black` clean.

## Related issues

Consumer side of the incremental RtD build (**#64277**); producer repaired in **#64414**. Related to **[DOC-1047](https://anyscale1.atlassian.net/browse/DOC-1047)** (epic DOC-1046).

## Additional information

Credit to the reviewer who pinpointed the shallow-`HEAD` / wrong-ref root cause. This is only fully exercised on a real RtD PR build (the `--depth 1` clone + `post_checkout` deepen), so worth confirming on this PR's own preview that it logs `Use build cache for commit …` and an incremental `N changed` instead of `3967 added, 0 changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
