### PR TITLE
[Data] Add SchedulingHints sibling field on BlockEntry / wire envelope

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -309,7 +309,13 @@ class DataOpTask(OpTask):
             meta = meta_with_schema.metadata
             self._output_ready_callback(
                 RefBundle(
-                    [BlockEntry(self._pending_block_ref, meta)],
+                    [
+                        BlockEntry(
+                            ref=self._pending_block_ref,
+                            metadata=meta,
+                            scheduling_hints=meta_with_schema.scheduling_hints,
+                        )
+                    ],
                     owns_blocks=True,
                     schema=meta_with_schema.schema,
                 ),

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -1,11 +1,12 @@
 import itertools
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple
 
 import ray
 from .common import NodeIdStr
 from ray.data._internal.memory_tracing import trace_deallocation
+from ray.data._internal.scheduling_hints import SchedulingHints
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -33,16 +34,19 @@ class BlockSlice:
 
 @dataclass(frozen=True, slots=True)
 class BlockEntry:
-    """One block delivery: the ref + the block's measured metadata.
+    """One block delivery: ref, measured metadata, and producer forecasts.
 
-    Used as the element type of ``RefBundle.blocks`` (replaces the legacy
-    ``(ObjectRef, BlockMetadata)`` 2-tuple shape). Naming the fields makes
-    every call site self-describing and reserves room for the bundle entry
-    to grow without disturbing the surrounding shape.
+    Used as the element type of ``RefBundle.blocks``. ``metadata`` describes
+    the block as it stands (retrospective state). ``scheduling_hints`` is a
+    prospective forecast the producer staged about the *next consumer* (see
+    :mod:`ray.data._internal.scheduling_hints`). The two fields are siblings
+    so the retrospective/prospective split is visible at the type level —
+    callers that don't care about hints just ignore the field.
     """
 
     ref: ObjectRef[Block]
     metadata: BlockMetadata
+    scheduling_hints: Optional[SchedulingHints] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -150,6 +154,17 @@ class RefBundle:
     def metadata(self) -> List[BlockMetadata]:
         """List of block metadata in this bundle."""
         return [entry.metadata for entry in self.blocks]
+
+    @property
+    def scheduling_hints(self) -> List[Optional[SchedulingHints]]:
+        """Per-block scheduling hints staged by the upstream producer.
+
+        Parallel to :attr:`block_refs` / :attr:`metadata`. Entries are
+        ``None`` when the upstream did not stage hints for that block.
+        Consumers (operator planners) walk this list to size per-task Ray
+        resource requests — see ``ray.data._internal.scheduling_hints``.
+        """
+        return [entry.scheduling_hints for entry in self.blocks]
 
     def num_rows(self) -> Optional[int]:
         """Number of rows present in this bundle, if known.

--- a/python/ray/data/_internal/execution/interfaces/task_context.py
+++ b/python/ray/data/_internal/execution/interfaces/task_context.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional
 if TYPE_CHECKING:
     from ray.data._internal.execution.operators.map_transformer import MapTransformer
     from ray.data._internal.progress.base_progress import BaseProgressBar
+    from ray.data._internal.scheduling_hints import SchedulingHints
 
 
 _thread_local = threading.local()
@@ -49,6 +50,20 @@ class TaskContext:
 
     # Additional keyword arguments passed to the task.
     kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    # Scheduling hints to attach to the *next* block this task yields. Read
+    # and cleared by ``_map_task`` after each yield (via
+    # :meth:`consume_next_block_scheduling_hints`), so callers must restage
+    # before every emit — leaving a stale value would silently mis-tag
+    # later blocks. See ``ray.data._internal.scheduling_hints`` for the
+    # producer-side helpers that write to this field.
+    next_block_scheduling_hints: Optional["SchedulingHints"] = None
+
+    def consume_next_block_scheduling_hints(self) -> Optional["SchedulingHints"]:
+        """Return the staged ``next_block_scheduling_hints`` and clear it."""
+        hints = self.next_block_scheduling_hints
+        self.next_block_scheduling_hints = None
+        return hints
 
     @classmethod
     def get_current(cls) -> Optional["TaskContext"]:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -853,6 +853,10 @@ def _map_task(
 
         with MemoryProfiler(data_context.memory_usage_poll_interval_s) as profiler:
             for block in block_iter:
+                # Capture any per-yield scheduling hints the transform
+                # staged before this yield. Cleared on consume so subsequent
+                # yields are not silently mis-tagged with a stale value.
+                scheduling_hints = ctx.consume_next_block_scheduling_hints()
                 block_meta = BlockAccessor.for_block(block).get_metadata()
                 block_schema = BlockAccessor.for_block(block).schema()
 
@@ -882,6 +886,7 @@ def _map_task(
                             ),
                         ),
                         schema=block_schema if not yielded_schema else None,
+                        scheduling_hints=scheduling_hints,
                     )
 
                 yield from yield_block_with_stats(block, build_metadata)

--- a/python/ray/data/_internal/scheduling_hints.py
+++ b/python/ray/data/_internal/scheduling_hints.py
@@ -1,0 +1,75 @@
+"""Pre-scheduling hints for sizing the next consumer task.
+
+Producers (typically the operator that knows the *output* cost of the work
+it is about to hand downstream — e.g. a download op that has measured file
+sizes) stage a :class:`SchedulingHints` via :func:`stage_scheduling_hints`.
+The next ``_map_task`` yield captures it onto the per-block wire envelope
+(``BlockMetadataWithSchema``) and the driver lifts it onto the
+``RefBundle``'s ``BlockEntry`` for the next operator to consume.
+
+These hints are **prospective**: they describe what the next consumer is
+expected to do with this block. They are deliberately kept separate from
+``BlockMetadata`` (which describes the block's measured, retrospective
+state) so the type system surfaces the difference between "this is what
+the block is" and "this is what we forecast the next op will need."
+
+No operator stages or reads hints in this initial landing — the infra is
+shipped first and adopted by Download (and others) in follow-on PRs.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ray.data._internal.execution.interfaces.task_context import TaskContext
+
+
+@dataclass(frozen=True)
+class SchedulingHints:
+    """Producer forecast for sizing the next consumer task.
+
+    All fields default to ``None`` so producers fill only the axes they can
+    forecast. Consumers ignore axes they don't care about — a Download op
+    that only cares about ``memory`` simply skips the rest. New hint axes
+    (cpu, gpu, locality, scheduling strategy) can be added here without
+    touching ``BlockMetadata`` or the producer/consumer call sites.
+    """
+
+    # Worker memory (bytes) the downstream task processing this block is
+    # expected to need. Plug directly into ``ray.remote(memory=...)``.
+    memory: Optional[int] = None
+    # Future, additive:
+    # num_cpus: Optional[float] = None
+    # num_gpus: Optional[float] = None
+    # preferred_node_id: Optional[str] = None
+    # scheduling_strategy: Optional[str] = None
+
+
+def stage_scheduling_hints(hints: SchedulingHints) -> None:
+    """Stage a per-yield ``SchedulingHints`` on the current ``TaskContext``.
+
+    Call this immediately before yielding a block from a map transform.
+    ``_map_task`` reads-and-clears the hints after the yield (see
+    :meth:`TaskContext.consume_next_block_scheduling_hints`), so calling
+    this again before each subsequent yield is required — a stale value
+    would silently mis-tag later blocks.
+
+    Calls without an active ``TaskContext`` (e.g. direct unit-test
+    invocation of a transform) are silent no-ops so tests do not need to
+    construct fake contexts.
+    """
+    ctx = TaskContext.get_current()
+    if ctx is None:
+        return
+    ctx.next_block_scheduling_hints = hints
+
+
+def stage_memory_hint(memory: int) -> None:
+    """Convenience wrapper for the single-axis memory hint case.
+
+    Equivalent to ``stage_scheduling_hints(SchedulingHints(memory=memory))``.
+    Non-positive values are dropped silently — a zero-memory request would
+    be meaningless to the scheduler.
+    """
+    if memory <= 0:
+        return
+    stage_scheduling_hints(SchedulingHints(memory=memory))

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -24,6 +24,7 @@ import numpy as np
 import pyarrow as pa
 
 import ray
+from ray.data._internal.scheduling_hints import SchedulingHints
 from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
 from ray.data.context import DataContext
 from ray.types import ObjectRef
@@ -348,10 +349,18 @@ def _read_arrow_schema_cached(schema_bytes: bytes) -> "pa.Schema":
 @dataclass(frozen=True)
 class BlockMetadataWithSchema(BlockMetadata):
     schema: Optional[Schema] = None
+    # Prospective forecast for the next consumer of this block, set by the
+    # producing transform via ``stage_scheduling_hints`` and lifted into
+    # the next RefBundle's ``BlockEntry.scheduling_hints`` on the driver.
+    # Lives on the wire envelope (BMWS) rather than on ``BlockMetadata``
+    # itself because hints describe the block's *delivery*, not the block.
+    scheduling_hints: Optional[SchedulingHints] = None
 
     @staticmethod
     def from_metadata(
-        metadata: "BlockMetadata", schema: Optional["Schema"] = None
+        metadata: "BlockMetadata",
+        schema: Optional["Schema"] = None,
+        scheduling_hints: Optional[SchedulingHints] = None,
     ) -> "BlockMetadataWithSchema":
         return BlockMetadataWithSchema(
             num_rows=metadata.num_rows,
@@ -360,6 +369,7 @@ class BlockMetadataWithSchema(BlockMetadata):
             task_exec_stats=metadata.task_exec_stats,
             input_files=metadata.input_files,
             schema=schema,
+            scheduling_hints=scheduling_hints,
         )
 
     @staticmethod
@@ -367,6 +377,7 @@ class BlockMetadataWithSchema(BlockMetadata):
         block: Block,
         block_exec_stats: Optional["BlockExecStats"] = None,
         task_exec_stats: Optional["TaskExecWorkerStats"] = None,
+        scheduling_hints: Optional[SchedulingHints] = None,
     ) -> "BlockMetadataWithSchema":
         accessor = BlockAccessor.for_block(block)
 
@@ -376,6 +387,7 @@ class BlockMetadataWithSchema(BlockMetadata):
                 task_exec_stats=task_exec_stats,
             ),
             schema=accessor.schema(),
+            scheduling_hints=scheduling_hints,
         )
 
     @property

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -7,6 +7,7 @@ import pytest
 from ray import ObjectRef
 from ray.data._internal.execution.interfaces import BlockSlice, RefBundle
 from ray.data._internal.execution.interfaces.ref_bundle import BlockEntry
+from ray.data._internal.scheduling_hints import SchedulingHints
 from ray.data.block import BlockMetadata
 
 _TEST_SCHEMA = pa.schema([("col", pa.int64())])
@@ -552,6 +553,34 @@ class TestBlockEntryAndSchedulingHints:
         )
         assert bundle.num_rows() == 8
         assert bundle.size_bytes() == 80
+
+    def test_scheduling_hints_default_none(self):
+        ref = ObjectRef(b"1" * 28)
+        entry = BlockEntry(ref=ref, metadata=self._meta())
+        assert entry.scheduling_hints is None
+
+    def test_scheduling_hints_carried_on_blockentry(self):
+        ref = ObjectRef(b"1" * 28)
+        hints = SchedulingHints(memory=4096)
+        entry = BlockEntry(ref=ref, metadata=self._meta(), scheduling_hints=hints)
+        assert entry.scheduling_hints == hints
+
+    def test_scheduling_hints_accessor_returns_parallel_list(self):
+        ref_a = ObjectRef(b"1" * 28)
+        ref_b = ObjectRef(b"2" * 28)
+        meta = self._meta()
+        hints = SchedulingHints(memory=999)
+
+        bundle = RefBundle(
+            blocks=[
+                BlockEntry(ref=ref_a, metadata=meta),
+                BlockEntry(ref=ref_b, metadata=meta, scheduling_hints=hints),
+            ],
+            owns_blocks=True,
+            schema=None,
+        )
+
+        assert bundle.scheduling_hints == [None, hints]
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_scheduling_hints.py
+++ b/python/ray/data/tests/test_scheduling_hints.py
@@ -1,0 +1,129 @@
+"""Tests for the pre-scheduling hint infrastructure.
+
+Producer-side helpers, ``TaskContext`` staging field, and the wire envelope
+(``BlockMetadataWithSchema``). No operator wiring is tested here — Download
+and other consumers land in follow-on PRs.
+"""
+
+import pickle
+
+import pytest
+
+from ray.data._internal.execution.interfaces.task_context import TaskContext
+from ray.data._internal.scheduling_hints import (
+    SchedulingHints,
+    stage_memory_hint,
+    stage_scheduling_hints,
+)
+from ray.data.block import BlockMetadata, BlockMetadataWithSchema
+
+
+class TestSchedulingHints:
+    def test_defaults_are_none(self):
+        hints = SchedulingHints()
+        assert hints.memory is None
+
+    def test_equality(self):
+        assert SchedulingHints(memory=10) == SchedulingHints(memory=10)
+        assert SchedulingHints(memory=10) != SchedulingHints(memory=11)
+        assert SchedulingHints() != SchedulingHints(memory=10)
+
+    def test_is_hashable_and_frozen(self):
+        # Frozen dataclasses are hashable, so hints can be used as dict keys
+        # or set members if a consumer ever wants to dedupe forecasts.
+        {SchedulingHints(memory=10): "ok"}
+        with pytest.raises(Exception):
+            SchedulingHints().memory = 5  # immutable
+
+    def test_pickle_round_trip(self):
+        hints = SchedulingHints(memory=1234)
+        restored = pickle.loads(pickle.dumps(hints))
+        assert restored == hints
+
+
+class TestStageHelpers:
+    def test_stage_scheduling_hints_writes_taskcontext(self):
+        ctx = TaskContext(task_idx=0, op_name="t")
+        with TaskContext.current(ctx):
+            stage_scheduling_hints(SchedulingHints(memory=4096))
+            assert ctx.next_block_scheduling_hints == SchedulingHints(memory=4096)
+
+    def test_stage_scheduling_hints_no_context_is_noop(self):
+        # Must not raise — direct unit-test callers may invoke a transform
+        # without setting up a TaskContext.
+        stage_scheduling_hints(SchedulingHints(memory=4096))
+
+    def test_stage_memory_hint_is_equivalent_to_scheduling_hints(self):
+        ctx = TaskContext(task_idx=0, op_name="t")
+        with TaskContext.current(ctx):
+            stage_memory_hint(99)
+            assert ctx.next_block_scheduling_hints == SchedulingHints(memory=99)
+
+    def test_stage_memory_hint_drops_nonpositive(self):
+        ctx = TaskContext(task_idx=0, op_name="t")
+        with TaskContext.current(ctx):
+            stage_memory_hint(0)
+            stage_memory_hint(-1)
+            assert ctx.next_block_scheduling_hints is None
+
+    def test_stage_memory_hint_no_context_is_noop(self):
+        stage_memory_hint(99)  # must not raise
+
+
+class TestTaskContextConsume:
+    def test_consume_returns_and_clears(self):
+        ctx = TaskContext(
+            task_idx=0,
+            op_name="t",
+            next_block_scheduling_hints=SchedulingHints(memory=42),
+        )
+        assert ctx.consume_next_block_scheduling_hints() == SchedulingHints(memory=42)
+        assert ctx.next_block_scheduling_hints is None
+        # Second call: no stale carryover.
+        assert ctx.consume_next_block_scheduling_hints() is None
+
+    def test_consume_when_unset(self):
+        ctx = TaskContext(task_idx=0, op_name="t")
+        assert ctx.consume_next_block_scheduling_hints() is None
+
+
+class TestBlockMetadataWithSchemaScheduling:
+    """Verify the wire envelope round-trips the new field."""
+
+    def test_default_is_none(self):
+        bm = BlockMetadataWithSchema(num_rows=1, size_bytes=2, exec_stats=None)
+        assert bm.scheduling_hints is None
+
+    def test_from_metadata_threads_hints(self):
+        meta = BlockMetadata(num_rows=1, size_bytes=2, exec_stats=None)
+        bm = BlockMetadataWithSchema.from_metadata(
+            meta, scheduling_hints=SchedulingHints(memory=512)
+        )
+        assert bm.scheduling_hints == SchedulingHints(memory=512)
+
+    def test_metadata_property_does_not_expose_hints(self):
+        # ``BlockMetadataWithSchema.metadata`` is the "block-state-only"
+        # projection. Hints live on the envelope, not on the projection.
+        bm = BlockMetadataWithSchema(
+            num_rows=1,
+            size_bytes=2,
+            exec_stats=None,
+            scheduling_hints=SchedulingHints(memory=512),
+        )
+        assert not hasattr(bm.metadata, "scheduling_hints")
+
+    def test_pickle_round_trip_preserves_hints(self):
+        bm = BlockMetadataWithSchema(
+            num_rows=1,
+            size_bytes=2,
+            exec_stats=None,
+            scheduling_hints=SchedulingHints(memory=512),
+        )
+        restored = pickle.loads(pickle.dumps(bm))
+        assert restored.scheduling_hints == SchedulingHints(memory=512)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Adds an opt-in, producer-supplied forecast about what the *next consumer* of a block will need (memory today; cpu/gpu/locality/strategy in future additions on the same dataclass). Designed to be layered on top of the BlockEntry foundation without disturbing existing call sites.

Surface:
- New module `ray.data._internal.scheduling_hints` with:
  * `SchedulingHints` frozen dataclass (memory: Optional[int]; additive)
  * `stage_scheduling_hints(hints)` — producer helper; writes to ``TaskContext.next_block_scheduling_hints`` before each yield.
  * `stage_memory_hint(memory)` — single-axis convenience.
- `BlockEntry.scheduling_hints: Optional[SchedulingHints]` — sibling field to `metadata`, defaulting to None.
- `BlockMetadataWithSchema.scheduling_hints` — wire-envelope field that carries the hint from worker to driver alongside the per-block metadata. `from_metadata` / `from_block` thread it through.
- `TaskContext.next_block_scheduling_hints` + `consume_next_block_scheduling_hints()` — staging slot consumed and cleared by `_map_task` after each yield, so a stale value can't silently mis-tag later blocks.
- `RefBundle.scheduling_hints` accessor — parallel list to `block_refs` / `metadata`, returns the per-block forecasts.

Plumbing:
- `_map_task` reads the staged hints, attaches them to the ``BlockMetadataWithSchema`` it pickles per yield.
- `PhysicalOperator` driver-side bundle assembly lifts hints from BMWS into `BlockEntry.scheduling_hints` so consumers see them via the bundle's accessor.

This PR ships the infra only — no operator currently stages or reads hints. The Download operator wires producer (file-size totals → memory forecast) and consumer (bundle hint sum → per-task `memory` resource) in a follow-on PR.