### PR TITLE
[Serve] Fix serve.ingress with include_router on FastAPI >= 0.137

### DIFF
--- a/python/ray/llm/_internal/serve/observability/metrics/middleware.py
+++ b/python/ray/llm/_internal/serve/observability/metrics/middleware.py
@@ -1,10 +1,9 @@
 import time
 from asyncio import CancelledError
-from typing import Dict
+from typing import Dict, Optional
 
 from fastapi import FastAPI
 from starlette.requests import Request
-from starlette.routing import Match
 from starlette.types import Message
 
 from ray.llm._internal.serve.core.ingress.middleware import (
@@ -21,6 +20,7 @@ from ray.llm._internal.serve.observability.metrics.fastapi_utils import (
     FASTAPI_HTTP_USER_ID_TAG_KEY,
     get_app_name,
 )
+from ray.serve._private.thirdparty.get_asgi_route_name import _get_route_name
 
 logger = get_logger("ray.serve")
 
@@ -114,7 +114,7 @@ class MeasureHTTPRequestMetricsMiddleware:
                 )
 
 
-def _get_route_details(scope: dict) -> str:
+def _get_route_details(scope: dict) -> Optional[str]:
     """
     Function to retrieve Starlette route from scope.
     TODO: there is currently no way to retrieve http.route from
@@ -125,17 +125,11 @@ def _get_route_details(scope: dict) -> str:
     Returns:
         A string containing the route or None
     """
-    app = scope["app"]
-    route = None
-
-    for starlette_route in app.routes:
-        match, _ = starlette_route.matches(scope)
-        if match == Match.FULL:
-            route = starlette_route.path
-            break
-        if match == Match.PARTIAL:
-            route = starlette_route.path
-    return route
+    # Delegate to Serve's shared route-name resolver, which walks the route tree
+    # and handles FastAPI >= 0.137 `_IncludedRouter` nodes (added by
+    # `include_router`) that have no `.path` attribute of their own. Accessing
+    # `.path` on such a node previously raised AttributeError here (#64245).
+    return _get_route_name(scope, scope["app"].routes)
 
 
 def _get_tags(request: Request, status_code: int, app: FastAPI) -> Dict[str, str]:

--- a/python/ray/llm/tests/serve/cpu/observability/test_metrics_middleware.py
+++ b/python/ray/llm/tests/serve/cpu/observability/test_metrics_middleware.py
@@ -1,0 +1,64 @@
+"""Tests for the LLM Serve metrics middleware route resolution."""
+import sys
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from ray.llm._internal.serve.observability.metrics.middleware import (
+    _get_route_details,
+)
+
+
+def _scope(
+    path: str, method: str = "GET", scope_type: str = "http", root_path: str = ""
+):
+    return {
+        "type": scope_type,
+        "method": method,
+        "path": path,
+        "headers": [],
+        "app": None,  # set by caller
+        "path_params": {},
+        "root_path": root_path,
+    }
+
+
+def test_get_route_details_include_router():
+    """Routes added via `include_router` must resolve without crashing (#64245).
+
+    On FastAPI >= 0.137 these routes are nested under an `_IncludedRouter` node
+    that has no `.path` attribute; accessing it previously raised
+    ``AttributeError: '_IncludedRouter' object has no attribute 'path'``.
+    """
+    app = FastAPI()
+
+    @app.get("/direct")
+    def direct():
+        return {}
+
+    router = APIRouter(prefix="/api")
+
+    @router.get("/items/{item_id}")
+    def get_item(item_id: str):
+        return item_id
+
+    app.include_router(router)
+
+    # Directly decorated route.
+    scope = _scope("/direct")
+    scope["app"] = app
+    assert _get_route_details(scope) == "/direct"
+
+    # Route registered via include_router (the #64245 regression).
+    scope = _scope("/api/items/123")
+    scope["app"] = app
+    assert _get_route_details(scope) == "/api/items/{item_id}"
+
+    # Unmatched path resolves to None (unchanged behavior).
+    scope = _scope("/does-not-exist")
+    scope["app"] = app
+    assert _get_route_details(scope) is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -24,12 +24,21 @@ import starlette
 import uvicorn
 from fastapi import FastAPI
 from fastapi.encoders import jsonable_encoder
+from fastapi.routing import APIRoute, APIWebSocketRoute
 from packaging import version
 from starlette.datastructures import MutableHeaders
 from starlette.middleware import Middleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from uvicorn.config import Config
 from uvicorn.lifespan.on import LifespanOn
+
+try:
+    # `_IncludedRouter` only exists on FastAPI >= 0.137, where routes registered
+    # via `include_router` are nested under it instead of being flattened into
+    # the parent's `routes` list. It is `None` on older versions.
+    from fastapi.routing import _IncludedRouter
+except ImportError:  # FastAPI < 0.137
+    _IncludedRouter = None
 
 from ray._common.network_utils import is_ipv6
 from ray.exceptions import RayActorError, RayTaskError
@@ -419,6 +428,33 @@ class ASGIReceiveProxy:
         return message
 
 
+def _walk_fastapi_routes(router, prefix: str = ""):
+    """Yield ``(route, parent_router, prefix)`` for every API route under ``router``.
+
+    Starting with FastAPI 0.137, ``include_router`` no longer flattens the
+    included routes into the parent's ``routes`` list. Instead it appends a
+    single ``_IncludedRouter`` node that holds a reference to the original
+    router (``route.original_router``) and resolves the child routes lazily at
+    request time. We recurse into those nodes so that routes registered via
+    ``include_router`` (e.g. vLLM's OpenAI-compatible endpoints) are still
+    discovered. On older FastAPI versions ``_IncludedRouter`` doesn't exist and
+    this simply iterates the flat ``routes`` list.
+
+    ``prefix`` is the URL prefix accumulated from the ``include_router(...,
+    prefix=...)`` calls above this route. When a prefix is supplied at include
+    time (rather than baked into an ``APIRouter(prefix=...)``), FastAPI >= 0.137
+    keeps it on the ``_IncludedRouter`` node instead of in the route's own
+    ``path``, so callers need it to reconstruct the absolute path.
+    """
+    for route in router.routes:
+        if isinstance(route, (APIRoute, APIWebSocketRoute)):
+            yield route, router, prefix
+        elif _IncludedRouter is not None and isinstance(route, _IncludedRouter):
+            yield from _walk_fastapi_routes(
+                route.original_router, prefix + route.include_context.prefix
+            )
+
+
 def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     """Transform the `cls`'s methods and class annotations to FastAPI routes.
 
@@ -438,20 +474,21 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     """
     # Delayed import to prevent ciruclar imports in workers.
     from fastapi import APIRouter, Depends
-    from fastapi.routing import APIRoute, APIWebSocketRoute
+    from starlette.routing import compile_path
 
     async def get_current_servable_instance():
         from ray import serve
 
         return serve.get_replica_context().servable_object
 
-    # Find all the class method routes
+    # Find all the class method routes. We walk the route tree recursively so
+    # that routes registered via `include_router` are discovered on FastAPI
+    # >= 0.137, where they are nested under `_IncludedRouter` nodes rather than
+    # flattened into `fastapi_app.routes`. Each entry keeps the parent router so
+    # the route can be removed from the correct list below.
     class_method_routes = [
-        route
-        for route in fastapi_app.routes
-        if
-        # User defined routes must all be APIRoute or APIWebSocketRoute.
-        isinstance(route, (APIRoute, APIWebSocketRoute))
+        (route, parent, prefix)
+        for route, parent, prefix in _walk_fastapi_routes(fastapi_app)
         # We want to find the route that's bound to the `cls`.
         # NOTE(simon): we can't use `route.endpoint in inspect.getmembers(cls)`
         # because the FastAPI supports different routes for the methods with
@@ -461,7 +498,7 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
         # the parent class (e.g., "ParentClass.method" not "ChildClass.method").
         # We use "ClassName." prefix matching (not substring) to avoid false
         # positives where class "A" would incorrectly match routes from "AA".
-        and any(
+        if any(
             route.endpoint.__qualname__.startswith(base.__qualname__ + ".")
             for base in cls.__mro__
             if base is not object
@@ -473,8 +510,20 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     # the laster fastapi_app.include_router to re-run the dependency analysis
     # for each routes.
     new_router = APIRouter()
-    for route in class_method_routes:
-        fastapi_app.routes.remove(route)
+    for route, parent, prefix in class_method_routes:
+        parent.routes.remove(route)
+
+        # Preserve the full URL path. When a route was registered via
+        # `include_router(..., prefix=...)`, FastAPI >= 0.137 keeps the prefix on
+        # the `_IncludedRouter` node rather than in `route.path`, so re-mounting
+        # the route on `new_router` (which has no prefix) would drop it. Fold the
+        # accumulated prefix back into the route's path before re-mounting.
+        if prefix:
+            full_path = prefix + route.path
+            route.path = full_path
+            route.path_regex, route.path_format, route.param_convertors = compile_path(
+                full_path
+            )
 
         # This block just adds a default values to the self parameters so that
         # FastAPI knows to inject the object when calling the route.
@@ -505,16 +554,13 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
         new_router.routes.append(route)
     fastapi_app.include_router(new_router)
 
-    routes_to_remove = list()
-    for route in fastapi_app.routes:
-        if not isinstance(route, (APIRoute, APIWebSocketRoute)):
-            continue
-
-        # Remove endpoints that belong to other class based views.
+    # Remove endpoints that belong to other class based views. We walk the tree
+    # recursively (see `_walk_fastapi_routes`) so that endpoints nested under
+    # `_IncludedRouter` nodes are also cleaned up on FastAPI >= 0.137.
+    for route, parent, _prefix in list(_walk_fastapi_routes(fastapi_app)):
         serve_cls = getattr(route.endpoint, "_serve_cls", None)
         if serve_cls is not None and serve_cls != cls:
-            routes_to_remove.append(route)
-    fastapi_app.routes[:] = [r for r in fastapi_app.routes if r not in routes_to_remove]
+            parent.routes.remove(route)
 
 
 def set_socket_reuse_port(sock: socket.socket) -> bool:

--- a/python/ray/serve/_private/thirdparty/get_asgi_route_name.py
+++ b/python/ray/serve/_private/thirdparty/get_asgi_route_name.py
@@ -37,6 +37,26 @@ from typing import Dict, List, Optional, Set
 from starlette.routing import Match, Mount, Route
 from starlette.types import ASGIApp, Scope
 
+try:
+    # `_IncludedRouter` only exists on FastAPI >= 0.137, where routes registered
+    # via `include_router` are nested under it instead of being flattened into
+    # the parent's `routes` list. It is `None` on older versions.
+    from fastapi.routing import _IncludedRouter
+except ImportError:  # FastAPI < 0.137
+    _IncludedRouter = None
+
+
+def _included_router_prefix(route: "Route") -> str:
+    """Return the URL prefix an ``_IncludedRouter`` node applies to its routes.
+
+    Accesses ``_IncludedRouter``'s private attributes directly (rather than
+    defensively) so that a structural change in a future FastAPI version raises
+    loudly instead of silently returning a wrong route name. Both callers are
+    wrapped in ``try``/``except`` that fall back to the route prefix and log the
+    error, so a failure here degrades gracefully while staying visible.
+    """
+    return route.include_context.prefix
+
 
 @dataclass(frozen=True)
 class RoutePattern:
@@ -56,6 +76,28 @@ def _get_route_name(
     scope: Scope, routes: List[Route], *, route_name: Optional[str] = None
 ) -> Optional[str]:
     for route in routes:
+        if _IncludedRouter is not None and isinstance(route, _IncludedRouter):
+            # FastAPI >= 0.137: routes added via `include_router` live on
+            # `route.original_router.routes` with paths relative to the include
+            # prefix. Unlike `Mount`, `_IncludedRouter.matches()` doesn't return
+            # a prefix-stripped child scope, so we strip it ourselves and prepend
+            # the prefix back to the resolved child name. This mirrors the Mount
+            # handling below and works for both HTTP and WebSocket routes.
+            prefix = _included_router_prefix(route)
+            path = scope.get("path", "")
+            if prefix:
+                if not path.startswith(prefix):
+                    continue
+                child_scope = {**scope, "path": path[len(prefix) :]}
+            else:
+                child_scope = scope
+            child_route_name = _get_route_name(
+                child_scope, route.original_router.routes
+            )
+            if child_route_name is not None:
+                return prefix + child_route_name
+            continue
+
         match, child_scope = route.matches(scope)
         if match == Match.FULL:
             route_name = route.path
@@ -129,6 +171,16 @@ def extract_route_patterns(app: ASGIApp) -> List[RoutePattern]:
 
     def _extract_from_routes(routes: List[Route], prefix: str = "") -> None:
         for route in routes:
+            if _IncludedRouter is not None and isinstance(route, _IncludedRouter):
+                # FastAPI >= 0.137: recurse into routes registered via
+                # `include_router`, applying the include prefix (see
+                # `_get_route_name` for details).
+                _extract_from_routes(
+                    route.original_router.routes,
+                    prefix + _included_router_prefix(route),
+                )
+                continue
+
             route_path = prefix + route.path
 
             if isinstance(route, Mount):

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -16,6 +16,7 @@ from fastapi import (
     Query,
     Request,
     Response,
+    params as fastapi_params,
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -31,7 +32,10 @@ from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.constants import (
     SERVE_DEFAULT_APP_NAME,
 )
-from ray.serve._private.http_util import make_fastapi_class_based_view
+from ray.serve._private.http_util import (
+    _walk_fastapi_routes,
+    make_fastapi_class_based_view,
+)
 from ray.serve._private.test_utils import get_application_url
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import DeploymentHandle
@@ -123,39 +127,65 @@ def test_class_based_view(serve_instance):
     assert handle.other.remote("world").result() == "world"
 
 
+def _find_route(app, endpoint):
+    """Return the route whose endpoint is ``endpoint``, searching nested routers.
+
+    FastAPI >= 0.137 nests routes registered via ``include_router`` under
+    ``_IncludedRouter`` nodes, so we can't rely on flat ``app.routes`` indexing.
+    """
+    for route, _parent, _prefix in _walk_fastapi_routes(app):
+        if route.endpoint == endpoint:
+            return route
+    raise AssertionError(f"route for {endpoint} not found")
+
+
 @pytest.mark.parametrize("websocket", [False, True])
-def test_make_fastapi_class_based_view(websocket: bool):
+@pytest.mark.parametrize("via_router", [False, True])
+def test_make_fastapi_class_based_view(websocket: bool, via_router: bool):
     app = FastAPI()
+    router = APIRouter(prefix="/prefix")
+    # When `via_router` is set, register the endpoint through `include_router`.
+    # On FastAPI >= 0.137 such routes are nested under an `_IncludedRouter`,
+    # which previously hid them from the class-based-view transform (#64475).
+    target = router if via_router else app
 
     if websocket:
 
         class A:
-            @app.get("/{i}")
+            @target.websocket("/{i}")
             def b(self, i: int):
                 pass
 
     else:
 
         class A:
-            @app.websocket("/{i}")
+            @target.get("/{i}")
             def b(self, i: int):
                 pass
 
-    # before, "self" is treated as a query params
-    assert app.routes[-1].endpoint == A.b
-    assert app.routes[-1].dependant.query_params[0].name == "self"
-    assert len(app.routes[-1].dependant.dependencies) == 0
+    if via_router:
+        app.include_router(router)
+
+    # before, "self" is treated as a query param.
+    route = _find_route(app, A.b)
+    assert route.dependant.query_params[0].name == "self"
+    assert len(route.dependant.dependencies) == 0
 
     make_fastapi_class_based_view(app, A)
 
-    # after, "self" is treated as a dependency instead of query params
-    assert app.routes[-1].endpoint == A.b
-    assert len(app.routes[-1].dependant.query_params) == 0
-    assert len(app.routes[-1].dependant.dependencies) == 1
-    self_dep = app.routes[-1].dependant.dependencies[0]
-    assert self_dep.name == "self"
-    assert inspect.isfunction(self_dep.call)
-    assert "get_current_servable" in str(self_dep.call)
+    # After the transform "self" is injected via a dependency. We assert on the
+    # endpoint signature (which the transform rewrites directly) rather than on
+    # `route.dependant`: FastAPI >= 0.137 recomputes the dependant lazily at
+    # request time for routes registered via `include_router`, so the route
+    # object's cached `dependant` may still reflect the pre-transform signature.
+    params = list(inspect.signature(A.b).parameters.values())
+    assert params[0].name == "self"
+    assert isinstance(params[0].default, fastapi_params.Depends)
+    assert "get_current_servable" in str(params[0].default.dependency)
+    # Remaining params become keyword-only since `self` is no longer positional.
+    assert all(p.kind == inspect.Parameter.KEYWORD_ONLY for p in params[1:]), [
+        (p.name, p.kind) for p in params[1:]
+    ]
 
 
 class Nested(BaseModel):
@@ -1224,6 +1254,72 @@ def test_ingress_direct_inheritance(serve_instance):
     resp = httpx.get(f"{url}/direct")
     assert resp.status_code == 200, f"Direct failed: {resp.text}"
     assert resp.json() == {"level": "direct"}
+
+
+def test_ingress_include_router_with_self(serve_instance):
+    """Endpoints registered via ``include_router`` must strip ``self`` (#64475).
+
+    FastAPI >= 0.137 nests routes added through ``include_router`` under an
+    ``_IncludedRouter`` node instead of flattening them into ``app.routes``.
+    The class-based-view transform previously only scanned the flat list, so
+    ``self`` was left in the signature and treated as a required query param,
+    causing requests to fail with 'Field required at ('query', 'self')' (422).
+    """
+    app = FastAPI()
+    # A router whose prefix is baked into the route path via `APIRouter(prefix=)`.
+    router = APIRouter(prefix="/prefix")
+    # A router whose prefix is supplied at `include_router(..., prefix=)` time.
+    # On FastAPI >= 0.137 this prefix lives on the `_IncludedRouter` node rather
+    # than in the route's own path, so the transform must fold it back in when
+    # re-mounting the route (otherwise the endpoint moves to the wrong path).
+    prefixed_router = APIRouter()
+
+    class Ingress:
+        @router.get("/routed")
+        def routed_endpoint(self, name: str = "world"):
+            return {"source": "router", "name": name}
+
+        @prefixed_router.get("/models/{model_id}")
+        def prefixed_endpoint(self, model_id: str):
+            return {"source": "prefixed", "model_id": model_id}
+
+        @app.get("/direct")
+        def direct_endpoint(self):
+            return {"source": "app"}
+
+    # Registered before the class is wrapped by `serve.ingress`, mirroring how
+    # applications (e.g. vLLM) compose their routers.
+    app.include_router(router)
+    app.include_router(prefixed_router, prefix="/api")
+
+    @serve.deployment
+    @serve.ingress(app)
+    class ServedIngress(Ingress):
+        pass
+
+    serve.run(ServedIngress.bind())
+
+    url = get_application_url("HTTP")
+
+    # The included route must resolve without a bogus `self` query param.
+    resp = httpx.get(f"{url}/prefix/routed")
+    assert resp.status_code == 200, f"Routed failed: {resp.text}"
+    assert resp.json() == {"source": "router", "name": "world"}
+
+    # Regular query params on the included route still work.
+    resp = httpx.get(f"{url}/prefix/routed", params={"name": "serve"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"source": "router", "name": "serve"}
+
+    # An include-time prefix must be preserved (route stays at /api/...).
+    resp = httpx.get(f"{url}/api/models/gpt")
+    assert resp.status_code == 200, f"Prefixed failed: {resp.text}"
+    assert resp.json() == {"source": "prefixed", "model_id": "gpt"}
+
+    # Directly decorated routes keep working too.
+    resp = httpx.get(f"{url}/direct")
+    assert resp.status_code == 200, f"Direct failed: {resp.text}"
+    assert resp.json() == {"source": "app"}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_extract_route_patterns.py
+++ b/python/ray/serve/tests/unit/test_extract_route_patterns.py
@@ -1,6 +1,6 @@
 """Unit tests for extract_route_patterns function."""
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
 
@@ -90,6 +90,51 @@ def test_extract_route_patterns_with_mounts():
     assert has_path(patterns, "/")
     assert has_path(patterns, "/admin/health")
     assert has_path(patterns, "/admin/status")
+
+
+def test_extract_route_patterns_included_router():
+    """Routes registered via `include_router` must be extracted.
+
+    On FastAPI >= 0.137 these routes are nested under an `_IncludedRouter` node
+    instead of being flattened into `app.routes` (see #64475).
+    """
+    app = FastAPI()
+
+    @app.get("/direct")
+    def direct():
+        return {}
+
+    # Router with its own prefix, included without an include-time prefix.
+    router = APIRouter(prefix="/prefix")
+
+    @router.get("/routed/{user_id}")
+    def routed():
+        return {}
+
+    @router.websocket("/ws")
+    async def ws():
+        pass
+
+    # Router included with an include-time prefix.
+    other = APIRouter()
+
+    @other.post("/create")
+    def create():
+        return {}
+
+    app.include_router(router)
+    app.include_router(other, prefix="/other")
+
+    patterns = extract_route_patterns(app)
+
+    assert has_path(patterns, "/direct")
+    assert has_path(patterns, "/prefix/routed/{user_id}")
+    assert get_methods_for_path(patterns, "/prefix/routed/{user_id}") == ["GET"]
+    assert has_path(patterns, "/other/create")
+    assert get_methods_for_path(patterns, "/other/create") == ["POST"]
+    # WebSocket routes have no method restrictions.
+    assert has_path(patterns, "/prefix/ws")
+    assert get_methods_for_path(patterns, "/prefix/ws") is None
 
 
 def test_extract_route_patterns_nested_mounts():

--- a/python/ray/serve/tests/unit/test_get_asgi_app_route.py
+++ b/python/ray/serve/tests/unit/test_get_asgi_app_route.py
@@ -1,7 +1,7 @@
 import sys
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 
 from ray.serve._private.thirdparty.get_asgi_route_name import get_asgi_route_name
 
@@ -136,6 +136,70 @@ def test_mounted_app():
         get_asgi_route_name(
             app, {"type": "http", "method": "GET", "path": "/mounted/some-other-path"}
         )
+        is None
+    )
+
+
+def test_included_router():
+    """Routes registered via `include_router` must resolve their route name.
+
+    On FastAPI >= 0.137 these routes are nested under an `_IncludedRouter` node
+    instead of being flattened into `app.routes` (see #64475).
+    """
+    app = FastAPI()
+
+    @app.get("/direct")
+    def direct():
+        pass
+
+    # Router with its own prefix, included without an include-time prefix.
+    router = APIRouter(prefix="/prefix")
+
+    @router.get("/routed/{user_id}")
+    def routed():
+        pass
+
+    @router.websocket("/ws")
+    async def ws():
+        pass
+
+    # Router included with an include-time prefix.
+    other = APIRouter()
+
+    @other.post("/create")
+    def create():
+        pass
+
+    app.include_router(router)
+    app.include_router(other, prefix="/other")
+
+    # Directly decorated route still resolves.
+    assert (
+        get_asgi_route_name(app, {"type": "http", "method": "GET", "path": "/direct"})
+        == "/direct"
+    )
+    # Route from an included router (with dynamic segment).
+    assert (
+        get_asgi_route_name(
+            app, {"type": "http", "method": "GET", "path": "/prefix/routed/abc123"}
+        )
+        == "/prefix/routed/{user_id}"
+    )
+    # WebSocket route from an included router.
+    assert (
+        get_asgi_route_name(app, {"type": "websocket", "path": "/prefix/ws"})
+        == "/prefix/ws"
+    )
+    # Route from a router included with an include-time prefix.
+    assert (
+        get_asgi_route_name(
+            app, {"type": "http", "method": "POST", "path": "/other/create"}
+        )
+        == "/other/create"
+    )
+    # Unknown path still returns None.
+    assert (
+        get_asgi_route_name(app, {"type": "http", "method": "GET", "path": "/nope"})
         is None
     )
 


### PR DESCRIPTION
## Why are these changes needed?

FastAPI 0.137 quietly changed how `include_router` works. Included routes used to get flattened straight into `app.routes`, but now they're tucked under a new `_IncludedRouter` node that only resolves its children lazily at request time. A few spots in Serve walk `app.routes` expecting a flat list of routes, and those broke.

Two user-facing symptoms came out of this:

1. **`serve.ingress` returns 422 for routes added via `include_router`.** The class-based-view transform only looked at the top level of `app.routes`, so it never found the nested routes and never stripped their `self` parameter. FastAPI then saw `self` as a required query param, and every request came back with `422 Field required (query, self)` unless you literally appended `?self=x`. This is what broke vLLM and any other ingress app that composes routers. (#64475)

2. **The LLM metrics middleware crashes.** `_get_route_details` reached for `.path` on each route, which an `_IncludedRouter` node doesn't have, so it raised `AttributeError: '_IncludedRouter' object has no attribute 'path'`. (#64245)

The fix is to teach the route walking to descend into `_IncludedRouter` nodes. It's guarded behind a `try/except ImportError` so older FastAPI (where the symbol doesn't exist) keeps working exactly as before. Concretely:

- `make_fastapi_class_based_view` now walks the route tree recursively and removes/rewrites routes from whichever router actually holds them.
- `get_asgi_route_name` / `extract_route_patterns` (the route-name telemetry helpers) handle `_IncludedRouter` the same way `Mount` is handled, reconstructing the full path from the include prefix. This also covers WebSocket routes, which the internal FastAPI helpers leave with an empty path.
- `_get_route_details` in the LLM metrics middleware no longer hand-rolls its own route matching — it now delegates to Serve's shared `_get_route_name`, which fixes the crash and removes a near-duplicate of the same logic. It intentionally avoids the `root_path` prefixing that the outer helper does, so the emitted metric tag is unchanged for the cases that already worked.

### How this was verified

I ran the exact reproductions from both issues against a real Serve deployment on FastAPI 0.137.2 (they fail on `master`, pass here), and confirmed the whole thing still passes on the currently pinned FastAPI version. New regression tests cover the ingress path, the telemetry helpers, and the metrics middleware, including WebSocket and nested-router cases.

Note this doesn't bump the FastAPI pin — Serve stays compatible with `>=0.133.0`. Raising the ceiling to allow 0.137 can be a separate change if desired.

## Related issue number

Closes #64475
Closes #64245

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. Or if not applicable, I've explained why.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the related [Ray CI Test Support](https://ray-project.github.io/) doc.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

🤖 Generated with [Claude Code](https://claude.com/claude-code)