### PR TITLE
[core] fix duplicated test_streaming_generator_backpressure.py in bazel

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -377,22 +377,6 @@ py_test_module_list(
 )
 
 py_test_module_list(
-    size = "large",
-    files = [
-        "test_streaming_generator_backpressure.py",
-    ],
-    tags = [
-        "exclusive",
-        "large_size_python_tests_shard_1",
-        "team:core",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test_module_list(
     size = "medium",
     files = [
         "test_logging_java.py",


### PR DESCRIPTION
Fix the bazel lint failure:

```
[2026-07-07T18:37:09Z] ERROR: Traceback (most recent call last):
--
  | [2026-07-07T18:37:09Z] 	File "/ray/python/ray/tests/BUILD.bazel", line 918, column 20, in <toplevel>
  | [2026-07-07T18:37:09Z] 		py_test_module_list(
  | [2026-07-07T18:37:09Z] 	File "/ray/bazel/python.bzl", line 79, column 23, in py_test_module_list
  | [2026-07-07T18:37:09Z] 		native.py_test(
  | [2026-07-07T18:37:09Z] 	File "/virtual_builtins_bzl/common/python/py_test_macro.bzl", line 21, column 17, in py_test
  | [2026-07-07T18:37:09Z] Error in py_test: py_test rule 'test_streaming_generator_backpressure' in package 'python/ray/tests' conflicts with existing py_test rule, defined at /ray/python/ray/tests/BUILD.bazel:379:20
  | [2026-07-07T18:37:09Z] ERROR: package contains errors: python/ray/tests
  | [2026-07-07T18:37:09Z] Loading: 133 packages loaded
  | [2026-07-07T18:37:09Z]     currently loading: doc ... (2 packages)
  | [2026-07-07T18:37:10Z] ERROR: package contains errors: python/ray/tests: Traceback (most recent call last):
  | [2026-07-07T18:37:10Z] 	File "/ray/python/ray/tests/BUILD.bazel", line 918, column 20, in <toplevel>
  | [2026-07-07T18:37:10Z] 		py_test_module_list(
  | [2026-07-07T18:37:10Z] 	File "/ray/bazel/python.bzl", line 79, column 23, in py_test_module_list
  | [2026-07-07T18:37:10Z] 		native.py_test(
  | [2026-07-07T18:37:10Z] 	File "/virtual_builtins_bzl/common/python/py_test_macro.bzl", line 21, column 17, in py_test
  | [2026-07-07T18:37:10Z] Error in py_test: py_test rule 'test_streaming_generator_backpressure' in package 'python/ray/tests' conflicts with existing py_test rule, defined at /ray/python/ray/tests/BUILD.bazel:379:20
  | [2026-07-07T18:37:10Z] ERROR: Error evaluating '//...': error loading package 'python/ray/tests': Package 'python/ray/tests' contains errors

```

`test_streaming_generator_backpressure` is included in the `large_size_python_tests_shard_0`, no need to duplicate.