### PR TITLE
[RLlib] Fix TypeError in legacy replay buffer setup when type is a class

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1674,6 +1674,17 @@ py_test(
 )
 
 py_test(
+    name = "test_replay_buffer_type_resolution",
+    size = "small",
+    srcs = ["algorithms/tests/test_replay_buffer_type_resolution.py"],
+    tags = [
+        "algorithms",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
+py_test(
     name = "test_registry",
     size = "small",
     srcs = ["algorithms/tests/test_registry.py"],

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -4467,9 +4467,11 @@ class Algorithm(Checkpointable, Trainable):
         # actual class, so `type` may be either a str or a class here. Compare
         # against the class name in both cases; a substring `in` on a class object
         # raises `TypeError: argument of type 'ABCMeta' is not iterable` (#60491).
-        buffer_type = config["replay_buffer_config"]["type"]
+        buffer_type = config["replay_buffer_config"].get("type")
         buffer_type_name = (
-            buffer_type if isinstance(buffer_type, str) else buffer_type.__name__
+            buffer_type
+            if isinstance(buffer_type, str)
+            else getattr(buffer_type, "__name__", "")
         )
         if "EpisodeReplayBuffer" in buffer_type_name:
             # TODO (simon): Subclassing needs a proper class and therefore

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -4463,7 +4463,15 @@ class Algorithm(Checkpointable, Trainable):
             return
 
         # Add parameters, if necessary.
-        if "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
+        # `AlgorithmConfig.validate()` resolves `["type"]` from a string into the
+        # actual class, so `type` may be either a str or a class here. Compare
+        # against the class name in both cases; a substring `in` on a class object
+        # raises `TypeError: argument of type 'ABCMeta' is not iterable` (#60491).
+        buffer_type = config["replay_buffer_config"]["type"]
+        buffer_type_name = (
+            buffer_type if isinstance(buffer_type, str) else buffer_type.__name__
+        )
+        if "EpisodeReplayBuffer" in buffer_type_name:
             # TODO (simon): Subclassing needs a proper class and therefore
             # we need at this moment the string checking. Because we add
             # this keyword argument the old stack ReplayBuffer constructors

--- a/rllib/algorithms/tests/test_replay_buffer_type_resolution.py
+++ b/rllib/algorithms/tests/test_replay_buffer_type_resolution.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.utils.replay_buffers import (
+    EpisodeReplayBuffer,
+    MultiAgentPrioritizedReplayBuffer,
+)
+
+
+def _call(config, smoothing=5):
+    """Call the (unbound) buffer factory with a minimal fake `self`."""
+    fake_self = SimpleNamespace(
+        config=SimpleNamespace(metrics_num_episodes_for_smoothing=smoothing)
+    )
+    with mock.patch(
+        "ray.rllib.algorithms.algorithm.from_config", return_value="BUFFER"
+    ):
+        return Algorithm._create_local_replay_buffer_if_necessary(fake_self, config)
+
+
+def test_replay_buffer_type_as_class_does_not_crash():
+    """`replay_buffer_config["type"]` may be a class, not a string.
+
+    Regression test for #60491: `AlgorithmConfig.validate()` resolves the
+    `type` string into the actual class, after which the substring check
+    `"EpisodeReplayBuffer" in type` raised
+    `TypeError: argument of type 'ABCMeta' is not iterable`.
+    """
+    # Non-episode buffer class -> branch skipped, still returns a buffer.
+    config = {
+        "replay_buffer_config": {
+            "type": MultiAgentPrioritizedReplayBuffer,
+            "capacity": 100,
+        }
+    }
+    assert _call(config) == "BUFFER"
+
+
+def test_episode_replay_buffer_class_injects_smoothing():
+    """An EpisodeReplayBuffer class triggers the smoothing-kwarg injection."""
+    config = {"replay_buffer_config": {"type": EpisodeReplayBuffer, "capacity": 100}}
+    assert _call(config, smoothing=42) == "BUFFER"
+    assert config["replay_buffer_config"]["metrics_num_episodes_for_smoothing"] == 42
+
+
+def test_replay_buffer_type_as_string_still_works():
+    """The legacy string form of `type` must keep working."""
+    config = {
+        "replay_buffer_config": {
+            "type": "MultiAgentPrioritizedReplayBuffer",
+            "capacity": 100,
+        }
+    }
+    assert _call(config) == "BUFFER"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Building an old-API-stack algorithm (e.g. DQN) with a replay buffer configured by name crashes:

```python
DQNConfig.from_dict(...).api_stack(
    enable_rl_module_and_learner=False,
    enable_env_runner_and_connector_v2=False,
).training(replay_buffer_config={"type": "MultiAgentPrioritizedReplayBuffer", ...}).build()
```

```
File "ray/rllib/algorithms/algorithm.py", in _create_local_replay_buffer_if_necessary
    if "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
TypeError: argument of type 'ABCMeta' is not iterable
```

`AlgorithmConfig.validate()` resolves `replay_buffer_config["type"]` from a string into the actual **class**. The legacy setup path still did a substring `in` check that assumed a string, which fails on a class object.

The fix compares against the class name, handling both the `str` and class forms (behavior-preserving for the string case).

Verified against the real method (with `from_config` mocked): the current code raises `argument of type 'ABCMeta' is not iterable` for a class-typed buffer; with the fix it returns the buffer.

## Related issue number

Closes #60491

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_replay_buffer_type_resolution.py` covering a class-typed non-episode buffer (no crash), a class-typed `EpisodeReplayBuffer` (smoothing kwarg injected), and the legacy string form (registered in `BUILD.bazel`).