### PR TITLE
[Data] Fix ResourceBudget backpressure causing pipeline pseudo-hang

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -599,6 +599,30 @@ class OpResourceAllocator(ABC):
         allocation is unlimited."""
         ...
 
+    def is_task_submission_blocked_on_object_store(self, op: PhysicalOperator) -> bool:
+        """Whether ``op``'s object-store *output* budget is exhausted, i.e. the
+        object-store condition of ``can_submit_new_task`` is violated.
+
+        Returns True whenever object store is a binding constraint, even if the
+        op is *also* blocked on CPU/GPU -- because relaxing wouldn't help in that
+        case either (object store would still block submission).
+
+        This distinction matters for the output-backpressure liveness escape
+        hatch: relaxing upstream output backpressure lets upstream tasks finish
+        and release the resources they hold, which helps a downstream op blocked
+        on CPU/GPU/slots. But it does the opposite for one blocked on object
+        store -- upstream completing only writes *more* output into an
+        already-full store, pushing usage further past the limit while the
+        downstream op still can't schedule. The hatch keys on this to avoid
+        overshooting the object-store memory limit.
+        """
+        budget = self.get_budget(op)
+        if budget is None:
+            return False
+        return budget.object_store_memory < (
+            op.metrics.obj_store_mem_max_pending_output_per_task or 0
+        )
+
     def _get_eligible_ops(self) -> List[PhysicalOperator]:
         """Returns a list of operators eligible for allocation.
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -174,7 +174,18 @@ class OutputBackpressureGuard:
                 #
                 # In this case by relaxing output backpressure we allow upstream
                 # operator's task to complete sooner to free up resources.
+                #
+                # The exception is when downstream can't schedule specifically
+                # because its object-store *output* budget is exhausted.
+                # Relaxing frees the resources upstream *holds* (CPU/GPU/slots),
+                # but upstream completing only writes more output into the
+                # already-full store -- so it wouldn't unblock downstream and
+                # would push object-store usage further past the limit. In that
+                # case we keep backpressure and rely on the idle detector below
+                # as the bounded safety net for a genuine deadlock.
                 if not self._can_submit_new_task(downstream_op):
+                    if self._is_blocked_on_object_store(downstream_op):
+                        continue
                     return True
 
                 # Case 2: Downstream operator
@@ -201,6 +212,18 @@ class OutputBackpressureGuard:
         if not self._resource_manager.op_resource_allocator_enabled():
             return True
         return self._resource_manager.op_resource_allocator.can_submit_new_task(op)
+
+    def _is_blocked_on_object_store(self, op: PhysicalOperator) -> bool:
+        """Whether ``op`` can't submit a new task because its object-store
+        output budget is exhausted (rather than CPU/GPU or other resources).
+
+        Returns False when no op-level resource allocator is enabled -- there is
+        no object-store budget to be blocked on in that case.
+        """
+        if not self._resource_manager.op_resource_allocator_enabled():
+            return False
+        allocator = self._resource_manager.op_resource_allocator
+        return allocator.is_task_submission_blocked_on_object_store(op)
 
 
 class OpBufferQueue:

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -983,6 +983,99 @@ class TestOutputBackpressureGuard:
         topo[o3].total_enqueued_input_blocks = MagicMock(return_value=0)
         assert guard.should_unblock(o2) is True
 
+    def test_no_unblock_when_downstream_blocked_on_object_store(
+        self, restore_data_context
+    ):
+        """Case 1 must NOT relax output backpressure when the downstream op
+        can't schedule because its object-store *output* budget is exhausted.
+
+        Relaxing lets upstream produce more output, pushing object-store usage
+        further past the limit while downstream still can't run (the steady-state
+        overshoot). It should keep backpressure and fall back to the idle
+        detector. When downstream is blocked on CPU/GPU instead, relaxing frees
+        upstream resources and the original liveness behavior is preserved.
+        """
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1)
+        o3 = mock_map_op(o2)
+
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
+
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(),
+            DataContext.get_current(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+        )
+        guard = OutputBackpressureGuard(topo, resource_manager)
+        o3.num_active_tasks = MagicMock(return_value=0)
+        guard._idle_detector.detect_idle = MagicMock(return_value=False)
+
+        # Downstream cannot submit a new task.
+        resource_manager.op_resource_allocator.can_submit_new_task = MagicMock(
+            return_value=False
+        )
+
+        # ...because its object-store output budget is exhausted -> keep
+        # backpressure (fall back to idle detector, which returns False here).
+        resource_manager.op_resource_allocator.is_task_submission_blocked_on_object_store = MagicMock(  # noqa: E501
+            return_value=True
+        )
+        assert guard.should_unblock(o2) is False
+
+        # ...because of CPU/GPU (not object store) -> relax to free upstream
+        # resources, preserving the original deadlock-prevention behavior.
+        resource_manager.op_resource_allocator.is_task_submission_blocked_on_object_store = MagicMock(  # noqa: E501
+            return_value=False
+        )
+        assert guard.should_unblock(o2) is True
+
+    def test_is_task_submission_blocked_on_object_store(self, restore_data_context):
+        """The allocator predicate reports True only when the op's object-store
+        output budget is below its per-task pending output estimate."""
+        from unittest.mock import PropertyMock
+
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1)
+        o3 = mock_map_op(o2)
+
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(),
+            DataContext.get_current(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+        )
+        alloc = resource_manager.op_resource_allocator
+
+        alloc._op_budgets[o3] = ExecutionResources(object_store_memory=100)
+
+        # ``obj_store_mem_max_pending_output_per_task`` is a read-only property
+        # on OpRuntimeMetrics, so patch it at the class level.
+        with patch.object(
+            type(o3.metrics),
+            "obj_store_mem_max_pending_output_per_task",
+            new_callable=PropertyMock,
+        ) as mock_metric:
+            # budget (100) >= per-task pending output (50) -> not blocked.
+            mock_metric.return_value = 50
+            assert alloc.is_task_submission_blocked_on_object_store(o3) is False
+
+            # budget (100) < per-task pending output (150) -> blocked.
+            mock_metric.return_value = 150
+            assert alloc.is_task_submission_blocked_on_object_store(o3) is True
+
+            # No output produced yet -> estimate is None -> threshold 0 -> not
+            # blocked (matches can_submit_new_task's ``... or 0`` semantics).
+            mock_metric.return_value = None
+            assert alloc.is_task_submission_blocked_on_object_store(o3) is False
+
+        # Op has no budget entry (unlimited budget) -> not blocked.
+        del alloc._op_budgets[o3]
+        assert alloc.is_task_submission_blocked_on_object_store(o3) is False
+
     def test_unblock_backpressure_fallback_to_idle_detector(self, restore_data_context):
         """When unblock conditions not met, falls back to idle detector result."""
         o1 = InputDataBuffer(DataContext.get_current(), [])


### PR DESCRIPTION
# [Data] Fix ResourceBudget backpressure causing pipeline pseudo-hang

## Why are these changes needed?

`OutputBackpressureGuard.should_unblock` relaxes output backpressure when a downstream operator has no active tasks and can't submit new tasks — an escape hatch to preserve pipeline liveness. When the downstream operator is blocked specifically on its object store memory budget, this assumption backfires: the upstream operator completing only pushes more output into the object store, overshooting the limit until every operator is under `ResourceBudget` backpressure and the pipeline pseudo-hangs (CPU/GPU idle, no error logged).

Additionally, the shared resource allocation in `update_budgets` can restore an operator's resource budget even after its object store memory usage has exceeded its reservation, letting it submit more tasks and compounding the overshoot.

## Fix

1. In `should_unblock`, don't relax output backpressure when the downstream operator is blocked on object store memory (new predicate `is_task_submission_blocked_on_object_store`). `IdleDetector` remains the liveness fallback.
2. Optionally withhold shared object store memory from operators that satisfy **both**: (a) per-operator usage exceeds `object_store_reservation_overshoot_ratio` × its reservation, AND (b) global object store usage exceeds `object_store_pool_pressure_fraction` of its limit. Both thresholds must be set to enable the throttle; either being None (default) keeps the feature off.

Fix 2 is applied in both the per-operator shared resource loop and the fallback branch, so leftover budget cannot be routed back to an over-reserved operator.

## Related issues

None.

## Additional information

**Tests** (`test_resource_manager.py::TestOutputBackpressureGuard`):

- `test_no_unblock_when_downstream_blocked_on_object_store`
- `test_is_task_submission_blocked_on_object_store`
- `test_is_op_over_reserved_on_object_store`
