### PR TITLE
[doc] sphinx-fix: collapse a masked warning flood to its root

### DIFF
--- a/doc/.claude/skills/sphinx-fix/SKILL.md
+++ b/doc/.claude/skills/sphinx-fix/SKILL.md
@@ -64,12 +64,13 @@ Stdlib-only — no install. It prefers PyYAML to read `rules.yaml` but falls bac
 
 ## Reading the output
 
-The report has four parts, in priority order:
+The report has five parts, in priority order:
 
 1. **Abort banner** (only if present) — a hard-broken build (a `conf.py`/extension error, a traceback, or `SEVERE:` with no completion summary) aborted before the warning pass. **Fix this first; the rest of the log is unreliable.** For an autosummary import abort, the banner adds a `hint:` — the named module is usually a decoy for an unrelated module whose import chain broke (often a dep mocked by `autodoc_mock_imports` but used at import time); trace it and make the eager import lazy.
-2. **Findings**, grouped by tier (1 → 2 → 3). Each row is `[T2] <rule-id> <path:line>` plus the warning message, the canonical `fix:` (with a `Suggested:` rewrite for mechanical rules), and a `safety:` flag. `judgment` findings need your decision.
-3. **Unclassified** — warnings no rule matched. **Never silently dropped.** Resolve each with the user, then file a skill-improvement ticket so `rules.yaml` gains a rule (see below).
-4. **Suppressed** — known-benign classes the build already filters; not actionable.
+2. **Root-cause groups** (only if present) — a single structural root (an ungenerated `autosummary` stub for a module or class) masks a flood of downstream `py:* reference target not found` warnings for the *same* objects. Rather than list the flood as N equal-looking rows, the report collapses it: `ROOT [T2] ... — <prefix>.* (N stubs not generated, masking M downstream references)`, the root's fix once, then the masked references collapsed under it (capped in the rendered view, with the dropped count shown). **Fix the root, rebuild, and the masked references clear together** — don't chase the individual references. The full flat list is always in `--json`.
+3. **Findings**, grouped by tier (1 → 2 → 3), for everything not absorbed into a root-cause group. Each row is `[T2] <rule-id> <path:line>` plus the warning message, the canonical `fix:` (with a `Suggested:` rewrite for mechanical rules), and a `safety:` flag. `judgment` findings need your decision.
+4. **Unclassified** — warnings no rule matched. **Never silently dropped.** Resolve each with the user, then file a skill-improvement ticket so `rules.yaml` gains a rule (see below).
+5. **Suppressed** — known-benign classes the build already filters; not actionable.
 
 ---
 

--- a/doc/.claude/skills/sphinx-fix/rules.yaml
+++ b/doc/.claude/skills/sphinx-fix/rules.yaml
@@ -111,6 +111,21 @@ rules:
     version_myst: ">=5.0,<6"
     notes: "Shared with rst-to-myst Hard rule 2."
 
+  - id: unknown-document
+    title: "{doc}/toctree reference to an unknown document"
+    tier: 3
+    safety: mechanical
+    match: any
+    categories:
+      - ref.doc
+    signatures:
+      - "unknown document:"
+    cause: "A {doc} role, a :doc: reference, or a toctree entry points at a document path that does not resolve -- a renamed or moved page, a typo, or a relative path that is wrong from the referencing file. Distinct from toctree-nonexisting, which is the toctree-directive-specific wording."
+    fix: "Repoint to the correct document: a path relative to the referencing page, or an absolute path from doc/source with a leading slash. Remove the reference if the target is gone. Grep the bare stem across doc/ to find every caller."
+    target_extract: "unknown document: '?(?P<target>[^'\\s]+)"
+    version_sphinx: ">=8.0,<9"
+    notes: "Category ref.doc confirmed on real Ray RtD builds; the tag is sometimes absent on the first emission, so the signature carries the match."
+
   - id: toctree-nonexisting
     title: "toctree references a nonexisting document"
     tier: 2
@@ -164,6 +179,28 @@ rules:
     version_sphinx: ">=8.0,<9"
     notes: "Category ref.ref is a best-effort guess; signature carries the match."
 
+  - id: py-xref-target-not-found
+    title: "Python-domain reference target not found (meth/func/class/obj/exc)"
+    tier: 3
+    safety: judgment
+    match: any
+    categories:
+      - ref.meth
+      - ref.obj
+      - ref.func
+      - ref.class
+      - ref.exc
+      - ref.attr
+      - ref.mod
+      - ref.python
+    signatures:
+      - "py:\\w+ reference target not found:"
+    cause: "A Python-domain role ({meth}/{class}/{func}/{obj}/{exc}/:py:*:) points at an object not in the resolved API inventory. Two very different roots: (1) the object is documented elsewhere but its autosummary stub was not generated, or its module aborted import, so the inventory entry is missing -- these arrive as a large flood sharing an object prefix and are DOWNSTREAM symptoms, not separate defects; (2) the reference is genuinely wrong -- a renamed, moved, or mistyped target, or a stdlib/third-party name that needs intersphinx."
+    fix: "Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name."
+    target_extract: "py:\\w+ reference target not found: (?P<target>\\S+)"
+    version_sphinx: ">=8.0,<9"
+    notes: "Categories confirmed on real Ray RtD builds (ref.meth, ref.obj, ref.func, ref.python); the signature carries the rest of the py domain (ref.exc, ref.attr). safety=judgment: both the correct target and the correct root (edit one reference vs revert a restructuring) need a human decision -- never auto-apply. A correlated flood sharing an object prefix with autosummary-stub-not-found warnings is that rule's masked downstream; triage the tier-2 root, not each reference."
+
   - id: image-not-readable
     title: "Image file not readable"
     tier: 3
@@ -179,6 +216,32 @@ rules:
     version_sphinx: ">=8.0,<9"
     notes: "Category image.not_readable is a best-effort guess; signature carries the match."
 
+  - id: docutils-inline-markup
+    title: "Unbalanced inline emphasis/strong markup"
+    tier: 3
+    safety: mechanical
+    match: any
+    categories:
+      - docutils
+    signatures:
+      - "Inline .+ start-string without end-string"
+    cause: "A docstring or RST body has an unbalanced inline marker -- a lone * (emphasis) or ** (strong) with no closing marker. Common in API docstrings that write *args or **kwargs, or a bare asterisk, outside a code span. It surfaces from an <autosummary> generated stub at the docstring's location."
+    fix: "Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\\*)."
+    version_sphinx: ">=8.0,<9"
+    notes: "Category docutils confirmed on real Ray RtD builds. No target extraction: the message does not carry the offending text, so locate the unbalanced marker at the cited docstring."
+
+  - id: intersphinx-inventory-unreachable
+    title: "intersphinx inventory not fetchable (network/transient)"
+    tier: 3
+    safety: judgment
+    match: any
+    signatures:
+      - "failed to reach any of the inventories"
+    cause: "Sphinx could not download an external intersphinx objects.inv (for example docs.python.org or spark.apache.org). On the RtD build network this is usually a transient connectivity failure, not a defect in the docs; with fail_on_warning it still fails the build."
+    fix: "Re-run the build first -- this is usually transient. If it persists, the inventory URL in intersphinx_mapping (conf.py) is unreachable or wrong: confirm the URL. This is not a per-page content fix."
+    version_sphinx: ">=8.0,<9"
+    notes: "Untagged (no [category]); signature-only. The URL and error detail sit on an unindented continuation line the parser does not capture as a warning record, so match on the WARNING line. safety=judgment: re-run vs investigate intersphinx_mapping is a human call."
+
   - id: literalinclude-out-of-range
     title: "literalinclude line/marker out of range"
     tier: 2
@@ -191,6 +254,19 @@ rules:
     fix: "Update the :lines: range or the :start-after:/:end-before: markers to match the current source file."
     version_sphinx: ">=8.0,<9"
     notes: "Signature-only pending [category] confirmation."
+
+  - id: autosummary-stub-not-found
+    title: "autosummary stub file not generated for a listed member"
+    tier: 2
+    safety: judgment
+    match: any
+    signatures:
+      - "autosummary: stub file not found '[^']+'\\. Check your autosummary_generate"
+    cause: "An autosummary directive lists a member whose stub .rst was never generated. A lone entry usually means the member was renamed or removed. A bulk failure across a whole module or API-ref page means autosummary could not introspect the module -- commonly the module failed to import under the build's autodoc_mock_imports set, or an in-progress API-ref restructuring moved or renamed the source. It is a tier-2 structural condition: the ungenerated stubs mask the py:* reference-target-not-found warnings for the same objects (see py-xref-target-not-found)."
+    fix: "Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry."
+    target_extract: "stub file not found '(?P<target>[^']+)'"
+    version_sphinx: ">=8.0,<9"
+    notes: "Untagged core-Sphinx warning (no [category]); signature-only. Seen at scale in a Ray API-ref rework where dozens of missing stubs masked hundreds of downstream py:ref failures. Fix this tier-2 root first, rebuild, and most of the py-xref-target-not-found flood clears."
 
 # Known-benign warning classes the build already suppresses or filters in
 # doc/source/conf.py. The engine segregates these into a not-actionable bucket

--- a/doc/.claude/skills/sphinx-fix/sphinx_fix.py
+++ b/doc/.claude/skills/sphinx-fix/sphinx_fix.py
@@ -677,6 +677,117 @@ def exit_code_for(report: Report) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# Root-cause collapse (rendered-report affordance only)
+# --------------------------------------------------------------------------- #
+# One structural failure -- an autosummary stub that could not be generated for a
+# module/class -- masks a flood of downstream py:* reference-target-not-found
+# warnings for the SAME objects. Left flat, a single root renders as hundreds of
+# equal-looking rows (one API-ref rework produced ~70 stub warnings masking ~291
+# reference warnings). Collapse groups the downstream flood under its masking root
+# so the human sees "1 root -> N masked references" instead of N sibling rows.
+#
+# This is a human-readability affordance for render_human ONLY. report.findings
+# stays the full flat list, so --json (the agent surface) is unchanged and
+# complete, and the verdict/exit code still see every finding.
+#
+# Correlation is by shared parent namespace: the stub warnings and the reference
+# warnings are emitted for the same members, so both dotted paths share a parent
+# (e.g. ray.data.Dataset.map_batches and ray.data.Dataset.map -> ray.data.Dataset).
+# A tier-1 import abort is the other root of this same flood, but it surfaces
+# separately as the HARD-BROKEN banner (and empties the finding list), so collapse
+# runs only when the build completed far enough to emit findings.
+ROOT_RULE = "autosummary-stub-not-found"
+DOWNSTREAM_RULE = "py-xref-target-not-found"
+COLLAPSE_LIST_CAP = 5
+
+
+@dataclass
+class RootCauseGroup:
+    prefix: str
+    roots: list[Finding]  # autosummary-stub-not-found findings (the root)
+    downstream: list[Finding]  # py-xref-target-not-found findings it masks
+
+
+def _object_prefix(target: str | None) -> str | None:
+    """Parent namespace of a dotted object path (drop the last segment)."""
+    if not target:
+        return None
+    head = target.rpartition(".")[0]
+    return head or None
+
+
+def compute_root_cause_groups(findings: list[Finding]) -> list[RootCauseGroup]:
+    """Group a masked py-xref flood under its autosummary-stub root, by prefix.
+
+    A group forms for a parent-namespace prefix only when it has BOTH at least
+    one stub root and at least one downstream reference sharing that prefix -- the
+    masking scenario. A lone stub (no downstream) or a genuinely independent
+    reference (no matching stub) is left untouched in the normal findings list.
+    """
+    roots_by_prefix: dict[str, list[Finding]] = {}
+    downstream_by_prefix: dict[str, list[Finding]] = {}
+    for f in findings:
+        prefix = _object_prefix(f.target)
+        if not prefix:
+            continue
+        if f.rule_id == ROOT_RULE:
+            roots_by_prefix.setdefault(prefix, []).append(f)
+        elif f.rule_id == DOWNSTREAM_RULE:
+            downstream_by_prefix.setdefault(prefix, []).append(f)
+    groups = []
+    for prefix in sorted(set(roots_by_prefix) & set(downstream_by_prefix)):
+        groups.append(
+            RootCauseGroup(
+                prefix, roots_by_prefix[prefix], downstream_by_prefix[prefix]
+            )
+        )
+    return groups
+
+
+def _dedup(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for it in items:
+        if it not in seen:
+            seen.add(it)
+            out.append(it)
+    return out
+
+
+def _capped(items: list[str]) -> str:
+    """Comma-join up to the cap, appending an explicit dropped-count (never silent)."""
+    shown = ", ".join(items[:COLLAPSE_LIST_CAP])
+    if len(items) > COLLAPSE_LIST_CAP:
+        shown += f", ... and {len(items) - COLLAPSE_LIST_CAP} more"
+    return shown
+
+
+def _render_group(g: RootCauseGroup, out: list[str]) -> None:
+    n_roots, n_down = len(g.roots), len(g.downstream)
+    root = g.roots[0]
+    safety = root.safety + (" (needs your call)" if root.safety == "judgment" else "")
+    out.append(
+        f"  ROOT [T{root.tier}] {ROOT_RULE} — {g.prefix}.* "
+        f"({n_roots} stub{'s' if n_roots != 1 else ''} not generated, "
+        f"masking {n_down} downstream reference{'s' if n_down != 1 else ''})"
+    )
+    out.append(f"        where:  {_capped(_dedup([_loc(r.warning) for r in g.roots]))}")
+    out.append(
+        f"        stubs:  {_capped([r.target or r.warning.message for r in g.roots])}"
+    )
+    out.append(f"        fix:    {root.fix}")
+    out.append(f"        safety: {safety}")
+    out.append(
+        f"    masks {n_down} downstream py:* reference(s) — "
+        "collapsed (full list in --json):"
+    )
+    for d in g.downstream[:COLLAPSE_LIST_CAP]:
+        out.append(f"          {_loc(d.warning)}  {d.target or d.warning.message}")
+    if n_down > COLLAPSE_LIST_CAP:
+        out.append(f"          ... and {n_down - COLLAPSE_LIST_CAP} more (see --json)")
+
+
 def render_human(report: Report) -> str:
     out: list[str] = []
     st = report.build_state
@@ -709,17 +820,34 @@ def render_human(report: Report) -> str:
         out.append("Build: " + "  ".join(bits))
         out.append("")
 
+    # Collapse a masked downstream flood under its root (rendered-report only;
+    # report.findings stays flat). Skip on an aborted build -- the warning pass
+    # didn't complete, so the flood/root relationship isn't trustworthy yet.
+    groups = [] if report.abort else compute_root_cause_groups(report.findings)
+    grouped_ids = {id(f) for g in groups for f in (*g.roots, *g.downstream)}
+    remaining = [f for f in report.findings if id(f) not in grouped_ids]
+
+    if groups:
+        out.append(
+            f"Root-cause groups ({len(groups)}) — a structural root masks a "
+            "downstream flood; fix the root, rebuild, and the masked references "
+            "clear together:"
+        )
+        for g in groups:
+            _render_group(g, out)
+        out.append("")
+
     header = (
         "Partial findings (warning pass did not complete)"
         if report.abort
         else "Findings"
     )
-    out.append(f"{header} ({len(report.findings)}):")
-    if not report.findings:
+    out.append(f"{header} ({len(remaining)}):")
+    if not remaining:
         out.append("  (none)")
     else:
         by_tier: dict[int, list[Finding]] = {}
-        for f in report.findings:
+        for f in remaining:
             by_tier.setdefault(f.tier, []).append(f)
         for tier in sorted(by_tier):
             out.append(f"  Tier {tier} — {TIER_LABEL[tier]}:")

--- a/doc/.claude/skills/sphinx-fix/sphinx_fix.py
+++ b/doc/.claude/skills/sphinx-fix/sphinx_fix.py
@@ -375,6 +375,10 @@ def is_noise(line: str) -> bool:
     """True for python-logging lines and JSON log records (not Sphinx warnings)."""
     if "\tWARNING " in line or "\tERROR " in line:
         return True
+    # urllib3 retry chatter from the pip-install phase (Sphinx never emits
+    # "Retrying (Retry(" and pip index URLs are /simple/...), not a doc warning.
+    if "Retrying (Retry(" in line and "after connection broken" in line:
+        return True
     s = line.strip()
     return s.startswith("{") and '"levelname"' in s
 

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/autosummary_stub_flood.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/autosummary_stub_flood.txt
@@ -1,0 +1,22 @@
+Build: 4156675   State: Finished   Success: False   Duration: 1042s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (15):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.map_batches'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.map'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.filter'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.flat_map'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.groupby'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.sort'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.map_batches [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.map [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.filter [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.flat_map [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/transform.rst:10: WARNING: py:meth reference target not found: ray.data.Dataset.groupby [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/transform.rst:10: WARNING: py:meth reference target not found: ray.data.Dataset.sort [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/transform.rst:10: WARNING: py:meth reference target not found: ray.data.Dataset.limit [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/transform.rst:10: WARNING: py:meth reference target not found: ray.data.Dataset.show [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/python/ray/train/collective/__init__.py:docstring of ray.train.collective.broadcast_from_rank_zero:: WARNING: py:exc reference target not found: pickle.PicklingError [ref.exc]
+
+Summary line: build finished with problems, 15 warnings.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/autosummary_stub_masking.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/autosummary_stub_masking.txt
@@ -1,0 +1,11 @@
+Build: 4156675   State: Finished   Success: False   Duration: 1004s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (4):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.map_batches'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/ray.data.Dataset.rst:20: WARNING: autosummary: stub file not found 'ray.data.Dataset.map'. Check your autosummary_generate setting.
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.map_batches [ref.meth]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/64387/doc/source/apis/data/aggregate.rst:6: WARNING: py:meth reference target not found: ray.data.Dataset.map [ref.meth]
+
+Summary line: build finished with problems, 4 warnings.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/docutils_inline_markup.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/docutils_inline_markup.txt
@@ -1,0 +1,9 @@
+Build: 4144240   State: Finished   Success: False   Duration: 604s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (2):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/releases-2.56.0/doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1: WARNING: Inline emphasis start-string without end-string. [docutils]
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/releases-2.56.0/doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1: WARNING: Inline strong start-string without end-string. [docutils]
+
+Summary line: build finished with problems, 2 warnings.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/intersphinx_unreachable.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/intersphinx_unreachable.txt
@@ -1,0 +1,8 @@
+Build: 4159413   State: Finished   Success: False   Duration: 1078s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+WARNING: failed to reach any of the inventories with the following issues:
+intersphinx inventory 'https://docs.python.org/3/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='docs.python.org', port=443): Max retries exceeded with url: /3/objects.inv (Caused by NewConnectionError('Failed to establish a new connection: [Errno 101] Network is unreachable'))
+
+Summary line: build finished with problems, 1 warning.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/py_xref_independent.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/py_xref_independent.txt
@@ -1,0 +1,8 @@
+Build: 4161499   State: Finished   Success: False   Duration: 669s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (1):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/releases-2.56.0/python/ray/train/collective/__init__.py:docstring of ray.train.collective.broadcast_from_rank_zero:: WARNING: py:exc reference target not found: pickle.PicklingError [ref.exc]
+
+Summary line: build finished with problems, 1 warning.

--- a/doc/.claude/skills/sphinx-fix/tests/fixtures/unknown_document.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/fixtures/unknown_document.txt
@@ -1,0 +1,8 @@
+Build: 4155333   State: Finished   Success: False   Duration: 628s
+Failing command: python -m sphinx -T -W --keep-going -j auto -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+Exit code: 1
+
+Sphinx warnings (1):
+  /home/docs/checkouts/readthedocs.org/user_builds/anyscale-ray/checkouts/63617/doc/source/serve/llm/examples.md:17: WARNING: unknown document: '/_collections/serve/tutorials/deployment-serve-llm/npu-ascend/README' [ref.doc]
+
+Summary line: build finished with problems, 1 warning.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_flood.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_flood.txt
@@ -1,0 +1,28 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 15 warnings.
+
+Root-cause groups (1) — a structural root masks a downstream flood; fix the root, rebuild, and the masked references clear together:
+  ROOT [T2] autosummary-stub-not-found — ray.data.Dataset.* (6 stubs not generated, masking 8 downstream references)
+        where:  doc/source/apis/data/ray.data.Dataset.rst:20
+        stubs:  ray.data.Dataset.map_batches, ray.data.Dataset.map, ray.data.Dataset.filter, ray.data.Dataset.flat_map, ray.data.Dataset.groupby, ... and 1 more
+        fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
+        safety: judgment (needs your call)
+    masks 8 downstream py:* reference(s) — collapsed (full list in --json):
+          doc/source/apis/data/aggregate.rst:6  ray.data.Dataset.map_batches
+          doc/source/apis/data/aggregate.rst:6  ray.data.Dataset.map
+          doc/source/apis/data/aggregate.rst:6  ray.data.Dataset.filter
+          doc/source/apis/data/aggregate.rst:6  ray.data.Dataset.flat_map
+          doc/source/apis/data/transform.rst:10  ray.data.Dataset.groupby
+          ... and 3 more (see --json)
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] py-xref-target-not-found  python/ray/train/collective/__init__.py:docstring of ray.train.collective.broadcast_from_rank_zero:
+          msg:    py:exc reference target not found: pickle.PicklingError
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: fix Tier 2 first (it masks others), then rebuild and re-run — do not assume one pass is complete.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_masking.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_masking.txt
@@ -1,24 +1,17 @@
 Build: state=Finished  success=False  exit=1  build finished with problems, 4 warnings.
 
-Findings (4):
-  Tier 2 — structural/parse (fix first; these mask warnings beneath them):
-    [T2] autosummary-stub-not-found  doc/source/apis/data/ray.data.Dataset.rst:20
-          msg:    autosummary: stub file not found 'ray.data.Dataset.map_batches'. Check your autosummary_generate setting.
-          fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
-          safety: judgment (needs your call)
-    [T2] autosummary-stub-not-found  doc/source/apis/data/ray.data.Dataset.rst:20
-          msg:    autosummary: stub file not found 'ray.data.Dataset.map'. Check your autosummary_generate setting.
-          fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
-          safety: judgment (needs your call)
-  Tier 3 — warnings:
-    [T3] py-xref-target-not-found  doc/source/apis/data/aggregate.rst:6
-          msg:    py:meth reference target not found: ray.data.Dataset.map_batches
-          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
-          safety: judgment (needs your call)
-    [T3] py-xref-target-not-found  doc/source/apis/data/aggregate.rst:6
-          msg:    py:meth reference target not found: ray.data.Dataset.map
-          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
-          safety: judgment (needs your call)
+Root-cause groups (1) — a structural root masks a downstream flood; fix the root, rebuild, and the masked references clear together:
+  ROOT [T2] autosummary-stub-not-found — ray.data.Dataset.* (2 stubs not generated, masking 2 downstream references)
+        where:  doc/source/apis/data/ray.data.Dataset.rst:20
+        stubs:  ray.data.Dataset.map_batches, ray.data.Dataset.map
+        fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
+        safety: judgment (needs your call)
+    masks 2 downstream py:* reference(s) — collapsed (full list in --json):
+          doc/source/apis/data/aggregate.rst:6  ray.data.Dataset.map_batches
+          doc/source/apis/data/aggregate.rst:6  ray.data.Dataset.map
+
+Findings (0):
+  (none)
 
 Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
 

--- a/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_masking.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/autosummary_stub_masking.txt
@@ -1,0 +1,27 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 4 warnings.
+
+Findings (4):
+  Tier 2 — structural/parse (fix first; these mask warnings beneath them):
+    [T2] autosummary-stub-not-found  doc/source/apis/data/ray.data.Dataset.rst:20
+          msg:    autosummary: stub file not found 'ray.data.Dataset.map_batches'. Check your autosummary_generate setting.
+          fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
+          safety: judgment (needs your call)
+    [T2] autosummary-stub-not-found  doc/source/apis/data/ray.data.Dataset.rst:20
+          msg:    autosummary: stub file not found 'ray.data.Dataset.map'. Check your autosummary_generate setting.
+          fix:    Do not fix per entry when the failure is in bulk. Determine scope first: many missing stubs sharing a module prefix point at one root -- confirm the module imports under the build's mock set (autodoc_mock_imports) and that autosummary_generate is on; when an API-ref restructuring is in flight, the correct move may be to revert or repair the file moves rather than edit each entry. A lone missing stub means the member no longer exists -- update or drop the autosummary entry.
+          safety: judgment (needs your call)
+  Tier 3 — warnings:
+    [T3] py-xref-target-not-found  doc/source/apis/data/aggregate.rst:6
+          msg:    py:meth reference target not found: ray.data.Dataset.map_batches
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+    [T3] py-xref-target-not-found  doc/source/apis/data/aggregate.rst:6
+          msg:    py:meth reference target not found: ray.data.Dataset.map
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: fix Tier 2 first (it masks others), then rebuild and re-run — do not assume one pass is complete.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
@@ -1,0 +1,18 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 2 warnings.
+
+Findings (2):
+  Tier 3 — warnings:
+    [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
+          msg:    Inline emphasis start-string without end-string.
+          fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
+          safety: mechanical
+    [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
+          msg:    Inline strong start-string without end-string.
+          fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
+          safety: mechanical
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/intersphinx_unreachable.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/intersphinx_unreachable.txt
@@ -1,0 +1,14 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 1 warning.
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] intersphinx-inventory-unreachable  (no location)
+          msg:    failed to reach any of the inventories with the following issues:
+          fix:    Re-run the build first -- this is usually transient. If it persists, the inventory URL in intersphinx_mapping (conf.py) is unreachable or wrong: confirm the URL. This is not a per-page content fix.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/py_xref_independent.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/py_xref_independent.txt
@@ -1,0 +1,14 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 1 warning.
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] py-xref-target-not-found  python/ray/train/collective/__init__.py:docstring of ray.train.collective.broadcast_from_rank_zero:
+          msg:    py:exc reference target not found: pickle.PicklingError
+          fix:    Check for a co-occurring tier-2 autosummary-stub-not-found or tier-1 import abort for the same module first. If present, fix that root (up to and including reverting an in-progress API-ref restructuring) and rebuild -- the flood clears at once. Only when the build is otherwise healthy is the reference itself wrong: repoint to the correct dotted path, or fix the intersphinx target for a stdlib/third-party name.
+          safety: judgment (needs your call)
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.

--- a/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
@@ -1,0 +1,14 @@
+Build: state=Finished  success=False  exit=1  build finished with problems, 1 warning.
+
+Findings (1):
+  Tier 3 — warnings:
+    [T3] unknown-document  doc/source/serve/llm/examples.md:17
+          msg:    unknown document: '/_collections/serve/tutorials/deployment-serve-llm/npu-ascend/README'
+          fix:    Repoint to the correct document: a path relative to the referencing page, or an absolute path from doc/source with a leading slash. Remove the reference if the target is gone. Grep the bare stem across doc/ to find every caller.
+          safety: mechanical
+
+Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
+
+Suppressed (0) — known-benign, not actionable:
+
+Next: apply the fixes above, then rebuild and re-run to confirm clean.


### PR DESCRIPTION
## Summary

Stacked on #64502 (review after it merges — until then this PR's diff includes that branch's commit; it self-cleans once #64502 lands on master).

The `sphinx-fix` skill assigns the right tiers, but a single structural failure still renders as hundreds of equal-looking rows. One API-ref restructuring produced ~70 `autosummary: stub file not found` warnings (tier 2) that masked ~291 `py:* reference target not found` warnings (tier 3) for the *same* objects. Those reference failures are downstream symptoms, not separate defects, yet the engine listed every one as an individual tier-3 row.

This teaches `sphinx_fix.py` to collapse the downstream flood under its root in the rendered report:

- Group `py-xref-target-not-found` findings by shared parent namespace.
- Correlate each group against `autosummary-stub-not-found` findings for the same prefix.
- Render `ROOT [T2] … — ray.data.Dataset.* (N stubs not generated, masking M downstream references)` with the references collapsed under it (list capped, with the dropped count shown) instead of M sibling rows.

Collapse is a human-readability affordance for the rendered report **only**. `report.findings` stays the full flat list, so `--json` (the agent surface) is unchanged and complete, and the verdict/exit code still see every finding. A genuinely independent reference (no matching stub) is left untouched in the normal findings list.

## Changes

- `sphinx_fix.py`: root-cause grouping + collapsed rendering; `--json` unchanged.
- `tests/fixtures/autosummary_stub_flood.txt` + golden: many-refs-one-stub-root shape exercising both list caps and an independent reference alongside the flood.
- `tests/golden/autosummary_stub_masking.txt`: regenerated to the collapsed form.
- `SKILL.md`: documents the new report section.

## Verification

- `python doc/.claude/skills/sphinx-fix/sphinx_fix.py --selftest` — green (16 fixtures).
- `ruff check` clean; no new `ruff format` diffs on the added code.
