### PR TITLE
[Data.LLM] Add request_timeout_s to ServeDeploymentProcessor to prevent indefinite hangs

### DIFF
--- a/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
+++ b/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
@@ -38,6 +38,15 @@ class ServeDeploymentProcessorConfig(ProcessorConfig):
         "'__inference_error__' column containing the error message. Error rows "
         "bypass postprocess. If False (default), any inference error raises.",
     )
+    request_timeout_s: Optional[float] = Field(
+        default=None,
+        description="Optional per-request timeout in seconds. When set, a request "
+        "that does not return within this many seconds raises TimeoutError instead "
+        "of blocking indefinitely (e.g. when replicas are saturated). TimeoutError "
+        "is recoverable, so combine with should_continue_on_error=True to drop the "
+        "slow row as an error instead of failing the job. If None (default), "
+        "requests wait indefinitely.",
+    )
 
 
 def build_serve_deployment_processor(
@@ -71,6 +80,7 @@ def build_serve_deployment_processor(
                 app_name=config.app_name,
                 dtype_mapping=config.dtype_mapping,
                 should_continue_on_error=config.should_continue_on_error,
+                request_timeout_s=config.request_timeout_s,
             ),
             map_batches_kwargs=dict(
                 compute=ActorPoolStrategy(

--- a/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
+++ b/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
@@ -40,6 +40,7 @@ class ServeDeploymentProcessorConfig(ProcessorConfig):
     )
     request_timeout_s: Optional[float] = Field(
         default=None,
+        gt=0,
         description="Optional per-request timeout in seconds. When set, a request "
         "that does not return within this many seconds raises TimeoutError instead "
         "of blocking indefinitely (e.g. when replicas are saturated). TimeoutError "

--- a/python/ray/llm/_internal/batch/stages/serve_deployment_stage.py
+++ b/python/ray/llm/_internal/batch/stages/serve_deployment_stage.py
@@ -21,10 +21,13 @@ logger = logging.getLogger(__name__)
 _MAX_PROMPT_LENGTH_IN_ERROR = 200
 
 # Request-level errors safe to catch. Unknown errors are treated as fatal.
+# TimeoutError is included so a single stuck request (see request_timeout_s)
+# is dropped as an error row rather than blocking the batch forever.
 _SERVE_RECOVERABLE_ERRORS = (
     ValueError,
     TypeError,
     ValidationError,
+    TimeoutError,
 )
 
 
@@ -38,6 +41,7 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
         app_name: str,
         dtype_mapping: Dict[str, Type[Any]],
         should_continue_on_error: bool = False,
+        request_timeout_s: Optional[float] = None,
     ):
         """
         Initialize the ServeDeploymentStageUDF.
@@ -51,10 +55,16 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
             should_continue_on_error: If True, continue processing when inference
                 fails for a row instead of raising. Failed rows will have
                 '__inference_error__' set to the error message.
+            request_timeout_s: Optional per-request timeout in seconds. When set,
+                a request that does not return within this many seconds raises
+                TimeoutError instead of awaiting indefinitely. TimeoutError is
+                recoverable, so with should_continue_on_error=True the row is
+                emitted as an error row rather than crashing the batch.
         """
         super().__init__(data_column, expected_input_keys)
         self._dtype_mapping = dtype_mapping
         self.should_continue_on_error = should_continue_on_error
+        self.request_timeout_s = request_timeout_s
 
         # Using stream=True as LLM serve deployments return async generators.
         # TODO (Kourosh): Generalize this to support non-streaming deployments.
@@ -119,7 +129,19 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
 
         t = time.perf_counter()
         # Directly using anext() requires python3.10 and above
-        output_data = await getattr(self._dh, method).remote(request_obj).__anext__()
+        response_gen = getattr(self._dh, method).remote(request_obj)
+        if self.request_timeout_s is not None:
+            try:
+                output_data = await asyncio.wait_for(
+                    response_gen.__anext__(), timeout=self.request_timeout_s
+                )
+            except asyncio.TimeoutError as e:
+                raise TimeoutError(
+                    f"Request timed out after {self.request_timeout_s}s waiting "
+                    f"for deployment '{method}' to return a response."
+                ) from e
+        else:
+            output_data = await response_gen.__anext__()
         time_taken = time.perf_counter() - t
 
         # Convert the output data to a dict if it is a Pydantic model.

--- a/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
@@ -39,6 +39,7 @@ def test_serve_deployment_processor(dtype_mapping):
         "app_name": app_name,
         "dtype_mapping": dtype_mapping,
         "should_continue_on_error": False,
+        "request_timeout_s": None,
     }
 
     assert "compute" in stage.map_batches_kwargs

--- a/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -454,6 +455,87 @@ async def test_serve_udf_success_with_continue_on_error_includes_none_error(
     assert len(results) == 1
     assert results[0]["__inference_error__"] == ""
     assert results[0]["generated_text"] == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_serve_udf_timeout_raises_by_default(mock_serve_deployment_handle):
+    """With a request_timeout_s and default error handling, a slow request raises."""
+
+    def mock_remote_call(*args, **kwargs):
+        async def mock_async_iterator():
+            await asyncio.sleep(10)
+            yield {"generated_text": "too late"}
+
+        return mock_async_iterator()
+
+    mock_serve_deployment_handle.completions.remote.side_effect = mock_remote_call
+
+    udf = ServeDeploymentStageUDF(
+        data_column="__data",
+        expected_input_keys=["method", "request_kwargs"],
+        deployment_name="test_deployment",
+        app_name="test_app",
+        dtype_mapping={"CompletionRequest": CompletionRequest},
+        request_timeout_s=0.05,
+    )
+
+    batch = {
+        "__data": [
+            {
+                "method": "completions",
+                "dtype": "CompletionRequest",
+                "request_kwargs": {"prompt": "test", "temperature": 0.7},
+            }
+        ]
+    }
+
+    with pytest.raises(TimeoutError, match="timed out after 0.05s"):
+        async for _ in udf(batch):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_serve_udf_timeout_recovers_with_continue_on_error(
+    mock_serve_deployment_handle,
+):
+    """A timed-out request becomes an error row when should_continue_on_error=True."""
+
+    def mock_remote_call(*args, **kwargs):
+        async def mock_async_iterator():
+            await asyncio.sleep(10)
+            yield {"generated_text": "too late"}
+
+        return mock_async_iterator()
+
+    mock_serve_deployment_handle.completions.remote.side_effect = mock_remote_call
+
+    udf = ServeDeploymentStageUDF(
+        data_column="__data",
+        expected_input_keys=["method", "request_kwargs"],
+        deployment_name="test_deployment",
+        app_name="test_app",
+        dtype_mapping={"CompletionRequest": CompletionRequest},
+        should_continue_on_error=True,
+        request_timeout_s=0.05,
+    )
+
+    batch = {
+        "__data": [
+            {
+                "method": "completions",
+                "dtype": "CompletionRequest",
+                "request_kwargs": {"prompt": "test prompt", "temperature": 0.7},
+            }
+        ]
+    }
+
+    results = []
+    async for result in udf(batch):
+        results.extend(result["__data"])
+
+    assert len(results) == 1
+    assert "TimeoutError" in results[0]["__inference_error__"]
+    assert "request_kwargs" in results[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`ServeDeploymentStageUDF.generate_async` awaits the deployment response with no timeout:

```python
output_data = await getattr(self._dh, method).remote(request_obj).__anext__()
```

When Serve replicas are saturated, the router retries rejected requests in an unbounded loop (by design, it relies on the caller to impose a timeout). With no caller-side timeout, a single stuck request blocks its batch indefinitely — the whole pipeline quiesces with no error and no diagnostics.

This PR adds an optional per-request `request_timeout_s` to `ServeDeploymentProcessorConfig`, plumbed into `ServeDeploymentStageUDF`:

- When set, the `__anext__()` await is wrapped in `asyncio.wait_for`; on expiry it raises `TimeoutError` with an actionable message.
- `TimeoutError` is added to `_SERVE_RECOVERABLE_ERRORS`, so with `should_continue_on_error=True` a timed-out row is emitted as an `__inference_error__` row instead of failing the job.
- Default `None` preserves the current indefinite-wait behavior, so this is fully backward-compatible.

## Additional information

Usage:

```python
config = ServeDeploymentProcessorConfig(
    deployment_name="...",
    app_name="...",
    request_timeout_s=300,
    should_continue_on_error=True,
)
```

Adds unit tests covering both the default (raises `TimeoutError`) and the recover path (emits an error row when `should_continue_on_error=True`).