### PR TITLE
[serve] Fix rank corruption on controller recovery after lightweight reconfigure

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3746,7 +3746,7 @@ class DeploymentState:
                     replica.replica_id.unique_id
                 )
                 actor_updating = replica.reconfigure(
-                    self._target_state.version, rank=current_rank.rank
+                    self._target_state.version, rank=current_rank
                 )
                 if actor_updating:
                     self._replicas.add(ReplicaState.UPDATING, replica)

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -7297,6 +7297,77 @@ class TestDeploymentRankManagerIntegrationE2E:
         # Clean up
         replica_rank_context.clear()
 
+    def test_rank_recovery_after_lightweight_reconfigure(
+        self, mock_deployment_state_manager
+    ):
+        """Lightweight reconfigure must pass the ReplicaRank object, not the int.
+
+        Regression test for the lightweight-update branch calling
+        `replica.reconfigure(version, rank=current_rank.rank)` (a bare int).
+        The replica stored the int and reported it back on controller
+        recovery, where `_recover_rank_impl` failed with
+        `'int' object has no attribute 'rank'`, leaving every surviving
+        replica without a rank and `_check_rank_consistency_impl` looping
+        "Rank system is in an invalid state".
+        """
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        replica_rank_context.clear()
+
+        # Deploy 3 replicas with a user_config and get them running.
+        info_1, v1 = deployment_info(num_replicas=3, version="1", user_config="1")
+        assert dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
+        dsm.save_checkpoint()
+        ds: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+        dsm.update()
+        check_counts(ds, total=3, by_state=[(ReplicaState.STARTING, 3, v1)])
+        self._set_replicas_ready(ds, [ReplicaState.STARTING])
+        dsm.update()
+        check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v1)])
+
+        # Lightweight update: same code version, new user_config. Replicas
+        # are reconfigured in place (rolling), not restarted.
+        info_2, v2 = deployment_info(num_replicas=3, version="1", user_config="2")
+        assert dsm.deploy(TEST_DEPLOYMENT_ID, info_2)
+        dsm.save_checkpoint()
+        for _ in range(10):
+            dsm.update()
+            self._set_replicas_ready(ds, [ReplicaState.UPDATING])
+        check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v2)])
+
+        # The reconfigure must have handed each replica the full ReplicaRank
+        # object; this is what replicas report back on controller recovery.
+        replicas = ds._replicas.get([ReplicaState.RUNNING])
+        for replica in replicas:
+            stored_rank = replica_rank_context[replica.replica_id.unique_id]
+            assert isinstance(
+                stored_rank, ReplicaRank
+            ), f"Replica stored {stored_rank!r} instead of a ReplicaRank"
+
+        # Simulate controller crash and recover from the live replicas.
+        replica_ids = [replica.replica_id for replica in replicas]
+        new_dsm: DeploymentStateManager = create_dsm(
+            [replica_id.to_full_id_str() for replica_id in replica_ids]
+        )
+        new_ds = new_dsm._deployment_states[TEST_DEPLOYMENT_ID]
+        check_counts(new_ds, total=3, by_state=[(ReplicaState.RECOVERING, 3, v2)])
+        self._set_replicas_ready(new_ds, [ReplicaState.RECOVERING])
+        new_dsm.update()
+        check_counts(new_ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v2)])
+
+        # Every recovered replica must have its rank restored.
+        for replica_id in replica_ids:
+            assert new_ds._rank_manager.has_replica_rank(
+                replica_id.unique_id
+            ), f"Rank for {replica_id.unique_id} was not recovered"
+        ranks_mapping = new_ds._get_replica_ranks_mapping()
+        ranks = sorted([r.rank for r in ranks_mapping.values()])
+        assert ranks == [0, 1, 2], f"Expected recovered ranks [0, 1, 2], got {ranks}"
+
+        # Clean up
+        replica_rank_context.clear()
+
     def test_complex_reassignment_scenario(self, mock_deployment_state_manager):
         """Test complex reassignment with many gaps through deployment state manager."""
         create_dsm, _, _, _ = mock_deployment_state_manager


### PR DESCRIPTION
## Why are these changes needed?

The lightweight-update branch of per-replica reconciliation passes the bare
int instead of the `ReplicaRank` object to `replica.reconfigure()`:

    current_rank = self._rank_manager.get_replica_rank(replica.replica_id.unique_id)
    actor_updating = replica.reconfigure(
        self._target_state.version, rank=current_rank.rank   # <-- int, not ReplicaRank
    )

The replica stores this value in its `ReplicaContext` and reports it back to
the controller on recovery (`initialize_and_get_metadata()` → `get_metadata()`
→ `context.rank`). The recovering controller then calls
`_recover_rank_impl`, which does `rank.rank` and fails:

    ERROR ... Error executing function _recover_rank_impl: 'int' object has no attribute 'rank'

Because the error is swallowed by `_execute_with_error_handling`, every
surviving replica is silently left without a rank, and the controller loops
forever with:

    ERROR ... Found active keys without ranks: {...}. This should never happen. Please report this as a bug.
    ERROR ... Error executing function _check_rank_consistency_impl: Rank system is in an invalid state.

**Reproduction** (verified on 2.56.0 and master): deploy any deployment with a
`user_config` (or otherwise trigger a lightweight in-place reconfigure), then
`kill -9` the ServeController. The recovered controller emits the errors
above and the rank system never becomes consistent again. This is the
mechanism behind the ranker instability reported in #63862 — the OOM killer
there is just one way to kill the controller; any controller crash after a
lightweight reconfigure corrupts rank recovery.

The fix is to pass the `ReplicaRank` object, matching the other
`replica.reconfigure()` call site (`_reconfigure_replicas_with_new_ranks`) and
the `reconfigure(self, version, rank: ReplicaRank)` signature.

Added regression test `test_rank_recovery_after_lightweight_reconfigure`:
deploys 3 replicas with a `user_config`, performs a rolling lightweight
update, asserts the replicas were handed a `ReplicaRank` (not an int), then
simulates a controller crash and asserts all ranks are recovered. The test
fails on master without the one-line fix (at the `isinstance` assertion) and
passes with it.

## Related issue number

Fixes the ranker/rank-recovery instability in #63862 (repro details posted
there).