### PR TITLE
[RLlib][OldAPIStack] Apply observation filter in compute_single_action

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1685,6 +1685,17 @@ py_test(
 )
 
 py_test(
+    name = "test_compute_single_action_filter",
+    size = "medium",
+    srcs = ["algorithms/tests/test_compute_single_action_filter.py"],
+    tags = [
+        "algorithms",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
+py_test(
     name = "test_node_failures",
     size = "large",
     srcs = ["algorithms/tests/test_node_failures.py"],

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -4709,7 +4709,7 @@ class Algorithm(Checkpointable, Trainable):
         # `compute_actions` and avoids silently returning actions computed from
         # unfiltered observations (issue #64087). `NoFilter` (the default) leaves
         # the observation unchanged.
-        if observation is not None:
+        if observation is not None and self.env_runner_group is not None:
             local_env_runner = self.env_runner_group.local_env_runner
             obs_filter = (
                 local_env_runner.filters.get(policy_id)

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -4704,6 +4704,21 @@ class Algorithm(Checkpointable, Trainable):
                 ac_o = pp([acd])[0]
                 observation = ac_o.data[Columns.OBS]
 
+        # Apply the observation filter (e.g. `MeanStdFilter`) so filter
+        # statistics learned during training are used here as well. This mirrors
+        # `compute_actions` and avoids silently returning actions computed from
+        # unfiltered observations (issue #64087). `NoFilter` (the default) leaves
+        # the observation unchanged.
+        if observation is not None:
+            local_env_runner = self.env_runner_group.local_env_runner
+            obs_filter = (
+                local_env_runner.filters.get(policy_id)
+                if local_env_runner is not None
+                else None
+            )
+            if obs_filter is not None:
+                observation = obs_filter(observation, update=False)
+
         if input_dict is not None:
             input_dict[Columns.OBS] = observation
             action, state, extra = policy.compute_single_action(

--- a/rllib/algorithms/tests/test_compute_single_action_filter.py
+++ b/rllib/algorithms/tests/test_compute_single_action_filter.py
@@ -1,0 +1,72 @@
+import unittest
+
+import numpy as np
+
+import ray
+from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
+
+
+class _RecordingFilter:
+    """Wraps an observation filter and records how it is called."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.calls = []
+
+    def __call__(self, x, *args, **kwargs):
+        self.calls.append(kwargs.get("update", None))
+        return self._inner(x, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+class TestComputeSingleActionFilter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        ray.shutdown()
+
+    def test_compute_single_action_applies_obs_filter(self):
+        """`compute_single_action` must apply the observation filter.
+
+        Regression test for #64087: it previously skipped the observation filter
+        (e.g. `MeanStdFilter`) that `compute_actions` applies, silently returning
+        actions computed from unfiltered observations.
+        """
+        config = (
+            PPOConfig()
+            .api_stack(
+                enable_rl_module_and_learner=False,
+                enable_env_runner_and_connector_v2=False,
+            )
+            .environment("CartPole-v1")
+            .env_runners(observation_filter="MeanStdFilter", num_env_runners=0)
+        )
+        algo = config.build()
+        try:
+            worker = algo.env_runner_group.local_env_runner
+            recorder = _RecordingFilter(worker.filters[DEFAULT_POLICY_ID])
+            worker.filters[DEFAULT_POLICY_ID] = recorder
+
+            obs = np.array([0.1, -0.2, 0.05, 0.3], dtype=np.float32)
+            algo.compute_single_action(obs, explore=False)
+
+            # The filter must have been applied exactly once, in eval mode
+            # (update=False), matching `compute_actions`.
+            self.assertEqual(len(recorder.calls), 1)
+            self.assertEqual(recorder.calls[0], False)
+        finally:
+            algo.stop()
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

`Algorithm.compute_single_action` applies the observation preprocessor but **not** the observation filter (e.g. `MeanStdFilter`), whereas `Algorithm.compute_actions` applies both:

```python
# compute_actions (already filters):
preprocessed = worker.preprocessors[policy_id].transform(ob)
filtered = worker.filters[policy_id](preprocessed, update=False)
```

So when an observation filter is learned during training, `compute_single_action` silently computes actions from **unfiltered** observations — the results disagree with rollout/training behavior, which is easy to miss (reported in #64087, e.g. custom policy evaluation).

This applies the local EnvRunner's filter (with `update=False`) after preprocessing, mirroring `compute_actions`. `NoFilter` (the default) is a no-op, so the common case is unchanged.

## Verification

Built `master` from source and confirmed with a spy on the filter:
- **Before:** `compute_single_action` invokes the filter **0** times.
- **After:** it invokes the filter **1** time, with `update=False`.

## Related issue number

Closes #64087

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_compute_single_action_filter.py`, which wraps the EnvRunner's filter and asserts `compute_single_action` calls it exactly once with `update=False`. Fails on current master, passes with this fix.