### PR TITLE
[Data] Fix error message and off-by-one bounds check in operators

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -451,7 +451,7 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
     for arr in arrs:
         assert not isinstance(arr.type, tensor_types), (
             "'_concatenate_chunked_arrays' should only be used on non-tensor "
-            f"extension types, but got a chunked array of type {type_}."
+            f"extension types, but got a chunked array of type {arr.type}."
         )
         if type_ is None and not pyarrow.types.is_null(arr.type):
             type_ = arr.type

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -93,7 +93,7 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
 
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.has_completed()
-        assert 0 <= input_index <= len(self._input_dependencies), input_index
+        assert 0 <= input_index < len(self._input_dependencies), input_index
         if self._preserve_order:
             self._input_buffers[input_index].add(refs)
             self._metrics.on_input_queued(refs, input_index=input_index)

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -99,7 +99,7 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
 
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.has_completed()
-        assert 0 <= input_index <= len(self._input_dependencies), input_index
+        assert 0 <= input_index < len(self._input_dependencies), input_index
         self._input_buffers[input_index].add(refs)
         self._metrics.on_input_queued(refs, input_index=input_index)
 

--- a/python/ray/data/tests/unit/test_fix_operator_bounds_check.py
+++ b/python/ray/data/tests/unit/test_fix_operator_bounds_check.py
@@ -1,0 +1,74 @@
+"""Tests for the three bug fixes:
+1. _concatenate_chunked_arrays error message prints actual type, not None
+2. UnionOperator._add_input_inner rejects input_index == len(input_dependencies)
+3. ZipOperator._add_input_inner rejects input_index == len(input_dependencies)
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.arrow_ops.transform_pyarrow import _concatenate_chunked_arrays
+from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.operators.union_operator import UnionOperator
+from ray.data._internal.execution.operators.zip_operator import ZipOperator
+from ray.data.context import DataContext
+from ray.data.extensions import ArrowTensorArray
+
+
+def test_concatenate_chunked_arrays_tensor_error_message_contains_type():
+    """Bug 1: The assertion error in _concatenate_chunked_arrays used {type_}
+    which was None. It should print {arr.type} (the actual tensor type)."""
+    # Create a chunked array with a tensor extension type.
+    tensor_arr = ArrowTensorArray.from_numpy(np.zeros((2, 3)))
+    chunked = pa.chunked_array([tensor_arr])
+
+    # The function should raise an AssertionError whose message contains the
+    # actual tensor type, not "None".
+    with pytest.raises(AssertionError) as exc_info:
+        _concatenate_chunked_arrays([chunked])
+    msg = str(exc_info.value)
+    # The bug: the old code printed {type_} which was None at that point.
+    assert "None" not in msg, f"Error message should not contain 'None', got: {msg}"
+    # The fix: should print {arr.type} which is the actual tensor type.
+    assert (
+        "TensorType" in msg or "tensor" in msg.lower()
+    ), f"Error message should contain the tensor type, got: {msg}"
+
+
+def test_union_operator_rejects_out_of_bounds_input_index():
+    """Bug 2: UnionOperator._add_input_inner used <= instead of <, allowing
+    input_index == len(input_dependencies) which is out of bounds."""
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    op = UnionOperator(DataContext.get_current(), input1, input2)
+
+    # Valid indices: 0 and 1. Index 2 == len(input_dependencies) should fail.
+    assert len(op._input_dependencies) == 2
+
+    # input_index == len(input_dependencies) must raise AssertionError.
+    with pytest.raises(AssertionError):
+        # refs is None here, but the assert fires before refs is used.
+        op._add_input_inner(None, input_index=2)
+
+
+def test_zip_operator_rejects_out_of_bounds_input_index():
+    """Bug 3: ZipOperator._add_input_inner used <= instead of <, allowing
+    input_index == len(input_dependencies) which is out of bounds."""
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    op = ZipOperator(DataContext.get_current(), input1, input2)
+
+    # Valid indices: 0 and 1. Index 2 == len(input_dependencies) should fail.
+    assert len(op._input_dependencies) == 2
+
+    # input_index == len(input_dependencies) must raise AssertionError.
+    with pytest.raises(AssertionError):
+        # refs is None here, but the assert fires before refs is used.
+        op._add_input_inner(None, input_index=2)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Three minor bugs in Ray Data operators:

1. `_concatenate_chunked_arrays` prints `type: None` in its assertion error message instead of the actual array type. The f-string uses `{type_}` which is always `None` at that point in the loop — it is initialized to `None` and only reassigned after the assertion.

2. `UnionOperator._add_input_inner` uses `<=` instead of `<` in its bounds check, allowing `input_index == len(self._input_dependencies)`. This is semantically incorrect — `input_index` is 0-based, so valid values are `[0, len-1]`. The `<=` allows an out-of-bounds index to pass the assertion.

3. `ZipOperator._add_input_inner` has the same off-by-one bounds check.

Both off-by-one bugs are corrected to match the pattern used by `MixOperator._add_input_inner` (line 95), which correctly uses strict `<`.

## What changes are made?

- `python/ray/data/_internal/arrow_ops/transform_pyarrow.py`: Change `{type_}` to `{arr.type}` in assertion error message
- `python/ray/data/_internal/execution/operators/union_operator.py`: Change `<=` to `<` in bounds check
- `python/ray/data/_internal/execution/operators/zip_operator.py`: Change `<=` to `<` in bounds check
- `python/ray/data/tests/unit/test_fix_operator_bounds_check.py`: Add 3 tests covering the fixes

## Related issues

N/A

## Checks

- [x] I've signed off every commit (using `git commit -s`)
- [x] I've run pre-commit hooks (ruff, black, semgrep, pydoclint) to lint the changes
- [x] I've added tests for the new behavior
