### PR TITLE
[serve][test] Deflake test_rank_assignment_with_autoscaling under HAProxy

### DIFF
--- a/python/ray/serve/tests/test_replica_ranks.py
+++ b/python/ray/serve/tests/test_replica_ranks.py
@@ -372,6 +372,7 @@ def test_rank_assignment_with_autoscaling(serve_instance):
     # Check that ranks are still contiguous after scale-up
     wait_for_condition(
         lambda: check_rank_assignment_complete("AutoscalingRankTracker", 4),
+        timeout=20,
     )
 
     scaled_ranks = get_replica_ranks("AutoscalingRankTracker")
@@ -380,14 +381,16 @@ def test_rank_assignment_with_autoscaling(serve_instance):
 
     signal_actor.send.remote()
 
-    # Wait for scale-down (no more load)
+    # Scale-down needs more than look_back_period_s of low load before ranks reassign.
     wait_for_condition(
         lambda: check_num_replicas_eq("AutoscalingRankTracker", 2, use_controller=True),
+        timeout=30,
     )
 
     # Check that ranks are reassigned and contiguous after scale-down
     wait_for_condition(
         lambda: check_rank_assignment_complete("AutoscalingRankTracker", 2),
+        timeout=20,
     )
 
     final_ranks = get_replica_ranks("AutoscalingRankTracker")


### PR DESCRIPTION
## Why are these changes needed?

Running the full serve suite under HAProxy (#64210) surfaced a benign timeout in `test_rank_assignment_with_autoscaling`. It passes natively.

The scale-down waits used the default 10s `wait_for_condition` timeout, shorter than the autoscaler's `look_back_period_s` plus `downscale_delay_s`, so rank reassignment after downscale could expire under HAProxy's heavier CI environment. The downscale and rank-reassignment waits get explicit headroom.

Split out of #64427 so each PR covers one test file.

## Related issue number

Surfaced by #64210.

## Checks

- [x] I've signed off every commit (by using the -s flag).
- [x] I've made sure the tests are passing.
