### PR TITLE
[serve] Build serve_haproxy_* metrics through MetricRegistry

### DIFF
--- a/python/ray/serve/_private/haproxy_metrics.py
+++ b/python/ray/serve/_private/haproxy_metrics.py
@@ -2,8 +2,10 @@
 
 HAProxy is configured to emit one RFC 5424 syslog line per request to a
 dedicated Unix dgram socket. Existing rfc3164 log targets are unaffected.
-`HAProxyMetricsCollector` owns the parsing and the `ray.util.metrics`
-objects; `_DatagramHandler` is the asyncio glue that hands datagrams in.
+`HAProxyMetricsCollector` owns the parsing and records through handles from
+a shared `MetricRegistry` (namespace `serve_haproxy`), which dedups metric
+creation across collector instances; `_DatagramHandler` is the asyncio glue
+that hands datagrams in.
 """
 
 import asyncio
@@ -17,9 +19,15 @@ from typing import Optional
 from ray.serve._private.common import RequestProtocol
 from ray.serve._private.haproxy import HAProxyApi
 from ray.serve._private.request_ingress_metrics import RequestIngressMetrics
-from ray.util import metrics
+from ray.util.metric_registry import MetricRegistry
 
 logger = logging.getLogger(__name__)
+
+# Shared registry for every serve_haproxy_* metric. Module-level so that
+# re-constructing a collector in the same process (e.g. tests, actor
+# restarts) reuses the existing Ray metric objects instead of re-creating
+# them.
+_METRIC_REGISTRY = MetricRegistry(namespace="serve_haproxy")
 
 # SD-ID we publish under. The leading bracket + this string is what the
 # parser anchors on; only lines containing this section are processed.
@@ -142,8 +150,12 @@ class HAProxyMetricsCollector:
             node_ip_address=node_ip_address,
         )
 
-        self.truncated_bodies_counter = metrics.Counter(
-            "serve_haproxy_ingress_router_truncations",
+        # All serve_haproxy_* metrics are created through the shared
+        # registry, which get-or-creates by name (namespace prefix applied
+        # there) and hands back record-through handles.
+        self.metric_registry = _METRIC_REGISTRY
+        self.truncated_bodies_counter = self.metric_registry.counter(
+            "ingress_router_truncations",
             description=(
                 "Count of requests whose body was truncated by HAProxy "
                 "(exceeded tune.bufsize) before being forwarded to the "
@@ -151,18 +163,18 @@ class HAProxyMetricsCollector:
             ),
             tag_keys=("application",),
         )
-        self.latency_histogram = metrics.Histogram(
-            "serve_haproxy_ingress_router_latency_ms",
+        self.latency_histogram = self.metric_registry.histogram(
+            "ingress_router_latency_ms",
+            buckets=self._LATENCY_BUCKETS_MS,
             description=(
                 "Wall-clock time (in milliseconds) HAProxy spent to resolve "
                 "the request to a server via the ingress request router. "
                 "Only includes successful routing attempts."
             ),
-            boundaries=self._LATENCY_BUCKETS_MS,
             tag_keys=("application", "outcome"),
         )
-        self.replica_mismatches_counter = metrics.Counter(
-            "serve_haproxy_ingress_router_server_mismatch",
+        self.replica_mismatches_counter = self.metric_registry.counter(
+            "ingress_router_server_mismatch",
             description=(
                 "Count of requests where HAProxy ultimately routed to a "
                 "different replica than the one the ingress request router "
@@ -171,8 +183,8 @@ class HAProxyMetricsCollector:
             ),
             tag_keys=("application",),
         )
-        self.failures_counter = metrics.Counter(
-            "serve_haproxy_ingress_router_failures",
+        self.failures_counter = self.metric_registry.counter(
+            "ingress_router_failures",
             description=(
                 "Count of ingress-request-router consultations that failed "
                 "to pin a replica, broken down by reason. Possible reasons: "
@@ -187,8 +199,8 @@ class HAProxyMetricsCollector:
             ),
             tag_keys=("application", "reason"),
         )
-        self.requests_counter = metrics.Counter(
-            "serve_haproxy_ingress_router_requests",
+        self.requests_counter = self.metric_registry.counter(
+            "ingress_router_requests",
             description=(
                 "The number of requests that have been processed by "
                 "the ingress request router. This includes both successful "
@@ -198,8 +210,8 @@ class HAProxyMetricsCollector:
         )
 
         # Node-level gauges, sampled by _report_node_metrics_forever.
-        self.process_count_gauge = metrics.Gauge(
-            "serve_haproxy_process_count",
+        self.process_count_gauge = self.metric_registry.gauge(
+            "process_count",
             description=(
                 "Number of HAProxy processes running on the node for this proxy, "
                 "spanning the live worker, draining workers from prior reloads, "
@@ -208,8 +220,8 @@ class HAProxyMetricsCollector:
             ),
             tag_keys=("node_id",),
         )
-        self.target_mismatch_gauge = metrics.Gauge(
-            "serve_haproxy_target_mismatch",
+        self.target_mismatch_gauge = self.metric_registry.gauge(
+            "target_mismatch",
             description=(
                 "Number of targets that differ between the controller's "
                 "broadcasted target set and the targets HAProxy actually reports "

--- a/python/ray/serve/tests/test_haproxy_metrics.py
+++ b/python/ray/serve/tests/test_haproxy_metrics.py
@@ -993,6 +993,22 @@ def test_rendered_lua_has_no_timing_calls_when_metrics_disabled() -> None:
     assert "ingress_request_router_truncated_full_length" not in lua
 
 
+def test_metric_registry_dedups_across_collectors() -> None:
+    """Re-constructing a collector in the same process must reuse the shared
+    registry's metric handles instead of re-creating Ray metric objects, and
+    the exported metric names must be unchanged by the registry migration."""
+    a = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi(), node_id="node-a")
+    b = HAProxyMetricsCollector(haproxy_api=_FakeHAProxyApi(), node_id="node-b")
+
+    assert a.requests_counter is b.requests_counter
+    assert a.latency_histogram is b.latency_histogram
+    assert a.process_count_gauge is b.process_count_gauge
+
+    assert a.requests_counter.info["name"] == "serve_haproxy_ingress_router_requests"
+    assert a.latency_histogram.info["name"] == "serve_haproxy_ingress_router_latency_ms"
+    assert a.process_count_gauge.info["name"] == "serve_haproxy_process_count"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

Replaces the seven raw `ray.util.metrics` constructions in `HAProxyMetricsCollector` with handles from a shared, module-level `MetricRegistry(namespace="serve_haproxy")`. The registry get-or-creates by name, so re-constructing a collector in the same process (tests, actor restarts) reuses the existing Ray metric objects instead of re-creating them.

**No behavior change**: exported metric names, descriptions, tag keys, histogram buckets, and default tags are byte-identical (the requests counter still gains `_total` from Ray on export), and the record paths are untouched — registry handles expose the same `inc`/`set`/`observe` verbs with Ray semantics.

This is PR 3 of a 3-PR stack (stacked on #64670 and #64671; only the last commit is new here):
1. #64670 — `MetricRegistry`
2. #64671 — `PrometheusCollector`
3. **This PR** — serve HAProxy metrics on the registry

## Related issues

N/A

## Additional information

The existing pure parse/record unit tests pass unmodified; adds one regression test asserting handle dedup across collector constructions and the unchanged exported names.

```
python -m pytest python/ray/serve/tests/test_haproxy_metrics.py  # 58 passed
```

(3 pre-existing `AF_UNIX path too long` failures on macOS reproduce identically on the base branch — environmental, unrelated.)