### PR TITLE
[core][metrics] Add PrometheusCollector: mirror any /metrics exposition into Ray metrics

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -843,6 +843,7 @@ py_test_module_list(
         "test_metric_registry.py",
         "test_monitor.py",
         "test_node_provider_availability_tracker.py",
+        "test_prometheus_collector.py",
         "test_response_cache.py",
     ],
     tags = [

--- a/python/ray/tests/test_prometheus_collector.py
+++ b/python/ray/tests/test_prometheus_collector.py
@@ -1,0 +1,277 @@
+"""Unit tests for ray.util.prometheus_collector.
+
+Pure tests: `scrape()` is driven with inline Prometheus text expositions and
+assertions are made against the underlying `ray.util.metrics` objects, which
+are swapped for MagicMocks as soon as the registry creates them (constructing
+a Ray metric does not require a cluster). No network, no ray.init().
+"""
+
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from ray.util.metric_registry import MetricRegistry
+from ray.util.prometheus_collector import (
+    HTTPSource,
+    PrometheusCollector,
+)
+
+
+class _MockedRegistry(MetricRegistry):
+    """A registry whose handles record into MagicMocks instead of Ray.
+
+    The mock for each metric is available in `self.mocks`, keyed by the
+    sanitized metric name (for counters, before the `_total` strip).
+    """
+
+    def __init__(self, namespace: str = ""):
+        super().__init__(namespace)
+        self.mocks = {}
+
+    def declare(self, name, kind, tag_keys, description="", buckets=None):
+        handle = super().declare(name, kind, tag_keys, description, buckets)
+        sanitized = self._sanitize(name)
+        if sanitized not in self.mocks:
+            self.mocks[sanitized] = handle._metric = MagicMock()
+        return handle
+
+
+@pytest.fixture
+def registry():
+    return _MockedRegistry()
+
+
+def _collector(registry, **kwargs):
+    # url=None: these tests drive scrape() directly, never the source.
+    return PrometheusCollector(None, registry, **kwargs)
+
+
+def test_counter_mirrored_as_per_scrape_deltas(registry):
+    collector = _collector(registry)
+    exposition = """\
+# HELP requests_total Total requests.
+# TYPE requests_total counter
+requests_total{path="/a"} 5.0
+"""
+    collector.scrape(exposition)
+    mock = registry.mocks["requests_total"]
+    mock.inc.assert_called_once_with(5.0, {"path": "/a"})
+
+    mock.reset_mock()
+    collector.scrape(exposition.replace("5.0", "7.5"))
+    mock.inc.assert_called_once_with(2.5, {"path": "/a"})
+
+    # An unchanged cumulative value is a zero delta: no inc call.
+    mock.reset_mock()
+    collector.scrape(exposition.replace("5.0", "7.5"))
+    mock.inc.assert_not_called()
+
+
+def test_counter_reset_records_new_value(registry):
+    # A cumulative value that goes backwards means the source restarted;
+    # the new reading is the increment since zero, not a value to drop.
+    collector = _collector(registry)
+    exposition = "# TYPE restarts_total counter\nrestarts_total 7.0\n"
+    collector.scrape(exposition)
+    mock = registry.mocks["restarts_total"]
+    mock.reset_mock()
+
+    collector.scrape(exposition.replace("7.0", "3.0"))
+    mock.inc.assert_called_once_with(3.0, {})
+
+
+def test_counter_exported_name_folds_total_suffix():
+    # Use a real (unmocked) registry to check the constructed Ray metric:
+    # Ray's Counter re-appends `_total`, so it must be built without it.
+    registry = MetricRegistry()
+    collector = PrometheusCollector(None, registry)
+    collector.scrape("# TYPE fold_check_total counter\nfold_check_total 1.0\n")
+    handle = registry.counter("fold_check_total")
+    assert handle.info["name"] == "fold_check"
+
+
+def test_gauge_mirrors_latest_value(registry):
+    collector = _collector(registry)
+    exposition = '# TYPE queue_depth gauge\nqueue_depth{shard="0"} 12.0\n'
+    collector.scrape(exposition)
+    mock = registry.mocks["queue_depth"]
+    mock.set.assert_called_once_with(12.0, {"shard": "0"})
+
+    mock.reset_mock()
+    collector.scrape(exposition.replace("12.0", "3.0"))
+    mock.set.assert_called_once_with(3.0, {"shard": "0"})
+
+
+def test_histogram_subseries_mirrored_as_gauges_with_labels(registry):
+    # Histogram sub-series are pre-aggregated cumulative values, so they are
+    # gauge-mirrored -- and each sub-series must keep all its labels
+    # (including `le`), which requires declaring per sample name rather than
+    # per family name.
+    collector = _collector(registry)
+    collector.scrape(
+        """\
+# HELP lat_seconds Request latency.
+# TYPE lat_seconds histogram
+lat_seconds_bucket{le="0.1",op="read"} 1.0
+lat_seconds_bucket{le="+Inf",op="read"} 2.0
+lat_seconds_sum{op="read"} 3.4
+lat_seconds_count{op="read"} 2.0
+"""
+    )
+    bucket = registry.mocks["lat_seconds_bucket"]
+    assert bucket.set.call_args_list[0][0] == (1.0, {"le": "0.1", "op": "read"})
+    assert bucket.set.call_args_list[1][0] == (2.0, {"le": "+Inf", "op": "read"})
+    registry.mocks["lat_seconds_sum"].set.assert_called_once_with(3.4, {"op": "read"})
+    registry.mocks["lat_seconds_count"].set.assert_called_once_with(2.0, {"op": "read"})
+    assert "lat_seconds" not in registry.mocks
+
+
+def test_created_and_nan_samples_skipped(registry):
+    collector = _collector(registry)
+    collector.scrape(
+        """\
+# TYPE something_created gauge
+something_created 1.6e9
+# TYPE maybe_nan gauge
+maybe_nan NaN
+"""
+    )
+    assert "something_created" not in registry.mocks
+    assert "maybe_nan" not in registry.mocks
+
+
+def test_custom_filters_replace_defaults(registry):
+    collector = _collector(registry, filters=(lambda s: s.name.startswith("noisy_"),))
+    collector.scrape(
+        """\
+# TYPE noisy_gauge gauge
+noisy_gauge 1.0
+# TYPE kept_created gauge
+kept_created 2.0
+"""
+    )
+    # The custom filter drops `noisy_*`; the default `_created` skip is
+    # replaced, so `kept_created` now comes through.
+    assert "noisy_gauge" not in registry.mocks
+    registry.mocks["kept_created"].set.assert_called_once_with(2.0, {})
+
+
+def test_help_text_and_colon_sanitizing():
+    registry = MetricRegistry()
+    collector = PrometheusCollector(None, registry)
+    collector.scrape(
+        """\
+# HELP sglang:num_running Number of running requests.
+# TYPE sglang:num_running gauge
+sglang:num_running 4.0
+"""
+    )
+    handle = registry.gauge("sglang:num_running")
+    assert handle.info["name"] == "sglang_num_running"
+    assert handle.info["description"] == "Number of running requests."
+
+
+# `propagate_logs` (conftest.py) is required for caplog to see `ray.*`
+# loggers: Ray sets propagate=False on the "ray" logger at import, and
+# pytest < 8 only captures via the root handler.
+def test_label_first_seen_later_warns_and_drops(registry, caplog, propagate_logs):
+    # Ray cannot widen a metric's tag keys after creation: a label that
+    # first appears on a later scrape is warned about once and dropped
+    # rather than raising.
+    collector = _collector(registry)
+    collector.scrape("# TYPE late_labels gauge\nlate_labels 1.0\n")
+    mock = registry.mocks["late_labels"]
+    mock.reset_mock()
+
+    with caplog.at_level("WARNING", logger="ray.util.metric_registry"):
+        collector.scrape('# TYPE late_labels gauge\nlate_labels{new="x"} 2.0\n')
+    assert any("'new'" in r.getMessage() for r in caplog.records)
+    mock.set.assert_called_once_with(2.0, {})
+
+
+def test_url_string_builds_http_source_and_registry():
+    collector = PrometheusCollector("http://localhost:1234/metrics", timeout_s=9.0)
+    assert isinstance(collector._source, HTTPSource)
+    assert collector._source.url == "http://localhost:1234/metrics"
+    assert collector._source.timeout_s == 9.0
+    assert isinstance(collector.registry, MetricRegistry)
+
+
+def test_namespace_prefixes_mirrored_names():
+    collector = PrometheusCollector("http://x/metrics", namespace="node")
+    collector.scrape("# TYPE load1 gauge\nload1 0.5\n")
+    assert collector.registry.gauge("load1").info["name"] == "node_load1"
+
+
+def test_registry_and_namespace_are_mutually_exclusive():
+    with pytest.raises(ValueError, match="not both"):
+        PrometheusCollector("http://x/metrics", MetricRegistry(), namespace="node")
+
+
+class _FakeSource:
+    """Source stub: counts fetches; optionally fails the first N of them."""
+
+    def __init__(self, fail_first: int = 0):
+        self.calls = 0
+        self._fail_first = fail_first
+
+    def fetch(self) -> str:
+        self.calls += 1
+        if self.calls <= self._fail_first:
+            raise RuntimeError("scrape failed")
+        return "# TYPE up gauge\nup 1.0\n"
+
+
+def _wait_for(predicate, timeout_s: float = 5.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise TimeoutError("condition not met in time")
+
+
+def test_start_scrapes_and_stop_is_prompt(registry):
+    source = _FakeSource()
+    collector = PrometheusCollector(source, registry).start(interval_s=0.01)
+    _wait_for(lambda: source.calls >= 3)
+    collector.stop()
+    assert collector._thread is None
+    calls_after_stop = source.calls
+    time.sleep(0.05)
+    assert source.calls == calls_after_stop
+
+
+def test_start_after_stop_restarts(registry):
+    # start() after stop() must begin a new run: the stop event from the
+    # prior run must not leak into the new thread (which would make it
+    # exit before its first scrape).
+    source = _FakeSource()
+    collector = PrometheusCollector(source, registry)
+    collector.start(interval_s=0.01)
+    _wait_for(lambda: source.calls >= 1)
+    collector.stop()
+
+    calls_after_stop = source.calls
+    collector.start(interval_s=0.01)
+    _wait_for(lambda: source.calls >= calls_after_stop + 2)
+    collector.stop()
+
+
+def test_scrape_loop_survives_fetch_errors(registry):
+    source = _FakeSource(fail_first=1)
+    collector = PrometheusCollector(source, registry).start(interval_s=0.01)
+    try:
+        # First fetch raises; the loop must stay alive, back off, and scrape
+        # again successfully (backoff for the first error is 1s).
+        _wait_for(lambda: source.calls >= 2, timeout_s=10.0)
+        assert threading.active_count() >= 1
+    finally:
+        collector.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/prometheus_collector.py
+++ b/python/ray/util/prometheus_collector.py
@@ -1,0 +1,266 @@
+"""Mirror any Prometheus /metrics exposition into Ray custom metrics.
+
+`PrometheusCollector` is service-agnostic: give it a scrape URL and it
+re-publishes every series it finds through :mod:`ray.util.metrics`, so they
+surface in Ray's Prometheus export with a ``ray_`` prefix. Metric names,
+types, labels, and HELP text are discovered from the exposition itself --
+nothing is hard-coded, so it works unchanged against SGLang, vLLM, TGI,
+node_exporter, or any endpoint that speaks the Prometheus text format.
+
+    collector = PrometheusCollector("http://127.0.0.1:30000/metrics")
+    collector.start()   # scrape every 2s in a daemon thread
+    ...
+    collector.stop()
+
+`start()` scrapes immediately and retries failed scrapes with backoff, so
+it is safe to call before the endpoint is up.
+
+The exposition is parsed by the official ``prometheus_client`` parser, so
+escaping, +Inf/NaN, exemplars, and histogram/summary sub-samples are all
+handled correctly.
+
+Translation notes:
+
+- **Counters** are cumulative in Prometheus but Ray's ``Counter`` takes
+  deltas, so the collector keeps the last cumulative value per series and
+  records the difference. A value that goes *backwards* means the source
+  restarted; the new reading is the increment since zero and is recorded
+  as-is rather than dropped.
+- **Histograms and summaries** are mirrored as gauges: their ``_bucket`` /
+  ``_sum`` / ``_count`` sub-series are pre-aggregated cumulative values, and
+  Ray's native ``Histogram`` wants raw ``observe()`` calls we don't have.
+  Monotonically-set gauges still give correct results under ``rate()`` /
+  ``histogram_quantile()``.
+"""
+
+import logging
+import math
+import threading
+import urllib.request
+from typing import Callable, Dict, Iterable, Optional, Protocol, Tuple, Union
+
+from prometheus_client.parser import text_string_to_metric_families
+
+from ray.util.annotations import DeveloperAPI
+from ray.util.metric_registry import MetricKind, MetricRegistry
+
+logger = logging.getLogger(__name__)
+
+# A sample-level filter returns True to skip the sample. Applied both when
+# declaring metrics and when writing values.
+SampleFilter = Callable[..., bool]
+
+
+def _skip_created(sample) -> bool:
+    """Skip `_created` series (creation timestamps, not useful to mirror)."""
+    return sample.name.endswith("_created")
+
+
+def _skip_nan(sample) -> bool:
+    """Skip NaN values (e.g. summary quantiles with no observations)."""
+    return math.isnan(sample.value)
+
+
+@DeveloperAPI
+class Source(Protocol):
+    """Anything that can produce one Prometheus text exposition."""
+
+    def fetch(self) -> str:
+        ...
+
+
+@DeveloperAPI
+class HTTPSource:
+    """Fetch an exposition over HTTP(S) with a bounded timeout."""
+
+    def __init__(self, url: str, timeout_s: float = 5.0):
+        self.url = url
+        self.timeout_s = timeout_s
+
+    def fetch(self) -> str:
+        with urllib.request.urlopen(self.url, timeout=self.timeout_s) as response:
+            return response.read().decode()
+
+
+@DeveloperAPI
+class PrometheusCollector:
+    """Mirror a Prometheus exposition endpoint into Ray custom metrics.
+
+    The common case is two lines::
+
+        PrometheusCollector("http://127.0.0.1:30000/metrics").start()
+
+    `scrape` is pure with respect to the network, so it can be unit-tested
+    against a captured /metrics fixture; `collect_once` pulls one exposition
+    from the source and scrapes it; `start`/`stop` run `collect_once` on an
+    interval in a daemon thread.
+
+    Args:
+        url: A ``/metrics`` URL to scrape over HTTP(S), or anything with a
+            ``fetch() -> str`` method returning one Prometheus text
+            exposition (e.g. :class:`HTTPSource`, a file reader, a test
+            fixture).
+        registry: Optional pre-built :class:`MetricRegistry` to mirror into
+            (e.g. one shared with first-party metrics). Mutually exclusive
+            with ``namespace``; when omitted, a registry is created from
+            ``namespace``.
+        namespace: Prefix for every mirrored metric name. Leave it empty for
+            sources that already namespace their metrics (e.g. ``sglang:*``,
+            ``vllm:*``); set it for ones that don't (e.g. node_exporter).
+        timeout_s: HTTP timeout per scrape. Only used when ``url`` is a
+            string; a ``Source`` object owns its own timeout.
+        filters: Sample-level predicates; a sample is skipped when any
+            returns True. Defaults to skipping ``_created`` series and NaN
+            values.
+
+    Raises:
+        ValueError: if both ``registry`` and ``namespace`` are passed.
+    """
+
+    def __init__(
+        self,
+        url: Union[str, Source],
+        registry: Optional[MetricRegistry] = None,
+        *,
+        namespace: str = "",
+        timeout_s: float = 5.0,
+        filters: Iterable[SampleFilter] = (),
+    ):
+        if registry is not None and namespace:
+            raise ValueError("Pass `namespace` or a pre-built `registry`, not both.")
+        self._source = HTTPSource(url, timeout_s) if isinstance(url, str) else url
+        self._reg = registry if registry is not None else MetricRegistry(namespace)
+        self._filters = tuple(filters) or (_skip_created, _skip_nan)
+        # (sample name, sorted label items) -> last cumulative counter value.
+        self._prev: Dict[Tuple, float] = {}
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def registry(self) -> MetricRegistry:
+        """The registry mirrored metrics are created in."""
+        return self._reg
+
+    def collect_once(self) -> None:
+        """Fetch one exposition from the source and mirror it."""
+        self.scrape(self._source.fetch())
+
+    def scrape(self, text: str) -> None:
+        """Parse one exposition and mirror every sample."""
+        families = list(text_string_to_metric_families(text))
+
+        # Pass 1: declare each sample name once, with the union of the label
+        # keys seen across its series and the HELP text as description.
+        # Declaration is per *sample* name, not per family name: histogram /
+        # summary sub-series (`_bucket`/`_sum`/`_count`, quantiles) record
+        # under their own names, and declaring them lazily at write time
+        # would fix their tag_keys to whatever the first series carried.
+        for family in families:
+            label_keys: Dict[str, set] = {}
+            for sample in family.samples:
+                if self._skip(sample):
+                    continue
+                label_keys.setdefault(sample.name, set()).update(sample.labels)
+            for name, keys in label_keys.items():
+                self._reg.declare(
+                    name,
+                    self._kind_for(family, name),
+                    keys,
+                    description=family.documentation,
+                )
+
+        # Pass 2: write values.
+        for family in families:
+            for sample in family.samples:
+                if self._skip(sample):
+                    continue
+                self._write(family, sample)
+
+    def start(self, interval_s: float = 2.0) -> "PrometheusCollector":
+        """Scrape every ``interval_s`` seconds in a daemon thread.
+
+        Idempotent while running; restartable after `stop`. Scrape errors are
+        logged and retried with exponential backoff (1s, capped at 10s)
+        rather than killing the loop. Returns ``self``.
+
+        Args:
+            interval_s: Seconds between scrapes.
+
+        Returns:
+            This collector, so ``PrometheusCollector(url).start()`` chains.
+        """
+        if self._thread is None:
+            # Fresh event per run: reusing the event set by a prior stop()
+            # would make the new thread exit before its first scrape, and
+            # clear()-ing it instead would un-signal a previous thread still
+            # draining its join timeout. The event is passed into _run so a
+            # lingering old thread keeps watching its own (set) event.
+            self._stop_event = threading.Event()
+            self._thread = threading.Thread(
+                target=self._run,
+                args=(self._stop_event, interval_s),
+                name="prometheus-collector",
+                daemon=True,
+            )
+            self._thread.start()
+        return self
+
+    def stop(self, timeout_s: float = 5.0) -> None:
+        """Signal the scrape loop to exit and wait for the thread to finish."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout_s)
+            self._thread = None
+
+    def _run(self, stop_event: threading.Event, interval_s: float) -> None:
+        consecutive_errors = 0
+        while not stop_event.is_set():
+            try:
+                self.collect_once()
+                consecutive_errors = 0
+                wait_s = interval_s
+            except Exception:
+                logger.exception("Error scraping Prometheus metrics.")
+                # Exponential backoff starting at 1s and capping at 10s.
+                wait_s = min(10, 2**consecutive_errors)
+                consecutive_errors += 1
+            stop_event.wait(wait_s)
+
+    def _skip(self, sample) -> bool:
+        return any(f(sample) for f in self._filters)
+
+    @staticmethod
+    def _kind_for(family, sample_name: str) -> MetricKind:
+        """Counter families' cumulative sample maps to a Ray Counter;
+        everything else (gauges, untyped, histogram/summary sub-series) is
+        mirrored as a Gauge."""
+        if family.type == "counter" and sample_name in (
+            family.name,
+            family.name + "_total",
+        ):
+            return MetricKind.COUNTER
+        return MetricKind.GAUGE
+
+    def _write(self, family, sample) -> None:
+        if self._kind_for(family, sample.name) is MetricKind.COUNTER:
+            handle = self._reg.counter(sample.name)
+            series_key = (sample.name, tuple(sorted(sample.labels.items())))
+            prev = self._prev.get(series_key)
+            # Cumulative -> delta. If the counter went backwards the source
+            # was reset, so the new reading IS the increment since zero;
+            # dropping it (like a naive `delta > 0` check) would lose data.
+            if prev is None or sample.value < prev:
+                delta = sample.value
+            else:
+                delta = sample.value - prev
+            self._prev[series_key] = sample.value
+            handle.record(delta, sample.labels)  # no-ops on delta == 0
+        else:
+            self._reg.gauge(sample.name).record(sample.value, sample.labels)
+
+
+__all__ = [
+    "HTTPSource",
+    "PrometheusCollector",
+    "Source",
+]


### PR DESCRIPTION
## Description

Adds `ray.util.prometheus_collector` (DeveloperAPI): mirrors every series from a Prometheus text exposition into Ray custom metrics via `MetricRegistry`, so external engines' metrics (SGLang, vLLM, TGI, node_exporter, ...) surface in Ray's Prometheus export with a `ray_` prefix. Names, types, labels, and HELP text are discovered from the exposition itself — nothing is hard-coded.

The common case is two lines:

```python
collector = PrometheusCollector("http://127.0.0.1:30000/metrics")
collector.start()   # scrape every 2s in a daemon thread; collector.stop() to end
```

The constructor accepts a URL string (wrapped in `HTTPSource` with `timeout_s`) or any `Source` (`fetch() -> str`) for tests/files, and builds a `MetricRegistry` from `namespace=` unless a pre-built one is injected (mutually exclusive).

Translation semantics:
- **Counters**: cumulative → per-scrape deltas, with correct reset handling — a value that goes backwards means the source restarted, so the new reading is recorded as the increment since zero rather than dropped.
- **Histograms/summaries**: sub-series (`_bucket`/`_sum`/`_count`, quantiles) are gauge-mirrored with all labels intact; Ray's native `Histogram` needs raw `observe()` calls that pre-aggregated buckets can't provide. Declaration is per *sample* name so `le` and friends keep their tag keys.
- `_created` series and NaN values are skipped by default; filters are pluggable.

`scrape()` is pure w.r.t. the network for fixture-driven unit testing; the built-in `start()`/`stop()` loop is restartable (fresh stop event per run), stops promptly (interruptible wait), and retries scrape errors with exponential backoff, modeled on serve's metrics loops.

This is PR 2 of a 3-PR stack (stacked on #64670; only the last commit is new here):
1. #64670 — `MetricRegistry`
2. **This PR** — `PrometheusCollector`
3. Migrate serve's `haproxy_metrics.py` onto the registry

## Related issues

N/A

## Additional information

```
python -m pytest python/ray/tests/test_prometheus_collector.py  # 15 passed
```

Covers per-scrape deltas, counter reset, `_total` name folding, histogram sub-series label preservation, filter injection, HELP/`:` sanitizing, late-label warn-and-drop, constructor conveniences (URL/timeout/namespace, registry-vs-namespace exclusivity), and start/stop/restart/error-survival of the scrape loop.