### PR TITLE
[serve][llm] Flush first streamed result immediately instead of waiting out the batching interval

### DIFF
--- a/python/ray/llm/_internal/serve/utils/batcher.py
+++ b/python/ray/llm/_internal/serve/utils/batcher.py
@@ -40,6 +40,7 @@ class Batcher(Generic[T]):
             return
 
         self.done_event: asyncio.Event = asyncio.Event()
+        self.first_item_event: asyncio.Event = asyncio.Event()
 
         # We are okay with this task getting cancelled (to propagate cancellations)
         self.read_task = asyncio.create_task(self.read())
@@ -57,6 +58,23 @@ class Batcher(Generic[T]):
             return
 
         try:
+            if self.interval_s is not None:
+                # Flush the first result(s) as soon as they are available instead
+                # of waiting out the first full interval. Time-to-first-token is
+                # latency-critical for streaming responses, while batching only
+                # exists to amortize per-chunk overhead for the rest of the
+                # stream. Without this, the batching interval is added to the
+                # TTFT of every request (https://github.com/ray-project/ray/issues/59681).
+                await self.first_item_event.wait()
+
+                results, is_done = self.check_done_and_drain()
+                if results:
+                    yield self._merge_results(results)
+                if is_done:
+                    # Raise exception, if any
+                    self.read_task.result()
+                    return
+
             while True:
                 # Wait for the interval or until we finish, whichever is faster.
                 # We use an event to avoid asyncio.wait_for cancelling the real task on timeout.
@@ -97,8 +115,13 @@ class Batcher(Generic[T]):
         try:
             async for x in self.generator:
                 self.queue.put_nowait(x)
+                if not self.first_item_event.is_set():
+                    self.first_item_event.set()
         finally:
             self.done_event.set()
+            # Unblock stream() if the generator finished (or raised) before
+            # producing any items.
+            self.first_item_event.set()
 
     def drain_queue(self):
         """Drain all results currently in the queue"""

--- a/python/ray/llm/_internal/serve/utils/batcher.py
+++ b/python/ray/llm/_internal/serve/utils/batcher.py
@@ -58,35 +58,30 @@ class Batcher(Generic[T]):
             return
 
         try:
-            if self.interval_s is not None:
-                # Flush the first result(s) as soon as they are available instead
-                # of waiting out the first full interval. Time-to-first-token is
-                # latency-critical for streaming responses, while batching only
-                # exists to amortize per-chunk overhead for the rest of the
-                # stream. Without this, the batching interval is added to the
-                # TTFT of every request (https://github.com/ray-project/ray/issues/59681).
-                await self.first_item_event.wait()
-
-                results, is_done = self.check_done_and_drain()
-                if results:
-                    yield self._merge_results(results)
-                if is_done:
-                    # Raise exception, if any
-                    self.read_task.result()
-                    return
+            # For the very first flush we wait only until the first result is
+            # available instead of waiting out the full interval: time-to-first-
+            # token is latency-critical, while batching only exists to amortize
+            # per-chunk overhead for the rest of the stream. Otherwise the
+            # interval would be added to the TTFT of every request
+            # (https://github.com/ray-project/ray/issues/59681).
+            first_flush_pending = self.interval_s is not None
 
             while True:
-                # Wait for the interval or until we finish, whichever is faster.
-                # We use an event to avoid asyncio.wait_for cancelling the real task on timeout.
-                try:
-                    if self.interval_s is None:
-                        await self.done_event.wait()
-                    else:
-                        await asyncio.wait_for(
-                            self.done_event.wait(), timeout=self.interval_s
-                        )
-                except asyncio.TimeoutError:
-                    pass
+                if first_flush_pending:
+                    await self.first_item_event.wait()
+                    first_flush_pending = False
+                else:
+                    # Wait for the interval or until we finish, whichever is faster.
+                    # We use an event to avoid asyncio.wait_for cancelling the real task on timeout.
+                    try:
+                        if self.interval_s is None:
+                            await self.done_event.wait()
+                        else:
+                            await asyncio.wait_for(
+                                self.done_event.wait(), timeout=self.interval_s
+                            )
+                    except asyncio.TimeoutError:
+                        pass
 
                 # Get all elements from the queue
                 results, is_done = self.check_done_and_drain()

--- a/python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py
@@ -115,18 +115,23 @@ class TestBatching:
         """The first result must be yielded as soon as it is available rather
         than after the first full batching interval. Otherwise the batching
         interval is added to the time-to-first-token of every streaming
-        request (https://github.com/ray-project/ray/issues/59681)."""
+        request (https://github.com/ray-project/ray/issues/59681).
 
-        first_item_ready = asyncio.Event()
+        A deliberately large interval is used so the assertion has a wide
+        margin and stays deterministic under CI scheduling jitter: with the
+        fix the first flush is immediate (<< interval), without it the first
+        flush would take ~interval.
+        """
+
+        interval_ms = 1000.0
 
         async def generator():
             yield dict(num_generated_tokens=1, generated_text=TEXT_VALUE)
-            first_item_ready.set()
             # Keep the stream open well past the first flush.
-            await asyncio.sleep(MODEL_RESPONSE_BATCH_TIMEOUT_MS / 1000 * 3)
+            await asyncio.sleep(interval_ms / 1000 * 3)
             yield dict(num_generated_tokens=1, generated_text=FINAL_TEXT_VALUE)
 
-        batcher = TestBatcher(generator())
+        batcher = TestBatcher(generator(), interval_ms=interval_ms)
         stream = batcher.stream()
 
         start = time.perf_counter()
@@ -134,10 +139,9 @@ class TestBatching:
         first_batch_ms = (time.perf_counter() - start) * 1e3
 
         assert first_batch["generated_text"] == TEXT_VALUE
-        assert first_batch_ms < MODEL_RESPONSE_BATCH_TIMEOUT_MS / 2, (
+        assert first_batch_ms < interval_ms / 2, (
             f"First batch took {first_batch_ms:.1f}ms; it should be yielded "
-            "immediately, not after the batching interval "
-            f"({MODEL_RESPONSE_BATCH_TIMEOUT_MS}ms)."
+            f"immediately, not after the batching interval ({interval_ms}ms)."
         )
 
         token_count = first_batch["num_generated_tokens"]

--- a/python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py
@@ -111,6 +111,42 @@ class TestBatching:
         assert batcher.queue.empty()
 
     @pytest.mark.asyncio
+    async def test_first_batch_not_delayed_by_interval(self):
+        """The first result must be yielded as soon as it is available rather
+        than after the first full batching interval. Otherwise the batching
+        interval is added to the time-to-first-token of every streaming
+        request (https://github.com/ray-project/ray/issues/59681)."""
+
+        first_item_ready = asyncio.Event()
+
+        async def generator():
+            yield dict(num_generated_tokens=1, generated_text=TEXT_VALUE)
+            first_item_ready.set()
+            # Keep the stream open well past the first flush.
+            await asyncio.sleep(MODEL_RESPONSE_BATCH_TIMEOUT_MS / 1000 * 3)
+            yield dict(num_generated_tokens=1, generated_text=FINAL_TEXT_VALUE)
+
+        batcher = TestBatcher(generator())
+        stream = batcher.stream()
+
+        start = time.perf_counter()
+        first_batch = await stream.__anext__()
+        first_batch_ms = (time.perf_counter() - start) * 1e3
+
+        assert first_batch["generated_text"] == TEXT_VALUE
+        assert first_batch_ms < MODEL_RESPONSE_BATCH_TIMEOUT_MS / 2, (
+            f"First batch took {first_batch_ms:.1f}ms; it should be yielded "
+            "immediately, not after the batching interval "
+            f"({MODEL_RESPONSE_BATCH_TIMEOUT_MS}ms)."
+        )
+
+        token_count = first_batch["num_generated_tokens"]
+        async for batch in stream:
+            token_count += batch["num_generated_tokens"]
+        assert token_count == 2, "No tokens should be lost or duplicated"
+        assert batcher.queue.empty()
+
+    @pytest.mark.asyncio
     async def test_batch_no_interval(self):
         """Check that the class creates only one batch if there's no interval."""
 


### PR DESCRIPTION
## Why are these changes needed?

`Batcher.stream()` waits out the full batching interval (`MODEL_RESPONSE_BATCH_TIMEOUT_MS`, default **50 ms**) before draining the queue for the first time. The engine typically produces the first token well before the first timer tick, so that token sits in the queue and **every streaming request pays up to the full interval in added TTFT**, regardless of engine speed.

This accounts for most of the fixed per-request overhead of Ray Serve LLM vs bare vLLM reported in #59681. Measured on a single node (RTX 5050, `Qwen/Qwen2.5-0.5B-Instruct`, ray 2.56.0, vLLM 0.22.0, streaming chat completions, `temperature=0`, `max_tokens=128`, loopback):

| TTFT p50, c=1 | value |
|---|---|
| bare vLLM (`vllm serve`) | 16.9 ms |
| Serve LLM, default config, **before** | 64.8 ms |
| Serve LLM, `stream_batching_interval_ms=0` (knob confirmation) | 26.3 ms |
| Serve LLM, default config, **after this PR** | **24.9 ms** |

A back-to-back A/B under identical conditions (same process lifetime, same thermal state) shows **62.8 ms → 35.6 ms** p50. Throughput at c=8/c=32 is unchanged (283 vs 289 tok/s in same-conditions A/B) — batching still amortizes per-chunk overhead for the rest of the stream; only the first flush is exempted.

## What is changed?

- `Batcher.read()` sets a `first_item_event` when the first result arrives (and on generator completion, so an empty/failing generator can't hang the stream).
- `Batcher.stream()` waits for that event, flushes the first drain immediately, then falls back to the existing interval loop.
- `interval_ms=None` (batch everything) and `interval_ms=0` (no batching) semantics are unchanged.

## Testing

- New regression test `test_first_batch_not_delayed_by_interval` asserts the first batch arrives well under the interval and no tokens are lost.
- Full `test_batcher.py` suite passes (14/14) against ray 2.56.0.

## Related issue number

Contributes the dominant fixed-overhead fix for #59681 (the remaining ~9 ms vs bare vLLM is handle-hop/validation cost, and the high-concurrency tail degradation is a separate bottleneck unaffected by this timer — details in the issue).

## Checks

- [x] Signed off every commit (DCO)
- [x] Unit tests added and passing
- [x] `black`/`ruff` (repo-pinned versions) pass on changed files