### PR TITLE
[Data] Add unexpected worker kills and Ray OOM kills to usage collection

### DIFF
--- a/python/ray/data/_internal/usage/collector.py
+++ b/python/ray/data/_internal/usage/collector.py
@@ -26,8 +26,10 @@ from ray._common.usage.usage_lib import (
     usage_stats_enabled,
 )
 from ray._private.internal_api import get_memory_info_reply, get_state_from_address
+from ray._private.state import state as global_state
 from ray._private.worker import global_worker
-from ray.core.generated.gcs_pb2 import GcsNodeInfo
+from ray.core.generated.common_pb2 import WorkerExitType
+from ray.core.generated.gcs_pb2 import GcsNodeInfo, WorkerTableData
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.logical.operators import MapBatches
 from ray.data._internal.usage.util import anonymize_op_name
@@ -183,6 +185,39 @@ def cluster_dead_node_count() -> Optional[int]:
     except Exception:
         logger.debug("Failed to read cluster dead node count", exc_info=True)
         return None
+
+
+def cluster_worker_kill_counts() -> Tuple[Optional[int], Optional[int]]:
+    """Get counts of dead workers by exit type on the cluster, read from the GCS
+    worker table. Return tuple of number of ``(oom_kills, unexpected_worker_kills)``.
+
+    ``oom_kills`` counts workers killed by Ray's memory monitor
+    (``NODE_OUT_OF_MEMORY``); ``unexpected_worker_kills`` counts workers that
+    exited due to a system error (``SYSTEM_ERROR``), e.g. a crash or kernel OOM.
+
+    The worker table has no server-side exit-type filter, so the whole table is
+    fetched and counted client-side. Returns ``(None, None)`` on any failure.
+    """
+    if not ray.is_initialized():
+        return None, None
+    try:
+        accessor = global_state._connect_and_get_accessor()
+        oom_kills = 0
+        unexpected_worker_kills = 0
+        for serialized in accessor.get_worker_table():
+            worker = WorkerTableData.FromString(serialized)
+            # exit_type is only meaningful for dead workers, and is optional so
+            # an unset field must not be miscounted as SYSTEM_ERROR (value 0).
+            if worker.is_alive or not worker.HasField("exit_type"):
+                continue
+            if worker.exit_type == WorkerExitType.NODE_OUT_OF_MEMORY:
+                oom_kills += 1
+            elif worker.exit_type == WorkerExitType.SYSTEM_ERROR:
+                unexpected_worker_kills += 1
+        return oom_kills, unexpected_worker_kills
+    except Exception:
+        logger.debug("Failed to read cluster worker kill counts", exc_info=True)
+        return None, None
 
 
 def compute_delta(start: Optional[int], end: Optional[int]) -> Optional[int]:

--- a/python/ray/data/_internal/usage/execution_callback.py
+++ b/python/ray/data/_internal/usage/execution_callback.py
@@ -48,6 +48,9 @@ class UsageCallback(ExecutionCallback):
         self._spilled_at_end: Optional[int] = None
         self._dead_nodes_at_start: Optional[int] = None
         self._dead_nodes_at_end: Optional[int] = None
+        # (oom_kills, unexpected_worker_kills) sampled from the GCS worker table.
+        self._worker_kills_at_start: Tuple[Optional[int], Optional[int]] = (None, None)
+        self._worker_kills_at_end: Tuple[Optional[int], Optional[int]] = (None, None)
         self._executor: Optional["StreamingExecutor"] = None
         self._finished = False
 
@@ -105,6 +108,7 @@ class UsageCallback(ExecutionCallback):
         self._started_at = time.time()
         self._spilled_at_start = collector.cluster_spilled_bytes()
         self._dead_nodes_at_start = collector.cluster_dead_node_count()
+        self._worker_kills_at_start = collector.cluster_worker_kill_counts()
 
     def on_collection_end(
         self, executor: "StreamingExecutor", error: Optional[Exception]
@@ -114,6 +118,7 @@ class UsageCallback(ExecutionCallback):
         success); subclasses may override to capture it."""
         self._spilled_at_end = collector.cluster_spilled_bytes()
         self._dead_nodes_at_end = collector.cluster_dead_node_count()
+        self._worker_kills_at_end = collector.cluster_worker_kill_counts()
 
     def build_usage_info(self) -> UsageInfo:
         """Assemble the usage collection payload for this execution."""
@@ -126,9 +131,15 @@ class UsageCallback(ExecutionCallback):
             )
         performance = None
         if self._finished:
+            oom_at_start, unexpected_at_start = self._worker_kills_at_start
+            oom_at_end, unexpected_at_end = self._worker_kills_at_end
             performance = PipelinePerf(
                 bytes_spilled=collector.compute_delta(
                     self._spilled_at_start, self._spilled_at_end
+                ),
+                oom_kills=collector.compute_delta(oom_at_start, oom_at_end),
+                unexpected_worker_kills=collector.compute_delta(
+                    unexpected_at_start, unexpected_at_end
                 ),
                 node_deaths=collector.compute_delta(
                     self._dead_nodes_at_start, self._dead_nodes_at_end

--- a/python/ray/data/tests/test_usage.py
+++ b/python/ray/data/tests/test_usage.py
@@ -43,6 +43,7 @@ def reset_collector(monkeypatch):
     # zero so tests never touch the real cluster and deltas are deterministic.
     monkeypatch.setattr(collector, "cluster_spilled_bytes", lambda: 0)
     monkeypatch.setattr(collector, "cluster_dead_node_count", lambda: 0)
+    monkeypatch.setattr(collector, "cluster_worker_kill_counts", lambda: (0, 0))
     yield
     collector.reset_for_testing()
 
@@ -76,6 +77,8 @@ def test_round_trip_payload_shape(reset_collector, mock_record, executor):
     # return 0 at start and end, so the clamped deltas are 0.
     assert entry["performance"]["bytes_spilled"] == 0
     assert entry["performance"]["node_deaths"] == 0
+    assert entry["performance"]["oom_kills"] == 0
+    assert entry["performance"]["unexpected_worker_kills"] == 0
     # No issues detected in this run; the key is present and empty.
     assert entry["detected_issues"] == []
 


### PR DESCRIPTION
## Description
Record the number of worker kills during an execution as part of usage collection. In order to get a better understanding of the performance issues during a Ray Data execution, we return the number of `oom_kills, unexpected_worker_kills` recorded by measuring the delta between execution start and end via the usage execution callback.

The function `cluster_worker_kill_counts` uses WorkerTableData from the GCS to track the above metrics.

## Additional information
We filter the serialized worker table from the GCS by dead workers, keeping track of the worker death as a Ray OOM kill if its exit type was reported as `WorkerExitType.NODE_OUT_OF_MEMORY` and as an unexpected worker kill if its exit type is WorkerExitType.SYSTEM_ERROR
