### PR TITLE
[core][actor scalability] Prefill PG bundle cache at creation to fix actor submission bottleneck

### DIFF
--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -221,7 +221,10 @@ def placement_group(
         stripped_topology_strategy,
     )
 
-    return PlacementGroup(placement_group_id)
+    return PlacementGroup(
+        placement_group_id,
+        bundle_cache=[{k: float(v) for k, v in bundle.items()} for bundle in bundles],
+    )
 
 
 @PublicAPI


### PR DESCRIPTION
## Description

I am improving actor scalability for RL / post-training / pre-training. One of the bottlenecks I hit when moving to centralized scheduling (apparently this is also a bottleneck for current Ray) is the actor submission speed in the driver.

You can see the benchmark code here: https://github.com/ray-project/ray/pull/64446.

But basically, the ideal workload pattern for RL / post-training / pre-training is one PG per rack, one bundle per node in the rack. Each bundle is a whole worker node, and 4 actors are scheduled into each (since there are 4 GPUs in GB300).

In current Ray, when the driver submits an actor with PG resource requirements, Ray checks whether any bundle has the capacity to fit the actor, this guards against the case where no bundle can actually fit it. The driver only submits the actor once this check passes, and raises an error if it doesn't. Without this check, the user would see no error and the actor would just stay pending in scheduling forever.

However, the current way Ray gets the bundle info is to always query GCS. In the workload pattern we have, especially in a large Ray cluster, GCS is already super busy. So querying the PG bundle information itself takes little time, but GCS may respond very slowly because it needs to finish all the events ahead of it first.

And actually, for most use cases, it's the driver that creates the PG and then directly submits the actors. So the driver already knows the bundle info, it could just cache it when creates PG. No need to query GCS.

Ray used to cache this! But after several refactors, I think we removed this cache accidentally (we were trying to unify the way bundles are fetched, using laze fetch). This PR fixes it by just adding back the bundle info when PG got created............



See the picture below for the big gain we got:


<img width="2446" height="762" alt="image" src="https://github.com/user-attachments/assets/6619bbe7-d271-4856-a68b-8667aa02c8e7" />

<img width="2446" height="762" alt="image" src="https://github.com/user-attachments/assets/306ac263-907b-4aa4-9d0e-b6f8bbf50abb" />

