### PR TITLE
[Docs] Add a documentation style and grammar guide for contributors and agents

### DIFF
--- a/doc/.claude/rules/prose-style.md
+++ b/doc/.claude/rules/prose-style.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "doc/source/**/*.md"
+  - "doc/source/**/*.rst"
+---
+<!-- Prose style for Ray documentation. -->
+<!-- Source of truth: doc/source/ray-contribute/writing-style.md — read it before writing or editing docs prose. -->
+<!-- These bullets are the highest-frequency corrections; the full guide is broader. -->
+
+- Read `doc/source/ray-contribute/writing-style.md` before writing or editing docs prose. It's the source of truth and supersedes prior style guidance.
+- Active voice with a named actor. Present tense. Second person ("you"). Imperative for instructions.
+- No first-person plural. Rewrite to remove "we" and "our"; use "The Ray project" only when a subject is unavoidable.
+- Use contractions (don't, isn't, can't), except in warnings and error messages.
+- "such as," not "like," for examples. "ID," not "id," in prose. Plain words: "use" (not utilize/leverage), "through" (not via), "before" (not prior to).
+- Cut filler: simply, just, basically, actually, really, very. Cut time-relative words: currently, now, recently, new.
+- Sentence-case headings; imperative for tasks, questions for concepts.
+- Short sentences. No dashes, parentheticals, or semicolons in prose. A colon only introduces a list or code block.
+- List items that are sentences or contain verbs get periods. Lead-ins are complete sentences ending in a colon.
+- MyST admonitions (`:::{note}`, `:::{warning}`), not bold inline labels. Tag code blocks with a language; no `$` prompt.
+- Cross-references: `{doc}` for whole pages (required when the target source is `.rst`), `{ref}` for labeled targets, `[text](page.md)` between `.md` pages.
+- Never fabricate technical details. Every technical claim needs a verifiable source: the docs, the source code, or a config file. When you can't verify a detail, leave it out.

--- a/doc/.cursor/rules/ray-docs-style.mdc
+++ b/doc/.cursor/rules/ray-docs-style.mdc
@@ -4,168 +4,45 @@ alwaysApply: true
 path: doc/**/*
 ---
 
-# Ray Documentation Style Guide
+# Ray documentation style
 
-These rules apply ONLY to documentation files in the `/doc` directory for the Ray project, not to the codebase. They're based on Google Developer Documentation Style Guide with Ray-specific adaptations for Sphinx/reStructuredText.
+The full style and grammar standard for Ray docs is `doc/source/ray-contribute/writing-style.md`. Read it before writing or editing any file under `doc/`. It's the source of truth and supersedes prior style guidance. It builds on the Google developer documentation style guide as a fallback.
 
-## Voice and Grammar
+The rules below are the highest-frequency corrections. The full guide covers word choice, sentence structure, links, admonitions, tables, and human-writing patterns in depth.
 
-### Use active voice
-- ✅ "The system retries failed tasks"
-- ✅ "Ray Serve supports only synchronous handlers"
-- ✅ "You can configure the adapter"
-- ❌ "Failed tasks are retried by the system"
-- ❌ "Synchronous handlers are supported"
-- ❌ "The adapter can be configured"
+## Voice
 
-### Always use contractions
-Use contractions to create a conversational tone:
-- don't (not "do not")
-- doesn't (not "does not")
-- can't (not "cannot")
-- won't (not "will not")
-- isn't (not "is not")
-- aren't (not "are not")
-- it's (not "it is" when meaning "it is")
+- Active voice with a named actor: "The scheduler retries failed tasks," not "Failed tasks are retried."
+- Present tense, second person ("you"), imperative for instructions.
+- No first-person plural. Rewrite to remove "we" and "our." Use "The Ray project" only when a subject is unavoidable.
 
-**Exception**: Don't use contractions in formal warnings or error messages.
+## Word choice
 
-### Avoid timeless writing pitfalls
-- Remove "currently," "now," "recently," "at this time"
-- ✅ "Ray Serve supports only synchronous handlers"
-- ❌ "Ray Serve currently supports only synchronous handlers"
+- Use contractions (don't, isn't, can't), except in warnings and error messages.
+- "such as," not "like," for examples.
+- Cut filler: simply, just, basically, actually, really, very.
+- Plain words: "use" (not utilize or leverage), "to" (not in order to), "through" (not via), "before" (not prior to).
+- "ID," not "id," in prose.
+- No time-relative words: currently, now, recently, new.
+- Angle-bracket placeholders (`<head-node-ip>`), not UPPERCASE.
 
-## Headings and Structure
+## Headings
 
-### Use sentence case for all headings
-- ✅ `## Dead letter queues (DLQs)`
-- ✅ `## Why asynchronous inference?`
-- ✅ `## End-to-end example: Document indexing`
-- ❌ `## Dead Letter Queues (DLQs)`
-- ❌ `## Why Asynchronous Inference?`
+- Sentence case: "Configure the runtime environment," not "Configure the Runtime Environment."
+- Imperative for task headings, questions for conceptual headings.
 
-### Use imperative mood for procedural headings
-- ✅ `## Configure authentication`
-- ✅ `## Submit tasks from outside Serve`
-- ❌ `## Configuring authentication`
-- ❌ `## How to submit tasks`
+## Structure and formatting
 
-## Code Examples
+- Short sentences. No dashes, parentheticals, or semicolons in prose. A colon only introduces a list or code block.
+- List items that are complete sentences or contain verbs get periods. Lead-ins are complete sentences ending in a colon.
+- MyST admonitions (`:::{note}`, `:::{warning}`), not bold inline labels.
+- Tag code blocks with a language. No `$` shell prompt. Code comments start capitalized and use the imperative.
+- Reserve bold for UI elements, admonition labels, and definition-list terms. Italicize a term on first use.
 
-### Use complete sentences for code lead-ins
-Replace generic "Example:" with complete descriptive sentences:
-- ✅ "The following example shows how to configure the Celery adapter:"
-- ✅ "The following code creates a task consumer:"
-- ✅ "This example demonstrates how to enqueue tasks from external code:"
-- ✅ "The following is an example Celery adapter configuration:"
-- ❌ "Example:"
-- ❌ "To configure the Celery adapter:"
-- ❌ "Here's how to create a task consumer:"
+## Cross-references
 
-### Keep code comments concise and clear
-- Start comments with capital letters
-- Use imperative mood in comments
-- ✅ `# Configure the task processor`
-- ✅ `# Your implementation`
-- ❌ `# this configures the task processor`
-- ❌ `# you should implement this`
+- `{doc}` for whole pages (required when the target's source is `.rst`), `{ref}` for labeled targets, `[text](page.md)` between `.md` pages.
 
-## Word Choice
+## Never fabricate technical details
 
-### Never use "like" for examples
-- ✅ "such as Celery"
-- ✅ "for example, video processing"
-- ✅ "including Redis and RabbitMQ"
-- ❌ "like Celery"
-- ❌ "e.g., video processing"
-
-### Use "ID" not "id" or "identity" in prose
-- ✅ "task ID"
-- ✅ "returns TaskResult with ID"
-- ❌ "task id"
-- ❌ "task identity"
-
-### Prefer simple prepositions
-- ✅ "through" (not "via")
-- ✅ "with" (not "using" when possible)
-- ✅ "for" (not "in order to")
-
-## Lists and Punctuation
-
-### End list items with periods when they're sentences or contain verbs
-- Complete sentences always get periods.
-- Fragments with verbs get periods.
-- Brief noun phrases don't need periods
-
-### Use colons correctly for lists
-When introducing a list with a complete sentence, use a colon:
-- ✅ "Dead letter queues handle two types of problematic tasks:"
-- ✅ "Recommendations:"
-
-## Ray-Specific Conventions
-
-### Component capitalization
-- Ray Serve (always capitalized)
-- Ray Data
-- Ray Train
-- Ray Core
-
-### Use Sphinx directives (not Markdown)
-Since Ray uses Sphinx with reStructuredText:
-- Use `:::{note}` instead of Markdown blockquotes
-- Use `:::{warning}` for warnings
-- Use `:doc:` and `:ref:` for cross-references
-
-### Technical terms
-These are valid technical terms (not typos):
-- Transcoding
-- Pluggable
-- enqueues/enqueue
-- Unprocessable
-- DLQ/DLQs (after first defining "Dead letter queues")
-- broker (lowercase)
-- adapter (lowercase)
-
-## Examples and Descriptions
-
-### Write clear, scannable introductions
-Start sections with what the feature/component does:
-- ✅ "Configuration for the Celery adapter, including broker and backend URLs and worker settings."
-- ❌ "This is the configuration for the Celery adapter."
-
-### Focus on user actions
-Frame documentation around what users can do:
-- ✅ "You can enqueue tasks from external producers"
-- ✅ "To manage concurrency, configure..."
-- ❌ "Tasks can be enqueued from external producers"
-- ❌ "Concurrency is managed by configuring..."
-
-## Common Patterns to Apply
-
-### When describing system behavior
-- Use "the system" as the actor for automated processes
-- ✅ "The system routes failed tasks to the DLQ"
-- ❌ "Failed tasks are routed to the DLQ"
-
-### When describing user capabilities
-- Use "you" directly
-- ✅ "You can configure multiple adapters"
-- ❌ "Multiple adapters can be configured"
-- ❌ "Users can configure multiple adapters"
-
-### When describing features
-- State what Ray Serve does, not what it supports
-- ✅ "Ray Serve processes tasks asynchronously"
-- ❌ "Asynchronous task processing is supported"
-
-## Quick Checklist
-
-Before committing documentation:
-- [ ] All headings use sentence case
-- [ ] Contractions used throughout (except warnings)
-- [ ] No passive voice constructions
-- [ ] Code examples have action-oriented lead-ins
-- [ ] No "currently" or other time-sensitive words
-- [ ] "such as" used instead of "like" for examples
-- [ ] Active voice with clear actors (you, the system, Ray Serve)
-- [ ] Technical terms are used consistently
+Every technical claim needs a verifiable source: the existing docs, the source code, or a config file. When you can't verify a detail, leave it out.

--- a/doc/source/ray-contribute/docs.md
+++ b/doc/source/ray-contribute/docs.md
@@ -13,15 +13,9 @@ This document walks you through everything you need to do to get started.
 
 ## Editorial style
 
-We follow the [Google developer documentation style guide](https://developers.google.com/style). Here are some highlights:
+The Ray documentation follows a house style guide that covers voice, word choice, sentence structure, headings, lists, links, and formatting. Read it before you write or edit a page. See {ref}`documentation-style`.
 
-* [Use present tense](https://developers.google.com/style/tense)
-* [Use second person](https://developers.google.com/style/person)
-* [Use contractions](https://developers.google.com/style/contractions)
-* [Use active voice](https://developers.google.com/style/voice)
-* [Use sentence case](https://developers.google.com/style/capitalization)
-
-Vale enforces the editorial style in CI. For more information, see [How to use Vale](vale).
+The house guide builds on the [Google developer documentation style guide](https://developers.google.com/style), which is the fallback for anything the house guide doesn't cover. Vale enforces an automated subset of the Google guide in CI. For more information, see [How to use Vale](vale).
 
 ## Building the Ray documentation
 

--- a/doc/source/ray-contribute/getting-involved.md
+++ b/doc/source/ray-contribute/getting-involved.md
@@ -18,6 +18,7 @@ myst:
 development
 ci
 docs
+writing-style
 writing-code-snippets
 fake-autoscaler
 testing-tips

--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -1,0 +1,343 @@
+---
+myst:
+  html_meta:
+    description: "The Ray documentation style and grammar guide: voice, word choice, sentence structure, headings, lists, links, admonitions, and MyST formatting conventions. Read this before writing or editing Ray documentation, whether you're a human contributor or an AI coding agent."
+---
+
+(documentation-style)=
+
+# Ray documentation style guide
+
+This page is the style and grammar standard for the Ray documentation. It covers how to write Ray docs: voice, word choice, sentence structure, headings, lists, links, admonitions, and MyST formatting. Read it before you write or edit a page, then apply it as you go.
+
+The guidance here is for everyone who writes Ray docs, including AI coding agents. When an agent edits documentation under `doc/source/`, it follows this guide. See {ref}`agent-development` for how the repository configures AI coding agents.
+
+## How to use this guide
+
+When two rules conflict, follow this order:
+
+1. This guide.
+1. The [Google developer documentation style guide](https://developers.google.com/style), as the general fallback for anything this guide doesn't cover.
+
+Vale enforces an automated subset of the Google style guide in CI, currently on the Ray Data docs and the example gallery. Passing Vale is the baseline, not the whole standard. This guide is broader than what Vale checks, so a page can pass Vale and still need edits to meet the standard here. For how to run Vale, see {ref}`vale`.
+
+New pages are MyST Markdown (`.md`). A lint check rejects newly added reStructuredText (`.rst`) files, though edits to existing `.rst` files are fine. The examples in this guide use MyST. The prose rules apply to both formats. Only the formatting and cross-reference syntax differs.
+
+## Voice and grammar
+
+### Write in active voice
+
+Name the actor and put it in front of the verb. Passive voice hides who does what.
+
+- Use: "The scheduler retries failed tasks."
+- Not: "Failed tasks are retried by the scheduler."
+
+Keep passive voice when the object is the real focus, when the actor is unknown, or when naming the actor adds nothing. "The object is spilled to disk" is fine when the point is what happens to the object, not what spills it.
+
+### Write in present tense
+
+Describe current behavior in the present tense. Avoid "will" for things that are always true.
+
+- Use: "Ray Serve routes the request to a replica."
+- Not: "Ray Serve will route the request to a replica."
+
+### Address the reader as "you"
+
+Write in second person. Don't write about "the user" or "developers" in the abstract.
+
+- Use: "You can configure the number of replicas."
+- Not: "Users can configure the number of replicas."
+
+### Use the imperative for instructions
+
+Write steps and commands as direct instructions.
+
+- Use: "Set `num_cpus` to reserve cores for the task."
+- Not: "You should set `num_cpus` to reserve cores for the task."
+
+### Avoid first-person plural
+
+Don't write "we," "our," or "let's." Rewrite the sentence to remove the first person. Address the reader with "you" or the imperative, or make the feature the subject. When a sentence genuinely needs a subject that acts on behalf of the project, use "The Ray project" or the relevant component.
+
+- Use: "Ray tests every code snippet in the documentation." Not: "We test every code snippet."
+- Use: "To build the docs, follow these steps:" Not: "Let's build the docs."
+- Use: "The Ray project welcomes contributions of all kinds." Not: "We welcome all contributions."
+
+### Capitalize Ray components and product names
+
+Capitalize Ray and its libraries: Ray, Ray Core, Ray Data, Ray Serve, Ray Train, Ray Tune, RLlib. Capitalize other proper nouns: Python, Sphinx, AWS, GCP, Kubernetes. Lowercase generic nouns even when they name a Ray concept: task, actor, object, cluster, worker, node, placement group.
+
+### Define acronyms on first use
+
+Spell out the full term the first time, with the acronym in parentheses: "reinforcement learning (RL)." Use the acronym consistently afterward. Don't redefine it later on the same page.
+
+### Keep comparisons precise
+
+State what's better and by what measure. Vague comparisons read as marketing.
+
+- Use: "Streaming execution uses less memory than materializing the full dataset."
+- Not: "Streaming execution is better."
+
+### Keep parallel structure
+
+Match the grammatical form of items in a series and avoid redundant conjunctions.
+
+- Use: "This preserves throughput while reducing memory usage."
+- Not: "This preserves throughput and can also reduce memory usage."
+
+## Word choice
+
+### Use contractions
+
+Contractions read naturally: don't, doesn't, can't, won't, it's, you're, isn't, aren't, wouldn't, shouldn't. Avoid contractions in a warning or an error message, where the extra weight of the full form helps.
+
+Never use "would've," "could've," "should've," "ain't," or "y'all."
+
+### Use "such as," not "like," for examples
+
+Reserve "like" for genuine comparisons.
+
+- Use: "distributed frameworks such as Ray"
+- Not: "distributed frameworks like Ray"
+- Fine: "The API behaves like a Python dictionary." (a real comparison)
+
+### Cut qualifiers and filler
+
+Delete words that add no information: simply, just, basically, actually, really, very, quite, easily, of course, obviously, clearly, note that. Also drop the sentiment adverbs "luckily," "fortunately," and "unfortunately."
+
+- Use: "Call `ray.get` to retrieve the result."
+- Not: "You can simply just call `ray.get` to retrieve the result."
+
+### Prefer plain words
+
+Choose the simpler word.
+
+- "utilize" or "leverage" → "use"
+- "in order to" → "to"
+- "prior to" → "before"
+- "due to the fact that" → "because"
+- "via" → "through" or "with"
+
+### Turn hedging into direct advice
+
+Recommend directly. Don't soften real guidance into a suggestion.
+
+- "Prefer X" → "Use X"
+- "Consider using X" → "Use X"
+- "You might want to enable caching" → "Enable caching."
+
+Keep "might," "can," or "may" when they express genuine possibility, as in "The build might fail if the network is unstable."
+
+### Focus on what the reader does
+
+Avoid "lets," "allows," and "enables." They describe what the product permits instead of what the reader accomplishes.
+
+- Use: "Scale a deployment by adding replicas."
+- Not: "Ray Serve lets you scale a deployment."
+
+### Streamline references
+
+- "Please refer to" → "See"
+- "Refer to the configuration guide" → "See the configuration guide"
+- "Check the API documentation" → "See the API documentation"
+
+### Write "ID," not "id"
+
+In prose, write "ID" (or "IDs"). Reserve `id` for code, where it's a literal identifier.
+
+- Use: "Ray assigns each task a task ID."
+- Not: "Ray assigns each task a task id."
+
+### Use words for symbols in prose
+
+Outside code, spell out operators and separators.
+
+- "X + Y" → "X and Y"
+- "X vs. Y" → "X versus Y"
+- "X/Y" → "X or Y" or "X and Y"
+
+### Don't write "etc." after "such as," "for example," or "including"
+
+Those phrases already signal a partial list. Give specific examples, or end with "and more" if you must.
+
+### Avoid time-relative words
+
+Words such as "currently," "recently," "new," "now," and "at this time" go stale as Ray evolves. Remove them, or replace them with a specific version when the timing matters.
+
+- Use: "Ray Serve supports synchronous handlers." Or: "As of Ray 2.9, Ray Serve supports asynchronous handlers."
+- Not: "Ray Serve currently supports synchronous handlers."
+
+### Use angle brackets for placeholders
+
+Mark values the reader replaces with angle brackets, not uppercase.
+
+- Use: `ray start --address=<head-node-ip>:6379`
+- Not: `ray start --address=HEAD_NODE_IP:6379`
+
+Uppercase placeholders are ambiguous with real constants and environment variables.
+
+## Sentence structure
+
+Prefer short, direct sentences. Split a long sentence into two rather than joining clauses with punctuation.
+
+Avoid dashes (`--`, em dashes, en dashes), parentheticals, and semicolons in prose. Restructure instead. Use a colon only to introduce a list or a code block.
+
+- Use: "Ray splits the nodes into two groups: spot and on-demand. Ray ranks on-demand above spot."
+- Not: "Ray splits the nodes into two groups -- spot and on-demand -- and ranks them (on-demand first)."
+
+## Headings
+
+Use sentence case for every heading. Capitalize only the first word and proper nouns.
+
+- Use: "Configure the runtime environment"
+- Not: "Configure the Runtime Environment"
+
+Write conceptual headings as questions and task headings as imperatives. Keep them short.
+
+- Conceptual: "What is a placement group?"
+- Task: "Launch a cluster on AWS"
+- Too long: "Understanding the fundamentals of placement groups" → "Placement group basics"
+
+Don't stack heading levels without prose between them. A section heading that introduces subsections needs a lead-in paragraph first. Avoid nesting beyond the fourth level; reaching that depth usually means the page should be split.
+
+## Lists and punctuation
+
+Use a list to enumerate things, map topics to pages, or present a scannable reference. Don't use a list to explain how something works or to sell benefits. Fold that into prose.
+
+End a list item with a period when it's a complete sentence or contains a verb. Leave brief noun phrases unpunctuated. Be consistent within a single list.
+
+Write list lead-ins as complete sentences, and end them with a colon.
+
+- Use: "To invite users, do the following:"
+- Not: "To invite users:"
+
+Use the Oxford comma: "tasks, actors, and objects."
+
+When you name a fixed set, state the count: "Ray offers two scheduling strategies:" rather than "Ray offers several scheduling strategies:".
+
+In Markdown, number every ordered-list item `1.`. MyST renders them in source order, so writing `1.` throughout means inserting or reordering a step is a one-line edit instead of a renumber pass.
+
+## Formatting
+
+### Admonitions
+
+Use MyST admonitions for asides, not bold inline labels. Ray uses `note`, `tip`, `warning`, `caution`, and `important`:
+
+````markdown
+:::{note}
+Ray caches the object in the local object store.
+:::
+````
+
+Choose the level by severity. Use `tip` for optional advice, `note` for supporting information, `caution` for something that needs care, and `warning` for an action that can lose data or break a workload. Convert a standalone caveat or limitation into the matching admonition so it stands out instead of hiding in a paragraph.
+
+### Code blocks
+
+Tag every fenced code block with a language: `python`, `bash`, `yaml`, `json`, `text`, or `dockerfile`. Don't prefix shell commands with `$` or `#`, so readers can copy and paste them.
+
+Every runnable snippet in the docs is tested. Write examples that run out of the box, and use `literalinclude` or a testable code cell rather than pasting untested code. See {ref}`How to write code snippets <writing-code-snippets_ref>`.
+
+In code comments, start with a capital letter and use the imperative.
+
+- Use: `# Reserve two GPUs for the actor.`
+- Not: `# this reserves two gpus`
+
+### Bold and italics
+
+Italicize a term when you first define it. Reserve bold for three uses: the name of a UI element (a button, menu, tab, or field), the short lead-in label of an admonition, and the term in a bold definition list (`**Term**: explanation`).
+
+Don't bold ordinary prose for emphasis, and don't bold inline code. Code styling already sets it apart. Pervasive bold reads as shouting.
+
+- Use: "supports capacity reservations, spot instances, and on-demand instances"
+- Not: "supports **capacity reservations**, **spot instances**, and **on-demand instances**"
+
+### Tables
+
+Use a Markdown table for simple rows with single-line cells. Always include a header row, and introduce the table with a sentence of prose. For cells that hold code blocks, multiple lines, or other complex content, use the `list-table` directive:
+
+````markdown
+:::{list-table} Scheduling strategies
+:header-rows: 1
+
+* - Strategy
+  - Behavior
+* - `DEFAULT`
+  - Packs tasks onto the fewest nodes.
+* - `SPREAD`
+  - Spreads tasks across available nodes.
+:::
+````
+
+## Links and cross-references
+
+Ray docs use Sphinx cross-references, which resolve at build time and survive page moves. Prefer them over hardcoded URLs to other docs pages.
+
+- Link to a whole page with the `{doc}` role: `` {doc}`writing-code-snippets` ``. Use `{doc}` when the target's source is `.rst`. A bare `[text](path.md)` link to an `.rst` source emits `myst.xref_missing`, which fails the build.
+- Link to a labeled target with the `{ref}` role: `` {ref}`vale` `` or `` {ref}`custom text <vale>` ``. Define the target with a MyST label on the line above the heading:
+
+  ```markdown
+  (my-label)=
+  ## The section to link
+  ```
+
+- Link between `.md` pages with a standard Markdown link: `[text](other-page.md)`.
+- Link to the API reference with autodoc cross-reference roles, such as `` {py:func}`ray.init` `` or `` {py:class}`ray.data.Dataset` ``.
+
+Write descriptive link text that says where the link goes. Don't write "click [here](path)." Wrap external URLs in Markdown; don't paste a bare URL into prose.
+
+Link to a given page once per section. Repeating a link in a later section is fine when readers might enter the page at different points. For a cluster of related links, gather them under a "See also" list at the end of the section.
+
+## MyST and Markdown specifics
+
+### Soft-wrap prose
+
+Write one logical line per paragraph and list item, and let your editor wrap the display. Don't hard-wrap prose at a fixed column. One paragraph is one source line, however long. Hard wrapping makes diffs noisy and edits awkward.
+
+### Front matter
+
+Give every page a `description` in its MyST `html_meta` front matter. Search engines and the page's social preview use it:
+
+```markdown
+---
+myst:
+  html_meta:
+    description: "One or two sentences describing what the page covers."
+---
+```
+
+### Numbers and units
+
+Spell out zero through nine in prose. Use numerals for 10 and above. Don't wrap a single-digit number in backticks when it carries a unit: write "1 GiB," not "`1` GiB." Use backticks for configuration values, as in `num_replicas: 1`.
+
+### Alt text
+
+Give every image descriptive alt text that says what the image shows. Don't write "screenshot of..." or "image of...".
+
+### HTML comments
+
+Preserve existing HTML comments that read as author notes. They're working notes contributors leave for each other across revisions. Don't remove or reword them as part of an unrelated edit.
+
+## Write for humans
+
+Documentation should read as though a person wrote it, because a person should have.
+
+- Vary your sentence and list structure. Don't produce perfectly symmetrical bullet lists where every item has the same shape and length.
+- Explain how something works in prose, not a numbered list. Reserve numbered lists for sequential steps.
+- Cut benefits lists. If a feature is worth recommending, recommend it directly. Don't follow "This approach provides:" with a list of adjectives.
+- Skip opening previews. Don't open a section with a bullet list that restates the headings below it. Start with substance.
+- Open a page with one or two sentences that say what it covers, then get into the content.
+
+## Don't fabricate technical details
+
+Every technical claim needs a verifiable source: existing Ray documentation, the source code, a configuration file, or something the contributor gives you. Don't invent behavior from what seems plausible, extrapolate implementation details from a feature name, or guess at metrics, defaults, or version cutoffs.
+
+When you can't verify a detail, leave it out. Incomplete but accurate documentation beats complete but partly fabricated documentation. This matters most for AI agents, which can produce fluent, confident prose that's wrong. Fabrication is the most damaging error in documentation.
+
+## Choosing a format
+
+Pick the format that makes the information easiest to extract:
+
+- Enumerating distinct things, such as options or components, is a list.
+- Explaining what something is or how it works is prose.
+- Mapping topics to pages, or comparing options side by side, is a table.
+- Listing benefits is usually a cut. Fold the one point that matters into prose.

--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -283,7 +283,7 @@ Ray docs use Sphinx cross-references, which resolve at build time and survive pa
 - Link between `.md` pages with a standard Markdown link: `[text](other-page.md)`.
 - Link to the API reference with autodoc cross-reference roles, such as `` {py:func}`ray.init` `` or `` {py:class}`ray.data.Dataset` ``.
 
-Write descriptive link text that says where the link goes. Don't write "click [here](path)." Wrap external URLs in Markdown; don't paste a bare URL into prose.
+Write descriptive link text that says where the link goes. Don't write `click [here](path).` Wrap external URLs in Markdown; don't paste a bare URL into prose.
 
 Link to a given page once per section. Repeating a link in a later section is fine when readers might enter the page at different points. For a cluster of related links, gather them under a "See also" list at the end of the section.
 


### PR DESCRIPTION
## Why are these changes needed?

The Ray documentation had no single prose style standard. Guidance was thin and scattered across three surfaces that didn't agree:

- `docs.md` linked to the Google developer style guide with five highlight bullets.
- A Cursor rule (`doc/.cursor/rules/ray-docs-style.mdc`) carried a partial style guide that had accumulated topic-specific leftovers.
- AI coding agents using Claude Code had no prose guidance at all.

This PR establishes a single source of truth and points every surface at it.

**New canonical guide.** `doc/source/ray-contribute/writing-style.md` covers voice, word choice, sentence structure, headings, lists, links, admonitions, tables, and MyST formatting, with the Google developer documentation style guide as the fallback for anything it doesn't cover. It's written for both human contributors and AI coding agents.

**Wiring:**

- `docs.md` "Editorial style" now points to the new guide.
- `getting-involved.md` toctree includes the new page.
- `doc/.cursor/rules/ray-docs-style.mdc` slims to a high-frequency subset plus a pointer to the full guide.
- `doc/.claude/rules/prose-style.md` (new) gives Claude Code agents parity with Cursor, scoped to `doc/source` Markdown and rST.

**Note on scope:** this PR touches AI agent configuration (`.cursor` and `.claude`) so that both agent surfaces reference the same standard as the published guide.

**Not in this PR:** Vale runs in CI only on `doc/source/data` and the example gallery. Broadening prose enforcement is a separate, reviewer-sensitive change.

## Related issue number

None.

## Checks

- [x] I've signed off every commit (`git commit -s`) to meet the DCO requirement.
- [x] I've made sure the tests are passing. This is a docs-only change; the Read the Docs build validates it.
- [x] Testing strategy: the Read the Docs build (`fail_on_warning`) is the gate for cross-references and toctree wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
