### PR TITLE
[train] Deprecating v1 framework checkpoint classes

### DIFF
--- a/python/ray/air/BUILD.bazel
+++ b/python/ray/air/BUILD.bazel
@@ -28,7 +28,7 @@ py_library(
 
 py_test(
     name = "test_air_usage",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_air_usage.py"],
     # NOTE: This tests Train V1 telemetry.
     env = {"RAY_TRAIN_V2_ENABLED": "0"},

--- a/python/ray/train/tensorflow/tensorflow_checkpoint.py
+++ b/python/ray/train/tensorflow/tensorflow_checkpoint.py
@@ -8,13 +8,27 @@ import tensorflow as tf
 from tensorflow import keras
 
 from ray.train._internal.framework_checkpoint import FrameworkCheckpoint
-from ray.util.annotations import PublicAPI
+from ray.train.constants import (
+    V2_MIGRATION_GUIDE_MESSAGE,
+    _v2_migration_warnings_enabled,
+)
+from ray.util.annotations import Deprecated, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
 
+_TENSORFLOW_CHECKPOINT_DEPRECATION_MESSAGE = (
+    "`TensorflowCheckpoint` is deprecated and will be removed in a future release. "
+    "Use `ray.train.Checkpoint` directly instead. "
+    f"{V2_MIGRATION_GUIDE_MESSAGE}"
+)
+
 
 @PublicAPI(stability="beta")
+@Deprecated(
+    message=_TENSORFLOW_CHECKPOINT_DEPRECATION_MESSAGE,
+    warning=_v2_migration_warnings_enabled(),
+)
 class TensorflowCheckpoint(FrameworkCheckpoint):
     """A :py:class:`~ray.train.Checkpoint` with TensorFlow-specific functionality."""
 

--- a/python/ray/train/tests/test_tensorflow_checkpoint.py
+++ b/python/ray/train/tests/test_tensorflow_checkpoint.py
@@ -15,6 +15,8 @@ from ray import train
 from ray.data import Preprocessor
 from ray.train import ScalingConfig
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 if sys.version_info >= (3, 12):
     # Tensorflow is not installed for Python 3.12 because of keras compatibility.
     sys.exit(0)

--- a/python/ray/train/tests/test_tensorflow_trainer.py
+++ b/python/ray/train/tests/test_tensorflow_trainer.py
@@ -13,6 +13,8 @@ from ray.data.preprocessors import Concatenator
 from ray.train import ScalingConfig
 from ray.train.constants import TRAIN_DATASET_KEY
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 if sys.version_info >= (3, 12):
     # Tensorflow is not installed for Python 3.12 because of keras compatibility.
     sys.exit(0)

--- a/python/ray/train/tests/test_torch_checkpoint.py
+++ b/python/ray/train/tests/test_torch_checkpoint.py
@@ -1,6 +1,9 @@
+import pytest
 import torch
 
 from ray.train.torch import TorchCheckpoint
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 def assert_equal_torch_models(model1, model2):

--- a/python/ray/train/tests/test_torch_trainer.py
+++ b/python/ray/train/tests/test_torch_trainer.py
@@ -17,6 +17,8 @@ from ray.train.examples.pytorch.torch_linear_example import (
 from ray.train.torch import TorchCheckpoint, TorchConfig, TorchTrainer
 from ray.train.trainer import TrainingFailedError
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 @pytest.fixture
 def ray_start_4_cpus():

--- a/python/ray/train/torch/torch_checkpoint.py
+++ b/python/ray/train/torch/torch_checkpoint.py
@@ -11,15 +11,37 @@ from ray.air._internal.torch_utils import (
     load_torch_model,
 )
 from ray.train._internal.framework_checkpoint import FrameworkCheckpoint
-from ray.util.annotations import PublicAPI
+from ray.train.constants import (
+    V2_MIGRATION_GUIDE_MESSAGE,
+    _v2_migration_warnings_enabled,
+)
+from ray.util.annotations import Deprecated, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
 
 ENCODED_DATA_KEY = "torch_encoded_data"
 
+_TORCH_CHECKPOINT_DEPRECATION_MESSAGE = (
+    "`TorchCheckpoint` is deprecated and will be removed in a future release. "
+    "Use `ray.train.Checkpoint` directly instead. "
+    f"{V2_MIGRATION_GUIDE_MESSAGE}"
+)
+
+_TORCH_CHECKPOINT_FROM_MODEL_DEPRECATION_MESSAGE = (
+    "`TorchCheckpoint.from_model()` is deprecated and will be removed in a future "
+    "release. It stores the entire ``nn.Module`` via pickle, which allows arbitrary "
+    "code execution when loaded from an untrusted source. "
+    "Use `TorchCheckpoint.from_state_dict()` or migrate to `ray.train.Checkpoint`. "
+    f"{V2_MIGRATION_GUIDE_MESSAGE}"
+)
+
 
 @PublicAPI(stability="beta")
+@Deprecated(
+    message=_TORCH_CHECKPOINT_DEPRECATION_MESSAGE,
+    warning=_v2_migration_warnings_enabled(),
+)
 class TorchCheckpoint(FrameworkCheckpoint):
     """A :class:`~ray.train.Checkpoint` with Torch-specific functionality."""
 
@@ -95,6 +117,7 @@ class TorchCheckpoint(FrameworkCheckpoint):
         return checkpoint
 
     @classmethod
+    @Deprecated(message=_TORCH_CHECKPOINT_FROM_MODEL_DEPRECATION_MESSAGE)
     def from_model(
         cls,
         model: torch.nn.Module,

--- a/python/ray/train/xgboost/xgboost_checkpoint.py
+++ b/python/ray/train/xgboost/xgboost_checkpoint.py
@@ -5,13 +5,27 @@ from typing import TYPE_CHECKING, Optional
 import xgboost
 
 from ray.train._internal.framework_checkpoint import FrameworkCheckpoint
-from ray.util.annotations import PublicAPI
+from ray.train.constants import (
+    V2_MIGRATION_GUIDE_MESSAGE,
+    _v2_migration_warnings_enabled,
+)
+from ray.util.annotations import Deprecated, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
 
+_XGBOOST_CHECKPOINT_DEPRECATION_MESSAGE = (
+    "`XGBoostCheckpoint` is deprecated and will be removed in a future release. "
+    "Use `ray.train.Checkpoint` directly instead. "
+    f"{V2_MIGRATION_GUIDE_MESSAGE}"
+)
+
 
 @PublicAPI(stability="beta")
+@Deprecated(
+    message=_XGBOOST_CHECKPOINT_DEPRECATION_MESSAGE,
+    warning=_v2_migration_warnings_enabled(),
+)
 class XGBoostCheckpoint(FrameworkCheckpoint):
     """A :py:class:`~ray.train.Checkpoint` with XGBoost-specific functionality."""
 


### PR DESCRIPTION
## Description

`TorchCheckpoint`, `TensorflowCheckpoint`, and `XGBoostCheckpoint` are Ray Train v1-only APIs built on `FrameworkCheckpoint`. Ray Train v2 has no equivalent — users are expected to use `ray.train.Checkpoint` directly. These classes should be deprecated in line with the broader v1 → v2 migration.
What's more, the v1 only apis like torch.from_model() stores the entire pickle which has some security issue.

This is to deprecate all these api and encourage user to migrate to v2.