### PR TITLE
[serve] Skip the direct-ingress port reconcile when ingress membership is unchanged

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -203,6 +203,8 @@ class ServeController:
         self._direct_ingress_enabled = RAY_SERVE_ENABLE_DIRECT_INGRESS
         # Last full set of ingress-port tuples fed to update_ports (for the per-tick set-diff).
         self._last_ingress_port_tuples: set = set()
+        # Last ingress membership version seen; -1 forces the first tick to run.
+        self._last_ingress_membership_version: int = -1
         if self._ha_proxy_enabled:
             logger.info(
                 "HAProxy is enabled in ServeController, replacing Serve proxy "
@@ -688,6 +690,16 @@ class ServeController:
         """Update ingress ports if direct ingress is enabled."""
         # Direct ingress port management
         if self._direct_ingress_enabled:
+            # Skip the whole O(replicas) port reconcile on ticks where no ingress
+            # replica's membership/node/ports changed and no quarantined port is awaiting
+            # reclaim. The membership version is a monotonic counter (immune to the
+            # same-tick clear of the per-deployment broadcast dirty flag).
+            version = self.deployment_state_manager.get_ingress_membership_version()
+            if (
+                version == self._last_ingress_membership_version
+                and not NodePortManager.any_pending_quarantine()
+            ):
+                return
             # Update port values for ingress replicas.
             # Ingress request router replicas also need direct-ingress ports.
             ingress_replicas_info_list: List[
@@ -706,6 +718,11 @@ class ServeController:
             # Clean up stale ports
             # get all alive replica ids and their node ids.
             NodePortManager.prune(self._get_node_id_to_alive_replica_ids())
+
+            # Mark this membership version reconciled only after update_ports +
+            # prune succeed. If either raised, the version is left unchanged so the
+            # control loop retries the reconcile next tick instead of skipping it.
+            self._last_ingress_membership_version = version
 
     def broadcast_target_groups_if_changed(self) -> None:
         """Broadcast target groups over long poll if they have changed.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3016,6 +3016,13 @@ class DeploymentState:
         self._in_transition = True
 
         self._last_broadcasted_running_replica_infos: List[RunningReplicaInfo] = []
+        # Set when an ingress replica is permanently removed from the
+        # container. The running-replica-set comparison misses removals (the
+        # replica already left {RUNNING, PENDING_MIGRATION} when it entered
+        # STOPPING), but the direct-ingress port reconcile/prune key off all
+        # container states, so the ingress port version must advance on removal
+        # too -- otherwise a departed replica's port is never reclaimed.
+        self._ingress_membership_removed: bool = False
         self._last_broadcasted_availability: Optional[bool] = None
         self._last_broadcasted_deployment_config = None
 
@@ -3322,7 +3329,16 @@ class DeploymentState:
     def list_recent_dead_replicas(self) -> List[ReplicaDetails]:
         return list(self._recent_dead_replicas)
 
-    def broadcast_running_replicas_if_changed(self) -> None:
+    def consume_ingress_membership_removed(self) -> bool:
+        """Return whether an ingress replica was permanently removed from the
+        container since the last call, then clear the flag. Paired with the
+        running-set-change signal to advance the ingress port version on removals
+        (which the running-set comparison misses). See _ingress_membership_removed."""
+        removed = self._ingress_membership_removed
+        self._ingress_membership_removed = False
+        return removed
+
+    def broadcast_running_replicas_if_changed(self) -> bool:
         """Broadcasts the set of running replicas over long poll if it has changed.
 
         Keeps an in-memory record of the last set of running replicas that was broadcast
@@ -3341,20 +3357,23 @@ class DeploymentState:
             not self._broadcasted_replicas_set_changed
             and not self._request_routing_info_updated
         ):
-            return
+            return False
 
         # Hold off on broadcasting while replicas are in RECOVERING state to avoid sending
         # partial or empty routable set.
         if self._replicas.count(states=[ReplicaState.RECOVERING]) > 0:
-            return
+            # Membership may have changed, but we hold off broadcasting; report changed
+            # so the ingress-port reconcile does not skip while recovering.
+            return True
 
         running_replica_infos = self.get_running_replica_infos()
         is_available = not self._terminally_failed()
 
+        running_set_changed = set(self._last_broadcasted_running_replica_infos) != set(
+            running_replica_infos
+        )
         running_broadcasted_replicas_set_changed = (
-            set(self._last_broadcasted_running_replica_infos)
-            != set(running_replica_infos)
-            or self._request_routing_info_updated
+            running_set_changed or self._request_routing_info_updated
         )
         availability_changed = is_available != self._last_broadcasted_availability
 
@@ -3362,7 +3381,7 @@ class DeploymentState:
         self._broadcasted_replicas_set_changed = False
 
         if not running_broadcasted_replicas_set_changed and not availability_changed:
-            return
+            return running_set_changed
 
         deployment_metadata = DeploymentTargetInfo(
             is_available=is_available,
@@ -3387,6 +3406,7 @@ class DeploymentState:
         self._last_broadcasted_running_replica_infos = running_replica_infos
         self._last_broadcasted_availability = is_available
         self._request_routing_info_updated = False
+        return running_set_changed
 
     def broadcast_deployment_config_if_changed(self) -> None:
         """Broadcasts the deployment config over long poll if it has changed.
@@ -4853,6 +4873,13 @@ class DeploymentState:
             else:
                 logger.info(f"{replica.replica_id} is stopped.")
 
+                # This replica is permanently leaving the container. Record
+                # the removal so the ingress port version advances and the
+                # direct-ingress port reconcile/prune runs to reclaim its port
+                # (the running-replica-set comparison won't flag this).
+                if self.owns_direct_ingress_ports():
+                    self._ingress_membership_removed = True
+
                 # Retain replicas that allocated a log file so the dashboard can
                 # still show their logs after the actor is gone.
                 if replica.actor_details.log_file_path is not None:
@@ -5183,6 +5210,13 @@ class DeploymentState:
     def is_ingress_request_router(self) -> bool:
         return self._target_state.info.ingress_request_router
 
+    def owns_direct_ingress_ports(self) -> bool:
+        """Whether this deployment owns direct-ingress ports -- i.e. it is an
+        ingress deployment or an ingress request router. These are exactly the
+        deployments the direct-ingress port reconcile (and its membership-version
+        gate) manages."""
+        return self.is_ingress() or self.is_ingress_request_router()
+
     def get_outbound_deployments(self) -> Optional[List[DeploymentID]]:
         """Get the outbound deployments.
 
@@ -5463,6 +5497,10 @@ class DeploymentStateManager:
         self._shutting_down = False
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # Monotonic counter bumped whenever an ingress deployment's running-replica
+        # set (node/ports included) changes; the controller gates the direct-ingress port
+        # reconcile on it, skipping the O(replicas) pass on ticks with no change.
+        self._ingress_membership_version: int = 0
         self._app_deployment_mapping: Dict[str, Set[str]] = defaultdict(set)
 
         # Metric for tracking deployment status
@@ -5981,7 +6019,16 @@ class DeploymentStateManager:
 
         # STEP 7: Broadcast long poll information
         for deployment_id, deployment_state in self._deployment_states.items():
-            deployment_state.broadcast_running_replicas_if_changed()
+            running_set_changed = (
+                deployment_state.broadcast_running_replicas_if_changed()
+            )
+            ingress_replica_removed = (
+                deployment_state.consume_ingress_membership_removed()
+            )
+            if (
+                running_set_changed or ingress_replica_removed
+            ) and deployment_state.owns_direct_ingress_ports():
+                self._ingress_membership_version += 1
             deployment_state.broadcast_deployment_config_if_changed()
             if deployment_state.should_autoscale():
                 self._autoscaling_state_manager.update_running_replica_ids(
@@ -6209,6 +6256,12 @@ class DeploymentStateManager:
             node_ids.update(deployment_state.get_active_node_ids())
         return node_ids
 
+    def get_ingress_membership_version(self) -> int:
+        """Monotonic counter of ingress running-replica-set changes (node/ports
+        included). The controller skips the direct-ingress port reconcile on ticks where
+        this is unchanged. See _ingress_membership_version."""
+        return self._ingress_membership_version
+
     def get_ingress_replicas_info(self) -> List[Tuple[str, str, int, int]]:
         """Get replicas that own direct-ingress ports.
 
@@ -6217,8 +6270,7 @@ class DeploymentStateManager:
         ingress_replicas_list = [
             deployment_state._replicas.get()
             for deployment_state in self._deployment_states.values()
-            if deployment_state.is_ingress()
-            or deployment_state.is_ingress_request_router()
+            if deployment_state.owns_direct_ingress_ports()
         ]
 
         ingress_replicas_info = []

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3016,12 +3016,9 @@ class DeploymentState:
         self._in_transition = True
 
         self._last_broadcasted_running_replica_infos: List[RunningReplicaInfo] = []
-        # Set when an ingress replica is permanently removed from the
-        # container. The running-replica-set comparison misses removals (the
-        # replica already left {RUNNING, PENDING_MIGRATION} when it entered
-        # STOPPING), but the direct-ingress port reconcile/prune key off all
-        # container states, so the ingress port version must advance on removal
-        # too -- otherwise a departed replica's port is never reclaimed.
+        # Set when an ingress replica is permanently removed, so the ingress port
+        # version advances and its port is reclaimed on the next reconcile. See
+        # consume_ingress_membership_removed.
         self._ingress_membership_removed: bool = False
         self._last_broadcasted_availability: Optional[bool] = None
         self._last_broadcasted_deployment_config = None
@@ -3351,6 +3348,16 @@ class DeploymentState:
         when no replicas have transitioned and no routing info has been updated.
         RunningReplicaInfo objects are only constructed when a broadcast may
         actually be needed.
+
+        Returns:
+            True if the set of running replicas *changed* since the last broadcast
+            (i.e. membership changed), else False. The controller pairs this with
+            ``consume_ingress_membership_removed`` to advance the ingress-port
+            membership version, so it deliberately reflects membership change --
+            NOT "a broadcast was sent": a routing-info-only change still broadcasts
+            but returns False (ports are unaffected), and while any replica is
+            RECOVERING it returns True conservatively so the ingress-port reconcile
+            does not skip on a possibly-stale running set.
         """
         # Fast path: nothing could have changed, skip entirely.
         if (

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -239,6 +239,11 @@ class NodePortManager:
         return cls._node_managers[node_id]
 
     @classmethod
+    def any_pending_quarantine(cls) -> bool:
+        """True if any node manager still holds a port in quarantine awaiting reclaim."""
+        return any(m.has_pending_quarantine() for m in cls._node_managers.values())
+
+    @classmethod
     def prune(cls, node_id_to_alive_replica_ids: Dict[str, Set[str]]):
         # this doesn't need to be behind a lock because it will already be called from same thread
         for node_id in list(cls._node_managers):

--- a/python/ray/serve/tests/unit/test_controller_direct_ingress.py
+++ b/python/ray/serve/tests/unit/test_controller_direct_ingress.py
@@ -205,6 +205,13 @@ class FakeDeploymentStateManager:
     def get_ingress_replicas_info(self) -> List[Tuple[str, str, int, int]]:
         return []
 
+    def get_ingress_membership_version(self) -> int:
+        # Advance every call so the reconcile gate never skips in tests that
+        # exercise the reconcile body. The gate's skip behavior is covered by
+        # test_ingress_port_reconcile_gated_on_membership_version.
+        self._ingress_version = getattr(self, "_ingress_version", 0) + 1
+        return self._ingress_version
+
 
 class FakeTestingDeploymentStateManager:
     def __init__(self):
@@ -238,6 +245,7 @@ class FakeDirectIngressController(ServeController):
         self.proxy_state_manager = proxy_state_manager
         self._direct_ingress_enabled = True
         self._last_ingress_port_tuples = set()
+        self._last_ingress_membership_version = -1
         self._ha_proxy_enabled = False
         self._controller_node_id = "head_node_id"
 
@@ -1193,6 +1201,61 @@ def test_recon_port_gate_prune_skips_unchanged_node(
         # Second tick: alive set unchanged -> reclaim scan skipped.
         direct_ingress_controller._maybe_update_ingress_ports()
         assert spy.call_count == 1
+
+
+def test_ingress_port_reconcile_gated_on_membership_version(
+    direct_ingress_controller: FakeDirectIngressController,
+):
+    """The direct-ingress port reconcile is skipped on ticks where the ingress
+    membership version is unchanged and no port is awaiting quarantine reclaim, and
+    runs again as soon as the version advances."""
+    dsm = FakeDeploymentStateManager(running_replica_infos={})
+    dsm.get_ingress_replicas_info = lambda: [("node1", "r1", 30000, 40000)]
+    version = {"v": 1}
+    # Constant version until we bump it (overrides the always-advancing fake default).
+    dsm.get_ingress_membership_version = lambda: version["v"]
+    direct_ingress_controller.deployment_state_manager = dsm
+
+    with mock.patch.object(NodePortManager, "update_ports") as mock_update:
+        # First tick: version (1) differs from the controller's initial -1 -> runs.
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert mock_update.call_count == 1
+
+        # Unchanged version and nothing quarantined -> gate skips the reconcile.
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert mock_update.call_count == 1
+
+        # Membership version advances -> reconcile runs again.
+        version["v"] = 2
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert mock_update.call_count == 2
+
+
+def test_reconcile_version_not_advanced_on_failure(
+    direct_ingress_controller: FakeDirectIngressController,
+):
+    """If the port reconcile raises, the ingress membership version must NOT be marked
+    reconciled -- otherwise the gate would skip the retry (the outer control loop catches
+    the exception and re-runs the step next tick) and leave ports out of sync."""
+    dsm = FakeDeploymentStateManager(running_replica_infos={})
+    dsm.get_ingress_replicas_info = lambda: [("node1", "r1", 30000, 40000)]
+    dsm.get_ingress_membership_version = lambda: 1
+    direct_ingress_controller.deployment_state_manager = dsm
+
+    # First tick: update_ports raises -> reconcile fails.
+    with mock.patch.object(
+        NodePortManager, "update_ports", side_effect=RuntimeError("boom")
+    ):
+        with pytest.raises(RuntimeError):
+            direct_ingress_controller._maybe_update_ingress_ports()
+    # Version stays at the initial sentinel -> the failed reconcile is still pending.
+    assert direct_ingress_controller._last_ingress_membership_version == -1
+
+    # Next tick: update_ports succeeds -> the reconcile is retried, not skipped.
+    with mock.patch.object(NodePortManager, "update_ports") as ok:
+        direct_ingress_controller._maybe_update_ingress_ports()
+        assert ok.call_count == 1  # retried
+    assert direct_ingress_controller._last_ingress_membership_version == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9641,5 +9641,112 @@ class TestGangDraining:
         assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
 
+def _ingress_deployment_info(num_replicas=1):
+    """Like deployment_info() but marks the deployment as a direct-ingress deployment.
+
+    DeploymentInfo.ingress lives on DeploymentInfo (not DeploymentConfig), so the shared
+    deployment_info() helper -- which forwards **config_opts to DeploymentConfig -- can't
+    set it.
+    """
+    info = DeploymentInfo(
+        version="1",
+        start_time_ms=0,
+        actor_name="abc",
+        deployment_config=DeploymentConfig(num_replicas=num_replicas),
+        replica_config=ReplicaConfig.create(lambda x: x),
+        deployer_job_id="",
+        ingress=True,
+    )
+    version = DeploymentVersion(
+        "1", info.deployment_config, info.replica_config.ray_actor_options
+    )
+    return info, version
+
+
+def test_ingress_membership_version_bumps_on_add_and_removal(
+    mock_deployment_state_manager,
+):
+    """The direct-ingress port reconcile is gated on get_ingress_membership_version().
+
+    The version must advance both when an ingress replica is ADDED (so its port is
+    assigned) and when one is permanently REMOVED from the container (so its port is
+    reclaimed). The removal case is the regression: a replica leaves the running set
+    ({RUNNING, PENDING_MIGRATION}) at RUNNING->STOPPING, so comparing the running set
+    alone does NOT observe the later container removal -- yet the reconcile/prune key off
+    all container states. Without the explicit removal signal the version stays flat at
+    removal and the departed replica's port is never reclaimed.
+    """
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    info, _ = _ingress_deployment_info()
+    dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    # A STARTING replica is not yet in the running set -> no bump.
+    v_start = dsm.get_ingress_membership_version()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    assert dsm.get_ingress_membership_version() == v_start
+
+    # STARTING -> RUNNING adds it to the running set -> version bumps (port assigned).
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+    v_running = dsm.get_ingress_membership_version()
+    assert v_running > v_start
+
+    # Steady state: no membership change over many ticks -> version stays constant
+    # (churn-insensitive -- this is what lets the reconcile be skipped).
+    for _ in range(3):
+        dsm.update()
+    assert dsm.get_ingress_membership_version() == v_running
+
+    # Delete -> RUNNING -> STOPPING: the replica leaves the running set -> bumps once.
+    ds.delete()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+    v_stopping = dsm.get_ingress_membership_version()
+    assert v_stopping > v_running
+
+    # Still STOPPING (not yet removed) -> no further bump.
+    dsm.update()
+    assert dsm.get_ingress_membership_version() == v_stopping
+
+    # Permanent removal from the container MUST bump again so the port is reclaimed,
+    # even though the running set already excluded the replica back at STOPPING.
+    ds._replicas.get()[0]._actor.set_done_stopping()
+    dsm.update()
+    check_counts(ds, total=0)
+    assert dsm.get_ingress_membership_version() > v_stopping
+
+
+def test_ingress_membership_version_ignores_non_ingress_deployment(
+    mock_deployment_state_manager,
+):
+    """A non-ingress deployment's replica churn must never bump the ingress version."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    info, _ = deployment_info()  # ingress defaults to False
+    dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    v0 = dsm.get_ingress_membership_version()
+    dsm.update()
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()  # STARTING -> RUNNING
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+
+    ds.delete()
+    dsm.update()  # RUNNING -> STOPPING
+    ds._replicas.get()[0]._actor.set_done_stopping()
+    dsm.update()  # removed
+    check_counts(ds, total=0)
+
+    # A full add + removal on a non-ingress deployment: the ingress version never moved.
+    assert dsm.get_ingress_membership_version() == v0
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

The direct-ingress port reconcile (added in #64508) still does a few O(replicas)
passes on every control-loop iteration even when nothing changed — rebuilding the
ingress-tuple set and the alive-replica map each tick. This adds an outer gate that
skips the whole reconcile on ticks where no ingress replica's membership changed and
no port is awaiting quarantine reclaim.

### How it works

The controller gates the reconcile on a monotonic ingress membership version tracked by
`DeploymentStateManager`. The version advances only on an actual **content** change of
the ingress running-replica set — the per-deployment broadcast dirty flag merely forces
the set comparison to run; an equal comparison advances nothing. In the default config
no `RunningReplicaInfo` hash field changes per heartbeat, so a steady fleet skips the
reconcile every tick.

An earlier naive version-gate was dropped in review because the per-tick health-check
re-broadcast made the gate look changed every tick. This one is immune to that: it keys
on membership content equality, not on the re-broadcast.

### Stale-port safety

The version also advances when an ingress replica is permanently **removed** from the
container. The running-set comparison alone misses that — the replica already left
`{RUNNING, PENDING_MIGRATION}` when it entered `STOPPING` — but the reconcile and its
port-prune key off all container states. Without a removal signal, a downscaled,
crashed, or failed-to-start replica's port would never be reclaimed (a teardown leak).
`DeploymentState` now records permanent ingress removals and folds that into the version
bump, so `prune()` runs on the removal tick.

### What changed

- `DeploymentStateManager` tracks `_ingress_membership_version`, bumped on an ingress
  running-replica-set content change or a permanent ingress container removal.
- The controller skips the direct-ingress port reconcile when the version is unchanged
  and no port is in quarantine, restoring the O(replicas) work only when it can matter.
- Factored the repeated `is_ingress() or is_ingress_request_router()` check into
  `DeploymentState.owns_direct_ingress_ports()`.

### Testing

- Unit tests for the membership version: bumps on add and on permanent removal, stays
  constant under steady-state health-check churn, and ignores non-ingress deployments.
- A controller-level test that the reconcile is skipped when the version is unchanged
  and runs again once it advances.
- Full `test_deployment_state.py` unit suite passes.

An attached html document lists all of the optimizations that were implemented as part of a larger Serve controller scaling effort. This PR is for optimization C1.

Follow-up to #64508
<img width="1998" height="829" alt="image" src="https://github.com/user-attachments/assets/06d9ce3c-980a-444a-98e5-ee7236b8f87f" />
