### PR TITLE
[Data] Guard hash shuffle v2 with env flag

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -58,7 +58,7 @@ def _plan_gpu_shuffle_repartition(
     )
 
 
-def _plan_hash_shuffle_repartition(
+def _plan_hash_shuffle_repartition_v2(
     data_context: DataContext,
     logical_op: Repartition,
     input_physical_op: PhysicalOperator,
@@ -107,6 +107,27 @@ def _plan_hash_shuffle_repartition(
         ),
     )
     return reduce_op
+
+
+def _plan_hash_shuffle_repartition(
+    data_context: DataContext,
+    logical_op: Repartition,
+    input_physical_op: PhysicalOperator,
+) -> PhysicalOperator:
+    from ray.data._internal.execution.operators.hash_shuffle import (
+        HashShuffleOperator,
+    )
+    from ray.data._internal.planner.exchange.sort_task_spec import SortKey
+
+    normalized_key_columns = SortKey(logical_op.keys).get_columns()
+
+    return HashShuffleOperator(
+        input_physical_op,
+        data_context,
+        key_columns=tuple(normalized_key_columns),
+        num_partitions=logical_op.num_outputs,
+        should_sort=logical_op.sort,
+    )
 
 
 def _plan_hash_shuffle_aggregate(
@@ -217,6 +238,10 @@ def plan_all_to_all_op(
                     data_context, op, input_physical_dag
                 )
             elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE:
+                if data_context.use_hash_shuffle_v2:
+                    return _plan_hash_shuffle_repartition_v2(
+                        data_context, op, input_physical_dag
+                    )
                 return _plan_hash_shuffle_repartition(
                     data_context, op, input_physical_dag
                 )

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -604,7 +604,26 @@ class TestPlanAllToAllOpRouting:
 
         assert isinstance(op, GPUShuffleOperator)
 
-    def test_hash_shuffle_routes_to_shuffle_reduce_op(self):
+    def test_hash_shuffle_still_routes_to_hash_shufflle_v1(self, restore_data_context):
+        from ray.data._internal.execution.operators.hash_shuffle import (
+            HashShuffleOperator,
+        )
+
+        ctx = DataContext()
+        ctx._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+
+        with patch(
+            "ray.data._internal.execution.operators.hash_shuffle"
+            "._get_total_cluster_resources",
+            return_value=ExecutionResources(cpu=4, gpu=0),
+        ):
+            logical_op = self._make_repartition_op(keys=["user_id"], num_outputs=8)
+            input_physical_op = _make_input_op_mock()
+            op = plan_all_to_all_op(logical_op, [input_physical_op], ctx)
+
+        assert isinstance(op, HashShuffleOperator)
+
+    def test_hash_shuffle_still_routes_to_hash_shufflle_v2(self, restore_data_context):
         """V2 hash shuffle is a two-op DAG; planner returns the ShuffleReduceOp
         with the ShuffleMapOp as its upstream input dependency."""
         from ray.data._internal.execution.operators.shuffle_operators.shuffle_map_operator import (  # noqa: E501
@@ -615,6 +634,7 @@ class TestPlanAllToAllOpRouting:
         )
 
         ctx = DataContext()
+        ctx.use_hash_shuffle_v2 = True
         ctx._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
         logical_op = self._make_repartition_op(keys=["user_id"], num_outputs=8)

--- a/python/ray/data/tests/test_hash_shuffle_v2.py
+++ b/python/ray/data/tests/test_hash_shuffle_v2.py
@@ -49,31 +49,32 @@ def _assert_keys_colocated(per_block):
     ), f"A key landed in more than one block: {per_block}"
 
 
+@pytest.fixture(autouse=True)
+def data_context_use_hash_shuffle_v2():
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx.use_hash_shuffle_v2 = True
+
+
 @pytest.mark.parametrize("num_partitions", [1, 4, 8])
 def test_repartition_keys_preserves_rows(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
     num_partitions,
 ):
     """No rows are lost or duplicated; key totals are preserved."""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     ds = ray.data.range(1000, override_num_blocks=10)
-    out = ds.repartition(num_partitions, keys=["id"])
+    out = ds.repartition(num_partitions, keys=["id"]).materialize()
     assert out.count() == 1000
     assert out.sum("id") == sum(range(1000))
 
 
 def test_repartition_block_number_matched(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
 ):
     """All-non-empty partitions => exactly num_partitions output blocks."""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     # 1000 distinct keys over 8 buckets => all 8 partitions are non-empty.
     ds = ray.data.range(1000, override_num_blocks=20)
@@ -83,12 +84,9 @@ def test_repartition_block_number_matched(
 
 def test_same_key_lands_in_same_block(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
 ):
     """All rows sharing a key should end up in one block."""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     ds = ray.data.range(500, override_num_blocks=10).map(
         lambda row: {"k": row["id"] % 25, "v": row["id"]}
@@ -101,13 +99,10 @@ def test_same_key_lands_in_same_block(
 
 def test_multi_column_keys(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
 ):
     """Composite keys hash on all columns: every distinct (a, b) tuple lands in
     exactly one block."""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     ds = ray.data.range(500, override_num_blocks=10).map(
         lambda row: {"a": row["id"] % 5, "b": row["id"] % 7, "v": row["id"]}
@@ -120,13 +115,10 @@ def test_multi_column_keys(
 
 def test_more_partitions_than_keys_emits_empty_blocks(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
 ):
     """Requesting more partitions than there are distinct keys emits the extra
     partitions as empty (0-row) blocks that still carry the dataset schema."""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     # 3 distinct keys into 50 partitions => at most 3 non-empty, >=47 empty.
     ds = ray.data.range(600, override_num_blocks=10).map(
@@ -153,12 +145,9 @@ def test_more_partitions_than_keys_emits_empty_blocks(
 
 def test_repartition_empty_dataset(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
 ):
     """Empty dataset should still output N blocks"""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     ds = ray.data.range(100, override_num_blocks=4).filter(lambda row: False)
     out = ds.repartition(4, keys=["id"]).materialize()
@@ -174,12 +163,9 @@ def test_repartition_empty_dataset(
 
 def test_repartition_with_sort_produces_sorted_partitions(
     ray_start_regular_shared_2_cpus,
-    restore_data_context,
     disable_fallback_to_object_extension,
 ):
     """Check that rows are sorted in every partition."""
-    ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     ds = ray.data.range(200, override_num_blocks=4)
     out = ds.repartition(4, keys=["id"], sort=True)

--- a/python/ray/data/tests/test_hash_shuffle_v2.py
+++ b/python/ray/data/tests/test_hash_shuffle_v2.py
@@ -50,8 +50,8 @@ def _assert_keys_colocated(per_block):
 
 
 @pytest.fixture(autouse=True)
-def data_context_use_hash_shuffle_v2():
-    ctx = DataContext.get_current()
+def data_context_use_hash_shuffle_v2(restore_data_context):
+    ctx = restore_data_context
     ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
     ctx.use_hash_shuffle_v2 = True
 

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -560,7 +560,9 @@ def test_read_map_batches_operator_fusion_with_repartition_operator(
 def test_fuse_map_into_shuffle_reduce(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
-    DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx.use_hash_shuffle_v2 = True
 
     ds = ray.data.range(100).repartition(4, keys=["id"]).map_batches(lambda b: b)
     dag = get_execution_plan(ds._logical_plan)[0].dag
@@ -576,7 +578,9 @@ def test_fuse_map_into_shuffle_reduce(
 def test_map_not_fused_into_shuffle_reduce_with_downstream_limit(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
-    DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx.use_hash_shuffle_v2 = True
 
     ds = (
         ray.data.range(100)
@@ -599,10 +603,9 @@ def test_map_not_fused_into_shuffle_reduce_with_downstream_limit(
 def test_concurrency_capped_map_not_fused_into_shuffle_reduce(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
-    """A map with a ``concurrency=`` cap is NOT fused into the reduce. The
-    reduce runs one task per partition with no concurrency cap, so fusing would
-    silently ignore the user's limit; keeping the map separate honors it."""
-    DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx.use_hash_shuffle_v2 = True
 
     ds = (
         ray.data.range(100)
@@ -622,7 +625,9 @@ def test_non_file_datasink_write_not_fused_into_shuffle_reduce(
 ):
     from ray.data.datasource.datasink import Datasink
 
-    DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+    ctx.use_hash_shuffle_v2 = True
 
     class _NoopDatasink(Datasink):
         def write(self, blocks, ctx):


### PR DESCRIPTION
## Description
Same as join, v2 hash repartition should be guard with env `RAY_DATA_USE_HASH_SHUFFLE_V2` too.

This PR brings back the old planner function and test both v1 & v2 shuffle for repartition.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
