### PR TITLE
[serve] Use get_application_url in test_grpc

### DIFF
--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -65,6 +65,10 @@ def test_serving_grpc_requests(ray_cluster):
 
     serve.run(g)
 
+    # Get the ingress address dynamically
+    grpc_url = get_application_url("gRPC", use_localhost=True)
+    channel = grpc.insecure_channel(grpc_url)
+
     # Ensures ListApplications method succeeding.
     ping_grpc_list_applications(channel, [app_name])
 

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -88,6 +88,7 @@ def test_serving_grpc_requests(ray_cluster):
     serve.run(g2)
 
     # Ensure model composition is responding correctly.
+    grpc_url = get_application_url("gRPC", use_localhost=True)
     channel = grpc.insecure_channel(grpc_url)
     ping_fruit_stand(channel, app_name)
 

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -88,7 +88,7 @@ def test_serving_grpc_requests(ray_cluster):
     serve.run(g2)
 
     # Ensure model composition is responding correctly.
-    channel = grpc.insecure_channel("localhost:9000")
+    channel = grpc.insecure_channel(grpc_url)
     ping_fruit_stand(channel, app_name)
 
 


### PR DESCRIPTION
Dynamically get the application url instead of hardcoding localhost:9000