### PR TITLE
[core] remove the dead GetItemsUnconsumed and OnReport for streaming generator

### DIFF
--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -117,7 +117,6 @@ cdef extern from "ray/core_worker/generator_waiter.h" nogil:
         CRayStatus ReserveSlot(int64_t num_objects)
         c_bool TryReserveSlot(int64_t num_objects)
         void ReleaseSlot(int64_t num_objects)
-        void OnReport(int64_t total)
         void Teardown()
 
 cdef extern from "ray/core_worker/core_worker.h" nogil:

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -63,33 +63,6 @@ rpc::ErrorType MapPlasmaPutStatusToErrorType(const Status &status) {
 
 }  // namespace
 
-absl::flat_hash_set<ObjectID> ObjectRefStream::GetItemsUnconsumed() const {
-  absl::flat_hash_set<ObjectID> result;
-  for (int64_t index = 0; index <= max_index_seen_; index++) {
-    const auto &object_id = GetObjectRefAtIndex(index);
-    if (refs_written_to_stream_.find(object_id) == refs_written_to_stream_.end()) {
-      continue;
-    }
-
-    if (index >= next_index_) {
-      result.emplace(object_id);
-    }
-  }
-
-  if (end_of_stream_index_ != -1) {
-    // End of stream index is never consumed by a caller
-    // so we should add it here.
-    const auto &object_id = GetObjectRefAtIndex(end_of_stream_index_);
-    result.emplace(object_id);
-  }
-
-  // Temporarily owned refs are not consumed.
-  for (const auto &object_id : temporarily_owned_refs_) {
-    result.emplace(object_id);
-  }
-  return result;
-}
-
 std::vector<ObjectID> ObjectRefStream::PopUnconsumedItems() {
   // Get all unconsumed refs.
   std::vector<ObjectID> unconsumed_ids;

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -176,11 +176,6 @@ class ObjectRefStream {
    */
   void MarkEndOfStream(int64_t item_index, std::vector<ObjectID> *object_ids_to_eof);
 
-  /// Get all the ObjectIDs that are not read yet via TryReadNextItem.
-  ///
-  /// \return A list of object IDs that are not read yet.
-  absl::flat_hash_set<ObjectID> GetItemsUnconsumed() const;
-
   /// Pop all ObjectIDs that are not read yet via
   /// TryReadNextItem.
   ///


### PR DESCRIPTION
## Description

`GetItemsUnconsumed` and `OnReport` are dead and no one uses them, so delete them.
