### PR TITLE
[ci] Drop CODEOWNERS entry for removed serve_hap_test_names.txt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,7 +117,6 @@
 /ci/docker @ray-project/ray-ci
 /ci/ray_ci @ray-project/ray-ci
 /ci/ray_ci/serve_di_test_names.txt @ray-project/ray-serve
-/ci/ray_ci/serve_hap_test_names.txt @ray-project/ray-serve
 
 /.rayciversion @ray-project/ray-ci
 


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to #64210, which deletes `ci/ray_ci/serve_hap_test_names.txt` (the HAProxy test allowlist). This removes the now-dead CODEOWNERS entry that would otherwise point at a nonexistent path.

Split out from #64210 so that PR does not require a CODEOWNERS review to merge.

**Merge after #64210.**

## Related issue number

Follow-up to #64210.

## Checks

- [x] I've signed off every commit (by using the -s flag).
