### PR TITLE
[Jobs] Replace assert with RuntimeError in put_status for state machine protection

### DIFF
--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -373,7 +373,10 @@ class JobInfoStorageClient:
         )
         if old_info is not None:
             if status != old_info.status and old_info.status.is_terminal():
-                assert False, "Attempted to change job status from a terminal state."
+                raise RuntimeError(
+                    f"Attempted to change job status from a terminal state: "
+                    f"{old_info.status} -> {status}"
+                )
             new_info = replace(old_info, **jobinfo_replace_kwargs)
         else:
             new_info = JobInfo(


### PR DESCRIPTION
## Why are these changes needed?

`JobInfoStorageClient.put_status` uses `assert False` to prevent invalid job status transitions (e.g., SUCCEEDED → FAILED). However, `assert` statements are removed when Python runs with the `-O` flag (`python -O`), silently disabling the state machine protection. This allows invalid transitions like `SUCCEEDED → FAILED` or `FAILED → RUNNING` to pass without error.

Using `assert` for control flow is a known anti-pattern in Python — `assert` is a debugging tool, not a runtime safety mechanism.

## What changes are made?

- `python/ray/dashboard/modules/job/common.py`: Replace `assert False, "..."` with `raise RuntimeError(f"...")` that includes the specific status transition (`{old_info.status} -> {status}`) in the error message for easier debugging

## Related issues

Fixes #64564

## Checks

- [x] I've signed off every commit (using `git commit -s`)
- [x] I've run `scripts/format.sh` to lint the changes
- [x] I've verified existing tests cover the changed behavior
