### PR TITLE
[Serve] Let multiplexed models fill batches independently

### DIFF
--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -122,6 +122,8 @@ class _BatchQueue:
         max_concurrent_batches: int,
         handle_batch_func: Optional[Callable] = None,
         batch_size_fn: Optional[Callable[[List], int]] = None,
+        semaphore: Optional[asyncio.Semaphore] = None,
+        on_idle: Optional[Callable[[], None]] = None,
     ) -> None:
         """Async queue that accepts individual items and returns batches.
 
@@ -153,9 +155,11 @@ class _BatchQueue:
         self.batch_wait_timeout_s = batch_wait_timeout_s
         self.max_concurrent_batches = max_concurrent_batches
         self.batch_size_fn = batch_size_fn
-        self.semaphore = asyncio.Semaphore(max_concurrent_batches)
+        self.semaphore = semaphore or asyncio.Semaphore(max_concurrent_batches)
+        self._on_idle = on_idle
         self.requests_available_event = asyncio.Event()
         self.tasks: Set[asyncio.Task] = set()
+        self._pending_batch_count = 0
 
         # Used for observability.
         self.curr_iteration_start_times: Dict[asyncio.Task, float] = {}
@@ -440,37 +444,6 @@ class _BatchQueue:
             for future in futures:
                 _set_exception_if_not_done(future, e)
 
-    def _split_batch_by_model_id(
-        self, batch: List[_SingleRequest]
-    ) -> List[List[_SingleRequest]]:
-        """Split a batch into sub-batches based on multiplexed_model_id.
-
-        When using model multiplexing with batching, requests for different models
-        may end up in the same batch. This method ensures that each sub-batch only
-        contains requests for the same model, preventing issues where a single batch
-        contains requests for different models.
-
-        If no requests have a multiplexed_model_id set, returns the original batch
-        as a single sub-batch.
-
-        Args:
-            batch: The batch of requests to split.
-
-        Returns:
-            A list of sub-batches, where each sub-batch contains requests for the
-            same multiplexed_model_id.
-        """
-        # Group requests by their multiplexed_model_id
-        model_id_to_requests: Dict[str, List[_SingleRequest]] = {}
-        for request in batch:
-            model_id = request.request_context.multiplexed_model_id
-            if model_id not in model_id_to_requests:
-                model_id_to_requests[model_id] = []
-            model_id_to_requests[model_id].append(request)
-
-        # Return sub-batches for each model_id
-        return list(model_id_to_requests.values())
-
     async def _process_batches(self, func: Callable) -> None:
         """Loops infinitely and processes queued request batches."""
         # When asyncio task is created, the task will inherit the request context from the current context.
@@ -479,52 +452,23 @@ class _BatchQueue:
         while not self._loop.is_closed():
             batch, _ = await self.wait_for_batch()
 
-            # Split batch by multiplexed_model_id to ensure requests for different
-            # models are processed in separate batches. This is necessary when using
-            # model multiplexing with batching, as a single batch containing requests
-            # for different models would not work correctly.
-            sub_batches = self._split_batch_by_model_id(batch)
+            self._pending_batch_count += 1
+            try:
+                await self.semaphore.acquire()
+            except asyncio.CancelledError:
+                self._pending_batch_count -= 1
+                raise
 
-            # Process all sub-batches together under a single semaphore permit.
-            # This ensures sub-batches from the same original batch run concurrently
-            # rather than being serialized by the semaphore.
-            promise = self._process_sub_batches(func, sub_batches)
+            promise = self._process_batch_inner(func, batch)
             task = asyncio.create_task(promise)
             self.tasks.add(task)
             self.curr_iteration_start_times[task] = time.time()
+            self._pending_batch_count -= 1
             task.add_done_callback(self._handle_completed_task)
-
-    async def _process_sub_batches(
-        self, func: Callable, sub_batches: List[List[_SingleRequest]]
-    ) -> None:
-        """Processes multiple sub-batches concurrently under a single semaphore permit.
-
-        This method acquires the semaphore once and then processes all sub-batches
-        in parallel, ensuring that sub-batches from the same original batch don't
-        compete for semaphore permits.
-        """
-        # NOTE: this semaphore caps the number of concurrent batches specified by `max_concurrent_batches`
-        async with self.semaphore:
-            # Create tasks for each sub-batch. We use asyncio.create_task() instead
-            # of passing coroutines directly to asyncio.gather() because create_task
-            # copies the current context, giving each sub-batch its own isolated
-            # contextvars. This prevents concurrent sub-batches from overwriting
-            # each other's _serve_batch_request_context, which would cause
-            # get_multiplexed_model_id() to return wrong values.
-            tasks = [
-                asyncio.create_task(self._process_batch_inner(func, sub_batch))
-                for sub_batch in sub_batches
-            ]
-            await asyncio.gather(*tasks)
 
     async def _process_batch_inner(
         self, func: Callable, batch: List[_SingleRequest]
     ) -> None:
-        """Processes a single batch without acquiring the semaphore.
-
-        This is the inner implementation called by _process_sub_batches after
-        the semaphore has already been acquired.
-        """
         # Remove requests that have been cancelled from the batch. If
         # all requests have been cancelled, simply return and wait for
         # the next batch.
@@ -532,8 +476,7 @@ class _BatchQueue:
         if len(batch) == 0:
             return
 
-        # Compute batch size for this sub-batch. Each sub-batch may have a different
-        # size, especially when splitting by model_id, so we compute it here.
+        # Compute batch size after dropping cancelled requests.
         computed_batch_size = self._compute_batch_size(batch)
 
         # Calculate and record batch utilization percentage.
@@ -599,9 +542,17 @@ class _BatchQueue:
             )
 
     def _handle_completed_task(self, task: asyncio.Task) -> None:
-        self.tasks.remove(task)
-        del self.curr_iteration_start_times[task]
-        self._log_if_exception(task.exception())
+        try:
+            self.tasks.remove(task)
+            del self.curr_iteration_start_times[task]
+            if task.cancelled():
+                logger.debug("Task was cancelled")
+            else:
+                self._log_if_exception(task.exception())
+        finally:
+            self.semaphore.release()
+            if self._on_idle is not None and self.is_idle():
+                self._on_idle()
 
     @staticmethod
     def _log_if_exception(exception_maybe: Optional[BaseException]) -> None:
@@ -611,6 +562,23 @@ class _BatchQueue:
             else:
                 logger.exception("Task failed unexpectedly")
 
+    def is_idle(self) -> bool:
+        return (
+            self.queue.empty()
+            and self._pending_batch_count == 0
+            and len(self.tasks) == 0
+            and len(self.curr_iteration_start_times) == 0
+        )
+
+    def shutdown(self) -> None:
+        if self._handle_batch_task is None or self._handle_batch_task.done():
+            return
+
+        # TODO(edoakes): although we try to gracefully shutdown here, it still
+        # causes some errors when the process exits due to the asyncio loop
+        # already being destroyed.
+        self._handle_batch_task.cancel()
+
     def __del__(self):
         if (
             self._handle_batch_task is None
@@ -618,10 +586,7 @@ class _BatchQueue:
         ):
             return
 
-        # TODO(edoakes): although we try to gracefully shutdown here, it still
-        # causes some errors when the process exits due to the asyncio loop
-        # already being destroyed.
-        self._handle_batch_task.cancel()
+        self.shutdown()
 
 
 class _LazyBatchQueueWrapper:
@@ -640,42 +605,68 @@ class _LazyBatchQueueWrapper:
         handle_batch_func: Optional[Callable] = None,
         batch_size_fn: Optional[Callable[[List], int]] = None,
     ):
-        self._queue: Optional[_BatchQueue] = None
+        self._queues: Dict[str, _BatchQueue] = {}
         self.max_batch_size = max_batch_size
         self.batch_wait_timeout_s = batch_wait_timeout_s
         self.max_concurrent_batches = max_concurrent_batches
         self.handle_batch_func = handle_batch_func
         self.batch_size_fn = batch_size_fn
+        self.semaphore = asyncio.Semaphore(max_concurrent_batches)
 
     @property
     def queue(self) -> _BatchQueue:
-        """Returns _BatchQueue.
+        """Returns the default _BatchQueue.
 
-        Initializes queue when called for the first time.
+        Initializes the default queue when called for the first time.
         """
-        if self._queue is None:
-            self._queue = _BatchQueue(
+        return self.get_queue("")
+
+    def get_queue(self, multiplexed_model_id: str) -> _BatchQueue:
+        """Returns the _BatchQueue for a multiplexed model ID."""
+        queue_key = multiplexed_model_id or ""
+        if queue_key not in self._queues:
+            queue: Optional[_BatchQueue] = None
+
+            def remove_queue_if_idle() -> None:
+                self._remove_queue_if_idle(queue_key, queue)
+
+            queue = _BatchQueue(
                 self.max_batch_size,
                 self.batch_wait_timeout_s,
                 self.max_concurrent_batches,
                 self.handle_batch_func,
                 self.batch_size_fn,
+                self.semaphore,
+                remove_queue_if_idle,
             )
-        return self._queue
+            self._queues[queue_key] = queue
+        return self._queues[queue_key]
+
+    def _remove_queue_if_idle(
+        self, queue_key: str, queue: Optional[_BatchQueue]
+    ) -> None:
+        if queue_key == "" or queue is None:
+            return
+
+        if self._queues.get(queue_key) is not queue or not queue.is_idle():
+            return
+
+        queue.shutdown()
+        del self._queues[queue_key]
 
     def set_max_batch_size(self, new_max_batch_size: int) -> None:
         """Updates queue's max_batch_size."""
 
         self.max_batch_size = new_max_batch_size
 
-        if self._queue is not None:
-            self._queue.set_max_batch_size(new_max_batch_size)
+        for queue in self._queues.values():
+            queue.set_max_batch_size(new_max_batch_size)
 
     def set_batch_wait_timeout_s(self, new_batch_wait_timeout_s: float) -> None:
         self.batch_wait_timeout_s = new_batch_wait_timeout_s
 
-        if self._queue is not None:
-            self._queue.batch_wait_timeout_s = new_batch_wait_timeout_s
+        for queue in self._queues.values():
+            queue.batch_wait_timeout_s = new_batch_wait_timeout_s
 
     def get_max_batch_size(self) -> int:
         return self.max_batch_size
@@ -685,9 +676,10 @@ class _LazyBatchQueueWrapper:
 
     def _get_curr_iteration_start_times(self) -> _RuntimeSummaryStatistics:
         """Gets summary statistics of current iteration's start times."""
-        return _RuntimeSummaryStatistics(
-            list(self.queue.curr_iteration_start_times.values())
-        )
+        start_times = []
+        for queue in self._queues.values():
+            start_times.extend(queue.curr_iteration_start_times.values())
+        return _RuntimeSummaryStatistics(start_times)
 
     async def _is_batching_task_alive(self) -> bool:
         """Gets whether default _BatchQueue's background task is alive.
@@ -695,10 +687,13 @@ class _LazyBatchQueueWrapper:
         Returns False if the batch handler doesn't use a default _BatchQueue.
         """
 
-        if hasattr(self.queue, "_handle_batch_task"):
-            return not self.queue._handle_batch_task.done()
-        else:
-            return False
+        if not self._queues:
+            _ = self.queue
+
+        return any(
+            hasattr(queue, "_handle_batch_task") and not queue._handle_batch_task.done()
+            for queue in self._queues.values()
+        )
 
     async def _get_handling_task_stack(self) -> Optional[str]:
         """Gets the stack for the default _BatchQueue's background task.
@@ -706,12 +701,17 @@ class _LazyBatchQueueWrapper:
         Returns empty string if the batch handler doesn't use a default _BatchQueue.
         """
 
-        if hasattr(self.queue, "_handle_batch_task"):
-            str_buffer = io.StringIO()
-            self.queue._handle_batch_task.print_stack(file=str_buffer)
-            return str_buffer.getvalue()
-        else:
-            return None
+        if not self._queues:
+            _ = self.queue
+
+        stack_traces = []
+        for queue in self._queues.values():
+            if hasattr(queue, "_handle_batch_task"):
+                str_buffer = io.StringIO()
+                queue._handle_batch_task.print_stack(file=str_buffer)
+                stack_traces.append(str_buffer.getvalue())
+
+        return "\n".join(stack_traces) if stack_traces else None
 
 
 def _validate_max_batch_size(max_batch_size):
@@ -954,10 +954,11 @@ def batch(
             if self is not None:
                 flattened_args = flattened_args[2:]
 
-            batch_queue = lazy_batch_queue_wrapper.queue
-
             future = get_or_create_event_loop().create_future()
             request_context = serve.context._get_serve_request_context()
+            batch_queue = lazy_batch_queue_wrapper.get_queue(
+                request_context.multiplexed_model_id
+            )
             trace_context = get_trace_context()
             batch_queue.put(
                 _SingleRequest(

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -160,6 +160,7 @@ class _BatchQueue:
         self.requests_available_event = asyncio.Event()
         self.tasks: Set[asyncio.Task] = set()
         self._pending_batch_count = 0
+        self._current_batch: List[_SingleRequest] = []
 
         # Used for observability.
         self.curr_iteration_start_times: Dict[asyncio.Task, float] = {}
@@ -268,103 +269,112 @@ class _BatchQueue:
         """
 
         batch = []
-        first_item = await self.queue.get()  # Block until first item arrives
+        try:
+            first_item = await self.queue.get()  # Block until first item arrives
+            batch.append(first_item)
+            self._current_batch = batch
 
-        # Cache current max_batch_size and batch_wait_timeout_s for this batch.
-        max_batch_size = self.max_batch_size
-        batch_wait_timeout_s = self.batch_wait_timeout_s
+            # Cache current max_batch_size and batch_wait_timeout_s for this batch.
+            max_batch_size = self.max_batch_size
+            batch_wait_timeout_s = self.batch_wait_timeout_s
 
-        # Check if first item alone exceeds max_batch_size (only with batch_size_fn)
-        if self.batch_size_fn is not None:
-            first_item_size = self._compute_batch_size([first_item])
-            if first_item_size > max_batch_size:
-                exc = RuntimeError(
-                    "Size of item is greater than max_batch_size. "
-                    "Please increase the max_batch_size or check the "
-                    "implementation of the batch_size_fn."
-                )
-                # Set exception on the future so the caller receives it
-                first_item.future.set_exception(exc)
-                return [], 0
-
-        batch.append(first_item)
-
-        # Wait self.timeout_s seconds for new queue arrivals.
-        batch_start_time = time.time()
-        while True:
-            # Record queue length metric.
-            self._batch_queue_length_gauge.set(
-                self.queue.qsize(), tags={"function_name": self._function_name}
-            )
-
-            remaining_batch_time_s = max(
-                batch_wait_timeout_s - (time.time() - batch_start_time), 0
-            )
-            try:
-                # Wait for new arrivals.
-                await asyncio.wait_for(
-                    self.requests_available_event.wait(), remaining_batch_time_s
-                )
-            except asyncio.TimeoutError:
-                pass
-
-            # Custom batch size function logic
+            # Check if first item alone exceeds max_batch_size (only with batch_size_fn)
             if self.batch_size_fn is not None:
-                # Add all new arrivals to the batch.
-                # Track items we need to put back if they don't fit
-                deferred_item = None
-                while not self.queue.empty():
-                    next_item = self.queue.get_nowait()
-                    # Temporarily add to check size
-                    batch.append(next_item)
-                    new_size = self._compute_batch_size(batch)
+                first_item_size = self._compute_batch_size([first_item])
+                if first_item_size > max_batch_size:
+                    exc = RuntimeError(
+                        "Size of item is greater than max_batch_size. "
+                        "Please increase the max_batch_size or check the "
+                        "implementation of the batch_size_fn."
+                    )
+                    # Set exception on the future so the caller receives it
+                    first_item.future.set_exception(exc)
+                    return [], 0
 
-                    if new_size > max_batch_size:
-                        # Would exceed limit, remove it and save for later
-                        batch.pop()
-                        deferred_item = next_item
+            # Wait self.timeout_s seconds for new queue arrivals.
+            batch_start_time = time.time()
+            while True:
+                # Record queue length metric.
+                self._batch_queue_length_gauge.set(
+                    self.queue.qsize(), tags={"function_name": self._function_name}
+                )
+
+                remaining_batch_time_s = max(
+                    batch_wait_timeout_s - (time.time() - batch_start_time), 0
+                )
+                try:
+                    # Wait for new arrivals.
+                    await asyncio.wait_for(
+                        self.requests_available_event.wait(), remaining_batch_time_s
+                    )
+                except asyncio.TimeoutError:
+                    pass
+
+                # Custom batch size function logic
+                if self.batch_size_fn is not None:
+                    # Add all new arrivals to the batch.
+                    # Track items we need to put back if they don't fit
+                    deferred_item = None
+                    while not self.queue.empty():
+                        next_item = self.queue.get_nowait()
+                        # Temporarily add to check size
+                        batch.append(next_item)
+                        new_size = self._compute_batch_size(batch)
+
+                        if new_size > max_batch_size:
+                            # Would exceed limit, remove it and save for later
+                            batch.pop()
+                            deferred_item = next_item
+                            break
+                        # Size is OK, keep it in the batch (already added above)
+
+                    # Put deferred item back in queue for next batch
+                    if deferred_item is not None:
+                        # NOTE: The deferred item goes to the back of the queue
+                        # (FIFO), so newer requests may be processed before it.
+                        # Consider using asyncio.PriorityQueue if strict ordering
+                        # is required.
+                        self.queue.put_nowait(deferred_item)
+                        # Compute final batch size before breaking (batch is now
+                        # valid after popping the deferred item).
+                        current_batch_size = self._compute_batch_size(batch)
+                        # break the loop early because the deferred item is too
+                        # large to fit in the batch
                         break
-                    # Size is OK, keep it in the batch (already added above)
+                else:
+                    # Default behavior: use original len() check logic
+                    while len(batch) < max_batch_size and not self.queue.empty():
+                        batch.append(self.queue.get_nowait())
 
-                # Put deferred item back in queue for next batch
-                if deferred_item is not None:
-                    # NOTE: The deferred item goes to the back of the queue (FIFO),
-                    # so newer requests may be processed before it. Consider using
-                    # asyncio.PriorityQueue if strict ordering is required.
-                    self.queue.put_nowait(deferred_item)
-                    # Compute final batch size before breaking (batch is now valid
-                    # after popping the deferred item).
-                    current_batch_size = self._compute_batch_size(batch)
-                    # break the loop early because the deferred item is too large to fit in the batch
+                # Only clear the put event if the queue is empty. If it's not empty
+                # we can start constructing a new batch immediately in the next loop.
+                # The code that puts items into the queue runs on the same event loop
+                # as this code, so there's no race condition between the time we
+                # get objects in the queue (and clear the event) and when objects
+                # get added to the queue.
+                if self.queue.empty():
+                    self.requests_available_event.clear()
+
+                current_batch_size = self._compute_batch_size(batch)
+                if (
+                    time.time() - batch_start_time >= batch_wait_timeout_s
+                    or current_batch_size >= max_batch_size
+                ):
                     break
-            else:
-                # Default behavior: use original len() check logic
-                while len(batch) < max_batch_size and not self.queue.empty():
-                    batch.append(self.queue.get_nowait())
 
-            # Only clear the put event if the queue is empty. If it's not empty
-            # we can start constructing a new batch immediately in the next loop.
-            # The code that puts items into the queue runs on the same event loop
-            # as this code, so there's no race condition between the time we
-            # get objects in the queue (and clear the event) and when objects
-            # get added to the queue.
-            if self.queue.empty():
-                self.requests_available_event.clear()
+            # Record batch wait time metric (time spent waiting for batch to fill).
+            batch_wait_time_ms = (time.time() - batch_start_time) * 1000
+            self._batch_wait_time_histogram.observe(
+                batch_wait_time_ms, tags={"function_name": self._function_name}
+            )
 
-            current_batch_size = self._compute_batch_size(batch)
-            if (
-                time.time() - batch_start_time >= batch_wait_timeout_s
-                or current_batch_size >= max_batch_size
-            ):
-                break
-
-        # Record batch wait time metric (time spent waiting for batch to fill).
-        batch_wait_time_ms = (time.time() - batch_start_time) * 1000
-        self._batch_wait_time_histogram.observe(
-            batch_wait_time_ms, tags={"function_name": self._function_name}
-        )
-
-        return batch, current_batch_size
+            return batch, current_batch_size
+        except asyncio.CancelledError as e:
+            for request in batch:
+                _set_exception_if_not_done(request.future, e)
+            raise
+        finally:
+            self._current_batch = []
 
     def _validate_results(
         self, results: Iterable[Any], input_batch_length: int
@@ -455,7 +465,9 @@ class _BatchQueue:
             self._pending_batch_count += 1
             try:
                 await self.semaphore.acquire()
-            except asyncio.CancelledError:
+            except asyncio.CancelledError as e:
+                for request in batch:
+                    _set_exception_if_not_done(request.future, e)
                 self._pending_batch_count -= 1
                 raise
 
@@ -568,6 +580,7 @@ class _BatchQueue:
             and self._pending_batch_count == 0
             and len(self.tasks) == 0
             and len(self.curr_iteration_start_times) == 0
+            and len(self._current_batch) == 0
         )
 
     def shutdown(self) -> None:

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -724,7 +724,11 @@ def test_multiplexed_batching_concurrent_subbatches_context_isolation(serve_inst
         async def get_model(self, model_id: str):
             return model_id
 
-        @serve.batch(max_batch_size=10, batch_wait_timeout_s=1.0)
+        @serve.batch(
+            max_batch_size=10,
+            batch_wait_timeout_s=1.0,
+            max_concurrent_batches=3,
+        )
         async def batched_predict(self, inputs: List[str]):
             # Phase 1: Wait at the barrier.
             await signal_barrier.wait.remote()
@@ -752,7 +756,7 @@ def test_multiplexed_batching_concurrent_subbatches_context_isolation(serve_inst
     handle = serve.run(ConcurrentBatchedModel.bind())
 
     # Send concurrent requests with different model IDs.
-    # These will be split into separate sub-batches and processed concurrently.
+    # These will be processed by separate per-model queues concurrently.
     refs = []
     model_ids = ["model_a", "model_b", "model_c"]
     requests_per_model = 3
@@ -765,12 +769,12 @@ def test_multiplexed_batching_concurrent_subbatches_context_isolation(serve_inst
                 )
             )
 
-    # Wait for all sub-batches to be at the barrier
+    # Wait for all model-specific batches to be at the barrier.
     wait_for_condition(
         lambda: ray.get(signal_barrier.cur_num_waiters.remote()) == len(model_ids)
     )
 
-    # Release all sub-batches to read their model_id
+    # Release all batches to read their model_id.
     ray.get(signal_barrier.send.remote())
 
     # Collect results
@@ -782,8 +786,8 @@ def test_multiplexed_batching_concurrent_subbatches_context_isolation(serve_inst
         expected_model = model_ids[i // requests_per_model]
         assert result.startswith(f"{expected_model}:"), (
             f"Expected result to start with '{expected_model}:', got '{result}'. "
-            "This indicates context isolation failure - a sub-batch read another "
-            "sub-batch's model_id because they share the same context."
+            "This indicates context isolation failure - a model queue batch read "
+            "another model queue batch's model_id."
         )
 
     # Verify model ID readings
@@ -792,13 +796,13 @@ def test_multiplexed_batching_concurrent_subbatches_context_isolation(serve_inst
     # Count how many different model_ids were read
     read_model_ids = {r["model_id"] for r in readings}
 
-    # With the bug: all sub-batches read the same model_id (only 1 unique)
-    # With the fix: each sub-batch reads its own model_id (3 unique)
+    # With the bug: all batches read the same model_id (only 1 unique)
+    # With the fix: each model queue batch reads its own model_id (3 unique)
     assert len(read_model_ids) == len(model_ids), (
         f"Expected {len(model_ids)} different model_ids to be read, but got "
         f"{len(read_model_ids)}: {read_model_ids}. "
-        f"This indicates context isolation failure - multiple sub-batches "
-        f"read the same model_id because they share context. "
+        f"This indicates context isolation failure - multiple model queue batches "
+        f"read the same model_id. "
         f"Full readings: {readings}"
     )
 

--- a/python/ray/serve/tests/unit/test_batching.py
+++ b/python/ray/serve/tests/unit/test_batching.py
@@ -37,6 +37,21 @@ class FakeStream:
         self.messages = []
 
 
+def _make_request(func, request, model_id: str = ""):
+    future = get_or_create_event_loop().create_future()
+    request_context = ray.serve.context._RequestContext(
+        multiplexed_model_id=model_id
+    )
+    single_request = _SingleRequest(
+        self_arg=None,
+        flattened_args=flatten_args(extract_signature(func), (request,), {}),
+        future=future,
+        request_context=request_context,
+        trace_context=None,
+    )
+    return single_request, future
+
+
 # We use a single event loop for the entire test session. Without this
 # fixture, the event loop is sometimes prematurely terminated by pytest.
 @pytest.fixture(scope="session")
@@ -529,6 +544,114 @@ async def test_pending_multiplexed_batch_queue_not_cleaned_up():
     finally:
         model_queue._pending_batch_count = 0
         model_queue._handle_batch_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_accumulating_multiplexed_batch_queue_not_cleaned_up():
+    batch_started_event = asyncio.Event()
+    finish_batch_event = asyncio.Event()
+
+    async def blocked_batch(requests):
+        batch_started_event.set()
+        await finish_batch_event.wait()
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(
+        max_batch_size=2,
+        batch_wait_timeout_s=1000,
+        max_concurrent_batches=1,
+        handle_batch_func=blocked_batch,
+    )
+    model_queue = wrapper.get_queue("model-a")
+
+    try:
+        first_request, first_future = _make_request(
+            blocked_batch, "request-1", "model-a"
+        )
+        second_request, second_future = _make_request(
+            blocked_batch, "request-2", "model-a"
+        )
+        model_queue.put(first_request)
+        model_queue.put(second_request)
+
+        await asyncio.wait_for(batch_started_event.wait(), timeout=1)
+
+        third_request, third_future = _make_request(
+            blocked_batch, "request-3", "model-a"
+        )
+        model_queue.put(third_request)
+
+        for _ in range(100):
+            if model_queue.queue.empty():
+                break
+            await asyncio.sleep(0)
+        assert model_queue.queue.empty()
+
+        finish_batch_event.set()
+        assert await asyncio.wait_for(
+            asyncio.gather(first_future, second_future), timeout=1
+        ) == ["request-1", "request-2"]
+
+        await asyncio.sleep(0)
+        assert wrapper._queues["model-a"] is model_queue
+        assert not model_queue._handle_batch_task.cancelled()
+        assert not third_future.done()
+
+        fourth_request, fourth_future = _make_request(
+            blocked_batch, "request-4", "model-a"
+        )
+        model_queue.put(fourth_request)
+
+        assert await asyncio.wait_for(
+            asyncio.gather(third_future, fourth_future), timeout=1
+        ) == ["request-3", "request-4"]
+
+        for _ in range(10):
+            if "model-a" not in wrapper._queues:
+                break
+            await asyncio.sleep(0)
+        assert "model-a" not in wrapper._queues
+    finally:
+        if "model-a" in wrapper._queues:
+            model_queue.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_pending_batch_sets_dequeued_request_exceptions():
+    async def no_op(requests):
+        return requests
+
+    semaphore = asyncio.Semaphore(1)
+    await semaphore.acquire()
+
+    queue = _BatchQueue(
+        max_batch_size=1,
+        batch_wait_timeout_s=0,
+        max_concurrent_batches=1,
+        handle_batch_func=no_op,
+        semaphore=semaphore,
+    )
+    request, future = _make_request(no_op, "request")
+    queue.put(request)
+
+    try:
+        for _ in range(100):
+            if queue._pending_batch_count == 1 and queue.queue.empty():
+                break
+            await asyncio.sleep(0)
+        assert queue._pending_batch_count == 1
+        assert queue.queue.empty()
+
+        queue.shutdown()
+        with pytest.raises(asyncio.CancelledError):
+            await queue._handle_batch_task
+
+        assert future.done()
+        with pytest.raises(asyncio.CancelledError):
+            future.result()
+    finally:
+        semaphore.release()
+        queue.shutdown()
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/unit/test_batching.py
+++ b/python/ray/serve/tests/unit/test_batching.py
@@ -7,11 +7,12 @@ import pytest
 
 import ray
 from ray import serve
+from ray._common.signature import extract_signature, flatten_args
 from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import DeploymentID, ReplicaID
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import SERVE_LOGGER_NAME
-from ray.serve.batching import _BatchQueue
+from ray.serve.batching import _BatchQueue, _LazyBatchQueueWrapper, _SingleRequest
 from ray.serve.exceptions import RayServeException
 
 # Setup the global replica context for the test.
@@ -305,6 +306,292 @@ async def test_batch_size_multiple_long_timeout(use_class):
         t2.result()
     with pytest.raises(ZeroDivisionError):
         t3.result()
+
+
+@pytest.mark.asyncio
+async def test_multiplexed_batches_fill_per_model_id():
+    batch_records = []
+
+    @serve.batch(max_batch_size=5, batch_wait_timeout_s=1000)
+    async def multiplexed_batch(requests):
+        model_id = serve.get_multiplexed_model_id()
+        batch_records.append((model_id, len(requests), list(requests)))
+        return [f"{model_id}:{request}" for request in requests]
+
+    async def call(model_id: str, request: str):
+        ray.serve.context._set_request_context(multiplexed_model_id=model_id)
+        try:
+            return await multiplexed_batch(request)
+        finally:
+            ray.serve.context._unset_request_context()
+
+    tasks = []
+    for i in range(5):
+        tasks.append(get_or_create_event_loop().create_task(call("model-a", f"a-{i}")))
+        tasks.append(get_or_create_event_loop().create_task(call("model-b", f"b-{i}")))
+
+    assert await asyncio.gather(*tasks) == [
+        "model-a:a-0",
+        "model-b:b-0",
+        "model-a:a-1",
+        "model-b:b-1",
+        "model-a:a-2",
+        "model-b:b-2",
+        "model-a:a-3",
+        "model-b:b-3",
+        "model-a:a-4",
+        "model-b:b-4",
+    ]
+
+    assert sorted((model_id, size) for model_id, size, _ in batch_records) == [
+        ("model-a", 5),
+        ("model-b", 5),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiplexed_batches_do_not_run_before_model_batch_fills():
+    batch_records = []
+
+    @serve.batch(max_batch_size=5, batch_wait_timeout_s=1000)
+    async def multiplexed_batch(requests):
+        model_id = serve.get_multiplexed_model_id()
+        batch_records.append((model_id, len(requests), list(requests)))
+        return [f"{model_id}:{request}" for request in requests]
+
+    async def call(model_id: str, request: str):
+        ray.serve.context._set_request_context(multiplexed_model_id=model_id)
+        try:
+            return await multiplexed_batch(request)
+        finally:
+            ray.serve.context._unset_request_context()
+
+    model_a_tasks = [
+        get_or_create_event_loop().create_task(call("model-a", f"a-{i}"))
+        for i in range(4)
+    ]
+    first_model_b_task = get_or_create_event_loop().create_task(call("model-b", "b-0"))
+
+    done, _ = await asyncio.wait(model_a_tasks + [first_model_b_task], timeout=0.05)
+    assert len(done) == 0
+    assert batch_records == []
+
+    final_model_a_task = get_or_create_event_loop().create_task(call("model-a", "a-4"))
+    assert await asyncio.wait_for(
+        asyncio.gather(*model_a_tasks, final_model_a_task), timeout=1
+    ) == [
+        "model-a:a-0",
+        "model-a:a-1",
+        "model-a:a-2",
+        "model-a:a-3",
+        "model-a:a-4",
+    ]
+
+    done, _ = await asyncio.wait([first_model_b_task], timeout=0.05)
+    assert len(done) == 0
+    assert batch_records == [("model-a", 5, ["a-0", "a-1", "a-2", "a-3", "a-4"])]
+
+    remaining_model_b_tasks = [
+        get_or_create_event_loop().create_task(call("model-b", f"b-{i}"))
+        for i in range(1, 5)
+    ]
+    assert await asyncio.wait_for(
+        asyncio.gather(first_model_b_task, *remaining_model_b_tasks), timeout=1
+    ) == [
+        "model-b:b-0",
+        "model-b:b-1",
+        "model-b:b-2",
+        "model-b:b-3",
+        "model-b:b-4",
+    ]
+
+    assert batch_records == [
+        ("model-a", 5, ["a-0", "a-1", "a-2", "a-3", "a-4"]),
+        ("model-b", 5, ["b-0", "b-1", "b-2", "b-3", "b-4"]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiplexed_batch_queues_share_max_concurrent_batches():
+    running_batches = 0
+    max_running_batches = 0
+    batch_started_event = asyncio.Event()
+    finish_batches_event = asyncio.Event()
+
+    async def blocked_batch(requests):
+        nonlocal running_batches, max_running_batches
+
+        running_batches += 1
+        max_running_batches = max(max_running_batches, running_batches)
+        if running_batches == 2:
+            batch_started_event.set()
+
+        await finish_batches_event.wait()
+        running_batches -= 1
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(
+        max_batch_size=1,
+        batch_wait_timeout_s=0,
+        max_concurrent_batches=2,
+        handle_batch_func=blocked_batch,
+    )
+
+    futures = []
+    for model_id in ["model-a", "model-b", "model-c"]:
+        future = get_or_create_event_loop().create_future()
+        request_context = ray.serve.context._RequestContext(
+            multiplexed_model_id=model_id
+        )
+        wrapper.get_queue(model_id).put(
+            _SingleRequest(
+                self_arg=None,
+                flattened_args=flatten_args(
+                    extract_signature(blocked_batch), (model_id,), {}
+                ),
+                future=future,
+                request_context=request_context,
+                trace_context=None,
+            )
+        )
+        futures.append(future)
+
+    await asyncio.wait_for(batch_started_event.wait(), timeout=1)
+    await asyncio.sleep(0.05)
+
+    assert running_batches == 2
+    assert max_running_batches == 2
+    assert not futures[2].done()
+
+    finish_batches_event.set()
+    assert await asyncio.wait_for(asyncio.gather(*futures), timeout=1) == [
+        "model-a",
+        "model-b",
+        "model-c",
+    ]
+    assert max_running_batches == 2
+
+
+@pytest.mark.asyncio
+async def test_idle_multiplexed_batch_queue_cleanup():
+    async def no_op(requests):
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(max_batch_size=1, handle_batch_func=no_op)
+    default_queue = wrapper.get_queue("")
+    model_queue = wrapper.get_queue("model-a")
+    model_queue_task = model_queue._handle_batch_task
+
+    wrapper._remove_queue_if_idle("", default_queue)
+    assert wrapper._queues[""] is default_queue
+
+    wrapper._remove_queue_if_idle("model-a", model_queue)
+    await asyncio.sleep(0)
+
+    assert "model-a" not in wrapper._queues
+    assert model_queue_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_active_multiplexed_batch_queue_not_cleaned_up():
+    async def no_op(requests):
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(max_batch_size=1, handle_batch_func=no_op)
+    model_queue = wrapper.get_queue("model-a")
+    active_task = get_or_create_event_loop().create_task(asyncio.sleep(1000))
+    model_queue.tasks.add(active_task)
+
+    try:
+        wrapper._remove_queue_if_idle("model-a", model_queue)
+
+        assert wrapper._queues["model-a"] is model_queue
+        assert not model_queue._handle_batch_task.cancelled()
+    finally:
+        active_task.cancel()
+        model_queue._handle_batch_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_pending_multiplexed_batch_queue_not_cleaned_up():
+    async def no_op(requests):
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(max_batch_size=1, handle_batch_func=no_op)
+    model_queue = wrapper.get_queue("model-a")
+    model_queue._pending_batch_count = 1
+
+    try:
+        wrapper._remove_queue_if_idle("model-a", model_queue)
+
+        assert wrapper._queues["model-a"] is model_queue
+        assert not model_queue._handle_batch_task.cancelled()
+    finally:
+        model_queue._pending_batch_count = 0
+        model_queue._handle_batch_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_completed_multiplexed_batch_queue_cleans_itself_up():
+    async def no_op(requests):
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(max_batch_size=1, handle_batch_func=no_op)
+    model_queue = wrapper.get_queue("model-a")
+    future = get_or_create_event_loop().create_future()
+    request_context = ray.serve.context._RequestContext(multiplexed_model_id="model-a")
+
+    model_queue.put(
+        _SingleRequest(
+            self_arg=None,
+            flattened_args=flatten_args(extract_signature(no_op), ("request",), {}),
+            future=future,
+            request_context=request_context,
+            trace_context=None,
+        )
+    )
+
+    assert await future == "request"
+
+    for _ in range(10):
+        if "model-a" not in wrapper._queues:
+            break
+        await asyncio.sleep(0)
+
+    assert "model-a" not in wrapper._queues
+
+
+@pytest.mark.asyncio
+async def test_cancelled_multiplexed_batch_queue_cleans_itself_up():
+    async def no_op(requests):
+        return requests
+
+    wrapper = _LazyBatchQueueWrapper(
+        max_batch_size=10,
+        batch_wait_timeout_s=0,
+        handle_batch_func=no_op,
+    )
+    model_queue = wrapper.get_queue("model-a")
+    future = get_or_create_event_loop().create_future()
+    future.cancel()
+    request_context = ray.serve.context._RequestContext(multiplexed_model_id="model-a")
+
+    model_queue.put(
+        _SingleRequest(
+            self_arg=None,
+            flattened_args=flatten_args(extract_signature(no_op), ("request",), {}),
+            future=future,
+            request_context=request_context,
+            trace_context=None,
+        )
+    )
+
+    for _ in range(10):
+        if "model-a" not in wrapper._queues:
+            break
+        await asyncio.sleep(0)
+
+    assert "model-a" not in wrapper._queues
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This is a follow-up to #59334 for the batching + multiplexing behavior reported in #56633.

#59334 prevents requests for different multiplexed model IDs from being processed in the same user batch, but requests still enter a shared batch queue before being split by model ID. When multiple models receive traffic concurrently, that shared queue can fill with requests for different models, so each model receives only a partial sub-batch.

This PR routes batched Serve requests through per-model-ID batch queues so each multiplexed model can fill its own batch up to `max_batch_size` or until the batching timeout.

## Related issues

Related to #56633
Follow-up to #59334

## Additional information

The per-model queues share the same `max_concurrent_batches` semaphore, so this preserves the replica-level concurrency limit across multiplexed model IDs.

Idle non-default model queues are cleaned up after their work drains so one-off model IDs do not leave queue state behind.

Tested with:

```bash
python -m pytest -v -s --pyargs ray.serve.tests.unit.test_batching
ray stop --force
python -m pytest -v -s --pyargs ray.serve.tests.test_multiplex
python -m pytest -v -s --pyargs ray.serve.tests.unit.test_build_app -k "multiplex"