### PR TITLE
[serve] Fix HAProxy healthz falling through to 404 with no backends

### DIFF
--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -21,9 +21,10 @@ HAPROXY_HEALTHZ_RULES_TEMPLATE = """    # Health check endpoint
     http-request return status {{ health_info.status }} content-type text/plain string "{{ health_info.health_message }}" if healthcheck backend_{{ backend.name or 'unknown' }}_server_up
 {%-   endfor %}
     http-request return status 503 content-type text/plain string "Service Unavailable" if healthcheck
-{%- else %}
-    # Healthy node with no app backends. Return 200 so healthz does not fall
-    # through to the 404 default_backend.
+{%- elif config.is_head %}
+    # Head node stays ready with no app backends so a request can trigger upscale
+    # after apps scale to zero. Mirrors ProxyRouter.ready_for_traffic. A worker
+    # with no backends is not ready and falls through to the 404 default_backend.
     http-request return status {{ health_info.status }} content-type text/plain string "{{ health_info.health_message }}" if healthcheck
 {%- endif %}
 """
@@ -49,9 +50,10 @@ HAPROXY_GRPC_HEALTHZ_RULES_TEMPLATE = """    # Health check endpoint (gRPC `Heal
     http-request return status 200 content-type application/grpc hdr grpc-status 0 if is_healthz backend_{{ backend.name or 'unknown' }}_server_up
 {%-   endfor %}
     http-request return status 200 content-type application/grpc hdr grpc-status 14 hdr grpc-message "Service Unavailable" if is_healthz
-{%- else %}
-    # Healthy node with no app backends. Return OK so Healthz does not fall
-    # through to the NOT_FOUND default backend.
+{%- elif config.is_head %}
+    # Head node stays ready with no app backends so a request can trigger upscale
+    # after apps scale to zero. Mirrors ProxyRouter.ready_for_traffic. A worker
+    # with no backends is not ready and falls through to the NOT_FOUND backend.
     http-request return status 200 content-type application/grpc hdr grpc-status 0 if is_healthz
 {%- endif %}
 """

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -21,6 +21,10 @@ HAPROXY_HEALTHZ_RULES_TEMPLATE = """    # Health check endpoint
     http-request return status {{ health_info.status }} content-type text/plain string "{{ health_info.health_message }}" if healthcheck backend_{{ backend.name or 'unknown' }}_server_up
 {%-   endfor %}
     http-request return status 503 content-type text/plain string "Service Unavailable" if healthcheck
+{%- else %}
+    # Healthy node with no app backends. Return 200 so healthz does not fall
+    # through to the 404 default_backend.
+    http-request return status {{ health_info.status }} content-type text/plain string "{{ health_info.health_message }}" if healthcheck
 {%- endif %}
 """
 
@@ -45,6 +49,10 @@ HAPROXY_GRPC_HEALTHZ_RULES_TEMPLATE = """    # Health check endpoint (gRPC `Heal
     http-request return status 200 content-type application/grpc hdr grpc-status 0 if is_healthz backend_{{ backend.name or 'unknown' }}_server_up
 {%-   endfor %}
     http-request return status 200 content-type application/grpc hdr grpc-status 14 hdr grpc-message "Service Unavailable" if is_healthz
+{%- else %}
+    # Healthy node with no app backends. Return OK so Healthz does not fall
+    # through to the NOT_FOUND default backend.
+    http-request return status 200 content-type application/grpc hdr grpc-status 0 if is_healthz
 {%- endif %}
 """
 

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -22,9 +22,8 @@ HAPROXY_HEALTHZ_RULES_TEMPLATE = """    # Health check endpoint
 {%-   endfor %}
     http-request return status 503 content-type text/plain string "Service Unavailable" if healthcheck
 {%- elif config.is_head %}
-    # Head node stays ready with no app backends so a request can trigger upscale
-    # after apps scale to zero. Mirrors ProxyRouter.ready_for_traffic. A worker
-    # with no backends is not ready and falls through to the 404 default_backend.
+    # Head is the always-on ingress endpoint, so it stays ready with no backends.
+    # Mirrors is_head in ProxyRouter.ready_for_traffic.
     http-request return status {{ health_info.status }} content-type text/plain string "{{ health_info.health_message }}" if healthcheck
 {%- endif %}
 """
@@ -51,9 +50,8 @@ HAPROXY_GRPC_HEALTHZ_RULES_TEMPLATE = """    # Health check endpoint (gRPC `Heal
 {%-   endfor %}
     http-request return status 200 content-type application/grpc hdr grpc-status 14 hdr grpc-message "Service Unavailable" if is_healthz
 {%- elif config.is_head %}
-    # Head node stays ready with no app backends so a request can trigger upscale
-    # after apps scale to zero. Mirrors ProxyRouter.ready_for_traffic. A worker
-    # with no backends is not ready and falls through to the NOT_FOUND backend.
+    # Head is the always-on ingress endpoint, so it stays ready with no backends.
+    # Mirrors is_head in ProxyRouter.ready_for_traffic.
     http-request return status 200 content-type application/grpc hdr grpc-status 0 if is_healthz
 {%- endif %}
 """

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -1004,6 +1004,11 @@ def test_haproxy_empty_backends_for_scaled_down_apps(ray_shutdown):
     r = httpx.get("http://localhost:8000/test")
     assert r.status_code == 404
 
+    # Healthz stays 200 with no app backends instead of hitting the 404 default backend.
+    wait_for_condition(
+        lambda: httpx.get("http://localhost:8000/-/healthz").status_code == 200
+    )
+
     serve.shutdown()
 
 


### PR DESCRIPTION
## Why are these changes needed?

`test_head_and_worker_nodes_no_replicas` passed on [#64427](https://github.com/ray-project/ray/pull/64427), the PR that enabled it under HAProxy, then failed on nearly every run since. After `serve.delete` the head proxy briefly holds a fallback-backed config that answers `/-/healthz` with 200, then settles to an empty config that answers 404. The test passes or fails on which state its health check hits, and #64427 landed in the 200 window.

The head proxy is supposed to stay healthy even with zero backends. [`ProxyRouter.ready_for_traffic` returns ready for the head node even with no running replicas](https://github.com/ray-project/ray/blob/2214cc2b94b3be1010673f45bc7e78a5780e200b/python/ray/serve/_private/proxy_router.py#L72-L79), so a request can still arrive and trigger upscale after all deployments scale to zero. The native proxy returns 200 there, and HAProxy's `build_health_route_info` already computes the same `healthy=True, status=200`.

The bug is one layer down: `HAPROXY_HEALTHZ_RULES_TEMPLATE` only emits the return rule inside `{% elif backends %}`, so with zero backends nothing is rendered and the request falls through to the 404 default backend. gRPC `Healthz` has the same gap and falls through to NOT_FOUND.

The fix adds an `elif config.is_head` branch to both templates so a head node with no backends returns its healthy status, 200 for HTTP and grpc-status 0 for gRPC, mirroring the `is_head` short-circuit in `ready_for_traffic`. A worker with no backends stays not-ready as before, since it keeps `has_received_servers` set and native returns `NO_REPLICAS` for it. The drain and healthy-with-backends paths are unchanged. `test_haproxy_empty_backends_for_scaled_down_apps` gains a healthz-200-after-delete assertion.

## Related issue number

Closes #64585. Deflakes `test_head_and_worker_nodes_no_replicas` under HAProxy.

## Checks

- [x] I've signed off every commit (by using the -s flag).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've made sure the tests are passing.
