### PR TITLE
[serve] Router: sticky latency-adaptive queue-length probe deadline (F)

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -540,6 +540,17 @@ RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S = get_env_float(
     "RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S", 1.0
 )
 
+# Queue-length probe deadline auto-tuning (RequestRouter._probe_queue_lens): the
+# deadline is seeded from an EWMA of recent probe round-trip times. ALPHA is the
+# EWMA weight per new sample ([0, 1]); MULTIPLIER pads the EWMA (>= 1, so the
+# seeded deadline never sits below the measured RTT).
+RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA = min(
+    1.0, max(0.0, get_env_float("RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA", 0.3))
+)
+RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER = max(
+    1.0, get_env_float("RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER", 2.0)
+)
+
 # Length of time to respect entries in the queue length cache when routing requests.
 RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S = get_env_float_non_negative(
     "RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S", 10.0

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -522,6 +522,17 @@ RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S = get_env_float(
     "RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S", 1.0
 )
 
+# Queue-length probe deadline auto-tuning (RequestRouter._probe_queue_lens): the
+# deadline is seeded from an EWMA of recent probe round-trip times. ALPHA is the
+# EWMA weight per new sample ([0, 1]); MULTIPLIER pads the EWMA (>= 1, so the
+# seeded deadline never sits below the measured RTT).
+RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA = min(
+    1.0, max(0.0, get_env_float("RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA", 0.3))
+)
+RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER = max(
+    1.0, get_env_float("RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER", 2.0)
+)
+
 # Length of time to respect entries in the queue length cache when routing requests.
 RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S = get_env_float_non_negative(
     "RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S", 10.0

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -31,6 +31,8 @@ from ray.serve._private.constants import (
     DEFAULT_LATENCY_BUCKET_MS,
     RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
     RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S,
+    RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA,
+    RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER,
     RAY_SERVE_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
     RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S,
     RAY_SERVE_ROUTER_RETRY_BACKOFF_MULTIPLIER,
@@ -513,6 +515,12 @@ class RequestRouter(ABC):
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
         self._queue_len_gauge_last_update: Dict[ReplicaID, float] = {}
 
+        # Sticky, latency-adaptive probe deadline: EWMA of recent successful
+        # queue-length probe round-trip times, used to seed the per-request probe
+        # deadline near the cluster's real probe latency instead of re-climbing from
+        # the static base each routing decision. None until the first clean probe.
+        self._probe_rtt_ewma_s: Optional[float] = None
+
         # NOTE(edoakes): Python 3.10 removed the `loop` parameter to `asyncio.Event`.
         # Now, the `asyncio.Event` will call `get_running_loop` in its constructor to
         # determine the loop to attach to. This class can be constructed for the handle
@@ -962,23 +970,46 @@ class RequestRouter(ABC):
             self.max_queue_len_response_deadline_s,
         )
 
+        # Seed the deadline from the EWMA of recent successful probe round-trip
+        # times (padded by RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER), bounded below
+        # by the configured base so a healthy cluster stays at the fast default and
+        # above by the max. This lets the deadline track real probe latency without
+        # re-climbing the exponential backoff from the base every routing decision.
+        # Once real RTT reaches max/multiplier the seed saturates at the max deadline
+        # -- the cap working as designed (auto-reaching the static-inflate workaround).
+        adaptive_base_deadline_s = self.queue_len_response_deadline_s
+        if self._probe_rtt_ewma_s is not None:
+            adaptive_base_deadline_s = min(
+                max(
+                    self.queue_len_response_deadline_s,
+                    self._probe_rtt_ewma_s
+                    * RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER,
+                ),
+                max_queue_len_response_deadline_s,
+            )
+
         try:
             queue_len_response_deadline_s = min(
-                self.queue_len_response_deadline_s * (2**backoff_index),
+                adaptive_base_deadline_s * (2**backoff_index),
                 max_queue_len_response_deadline_s,
             )
         except OverflowError:
-            # self.queue_len_response_deadline_s * (2**backoff_index)
+            # adaptive_base_deadline_s * (2**backoff_index)
             # can overflow if backoff_index gets sufficiently large (e.g.
-            # 1024 when queue_len_response_deadline_s is 0.1).
+            # 1024 when the base deadline is 0.1).
             queue_len_response_deadline_s = max_queue_len_response_deadline_s
+
+        async def _timed_get_queue_len(replica):
+            start = self._event_loop.time()
+            queue_len = await replica.get_queue_len(
+                deadline_s=queue_len_response_deadline_s
+            )
+            return queue_len, self._event_loop.time() - start
 
         get_queue_len_tasks = []
         task_to_replica: Dict[asyncio.Task, RunningReplica] = {}
         for r in replicas:
-            t = self._event_loop.create_task(
-                r.get_queue_len(deadline_s=queue_len_response_deadline_s)
-            )
+            t = self._event_loop.create_task(_timed_get_queue_len(r))
             task_to_replica[t] = r
             get_queue_len_tasks.append(t)
 
@@ -987,6 +1018,11 @@ class RequestRouter(ABC):
             timeout=queue_len_response_deadline_s,
             return_when=asyncio.ALL_COMPLETED,
         )
+        # Clean round = every probed replica answered (no timeout, no error). Take RTTs
+        # from the task results below, not a shared list, so a timed-out task that
+        # finishes late can't add an RTT after it was already recorded as failed.
+        round_is_clean = len(pending) == 0
+        clean_round_rtts: List[float] = []
         for t in pending:
             replica = task_to_replica[t]
             result.append((replica, None))
@@ -1002,6 +1038,7 @@ class RequestRouter(ABC):
         for t in done:
             replica = task_to_replica[t]
             if t.exception() is not None:
+                round_is_clean = False
                 result.append((replica, None))
                 msg = (
                     "Failed to fetch queue length for "
@@ -1031,13 +1068,33 @@ class RequestRouter(ABC):
 
                 logger.warning(msg)
             else:
-                queue_len = t.result()
+                queue_len, rtt = t.result()
+                clean_round_rtts.append(rtt)
                 result.append((replica, queue_len))
                 self._replica_queue_len_cache.update(replica.replica_id, queue_len)
                 self._update_router_queue_len_gauge(replica.replica_id, queue_len)
 
+        # Fold into the RTT EWMA only on a clean round. A censored round's timed-out
+        # replicas have unknown, over-deadline RTTs, so folding only the fast successes
+        # would bias the estimate low.
+        if round_is_clean:
+            self._update_probe_rtt_ewma(clean_round_rtts)
+
         assert len(result) == len(replicas)
         return result
+
+    def _update_probe_rtt_ewma(self, rtts: List[float]) -> None:
+        """Fold each probe RTT into the EWMA with equal per-sample weight (first
+        sample seeds it). Per-replica folding makes a larger clean round shift the
+        estimate more, but boundedly -- every RTT is <= that round's deadline.
+        """
+        alpha = RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA
+        for rtt in rtts:
+            self._probe_rtt_ewma_s = (
+                rtt
+                if self._probe_rtt_ewma_s is None
+                else (1.0 - alpha) * self._probe_rtt_ewma_s + alpha * rtt
+            )
 
     async def _select_from_candidate_replicas(
         self,

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -31,6 +31,8 @@ from ray.serve._private.constants import (
     DEFAULT_LATENCY_BUCKET_MS,
     RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
     RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S,
+    RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA,
+    RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER,
     RAY_SERVE_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
     RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S,
     RAY_SERVE_ROUTER_RETRY_BACKOFF_MULTIPLIER,
@@ -505,6 +507,12 @@ class RequestRouter(ABC):
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
         self._queue_len_gauge_last_update: Dict[ReplicaID, float] = {}
 
+        # Sticky, latency-adaptive probe deadline: EWMA of recent successful
+        # queue-length probe round-trip times, used to seed the per-request probe
+        # deadline near the cluster's real probe latency instead of re-climbing from
+        # the static base each routing decision. None until the first clean probe.
+        self._probe_rtt_ewma_s: Optional[float] = None
+
         # NOTE(edoakes): Python 3.10 removed the `loop` parameter to `asyncio.Event`.
         # Now, the `asyncio.Event` will call `get_running_loop` in its constructor to
         # determine the loop to attach to. This class can be constructed for the handle
@@ -949,22 +957,45 @@ class RequestRouter(ABC):
             self.max_queue_len_response_deadline_s,
         )
 
+        # Seed the deadline from the EWMA of recent successful probe round-trip
+        # times (padded by RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER), bounded below
+        # by the configured base so a healthy cluster stays at the fast default and
+        # above by the max. This lets the deadline track real probe latency without
+        # re-climbing the exponential backoff from the base every routing decision.
+        # Once real RTT reaches max/multiplier the seed saturates at the max deadline
+        # -- the cap working as designed (auto-reaching the static-inflate workaround).
+        adaptive_base_deadline_s = self.queue_len_response_deadline_s
+        if self._probe_rtt_ewma_s is not None:
+            adaptive_base_deadline_s = min(
+                max(
+                    self.queue_len_response_deadline_s,
+                    self._probe_rtt_ewma_s
+                    * RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER,
+                ),
+                max_queue_len_response_deadline_s,
+            )
+
         try:
             queue_len_response_deadline_s = min(
-                self.queue_len_response_deadline_s * (2**backoff_index),
+                adaptive_base_deadline_s * (2**backoff_index),
                 max_queue_len_response_deadline_s,
             )
         except OverflowError:
-            # self.queue_len_response_deadline_s * (2**backoff_index)
+            # adaptive_base_deadline_s * (2**backoff_index)
             # can overflow if backoff_index gets sufficiently large (e.g.
-            # 1024 when queue_len_response_deadline_s is 0.1).
+            # 1024 when the base deadline is 0.1).
             queue_len_response_deadline_s = max_queue_len_response_deadline_s
+
+        async def _timed_get_queue_len(replica):
+            start = self._event_loop.time()
+            queue_len = await replica.get_queue_len(
+                deadline_s=queue_len_response_deadline_s
+            )
+            return queue_len, self._event_loop.time() - start
 
         get_queue_len_tasks = []
         for r in replicas:
-            t = self._event_loop.create_task(
-                r.get_queue_len(deadline_s=queue_len_response_deadline_s)
-            )
+            t = self._event_loop.create_task(_timed_get_queue_len(r))
             t.replica = r
             get_queue_len_tasks.append(t)
 
@@ -973,6 +1004,11 @@ class RequestRouter(ABC):
             timeout=queue_len_response_deadline_s,
             return_when=asyncio.ALL_COMPLETED,
         )
+        # Clean round = every probed replica answered (no timeout, no error). Take RTTs
+        # from the task results below, not a shared list, so a timed-out task that
+        # finishes late can't add an RTT after it was already recorded as failed.
+        round_is_clean = len(pending) == 0
+        clean_round_rtts: List[float] = []
         for t in pending:
             replica = t.replica
             result.append((replica, None))
@@ -988,6 +1024,7 @@ class RequestRouter(ABC):
         for t in done:
             replica = t.replica
             if t.exception() is not None:
+                round_is_clean = False
                 result.append((replica, None))
                 msg = (
                     "Failed to fetch queue length for "
@@ -1017,13 +1054,33 @@ class RequestRouter(ABC):
 
                 logger.warning(msg)
             else:
-                queue_len = t.result()
+                queue_len, rtt = t.result()
+                clean_round_rtts.append(rtt)
                 result.append((replica, queue_len))
                 self._replica_queue_len_cache.update(replica.replica_id, queue_len)
                 self._update_router_queue_len_gauge(replica.replica_id, queue_len)
 
+        # Fold into the RTT EWMA only on a clean round. A censored round's timed-out
+        # replicas have unknown, over-deadline RTTs, so folding only the fast successes
+        # would bias the estimate low.
+        if round_is_clean:
+            self._update_probe_rtt_ewma(clean_round_rtts)
+
         assert len(result) == len(replicas)
         return result
+
+    def _update_probe_rtt_ewma(self, rtts: List[float]) -> None:
+        """Fold each probe RTT into the EWMA with equal per-sample weight (first
+        sample seeds it). Per-replica folding makes a larger clean round shift the
+        estimate more, but boundedly -- every RTT is <= that round's deadline.
+        """
+        alpha = RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA
+        for rtt in rtts:
+            self._probe_rtt_ewma_s = (
+                rtt
+                if self._probe_rtt_ewma_s is None
+                else (1.0 - alpha) * self._probe_rtt_ewma_s + alpha * rtt
+            )
 
     async def _select_from_candidate_replicas(
         self,

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -21,6 +21,8 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.constants import (
     RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S,
+    RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA,
+    RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER,
     RAY_SERVE_ROUTER_RETRY_BACKOFF_MULTIPLIER,
     RAY_SERVE_ROUTER_RETRY_INITIAL_BACKOFF_S,
     RAY_SERVE_ROUTER_RETRY_MAX_BACKOFF_S,
@@ -2181,6 +2183,127 @@ def test_compute_backoff_s_does_not_overflow():
     )
 
     assert router._compute_backoff_s(2048) == router.max_backoff_s
+
+
+@pytest.mark.asyncio
+async def test_probe_deadline_adapts_to_rtt_ewma(pow_2_router):
+    """The per-request probe deadline is seeded from the EWMA of recent successful
+    probe round-trip times (padded by RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER),
+    bounded below by the base deadline and above by the max."""
+    s = pow_2_router
+    s.queue_len_response_deadline_s = 0.1
+    s.max_queue_len_response_deadline_s = 1.0
+    mult = RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER
+
+    async def first_deadline_for_ewma(name, ewma):
+        r = FakeRunningReplica(name)
+        r.set_queue_len_response(0)  # respond immediately -> clean round
+        s._probe_rtt_ewma_s = ewma
+        await s._probe_queue_lens([r], 0)
+        return r.queue_len_deadline_history[0]
+
+    # In-range EWMA -> the starting deadline tracks ewma * multiplier.
+    assert await first_deadline_for_ewma("mid", 0.2) == pytest.approx(0.2 * mult)
+    # Tiny EWMA -> floored at the base deadline (healthy cluster stays fast).
+    assert await first_deadline_for_ewma("low", 1e-6) == pytest.approx(0.1)
+    # Huge EWMA -> capped at the max deadline.
+    assert await first_deadline_for_ewma("high", 100.0) == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_probe_rtt_ewma_updates_only_on_clean_round(pow_2_router):
+    """The RTT EWMA is updated from a clean probe round (every replica answered) and
+    left unchanged when a probe times out (a censored sample)."""
+    s = pow_2_router
+    assert s._probe_rtt_ewma_s is None
+
+    # Clean round: replica answers within the deadline -> EWMA becomes set.
+    r_ok = FakeRunningReplica("ok")
+    r_ok.set_queue_len_response(0)
+    await s._probe_queue_lens([r_ok], 0)
+    assert s._probe_rtt_ewma_s is not None
+    assert s._probe_rtt_ewma_s >= 0.0
+
+    # Timed-out round: replica never answers -> EWMA left unchanged.
+    prev = s._probe_rtt_ewma_s
+    s.queue_len_response_deadline_s = 0.001
+    s.max_queue_len_response_deadline_s = 0.001
+    r_slow = FakeRunningReplica("slow")  # no response set -> times out
+    await s._probe_queue_lens([r_slow], 0)
+    assert s._probe_rtt_ewma_s == prev
+
+
+def test_update_probe_rtt_ewma_blends_each_sample(pow_2_router):
+    """Each probe RTT is folded with equal per-sample weight: the prior decays by
+    (1 - alpha) per sample and the newest enters with weight alpha; the first sample
+    seeds the EWMA and a multi-sample round folds each in order."""
+    s = pow_2_router
+    alpha = RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA
+    assert s._probe_rtt_ewma_s is None
+    s._update_probe_rtt_ewma([0.10])  # first sample seeds
+    assert s._probe_rtt_ewma_s == pytest.approx(0.10)
+    s._update_probe_rtt_ewma([0.20])  # second blends
+    assert s._probe_rtt_ewma_s == pytest.approx((1 - alpha) * 0.10 + alpha * 0.20)
+    # A two-sample round folds each in order -> same as two sequential single folds.
+    s._probe_rtt_ewma_s = None
+    s._update_probe_rtt_ewma([0.10, 0.20])
+    assert s._probe_rtt_ewma_s == pytest.approx((1 - alpha) * 0.10 + alpha * 0.20)
+
+
+def test_update_probe_rtt_ewma_decays_toward_recent(pow_2_router):
+    """After a high sample, repeated low samples pull the EWMA back down toward the
+    recent (low) RTT -- the estimate recovers when probe latency drops."""
+    s = pow_2_router
+    s._update_probe_rtt_ewma([1.0])
+    assert s._probe_rtt_ewma_s == pytest.approx(1.0)
+    for _ in range(50):
+        s._update_probe_rtt_ewma([0.01])
+    assert s._probe_rtt_ewma_s == pytest.approx(0.01, abs=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_probe_rtt_ewma_skips_partial_rounds(pow_2_router):
+    """A censored round -- some probed replicas time out while others succeed -- must
+    NOT update the EWMA. Folding only the fast successes would bias it low, below
+    what the slow (timed-out) replica needs."""
+    s = pow_2_router
+    s.queue_len_response_deadline_s = 0.05
+    s.max_queue_len_response_deadline_s = 0.05
+    assert s._probe_rtt_ewma_s is None
+    r_ok = FakeRunningReplica("ok")
+    r_ok.set_queue_len_response(0)
+    r_slow = FakeRunningReplica("slow")  # never answers -> times out
+    await s._probe_queue_lens([r_ok, r_slow], 0)
+    # Partial round (r_ok answered, r_slow timed out) -> EWMA left unchanged.
+    assert s._probe_rtt_ewma_s is None
+
+
+@pytest.mark.asyncio
+async def test_probe_deadline_seeds_from_folded_rtt_and_scales_with_backoff(
+    pow_2_router,
+):
+    """End-to-end fold -> seed: a folded RTT seeds the next round's deadline (padded by
+    the multiplier), and the seed scales by 2 ** backoff_index."""
+    s = pow_2_router
+    s.queue_len_response_deadline_s = 0.1
+    s.max_queue_len_response_deadline_s = 10.0
+    mult = RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER
+
+    async def deadline_at(backoff_index):
+        r = FakeRunningReplica(f"r{backoff_index}")
+        r.set_queue_len_response(0)  # clean round; deadline recorded before this folds
+        await s._probe_queue_lens([r], backoff_index)
+        return r.queue_len_deadline_history[0]
+
+    # Folding a 0.3s RTT seeds the deadline at ewma * multiplier.
+    s._update_probe_rtt_ewma([0.3])
+    assert await deadline_at(0) == pytest.approx(0.3 * mult)
+    # The seed scales by 2 ** backoff_index (reset the EWMA -- the probe above folded a
+    # ~0 sample into it -- so we isolate the backoff scaling).
+    s._probe_rtt_ewma_s = 0.3
+    assert await deadline_at(1) == pytest.approx(0.3 * mult * 2)
+    s._probe_rtt_ewma_s = 0.3
+    assert await deadline_at(2) == pytest.approx(0.3 * mult * 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When sending a request to a downstream deployment, a replica's router selects which 
downstream replica is the best replica to process the request.  To do this, it maintains a 
cache of the number of in-flight requests for each replica, but it must periodically probe
the downstream replicas to update the cache for future decisions.  The router sends 
the probe with an initial deadline of 100 ms which can climb via exponential backoff. 
Because the deadline resets to 100 ms on every routing decision, a cluster whose real 
probe latency exceeds 100 ms experiences the backoff delay every request.
Large, high-latency clusters commonly have to statically increase the deadline to improve
probe success and reduce router latency.

This change seeds the starting deadline from an exponentially weighted moving average 
(EWMA) of recent successful probe round-trip times. The deadline self-tunes.  It stays
at the fast 100 ms default on a healthy cluster and starts near the real probe latency under load, 
instead of re-climbing the backoff each request. The EWMA updates only after a clean round 
in which every probed replica answered before the deadline.  If any probe times out or errors, 
the whole round is skipped and the EWMA is not updated.

The EWMA deadline is maintained per router/handle.  The EWMA is actually padded with a
configurable multiplier, RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_MULTIPLIER (2).  The EWMA 
changes can be smoothed by configuring RAY_SERVE_QUEUE_LENGTH_PROBE_RTT_EWMA_ALPHA (0.3).

This is a Router change only.  Healthy-cluster behavior is unchanged (base floor).  Unit
tests added for the deadline seeding (floor/track/cap) and to verify only successful probes
update the EWMA deadline.