### PR TITLE
[core/state] Make `ray list nodes` default output concise

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -592,8 +592,10 @@ def test_runtime_env_state_humanify_creation_time_ms():
 
 
 def test_default_table_output_preserves_wrapper_for_non_node_resources():
-    """Regression:搬默认表格逻辑进 StateSchema.format_table_output 后,
-    非 Node 资源(PlacementGroupState)默认表格仍带 Stats/Table 包装头与原列。"""
+    """Regression test: After moving the default table logic into
+    StateSchema.format_table_output, non-Node resources
+    (PlacementGroupState) should still render with the Stats/Table
+    wrapper and original columns."""
     pg = {
         "placement_group_id": "pg_abcdef0123456789",
         "name": "test-pg",
@@ -638,8 +640,9 @@ def _sample_node_state():
 
 
 def test_node_default_output_is_concise():
-    """`ray list nodes` 默认输出为精简裸表:
-    截断 node_id、CPU/GPU/MEMORY/OBJ_STORE 独立列、无行号、无 Stats/Table 包装头。"""
+    """The default `ray list nodes` output is a concise bare table:
+    truncated node_id, separate CPU/GPU/MEMORY/OBJ_STORE columns, no row
+    index, and no Stats/Table wrapper."""
     out = output_with_format(
         [_sample_node_state()],
         schema=NodeState,
@@ -647,11 +650,11 @@ def test_node_default_output_is_concise():
         detail=False,
     )
     lines = out.splitlines()
-    # 裸表:无包装头
+    # Bare table: no wrapper header.
     assert "Stats:" not in out
     assert "Table:" not in out
     assert "List:" not in out
-    # 表头是第一行,且含新资源列
+    # First line is the header row and contains the new resource columns.
     assert lines[0].startswith("NODE_ID")
     for col in (
         "NODE_IP",
@@ -664,36 +667,40 @@ def test_node_default_output_is_concise():
         "OBJ_STORE",
     ):
         assert col in lines[0]
-    # 旧的冗长列已从默认输出移除
+    # Verbose legacy columns are removed from the default output.
     assert "STATE_MESSAGE" not in out
     assert "LABELS" not in out
     assert "RESOURCES_TOTAL" not in out
-    # node_id 截断为前 8 字符 + ...
+    # node_id is truncated to the first 8 chars + "...".
     assert "057ae870..." in out
-    # 完整 node_id 不出现在默认输出中(未截断部分不出现)
+    # The full node_id does not appear in the default output (the untruncated
+    # part is absent).
     full_id = "057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475cd507ab9f"
     assert full_id not in out
-    # 数据行直接以截断 id 开头(无行号索引)
+    # The data row starts directly with the truncated id (no row index).
     assert lines[1].startswith("057ae870...")
-    # memory / object_store_memory 已被 humanify 成可读单位
+    # memory / object_store_memory are humanified into readable units.
     assert "8.000 GiB" in out
     assert "48.000 GiB" in out
 
 
 def test_node_detail_output_delegates_to_base():
-    """`detail=True` 委托基类默认实现:完整表 + 包装头(Stats/Table)。"""
+    """`detail=True` delegates to the base class implementation: a full table
+    with the Stats/Table wrapper."""
     out = NodeState.format_table_output([_sample_node_state()], detail=True)
     assert "Stats:" in out
     assert "Table:" in out
-    # detail=True 委托基类:完整 node_id(未截断)+ RESOURCES_TOTAL 全列
+    # detail=True delegates to the base: full node_id (untruncated) + the full
+    # RESOURCES_TOTAL column.
     full_id = "057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475cd507ab9f"
     assert full_id in out
     assert "RESOURCES_TOTAL" in out
 
 
 def test_node_json_yaml_unchanged():
-    """json / yaml 路径(detail=False)逐字节不变:
-    resources_total 完整(含 CPU/GPU/memory/object_store_memory)、node_id 完整未截断。"""
+    """JSON/YAML output paths (with detail=False) remain byte-identical:
+    resources_total is complete (including CPU/GPU/memory/object_store_memory)
+    and node_id is untruncated."""
     node = _sample_node_state()
     # JSON
     out_json = output_with_format(

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -78,7 +78,9 @@ from ray.util.state import (
 from ray.util.state.common import (
     ActorState,
     Humanify,
+    NodeState,
     ObjectState,
+    PlacementGroupState,
     RuntimeEnvState,
     StateResource,
     StateSchema,
@@ -90,6 +92,7 @@ from ray.util.state.state_cli import (
     _normalize_filter_keys,
     _parse_filter,
     format_list_api_output,
+    output_with_format,
     ray_get,
     ray_list,
     summary_state_cli_group,
@@ -588,6 +591,140 @@ def test_runtime_env_state_humanify_creation_time_ms():
     assert state["creation_time_ms"] == "0:00:36.639000"
 
 
+def test_default_table_output_preserves_wrapper_for_non_node_resources():
+    """Regression:搬默认表格逻辑进 StateSchema.format_table_output 后,
+    非 Node 资源(PlacementGroupState)默认表格仍带 Stats/Table 包装头与原列。"""
+    pg = {
+        "placement_group_id": "pg_abcdef0123456789",
+        "name": "test-pg",
+        "creator_job_id": "01000000",
+        "state": "CREATED",
+        "bundles": [{"CPU": 1.0}],
+        "is_detached": True,
+        "stats": {},
+        "topology_strategy": {},
+        "topology_assignments": {},
+    }
+    out = output_with_format(
+        [pg],
+        schema=PlacementGroupState,
+        format=AvailableFormat.DEFAULT,
+        detail=False,
+    )
+    assert "Stats:" in out
+    assert "Table:" in out
+    assert "PLACEMENT_GROUP_ID" in out
+    assert "CREATED" in out
+
+
+def _sample_node_state():
+    return {
+        "node_id": "057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475cd507ab9f",
+        "node_ip": "10.121.130.4",
+        "is_head_node": False,
+        "state": "ALIVE",
+        "state_message": None,
+        "node_name": "10.121.130.4",
+        "resources_total": {
+            "CPU": 4.0,
+            "GPU": 1.0,
+            "memory": 8589934592,
+            "object_store_memory": 51539607552,
+        },
+        "labels": {"ray.io/node-group": "worker-group"},
+        "start_time_ms": 123,
+        "end_time_ms": 0,
+    }
+
+
+def test_node_default_output_is_concise():
+    """`ray list nodes` 默认输出为精简裸表:
+    截断 node_id、CPU/GPU/MEMORY/OBJ_STORE 独立列、无行号、无 Stats/Table 包装头。"""
+    out = output_with_format(
+        [_sample_node_state()],
+        schema=NodeState,
+        format=AvailableFormat.DEFAULT,
+        detail=False,
+    )
+    lines = out.splitlines()
+    # 裸表:无包装头
+    assert "Stats:" not in out
+    assert "Table:" not in out
+    assert "List:" not in out
+    # 表头是第一行,且含新资源列
+    assert lines[0].startswith("NODE_ID")
+    for col in (
+        "NODE_IP",
+        "IS_HEAD_NODE",
+        "STATE",
+        "NODE_NAME",
+        "CPU",
+        "GPU",
+        "MEMORY",
+        "OBJ_STORE",
+    ):
+        assert col in lines[0]
+    # 旧的冗长列已从默认输出移除
+    assert "STATE_MESSAGE" not in out
+    assert "LABELS" not in out
+    assert "RESOURCES_TOTAL" not in out
+    # node_id 截断为前 8 字符 + ...
+    assert "057ae870..." in out
+    # 完整 node_id 不出现在默认输出中(未截断部分不出现)
+    full_id = "057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475cd507ab9f"
+    assert full_id not in out
+    # 数据行直接以截断 id 开头(无行号索引)
+    assert lines[1].startswith("057ae870...")
+    # memory / object_store_memory 已被 humanify 成可读单位
+    assert "8.000 GiB" in out
+    assert "48.000 GiB" in out
+
+
+def test_node_detail_output_delegates_to_base():
+    """`detail=True` 委托基类默认实现:完整表 + 包装头(Stats/Table)。"""
+    out = NodeState.format_table_output([_sample_node_state()], detail=True)
+    assert "Stats:" in out
+    assert "Table:" in out
+    # detail=True 委托基类:完整 node_id(未截断)+ RESOURCES_TOTAL 全列
+    full_id = "057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475cd507ab9f"
+    assert full_id in out
+    assert "RESOURCES_TOTAL" in out
+
+
+def test_node_json_yaml_unchanged():
+    """json / yaml 路径(detail=False)逐字节不变:
+    resources_total 完整(含 CPU/GPU/memory/object_store_memory)、node_id 完整未截断。"""
+    node = _sample_node_state()
+    # JSON
+    out_json = output_with_format(
+        [node], schema=NodeState, format=AvailableFormat.JSON, detail=False
+    )
+    data = json.loads(out_json)[0]
+    assert "resources_total" in data
+    assert "state_message" in data
+    assert "labels" in data
+    res = data["resources_total"]
+    for key in ("CPU", "GPU", "memory", "object_store_memory"):
+        assert key in res
+    full_id = "057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475cd507ab9f"
+    assert data["node_id"] == full_id
+    # YAML
+    out_yaml = output_with_format(
+        [_sample_node_state()],
+        schema=NodeState,
+        format=AvailableFormat.YAML,
+        detail=False,
+    )
+    ydata = yaml.safe_load(out_yaml)[0]
+    assert "resources_total" in ydata
+    assert "state_message" in ydata
+    assert "labels" in ydata
+    yres = ydata["resources_total"]
+    for key in ("CPU", "GPU", "memory", "object_store_memory"):
+        assert key in yres
+    assert ydata["node_id"] == full_id
+
+
 def is_hex(val):
     try:
         int_val = int(val, 16)
@@ -666,7 +803,7 @@ def test_cli_apis_sanity_check(ray_start_cluster):
         lambda: verify_output(ray_list, ["workers"], ["Stats:", "Table:", "WORKER_ID"])
     )
     wait_for_condition(
-        lambda: verify_output(ray_list, ["nodes"], ["Stats:", "Table:", "NODE_ID"])
+        lambda: verify_output(ray_list, ["nodes"], ["NODE_ID", "CPU", "OBJ_STORE"])
     )
     wait_for_condition(
         lambda: verify_output(

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -349,7 +349,7 @@ class StateSchema(ABC):
             for col in cols:
                 if col in keys:
                     headers.append(col.upper())
-            table.append([data[header.lower()] for header in headers])
+            table.append([data[h.lower()] for h in headers])
         return f"""
 {header}
 Stats:

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -8,6 +8,8 @@ from dataclasses import asdict, field, fields
 from enum import Enum, unique
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
+import yaml
+
 import ray.dashboard.utils as dashboard_utils
 
 # TODO(aguo): Instead of a version check, modify the below models
@@ -27,6 +29,7 @@ from ray._private.custom_types import (
     TypeWorkerType,
 )
 from ray._private.ray_constants import env_integer
+from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray.core.generated.common_pb2 import TaskStatus, TaskType
 from ray.core.generated.gcs_pb2 import TaskEvents
 from ray.dashboard.modules.job.pydantic_models import JobDetails
@@ -317,6 +320,46 @@ class StateSchema(ABC):
                 except Exception as e:
                     logger.error(f"Failed to format {f.name}:{state[f.name]} with {e}")
         return state
+
+    @classmethod
+    def format_table_output(cls, state_data: List, detail: bool) -> str:
+        """Render state_data as a table string.
+
+        The table headers are ordered as defined in the dataclass. Subclasses
+        may override this for a custom (e.g. more concise) table layout.
+
+        Args:
+            state_data: A list of state data dicts.
+            detail: Whether to include columns marked as detail-only.
+
+        Returns:
+            The table formatted string.
+        """
+        time = datetime.datetime.now()
+        header = "=" * 8 + f" List: {time} " + "=" * 8
+        headers = []
+        table = []
+        cols = cls.list_columns(detail=detail)
+        for data in state_data:
+            for key, val in data.items():
+                if isinstance(val, dict):
+                    data[key] = yaml.dump(val, indent=2)
+            keys = set(data.keys())
+            headers = []
+            for col in cols:
+                if col in keys:
+                    headers.append(col.upper())
+            table.append([data[header.lower()] for header in headers])
+        return f"""
+{header}
+Stats:
+------------------------------
+Total: {len(state_data)}
+
+Table:
+------------------------------
+{tabulate(table, headers=headers, showindex=True, tablefmt="plain", floatfmt=".3f")}
+"""
 
     @classmethod
     def list_columns(cls, detail: bool = True) -> List[str]:
@@ -616,6 +659,63 @@ class NodeState(StateSchema):
     end_time_ms: Optional[int] = state_column(
         filterable=False, detail=True, format_fn=Humanify.timestamp
     )
+
+    @classmethod
+    def format_table_output(cls, state_data: List, detail: bool) -> str:
+        """Concise single-line table for ``ray list nodes``.
+
+        When ``detail`` is False, render a compact table (trimmed node_id, no
+        row index, no wrapper) with CPU/GPU/MEMORY/OBJ_STORE promoted out of
+        ``resources_total``. When ``detail`` is True, fall back to the default
+        verbose table (full node_id, all columns, wrapper).
+
+        Note: ``resources_total["memory"]`` / ``["object_store_memory"]`` have
+        already been humanified into ``"X GiB"`` strings by
+        ``Humanify.node_resources`` in ``output_with_format`` before this method
+        is called, so they are taken as-is.
+        """
+        if detail:
+            # Use zero-arg super() so cls stays bound to NodeState; calling
+            # StateSchema.format_table_output directly would bind cls to the
+            # abstract base class and lose NodeState's field list.
+            return super().format_table_output(state_data, detail)
+
+        headers = [
+            "NODE_ID",
+            "NODE_IP",
+            "IS_HEAD_NODE",
+            "STATE",
+            "NODE_NAME",
+            "CPU",
+            "GPU",
+            "MEMORY",
+            "OBJ_STORE",
+        ]
+        table = []
+        for data in state_data:
+            resources = data.get("resources_total") or {}
+            node_id = data.get("node_id") or ""
+            node_id = (node_id[:8] + "...") if len(node_id) > 8 else node_id
+            table.append(
+                [
+                    node_id,
+                    data.get("node_ip"),
+                    data.get("is_head_node"),
+                    data.get("state"),
+                    data.get("node_name"),
+                    resources.get("CPU", 0),
+                    resources.get("GPU", 0),
+                    resources.get("memory", "0"),
+                    resources.get("object_store_memory", "0"),
+                ]
+            )
+        return tabulate(
+            table,
+            headers=headers,
+            showindex=False,
+            tablefmt="plain",
+            floatfmt=".3f",
+        )
 
 
 # NOTE: Declaring this as dataclass would make __init__ not being called properly.

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -157,18 +157,10 @@ def _get_available_resources(
 def get_table_output(state_data: List, schema: StateSchema, detail: bool) -> str:
     """Display the table output.
 
-    The table headers are ordered as the order defined in the dataclass of
-    `StateSchema`. For example,
-
-    @dataclass
-    class A(StateSchema):
-        a: str
-        b: str
-        c: str
-
-    will create headers
-    A B C
-    -----
+    Delegates to the schema's ``format_table_output`` so each resource schema
+    can customize its own table layout. When ``schema`` is ``None`` (no schema
+    provided), falls back to the default implementation below for backward
+    compatibility.
 
     Args:
         state_data: A list of state data.
@@ -178,11 +170,15 @@ def get_table_output(state_data: List, schema: StateSchema, detail: bool) -> str
     Returns:
         The table formatted string.
     """
+    if schema is not None:
+        return schema.format_table_output(state_data, detail)
+
+    # Backward-compat fallback (schema is None): original default logic.
     time = datetime.now()
     header = "=" * 8 + f" List: {time} " + "=" * 8
     headers = []
     table = []
-    cols = schema.list_columns(detail=detail)
+    cols = []
     for data in state_data:
         for key, val in data.items():
             if isinstance(val, dict):


### PR DESCRIPTION
## Motivation

The default `ray list nodes` table output is hard to scan when a cluster has many nodes: a full 40+ character `node_id`, the `state_message` and `labels` columns, a nested `resources_total` dict column, and a per-row index all push the useful signal off-screen.

Issue #64617 asks for a `kubectl get pods`-style concise default view, while keeping full information available via `--detail`.

Example before (default, verbose):

```
======== List: ... ========
Stats:
------------------------------
Total: 1

Table:
------------------------------
      NODE_ID                                        NODE_IP  ...  RESOURCES_TOTAL ...
 0  057ae8704b49ce135e8f6665d66f44c6a81572f7e9d6475  10.x.x.x ...  {CPU: 4.0, ...}
```

Example after (default, concise):

<img width="936" height="379" alt="image" src="https://github.com/user-attachments/assets/f2e7977e-b668-4a9f-b90e-7705deb0c4ae" />


## Implementation Details

### Approach

Introduce a per-schema table-rendering hook so that **only `NodeState`** changes its default layout. No other resource's output and no programmatic (json/yaml) output are touched.

### Changes

**`python/ray/util/state/common.py`**

- Added `StateSchema.format_table_output(cls, state_data, detail)` classmethod:  a behavior-equivalent move of the existing table-rendering logic out of  `state_cli.get_table_output` (same `yaml.dump` for dict values, same  `tabulate(..., showindex=True, tablefmt="plain", floatfmt=".3f")`, same  `Stats:`/`Table:` wrapper). Uses `cls.list_columns(detail)` so the correct  subclass field list is picked up.
- Overrode `NodeState.format_table_output`:
  - `detail=False` -> concise bare table. Columns in order:    `NODE_ID NODE_IP IS_HEAD_NODE STATE NODE_NAME CPU GPU MEMORY OBJ_STORE`.
    `node_id` is trimmed to the first 8 chars + `"..."` (only when longer than    8). `CPU`/`GPU`/`MEMORY`/`OBJ_STORE` are promoted out of `resources_total`    as their own columns. No `Stats:`/`Table:`/`List:` wrapper, no row index
    (`showindex=False`).
  - `detail=True` -> delegates to the base via zero-arg    `super().format_table_output(...)` so `cls` stays bound to `NodeState`    (calling `StateSchema.format_table_output(...)` directly would bind `cls`    to the abstract base and lose the field list). Preserves full `node_id`,    all columns, and the wrapper.
- Added imports: `yaml`, vendored `tabulate`.

**`python/ray/util/state/state_cli.py`**

- `get_table_output` now delegates to `schema.format_table_output(state_data,  detail)` when a schema is provided. A backward-compat fallback (original  logic with `cols=[]`) is kept for `schema=None`, which previously raised  `AttributeError`.

### Properties preserved

- **json/yaml output is byte-identical**: `output_with_format`'s json/yaml  branches are untouched; NodeState.format_table_output` only runs for the  DEFAULT (table) format.
- **Other resources are unaffected**: `ActorState`/`WorkerState`/`TaskState`/`ObjectState`/`PlacementGroupState`/`RuntimeEnvState`/`JobDetails` have no  override and still render with the `Stats:`/`Table:` wrapper via the base  class.
- **humanify timing unchanged**: `output_with_format` still calls  `schema.humanify(state)` before table rendering, so  `resources_total["memory"]`/`["object_store_memory"]` are already  human-readable `"X GiB"` strings when NodeState.format_table_output` reads  them; `CPU`/`GPU` stay as raw numbers.

## Related issue
Closes #64617.
