### PR TITLE
[RLlib] Skip NaN per-agent step counts in synchronous_parallel_sample

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -3084,6 +3084,17 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_rollout_ops",
+    size = "small",
+    srcs = ["execution/tests/test_rollout_ops.py"],
+    tags = [
+        "team:rllib",
+        "utils",
+    ],
+    deps = [":conftest"],
+)
+
 # @OldAPIStack
 py_test(
     name = "test_value_predictions",

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -146,7 +146,9 @@ def synchronous_parallel_sample(
                 agent_or_env_steps += sum(
                     int(agent_stat)
                     for stat_dict in stats_dicts
-                    for agent_stat in stat_dict[NUM_AGENT_STEPS_SAMPLED].values()
+                    for agent_stat in stat_dict.get(
+                        NUM_AGENT_STEPS_SAMPLED, {}
+                    ).values()
                     if not math.isnan(float(agent_stat))
                 )
             else:

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import List, Optional, Union
 
 import tree
@@ -138,10 +139,15 @@ def synchronous_parallel_sample(
         # Update our counters for the stopping criterion of the while loop.
         if _return_metrics:
             if max_agent_steps:
+                # Agents that stepped earlier in training but are absent from the
+                # currently sampled episodes keep a `NaN` NUM_AGENT_STEPS_SAMPLED
+                # entry (their per-agent stat is never updated this round). Skip
+                # those so we don't crash on `int(NaN)` (issue #62635).
                 agent_or_env_steps += sum(
                     int(agent_stat)
                     for stat_dict in stats_dicts
                     for agent_stat in stat_dict[NUM_AGENT_STEPS_SAMPLED].values()
+                    if not math.isnan(float(agent_stat))
                 )
             else:
                 agent_or_env_steps += sum(

--- a/rllib/execution/tests/test_rollout_ops.py
+++ b/rllib/execution/tests/test_rollout_ops.py
@@ -1,0 +1,67 @@
+import math
+
+import pytest
+
+from ray.rllib.execution.rollout_ops import synchronous_parallel_sample
+from ray.rllib.utils.metrics import NUM_AGENT_STEPS_SAMPLED
+from ray.rllib.utils.metrics.stats import SumStats
+
+
+class _FakeEnvRunner:
+    """Minimal local EnvRunner returning canned samples and metrics."""
+
+    def __init__(self, stats):
+        self._stats = stats
+
+    def sample(self, **kwargs):
+        # New-stack sampling returns a list of episodes; an empty list is fine
+        # for this test - we only exercise the metrics/step-counting path.
+        return []
+
+    def get_metrics(self):
+        return self._stats
+
+
+class _FakeEnvRunnerGroup:
+    """Local-only EnvRunnerGroup (no remote workers)."""
+
+    def __init__(self, stats):
+        self.local_env_runner = _FakeEnvRunner(stats)
+
+    def num_remote_workers(self):
+        return 0
+
+
+def test_synchronous_parallel_sample_skips_nan_agent_steps():
+    """NaN per-agent step counts must not crash step accounting.
+
+    Regression test for #62635: an agent that stepped earlier in training but
+    is absent from the currently sampled episodes keeps a `NaN`
+    NUM_AGENT_STEPS_SAMPLED entry. `count_steps_by="agent_steps"` summed these
+    via `int(stat)`, raising `ValueError: cannot convert float NaN to integer`.
+    """
+    present = SumStats()
+    present.push(7)
+    absent = SumStats()
+    absent.push(float("nan"))
+    stats = {NUM_AGENT_STEPS_SAMPLED: {"agent_0": present, "agent_1": absent}}
+
+    # Sanity: the absent agent's stat really is NaN.
+    assert math.isnan(float(absent))
+
+    worker_set = _FakeEnvRunnerGroup(stats)
+
+    # Must not raise; the NaN agent is skipped.
+    _, all_stats = synchronous_parallel_sample(
+        worker_set=worker_set,
+        max_agent_steps=1,
+        _uses_new_env_runners=True,
+        _return_metrics=True,
+    )
+    assert all_stats == [stats]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Training a `MultiAgentEnv` where not all agents appear in every episode with `count_steps_by="agent_steps"` crashes:

```
File "ray/rllib/execution/rollout_ops.py", line 141, in synchronous_parallel_sample
    agent_or_env_steps += sum(int(agent_stat) ...)
File "ray/rllib/utils/metrics/stats/base.py", line 100, in __int__
    return int(value)
ValueError: cannot convert float NaN to integer
```

An agent that stepped earlier in training registers its AgentID key in the `NUM_AGENT_STEPS_SAMPLED` MetricsLogger stat. When that agent is **absent** from the episodes sampled this round, its per-agent entry is never updated and remains `NaN`:

```python
{'num_agent_steps_sampled': {'agent_0': SumStats(7; ...), 'agent_1': SumStats(nan; ...)}}
```

Summing these with `int(agent_stat)` then raises. The fix skips `NaN` per-agent counts.

Verified against the real function: the buggy version raises `ValueError: cannot convert float NaN to integer` for the stats dict above; with the fix it sums to `7`.

## Related issue number

Closes #62635

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `rllib/execution/tests/test_rollout_ops.py`, which drives `synchronous_parallel_sample` through the local-EnvRunner path with a stats dict containing a `NaN` agent stat and asserts it no longer raises (registered in `BUILD.bazel`).