### PR TITLE
[serve] Dirty-set health-check reconcile: sweep RUNNING replicas round-robin instead of every tick

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -264,23 +264,12 @@ DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S = 20
 DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S = 2
 DEFAULT_HEALTH_CHECK_PERIOD_S = 10
 
-# Dirty-set health-check reconcile: instead of health-checking every RUNNING replica
-# each control tick, poll only replicas with an in-flight check plus a round-robin slice
-# sized to sweep the bucket within RAY_SERVE_RECON_SWEEP_FRACTION of the reconcile period
-# -- every replica is still checked on schedule, at O(slice) per tick instead of O(N).
-# Engages automatically above this many RUNNING replicas (smaller deployments keep the
-# full per-tick sweep). See DeploymentState._dirty_set_active_pairs.
-RAY_SERVE_RECON_DIRTYSET_MIN = get_env_int_positive("RAY_SERVE_RECON_DIRTYSET_MIN", 64)
-# Fraction of the reconcile period (min of health_check_period_s and
-# request_routing_stats_period_s) that one full round-robin sweep takes -- i.e. every
-# RUNNING replica is health-checked / routing-stats-pulled at least once per
-# RAY_SERVE_RECON_SWEEP_FRACTION x period. Tunes the staleness/speed tradeoff: SMALLER
-# tightens per-replica staleness (a due check starts within fraction x period of coming
-# due) at the cost of a larger per-tick slice (less controller-tick speedup); LARGER
-# gives more speedup but more staleness. 0.5 sweeps each replica ~twice per period -- a
-# conservative 2x margin so a due check is not missed within the period. A value >= 1.0
-# lets a replica be checked less than once per period; only raise it if health/routing
-# staleness up to ~fraction x period is acceptable in exchange for faster ticks.
+# Dirty-set health-check reconcile: each control tick polls only replicas with an
+# in-flight check plus a round-robin slice, so a tick costs O(slice) instead of O(N).
+# RAY_SERVE_RECON_SWEEP_FRACTION is how long one full sweep takes as a fraction of the
+# reconcile period (min of health_check_period_s and request_routing_stats_period_s):
+# every replica is checked at least once per fraction x period. Smaller = fresher checks
+# but less speedup; larger = more speedup but staler. Default 0.5 = ~2 sweeps per period.
 RAY_SERVE_RECON_SWEEP_FRACTION = get_env_float_positive(
     "RAY_SERVE_RECON_SWEEP_FRACTION", 0.5
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -266,12 +266,12 @@ DEFAULT_HEALTH_CHECK_PERIOD_S = 10
 
 # Dirty-set health-check reconcile: each control tick polls only replicas with an
 # in-flight check plus a round-robin slice, so a tick costs O(slice) instead of O(N).
-# RAY_SERVE_RECON_SWEEP_FRACTION is how long one full sweep takes as a fraction of the
+# CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION is how long one full sweep takes as a fraction of the
 # reconcile period (min of health_check_period_s and request_routing_stats_period_s):
 # every replica is checked at least once per fraction x period. Smaller = fresher checks
 # but less speedup; larger = more speedup but staler. Default 0.5 = ~2 sweeps per period.
-RAY_SERVE_RECON_SWEEP_FRACTION = get_env_float_positive(
-    "RAY_SERVE_RECON_SWEEP_FRACTION", 0.5
+CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION = get_env_float_positive(
+    "RAY_SERVE_CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION", 0.5
 )
 DEFAULT_HEALTH_CHECK_TIMEOUT_S = 30
 DEFAULT_MAX_ONGOING_REQUESTS = 5

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -263,6 +263,27 @@ CONTROLLER_MAX_CONCURRENCY = get_env_int_positive(
 DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S = 20
 DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S = 2
 DEFAULT_HEALTH_CHECK_PERIOD_S = 10
+
+# Dirty-set health-check reconcile: instead of health-checking every RUNNING replica
+# each control tick, poll only replicas with an in-flight check plus a round-robin slice
+# sized to sweep the bucket within RAY_SERVE_RECON_SWEEP_FRACTION of the reconcile period
+# -- every replica is still checked on schedule, at O(slice) per tick instead of O(N).
+# Engages automatically above this many RUNNING replicas (smaller deployments keep the
+# full per-tick sweep). See DeploymentState._dirty_set_active_pairs.
+RAY_SERVE_RECON_DIRTYSET_MIN = get_env_int_positive("RAY_SERVE_RECON_DIRTYSET_MIN", 64)
+# Fraction of the reconcile period (min of health_check_period_s and
+# request_routing_stats_period_s) that one full round-robin sweep takes -- i.e. every
+# RUNNING replica is health-checked / routing-stats-pulled at least once per
+# RAY_SERVE_RECON_SWEEP_FRACTION x period. Tunes the staleness/speed tradeoff: SMALLER
+# tightens per-replica staleness (a due check starts within fraction x period of coming
+# due) at the cost of a larger per-tick slice (less controller-tick speedup); LARGER
+# gives more speedup but more staleness. 0.5 sweeps each replica ~twice per period -- a
+# conservative 2x margin so a due check is not missed within the period. A value >= 1.0
+# lets a replica be checked less than once per period; only raise it if health/routing
+# staleness up to ~fraction x period is acceptable in exchange for faster ticks.
+RAY_SERVE_RECON_SWEEP_FRACTION = get_env_float_positive(
+    "RAY_SERVE_RECON_SWEEP_FRACTION", 0.5
+)
 DEFAULT_HEALTH_CHECK_TIMEOUT_S = 30
 DEFAULT_MAX_ONGOING_REQUESTS = 5
 DEFAULT_TARGET_ONGOING_REQUESTS = 2

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -62,7 +62,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
-    RAY_SERVE_RECON_DIRTYSET_MIN,
     RAY_SERVE_RECON_SWEEP_FRACTION,
     RAY_SERVE_RETAINED_DEAD_REPLICAS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
@@ -4751,29 +4750,14 @@ class DeploymentState:
 
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
-        # Whether the dirty-set slice path is taken this tick (only a subset of
-        # RUNNING is health-checked) -- the healthy gauge below accounts for it.
-        used_dirtyset = False
 
-        # Profile-guided: for the common non-gang case, iterate
-        # RUNNING/PENDING_MIGRATION IN PLACE. Healthy replicas that stay in their state
-        # bucket are never popped+re-added -> eliminates the O(num_replicas) container
-        # churn on the control loop at scale. Gang deployments fall back to the
-        # original pop/re-add path (their force-stop reshuffles the lists).
+        # Non-gang deployments health-check a dirty-set round-robin slice and iterate
+        # RUNNING/PENDING_MIGRATION in place, avoiding the O(num_replicas) pop/re-add
+        # churn at scale. Gang deployments use the pop/re-add path (their force-stop
+        # reshuffles the lists).
         if not self._is_gang_deployment:
             origin: List[ReplicaState] = []
-            used_dirtyset = (
-                self._replicas.count_state(ReplicaState.RUNNING)
-                > RAY_SERVE_RECON_DIRTYSET_MIN
-            )
-            if used_dirtyset:
-                pairs = self._dirty_set_active_pairs()
-            else:
-                pairs = [
-                    (replica, st)
-                    for st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
-                    for replica in self._replicas.get([st])
-                ]
+            pairs = self._dirty_set_active_pairs()
             healths = [replica.check_health() for replica, _ in pairs]
             for (replica, st), is_healthy in zip(pairs, healths):
                 self._record_health_check_metrics(replica)
@@ -4788,23 +4772,17 @@ class DeploymentState:
                     self._outstanding_dirty_set.add(replica.replica_id)
                 else:
                     self._outstanding_dirty_set.discard(replica.replica_id)
-                # Re-bucket a healthy replica only if its state changed -- avoiding the
-                # pop/re-add churn is the whole point of the in-place path.
-                # actor_details.state is only set via ReplicaStateContainer.add() and
-                # check_health() never transitions state, so for RUNNING/PENDING_MIGRATION
-                # this is a no-op today; kept as a defensive guard so the in-place path
-                # stays behavior-identical to the pop/re-add path if that ever changes.
+                # Re-bucket only if the state changed. check_health() never transitions
+                # state today, so this is a defensive no-op that keeps the in-place path
+                # identical to pop/re-add should that ever change.
                 if replica.actor_details.state != st:
                     self._replicas.remove({replica.replica_id})
                     self._replicas.add(replica.actor_details.state, replica)
-            # Batch-remove all unhealthy replicas in a single O(num_replicas) pass;
-            # a per-replica remove() would be O(unhealthy * num_replicas) -> O(N^2)
-            # during mass health-check failures (e.g. a node/AZ outage).
+            # Batch-remove unhealthy replicas in one O(num_replicas) pass; per-replica
+            # remove() would be O(unhealthy * num_replicas) during mass failures.
             self._replicas.remove(
                 {replica.replica_id for replica in unhealthy_replicas}
             )
-            for replica in unhealthy_replicas:
-                self._stop_unhealthy_replica(replica)
         else:
             for replica in self._replicas.pop(
                 states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
@@ -4816,9 +4794,9 @@ class DeploymentState:
                 else:
                     unhealthy_replicas.append(replica)
 
-            # Under the RESTART_GANG policy, force-stop all members of any gang that has at
-            # least one unhealthy replica. Replicas handled here are removed from the lists;
-            # remaining replicas continue to respect FORCE_STOP_UNHEALTHY_REPLICAS.
+            # Under RESTART_GANG, force-stop all members of any gang with >=1 unhealthy
+            # replica; handled replicas leave the lists, the rest respect
+            # FORCE_STOP_UNHEALTHY_REPLICAS.
             if (
                 self._is_gang_deployment
                 and self.get_gang_config().runtime_failure_policy
@@ -4835,9 +4813,9 @@ class DeploymentState:
                 self._replicas.add(replica.actor_details.state, replica)
                 self._process_healthy_replica(replica)
 
-            # Only single-replica scheduling replicas remain.
-            for replica in unhealthy_replicas:
-                self._stop_unhealthy_replica(replica)
+        # Stop every unhealthy replica; both branches already removed them from _replicas.
+        for replica in unhealthy_replicas:
+            self._stop_unhealthy_replica(replica)
 
         # In steady state there are no STARTING/UPDATING/RECOVERING/STOPPING
         # replicas, so skip startup/stopping checks.  The rank consistency
@@ -4850,15 +4828,11 @@ class DeploymentState:
             # deployment/application series. Emit the count of replicas that
             # passed health checks in this iteration so newly promoted replicas
             # are not counted before their first successful health check.
-            if used_dirtyset:
-                # Only a round-robin slice was health-checked this tick, so rebuilding
-                # the set from healthy_replicas would undercount -- add the newly-
-                # confirmed-healthy ids instead. Then drop any id whose replica is no
-                # longer RUNNING/PENDING_MIGRATION: a replica can leave RUNNING without
-                # stopping (e.g. RUNNING->UPDATING on a lightweight reconfigure, which
-                # does not go through _stop_replica's discard), and the incremental set
-                # would otherwise keep counting it. This keeps the gauge equal to what
-                # the else-branch rebuild would produce.
+            if not self._is_gang_deployment:
+                # Only a slice was checked this tick, so add the newly-healthy ids
+                # incrementally (a full rebuild would undercount) and drop any id whose
+                # replica is no longer RUNNING/PENDING_MIGRATION (e.g. a lightweight
+                # RUNNING->UPDATING reconfigure, which skips _stop_replica's discard).
                 self._last_health_check_healthy_replica_ids.update(
                     replica.replica_id.unique_id for replica in healthy_replicas
                 )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -44,7 +44,10 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
+    CONTROL_LOOP_INTERVAL_S,
+    DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_LATENCY_BUCKET_MS,
+    DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_PERIOD_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_TIMEOUT_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
@@ -59,6 +62,8 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
+    RAY_SERVE_RECON_DIRTYSET_MIN,
+    RAY_SERVE_RECON_SWEEP_FRACTION,
     RAY_SERVE_RETAINED_DEAD_REPLICAS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
@@ -824,6 +829,19 @@ class ActorReplicaWrapper:
                 "replica": self._replica_id.unique_id,
                 "application": self._deployment_id.app_name,
             }
+        )
+
+    @property
+    def has_in_flight_health_or_routing_probe(self) -> bool:
+        """True while a health-check or routing-stats RPC is in flight.
+
+        References the refs directly (no getattr default) so a future rename of either
+        fails loudly here rather than silently reporting no probe in flight -- which
+        would drop the replica from the dirty-set poll set and delay re-polling it.
+        """
+        return (
+            self._health_check_ref is not None
+            or self._record_routing_stats_ref is not None
         )
 
     @property
@@ -2067,6 +2085,11 @@ class DeploymentReplica:
             self._actor.force_stop()
         return False
 
+    @property
+    def has_outstanding_check(self) -> bool:
+        """True if a health-check or routing-stats ref is in flight (dirty-set poll set)."""
+        return self._actor.has_in_flight_health_or_routing_probe
+
     def check_health(self) -> bool:
         """Check if the replica is healthy.
 
@@ -2205,6 +2228,16 @@ class ReplicaStateContainer:
             The DeploymentReplica if found, else None.
         """
         return self._replica_id_index.get(replica_id)
+
+    def count_state(self, state: ReplicaState) -> int:
+        """O(1) count of replicas in a single state (dirty-set slice sizing)."""
+        return len(self._replicas[state])
+
+    def slice_state(
+        self, state: ReplicaState, start: int, count: int
+    ) -> List[DeploymentReplica]:
+        """replicas[start:start+count] from one bucket, no full-bucket copy."""
+        return self._replicas[state][start : start + count]
 
     def pop(
         self,
@@ -2850,6 +2883,10 @@ class DeploymentState:
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
         self._target_state: DeploymentTargetState = DeploymentTargetState.default()
+        # Dirty-set health-check reconcile state: RUNNING replica IDs with an
+        # in-flight health/routing ref to re-poll, and a round-robin cursor over RUNNING.
+        self._outstanding_dirty_set: Set[ReplicaID] = set()
+        self._dirty_set_rr_cursor: int = 0
 
         self._prev_startup_warning: float = time.time()
         self._replica_constructor_error_msg: Optional[str] = None
@@ -4634,6 +4671,77 @@ class DeploymentState:
         graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
         self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
 
+    def _dirty_set_active_pairs(self):
+        """Dirty-set: only the replicas needing attention this tick -- those with an
+        in-flight ref (poll), a round-robin RUNNING slice sized to sweep the bucket
+        within RAY_SERVE_RECON_SWEEP_FRACTION of the reconcile period (so each is
+        processed on schedule; see _reconcile_sweep_period_s), and all PENDING_MIGRATION
+        (transient). Idle replicas are skipped (check_health no-ops)."""
+        container = self._replicas
+        pairs = []
+        seen = set()
+        for replica in container.get([ReplicaState.PENDING_MIGRATION]):
+            pairs.append((replica, ReplicaState.PENDING_MIGRATION))
+            seen.add(replica.replica_id)
+        still = set()
+        for rid in self._outstanding_dirty_set:
+            rep = container.get_by_id(rid)
+            # Only re-poll it as RUNNING if it is still RUNNING -- a replica that
+            # transitioned out (e.g. to STOPPING) is handled by its own path;
+            # processing it here as RUNNING would corrupt the state machine.
+            if (
+                rep is not None
+                and rid not in seen
+                and rep.actor_details.state == ReplicaState.RUNNING
+            ):
+                pairs.append((rep, ReplicaState.RUNNING))
+                seen.add(rid)
+                still.add(rid)
+        self._outstanding_dirty_set = still
+        n = container.count_state(ReplicaState.RUNNING)
+        if n:
+            period = self._reconcile_sweep_period_s()
+            ticks = max(
+                1,
+                int(
+                    RAY_SERVE_RECON_SWEEP_FRACTION
+                    * period
+                    / max(CONTROL_LOOP_INTERVAL_S, 1e-3)
+                ),
+            )
+            slice_n = max(1, (n + ticks - 1) // ticks)
+            start = self._dirty_set_rr_cursor % n
+            sl = container.slice_state(ReplicaState.RUNNING, start, slice_n)
+            overflow = start + slice_n - n
+            if overflow > 0:
+                sl = sl + container.slice_state(ReplicaState.RUNNING, 0, overflow)
+            self._dirty_set_rr_cursor = (start + slice_n) % n
+            for replica in sl:
+                if replica.replica_id not in seen:
+                    pairs.append((replica, ReplicaState.RUNNING))
+                    seen.add(replica.replica_id)
+        return pairs
+
+    def _reconcile_sweep_period_s(self) -> float:
+        """The per-replica reconcile period the dirty-set sweep must keep pace with.
+
+        _process_healthy_replica runs both the health check (health_check_period_s) and
+        the routing-stats pull (request_routing_stats_period_s), so the sweep is sized
+        off the tighter of the two -- otherwise a deployment whose routing-stats period
+        is < 0.5 x health-check period would refresh routing stats slower than
+        configured. Falls back to the defaults before a target is set.
+        """
+        try:
+            cfg = self._target_state.info.deployment_config
+            return min(
+                cfg.health_check_period_s,
+                cfg.request_router_config.request_routing_stats_period_s,
+            )
+        except AttributeError:
+            return min(
+                DEFAULT_HEALTH_CHECK_PERIOD_S, DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S
+            )
+
     def check_and_update_replicas(self):
         """
         Check current state of all DeploymentReplica being tracked, and compare
@@ -4643,6 +4751,9 @@ class DeploymentState:
 
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
+        # Whether the dirty-set slice path is taken this tick (only a subset of
+        # RUNNING is health-checked) -- the healthy gauge below accounts for it.
+        used_dirtyset = False
 
         # Profile-guided: for the common non-gang case, iterate
         # RUNNING/PENDING_MIGRATION IN PLACE. Healthy replicas that stay in their state
@@ -4651,11 +4762,18 @@ class DeploymentState:
         # original pop/re-add path (their force-stop reshuffles the lists).
         if not self._is_gang_deployment:
             origin: List[ReplicaState] = []
-            pairs = [
-                (replica, st)
-                for st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
-                for replica in self._replicas.get([st])
-            ]
+            used_dirtyset = (
+                self._replicas.count_state(ReplicaState.RUNNING)
+                > RAY_SERVE_RECON_DIRTYSET_MIN
+            )
+            if used_dirtyset:
+                pairs = self._dirty_set_active_pairs()
+            else:
+                pairs = [
+                    (replica, st)
+                    for st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
+                    for replica in self._replicas.get([st])
+                ]
             healths = [replica.check_health() for replica, _ in pairs]
             for (replica, st), is_healthy in zip(pairs, healths):
                 self._record_health_check_metrics(replica)
@@ -4666,6 +4784,10 @@ class DeploymentState:
                     unhealthy_replicas.append(replica)
             for replica, st in zip(healthy_replicas, origin):
                 self._process_healthy_replica(replica)
+                if replica.has_outstanding_check:
+                    self._outstanding_dirty_set.add(replica.replica_id)
+                else:
+                    self._outstanding_dirty_set.discard(replica.replica_id)
                 # Re-bucket a healthy replica only if its state changed -- avoiding the
                 # pop/re-add churn is the whole point of the in-place path.
                 # actor_details.state is only set via ReplicaStateContainer.add() and
@@ -4728,9 +4850,29 @@ class DeploymentState:
             # deployment/application series. Emit the count of replicas that
             # passed health checks in this iteration so newly promoted replicas
             # are not counted before their first successful health check.
-            self._last_health_check_healthy_replica_ids = {
-                replica.replica_id.unique_id for replica in healthy_replicas
-            }
+            if used_dirtyset:
+                # Only a round-robin slice was health-checked this tick, so rebuilding
+                # the set from healthy_replicas would undercount -- add the newly-
+                # confirmed-healthy ids instead. Then drop any id whose replica is no
+                # longer RUNNING/PENDING_MIGRATION: a replica can leave RUNNING without
+                # stopping (e.g. RUNNING->UPDATING on a lightweight reconfigure, which
+                # does not go through _stop_replica's discard), and the incremental set
+                # would otherwise keep counting it. This keeps the gauge equal to what
+                # the else-branch rebuild would produce.
+                self._last_health_check_healthy_replica_ids.update(
+                    replica.replica_id.unique_id for replica in healthy_replicas
+                )
+                live_ids = {
+                    r.replica_id.unique_id
+                    for r in self._replicas.get(
+                        [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                    )
+                }
+                self._last_health_check_healthy_replica_ids &= live_ids
+            else:
+                self._last_health_check_healthy_replica_ids = {
+                    replica.replica_id.unique_id for replica in healthy_replicas
+                }
             self.health_check_gauge.set(
                 len(self._last_health_check_healthy_replica_ids)
             )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -45,6 +45,7 @@ from ray.serve._private.common import (
 from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
     CONTROL_LOOP_INTERVAL_S,
+    CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION,
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_LATENCY_BUCKET_MS,
     DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S,
@@ -62,7 +63,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
-    RAY_SERVE_RECON_SWEEP_FRACTION,
     RAY_SERVE_RETAINED_DEAD_REPLICAS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
@@ -4673,7 +4673,7 @@ class DeploymentState:
     def _dirty_set_active_pairs(self):
         """Dirty-set: only the replicas needing attention this tick -- those with an
         in-flight ref (poll), a round-robin RUNNING slice sized to sweep the bucket
-        within RAY_SERVE_RECON_SWEEP_FRACTION of the reconcile period (so each is
+        within CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION of the reconcile period (so each is
         processed on schedule; see _reconcile_sweep_period_s), and all PENDING_MIGRATION
         (transient). Idle replicas are skipped (check_health no-ops)."""
         container = self._replicas
@@ -4703,7 +4703,7 @@ class DeploymentState:
             ticks = max(
                 1,
                 int(
-                    RAY_SERVE_RECON_SWEEP_FRACTION
+                    CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION
                     * period
                     / max(CONTROL_LOOP_INTERVAL_S, 1e-3)
                 ),

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -540,6 +540,12 @@ class MockReplicaActorWrapper:
         return self._is_cross_language
 
     @property
+    def has_in_flight_health_or_routing_probe(self) -> bool:
+        # The mock's health/routing checks are synchronous (no in-flight ObjectRef), so
+        # nothing is ever in flight -- matches the real wrapper reporting no pending ref.
+        return False
+
+    @property
     def replica_id(self) -> ReplicaID:
         return self._replica_id
 

--- a/python/ray/serve/tests/test_healthcheck.py
+++ b/python/ray/serve/tests/test_healthcheck.py
@@ -135,6 +135,62 @@ async def test_multiple_replicas(serve_instance):
     assert len(new_actors.intersection(actors)) == 1
 
 
+@pytest.mark.asyncio
+async def test_failing_replica_found_among_many(serve_instance):
+    """The health-check sweep finds a single failing replica at an arbitrary
+    position among many healthy ones and replaces only it."""
+    h = serve.run(
+        Patient.options(num_replicas=12, ray_actor_options={"num_cpus": 0.1}).bind()
+    )
+    actors = set()
+
+    async def all_replicas_seen():
+        actors.clear()
+        actors.update(
+            a._actor_id for a in await asyncio.gather(*[h.remote() for _ in range(300)])
+        )
+        return len(actors) == 12
+
+    await async_wait_for_condition(all_replicas_seen, timeout=30)
+
+    failed = (await h.set_should_fail.remote())._actor_id
+    await async_wait_for_condition(
+        check_new_actor_started, handle=h, original_actors=actors, timeout=60
+    )
+
+    async def only_failed_replica_replaced():
+        new_actors = {
+            a._actor_id for a in await asyncio.gather(*[h.remote() for _ in range(300)])
+        }
+        return (
+            len(new_actors) == 12
+            and failed not in new_actors
+            and len(new_actors.intersection(actors)) == 11
+        )
+
+    await async_wait_for_condition(only_failed_replica_replaced, timeout=60)
+
+
+@pytest.mark.asyncio
+async def test_crashed_replica_replaced_among_many(serve_instance):
+    """A replica whose actor dies outright is detected by the sweep and
+    replaced, restoring the full replica set."""
+    h = serve.run(
+        Patient.options(num_replicas=12, ray_actor_options={"num_cpus": 0.1}).bind()
+    )
+    victim = await h.remote()
+    victim_id = victim._actor_id
+    ray.kill(victim)
+
+    async def victim_replaced():
+        new_actors = {
+            a._actor_id for a in await asyncio.gather(*[h.remote() for _ in range(300)])
+        }
+        return victim_id not in new_actors and len(new_actors) == 12
+
+    await async_wait_for_condition(victim_replaced, timeout=60)
+
+
 def test_inherit_healthcheck(serve_instance):
     class Parent:
         def __init__(self):

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2241,6 +2241,16 @@ def test_scale_num_replicas(mock_deployment_state_manager, target_capacity_direc
     )
 
 
+def _advance_until(dsm, cond, max_ticks=50):
+    """Run control-loop ticks until cond() holds (the dirty-set sweep may health-check a
+    replica on a later tick, not every tick). Fails if not reached within max_ticks."""
+    for _ in range(max_ticks):
+        if cond():
+            return
+        dsm.update()
+    assert cond(), "condition not reached within the health-check deadline"
+
+
 @pytest.mark.parametrize("force_stop_unhealthy_replicas", [False, True])
 def test_health_check(
     mock_deployment_state_manager, force_stop_unhealthy_replicas: bool
@@ -2276,16 +2286,16 @@ def test_health_check(
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
-    dsm.update()
-    for replica in ds._replicas.get():
-        # Health check shouldn't be called until it's ready.
-        assert replica._actor.health_check_called
+    # Every replica is health-checked within the deadline (the dirty-set sweep may
+    # spread checks across ticks rather than checking all every tick).
+    _advance_until(
+        dsm, lambda: all(r._actor.health_check_called for r in ds._replicas.get())
+    )
 
-    # Mark one replica unhealthy; it should be stopped.
+    # Mark one replica unhealthy; within the deadline it is detected, stopped, and a
+    # replacement is started.
     ds._replicas.get()[0]._actor.set_unhealthy()
-    dsm.update()
-    # SIMULTANEOUSLY a new replica should be started to try to reach
-    # the target number of healthy replicas.
+    _advance_until(dsm, lambda: ds._replicas.count(states=[ReplicaState.STOPPING]) >= 1)
     check_counts(
         ds,
         total=3,
@@ -2363,15 +2373,14 @@ def test_health_gauge_caching(mock_deployment_state_manager):
     dsm.update()
     check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
 
-    # Second update: check_and_update_replicas processes the RUNNING replicas
-    # for the first time, calling check_health() and setting the gauge.
-    dsm.update()
-
+    # Within the deadline every RUNNING replica is health-checked and cached at value 1.
     replica_ids = [r.replica_id.unique_id for r in ds._replicas.get()]
-    # After the second update the cache should have (value=1, timestamp) for both.
-    for rid in replica_ids:
-        cached_value, cached_time = ds._health_gauge_cache[rid]
-        assert cached_value == 1
+    _advance_until(
+        dsm,
+        lambda: all(
+            ds._health_gauge_cache.get(rid, (None,))[0] == 1 for rid in replica_ids
+        ),
+    )
 
     # Track how many times Gauge.set is called using a wrapper.
     original_set = ds.health_check_gauge.set
@@ -2394,20 +2403,17 @@ def test_health_gauge_caching(mock_deployment_state_manager):
         "expected 0 (should be cached)"
     )
 
-    # After the TTL expires, the gauge should be re-reported even though
-    # the value hasn't changed.
+    # After the TTL expires, each replica re-reports its gauge once as it is re-checked
+    # within the deadline.
     timer.advance(RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S + 1)
-    dsm.update()
-    assert call_count == len(replica_ids), (
-        f"Gauge.set was called {call_count} times after TTL expired; "
-        f"expected {len(replica_ids)} (one per replica)"
-    )
+    _advance_until(dsm, lambda: call_count == len(replica_ids))
+    assert call_count == len(replica_ids)
 
-    # Mark one replica unhealthy — gauge should transition to 0.
+    # Mark one replica unhealthy — within the deadline it is detected and its gauge
+    # transitions to 0.
     call_count = 0
     ds._replicas.get()[0]._actor.set_unhealthy()
-    dsm.update()
-    # Gauge.set should have been called at least once (for the now-unhealthy replica).
+    _advance_until(dsm, lambda: ds._replicas.count(states=[ReplicaState.STOPPING]) >= 1)
     assert call_count >= 1
     # The stopping replica should have cache value 0.
     stopping = ds._replicas.get(states=[ReplicaState.STOPPING])
@@ -2453,14 +2459,13 @@ def test_update_while_unhealthy(mock_deployment_state_manager):
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
-    dsm.update()
-    for replica in ds._replicas.get():
-        # Health check shouldn't be called until it's ready.
-        assert replica._actor.health_check_called
+    _advance_until(
+        dsm, lambda: all(r._actor.health_check_called for r in ds._replicas.get())
+    )
 
-    # Mark one replica unhealthy. It should be stopped.
+    # Mark one replica unhealthy. Within the deadline it is detected and stopped.
     ds._replicas.get()[0]._actor.set_unhealthy()
-    dsm.update()
+    _advance_until(dsm, lambda: ds._replicas.count(states=[ReplicaState.STOPPING]) >= 1)
     check_counts(
         ds,
         total=3,
@@ -2514,7 +2519,7 @@ def test_update_while_unhealthy(mock_deployment_state_manager):
 
     # Mark the remaining running replica of the old version as unhealthy
     ds._replicas.get(states=[ReplicaState.RUNNING])[0]._actor.set_unhealthy()
-    dsm.update()
+    _advance_until(dsm, lambda: ds._replicas.count(states=[ReplicaState.RUNNING]) == 0)
     # A replica of the new version should get started to try to reach
     # the target number of healthy replicas
     check_counts(
@@ -9928,9 +9933,8 @@ def test_dirty_set_gauge_prunes_ids_no_longer_running(
     replica, which is exactly the state a reconfigured replica leaves behind."""
     import ray.serve._private.deployment_state as ds_mod
 
-    # Force the dirty-set path on with just a couple of replicas, and use the
-    # low-cardinality gauge path (the one that maintains the healthy-id set).
-    monkeypatch.setattr(ds_mod, "RAY_SERVE_RECON_DIRTYSET_MIN", 0)
+    # Use the low-cardinality gauge path (the one that maintains the healthy-id set);
+    # non-gang deployments always use the dirty-set sweep.
     monkeypatch.setattr(
         ds_mod, "RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS", False
     )

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1,5 +1,6 @@
 import sys
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
@@ -121,6 +122,7 @@ class FakeDeploymentReplica:
         self._replica_id = ReplicaID(
             get_random_string(), deployment_id=DeploymentID(name="fake")
         )
+        self._state = None
 
     @property
     def replica_id(self):
@@ -131,7 +133,11 @@ class FakeDeploymentReplica:
         return self._version
 
     def update_state(self, state):
-        pass
+        self._state = state
+
+    @property
+    def actor_details(self):
+        return SimpleNamespace(state=self._state)
 
 
 def replica(version: Optional[DeploymentVersion] = None) -> FakeDeploymentReplica:
@@ -9763,6 +9769,198 @@ def test_ingress_membership_version_ignores_non_ingress_deployment(
 
     # A full add + removal on a non-ingress deployment: the ingress version never moved.
     assert dsm.get_ingress_membership_version() == v0
+
+
+class TestDirtySet:
+    """Dirty-set health-check reconcile: _dirty_set_active_pairs selects only replicas
+    needing work this tick (round-robin sweep + in-flight polls + pending-migration),
+    not all N, while still covering every RUNNING replica within one sweep window."""
+
+    def _shim(self, container):
+        s = type("Shim", (), {})()
+        s._replicas = container
+        s._outstanding_dirty_set = set()
+        s._dirty_set_rr_cursor = 0
+        s._target_state = object()  # .info access raises -> default reconcile period
+        # Bind the real period helper so _dirty_set_active_pairs can call it on the shim.
+        s._reconcile_sweep_period_s = DeploymentState._reconcile_sweep_period_s.__get__(
+            s
+        )
+        return s
+
+    def test_covers_all_running_within_one_sweep(self):
+        c = ReplicaStateContainer()
+        reps = [replica() for _ in range(100)]
+        for r in reps:
+            c.add(ReplicaState.RUNNING, r)
+        shim = self._shim(c)
+        covered = set()
+        for _ in range(50):  # ticks = 0.5*period(10)/loop(0.1)
+            covered.update(
+                p[0].replica_id for p in DeploymentState._dirty_set_active_pairs(shim)
+            )
+        assert covered == {r.replica_id for r in reps}  # no starvation
+
+    def test_sweep_fraction_sizes_the_window(self, monkeypatch):
+        """A smaller RAY_SERVE_RECON_SWEEP_FRACTION sweeps all RUNNING replicas in
+        proportionally fewer ticks (larger per-tick slice)."""
+        import ray.serve._private.deployment_state as ds_mod
+
+        monkeypatch.setattr(ds_mod, "RAY_SERVE_RECON_SWEEP_FRACTION", 0.25)
+        c = ReplicaStateContainer()
+        reps = [replica() for _ in range(100)]
+        for r in reps:
+            c.add(ReplicaState.RUNNING, r)
+        shim = self._shim(c)
+        covered = set()
+        for _ in range(25):  # ticks = 0.25 * period(10) / loop(0.1)
+            covered.update(
+                p[0].replica_id for p in DeploymentState._dirty_set_active_pairs(shim)
+            )
+        assert covered == {r.replica_id for r in reps}  # full coverage in 25 ticks
+
+    def test_always_polls_outstanding(self):
+        c = ReplicaStateContainer()
+        reps = [replica() for _ in range(100)]
+        for r in reps:
+            c.add(ReplicaState.RUNNING, r)
+        shim = self._shim(c)
+        target = reps[42].replica_id
+        for _ in range(20):
+            shim._outstanding_dirty_set = {target}
+            pairs = DeploymentState._dirty_set_active_pairs(shim)
+            assert any(p[0].replica_id == target for p in pairs)
+
+    def test_always_includes_pending_migration(self):
+        c = ReplicaStateContainer()
+        for r in [replica() for _ in range(100)]:
+            c.add(ReplicaState.RUNNING, r)
+        pm = replica()
+        c.add(ReplicaState.PENDING_MIGRATION, pm)
+        shim = self._shim(c)
+        for _ in range(10):
+            pairs = DeploymentState._dirty_set_active_pairs(shim)
+            assert any(
+                p[0].replica_id == pm.replica_id
+                and p[1] == ReplicaState.PENDING_MIGRATION
+                for p in pairs
+            )
+
+    def test_active_set_is_sublinear(self):
+        c = ReplicaStateContainer()
+        for r in [replica() for _ in range(1000)]:
+            c.add(ReplicaState.RUNNING, r)
+        shim = self._shim(c)
+        pairs = DeploymentState._dirty_set_active_pairs(shim)
+        assert len(pairs) <= 50  # slice ceil(1000/50)=20; NOT 1000
+
+    def test_outstanding_excluded_when_no_longer_running(self):
+        """An outstanding id whose replica has transitioned out of RUNNING (e.g. to
+        STOPPING) is not re-polled as RUNNING and is dropped from the outstanding set,
+        so the reconcile can't process a stopping replica through the RUNNING path."""
+        c = ReplicaStateContainer()
+        running = replica()
+        c.add(ReplicaState.RUNNING, running)
+        stopping = replica()
+        c.add(ReplicaState.STOPPING, stopping)
+        shim = self._shim(c)
+        shim._outstanding_dirty_set = {running.replica_id, stopping.replica_id}
+        pairs = DeploymentState._dirty_set_active_pairs(shim)
+        ids = {p[0].replica_id for p in pairs}
+        assert running.replica_id in ids
+        assert stopping.replica_id not in ids  # not re-polled as RUNNING
+        assert stopping.replica_id not in shim._outstanding_dirty_set  # dropped
+        assert running.replica_id in shim._outstanding_dirty_set
+
+    def test_outstanding_dropped_when_replica_removed(self):
+        """An outstanding id whose replica has left the container is pruned; a
+        still-RUNNING one is retained."""
+        c = ReplicaStateContainer()
+        live = replica()
+        c.add(ReplicaState.RUNNING, live)
+        shim = self._shim(c)
+        gone = replica()  # never added -> get_by_id returns None
+        shim._outstanding_dirty_set = {live.replica_id, gone.replica_id}
+        pairs = DeploymentState._dirty_set_active_pairs(shim)
+        assert gone.replica_id not in shim._outstanding_dirty_set
+        assert live.replica_id in shim._outstanding_dirty_set
+        assert any(p[0].replica_id == live.replica_id for p in pairs)
+
+    def test_sweep_period_is_min_of_health_and_routing(self):
+        """The sweep is sized off min(health_check_period_s,
+        request_routing_stats_period_s): _process_healthy_replica drives both the health
+        check and the routing-stats pull, so a tighter routing-stats period must tighten
+        the sweep. Falls back to the min of the defaults before a target is set."""
+        from types import SimpleNamespace
+
+        from ray.serve._private.constants import (
+            DEFAULT_HEALTH_CHECK_PERIOD_S,
+            DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S,
+        )
+
+        shim = type("Shim", (), {})()
+        shim._target_state = SimpleNamespace(
+            info=SimpleNamespace(
+                deployment_config=SimpleNamespace(
+                    health_check_period_s=10.0,
+                    request_router_config=SimpleNamespace(
+                        request_routing_stats_period_s=1.0
+                    ),
+                )
+            )
+        )
+        assert DeploymentState._reconcile_sweep_period_s(shim) == 1.0
+
+        # No target set yet -> falls back to the min of the defaults.
+        shim._target_state = object()
+        assert DeploymentState._reconcile_sweep_period_s(shim) == min(
+            DEFAULT_HEALTH_CHECK_PERIOD_S, DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S
+        )
+
+
+def test_dirty_set_gauge_prunes_ids_no_longer_running(
+    mock_deployment_state_manager, monkeypatch
+):
+    """Dirty-set health gauge must drop ids whose replica left RUNNING without stopping
+    (e.g. RUNNING->UPDATING on a lightweight reconfigure -- which does not go through
+    _stop_replica's discard); otherwise the incremental set overcounts vs the rebuild
+    path. Modeled with a lingering id not backed by any live RUNNING/PENDING_MIGRATION
+    replica, which is exactly the state a reconfigured replica leaves behind."""
+    import ray.serve._private.deployment_state as ds_mod
+
+    # Force the dirty-set path on with just a couple of replicas, and use the
+    # low-cardinality gauge path (the one that maintains the healthy-id set).
+    monkeypatch.setattr(ds_mod, "RAY_SERVE_RECON_DIRTYSET_MIN", 0)
+    monkeypatch.setattr(
+        ds_mod, "RAY_SERVE_CONTROLLER_METRICS_INCLUDE_HIGH_CARDINALITY_TAGS", False
+    )
+
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+    info, v1 = deployment_info(num_replicas=2, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_ready()
+    dsm.update()  # STARTING -> RUNNING
+    # The round-robin dirty-set sweep health-checks only a slice per tick, so it takes a
+    # few ticks to cover every RUNNING replica and populate the healthy-id set.
+    for _ in range(5):
+        dsm.update()
+
+    running_ids = {
+        r.replica_id.unique_id for r in ds._replicas.get([ReplicaState.RUNNING])
+    }
+    assert ds._last_health_check_healthy_replica_ids == running_ids
+
+    # A replica that left RUNNING without stopping leaves its id in the healthy set with
+    # no backing RUNNING/PENDING_MIGRATION replica. The next dirty-set tick must prune it
+    # so the gauge does not overcount.
+    ds._last_health_check_healthy_replica_ids.add("ghost-reconfiguring-replica")
+    dsm.update()
+    assert ds._last_health_check_healthy_replica_ids == running_ids
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+import ray.serve._private.deployment_state as ds_mod
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray._raylet import NodeID
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
@@ -30,6 +31,7 @@ from ray.serve._private.constants import (
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_HEALTH_CHECK_TIMEOUT_S,
     DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_INTERNAL_DEPLOYMENT_ACTOR_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
@@ -9807,11 +9809,11 @@ class TestDirtySet:
         assert covered == {r.replica_id for r in reps}  # no starvation
 
     def test_sweep_fraction_sizes_the_window(self, monkeypatch):
-        """A smaller RAY_SERVE_RECON_SWEEP_FRACTION sweeps all RUNNING replicas in
+        """A smaller CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION sweeps all RUNNING replicas in
         proportionally fewer ticks (larger per-tick slice)."""
-        import ray.serve._private.deployment_state as ds_mod
-
-        monkeypatch.setattr(ds_mod, "RAY_SERVE_RECON_SWEEP_FRACTION", 0.25)
+        monkeypatch.setattr(
+            ds_mod, "CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION", 0.25
+        )
         c = ReplicaStateContainer()
         reps = [replica() for _ in range(100)]
         for r in reps:
@@ -9896,13 +9898,6 @@ class TestDirtySet:
         request_routing_stats_period_s): _process_healthy_replica drives both the health
         check and the routing-stats pull, so a tighter routing-stats period must tighten
         the sweep. Falls back to the min of the defaults before a target is set."""
-        from types import SimpleNamespace
-
-        from ray.serve._private.constants import (
-            DEFAULT_HEALTH_CHECK_PERIOD_S,
-            DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S,
-        )
-
         shim = type("Shim", (), {})()
         shim._target_state = SimpleNamespace(
             info=SimpleNamespace(
@@ -9931,8 +9926,6 @@ def test_dirty_set_gauge_prunes_ids_no_longer_running(
     _stop_replica's discard); otherwise the incremental set overcounts vs the rebuild
     path. Modeled with a lingering id not backed by any live RUNNING/PENDING_MIGRATION
     replica, which is exactly the state a reconfigured replica leaves behind."""
-    import ray.serve._private.deployment_state as ds_mod
-
     # Use the low-cardinality gauge path (the one that maintains the healthy-id set);
     # non-gang deployments always use the dirty-set sweep.
     monkeypatch.setattr(


### PR DESCRIPTION
## Why are these changes needed?

The controller's health-check reconcile visits every replica of a deployment on
every control-loop tick, so its per-tick cost is O(num_replicas). At high
replica counts this dominates the control loop and slows everything the loop
does (autoscaling decisions, rollouts, proxy updates).

This PR replaces the per-tick full scan with a **dirty-set reconcile**: each
tick processes only the replicas that need attention —

- a **round-robin slice** of RUNNING replicas, sized so a full sweep of the
  bucket spans `CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION x
  reconcile_period` nominal ticks (the reconcile period is
  `min(health_check_period_s, request_routing_stats_period_s)`),
- all replicas with an **in-flight health check** (re-polled every tick, so
  probe completions and actor crashes are still observed promptly), and
- all `PENDING_MIGRATION` replicas.

Per-tick reconcile cost becomes O(slice) = O(num_replicas / ticks_per_sweep).
The health gauge is maintained incrementally against the swept set instead of
being rebuilt each tick.

`RAY_SERVE_CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION` (default 0.5)
controls the trade: smaller values sweep faster (fresher checks, more per-tick
work); larger values spread the sweep out (cheaper ticks, staler checks).

### Health-check cadence semantics

Health checks themselves never time out or fail due to this change — a check
fires at a replica's next sweep visit once its `health_check_period_s` has
elapsed, so the *effective* check period is the configured period rounded up
to the sweep time. The measured cadence per replica count and fraction (36
samples/cell, pinned replicas, one deployment, m5.2xlarge head; loop times
were measured with the full set of controller-scaling optimizations applied,
while the cadence columns are a property of this PR's sweep):

| replicas | fraction | p99 check gap (s) | p90 | p100 | loop (ms) | loops/s |
|---:|---:|---:|---:|---:|---:|---:|
| 16384 | 0.25 | 27.0 | 24.5 | 28.3 | 599 | 0.95 |
| 16384 | 0.50 | 34.0 | 31.5 | 34.4 | 353 | 1.36 |
| 16384 | 0.75 | 40.0 | 39.0 | 40.6 | 286 | 1.67 |
| 14336 | 0.25 | 25.0 | 22.0 | 25.6 | 531 | 1.08 |
| 14336 | 0.50 | 31.0 | 30.0 | 32.5 | 323 | 1.46 |
| 14336 | 0.75 | 40.5 | 38.0 | 41.8 | 283 | 1.73 |
| 12288 | 0.25 | 21.0 | 19.5 | 22.4 | 457 | 1.20 |
| 12288 | 0.50 | 26.5 | 25.0 | 27.5 | 284 | 1.70 |
| 12288 | 0.75 | 34.0 | 33.0 | 34.8 | 245 | 2.01 |
| 10240 | 0.25 | 16.0 | 15.0 | 15.9 | 352 | 1.44 |
| 10240 | 0.50 | 20.5 | 20.0 | 21.4 | 214 | 1.92 |
| 10240 | 0.75 | 27.5 | 27.0 | 27.7 | 204 | 2.15 |
| 8192 | 0.25 | 11.0 | 8.5 | 11.8 | 144 | 2.42 |
| 8192 | 0.50 | 18.5 | 16.0 | 18.5 | 147 | 2.45 |
| 8192 | 0.75 | 21.5 | 20.5 | 21.5 | 124 | 2.69 |
| 6144 | 0.25 | 9.0 | 6.0 | 9.5 | 89 | 3.34 |
| 6144 | 0.50 | 14.0 | 12.0 | 14.2 | 80 | 3.46 |
| 6144 | 0.75 | 18.0 | 16.5 | 17.8 | 84 | 3.46 |
| 4096 | 0.25 | 6.5 | 5.0 | 6.7 | 55 | 4.52 |
| 4096 | 0.50 | 10.0 | 8.0 | 10.0 | 46 | 4.77 |
| 4096 | 0.75 | 13.5 | 12.5 | 14.5 | 45 | 4.82 |

Reading the table: the p99 column is the check period the controller can
actually honor at that scale and fraction — e.g. the default 10s period is
genuinely met up to ~4096 replicas at the default fraction (or ~6144 at
fraction 0.25), and at 16384 replicas an operator can choose ~27s freshness at
599ms loops or ~40s at 286ms. Since a failed replica is stopped after 3
consecutive failed checks, time-to-detect an application-level failure scales
with the same cadence (hard crashes are caught faster: the in-flight check ref
errors immediately and in-flight replicas are re-polled every tick).

Guidance for tuning: smaller fractions buy fresher checks roughly linearly
until the sweep is bounded by total check work; if the configured
`health_check_period_s` is below the sweep time for your replica count, raise
the period (checks are stale, not failing) or lower the fraction.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. (N/A — internal constants only.)
- [x] I've made sure the tests are passing. Unit: `TestDirtySet` (sweep
  coverage, sizing, outstanding-poll, pending-migration, starvation) and the
  existing health-check tests rewritten to assert the real invariant (every
  replica checked within one sweep window). Integration: a failing replica at
  an arbitrary rotation position among 12 is found and replaced (and only it);
  a replica whose actor dies outright is detected and replaced.

An attached html document lists all of the optimizations that were implemented as part of a larger Serve controller scaling effort. This PR is for optimization A2.

Controller-scaling optimization series (builds on the in-place reconcile, #64507)
<img width="2025" height="810" alt="image" src="https://github.com/user-attachments/assets/d2cd8107-b359-4822-8103-99305337ec0d" />
