### PR TITLE
[Tune] Clear queued trial decision on pause to fix PBT KeyError

### DIFF
--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -1973,6 +1973,12 @@ class TuneController:
         # NOTE: The cached trial decision is not needed since we will overrule this
         # decision with PAUSE.
         self._cached_trial_decisions.pop(trial.trial_id, None)
+        # Also drop any queued decision (e.g. a buffered `CONTINUE` from a result
+        # whose perturbation interval had not yet been reached). The trial is being
+        # paused and its actor torn down, so executing a stale queued decision would
+        # try to train a trial with no actor and raise `KeyError` in
+        # `_schedule_trial_train` (issue #58483).
+        self._queued_trial_decisions.pop(trial.trial_id, None)
         self._schedule_trial_pause(trial, should_checkpoint=should_checkpoint)
 
     def cleanup(self):

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -1371,6 +1371,12 @@ class TuneController:
 
         logger.debug(f"Requesting to STOP actor for trial {trial}")
 
+        # A trial being stopped must not retain a stale queued decision (e.g. a
+        # buffered `CONTINUE`). On the failure/recovery path the trial is requeued
+        # with a new actor without going through `pause_trial`, so a leftover
+        # queued decision could later be executed against the wrong actor (#58483).
+        self._queued_trial_decisions.pop(trial.trial_id, None)
+
         if trial.is_saving:
             logger.debug(
                 f"Trial {trial} is currently saving/pausing. Scheduling STOP after "

--- a/python/ray/tune/tests/execution/test_controller_control_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_control_integration.py
@@ -143,5 +143,47 @@ def test_remove_actor_tracking(ray_start_4_cpus_2_gpus_extra, resource_manager_c
     assert len(runner._stopping_actors) == 0
 
 
+@pytest.mark.parametrize(
+    "resource_manager_cls", [FixedResourceManager, PlacementGroupResourceManager]
+)
+def test_pause_trial_clears_queued_decision(
+    ray_start_4_cpus_2_gpus_extra, resource_manager_cls
+):
+    """Pausing a trial must clear any queued decision for it.
+
+    Regression test for #58483: with buffered results, PBT can queue a
+    ``CONTINUE`` decision for a trial and then pause it during an exploit step.
+    ``pause_trial`` used to clear only ``_cached_trial_decisions``, leaving the
+    stale ``CONTINUE`` in ``_queued_trial_decisions``; executing it later tried
+    to train a trial whose actor was already gone, raising a ``KeyError``.
+    """
+    from ray.tune.schedulers import TrialScheduler
+
+    register_mock_trainable()
+    runner = TuneController(
+        resource_manager_factory=lambda: resource_manager_cls(), storage=STORAGE
+    )
+    kwargs = {
+        "stopping_criterion": {"training_iteration": 10},
+        "placement_group_factory": PlacementGroupFactory([{"CPU": 2, "GPU": 1}]),
+        "config": {"sleep": 1},
+        "storage": STORAGE,
+    }
+    trial = Trial(MOCK_TRAINABLE_NAME, **kwargs)
+    runner.add_trial(trial)
+
+    while trial.status != Trial.RUNNING:
+        runner.step()
+
+    # Simulate a buffered `CONTINUE` decision still queued for this trial.
+    runner._queued_trial_decisions[trial.trial_id] = TrialScheduler.CONTINUE
+
+    runner.pause_trial(trial)
+
+    # The queued decision must have been dropped so it can't be executed against
+    # a trial whose actor has been torn down.
+    assert trial.trial_id not in runner._queued_trial_decisions
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "--reruns", "3", __file__]))

--- a/python/ray/tune/tests/execution/test_controller_control_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_control_integration.py
@@ -185,5 +185,42 @@ def test_pause_trial_clears_queued_decision(
     assert trial.trial_id not in runner._queued_trial_decisions
 
 
+@pytest.mark.parametrize(
+    "resource_manager_cls", [FixedResourceManager, PlacementGroupResourceManager]
+)
+def test_stop_trial_clears_queued_decision(
+    ray_start_4_cpus_2_gpus_extra, resource_manager_cls
+):
+    """Stopping a trial must clear any queued decision for it.
+
+    Regression test for #58483 (failure/recovery path): a trial can be stopped
+    and requeued with a new actor without going through ``pause_trial``, so a
+    stale queued decision must be dropped in ``_schedule_trial_stop`` as well.
+    """
+    from ray.tune.schedulers import TrialScheduler
+
+    register_mock_trainable()
+    runner = TuneController(
+        resource_manager_factory=lambda: resource_manager_cls(), storage=STORAGE
+    )
+    kwargs = {
+        "stopping_criterion": {"training_iteration": 10},
+        "placement_group_factory": PlacementGroupFactory([{"CPU": 2, "GPU": 1}]),
+        "config": {"sleep": 1},
+        "storage": STORAGE,
+    }
+    trial = Trial(MOCK_TRAINABLE_NAME, **kwargs)
+    runner.add_trial(trial)
+
+    while trial.status != Trial.RUNNING:
+        runner.step()
+
+    runner._queued_trial_decisions[trial.trial_id] = TrialScheduler.CONTINUE
+
+    runner._schedule_trial_stop(trial)
+
+    assert trial.trial_id not in runner._queued_trial_decisions
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "--reruns", "3", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

With PBT and buffered results (`TUNE_RESULT_BUFFER_LENGTH > 1`, or a trainable returning multiple results), a trial can crash with a `KeyError`:

```
File "ray/tune/execution/tune_controller.py", in _schedule_trial_task
    tracked_actor = self._trial_to_actor[trial]
KeyError: <trial>
```

**Root cause:** for a buffered result whose perturbation interval hasn't been reached, PBT returns `CONTINUE`, which `TuneController._process_trial_result` queues in `_queued_trial_decisions`. When the perturbation step then triggers an **exploit**, the trial is paused and its actor is torn down — but `pause_trial` cleared only `_cached_trial_decisions`, leaving the stale `CONTINUE` queued. Executing that queued decision later (`_maybe_execute_queued_decision` → `_execute_action(CONTINUE)` → `_schedule_trial_train`) then indexes `_trial_to_actor[trial]` for an actor that no longer exists.

The fix also drops the queued decision in `pause_trial`.

## Related issue number

Closes #58483

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_pause_trial_clears_queued_decision` (both resource managers), which starts a trial, queues a `CONTINUE`, calls `pause_trial`, and asserts the queued decision is cleared. Fails on current master, passes with this fix.