### PR TITLE
Rename actor_submit_queue to actor_submit_queue_interface

### DIFF
--- a/src/ray/core_worker/task_submission/BUILD.bazel
+++ b/src/ray/core_worker/task_submission/BUILD.bazel
@@ -19,7 +19,7 @@ ray_cc_library(
 
 ray_cc_library(
     name = "actor_submit_queue",
-    hdrs = ["actor_submit_queue.h"],
+    hdrs = ["actor_submit_queue_interface.h"],
     visibility = ["//visibility:private"],
     deps = [
         "//src/ray/common:id",

--- a/src/ray/core_worker/task_submission/actor_submit_queue_interface.h
+++ b/src/ray/core_worker/task_submission/actor_submit_queue_interface.h
@@ -26,7 +26,7 @@ namespace ray {
 namespace core {
 
 /**
- * IActorSubmitQueue is responsible for queuing per actor requests on the client.
+ * ActorSubmitQueueInterface is responsible for queuing per actor requests on the client.
  * To use ActorSubmitQueue, user should Emplace a task with a monotincally increasing
  * (and unique) sequence_no.
  * The task is not ready until it's being marked as
@@ -39,9 +39,9 @@ namespace core {
  *
  * This class is not thread safe.
  */
-class IActorSubmitQueue {
+class ActorSubmitQueueInterface {
  public:
-  virtual ~IActorSubmitQueue() = default;
+  virtual ~ActorSubmitQueueInterface() = default;
   /// Add a task into the queue.
   virtual void Emplace(const std::string &concurrency_group,
                        uint64_t sequence_no,

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -28,7 +28,7 @@
 #include "ray/core_worker/actor_management/actor_creator.h"
 #include "ray/core_worker/reference_counter_interface.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
-#include "ray/core_worker/task_submission/actor_submit_queue.h"
+#include "ray/core_worker/task_submission/actor_submit_queue_interface.h"
 #include "ray/core_worker/task_submission/dependency_resolver.h"
 #include "ray/core_worker/task_submission/out_of_order_actor_submit_queue.h"
 #include "ray/core_worker/task_submission/sequential_actor_submit_queue.h"
@@ -319,7 +319,7 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
     bool is_restartable_ = false;
 
     /// The queue that orders actor requests.
-    std::unique_ptr<IActorSubmitQueue> actor_submit_queue_;
+    std::unique_ptr<ActorSubmitQueueInterface> actor_submit_queue_;
 
     /// Tasks that can't be sent because 1) the callee actor is dead. 2) network error.
     /// For 1) the task will wait for the DEAD state notification, then mark task as

--- a/src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.h
+++ b/src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.h
@@ -22,7 +22,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "ray/common/id.h"
-#include "ray/core_worker/task_submission/actor_submit_queue.h"
+#include "ray/core_worker/task_submission/actor_submit_queue_interface.h"
 
 namespace ray {
 namespace core {
@@ -34,7 +34,7 @@ namespace core {
  * Emplaced request is inserted into pending queue; once the request's dependency
  * is resolved it's moved from pending queue into sending queue.
  */
-class OutofOrderActorSubmitQueue : public IActorSubmitQueue {
+class OutofOrderActorSubmitQueue : public ActorSubmitQueueInterface {
  public:
   /// Add a task into the queue.
   void Emplace(const std::string &concurrency_group,

--- a/src/ray/core_worker/task_submission/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/task_submission/sequential_actor_submit_queue.h
@@ -22,16 +22,15 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "ray/common/id.h"
-#include "ray/core_worker/task_submission/actor_submit_queue.h"
-
+#include "ray/core_worker/task_submission/actor_submit_queue_interface.h"
 namespace ray {
 namespace core {
 
 /**
- * SequentialActorSumitQueue extends IActorSubmitQueue and ensures tasks are send
+ * SequentialActorSumitQueue extends ActorSubmitQueueInterface and ensures tasks are send
  * in the sequential order defined by the sequence no.
  */
-class SequentialActorSubmitQueue : public IActorSubmitQueue {
+class SequentialActorSubmitQueue : public ActorSubmitQueueInterface {
  public:
   /// Add a task into the queue.
   void Emplace(const std::string &concurrency_group,

--- a/src/ray/core_worker/task_submission/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/task_submission/sequential_actor_submit_queue.h
@@ -27,7 +27,7 @@ namespace ray {
 namespace core {
 
 /**
- * SequentialActorSumitQueue extends ActorSubmitQueueInterface and ensures tasks are send
+ * SequentialActorSubmitQueue extends ActorSubmitQueueInterface and ensures tasks are send
  * in the sequential order defined by the sequence no.
  */
 class SequentialActorSubmitQueue : public ActorSubmitQueueInterface {


### PR DESCRIPTION
## Description
This is a pure rename with no logic changes, for clarity:
- Renamed the `IActorSubmitQueue` class to `ActorSubmitQueueInterface`
- Renamed `actor_submit_queue.h` to `actor_submit_queue_interface.h`

## Related issues
N/A

## Test
- Ran `bazel test //src/ray/core_worker/task_submission/tests/...` — all 5 targets pass
