### PR TITLE
[doc] Expand sphinx-fix rules from real RtD build-failure corpus

### DIFF
--- a/doc/.claude/skills/sphinx-fix/rules.yaml
+++ b/doc/.claude/skills/sphinx-fix/rules.yaml
@@ -111,6 +111,21 @@ rules:
     version_myst: ">=5.0,<6"
     notes: "Shared with rst-to-myst Hard rule 2."
 
+  - id: unknown-document
+    title: "{doc}/toctree reference to an unknown document"
+    tier: 3
+    safety: mechanical
+    match: any
+    categories:
+      - ref.doc
+    signatures:
+      - "unknown document:"
+    cause: "A {doc} role, a :doc: reference, or a toctree entry points at a document path that does not resolve -- a renamed or moved page, a typo, or a relative path that is wrong from the referencing file. Distinct from toctree-nonexisting, which is the toctree-directive-specific wording."
+    fix: "Repoint to the correct document: a path relative to the referencing page, or an absolute path from doc/source with a leading slash. Remove the reference if the target is gone. Grep the bare stem across doc/ to find every caller."
+    target_extract: "unknown document: '?(?P<target>[^'\\s]+)"
+    version_sphinx: ">=8.0,<9"
+    notes: "Category ref.doc confirmed on real Ray RtD builds; the tag is sometimes absent on the first emission, so the signature carries the match."
+
   - id: toctree-nonexisting
     title: "toctree references a nonexisting document"
     tier: 2
@@ -164,6 +179,28 @@ rules:
     version_sphinx: ">=8.0,<9"
     notes: "Category ref.ref is a best-effort guess; signature carries the match."
 
+  - id: py-xref-target-not-found
+    title: "Python-domain reference target not found (meth/func/class/obj/exc)"
+    tier: 3
+    safety: judgment
+    match: any
+    categories:
+      - ref.meth
+      - ref.obj
+      - ref.func
+      - ref.class
+      - ref.exc
+      - ref.attr
+      - ref.mod
+      - ref.python
+    signatures:
+      - "py:\\w+ reference target not found:"
+    cause: "A Python-domain role ({meth}/{class}/{func}/{obj}/{exc}/:py:*:) points at an object not in the resolved API inventory. Two very different roots: (1) the object is documented elsewhere but its autosummary stub was not generated, or its module aborted import, so the inventory entry is missing -- these arrive as a large flood sharing an object prefix and are DOWNSTREAM symptoms, not separate defects; (2) the reference is genuinely wrong -- a renamed, moved, or mistyped target, or a stdlib/third-party name that needs intersphinx."
+    fix: "Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name."
+    target_extract: "py:\\w+ reference target not found: (?P<target>\\S+)"
+    version_sphinx: ">=8.0,<9"
+    notes: "Categories confirmed on real Ray RtD builds (ref.meth, ref.obj, ref.func, ref.python); the signature carries the rest of the py domain (ref.exc, ref.attr). safety=judgment: both the correct target and the correct root (edit one reference vs revert a restructuring) need a human decision -- never auto-apply. A correlated flood sharing an object prefix with autosummary-stub-not-found warnings is that rule's masked downstream; triage the tier-2 root, not each reference."
+
   - id: image-not-readable
     title: "Image file not readable"
     tier: 3
@@ -179,6 +216,32 @@ rules:
     version_sphinx: ">=8.0,<9"
     notes: "Category image.not_readable is a best-effort guess; signature carries the match."
 
+  - id: docutils-inline-markup
+    title: "Unbalanced inline emphasis/strong markup"
+    tier: 3
+    safety: mechanical
+    match: any
+    categories:
+      - docutils
+    signatures:
+      - "Inline .+ start-string without end-string"
+    cause: "A docstring or RST body has an unbalanced inline marker -- a lone * (emphasis) or ** (strong) with no closing marker. Common in API docstrings that write *args or **kwargs, or a bare asterisk, outside a code span. It surfaces from an <autosummary> generated stub at the docstring's location."
+    fix: "Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\\*)."
+    version_sphinx: ">=8.0,<9"
+    notes: "Category docutils confirmed on real Ray RtD builds. No target extraction: the message does not carry the offending text, so locate the unbalanced marker at the cited docstring."
+
+  - id: intersphinx-inventory-unreachable
+    title: "intersphinx inventory not fetchable (network/transient)"
+    tier: 3
+    safety: judgment
+    match: any
+    signatures:
+      - "failed to reach any of the inventories"
+    cause: "Sphinx could not download an external intersphinx objects.inv (for example docs.python.org or spark.apache.org). On the RtD build network this is usually a transient connectivity failure, not a defect in the docs; with fail_on_warning it still fails the build."
+    fix: "Re-run the build first -- this is usually transient. If it persists, the inventory URL in intersphinx_mapping (conf.py) is unreachable or wrong: confirm the URL. This is not a per-page content fix."
+    version_sphinx: ">=8.0,<9"
+    notes: "Untagged (no [category]); signature-only. The URL and error detail sit on an unindented continuation line the parser does not capture as a warning record, so match on the WARNING line. safety=judgment: re-run vs investigate intersphinx_mapping is a human call."
+
   - id: literalinclude-out-of-range
     title: "literalinclude line/marker out of range"
     tier: 2
@@ -191,6 +254,19 @@ rules:
     fix: "Update the :lines: range or the :start-after:/:end-before: markers to match the current source file."
     version_sphinx: ">=8.0,<9"
     notes: "Signature-only pending [category] confirmation."
+
+  - id: autosummary-stub-not-found
+    title: "autosummary stub file not generated for a listed member"
+    tier: 2
+    safety: judgment
+    match: any
+    signatures:
+      - "autosummary: stub file not found '[^']+'\\. Check your autosummary_generate"
+    cause: "An autosummary directive lists a member whose stub .rst was never generated. A lone entry usually means the member was renamed or removed. A bulk failure across a whole module or API-ref page means autosummary could not introspect the module -- commonly the module failed to import under the build's autodoc_mock_imports set, or an in-progress API-ref restructuring moved or renamed the source. It is a tier-2 structural condition: the ungenerated stubs mask the py:* reference-target-not-found warnings for the same objects (see py-xref-target-not-found)."
+    fix: "Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry."
+    target_extract: "stub file not found '(?P<target>[^']+)'"
+    version_sphinx: ">=8.0,<9"
+    notes: "Untagged core-Sphinx warning (no [category]); signature-only. Seen at scale in a Ray API-ref rework where dozens of missing stubs masked hundreds of downstream py:ref failures. Fix this tier-2 root first, rebuild, and most of the py-xref-target-not-found flood clears."
 
 # Known-benign warning classes the build already suppresses or filters in
 # doc/source/conf.py. The engine segregates these into a not-actionable bucket

--- a/doc/.claude/skills/sphinx-fix/rules.yaml
+++ b/doc/.claude/skills/sphinx-fix/rules.yaml
@@ -114,7 +114,7 @@ rules:
   - id: unknown-document
     title: "{doc}/toctree reference to an unknown document"
     tier: 3
-    safety: mechanical
+    safety: judgment
     match: any
     categories:
       - ref.doc
@@ -219,7 +219,7 @@ rules:
   - id: docutils-inline-markup
     title: "Unbalanced inline emphasis/strong markup"
     tier: 3
-    safety: mechanical
+    safety: judgment
     match: any
     categories:
       - docutils

--- a/doc/.claude/skills/sphinx-fix/sphinx_fix.py
+++ b/doc/.claude/skills/sphinx-fix/sphinx_fix.py
@@ -375,6 +375,10 @@ def is_noise(line: str) -> bool:
     """True for python-logging lines and JSON log records (not Sphinx warnings)."""
     if "\tWARNING " in line or "\tERROR " in line:
         return True
+    # urllib3 retry chatter from the pip-install phase (Sphinx never emits
+    # "Retrying (Retry(" and pip index URLs are /simple/...), not a doc warning.
+    if "Retrying (Retry(" in line and "after connection broken" in line:
+        return True
     s = line.strip()
     return s.startswith("{") and '"levelname"' in s
 

--- a/doc/.claude/skills/sphinx-fix/sphinx_fix.py
+++ b/doc/.claude/skills/sphinx-fix/sphinx_fix.py
@@ -375,9 +375,10 @@ def is_noise(line: str) -> bool:
     """True for python-logging lines and JSON log records (not Sphinx warnings)."""
     if "\tWARNING " in line or "\tERROR " in line:
         return True
-    # urllib3 retry chatter from the pip-install phase (Sphinx never emits
-    # "Retrying (Retry(" and pip index URLs are /simple/...), not a doc warning.
-    if "Retrying (Retry(" in line and "after connection broken" in line:
+    # urllib3 retry chatter from the pip-install phase. Sphinx never emits
+    # "Retrying (Retry(", so that signature alone is enough -- and it also catches
+    # read-timeout/status retries that lack the "after connection broken" wording.
+    if "Retrying (Retry(" in line:
         return True
     s = line.strip()
     return s.startswith("{") and '"levelname"' in s

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/autosummary_stub_masking.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/autosummary_stub_masking.txt
@@ -1,0 +1,11 @@
+Build: 4156675   State: Finished   Success: False   Duration: 1004s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (4):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.map_batches'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.map'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.map_batches [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.map [ref.meth]
+
+Summary line: build finished with problems, 4 warnings.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/docutils_inline_markup.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/docutils_inline_markup.txt
@@ -1,0 +1,9 @@
+Build: 4144240   State: Finished   Success: False   Duration: 604s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (2):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/releases-2.56.0/doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1: WARNING: Inline emphasis start-string without end-string. [docutils]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/releases-2.56.0/doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1: WARNING: Inline strong start-string without end-string. [docutils]
+
+Summary line: build finished with problems, 2 warnings.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/intersphinx_unreachable.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/intersphinx_unreachable.txt
@@ -1,0 +1,8 @@
+Build: 4159413   State: Finished   Success: False   Duration: 1078s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+WARNING: failed to reach any of the inventories with the following issues:
+intersphinx inventory 'https://docs.python.org/3/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='docs.python.org', port=443): Max retries exceeded with url: /3/objects.inv (Caused by NewConnectionError('Failed to establish a new connection: [Errno 101] Network is unreachable'))
+
+Summary line: build finished with problems, 1 warning.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/py_xref_independent.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/py_xref_independent.txt
@@ -1,0 +1,8 @@
+Build: 4161499   State: Finished   Success: False   Duration: 669s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (1):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/releases-2.56.0/python/ray/train/collective/__init__.py:docstring of ray.train.collective.broadcast_from_rank_zero:: WARNING: py:exc reference target not found: pickle.PicklingError [ref.exc]
+
+Summary line: build finished with problems, 1 warning.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/unknown_document.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/unknown_document.txt
@@ -1,0 +1,8 @@
+Build: 4155333   State: Finished   Success: False   Duration: 628s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (1):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/63617/doc/source/serve/llm/examples.md:17: WARNING: unknown document: '/_collections/serve/tutorials/deployment-serve-llm/npu-ascend/README' [ref.doc]
+
+Summary line: build finished with problems, 1 warning.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_masking.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_masking.txt
@@ -1,0 +1,27 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 4 warnings.
+
+Findings (4):
+  Tier 2 — structural/parse (fix first; these mask warnings beneath them):
+    [T2] autosummary-stub-not-found  doc/source/apis/data/ray.data.Dataset.rst:20
+          msg:    autosummary: stub file not found 'ray.data.Dataset.map_batches'. Check your autosummary_generate setting.
+          fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
+          safety: judgment (needs your call)
+    [T2] autosummary-stub-not-found  doc/source/apis/data/ray.data.Dataset.rst:20
+          msg:    autosummary: stub file not found 'ray.data.Dataset.map'. Check your autosummary_generate setting.
+          fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
+          safety: judgment (needs your call)
+  Tier 3 — warnings:
+    [T3] py-xref-target-not-found  doc/source/apis/data/aggregate.rst:6
+          msg:    py:meth reference target not found: ray.data.Dataset.map_batches
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+    [T3] py-xref-target-not-found  doc/source/apis/data/aggregate.rst:6
+          msg:    py:meth reference target not found: ray.data.Dataset.map
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: fix Tier 2 first (it masks others), then rebuild and re-run — do not assume one pass is complete.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
@@ -5,11 +5,11 @@ Findings (2):
     [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
           msg:    Inline emphasis start-string without end-string.
           fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
-          safety: mechanical
+          safety: judgment (needs your call)
     [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
           msg:    Inline strong start-string without end-string.
           fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
-          safety: mechanical
+          safety: judgment (needs your call)
 
 Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
 

--- a/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
@@ -1,0 +1,18 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 2 warnings.
+
+Findings (2):
+  Tier 3 — warnings:
+    [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
+          msg:    Inline emphasis start-string without end-string.
+          fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
+          safety: mechanical
+    [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
+          msg:    Inline strong start-string without end-string.
+          fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
+          safety: mechanical
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/intersphinx_unreachable.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/intersphinx_unreachable.txt
@@ -1,0 +1,14 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 1 warning.
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] intersphinx-inventory-unreachable  (no location)
+          msg:    failed to reach any of the inventories with the following issues:
+          fix:    Re-run the build first -- this is usually transient. If it persists, the inventory URL in intersphinx_mapping (conf.py) is unreachable or wrong: confirm the URL. This is not a per-page content fix.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/py_xref_independent.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/py_xref_independent.txt
@@ -1,0 +1,14 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 1 warning.
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] py-xref-target-not-found  python/ray/train/collective/__init__.py:docstring of ray.train.collective.broadcast_from_rank_zero:
+          msg:    py:exc reference target not found: pickle.PicklingError
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
@@ -1,0 +1,14 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 1 warning.
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] unknown-document  doc/source/serve/llm/examples.md:17
+          msg:    unknown document: '/_collections/serve/tutorials/deployment-serve-llm/npu-ascend/README'
+          fix:    Repoint to the correct document: a path relative to the referencing page, or an absolute path from doc/source with a leading slash. Remove the reference if the target is gone. Grep the bare stem across doc/ to find every caller.
+          safety: mechanical
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
@@ -5,7 +5,7 @@ Findings (1):
     [T3] unknown-document  doc/source/serve/llm/examples.md:17
           msg:    unknown document: '/_collections/serve/tutorials/deployment-serve-llm/npu-ascend/README'
           fix:    Repoint to the correct document: a path relative to the referencing page, or an absolute path from doc/source with a leading slash. Remove the reference if the target is gone. Grep the bare stem across doc/ to find every caller.
-          safety: mechanical
+          safety: judgment (needs your call)
 
 Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
 


### PR DESCRIPTION
## Why are these changes needed?

The `sphinx-fix` skill classifies Ray doc-build warnings against a rules table. The seed table was known to be incomplete. To grow it from real misses (the feedback loop the skill documents), I ran the engine over a corpus of recent **finished-and-failed** `anyscale-ray` Read the Docs builds. **1,114 warnings landed in the unclassified bucket**, clustering into five recurring classes the table didn't cover. This PR adds a rule for each. On the same corpus, unclassified drops to **0**, and the `--selftest` stays green.

### New rules

- **`py-xref-target-not-found`** (tier 3) — Python-domain reference target not found (`py:meth`/`obj`/`func`/`exc`/…). This is the largest class. It is *frequently a downstream symptom* of a tier-2 autosummary-stub failure or a tier-1 import abort for the same module, so the fix guidance is to triage the root first rather than chase each of hundreds of references.
- **`autosummary-stub-not-found`** (**tier 2**) — an autosummary member whose stub `.rst` was never generated. Classified tier 2 because the ungenerated stubs **mask** the `py:*` reference-target-not-found warnings for the same objects. The verdict now reads "fix tier 2 first" instead of listing hundreds of equal-looking downstream findings. A bulk failure sharing a module prefix points at one root (a module that failed to import under the build's mock set, or an in-progress API-ref restructuring).
- **`unknown-document`** (tier 3) — a `{doc}`/toctree reference to a document path that doesn't resolve.
- **`intersphinx-inventory-unreachable`** (tier 3) — a transient network failure fetching an external `objects.inv`; labeled *not a content defect* so it isn't chased as a doc bug.
- **`docutils-inline-markup`** (tier 3) — unbalanced inline emphasis/strong (`*`/`**`).

The parser's noise gate also now drops urllib3 pip-install retry chatter (Sphinx never emits `Retrying (Retry(`).

Each class ships a fixture and a golden regenerated from it. Rules and goldens are additive — no existing rule or golden changed.

## Related issue number

Extends the `sphinx-fix` skill added in #64147.

## Checks

- [x] `python doc/.claude/skills/sphinx-fix/sphinx_fix.py --selftest` passes (15 fixtures, 15 rules, 4 suppressions).
- [x] Validated on a corpus of 33 real failed RtD builds: unclassified 1,114 → 0, no regression in previously-classified findings.
