### PR TITLE
[core][metrics] Add MetricRegistry: idempotent facade over ray.util.metrics

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -840,6 +840,7 @@ py_test_module_list(
         "test_client_metadata.py",
         "test_client_terminate.py",
         "test_coordinator_server.py",
+        "test_metric_registry.py",
         "test_monitor.py",
         "test_node_provider_availability_tracker.py",
         "test_response_cache.py",

--- a/python/ray/tests/test_metric_registry.py
+++ b/python/ray/tests/test_metric_registry.py
@@ -1,0 +1,204 @@
+"""Unit tests for ray.util.metric_registry.
+
+These are pure wrapper tests in the style of the custom-metrics tests in
+test_metrics_agent.py: real handles are created (constructing a Ray metric
+does not require a cluster) and the underlying `ray.util.metrics` object is
+swapped for a MagicMock to assert on the recorded calls. No ray.init().
+"""
+
+import sys
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from ray.util.metric_registry import (
+    CounterHandle,
+    GaugeHandle,
+    HistogramHandle,
+    MetricKind,
+    MetricRegistry,
+)
+
+
+@pytest.fixture
+def registry():
+    return MetricRegistry()
+
+
+def _mock_out(handle) -> MagicMock:
+    """Replace the handle's underlying Ray metric with a MagicMock."""
+    mock = MagicMock()
+    handle._metric = mock
+    return mock
+
+
+def test_get_or_create_dedups_by_name(registry):
+    c1 = registry.counter("dedup_requests", tag_keys=("a",))
+    c2 = registry.counter("dedup_requests")
+    c3 = registry.declare("dedup_requests", MetricKind.COUNTER, ())
+    assert c1 is c2 is c3
+    assert isinstance(c1, CounterHandle)
+
+
+def test_namespace_prefix_and_colon_sanitizing():
+    reg = MetricRegistry("myns")
+    g = reg.gauge("cache:hits")
+    assert g.info["name"] == "myns_cache_hits"
+    # Same logical name resolves to the same handle after sanitizing.
+    assert reg.gauge("cache:hits") is g
+
+
+def test_counter_total_suffix_folded_in(registry):
+    # Ray's Counter re-appends `_total` on export, so a trailing `_total`
+    # in the requested name is stripped before construction.
+    c = registry.counter("num_requests_total")
+    assert c.info["name"] == "num_requests"
+    # The fold applies to the registry key too: both spellings must dedup
+    # to the same handle rather than creating two Ray metrics that would
+    # export the same `num_requests_total` series.
+    assert registry.counter("num_requests") is c
+    assert registry.declare("num_requests_total", MetricKind.COUNTER, ()) is c
+    without = registry.counter("num_launches")
+    assert without.info["name"] == "num_launches"
+    # Non-counters keep the suffix untouched.
+    g = registry.gauge("weird_gauge_total")
+    assert g.info["name"] == "weird_gauge_total"
+
+
+def test_kind_mismatch_raises(registry):
+    registry.counter("kind_clash")
+    with pytest.raises(ValueError, match="already declared as counter"):
+        registry.gauge("kind_clash")
+
+
+def test_declare_accepts_string_kind(registry):
+    h = registry.declare("string_kind", "gauge", ("a",))
+    assert isinstance(h, GaugeHandle)
+    assert h.kind is MetricKind.GAUGE
+
+
+def test_histogram_requires_buckets(registry):
+    with pytest.raises(ValueError, match="buckets"):
+        registry.declare("no_buckets_hist", MetricKind.HISTOGRAM, ())
+    h = registry.histogram("with_buckets_hist", buckets=[1.0, 2.0])
+    assert isinstance(h, HistogramHandle)
+    assert h.info["boundaries"] == [1.0, 2.0]
+    # Buckets bind on first creation only; a later get returns the
+    # existing metric unchanged.
+    again = registry.histogram("with_buckets_hist", buckets=[5.0])
+    assert again is h
+    assert again.info["boundaries"] == [1.0, 2.0]
+
+
+def test_description_binds_on_first_creation(registry):
+    c = registry.counter("described", description="first")
+    registry.counter("described", description="second")
+    assert c.info["description"] == "first"
+
+
+def test_missing_declared_tags_are_padded(registry):
+    g = registry.gauge("padded_gauge", tag_keys=("a", "b"))
+    mock = _mock_out(g)
+    g.set(1, {"a": "x"})
+    mock.set.assert_called_once_with(1, {"a": "x", "b": ""})
+    mock.reset_mock()
+    g.record(2)
+    mock.set.assert_called_once_with(2, {"a": "", "b": ""})
+
+
+def test_default_tags_are_not_padded_over(registry):
+    # A key covered by default tags must be left absent from the record-time
+    # tags, otherwise the "" padding would override the default.
+    g = registry.gauge("default_tagged", tag_keys=("node_id", "other"))
+    mock = _mock_out(g)
+    g.set_default_tags({"node_id": "n1"})
+    mock.set_default_tags.assert_called_once_with({"node_id": "n1"})
+    g.set(3)
+    mock.set.assert_called_once_with(3, {"other": ""})
+
+
+def test_gauge_set_none_is_a_true_noop(registry, caplog, propagate_logs):
+    # Ray's Gauge.set no-ops on None; the handle must return before tag
+    # normalization so the call also has no warning side effects.
+    g = registry.gauge("noop_gauge", tag_keys=("a",))
+    mock = _mock_out(g)
+    with caplog.at_level("WARNING", logger="ray.util.metric_registry"):
+        g.set(None, {"unknown_key": "x"})
+    mock.set.assert_not_called()
+    assert not caplog.records
+
+
+# `propagate_logs` (conftest.py) is required for caplog to see `ray.*`
+# loggers: Ray sets propagate=False on the "ray" logger at import, and
+# pytest < 8 only captures via the root handler.
+def test_unknown_tag_key_warns_once_and_is_dropped(registry, caplog, propagate_logs):
+    g = registry.gauge("surprise_keys", tag_keys=("a",))
+    mock = _mock_out(g)
+    with caplog.at_level("WARNING", logger="ray.util.metric_registry"):
+        g.set(1, {"a": "x", "new": "y"})
+        g.set(2, {"a": "x", "new": "y"})
+    warnings = [r for r in caplog.records if "new" in r.getMessage()]
+    assert len(warnings) == 1
+    mock.set.assert_called_with(2, {"a": "x"})
+
+
+def test_redeclare_with_new_key_warns_and_keeps_keys(registry, caplog, propagate_logs):
+    g = registry.gauge("widen_attempt", tag_keys=("a",))
+    with caplog.at_level("WARNING", logger="ray.util.metric_registry"):
+        again = registry.gauge("widen_attempt", tag_keys=("a", "b"))
+    assert again is g
+    assert g.tag_keys == ("a",)
+    assert any("'b'" in r.getMessage() for r in caplog.records)
+
+
+def test_counter_record_noops_on_nonpositive(registry):
+    c = registry.counter("delta_counter")
+    mock = _mock_out(c)
+    c.record(0)
+    c.record(-1.5)
+    mock.inc.assert_not_called()
+    c.record(2.5)
+    mock.inc.assert_called_once_with(2.5, {})
+
+
+def test_counter_inc_keeps_strict_ray_semantics(registry):
+    # inc() delegates to Ray's Counter.inc, which rejects value <= 0.
+    c = registry.counter("strict_counter")
+    with pytest.raises(ValueError):
+        c.inc(0)
+
+
+def test_histogram_observe_and_timer(registry):
+    h = registry.histogram("timed_hist", buckets=[0.1, 1.0], tag_keys=("op",))
+    mock = _mock_out(h)
+    h.observe(0.5, {"op": "read"})
+    mock.observe.assert_called_once_with(0.5, {"op": "read"})
+    mock.reset_mock()
+
+    with h.timer({"op": "write"}):
+        pass
+    (value, tags), _ = mock.observe.call_args
+    assert value >= 0
+    assert tags == {"op": "write"}
+
+
+def test_get_or_create_is_thread_safe(registry):
+    handles = []
+    barrier = threading.Barrier(8)
+
+    def create():
+        barrier.wait()
+        handles.append(registry.counter("racy_counter", tag_keys=("a",)))
+
+    threads = [threading.Thread(target=create) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len({id(h) for h in handles}) == 1
+    assert len(registry._metrics) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/metric_registry.py
+++ b/python/ray/util/metric_registry.py
@@ -1,0 +1,340 @@
+"""Idempotent, thread-safe registry over :mod:`ray.util.metrics` primitives.
+
+`MetricRegistry` is the single place that maps "a named Prometheus-style
+metric with dynamic tags" onto Ray's fixed-``tag_keys`` primitives
+(:class:`~ray.util.metrics.Counter`, :class:`~ray.util.metrics.Gauge`,
+:class:`~ray.util.metrics.Histogram`). It owns the quirks every caller
+otherwise re-solves by hand:
+
+- **Dedup by name.** ``registry.counter("x")`` twice returns a handle to the
+  same underlying Ray metric, so callers don't manage their own caches.
+- **Name sanitizing.** ``:`` is illegal in a Ray metric name and is replaced
+  with ``_``; an optional registry-wide namespace prefix is applied once.
+- **The Counter ``_total`` quirk.** Ray's ``Counter`` re-appends ``_total``
+  on export, so a trailing ``_total`` is folded out of both the registry key
+  and the constructed name: ``counter("x_total")`` and ``counter("x")`` dedup
+  to the same handle and the exported name comes out unchanged.
+- **Tag-key superset, declared once.** Ray fixes ``tag_keys`` at metric
+  construction and validates strictly at record time. Handles pad
+  declared-but-missing keys with ``""`` and warn once (then drop) when a
+  never-before-seen key shows up after creation -- Ray cannot widen
+  ``tag_keys``, so this is a documented limitation rather than a crash.
+
+Example:
+    >>> from ray.util.metric_registry import MetricRegistry
+    >>> reg = MetricRegistry("myapp")
+    >>> reg.gauge("queue_depth", tag_keys=("shard",)).set(12, {"shard": "0"})
+    >>> with reg.histogram("step_seconds", buckets=[0.1, 1, 10]).timer():
+    ...     do_work()  # doctest: +SKIP
+"""
+
+import enum
+import logging
+import threading
+import time
+from typing import Dict, Iterable, List, Optional, Union
+
+from ray.util.annotations import DeveloperAPI
+from ray.util.metrics import Counter, Gauge, Histogram, Metric
+
+logger = logging.getLogger(__name__)
+
+
+@DeveloperAPI
+class MetricKind(enum.Enum):
+    """The three metric kinds supported by :mod:`ray.util.metrics`."""
+
+    COUNTER = "counter"
+    GAUGE = "gauge"
+    HISTOGRAM = "histogram"
+
+
+class MetricHandle:
+    """A recorded-through wrapper around one Ray metric.
+
+    Handles are created by :class:`MetricRegistry` (never directly) and add
+    tag normalization on top of the underlying metric: unknown tag keys are
+    warned about once and dropped, and declared-but-missing keys are padded
+    with ``""`` (unless covered by a default tag) so Ray's strict record-time
+    validation never raises.
+    """
+
+    def __init__(self, metric: Metric, kind: MetricKind, tag_keys: tuple):
+        self._metric = metric
+        self._kind = kind
+        self._tag_keys = tag_keys
+        # Set mirror of _tag_keys for O(1) membership checks on the
+        # per-record tag-normalization path.
+        self._tag_keys_set = frozenset(tag_keys)
+        self._default_tags: Dict[str, str] = {}
+        # Tag keys we've already warned about, so post-creation surprises are
+        # logged once per (metric, key) rather than once per record call.
+        self._warned_keys = set()
+
+    @property
+    def kind(self) -> MetricKind:
+        return self._kind
+
+    @property
+    def tag_keys(self) -> tuple:
+        return self._tag_keys
+
+    @property
+    def info(self) -> dict:
+        """Proxy of the underlying :attr:`Metric.info`."""
+        return self._metric.info
+
+    def set_default_tags(self, default_tags: Dict[str, str]) -> "MetricHandle":
+        """Set default tags on the underlying metric. Returns ``self``."""
+        self._metric.set_default_tags(default_tags)
+        self._default_tags = default_tags
+        return self
+
+    def record(self, value: Union[int, float], tags: Optional[Dict[str, str]] = None):
+        """Kind-agnostic record: counter ``inc``, gauge ``set``, histogram
+        ``observe``.
+
+        Unlike the kind-native methods, a counter ``record`` silently no-ops
+        on ``value <= 0`` (Ray's ``Counter.inc`` rejects non-positive values;
+        a zero delta from a mirrored cumulative counter is normal, not an
+        error).
+        """
+        tags = self._normalize_tags(tags)
+        if self._kind is MetricKind.COUNTER:
+            if value > 0:
+                self._metric.inc(value, tags)
+        elif self._kind is MetricKind.GAUGE:
+            self._metric.set(value, tags)
+        else:
+            self._metric.observe(value, tags)
+
+    def _note_tag_keys(self, tag_keys: Iterable[str]) -> None:
+        """Warn once per key that arrived after the metric was created."""
+        for key in tag_keys:
+            if key not in self._tag_keys_set and key not in self._warned_keys:
+                self._warned_keys.add(key)
+                logger.warning(
+                    "Tag key %r appeared on metric %r after it was created "
+                    "with tag_keys=%s. Ray cannot widen a metric's tag keys, "
+                    "so this dimension will be dropped.",
+                    key,
+                    self._metric.info["name"],
+                    self._tag_keys,
+                )
+
+    def _normalize_tags(self, tags: Optional[Dict[str, str]]) -> Dict[str, str]:
+        tags = dict(tags) if tags else {}
+        unknown = [k for k in tags if k not in self._tag_keys_set]
+        if unknown:
+            self._note_tag_keys(unknown)
+            for key in unknown:
+                del tags[key]
+        # Pad declared keys that neither the call nor the default tags cover,
+        # so Ray's strict missing-tag validation never raises. Keys covered by
+        # default tags are left absent (padding "" would override the default).
+        for key in self._tag_keys:
+            if key not in tags and key not in self._default_tags:
+                tags[key] = ""
+        return tags
+
+
+@DeveloperAPI
+class CounterHandle(MetricHandle):
+    """Handle to a registry-managed :class:`~ray.util.metrics.Counter`."""
+
+    def inc(self, value: Union[int, float] = 1.0, tags: Dict[str, str] = None):
+        """Increment by ``value``. Keeps Ray semantics: raises on ``<= 0``."""
+        self._metric.inc(value, self._normalize_tags(tags))
+
+
+@DeveloperAPI
+class GaugeHandle(MetricHandle):
+    """Handle to a registry-managed :class:`~ray.util.metrics.Gauge`."""
+
+    def set(self, value: Optional[Union[int, float]], tags: Dict[str, str] = None):
+        if value is None:
+            # Ray's Gauge.set is a no-op on None; return before tag
+            # normalization so a no-op call has no cost and no warning
+            # side effects.
+            return
+        self._metric.set(value, self._normalize_tags(tags))
+
+
+@DeveloperAPI
+class HistogramHandle(MetricHandle):
+    """Handle to a registry-managed :class:`~ray.util.metrics.Histogram`."""
+
+    def observe(self, value: Union[int, float], tags: Dict[str, str] = None):
+        self._metric.observe(value, self._normalize_tags(tags))
+
+    def timer(self, tags: Dict[str, str] = None) -> "_Timer":
+        """Context manager observing the elapsed wall-clock seconds."""
+        return _Timer(self, tags)
+
+
+class _Timer:
+    def __init__(self, handle: HistogramHandle, tags: Optional[Dict[str, str]]):
+        self._handle = handle
+        self._tags = tags
+        self._start = None
+
+    def __enter__(self) -> "_Timer":
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self._handle.observe(time.monotonic() - self._start, self._tags)
+
+
+_HANDLE_CLASSES = {
+    MetricKind.COUNTER: CounterHandle,
+    MetricKind.GAUGE: GaugeHandle,
+    MetricKind.HISTOGRAM: HistogramHandle,
+}
+
+
+@DeveloperAPI
+class MetricRegistry:
+    """Idempotent, thread-safe factory over :mod:`ray.util.metrics` primitives.
+
+    One registry ~= one logical namespace. Calling :meth:`counter`,
+    :meth:`gauge`, :meth:`histogram`, or :meth:`declare` with the same name
+    returns a handle to the same underlying Ray metric.
+
+    Args:
+        namespace: Optional prefix applied to every metric name, joined with
+            ``_`` (e.g. namespace ``"sglang"`` + name ``"num_requests"`` ->
+            ``sglang_num_requests``). Leave empty for sources that already
+            namespace their metrics.
+    """
+
+    def __init__(self, namespace: str = ""):
+        self._namespace = namespace
+        self._lock = threading.Lock()
+        self._metrics: Dict[str, MetricHandle] = {}
+
+    def counter(
+        self,
+        name: str,
+        description: str = "",
+        tag_keys: Iterable[str] = (),
+    ) -> CounterHandle:
+        """Get or create a Counter. The exported name gains a ``_total``
+        suffix (a trailing ``_total`` on ``name`` is folded in, not doubled).
+        """
+        return self.declare(name, MetricKind.COUNTER, tag_keys, description)
+
+    def gauge(
+        self,
+        name: str,
+        description: str = "",
+        tag_keys: Iterable[str] = (),
+    ) -> GaugeHandle:
+        """Get or create a Gauge."""
+        return self.declare(name, MetricKind.GAUGE, tag_keys, description)
+
+    def histogram(
+        self,
+        name: str,
+        buckets: List[float],
+        description: str = "",
+        tag_keys: Iterable[str] = (),
+    ) -> HistogramHandle:
+        """Get or create a Histogram with the given bucket boundaries.
+
+        ``buckets`` binds only on first creation; a later get with different
+        buckets returns the existing metric unchanged.
+        """
+        return self.declare(
+            name, MetricKind.HISTOGRAM, tag_keys, description, buckets=buckets
+        )
+
+    def declare(
+        self,
+        name: str,
+        kind: Union[MetricKind, str],
+        tag_keys: Iterable[str],
+        description: str = "",
+        buckets: Optional[List[float]] = None,
+    ) -> MetricHandle:
+        """Get or create a metric of ``kind`` with the full tag-key superset.
+
+        This is the discovery-phase entry point: pass the union of all label
+        keys the metric will ever carry, since Ray cannot widen ``tag_keys``
+        after creation. ``description`` and ``buckets`` bind only on first
+        creation.
+
+        Args:
+            name: Metric name (sanitized and namespaced by the registry).
+            kind: A :class:`MetricKind` or its string value
+                (``"counter"``/``"gauge"``/``"histogram"``).
+            tag_keys: Union of all tag keys the metric will ever carry.
+            description: Metric description; binds on first creation only.
+            buckets: Histogram bucket boundaries; required for histograms,
+                ignored otherwise. Binds on first creation only.
+
+        Returns:
+            The (possibly pre-existing) handle for the metric.
+
+        Raises:
+            ValueError: if the name already exists with a different kind, or
+                a histogram is declared without ``buckets``.
+        """
+        kind = MetricKind(kind)
+        sanitized = self._sanitize(name)
+        if kind is MetricKind.COUNTER and sanitized.endswith("_total"):
+            # Fold the `_total` before the registry lookup, not just before
+            # construction: counter("x_total") and counter("x") must dedup to
+            # the same handle (Ray's Counter re-appends `_total` on export
+            # either way, so keying them separately would create two Ray
+            # metrics exporting the same series).
+            sanitized = sanitized[: -len("_total")]
+        keys = tuple(sorted(set(tag_keys)))
+        with self._lock:
+            handle = self._metrics.get(sanitized)
+            if handle is not None:
+                if handle.kind is not kind:
+                    raise ValueError(
+                        f"Metric {sanitized!r} already declared as "
+                        f"{handle.kind.value}, cannot redeclare as {kind.value}."
+                    )
+                handle._note_tag_keys(keys)
+                return handle
+            handle = self._create(sanitized, kind, description, keys, buckets)
+            self._metrics[sanitized] = handle
+            return handle
+
+    @staticmethod
+    def _create(
+        name: str,
+        kind: MetricKind,
+        description: str,
+        tag_keys: tuple,
+        buckets: Optional[List[float]],
+    ) -> MetricHandle:
+        if kind is MetricKind.COUNTER:
+            # `name` already has any trailing `_total` folded away by
+            # declare(); Ray's Counter re-appends it on export.
+            metric = Counter(name, description, tag_keys)
+        elif kind is MetricKind.HISTOGRAM:
+            if not buckets:
+                raise ValueError(f"Histogram {name!r} requires non-empty `buckets`.")
+            metric = Histogram(name, description, buckets, tag_keys)
+        else:
+            metric = Gauge(name, description, tag_keys)
+        return _HANDLE_CLASSES[kind](metric, kind, tag_keys)
+
+    def _sanitize(self, name: str) -> str:
+        full = f"{self._namespace}_{name}" if self._namespace else name
+        # ':' is legal in Prometheus (recording-rule convention) but illegal
+        # in a Ray metric name.
+        return full.replace(":", "_")
+
+
+__all__ = [
+    "MetricKind",
+    "MetricRegistry",
+    "CounterHandle",
+    "GaugeHandle",
+    "HistogramHandle",
+]


### PR DESCRIPTION
## Description

Adds `ray.util.metric_registry.MetricRegistry` (DeveloperAPI): a thread-safe, get-or-create factory over the three custom-metric primitives (`Counter`/`Gauge`/`Histogram`). It owns the quirks every caller currently re-solves by hand:

- **Dedup by name** — the same name returns a handle to the same underlying Ray metric, so callers don't manage their own caches.
- **Name sanitizing** — `:` → `_` (illegal in Ray metric names), optional namespace prefix.
- **The Counter `_total` quirk** — Ray's `Counter` re-appends `_total` on export; a trailing `_total` in the requested name is folded in rather than doubled.
- **Fixed-`tag_keys` handling** — Ray fixes `tag_keys` at construction and validates strictly at record time. Handles pad declared-but-missing keys with `""` (without clobbering default tags), and a label key first seen after creation warns once and is dropped instead of raising (Ray cannot widen `tag_keys`).

Handles keep the kind-native verbs (`inc`/`set`/`observe`) with Ray semantics, plus a kind-agnostic `record()` for mirroring pipelines (counter `record()` no-ops on non-positive deltas) and a histogram `timer()` context manager.

This is PR 1 of a 3-PR stack:
1. **This PR** — `MetricRegistry`
2. `PrometheusCollector` — mirror any Prometheus /metrics exposition into Ray metrics via the registry
3. Migrate serve's `haproxy_metrics.py` onto the registry

## Related issues

N/A

## Additional information

Tests are pure wrapper tests (no cluster) following the `metric_mock` pattern from `test_metrics_agent.py`:

```
python -m pytest python/ray/tests/test_metric_registry.py  # 15 passed
```