### PR TITLE
BUG: Local File Inclusion impacting /logs API endpoint

### DIFF
--- a/dashboard/modules/log/log_agent.py
+++ b/dashboard/modules/log/log_agent.py
@@ -297,8 +297,8 @@ class LogAgentV1Grpc(dashboard_utils.DashboardAgentModule):
 
         if request.glob_filter:
             glob_path = Path(request.glob_filter)
-            if glob_path.is_absolute() or ".." in glob_path.parts:
-                raise FileNotFoundError(
+            if glob_path.anchor or ".." in glob_path.parts:
+                raise ValueError(
                     f"Invalid glob filter: path traversal detected: "
                     f"{request.glob_filter}"
                 )

--- a/dashboard/modules/log/log_agent.py
+++ b/dashboard/modules/log/log_agent.py
@@ -294,9 +294,19 @@ class LogAgentV1Grpc(dashboard_utils.DashboardAgentModule):
                 f"Could not find log dir at path: {self._dashboard_agent.log_dir}"
                 "It is unexpected. Please report an issue to Ray Github."
             )
+
+        if request.glob_filter:
+            glob_path = Path(request.glob_filter)
+            if glob_path.is_absolute() or ".." in glob_path.parts:
+                raise FileNotFoundError(
+                    f"Invalid glob filter: path traversal detected: "
+                    f"{request.glob_filter}"
+                )
+
         log_files = []
         for p in path.glob(request.glob_filter):
             log_files.append(str(p.relative_to(path)) + ("/" if p.is_dir() else ""))
+
         return reporter_pb2.ListLogsReply(log_files=log_files)
 
     @classmethod


### PR DESCRIPTION
## Description
Added input validation to **LogAgentV1Grpc.ListLogs()** in _python/ray/dashboard/modules/log/log_agent.py_ to reject path traversal attempts by ensuring log filenames and glob filters cannot be absolute paths or contain `..` path components before they are processed. This prevents attackers from escaping Ray's log directory when resolving or listing log files.

## Related issues
Fixes #45751


