### PR TITLE
[doc] Update vllm embedding model example in Ray Serve LLM

### DIFF
--- a/doc/source/serve/llm/user-guides/vllm-compatibility.md
+++ b/doc/source/serve/llm/user-guides/vllm-compatibility.md
@@ -14,7 +14,7 @@ This guide shows how to use vLLM features such as embeddings, structured output,
 
 ## Embeddings
 
-You can generate embeddings by setting the `task` parameter to `"embed"` in the engine arguments. Models supporting this use case are listed in the [vLLM text embedding models documentation](https://docs.vllm.ai/en/stable/models/supported_models.html#text-embedding-task-embed).
+In vLLM, embedding generation falls in the category of [Pooling Models](https://docs.vllm.ai/en/stable/models/pooling_models/). You can generate embeddings by setting the `pooler-config.task` [parameter](https://docs.vllm.ai/en/stable/models/pooling_models/#pooling-tasks) to `"embed"` in the engine arguments. Models supporting this use case are listed in the [vLLM embedding models documentation](https://docs.vllm.ai/en/stable/models/pooling_models/embed/#supported-models).
 
 
 ### Deploy an embedding model
@@ -34,7 +34,7 @@ llm_config = LLMConfig(
         model_source="Qwen/Qwen2.5-0.5B-Instruct",
     ),
     engine_kwargs=dict(
-        task="embed",
+        pooler_config=dict(task="embed"),
     ),
 )
 

--- a/doc/source/serve/llm/user-guides/vllm-compatibility.md
+++ b/doc/source/serve/llm/user-guides/vllm-compatibility.md
@@ -14,7 +14,7 @@ This guide shows how to use vLLM features such as embeddings, structured output,
 
 ## Embeddings
 
-In vLLM, embedding generation falls in the category of [Pooling Models](https://docs.vllm.ai/en/stable/models/pooling_models/). You can generate embeddings by setting the `pooler-config.task` [parameter](https://docs.vllm.ai/en/stable/models/pooling_models/#pooling-tasks) to `"embed"` in the engine arguments. Models supporting this use case are listed in the [vLLM embedding models documentation](https://docs.vllm.ai/en/stable/models/pooling_models/embed/#supported-models).
+In vLLM, embedding generation falls in the category of [Pooling Models](https://docs.vllm.ai/en/stable/models/pooling_models/). You can generate embeddings by setting the 'pooler_config' [parameter](https://docs.vllm.ai/en/stable/models/pooling_models/#pooling-tasks) to '{"task": "embed"}' in the engine arguments. Models supporting this use case are listed in the [vLLM embedding models documentation](https://docs.vllm.ai/en/stable/models/pooling_models/embed/#supported-models).
 
 
 ### Deploy an embedding model


### PR DESCRIPTION
## Description
This PR aims to update documentation for embedding deployment in Serve LLM.

Was following the [Deploy an embedding model](https://docs.ray.io/en/latest/serve/llm/user-guides/vllm-compatibility.html#deploy-an-embedding-model) documentation and came across an error. When specifying `task="embed"`, it fails with `ValueError: Unknown engine argument: task`.

It's due to it referencing outdated docs. Atm, in [vLLM's Supported Models documentation](https://docs.vllm.ai/en/stable/cli/serve/#vllm-serve), I can't find the `text-embedding-task-embed` section. It seems everything has been subsumed under the [Pooling Models](https://docs.vllm.ai/en/stable/models/pooling_models/) section.

## Related issues
Closes #64466.

## Approach
In the documentation update, I link to [both text and multi-modal embedding use cases](https://docs.vllm.ai/en/stable/models/pooling_models/embed/#supported-models). Let me know if that's okay, or if we should keep it to just text.