### PR TITLE
[data] Fix O(n^2) schema reconciliation in unify_schemas

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -416,17 +416,17 @@ def unify_schemas(
     if not overrides:
         raise pyarrow_exception
 
-    # Apply overrides to schemas
+    # Apply overrides to schemas. Rebuild each schema once by scanning its
+    # fields a single time, rather than calling Schema.set() per override:
+    # set() copies the whole schema on every call, which is O(n^2) when
+    # many/all columns diverge. This is O(fields + overrides) per schema.
     updated_schemas = []
     for schema in schemas_to_unify:
-        for name, new_type in overrides.items():
-            try:
-                idx = schema.get_field_index(name)
-                field = schema.field(name).with_type(new_type)
-                schema = schema.set(idx, field)
-            except KeyError:
-                pass
-        updated_schemas.append(schema)
+        fields = [
+            field.with_type(overrides[field.name]) if field.name in overrides else field
+            for field in schema
+        ]
+        updated_schemas.append(pyarrow.schema(fields, metadata=schema.metadata))
     schemas_to_unify = updated_schemas
 
     # Final unification with overrides applied

--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -1531,12 +1531,27 @@ def unify_tensor_types(
     if len(shapes) == 1:
         return next(iter(types))
 
-    return ArrowVariableShapedTensorType(
+    # NOTE: Cardinality of variable-shaped tensor type's (``ndims``) is
+    #       derived as the max length of the shapes that are making it up
+    return _get_variable_shaped_tensor_type(
         dtype=value_types.pop(),
-        # NOTE: Cardinality of variable-shaped tensor type's (``ndims``) is
-        #       derived as the max length of the shapes that are making it up
         ndim=max(len(s) for s in shapes),
     )
+
+
+@functools.lru_cache(maxsize=ARROW_EXTENSION_SERIALIZATION_CACHE_MAXSIZE)
+def _get_variable_shaped_tensor_type(
+    dtype: pa.DataType, ndim: int
+) -> "ArrowVariableShapedTensorType":
+    """Construct (and cache) a variable-shaped tensor type.
+
+    ``ArrowVariableShapedTensorType`` is an immutable value type fully keyed by
+    ``(dtype, ndim)``, but constructing one is expensive: pyarrow's ext-type
+    registration serializes the metadata on every instantiation. Schema
+    unification builds the same handful of types over and over (once per
+    diverging column, per call), so we memoize construction here.
+    """
+    return ArrowVariableShapedTensorType(dtype=dtype, ndim=ndim)
 
 
 @DeveloperAPI(stability="alpha")


### PR DESCRIPTION
## Why are these changes needed?

`transform_pyarrow.unify_schemas()` is called whenever blocks with differing
schemas need a common schema (e.g. combining outputs of `map`/`read` where
workers produced slightly different column types). When PyArrow's own
`unify_schemas` can't reconcile the fields (tensor/object/struct divergence), we
fall back to `_reconcile_diverging_fields` and then **apply the reconciled type
overrides back onto each schema**.

The override-application loop called `Schema.set()` **once per diverging field**:

```python
for schema in schemas_to_unify:
    for name, new_type in overrides.items():
        idx = schema.get_field_index(name)
        field = schema.field(name).with_type(new_type)
        schema = schema.set(idx, field)   # <-- copies the WHOLE schema every call
    updated_schemas.append(schema)
```

Each `Schema.set()` constructs a brand-new `arrow::Schema` and **rebuilds the
entire name→index hash map over all N fields**. So when many/all columns
diverge, applying N overrides is **O(N²)**.

### The fix

1. **Rebuild each schema once** by scanning its fields a single time
   (`O(fields + overrides)` per schema, dict-lookup per field — no `Schema.set`,
   no dependency on `get_field_index` complexity, and it correctly handles
   duplicate field names).
2. **Memoize `ArrowVariableShapedTensorType` construction** (keyed on
   `(dtype, ndim)`) so repeated reconciliation doesn't re-pay pyarrow's
   extension-type registration + metadata serialization on every call.

### Results

Benchmark: `unify_schemas([A, B])` where A and B share N columns, each a
fixed-shape tensor type with a **different shape** (forces every column through
reconciliation).

| N columns | before | after | speedup |
|---|---|---|---|
| 200  | 7.06 ms/call | 1.54 ms/call | **~4.6x** |
| 5000 | ~3.29 s/call | 43 ms/call | **~76x** |

The remaining cost after the fix is linear (field-list rebuild +
`_reconcile_diverging_fields`), so it scales with column count instead of its
square.

## Evidence

Three independent methods agree the bottleneck was `Schema.set`:

**1. Deterministic profile (cProfile), 2000 cols × 50 iters — identical call
counts, so it isn't Python overhead:**

| | Python calls | own time | per iter |
|---|---|---|---|
| OLD `schema.set` loop | ~400K | **25.15 s** | 503 ms |
| NEW single rebuild    | ~400K | **0.13 s**  | 3 ms |

**2. O(N²) scaling — the old loop's time ÷ N² stays ~flat (4x per doubling);
the new loop is linear (2x per doubling):**

| N cols | old (set-loop) | new (rebuild) |
|---|---|---|
| 50  | 0.39 ms | 0.10 ms |
| 100 | 1.35 ms | 0.19 ms |
| 200 | 5.32 ms | 0.37 ms |
| 400 | 20.2 ms | 0.75 ms |
| 800 | 79.1 ms | 1.48 ms |

**3. Native flamegraph (`py-spy record --native`, Linux) — the C++ smoking
gun.** `run_old` = 60.4% of the whole capture vs `run_new` = 0.9%, bottoming
out in the schema-copy machinery:

```
run_old tower (schema.set loop) ................ 60.4%
  set (pyarrow.lib) ............................ 74.0% of tower
  └─ arrow::Schema::SetField ................... 73.6%
     ├─ arrow::internal::ReplaceVectorElement ...  7.0%   copy N-field vector
     └─ arrow::Schema::Schema (new ctor) ........ 61.9%
        └─ CreateNameToIndexMap ................. 61.9%   rebuild WHOLE name→index map
           └─ std::_Hashtable inserts ........... 61.1%
     + arrow::Schema::~Schema (destroy old) ..... 19.0%

run_new tower (single rebuild) ................. 0.9%
  (field iteration feeding ONE pa.schema(fields) → CreateNameToIndexMap once)
```

`CreateNameToIndexMap` dominating is the same fact from two sides: that prebuilt
map is why `get_field_index` is O(1), but `Schema.set()` pays to rebuild the
**entire** map on every call.

<!-- FLAMEGRAPHS: drag-drop the SVGs here in the GitHub editor -->
<!-- native.svg (the definitive native capture) -->
<!-- unify_flame.svg (original profile that motivated this) -->

### Reproduction

```python
import time
import pyarrow as pa
from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
from ray.data._internal.tensor_extensions.arrow import ArrowTensorType

N_COLS, N_ITERS = 200, 2000

def make_schemas():
    dtype = pa.float32()
    a = pa.schema([(f"col_{i}", ArrowTensorType((2, 2), dtype)) for i in range(N_COLS)])
    b = pa.schema([(f"col_{i}", ArrowTensorType((3, 4), dtype)) for i in range(N_COLS)])
    return a, b

schema_a, schema_b = make_schemas()
assert len(unify_schemas([schema_a, schema_b])) == N_COLS  # all columns reconciled

start = time.perf_counter()
for _ in range(N_ITERS):
    unify_schemas([schema_a, schema_b])
elapsed = time.perf_counter() - start
print(f"{elapsed / N_ITERS * 1e3:.3f} ms/call")
```
<img width="1648" height="403" alt="Screenshot 2026-07-06 at 3 59 09 PM" src="https://github.com/user-attachments/assets/fffcb57a-27ec-4dd3-94a8-70e852fd0379" />
