### PR TITLE
[Serve][LLM] Use asyncio.create_task instead of ensure_future in KVRouterActor

### DIFF
--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
@@ -135,7 +135,7 @@ class KVRouterActor:
         """Run a coroutine on the actor's event loop, holding a reference until
         it completes.
         """
-        task = asyncio.ensure_future(coro)
+        task = asyncio.create_task(coro)
         self._pending_tasks.add(task)
         task.add_done_callback(self._pending_tasks.discard)
 

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/pd_server.py
@@ -369,7 +369,7 @@ class PDOrchestratorMixin:
                 stream must be drained to exhaustion, never abandoned. Prefill
                 is clamped to a single token, so draining is bounded either way.
         """
-        prefill_task = asyncio.ensure_future(_drain_prefill(prefill_resp))
+        prefill_task = asyncio.create_task(_drain_prefill(prefill_resp))
         completed = False
         local_gen = None
         next_fut = None


### PR DESCRIPTION
## Why are these changes needed?

A review comment on #64327 (merged) noted that `KVRouterActor._schedule` uses `asyncio.ensure_future()` for its fire-and-forget task pattern. Since `_schedule` is only ever called with a fresh coroutine (never a pre-existing
`Task`/`Future`), `asyncio.create_task()` is the more explicit modern equivalent — it only accepts coroutines, always schedules on the currently running loop, and removes any ambiguity about whether the passed-in awaitable was already in flight.

Small, self-contained follow-up cleanup — no behavior change.

## Related issue number

Follow-up to #64327 (tracked under #64389).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference. For example, if I added a
      method in Tune, I've added it in `doc/source/tune/api/` under the
      corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few
      flaky tests, see the recent failures at https://flakey-tests.ray.io/