### PR TITLE
[Data] Migrate release compute configs to `enable_cross_zone_scaling`

### DIFF
--- a/release/nightly_tests/dataset/image_embedding_from_uris/autoscaling_cluster_compute.yaml
+++ b/release/nightly_tests/dataset/image_embedding_from_uris/autoscaling_cluster_compute.yaml
@@ -1,5 +1,7 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
+enable_cross_zone_scaling: true
+
 advanced_instance_config:
     IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
 
@@ -11,6 +13,3 @@ worker_nodes:
       min_nodes: 0
       max_nodes: 100
       market_type: ON_DEMAND
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/release/nightly_tests/dataset/image_embedding_from_uris/fixed_size_cluster_compute.yaml
+++ b/release/nightly_tests/dataset/image_embedding_from_uris/fixed_size_cluster_compute.yaml
@@ -1,5 +1,7 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
+enable_cross_zone_scaling: true
+
 advanced_instance_config:
     IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
 
@@ -11,6 +13,3 @@ worker_nodes:
       min_nodes: 100
       max_nodes: 100
       market_type: ON_DEMAND
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/release/nightly_tests/dataset/text_embedding/autoscaling_cluster_compute.yaml
+++ b/release/nightly_tests/dataset/text_embedding/autoscaling_cluster_compute.yaml
@@ -1,5 +1,7 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
+enable_cross_zone_scaling: true
+
 advanced_instance_config:
     IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
 
@@ -11,6 +13,3 @@ worker_nodes:
       min_nodes: 1
       max_nodes: 100
       market_type: ON_DEMAND
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/release/nightly_tests/dataset/text_embedding/fixed_size_cluster_compute.yaml
+++ b/release/nightly_tests/dataset/text_embedding/fixed_size_cluster_compute.yaml
@@ -1,5 +1,7 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
+enable_cross_zone_scaling: true
+
 advanced_instance_config:
     IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
 
@@ -11,6 +13,3 @@ worker_nodes:
       min_nodes: 100
       max_nodes: 100
       market_type: ON_DEMAND
-
-flags:
-  allow-cross-zone-autoscaling: true


### PR DESCRIPTION
`allow-cross-zone-autoscaling` was a field in our release test YAMLs that made Anyscale provision instances across availability zones. In https://github.com/ray-project/ray/pull/62863, Sai replaced `allow-cross-zone-autoscaling` with the newer `enable_cross_zone_scaling` field.

In this PR, I'm updating the remaining Data release tests to use the new flag.