### PR TITLE
[Train] Fix WorkerMetricsCallback method name to match WorkerCallback interface

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/metrics.py
+++ b/python/ray/train/v2/_internal/callbacks/metrics.py
@@ -88,7 +88,7 @@ class WorkerMetricsCallback(WorkerCallback, TrainContextCallback):
             self._run_name, self._run_id, world_rank, worker_actor_id
         )
 
-    def before_shutdown(self):
+    def before_worker_shutdown(self):
         """Shutdown metrics before shutdown."""
         for metric in self._metrics.values():
             metric.reset()

--- a/python/ray/train/v2/_internal/callbacks/metrics.py
+++ b/python/ray/train/v2/_internal/callbacks/metrics.py
@@ -90,8 +90,9 @@ class WorkerMetricsCallback(WorkerCallback, TrainContextCallback):
 
     def before_worker_shutdown(self):
         """Shutdown metrics before shutdown."""
-        for metric in self._metrics.values():
-            metric.reset()
+        if self._metrics:
+            for metric in self._metrics.values():
+                metric.reset()
 
     @contextmanager
     def on_report(self):

--- a/python/ray/train/v2/tests/test_metrics.py
+++ b/python/ray/train/v2/tests/test_metrics.py
@@ -203,6 +203,13 @@ def test_worker_checkpoint_metrics_callback(
     assert callback._metrics[metric_name].get_value() == 0.0
 
 
+def test_worker_metrics_callback_shutdown_without_init(mock_gauge):
+    """before_worker_shutdown should not crash when _metrics is None."""
+    callback = WorkerMetricsCallback(train_run_context=create_dummy_run_context())
+    # _metrics is None — after_init_train_context was never called
+    callback.before_worker_shutdown()  # should not raise
+
+
 def test_controller_metrics_callback(monkeypatch, mock_gauge):
     t1 = 0.0
     t2 = 1.0

--- a/python/ray/train/v2/tests/test_metrics.py
+++ b/python/ray/train/v2/tests/test_metrics.py
@@ -155,7 +155,7 @@ def test_worker_metrics_callback(monkeypatch, mock_gauge):
         t2 - t1
     ) + (t4 - t3)
 
-    callback.before_shutdown()
+    callback.before_worker_shutdown()
     assert (
         callback._metrics[WorkerMetrics.REPORT_TOTAL_BLOCKED_TIME_S].get_value() == 0.0
     )
@@ -199,7 +199,7 @@ def test_worker_checkpoint_metrics_callback(
         pass
     assert callback._metrics[metric_name].get_value() == (t2 - t1) + (t4 - t3)
 
-    callback.before_shutdown()
+    callback.before_worker_shutdown()
     assert callback._metrics[metric_name].get_value() == 0.0
 
 


### PR DESCRIPTION
## Why are these changes needed?

`WorkerMetricsCallback` defines a method named `before_shutdown`, but the `WorkerCallback` interface defines the lifecycle hook as `before_worker_shutdown`. The callback dispatcher in `worker.py` calls `callback.before_worker_shutdown()`, so the implementation's `before_shutdown()` is never invoked. Worker metrics (e.g., `REPORT_TOTAL_BLOCKED_TIME_S`) are never reset on shutdown, leaving stale values after worker restarts.

The unit test at `test_metrics.py` also called `callback.before_shutdown()` directly, which masked the bug by testing the misnamed method instead of the dispatcher path.

## What changes are made?

- `python/ray/train/v2/_internal/callbacks/metrics.py`: Rename `before_shutdown` → `before_worker_shutdown` to match the `WorkerCallback` interface
- `python/ray/train/v2/tests/test_metrics.py`: Update 2 test call sites from `callback.before_shutdown()` to `callback.before_worker_shutdown()`

## Related issues

Fixes #64563

## Checks

- [x] I've signed off every commit (using `git commit -s`)
- [x] I've run `scripts/format.sh` to lint the changes
- [x] I've verified existing tests cover the changed behavior
