### PR TITLE
[serve] Fast-path orphaned-actor check when no deployment actors exist

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -506,6 +506,10 @@ class DeploymentActorContainer:
         """Return the set of code versions currently in the container."""
         return {entry.code_version for _, entry in self._actors_index.values()}
 
+    def is_empty(self) -> bool:
+        """O(1): True if no actor wrappers are tracked in any state."""
+        return not self._actors_index
+
 
 class ReplicaStartupStatus(Enum):
     PENDING_ALLOCATION = 1
@@ -5313,6 +5317,13 @@ class DeploymentState:
         """
         target_version = self._target_state.version
         if target_version is None:
+            return set()
+
+        # Fast path: with no deployment-scoped actors tracked, nothing can be orphaned
+        # (get_code_versions() is empty, and empty - anything == empty). Skips the O(N)
+        # self._replicas.get() materialization on every scale_deployment_replicas tick
+        # for the common deployment that has no deployment-scoped actors.
+        if self._deployment_actors.is_empty():
             return set()
 
         versions_to_keep = {r.version.code_version for r in self._replicas.get()}

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -389,6 +389,16 @@ class TestDeploymentActorContainer:
         assert c.count(code_version="v2") == 1
         assert c.count(code_version="v3") == 0
 
+    def test_is_empty(self):
+        dep_id = DeploymentID(name="test", app_name="app")
+        c = DeploymentActorContainer(dep_id)
+        assert c.is_empty()
+        w = _mock_deployment_actor_wrapper(dep_id, "v1", "actor_a")
+        c.add(DeploymentActorState.STARTING, w)
+        assert not c.is_empty()
+        c.pop()  # remove all tracked actors
+        assert c.is_empty()
+
     def test_add_moves_existing(self):
         """Adding same (code_version, name) moves from old state to new."""
         dep_id = DeploymentID(name="test", app_name="app")


### PR DESCRIPTION
_orphaned_deployment_actor_code_versions() runs on every scale_deployment_replicas tick and unconditionally materializes {r.version.code_version for r in self._replicas.get()} -- an O(num_replicas) build -- before subtracting it from the tracked deployment-actor code versions.

The common deployment has no deployment-scoped actors at all, in which case self._deployment_actors.get_code_versions() is empty and the result is empty regardless (empty - anything == empty). Add DeploymentActorContainer.is_empty() (O(1)) and short-circuit to return set() up front in that case, skipping the O(num_replicas) materialization every tick.

Behavior is unchanged: the fast path returns exactly what the full computation would (the empty set) whenever it fires. Unconditional (no flag).
<img width="1170" height="810" alt="image" src="https://github.com/user-attachments/assets/0b772e4f-7448-4ec8-84ba-6cb9326f7e7e" />
