### PR TITLE
Add Windows Python 3.13/3.14 wheel builds and update documentation

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -46,6 +46,8 @@ steps:
       - "3.10"
       - "3.11"
       - "3.12"
+      - "3.13"
+      - "3.14"
     depends_on:
       - windowsbuild
       - block-windows-tests

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -52,11 +52,6 @@ def _get_wheel_names(ray_version: str) -> List[str]:
 
     for python_version in PYTHON_VERSIONS:
         for platform in ALL_PLATFORMS:
-            if (
-                python_version in ("cp313-cp313", "cp314-cp314")
-                and platform == "win_amd64"
-            ):
-                continue
             wheel_name = f"ray-{ray_version}-{python_version}-{platform}"
             wheel_names.append(wheel_name)
 

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -31,8 +31,8 @@ def test_get_wheel_names():
 
     assert (
         len(wheel_names)
-        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) + len(ALL_PLATFORMS) - 2
-    )  # Except for the win_amd64 wheel for cp313 and cp314
+        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) + len(ALL_PLATFORMS)
+    )
     python_versions = list(PYTHON_VERSIONS) + ["py3-none"]
 
     for wheel_name in wheel_names:

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -134,8 +134,8 @@ You can install the nightly Ray wheels via the following links. These daily rele
            * - `Windows Python 3.10 (amd64)`_
            * - `Windows Python 3.11 (amd64)`_
            * - `Windows Python 3.12 (amd64)`_
-           * - `Windows Python 3.13 (amd64)`_ (beta)
-           * - `Windows Python 3.14 (amd64)`_ (beta)
+           * - `Windows Python 3.13 (amd64)`_
+           * - `Windows Python 3.14 (amd64)`_
 
 .. note::
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -134,6 +134,8 @@ You can install the nightly Ray wheels via the following links. These daily rele
            * - `Windows Python 3.10 (amd64)`_
            * - `Windows Python 3.11 (amd64)`_
            * - `Windows Python 3.12 (amd64)`_
+           * - `Windows Python 3.13 (amd64)`_ (beta)
+           * - `Windows Python 3.14 (amd64)`_ (beta)
 
 .. note::
 
@@ -166,6 +168,8 @@ You can install the nightly Ray wheels via the following links. These daily rele
 .. _`Windows Python 3.10 (amd64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-win_amd64.whl
 .. _`Windows Python 3.11 (amd64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-win_amd64.whl
 .. _`Windows Python 3.12 (amd64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-win_amd64.whl
+.. _`Windows Python 3.13 (amd64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-win_amd64.whl
+.. _`Windows Python 3.14 (amd64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-win_amd64.whl
 
 Installing from a specific commit
 ---------------------------------


### PR DESCRIPTION
## Description
Windows wheels are currently only built for Python 3.10–3.12. Support for 3.13/3.14 was explicitly excluded in https://github.com/ray-project/ray/pull/52689. Linux and macOS already ship 3.13/3.14 wheels. This PR wires up the minimal changes to let CI surface what breaks when attempting 3.13/3.14 Windows wheels.

## Related issues
- https://github.com/ray-project/ray/issues/63242
