### PR TITLE
Add tracing support to async/sync actor from PR63321 (stale)

### DIFF
--- a/python/ray/tests/test_tracing.py
+++ b/python/ray/tests/test_tracing.py
@@ -259,10 +259,91 @@ def test_tracing_actor_client_mode(cleanup_dirs, ray_start_cli_tracing_with_clie
         assert span["attributes"]["ray.actor_id"] == actor_id
 
 
-def test_wrapping(ray_start_init_tracing):
+def test_wrapping(cleanup_dirs, ray_start_init_tracing):
     @ray.remote
     def f(**_kwargs):
         pass
+
+
+def generator_actor_helper():
+    """Run a Ray actor with generator method and check the spans produced."""
+
+    @ray.remote
+    class GeneratorActor:
+        def __init__(self, factor: int) -> None:
+            self.factor = factor
+
+        def generator(self, n_steps: int):
+            for k in range(n_steps):
+                yield self.factor * k
+
+    actor = GeneratorActor.remote(factor=2)
+    results = ray.get(list(actor.generator.remote(n_steps=3)))
+    assert results == [0, 2, 4], f"Expected [0, 2, 4], got {results}"
+
+    span_list = get_span_list()
+    # Should have spans for __init__ and generator methods
+    # At minimum, we need spans for both methods on client and worker side
+    assert (
+        len(span_list) >= 4
+    ), f"Expected at least 4 spans, got {len(span_list)}: {span_list}"
+
+    span_names = get_span_dict(span_list)
+    # Check that generator method was traced (search for generator in span names)
+    generator_spans = [name for name in span_names.keys() if "generator" in name]
+    assert (
+        len(generator_spans) > 0
+    ), f"Expected generator spans, got: {list(span_names.keys())}"
+
+
+def async_generator_actor_helper():
+    """Run a Ray actor with async generator method and check the spans produced."""
+
+    @ray.remote
+    class AsyncGeneratorActor:
+        def __init__(self, factor: int) -> None:
+            self.factor = factor
+
+        async def async_generator(self, n_steps: int):
+            for k in range(n_steps):
+                yield self.factor * k
+
+    actor = AsyncGeneratorActor.remote(factor=3)
+    results = ray.get(list(actor.async_generator.remote(n_steps=3)))
+    assert results == [0, 3, 6], f"Expected [0, 3, 6], got {results}"
+
+    span_list = get_span_list()
+    # Should have spans for __init__ and async_generator methods
+    assert (
+        len(span_list) >= 4
+    ), f"Expected at least 4 spans, got {len(span_list)}: {span_list}"
+
+    span_names = get_span_dict(span_list)
+    # Check that async_generator method was traced (search for async_generator in span names)
+    async_gen_spans = [name for name in span_names.keys() if "async_generator" in name]
+    assert (
+        len(async_gen_spans) > 0
+    ), f"Expected async_generator spans, got: {list(span_names.keys())}"
+
+
+def test_tracing_generator_actor_init_workflow(cleanup_dirs, ray_start_init_tracing):
+    generator_actor_helper()
+
+
+def test_tracing_generator_actor_start_workflow(cleanup_dirs, ray_start_cli_tracing):
+    generator_actor_helper()
+
+
+def test_tracing_async_generator_actor_init_workflow(
+    cleanup_dirs, ray_start_init_tracing
+):
+    async_generator_actor_helper()
+
+
+def test_tracing_async_generator_actor_start_workflow(
+    cleanup_dirs, ray_start_cli_tracing
+):
+    async_generator_actor_helper()
 
 
 def test_deserialization_works_without_opentelemetry(ray_start_regular):

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -487,9 +487,7 @@ def _inject_tracing_into_class(_cls):
                 return method(self, *_args, **_kwargs)
 
             opentelemetry = _get_opentelemetry()
-            tracer: opentelemetry.trace.Tracer = opentelemetry.trace.get_tracer(
-                __name__
-            )
+            tracer = opentelemetry.trace.get_tracer(__name__)
 
             # Retrieves the context from the _ray_trace_ctx dictionary we
             # injected.
@@ -537,18 +535,80 @@ def _inject_tracing_into_class(_cls):
 
         return _resume_span
 
+    def gen_span_wrapper(method: Callable[..., Any]) -> Any:
+        def _resume_span(
+            self: Any,
+            *_args: Any,
+            _ray_trace_ctx: Optional[Dict[str, Any]] = None,
+            **_kwargs: Any,
+        ) -> Generator[Any, None, None]:
+            """
+            Wrap a generator method to preserve generator nature while adding tracing.
+            Uses 'yield from' to maintain the generator protocol.
+            """
+            # If tracing feature flag is not on, perform a no-op
+            if not _is_tracing_enabled() or _ray_trace_ctx is None:
+                yield from method(self, *_args, **_kwargs)
+                return
+
+            opentelemetry = _get_opentelemetry()
+            tracer = opentelemetry.trace.get_tracer(__name__)
+
+            # Retrieves the context from the _ray_trace_ctx dictionary we
+            # injected.
+            with _use_context(
+                _DictPropagator.extract(_ray_trace_ctx)
+            ), tracer.start_as_current_span(
+                _actor_span_consumer_name(self.__class__.__name__, method),
+                kind=opentelemetry.trace.SpanKind.CONSUMER,
+                attributes=_actor_hydrate_span_args(self.__class__.__name__, method),
+            ):
+                yield from method(self, *_args, **_kwargs)
+
+        return _resume_span
+
+    def asyncgen_span_wrapper(method: Callable[..., Any]) -> Any:
+        async def _resume_span(
+            self: Any,
+            *_args: Any,
+            _ray_trace_ctx: Optional[Dict[str, Any]] = None,
+            **_kwargs: Any,
+        ) -> Any:
+            """
+            Wrap an async generator method to preserve async generator nature while adding tracing.
+            Uses 'async yield from' to maintain the async generator protocol.
+            """
+            # If tracing feature flag is not on, perform a no-op
+            if not _is_tracing_enabled() or _ray_trace_ctx is None:
+                async for item in method(self, *_args, **_kwargs):
+                    yield item
+                return
+
+            opentelemetry = _get_opentelemetry()
+            tracer = opentelemetry.trace.get_tracer(__name__)
+
+            # Retrieves the context from the _ray_trace_ctx dictionary we
+            # injected.
+            with _use_context(
+                _DictPropagator.extract(_ray_trace_ctx)
+            ), tracer.start_as_current_span(
+                _actor_span_consumer_name(self.__class__.__name__, method.__name__),
+                kind=opentelemetry.trace.SpanKind.CONSUMER,
+                attributes=_actor_hydrate_span_args(
+                    self.__class__.__name__, method.__name__
+                ),
+            ):
+                async for item in method(self, *_args, **_kwargs):
+                    yield item
+
+        return _resume_span
+
     methods = inspect.getmembers(_cls, is_function_or_method)
     for name, method in methods:
         # Skip tracing for staticmethod or classmethod, because these method
         # might not be called directly by remote calls. Additionally, they are
         # tricky to get wrapped and unwrapped.
         if is_static_method(_cls, name) or is_class_method(method):
-            continue
-
-        if inspect.isgeneratorfunction(method) or inspect.isasyncgenfunction(method):
-            # Right now, this method somehow changes the signature of the method
-            # when they are generator.
-            # TODO(sang): Fix it.
             continue
 
         # Don't decorate the __del__ magic method.
@@ -587,7 +647,11 @@ def _inject_tracing_into_class(_cls):
         if getattr(method, "__ray_tracing_wrapped__", False):
             continue
 
-        if inspect.iscoroutinefunction(method):
+        if inspect.isgeneratorfunction(method):
+            wrapped_method = wraps(method)(gen_span_wrapper(method))
+        elif inspect.isasyncgenfunction(method):
+            wrapped_method = wraps(method)(asyncgen_span_wrapper(method))
+        elif inspect.iscoroutinefunction(method):
             # If the method was async, swap out sync wrapper into async
             wrapped_method = wraps(method)(async_span_wrapper(method))
         else:


### PR DESCRIPTION
## Description

> This PR addresses the same issue as #63321. Since that PR has been inactive for several weeks and still requires changes, I've opened this PR with those changes incorporated.

When OpenTelemetry tracing is enabled on Ray actor classes, invoking actor methods that return generators results in a `TypeError: got an unexpected keyword argument _ray_trace_ctx`. This occurs because generator methods are skipped in the tracing injection logic, while their method signatures are still modified to accept the tracing context parameter, creating a mismatch between expected and actual arguments.

The `_inject_tracing_into_class()` function in `ray/util/tracing/tracing_helper.py` intentionally skips wrapping generator and async generator methods (lines 520-524 with a TODO comment), but still modifies their signatures to include the `_ray_trace_ctx` parameter (lines 548-553). When these methods are called via actor remoting, the `_ray_trace_ctx` parameter is passed by the tracing decorator, but the unwrapped generator method doesn't know how to handle it.

## Related issues

#63267