### PR TITLE
[Serve] Fix ZeroDivisionError in router and AttributeError in Deployment.__eq__

### DIFF
--- a/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
+++ b/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
@@ -265,7 +265,10 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
                             input_text, candidate_replica_ids_strings
                         )
                     )
-                    match_rate = len(matched_text) / len(input_text)
+                    if len(input_text) == 0:
+                        match_rate = 0.0
+                    else:
+                        match_rate = len(matched_text) / len(input_text)
                     if match_rate < self._match_rate_threshold:
                         smallest_tenants_id_strings = ray.get(
                             self._tree_actor.get_smallest_tenants.remote()

--- a/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
@@ -401,6 +401,44 @@ class TestPromptNormalization:
         await asyncio.sleep(0.1)
 
 
+class TestEmptyInputHandling:
+    """Tests that empty input text does not cause ZeroDivisionError."""
+
+    @pytest.mark.asyncio
+    async def test_empty_input_does_not_raise(self, prefix_request_router):
+        """Empty input text should return 0.0 match rate, not ZeroDivisionError."""
+        r1 = FakeRunningReplica("r1")
+        r1.set_queue_len_response(0)
+        r2 = FakeRunningReplica("r2")
+        r2.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r1, r2])
+
+        # Insert some text so the prefix tree has data
+        ray.get(
+            prefix_request_router._tree_actor.insert.remote(
+                "hello", r1.replica_id.to_full_id_str(), time.time()
+            )
+        )
+
+        # Create a request with empty content (unsupported multimodal)
+        empty_req = fake_pending_request(
+            messages=[
+                {
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://example.com"},
+                        },
+                    ]
+                }
+            ]
+        )
+        # Should not raise ZeroDivisionError
+        chosen = await prefix_request_router._choose_replica_for_request(empty_req)
+        # Should fall back to smallest tenant (both have 0 from empty text perspective)
+        assert chosen in [r1, r2]
+
+
 class TestMultiDeploymentIsolation:
     """Tests that multiple deployments get isolated prefix tree actors."""
 

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -456,6 +456,8 @@ class Deployment:
         )
 
     def __eq__(self, other):
+        if not isinstance(other, Deployment):
+            return NotImplemented
         return all(
             [
                 self._name == other._name,
@@ -494,9 +496,9 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
 
     deployment_options = {
         "name": d.name,
-        "num_replicas": None
-        if d._deployment_config.autoscaling_config
-        else d.num_replicas,
+        "num_replicas": (
+            None if d._deployment_config.autoscaling_config else d.num_replicas
+        ),
         "max_ongoing_requests": d.max_ongoing_requests,
         "max_queued_requests": d.max_queued_requests,
         "backpressure_config": d.backpressure_config,

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1636,5 +1636,38 @@ class TestTracingConfig:
         assert config.exporter_import_path == ""
 
 
+class TestDeploymentEquality:
+    """Tests for Deployment.__eq__ behavior with non-Deployment objects."""
+
+    def test_eq_with_non_deployment_returns_not_implemented(self):
+        """Comparing Deployment to non-Deployment should return NotImplemented."""
+        dc = DeploymentConfig.from_default()
+        rc = ReplicaConfig.create(lambda: None)
+        dep = Deployment(
+            name="test",
+            deployment_config=dc,
+            replica_config=rc,
+            _internal=True,
+        )
+        assert dep.__eq__("not a deployment") is NotImplemented
+        assert dep.__eq__(42) is NotImplemented
+        assert dep.__eq__(None) is NotImplemented
+
+    def test_eq_with_non_deployment_does_not_raise(self):
+        """Comparing Deployment to non-Deployment should not raise AttributeError."""
+        dc = DeploymentConfig.from_default()
+        rc = ReplicaConfig.create(lambda: None)
+        dep = Deployment(
+            name="test",
+            deployment_config=dc,
+            replica_config=rc,
+            _internal=True,
+        )
+        # These should not raise AttributeError (the bug was accessing other._name)
+        assert dep != "not a deployment"
+        assert dep != 42
+        assert dep != None  # noqa: E711
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Two boundary check bugs in Ray Serve:

1. `prefix_aware_router` crashes with `ZeroDivisionError` when `input_text` is an empty string (e.g., for unsupported multimodal content that yields no extractable text). The match rate calculation `len(matched_text) / len(input_text)` divides by zero.

2. `Deployment.__eq__()` directly accesses `other._name` without checking if `other` is a `Deployment` instance. Comparing a `Deployment` to any non-Deployment object (string, None, int) raises `AttributeError`.

## What changes are made?

- `python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py`: Add empty string guard before match rate division, setting `match_rate = 0.0` to trigger fallback routing
- `python/ray/serve/deployment.py`: Add `isinstance(other, Deployment)` guard returning `NotImplemented` per Python's data model convention
- `python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py`: Add test for empty input handling
- `python/ray/serve/tests/unit/test_schema.py`: Add tests for `__eq__` with non-Deployment types
- Minor formatting adjustment in `deployment_to_schema` (parenthesized ternary, auto-formatted by black)

## Related issues

Fixes #64573
Fixes #64574

## Checks

- [x] I've signed off every commit (using `git commit -s`)
- [x] I've run pre-commit hooks (ruff, black, semgrep, pydoclint) to lint the changes
- [x] I've added tests for the new behavior
