### PR TITLE
[Data] Support reading multiple paths in `read_lance`

### DIFF
--- a/python/ray/data/_internal/datasource/lance_datasource.py
+++ b/python/ray/data/_internal/datasource/lance_datasource.py
@@ -1,5 +1,4 @@
-import logging
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -14,15 +13,12 @@ if TYPE_CHECKING:
     import pyarrow
 
 
-logger = logging.getLogger(__name__)
-
-
 class LanceDatasource(Datasource):
     """Lance datasource, for reading Lance dataset."""
 
     def __init__(
         self,
-        uri: str,
+        uri: Union[str, List[str]],
         version: Optional[Union[int, str]] = None,
         columns: Optional[List[str]] = None,
         filter: Optional[str] = None,
@@ -35,16 +31,33 @@ class LanceDatasource(Datasource):
         import lance
 
         self._projection_map = None
-        self.uri = uri
+        if isinstance(uri, str):
+            self.uris = [uri]
+        else:
+            self.uris = list(uri)
+        if len(self.uris) == 0:
+            raise ValueError("`uri` must not be empty.")
         self.scanner_options = scanner_options or {}
         if columns is not None:
             self.scanner_options["columns"] = columns
         if filter is not None:
             self.scanner_options["filter"] = filter
         self.storage_options = storage_options
-        self.lance_ds = lance.dataset(
-            uri=uri, version=version, storage_options=storage_options
-        )
+        self.lance_datasets = [
+            lance.dataset(uri=u, version=version, storage_options=storage_options)
+            for u in self.uris
+        ]
+        # Use the dataset-level (not fragment-level) schema: Lance fills nulls
+        # for columns missing from older fragments under schema evolution, so
+        # only the dataset schema is a correct output contract.
+        if len(self.lance_datasets) > 1:
+            from ray.data._internal.util import unify_schemas_with_validation
+
+            self._schema = unify_schemas_with_validation(
+                [ds.schema for ds in self.lance_datasets]
+            )
+        else:
+            self._schema = self.lance_datasets[0].schema
 
         data_context = DataContext.get_current()
         lance_config = data_context.lance_config
@@ -68,9 +81,6 @@ class LanceDatasource(Datasource):
         data_context: Optional["DataContext"] = None,
     ) -> List[ReadTask]:
         read_tasks = []
-        ds_fragments = self.scanner_options.get("fragments")
-        if ds_fragments is None:
-            ds_fragments = self.lance_ds.get_fragments()
 
         # Lance scanner's filter attr accepts only a string (SQL).
         # See: https://github.com/lance-format/lance/blob/aac74b441cdb6df7d78700dbba33c521e6379ca5/python/python/lance/lance/__init__.pyi#L230
@@ -87,14 +97,62 @@ class LanceDatasource(Datasource):
                 else f"({filter_expr}) AND ({filter_from_arg})"
             )
 
-        for fragments in np.array_split(ds_fragments, parallelism):
-            if len(fragments) <= 0:
+        fragments_override = self.scanner_options.get("fragments")
+        if fragments_override is not None and len(self.lance_datasets) > 1:
+            raise ValueError(
+                "scanner_options['fragments'] is not supported when reading "
+                "multiple Lance datasets."
+            )
+        if fragments_override is not None:
+            fragments_per_dataset = [fragments_override]
+        else:
+            fragments_per_dataset = [
+                lance_ds.get_fragments() for lance_ds in self.lance_datasets
+            ]
+
+        total_fragments = sum(len(fragments) for fragments in fragments_per_dataset)
+        if total_fragments == 0:
+            return read_tasks
+
+        fragment_entries = [
+            (lance_ds, fragment)
+            for lance_ds, fragments in zip(self.lance_datasets, fragments_per_dataset)
+            for fragment in fragments
+        ]
+
+        def _make_read_fn(groups, opts, retry, schema):
+            return lambda: _read_fragments_with_retry(groups, opts, retry, schema)
+
+        # Cap at the fragment count, since we can't create more non-empty read tasks
+        # than fragments. Guard against parallelism <= 0 to avoid ZeroDivisionError
+        # in np.array_split.
+        num_read_tasks = max(1, min(parallelism, total_fragments))
+        for chunk_indices in np.array_split(range(total_fragments), num_read_tasks):
+            if len(chunk_indices) <= 0:
                 continue
 
-            fragment_ids = [f.metadata.id for f in fragments]
-            num_rows = sum(f.count_rows() for f in fragments)
+            dataset_fragment_groups = []
+            current_lance_ds = None
+            current_fragment_ids = []
+            chunk_fragments = []
+            for index in chunk_indices:
+                lance_ds, fragment = fragment_entries[index]
+                if current_lance_ds is not None and lance_ds is not current_lance_ds:
+                    dataset_fragment_groups.append(
+                        (current_lance_ds, current_fragment_ids)
+                    )
+                    current_fragment_ids = []
+                current_lance_ds = lance_ds
+                current_fragment_ids.append(fragment.metadata.id)
+                chunk_fragments.append(fragment)
+            if current_lance_ds is not None:
+                dataset_fragment_groups.append((current_lance_ds, current_fragment_ids))
+
+            num_rows = sum(fragment.count_rows() for fragment in chunk_fragments)
             input_files = [
-                data_file.path() for f in fragments for data_file in f.data_files()
+                data_file.path()
+                for fragment in chunk_fragments
+                for data_file in fragment.data_files()
             ]
 
             # TODO(chengsu): Take column projection into consideration for schema.
@@ -104,22 +162,21 @@ class LanceDatasource(Datasource):
                 input_files=input_files,
                 exec_stats=None,
             )
-            # Use a copy per task to avoid mutation races when tasks run in parallel
+            # Use a copy per task to avoid mutation races when tasks run in parallel.
             task_scanner_options = dict(self.scanner_options)
             if filter_expr is not None:
                 task_scanner_options["filter"] = filter_expr
-            lance_ds = self.lance_ds
             retry_params = self._retry_params
 
             read_task = ReadTask(
-                lambda f=fragment_ids, opts=task_scanner_options: _read_fragments_with_retry(
-                    f,
-                    lance_ds,
-                    opts,
+                _make_read_fn(
+                    dataset_fragment_groups,
+                    task_scanner_options,
                     retry_params,
+                    self._schema,
                 ),
                 metadata,
-                schema=fragments[0].schema,
+                schema=self._schema,
                 per_task_row_limit=per_task_row_limit,
             )
             read_tasks.append(read_task)
@@ -131,21 +188,21 @@ class LanceDatasource(Datasource):
 
 
 def _read_fragments_with_retry(
-    fragment_ids,
-    lance_ds,
+    dataset_fragment_groups,
     scanner_options,
     retry_params,
+    schema,
 ) -> Iterator["pyarrow.Table"]:
     return call_with_retry(
-        lambda: _read_fragments(fragment_ids, lance_ds, scanner_options),
+        lambda: _read_fragments(dataset_fragment_groups, scanner_options, schema),
         **retry_params,
     )
 
 
 def _read_fragments(
-    fragment_ids,
-    lance_ds,
+    dataset_fragment_groups: List[Tuple[Any, List[int]]],
     scanner_options,
+    schema,
 ) -> Iterator["pyarrow.Table"]:
     """Read Lance fragments in batches.
 
@@ -154,12 +211,32 @@ def _read_fragments(
     """
     import pyarrow
 
-    fragments = [lance_ds.get_fragment(id) for id in fragment_ids]
-    scanner_options["fragments"] = fragments
-    scanner = lance_ds.scanner(**scanner_options)
-    for batch in scanner.to_reader():
-        table = pyarrow.Table.from_batches([batch])
-        # When you unpickle untrusted data, attackers can execute arbitrary code. To
-        # avoid exposing our users, raise unless the user has explicitly opted in.
-        raise_on_pickle_object_columns(table)
-        yield table
+    for lance_ds, fragment_ids in dataset_fragment_groups:
+        fragments = [lance_ds.get_fragment(id) for id in fragment_ids]
+        task_scanner_options = dict(scanner_options)
+        task_scanner_options["fragments"] = fragments
+        scanner = lance_ds.scanner(**task_scanner_options)
+        for batch in scanner.to_reader():
+            table = pyarrow.Table.from_batches([batch])
+            # When you unpickle untrusted data, attackers can execute arbitrary code. To
+            # avoid exposing our users, raise unless the user has explicitly opted in.
+            raise_on_pickle_object_columns(table)
+            table = _fill_missing_columns(table, schema, task_scanner_options)
+            yield table
+
+
+def _fill_missing_columns(table, schema, scanner_options) -> "pyarrow.Table":
+    """Null-fill columns advertised by the ReadTask schema but omitted by a per-dataset scan so each block conforms; skipped under `columns=` projection."""
+    if scanner_options.get("columns") is not None:
+        # Projection already trims to the requested columns.
+        return table
+    import pyarrow as pa
+
+    missing = [f.name for f in schema if f.name not in table.schema.names]
+    if not missing:
+        return table
+    for name in missing:
+        table = table.append_column(
+            name, pa.nulls(len(table), type=schema.field(name).type)
+        )
+    return table

--- a/python/ray/data/_internal/datasource/lance_datasource.py
+++ b/python/ray/data/_internal/datasource/lance_datasource.py
@@ -226,17 +226,19 @@ def _read_fragments(
 
 
 def _fill_missing_columns(table, schema, scanner_options) -> "pyarrow.Table":
-    """Null-fill columns advertised by the ReadTask schema but omitted by a per-dataset scan so each block conforms; skipped under `columns=` projection."""
+    """Null-fill and reorder each block to the unified ReadTask schema; skipped under `columns=` projection."""
     if scanner_options.get("columns") is not None:
         # Projection already trims to the requested columns.
         return table
     import pyarrow as pa
 
     missing = [f.name for f in schema if f.name not in table.schema.names]
-    if not missing:
-        return table
-    for name in missing:
-        table = table.append_column(
-            name, pa.nulls(len(table), type=schema.field(name).type)
-        )
+    if missing:
+        for name in missing:
+            table = table.append_column(
+                name, pa.nulls(len(table), type=schema.field(name).type)
+            )
+    # Scanners return columns out of unified-schema order; reorder via select.
+    if table.schema.names != schema.names:
+        table = table.select(schema.names)
     return table

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -4787,7 +4787,7 @@ def read_iceberg(
 
 @PublicAPI
 def read_lance(
-    uri: str,
+    uri: Union[str, List[str]],
     *,
     version: Optional[Union[int, str]] = None,
     columns: Optional[List[str]] = None,
@@ -4802,8 +4802,8 @@ def read_lance(
     override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """
-    Create a :class:`~ray.data.Dataset` from a
-    `Lance Dataset <https://lance-format.github.io/lance-python-doc/dataset.html>`_.
+    Create a :class:`~ray.data.Dataset` from one or more
+    `Lance Datasets <https://lance-format.github.io/lance-python-doc/dataset.html>`_.
 
     Examples:
         >>> import ray
@@ -4812,10 +4812,15 @@ def read_lance(
         ...     columns=["image", "label"],
         ...     filter="label = 2 AND text IS NOT NULL",
         ... )
+        >>> # Read from multiple Lance datasets:
+        >>> ds = ray.data.read_lance( # doctest: +SKIP
+        ...     uri=["./db1.lance", "./db2.lance"],
+        ... )
 
     Args:
-        uri: The URI of the Lance dataset to read from. Local file paths, S3, and GCS
-            are supported.
+        uri: The URI (or list of URIs) of the Lance dataset(s) to read from.
+            Local file paths, S3, and GCS are supported. When multiple URIs are
+            provided, the data from all datasets is combined into a single Dataset.
         version: Load a specific version of the Lance dataset. This can be an
             integer version number or a string tag. By default, the
             latest version is loaded.
@@ -4831,6 +4836,7 @@ def read_lance(
         scanner_options: Additional options to configure the `LanceDataset.scanner()`
             method, such as `batch_size`. For more information,
             see `Lance Python API doc <https://lance-format.github.io/lance-python-doc/all-modules.html#lance.dataset.LanceDataset.scanner>`_
+            The `fragments` option is not supported when reading multiple datasets.
         ray_remote_args: kwargs passed to :func:`ray.remote` in the read tasks.
         num_cpus: The number of CPUs to reserve for each parallel read worker.
         num_gpus: The number of GPUs to reserve for each parallel read worker. For
@@ -4847,7 +4853,7 @@ def read_lance(
             value in most cases.
 
     Returns:
-        A :class:`~ray.data.Dataset` producing records read from the Lance dataset.
+        A :class:`~ray.data.Dataset` producing records read from the Lance dataset(s).
     """  # noqa: E501
 
     # Check for deprecated filter parameter
@@ -4858,6 +4864,9 @@ def read_lance(
             DeprecationWarning,
             stacklevel=2,
         )
+
+    if isinstance(uri, list) and len(uri) == 0:
+        raise ValueError("`uri` list must not be empty.")
 
     datasource = LanceDatasource(
         uri=uri,

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -135,6 +135,33 @@ def test_lance_read_with_scanner_fragments(data_path, ray_start_regular_shared):
 
 
 @pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
+def test_read_lance_multi_uri_null_fills_missing_columns(
+    data_path, ray_start_regular_shared
+):
+    # Heterogeneous multi-URI read: each block must null-fill the columns
+    # that exist only in the other dataset so it matches the unified schema.
+    setup_data_path = _unwrap_protocol(data_path)
+    p1 = os.path.join(setup_data_path, "part1.lance")
+    p2 = os.path.join(setup_data_path, "part2.lance")
+    lance.write_dataset(pa.table({"a": [1, 2], "b": ["x", "y"]}), p1)
+    lance.write_dataset(pa.table({"a": [3, 4], "c": [True, False]}), p2)
+
+    ds = ray.data.read_lance([p1, p2])
+    assert set(ds.schema().names) == {"a", "b", "c"}
+
+    collected = ds.take_all()
+    assert len(collected) == 4
+    for row in collected:
+        assert set(row.keys()) == {"a", "b", "c"}
+        if row["a"] <= 2:
+            assert row["b"] in ("x", "y")
+            assert row["c"] is None
+        else:
+            assert row["b"] is None
+            assert row["c"] in (True, False)
+
+
+@pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
 def test_lance_read_many_files(data_path, ray_start_regular_shared):
     setup_data_path = _unwrap_protocol(data_path)
     path = os.path.join(setup_data_path, "test.lance")

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -162,6 +162,38 @@ def test_read_lance_multi_uri_null_fills_missing_columns(
 
 
 @pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
+def test_read_lance_block_columns_match_unified_schema_order(
+    data_path, ray_start_regular_shared
+):
+    # Per-dataset scanners return columns in their own order; _fill_missing_columns
+    # must reorder every block to the unified ReadTask schema so positional
+    # consumers (Table.cast, RecordBatchReader.from_batches) see a stable order.
+    from ray.data._internal.datasource.lance_datasource import _fill_missing_columns
+
+    schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+
+    # Missing column is appended in schema order.
+    out = _fill_missing_columns(pa.table({"a": [1]}), schema, {})
+    assert out.schema.names == ["a", "b"]
+
+    # A reversed column order is reordered to the unified schema order.
+    out = _fill_missing_columns(pa.table({"b": ["x"], "a": [1]}), schema, {})
+    assert out.schema.names == ["a", "b"]
+
+    # Missing + reversed: appends in schema order, then reorders the block.
+    out = _fill_missing_columns(pa.table({"b": ["x"]}), schema, {})
+    assert out.schema.names == ["a", "b"]
+
+    # Already-ordered blocks are left in place (no-op).
+    out = _fill_missing_columns(pa.table({"a": [1], "b": ["x"]}), schema, {})
+    assert out.schema.names == ["a", "b"]
+
+    # Under `columns=` projection the block is returned untouched.
+    out = _fill_missing_columns(pa.table({"b": ["x"]}), schema, {"columns": ["b"]})
+    assert out.schema.names == ["b"]
+
+
+@pytest.mark.parametrize("data_path", [lazy_fixture("local_path")])
 def test_lance_read_many_files(data_path, ray_start_regular_shared):
     setup_data_path = _unwrap_protocol(data_path)
     path = os.path.join(setup_data_path, "test.lance")


### PR DESCRIPTION
## Why are these changes needed?

Our upstream produces data as many small Lance directories, but
`ray.data.read_lance` only accepts a single `uri`, so reading them all requires
calling `read_lance` per directory and unioning the results by hand.

This PR lets `read_lance` also accept a list of URIs:

```python
ds = ray.data.read_lance(["./part_0.lance", "./part_1.lance", "./part_2.lance"])
```

Passing a single string works exactly as before.

Note: a read task can only read fragments from one Lance dataset, so the number
of read tasks is at least the number of directories, even when `parallelism` is
smaller.

## Related issue number

None.

## Checks

- [x] I've signed off every commit (by using the `-s` flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] Unit tests added in `python/ray/data/tests/test_lance.py`.
