### PR TITLE
[RLlib] Fix MultiRLModuleSpec crash with a single shared RLModuleSpec

### DIFF
--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -577,10 +577,18 @@ class MultiRLModuleSpec:
         # Figure out global inference_only setting.
         # If not provided (None), only if all submodules are
         # inference_only, this MultiRLModule will be inference_only.
+        # `rl_module_specs` may be a single (shared) `RLModuleSpec` - as shown in
+        # the shared-policy docs example - not just a dict, so normalize before
+        # iterating (issue #63616). The AlgorithmConfig later expands a single
+        # shared spec into a per-module dict.
+        if isinstance(self.rl_module_specs, dict):
+            specs = self.rl_module_specs.values()
+        else:
+            specs = [self.rl_module_specs]
         self.inference_only = (
             self.inference_only
             if self.inference_only is not None
-            else all(spec.inference_only for spec in self.rl_module_specs.values())
+            else all(spec.inference_only for spec in specs)
         )
 
     @OverrideToImplementCustomLogic

--- a/rllib/core/rl_module/tests/test_multi_rl_module.py
+++ b/rllib/core/rl_module/tests/test_multi_rl_module.py
@@ -42,6 +42,30 @@ class TestMultiRLModule(unittest.TestCase):
         self.assertIsInstance(multi_rl_module["module1"], VPGTorchRLModule)
         self.assertIsInstance(multi_rl_module["module2"], VPGTorchRLModule)
 
+    def test_multi_rl_module_spec_with_single_shared_spec(self):
+        """MultiRLModuleSpec accepts a single shared RLModuleSpec.
+
+        Regression test for #63616: constructing a `MultiRLModuleSpec` with a
+        single (shared) `RLModuleSpec` - as shown in the shared-policy docs
+        example - used to crash in `__post_init__` with
+        `'RLModuleSpec' object has no attribute 'values'`.
+        """
+        env = gym.make("CartPole-v1")
+        shared_spec = RLModuleSpec(
+            module_class=VPGTorchRLModule,
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            model_config={"hidden_dim": 32},
+            inference_only=False,
+        )
+
+        spec = MultiRLModuleSpec(rl_module_specs=shared_spec)
+
+        # The single shared spec is preserved (AlgorithmConfig expands it into a
+        # per-module dict later), and `inference_only` is derived from it.
+        self.assertIs(spec.rl_module_specs, shared_spec)
+        self.assertFalse(spec.inference_only)
+
     def test_as_multi_rl_module(self):
 
         env_class = make_multi_agent("CartPole-v0")


### PR DESCRIPTION
## Why are these changes needed?

The shared-policy example in the [RL Modules docs](https://docs.ray.io/en/latest/rllib/rl-modules.html) passes a single `RLModuleSpec` to `MultiRLModuleSpec`:

```python
MultiRLModuleSpec(rl_module_specs=RLModuleSpec(observation_space=..., action_space=...))
```

This crashes immediately at construction:

```
File "ray/rllib/core/rl_module/multi_rl_module.py", line 583, in __post_init__
    else all(spec.inference_only for spec in self.rl_module_specs.values())
AttributeError: 'RLModuleSpec' object has no attribute 'values'
```

`MultiRLModuleSpec.rl_module_specs` is typed `Union[RLModuleSpec, Dict[ModuleID, RLModuleSpec]]`, so the single-spec form is intended. `AlgorithmConfig._get_multi_rl_module_spec` already expands a single shared spec into a per-module dict (via `isinstance(current_rl_module_spec.rl_module_specs, RLModuleSpec)`), but `__post_init__` raises before that expansion can run.

The fix normalizes `rl_module_specs` to an iterable of specs before computing `inference_only`, so both the single-spec and dict forms work.

## Related issue number

Closes #63616

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_multi_rl_module_spec_with_single_shared_spec`, which constructs a `MultiRLModuleSpec` from a single shared `RLModuleSpec` and asserts it no longer raises and derives `inference_only` correctly.