### PR TITLE
[doc][data] Add best practice for isolating Ray Data workers from training nodes

### DIFF
--- a/doc/source/data/concurrent-dataset-execution.md
+++ b/doc/source/data/concurrent-dataset-execution.md
@@ -21,7 +21,7 @@ There are two steps.
 
 ### 1. Label your worker nodes
 
-Label each worker node with the reserved key `ray-subcluster` to mark which subcluster it belongs to. See {ref}`labels` for how to configure labels — the mechanism depends on your deployment (cluster YAML, KubeRay, or `ray start --labels`).
+Label each worker node with the reserved key `ray-subcluster` to mark which subcluster it belongs to. See {ref}`labels` for how to configure labels. The mechanism used depends on your deployment (cluster YAML, KubeRay, or `ray start --labels`).
 
 For example, in a Ray cluster YAML config:
 

--- a/doc/source/data/concurrent-dataset-execution.md
+++ b/doc/source/data/concurrent-dataset-execution.md
@@ -21,22 +21,26 @@ There are two steps.
 
 ### 1. Label your worker nodes
 
-In your Anyscale [compute config](https://docs.anyscale.com/reference/compute-config-api/), add a `labels` block to each worker pool. Use the reserved key `ray-subcluster` to mark which subcluster each pool belongs to.
+Label each worker node with the reserved key `ray-subcluster` to mark which subcluster it belongs to. See {ref}`labels` for how to configure labels — the mechanism depends on your deployment (cluster YAML, KubeRay, or `ray start --labels`).
+
+For example, in a Ray cluster YAML config:
 
 ```yaml
-worker_nodes:
-  - name: train-workers
-    instance_type: g5.xlarge
-    min_nodes: 2
-    max_nodes: 4
+available_node_types:
+  train_workers:
+    min_workers: 2
+    max_workers: 4
     labels:
       ray-subcluster: training
-  - name: validation-workers
-    instance_type: g4dn.xlarge
-    min_nodes: 0
-    max_nodes: 2
+    node_config:
+      InstanceType: g5.xlarge
+  validation_workers:
+    min_workers: 0
+    max_workers: 2
     labels:
       ray-subcluster: validation
+    node_config:
+      InstanceType: g4dn.xlarge
 ```
 
 Subcluster values are arbitrary strings (`"training"`, `"validation"`, `"tenant_a"`, `"team-blue"`) — pick whatever makes sense for your workload.

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -662,9 +662,12 @@ In general, adding CPU-only nodes can help in two ways:
 Isolating Ray Data worker processes from training nodes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When training workers reserve most or all CPUs on their nodes, Ray Data can't schedule tasks there.
-However, Ray Data still counts those nodes' object store memory in its budget, which inflates the
-budget beyond what is actually usable and can cause unexpected spilling.
+You may sometimes want to prevent Ray Data CPU tasks from running on training worker nodes
+when training workers themselves run CPU/RAM-heavy operations
+such as storing large local shuffle buffers or running expensive collate functions.
+Launching more Ray Data processes would oversubscribe the training worker nodes.
+Instead, the Ray Data tasks should run on a separate set of CPU nodes in your heterogeneous
+cluster (ex: 4 GPU training nodes + 4 CPU-only nodes).
 
 One workaround is to force full-node exclusion by reserving all CPUs per training worker via
 ``resources_per_worker={"CPU": node_cpus // num_gpus_per_node, "GPU": 1}`` in ``ScalingConfig``.
@@ -704,11 +707,9 @@ where data tasks can actually run. It requires adding labels to your worker node
 
 .. tip::
 
-    Node isolation is most often needed when training workers run CPU-heavy operations
-    like large local shuffle buffers or expensive collate functions in-process, consuming
-    CPUs that Ray Data would otherwise use for its tasks.
-    Before isolating nodes, consider offloading that heavy work from training workers to the
-    data pipeline instead: :ref:`scale out expensive collation <scaling_collation_functions>`
+    Before resorting to isolating Ray Data tasks from training nodes, consider offloading that
+    heavy work from training workers to the data pipeline instead:
+    :ref:`scale out expensive collation <scaling_collation_functions>`
     and use :ref:`map_batches-based shuffling <map_batches_shuffle>` in place of large local
     shuffle buffers. These reduce CPU pressure on training workers and often eliminate the
     need for node isolation entirely.

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -682,7 +682,10 @@ where data tasks can actually run. It requires adding labels to your worker node
 
 .. code-block:: python
 
+    import ray
     from ray.data import ExecutionOptions
+    from ray.train import DataConfig
+    from ray.train.torch import TorchTrainer
 
     # (1) Pin construction-time tasks (schema inference, file listing).
     ctx = ray.data.DataContext.get_current().copy()
@@ -692,10 +695,10 @@ where data tasks can actually run. It requires adding labels to your worker node
 
     # (2) Pin per-worker ingest — Train replaces ds.context options
     # wholesale, so the selector must be restated here.
-    trainer = ray.train.torch.TorchTrainer(
+    trainer = TorchTrainer(
         ...,
         datasets={"train": train_dataset},
-        dataset_config=ray.train.DataConfig(
+        dataset_config=DataConfig(
             datasets_to_split=["train"],
             execution_options={
                 "train": ExecutionOptions(

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -659,6 +659,55 @@ In general, adding CPU-only nodes can help in two ways:
 * Adding more CPU cores helps further parallelize preprocessing. This approach is helpful when CPU compute time is the bottleneck.
 * Increasing object store memory, which 1) allows Ray Data to buffer more data in between preprocessing and training stages, and 2) provides more memory to make it possible to :ref:`cache the preprocessed dataset <dataset_cache_performance>`. This approach is helpful when memory is the bottleneck.
 
+Isolating data ingest from training nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When training workers reserve most or all CPUs on their nodes, Ray Data can't schedule tasks there.
+However, Ray Data still counts those nodes' object store memory in its budget, which inflates the
+budget beyond what is actually usable and can cause unexpected spilling.
+
+One workaround is to force full-node exclusion by reserving all CPUs per training worker via
+``resources_per_worker={"CPU": node_cpus // num_gpus_per_node, "GPU": 1}`` in ``ScalingConfig``.
+This is fragile because it's tied to specific node shapes and wastes CPU resources.
+
+The recommended approach is to use :ref:`subclusters <data_concurrent_execution>` to pin the
+training Dataset to CPU-only nodes. This correctly scopes the memory budget to only the nodes
+where data tasks can actually run. It requires labeling your worker pools in the
+`compute config <https://docs.anyscale.com/reference/compute-config-api/>`_ and setting the
+``label_selector`` in two places:
+
+.. code-block:: python
+
+    from ray.data import ExecutionOptions
+
+    # (1) Pin construction-time tasks (schema inference, file listing).
+    ctx = ray.data.DataContext.get_current().copy()
+    ctx.execution_options.label_selector = {"ray-subcluster": "data"}
+    with ray.data.DataContext.current(ctx):
+        train_dataset = ray.data.read_parquet(...)
+
+    # (2) Pin per-worker ingest — Train replaces ds.context options
+    # wholesale, so the selector must be restated here.
+    trainer = ray.train.torch.TorchTrainer(
+        ...,
+        datasets={"train": train_dataset},
+        dataset_config=ray.train.DataConfig(
+            datasets_to_split=["train"],
+            execution_options={
+                "train": ExecutionOptions(
+                    label_selector={"ray-subcluster": "data"}
+                ),
+            },
+        ),
+    )
+
+.. tip::
+
+    Before isolating nodes, consider offloading heavy work from training workers to the
+    data pipeline instead: :ref:`scale out expensive collation <scaling_collation_functions>`
+    and use :ref:`map_batches-based shuffling <map_batches_shuffle>` in place of large local
+    shuffle buffers. These reduce CPU pressure on training workers and often eliminate the
+    need for node isolation entirely.
+
 .. _balancing-data-production-consumption:
 
 Balancing data production and consumption

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -659,20 +659,22 @@ In general, adding CPU-only nodes can help in two ways:
 * Adding more CPU cores helps further parallelize preprocessing. This approach is helpful when CPU compute time is the bottleneck.
 * Increasing object store memory, which 1) allows Ray Data to buffer more data in between preprocessing and training stages, and 2) provides more memory to make it possible to :ref:`cache the preprocessed dataset <dataset_cache_performance>`. This approach is helpful when memory is the bottleneck.
 
-Isolating data ingest from training nodes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Isolating Ray Data worker processes from training nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 When training workers reserve most or all CPUs on their nodes, Ray Data can't schedule tasks there.
 However, Ray Data still counts those nodes' object store memory in its budget, which inflates the
 budget beyond what is actually usable and can cause unexpected spilling.
 
 One workaround is to force full-node exclusion by reserving all CPUs per training worker via
 ``resources_per_worker={"CPU": node_cpus // num_gpus_per_node, "GPU": 1}`` in ``ScalingConfig``.
-This is fragile because it's tied to specific node shapes and wastes CPU resources.
+This method is fragile since it's tied to node shapes, and Ray Data also doesn't exclude other
+resources such as object store memory properly, since the typical configuration is to only take up logical
+CPUs and GPUs.
 
 The recommended approach is to use :ref:`subclusters <data_concurrent_execution>` to pin the
 training Dataset to CPU-only nodes. This correctly scopes the memory budget to only the nodes
-where data tasks can actually run. It requires labeling your worker pools in the
-`compute config <https://docs.anyscale.com/reference/compute-config-api/>`_ and setting the
+where data tasks can actually run. It requires adding labels to your worker node configurations and setting the
 ``label_selector`` in two places:
 
 .. code-block:: python

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -704,7 +704,10 @@ where data tasks can actually run. It requires adding labels to your worker node
 
 .. tip::
 
-    Before isolating nodes, consider offloading heavy work from training workers to the
+    Node isolation is most often needed when training workers run CPU-heavy operations
+    like large local shuffle buffers or expensive collate functions in-process, consuming
+    CPUs that Ray Data would otherwise use for its tasks.
+    Before isolating nodes, consider offloading that heavy work from training workers to the
     data pipeline instead: :ref:`scale out expensive collation <scaling_collation_functions>`
     and use :ref:`map_batches-based shuffling <map_batches_shuffle>` in place of large local
     shuffle buffers. These reduce CPU pressure on training workers and often eliminate the

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -663,11 +663,11 @@ Isolating Ray Data worker processes from training nodes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You may sometimes want to prevent Ray Data CPU tasks from running on training worker nodes
-when training workers themselves run CPU/RAM-heavy operations
+when training workers themselves run CPU or RAM-heavy operations
 such as storing large local shuffle buffers or running expensive collate functions.
 Launching more Ray Data processes would oversubscribe the training worker nodes.
 Instead, the Ray Data tasks should run on a separate set of CPU nodes in your heterogeneous
-cluster (ex: 4 GPU training nodes + 4 CPU-only nodes).
+cluster (for example, 4 GPU training nodes and 4 CPU-only nodes).
 
 One workaround is to force full-node exclusion by reserving all CPUs per training worker via
 ``resources_per_worker={"CPU": node_cpus // num_gpus_per_node, "GPU": 1}`` in ``ScalingConfig``.


### PR DESCRIPTION
## Description

Adds a new "Isolating Ray Data worker processes from training nodes" section to the data loading performance tips, explaining how training workers that reserve all CPUs on GPU nodes can inflate Ray Data's object store memory budget and cause unexpected spilling.

Documents the `resources_per_worker` workaround and recommends `subclusters` (`label_selector`) as the preferred approach, with a code example showing both `DataContext.current()` and `DataConfig.execution_options` configuration points.

Also updates `concurrent-dataset-execution.md` to replace the Anyscale compute config reference with OSS Ray node labels docs and a cluster YAML example.