### PR TITLE
[Core] Retain previous worker IDs on ActorTableData across restarts

### DIFF
--- a/python/ray/dashboard/modules/log/log_manager.py
+++ b/python/ray/dashboard/modules/log/log_manager.py
@@ -12,6 +12,7 @@ from ray.util.state.common import (
     GetLogOptions,
     protobuf_to_task_state_dict,
 )
+from ray.util.state.exception import DataSourceUnavailable
 from ray.util.state.state_manager import StateDataSourceClient
 
 if BaseModel is None:
@@ -223,31 +224,76 @@ class LogsManager:
         actor_data = await get_actor_fn(actor_id)
         if actor_data is None:
             raise ValueError(f"Actor ID {actor_id} not found.")
-        # TODO(sang): Only the latest worker id can be obtained from
-        # actor information now. That means, if actors are restarted,
-        # there's no way for us to get the past worker ids.
+
+        # Build the (node_id, worker_id) candidate list: try the current
+        # incarnation first, then previous_incarnations newest-to-oldest.
+        # Each previous incarnation carries its own node_id because after a
+        # restart the actor may run on a different node, and log files stay
+        # on the node where they were written.
+        #
+        # NOTE: during a RESTARTING window GCS clears `address` but has
+        # already appended the departing incarnation to
+        # `previous_incarnations`. So we only error out when *both* the
+        # current address and previous_incarnations are empty; otherwise
+        # we can still surface pre-restart logs.
+        candidates: List[Tuple[bytes, bytes]] = []
         worker_id_binary = actor_data.address.worker_id
-        if not worker_id_binary:
+        node_id_binary = actor_data.address.node_id
+        if worker_id_binary and node_id_binary:
+            candidates.append((node_id_binary, worker_id_binary))
+        previous = list(actor_data.previous_incarnations)
+        for entry in reversed(previous):
+            if entry.worker_id and entry.node_id:
+                candidates.append((entry.node_id, entry.worker_id))
+
+        if not candidates:
             raise ValueError(
                 f"Worker ID for Actor ID {actor_id} not found. "
                 "Actor is not scheduled yet."
             )
-        worker_id = WorkerID(worker_id_binary)
-        node_id_binary = actor_data.address.node_id
-        if not node_id_binary:
-            raise ValueError(
-                f"Node ID for Actor ID {actor_id} not found. "
-                "Actor is not scheduled yet."
-            )
-        node_id = NodeID(node_id_binary)
-        log_filename = await self._resolve_worker_file(
-            node_id_hex=node_id.hex(),
-            worker_id_hex=worker_id.hex(),
-            pid=None,
-            suffix=suffix,
-            timeout=timeout,
-        )
-        return node_id.hex(), log_filename
+
+        # A candidate's node may be gone by the time we look — the common
+        # case after a node-death restart, where the previous incarnation's
+        # node no longer has a log agent. Those lookups raise rather than
+        # returning an empty result, so swallow them per-candidate and keep
+        # walking instead of aborting the whole fallback chain.
+        first_lookup_error = None
+        reached_any_node = False
+        for candidate_node_binary, candidate_worker_binary in candidates:
+            candidate_node_id_hex = NodeID(candidate_node_binary).hex()
+            try:
+                log_filename = await self._resolve_worker_file(
+                    node_id_hex=candidate_node_id_hex,
+                    worker_id_hex=WorkerID(candidate_worker_binary).hex(),
+                    pid=None,
+                    suffix=suffix,
+                    timeout=timeout,
+                )
+            except (ValueError, DataSourceUnavailable) as e:
+                # Node is unreachable (dead, drained, or agent down).
+                logger.debug(
+                    f"Skipping node {candidate_node_id_hex} while resolving logs "
+                    f"for actor {actor_id}: {e}"
+                )
+                if first_lookup_error is None:
+                    first_lookup_error = e
+                continue
+
+            reached_any_node = True
+            if log_filename is not None:
+                return candidate_node_id_hex, log_filename
+
+        if not reached_any_node:
+            # Every candidate node was unreachable — surface why rather than
+            # reporting a misleading "no such log file". A reachable node that
+            # simply has no matching file is a clean miss and falls through to
+            # the FileNotFoundError raised by `resolve_filename`.
+            raise first_lookup_error
+
+        # Nothing matched. Report the first candidate's node (current if
+        # present, otherwise the newest previous) so the error message from
+        # `resolve_filename` points at the right node.
+        return NodeID(candidates[0][0]).hex(), None
 
     async def _resolve_task_filename(
         self, task_id: str, attempt_number: int, suffix: str, timeout: int

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -78,21 +78,33 @@ def generate_task_event(
     return task_event
 
 
-async def generate_actor_data(id, node_id, worker_id):
-    if worker_id:
-        worker_id = worker_id.binary()
+async def generate_actor_data(
+    id, node_id, worker_id, previous_incarnations=None, state=None
+):
+    from ray.core.generated.gcs_pb2 import PreviousActorIncarnation
+
+    # node_id and worker_id may be None to model the RESTARTING window
+    # where GCS has cleared the address but retained
+    # previous_incarnations. previous_incarnations is a list of
+    # (WorkerID, NodeID) tuples ordered oldest-first.
+    address_kwargs = {"ip_address": "127.0.0.1", "port": 1234}
+    if node_id is not None:
+        address_kwargs["node_id"] = node_id.binary()
+    if worker_id is not None:
+        address_kwargs["worker_id"] = worker_id.binary()
+
+    previous = [
+        PreviousActorIncarnation(worker_id=w.binary(), node_id=n.binary())
+        for (w, n) in (previous_incarnations or [])
+    ]
     message = ActorTableData(
         actor_id=id.binary(),
-        state=ActorTableData.ActorState.ALIVE,
+        state=state if state is not None else ActorTableData.ActorState.ALIVE,
         name="abc",
         pid=1234,
         class_name="class",
-        address=Address(
-            node_id=node_id.binary(),
-            ip_address="127.0.0.1",
-            port=1234,
-            worker_id=worker_id,
-        ),
+        address=Address(**address_kwargs),
+        previous_incarnations=previous,
     )
     return message
 
@@ -677,6 +689,271 @@ async def test_logs_manager_resolve_file(logs_manager):
         node_id.hex(), 10, glob_filter=f"*{pid}*err"
     )
     assert log_file_name == f"worker-123-123-{pid}.err"
+
+
+@pytest.mark.asyncio
+async def test_logs_manager_resolve_actor_falls_back_to_previous_incarnation(
+    logs_manager,
+):
+    """When the current worker's log file is absent (e.g. the actor was
+    restarted and the current incarnation hasn't produced output yet), the
+    resolver must fall back to `previous_incarnations` in newest-to-oldest
+    order, and each candidate must be looked up on its *own* node — a
+    previous incarnation may live on a different node than the current one.
+    """
+    current_node_id = NodeID(b"1" * 28)
+    older_node_id = NodeID(b"6" * 28)
+    newer_previous_node_id = NodeID(b"7" * 28)
+    actor_id = ActorID(b"2" * 16)
+    current_worker_id = WorkerID(b"3" * 28)
+    older_worker_id = WorkerID(b"4" * 28)
+    newer_previous_worker_id = WorkerID(b"5" * 28)
+
+    async def list_logs_side_effect(node_id_hex, _timeout, glob_filter):
+        # Only the "newer previous" incarnation has a matching log file,
+        # AND the caller must query the correct node to find it.
+        if (
+            node_id_hex == newer_previous_node_id.hex()
+            and newer_previous_worker_id.hex() in glob_filter
+        ):
+            return {
+                "worker_out": [f"worker-{newer_previous_worker_id.hex()}-123-456.out"],
+                "worker_err": [],
+            }
+        return {"worker_out": [], "worker_err": []}
+
+    logs_manager.list_logs = AsyncMock(side_effect=list_logs_side_effect)
+
+    # previous_incarnations is stored oldest-to-newest, so the newest-first
+    # fallback should hit `newer_previous_*` before `older_*`.
+    res = await logs_manager.resolve_filename(
+        node_id=current_node_id.hex(),
+        log_filename=None,
+        actor_id=actor_id.hex(),
+        task_id=None,
+        pid=None,
+        get_actor_fn=lambda _: generate_actor_data(
+            actor_id,
+            current_node_id,
+            current_worker_id,
+            previous_incarnations=[
+                (older_worker_id, older_node_id),
+                (newer_previous_worker_id, newer_previous_node_id),
+            ],
+        ),
+        timeout=10,
+    )
+    assert res.filename == f"worker-{newer_previous_worker_id.hex()}-123-456.out"
+    # The reported node_id must be the node where the log was actually
+    # found, not the actor's current node.
+    assert res.node_id == newer_previous_node_id.hex()
+
+    # Verify iteration order: current node/worker → newest previous → older.
+    calls = logs_manager.list_logs.await_args_list
+    node_ids_queried = [c.args[0] for c in calls]
+    workers_queried = [c.kwargs["glob_filter"] for c in calls]
+    assert node_ids_queried[0] == current_node_id.hex()
+    assert current_worker_id.hex() in workers_queried[0]
+    assert node_ids_queried[1] == newer_previous_node_id.hex()
+    assert newer_previous_worker_id.hex() in workers_queried[1]
+    # Search stops after the hit — older incarnation must never be queried.
+    assert all(older_worker_id.hex() not in c for c in workers_queried)
+    assert all(older_node_id.hex() not in n for n in node_ids_queried)
+
+
+@pytest.mark.asyncio
+async def test_logs_manager_resolve_actor_during_restarting_window(logs_manager):
+    """During a RESTARTING window GCS clears `address` (both worker_id and
+    node_id are empty) but has already appended the departing incarnation
+    to `previous_incarnations`. Log lookup must still work — using the
+    most recent previous incarnation — rather than erroring out because
+    the current address is empty.
+    """
+    previous_node_id = NodeID(b"8" * 28)
+    actor_id = ActorID(b"2" * 16)
+    previous_worker_id = WorkerID(b"9" * 28)
+
+    logs_manager.list_logs = AsyncMock(
+        return_value={
+            "worker_out": [f"worker-{previous_worker_id.hex()}-123-456.out"],
+            "worker_err": [],
+        }
+    )
+
+    res = await logs_manager.resolve_filename(
+        node_id=None,
+        log_filename=None,
+        actor_id=actor_id.hex(),
+        task_id=None,
+        pid=None,
+        get_actor_fn=lambda _: generate_actor_data(
+            actor_id,
+            node_id=None,
+            worker_id=None,
+            previous_incarnations=[(previous_worker_id, previous_node_id)],
+            state=ActorTableData.ActorState.RESTARTING,
+        ),
+        timeout=10,
+    )
+    assert res.filename == f"worker-{previous_worker_id.hex()}-123-456.out"
+    assert res.node_id == previous_node_id.hex()
+    # Only one lookup, and it was against the previous incarnation's node.
+    logs_manager.list_logs.assert_awaited_once()
+    assert logs_manager.list_logs.await_args.args[0] == previous_node_id.hex()
+
+
+@pytest.mark.asyncio
+async def test_logs_manager_resolve_actor_no_previous_incarnations(logs_manager):
+    """When previous_incarnations is empty and the current worker's log
+    file is absent, `resolve_filename` raises FileNotFoundError — the
+    fallback loop is not entered when there's nothing to fall back to.
+    """
+    node_id = NodeID(b"1" * 28)
+    actor_id = ActorID(b"2" * 16)
+    worker_id = WorkerID(b"3" * 28)
+
+    logs_manager.list_logs = AsyncMock(
+        return_value={"worker_out": [], "worker_err": []}
+    )
+
+    with pytest.raises(FileNotFoundError):
+        await logs_manager.resolve_filename(
+            node_id=node_id.hex(),
+            log_filename=None,
+            actor_id=actor_id.hex(),
+            task_id=None,
+            pid=None,
+            get_actor_fn=lambda _: generate_actor_data(actor_id, node_id, worker_id),
+            timeout=10,
+        )
+    # Only the current worker was queried; no fallback iteration happened
+    # because previous_incarnations is empty.
+    assert logs_manager.list_logs.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_logs_manager_resolve_actor_skips_unreachable_nodes(logs_manager):
+    """A previous incarnation's node is frequently gone by lookup time —
+    that is the common case after a node-death restart. `list_logs` raises
+    for those nodes instead of returning an empty result, and that must not
+    abort the fallback chain: the remaining candidates still get tried.
+    """
+    dead_current_node_id = NodeID(b"1" * 28)
+    dead_previous_node_id = NodeID(b"7" * 28)
+    live_node_id = NodeID(b"6" * 28)
+    actor_id = ActorID(b"2" * 16)
+    current_worker_id = WorkerID(b"3" * 28)
+    dead_previous_worker_id = WorkerID(b"5" * 28)
+    live_worker_id = WorkerID(b"4" * 28)
+
+    async def list_logs_side_effect(node_id_hex, _timeout, glob_filter):
+        # Both the current node and the newest previous node are gone.
+        if node_id_hex in (dead_current_node_id.hex(), dead_previous_node_id.hex()):
+            raise ValueError(f"Agent for node id: {node_id_hex} doesn't exist.")
+        return {
+            "worker_out": [f"worker-{live_worker_id.hex()}-123-456.out"],
+            "worker_err": [],
+        }
+
+    logs_manager.list_logs = AsyncMock(side_effect=list_logs_side_effect)
+
+    res = await logs_manager.resolve_filename(
+        node_id=dead_current_node_id.hex(),
+        log_filename=None,
+        actor_id=actor_id.hex(),
+        task_id=None,
+        pid=None,
+        get_actor_fn=lambda _: generate_actor_data(
+            actor_id,
+            dead_current_node_id,
+            current_worker_id,
+            previous_incarnations=[
+                (live_worker_id, live_node_id),
+                (dead_previous_worker_id, dead_previous_node_id),
+            ],
+        ),
+        timeout=10,
+    )
+    # The surviving node's log is found even though two earlier candidates
+    # raised on the way there.
+    assert res.filename == f"worker-{live_worker_id.hex()}-123-456.out"
+    assert res.node_id == live_node_id.hex()
+    assert logs_manager.list_logs.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_logs_manager_resolve_actor_clean_miss_when_a_node_is_reachable(
+    logs_manager,
+):
+    """If at least one candidate node answers but has no matching file, the
+    result is a plain "no such log" (FileNotFoundError) — an unreachable
+    node elsewhere in the chain must not turn a clean miss into a
+    node-lookup error.
+    """
+    live_node_id = NodeID(b"1" * 28)
+    dead_node_id = NodeID(b"7" * 28)
+    actor_id = ActorID(b"2" * 16)
+    current_worker_id = WorkerID(b"3" * 28)
+    previous_worker_id = WorkerID(b"5" * 28)
+
+    async def list_logs_side_effect(node_id_hex, _timeout, glob_filter):
+        if node_id_hex == dead_node_id.hex():
+            raise ValueError(f"Agent for node id: {node_id_hex} doesn't exist.")
+        return {"worker_out": [], "worker_err": []}
+
+    logs_manager.list_logs = AsyncMock(side_effect=list_logs_side_effect)
+
+    with pytest.raises(FileNotFoundError):
+        await logs_manager.resolve_filename(
+            node_id=live_node_id.hex(),
+            log_filename=None,
+            actor_id=actor_id.hex(),
+            task_id=None,
+            pid=None,
+            get_actor_fn=lambda _: generate_actor_data(
+                actor_id,
+                live_node_id,
+                current_worker_id,
+                previous_incarnations=[(previous_worker_id, dead_node_id)],
+            ),
+            timeout=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_logs_manager_resolve_actor_all_nodes_unreachable(logs_manager):
+    """When *every* candidate node is unreachable we surface the underlying
+    lookup failure rather than a misleading "could not find a log file".
+    This also preserves the pre-existing behaviour for actors with no
+    incarnation history whose only node is gone.
+    """
+    dead_node_id = NodeID(b"1" * 28)
+    other_dead_node_id = NodeID(b"7" * 28)
+    actor_id = ActorID(b"2" * 16)
+    current_worker_id = WorkerID(b"3" * 28)
+    previous_worker_id = WorkerID(b"5" * 28)
+
+    logs_manager.list_logs = AsyncMock(
+        side_effect=ValueError("Agent for node id doesn't exist.")
+    )
+
+    with pytest.raises(ValueError, match="Agent for node id"):
+        await logs_manager.resolve_filename(
+            node_id=dead_node_id.hex(),
+            log_filename=None,
+            actor_id=actor_id.hex(),
+            task_id=None,
+            pid=None,
+            get_actor_fn=lambda _: generate_actor_data(
+                actor_id,
+                dead_node_id,
+                current_worker_id,
+                previous_incarnations=[(previous_worker_id, other_dead_node_id)],
+            ),
+            timeout=10,
+        )
+    # Both candidates were attempted before giving up.
+    assert logs_manager.list_logs.await_count == 2
 
 
 async def get_actor_info_raises(actor_id):

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -432,13 +432,27 @@ RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_min_interval_ms, 100)
 RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 1000)
 RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5)
 /// Maximum number of destroyed actors in GCS server memory cache.
-/// ActorTableData entry ≈ 200-400B serialize (~600B-1.5KB deserialized).
-/// Worst-case footprint: 100,000 x ~600B-1.5KB =~ 60-150MB
+/// ActorTableData entry ≈ 200-400B serialized (~600B-1.5KB deserialized),
+/// plus `previous_incarnations` for actors that have restarted: up to ~600B
+/// serialized (~2KB deserialized) at the default
+/// `maximum_actor_previous_incarnations` of 10. An actor sitting at that cap
+/// is therefore ≈ 800B-1KB serialized (~2.4-4KB deserialized).
+/// Worst-case footprint: 100,000 x ~2.4-4KB =~ 240-400MB, which assumes every
+/// cached actor exhausted its restart history; actors that never restarted
+/// are unchanged at ~600B-1.5KB.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
 /// Maximum number of dead workers in GCS server memory cache.
 /// WorkerTableData entry ≈ ~130B serialized (~400-800B deserialized).
 /// Worst-case footprint: 100,000 x ~130B-800B =~ 13-80MB
 RAY_CONFIG(uint32_t, maximum_gcs_dead_worker_cached_count, 100000)
+/// Maximum number of previous incarnations retained on `ActorTableData` for
+/// looking up logs from prior actor incarnations. When exceeded, the
+/// oldest entry is evicted FIFO. Set to 0 to disable history tracking.
+/// PreviousActorIncarnation entry ≈ ~60B serialized. Worst-case added
+/// footprint per actor: 10 x ~60B =~ 600B, which also multiplies against
+/// `maximum_gcs_destroyed_actor_cached_count` in the GCS destroyed-actor
+/// cache — see the footprint note there before raising this.
+RAY_CONFIG(uint32_t, maximum_actor_previous_incarnations, 10)
 /// Maximum number of dead nodes in GCS server memory cache.
 /// GcsNodeInfo entry ≈ ~150-250 bytes serialized (~500B-1KB deserialized).
 /// Worst-case footprint: 1,000 x ~500B-1KB =~ 0.5-1MB

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1532,6 +1532,33 @@ void GcsActorManager::RestartActor(
 
     actor->UpdateState(rpc::ActorTableData::RESTARTING);
     actor->GetMutableTaskSpec()->set_attempt_number(new_num_restarts);
+    // Retain the departing (worker_id, node_id) so dashboard log lookups
+    // can surface logs from prior incarnations even after the actor is
+    // rescheduled onto a different node (log files stay on the node where
+    // they were written). Bounded by
+    // `maximum_actor_previous_incarnations` (FIFO eviction); a value of 0
+    // disables history tracking.
+    //
+    // This append is idempotent across repeated restart attempts for the
+    // same incarnation: `worker_id` is read from the actor's address, and
+    // the address is cleared just below. A duplicate or retried restart
+    // for an actor that has not yet been rescheduled therefore sees a nil
+    // `worker_id` and skips the append, so a lost/retried death
+    // notification cannot record the same incarnation twice. Keep the nil
+    // check and the address reset in this order.
+    if (!worker_id.IsNil()) {
+      const uint32_t limit = RayConfig::instance().maximum_actor_previous_incarnations();
+      if (limit > 0) {
+        auto *previous_incarnations =
+            mutable_actor_table_data->mutable_previous_incarnations();
+        auto *entry = previous_incarnations->Add();
+        entry->set_worker_id(worker_id.Binary());
+        entry->set_node_id(node_id.Binary());
+        while (static_cast<uint32_t>(previous_incarnations->size()) > limit) {
+          previous_incarnations->erase(previous_incarnations->begin());
+        }
+      }
+    }
     // Make sure to reset the address before flushing to GCS. Otherwise,
     // GCS will mistakenly consider this lease request succeeds when restarting.
     actor->UpdateAddress(rpc::Address());

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -598,6 +598,9 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   FRIEND_TEST(GcsActorManagerTest, TestGetAllActorInfoLimit);
   FRIEND_TEST(GcsActorManagerTest, TestDestroyWhileRegistering);
   FRIEND_TEST(GcsActorManagerTest, TestNodeFailureDestroysAllOwnedActors);
+  FRIEND_TEST(GcsActorManagerTest, TestPreviousIncarnationsAppendedOnRestart);
+  FRIEND_TEST(GcsActorManagerTest, TestPreviousIncarnationsBoundedByLimit);
+  FRIEND_TEST(GcsActorManagerTest, TestPreviousIncarnationsIdempotentOnRetriedRestart);
 
   friend class GcsActorManagerTest;
 };

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -894,6 +894,214 @@ TEST_F(GcsActorManagerTest, TestActorReconstruction) {
   ASSERT_TRUE(worker_client_->Reply());
 }
 
+TEST_F(GcsActorManagerTest, TestPreviousIncarnationsAppendedOnRestart) {
+  // Verify that on actor restart, the departing (worker_id, node_id) is
+  // appended to ActorTableData.previous_incarnations in order (oldest
+  // first), and that a restart onto a different node preserves the prior
+  // node_id (so log lookups can still find the old node's files).
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id,
+                                        /*max_restarts=*/3,
+                                        /*detached=*/false);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
+  RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&finished_actors](std::shared_ptr<gcs::GcsActor> result_actor,
+                         const rpc::PushTaskReply &,
+                         const Status &) {
+        finished_actors.emplace_back(result_actor);
+      }));
+
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // First incarnation: alive.
+  auto address1 = RandomAddress();
+  auto node_id1 = NodeID::FromBinary(address1.node_id());
+  auto worker_id1 = WorkerID::FromBinary(address1.worker_id());
+  actor->UpdateAddress(address1);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  io_service_.run_one();
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations_size(), 0);
+
+  // Kill node1 → restart triggered → (worker_id1, node_id1) recorded.
+  EXPECT_CALL(*mock_actor_scheduler_, CancelOnNode(node_id1));
+  OnNodeDead(node_id1);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations_size(), 1);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).worker_id(),
+            worker_id1.Binary());
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).node_id(),
+            node_id1.Binary());
+
+  // Second incarnation on a *different* node.
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  mock_actor_scheduler_->actors.clear();
+  auto address2 = RandomAddress();
+  auto node_id2 = NodeID::FromBinary(address2.node_id());
+  auto worker_id2 = WorkerID::FromBinary(address2.worker_id());
+  ASSERT_NE(node_id1, node_id2);
+  actor->UpdateAddress(address2);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  io_service_.run_one();
+  io_service_.run_one();
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+
+  // Kill node2 → second entry appended, in order. The prior entry must
+  // still carry the *original* node_id, not the current actor's node_id.
+  EXPECT_CALL(*mock_actor_scheduler_, CancelOnNode(node_id2));
+  OnNodeDead(node_id2);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations_size(), 2);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).worker_id(),
+            worker_id1.Binary());
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).node_id(),
+            node_id1.Binary());
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(1).worker_id(),
+            worker_id2.Binary());
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(1).node_id(),
+            node_id2.Binary());
+
+  ASSERT_TRUE(worker_client_->Reply());
+}
+
+TEST_F(GcsActorManagerTest, TestPreviousIncarnationsBoundedByLimit) {
+  // Verify that when previous_incarnations exceeds
+  // maximum_actor_previous_incarnations, the oldest entry is evicted FIFO.
+  RayConfig::instance().initialize(
+      R"(
+{
+  "maximum_actor_previous_incarnations": 2
+}
+  )");
+
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id,
+                                        /*max_restarts=*/-1,
+                                        /*detached=*/false);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
+  RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&finished_actors](std::shared_ptr<gcs::GcsActor> result_actor,
+                         const rpc::PushTaskReply &,
+                         const Status &) {
+        finished_actors.emplace_back(result_actor);
+      }));
+
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // Drive 3 restarts. After each, verify the list never exceeds the limit
+  // and retains the newest entries.
+  std::vector<WorkerID> worker_ids;
+  std::vector<NodeID> node_ids;
+  for (int i = 0; i < 3; ++i) {
+    auto address = RandomAddress();
+    node_ids.push_back(NodeID::FromBinary(address.node_id()));
+    worker_ids.push_back(WorkerID::FromBinary(address.worker_id()));
+    actor->UpdateAddress(address);
+    gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+    io_service_.run_one();
+    if (i > 0) {
+      io_service_.run_one();
+    }
+    ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+
+    EXPECT_CALL(*mock_actor_scheduler_, CancelOnNode(node_ids.back()));
+    OnNodeDead(node_ids.back());
+    ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+
+    ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+    mock_actor_scheduler_->actors.clear();
+  }
+
+  // After 3 restarts with a cap of 2, expect only indices [1] and [2];
+  // index [0] must have been evicted FIFO.
+  const auto &previous = actor->GetActorTableData().previous_incarnations();
+  ASSERT_EQ(previous.size(), 2);
+  ASSERT_EQ(previous.Get(0).worker_id(), worker_ids[1].Binary());
+  ASSERT_EQ(previous.Get(0).node_id(), node_ids[1].Binary());
+  ASSERT_EQ(previous.Get(1).worker_id(), worker_ids[2].Binary());
+  ASSERT_EQ(previous.Get(1).node_id(), node_ids[2].Binary());
+
+  // Restore default limit so subsequent tests aren't affected.
+  RayConfig::instance().initialize(
+      R"(
+{
+  "maximum_gcs_destroyed_actor_cached_count": 10
+}
+  )");
+}
+
+TEST_F(GcsActorManagerTest, TestPreviousIncarnationsIdempotentOnRetriedRestart) {
+  // A restart can be driven more than once for the same incarnation — a
+  // retried/duplicated death notification, or a worker-death signal racing
+  // node death. The incarnation history must record that incarnation
+  // exactly once; appending it twice would waste the bounded history and
+  // make the dashboard query the same worker repeatedly.
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id,
+                                        /*max_restarts=*/3,
+                                        /*detached=*/false);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
+  RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&finished_actors](std::shared_ptr<gcs::GcsActor> result_actor,
+                         const rpc::PushTaskReply &,
+                         const Status &) {
+        finished_actors.emplace_back(result_actor);
+      }));
+
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  auto address = RandomAddress();
+  auto node_id = NodeID::FromBinary(address.node_id());
+  auto worker_id = WorkerID::FromBinary(address.worker_id());
+  actor->UpdateAddress(address);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  io_service_.run_one();
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+
+  const auto actor_id = actor->GetActorID();
+  rpc::ActorDeathCause death_cause;
+  death_cause.mutable_actor_died_error_context()->set_error_message("worker died");
+
+  // First restart records the departing incarnation.
+  gcs_actor_manager_->RestartActor(actor_id, /*need_reschedule=*/true, death_cause);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations_size(), 1);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).worker_id(),
+            worker_id.Binary());
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).node_id(),
+            node_id.Binary());
+
+  // The actor has not been rescheduled yet, so its address is still cleared.
+  // A repeated restart for that same incarnation must be a no-op for the
+  // history rather than appending a duplicate entry.
+  gcs_actor_manager_->RestartActor(actor_id, /*need_reschedule=*/true, death_cause);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations_size(), 1);
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).worker_id(),
+            worker_id.Binary());
+  ASSERT_EQ(actor->GetActorTableData().previous_incarnations(0).node_id(),
+            node_id.Binary());
+}
+
 TEST_F(GcsActorManagerTest, TestActorRestartWhenOwnerDead) {
   auto job_id = JobID::FromInt(1);
   auto registered_actor = RegisterActor(job_id,

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -165,6 +165,24 @@ message ActorTableData {
   // The key-value labels for actor.
   map<string, string> labels = 37;
   optional FallbackStrategy fallback_strategy = 38;
+  // Previous (worker_id, node_id) pairs from this actor's earlier
+  // incarnations across restarts, in order from oldest to newest. Used by
+  // the dashboard log-lookup path to surface logs from before the current
+  // worker. Bounded by `RayConfig::maximum_actor_previous_incarnations`; when
+  // the cap is reached, the oldest entry is evicted FIFO.
+  repeated PreviousActorIncarnation previous_incarnations = 39;
+}
+
+// A prior (worker_id, node_id) pair for an actor that has been restarted.
+// Recorded on `ActorTableData.previous_incarnations`.
+message PreviousActorIncarnation {
+  // The worker that ran this incarnation of the actor.
+  bytes worker_id = 1;
+  // The node that worker ran on. Stored per-entry rather than reusing the
+  // actor's current node because a restart may place the actor on a
+  // different node, while log files stay on the node where they were
+  // written — so worker_id alone is not enough to locate them.
+  bytes node_id = 2;
 }
 
 message ErrorTableData {


### PR DESCRIPTION
fixes  the (backend + pipeline) for #43471 

## Description
When an actor restarts, GCS assigns it a new worker process (and worker ID), and the dashboard log-lookup path loses the link to any log files produced by prior incarnations. There is a long-standing TODO in python/ray/dashboard/modules/log/log_manager.py acknowledging this.

Approach (per discussion on #43471 with @kouroshHakha and @edoakes): add a bounded history of previous worker IDs on ActorTableData so the dashboard can surface logs from before the current restart.

Changes:
- proto: add `repeated bytes previous_worker_ids = 39` to ActorTableData (src/ray/protobuf/gcs.proto).
- config: new knob `actor_previous_worker_ids_limit` (default 10; set to 0 to disable) to bound the list size.
- writer: in GcsActorManager::RestartActor, append the departing worker_id before clearing the actor's address, with FIFO eviction when the list exceeds the cap.
- reader: update _resolve_actor_filename in log_manager.py to try the current worker first and fall back to previous_worker_ids in newest-to-oldest order. Drops the old TODO(sang).

Tests:
- C++: TestPreviousWorkerIdsAppendedOnRestart verifies order across two restarts; TestPreviousWorkerIdsBoundedByLimit verifies FIFO eviction at the cap.
- Python: two logs_manager unit tests covering the fallback hit path and the empty-previous-workers path.

Dashboard UI surface (per-restart selector, "at limit" indicator) will land as a follow-up PR to keep this one reviewable.

Related-to: #43471

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
