### PR TITLE
[Data] Add reducer remote args

### DIFF
--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -353,9 +353,6 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         if sizes:
             avg_bytes = sum(sizes) / len(sizes)
             memory = int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
-        # Read the resource fields off the same remote args a reduce task is
-        # submitted with, so the budget allocator and the actual Ray
-        # reservation agree.
         return ExecutionResources.from_resource_dict(
             self._reduce_task_remote_args(memory)
         )

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -53,7 +53,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         disallow_block_splitting: If True, output blocks are emitted as-is
             without being reshaped to `target_max_block_size` — required
             for hash-shuffle's "partition = block" contract.
-        reduce_cpus: CPU request per reduce task.  Defaults to 1.
+        reduce_ray_remote_args: Remote args for the reducer tasks.
         name: Display name shown in progress bars and logs.
         fused_output_map_transformer: Set by ``FuseOperators`` when a
             ``TaskPoolMapOperator`` directly downstream is fused into this
@@ -75,7 +75,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         num_partitions: int,
         reduce_fn: ReduceFn,
         disallow_block_splitting: bool = False,
-        reduce_cpus: Optional[float] = None,
+        reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
         name: str = "ShuffleReduce",
         fused_output_map_transformer: Optional["MapTransformer"] = None,
         fused_output_map_task_kwargs: Optional[Dict[str, Any]] = None,
@@ -92,10 +92,8 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         self._disallow_block_splitting: bool = disallow_block_splitting
 
         # -- Reduce task config & tracking -----------------------------------
-        self._shuffle_reduce_task_num_cpus: float = (
-            reduce_cpus
-            if reduce_cpus is not None
-            else self._DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS
+        self._reduce_ray_remote_args: Dict[str, Any] = dict(
+            reduce_ray_remote_args or {}
         )
         self._shuffle_reduce_tasks: Dict[int, DataOpTask] = {}
         self._num_reduce_tasks_submitted: int = 0
@@ -146,17 +144,18 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         estimated_bytes = sum((m.size_bytes or 0) for m in refs.metadata)
 
         reduce_resources: Dict[str, Any] = {
-            "num_cpus": self._shuffle_reduce_task_num_cpus,
+            "num_cpus": self._DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS,
         }
         if estimated_bytes > 0:
             reduce_resources["memory"] = int(
                 estimated_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER
             )
-        reduce_options = {
+        reduce_options: Dict[str, Any] = {
             **reduce_resources,
             "scheduling_strategy": "SPREAD",
-            "num_returns": "streaming",
         }
+        reduce_options.update(self._reduce_ray_remote_args)
+        reduce_options["num_returns"] = "streaming"
 
         target_max_block_size = (
             None
@@ -354,8 +353,10 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             avg_bytes = sum(sizes) / len(sizes)
             memory = int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
         return ExecutionResources(
-            cpu=self._shuffle_reduce_task_num_cpus,
-            memory=memory,
+            cpu=self._reduce_ray_remote_args.get(
+                "num_cpus", self._DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS
+            ),
+            memory=self._reduce_ray_remote_args.get("memory", memory),
         )
 
     def min_scheduling_resources(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -114,6 +114,17 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         # -- Sub-progress bars -----------------------------------------------
         self._reduce_bar: Optional["BaseProgressBar"] = None
 
+    def _reduce_task_remote_args(self, memory_estimate: int) -> Dict[str, Any]:
+        remote_args: Dict[str, Any] = {
+            "num_cpus": self._DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS,
+            "scheduling_strategy": "SPREAD",
+        }
+        if memory_estimate > 0:
+            remote_args["memory"] = memory_estimate
+        remote_args.update(self._reduce_ray_remote_args)
+        remote_args["num_returns"] = "streaming"
+        return remote_args
+
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         """Submit one reducer task for this partition-bundle.
 
@@ -143,19 +154,11 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         shard_refs = list(refs.block_refs)
         estimated_bytes = sum((m.size_bytes or 0) for m in refs.metadata)
 
-        reduce_resources: Dict[str, Any] = {
-            "num_cpus": self._DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS,
-        }
-        if estimated_bytes > 0:
-            reduce_resources["memory"] = int(
-                estimated_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER
-            )
-        reduce_options: Dict[str, Any] = {
-            **reduce_resources,
-            "scheduling_strategy": "SPREAD",
-        }
-        reduce_options.update(self._reduce_ray_remote_args)
-        reduce_options["num_returns"] = "streaming"
+        reduce_options = self._reduce_task_remote_args(
+            int(estimated_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
+            if estimated_bytes > 0
+            else 0
+        )
 
         target_max_block_size = (
             None
@@ -197,9 +200,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             task_done_callback=functools.partial(
                 self._handle_reduce_done, partition_id, refs
             ),
-            task_resource_bundle=ExecutionResources.from_resource_dict(
-                reduce_resources
-            ),
+            task_resource_bundle=ExecutionResources.from_resource_dict(reduce_options),
             operator_name=self.name,
         )
 
@@ -352,11 +353,11 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         if sizes:
             avg_bytes = sum(sizes) / len(sizes)
             memory = int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
-        return ExecutionResources(
-            cpu=self._reduce_ray_remote_args.get(
-                "num_cpus", self._DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS
-            ),
-            memory=self._reduce_ray_remote_args.get("memory", memory),
+        # Read the resource fields off the same remote args a reduce task is
+        # submitted with, so the budget allocator and the actual Ray
+        # reservation agree.
+        return ExecutionResources.from_resource_dict(
+            self._reduce_task_remote_args(memory)
         )
 
     def min_scheduling_resources(self) -> ExecutionResources:

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -389,7 +389,7 @@ class FuseOperators(Rule):
             num_partitions=up_op._num_partitions,
             reduce_fn=up_op._reduce_fn,
             disallow_block_splitting=up_op._disallow_block_splitting,
-            reduce_cpus=up_op._shuffle_reduce_task_num_cpus,
+            reduce_ray_remote_args=up_op._reduce_ray_remote_args,
             name=name,
             fused_output_map_transformer=down_op.get_map_transformer(),
             fused_output_map_task_kwargs=down_op.get_map_task_kwargs(),


### PR DESCRIPTION
## Description
As title, now we pass the reducer remote args to reducer tasks and remove the `reduce_cpus` args because we can pass that in remote args.
This allow other apis to pass remote args to reducers, e.g. Join

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
