### PR TITLE
[core] Exclude ray_syncer_io_context from health check and raise probe deadline to 30s

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -631,7 +631,7 @@ RAY_CONFIG(int64_t, io_context_monitor_probe_interval_ms, 1000)
 
 /// If a probe has been outstanding longer than this, the io_context is marked
 /// unhealthy.
-RAY_CONFIG(int64_t, io_context_monitor_healthy_deadline_ms, 5000)
+RAY_CONFIG(int64_t, io_context_monitor_healthy_deadline_ms, 30000)
 
 /// Sliding window over which the max probe latency is tracked and exported. The
 /// Prometheus metrics scrape interval is usually 15s; we exceed it so that the

--- a/src/ray/gcs/gcs_server_io_context_policy.h
+++ b/src/ray/gcs/gcs_server_io_context_policy.h
@@ -89,7 +89,7 @@ struct GcsServerIOContextPolicy {
        /*used_for_health_check=*/false},
       {"ray_syncer_io_context",
        /*enable_lag_probe=*/true,
-       /*used_for_health_check=*/true},
+       /*used_for_health_check=*/false},
       {"ray_event_io_context",
        /*enable_lag_probe=*/true,
        /*used_for_health_check=*/false},

--- a/src/ray/gcs/tests/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/tests/gcs_server_rpc_test.cc
@@ -70,6 +70,8 @@ class GcsServerTest : public ::testing::Test {
   virtual ~GcsServerTest() { TestSetupUtil::ShutDownRedisServers(); }
 
   void SetUp() override {
+    RayConfig::instance().io_context_monitor_healthy_deadline_ms() = 5000;
+
     gcs::GcsServerConfig config;
     config.grpc_server_port = 0;
     config.grpc_server_name = "MockedGcsServer";


### PR DESCRIPTION
## Description

Two changes to how the io_context monitor drives the health check:

- `io_context_monitor_healthy_deadline_ms`: 5s -> 30s. 5s might be too tight.
- `ray_syncer_io_context` no longer gates the serving status. In a large Ray cluster (e.g. 10k nodes), the syncer has to process resource views from 10k nodes and fan each update out to the other 9999, which can be extremely slow. It is not harmful enough that the whole GCS should be marked NOT_SERVING.

Excluded contexts are still probed and still emit the deadline warning and latency/unhealthy metrics; only the aggregate serving status skips them.



See context in: https://anyscaleteam.slack.com/archives/C0A0SKA55FY/p1783016132492409?thread_ts=1782774966.829129&cid=C0A0SKA55FY