### PR TITLE
[Data] Fix Dataset.summary() crash on boolean columns

### DIFF
--- a/python/ray/data/stats.py
+++ b/python/ray/data/stats.py
@@ -277,6 +277,37 @@ def _basic_aggregators(column: str) -> List[AggregateFnV2]:
     ]
 
 
+def _boolean_aggregators(column: str) -> List[AggregateFnV2]:
+    """Generate default metrics for boolean columns.
+
+    Booleans are numeric-like, but PyArrow has no compute kernels for the
+    operations behind ``Std`` (``subtract(bool, double)``),
+    ``ApproximateQuantile`` (``quantile(bool)``) and ``ZeroPercentage``
+    (``equal(bool, int64)``), so including those aggregators makes
+    ``Dataset.summary()`` crash with ``ArrowNotImplementedError`` (issue
+    #62235). Only the metrics whose kernels support booleans are returned:
+
+    - count
+    - mean
+    - min
+    - max
+    - missing_value_percentage
+
+    Args:
+        column: The name of the boolean column to compute metrics for.
+
+    Returns:
+        A list of AggregateFnV2 instances that can be used with Dataset.aggregate()
+    """
+    return [
+        Count(on=column, ignore_nulls=False),
+        Mean(on=column, ignore_nulls=True),
+        Min(on=column, ignore_nulls=True),
+        Max(on=column, ignore_nulls=True),
+        MissingValuePercentage(on=column),
+    ]
+
+
 def _default_dtype_aggregators() -> Dict[
     Union["DataType", "TypeCategory"], Callable[[str], List[AggregateFnV2]]
 ]:
@@ -310,7 +341,7 @@ def _default_dtype_aggregators() -> Dict[
         DataType.uint64(): _numerical_aggregators,
         DataType.float32(): _numerical_aggregators,
         DataType.float64(): _numerical_aggregators,
-        DataType.bool(): _numerical_aggregators,
+        DataType.bool(): _boolean_aggregators,
         # String and binary types
         DataType.string(): _basic_aggregators,
         DataType.binary(): _basic_aggregators,

--- a/python/ray/data/tests/test_dataset_stats.py
+++ b/python/ray/data/tests/test_dataset_stats.py
@@ -50,14 +50,14 @@ class TestDtypeAggregatorsForDataset:
                 {"num": "DataType(arrow:int64)", "str": "DataType(arrow:string)"},
                 11,  # 1 numerical * 8 + 1 string * 3
             ),
-            # Boolean treated as numerical
+            # Boolean uses its own aggregator set (see #62235)
             (
                 [{"bool_col": True, "int_col": 1}],
                 {
                     "bool_col": "DataType(arrow:bool)",
                     "int_col": "DataType(arrow:int64)",
                 },
-                16,  # 2 columns * 8 aggregators each
+                13,  # 1 boolean * 5 + 1 numerical * 8
             ),
         ],
     )

--- a/python/ray/data/tests/test_dataset_stats.py
+++ b/python/ray/data/tests/test_dataset_stats.py
@@ -21,6 +21,7 @@ from ray.data.datatype import DataType
 from ray.data.stats import (
     DatasetSummary,
     _basic_aggregators,
+    _boolean_aggregators,
     _default_dtype_aggregators,
     _dtype_aggregators_for_dataset,
     _numerical_aggregators,
@@ -194,6 +195,24 @@ class TestIndividualAggregatorFunctions:
             ZeroPercentage,
         ]
 
+    def test_boolean_aggregators(self):
+        """Test _boolean_aggregators excludes aggregators that crash on booleans.
+
+        Regression test for #62235: Std, ApproximateQuantile and ZeroPercentage
+        rely on PyArrow kernels that have no boolean implementation, so they must
+        not be part of the boolean column defaults.
+        """
+        aggs = _boolean_aggregators("test_col")
+
+        assert all(agg.get_target_column() == "test_col" for agg in aggs)
+        assert [type(agg) for agg in aggs] == [
+            Count,
+            Mean,
+            Min,
+            Max,
+            MissingValuePercentage,
+        ]
+
     def test_temporal_aggregators(self):
         """Test _temporal_aggregators function."""
         aggs = _temporal_aggregators("test_col")
@@ -260,13 +279,10 @@ class TestDefaultDtypeAggregators:
                     Mean,
                     Min,
                     Max,
-                    Std,
-                    ApproximateQuantile,
                     MissingValuePercentage,
-                    ZeroPercentage,
                 ],
                 False,
-            ),  # Numerical
+            ),  # Boolean (Std/ApproximateQuantile/ZeroPercentage excluded, see #62235)
             (
                 DataType.string,
                 [Count, MissingValuePercentage, ApproximateTopK],


### PR DESCRIPTION
## Why are these changes needed?

`Dataset.summary()` crashes with `ArrowNotImplementedError` whenever the dataset contains a boolean column.

`DataType.bool()` is mapped to `_numerical_aggregators`, which includes three aggregators whose underlying PyArrow compute kernels have no boolean implementation:

| Aggregator | Kernel | Error |
|---|---|---|
| `Std` | `subtract(bool, double)` | `no kernel matching input types (bool, double)` |
| `ApproximateQuantile` | `quantile(bool)` | `no kernel matching input types (bool)` |
| `ZeroPercentage` | `equal(bool, int64)` | `no kernel matching input types (bool, int64)` |

All three reproduce directly in PyArrow:

```python
import pyarrow as pa, pyarrow.compute as pac
b = pa.array([True, False, True])
pac.subtract(b, pac.mean(b).as_py())  # ArrowNotImplementedError
pac.quantile(b, q=0.5)                # ArrowNotImplementedError
pac.equal(b, 0)                       # ArrowNotImplementedError
```

The remaining metrics — `Count`, `Mean`, `Min`, `Max`, `MissingValuePercentage` — work fine on booleans (verified against a real boolean `Dataset`: `count=3, mean=0.667, min=False, max=True`).

This adds a dedicated `_boolean_aggregators` factory with only those safe aggregators and maps `DataType.bool()` to it.

## Related issue number

Closes #62235

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_boolean_aggregators` (asserts the boolean defaults contain exactly `Count, Mean, Min, Max, MissingValuePercentage`) and updated the `DataType.bool` case in `test_default_mappings`.