### PR TITLE
[Data] Preserve schema columns in to_pandas() for empty datasets

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6803,9 +6803,9 @@ class Dataset:
         df = BlockAccessor.for_block(block).to_pandas()
 
         # An empty dataset yields no batches above, so the builder produces a
-        # DataFrame with no columns. Restore the columns (and dtypes, when the
-        # underlying schema is an Arrow schema) from the dataset schema so the
-        # result still matches the dataset's structure (issue #59946).
+        # DataFrame with no columns. Restore the columns and dtypes from the
+        # dataset schema so the result still matches the dataset's structure
+        # (issue #59946).
         if df.shape[1] == 0:
             import pyarrow as pa
 
@@ -6817,7 +6817,17 @@ class Dataset:
                 else:
                     import pandas
 
-                    df = pandas.DataFrame(columns=list(schema.names))
+                    # Pandas-backed schema: preserve per-column dtypes when known.
+                    types = getattr(base_schema, "types", None)
+                    if types is not None and len(types) == len(schema.names):
+                        df = pandas.DataFrame(
+                            {
+                                name: pandas.Series([], dtype=dtype)
+                                for name, dtype in zip(schema.names, types)
+                            }
+                        )
+                    else:
+                        df = pandas.DataFrame(columns=list(schema.names))
 
         return df
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6813,7 +6813,11 @@ class Dataset:
             if schema is not None and schema.names:
                 base_schema = getattr(schema, "base_schema", None)
                 if isinstance(base_schema, pa.Schema):
-                    df = base_schema.empty_table().to_pandas()
+                    # Route the empty Arrow table through the same
+                    # `BlockAccessor.to_pandas()` path used for non-empty blocks
+                    # so the two agree on column types (types_mapper, tensor
+                    # casting, etc.).
+                    df = BlockAccessor.for_block(base_schema.empty_table()).to_pandas()
                 else:
                     import pandas
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6800,7 +6800,26 @@ class Dataset:
         # `PandasBlockBuilder` creates a dataframe with internal extension types like
         # 'TensorDtype'. We use the `to_pandas` method to convert these extension
         # types to regular types.
-        return BlockAccessor.for_block(block).to_pandas()
+        df = BlockAccessor.for_block(block).to_pandas()
+
+        # An empty dataset yields no batches above, so the builder produces a
+        # DataFrame with no columns. Restore the columns (and dtypes, when the
+        # underlying schema is an Arrow schema) from the dataset schema so the
+        # result still matches the dataset's structure (issue #59946).
+        if df.shape[1] == 0:
+            import pyarrow as pa
+
+            schema = self.schema(fetch_if_missing=True)
+            if schema is not None and schema.names:
+                base_schema = getattr(schema, "base_schema", None)
+                if isinstance(base_schema, pa.Schema):
+                    df = base_schema.empty_table().to_pandas()
+                else:
+                    import pandas
+
+                    df = pandas.DataFrame(columns=list(schema.names))
+
+        return df
 
     @ConsumptionAPI(pattern="Time complexity:")
     @DeveloperAPI

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -360,8 +360,12 @@ def test_to_pandas_empty_dataset_preserves_columns(ray_start_regular_shared):
     df = ds.to_pandas()
     assert list(df.columns) == ["apples"]
     assert len(df) == 0
-    # Arrow-backed dtypes are preserved (int32 -> pandas int32).
-    assert df["apples"].dtype == np.int32
+    # The empty-dataset dtype must match what a non-empty dataset of the same
+    # schema produces (routed through the same BlockAccessor conversion).
+    nonempty = ray.data.from_arrow_refs(
+        [ray.put(pa.table([pa.array([1], pa.int32())], ["apples"]))]
+    ).to_pandas()
+    assert df["apples"].dtype == nonempty["apples"].dtype
 
     # Multiple columns are preserved too.
     ds2 = ray.data.from_arrow_refs(

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -360,6 +360,8 @@ def test_to_pandas_empty_dataset_preserves_columns(ray_start_regular_shared):
     df = ds.to_pandas()
     assert list(df.columns) == ["apples"]
     assert len(df) == 0
+    # Arrow-backed dtypes are preserved (int32 -> pandas int32).
+    assert df["apples"].dtype == np.int32
 
     # Multiple columns are preserved too.
     ds2 = ray.data.from_arrow_refs(
@@ -372,6 +374,16 @@ def test_to_pandas_empty_dataset_preserves_columns(ray_start_regular_shared):
         ]
     )
     assert list(ds2.to_pandas().columns) == ["a", "b"]
+
+    # Pandas-backed empty datasets preserve columns and dtypes too.
+    pandas_df = pd.DataFrame(
+        {"a": pd.Series([], dtype="int64"), "b": pd.Series([], dtype="float64")}
+    )
+    ds3 = ray.data.from_pandas(pandas_df)
+    df3 = ds3.to_pandas()
+    assert list(df3.columns) == ["a", "b"]
+    assert df3["a"].dtype == np.int64
+    assert df3["b"].dtype == np.float64
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -347,5 +347,32 @@ def test_arrow_block_to_pandas_preserves_arrow_types_through_roundtrip(
     assert roundtripped.to_pydict() == {"x": expected_values}
 
 
+def test_to_pandas_empty_dataset_preserves_columns(ray_start_regular_shared):
+    """`to_pandas()` on an empty dataset must keep the schema's columns.
+
+    Regression test for #59946: an empty Arrow table with columns was converted
+    to a column-less pandas DataFrame because `to_pandas()` builds only from the
+    (zero) batches of an empty dataset and ignored the known schema.
+    """
+    ds = ray.data.from_arrow_refs(
+        [ray.put(pa.table([pa.array([], pa.int32())], ["apples"]))]
+    )
+    df = ds.to_pandas()
+    assert list(df.columns) == ["apples"]
+    assert len(df) == 0
+
+    # Multiple columns are preserved too.
+    ds2 = ray.data.from_arrow_refs(
+        [
+            ray.put(
+                pa.table(
+                    [pa.array([], pa.int32()), pa.array([], pa.string())], ["a", "b"]
+                )
+            )
+        ]
+    )
+    assert list(ds2.to_pandas().columns) == ["a", "b"]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

`Dataset.to_pandas()` drops columns for an empty dataset:

```python
import pyarrow as pa, ray
empty_ref = ray.put(pa.table([pa.array([], pa.int32())], ["apples"]))
rd = ray.data.from_arrow_refs([empty_ref])
assert list(rd.to_pandas().columns) == ["apples"]  # fails: columns == []
```

`to_pandas()` builds the result by iterating `iter_batches`, which yields **no batches** for an empty dataset. `PandasBlockBuilder.build()` then produces a DataFrame with **zero columns**, even though the dataset's schema (`apples: int32`) is known.

The fix: when the built DataFrame has no columns, reconstruct the columns — and dtypes, when the underlying schema is an Arrow schema (via `base_schema.empty_table()`) — from the dataset schema.

## Verification

Built `master` from source and confirmed:
- Issue's repro: `["apples"]` (was `[]`).
- Empty multi-column table: `["a", "b"]` preserved.
- Non-empty datasets: unchanged (columns and row counts correct).

## Related issue number

Closes #59946

## Checks

- [x] I've signed off every commit (`git commit -s`) so that DCO passes.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
   - [x] Unit tests: added `test_to_pandas_empty_dataset_preserves_columns` in `test_arrow_block.py` (single- and multi-column empty tables). Fails on current master, passes with this fix.