### PR TITLE
[Serve] Fix serve.shutdown() skipping live shutdown when cached controller client is stale after driver reconnect

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -53,11 +53,11 @@ from ray.serve.context import (
     DeploymentActorContext,
     ReplicaContext,
     _check_cached_client_alive,
+    _disconnect,
     _get_deployment_actor,
     _get_global_client,
     _get_internal_deployment_actor_context,
     _get_internal_replica_context,
-    _set_global_client,
 )
 from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
@@ -152,7 +152,7 @@ def shutdown():
             return
 
     client.shutdown()
-    _set_global_client(None)
+    _disconnect()
 
 
 @PublicAPI(stability="alpha")
@@ -180,7 +180,7 @@ async def shutdown_async():
             return
 
     await client.shutdown_async()
-    _set_global_client(None)
+    _disconnect()
 
 
 @DeveloperAPI

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -37,6 +37,10 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 _INTERNAL_REPLICA_CONTEXT: "ReplicaContext" = None
 _INTERNAL_DEPLOYMENT_ACTOR_CONTEXT: "DeploymentActorContext" = None
 _global_client: ServeControllerClient = None
+# Ray job id (driver session) that created the cached client above. ray.shutdown()
+# leaves this module global intact, so after a reconnect (new job id) the cached
+# handle is unusable and must not be reused. See #64647.
+_global_client_job_id: Optional[str] = None
 
 
 @DeveloperAPI
@@ -114,9 +118,12 @@ def _get_global_client(
             and raise_if_no_controller_running is set to True.
     """
 
-    if _global_client is not None:
+    if _cached_client_from_current_session():
         return _global_client
 
+    # No usable cache (never set, or left over from a previous driver session).
+    # Drop any stale handle and rediscover the controller by name.
+    _disconnect()
     return _connect(raise_if_no_controller_running)
 
 
@@ -125,17 +132,22 @@ def _check_cached_client_alive() -> tuple:
 
     Returns:
         (client, had_cached) tuple.
-        - ``(client, True)`` — cached client is alive.
-        - ``(None, True)``  — cached client existed but is unreachable;
-          the cache has been cleared.  Callers should **not** attempt to
-          reconnect via ``_connect()`` because GCS is likely dead and
+        - ``(client, True)``: cached client from the current session is alive.
+        - ``(None, True)``: cached client from the current session existed but
+          is unreachable; the cache has been cleared. Callers should **not**
+          attempt to reconnect via ``_connect()`` because GCS is likely dead and
           ``ray.get_actor()`` would hang until the 60-second C++ GCS
           reconnection timeout kills the process.
-        - ``(None, False)`` — no cached client.  Callers may safely call
+        - ``(None, False)``: no usable cached client (never set, or left over
+          from a previous driver session). Callers may safely call
           ``_get_global_client()`` to discover a running controller.
     """
 
-    if _global_client is None:
+    if not _cached_client_from_current_session():
+        # Either nothing cached, or a handle left behind by a previous driver
+        # session. In the latter case GCS is alive (we are connected now), so it
+        # is safe for callers to reconnect. Drop any stale handle.
+        _disconnect()
         return None, False
 
     try:
@@ -143,13 +155,38 @@ def _check_cached_client_alive() -> tuple:
         return _global_client, True
     except Exception as e:
         logger.info(f"The cached controller has died or is unreachable: {e}.")
-        _set_global_client(None)
+        _disconnect()
         return None, True
 
 
 def _set_global_client(client):
-    global _global_client
+    global _global_client, _global_client_job_id
     _global_client = client
+    _global_client_job_id = (
+        ray.get_runtime_context().get_job_id() if client is not None else None
+    )
+
+
+def _disconnect():
+    """Forget the cached controller client for this driver session.
+
+    Mirrors ``_connect()``. This does **not** shut Serve down on the cluster; it
+    only drops the local cached handle so the next call rediscovers the
+    controller by name.
+    """
+    _set_global_client(None)
+
+
+def _cached_client_from_current_session() -> bool:
+    """Whether a usable cached client exists for the current Ray session.
+
+    ``_global_client`` is a module global that survives ``ray.shutdown()``, so a
+    handle cached by a previous driver session cannot be used after the driver
+    reconnects (which yields a new job id). Comparing job ids detects that case.
+    """
+    if _global_client is None or not ray.is_initialized():
+        return False
+    return _global_client_job_id == ray.get_runtime_context().get_job_id()
 
 
 def _get_internal_replica_context():

--- a/python/ray/serve/tests/test_shutdown.py
+++ b/python/ray/serve/tests/test_shutdown.py
@@ -430,6 +430,49 @@ async def test_shutdown_async_after_driver_reconnect(ray_shutdown):
         await serve.shutdown_async()
 
 
+def test_shutdown_after_reconnect_shuts_down_live_serve(ray_cluster):
+    """serve.shutdown() must shut down a still-running Serve after the driver
+    reconnects to a long-lived cluster.
+
+    Regression test for https://github.com/ray-project/ray/issues/64647.
+    Unlike test_shutdown_after_driver_reconnect (which starts a fresh in-process
+    cluster on each ray.init(), so no controller ever survives), this uses a
+    persistent cluster. The detached controller survives the driver's
+    ray.shutdown(), so a stale cached _global_client left over from the first
+    session must not make serve.shutdown() skip shutting the live controller down.
+    """
+    cluster = ray_cluster
+    head_node = cluster.add_node(num_cpus=8)
+
+    @serve.deployment
+    class First:
+        def __call__(self):
+            return "first"
+
+    # Session 1: start Serve. The detached controller survives disconnect.
+    ray.init(head_node.address, namespace=SERVE_NAMESPACE)
+    serve.start()
+    serve.run(First.bind())
+    ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)  # sanity: exists
+    # Intentionally do NOT clear serve.context._global_client: the stale cached
+    # client left behind here is exactly what triggers the bug.
+    ray.shutdown()
+
+    # Session 2: reconnect to the same cluster and shut Serve down.
+    ray.init(head_node.address, namespace=SERVE_NAMESPACE)
+    serve.shutdown()
+
+    # The live controller must actually be gone now.
+    def controller_gone():
+        try:
+            ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
+            return False
+        except ValueError:
+            return True
+
+    wait_for_condition(controller_gone, timeout=20)
+
+
 def test_serve_shutdown_cleans_up_deployment_actors(ray_shutdown):
     """serve.shutdown() kills all deployment actors.
 


### PR DESCRIPTION
## Summary

`serve.shutdown()` silently skips shutting down a running Serve instance when the Python process holds a stale cached controller client from an earlier `ray.init()` session against a long-lived cluster. After the failed shutdown the old HTTP port stays alive and a later `serve.start(port=...)` on a new port is ignored. Fixes #64647.

## Root cause

`_global_client` (a module-level cached `ServeControllerClient`) is never cleared on `ray.shutdown()`. After the driver disconnects and reconnects, the cached actor handle belongs to the previous session's core worker, so calling a method on it fails **instantly** with a local `NotFound` ("... from a different cluster") even though the GCS is alive and the detached controller is still running.

`_check_cached_client_alive()` reported that failure as `had_cached=True`, and `shutdown()` interpreted `had_cached=True` as "GCS is likely dead", logged `Nothing to shut down`, and returned without reconnecting. The reconnect it skipped (`_connect()` -> `ray.get_actor(SERVE_CONTROLLER_NAME, ...)`) would have found the live controller and shut it down (this is exactly what the issue's `_set_global_client(None)` workaround forces).

## Fix

Tag the cached client with the Ray job id of the session that created it (`get_job_id()` yields a new id on every reconnect, even to the same cluster). The cache is only reused when it belongs to the current session:

- **Cache from a different session** -> dropped, controller rediscovered by name -> shut down correctly.
- **Same-session cache that fails its health check** -> still returns early, preserving the dead-GCS "no 60s hang" protection added in #62368 (that scenario stays within one session).

Adds a `_disconnect()` helper (symmetric to `_connect()`) as the single teardown point; the two post-shutdown clears in `api.py` now route through it.

## Test

`test_shutdown_after_reconnect_shuts_down_live_serve` uses a persistent cluster (`ray_cluster`) so the detached controller actually survives the driver's `ray.shutdown()`. The existing `test_shutdown_after_driver_reconnect` starts a fresh in-process cluster on each `ray.init()`, so no controller ever survives, and it never exercised this path.

Verified: fails before the fix (controller left alive after reconnect), passes after; full `test_shutdown.py` passes (14/14); the end-to-end repro from the issue passes without the workaround (port 8000 dead, restart on 8001 works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
