### PR TITLE
[docs] Document Tigris in S3-compatible storage examples for Ray Train

### DIFF
--- a/doc/source/train/user-guides/persistent-storage.rst
+++ b/doc/source/train/user-guides/persistent-storage.rst
@@ -297,11 +297,11 @@ You can use any of these implementations by wrapping the ``fsspec`` filesystem w
 
 
 
-S3-compatible storage (Backblaze B2, MinIO, etc.)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+S3-compatible storage (Backblaze B2, MinIO, Tigris, etc.)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For S3-compatible stores like `Backblaze B2 <https://www.backblaze.com/cloud-storage>`_
-or `MinIO <https://min.io/>`_, follow the
+For S3-compatible stores like `Backblaze B2 <https://www.backblaze.com/cloud-storage>`_,
+`MinIO <https://min.io/>`_, or `Tigris <https://www.tigrisdata.com>`_, follow the
 :ref:`custom-filesystem examples above <custom-storage-filesystem>`, or pass
 the endpoint as a query parameter in the ``storage_path`` URI:
 
@@ -318,6 +318,8 @@ the endpoint as a query parameter in the ``storage_path`` URI:
             storage_path="s3://bucket-name/sub-path?endpoint_override=https://s3.us-west-001.backblazeb2.com",
             # MinIO running locally:
             # storage_path="s3://bucket-name/sub-path?endpoint_override=http://localhost:9000",
+            # Tigris (single global endpoint, no egress fees):
+            # storage_path="s3://bucket-name/sub-path?endpoint_override=https://t3.storage.dev",
             name="unique-run-id",
         )
     )
@@ -327,7 +329,13 @@ variables Arrow reads (see
 `Arrow's S3 environment variables <https://arrow.apache.org/docs/cpp/env_vars.html>`_)
 and use a plain ``storage_path="s3://bucket/path"``. For Backblaze B2, set
 ``AWS_ENDPOINT_URL_S3`` to your bucket's endpoint, and ``AWS_ACCESS_KEY_ID`` /
-``AWS_SECRET_ACCESS_KEY`` to your B2 application key ID and key.
+``AWS_SECRET_ACCESS_KEY`` to your B2 application key ID and key. For Tigris,
+use ``https://t3.storage.dev`` as the endpoint; access key IDs are prefixed
+with ``tid_`` and secret keys with ``tsec_``.
+
+For Ray Train fleets that span regions, the same ``storage_path`` works from
+every node without cross-region egress. Checkpoints re-materialized after
+preemption or a restart are read from the nearest region for free.
 
 See `this end-to-end notebook <https://github.com/backblaze-b2-samples/notebooks/tree/main/ray-train-tune-checkpoints>`_ for a worked Backblaze B2 example.
 


### PR DESCRIPTION
## Description

Adds Tigris to the S3-compatible storage subsection of `doc/source/train/user-guides/persistent-storage.rst`, alongside the existing Backblaze B2 and MinIO entries. Tigris is a widely used S3-compatible object store, and Ray Train works with it out of the box via the same `endpoint_override` mechanism already documented for the other two providers.

Concretely:

- Section title: `S3-compatible storage (Backblaze B2, MinIO, etc.)` → `S3-compatible storage (Backblaze B2, MinIO, Tigris, etc.)`
- Added Tigris to the intro paragraph's list of named providers.
- Added a commented Tigris line to the `storage_path` example inside the existing `testcode` block, matching the Backblaze B2 and MinIO lines already there.
- Added Tigris to the environment-variable configuration paragraph, showing the endpoint URL and the `tid_` / `tsec_` access-key prefixes.

Docs only; no code changes.

## Related issues

None.

## Additional information

The category-first framing (Backblaze B2, MinIO, Tigris) matches how the section already treats S3-compatible providers — the existing subsection was set up as a general S3-compatible pattern with specific providers named. No new prose beyond what's needed to make the existing pattern applicable to a third named provider.