### PR TITLE
[docs] Skip the RtD PR build for code-only PRs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,11 @@ build:
     # The guard matches doc/ but excludes doc/.claude/ (Claude Code skills
     # and agent files), which never participate in the Sphinx build, so a
     # PR that changes only those paths skips the build instead of running one.
+    # Code sources (python/ray/, rllib/) are intentionally not matched, so a
+    # code-only PR skips this PR preview. The RTD PR check is not a required
+    # merge gate, and the post-merge master build and the Buildkite doc_build
+    # still render docstring-driven API-reference changes. This trades a
+    # non-gating premerge preview for less pressure on the shared RTD slots.
     # See https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
     #
     # Some constructs are avoided deliberately because RTD's job runner
@@ -39,14 +44,14 @@ build:
           echo "Could not determine merge-base with origin/master; building docs to be safe."
           exit 0
         fi
-        if git diff --quiet origin/master...HEAD -- doc/ ':!doc/.claude/' python/ray/ rllib/ .readthedocs.yaml; then
+        if git diff --quiet origin/master...HEAD -- doc/ ':!doc/.claude/' .readthedocs.yaml; then
           echo "No doc-affecting files changed in this PR; skipping Sphinx build."
           echo "Files changed in PR:"
           git diff --name-only origin/master...HEAD
           exit 183
         fi
         echo "Doc-affecting files changed; building docs. Changed doc-relevant paths:"
-        git diff --name-only origin/master...HEAD -- doc/ ':!doc/.claude/' python/ray/ rllib/ .readthedocs.yaml
+        git diff --name-only origin/master...HEAD -- doc/ ':!doc/.claude/' .readthedocs.yaml
     # Override the html build step. On PR (external) builds, build incrementally
     # from the latest master doc cache, falling back to a clean build
     # (rtd-fallback) if it fails. PRs that delete or move doc sources skip the


### PR DESCRIPTION
## Why are these changes needed?

The `post_checkout` skip-guard in `.readthedocs.yaml` currently triggers a full RtD Sphinx build on any PR that changes `doc/`, `python/ray/`, or `rllib/`. Because `python/ray/` and `rllib/` are in that pathspec (autodoc renders their docstrings into the API reference), a **code-only PR that touches no doc source still runs a full RtD build**.

That preview is low value:

- The `docs/readthedocs.com:anyscale-ray` PR check is **not a required merge gate** (PRs merge with it pending/red), so a failing build on a code PR is noise and queue pressure on the shared RtD slots, not a blocker.
- The large majority of PR-triggered RtD builds are for PRs that touch no doc source at all, so their authors never open the preview link.

This PR narrows the guard to doc-source paths (`doc/` minus `doc/.claude/`, plus `.readthedocs.yaml`), so code-only PRs skip the preview. Docstring-driven API-reference changes are still rendered post-merge: RtD builds `/en/master/` on every master push and Buildkite runs `doc_build`. Mixed PRs that touch both `doc/` and code still build, since the guard still matches `doc/`.

Follow-up to #64480 (the `doc/.claude/` exclusion), same guard, same RtD-preprocessor constraints (single-line expression, `:!` exclude shorthand, no shell comments in the block).

> **Draft:** holding until post-merge doc-build monitoring is in place, so a docstring change that breaks the API reference on master is caught promptly once code PRs stop rendering it premerge.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit (`git commit -s`).
- [x] I've made sure the tests are passing. (Config-only change; no test surface.)
