### PR TITLE
[serve] Control autoscaling ramp overshoot: clip the aggregation window + anti-windup cap

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -18,6 +18,8 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.constants import (
     RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER,
+    RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S,
+    RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR,
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S,
     SERVE_LOGGER_NAME,
@@ -61,6 +63,28 @@ def _resolve_policy_callable(policy: AutoscalingPolicy) -> Callable:
         )
         return raw(**policy.policy_kwargs)
     return raw
+
+
+def _clip_window_start(
+    window_start: Optional[float],
+    first_ts: float,
+    last_ts: float,
+    end_ts: float,
+    clip_window_s: float,
+) -> Optional[float]:
+    """Cap window_start to the most recent clip_window_s of [.., end_ts], dropping a
+    stale ramp transient from the aggregated request total. Apply only to the
+    scale-driving total; callers feeding custom policies pass 0 to keep the full window.
+    clip_window_s <= 0, or wider than the data, returns window_start unchanged (no-op).
+    Never clip past last_ts, or MAX/MIN (which hard-filter with no carry-forward)
+    would drop every sample and read 0 -- a false scale-down.
+    """
+    if clip_window_s <= 0:
+        return window_start
+    clip_limit = min(end_ts - clip_window_s, last_ts)
+    if window_start is None:
+        return clip_limit if clip_limit > first_ts else None
+    return max(window_start, clip_limit)
 
 
 class DeploymentAutoscalingState:
@@ -474,6 +498,7 @@ class DeploymentAutoscalingState:
     def _merge_and_aggregate_timeseries(
         self,
         timeseries_list: List[TimeSeries],
+        clip_window_s: float = 0.0,
     ) -> float:
         """Aggregate and average a metric from timeseries data using instantaneous merge.
 
@@ -481,6 +506,8 @@ class DeploymentAutoscalingState:
             timeseries_list: A list of TimeSeries (TimeSeries), where each
                 TimeSeries represents measurements from a single source (replica, handle, etc.).
                 Each list is sorted by timestamp ascending.
+            clip_window_s: If > 0, cap the window to the most recent
+                clip_window_s seconds (see _clip_window_start); 0 disables it.
 
         Returns:
             The time-weighted average of the metric
@@ -531,6 +558,16 @@ class DeploymentAutoscalingState:
                 aligned_start = max(ts[0].timestamp for ts in non_empty_series)
                 if aligned_start <= merged_timeseries[-1].timestamp:
                     window_start = max(aligned_start, merged_timeseries[0].timestamp)
+
+            # Cap the window to clip_window_s (0 = no clip); only the scale-driving
+            # total passes a value. See _clip_window_start.
+            window_start = _clip_window_start(
+                window_start,
+                merged_timeseries[0].timestamp,
+                merged_timeseries[-1].timestamp,
+                merged_timeseries[-1].timestamp + last_window_s,
+                clip_window_s,
+            )
 
             # Calculate the aggregated metric value
             value = aggregate_timeseries(
@@ -634,8 +671,18 @@ class DeploymentAutoscalingState:
         ongoing_requests_timeseries.extend(queued_timeseries)
 
         # Aggregate and add running requests to total
+        # Floor at 2x the record cadence so the window always spans real samples.
+        clip_window_s = RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S
+        if clip_window_s > 0:
+            clip_window_s = max(
+                clip_window_s,
+                2
+                * self._config.look_back_period_s
+                * RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR,
+            )
         ongoing_requests = self._merge_and_aggregate_timeseries(
-            ongoing_requests_timeseries
+            ongoing_requests_timeseries,
+            clip_window_s=clip_window_s,
         )
 
         return ongoing_requests

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -67,21 +67,17 @@ def _clip_window_start(
     window_start: Optional[float],
     first_ts: float,
     last_ts: float,
-    end_ts: float,
     clip_window_s: float,
 ) -> Optional[float]:
-    """Cap window_start to the most recent clip_window_s of [.., end_ts], dropping a
-    stale ramp transient from the aggregated request total. Apply only to the
-    scale-driving total; callers feeding custom policies pass 0 to keep the full window.
-    A no-op when clip_window_s <= 0, when the window is wider than the data, or when it
-    sits entirely past last_ts (stalled metrics) -- clipping there would leave MAX/MIN
-    (which hard-filter with no carry-forward) one sample or none, a false scale-down.
+    """Cap window_start to the last clip_window_s of DATA, dropping a stale ramp
+    transient from the aggregated request total. Anchored on last_ts rather than the
+    wall clock, so a metrics stall neither strands MAX/MIN (which hard-filter with no
+    carry-forward) on the final sample nor folds the transient back in as data ages.
+    Apply only to the scale-driving total; custom-policy callers pass 0 for the full window.
     """
     if clip_window_s <= 0:
         return window_start
-    clip_limit = end_ts - clip_window_s
-    if clip_limit >= last_ts:
-        return window_start
+    clip_limit = last_ts - clip_window_s
     if window_start is None:
         return clip_limit if clip_limit > first_ts else None
     return max(window_start, clip_limit)
@@ -568,7 +564,6 @@ class DeploymentAutoscalingState:
                 window_start,
                 merged_timeseries[0].timestamp,
                 merged_timeseries[-1].timestamp,
-                merged_timeseries[-1].timestamp + last_window_s,
                 clip_window_s,
             )
 

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -73,13 +73,15 @@ def _clip_window_start(
     """Cap window_start to the most recent clip_window_s of [.., end_ts], dropping a
     stale ramp transient from the aggregated request total. Apply only to the
     scale-driving total; callers feeding custom policies pass 0 to keep the full window.
-    clip_window_s <= 0, or wider than the data, returns window_start unchanged (no-op).
-    Never clip past last_ts, or MAX/MIN (which hard-filter with no carry-forward)
-    would drop every sample and read 0 -- a false scale-down.
+    A no-op when clip_window_s <= 0, when the window is wider than the data, or when it
+    sits entirely past last_ts (stalled metrics) -- clipping there would leave MAX/MIN
+    (which hard-filter with no carry-forward) one sample or none, a false scale-down.
     """
     if clip_window_s <= 0:
         return window_start
-    clip_limit = min(end_ts - clip_window_s, last_ts)
+    clip_limit = end_ts - clip_window_s
+    if clip_limit >= last_ts:
+        return window_start
     if window_start is None:
         return clip_limit if clip_limit > first_ts else None
     return max(window_start, clip_limit)

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -17,6 +17,8 @@ from ray.serve._private.common import (
     TimeSeries,
 )
 from ray.serve._private.constants import (
+    RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S,
+    RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR,
     RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S,
     SERVE_LOGGER_NAME,
 )
@@ -59,6 +61,28 @@ def _resolve_policy_callable(policy: AutoscalingPolicy) -> Callable:
         )
         return raw(**policy.policy_kwargs)
     return raw
+
+
+def _clip_window_start(
+    window_start: Optional[float],
+    first_ts: float,
+    last_ts: float,
+    end_ts: float,
+    clip_window_s: float,
+) -> Optional[float]:
+    """Cap window_start to the most recent clip_window_s of [.., end_ts], dropping a
+    stale ramp transient from the aggregated request total. Apply only to the
+    scale-driving total; callers feeding custom policies pass 0 to keep the full window.
+    clip_window_s <= 0, or wider than the data, returns window_start unchanged (no-op).
+    Never clip past last_ts, or MAX/MIN (which hard-filter with no carry-forward)
+    would drop every sample and read 0 -- a false scale-down.
+    """
+    if clip_window_s <= 0:
+        return window_start
+    clip_limit = min(end_ts - clip_window_s, last_ts)
+    if window_start is None:
+        return clip_limit if clip_limit > first_ts else None
+    return max(window_start, clip_limit)
 
 
 class DeploymentAutoscalingState:
@@ -475,6 +499,7 @@ class DeploymentAutoscalingState:
     def _merge_and_aggregate_timeseries(
         self,
         timeseries_list: List[TimeSeries],
+        clip_window_s: float = 0.0,
     ) -> float:
         """Aggregate and average a metric from timeseries data using instantaneous merge.
 
@@ -482,6 +507,8 @@ class DeploymentAutoscalingState:
             timeseries_list: A list of TimeSeries (TimeSeries), where each
                 TimeSeries represents measurements from a single source (replica, handle, etc.).
                 Each list is sorted by timestamp ascending.
+            clip_window_s: If > 0, cap the window to the most recent
+                clip_window_s seconds (see _clip_window_start); 0 disables it.
 
         Returns:
             The time-weighted average of the metric
@@ -532,6 +559,16 @@ class DeploymentAutoscalingState:
                 aligned_start = max(ts[0].timestamp for ts in non_empty_series)
                 if aligned_start <= merged_timeseries[-1].timestamp:
                     window_start = max(aligned_start, merged_timeseries[0].timestamp)
+
+            # Cap the window to clip_window_s (0 = no clip); only the scale-driving
+            # total passes a value. See _clip_window_start.
+            window_start = _clip_window_start(
+                window_start,
+                merged_timeseries[0].timestamp,
+                merged_timeseries[-1].timestamp,
+                merged_timeseries[-1].timestamp + last_window_s,
+                clip_window_s,
+            )
 
             # Calculate the aggregated metric value
             value = aggregate_timeseries(
@@ -612,8 +649,18 @@ class DeploymentAutoscalingState:
         ongoing_requests_timeseries.extend(queued_timeseries)
 
         # Aggregate and add running requests to total
+        # Floor at 2x the record cadence so the window always spans real samples.
+        clip_window_s = RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S
+        if clip_window_s > 0:
+            clip_window_s = max(
+                clip_window_s,
+                2
+                * self._config.look_back_period_s
+                * RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR,
+            )
         ongoing_requests = self._merge_and_aggregate_timeseries(
-            ongoing_requests_timeseries
+            ongoing_requests_timeseries,
+            clip_window_s=clip_window_s,
         )
 
         return ongoing_requests

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -476,6 +476,13 @@ RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR = get_env_float(
     "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR", 0.2
 )
 
+# Clip the scale-driving request total's aggregation window to the most recent N s,
+# dropping a stale ramp transient (delays settling). Aggregate-mode only (no-op in the
+# default config); floored at 2x the metric record cadence. Default 12 s; 0 disables.
+RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S = get_env_float_non_negative(
+    "RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S", 12.0
+)
+
 # Replica autoscaling metrics push interval.
 RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PUSH_INTERVAL_S = get_env_float(
     "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PUSH_INTERVAL_S", 10.0

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -458,6 +458,13 @@ RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR = get_env_float(
     "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR", 0.2
 )
 
+# Clip the scale-driving request total's aggregation window to the most recent N s,
+# dropping a stale ramp transient (delays settling). Aggregate-mode only (no-op in the
+# default config); floored at 2x the metric record cadence. Default 12 s; 0 disables.
+RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S = get_env_float_non_negative(
+    "RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S", 12.0
+)
+
 # Replica autoscaling metrics push interval.
 RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PUSH_INTERVAL_S = get_env_float(
     "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PUSH_INTERVAL_S", 10.0

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -477,8 +477,8 @@ RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR = get_env_float(
 )
 
 # Clip the scale-driving request total's aggregation window to the most recent N s,
-# dropping a stale ramp transient (delays settling). Aggregate-mode only (no-op in the
-# default config); floored at 2x the metric record cadence. Default 12 s; 0 disables.
+# dropping a stale ramp transient (delays settling); floored at 2x the metric record
+# cadence. Default 12 s; 0 disables.
 RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S = get_env_float_non_negative(
     "RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S", 12.0
 )

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -153,6 +153,12 @@ def _apply_default_params(
         desired_num_replicas, ctx.current_num_replicas, ctx.config
     )
 
+    # Anti-windup: while committed replicas are still starting (current<target), the
+    # transient backlog they'll drain inflates desired past the target. Cap desired at
+    # the target until they catch up (after the scaling factor, so it can't re-inflate).
+    if 0 < ctx.current_num_replicas < ctx.target_num_replicas:
+        desired_num_replicas = min(desired_num_replicas, ctx.target_num_replicas)
+
     # If curr num replicas is 0 and the policy wants to scale up (e.g. based on internal
     # signals like queue length), bypass the delay logic for immediate scale-up.
     if ctx.current_num_replicas == 0 and desired_num_replicas > 0:

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -161,6 +161,12 @@ def _apply_default_params(
         desired_num_replicas, ctx.current_num_replicas, ctx.config
     )
 
+    # Anti-windup: while committed replicas are still starting (current<target), the
+    # transient backlog they'll drain inflates desired past the target. Cap desired at
+    # the target until they catch up (after the scaling factor, so it can't re-inflate).
+    if 0 < ctx.current_num_replicas < ctx.target_num_replicas:
+        desired_num_replicas = min(desired_num_replicas, ctx.target_num_replicas)
+
     # If curr num replicas is 0 and the policy wants to scale up (e.g. based on internal
     # signals like queue length), bypass the delay logic for immediate scale-up.
     if ctx.current_num_replicas == 0 and desired_num_replicas > 0:

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -636,7 +637,8 @@ class TestReplicaQueueLengthPolicy:
         new_num_replicas, _ = wrapped_replica_queue_length_autoscaling_policy(ctx=ctx)
         assert new_num_replicas == 100
 
-        # Two new replicas spun up during this timestep.
+        # Still starting (current=3 < target=100): the transient backlog inflates the
+        # metric, but anti-windup holds desired at the committed target (100).
         ctx = create_context_with_overrides(
             ctx,
             total_num_requests=123,
@@ -644,7 +646,7 @@ class TestReplicaQueueLengthPolicy:
             target_num_replicas=100,
         )
         new_num_replicas, _ = wrapped_replica_queue_length_autoscaling_policy(ctx=ctx)
-        assert new_num_replicas == 123
+        assert new_num_replicas == 100
 
         # A lot of queries got drained and a lot of replicas started up, but
         # new_num_replicas should not decrease, because of the downscale delay.
@@ -652,10 +654,10 @@ class TestReplicaQueueLengthPolicy:
             ctx,
             total_num_requests=10,
             current_num_replicas=4,
-            target_num_replicas=123,
+            target_num_replicas=100,
         )
         new_num_replicas, _ = wrapped_replica_queue_length_autoscaling_policy(ctx=ctx)
-        assert new_num_replicas == 123
+        assert new_num_replicas == 100
 
     @pytest.mark.parametrize("delay_s", [30.0, 0.0])
     def test_fluctuating_ongoing_requests(self, delay_s):
@@ -1569,6 +1571,160 @@ class TestAppLevelPolicyStateIsolation:
         assert final_state[d2][SERVE_AUTOSCALING_DECISION_TIMESTAMP_KEY] == fake_now
         # user state remains intact
         assert final_state[d2]["counter"] == 5
+
+
+# ---- Autoscaling window clip (RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S) ----
+
+
+def _clip_state(aggregation_function=AggregationFunction.MEAN):
+    """A registered DeploymentAutoscalingState for exercising the aggregate path."""
+    state = DeploymentAutoscalingState(DeploymentID(name="test", app_name="app"))
+    info = MagicMock()
+    info.deployment_config.autoscaling_config = AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=10,
+        look_back_period_s=30,
+        aggregation_function=aggregation_function,
+    )
+    info.deployment_config.gang_scheduling_config = None
+    info.target_capacity = None
+    info.target_capacity_direction = None
+    info.config_changed.return_value = False
+    state.register(info, curr_target_num_replicas=1)
+    return state
+
+
+def test_clip_excludes_stale_transient_from_aggregate():
+    """A stale high transient early in the window inflates the aggregated request
+    total; the clip drops it so only the recent window is averaged."""
+    state = _clip_state()
+    now = time.time()
+    series = [
+        TimeStampedValue(now - 20, 100.0),  # stale ramp transient
+        TimeStampedValue(now - 3, 10.0),
+        TimeStampedValue(now - 2, 10.0),
+        TimeStampedValue(now - 1, 10.0),
+    ]
+    full = state._merge_and_aggregate_timeseries([series], clip_window_s=0.0)
+    clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=5.0)
+    assert clipped < full
+
+
+def test_clip_disabled_leaves_aggregate_unchanged(monkeypatch):
+    """clip_window_s<=0, or a clip wider than the data, is a no-op on the aggregate."""
+    state = _clip_state()
+    now = 1_000_000.0
+    # Freeze time: both aggregations must share one window (last_window_s reads time.time()).
+    monkeypatch.setattr("ray.serve._private.autoscaling_state.time.time", lambda: now)
+    series = [TimeStampedValue(now - 3, 10.0), TimeStampedValue(now - 1, 30.0)]
+    full = state._merge_and_aggregate_timeseries([series], clip_window_s=0.0)
+    wide = state._merge_and_aggregate_timeseries([series], clip_window_s=1000.0)
+    assert wide == full
+
+
+def test_clip_keeps_last_sample_under_max_aggregation():
+    """MAX/MIN hard-filter on window_start with no carry-forward, so if every sample is
+    older than the clip window (a metrics gap), the clip must keep the last sample
+    instead of dropping all -> None -> 0.0, a spurious scale-down."""
+    state = _clip_state(aggregation_function=AggregationFunction.MAX)
+    now = time.time()
+    series = [TimeStampedValue(now - 30, 40.0), TimeStampedValue(now - 25, 50.0)]
+    clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=5.0)
+    assert clipped == 50.0
+
+
+def test_clip_window_floored_to_two_record_intervals(monkeypatch):
+    """The clip is floored at 2x the record cadence (12s at the 30s default), so a
+    sub-cadence clip still spans real samples: through get_total_num_requests in
+    aggregate mode a now-8s sample stays inside the window (kept), now-15s falls outside
+    (dropped) even with CLIP_WINDOW_S=5. No floor -> 5s window drops now-8s too and MAX
+    reads 10, not 50."""
+    monkeypatch.setattr(
+        "ray.serve._private.autoscaling_state.RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S", 5.0
+    )
+    monkeypatch.setattr(
+        "ray.serve._private.autoscaling_state.RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER",
+        True,
+    )
+    state = _clip_state(aggregation_function=AggregationFunction.MAX)
+    now = time.time()
+    series = [
+        TimeStampedValue(now - 15, 100.0),  # outside the 12s window -> dropped
+        TimeStampedValue(now - 8, 50.0),  # kept only because of the floor
+        TimeStampedValue(now - 1, 10.0),
+    ]
+    monkeypatch.setattr(state, "_collect_replica_running_requests", lambda: [series])
+    monkeypatch.setattr(state, "_collect_handle_queued_requests", lambda: [])
+    assert state.get_total_num_requests() == 50.0
+
+
+# ---- Anti-windup desired-replica cap ----
+
+
+def _antiwindup_ctx(current, target, total_requests, up_factor=1.0, down_factor=1.0):
+    """Minimal queue-length context. With target_ongoing_requests=1, desired ==
+    total_requests before the scaling factor and the anti-windup cap."""
+    config = AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=100000,
+        target_ongoing_requests=1,
+        upscaling_factor=up_factor,
+        downscaling_factor=down_factor,
+        upscale_delay_s=0,
+        downscale_delay_s=0,
+    )
+    return AutoscalingContext(
+        config=config,
+        current_num_replicas=current,
+        target_num_replicas=target,
+        total_num_requests=total_requests,
+        capacity_adjusted_min_replicas=1,
+        capacity_adjusted_max_replicas=100000,
+        policy_state={},
+        deployment_id=None,
+        deployment_name=None,
+        app_name=None,
+        running_replicas=None,
+        current_time=None,
+        total_queued_requests=None,
+        aggregated_metrics=None,
+        raw_metrics=None,
+        last_scale_up_time=None,
+        last_scale_down_time=None,
+        total_pending_async_requests=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "current, target, total_requests, expected",
+    [
+        # starting (target>current); transient backlog would push desired>target
+        pytest.param(100, 200, 500, 200, id="caps_windup_while_starting"),
+        # target==current (not starting): initial jump untouched
+        pytest.param(100, 100, 500, 500, id="no_cap_on_initial_jump"),
+        # desired<target while starting: only upward windup capped, not scale-down
+        pytest.param(100, 200, 50, 50, id="scale_down_untouched"),
+    ],
+)
+def test_antiwindup_desired_cap(current, target, total_requests, expected):
+    """Anti-windup caps desired at the committed target while a batch is starting;
+    initial jumps (target==current) and scale-down are left untouched."""
+    desired, _ = wrapped_replica_queue_length_autoscaling_policy(
+        _antiwindup_ctx(current, target, total_requests)
+    )
+    assert desired == expected
+
+
+@pytest.mark.parametrize("factor", [0.5, 1.0, 2.0])
+def test_antiwindup_caps_after_scaling_factor(factor):
+    """The cap is applied after the scaling factor, so a non-unit factor can't
+    re-inflate desired past the target. current=100, target=200, raw desired=500 ->
+    cap-after gives 200 for any factor; a mis-ordered cap-before would give
+    100 + factor*(200-100) (150 at 0.5, 300 at 2.0). factor=1.0 can't tell them apart."""
+    desired, _ = wrapped_replica_queue_length_autoscaling_policy(
+        _antiwindup_ctx(100, 200, 500, up_factor=factor, down_factor=factor)
+    )
+    assert desired == 200
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -636,7 +637,8 @@ class TestReplicaQueueLengthPolicy:
         new_num_replicas, _ = wrapped_replica_queue_length_autoscaling_policy(ctx=ctx)
         assert new_num_replicas == 100
 
-        # Two new replicas spun up during this timestep.
+        # Still starting (current=3 < target=100): the transient backlog inflates the
+        # metric, but anti-windup holds desired at the committed target (100).
         ctx = create_context_with_overrides(
             ctx,
             total_num_requests=123,
@@ -644,7 +646,7 @@ class TestReplicaQueueLengthPolicy:
             target_num_replicas=100,
         )
         new_num_replicas, _ = wrapped_replica_queue_length_autoscaling_policy(ctx=ctx)
-        assert new_num_replicas == 123
+        assert new_num_replicas == 100
 
         # A lot of queries got drained and a lot of replicas started up, but
         # new_num_replicas should not decrease, because of the downscale delay.
@@ -652,10 +654,10 @@ class TestReplicaQueueLengthPolicy:
             ctx,
             total_num_requests=10,
             current_num_replicas=4,
-            target_num_replicas=123,
+            target_num_replicas=100,
         )
         new_num_replicas, _ = wrapped_replica_queue_length_autoscaling_policy(ctx=ctx)
-        assert new_num_replicas == 123
+        assert new_num_replicas == 100
 
     @pytest.mark.parametrize("delay_s", [30.0, 0.0])
     def test_fluctuating_ongoing_requests(self, delay_s):
@@ -1594,6 +1596,156 @@ class TestAppLevelPolicyStateIsolation:
         assert final_state[d2][SERVE_AUTOSCALING_DECISION_TIMESTAMP_KEY] == fake_now
         # user state remains intact
         assert final_state[d2]["counter"] == 5
+
+
+# ---- Autoscaling window clip (RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S) ----
+
+
+def _clip_state(aggregation_function=AggregationFunction.MEAN):
+    """A registered DeploymentAutoscalingState for exercising the aggregate path."""
+    state = DeploymentAutoscalingState(DeploymentID(name="test", app_name="app"))
+    info = MagicMock()
+    info.deployment_config.autoscaling_config = AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=10,
+        look_back_period_s=30,
+        aggregation_function=aggregation_function,
+    )
+    info.deployment_config.gang_scheduling_config = None
+    info.target_capacity = None
+    info.target_capacity_direction = None
+    info.config_changed.return_value = False
+    state.register(info, curr_target_num_replicas=1)
+    return state
+
+
+def test_clip_excludes_stale_transient_from_aggregate():
+    """A stale high transient early in the window inflates the aggregated request
+    total; the clip drops it so only the recent window is averaged."""
+    state = _clip_state()
+    now = time.time()
+    series = [
+        TimeStampedValue(now - 20, 100.0),  # stale ramp transient
+        TimeStampedValue(now - 3, 10.0),
+        TimeStampedValue(now - 2, 10.0),
+        TimeStampedValue(now - 1, 10.0),
+    ]
+    full = state._merge_and_aggregate_timeseries([series], clip_window_s=0.0)
+    clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=5.0)
+    assert clipped < full
+
+
+def test_clip_disabled_leaves_aggregate_unchanged(monkeypatch):
+    """clip_window_s<=0, or a clip wider than the data, is a no-op on the aggregate."""
+    state = _clip_state()
+    now = 1_000_000.0
+    # Freeze time: both aggregations must share one window (last_window_s reads time.time()).
+    monkeypatch.setattr("ray.serve._private.autoscaling_state.time.time", lambda: now)
+    series = [TimeStampedValue(now - 3, 10.0), TimeStampedValue(now - 1, 30.0)]
+    full = state._merge_and_aggregate_timeseries([series], clip_window_s=0.0)
+    wide = state._merge_and_aggregate_timeseries([series], clip_window_s=1000.0)
+    assert wide == full
+
+
+def test_clip_keeps_last_sample_under_max_aggregation():
+    """MAX/MIN hard-filter on window_start with no carry-forward, so if every sample is
+    older than the clip window (a metrics gap), the clip must keep the last sample
+    instead of dropping all -> None -> 0.0, a spurious scale-down."""
+    state = _clip_state(aggregation_function=AggregationFunction.MAX)
+    now = time.time()
+    series = [TimeStampedValue(now - 30, 40.0), TimeStampedValue(now - 25, 50.0)]
+    clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=5.0)
+    assert clipped == 50.0
+
+
+def test_clip_window_floored_to_two_record_intervals(monkeypatch):
+    """The clip is floored at 2x the record cadence (12s at the 30s default), so a
+    sub-cadence clip still spans real samples: through get_total_num_requests a
+    now-8s sample stays inside the window (kept), now-15s falls outside
+    (dropped) even with CLIP_WINDOW_S=5. No floor -> 5s window drops now-8s too and MAX
+    reads 10, not 50."""
+    monkeypatch.setattr(
+        "ray.serve._private.autoscaling_state.RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S", 5.0
+    )
+    state = _clip_state(aggregation_function=AggregationFunction.MAX)
+    now = time.time()
+    series = [
+        TimeStampedValue(now - 15, 100.0),  # outside the 12s window -> dropped
+        TimeStampedValue(now - 8, 50.0),  # kept only because of the floor
+        TimeStampedValue(now - 1, 10.0),
+    ]
+    monkeypatch.setattr(state, "_collect_replica_running_requests", lambda: [series])
+    monkeypatch.setattr(state, "_collect_handle_queued_requests", lambda: [])
+    assert state.get_total_num_requests() == 50.0
+
+
+# ---- Anti-windup desired-replica cap ----
+
+
+def _antiwindup_ctx(current, target, total_requests, up_factor=1.0, down_factor=1.0):
+    """Minimal queue-length context. With target_ongoing_requests=1, desired ==
+    total_requests before the scaling factor and the anti-windup cap."""
+    config = AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=100000,
+        target_ongoing_requests=1,
+        upscaling_factor=up_factor,
+        downscaling_factor=down_factor,
+        upscale_delay_s=0,
+        downscale_delay_s=0,
+    )
+    return AutoscalingContext(
+        config=config,
+        current_num_replicas=current,
+        target_num_replicas=target,
+        total_num_requests=total_requests,
+        capacity_adjusted_min_replicas=1,
+        capacity_adjusted_max_replicas=100000,
+        policy_state={},
+        deployment_id=None,
+        deployment_name=None,
+        app_name=None,
+        running_replicas=None,
+        current_time=None,
+        total_queued_requests=None,
+        aggregated_metrics=None,
+        raw_metrics=None,
+        last_scale_up_time=None,
+        last_scale_down_time=None,
+        total_pending_async_requests=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "current, target, total_requests, expected",
+    [
+        # starting (target>current); transient backlog would push desired>target
+        pytest.param(100, 200, 500, 200, id="caps_windup_while_starting"),
+        # target==current (not starting): initial jump untouched
+        pytest.param(100, 100, 500, 500, id="no_cap_on_initial_jump"),
+        # desired<target while starting: only upward windup capped, not scale-down
+        pytest.param(100, 200, 50, 50, id="scale_down_untouched"),
+    ],
+)
+def test_antiwindup_desired_cap(current, target, total_requests, expected):
+    """Anti-windup caps desired at the committed target while a batch is starting;
+    initial jumps (target==current) and scale-down are left untouched."""
+    desired, _ = wrapped_replica_queue_length_autoscaling_policy(
+        _antiwindup_ctx(current, target, total_requests)
+    )
+    assert desired == expected
+
+
+@pytest.mark.parametrize("factor", [0.5, 1.0, 2.0])
+def test_antiwindup_caps_after_scaling_factor(factor):
+    """The cap is applied after the scaling factor, so a non-unit factor can't
+    re-inflate desired past the target. current=100, target=200, raw desired=500 ->
+    cap-after gives 200 for any factor; a mis-ordered cap-before would give
+    100 + factor*(200-100) (150 at 0.5, 300 at 2.0). factor=1.0 can't tell them apart."""
+    desired, _ = wrapped_replica_queue_length_autoscaling_policy(
+        _antiwindup_ctx(100, 200, 500, up_factor=factor, down_factor=factor)
+    )
+    assert desired == 200
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1647,13 +1647,14 @@ def test_clip_disabled_leaves_aggregate_unchanged(monkeypatch):
     assert wide == full
 
 
-def test_clip_keeps_last_sample_under_max_aggregation():
-    """MAX/MIN hard-filter on window_start with no carry-forward, so if every sample is
-    older than the clip window (a metrics gap), the clip must keep the last sample
-    instead of dropping all -> None -> 0.0, a spurious scale-down."""
+def test_clip_skipped_when_window_misses_every_sample():
+    """MAX/MIN hard-filter on window_start with no carry-forward, so a clip window
+    sitting entirely past the data (a metrics gap) must not narrow it at all: clipping
+    to the last sample reads 40 and dropping every sample reads 0.0, both spurious
+    scale-downs. Ordered high-then-low so those two outcomes stay distinguishable."""
     state = _clip_state(aggregation_function=AggregationFunction.MAX)
     now = time.time()
-    series = [TimeStampedValue(now - 30, 40.0), TimeStampedValue(now - 25, 50.0)]
+    series = [TimeStampedValue(now - 30, 50.0), TimeStampedValue(now - 25, 40.0)]
     clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=5.0)
     assert clipped == 50.0
 

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1647,15 +1647,19 @@ def test_clip_disabled_leaves_aggregate_unchanged(monkeypatch):
     assert wide == full
 
 
-def test_clip_skipped_when_window_misses_every_sample():
-    """MAX/MIN hard-filter on window_start with no carry-forward, so a clip window
-    sitting entirely past the data (a metrics gap) must not narrow it at all: clipping
-    to the last sample reads 40 and dropping every sample reads 0.0, both spurious
-    scale-downs. Ordered high-then-low so those two outcomes stay distinguishable."""
+def test_clip_anchors_on_data_not_wall_clock_when_metrics_stall():
+    """Every sample older than the clip window (a stall, or synthetic test timestamps).
+    Anchoring on last_ts keeps the transient out and the recent pair in, so MAX reads 50.
+    A wall-clock anchor strands MAX on the final sample (40); skipping the clip folds the
+    transient back in (100). The three outcomes are distinct, so this pins the anchor."""
     state = _clip_state(aggregation_function=AggregationFunction.MAX)
     now = time.time()
-    series = [TimeStampedValue(now - 30, 50.0), TimeStampedValue(now - 25, 40.0)]
-    clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=5.0)
+    series = [
+        TimeStampedValue(now - 300, 100.0),
+        TimeStampedValue(now - 250, 50.0),
+        TimeStampedValue(now - 245, 40.0),
+    ]
+    clipped = state._merge_and_aggregate_timeseries([series], clip_window_s=10.0)
     assert clipped == 50.0
 
 


### PR DESCRIPTION
## Why are these changes needed?

The Ray Serve controller autoscales replicas based upon request activity.   When there
is a burst of requests, the controller's ramp-ups commonly overshoot the target replica 
count and are slow to shed it,  which keeps the deployment in transition and inflates the 
controller loop.  This PR includes two complementary fixes, one on each side of the 
autoscaling decision.

### Clip the aggregation window (input side)

For direct-ingress only (HA Proxy ON), `get_total_num_requests` averages each replica/handle's 
request metric over the full period (30 sec). During a ramp the transient queued high-water mark is
averaged in and lingers ~30 s after the ramp, so desired replicas reads **above** true steady 
demand and the autoscaler overshoots.   And because the `downscale_delay` (600 s) is long, 
the inflated count lingers long after the ramp.  This fix introduces 
`RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S` (default **12 s**) which clips the aggregation to 
the most recent N seconds so the stale transient isn't averaged in.  12s is also the floor as that
is 2 * metric record sampling cadence, a conservative floor.

### Anti-windup cap (output side)

The queue-length policy calculation of desired replicas includes queued requests.
While already-requested replicas are still starting that backlog is transient, the in-flight replicas
will drain it, so re-requesting on top of it every tick is integral windup that drives
mid-range overshoot. The cap holds `desired` at the committed target while replicas start,
the initial jump to true demand (`target == current`) and scale-down (`desired < current`)
are unaffected. Applies unconditionally.

### Impact

On the controller-scaling benchmark, the changes bring `actual ≈ target` (base overshoots
+14–20% @512–2048), loop otherwise neutral.

### What changed

- `constants.py`: `RAY_SERVE_AUTOSCALE_CLIP_WINDOW_S` (default 5 s).
- `autoscaling_state.py`: `_clip_window_start` helper + clip in `_merge_and_aggregate_timeseries`.
- `autoscaling_policy.py`: anti-windup cap in `_core_replica_queue_length_policy`.

### Testing

- `test_autoscale_clip_window.py` — clip arithmetic + no-op when the window is unset.
- `test_autoscale_antiwindup.py` — cap while starting; initial jump and scale-down untouched.

An attached html document lists all of the optimizations that were implemented as part of a larger Serve controller scaling effort. This PR is for optimizations D1 and D2.

Controller-scaling optimization series

<img width="2000" height="800" alt="image" src="https://github.com/user-attachments/assets/82719b35-6c3b-43dc-91fe-aac75443c075" />
