### PR TITLE
[RLlib] Fix KeyError in module-to-env connector with a changing agent set

### DIFF
--- a/rllib/connectors/module_to_env/unbatch_to_individual_items.py
+++ b/rllib/connectors/module_to_env/unbatch_to_individual_items.py
@@ -95,14 +95,16 @@ class UnBatchToIndividualItems(ConnectorV2):
                                 "mapping.",
                             )
                         # If an episode has not just started and the agent's episode
-                        # is done do not return data.
+                        # is done (or the agent is no longer part of the episode) do
+                        # not return data. With a changing number of agents, a module
+                        # may still emit an action for an agent whose `SingleAgentEpisode`
+                        # has already been removed, so look the agent up defensively to
+                        # avoid a `KeyError` (issue #61602).
                         # This should not be `True` for new `MultiAgentEpisode`s.
-                        if (
-                            episode.agent_episodes
-                            and episode.agent_episodes[agent_id].is_done
-                            and not episode.is_done
-                        ):
-                            continue
+                        if episode.agent_episodes and not episode.is_done:
+                            agent_eps = episode.agent_episodes.get(agent_id)
+                            if agent_eps is None or agent_eps.is_done:
+                                continue
 
                         new_column_data[key].append(column_data[i])
                     module_data[column] = dict(new_column_data)

--- a/rllib/env/tests/test_multi_agent_env_runner.py
+++ b/rllib/env/tests/test_multi_agent_env_runner.py
@@ -1,7 +1,11 @@
 import unittest
 
+import gymnasium as gym
+import numpy as np
+
 import ray
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
+from ray.rllib.env.multi_agent_env import MultiAgentEnv
 from ray.rllib.env.multi_agent_env_runner import MultiAgentEnvRunner
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.utils.metrics import (
@@ -9,6 +13,58 @@ from ray.rllib.utils.metrics import (
     EPISODE_MODULE_RETURN_MEAN,
 )
 from ray.rllib.utils.test_utils import check
+
+
+class AgentsComeAndGoEnv(MultiAgentEnv):
+    """A multi-agent env with a changing set of agents.
+
+    Every step the lowest-id agent terminates (leaves) and a brand-new agent id
+    joins, so the set of active agents keeps shifting. Used to reproduce the
+    connector `KeyError` from issue #61602, where a module still emits an action
+    for an agent whose `SingleAgentEpisode` has already been removed.
+    """
+
+    MAX_AGENTS = 300
+
+    def __init__(self, config=None):
+        super().__init__()
+        self._obs_space = gym.spaces.Box(-1.0, 1.0, (3,), np.float32)
+        self._act_space = gym.spaces.Discrete(2)
+        self.possible_agents = [str(i) for i in range(self.MAX_AGENTS)]
+        self.observation_spaces = dict.fromkeys(self.possible_agents, self._obs_space)
+        self.action_spaces = dict.fromkeys(self.possible_agents, self._act_space)
+
+    def reset(self, *, seed=None, options=None):
+        self._next_id = 3
+        self._t = 0
+        self._active = ["0", "1", "2"]
+        self.agents = list(self._active)
+        obs = {a: self._obs_space.sample() for a in self._active}
+        return obs, {a: {} for a in self._active}
+
+    def step(self, action_dict):
+        self._t += 1
+        leaving, survivors = self._active[0], self._active[1:]
+        newcomer = str(self._next_id)
+        self._next_id += 1
+        self._active = survivors + [newcomer]
+
+        obs = {a: self._obs_space.sample() for a in self._active}
+        rewards = dict.fromkeys(self._active, 1.0)
+        rewards[leaving] = 0.0
+        terminateds = dict.fromkeys(self._active, False)
+        terminateds[leaving] = True
+        truncateds = dict.fromkeys(self._active, False)
+        truncateds[leaving] = False
+
+        all_done = self._t >= 25 or self._next_id >= self.MAX_AGENTS - 4
+        terminateds["__all__"] = all_done
+        truncateds["__all__"] = False
+        # `agents` must cover every id referenced this step (incl. the leaver).
+        self.agents = [
+            a for a in set(obs) | set(rewards) | set(terminateds) if a != "__all__"
+        ]
+        return obs, rewards, terminateds, truncateds, {a: {} for a in obs}
 
 
 class TestMultiAgentEnvRunner(unittest.TestCase):
@@ -19,6 +75,31 @@ class TestMultiAgentEnvRunner(unittest.TestCase):
     @classmethod
     def tearDownClass(self) -> None:
         ray.shutdown()
+
+    def test_sample_with_changing_agents(self):
+        """Sampling an env with a changing agent set must not raise KeyError.
+
+        Regression test for #61602: with `batch_mode="truncate_episodes"` and a
+        set `rollout_fragment_length`, the module-to-env connector used to raise
+        `KeyError` when an action was produced for an agent whose
+        `SingleAgentEpisode` had already been removed.
+        """
+        config = (
+            PPOConfig()
+            .environment(AgentsComeAndGoEnv)
+            .multi_agent(
+                policies={"p"},
+                policy_mapping_fn=lambda aid, *args, **kwargs: "p",
+            )
+            .env_runners(
+                batch_mode="truncate_episodes",
+                rollout_fragment_length=32,
+            )
+        )
+        env_runner = MultiAgentEnvRunner(config=config)
+        # Several sampling rounds so the changing-agent connector path is hit.
+        for _ in range(6):
+            env_runner.sample(num_timesteps=64)
 
     def test_sample_timesteps(self):
         # Build a multi agent config.


### PR DESCRIPTION
## Why are these changes needed?

Training a multi-agent env whose set of agents changes over time (agents leave and new agent ids appear) crashes with a `KeyError` in the module-to-env connector:

```
File "ray/rllib/connectors/module_to_env/unbatch_to_individual_items.py", line 102, in __call__
    and episode.agent_episodes[agent_id].is_done
KeyError: '7'
```

The module can still emit an action for an agent whose `SingleAgentEpisode` has already been removed from the `MultiAgentEpisode`, so `episode.agent_episodes[agent_id]` raises. It reproduces with `batch_mode="truncate_episodes"` and a set `rollout_fragment_length` (issue #61602).

The fix looks the agent up defensively (`.get(agent_id)`) and treats a missing/removed agent the same as a done agent — its data is not forwarded to the env.

## Verification

Built `master` from source and reproduced end-to-end with a `MultiAgentEnv` whose agent ids keep changing:
- **Without** the fix: `KeyError` in `unbatch_to_individual_items` (matches the report).
- **With** the fix: sampling and training run cleanly (verified across multiple runs).

## Related issue number

Closes #61602

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_sample_with_changing_agents` in `test_multi_agent_env_runner.py`, which samples a `MultiAgentEnvRunner` on a changing-agent env. Confirmed it raises `KeyError` on current master and passes with this fix.