### PR TITLE
[serve] Refresh GCS node-info cache off the control loop (async)

### DIFF
--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -1,6 +1,7 @@
+import asyncio
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple
 
 import ray
 from ray._common.utils import binary_to_hex
@@ -8,6 +9,16 @@ from ray._raylet import GcsClient  # type: ignore[attr-defined]
 from ray.serve._private.constants import RAY_GCS_RPC_TIMEOUT_S, SERVE_LOGGER_NAME
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+class _NodeInfoSnapshot(NamedTuple):
+    """The node-info fields refresh computes and apply_pending swaps into the cache."""
+
+    alive_nodes: List[Tuple[str, str, str]]
+    alive_node_id_set: FrozenSet[str]
+    node_labels: Dict[str, Dict[str, str]]
+    total_resources_per_node: Dict[str, Dict]
+    available_resources_per_node: Dict[str, Dict[str, float]]
 
 
 class ClusterNodeInfoCache(ABC):
@@ -22,15 +33,88 @@ class ClusterNodeInfoCache(ABC):
         # Track alive node IDs to detect cluster membership changes and skip
         # rebuilding labels / total resources when nothing changed.
         self._alive_node_id_set: FrozenSet[str] = frozenset()
+        self._refresh_in_flight: bool = False
+        # Staged by refresh_async(); promoted by apply_pending() (see below).
+        self._pending_snapshot: Optional[_NodeInfoSnapshot] = None
 
     def update(self):
-        """Update the cache by fetching latest node information from GCS.
+        """Update the cache by fetching latest node information from GCS (blocking).
 
-        This should be called once in each update cycle.
-        Within an update cycle, everyone will see the same
-        cached node info avoiding any potential issues
-        caused by inconsistent node info seen by different components.
+        Applies synchronously. Used at controller startup (to warm the cache before the
+        control loop starts) and on the shutdown path, where the background refresh loop
+        has already exited.
         """
+        self._apply_snapshot(self._compute_snapshot(self._prior_state()))
+
+    async def refresh_async(self):
+        """Fetch node info off the event loop and STAGE it (apply_pending promotes
+        it). The GCS calls release the GIL, so the executor runs while a slow reply is
+        in flight. Single-flight: at most one refresh at a time."""
+        if self._refresh_in_flight:
+            return
+        self._refresh_in_flight = True
+        # Capture the carry-forward state on the event-loop thread so the executor
+        # never reads self while apply_pending() may be swapping in a newer snapshot.
+        prior = self._prior_state()
+        try:
+            loop = asyncio.get_running_loop()
+            self._pending_snapshot = await loop.run_in_executor(
+                None, self._compute_snapshot, prior
+            )
+        except Exception:
+            logger.warning(
+                "Async node-info refresh failed; node info cache will be stale.",
+                exc_info=True,
+            )
+        finally:
+            self._refresh_in_flight = False
+
+    def apply_pending(self) -> None:
+        """Promote the latest staged snapshot into the live cache. Called at the top
+        of each tick before any reader, so the cache stays immutable for the tick and
+        every component sees one consistent node-info view (the invariant the old
+        per-cycle update() held)."""
+        snapshot = self._pending_snapshot
+        if snapshot is not None:
+            self._pending_snapshot = None
+            self._apply_snapshot(snapshot)
+
+    def is_refresh_in_flight(self) -> bool:
+        """True while a background refresh_async() is fetching from the GCS."""
+        return self._refresh_in_flight
+
+    def _apply_snapshot(self, snapshot: _NodeInfoSnapshot):
+        # Positional unpack, no await -> atomic on the event-loop thread.
+        (
+            self._cached_alive_nodes,
+            self._alive_node_id_set,
+            self._cached_node_labels,
+            self._cached_total_resources_per_node,
+            self._cached_available_resources_per_node,
+        ) = snapshot
+
+    def _prior_state(self):
+        """Capture (on the event-loop thread) the fields _compute_snapshot carries
+        forward, so the executor never reads them while apply_pending() may be swapping
+        in a newer snapshot."""
+        return (
+            self._alive_node_id_set,
+            self._cached_node_labels,
+            self._cached_total_resources_per_node,
+            self._cached_available_resources_per_node,
+        )
+
+    def _compute_snapshot(self, prior):
+        """Fetch + compute the node-info snapshot from GCS without reading or mutating
+        self (other than the immutable GCS client), so it is safe to run in an executor
+        thread. `prior` is the carry-forward state captured by the caller via
+        _prior_state(). Returns the _NodeInfoSnapshot applied by _apply_snapshot."""
+        (
+            prior_alive_ids,
+            prior_node_labels,
+            prior_total_resources,
+            prior_available,
+        ) = prior
         nodes = self._gcs_client.get_all_node_info(timeout=RAY_GCS_RPC_TIMEOUT_S)
         alive_nodes = [
             (node_id.hex(), node.node_name, node.instance_id)
@@ -40,37 +124,46 @@ class ClusterNodeInfoCache(ABC):
             if node.state
             == ray.core.generated.gcs_pb2.GcsNodeInfo.ALIVE  # pyrefly: ignore[missing-attribute]
         ]
-
         # Sort on NodeID to ensure the ordering is deterministic across the cluster.
         alive_nodes.sort()
-        self._cached_alive_nodes = alive_nodes
 
-        # Detect whether the set of alive nodes has changed. Rebuild labels
-        # and total resources only when it has, since they are static per-node
-        # properties that don't change while a node stays alive.
+        # Detect whether the set of alive nodes has changed. Rebuild labels and total
+        # resources only when it has (static per-node properties).
         current_alive_ids = frozenset(node_id for node_id, _, _ in alive_nodes)
-        if current_alive_ids != self._alive_node_id_set:
-            self._alive_node_id_set = current_alive_ids
-            self._cached_node_labels = {
+        if current_alive_ids != prior_alive_ids:
+            node_labels = {
                 node_id.hex(): dict(node.labels)
                 for (node_id, node) in nodes.items()
                 if node_id.hex() in current_alive_ids
             }
-            self._cached_total_resources_per_node = {
+            total_resources = {
                 node_id.hex(): dict(node.resources_total)
                 for (node_id, node) in nodes.items()
                 if node_id.hex() in current_alive_ids
             }
+        else:
+            node_labels = prior_node_labels
+            total_resources = prior_total_resources
 
-        # Fetch available resources using the existing GCS client rather than
-        # the legacy GlobalStateAccessor path (which opens a second connection
-        # and performs redundant protobuf deserialization).
-        self._cached_available_resources_per_node = (
-            self._fetch_available_resources_per_node()
+        available = self._fetch_available_resources_per_node(
+            current_alive_ids, prior_available
+        )
+        return _NodeInfoSnapshot(
+            alive_nodes,
+            current_alive_ids,
+            node_labels,
+            total_resources,
+            available,
         )
 
-    def _fetch_available_resources_per_node(self) -> Dict[str, Dict[str, float]]:
-        """Fetch available resources per alive node via get_all_resource_usage()."""
+    def _fetch_available_resources_per_node(
+        self, alive_id_set: FrozenSet[str], prior_available: Dict[str, Dict[str, float]]
+    ) -> Dict[str, Dict[str, float]]:
+        """Fetch available resources per alive node via get_all_resource_usage().
+
+        `prior_available` is the carry-forward value returned if the GCS call fails; it
+        is passed in (not read from self) so this stays safe in an executor thread.
+        """
         try:
             reply = self._gcs_client.get_all_resource_usage(
                 timeout=RAY_GCS_RPC_TIMEOUT_S
@@ -81,13 +174,12 @@ class ClusterNodeInfoCache(ABC):
                 "Available resources cache will be stale.",
                 exc_info=True,
             )
-            return self._cached_available_resources_per_node
+            return prior_available
 
         return {
             node_id: dict(resource_data.resources_available)
             for resource_data in reply.resource_usage_data.batch
-            if (node_id := binary_to_hex(resource_data.node_id))
-            in self._alive_node_id_set
+            if (node_id := binary_to_hex(resource_data.node_id)) in alive_id_set
         }
 
     def get_alive_nodes(self) -> List[Tuple[str, str, str]]:

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -78,6 +78,11 @@ CONTROL_LOOP_INTERVAL_S = get_env_float_non_negative(
     "RAY_SERVE_CONTROL_LOOP_INTERVAL_S", 0.1
 )
 
+# Interval of the background node-info refresh loop.
+RAY_SERVE_NODE_INFO_REFRESH_S = get_env_float_positive(
+    "RAY_SERVE_NODE_INFO_REFRESH_S", 1.0
+)
+
 #: Max time to wait for HTTP proxy in `serve.start()`.
 HTTP_PROXY_TIMEOUT = 60
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -41,6 +41,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
     RAY_SERVE_FREEZE_GC_ON_STARTUP,
     RAY_SERVE_LOG_TO_STDERR,
+    RAY_SERVE_NODE_INFO_REFRESH_S,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
@@ -540,6 +541,16 @@ class ServeController:
         new_proxy_nodes.add(self._controller_node_id)
         self._proxy_nodes = new_proxy_nodes
 
+    async def _node_info_refresh_loop(self) -> None:
+        """Refresh the node-info cache off the control loop so the per-loop GCS query
+        (get_all_node_info / get_all_resource_usage) never blocks the event loop."""
+        while not self._shutting_down:
+            try:
+                await self.cluster_node_info_cache.refresh_async()
+            except Exception:
+                logger.exception("Exception in node-info refresh loop.")
+            await asyncio.sleep(RAY_SERVE_NODE_INFO_REFRESH_S)
+
     async def run_control_loop(self) -> None:
         # NOTE(edoakes): we catch all exceptions here and simply log them,
         # because an unhandled exception would cause the main control loop to
@@ -547,6 +558,7 @@ class ServeController:
         recovering_timeout = RECOVERING_LONG_POLL_BROADCAST_TIMEOUT_S
         num_loops = 0
         start_time = time.time()
+        run_background_task(self._node_info_refresh_loop())
         while True:
             loop_start_time = time.time()
             try:
@@ -585,16 +597,30 @@ class ServeController:
     async def run_control_loop_step(
         self, start_time: float, recovering_timeout: float, num_loops: int
     ):
-        try:
-            self.cluster_node_info_cache.update()
-        except Exception:
-            logger.exception("Exception updating cluster node info cache.")
-
         if self._shutting_down:
+            # Keep the cache current for shutdown reconciliation without hitting the
+            # GcsClient from two threads. The background refresh loop keeps running until
+            # it observes _shutting_down, so if a refresh is mid-call promote its latest
+            # staged snapshot (a pointer swap, no GCS); otherwise do a full synchronous
+            # refresh.
+            try:
+                if self.cluster_node_info_cache.is_refresh_in_flight():
+                    self.cluster_node_info_cache.apply_pending()
+                else:
+                    self.cluster_node_info_cache.update()
+            except Exception:
+                logger.exception("Exception updating cluster node info cache.")
             try:
                 self.shutdown()
             except Exception:
                 logger.exception("Exception during shutdown.")
+        else:
+            # Promote the most recent background node-info snapshot into the live cache
+            # once, before this tick's readers (deployment/application state managers,
+            # proxy state), so every component sees one consistent node-info view for the
+            # whole tick. The GCS fetch already ran off the event loop in
+            # _node_info_refresh_loop; this is just a cheap pointer swap.
+            self.cluster_node_info_cache.apply_pending()
 
         if (
             not self.done_recovering_event.is_set()

--- a/python/ray/serve/tests/test_cluster_node_info_cache.py
+++ b/python/ray/serve/tests/test_cluster_node_info_cache.py
@@ -1,7 +1,10 @@
+import asyncio
+
 import pytest
 
 import ray
 from ray._raylet import GcsClient
+from ray.serve._private.cluster_node_info_cache import DefaultClusterNodeInfoCache
 from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.test_utils import get_node_id
 from ray.tests.conftest import *  # noqa
@@ -46,6 +49,153 @@ def test_get_alive_nodes(ray_start_cluster):
         cluster_node_info_cache.get_alive_node_ids()
         == cluster_node_info_cache.get_active_node_ids()
     )
+
+
+# Snapshots shaped like _apply_snapshot's tuple:
+# (alive_nodes, alive_node_id_set, node_labels, total_resources, available_resources).
+_OLD = ([("old", "old", "")], frozenset({"old"}), {}, {}, {})
+_NEW = ([("new", "new", "")], frozenset({"new"}), {}, {}, {})
+
+
+def test_refresh_async_stages_without_touching_live_cache():
+    """refresh_async must NOT mutate the live cache when the executor completes -- it
+    only STAGES the snapshot. The live cache changes only when apply_pending() runs (at
+    the control-loop tick boundary), so a background refresh can never land mid-tick.
+    This is the invariant the per-cycle update() used to guarantee."""
+
+    async def _run():
+        cache = DefaultClusterNodeInfoCache(object())  # GCS is never called
+        cache._compute_snapshot = lambda *a: _NEW
+        assert cache.get_alive_nodes() is None  # nothing applied yet
+
+        await cache.refresh_async()
+        # Staged, but the LIVE cache is untouched.
+        assert cache._pending_snapshot == _NEW
+        assert cache.get_alive_nodes() is None
+
+        # The tick-boundary swap promotes it.
+        cache.apply_pending()
+        assert cache.get_alive_nodes() == _NEW[0]
+        assert cache._pending_snapshot is None  # consumed
+
+    asyncio.run(_run())
+
+
+def test_apply_pending_is_noop_without_staged_snapshot():
+    """apply_pending() with nothing staged leaves the live cache unchanged, so ticks
+    with no completed refresh keep the last snapshot."""
+
+    async def _run():
+        cache = DefaultClusterNodeInfoCache(object())
+        cache._compute_snapshot = lambda *a: _OLD
+        cache.update()  # seed the live cache synchronously
+        assert cache.get_alive_nodes() == _OLD[0]
+
+        cache.apply_pending()  # nothing staged
+        assert cache.get_alive_nodes() == _OLD[0]  # unchanged
+
+    asyncio.run(_run())
+
+
+def test_update_applies_synchronously():
+    """update() (startup + shutdown path) still fetches and applies in one blocking
+    call, independent of the staging mechanism."""
+
+    async def _run():
+        cache = DefaultClusterNodeInfoCache(object())
+        cache._compute_snapshot = lambda *a: _NEW
+        cache.update()
+        assert cache.get_alive_nodes() == _NEW[0]
+
+    asyncio.run(_run())
+
+
+def test_live_cache_frozen_while_refresh_in_flight():
+    """End-to-end of the reviewer's concern: while a refresh is suspended in the
+    executor, the live cache stays frozen, and when the executor result finally lands it
+    is STAGED (not applied), so an in-flight refresh cannot clobber a snapshot a reader
+    is mid-tick on -- including one written by a synchronous shutdown update()."""
+
+    async def _run():
+        cache = DefaultClusterNodeInfoCache(object())
+        loop = asyncio.get_running_loop()
+
+        # Seed a known live snapshot.
+        cache._compute_snapshot = lambda *a: _OLD
+        cache.update()
+        assert cache.get_alive_nodes() == _OLD[0]
+
+        # Route the executor step to a future we resolve by hand.
+        exec_future = loop.create_future()
+        loop.run_in_executor = lambda executor, fn, *a: exec_future
+
+        task = asyncio.create_task(cache.refresh_async())
+        await asyncio.sleep(0)  # let it suspend on the future
+        # Live cache is still the seeded snapshot while the refresh is in flight.
+        assert cache.get_alive_nodes() == _OLD[0]
+
+        # The executor result lands: it is STAGED, not applied.
+        exec_future.set_result(_NEW)
+        await task
+        assert cache.get_alive_nodes() == _OLD[0]  # live cache still frozen
+        assert cache._pending_snapshot == _NEW  # staged for the next tick
+
+    asyncio.run(_run())
+
+
+def test_refresh_async_single_flight():
+    """Only one refresh may be in flight; a concurrent call returns immediately without
+    issuing a second executor job."""
+
+    async def _run():
+        cache = DefaultClusterNodeInfoCache(object())
+        loop = asyncio.get_running_loop()
+        calls = {"n": 0}
+        exec_future = loop.create_future()
+
+        def _run_in_executor(executor, fn, *a):
+            calls["n"] += 1
+            return exec_future
+
+        loop.run_in_executor = _run_in_executor
+        cache._compute_snapshot = lambda *a: _NEW
+
+        first = asyncio.create_task(cache.refresh_async())
+        await asyncio.sleep(0)
+        # A second call while the first is in flight is a no-op.
+        await cache.refresh_async()
+        assert calls["n"] == 1
+
+        exec_future.set_result(_NEW)
+        await first
+        assert calls["n"] == 1
+
+    asyncio.run(_run())
+
+
+def test_refresh_async_captures_prior_state_before_executor():
+    """refresh_async snapshots the carry-forward state on the event loop and hands it to
+    the executor, so _compute_snapshot never reads self off-thread (guards against a
+    concurrent apply_pending() mutating self mid-compute)."""
+
+    async def _run():
+        cache = DefaultClusterNodeInfoCache(object())
+        cache._apply_snapshot(_OLD)  # live cache now holds _OLD's alive-id set
+
+        captured = {}
+
+        def _compute(prior):
+            captured["prior"] = prior
+            return _NEW
+
+        cache._compute_snapshot = _compute
+        await cache.refresh_async()
+
+        # prior[0] is the alive-id set, captured from self at call time (== _OLD), not
+        # read from self inside the executor.
+        assert captured["prior"][0] == _OLD[1]
+
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

To help with reconciliation and deployment, the Ray Serve Controller queries the underlying
Ray Global Control Store (GCS) to determine the current state of all nodes and resources.
The Controller refreshes this state (its node cache) once per control-loop iteration (tick), 
synchronously.  On large clusters the GCS responses are slow, and because they run inline, 
they block the control loop for their full duration every tick, inflating control-loop latency 
exactly when the cluster is largest.

This PR moves the GCS queries out of the control loop:

- **Background asynchronous refresh.**  The GCS queries now occur outside of the loop
  inside of a thread.  The GCS call itself releases the Python Global Interpreter Lock (GIL),
  allowing the control loop to continue executing.  The control loop no longer blocks on GCS
  responses.   Startup and shutdown still refresh synchronously via `update()`. The
  behavior is unconditional (no feature flag).

- **Staged, promoted at the tick boundary (consistency).** The background refresh does
  not apply its result inline; it stages into a snapshot which is applied at the top of each tick,
  before any reader. So the live cache is immutable for the duration of a tick.
  Every reader within a tick (deployment/application state managers, proxy state,
  target-group broadcast) sees one consistent node-info view.  This preserves the
  per-cycle consistency invariant the old synchronous per-tick guaranteed,
  and is robust to a future `await` being introduced in the reader chain.

## Checks

- Unit tests in `test_cluster_node_info_cache.py`: refresh stages without touching the
  live cache; `apply_pending()` promotes at the boundary and is a no-op when nothing is
  staged; the live cache stays frozen while a refresh is in flight; single-flight; and
  `_compute_snapshot` reads only the passed-in prior state (not `self`).
- The synchronous `update()` startup/shutdown path still applies in one blocking call.


An attached html document lists all of the optimizations that were implemented as part of a larger Serve controller scaling effort. This PR is for optimization E.

<img width="2000" height="800" alt="image" src="https://github.com/user-attachments/assets/a55a7af6-a9ac-4005-ab3c-b63aa3e1502a" />
