### PR TITLE
[Data] Fix ResourceBudget backpressure causing pipeline stall

### DIFF
--- a/python/ray/data/_internal/execution/__init__.py
+++ b/python/ray/data/_internal/execution/__init__.py
@@ -43,6 +43,12 @@ def create_resource_allocator(
         return ReservationOpResourceAllocator(
             resource_manager,
             reservation_ratio=data_context.op_resource_reservation_ratio,
+            object_store_reservation_overshoot_ratio=(
+                data_context.object_store_reservation_overshoot_ratio
+            ),
+            object_store_memory_pressure_fraction=(
+                data_context.object_store_memory_pressure_fraction
+            ),
         )
 
     else:

--- a/python/ray/data/_internal/execution/__init__.py
+++ b/python/ray/data/_internal/execution/__init__.py
@@ -43,6 +43,12 @@ def create_resource_allocator(
         return ReservationOpResourceAllocator(
             resource_manager,
             reservation_ratio=data_context.op_resource_reservation_ratio,
+            object_store_reservation_overshoot_ratio=(
+                data_context.object_store_reservation_overshoot_ratio
+            ),
+            object_store_pool_pressure_fraction=(
+                data_context.object_store_pool_pressure_fraction
+            ),
         )
 
     else:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -3,7 +3,15 @@ import math
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+)
 
 from ray._common.utils import env_bool, env_float
 from ray.data._internal.execution import create_resource_allocator
@@ -531,6 +539,18 @@ class ResourceManager:
             for op in self._get_downstream_ineligible_ops(op)
         )
 
+    def _feeds_blocking_materializing_op(self, op: PhysicalOperator) -> bool:
+        """Whether a blocking, materializing operator consumes ``op``'s output.
+
+        Unlike ``_is_blocking_materializing_op``, eligibility is irrelevant. Only
+        the immediate consumer counts: in ``Map1 -> Map2 -> Join`` it's Map2 that
+        holds the line, and exempting it keeps Map1 from backing up.
+        """
+        return any(
+            isinstance(downstream_op, _BLOCKING_MATERIALIZING_OPERATORS)
+            for downstream_op in self.get_downstream_eligible_ops(op)
+        )
+
 
 def _get_first_pending_materializing_op(topology: "Topology") -> int:
     for idx, op in enumerate(topology):
@@ -652,11 +672,38 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
     worse performance. And vice versa.
     """
 
-    def __init__(self, resource_manager: ResourceManager, reservation_ratio: float):
+    def __init__(
+        self,
+        resource_manager: ResourceManager,
+        reservation_ratio: float,
+        object_store_reservation_overshoot_ratio: Optional[float],
+        object_store_memory_pressure_fraction: Optional[float],
+    ):
         super().__init__(resource_manager)
 
         self._reservation_ratio = reservation_ratio
         assert 0.0 <= self._reservation_ratio <= 1.0
+        if (
+            object_store_reservation_overshoot_ratio is not None
+            and not 1.0 <= object_store_reservation_overshoot_ratio < math.inf
+        ):
+            raise ValueError(
+                "object_store_reservation_overshoot_ratio must be None or a finite "
+                f"float >= 1.0, got {object_store_reservation_overshoot_ratio}"
+            )
+        if object_store_memory_pressure_fraction is not None and not (
+            0.0 < object_store_memory_pressure_fraction <= 1.0
+        ):
+            raise ValueError(
+                "object_store_memory_pressure_fraction must be None or in the "
+                f"range (0.0, 1.0], got {object_store_memory_pressure_fraction}"
+            )
+        self._object_store_reservation_overshoot_ratio = (
+            object_store_reservation_overshoot_ratio
+        )
+        self._object_store_memory_pressure_fraction = (
+            object_store_memory_pressure_fraction
+        )
         # Per-op reserved resources, excluding `_reserved_for_op_outputs`.
         self._op_reserved: Dict[PhysicalOperator, ExecutionResources] = {}
         # Memory reserved exclusively for the outputs of each operator.
@@ -773,19 +820,43 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             )
 
     def can_submit_new_task(self, op: PhysicalOperator) -> bool:
-        """Return whether the given operator can submit a new task based on budget."""
+        """Return whether the given operator can submit a new task based on budget.
+
+        CPU/GPU/memory limits are always enforced. When only the object-store
+        output budget is exhausted, an idle operator holding queued input is
+        allowed one task, so it drains what it holds instead of upstream being
+        relaxed to push more into an already-full store.
+        """
         budget = self.get_budget(op)
 
         if budget is None:
             return True
 
+        if not op.incremental_resource_usage().satisfies_limit(budget):
+            return False
+
+        if not self._is_task_submission_blocked_on_output_budget(op, budget):
+            return True
+
+        # NOTE: Returning True below also stops Case 1 of
+        #       `OutputBackpressureGuard.should_unblock` relaxing upstream here,
+        #       which would only deepen the pressure.
+        #
+        # Pressure check first: it short-circuits on the default path, where the
+        # threshold is unset.
         return (
-            op.incremental_resource_usage().satisfies_limit(budget)
-            and
-            # Avoid scheduling if there's no more Object Store budget (for
-            # task outputs)
-            budget.object_store_memory
-            >= (op.metrics.obj_store_mem_max_pending_output_per_task or 0)
+            self._is_execution_object_store_under_pressure()
+            and op.num_active_tasks() == 0
+            and self._topology[op].total_enqueued_input_blocks() > 0
+        )
+
+    @staticmethod
+    def _is_task_submission_blocked_on_output_budget(
+        op: PhysicalOperator, budget: ExecutionResources
+    ) -> bool:
+        """Whether the task-output estimate exceeds the remaining budget."""
+        return budget.object_store_memory < (
+            op.metrics.obj_store_mem_max_pending_output_per_task or 0
         )
 
     def get_budget(self, op: PhysicalOperator) -> Optional[ExecutionResources]:
@@ -808,6 +879,20 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             object_store_memory=op_reserved.object_store_memory + reserved_for_outputs
         )
 
+    @staticmethod
+    def _most_downstream_uncapped_op(
+        ops: List[PhysicalOperator],
+        skip: AbstractSet[PhysicalOperator] = frozenset(),
+    ) -> Optional[PhysicalOperator]:
+        """The most downstream op in ``ops`` with no cap on its resource usage."""
+        for op in reversed(ops):
+            if op in skip:
+                continue
+            _, max_resource_usage = op.min_max_resource_requirements()
+            if max_resource_usage == ExecutionResources.inf():
+                return op
+        return None
+
     def max_task_output_bytes_to_read(self, op: PhysicalOperator) -> Optional[int]:
         if op not in self._op_budgets:
             return None
@@ -827,6 +912,77 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         assert res >= 0
         self._output_budgets[op] = res
         return res
+
+    def _is_execution_object_store_under_pressure(self) -> bool:
+        """Whether object-store usage exceeds the configured fraction of the limit.
+
+        Returns False when the limit is unknown (<=0), leaving both the throttle
+        and the liveness allowance disabled.
+        """
+        if self._object_store_memory_pressure_fraction is None:
+            return False
+        object_store_limit = (
+            self._resource_manager.get_global_limits().object_store_memory
+        )
+        if object_store_limit <= 0:
+            return False
+        object_store_usage = (
+            self._resource_manager.get_global_usage().object_store_memory
+        )
+        return (
+            object_store_usage
+            > self._object_store_memory_pressure_fraction * object_store_limit
+        )
+
+    def _is_op_overshooting_object_store_reservation(
+        self, op: PhysicalOperator
+    ) -> bool:
+        """Whether ``op`` should lose its object-store share this round.
+
+        Only object-store is withheld, never CPU/GPU: the goal is to stop ``op``
+        *producing* more output while it keeps *draining* what it holds.
+
+        Off unless both thresholds are set. Requires ``op``'s object-store usage to
+        exceed ``object_store_reservation_overshoot_ratio`` times its reservation
+        (the >1x headroom absorbs ordinary output-buffer fluctuation) while the
+        execution is above ``object_store_memory_pressure_fraction`` of its limit.
+        Materializing operators and their feeders are exempt.
+        """
+        if (
+            self._object_store_reservation_overshoot_ratio is None
+            or self._object_store_memory_pressure_fraction is None
+        ):
+            return False
+        # Cheapest first, and execution-global: skips the per-op work below.
+        if not self._is_execution_object_store_under_pressure():
+            return False
+        total_reserved_os = (
+            self._op_reserved[op].object_store_memory
+            + self._reserved_for_op_outputs[op]
+        )
+        if total_reserved_os <= 0:
+            return False
+        op_usage_os = self._resource_manager.get_op_usage(
+            op, include_ineligible_downstream=True
+        ).object_store_memory
+        if (
+            op_usage_os
+            <= self._object_store_reservation_overshoot_ratio * total_reserved_os
+        ):
+            return False
+        # A materializer emits nothing until fully fed, so throttling its feeder
+        # only delays the release of what it holds. Two checks because
+        # `_is_blocking_materializing_op` walks ineligible deps only, missing the
+        # hash-shuffle family. Last because both walk the topology.
+        #
+        # NOTE: The unbounded-budget grant in `update_budgets` deliberately keeps
+        #       only the first check; widening it there would drop object-store
+        #       backpressure for every hash-shuffle feeder.
+        if self._resource_manager._is_blocking_materializing_op(op):
+            return False
+        if self._resource_manager._feeds_blocking_materializing_op(op):
+            return False
+        return True
 
     def update_budgets(
         self,
@@ -876,10 +1032,30 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         remaining_shared = remaining_shared.max(ExecutionResources.zero())
 
+        # The throttle withholds object-store only, so every eligible op still
+        # shares CPU/GPU/memory. Object-store therefore needs its own participant
+        # count and position: reusing `i` would leave the pool un-shrunk on a
+        # throttled op's turn and skew the split toward upstream.
+        throttled_ops = {
+            op
+            for op in eligible_ops
+            if self._is_op_overshooting_object_store_reservation(op)
+        }
+        num_os_participants = len(eligible_ops) - len(throttled_ops)
+        os_position = 0
+
         # Allocate the remaining shared resources to each operator.
         for i, op in enumerate(reversed(eligible_ops)):
             # By default, divide the remaining shared resources equally.
             op_shared = remaining_shared.scale(1.0 / (len(eligible_ops) - i))
+            if op in throttled_ops:
+                op_shared = op_shared.copy(object_store_memory=0)
+            else:
+                op_shared = op_shared.copy(
+                    object_store_memory=remaining_shared.object_store_memory
+                    * (1.0 / (num_os_participants - os_position))
+                )
+                os_position += 1
             # But if the op's budget is less than `min_scheduling_resources`,
             # it will be useless. So we'll let the downstream operator
             # borrow some resources from the upstream operator, if remaining_shared
@@ -889,6 +1065,9 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                 .subtract(self._op_budgets[op].add(op_shared))
                 .max(ExecutionResources.zero())
             )
+            if op in throttled_ops:
+                # May top up CPU/GPU, but must not hand back withheld object-store.
+                to_borrow = to_borrow.copy(object_store_memory=0)
             if not to_borrow.is_zero() and op_shared.add(to_borrow).satisfies_limit(
                 remaining_shared
             ):
@@ -918,13 +1097,24 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             self._op_budgets[op] = self._op_budgets[op].add(op_shared)
 
         # Give any remaining shared resources to the most downstream uncapped op.
-        # This can happen when some ops have their shared allocation capped.
-        if eligible_ops and not remaining_shared.is_zero():
-            for op in reversed(eligible_ops):
-                _, max_resource_usage = op.min_max_resource_requirements()
-                if max_resource_usage == ExecutionResources.inf():
-                    self._op_budgets[op] = self._op_budgets[op].add(remaining_shared)
-                    break
+        # This can happen when some ops have their shared allocation capped. A
+        # throttled op may take the leftover CPU/GPU, but not the object-store.
+        if not remaining_shared.is_zero():
+            recipient = self._most_downstream_uncapped_op(eligible_ops)
+            if recipient is not None:
+                self._op_budgets[recipient] = self._op_budgets[recipient].add(
+                    remaining_shared.copy(object_store_memory=0)
+                )
+            if remaining_shared.object_store_memory > 0:
+                recipient = self._most_downstream_uncapped_op(
+                    eligible_ops, skip=throttled_ops
+                )
+                if recipient is not None:
+                    self._op_budgets[recipient] = self._op_budgets[recipient].add(
+                        ExecutionResources(
+                            object_store_memory=remaining_shared.object_store_memory
+                        )
+                    )
 
         # A materializing operator like `AllToAllOperator` waits for all its input
         # operator's outputs before processing data. This often forces the input

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -599,6 +599,30 @@ class OpResourceAllocator(ABC):
         allocation is unlimited."""
         ...
 
+    def is_task_submission_blocked_on_object_store(self, op: PhysicalOperator) -> bool:
+        """Whether ``op``'s object-store *output* budget is exhausted, i.e. the
+        object-store condition of ``can_submit_new_task`` is violated.
+
+        Returns True whenever object store is a binding constraint, even if the
+        op is *also* blocked on CPU/GPU -- because relaxing wouldn't help in that
+        case either (object store would still block submission).
+
+        This distinction matters for the output-backpressure liveness escape
+        hatch: relaxing upstream output backpressure lets upstream tasks finish
+        and release the resources they hold, which helps a downstream op blocked
+        on CPU/GPU/slots. But it does the opposite for one blocked on object
+        store -- upstream completing only writes *more* output into an
+        already-full store, pushing usage further past the limit while the
+        downstream op still can't schedule. The hatch keys on this to avoid
+        overshooting the object-store memory limit.
+        """
+        budget = self.get_budget(op)
+        if budget is None:
+            return False
+        return budget.object_store_memory < (
+            op.metrics.obj_store_mem_max_pending_output_per_task or 0
+        )
+
     def _get_eligible_ops(self) -> List[PhysicalOperator]:
         """Returns a list of operators eligible for allocation.
 
@@ -657,11 +681,38 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
     worse performance. And vice versa.
     """
 
-    def __init__(self, resource_manager: ResourceManager, reservation_ratio: float):
+    def __init__(
+        self,
+        resource_manager: ResourceManager,
+        reservation_ratio: float,
+        object_store_reservation_overshoot_ratio: Optional[float],
+        object_store_pool_pressure_fraction: Optional[float],
+    ):
         super().__init__(resource_manager)
 
         self._reservation_ratio = reservation_ratio
         assert 0.0 <= self._reservation_ratio <= 1.0
+        # Thresholds for `_is_op_over_reserved_on_object_store`; either being
+        # None disables the throttle (legacy behavior).
+        if (
+            object_store_reservation_overshoot_ratio is not None
+            and object_store_reservation_overshoot_ratio < 1.0
+        ):
+            raise ValueError(
+                "object_store_reservation_overshoot_ratio must be None or >= 1.0, "
+                f"got {object_store_reservation_overshoot_ratio}"
+            )
+        if object_store_pool_pressure_fraction is not None and not (
+            0.0 < object_store_pool_pressure_fraction <= 1.0
+        ):
+            raise ValueError(
+                "object_store_pool_pressure_fraction must be None or in the "
+                f"range (0.0, 1.0], got {object_store_pool_pressure_fraction}"
+            )
+        self._object_store_reservation_overshoot_ratio = (
+            object_store_reservation_overshoot_ratio
+        )
+        self._object_store_pool_pressure_fraction = object_store_pool_pressure_fraction
         # Per-op reserved resources, excluding `_reserved_for_op_outputs`.
         self._op_reserved: Dict[PhysicalOperator, ExecutionResources] = {}
         # Memory reserved exclusively for the outputs of each operator.
@@ -833,6 +884,59 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         self._output_budgets[op] = res
         return res
 
+    def _is_op_over_reserved_on_object_store(self, op: PhysicalOperator) -> bool:
+        """Whether ``op`` should be denied more shared object-store budget.
+
+        Disabled by default: when either ``object_store_reservation_overshoot_ratio``
+        or ``object_store_pool_pressure_fraction`` is None, the throttle never
+        fires and legacy allocation is preserved. When both are set, two
+        conditions must hold:
+
+        1. Per-op fairness: ``op``'s object-store usage exceeds
+           ``object_store_reservation_overshoot_ratio`` (e.g. 1.5x) times its
+           total reservation. The headroom above 1x lets healthy pipelines keep
+           some in-flight buffer (downstream inqueue and pending_task_inputs are
+           attributed back to upstream, so op_usage naturally overshoots the
+           reservation a bit under steady load). Total reservation = task-side
+           (``_op_reserved.object_store_memory``) + output-side
+           (``_reserved_for_op_outputs``). If both are zero (e.g. an
+           under-provisioned op that failed ``_reserved_min_resources``), we
+           skip the penalty so it isn't permanently excluded from the pool.
+
+        2. Pool pressure: the global object store is above
+           ``object_store_pool_pressure_fraction`` (e.g. 80%) of its limit.
+           Compounding collapse only happens as the shared pool approaches
+           exhaustion; if the pool still has headroom, a single op running
+           over its per-op slice is harmless -- other ops simply aren't using
+           their share -- and throttling it would slow the pipeline for no
+           reason (CPU/GPU idle, object store not full, yet the job crawls).
+           When None, the throttle is disabled (both thresholds must be set).
+        """
+        if self._object_store_reservation_overshoot_ratio is None:
+            return False
+        if self._object_store_pool_pressure_fraction is None:
+            return False
+        total_reserved_os = (
+            self._op_reserved[op].object_store_memory
+            + self._reserved_for_op_outputs[op]
+        )
+        if total_reserved_os <= 0:
+            return False
+        op_usage_os = self._resource_manager.get_op_usage(op).object_store_memory
+        if (
+            op_usage_os
+            <= self._object_store_reservation_overshoot_ratio * total_reserved_os
+        ):
+            return False
+        global_os_limit = self._resource_manager.get_global_limits().object_store_memory
+        if global_os_limit <= 0:
+            return True
+        global_os_usage = self._resource_manager.get_global_usage().object_store_memory
+        return (
+            global_os_usage
+            > self._object_store_pool_pressure_fraction * global_os_limit
+        )
+
     def update_budgets(
         self,
         *,
@@ -881,10 +985,20 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         remaining_shared = remaining_shared.max(ExecutionResources.zero())
 
+        # Pre-filter (instead of `continue` inside the loop below) so the
+        # sliding-fraction divisor stays aligned with the number of ops still
+        # receiving a share -- otherwise `remaining_shared` doesn't shrink on
+        # skipped iterations and the split skews toward upstream.
+        non_over_reserved_ops = [
+            op
+            for op in eligible_ops
+            if not self._is_op_over_reserved_on_object_store(op)
+        ]
+
         # Allocate the remaining shared resources to each operator.
-        for i, op in enumerate(reversed(eligible_ops)):
+        for i, op in enumerate(reversed(non_over_reserved_ops)):
             # By default, divide the remaining shared resources equally.
-            op_shared = remaining_shared.scale(1.0 / (len(eligible_ops) - i))
+            op_shared = remaining_shared.scale(1.0 / (len(non_over_reserved_ops) - i))
             # But if the op's budget is less than `min_scheduling_resources`,
             # it will be useless. So we'll let the downstream operator
             # borrow some resources from the upstream operator, if remaining_shared
@@ -923,9 +1037,11 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             self._op_budgets[op] = self._op_budgets[op].add(op_shared)
 
         # Give any remaining shared resources to the most downstream uncapped op.
-        # This can happen when some ops have their shared allocation capped.
-        if eligible_ops and not remaining_shared.is_zero():
-            for op in reversed(eligible_ops):
+        # Iterating the pre-filtered list ensures leftover OS budget doesn't
+        # undo the throttle; if every uncapped op is over-reserved, the
+        # leftover stays unallocated -- state is recomputed next iteration.
+        if non_over_reserved_ops and not remaining_shared.is_zero():
+            for op in reversed(non_over_reserved_ops):
                 _, max_resource_usage = op.min_max_resource_requirements()
                 if max_resource_usage == ExecutionResources.inf():
                     self._op_budgets[op] = self._op_budgets[op].add(remaining_shared)

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
-    AbstractSet,
     Callable,
     Dict,
     Iterable,
@@ -891,30 +890,6 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             object_store_memory=op_reserved.object_store_memory + reserved_for_outputs
         )
 
-    def _most_downstream_op_that_fits(
-        self,
-        ops: List[PhysicalOperator],
-        resources: ExecutionResources,
-        op_headroom: Dict[PhysicalOperator, ExecutionResources],
-        skip: AbstractSet[PhysicalOperator] = frozenset(),
-    ) -> Optional[PhysicalOperator]:
-        """The most downstream op in ``ops`` whose remaining headroom can absorb ``resources``.
-
-        ``op_headroom`` is filled by the allocation loop and records how much
-        each op can still take before hitting its ``max_resource_usage`` cap.
-        """
-        for op in reversed(ops):
-            if op in skip:
-                continue
-            _, max_resource_usage = op.min_max_resource_requirements()
-            if max_resource_usage == ExecutionResources.inf():
-                return op
-            if resources.satisfies_limit(
-                op_headroom.get(op, ExecutionResources.zero())
-            ):
-                return op
-        return None
-
     def max_task_output_bytes_to_read(self, op: PhysicalOperator) -> Optional[int]:
         if op not in self._op_budgets:
             return None
@@ -1122,31 +1097,23 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
             self._op_budgets[op] = self._op_budgets[op].add(op_shared)
 
-        # Give any remaining shared resources to the most downstream op that can
-        # absorb them. This can happen when some ops have their shared allocation
-        # capped. A throttled op may take the leftover CPU/GPU, but not the
-        # object-store.
-        if not remaining_shared.is_zero():
-            non_os_shared = remaining_shared.copy(object_store_memory=0)
-            if not non_os_shared.is_zero():
-                recipient = self._most_downstream_op_that_fits(
-                    eligible_ops, non_os_shared, op_headroom
-                )
-                if recipient is not None:
-                    self._op_budgets[recipient] = self._op_budgets[recipient].add(
-                        non_os_shared
-                    )
-            if remaining_shared.object_store_memory > 0:
-                os_shared = ExecutionResources(
-                    object_store_memory=remaining_shared.object_store_memory
-                )
-                recipient = self._most_downstream_op_that_fits(
-                    eligible_ops, os_shared, op_headroom, skip=throttled_ops
-                )
-                if recipient is not None:
-                    self._op_budgets[recipient] = self._op_budgets[recipient].add(
-                        os_shared
-                    )
+        # Hand leftover resources out from the most downstream operator upwards,
+        # each taking as much as its remaining headroom allows. Matching per
+        # resource keeps one nobody wants (e.g. GPU) from vetoing one that's
+        # needed (e.g. CPU). Throttled ops may take everything but object-store.
+        for op in reversed(eligible_ops):
+            if remaining_shared.is_zero():
+                break
+            # Ops absent from `op_headroom` were never capped, so they can absorb
+            # the whole leftover.
+            headroom = op_headroom.get(op, ExecutionResources.inf())
+            if op in throttled_ops:
+                headroom = headroom.copy(object_store_memory=0)
+            op_leftover = remaining_shared.min(headroom)
+            if op_leftover.is_zero():
+                continue
+            self._op_budgets[op] = self._op_budgets[op].add(op_leftover)
+            remaining_shared = remaining_shared.subtract(op_leftover)
 
         # A materializing operator like `AllToAllOperator` waits for all its input
         # operator's outputs before processing data. This often forces the input

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -542,9 +542,11 @@ class ResourceManager:
     def _feeds_blocking_materializing_op(self, op: PhysicalOperator) -> bool:
         """Whether a blocking, materializing operator consumes ``op``'s output.
 
-        Unlike ``_is_blocking_materializing_op``, eligibility is irrelevant. Only
-        the immediate consumer counts: in ``Map1 -> Map2 -> Join`` it's Map2 that
-        holds the line, and exempting it keeps Map1 from backing up.
+        Unlike ``_is_blocking_materializing_op``, eligibility is relevant here:
+        only the downstream *eligible* operators are inspected
+        (``get_downstream_eligible_ops`` skips over ineligible ones), and the op
+        itself is not checked. In ``Map1 -> Map2 -> Join`` it's Map2 that holds
+        the line, and exempting it keeps Map1 from backing up.
         """
         return any(
             isinstance(downstream_op, _BLOCKING_MATERIALIZING_OPERATORS)
@@ -838,9 +840,19 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if not self._is_task_submission_blocked_on_output_budget(op, budget):
             return True
 
-        # NOTE: Returning True below also stops Case 1 of
-        #       `OutputBackpressureGuard.should_unblock` relaxing upstream here,
-        #       which would only deepen the pressure.
+        # NOTE: Returning True below also stops ``OutputBackpressureGuard.should_unblock``
+        #       from relaxing the upstream op's output backpressure. That guard unblocks
+        #       an op when a downstream op can't submit new tasks; here this op still can
+        #       — it's under object-store pressure with buffered inputs — so unblocking
+        #       upstream would only deepen the pressure.
+        #
+        # NOTE: The pressure check is load-bearing, not just an optimization. Being
+        #       idle with queued input is the *normal* steady state of an operator
+        #       held back by output backpressure, not evidence of a stall, and the
+        #       condition re-arms every time a task finishes. Without the check the
+        #       allowance would therefore admit one more task per idle cycle
+        #       indefinitely, defeating object-store backpressure on the default
+        #       path (see `test_input_backpressure_e2e`).
         #
         # Pressure check first: it short-circuits on the default path, where the
         # threshold is unset.
@@ -879,17 +891,27 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             object_store_memory=op_reserved.object_store_memory + reserved_for_outputs
         )
 
-    @staticmethod
-    def _most_downstream_uncapped_op(
+    def _most_downstream_op_that_fits(
+        self,
         ops: List[PhysicalOperator],
+        resources: ExecutionResources,
+        op_headroom: Dict[PhysicalOperator, ExecutionResources],
         skip: AbstractSet[PhysicalOperator] = frozenset(),
     ) -> Optional[PhysicalOperator]:
-        """The most downstream op in ``ops`` with no cap on its resource usage."""
+        """The most downstream op in ``ops`` whose remaining headroom can absorb ``resources``.
+
+        ``op_headroom`` is filled by the allocation loop and records how much
+        each op can still take before hitting its ``max_resource_usage`` cap.
+        """
         for op in reversed(ops):
             if op in skip:
                 continue
             _, max_resource_usage = op.min_max_resource_requirements()
             if max_resource_usage == ExecutionResources.inf():
+                return op
+            if resources.satisfies_limit(
+                op_headroom.get(op, ExecutionResources.zero())
+            ):
                 return op
         return None
 
@@ -1032,19 +1054,20 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         remaining_shared = remaining_shared.max(ExecutionResources.zero())
 
-        # The throttle withholds object-store only, so every eligible op still
-        # shares CPU/GPU/memory. Object-store therefore needs its own participant
-        # count and position: reusing `i` would leave the pool un-shrunk on a
-        # throttled op's turn and skew the split toward upstream.
+        # Throttled ops don't participate in the object-store shared reservation,
+        # but still share CPU/GPU/memory, so the object-store split needs its own
+        # participant count and position.
         throttled_ops = {
             op
             for op in eligible_ops
             if self._is_op_overshooting_object_store_reservation(op)
         }
         num_os_participants = len(eligible_ops) - len(throttled_ops)
+        assert num_os_participants >= 0
         os_position = 0
 
         # Allocate the remaining shared resources to each operator.
+        op_headroom: Dict[PhysicalOperator, ExecutionResources] = {}
         for i, op in enumerate(reversed(eligible_ops)):
             # By default, divide the remaining shared resources equally.
             op_shared = remaining_shared.scale(1.0 / (len(eligible_ops) - i))
@@ -1085,6 +1108,9 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                     ExecutionResources.zero()
                 )
                 op_shared = op_shared.min(max_shared)
+                op_headroom[op] = max_shared.subtract(op_shared).max(
+                    ExecutionResources.zero()
+                )
 
             remaining_shared = remaining_shared.subtract(op_shared)
             assert remaining_shared.is_non_negative(), (
@@ -1096,24 +1122,30 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
             self._op_budgets[op] = self._op_budgets[op].add(op_shared)
 
-        # Give any remaining shared resources to the most downstream uncapped op.
-        # This can happen when some ops have their shared allocation capped. A
-        # throttled op may take the leftover CPU/GPU, but not the object-store.
+        # Give any remaining shared resources to the most downstream op that can
+        # absorb them. This can happen when some ops have their shared allocation
+        # capped. A throttled op may take the leftover CPU/GPU, but not the
+        # object-store.
         if not remaining_shared.is_zero():
-            recipient = self._most_downstream_uncapped_op(eligible_ops)
-            if recipient is not None:
-                self._op_budgets[recipient] = self._op_budgets[recipient].add(
-                    remaining_shared.copy(object_store_memory=0)
-                )
-            if remaining_shared.object_store_memory > 0:
-                recipient = self._most_downstream_uncapped_op(
-                    eligible_ops, skip=throttled_ops
+            non_os_shared = remaining_shared.copy(object_store_memory=0)
+            if not non_os_shared.is_zero():
+                recipient = self._most_downstream_op_that_fits(
+                    eligible_ops, non_os_shared, op_headroom
                 )
                 if recipient is not None:
                     self._op_budgets[recipient] = self._op_budgets[recipient].add(
-                        ExecutionResources(
-                            object_store_memory=remaining_shared.object_store_memory
-                        )
+                        non_os_shared
+                    )
+            if remaining_shared.object_store_memory > 0:
+                os_shared = ExecutionResources(
+                    object_store_memory=remaining_shared.object_store_memory
+                )
+                recipient = self._most_downstream_op_that_fits(
+                    eligible_ops, os_shared, op_headroom, skip=throttled_ops
+                )
+                if recipient is not None:
+                    self._op_budgets[recipient] = self._op_budgets[recipient].add(
+                        os_shared
                     )
 
         # A materializing operator like `AllToAllOperator` waits for all its input

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -174,7 +174,18 @@ class OutputBackpressureGuard:
                 #
                 # In this case by relaxing output backpressure we allow upstream
                 # operator's task to complete sooner to free up resources.
+                #
+                # The exception is when downstream can't schedule specifically
+                # because its object-store *output* budget is exhausted.
+                # Relaxing frees the resources upstream *holds* (CPU/GPU/slots),
+                # but upstream completing only writes more output into the
+                # already-full store -- so it wouldn't unblock downstream and
+                # would push object-store usage further past the limit. In that
+                # case we keep backpressure and rely on the idle detector below
+                # as the bounded safety net for a genuine deadlock.
                 if not self._can_submit_new_task(downstream_op):
+                    if self._is_blocked_on_object_store(downstream_op):
+                        continue
                     return True
 
                 # Case 2: Downstream operator
@@ -201,6 +212,18 @@ class OutputBackpressureGuard:
         if not self._resource_manager.op_resource_allocator_enabled():
             return True
         return self._resource_manager.op_resource_allocator.can_submit_new_task(op)
+
+    def _is_blocked_on_object_store(self, op: PhysicalOperator) -> bool:
+        """Whether ``op`` can't submit a new task because its object-store
+        output budget is exhausted (rather than CPU/GPU or other resources).
+
+        Returns False when no op-level resource allocator is enabled -- there is
+        no object-store budget to be blocked on in that case.
+        """
+        if not self._resource_manager.op_resource_allocator_enabled():
+            return False
+        allocator = self._resource_manager.op_resource_allocator
+        return allocator.is_task_submission_blocked_on_object_store(op)
 
 
 class OpBufferQueue:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -257,6 +257,25 @@ DEFAULT_OP_RESOURCE_RESERVATION_RATIO = float(
     os.environ.get("RAY_DATA_OP_RESERVATION_RATIO", "0.5")
 )
 
+# An operator is denied additional shared object-store budget once its usage
+# exceeds this multiple of its total reservation. The >1x headroom absorbs the
+# legitimate overshoot from downstream buffers being attributed back to upstream
+# under steady load; only clearly runaway ops are throttled. Defaults to None
+# (feature disabled -- preserves legacy behavior); only engages when explicitly
+# set by the user or via the env var.
+DEFAULT_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO = env_float(
+    "RAY_DATA_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO", None
+)
+
+# The overshoot throttle above only engages once the global object store is at
+# least this fraction of its limit. Below it the pool isn't under pressure, so a
+# single op running over its per-op slice isn't compounding toward collapse and
+# throttling it would only slow the pipeline. Defaults to None (no pressure gate:
+# the overshoot ratio alone decides).
+DEFAULT_OBJECT_STORE_POOL_PRESSURE_FRACTION = env_float(
+    "RAY_DATA_OBJECT_STORE_POOL_PRESSURE_FRACTION", None
+)
+
 DEFAULT_MAX_ERRORED_BLOCKS = 0
 
 # Use this to prefix important warning messages for the user.
@@ -604,6 +623,17 @@ class DataContext:
             operators to prevent resource contention.
         op_resource_reservation_ratio: The ratio of the total resources to reserve for
             each operator.
+        object_store_reservation_overshoot_ratio: An operator is denied additional
+            shared object-store budget once its usage exceeds this multiple of its
+            total reservation. The headroom above 1x absorbs the legitimate overshoot
+            from downstream buffers attributed back to upstream under steady load.
+            Defaults to None, which disables the throttle (legacy behavior); only
+            engages when set.
+        object_store_pool_pressure_fraction: The overshoot throttle only engages once
+            the global object store is above this fraction of its limit. Below it the
+            pool isn't under pressure and throttling would only slow the pipeline.
+            Defaults to None, which skips the pressure gate so the overshoot ratio
+            alone decides.
         max_errored_blocks: Max number of blocks that are allowed to have errors,
             unlimited if negative. This option allows application-level exceptions in
             block processing tasks. These exceptions may be caused by UDFs (e.g., due to
@@ -844,6 +874,12 @@ class DataContext:
     max_map_retries: int = DEFAULT_MAX_MAP_RETRIES
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
+    object_store_reservation_overshoot_ratio: Optional[
+        float
+    ] = DEFAULT_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO
+    object_store_pool_pressure_fraction: Optional[
+        float
+    ] = DEFAULT_OBJECT_STORE_POOL_PRESSURE_FRACTION
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS
     log_internal_stack_trace_to_stdout: bool = (
         DEFAULT_LOG_INTERNAL_STACK_TRACE_TO_STDOUT

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -322,6 +322,14 @@ DEFAULT_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S = env_float(
     "RAY_DATA_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S", None
 )
 
+DEFAULT_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO = env_float(
+    "RAY_DATA_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO", None
+)
+
+DEFAULT_OBJECT_STORE_MEMORY_PRESSURE_FRACTION = env_float(
+    "RAY_DATA_OBJECT_STORE_MEMORY_PRESSURE_FRACTION", None
+)
+
 DEFAULT_MAX_ERRORED_BLOCKS = 0
 
 # Use this to prefix important warning messages for the user.
@@ -719,6 +727,22 @@ class DataContext:
             operators to prevent resource contention.
         op_resource_reservation_ratio: The ratio of the total resources to reserve for
             each operator.
+        object_store_reservation_overshoot_ratio: An operator loses its share of the
+            shared object-store memory pool once its object-store usage exceeds this
+            multiple of its total reservation. The headroom above 1x absorbs the
+            ordinary fluctuation of an operator's own output buffer under steady
+            load. Only object-store memory is withheld: the operator keeps its full
+            CPU/GPU share so it can still drain what it already holds. Has no effect
+            unless ``object_store_memory_pressure_fraction`` is also set. Defaults to
+            None, which disables the overshoot throttle.
+        object_store_memory_pressure_fraction: Once this execution's object-store
+            usage exceeds this fraction of its memory limit, an idle operator with
+            queued input may run one task despite an exhausted object-store budget
+            for task outputs. This keeps the pipeline moving without releasing more
+            upstream output. The allowance is bounded to one task per operator and
+            takes effect with this threshold alone; CPU/GPU limits are always
+            enforced. Set together with ``object_store_reservation_overshoot_ratio``
+            it additionally enables the overshoot throttle. Defaults to None.
         execution_no_progress_timeout_s: Maximum time in seconds that an execution may
             go without any operator producing or consuming an output before it fails
             with `ExecutionTimeoutError`. Doesn't apply to Datasets with an
@@ -1070,6 +1094,13 @@ class DataContext:
     default_map_logical_memory_enabled: bool = (
         DEFAULT_DEFAULT_MAP_LOGICAL_MEMORY_ENABLED
     )
+
+    object_store_reservation_overshoot_ratio: Optional[
+        float
+    ] = DEFAULT_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO
+    object_store_memory_pressure_fraction: Optional[
+        float
+    ] = DEFAULT_OBJECT_STORE_MEMORY_PRESSURE_FRACTION
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -739,10 +739,12 @@ class DataContext:
             usage exceeds this fraction of its memory limit, an idle operator with
             queued input may run one task despite an exhausted object-store budget
             for task outputs. This keeps the pipeline moving without releasing more
-            upstream output. The allowance is bounded to one task per operator and
-            takes effect with this threshold alone; CPU/GPU limits are always
-            enforced. Set together with ``object_store_reservation_overshoot_ratio``
-            it additionally enables the overshoot throttle. Defaults to None.
+            upstream output. Only one such task runs at a time per operator, since
+            the allowance requires the operator to have no task in flight; CPU/GPU
+            limits are always enforced. Leaving this unset disables the allowance
+            entirely, which keeps object-store backpressure strict on the default
+            path. Set together with ``object_store_reservation_overshoot_ratio`` it
+            additionally enables the overshoot throttle. Defaults to None.
         execution_no_progress_timeout_s: Maximum time in seconds that an execution may
             go without any operator producing or consuming an output before it fails
             with `ExecutionTimeoutError`. Doesn't apply to Datasets with an

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -3,7 +3,7 @@ import time
 from dataclasses import replace
 from datetime import timedelta
 from typing import Any, Dict, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from freezegun import freeze_time
@@ -121,6 +121,30 @@ def _resource_manager_for_limits_only_test(
         DataContext.get_current(),
         BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
     )
+
+
+def _build_reservation_allocator(num_map_ops, ctx=None):
+    """Build a real ``ResourceManager`` over a linear chain of ``num_map_ops`` map
+    operators fed by an ``InputDataBuffer``.
+
+    Returns ``(resource_manager, topo, map_ops)``, where ``map_ops`` is ordered
+    upstream -> downstream and excludes the input buffer.
+    """
+    ctx = ctx or DataContext.get_current()
+    op = InputDataBuffer(ctx, [])
+    map_ops = []
+    for _ in range(num_map_ops):
+        op = mock_map_op(op)
+        map_ops.append(op)
+    topo = build_streaming_topology(op, ExecutionOptions(), noop_counter())
+    resource_manager = ResourceManager(
+        topo,
+        ExecutionOptions(),
+        MagicMock(),
+        ctx,
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+    )
+    return resource_manager, topo, map_ops
 
 
 class TestResourceManager:
@@ -983,6 +1007,75 @@ class TestOutputBackpressureGuard:
         topo[o3].total_enqueued_input_blocks = MagicMock(return_value=0)
         assert guard.should_unblock(o2) is True
 
+    def test_no_unblock_when_downstream_blocked_on_object_store(
+        self, restore_data_context
+    ):
+        """Case 1 must NOT relax output backpressure when the downstream op
+        can't schedule because its object-store *output* budget is exhausted.
+
+        Relaxing lets upstream produce more output, pushing object-store usage
+        further past the limit while downstream still can't run (the steady-state
+        overshoot). It should keep backpressure and fall back to the idle
+        detector. When downstream is blocked on CPU/GPU instead, relaxing frees
+        upstream resources and the original liveness behavior is preserved.
+        """
+        resource_manager, topo, (o2, o3) = _build_reservation_allocator(2)
+        guard = OutputBackpressureGuard(topo, resource_manager)
+        o3.num_active_tasks = MagicMock(return_value=0)
+        guard._idle_detector.detect_idle = MagicMock(return_value=False)
+
+        # Downstream cannot submit a new task.
+        resource_manager.op_resource_allocator.can_submit_new_task = MagicMock(
+            return_value=False
+        )
+
+        # ...because its object-store output budget is exhausted -> keep
+        # backpressure (fall back to idle detector, which returns False here).
+        resource_manager.op_resource_allocator.is_task_submission_blocked_on_object_store = MagicMock(  # noqa: E501
+            return_value=True
+        )
+        assert guard.should_unblock(o2) is False
+
+        # ...because of CPU/GPU (not object store) -> relax to free upstream
+        # resources, preserving the original deadlock-prevention behavior.
+        resource_manager.op_resource_allocator.is_task_submission_blocked_on_object_store = MagicMock(  # noqa: E501
+            return_value=False
+        )
+        assert guard.should_unblock(o2) is True
+
+    def test_is_task_submission_blocked_on_object_store(self, restore_data_context):
+        """The allocator predicate reports True only when the op's object-store
+        output budget is below its per-task pending output estimate."""
+        resource_manager, _, map_ops = _build_reservation_allocator(2)
+        o3 = map_ops[-1]
+        alloc = resource_manager.op_resource_allocator
+
+        alloc._op_budgets[o3] = ExecutionResources(object_store_memory=100)
+
+        # ``obj_store_mem_max_pending_output_per_task`` is a read-only property
+        # on OpRuntimeMetrics, so patch it at the class level.
+        with patch.object(
+            type(o3.metrics),
+            "obj_store_mem_max_pending_output_per_task",
+            new_callable=PropertyMock,
+        ) as mock_metric:
+            # budget (100) >= per-task pending output (50) -> not blocked.
+            mock_metric.return_value = 50
+            assert alloc.is_task_submission_blocked_on_object_store(o3) is False
+
+            # budget (100) < per-task pending output (150) -> blocked.
+            mock_metric.return_value = 150
+            assert alloc.is_task_submission_blocked_on_object_store(o3) is True
+
+            # No output produced yet -> estimate is None -> threshold 0 -> not
+            # blocked (matches can_submit_new_task's ``... or 0`` semantics).
+            mock_metric.return_value = None
+            assert alloc.is_task_submission_blocked_on_object_store(o3) is False
+
+        # Op has no budget entry (unlimited budget) -> not blocked.
+        del alloc._op_budgets[o3]
+        assert alloc.is_task_submission_blocked_on_object_store(o3) is False
+
     def test_unblock_backpressure_fallback_to_idle_detector(self, restore_data_context):
         """When unblock conditions not met, falls back to idle detector result."""
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -1078,6 +1171,113 @@ class TestIdleDetector:
             # After output, wait for interval with no new output - returns True (idle again)
             frozen.tick(timedelta(seconds=idle_detector.DETECTION_INTERVAL_S + 1))
             assert idle_detector.detect_idle(op) is True
+
+
+class TestReservationOpResourceAllocator:
+    """Tests for ReservationOpResourceAllocator's object-store budget throttle."""
+
+    def test_is_op_over_reserved_on_object_store(self, restore_data_context):
+        """The shared-pool throttle denies additional object store memory to an
+        operator only when both the per-op overshoot ratio AND global pool
+        pressure conditions are met."""
+        resource_manager, _, map_ops = _build_reservation_allocator(2)
+        o2 = map_ops[0]
+        alloc = resource_manager.op_resource_allocator
+
+        # Setup: give o2 a reservation of 100 bytes object store memory.
+        alloc._op_reserved[o2] = ExecutionResources(
+            cpu=1, gpu=0, object_store_memory=80
+        )
+        alloc._reserved_for_op_outputs[o2] = 20.0
+
+        # --- Feature off (default None) → always False ---
+        assert alloc._object_store_reservation_overshoot_ratio is None
+        resource_manager._op_usages[o2] = ExecutionResources(object_store_memory=300)
+        assert not alloc._is_op_over_reserved_on_object_store(o2)
+
+        # --- Enable ratio=1.5 only, pressure=None → feature still off ---
+        alloc._object_store_reservation_overshoot_ratio = 1.5
+        alloc._object_store_pool_pressure_fraction = None
+
+        # Both thresholds must be set for the throttle to engage.
+        resource_manager._op_usages[o2] = ExecutionResources(object_store_memory=200)
+        assert not alloc._is_op_over_reserved_on_object_store(o2)
+
+        # --- Enable pressure gate (fraction=0.8) → both thresholds set ---
+        alloc._object_store_pool_pressure_fraction = 0.8
+
+        # Usage 120 ≤ 1.5 * 100 → not over reserved (ratio not exceeded).
+        resource_manager._op_usages[o2] = ExecutionResources(object_store_memory=120)
+        resource_manager._global_limits = ExecutionResources(object_store_memory=1000)
+        resource_manager._global_limits_last_update_time = time.time()
+        resource_manager._global_usage = ExecutionResources(object_store_memory=900)
+        assert not alloc._is_op_over_reserved_on_object_store(o2)
+
+        # Usage 200 > 1.5 * 100, but pool NOT under pressure (5%) → False.
+        resource_manager._op_usages[o2] = ExecutionResources(object_store_memory=200)
+        resource_manager._global_usage = ExecutionResources(object_store_memory=50)
+        assert not alloc._is_op_over_reserved_on_object_store(o2)
+
+        # Pool IS under pressure (usage 900 / limit 1000 = 90% > 80%) → True.
+        resource_manager._global_usage = ExecutionResources(object_store_memory=900)
+        assert alloc._is_op_over_reserved_on_object_store(o2)
+
+        # Global limit unknown (<=0): pressure can't be measured, so the guard
+        # short-circuits to throttling the already-over-ratio op.
+        resource_manager._global_limits = ExecutionResources(object_store_memory=0)
+        resource_manager._global_limits_last_update_time = time.time()
+        assert alloc._is_op_over_reserved_on_object_store(o2)
+
+        # --- Edge case: total_reserved_os == 0 → never penalize ---
+        alloc._op_reserved[o2] = ExecutionResources(cpu=1, gpu=0, object_store_memory=0)
+        alloc._reserved_for_op_outputs[o2] = 0.0
+        resource_manager._op_usages[o2] = ExecutionResources(object_store_memory=9999)
+        assert not alloc._is_op_over_reserved_on_object_store(o2)
+
+    def test_update_budgets_splits_shared_evenly_when_op_over_reserved(
+        self, restore_data_context
+    ):
+        """Regression: when an op is filtered out as over-reserved, the remaining
+        shared pool must be split *evenly* among the surviving ops. A prior
+        version skipped over-reserved ops with ``continue`` inside the allocation
+        loop, leaving the sliding-fraction divisor misaligned so upstream ops
+        received a disproportionately larger share.
+        """
+        resource_manager, _, (o2, o3, o4) = _build_reservation_allocator(3)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3, o4]
+
+        # Drive the shared-allocation loop directly: bypass reservation
+        # recomputation and give every op an equal, generous reservation so no
+        # borrow/cap fires. Zero usage keeps ``remaining_shared == _total_shared``.
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(object_store_memory=900)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        for op in eligible:
+            alloc._op_reserved[op] = ExecutionResources(object_store_memory=100)
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+
+        # The middle op is over its reservation → excluded from the shared split.
+        alloc._is_op_over_reserved_on_object_store = MagicMock(
+            side_effect=lambda op: op is o3
+        )
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        # The two survivors split the 900 pool evenly (450 each on top of their
+        # 100 reservation); a skewed divisor would give upstream o2 more than o4.
+        assert alloc._op_budgets[o2].object_store_memory == 550
+        assert alloc._op_budgets[o4].object_store_memory == 550
+        # The over-reserved op keeps only its reservation, no shared bump.
+        assert alloc._op_budgets[o3].object_store_memory == 100
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -1000,7 +1000,13 @@ class TestOutputBackpressureGuard:
         self, restore_data_context
     ):
         """The allowance is opt-in, so leaving the threshold unset preserves the
-        pre-existing behavior exactly."""
+        pre-existing behavior exactly.
+
+        The threshold is what keeps the allowance from firing in the steady state:
+        an operator held back by output backpressure is idle with queued input on
+        every cycle, so an unconditional allowance would admit one extra task each
+        time a task finishes (see `test_input_backpressure_e2e`).
+        """
         metrics_patch, guard, alloc, o2, o3 = _build_blocked_downstream(
             ray_remote_args={"num_cpus": 4},
             num_cpus_budget=4,
@@ -1574,6 +1580,60 @@ class TestReservationOpResourceAllocator:
         # The capped ops stay at their cap rather than absorbing the leftover.
         assert alloc._op_budgets[o2].cpu == 0
         assert alloc._op_budgets[o4].cpu == 0
+
+    @pytest.mark.parametrize(
+        "downstream_max_cpu, expected_downstream_cpu",
+        [
+            # Headroom left after the split (1000 - 100) covers the 10 leftover.
+            (1000, 110),
+            # Only 5 of headroom left after the split, so the 10 leftover doesn't
+            # fit and must stay undistributed rather than breach the cap.
+            (105, 100),
+        ],
+    )
+    def test_leftover_respects_a_bounded_cap_already_partly_used(
+        self, downstream_max_cpu, expected_downstream_cpu, restore_data_context
+    ):
+        """A bounded-cap op may take the leftover only up to its *remaining* headroom.
+
+        The op has already received its share from the split above, so the leftover
+        has to be measured against what is left of the cap, not against the whole cap.
+        """
+        resource_manager, _, (o2, o3) = _build_reservation_allocator(2)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3]
+
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(cpu=200)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        for op in eligible:
+            alloc._op_reserved[op] = ExecutionResources.zero()
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+
+        # o3 takes its 100 share first; o2's tight cap then leaves 10 behind.
+        o3.min_max_resource_requirements = MagicMock(
+            return_value=(
+                ExecutionResources.zero(),
+                ExecutionResources(cpu=downstream_max_cpu),
+            )
+        )
+        o2.min_max_resource_requirements = MagicMock(
+            return_value=(ExecutionResources.zero(), ExecutionResources(cpu=90))
+        )
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        assert alloc._op_budgets[o3].cpu == expected_downstream_cpu
+        assert alloc._op_budgets[o3].cpu <= downstream_max_cpu
+        assert alloc._op_budgets[o2].cpu == 90
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -2,8 +2,8 @@ import math
 import time
 from collections import defaultdict
 from datetime import timedelta
-from typing import Any, Dict, Optional, Tuple
-from unittest.mock import MagicMock, patch
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from freezegun import freeze_time
@@ -24,12 +24,14 @@ from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.resource_manager import (
+    ReservationOpResourceAllocator,
     ResourceManager,
     create_resource_allocator,
 )
 from ray.data._internal.execution.streaming_executor_state import (
     IdleDetector,
     OutputBackpressureGuard,
+    Topology,
     build_streaming_topology,
 )
 from ray.data.context import DataContext
@@ -129,6 +131,107 @@ def _resource_manager_for_limits_only_test(
         DataContext.get_current(),
         BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
     )
+
+
+def _build_reservation_allocator(
+    num_map_ops: int,
+    ctx: Optional[DataContext] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+) -> Tuple[ResourceManager, Topology, List[PhysicalOperator]]:
+    """Build a real ``ResourceManager`` over a linear chain of ``num_map_ops`` map
+    operators fed by an ``InputDataBuffer``.
+
+    Returns ``(resource_manager, topo, map_ops)``, where ``map_ops`` is ordered
+    upstream -> downstream and excludes the input buffer.
+    """
+    ctx = ctx or DataContext.get_current()
+    op = InputDataBuffer(ctx, [])
+    map_ops = []
+    for _ in range(num_map_ops):
+        op = mock_map_op(op, ray_remote_args=ray_remote_args)
+        map_ops.append(op)
+    topo = build_streaming_topology(op, ExecutionOptions(), noop_counter())
+    resource_manager = ResourceManager(
+        topo,
+        ExecutionOptions(),
+        MagicMock(),
+        ctx,
+        BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+    )
+    return resource_manager, topo, map_ops
+
+
+def _build_blocked_downstream(
+    num_map_ops: int = 2,
+    ctx: Optional[DataContext] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+    *,
+    num_cpus_budget: float,
+    object_store_budget: float,
+    pressure_fraction: Optional[float],
+    execution_usage: float,
+    overshoot_ratio: Optional[float] = None,
+    op_object_store_usage: float = 0,
+) -> tuple:
+    """Build an executor whose most-downstream op is idle with queued input and an
+    exhausted output budget.
+
+    Returns ``(metrics_patch, guard, alloc, o2, o3)``, where ``o2`` feeds the
+    blocked downstream op ``o3``. ``metrics_patch`` must be entered to make each
+    task emit one byte of object-store output. The idle detector is disabled so
+    that ``should_unblock`` reflects Case 1 alone rather than falling back to it.
+    Use ``_set_queued_input_blocks(guard._topology, o3, n)`` to change the queue.
+
+    ``overshoot_ratio`` together with ``op_object_store_usage`` drive the shared
+    -allocation throttle: ``o3`` is given a 100-byte object-store reservation, so
+    a usage above ``overshoot_ratio * 100`` marks it as overshooting.
+    """
+    ctx = ctx or DataContext.get_current()
+    resource_manager, topo, map_ops = _build_reservation_allocator(
+        num_map_ops, ctx=ctx, ray_remote_args=ray_remote_args
+    )
+    o2, o3 = map_ops[-2], map_ops[-1]
+    guard = OutputBackpressureGuard(topo, resource_manager)
+    alloc = resource_manager.op_resource_allocator
+
+    o3.num_active_tasks = MagicMock(return_value=0)
+    guard._idle_detector.detect_idle = MagicMock(return_value=False)
+    topo[o3].total_enqueued_input_blocks = MagicMock(return_value=1)
+    alloc._op_budgets[o3] = ExecutionResources(
+        cpu=num_cpus_budget, gpu=0, object_store_memory=object_store_budget
+    )
+
+    alloc._object_store_memory_pressure_fraction = pressure_fraction
+    alloc._object_store_reservation_overshoot_ratio = overshoot_ratio
+    alloc._op_reserved[o3] = ExecutionResources(cpu=1, gpu=0, object_store_memory=80)
+    alloc._reserved_for_op_outputs[o3] = 20.0
+    resource_manager._op_usages[o3] = ExecutionResources(
+        object_store_memory=op_object_store_usage
+    )
+    resource_manager._global_limits = ExecutionResources(object_store_memory=1000)
+    resource_manager._global_limits_last_update_time = time.time()
+    resource_manager._global_usage = ExecutionResources(
+        object_store_memory=execution_usage
+    )
+    return (
+        patch.object(
+            type(o3.metrics),
+            "obj_store_mem_max_pending_output_per_task",
+            new_callable=PropertyMock,
+            return_value=1,
+        ),
+        guard,
+        alloc,
+        o2,
+        o3,
+    )
+
+
+def _set_queued_input_blocks(
+    topo: "Topology", op: PhysicalOperator, count: int
+) -> None:
+    """Set how many input blocks are queued for ``op``."""
+    topo[op].total_enqueued_input_blocks = MagicMock(return_value=count)
 
 
 class TestResourceManager:
@@ -820,6 +923,103 @@ class TestOutputBackpressureGuard:
         topo[o3].total_enqueued_input_blocks = MagicMock(return_value=0)
         assert guard.should_unblock(o2) is True
 
+    @pytest.mark.parametrize(
+        "overshoot_ratio, op_usage",
+        [
+            # Throttle disabled.
+            (None, 200),
+            # Throttle enabled and this op is overshooting (200 > 1.5 * 100).
+            (1.5, 200),
+            # Throttle enabled and this op is within its reservation.
+            (1.5, 120),
+        ],
+    )
+    def test_cpu_shortfall_always_relaxes_upstream(
+        self, overshoot_ratio, op_usage, restore_data_context
+    ):
+        """A CPU/GPU shortfall is always authoritative, throttled or not.
+
+        The throttle withholds only object-store budget, so a CPU shortfall is
+        never self-inflicted and always means real contention. The operator must
+        be held back so Case 1 relaxes upstream, letting upstream tasks finish and
+        release the CPU this operator is waiting on. Admitting it instead would
+        suppress that relaxation and leave ``IdleDetector``'s coarse interval as
+        the only way out.
+        """
+        metrics_patch, guard, alloc, o2, o3 = _build_blocked_downstream(
+            ray_remote_args={"num_cpus": 4},
+            # Only 1 CPU of budget against a 4-CPU task.
+            num_cpus_budget=1,
+            object_store_budget=0,
+            pressure_fraction=0.8,
+            execution_usage=900,
+            overshoot_ratio=overshoot_ratio,
+            op_object_store_usage=op_usage,
+        )
+        with metrics_patch:
+            assert alloc.can_submit_new_task(o3) is False
+            assert guard.should_unblock(o2) is True
+
+    def test_liveness_allowance_bounded_to_one_idle_task(self, restore_data_context):
+        """The allowance is one task for an idle op with something to consume.
+
+        Each condition is load-bearing: a busy task pool means progress is already
+        happening, and an empty queue means upstream output -- not another task --
+        is what this operator needs.
+        """
+        metrics_patch, guard, alloc, o2, o3 = _build_blocked_downstream(
+            ray_remote_args={"num_cpus": 4},
+            num_cpus_budget=4,
+            object_store_budget=0,
+            pressure_fraction=0.8,
+            execution_usage=900,
+        )
+        topo = guard._topology
+        with metrics_patch:
+            # Tasks already running and nothing queued: no liveness case to make.
+            o3.num_active_tasks.return_value = 7
+            _set_queued_input_blocks(topo, o3, 0)
+            assert alloc.can_submit_new_task(o3) is False
+
+            # Busy pool alone is disqualifying, even with input waiting.
+            _set_queued_input_blocks(topo, o3, 1)
+            assert alloc.can_submit_new_task(o3) is False
+
+            # Idle but nothing to consume: upstream output is what it needs.
+            o3.num_active_tasks.return_value = 0
+            _set_queued_input_blocks(topo, o3, 0)
+            assert alloc.can_submit_new_task(o3) is False
+            assert guard.should_unblock(o2) is True
+
+            # Idle with queued input: the one allowed recovery task.
+            _set_queued_input_blocks(topo, o3, 1)
+            assert alloc.can_submit_new_task(o3) is True
+            assert guard.should_unblock(o2) is False
+
+    def test_liveness_allowance_requires_the_pressure_threshold(
+        self, restore_data_context
+    ):
+        """The allowance is opt-in, so leaving the threshold unset preserves the
+        pre-existing behavior exactly."""
+        metrics_patch, guard, alloc, o2, o3 = _build_blocked_downstream(
+            ray_remote_args={"num_cpus": 4},
+            num_cpus_budget=4,
+            object_store_budget=0,
+            pressure_fraction=0.8,
+            execution_usage=900,
+        )
+        with metrics_patch:
+            # Output budget exhausted but CPU is sufficient: the allowance admits
+            # the task, so upstream output stays blocked.
+            assert alloc.can_submit_new_task(o3) is True
+            assert guard.should_unblock(o2) is False
+
+            # Without the opt-in threshold the allowance is off entirely, so the
+            # exhausted output budget blocks submission as it did before.
+            alloc._object_store_memory_pressure_fraction = None
+            assert alloc.can_submit_new_task(o3) is False
+            assert guard.should_unblock(o2) is True
+
     def test_unblock_backpressure_fallback_to_idle_detector(self, restore_data_context):
         """When unblock conditions not met, falls back to idle detector result."""
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -1002,6 +1202,378 @@ class TestIdleDetector:
             # After output, wait for interval with no new output - returns True (idle again)
             frozen.tick(timedelta(seconds=idle_detector.DETECTION_INTERVAL_S + 1))
             assert idle_detector.detect_idle(op) is True
+
+
+class TestReservationOpResourceAllocator:
+    """Tests for ReservationOpResourceAllocator's object-store budget throttle."""
+
+    @pytest.mark.parametrize(
+        "overshoot_ratio, pressure_fraction, expect_ok",
+        [
+            # Both None disables the feature; accepted.
+            (None, None, True),
+            # Valid boundary values.
+            (1.0, 1.0, True),
+            (1.5, 0.8, True),
+            # overshoot_ratio must be a finite float >= 1.0.
+            (0.5, None, False),
+            (math.inf, None, False),
+            # pressure_fraction must be in (0.0, 1.0].
+            (None, 0.0, False),
+            (None, 1.5, False),
+        ],
+    )
+    def test_init_validates_thresholds(
+        self, overshoot_ratio, pressure_fraction, expect_ok
+    ):
+        """The constructor rejects out-of-range or non-finite thresholds."""
+
+        def build():
+            return ReservationOpResourceAllocator(
+                MagicMock(),
+                reservation_ratio=0.5,
+                object_store_reservation_overshoot_ratio=overshoot_ratio,
+                object_store_memory_pressure_fraction=pressure_fraction,
+            )
+
+        if expect_ok:
+            build()
+        else:
+            with pytest.raises(ValueError):
+                build()
+
+    @pytest.mark.parametrize(
+        "ratio, fraction, reserved_os, op_usage, global_usage, global_limit, expected",
+        [
+            # Feature off: neither threshold set.
+            (None, None, 100, 300, 900, 1000, False),
+            # Only the ratio set -- both are required.
+            (1.5, None, 100, 200, 900, 1000, False),
+            # Both set and under pressure, but usage is within 1.5x reservation.
+            (1.5, 0.8, 100, 120, 900, 1000, False),
+            # Over the ratio, but the execution is not under pressure.
+            (1.5, 0.8, 100, 200, 50, 1000, False),
+            # Over the ratio and under pressure.
+            (1.5, 0.8, 100, 200, 900, 1000, True),
+            # Limit unknown, so pressure can't be measured.
+            (1.5, 0.8, 100, 200, 900, 0, False),
+            # A zero reservation would make any usage "over" it, so it is skipped
+            # rather than permanently throttling an under-provisioned operator.
+            (1.5, 0.8, 0, 9999, 900, 1000, False),
+        ],
+    )
+    def test_is_op_overshooting_object_store_reservation(
+        self,
+        ratio,
+        fraction,
+        reserved_os,
+        op_usage,
+        global_usage,
+        global_limit,
+        expected,
+        restore_data_context,
+    ):
+        """The throttle needs both thresholds, plus pressure, plus a real overshoot."""
+        resource_manager, _, map_ops = _build_reservation_allocator(2)
+        op = map_ops[0]
+        alloc = resource_manager.op_resource_allocator
+
+        alloc._object_store_reservation_overshoot_ratio = ratio
+        alloc._object_store_memory_pressure_fraction = fraction
+        # Reservation is split between the op and its outputs; only the total
+        # matters to the predicate.
+        alloc._op_reserved[op] = ExecutionResources(
+            cpu=1, gpu=0, object_store_memory=reserved_os * 0.8
+        )
+        alloc._reserved_for_op_outputs[op] = reserved_os * 0.2
+        resource_manager._op_usages[op] = ExecutionResources(
+            object_store_memory=op_usage
+        )
+        resource_manager._global_limits = ExecutionResources(
+            object_store_memory=global_limit
+        )
+        resource_manager._global_limits_last_update_time = time.time()
+        resource_manager._global_usage = ExecutionResources(
+            object_store_memory=global_usage
+        )
+
+        assert alloc._is_op_overshooting_object_store_reservation(op) is expected
+
+    def test_feeder_of_eligible_materializer_is_exempt(self, restore_data_context):
+        """A feeder of a blocking materializer is exempt even when that
+        materializer is *eligible*.
+
+        ``_is_blocking_materializing_op`` walks only ineligible deps, so it misses
+        the hash-shuffle family. Throttling their feeder is counterproductive:
+        they emit nothing until fully fed.
+
+        Only the immediate feeder is exempt -- in ``Map1 -> Map2 -> Join`` it's
+        Map2 that holds the line, so exempting it keeps Map1 from backing up.
+        """
+        ctx = DataContext.get_current()
+        map1 = mock_map_op(InputDataBuffer(ctx, []), name="Map1")
+        upstream_map = mock_map_op(map1, name="MapIntoJoin")
+        join = mock_join_op(upstream_map, InputDataBuffer(ctx, []))
+
+        topo = build_streaming_topology(join, ExecutionOptions(), noop_counter())
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(),
+            ctx,
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+        )
+        alloc = resource_manager.op_resource_allocator
+
+        # The join is eligible, so the accounting walk can't see it. This is the
+        # gap the scheduling check closes. Map1 is two hops away and stays out.
+        assert resource_manager.is_op_eligible(join) is True
+        assert resource_manager._is_blocking_materializing_op(upstream_map) is False
+        assert resource_manager._feeds_blocking_materializing_op(upstream_map) is True
+        assert resource_manager._feeds_blocking_materializing_op(map1) is False
+
+        # Both thresholds set, the map overshoots its 100-byte reservation
+        # (200 > 1.5 * 100), and the execution is under pressure (900/1000 > 0.8).
+        alloc._object_store_reservation_overshoot_ratio = 1.5
+        alloc._object_store_memory_pressure_fraction = 0.8
+        alloc._op_reserved[upstream_map] = ExecutionResources(
+            cpu=1, gpu=0, object_store_memory=80
+        )
+        alloc._reserved_for_op_outputs[upstream_map] = 20.0
+        resource_manager._op_usages[upstream_map] = ExecutionResources(
+            object_store_memory=200
+        )
+        resource_manager._global_limits = ExecutionResources(object_store_memory=1000)
+        resource_manager._global_limits_last_update_time = time.time()
+        resource_manager._global_usage = ExecutionResources(object_store_memory=900)
+
+        # Every numbered condition holds, so only the exemption spares the map.
+        assert alloc._is_execution_object_store_under_pressure() is True
+        assert not alloc._is_op_overshooting_object_store_reservation(upstream_map)
+
+        # Confirm the exemption is load-bearing: without it the same state throttles.
+        resource_manager._feeds_blocking_materializing_op = MagicMock(
+            return_value=False
+        )
+        assert alloc._is_op_overshooting_object_store_reservation(upstream_map)
+
+    def test_update_budgets_splits_shared_evenly_when_op_overshooting(
+        self, restore_data_context
+    ):
+        """The throttle withholds object-store only, and splits it evenly.
+
+        Two properties are asserted together because they trade off against each
+        other. The overshooting op must keep its CPU share -- starving it of CPU
+        would stop it draining what it already holds, the opposite of the intent.
+        And object-store must still divide *evenly* among the remaining ops: the
+        object-store dimension needs its own participant count, since reusing the
+        full set's divisor leaves the pool un-shrunk on the throttled op's turn and
+        skews the split toward upstream.
+        """
+        resource_manager, _, (o2, o3, o4) = _build_reservation_allocator(3)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3, o4]
+
+        # Drive the shared-allocation loop directly: bypass reservation
+        # recomputation and give every op an equal, generous reservation so no
+        # borrow/cap fires. Zero usage keeps ``remaining_shared == _total_shared``.
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(cpu=900, object_store_memory=900)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        for op in eligible:
+            alloc._op_reserved[op] = ExecutionResources(object_store_memory=100)
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+
+        # The middle op is over its reservation → loses its object-store share.
+        alloc._is_op_overshooting_object_store_reservation = MagicMock(
+            side_effect=lambda op: op is o3
+        )
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        # The two non-throttled ops split the 900 object-store pool evenly (450
+        # each on top of their 100 reservation); a divisor that counted the
+        # throttled op would give upstream o2 more than downstream o4.
+        assert alloc._op_budgets[o2].object_store_memory == 550
+        assert alloc._op_budgets[o4].object_store_memory == 550
+        # The overshooting op keeps only its object-store reservation...
+        assert alloc._op_budgets[o3].object_store_memory == 100
+        # ...but still gets its full, equal share of CPU: the throttle is an
+        # object-store policy and must not starve the op of the CPU it needs to
+        # drain what it holds.
+        assert alloc._op_budgets[o3].cpu == 300
+        assert alloc._op_budgets[o2].cpu == 300
+        assert alloc._op_budgets[o4].cpu == 300
+
+    def test_borrowing_cannot_hand_object_store_back_to_throttled_op(
+        self, restore_data_context
+    ):
+        """Borrowing may top up a throttled op's CPU, but never its object store.
+
+        When an op's share leaves it below ``min_scheduling_resources`` the loop
+        borrows the shortfall from the pool. For a throttled op that shortfall
+        includes the object-store budget just withheld, so the throttle has to be
+        re-applied after borrowing or it is silently undone.
+        """
+        resource_manager, _, (o2, o3) = _build_reservation_allocator(2)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3]
+
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(cpu=900, object_store_memory=900)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        for op in eligible:
+            # A small reservation, so the op lands below the minimum below.
+            alloc._op_reserved[op] = ExecutionResources(object_store_memory=10)
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+        # o3 needs 50 bytes to schedule but its share was zeroed, so borrowing
+        # would try to make up the 40-byte difference.
+        o3.min_scheduling_resources = MagicMock(
+            return_value=ExecutionResources(object_store_memory=50)
+        )
+        alloc._is_op_overshooting_object_store_reservation = MagicMock(
+            side_effect=lambda op: op is o3
+        )
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        # Still just its reservation: the borrow was not allowed to restore the
+        # withheld object-store budget.
+        assert alloc._op_budgets[o3].object_store_memory == 10
+        # CPU was still shared with it.
+        assert alloc._op_budgets[o3].cpu == 450
+
+    def test_update_budgets_withholds_leftover_from_overshooting_op(
+        self, restore_data_context
+    ):
+        """Leftover shared resources must skip an overshooting op.
+
+        After the main split, resources left over by a capped op are handed to the
+        most downstream *uncapped* op. That scan has to skip throttled ops: the
+        most downstream uncapped op here is overshooting, so an unfiltered scan
+        would hand it the leftover and undo the throttle the split just applied.
+
+        Unlike the sibling test above, this drives the *real*
+        ``_is_op_overshooting_object_store_reservation`` rather than mocking it,
+        so the predicate and the allocation loop are covered together.
+        """
+        resource_manager, _, (o2, o3, o4, o5) = _build_reservation_allocator(4)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3, o4, o5]
+
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(object_store_memory=900)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        for op in eligible:
+            alloc._op_reserved[op] = ExecutionResources(object_store_memory=100)
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+            # Uncapped, so each is a candidate to receive the leftover.
+            op.min_max_resource_requirements = MagicMock(
+                return_value=(ExecutionResources.zero(), ExecutionResources.inf())
+            )
+        # Cap the most *upstream* op at its reservation. It is iterated last with
+        # divisor 1, so without a cap it would absorb the whole remainder and
+        # there would be no leftover to distribute.
+        o2.min_max_resource_requirements = MagicMock(
+            return_value=(
+                ExecutionResources.zero(),
+                ExecutionResources(object_store_memory=100),
+            )
+        )
+
+        # Only o5 overshoots: 200 > 1.5 * 100. The loop reads usage through
+        # `get_mem_op_*` (mocked to 0 above), so this usage only drives the
+        # predicate, leaving every op's reserved budget intact at 100.
+        resource_manager.get_op_usage = MagicMock(
+            side_effect=lambda op, include_ineligible_downstream=False: (
+                ExecutionResources(object_store_memory=200)
+                if op is o5
+                else ExecutionResources.zero()
+            )
+        )
+        alloc._object_store_reservation_overshoot_ratio = 1.5
+        alloc._object_store_memory_pressure_fraction = 0.8
+        resource_manager._global_limits = ExecutionResources(object_store_memory=1000)
+        resource_manager._global_limits_last_update_time = time.time()
+        resource_manager._global_usage = ExecutionResources(object_store_memory=900)
+
+        # o5 is the most downstream uncapped op, so it would win an unfiltered scan.
+        assert alloc._is_op_overshooting_object_store_reservation(o5) is True
+        assert alloc._is_op_overshooting_object_store_reservation(o4) is False
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        # Sliding split over the three survivors [o4, o3, o2]: o4 takes 900/3=300,
+        # o3 takes 600/2=300, o2 is capped to 0 -- leaving 300 over.
+        assert alloc._op_budgets[o3].object_store_memory == 400
+        assert alloc._op_budgets[o2].object_store_memory == 100
+        # The 300 leftover goes to o4, the most downstream *non-overshooting* op.
+        assert alloc._op_budgets[o4].object_store_memory == 700
+        # o5 stays at its bare reservation: no share, and no leftover either.
+        assert alloc._op_budgets[o5].object_store_memory == 100
+
+    def test_leftover_skips_capped_ops(self, restore_data_context):
+        """The leftover recipient must respect resource caps.
+
+        Handing the remainder to a capped op would push its allocation past the
+        very cap that produced the remainder.
+        """
+        resource_manager, _, (o2, o3, o4) = _build_reservation_allocator(3)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3, o4]
+
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(cpu=900)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        for op in eligible:
+            alloc._op_reserved[op] = ExecutionResources.zero()
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+        # o4 is most downstream and o2 most upstream; capping both leaves a
+        # remainder that only the uncapped middle op may receive.
+        for op in (o2, o4):
+            op.min_max_resource_requirements = MagicMock(
+                return_value=(ExecutionResources.zero(), ExecutionResources.zero())
+            )
+        o3.min_max_resource_requirements = MagicMock(
+            return_value=(ExecutionResources.zero(), ExecutionResources.inf())
+        )
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        # o3 takes its 450 share plus the 450 the capped ops left behind.
+        assert alloc._op_budgets[o3].cpu == 900
+        # The capped ops stay at their cap rather than absorbing the leftover.
+        assert alloc._op_budgets[o2].cpu == 0
+        assert alloc._op_budgets[o4].cpu == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -1586,9 +1586,9 @@ class TestReservationOpResourceAllocator:
         [
             # Headroom left after the split (1000 - 100) covers the 10 leftover.
             (1000, 110),
-            # Only 5 of headroom left after the split, so the 10 leftover doesn't
-            # fit and must stay undistributed rather than breach the cap.
-            (105, 100),
+            # Only 5 of headroom left after the split, so the op absorbs 5 of the
+            # 10 leftover -- filling the cap exactly -- and the rest stays behind.
+            (105, 105),
         ],
     )
     def test_leftover_respects_a_bounded_cap_already_partly_used(
@@ -1634,6 +1634,51 @@ class TestReservationOpResourceAllocator:
         assert alloc._op_budgets[o3].cpu == expected_downstream_cpu
         assert alloc._op_budgets[o3].cpu <= downstream_max_cpu
         assert alloc._op_budgets[o2].cpu == 90
+
+    def test_leftover_is_matched_per_resource(self, restore_data_context):
+        """Leftover on a resource nobody wants must not veto the ones ops can use.
+
+        An operator that requests no memory reports a *zero* memory cap, so the
+        cluster's memory is never drawn out of the shared pool. Matching the
+        leftover as one bundle would let that stranded memory block the leftover
+        CPU, which a downstream op still has headroom for.
+        """
+        resource_manager, _, (o2, o3) = _build_reservation_allocator(2)
+        alloc = resource_manager.op_resource_allocator
+        eligible = [o2, o3]
+
+        alloc._update_reservation = MagicMock(return_value=ExecutionResources.zero())
+        alloc._get_eligible_ops = MagicMock(return_value=eligible)
+        alloc._total_shared = ExecutionResources(cpu=200, memory=1000)
+        resource_manager.get_mem_op_internal = MagicMock(return_value=0)
+        resource_manager.get_mem_op_outputs = MagicMock(return_value=0)
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        for op in eligible:
+            alloc._op_reserved[op] = ExecutionResources.zero()
+            alloc._reserved_for_op_outputs[op] = 0.0
+            op.min_scheduling_resources = MagicMock(
+                return_value=ExecutionResources.zero()
+            )
+
+        # Neither op requests memory, so both cap it at 0. o2's tight CPU cap
+        # leaves 10 CPU behind, which o3 still has room for.
+        o3.min_max_resource_requirements = MagicMock(
+            return_value=(ExecutionResources.zero(), ExecutionResources(cpu=1000))
+        )
+        o2.min_max_resource_requirements = MagicMock(
+            return_value=(ExecutionResources.zero(), ExecutionResources(cpu=90))
+        )
+
+        alloc.update_budgets(limits=ExecutionResources.zero())
+
+        # o3 takes its 100 share plus the 10 o2's cap left behind.
+        assert alloc._op_budgets[o3].cpu == 110
+        assert alloc._op_budgets[o2].cpu == 90
+        # The memory nobody capped room for stays undistributed.
+        assert alloc._op_budgets[o3].memory == 0
+        assert alloc._op_budgets[o2].memory == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Two interacting bugs in `ResourceBudgetBackpressurePolicy` can cause a Ray Data pipeline to stall indefinitely — CPU/GPU idle, Object Store filling up, no error logged, no progress. Reproducing this requires enough intermediate output to pressure the Object Store; small pipelines won't hit it.

### Background

`ResourceBudgetBackpressurePolicy` blocks an operator from submitting new tasks when **either**: (a) the operator's `incremental_resource_usage` (CPU/GPU/memory) exceeds its budget, or (b) the operator's Object Store budget for task outputs is below `obj_store_mem_max_pending_output_per_task`. When either fires, the operator enters `backpressured:tasks(ResourceBudget)` and stops scheduling.

### The two bugs

**Bug 1 — `OutputBackpressureGuard.should_unblock` doesn't distinguish Object Store–blocked from CPU/GPU-blocked.**
The liveness relaxation in `should_unblock` relaxes an upstream operator's output backpressure when a downstream operator has no active tasks and can't submit — so upstream can finish and release CPU/GPU/memory. This helps when downstream is blocked on condition (a). But when downstream is blocked on condition (b) — its Object Store budget for task outputs is exhausted — relaxing upstream only writes *more* output into the already-full store while downstream still can't schedule. The relaxation feeds the stall it's meant to prevent.

**Bug 2 — `update_budgets` unconditionally allocates shared resources to over-reserved operators.**
Each scheduling iteration, `update_budgets` recomputes every eligible operator's budget as its unused reservation plus a share of the remaining shared resources. Even when an operator's Object Store usage already exceeds its reserved resources (unused reservation is zero), it still receives a share of the remaining shared resources — restoring a positive budget, letting it submit more tasks, and further draining the shared resources that other operators depend on.

**How they compound:** Bug 2 keeps the upstream operator's budget alive so it keeps producing output. Bug 1 relaxes the upstream's output backpressure so that output flows unchecked. Together, the Object Store fills until every operator's budget is exhausted and the pipeline stalls.

## Fix

1. In `can_submit_new_task`, when an operator is blocked on condition (b) but sits idle with input already queued, admit one task so it consumes what it holds instead of relaxing upstream to push more into an already-full store. Bounded to one task per operator (`num_active_tasks() == 0`) and only while the execution is under Object Store memory pressure, so the default path is unchanged and recovery doesn't rest on `IdleDetector` alone. `should_unblock` is left untouched.

   An earlier revision instead suppressed the relaxation inside `should_unblock` with a `continue`. That left `IdleDetector` as the only recovery path — one block per `DETECTION_INTERVAL_S = 10.0` — and failed `test_e2e_liveness_with_output_backpressure_edge_case` 2/2 in premerge, where 100 blocks would need ~1000s against a 180s timeout.
2. Optionally withhold shared Object Store resources from operators that satisfy **both**: (a) per-operator usage exceeds `object_store_reservation_overshoot_ratio` × its total reserved resources (task-side + output-side), AND (b) this execution's Object Store usage exceeds `object_store_memory_pressure_fraction` of its limit. Both thresholds must be set to enable the throttle; either being `None` (default) preserves legacy behavior. Requiring both conditions avoids throttling when the Object Store is nearly empty (a single overshooting operator is harmless there) and avoids letting one operator drain the shared pool when the store is under pressure — a single threshold would misfire in one direction or the other.

Fix 2 pre-filters over-reserved operators before the shared-resource allocation loop (rather than skipping with `continue` inside the loop), keeping the per-operator share fraction aligned with the number of operators actually receiving resources. The fallback branch also iterates the pre-filtered list, preventing leftover budget from being routed back to an over-reserved operator.

## Related issues

None.

## Additional information

**Enabling the throttle (Fix 2)** — off by default. To enable, set both thresholds on `DataContext`:

```python
ctx = ray.data.DataContext.get_current()
ctx.object_store_reservation_overshoot_ratio = 1.5   # per-op overshoot headroom
ctx.object_store_memory_pressure_fraction = 0.8      # engage at 80% usage
```

Or via environment variables (equivalent):

```bash
export RAY_DATA_OBJECT_STORE_RESERVATION_OVERSHOOT_RATIO=1.5
export RAY_DATA_OBJECT_STORE_MEMORY_PRESSURE_FRACTION=0.8
```