### PR TITLE
[ci] Pin typescript in eslint pre-commit hook to fix plugin load crash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -239,5 +239,8 @@ repos:
           - eslint-plugin-prefer-arrow@1.2.3
           - '@typescript-eslint/parser@5.41.0'
           - '@typescript-eslint/eslint-plugin@5.41.0'
-          - '@typescript-eslint/parser@5.41.0'
-          - '@typescript-eslint/eslint-plugin@5.41.0'
+          # Pin typescript: eslint-config-react-app declares `typescript: "*"`,
+          # which otherwise floats to a TS major incompatible with
+          # @typescript-eslint 5.41 and breaks plugin load in CI. Matches the
+          # dashboard client's own typescript devDependency.
+          - typescript@4.8.4


### PR DESCRIPTION
The eslint pre-commit hook pinned @typescript-eslint parser/eslint-plugin to 5.41.0 but left `typescript` unpinned. eslint-config-react-app declares `typescript: "*"`, so npm floated it to a TS major (6.x) incompatible with @typescript-eslint 5.41, breaking plugin load in CI:

  Failed to load plugin '@typescript-eslint' ...
  Cannot read properties of undefined (reading 'Undefined')

Pin typescript to 4.8.4 (matching the dashboard client's own devDependency) so resolution is deterministic, and drop the duplicated parser/eslint-plugin entries.

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
