### PR TITLE
[serve][llm] Make OpenAI protocol imports optional

### DIFF
--- a/python/ray/llm/_internal/common/utils/import_utils.py
+++ b/python/ray/llm/_internal/common/utils/import_utils.py
@@ -7,6 +7,11 @@ from typing import Any, NoReturn, Optional, Type
 logger = logging.getLogger(__name__)
 
 
+def is_missing_module(error: ImportError, module: str) -> bool:
+    """Return whether an import failed because its top-level module is absent."""
+    return isinstance(error, ModuleNotFoundError) and error.name == module
+
+
 def try_import(name: str, error: bool = False) -> Optional[ModuleType]:
     """Try importing the module and returns the module (or None).
 
@@ -44,12 +49,8 @@ def raise_llm_engine_import_error(
         vllm_error: The ImportError raised when importing vLLM.
         sglang_error: The ImportError raised when importing SGLang.
     """
-    vllm_not_installed = (
-        isinstance(vllm_error, ModuleNotFoundError) and vllm_error.name == "vllm"
-    )
-    sglang_not_installed = (
-        isinstance(sglang_error, ModuleNotFoundError) and sglang_error.name == "sglang"
-    )
+    vllm_not_installed = is_missing_module(vllm_error, "vllm")
+    sglang_not_installed = is_missing_module(sglang_error, "sglang")
 
     if vllm_not_installed and sglang_not_installed:
         raise ImportError(

--- a/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
+++ b/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
@@ -1,8 +1,8 @@
-"""This module contains wrapper classes for OpenAI-compatible protocol models.
+"""Wrapper classes for OpenAI-compatible protocol models.
 
-Supports both vLLM and SGLang as the underlying engine. vLLM is tried first;
-on ImportError, SGLang models are imported as a fallback. If neither is
-installed, an ImportError is raised at import time.
+vLLM is tried first and SGLang second. If neither optional engine is installed,
+dependency-free models preserve the request payload for validation on the
+engine node.
 """
 
 import uuid
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Uni
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ray.llm._internal.common.utils.import_utils import raise_llm_engine_import_error
+from ray.llm._internal.common.utils.import_utils import (
+    is_missing_module,
+    raise_llm_engine_import_error,
+)
 
 try:
     from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -68,47 +71,86 @@ except ImportError as _vllm_import_error:
             TokenizeResponse as _TokenizeResponse,
         )
     except ImportError as _sglang_import_error:
-        raise_llm_engine_import_error(_vllm_import_error, _sglang_import_error)
+        if not (
+            is_missing_module(_vllm_import_error, "vllm")
+            and is_missing_module(_sglang_import_error, "sglang")
+        ):
+            raise_llm_engine_import_error(_vllm_import_error, _sglang_import_error)
 
-    def _unsupported_model(name: str, feature: str = ""):
-        """Create a BaseModel stub that raises NotImplementedError on instantiation."""
-        msg = f"{name} is not supported with the current backend." + (
-            f" {feature}" if feature else ""
+        class _FallbackRequest(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+            model: Optional[str] = None
+
+        class _FallbackChatRequest(_FallbackRequest):
+            messages: List[Any]
+
+        class _FallbackResponse(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+
+        _ChatCompletionRequest = _FallbackChatRequest
+        _CompletionRequest = _FallbackRequest
+        _EmbeddingChatRequest = _EmbeddingCompletionRequest = _FallbackRequest
+        _ScoreTextRequest = _DetokenizeRequest = _FallbackRequest
+        _TokenizeChatRequest = _TokenizeCompletionRequest = _FallbackRequest
+        _TranscriptionRequest = _FallbackRequest
+
+        _ChatCompletionResponse = _ChatCompletionStreamResponse = _FallbackResponse
+        _CompletionResponse = _CompletionStreamResponse = _FallbackResponse
+        _EmbeddingResponse = _ScoreResponse = _FallbackResponse
+        _DetokenizeResponse = _TokenizeResponse = _FallbackResponse
+        _TranscriptionResponse = _TranscriptionStreamResponse = _FallbackResponse
+
+        class _ErrorInfo(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            message: str
+            type: str
+            param: Optional[str] = None
+            code: int
+
+        class _ErrorResponse(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            error: _ErrorInfo
+
+    else:
+
+        def _unsupported_model(name: str, feature: str = ""):
+            """Create a model that raises when an unsupported feature is used."""
+            msg = f"{name} is not supported with the current backend." + (
+                f" {feature}" if feature else ""
+            )
+
+            class _Stub(BaseModel):
+                model_config = ConfigDict(arbitrary_types_allowed=True)
+
+                def __init__(self, **kwargs):
+                    raise NotImplementedError(msg)
+
+            _Stub.__name__ = _Stub.__qualname__ = name
+            return _Stub
+
+        # SGLang does not provide transcription protocol models.
+        _vllm_hint = "Install vLLM to use transcription endpoints."
+        _TranscriptionRequest = _unsupported_model("TranscriptionRequest", _vllm_hint)
+        _TranscriptionResponse = _unsupported_model("TranscriptionResponse", _vllm_hint)
+        _TranscriptionStreamResponse = _unsupported_model(
+            "TranscriptionStreamResponse", _vllm_hint
         )
 
-        class _Stub(BaseModel):
+        # SGLang has no equivalent to vLLM's nested
+        # ErrorResponse.error -> ErrorInfo pattern, so we define our own.
+        class _ErrorInfo(BaseModel):
             model_config = ConfigDict(arbitrary_types_allowed=True)
+            message: str
+            type: str
+            param: Optional[str] = None
+            code: int
 
-            def __init__(self, **kwargs):
-                raise NotImplementedError(msg)
+        class _ErrorResponse(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            error: _ErrorInfo
 
-        _Stub.__name__ = _Stub.__qualname__ = name
-        return _Stub
-
-    # SGLang does not provide transcription protocol models.
-    _vllm_hint = "Install vLLM to use transcription endpoints."
-    _TranscriptionRequest = _unsupported_model("TranscriptionRequest", _vllm_hint)
-    _TranscriptionResponse = _unsupported_model("TranscriptionResponse", _vllm_hint)
-    _TranscriptionStreamResponse = _unsupported_model(
-        "TranscriptionStreamResponse", _vllm_hint
-    )
-
-    # SGLang has no equivalent to vLLM's nested ErrorResponse.error -> ErrorInfo
-    # pattern, so we define our own.
-
-    class _ErrorInfo(BaseModel):
-        model_config = ConfigDict(arbitrary_types_allowed=True)
-        message: str
-        type: str
-        param: Optional[str] = None
-        code: int
-
-    class _ErrorResponse(BaseModel):
-        model_config = ConfigDict(arbitrary_types_allowed=True)
-        error: _ErrorInfo
-
-    _EmbeddingChatRequest = _EmbeddingCompletionRequest
-    _TokenizeChatRequest = _TokenizeCompletionRequest
+        _EmbeddingChatRequest = _EmbeddingCompletionRequest
+        _TokenizeChatRequest = _TokenizeCompletionRequest
 
 
 if TYPE_CHECKING:

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -33,7 +33,11 @@ from ray.llm._internal.serve.constants import (
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionStreamResponse,
     CompletionRequest,
+    CompletionResponse,
+    CompletionStreamResponse,
     DetokenizeRequest,
     DetokenizeResponse,
     EmbeddingRequest,
@@ -52,6 +56,8 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     TokenizeCompletionRequest,
     TokenizeResponse,
     TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionStreamResponse,
 )
 from ray.llm._internal.serve.core.ingress.middleware import (
     SetRequestIdMiddleware,
@@ -63,7 +69,12 @@ from ray.llm._internal.serve.core.ingress.utils import (
     _peek_at_generator,
     _sanitize_chat_completion_request,
 )
-from ray.llm._internal.serve.core.protocol import DeploymentProtocol, RawRequestInfo
+from ray.llm._internal.serve.core.protocol import (
+    DeploymentProtocol,
+    RawRequestInfo,
+    deserialize_openai_model,
+    serialize_openai_model,
+)
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.observability.metrics.fast_api_metrics import (
     add_http_metrics_middleware,
@@ -90,6 +101,23 @@ DEFAULT_INGRESS_OPTIONS = {
     "autoscaling_config": {
         "target_ongoing_requests": DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
     },
+}
+
+_OPENAI_RESPONSE_MODELS = {
+    model.__name__: model
+    for model in (
+        ChatCompletionResponse,
+        ChatCompletionStreamResponse,
+        CompletionResponse,
+        CompletionStreamResponse,
+        DetokenizeResponse,
+        EmbeddingResponse,
+        ErrorResponse,
+        ScoreResponse,
+        TokenizeResponse,
+        TranscriptionResponse,
+        TranscriptionStreamResponse,
+    )
 }
 
 
@@ -399,9 +427,9 @@ class OpenAiIngress(DeploymentProtocol):
             raw_request_info = RawRequestInfo.from_starlette_request(raw_request)
 
         async for response in getattr(model_handle, call_method).remote(
-            body, raw_request_info
+            serialize_openai_model(body), raw_request_info
         ):
-            yield response
+            yield deserialize_openai_model(response, _OPENAI_RESPONSE_MODELS)
 
     async def model(self, model_id: str) -> Optional[ModelCard]:
         if model_id in self._model_cards:

--- a/python/ray/llm/_internal/serve/core/protocol.py
+++ b/python/ray/llm/_internal/serve/core/protocol.py
@@ -5,8 +5,10 @@ from typing import (
     AsyncGenerator,
     Dict,
     List,
+    Mapping,
     Optional,
     Protocol,
+    Type,
     Union,
 )
 
@@ -70,6 +72,40 @@ class RawRequestInfo:
         if raw_request_info is not None:
             return raw_request_info.to_starlette_request()
         return None
+
+
+@dataclass
+class OpenAIModelPayload:
+    """Dependency-free transport for an OpenAI-compatible Pydantic model."""
+
+    model_type: str
+    data: Dict[str, Any]
+
+
+def serialize_openai_model(value: Any) -> Any:
+    """Convert Pydantic models in a response or request to transport payloads."""
+    if isinstance(value, (list, tuple)):
+        return type(value)(serialize_openai_model(item) for item in value)
+    if hasattr(value, "model_dump"):
+        return OpenAIModelPayload(
+            model_type=type(value).__name__, data=value.model_dump()
+        )
+    return value
+
+
+def deserialize_openai_model(value: Any, model_types: Mapping[str, Type[Any]]) -> Any:
+    """Rebuild transported models using the models available on this node."""
+    if isinstance(value, (list, tuple)):
+        return type(value)(
+            deserialize_openai_model(item, model_types) for item in value
+        )
+    if not isinstance(value, OpenAIModelPayload):
+        return value
+
+    model_type = model_types.get(value.model_type)
+    if model_type is None:
+        raise ValueError(f"Unknown OpenAI model payload type: {value.model_type}")
+    return model_type.model_validate(value.data)
 
 
 class DeploymentProtocol(Protocol):

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -29,7 +29,13 @@ from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
 )
 from ray.llm._internal.serve.core.engine.protocol import LLMEngine
-from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
+from ray.llm._internal.serve.core.protocol import (
+    LLMServerProtocol,
+    OpenAIModelPayload,
+    RawRequestInfo,
+    deserialize_openai_model,
+    serialize_openai_model,
+)
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     push_telemetry_report_for_all_models,
@@ -63,6 +69,43 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 T = TypeVar("T")
+
+
+def _deserialize_openai_request(request: Any) -> Any:
+    from ray.llm._internal.serve.core.configs.openai_api_models import (
+        ChatCompletionRequest,
+        CompletionRequest,
+        DetokenizeRequest,
+        EmbeddingChatRequest,
+        EmbeddingCompletionRequest,
+        ScoreRequest,
+        TokenizeChatRequest,
+        TokenizeCompletionRequest,
+        TranscriptionRequest,
+    )
+
+    request_models = {
+        model.__name__: model
+        for model in (
+            ChatCompletionRequest,
+            CompletionRequest,
+            DetokenizeRequest,
+            EmbeddingChatRequest,
+            EmbeddingCompletionRequest,
+            ScoreRequest,
+            TokenizeChatRequest,
+            TokenizeCompletionRequest,
+            TranscriptionRequest,
+        )
+    }
+    return deserialize_openai_model(request, request_models)
+
+
+async def _serialize_openai_responses(
+    generator: AsyncGenerator[Any, None],
+) -> AsyncGenerator[Any, None]:
+    async for response in generator:
+        yield serialize_openai_model(response)
 
 
 def _merge_replica_actor_and_child_actor_bundles(
@@ -356,6 +399,8 @@ class LLMServer(LLMServerProtocol):
             An AsyncGenerator of the response. If stream is True and batching is enabled, then the generator will yield a list of streaming responses (strings of the format data: {response_json}\n\n). Otherwise, it will yield the non-streaming response from engine directly.
         """
 
+        use_transport = isinstance(request, OpenAIModelPayload)
+        request = _deserialize_openai_request(request)
         await self._maybe_add_request_id_to_request(request)
         await self._maybe_resolve_lora_from_multiplex()
 
@@ -367,6 +412,8 @@ class LLMServer(LLMServerProtocol):
         else:
             stream = engine_stream
 
+        if use_transport:
+            return _serialize_openai_responses(stream)
         return stream
 
     async def chat(

--- a/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
@@ -5,6 +5,7 @@ SGLang fallback tests live in the llm_serve_sglang_e2e release test.
 
 import importlib
 import sys
+from contextlib import contextmanager
 
 import pytest
 
@@ -27,6 +28,18 @@ class _VLLMImportBlocker:
         return None
 
 
+class _LLMEngineImportBlocker:
+    """Meta-path finder that simulates both LLM engines being absent."""
+
+    def find_spec(self, fullname, path=None, target=None):
+        for package in ("vllm", "sglang"):
+            if fullname == package or fullname.startswith(f"{package}."):
+                err = ModuleNotFoundError(f"Mocked: {fullname} is not installed")
+                err.name = package
+                raise err
+        return None
+
+
 class _VLLMBrokenInstallBlocker:
     """Meta-path finder that simulates vLLM installed but broken at runtime
     (e.g. missing libcudart.so or a missing transitive dependency).
@@ -43,6 +56,8 @@ class _VLLMBrokenInstallBlocker:
 
 class TestVLLMBackend:
     def test_wrapper_classes_inherit_from_vllm(self):
+        pytest.importorskip("vllm")
+
         from ray.llm._internal.serve.core.configs.openai_api_models import (
             ChatCompletionRequest,
             CompletionRequest,
@@ -93,11 +108,9 @@ class TestVLLMBackend:
             sys.modules.pop(_OAI_MODELS_MOD, None)
             sys.modules.update(saved)
 
-    def test_import_error_when_vllm_blocked(self):
-        """SGLang is not installed here either, so blocking vLLM means neither
-        backend is available."""
-        with pytest.raises(ImportError, match="Neither vLLM nor SGLang"):
-            self._reload_oai_models_with_blocker(_VLLMImportBlocker())
+    def test_fallback_when_vllm_blocked(self):
+        """The dependency-free fallback is used when neither engine exists."""
+        self._reload_oai_models_with_blocker(_VLLMImportBlocker())
 
     def test_vllm_installed_but_broken_cuda(self):
         """Plain ImportError (e.g. missing libcudart.so) → clear message that
@@ -117,6 +130,165 @@ class TestVLLMBackend:
         blocker = _VLLMBrokenInstallBlocker(dep_err)
         with pytest.raises(ImportError, match="vLLM is installed but failed to import"):
             self._reload_oai_models_with_blocker(blocker)
+
+
+class TestNoEngineBackend:
+    @contextmanager
+    def _load_without_engines(self):
+        saved = {
+            key: sys.modules.pop(key)
+            for key in list(sys.modules)
+            if key in {"vllm", "sglang"}
+            or key.startswith("vllm.")
+            or key.startswith("sglang.")
+        }
+        old_module = sys.modules.pop(_OAI_MODELS_MOD, None)
+        blocker = _LLMEngineImportBlocker()
+        sys.meta_path.insert(0, blocker)
+        try:
+            yield importlib.import_module(_OAI_MODELS_MOD)
+        finally:
+            sys.meta_path.remove(blocker)
+            sys.modules.pop(_OAI_MODELS_MOD, None)
+            if old_module is not None:
+                sys.modules[_OAI_MODELS_MOD] = old_module
+            sys.modules.update(saved)
+
+    def test_import_and_engine_independent_models(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        with self._load_without_engines() as models:
+            request = models.ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "hello"}],
+                stream=False,
+            )
+            assert request.model == "test-model"
+            assert request.model_dump()["messages"][0]["content"] == "hello"
+
+            error = models.ErrorResponse(
+                error=models.ErrorInfo(
+                    message="something broke", code=500, type="InternalError"
+                )
+            )
+            assert error.model_dump()["error"]["message"] == "something broke"
+
+            app = FastAPI()
+
+            @app.post("/v1/chat/completions")
+            async def chat(body: models.ChatCompletionRequest):
+                return body.model_dump()
+
+            response = TestClient(app).post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "temperature": 0.5,
+                },
+            )
+            assert response.status_code == 200
+            assert response.json()["temperature"] == 0.5
+
+            response = TestClient(app).post(
+                "/v1/chat/completions", json={"model": "test-model"}
+            )
+            assert response.status_code == 422
+
+    def test_transport_round_trip(self):
+        import pickle
+
+        from ray.llm._internal.serve.core.protocol import (
+            deserialize_openai_model,
+            serialize_openai_model,
+        )
+        from ray.llm._internal.serve.core.server.llm_server import (
+            _deserialize_openai_request,
+        )
+
+        with self._load_without_engines() as models:
+            request = models.CompletionRequest(
+                model="test-model", prompt="hello", stream=False
+            )
+            payload = pickle.loads(pickle.dumps(serialize_openai_model(request)))
+
+        restored = _deserialize_openai_request(payload)
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            CompletionRequest,
+        )
+
+        assert isinstance(restored, CompletionRequest)
+        assert restored.model_dump() == request.model_dump()
+
+        transported = serialize_openai_model((request, "stream chunk"))
+        restored = deserialize_openai_model(
+            transported, {"CompletionRequest": CompletionRequest}
+        )
+        assert isinstance(restored, tuple)
+        assert isinstance(restored[0], CompletionRequest)
+        assert restored[1] == "stream chunk"
+
+
+class TestIngressTransport:
+    def test_request_and_response_cross_dependency_boundary(self):
+        import asyncio
+
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            CompletionRequest,
+            ErrorInfo,
+            ErrorResponse,
+        )
+        from ray.llm._internal.serve.core.ingress.ingress import OpenAiIngress
+        from ray.llm._internal.serve.core.protocol import (
+            OpenAIModelPayload,
+            serialize_openai_model,
+        )
+
+        class _RemoteMethod:
+            request = None
+
+            def remote(self, request, raw_request_info):
+                self.request = request
+
+                async def generate():
+                    yield serialize_openai_model(
+                        ErrorResponse(
+                            error=ErrorInfo(
+                                message="something broke",
+                                code=500,
+                                type="InternalError",
+                            )
+                        )
+                    )
+
+                return generate()
+
+        class _Handle:
+            completions = _RemoteMethod()
+
+            def options(self, **kwargs):
+                return self
+
+        handle = _Handle()
+        ingress = OpenAiIngress({"test-model": handle}, {"test-model": object()})
+        request = CompletionRequest(model="test-model", prompt="hello")
+
+        async def collect():
+            return [
+                item
+                async for item in ingress._get_response(
+                    body=request, call_method="completions"
+                )
+            ]
+
+        responses = asyncio.run(collect())
+
+        assert isinstance(handle.completions.request, OpenAIModelPayload)
+        assert handle.completions.request.model_type == "CompletionRequest"
+        assert handle.completions.request.data["prompt"] == "hello"
+        assert isinstance(responses[0], ErrorResponse)
+        assert responses[0].error.message == "something broke"
 
 
 class TestSanitizeChatCompletionRequest:


### PR DESCRIPTION
## Description

Ray Serve's OpenAI model module currently fails to import unless vLLM or SGLang is installed. This prevents an OpenAI ingress deployment from running in a CPU-only environment separate from its engine workers.

When both engines are absent, this change uses dependency-free Pydantic models that retain the OpenAI payload. A small internal envelope carries model data across the ingress-to-LLMServer boundary, where it is rebuilt and validated against the engine-backed model. Installed-but-broken engine imports still surface their original error, and direct LLMServer callers keep their existing response types.

## Related issues

Fixes #64661

## Additional information

Tested in a CPU-only environment with neither vLLM nor SGLang installed:

- `test_openai_api_models_backends.py`: 13 passed, 1 vLLM-only test skipped
- `ray.serve.llm` imports without loading either engine
- Ruff, Black, pydoclint, import order, compileall, and focused pre-commit hooks pass

Full vLLM/SGLang integration coverage is delegated to Linux CI because those engine environments are not available in the local Windows setup.
