### PR TITLE
[Data] Fix `from_tf` crash on ragged tensors

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -4324,8 +4324,27 @@ def from_tf(
     Returns:
         A :class:`MaterializedDataset` that contains the samples stored in the `TensorFlow Dataset`_.
     """  # noqa: E501
-    # FIXME: `as_numpy_iterator` errors if `dataset` contains ragged tensors.
-    return from_items(list(dataset.as_numpy_iterator()))
+    import tensorflow as tf
+
+    # `as_numpy_iterator` raises if `dataset` contains ragged tensors because
+    # `RaggedTensor` has no NumPy equivalent. When the dataset has ragged
+    # components, iterate the tensors directly and convert each element to NumPy
+    # ourselves (`RaggedTensor.numpy()` yields an object-dtype array of
+    # variable-length arrays). Otherwise, use the faster `as_numpy_iterator`.
+    def _contains_ragged(element_spec) -> bool:
+        return any(
+            isinstance(spec, tf.RaggedTensorSpec)
+            for spec in tf.nest.flatten(element_spec)
+        )
+
+    if _contains_ragged(dataset.element_spec):
+        items = [
+            tf.nest.map_structure(lambda value: value.numpy(), element)
+            for element in dataset
+        ]
+    else:
+        items = list(dataset.as_numpy_iterator())
+    return from_items(items)
 
 
 @PublicAPI

--- a/python/ray/data/tests/datasource/test_tensorflow_datasets.py
+++ b/python/ray/data/tests/datasource/test_tensorflow_datasets.py
@@ -41,6 +41,7 @@ def test_from_tf_ragged(ray_start_regular_shared_2_cpus):
     # after slicing to reproduce the crash, so use a `ragged_rank=2` tensor:
     # `from_tensor_slices` peels off the outer dimension and leaves each element
     # as a (ragged) `RaggedTensor`.
+    import numpy as np
     import tensorflow as tf
 
     tf_dataset = tf.data.Dataset.from_tensor_slices(
@@ -53,11 +54,16 @@ def test_from_tf_ragged(ray_start_regular_shared_2_cpus):
     ray_dataset = ray.data.from_tf(tf_dataset)
 
     actual_data = extract_values("item", ray_dataset.take_all())
-    expected_data = [[[1, 2], [3]], [[4, 5, 6]]]
+    # Each row materializes as an object-dtype array of variable-length arrays.
+    expected_data = [
+        [np.array([1, 2]), np.array([3])],
+        [np.array([4, 5, 6])],
+    ]
     assert len(actual_data) == len(expected_data)
-    for actual, expected in zip(actual_data, expected_data):
-        # Each row is an object-dtype array of variable-length arrays.
-        assert [list(subarray) for subarray in actual] == expected
+    for actual_row, expected_row in zip(actual_data, expected_data):
+        assert len(actual_row) == len(expected_row)
+        for actual_subarray, expected_subarray in zip(actual_row, expected_row):
+            assert np.array_equal(actual_subarray, expected_subarray)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_tensorflow_datasets.py
+++ b/python/ray/data/tests/datasource/test_tensorflow_datasets.py
@@ -34,5 +34,31 @@ def test_from_tf_e2e(ray_start_regular_shared_2_cpus):
     _check_usage_record(["FromItems"])
 
 
+def test_from_tf_ragged(ray_start_regular_shared_2_cpus):
+    # Regression test for https://github.com/ray-project/ray/issues/61570.
+    # `as_numpy_iterator` can't convert ragged tensors, so `from_tf` needs to
+    # convert them itself instead of crashing. The element spec must stay ragged
+    # after slicing to reproduce the crash, so use a `ragged_rank=2` tensor:
+    # `from_tensor_slices` peels off the outer dimension and leaves each element
+    # as a (ragged) `RaggedTensor`.
+    import tensorflow as tf
+
+    tf_dataset = tf.data.Dataset.from_tensor_slices(
+        tf.ragged.constant([[[1, 2], [3]], [[4, 5, 6]]])
+    )
+    assert isinstance(tf_dataset.element_spec, tf.RaggedTensorSpec), (
+        "Test dataset must have a ragged element spec to exercise the fix"
+    )
+
+    ray_dataset = ray.data.from_tf(tf_dataset)
+
+    actual_data = extract_values("item", ray_dataset.take_all())
+    expected_data = [[[1, 2], [3]], [[4, 5, 6]]]
+    assert len(actual_data) == len(expected_data)
+    for actual, expected in zip(actual_data, expected_data):
+        # Each row is an object-dtype array of variable-length arrays.
+        assert [list(subarray) for subarray in actual] == expected
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

`ray.data.from_tf()` crashes with `TypeError: Cannot convert a RaggedTensor to a NumPy array` when the input `tf.data.Dataset` yields ragged tensors. The root cause is the call to `tf.data.Dataset.as_numpy_iterator()`, which cannot convert `RaggedTensor` (it has no NumPy equivalent). The code even carried a `# FIXME` for this case.

This PR detects ragged components by checking the dataset's `element_spec` for `tf.RaggedTensorSpec` (the same detection pattern already used in `ray/data/_internal/utils/tensorflow_utils.py`). When ragged tensors are present, it iterates the dataset directly and converts each element with `tf.nest.map_structure(lambda v: v.numpy(), element)` — `RaggedTensor.numpy()` returns an object-dtype array of variable-length arrays, which is exactly what Ray Data uses for ragged data. Non-ragged datasets keep the original fast `as_numpy_iterator()` path, so existing behavior is unchanged.

## Related issues

Fixes #61570

## Additional information

Note on reproduction: the snippet in the issue (`from_tensor_slices(tf.ragged.constant([[1, 2], [3]]))`) does **not** actually trigger the crash — `from_tensor_slices` peels off the single ragged (`ragged_rank=1`) dimension, so each element becomes a *dense* tensor and `as_numpy_iterator()` succeeds. To exercise the real failure path, the element spec must remain ragged after slicing. The regression test therefore uses a `ragged_rank=2` tensor (`[[[1, 2], [3]], [[4, 5, 6]]]`) so each sliced element is still a `RaggedTensor`, and asserts the element spec is ragged before checking that `from_tf` no longer crashes and preserves the data.