### PR TITLE
[doc] Guard template zip extraction against path traversal

### DIFF
--- a/doc/source/template_collections.py
+++ b/doc/source/template_collections.py
@@ -24,6 +24,7 @@ changes to template fetching/publishing are scoped for CI and ownership, and
 import io
 import json
 import logging
+import os
 import pathlib
 import random
 import re
@@ -222,6 +223,22 @@ def _fetch_and_extract_zip(config):
             _urlopen_read_with_retries(url, _TEMPLATE_DOWNLOAD_TIMEOUT_S)
         )
         with zipfile.ZipFile(zip_bytes) as zf:
+            # Guard against Zip Slip: a member name like `../../foo` would make
+            # extractall write outside `target`. These archives come from the
+            # first-party templates.ci.ray.io host, so this is defense in depth,
+            # not a live threat, but the check is cheap and fails the build
+            # clearly if a malformed archive ever ships. Normalize member paths
+            # lexically (os.path.normpath, no filesystem I/O per member);
+            # extractall writes symlink entries as regular files, so there's no
+            # symlink-traversal risk that would need physical resolution.
+            target_resolved = target.resolve()
+            for member in zf.namelist():
+                dest = pathlib.Path(os.path.normpath(target_resolved / member))
+                if not dest.is_relative_to(target_resolved):
+                    raise RuntimeError(
+                        f"sphinx-collections: refusing to extract {member!r} from "
+                        f"template {name!r}: path escapes {target_resolved}."
+                    )
             zf.extractall(target)
         logger.info(
             "sphinx-collections: extracted %d files to %s",


### PR DESCRIPTION
## What

Validate each zip member's resolved destination against the target directory before `extractall()` in `_fetch_and_extract_zip`. A member name like `../../foo` would otherwise let `extractall` write outside the collection directory (a Zip Slip). If any member escapes, the build aborts with a clear, attributed error.

## Why

The docs build downloads template archives and extracts them with `ZipFile.extractall()`, which trusts member paths. The archives come from the first-party `templates.ci.ray.io` host, so this isn't a live threat — it's defense in depth. The check is a cheap resolved-path prefix test and fails the build clearly if a malformed archive ever ships, rather than silently writing outside the tree.

Surfaced by an automated code-review pass on #64637.

## Verification

- `python -m py_compile doc/source/template_collections.py` passes.
- The guard rejects any member whose resolved path is not within the resolved target directory; normal template archives (all members relative to the collection dir) extract unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
