### PR TITLE
[Data] Test join for both v1/v2 hash shuffle

### DIFF
--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -15,6 +15,13 @@ from ray.exceptions import RayTaskError
 from ray.tests.conftest import *  # noqa
 
 
+@pytest.fixture(autouse=True, params=[False, True], ids=["shufflev1", "shufflev2"])
+def hash_shuffle_version(request, restore_data_context):
+    """Run every join test on both v1 (old actor-based) & v2 shuffle."""
+    DataContext.get_current().use_hash_shuffle_v2 = request.param
+    return request.param
+
+
 @pytest.mark.parametrize(
     "num_rows_left,num_rows_right,partition_size_hint",
     [


### PR DESCRIPTION
## Description
We added `RAY_DATA_USE_HASH_SHUFFLE_V2` env for user to set whether to use v1 / v2 hash shuffle.
The test should test both.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
