### PR TITLE
[RLlib] Guard WindowStat.mean/std against empty window

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -3084,6 +3084,17 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_window_stat",
+    size = "small",
+    srcs = ["utils/metrics/tests/test_window_stat.py"],
+    tags = [
+        "team:rllib",
+        "utils",
+    ],
+    deps = [":conftest"],
+)
+
 # @OldAPIStack
 py_test(
     name = "test_value_predictions",

--- a/rllib/utils/metrics/tests/test_window_stat.py
+++ b/rllib/utils/metrics/tests/test_window_stat.py
@@ -1,0 +1,45 @@
+import warnings
+
+import numpy as np
+import pytest
+
+from ray.rllib.utils.metrics.window_stat import WindowStat
+
+
+def test_empty_window_stat_does_not_warn():
+    """An empty WindowStat must not emit numpy empty-slice RuntimeWarnings.
+
+    Regression test for issue #45659: `mean()`/`std()` used to call
+    `np.nanmean`/`np.nanstd` on an empty slice when no items had been pushed
+    yet, emitting "Mean of empty slice" and "Degrees of freedom <= 0"
+    RuntimeWarnings (e.g. when an env step is slow enough that a reporting
+    interval elapses before the first sample arrives).
+    """
+    win_stats = WindowStat("level", 3)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        # Neither of these may raise a RuntimeWarning on an empty window.
+        assert np.isnan(win_stats.mean())
+        assert np.isnan(win_stats.std())
+        # `stats()` calls `mean()` and `std()` internally.
+        stats = win_stats.stats()
+
+    assert stats["level_count"] == 0
+
+
+def test_window_stat_after_push():
+    """Sanity check that stats are still correct once items are pushed."""
+    win_stats = WindowStat("level", 3)
+    for value in (5.0, 7.0, 7.0, 10.0):
+        win_stats.push(value)
+
+    # Mean of the last 3 items: (7 + 7 + 10) / 3 == 8.0.
+    assert win_stats.mean() == pytest.approx(8.0)
+    assert win_stats.std() >= 0.0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/utils/metrics/window_stat.py
+++ b/rllib/utils/metrics/window_stat.py
@@ -55,10 +55,18 @@ class WindowStat:
 
     def mean(self) -> float:
         """Returns the (NaN-)mean of the last `self.window_size` items."""
+        # No items pushed yet -> avoid a "Mean of empty slice" RuntimeWarning
+        # from `np.nanmean` on an empty array (see issue #45659).
+        if not self.count:
+            return float("nan")
         return float(np.nanmean(self.items[: self.count]))
 
     def std(self) -> float:
         """Returns the (NaN)-stddev of the last `self.window_size` items."""
+        # No items pushed yet -> avoid a "Degrees of freedom <= 0" RuntimeWarning
+        # from `np.nanstd` on an empty array (see issue #45659).
+        if not self.count:
+            return float("nan")
         return float(np.nanstd(self.items[: self.count]))
 
     def quantiles(self) -> np.ndarray:


### PR DESCRIPTION
## Why are these changes needed?

`WindowStat.mean()` and `WindowStat.std()` compute over `self.items[:self.count]`, which is an **empty slice** before any item has been pushed. `np.nanmean` / `np.nanstd` on an empty array emit `RuntimeWarning: Mean of empty slice` and `RuntimeWarning: Degrees of freedom <= 0`.

This surfaces in normal use when a reporting/aggregation interval elapses before the first sample arrives — e.g. when the environment `step()` is slow enough (a `time.sleep(1/20)` is sufficient) that the metrics window is momentarily empty, as reported in #45659.

The fix returns `float("nan")` for the empty case, mirroring the guard `quantiles()` already has (`if not self.count: ...`). No behavioral change once items are present.

```python
def mean(self) -> float:
    if not self.count:
        return float("nan")
    return float(np.nanmean(self.items[: self.count]))
```

## Related issue number

Closes #45659

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `rllib/utils/metrics/tests/test_window_stat.py`, which asserts that `mean()`/`std()`/`stats()` on an empty window raise no `RuntimeWarning` (via `warnings.simplefilter("error", RuntimeWarning)`), and that values remain correct once items are pushed.