### PR TITLE
[chore][dashboard] Fix "automaticaly" typo in Grafana dashboard descriptions

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/data_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_grafana_dashboard_base.json
@@ -146,7 +146,7 @@
             },
             "datasource": "${datasource}",
             "definition": "label_values(ray_node_network_receive_speed{{{global_filters}}}, ray_io_cluster)",
-            "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automaticaly with Prometheus PodMonitor.",
+            "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
             "error": null,
             "hide": 0,
             "includeAll": true,

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_grafana_dashboard_base.json
@@ -171,7 +171,7 @@
         },
         "datasource": "${datasource}",
         "definition": "label_values(ray_node_network_receive_speed{{{global_filters}}}, ray_io_cluster)",
-        "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automaticaly with Prometheus PodMonitor.",
+        "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
         "error": null,
         "hide": 0,
         "includeAll": true,

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json
@@ -140,7 +140,7 @@
         },
         "datasource": "${datasource}",
         "definition": "label_values(ray_node_network_receive_speed{{{global_filters}}}, ray_io_cluster)",
-        "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automaticaly with Prometheus PodMonitor.",
+        "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
         "error": null,
         "hide": 0,
         "includeAll": true,


### PR DESCRIPTION
## Why are these changes needed?

The Cluster template variable descriptions in several Grafana dashboard base JSONs contain the misspelling "automaticaly". This corrects it to "automatically".

Affected files:
- `python/ray/dashboard/modules/metrics/dashboards/data_grafana_dashboard_base.json`
- `python/ray/dashboard/modules/metrics/dashboards/serve_deployment_grafana_dashboard_base.json`
- `python/ray/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json`

Documentation/string-only change; no behavior change.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(