### PR TITLE
[Rllib] Fix RLlib with Tune (revert #63695)

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -680,9 +680,10 @@ class AlgorithmConfig(_Config):
     def to_dict(self) -> AlgorithmConfigDict:
         """Converts all settings into a legacy config dict for backward compatibility.
 
-        Note: If using the new API stack (enable_rl_module_and_learner=True), the
-        returned dictionary will dynamically overwrite the legacy `train_batch_size` key
-        with the calculated `total_train_batch_size`.
+        Note: On the new API stack (enable_rl_module_and_learner=True), the effective
+        batch size is derived from `train_batch_size_per_learner` and `num_learners`;
+        read the `total_train_batch_size` property for it. The legacy `train_batch_size`
+        key in the returned dict is not authoritative on the new stack.
 
         Returns:
             A complete AlgorithmConfigDict, usable in backward-compatible Tune/RLlib
@@ -745,14 +746,6 @@ class AlgorithmConfig(_Config):
         ]:
             if config.get(dep_k) == DEPRECATED_VALUE:
                 config.pop(dep_k, None)
-
-        # If using the New API Stack, overwrite the stale legacy train_batch_size
-        # with the true computed total so to_dict() is not misleading.
-        if self.enable_rl_module_and_learner:
-            try:
-                config["train_batch_size"] = self.total_train_batch_size
-            except ValueError:
-                config["train_batch_size"] = None
 
         return config
 

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -456,7 +456,13 @@ class TestAlgorithmConfig(unittest.TestCase):
             )
 
     def test_to_dict_roundtrip_new_api_stack(self):
-        """Tests that to_dict() correctly outputs and round-trips New API stack batch sizes."""
+        """Tests that to_dict() round-trips New API stack batch sizes.
+
+        `to_dict()` does NOT eagerly resolve the effective batch size (that stays
+        lazy via the `total_train_batch_size` property). It only serializes the raw
+        fields, which is what makes it safe to call on an as-yet-unresolved config
+        (e.g. one carrying Tune search spaces).
+        """
         from ray.rllib.algorithms.ppo import PPOConfig
 
         # 1. Create a config on the New API Stack
@@ -469,24 +475,46 @@ class TestAlgorithmConfig(unittest.TestCase):
             .training(train_batch_size_per_learner=123)
         )
 
-        expected_total = config.total_train_batch_size
-
         # 2. Export to dictionary
         config_dict = config.to_dict()
 
-        # Verify our fix correctly populated the legacy batch size
-        self.assertEqual(config_dict["train_batch_size"], expected_total)
-
-        # Verify we did NOT inject these properties to prevent round-trip crashes/formula breaking
+        # to_dict() does not inject computed properties (would break round-trip).
         self.assertNotIn("total_train_batch_size", config_dict)
         self.assertNotIn("train_batch_size_per_learner", config_dict)
 
-        # 3. Roundtrip: Create a new config and update from the dictionary
+        # 3. Roundtrip: Create a new config and update from the dictionary, and
+        # verify the per-learner batch size (and the total derived from it) survives.
         new_config = PPOConfig().update_from_dict(config_dict)
-
-        # Verify the object successfully restored its dynamic state without crashing
         self.assertEqual(new_config.train_batch_size_per_learner, 123)
-        self.assertEqual(new_config.total_train_batch_size, expected_total)
+        self.assertEqual(new_config.total_train_batch_size, 123)
+
+    def test_to_dict_with_tune_search_space(self):
+        """to_dict() must not eagerly resolve batch size when it's a Tune search space.
+
+        Regression test: passing an AlgorithmConfig with a search-space
+        `train_batch_size_per_learner` as Tune's `param_space` calls `to_dict()` on
+        an unresolved config. Computing `total_train_batch_size` (`Domain * int`)
+        would raise TypeError, so `to_dict()` must not attempt it.
+        """
+        from ray import tune
+        from ray.rllib.algorithms.ppo import PPOConfig
+
+        config = (
+            PPOConfig()
+            .api_stack(
+                enable_rl_module_and_learner=True,
+                enable_env_runner_and_connector_v2=True,
+            )
+            .training(train_batch_size_per_learner=tune.qrandint(256, 2048, 64))
+        )
+
+        # Must not raise (this is the bug: TypeError from `Domain * int`).
+        config_dict = config.to_dict()
+
+        # The unresolved search space survives serialization so Tune can sample it.
+        self.assertIsInstance(
+            config_dict["_train_batch_size_per_learner"], tune.search.sample.Domain
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
`linux://rllib:examples/ray_tune/appo_hyperparameter_tune` was failing with 

```
==================== Test output for //rllib:examples/ray_tune/appo_hyperparameter_tune:
Traceback (most recent call last):
  File "rllib/examples/ray_tune/appo_hyperparameter_tune.py", line 155, in <module>
    tuner = tune.Tuner(
            ^^^^^^^^^^^
  File "/rayci/python/ray/tune/tuner.py", line 135, in __init__
    self._local_tuner = TunerInternal(**kwargs)
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/rayci/python/ray/tune/impl/tuner_internal.py", line 161, in __init__
    self.param_space = param_space
    ^^^^^^^^^^^^^^^^
  File "/rayci/python/ray/tune/impl/tuner_internal.py", line 502, in param_space
    param_space = param_space.to_dict()
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/rayci/python/ray/rllib/algorithms/algorithm_config.py", line 753, in to_dict
    config["train_batch_size"] = self.total_train_batch_size
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/rayci/python/ray/rllib/algorithms/algorithm_config.py", line 4321, in total_train_batch_size
    return self.train_batch_size_per_learner * (self.num_learners or 1)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'Integer' and 'int'
================================================================================
```

https://github.com/ray-project/ray/pull/63695 introduced a property for `total_train_batch_size` however this causes an issue for RLlib + Ray Tune. 
This PR largely reverts the #63695 and adds a check that a Tune parameter is usable