### PR TITLE
[tune] Clear queued trial decision when pausing a trial

### DIFF
--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -1971,8 +1971,12 @@ class TuneController:
                 for this paused trial. Defaults to True.
         """
         # NOTE: The cached trial decision is not needed since we will overrule this
-        # decision with PAUSE.
+        # decision with PAUSE. We also drop any queued decision: pausing removes
+        # the trial's actor, so a stale CONTINUE queued by an earlier buffered
+        # result must not be executed afterwards (it would schedule a train task
+        # on the removed actor and raise a KeyError).
         self._cached_trial_decisions.pop(trial.trial_id, None)
+        self._queued_trial_decisions.pop(trial.trial_id, None)
         self._schedule_trial_pause(trial, should_checkpoint=should_checkpoint)
 
     def cleanup(self):

--- a/python/ray/tune/tests/execution/test_actor_caching.py
+++ b/python/ray/tune/tests/execution/test_actor_caching.py
@@ -4,6 +4,7 @@ import pytest
 
 import ray
 from ray.tune import PlacementGroupFactory
+from ray.tune.schedulers import TrialScheduler
 from ray.tune.tests.execution.utils import TestingTrial, create_execution_test_objects
 
 
@@ -125,6 +126,38 @@ def test_actor_reuse_unstaged(tmpdir, ray_start_2_cpus):
     # self._actor_cache.increase_max(start_trial.placement_group_factory)
     tune_controller._actor_stopped(tracked_actorA1)
     tune_controller.step()
+
+
+def test_pause_trial_clears_queued_decision(tmpdir, ray_start_2_cpus):
+    """pause_trial must discard any queued trial decision.
+
+    Regression test for #58483: with PBT and buffered training results, an
+    earlier buffered result can queue a CONTINUE decision for a trial. When a
+    later result triggers PBT's exploit step it calls pause_trial, which tears
+    down the trial's actor. If the stale CONTINUE were left queued, the next
+    _maybe_execute_queued_decision would pop it and _execute_action(CONTINUE)
+    -> _schedule_trial_train -> _schedule_trial_task would raise KeyError on the
+    now-removed actor. pause_trial must clear the queued decision.
+    """
+    tune_controller, actor_manger, resource_manager = create_execution_test_objects(
+        max_pending_trials=8
+    )
+
+    trial = TestingTrial("trainable1", stub=True, trial_id="trial1")
+    tune_controller.add_trial(trial)
+    tune_controller.step()
+
+    tracked_actor, _, _ = actor_manger.added_actors[0]
+    tune_controller._actor_started(tracked_actor)
+    assert trial in tune_controller._trial_to_actor
+
+    # An earlier buffered result queued a CONTINUE for this trial.
+    tune_controller._queued_trial_decisions[trial.trial_id] = TrialScheduler.CONTINUE
+
+    # PBT's exploit step pauses the trial, removing its actor.
+    tune_controller.pause_trial(trial, should_checkpoint=False)
+
+    assert trial.trial_id not in tune_controller._queued_trial_decisions
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Fixes #58483.

`TuneController.pause_trial` pops the *cached* trial decision but leaves any *queued* decision in place:

```python
def pause_trial(self, trial, should_checkpoint=True):
    # NOTE: The cached trial decision is not needed since we will overrule this
    # decision with PAUSE.
    self._cached_trial_decisions.pop(trial.trial_id, None)
    self._schedule_trial_pause(trial, should_checkpoint=should_checkpoint)
```

With Population Based Training and buffered training results (`TUNE_RESULT_BUFFER_LENGTH > 1`, or a trainable that returns a list of results), the sequence is:

1. An early buffered result whose perturbation interval has not been reached queues a `CONTINUE` for the trial via `_queue_decision` (the first result sets `CONTINUE` with `setdefault`).
2. A later buffered result reaches the interval, and PBT's `_exploit` calls `tune_controller.pause_trial(...)`. `_schedule_trial_pause` tears down the trial's actor, but the stale `CONTINUE` stays in `_queued_trial_decisions`.
3. `_on_training_result` -> `_maybe_execute_queued_decision` pops that `CONTINUE` and runs `_execute_action(CONTINUE)` -> `_schedule_trial_train` -> `_schedule_trial_task`, which does `self._trial_to_actor[trial]` for the removed actor and raises `KeyError`.

Pausing a trial removes its actor, so any queued decision for it is stale and must not be executed afterwards. This drops the queued decision in `pause_trial` alongside the cached one (one line, next to the existing `pop`).

## Related

This is in the same file as the open PR #61448 (`_schedule_trial_pause` caching `STOP` instead of `PAUSE`), but a different method and a different bug: that PR corrects the *value* stored in `_cached_trial_decisions`, while this clears a stale entry in `_queued_trial_decisions`. They do not overlap.

## Checks

- [x] Regression test `test_pause_trial_clears_queued_decision` in `python/ray/tune/tests/execution/test_actor_caching.py`: queues a `CONTINUE` for a started trial, calls `pause_trial`, and asserts the queued decision is cleared. It fails on the current code and passes with this change (validated against the real `TuneController.pause_trial`).
- [x] `black` (22.10.0) clean.
- [x] DCO signed off.
