### PR TITLE
[Data] Debug log both wrapped and wrapper exception in `iterate_with_retry`

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1574,7 +1574,7 @@ def iterate_with_retry(
                 backoff = min((2 ** (attempt + 1)), max_backoff_s) * random.random()
                 logger.debug(
                     f"Retrying attempt {attempt + 1} to {description} "
-                    f"after {backoff:.1f}s due to: {e}"
+                    f"after {backoff:.1f}s due to: {error_str}"
                 )
                 time.sleep(backoff)
             else:


### PR DESCRIPTION
## Description
Currently, in `iterate_with_retry`, we have an option to set `unwrap_cause=True` which unwraps the exception caught when matching to decide whether to retry or not. While we match correctly, we currently only log the wrapper exception, which is misleading because it might hide the actual exception that was matched.

## Additional information
For example, when `iterate_with_retry` is called with a match list of `["RateLimitError"]` and the iterator is consuming a map transformer's inputs, we should retry on a `RateLimitError` wrapped as a `UserCodeException`, as this is raised in the UDF. Currently, the debug logs should look like:
### Before
```
2026-07-09 10:18:11,478 DEBUG util.py:1575 -- Retrying attempt 2 to apply UDF transform 
after 0.0s due to: ray.exceptions.UserCodeException: UDF failed to process a data block. 

```
With this PR, the change should instead log the entire error chain
### After
```
2026-07-09 10:18:11,478 DEBUG util.py:1575 -- Retrying attempt 2 to apply UDF transform 
after 0.0s due to: ray.exceptions.UserCodeException: UDF failed to process a data block. 
TransientError: transient failure on attempt 2 for row 0
```

We choose to log the entire chain because we don't know if the match happened due to the wrapper or the wrapped exception, and shouldn't assume either.