### PR TITLE
[serve][llm] Parse direct-streaming routing payload for body-aware routers (#64328)

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -1,15 +1,48 @@
+import json
+from types import SimpleNamespace
 from typing import Optional, Tuple
 
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
+from ray.llm._internal.serve.observability.logging import get_logger
 from ray.serve._private.http_util import _matches_session_id_header
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 
+logger = get_logger(__name__)
+
 _BODY_TRUNCATED_HEADER = "x-body-truncated"
 
+# A request body routes on one of these fields. Body-aware routers read it off
+# the namespace; a body without any of them degrades to load-balancing. Extend
+# as routers learn to route additional request types.
+_ROUTING_KEY_FIELDS = ("messages", "prompt")
+
 router_app = FastAPI()
+
+
+def _parse_routing_payload(body: bytes) -> Optional[SimpleNamespace]:
+    """Wrap a request body as a namespace a body-aware router routes on.
+
+    Routers read a routing field (``messages`` or ``prompt``) off the first
+    positional routing arg, the parsed request the normal ingress forwards.
+    Direct streaming has only the raw body, so this wraps the parsed body in a
+    namespace exposing every field by attribute, which a router reads the same
+    way regardless of request type. Returns ``None`` for an empty, non-object,
+    unparseable, or keyless body, so the caller falls back to load-balancing.
+    """
+    if not body:
+        return None
+    try:
+        data = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not any(data.get(field) for field in _ROUTING_KEY_FIELDS):
+        return None
+    return SimpleNamespace(**data)
 
 
 @serve.ingress(router_app)
@@ -29,16 +62,17 @@ class LLMRouter:
     Request:
         POST /internal/route
         Content-Type: application/json
-        Body: the target ChatCompletions / Completions request payload.
-            The body is plumbed through to ``choose_replica`` so future
-            body-aware policies (e.g. prefix-cache-aware) can score replicas
-            against ``messages`` / ``prompt``.
+        Body: the target ChatCompletions or Completions request payload.
+            Wrapped in a namespace by ``_parse_routing_payload`` and passed to
+            ``choose_replica`` positionally, exposing the request fields the way
+            the parsed request does. Body-aware policies then score replicas the
+            same way on both paths.
 
     Truncated bodies:
-        HAProxy may forward only a prefix of the request body for routing.
-        When it does, it must set the ``x-body-truncated`` header; both the
-        body bytes and this signal are forwarded to ``choose_replica`` for
-        future body-aware policies.
+        HAProxy may forward only a prefix of the body for routing and sets the
+        ``x-body-truncated`` header. A truncated prefix is usually not valid
+        JSON, so no routing key is derived and the request falls back to the
+        default load-balanced pick.
 
     Session affinity:
         If the client request carried the session-id header configured by
@@ -60,6 +94,10 @@ class LLMRouter:
         Serve uses ``check_health()`` for replica readiness, not HTTP.
     """
 
+    # Warn once per replica when no routing key is derived. Class-level default
+    # keeps the guard safe before __init__ runs.
+    _warned_no_routing_key: bool = False
+
     async def __init__(self, server: DeploymentHandle):
         self._handle: DeploymentHandle = server
         self._handle._init()
@@ -68,6 +106,18 @@ class LLMRouter:
     async def route(self, request: Request):
         body = await request.body()
         body_truncated = _BODY_TRUNCATED_HEADER in request.headers
+        routing_payload = _parse_routing_payload(body)
+        if routing_payload is None and not self._warned_no_routing_key:
+            self._warned_no_routing_key = True
+            logger.warning(
+                "Could not derive a routing key from the request body. "
+                "body_truncated=%s. Falling back to load-balanced replica "
+                "selection. A configured body-aware router such as "
+                "PrefixCacheAffinityRouter cannot take effect for these "
+                "requests. For truncated bodies, raise HAProxy's routing body "
+                "limit.",
+                body_truncated,
+            )
         # HAProxy forwards the configured session header on the same name,
         # but use the same case-insensitive, separator-tolerant matcher as
         # proxy.py / ingress.py so a `-`/`_` rewrite anywhere in the path
@@ -82,8 +132,7 @@ class LLMRouter:
         try:
             host, port, replica_id = await self._pick_replica(
                 handle=handle,
-                request_body=body,
-                body_truncated=body_truncated,
+                routing_payload=routing_payload,
             )
         except (RuntimeError, DeploymentUnavailableError) as e:
             raise HTTPException(status_code=503, detail=str(e))
@@ -96,8 +145,7 @@ class LLMRouter:
     async def _pick_replica(
         self,
         handle: DeploymentHandle,
-        request_body: Optional[bytes] = None,
-        body_truncated: bool = False,
+        routing_payload: Optional[SimpleNamespace] = None,
     ) -> Tuple[str, int, str]:
         """Pick a backend HTTP replica via the deployment's request router.
 
@@ -105,11 +153,11 @@ class LLMRouter:
         with ``.options(session_id=...)`` by the caller so session-aware
         routers see the session id on ``RequestMetadata``.
 
-        ``request_body`` (possibly a HAProxy-truncated prefix, indicated by
-        ``body_truncated``) is forwarded to ``choose_replica`` so a future
-        body-aware policy can score replicas against the request's prompt /
-        messages without changing the /internal/route contract or the call
-        site.
+        ``routing_payload``, when present, is passed to ``choose_replica``
+        positionally. It lands in ``pending_request.args`` where the normal
+        ingress puts the parsed request, so a body-aware policy scores replicas
+        as on the normal path. When ``None``, nothing is forwarded. The router
+        sees empty ``args`` and falls back to its default load-balanced pick.
 
         ``_reserve=False`` short-circuits the replica-side ``reserve_slot``
         actor RPC and the rejection-retry loop: the real request goes out via
@@ -117,9 +165,9 @@ class LLMRouter:
         the extra RPC + retry introduced burstiness compared to the prior
         local round-robin implementation.
         """
+        route_args = (routing_payload,) if routing_payload is not None else ()
         async with handle.choose_replica(
-            request_body=request_body,
-            body_truncated=body_truncated,
+            *route_args,
             _reserve=False,
         ) as selection:
             replica = selection._replica

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -1,7 +1,8 @@
 import sys
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import openai
 import pytest
@@ -14,11 +15,15 @@ from ray.llm._internal.serve.core.configs.llm_config import (
     ModelLoadingConfig,
 )
 from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
+from ray.llm._internal.serve.core.ingress import router as router_module
 from ray.llm._internal.serve.core.ingress.ingress import (
     OpenAiIngress,
     make_fastapi_ingress,
 )
-from ray.llm._internal.serve.core.ingress.router import LLMRouter
+from ray.llm._internal.serve.core.ingress.router import (
+    LLMRouter,
+    _parse_routing_payload,
+)
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
 from ray.serve._private.common import DeploymentID
@@ -126,14 +131,15 @@ def create_oai_client(llm_config: LLMConfig):
 
 class TestDirectStreamingLLMRouter:
     @pytest.mark.asyncio
-    async def test_route_forwards_body_and_truncation_signal(self):
+    async def test_route_parses_body_into_routing_payload(self):
+        """A parseable body becomes a routing payload passed positionally."""
         router = _new_direct_router()
         router._pick_replica = AsyncMock(
             return_value=("127.0.0.1", 9001, "DeploymentName#replica")
         )
 
-        body = b'{"model":"x","prompt":"' + (b"x" * 1024)
-        request = _FakeRequest(body, headers={"x-body-truncated": "1058/90000"})
+        body = b'{"model":"x","messages":[{"role":"user","content":"hi"}]}'
+        request = _FakeRequest(body)
 
         result = await router.route(request)
 
@@ -142,9 +148,39 @@ class TestDirectStreamingLLMRouter:
             "port": 9001,
             "replica_id": "DeploymentName#replica",
         }
-        router._pick_replica.assert_called_once_with(
-            handle=router._handle, request_body=body, body_truncated=True
+        _, kwargs = router._pick_replica.call_args
+        assert kwargs["handle"] is router._handle
+        payload = kwargs["routing_payload"]
+        assert isinstance(payload, SimpleNamespace)
+        assert payload.messages == [{"role": "user", "content": "hi"}]
+        # The whole body is exposed, so a router can read any field.
+        assert payload.model == "x"
+        assert not hasattr(payload, "prompt")
+        # A parseable body must not trip the "no routing key" warning.
+        assert router._warned_no_routing_key is False
+
+    @pytest.mark.asyncio
+    async def test_route_truncated_body_yields_no_payload_and_warns_once(self):
+        """A truncated body derives no key. ``route`` forwards ``None`` and
+        warns once per replica."""
+        router = _new_direct_router()
+        router._pick_replica = AsyncMock(
+            return_value=("127.0.0.1", 9001, "DeploymentName#replica")
         )
+
+        # Truncated prefix is not valid JSON so json.loads fails.
+        body = b'{"model":"x","prompt":"' + (b"x" * 1024)
+        request = _FakeRequest(body, headers={"x-body-truncated": "1058/90000"})
+
+        with patch.object(router_module.logger, "warning") as mock_warning:
+            await router.route(request)
+            await router.route(request)
+
+        # routing_payload is None on both calls. Warning fires once.
+        for call in router._pick_replica.call_args_list:
+            assert call.kwargs["routing_payload"] is None
+        assert mock_warning.call_count == 1
+        assert router._warned_no_routing_key is True
 
     @pytest.mark.asyncio
     async def test_route_returns_503_on_pick_failure(self):
@@ -184,34 +220,51 @@ class TestDirectStreamingLLMRouter:
         assert (host, port, replica_id) == ("10.0.0.1", 8123, "DeploymentName#r1")
 
     @pytest.mark.asyncio
-    async def test_pick_replica_forwards_body_to_choose_replica(self):
-        """``request_body`` / ``body_truncated`` reach the underlying router.
-
-        Future body-aware request routers read these off the PendingRequest.
-        """
+    async def test_pick_replica_forwards_payload_positionally(self):
+        """A routing payload reaches ``choose_replica`` as the first positional
+        arg, alongside the ``_reserve=False`` fast-path flag."""
         replica = _DirectRouterReplica("r1", full_id="d#r1")
 
-        captured_kwargs = {}
+        captured = {}
 
         @asynccontextmanager
         async def fake_choose_replica(*args, **kwargs):
-            captured_kwargs.update(kwargs)
+            captured["args"] = args
+            captured["kwargs"] = kwargs
             yield _selection_for(replica)
 
         handle = MagicMock()
         handle.choose_replica = fake_choose_replica
         router = _new_direct_router(handle)
 
-        body = b'{"messages": [{"role": "user", "content": "hi"}]}'
-        await router._pick_replica(
-            handle=handle, request_body=body, body_truncated=True
-        )
+        payload = SimpleNamespace(messages=[{"role": "user", "content": "hi"}])
+        await router._pick_replica(handle=handle, routing_payload=payload)
 
-        assert captured_kwargs == {
-            "request_body": body,
-            "body_truncated": True,
-            "_reserve": False,
-        }
+        assert captured["args"] == (payload,)
+        assert captured["kwargs"] == {"_reserve": False}
+
+    @pytest.mark.asyncio
+    async def test_pick_replica_omits_positional_arg_when_no_payload(self):
+        """With no routing payload, nothing is forwarded positionally. The
+        configured router then sees empty args and load-balances."""
+        replica = _DirectRouterReplica("r1", full_id="d#r1")
+
+        captured = {}
+
+        @asynccontextmanager
+        async def fake_choose_replica(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            yield _selection_for(replica)
+
+        handle = MagicMock()
+        handle.choose_replica = fake_choose_replica
+        router = _new_direct_router(handle)
+
+        await router._pick_replica(handle=handle, routing_payload=None)
+
+        assert captured["args"] == ()
+        assert captured["kwargs"] == {"_reserve": False}
 
     @pytest.mark.asyncio
     async def test_pick_replica_raises_when_endpoint_missing(self):
@@ -224,6 +277,70 @@ class TestDirectStreamingLLMRouter:
 
         with pytest.raises(RuntimeError, match="no backend HTTP endpoint"):
             await router._pick_replica(handle=handle)
+
+
+class TestRoutingPayload:
+    """Unit coverage for wrapping a body as a routing namespace."""
+
+    def test_parses_chat_messages(self):
+        body = b'{"model":"x","messages":[{"role":"user","content":"hi"}]}'
+        payload = _parse_routing_payload(body)
+        assert isinstance(payload, SimpleNamespace)
+        assert payload.messages == [{"role": "user", "content": "hi"}]
+        # A chat body exposes no `prompt`, so `_extract_text_from_request`
+        # resolves it as a chat request. Other fields are still exposed.
+        assert not hasattr(payload, "prompt")
+        assert payload.model == "x"
+
+    def test_parses_completion_prompt(self):
+        payload = _parse_routing_payload(b'{"model":"x","prompt":"hello"}')
+        assert isinstance(payload, SimpleNamespace)
+        assert payload.prompt == "hello"
+        assert not hasattr(payload, "messages")
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            b"",  # empty
+            b'{"model":"x","prompt":"' + (b"x" * 64),  # truncated, invalid JSON
+            b"not json",  # unparseable
+            b"[1, 2, 3]",  # valid JSON but not an object
+            b'{"model":"x","max_tokens":8}',  # object without messages or prompt
+            b'{"messages":[]}',  # empty messages carry no routing signal
+            b'{"prompt":""}',  # empty prompt carries no routing signal
+            b'{"model":"x","input":"hello"}',  # other request type, no routing key
+        ],
+    )
+    def test_returns_none_when_no_key_derivable(self, body):
+        assert _parse_routing_payload(body) is None
+
+    @pytest.mark.asyncio
+    async def test_payload_satisfies_prefix_router_contract(self):
+        """The normalized payload is read by the real
+        ``PrefixCacheAffinityRouter._extract_text_from_request``, the consumer
+        that regressed in #64326.
+
+        Async so a running event loop exists for the ``PendingRequest`` default
+        ``asyncio.Future``.
+        """
+        from ray.llm._internal.serve.routing_policies.prefix_aware.prefix_aware_router import (  # noqa: E501
+            PrefixCacheAffinityRouter,
+        )
+        from ray.serve._private.request_router.common import PendingRequest
+
+        # __new__ avoids the tree-actor setup in __init__. The method under test
+        # only uses self for the pure `_normalize_prompt_to_string` helper.
+        router = PrefixCacheAffinityRouter.__new__(PrefixCacheAffinityRouter)
+
+        chat = _parse_routing_payload(
+            b'{"messages":[{"role":"user","content":"hello world"}]}'
+        )
+        pr = PendingRequest(args=[chat], kwargs={}, metadata=MagicMock())
+        assert router._extract_text_from_request(pr) == "hello world"
+
+        completion = _parse_routing_payload(b'{"prompt":"hello world"}')
+        pr = PendingRequest(args=[completion], kwargs={}, metadata=MagicMock())
+        assert router._extract_text_from_request(pr) == "hello world"
 
 
 class TestOpenAiIngress:

--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1_prefix_cache.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1_prefix_cache.yaml
@@ -1,0 +1,19 @@
+model_loading_config:
+  model_id: neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
+
+accelerator_type: A10G
+
+engine_kwargs:
+  max_model_len: 8192
+  tensor_parallel_size: 1
+  # NOTE: This is used for perf testing as well, so cuda graph must be enabled.
+  enforce_eager: false
+
+deployment_config:
+  # Two replicas so the prefix-cache-aware router actually routes across
+  # replicas. With one replica affinity is trivial.
+  autoscaling_config:
+    min_replicas: 2
+    max_replicas: 2
+  request_router_config:
+    request_router_class: ray.serve.llm.request_router.PrefixCacheAffinityRouter

--- a/release/llm_tests/serve/configs/serve_llama_3dot1_8b_quantized_tp1_prefix_cache.yaml
+++ b/release/llm_tests/serve/configs/serve_llama_3dot1_8b_quantized_tp1_prefix_cache.yaml
@@ -1,0 +1,7 @@
+applications:
+  - args:
+      llm_configs:
+        - ./configs/model_config/llama_3dot1_8b_quantized_tp1_prefix_cache.yaml
+    import_path: ray.serve.llm:build_openai_app
+    name: llm-endpoint
+    route_prefix: /

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4251,6 +4251,33 @@
     long_running: false
     script: python run_llm_serve_test_and_bms.py --serve-config-file configs/serve_llama_3dot1_8b_quantized_tp1.yaml --run-vllm-profiler --run-serve-llm-profiler
 
+# Direct streaming with the prefix-cache-aware request router. Guards #64326,
+# where a body-aware router got no routing key on the direct-streaming path.
+- name: llm_serve_llama_3dot1_8B_quantized_tp_1_direct_streaming_prefix_cache
+  frequency: nightly
+  python: "3.12"
+  group: llm-serve
+  team: llm
+  working_dir: llm_tests/serve
+
+  cluster:
+    byod:
+      type: llm-cu130
+      runtime_env:
+        - RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1
+        - RAY_SERVE_ENABLE_HA_PROXY=1
+        - RAY_SERVE_DEFAULT_HTTP_HOST=0.0.0.0
+    anyscale_sdk_2026: true
+    cluster_compute: llm_auto_select_worker.yaml
+    # NOTE: Important for getting the correct secrets
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
+    project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
+
+  run:
+    timeout: 3600
+    long_running: false
+    script: python run_llm_serve_test_and_bms.py --serve-config-file configs/serve_llama_3dot1_8b_quantized_tp1_prefix_cache.yaml
+
 # Runs performance benchmark tests against vLLM service
 - name: llm_serve_llama_3dot1_8B_tp_2
   frequency: nightly


### PR DESCRIPTION
Cherry-pick of #64328 into `releases/2.56.1`.

## Why

Serve LLM direct streaming breaks with a content-based router such as `PrefixCacheAffinityRouter`. The trigger is `RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1` with `RAY_SERVE_ENABLE_HA_PROXY=1`. See #64326.

The router reads `.messages` or `.prompt` off the first positional routing arg, where the OpenAI ingress puts the parsed request. Direct streaming forwards the raw body bytes to `choose_replica` instead, so the router gets no routing key. Requests either hang or silently fall back to load-balancing.

## What

Normalize the body at the ingress so the router contract is the same on both paths.

- Add `_parse_routing_payload(body)`. It `json.loads` the body and wraps it in a `SimpleNamespace` over every field, gated by a frozen tuple of routing-key fields (`messages`, `prompt`). It returns `None` for an empty, non-object, unparseable, or keyless body.
- `route()` passes the namespace to `choose_replica` positionally, where body-aware routers already look. With no key, nothing is forwarded and the router load-balances.
- Warn once per replica when no key is derived.

`PrefixCacheAffinityRouter` is unchanged.

## Related issue number

Fixes #64326
Cherry-pick of #64328
