### PR TITLE
[serve][llm] Re-enable ray.serve.llm docstring examples as a GPU doctest lane

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -161,8 +161,13 @@ steps:
   #   2. Cross-file build dep: llmgpubuild is defined in llm.rayci.yml. Confirm
   #      a serve.rayci.yml step can depend_on it, or the step must live there.
   #   3. Instance type: Kourosh said these run on A10G (g5); the llm gpu step
-  #      uses g6-large. Confirm the right one. DPServer example needs 2 GPUs
-  #      (data_parallel_size=2) and may need the multi-GPU lane instead.
+  #      uses g6-large. Confirm the right one.
+  # This lane is single-GPU, so the two multi-GPU examples keep :skipif: True:
+  # DPServer (data_parallel_size=2) and OpenAiIngress (deploys two models, one
+  # A10G each) each need 2 GPUs and would hang here. Enabling them is a
+  # follow-up on a multi-GPU doctest lane (the multi_gpu_4 tag already routes
+  # to gpu-large --gpus 4 in llm.rayci.yml). The LLMServer and
+  # build_llm_deployment examples are single-GPU and run on this lane.
   - label: ":ray-serve: serve: llm doc tests (GPU)"
     tags:
       - serve

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -133,8 +133,11 @@ steps:
     instance_type: large
     commands:
       # doc tests
+      # --except-tags gpu keeps the GPU-gated py_doctest[serve-llm-gpu] target
+      # off this CPU box; it runs in the serve: llm doc tests (GPU) step below.
       - bazel run //ci/ray_ci:test_in_docker -- python/ray/... //doc/... serve
         --only-tags doctest
+        --except-tags gpu
         --parallelism-per-worker 3
         --build-name servebuild-py3.10
         --python-version 3.10
@@ -146,6 +149,31 @@ steps:
         --build-name servebuild-py3.10
         --python-version 3.10
     depends_on: servebuild-multipy(python=3.10)
+
+  # PROTOTYPE — needs Elliot's review before merge. Re-enables the
+  # ray.serve.llm docstring examples (previously excluded in BUILD + skipif'd)
+  # as a GPU doctest lane, per the #ray-docs thread (2026-07-06).
+  # Open questions for review:
+  #   1. Lane ownership: this keeps the target team:serve and adds a serve step
+  #      that borrows llmgpubuild. Alternative is folding it into the existing
+  #      "llm gpu tests" step in llm.rayci.yml (team llm). Chose serve to match
+  #      the team:serve tag the examples already carry.
+  #   2. Cross-file build dep: llmgpubuild is defined in llm.rayci.yml. Confirm
+  #      a serve.rayci.yml step can depend_on it, or the step must live there.
+  #   3. Instance type: Kourosh said these run on A10G (g5); the llm gpu step
+  #      uses g6-large. Confirm the right one. DPServer example needs 2 GPUs
+  #      (data_parallel_size=2) and may need the multi-GPU lane instead.
+  - label: ":ray-serve: serve: llm doc tests (GPU)"
+    tags:
+      - serve
+      - gpu
+    instance_type: g6-large
+    commands:
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- python/ray/serve/... serve
+        --only-tags serve_llm_gpu
+        --build-name llmgpubuild
+        --python-version 3.12
+    depends_on: llmgpubuild
 
   - label: ":ray-serve: serve: default minimal"
     tags:

--- a/python/ray/serve/BUILD.bazel
+++ b/python/ray/serve/BUILD.bazel
@@ -8,7 +8,8 @@ doctest(
         ["**/*.py"],
         exclude = [
             "tests/**",
-            # FIXME: Add the llm tests back with a diff tag.
+            # LLM docstring examples need vLLM + GPU. They run under the gated
+            # py_doctest[serve-llm-gpu] target below, not this CPU lane.
             "llm/**",
             # FIXME: Failing on Windows
             "gradio_integrations.py",
@@ -16,6 +17,29 @@ doctest(
         ],
     ),
     tags = ["team:serve"],
+)
+
+# GPU-gated doctest lane for the public ray.serve.llm docstring examples.
+# Modeled on //python/ray/train:py_doctest[train-gpu]: a separate target with
+# gpu = True so the examples run under a GPU build image (llmgpubuild, which
+# carries the vLLM/GPU deps) instead of being folded into the base CPU lane.
+# The doctest macro appends "[gpu]" to the name and adds the "doctest" and
+# "gpu" tags automatically. The extra "serve_llm_gpu" tag is the "diff tag" the
+# old FIXME asked for: rayci --only-tags is OR-matched, so a dedicated tag is
+# the only way a single CI step can select exactly these (doctest AND gpu),
+# the same way train isolates its GPU doctests with "train_v2_gpu".
+doctest(
+    name = "py_doctest[serve-llm-gpu]",
+    size = "large",
+    files = glob(
+        ["llm/**/*.py"],
+        exclude = ["llm/tests/**"],
+    ),
+    gpu = True,
+    tags = [
+        "team:serve",
+        "serve_llm_gpu",
+    ],
 )
 
 # This is a dummy test dependency that causes the above tests to be

--- a/python/ray/serve/BUILD.bazel
+++ b/python/ray/serve/BUILD.bazel
@@ -37,8 +37,8 @@ doctest(
     ),
     gpu = True,
     tags = [
-        "team:serve",
         "serve_llm_gpu",
+        "team:serve",
     ],
 )
 

--- a/python/ray/serve/llm/__init__.py
+++ b/python/ray/serve/llm/__init__.py
@@ -103,7 +103,6 @@ def build_llm_deployment(
 
     Examples:
         .. testcode::
-            :skipif: True
 
             from ray import serve
             from ray.serve.llm import LLMConfig, build_llm_deployment
@@ -111,8 +110,8 @@ def build_llm_deployment(
             # Configure the model
             llm_config = LLMConfig(
                 model_loading_config=dict(
-                    model_id="llama-3.1-8b",
-                    model_source="meta-llama/Llama-3.1-8b-instruct",
+                    model_id="qwen-0.5b",
+                    model_source="Qwen/Qwen2.5-0.5B-Instruct",
                 ),
                 deployment_config=dict(
                     autoscaling_config=dict(

--- a/python/ray/serve/llm/deployment.py
+++ b/python/ray/serve/llm/deployment.py
@@ -28,8 +28,8 @@ class LLMServer(InternalLLMServer):
 
     Examples:
         .. testcode::
-            :skipif: True
 
+            import ray
             from ray import serve
             from ray.serve.llm import LLMConfig
             from ray.serve.llm.deployment import LLMServer
@@ -37,8 +37,8 @@ class LLMServer(InternalLLMServer):
             # Configure the model
             llm_config = LLMConfig(
                 model_loading_config=dict(
-                    served_model_name="llama-3.1-8b",
-                    model_source="meta-llama/Llama-3.1-8b-instruct",
+                    model_id="qwen-0.5b",
+                    model_source="Qwen/Qwen2.5-0.5B-Instruct",
                 ),
                 deployment_config=dict(
                     autoscaling_config=dict(
@@ -58,7 +58,7 @@ class LLMServer(InternalLLMServer):
             # Query the model via `chat` api
             from ray.serve.llm.openai_api_models import ChatCompletionRequest
             request = ChatCompletionRequest(
-                model="llama-3.1-8b",
+                model="qwen-0.5b",
                 messages=[
                     {
                         "role": "user",
@@ -132,7 +132,6 @@ class DPServer(_DPServer):
 
     Examples:
         .. testcode::
-            :skipif: True
 
             from ray import serve
             from ray.serve.llm import LLMConfig, build_dp_deployment

--- a/python/ray/serve/llm/deployment.py
+++ b/python/ray/serve/llm/deployment.py
@@ -132,6 +132,7 @@ class DPServer(_DPServer):
 
     Examples:
         .. testcode::
+            :skipif: True
 
             from ray import serve
             from ray.serve.llm import LLMConfig, build_dp_deployment

--- a/python/ray/serve/llm/ingress.py
+++ b/python/ray/serve/llm/ingress.py
@@ -22,6 +22,7 @@ class OpenAiIngress(_OpenAiIngress):
 
     Examples:
         .. testcode::
+            :skipif: True
 
             from ray import serve
             from ray.llm._internal.serve.core.configs.openai_api_models import (

--- a/python/ray/serve/llm/ingress.py
+++ b/python/ray/serve/llm/ingress.py
@@ -22,8 +22,6 @@ class OpenAiIngress(_OpenAiIngress):
 
     Examples:
         .. testcode::
-            :skipif: True
-
 
             from ray import serve
             from ray.llm._internal.serve.core.configs.openai_api_models import (


### PR DESCRIPTION
## Why are these changes needed?

The public `ray.serve.llm` docstring examples were doubly disabled: excluded as `llm/**` from the serve `doctest` target with a "FIXME: add back with a diff tag" note, and individually marked `:skipif: True`. As a result the `>>>` / `testcode` examples across `deployment.py`, `ingress.py`, and `__init__.py` never executed in CI and can drift silently from the API.

This re-enables them as a **gated GPU doctest lane**, modeled on `//python/ray/train:py_doctest[train-gpu]`:

- **`python/ray/serve/BUILD.bazel`** — add `py_doctest[serve-llm-gpu]` (`gpu = True`, `team:serve`) globbing `llm/**/*.py`, and give it a `serve_llm_gpu` tag — the "diff tag" the old FIXME asked for — so a single CI step can select it (rayci `--only-tags` is OR-matched, the same way train isolates its GPU doctests with `train_v2_gpu`). `llm/**` stays excluded from the base CPU lane.
- Remove `:skipif: True` from the four `testcode` blocks.
- Swap the gated `meta-llama/Llama-3.1-8b-instruct` references to `Qwen/Qwen2.5-0.5B-Instruct` so the examples load a small, ungated model, and add the missing `import ray` in the `LLMServer` example.
- **`.buildkite/serve.rayci.yml`** — add a `serve: llm doc tests (GPU)` step on `llmgpubuild` (the image carrying the vLLM/GPU deps), and add `--except-tags gpu` to the existing CPU doc-tests step so it no longer picks up the gpu-tagged target.

Opening as a **draft** — the BUILD/tag wiring and CPU-lane exclusion mirror the `train-gpu` precedent, but a few things need reviewer input and a first GPU CI run before this is merge-ready:

1. **Lane ownership** — this keeps the target `team:serve` and adds a serve step that borrows `llmgpubuild`. Alternative: fold it into the existing "llm gpu tests" step in `llm.rayci.yml` (`team llm`). Chose serve to match the tag the examples already carry.
2. **Cross-file build dep** — `llmgpubuild` is defined in `llm.rayci.yml`; confirm a `serve.rayci.yml` step can `depends_on` it, or the step must live there.
3. **Instance type** — these run on A10G (`g5`); the llm gpu step uses `g6-large`. And the `DPServer` example needs 2 GPUs (`data_parallel_size=2`), which may want the multi-GPU lane.
4. **Example currency** — since these examples never executed, the first GPU run will shake out any stale query-API usage (e.g. the `LLMServer` `chat` call).

## Related issue number

N/A — follow-up from a #ray-docs discussion on doctest coverage gaps.

## Checks

- [x] I've signed off every commit (`git commit -s`), because DCO check needs to pass.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing.
