### PR TITLE
[serve] Incremental direct-ingress port reconcile (C2-C4)

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -979,6 +979,11 @@ RAY_SERVE_PORT_QUARANTINE_S = get_env_float_non_negative(
     "RAY_SERVE_PORT_QUARANTINE_S",
     float(RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S + 30),
 )
+
+# Gate the incremental direct-ingress port reconcile: feed update_ports only the
+# set-diff of new ingress tuples (C3) and skip a node's prune reclaim scan when its
+# alive-replica set is unchanged since the last tick (C4). Full reconcile runs when off.
+RAY_SERVE_RECON_PORT_GATE = get_env_bool("RAY_SERVE_RECON_PORT_GATE", "0")
 # The minimum drain period for a HTTP proxy.
 # If RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS is set to 1,
 # then the minimum draining period is 0.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -980,10 +980,6 @@ RAY_SERVE_PORT_QUARANTINE_S = get_env_float_non_negative(
     float(RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S + 30),
 )
 
-# Gate the incremental direct-ingress port reconcile: feed update_ports only the
-# set-diff of new ingress tuples (C3) and skip a node's prune reclaim scan when its
-# alive-replica set is unchanged since the last tick (C4). Full reconcile runs when off.
-RAY_SERVE_RECON_PORT_GATE = get_env_bool("RAY_SERVE_RECON_PORT_GATE", "0")
 # The minimum drain period for a HTTP proxy.
 # If RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS is set to 1,
 # then the minimum draining period is 0.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -40,7 +40,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
     RAY_SERVE_LOG_TO_STDERR,
-    RAY_SERVE_RECON_PORT_GATE,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
@@ -699,14 +698,9 @@ class ServeController:
             # the tuples NEW since the last sync (set-diff) -> the reconcile loop is
             # O(changed) not O(replicas). Full-tuple set recomputed + replaced each
             # tick, so it is restart-safe (empty cache -> full emit on the first tick).
-            if RAY_SERVE_RECON_PORT_GATE:
-                fresh = set(ingress_replicas_info_list)
-                NodePortManager.update_ports(
-                    list(fresh - self._last_ingress_port_tuples)
-                )
-                self._last_ingress_port_tuples = fresh
-            else:
-                NodePortManager.update_ports(ingress_replicas_info_list)
+            fresh = set(ingress_replicas_info_list)
+            NodePortManager.update_ports(list(fresh - self._last_ingress_port_tuples))
+            self._last_ingress_port_tuples = fresh
 
             # Clean up stale ports
             # get all alive replica ids and their node ids.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -40,6 +40,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
     RAY_SERVE_LOG_TO_STDERR,
+    RAY_SERVE_RECON_PORT_GATE,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
@@ -201,6 +202,8 @@ class ServeController:
 
         self._ha_proxy_enabled = RAY_SERVE_ENABLE_HA_PROXY
         self._direct_ingress_enabled = RAY_SERVE_ENABLE_DIRECT_INGRESS
+        # Last full set of ingress-port tuples fed to update_ports (P3-ports diff).
+        self._last_ingress_port_tuples: set = set()
         if self._ha_proxy_enabled:
             logger.info(
                 "HAProxy is enabled in ServeController, replacing Serve proxy "
@@ -692,7 +695,18 @@ class ServeController:
                 Tuple[str, str, int, int]
             ] = self.deployment_state_manager.get_ingress_replicas_info()
 
-            NodePortManager.update_ports(ingress_replicas_info_list)
+            # P3-ports: update_port_if_missing is additive + idempotent, so feed only
+            # the tuples NEW since the last sync (set-diff) -> the reconcile loop is
+            # O(changed) not O(replicas). Full-tuple set recomputed + replaced each
+            # tick, so it is restart-safe (empty cache -> full emit on the first tick).
+            if RAY_SERVE_RECON_PORT_GATE:
+                fresh = set(ingress_replicas_info_list)
+                NodePortManager.update_ports(
+                    list(fresh - self._last_ingress_port_tuples)
+                )
+                self._last_ingress_port_tuples = fresh
+            else:
+                NodePortManager.update_ports(ingress_replicas_info_list)
 
             # Clean up stale ports
             # get all alive replica ids and their node ids.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -201,7 +201,7 @@ class ServeController:
 
         self._ha_proxy_enabled = RAY_SERVE_ENABLE_HA_PROXY
         self._direct_ingress_enabled = RAY_SERVE_ENABLE_DIRECT_INGRESS
-        # Last full set of ingress-port tuples fed to update_ports (P3-ports diff).
+        # Last full set of ingress-port tuples fed to update_ports (for the per-tick set-diff).
         self._last_ingress_port_tuples: set = set()
         if self._ha_proxy_enabled:
             logger.info(
@@ -694,10 +694,11 @@ class ServeController:
                 Tuple[str, str, int, int]
             ] = self.deployment_state_manager.get_ingress_replicas_info()
 
-            # P3-ports: update_port_if_missing is additive + idempotent, so feed only
-            # the tuples NEW since the last sync (set-diff) -> the reconcile loop is
-            # O(changed) not O(replicas). Full-tuple set recomputed + replaced each
-            # tick, so it is restart-safe (empty cache -> full emit on the first tick).
+            # update_port_if_missing is additive and idempotent, so we send update_ports
+            # only the tuples added since the last tick (the set difference) instead of
+            # the full set every tick -- work proportional to what changed rather than to
+            # the replica count. The full set is recomputed and cached each tick, so after
+            # a controller restart the empty cache re-sends everything on the first tick.
             fresh = set(ingress_replicas_info_list)
             NodePortManager.update_ports(list(fresh - self._last_ingress_port_tuples))
             self._last_ingress_port_tuples = fresh

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -10,6 +10,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_DIRECT_INGRESS_MIN_GRPC_PORT,
     RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT,
     RAY_SERVE_PORT_QUARANTINE_S,
+    RAY_SERVE_RECON_PORT_GATE,
     SERVE_LOGGER_NAME,
 )
 
@@ -37,20 +38,31 @@ class PortAllocator:
         self._blocked_ports: Set[int] = set()
         # port -> monotonic deadline at which it leaves quarantine.
         self._quarantined_ports: Dict[int, float] = {}
+        # Min-heap of (deadline, port) mirroring _quarantined_ports so a no-op drain
+        # is O(1) (peek) instead of O(quarantined). Lazy-deleted (P2).
+        self._quarantine_heap: List[Tuple[float, int]] = []
 
     def _drain_expired_quarantine(self) -> None:
-        """Return quarantined ports past their expiry to the available pool."""
-        if not self._quarantined_ports:
+        """Return quarantined ports past their expiry to the available pool.
+
+        Drains via the min-heap keyed on expiry, so when nothing is due this is a
+        single O(1) peek instead of an O(quarantined) dict scan. Lazy deletion: a
+        popped heap entry is honored only if it still matches the live deadline in
+        _quarantined_ports (entries left stale by update_port_if_missing's reclaim
+        pop, or by a re-quarantine, are skipped).
+        """
+        if not self._quarantine_heap:
             return
         now = time.monotonic()
-        expired = [p for p, exp in self._quarantined_ports.items() if exp <= now]
-        for port in expired:
-            heapq.heappush(self._available_ports, port)
-            del self._quarantined_ports[port]
-            logger.info(
-                f"Released {self._protocol} port {port} from quarantine on "
-                f"node {self._node_id}; returning it to the available pool."
-            )
+        while self._quarantine_heap and self._quarantine_heap[0][0] <= now:
+            deadline, port = heapq.heappop(self._quarantine_heap)
+            if self._quarantined_ports.get(port) == deadline:
+                heapq.heappush(self._available_ports, port)
+                del self._quarantined_ports[port]
+                logger.info(
+                    f"Released {self._protocol} port {port} from quarantine on "
+                    f"node {self._node_id}; returning it to the available pool."
+                )
 
     def has_pending_quarantine(self) -> bool:
         """True if any port is still quarantined (drains expired entries first)."""
@@ -149,9 +161,9 @@ class PortAllocator:
                 f"{replica_id} on node {self._node_id}"
             )
         elif RAY_SERVE_PORT_QUARANTINE_S > 0:
-            self._quarantined_ports[port] = (
-                time.monotonic() + RAY_SERVE_PORT_QUARANTINE_S
-            )
+            deadline = time.monotonic() + RAY_SERVE_PORT_QUARANTINE_S
+            self._quarantined_ports[port] = deadline
+            heapq.heappush(self._quarantine_heap, (deadline, port))
             logger.info(
                 f"Quarantined {self._protocol} port {port} for "
                 f"{RAY_SERVE_PORT_QUARANTINE_S}s after releasing for replica "
@@ -233,8 +245,17 @@ class NodePortManager:
         for node_id in list(cls._node_managers):
             manager = cls._node_managers[node_id]
             alive = node_id_to_alive_replica_ids.get(node_id, set())
-            # Release ports of replicas no longer alive (quarantines them).
-            manager._prune_replica_ports(alive)
+            # P4-ports: skip the O(replicas) reclaim for a node whose alive-replica set
+            # is unchanged since the last prune (fingerprint = the full alive set, so a
+            # replica that left / arrived / moved nodes is caught). Liveness-only: a
+            # skipped node never reuses a live port (allocate() guards that). Teardown
+            # of an emptied+drained manager below still runs every tick.
+            if RAY_SERVE_RECON_PORT_GATE and alive == manager._last_pruned_alive:
+                pass
+            else:
+                # Release ports of replicas no longer alive (quarantines them).
+                manager._prune_replica_ports(alive)
+                manager._last_pruned_alive = set(alive)
             # Keep the manager until its quarantine drains; dropping it early
             # would discard the deadline and let the port be reused immediately.
             if not alive and not manager.has_pending_quarantine():
@@ -261,6 +282,9 @@ class NodePortManager:
 
     def __init__(self, node_id: str):
         self._node_id = node_id
+        # P4-ports: the alive-replica set this manager last pruned against. Skip the
+        # O(replicas) reclaim scan when unchanged. None sentinel -> first prune runs.
+        self._last_pruned_alive: Optional[Set[str]] = None
 
         self._http_allocator = PortAllocator(
             RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT,

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -244,11 +244,11 @@ class NodePortManager:
         for node_id in list(cls._node_managers):
             manager = cls._node_managers[node_id]
             alive = node_id_to_alive_replica_ids.get(node_id, set())
-            # P4-ports: skip the O(replicas) reclaim for a node whose alive-replica set
-            # is unchanged since the last prune (fingerprint = the full alive set, so a
-            # replica that left / arrived / moved nodes is caught). Liveness-only: a
-            # skipped node never reuses a live port (allocate() guards that). Teardown
-            # of an emptied+drained manager below still runs every tick.
+            # Skip the reclaim scan for a node whose set of alive replicas is unchanged
+            # since the last prune. Comparing the whole alive set means a replica that
+            # left, arrived, or moved nodes is still caught; skipping only defers reclaim
+            # and never reuses a live port (allocate() guards that). The emptied-manager
+            # teardown below still runs every tick.
             if alive == manager._last_pruned_alive:
                 pass
             else:
@@ -281,8 +281,8 @@ class NodePortManager:
 
     def __init__(self, node_id: str):
         self._node_id = node_id
-        # P4-ports: the alive-replica set this manager last pruned against. Skip the
-        # O(replicas) reclaim scan when unchanged. None sentinel -> first prune runs.
+        # Set of alive replicas this manager last pruned against; when unchanged, the
+        # reclaim scan is skipped. None means never pruned, so the first prune runs.
         self._last_pruned_alive: Optional[Set[str]] = None
 
         self._http_allocator = PortAllocator(

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -10,7 +10,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_DIRECT_INGRESS_MIN_GRPC_PORT,
     RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT,
     RAY_SERVE_PORT_QUARANTINE_S,
-    RAY_SERVE_RECON_PORT_GATE,
     SERVE_LOGGER_NAME,
 )
 
@@ -250,7 +249,7 @@ class NodePortManager:
             # replica that left / arrived / moved nodes is caught). Liveness-only: a
             # skipped node never reuses a live port (allocate() guards that). Teardown
             # of an emptied+drained manager below still runs every tick.
-            if RAY_SERVE_RECON_PORT_GATE and alive == manager._last_pruned_alive:
+            if alive == manager._last_pruned_alive:
                 pass
             else:
                 # Release ports of replicas no longer alive (quarantines them).

--- a/python/ray/serve/tests/unit/test_controller_direct_ingress.py
+++ b/python/ray/serve/tests/unit/test_controller_direct_ingress.py
@@ -237,6 +237,7 @@ class FakeDirectIngressController(ServeController):
         self.deployment_state_manager = deployment_state_manager
         self.proxy_state_manager = proxy_state_manager
         self._direct_ingress_enabled = True
+        self._last_ingress_port_tuples = set()
         self._ha_proxy_enabled = False
         self._controller_node_id = "head_node_id"
 
@@ -1134,6 +1135,68 @@ def test_stop_one_running_replica_for_testing_delegates_to_manager(
     direct_ingress_controller._stop_one_running_replica_for_testing(deployment_id)
 
     assert deployment_state_manager.stopped_deployment_id == deployment_id
+
+
+def test_recon_port_gate_feeds_only_new_ingress_tuples(
+    monkeypatch, direct_ingress_controller: FakeDirectIngressController
+):
+    """C3: with RAY_SERVE_RECON_PORT_GATE on, update_ports is fed only the set-diff of
+    ingress tuples new since the last sync -- the full set on the first tick (empty
+    cache) and an empty list on an unchanged second tick."""
+    monkeypatch.setattr("ray.serve._private.controller.RAY_SERVE_RECON_PORT_GATE", True)
+    tuples = [("node1", "r1", 30000, 40000), ("node2", "r2", 30001, 40001)]
+    direct_ingress_controller.deployment_state_manager.get_ingress_replicas_info = (
+        lambda: list(tuples)
+    )
+
+    with mock.patch.object(NodePortManager, "update_ports") as mock_update:
+        # First tick: cache empty -> full emit.
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert set(mock_update.call_args[0][0]) == set(tuples)
+
+        # Second tick: ingress set unchanged -> empty diff.
+        mock_update.reset_mock()
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert mock_update.call_args[0][0] == []
+
+
+def test_recon_port_gate_prune_skips_unchanged_node(
+    monkeypatch, direct_ingress_controller: FakeDirectIngressController
+):
+    """C4: with RAY_SERVE_RECON_PORT_GATE on, prune skips a node's O(replicas) reclaim
+    scan when that node's alive-replica set is unchanged since the last prune."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_RECON_PORT_GATE", True
+    )
+    deployment_id = DeploymentID(name="app1_ingress", app_name="app1")
+    replica_id = ReplicaID(unique_id="replica1", deployment_id=deployment_id)
+    replica_info = RunningReplicaInfo(
+        replica_id=replica_id,
+        node_id="node1",
+        node_ip="10.0.0.1",
+        availability_zone="az1",
+        actor_name="replica1",
+        max_ongoing_requests=100,
+    )
+    direct_ingress_controller.deployment_state_manager = FakeDeploymentStateManager(
+        running_replica_infos={deployment_id: [replica_info]},
+    )
+    direct_ingress_controller.allocate_replica_port(
+        "node1", replica_id.unique_id, RequestProtocol.HTTP
+    )
+    node1_manager = NodePortManager.get_node_manager("node1")
+
+    with mock.patch.object(
+        node1_manager,
+        "_prune_replica_ports",
+        wraps=node1_manager._prune_replica_ports,
+    ) as spy:
+        # First tick: fingerprint unset -> reclaim scan runs.
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert spy.call_count == 1
+        # Second tick: alive set unchanged -> reclaim scan skipped.
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert spy.call_count == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_controller_direct_ingress.py
+++ b/python/ray/serve/tests/unit/test_controller_direct_ingress.py
@@ -1138,12 +1138,11 @@ def test_stop_one_running_replica_for_testing_delegates_to_manager(
 
 
 def test_recon_port_gate_feeds_only_new_ingress_tuples(
-    monkeypatch, direct_ingress_controller: FakeDirectIngressController
+    direct_ingress_controller: FakeDirectIngressController,
 ):
-    """C3: with RAY_SERVE_RECON_PORT_GATE on, update_ports is fed only the set-diff of
+    """C3: update_ports is fed only the set-diff of
     ingress tuples new since the last sync -- the full set on the first tick (empty
     cache) and an empty list on an unchanged second tick."""
-    monkeypatch.setattr("ray.serve._private.controller.RAY_SERVE_RECON_PORT_GATE", True)
     tuples = [("node1", "r1", 30000, 40000), ("node2", "r2", 30001, 40001)]
     direct_ingress_controller.deployment_state_manager.get_ingress_replicas_info = (
         lambda: list(tuples)
@@ -1161,13 +1160,10 @@ def test_recon_port_gate_feeds_only_new_ingress_tuples(
 
 
 def test_recon_port_gate_prune_skips_unchanged_node(
-    monkeypatch, direct_ingress_controller: FakeDirectIngressController
+    direct_ingress_controller: FakeDirectIngressController,
 ):
-    """C4: with RAY_SERVE_RECON_PORT_GATE on, prune skips a node's O(replicas) reclaim
+    """C4: prune skips a node's O(replicas) reclaim
     scan when that node's alive-replica set is unchanged since the last prune."""
-    monkeypatch.setattr(
-        "ray.serve._private.node_port_manager.RAY_SERVE_RECON_PORT_GATE", True
-    )
     deployment_id = DeploymentID(name="app1_ingress", app_name="app1")
     replica_id = ReplicaID(unique_id="replica1", deployment_id=deployment_id)
     replica_info = RunningReplicaInfo(


### PR DESCRIPTION
## Why are these changes needed?

The controller's per-tick direct-ingress port reconcile does O(nodes × replicas) work on
every control-loop iteration, even when nothing changed: it re-feeds the full ingress
tuple set to `update_ports` and re-scans every node's ports for reclaim. At scale this is
a large, wasted chunk of the loop. This PR makes the reconcile incremental.

### Performance

Controller-scaling benchmark, pinned **8,192 replicas**, 36 steady-state samples per arm,
same image:

| Metric | base | incremental | Δ |
|---|---|---|---|
| Controller loop duration | 1267 ms | **1022 ms** | −19% (p < 0.05) |
| Deployment-state update | 969 ms | 761 ms | −21% (p < 0.05) |

<!-- Drag release/serve_tests/workloads output `perf_C_vs_base_8192.png` here: -->
![Controller loop + deployment-state at 8,192 replicas — base vs incremental port reconcile (36 samples, error bars = std)](REPLACE_WITH_UPLOADED_perf_C_vs_base_8192.png)

### What changed

- **C2 — min-heap quarantine drain** (`PortAllocator`): expired ports drain via a min-heap
  keyed on expiry, so a no-op drain is an O(1) peek instead of an O(quarantined) dict
  scan. Lazy deletion keeps stale heap entries from accumulating. (Equivalent refactor.)
- **C3 — set-diff `update_ports`**: feed only the ingress tuples new since the last sync
  (`fresh - last`) rather than the full set every tick → O(changed), not O(replicas). Safe
  because `update_port_if_missing` is additive + idempotent, and the full tuple set is
  recomputed and stored each tick (empty cache → full emit on the first tick, so it's
  restart-safe).
- **C4 — per-node prune fingerprint**: skip a node's O(replicas) reclaim scan when its
  alive-replica set is unchanged since the last prune (fingerprint = the full alive set,
  so any arrival/departure/move is caught). Node-manager teardown still runs every tick,
  outside the fingerprint check, so emptied+drained managers are always reclaimed.

C3/C4 shipped behind `RAY_SERVE_RECON_PORT_GATE` (default off); the flag has been
**removed** now that the path is proven — the incremental reconcile is unconditional.

### Safety

The no-early-reuse invariant is enforced at `allocate()` (a skipped reclaim only *delays*
reclamation, never reuses a live port), and `prune()`'s node-manager teardown runs every
tick regardless of the fingerprint — so an emptied manager's quarantine deadline is never
dropped. No API or schema changes; `deployment_state.py` is untouched.

### Testing

`test_controller_direct_ingress.py`: the C3 test asserts `update_ports` gets only the diff
on an unchanged tick (empty list) and the full set on the first tick; the C4 test asserts
prune skips a node whose alive set is unchanged. Both now exercise the default
(unconditional) behavior directly — the previous flag monkeypatches are gone.

### Note

The original outer version-gate (C1) was dropped during review: on master the health-check
reconcile re-adds all replicas each tick, which defeated actual skipping. C2–C4 deliver
the savings without it; a churn-insensitive C1 can follow later.