### PR TITLE
[Data] Shuffle reduce op `incremental_resource_usage` should consider all inputs 

### DIFF
--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -421,14 +421,13 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
 
     def incremental_resource_usage(self) -> ExecutionResources:
         """Per-task resource ask for the framework's budget allocator."""
-        upstream = self.input_dependencies[0]
-        assert isinstance(upstream, ShuffleMapOp)
-        partition_bytes = upstream.get_partition_bytes()
         memory = 0
-        sizes = [b for b in partition_bytes.values() if b > 0]
-        if sizes:
-            avg_bytes = sum(sizes) / len(sizes)
-            memory = int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
+        for upstream in self.input_dependencies:
+            assert isinstance(upstream, ShuffleMapOp)
+            sizes = [b for b in upstream.get_partition_bytes().values() if b > 0]
+            if sizes:
+                avg_bytes = sum(sizes) / len(sizes)
+                memory += int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
         return ExecutionResources.from_resource_dict(
             self._reduce_task_remote_args(memory)
         )


### PR DESCRIPTION
## Description
As in the title: previously `incremental_resource_usage` only accounted for the first upstream input, which could give the Ray Data scheduler a wrong estimate when a reducer has multiple inputs.

This PR sums the memory estimate across all upstream inputs.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
