### PR TITLE
[Data] Use work stealing for file listing

### DIFF
--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Iterable, Iterator, List, Optional, Tuple
+from typing import Callable, Iterable, Iterator, List, Optional, Tuple, Union
 
 from pyarrow.fs import FileSystem
 
@@ -13,7 +13,11 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
-from ray.data._internal.datasource_v2.listing.indexing_utils import _get_file_infos
+from ray.data._internal.datasource_v2.listing.indexing_utils import (
+    _get_file_infos,
+    _get_path_contents,
+)
+from ray.data._internal.dynamic_work_queue import parallel_process_work_stealing
 from ray.data._internal.util import make_async_gen
 from ray.data.block import BlockColumn
 from ray.data.datasource.path_util import _resolve_paths_and_filesystem
@@ -52,12 +56,40 @@ class FileIndexer(ABC):
         ...
 
 
-@dataclass
+@dataclass(frozen=True)
 class FileInfo:
     """File information for file listing."""
 
     path: str
     size: Optional[int]
+
+
+@dataclass(frozen=True)
+class _TraversalWorkItem:
+    """Work item for parallel directory traversal. Distinguishes seed paths
+    (user-provided, need resolution) from subdir paths (from filesystem listing,
+    use directly to avoid redundant resolution that breaks non-local
+    filesystems)."""
+
+    # Could be a file path or a directory path.
+    path: str
+    # True for subdirectories discovered during traversal; False for seed input paths.
+    is_discovered_subdir: bool = False
+    # Original seed-path index used to restore deterministic ordering when requested.
+    input_path_index: Optional[int] = None
+    # Top-level path the traversal started from, used to scope hidden-prefix
+    # exclusion to entries whose path relative to the root is hidden.
+    root_path: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OrderedFileResult:
+    """File result with order information for sorting when preserve_order is True."""
+
+    input_path_index: int
+    # The leaf file path.
+    file_path: str
+    file_info: FileInfo
 
 
 class NonSamplingFileIndexer(FileIndexer):
@@ -72,7 +104,7 @@ class NonSamplingFileIndexer(FileIndexer):
         "RAY_DATA_MAX_PATHS_PER_LIST_FILES_OUTPUT", 1000
     )
 
-    _DEFAULT_NUM_WORKERS = env_integer("RAY_DATA_LIST_FILES_THREADED_NUM_WORKERS", 4)
+    _DEFAULT_NUM_WORKERS = env_integer("RAY_DATA_LIST_FILES_THREADED_NUM_WORKERS", 8)
 
     def __init__(
         self,
@@ -149,35 +181,90 @@ class NonSamplingFileIndexer(FileIndexer):
         filesystem: "FileSystem",
         preserve_order: bool = False,
     ) -> Iterable[FileInfo]:
+        """Threaded file info iterator with work stealing for parallel directory
+        traversal. Subdirectories are added as work items for idle workers to
+        process."""
         paths_list = paths.to_pylist()
         if len(paths_list) == 0:
             return
 
-        num_workers = min(self._num_workers, len(paths_list))
+        num_workers = self._num_workers
 
-        def process_paths(
-            path_iterator: Iterator[str],
-        ) -> Iterator[FileInfo]:
-            for input_path in path_iterator:
-                resolved_paths, _ = _resolve_paths_and_filesystem(
-                    input_path, filesystem
-                )
+        seed_items = [
+            _TraversalWorkItem(
+                path=p,
+                is_discovered_subdir=False,
+                input_path_index=i if preserve_order else None,
+            )
+            for i, p in enumerate(paths_list)
+        ]
+
+        def process_fn(
+            item: _TraversalWorkItem,
+            add_work: Callable[[_TraversalWorkItem], None],
+            add_result: Callable[[Union[OrderedFileResult, FileInfo]], None],
+        ) -> None:
+            """Process a single item, adding discovered subdirs as work and
+            files as results."""
+            input_path_index = item.input_path_index
+
+            if item.is_discovered_subdir:
+                # Subdir paths from filesystem listing: use directly. Re-resolution
+                # would infer LocalFileSystem for scheme-less paths on S3/GCS,
+                # and add redundant overhead.
+                path = item.path
+                root_path = item.root_path
+            else:
+                # Seed paths from user: resolve once to get normalized path + fs.
+                resolved_paths, _ = _resolve_paths_and_filesystem(item.path, filesystem)
                 assert len(resolved_paths) == 1
+                path = resolved_paths[0]
+                root_path = path
 
-                for path, file_size in _get_file_infos(
-                    resolved_paths[0],
-                    filesystem,
-                    self._ignore_missing_paths,
-                ):
-                    yield FileInfo(path=path, size=file_size)
+            contents = _get_path_contents(
+                path, filesystem, self._ignore_missing_paths, root_path=root_path
+            )
+            for file_path, file_size in contents.files:
+                file_info_result = FileInfo(path=file_path, size=file_size)
+                if preserve_order:
+                    add_result(
+                        OrderedFileResult(
+                            input_path_index=input_path_index,
+                            file_path=file_path,
+                            file_info=file_info_result,
+                        )
+                    )
+                else:
+                    add_result(file_info_result)
+            for subdir_path in contents.subdirs:
+                add_work(
+                    _TraversalWorkItem(
+                        path=subdir_path,
+                        is_discovered_subdir=True,
+                        input_path_index=input_path_index,
+                        root_path=root_path,
+                    )
+                )
 
-        yield from make_async_gen(
-            base_iterator=iter(paths_list),
-            fn=process_paths,
-            preserve_ordering=preserve_order,
-            num_workers=num_workers,
-            buffer_size=self._queue_size_per_thread,
-        )
+        def _ordered_result_key(result: OrderedFileResult) -> Tuple[int, str]:
+            return (result.input_path_index, result.file_path)
+
+        if preserve_order:
+            for result in parallel_process_work_stealing(
+                seed_items=seed_items,
+                process_fn=process_fn,
+                num_workers=num_workers,
+                preserve_order=True,
+                order_key=_ordered_result_key,
+            ):
+                # Ordered mode returns `OrderedFileResult` for sorting, so unwrap.
+                yield result.file_info
+        else:
+            yield from parallel_process_work_stealing(
+                seed_items=seed_items,
+                process_fn=process_fn,
+                num_workers=num_workers,
+            )
 
     def _filter_file_infos(
         self,

--- a/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Iterable, Optional, Tuple
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
 
 import pyarrow as pa
 from pyarrow.fs import FileSelector, FileType
@@ -9,22 +10,12 @@ from ray.data.datasource.file_meta_provider import _handle_read_os_error
 logger = logging.getLogger(__name__)
 
 
-def _get_file_infos(
-    path: str, filesystem: pa.fs.FileSystem, ignore_missing_path: bool
-) -> Iterable[Tuple[str, Optional[int]]]:
-    try:
-        file_info = filesystem.get_file_info(path)
-    except OSError as e:
-        _handle_read_os_error(e, path)
+@dataclass(frozen=True)
+class PathContents:
+    """Contents of a path: files (path, size) and subdirectories to expand."""
 
-    if file_info.type == FileType.Directory:
-        yield from _expand_directory(path, filesystem, ignore_missing_path)
-    elif file_info.type == FileType.File:
-        yield (path, file_info.size)
-    elif file_info.type == FileType.NotFound and ignore_missing_path:
-        pass
-    else:
-        raise FileNotFoundError(path)
+    files: List[Tuple[str, Optional[int]]]
+    subdirs: List[str]
 
 
 def _expand_directory(
@@ -32,38 +23,101 @@ def _expand_directory(
     filesystem: pa.fs.FileSystem,
     ignore_missing_path: bool,
     *,
-    _root_path: Optional[str] = None,
-) -> Iterable[Tuple[str, Optional[int]]]:
+    root_path: Optional[str] = None,
+) -> PathContents:
+    """List one level of a directory.
+
+    Hidden-prefix (``.``/``_``) exclusion is applied relative to ``root_path``
+    (the top-level path the traversal started from), not the immediate parent,
+    so a nested entry is only excluded when its path *relative to the root*
+    begins with an excluded prefix. When ``root_path`` is ``None`` it defaults
+    to ``base_path``.
+    """
     exclude_prefixes = [".", "_"]
 
-    if _root_path is None:
-        _root_path = base_path
+    if root_path is None:
+        root_path = base_path
 
     selector = FileSelector(
         base_path, recursive=False, allow_not_found=ignore_missing_path
     )
-    files = filesystem.get_file_info(selector)
+    children = filesystem.get_file_info(selector)
 
-    assert isinstance(files, list), type(files)
-    files.sort(key=lambda file_: file_.path)
+    # Lineage reconstruction doesn't work if tasks aren't deterministic, and
+    # `filesystem.get_file_info` might return files in a non-deterministic order. So, we
+    # sort the files.
+    assert isinstance(children, list), type(children)
+    children.sort(key=lambda file_: file_.path)
 
-    for file_ in files:
-        if not file_.path.startswith(_root_path):
+    files: List[Tuple[str, Optional[int]]] = []
+    subdirs: List[str] = []
+
+    for child in children:
+        if not child.path.startswith(root_path):
             continue
 
-        relative = file_.path[len(_root_path) :].lstrip("/")
+        relative = child.path[len(root_path) :].lstrip("/")
         if any(relative.startswith(prefix) for prefix in exclude_prefixes):
             continue
 
-        if file_.type == FileType.File:
-            yield (file_.path, file_.size)
-        elif file_.type == FileType.Directory:
-            yield from _expand_directory(
-                file_.path, filesystem, ignore_missing_path, _root_path=_root_path
-            )
-        elif file_.type == FileType.UNKNOWN:
-            logger.warning(f"Discovered file with unknown type: '{file_.path}'")
+        if child.type == FileType.File:
+            files.append((child.path, child.size))
+        elif child.type == FileType.Directory:
+            subdirs.append(child.path)
+        elif child.type == FileType.UNKNOWN:
+            logger.warning(f"Discovered file with unknown type: '{child.path}'")
             continue
         else:
-            assert file_.type == FileType.NotFound
-            raise FileNotFoundError(file_.path)
+            assert child.type == FileType.NotFound
+            raise FileNotFoundError(child.path)
+
+    return PathContents(files=files, subdirs=subdirs)
+
+
+def _get_path_contents(
+    path: str,
+    filesystem: pa.fs.FileSystem,
+    ignore_missing_path: bool,
+    *,
+    root_path: Optional[str] = None,
+) -> PathContents:
+    """Get files and subdirs for a path. Handles File, Directory, and NotFound.
+
+    Only one level of a directory is expanded; discovered subdirectories are
+    returned in :attr:`PathContents.subdirs` for the caller to expand.
+    """
+    try:
+        file_info = filesystem.get_file_info(path)
+    except OSError as e:
+        _handle_read_os_error(e, path)
+
+    if file_info.type == FileType.File:
+        return PathContents(files=[(path, file_info.size)], subdirs=[])
+    elif file_info.type == FileType.Directory:
+        return _expand_directory(
+            path, filesystem, ignore_missing_path, root_path=root_path
+        )
+    elif file_info.type == FileType.NotFound and ignore_missing_path:
+        return PathContents(files=[], subdirs=[])
+    else:
+        raise FileNotFoundError(path)
+
+
+def _get_file_infos(
+    path: str,
+    filesystem: pa.fs.FileSystem,
+    ignore_missing_path: bool,
+    *,
+    _root_path: Optional[str] = None,
+) -> Iterable[Tuple[str, Optional[int]]]:
+    """Recursively expand a path (file or directory) into ``(path, size)`` tuples."""
+    if _root_path is None:
+        _root_path = path
+    contents = _get_path_contents(
+        path, filesystem, ignore_missing_path, root_path=_root_path
+    )
+    yield from contents.files
+    for subdir in contents.subdirs:
+        yield from _get_file_infos(
+            subdir, filesystem, ignore_missing_path, _root_path=_root_path
+        )


### PR DESCRIPTION
## Description

Speeds up recursive file listing in the `datasource_v2` `NonSamplingFileIndexer` by switching the threaded directory traversal from `make_async_gen` (round-robin over the top-level input paths) to the work-stealing `parallel_process_work_stealing` primitive.

The old threaded path only parallelized across the input paths, so listing a **single deep directory** used effectively one worker. With work stealing, each discovered subdirectory is pushed back onto a shared queue and any idle worker can pick it up, so traversal parallelizes across the directory tree regardless of how many top-level paths were passed in. The default worker count is also bumped from 4 to 8.

This is part 2/2. Part 1 (#64388, `[Data][1/2] - Dynamic work queue for traversals`) introduced the `parallel_process_work_stealing` utility that this PR consumes.

## Related issues

Builds on #64388.

## Additional information

**What changed**

- `NonSamplingFileIndexer._get_file_info_iterator_threaded` now drives `parallel_process_work_stealing` with `_TraversalWorkItem` seeds. Seed (user-provided) paths are resolved once via `_resolve_paths_and_filesystem`; discovered subdirs are used directly (re-resolving scheme-less subdir paths would incorrectly infer `LocalFileSystem` on S3/GCS). `preserve_order=True` buffers results and sorts by `(input_path_index, file_path)`.
- `indexing_utils._expand_directory` now lists a **single** level and returns `PathContents(files, subdirs)` instead of recursing internally. A new `_get_path_contents` handles the File / Directory / NotFound dispatch; `_get_file_infos` stays as a recursive tuple-yielding wrapper for the sequential code path and existing `file_meta_provider` callers.
- `_DEFAULT_NUM_WORKERS`: 4 → 8.

**Behavior preserved**

Hidden-prefix (`.` / `_`) exclusion remains anchored to the **top-level root** path — matching the long-standing `file_meta_provider._expand_directory` semantics (root-relative + `lstrip("/")`), i.e. a nested entry is only excluded when its path *relative to the root* is hidden. Because the traversal is no longer a single recursive call, the root is threaded through each work item via `_TraversalWorkItem.root_path`, so converting recursion → work-stealing does **not** change which files are listed.

**Testing**

- `python/ray/data/tests/unit/datasource_v2/test_file_indexer.py` — all pass.
- Rest of `python/ray/data/tests/unit/datasource_v2/` — pass.
- Verified end-to-end on a nested tree that root-relative exclusion still drops top-level `_metadata`/`.`-prefixed entries while keeping nested `year=.../part-*.parquet`, matching the legacy metadata provider output.
