### PR TITLE
[serve] Controller: in-place health-check reconcile of the deployment-state loop (A1)

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1045,6 +1045,7 @@ if RAY_SERVE_ENABLE_HA_PROXY:
 if RAY_SERVE_INGRESS_REQUEST_ROUTER_METRICS_ENABLED:
     RAY_SERVE_HAPROXY_METRICS_ENABLED = True
 
+RAY_SERVE_RECON_OPT = get_env_bool("RAY_SERVE_RECON_OPT", "1")
 # Feature flag to aggregate metrics at the controller instead of the replicas or handles.
 RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER = get_env_bool(
     "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER", "0"

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1045,7 +1045,6 @@ if RAY_SERVE_ENABLE_HA_PROXY:
 if RAY_SERVE_INGRESS_REQUEST_ROUTER_METRICS_ENABLED:
     RAY_SERVE_HAPROXY_METRICS_ENABLED = True
 
-RAY_SERVE_RECON_OPT = get_env_bool("RAY_SERVE_RECON_OPT", "1")
 # Feature flag to aggregate metrics at the controller instead of the replicas or handles.
 RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER = get_env_bool(
     "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER", "0"

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -59,6 +59,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
+    RAY_SERVE_RECON_OPT,
     RAY_SERVE_RETAINED_DEAD_REPLICAS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
@@ -4552,56 +4553,113 @@ class DeploymentState:
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
 
-        for replica in self._replicas.pop(
-            states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
-        ):
-            is_healthy = replica.check_health()
-
-            # Record health check latency and failure metrics.
-            if replica.last_health_check_latency_ms is not None:
-                self.health_check_latency_histogram.observe(
-                    replica.last_health_check_latency_ms
-                )
-            if replica.last_health_check_failed:
-                if RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS:
-                    self.health_check_failures_counter.inc(
-                        tags={"replica": replica.replica_id.unique_id}
+        # Profile-guided (RAY_SERVE_RECON_OPT): for the common non-gang case, iterate
+        # RUNNING/PENDING_MIGRATION IN PLACE. Healthy replicas that stay in their state
+        # bucket are never popped+re-added -> eliminates the O(num_replicas) container
+        # churn (~17-20% of the control loop at scale). Gang deployments fall back to the
+        # original pop/re-add path (their force-stop reshuffles the lists).
+        if RAY_SERVE_RECON_OPT and not self._is_gang_deployment:
+            _origin: List[ReplicaState] = []
+            _pairs = [
+                (replica, _st)
+                for _st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
+                for replica in self._replicas.get([_st])
+            ]
+            _healths = [_replica.check_health() for _replica, _ in _pairs]
+            for (replica, _st), is_healthy in zip(_pairs, _healths):
+                if replica.last_health_check_latency_ms is not None:
+                    self.health_check_latency_histogram.observe(
+                        replica.last_health_check_latency_ms
                     )
+                if replica.last_health_check_failed:
+                    if RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS:
+                        self.health_check_failures_counter.inc(
+                            tags={"replica": replica.replica_id.unique_id}
+                        )
+                    else:
+                        self.health_check_failures_counter.inc()
+                if is_healthy:
+                    healthy_replicas.append(replica)
+                    _origin.append(_st)
                 else:
-                    self.health_check_failures_counter.inc()
+                    unhealthy_replicas.append(replica)
+            for replica, _st in zip(healthy_replicas, _origin):
+                self._set_health_gauge(replica.replica_id.unique_id, 1)
+                routing_stats = replica.pull_routing_stats()
+                if routing_stats is not None and routing_stats != replica.routing_stats:
+                    self._broadcasted_replicas_set_changed = True
+                replica.record_routing_stats(routing_stats)
+                # Mirror of the original path's unconditional
+                # self._replicas.add(replica.actor_details.state, replica): re-bucket a
+                # healthy replica only if its state changed. actor_details.state is only
+                # ever set via ReplicaStateContainer.add(), and check_health() never
+                # transitions state, so for RUNNING/PENDING_MIGRATION this is a no-op
+                # today -- kept as a defensive guard so the in-place path stays behavior-
+                # identical to the pop/re-add path if that invariant ever changes.
+                if replica.actor_details.state != _st:
+                    self._replicas.remove({replica.replica_id})
+                    self._replicas.add(replica.actor_details.state, replica)
+            for replica in unhealthy_replicas:
+                logger.warning(
+                    f"Replica {replica.replica_id} failed health check, stopping it."
+                )
+                self._replicas.remove({replica.replica_id})
+                graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
+                self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
+        else:
+            for replica in self._replicas.pop(
+                states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+            ):
+                is_healthy = replica.check_health()
 
-            if is_healthy:
-                healthy_replicas.append(replica)
-            else:
-                unhealthy_replicas.append(replica)
+                # Record health check latency and failure metrics.
+                if replica.last_health_check_latency_ms is not None:
+                    self.health_check_latency_histogram.observe(
+                        replica.last_health_check_latency_ms
+                    )
+                if replica.last_health_check_failed:
+                    if RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS:
+                        self.health_check_failures_counter.inc(
+                            tags={"replica": replica.replica_id.unique_id}
+                        )
+                    else:
+                        self.health_check_failures_counter.inc()
 
-        # Under the RESTART_GANG policy, force-stop all members of any gang that has at
-        # least one unhealthy replica. Replicas handled here are removed from the lists;
-        # remaining replicas continue to respect FORCE_STOP_UNHEALTHY_REPLICAS.
-        if (
-            self._is_gang_deployment
-            and self.get_gang_config().runtime_failure_policy
-            == GangRuntimeFailurePolicy.RESTART_GANG
-        ):
-            healthy_replicas, unhealthy_replicas = self._forcefully_stop_gang_replicas(
-                healthy_replicas, unhealthy_replicas
-            )
+                if is_healthy:
+                    healthy_replicas.append(replica)
+                else:
+                    unhealthy_replicas.append(replica)
 
-        for replica in healthy_replicas:
-            self._replicas.add(replica.actor_details.state, replica)
-            self._set_health_gauge(replica.replica_id.unique_id, 1)
-            routing_stats = replica.pull_routing_stats()
-            if routing_stats is not None and routing_stats != replica.routing_stats:
-                self._broadcasted_replicas_set_changed = True
-            replica.record_routing_stats(routing_stats)
+            # Under the RESTART_GANG policy, force-stop all members of any gang that has at
+            # least one unhealthy replica. Replicas handled here are removed from the lists;
+            # remaining replicas continue to respect FORCE_STOP_UNHEALTHY_REPLICAS.
+            if (
+                self._is_gang_deployment
+                and self.get_gang_config().runtime_failure_policy
+                == GangRuntimeFailurePolicy.RESTART_GANG
+            ):
+                (
+                    healthy_replicas,
+                    unhealthy_replicas,
+                ) = self._forcefully_stop_gang_replicas(
+                    healthy_replicas, unhealthy_replicas
+                )
 
-        # Only single-replica scheduling replicas remain.
-        for replica in unhealthy_replicas:
-            logger.warning(
-                f"Replica {replica.replica_id} failed health check, stopping it."
-            )
-            graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
-            self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
+            for replica in healthy_replicas:
+                self._replicas.add(replica.actor_details.state, replica)
+                self._set_health_gauge(replica.replica_id.unique_id, 1)
+                routing_stats = replica.pull_routing_stats()
+                if routing_stats is not None and routing_stats != replica.routing_stats:
+                    self._broadcasted_replicas_set_changed = True
+                replica.record_routing_stats(routing_stats)
+
+            # Only single-replica scheduling replicas remain.
+            for replica in unhealthy_replicas:
+                logger.warning(
+                    f"Replica {replica.replica_id} failed health check, stopping it."
+                )
+                graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
+                self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
 
         # In steady state there are no STARTING/UPDATING/RECOVERING/STOPPING
         # replicas, so skip startup/stopping checks.  The rank consistency

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4559,14 +4559,14 @@ class DeploymentState:
         # churn (~17-20% of the control loop at scale). Gang deployments fall back to the
         # original pop/re-add path (their force-stop reshuffles the lists).
         if RAY_SERVE_RECON_OPT and not self._is_gang_deployment:
-            _origin: List[ReplicaState] = []
-            _pairs = [
-                (replica, _st)
-                for _st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
-                for replica in self._replicas.get([_st])
+            origin: List[ReplicaState] = []
+            pairs = [
+                (replica, st)
+                for st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
+                for replica in self._replicas.get([st])
             ]
-            _healths = [_replica.check_health() for _replica, _ in _pairs]
-            for (replica, _st), is_healthy in zip(_pairs, _healths):
+            healths = [replica.check_health() for replica, _ in pairs]
+            for (replica, st), is_healthy in zip(pairs, healths):
                 if replica.last_health_check_latency_ms is not None:
                     self.health_check_latency_histogram.observe(
                         replica.last_health_check_latency_ms
@@ -4580,10 +4580,10 @@ class DeploymentState:
                         self.health_check_failures_counter.inc()
                 if is_healthy:
                     healthy_replicas.append(replica)
-                    _origin.append(_st)
+                    origin.append(st)
                 else:
                     unhealthy_replicas.append(replica)
-            for replica, _st in zip(healthy_replicas, _origin):
+            for replica, st in zip(healthy_replicas, origin):
                 self._set_health_gauge(replica.replica_id.unique_id, 1)
                 routing_stats = replica.pull_routing_stats()
                 if routing_stats is not None and routing_stats != replica.routing_stats:
@@ -4596,7 +4596,7 @@ class DeploymentState:
                 # transitions state, so for RUNNING/PENDING_MIGRATION this is a no-op
                 # today -- kept as a defensive guard so the in-place path stays behavior-
                 # identical to the pop/re-add path if that invariant ever changes.
-                if replica.actor_details.state != _st:
+                if replica.actor_details.state != st:
                     self._replicas.remove({replica.replica_id})
                     self._replicas.add(replica.actor_details.state, replica)
             for replica in unhealthy_replicas:

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4600,7 +4600,7 @@ class DeploymentState:
         # Profile-guided (RAY_SERVE_RECON_OPT): for the common non-gang case, iterate
         # RUNNING/PENDING_MIGRATION IN PLACE. Healthy replicas that stay in their state
         # bucket are never popped+re-added -> eliminates the O(num_replicas) container
-        # churn (~17-20% of the control loop at scale). Gang deployments fall back to the
+        # churn on the control loop at scale. Gang deployments fall back to the
         # original pop/re-add path (their force-stop reshuffles the lists).
         if RAY_SERVE_RECON_OPT and not self._is_gang_deployment:
             origin: List[ReplicaState] = []

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -59,7 +59,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
-    RAY_SERVE_RECON_OPT,
     RAY_SERVE_RETAINED_DEAD_REPLICAS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
@@ -4546,7 +4545,7 @@ class DeploymentState:
     def _record_health_check_metrics(self, replica) -> None:
         """Record health-check latency + failure metrics for one replica.
 
-        Shared by the RAY_SERVE_RECON_OPT in-place path and the pop/re-add path
+        Shared by the in-place path and the pop/re-add (gang) path
         in ``check_and_update_replicas``.
         """
         if replica.last_health_check_latency_ms is not None:
@@ -4595,12 +4594,12 @@ class DeploymentState:
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
 
-        # Profile-guided (RAY_SERVE_RECON_OPT): for the common non-gang case, iterate
+        # Profile-guided: for the common non-gang case, iterate
         # RUNNING/PENDING_MIGRATION IN PLACE. Healthy replicas that stay in their state
         # bucket are never popped+re-added -> eliminates the O(num_replicas) container
         # churn on the control loop at scale. Gang deployments fall back to the
         # original pop/re-add path (their force-stop reshuffles the lists).
-        if RAY_SERVE_RECON_OPT and not self._is_gang_deployment:
+        if not self._is_gang_deployment:
             origin: List[ReplicaState] = []
             pairs = [
                 (replica, st)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4573,17 +4573,15 @@ class DeploymentState:
             self._broadcasted_replicas_set_changed = True
         replica.record_routing_stats(routing_stats)
 
-    def _stop_unhealthy_replica(self, replica, *, remove_from_container) -> None:
+    def _stop_unhealthy_replica(self, replica) -> None:
         """Log and stop a replica that failed its health check.
 
-        ``remove_from_container`` is True on the in-place path (the replica was
-        never popped) and False on the pop/re-add path (already removed).
+        The caller removes it from ``self._replicas`` first -- the pop/re-add path
+        already popped it; the in-place path batch-removes the whole unhealthy set.
         """
         logger.warning(
             f"Replica {replica.replica_id} failed health check, stopping it."
         )
-        if remove_from_container:
-            self._replicas.remove({replica.replica_id})
         graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
         self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
 
@@ -4628,8 +4626,14 @@ class DeploymentState:
                 if replica.actor_details.state != st:
                     self._replicas.remove({replica.replica_id})
                     self._replicas.add(replica.actor_details.state, replica)
+            # Batch-remove all unhealthy replicas in a single O(num_replicas) pass;
+            # a per-replica remove() would be O(unhealthy * num_replicas) -> O(N^2)
+            # during mass health-check failures (e.g. a node/AZ outage).
+            self._replicas.remove(
+                {replica.replica_id for replica in unhealthy_replicas}
+            )
             for replica in unhealthy_replicas:
-                self._stop_unhealthy_replica(replica, remove_from_container=True)
+                self._stop_unhealthy_replica(replica)
         else:
             for replica in self._replicas.pop(
                 states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
@@ -4662,7 +4666,7 @@ class DeploymentState:
 
             # Only single-replica scheduling replicas remain.
             for replica in unhealthy_replicas:
-                self._stop_unhealthy_replica(replica, remove_from_container=False)
+                self._stop_unhealthy_replica(replica)
 
         # In steady state there are no STARTING/UPDATING/RECOVERING/STOPPING
         # replicas, so skip startup/stopping checks.  The rank consistency

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4543,6 +4543,50 @@ class DeploymentState:
 
         return remaining_healthy, remaining_unhealthy
 
+    def _record_health_check_metrics(self, replica) -> None:
+        """Record health-check latency + failure metrics for one replica.
+
+        Shared by the RAY_SERVE_RECON_OPT in-place path and the pop/re-add path
+        in ``check_and_update_replicas``.
+        """
+        if replica.last_health_check_latency_ms is not None:
+            self.health_check_latency_histogram.observe(
+                replica.last_health_check_latency_ms
+            )
+        if replica.last_health_check_failed:
+            if RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS:
+                self.health_check_failures_counter.inc(
+                    tags={"replica": replica.replica_id.unique_id}
+                )
+            else:
+                self.health_check_failures_counter.inc()
+
+    def _process_healthy_replica(self, replica) -> None:
+        """Set the health gauge and pull/broadcast routing stats for a healthy replica.
+
+        Container re-bucketing differs between the two reconcile paths, so it is
+        left to the caller.
+        """
+        self._set_health_gauge(replica.replica_id.unique_id, 1)
+        routing_stats = replica.pull_routing_stats()
+        if routing_stats is not None and routing_stats != replica.routing_stats:
+            self._broadcasted_replicas_set_changed = True
+        replica.record_routing_stats(routing_stats)
+
+    def _stop_unhealthy_replica(self, replica, *, remove_from_container) -> None:
+        """Log and stop a replica that failed its health check.
+
+        ``remove_from_container`` is True on the in-place path (the replica was
+        never popped) and False on the pop/re-add path (already removed).
+        """
+        logger.warning(
+            f"Replica {replica.replica_id} failed health check, stopping it."
+        )
+        if remove_from_container:
+            self._replicas.remove({replica.replica_id})
+        graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
+        self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
+
     def check_and_update_replicas(self):
         """
         Check current state of all DeploymentReplica being tracked, and compare
@@ -4567,64 +4611,31 @@ class DeploymentState:
             ]
             healths = [replica.check_health() for replica, _ in pairs]
             for (replica, st), is_healthy in zip(pairs, healths):
-                if replica.last_health_check_latency_ms is not None:
-                    self.health_check_latency_histogram.observe(
-                        replica.last_health_check_latency_ms
-                    )
-                if replica.last_health_check_failed:
-                    if RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS:
-                        self.health_check_failures_counter.inc(
-                            tags={"replica": replica.replica_id.unique_id}
-                        )
-                    else:
-                        self.health_check_failures_counter.inc()
+                self._record_health_check_metrics(replica)
                 if is_healthy:
                     healthy_replicas.append(replica)
                     origin.append(st)
                 else:
                     unhealthy_replicas.append(replica)
             for replica, st in zip(healthy_replicas, origin):
-                self._set_health_gauge(replica.replica_id.unique_id, 1)
-                routing_stats = replica.pull_routing_stats()
-                if routing_stats is not None and routing_stats != replica.routing_stats:
-                    self._broadcasted_replicas_set_changed = True
-                replica.record_routing_stats(routing_stats)
-                # Mirror of the original path's unconditional
-                # self._replicas.add(replica.actor_details.state, replica): re-bucket a
-                # healthy replica only if its state changed. actor_details.state is only
-                # ever set via ReplicaStateContainer.add(), and check_health() never
-                # transitions state, so for RUNNING/PENDING_MIGRATION this is a no-op
-                # today -- kept as a defensive guard so the in-place path stays behavior-
-                # identical to the pop/re-add path if that invariant ever changes.
+                self._process_healthy_replica(replica)
+                # Re-bucket a healthy replica only if its state changed -- avoiding the
+                # pop/re-add churn is the whole point of the in-place path.
+                # actor_details.state is only set via ReplicaStateContainer.add() and
+                # check_health() never transitions state, so for RUNNING/PENDING_MIGRATION
+                # this is a no-op today; kept as a defensive guard so the in-place path
+                # stays behavior-identical to the pop/re-add path if that ever changes.
                 if replica.actor_details.state != st:
                     self._replicas.remove({replica.replica_id})
                     self._replicas.add(replica.actor_details.state, replica)
             for replica in unhealthy_replicas:
-                logger.warning(
-                    f"Replica {replica.replica_id} failed health check, stopping it."
-                )
-                self._replicas.remove({replica.replica_id})
-                graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
-                self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
+                self._stop_unhealthy_replica(replica, remove_from_container=True)
         else:
             for replica in self._replicas.pop(
                 states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
             ):
                 is_healthy = replica.check_health()
-
-                # Record health check latency and failure metrics.
-                if replica.last_health_check_latency_ms is not None:
-                    self.health_check_latency_histogram.observe(
-                        replica.last_health_check_latency_ms
-                    )
-                if replica.last_health_check_failed:
-                    if RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS:
-                        self.health_check_failures_counter.inc(
-                            tags={"replica": replica.replica_id.unique_id}
-                        )
-                    else:
-                        self.health_check_failures_counter.inc()
-
+                self._record_health_check_metrics(replica)
                 if is_healthy:
                     healthy_replicas.append(replica)
                 else:
@@ -4647,19 +4658,11 @@ class DeploymentState:
 
             for replica in healthy_replicas:
                 self._replicas.add(replica.actor_details.state, replica)
-                self._set_health_gauge(replica.replica_id.unique_id, 1)
-                routing_stats = replica.pull_routing_stats()
-                if routing_stats is not None and routing_stats != replica.routing_stats:
-                    self._broadcasted_replicas_set_changed = True
-                replica.record_routing_stats(routing_stats)
+                self._process_healthy_replica(replica)
 
             # Only single-replica scheduling replicas remain.
             for replica in unhealthy_replicas:
-                logger.warning(
-                    f"Replica {replica.replica_id} failed health check, stopping it."
-                )
-                graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
-                self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
+                self._stop_unhealthy_replica(replica, remove_from_container=False)
 
         # In steady state there are no STARTING/UPDATING/RECOVERING/STOPPING
         # replicas, so skip startup/stopping checks.  The rank consistency


### PR DESCRIPTION
## Why are these changes needed?

`DeploymentStateManager.check_and_update_replicas` runs on every control-loop tick
(~10×/s). Today it pops the entire RUNNING/PENDING_MIGRATION bucket and re-adds every
replica each tick — O(num_replicas) container churn regardless of whether any replica
actually changed state. In steady state almost nothing transitions per tick, so this
churn is near-pure overhead, and it grows linearly with fleet size.

This PR reconciles the common (non-gang) case **in place**: iterate replicas where they
are, health-check them, record routing stats, and re-bucket only the ones whose
lifecycle state actually changed. Gang deployments keep the original pop/re-add path
(their `RESTART_GANG` force-stop reshuffles the lists, so in-place isn't safe there) —
the path is selected by deployment type, not a flag.

### Performance

Measured on the controller-scaling benchmark — autoscaled to a pinned **8,192 replicas**
on a 211-node cluster, **36 steady-state samples** per arm, identical image for base and
opt:

| Metric | base | in-place | Δ |
|---|---|---|---|
| Controller loop duration | 1267 ms | **921 ms** | **−27%** (p < 0.05) |
| Deployment-state update | 969 ms | **674 ms** | **−30%** (p < 0.05) |

That's roughly a fifth to a quarter of controller loop time at several-thousand
replicas (≈1.2× on the HAProxy-on REALBENCH sweep; −27% here), and it widens with scale.
App-state update and metrics delay are unchanged.

<!-- Drag release/serve_tests/workloads output `perf_A1_vs_base_8192.png` here: -->
![Controller loop duration and deployment-state update at 8,192 replicas — base vs in-place (36 samples, error bars = std)](REPLACE_WITH_UPLOADED_perf_A1_vs_base_8192.png)

### What changed

`check_and_update_replicas` branches on deployment type:

- **non-gang** (`if not self._is_gang_deployment`): iterate RUNNING/PENDING_MIGRATION via
  `self._replicas.get(...)`, health-check, record routing stats, and `remove()+add()`
  only when `replica.actor_details.state` changed during the check. Healthy replicas that
  stay in their bucket are never touched. Unhealthy replicas are batch-removed in a single
  O(num_replicas) pass (a per-replica `remove()` would be O(unhealthy × num_replicas)).
- **gang**: the original pop/re-add path, unchanged.

Behavior is otherwise identical: same health checks, same routing-stats recording, same
unhealthy-replica handling, and the existing
`RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS` gate on the failure counter
is preserved. Correctness invariant: a replica is re-bucketed iff its state changed —
exactly what the pop/re-add path did implicitly.

An earlier revision gated this behind `RAY_SERVE_RECON_OPT` (default on); the flag has
been **removed** now that the path is proven, so there is a single non-gang reconcile
path and no new configuration surface.

### Compatibility & risk

No API or schema changes. Unconditional for non-gang deployments; gang deployments are
unaffected. Part of a controller-scaling optimization series.
<img width="2025" height="810" alt="image" src="https://github.com/user-attachments/assets/254df1ff-f2c5-4a17-b581-c0b651f5f0bb" />
