### PR TITLE
[doc] conf: enumerate llms_txt_exclude notebooks from git, not a live rglob

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -132,15 +132,17 @@ llms_txt_exclude = [
 # across environments for a given commit. See DOC-1344.
 _conf_dir = pathlib.Path(__file__).parent
 try:
-    _notebooks = subprocess.run(
-        ["git", "ls-files", "*.ipynb"],
+    _git_out = subprocess.run(
+        ["git", "ls-files", "-z", "*.ipynb"],
         cwd=_conf_dir,
         capture_output=True,
         text=True,
         check=True,
-    ).stdout.splitlines()
-except (OSError, subprocess.CalledProcessError):
-    # Non-git checkout (e.g. a source tarball): fall back to a filesystem scan.
+    ).stdout
+    # -z gives NUL-separated, unquoted paths (robust to spaces/newlines/unicode).
+    _notebooks = [nb for nb in _git_out.split("\0") if nb]
+except Exception:
+    # Non-git checkout or any git/decode failure: fall back to a filesystem scan.
     _notebooks = [
         p.relative_to(_conf_dir).as_posix() for p in _conf_dir.rglob("*.ipynb")
     ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import random
 import re
+import subprocess
 import sys
 import time
 import zipfile
@@ -122,10 +123,29 @@ llms_txt_exclude = [
 # fnmatch, so a `**/*.ipynb` pattern can't work — we enumerate each
 # notebook's docname instead. Notebooks remain fully rendered in the HTML
 # build; only the agent corpus drops them.
+# Enumerate notebook docnames from the git-tracked set, not a live filesystem
+# scan. A live rglob also picks up notebooks generated or restored during the
+# build, and that set differs between the clean cache-producer tree (Buildkite)
+# and the cache-restored consumer tree (Read the Docs). Since llms_txt_exclude
+# is an env-affecting config value, that difference makes Sphinx discard the
+# restored doctree cache and re-read every doc. The tracked set is identical
+# across environments for a given commit. See DOC-1344.
 _conf_dir = pathlib.Path(__file__).parent
+try:
+    _notebooks = subprocess.run(
+        ["git", "ls-files", "*.ipynb"],
+        cwd=_conf_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+except (OSError, subprocess.CalledProcessError):
+    # Non-git checkout (e.g. a source tarball): fall back to a filesystem scan.
+    _notebooks = [
+        p.relative_to(_conf_dir).as_posix() for p in _conf_dir.rglob("*.ipynb")
+    ]
 llms_txt_exclude += sorted(
-    p.relative_to(_conf_dir).with_suffix("").as_posix()
-    for p in _conf_dir.rglob("*.ipynb")
+    pathlib.Path(nb).with_suffix("").as_posix() for nb in _notebooks
 )
 
 # -- sphinx-collections: pull external template files at build time -----------


### PR DESCRIPTION
## Description

Part of making the incremental RtD doctree cache actually deliver its speedup (DOC-1047). #64414 (producer) and #64482 (consumer reaches the cache) are merged, but RtD still re-reads all ~3,967 docs on every preview: Sphinx restores the cache, then discards the doctree because `conf.py` evaluates to a different config than the cache was built with. Full audit in **DOC-1344**; this is the first cut — the single option Sphinx names as the doctree-rebuild trigger.

### Root cause

`llms_txt_exclude` was built from a live `rglob("*.ipynb")` over `doc/source`, so its value depends on which notebooks exist when `conf.py` runs:
- **Producer** (Buildkite `make html`, clean tree): `conf.py` runs before sphinx-collections pulls, so it sees only the **59 git-tracked** notebooks.
- **Consumer** (RtD `make rtd`, cache-restored tree): the cache captured the ~67 gitignored notebooks sphinx-collections pulled into `_collections/…`, so `conf.py` sees **59 + 67**.

`llms_txt_exclude` is an env-affecting config value, so that difference makes Sphinx invalidate the whole restored doctree → `[config changed ('llms_txt_exclude')] 3967 added` (verified on build 4166140, PR #64482).

### Fix

Enumerate notebooks from the **git-tracked** set (`git ls-files "*.ipynb"`) — identical across environments for a given commit — with a filesystem-scan fallback for non-git checkouts. This equals what the clean producer and the published `master` build already compute (their `conf.py` also runs before the pull), so `llms-full.txt` is unchanged there.

### Verified

- **Determinism:** adding an untracked `.ipynb` grows the old `rglob` (126→127) but leaves the git-tracked result stable (59→59).
- **Correctness:** on a clean checkout `rglob == git ls-files`; the local 126-vs-59 gap is exactly the 67 gitignored `_collections` pulled notebooks that cause the producer↔consumer mismatch.

## Related issues

First cut for **[DOC-1344](https://anyscale1.atlassian.net/browse/DOC-1344)** (doctree-cache config portability); unblocks **[DOC-1047](https://anyscale1.atlassian.net/browse/DOC-1047)**.

## Additional information

Only fully verifiable on a live RtD PR build — the payoff is `N changed` instead of `3967 added` on this PR's preview. This fixes only the env-rebuild trigger; the `html_*` env-var diffs (`version_match`, sidebars) still force HTML *re-output* (much cheaper — no re-read / notebook execution) and the `collections` function-ref hash remains — both enumerated in DOC-1344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
