### PR TITLE
[serve.llm] Run the direct-streaming ingress router one per node

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -87,10 +87,10 @@ def _build_openai_ingress_request_router(
     The returned Application is attached to the ingress application with
     ``Application._with_ingress_request_router``.
 
-    ``num_replicas`` is pinned to 1 because HAProxy's ingress request router
-    backend currently expects a single endpoint. TODO(eicherseiji): expose
-    these as a user-overridable IngressRequestRouterConfig once HAProxy
-    supports multiple router replicas.
+    The router runs one replica per node (``num_replicas="per_node"``) so each
+    node's HAProxy calls its co-located router and the ``/internal/route`` hop
+    stays on-node. ``max_ongoing_requests`` is raised from the Serve default so
+    the on-path router does not throttle ingress.
 
     Pre-routing tokenization is wired on only when ``llm_config`` configures a
     KVAwareRouter, the sole policy that scores replicas on prompt token IDs.
@@ -99,7 +99,7 @@ def _build_openai_ingress_request_router(
 
     deployment = serve.deployment(
         LLMRouter,
-        num_replicas=1,
+        num_replicas="per_node",
         max_ongoing_requests=1000,
     )
     return deployment.bind(

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -416,6 +416,24 @@ class TestBuildOpenaiApp:
             f"{RoundRobinRouter.__module__}.{RoundRobinRouter.__name__}"
         )
 
+    def test_direct_streaming_router_runs_one_per_node(
+        self, llm_config, disable_placement_bundles, monkeypatch
+    ):
+        """The ingress request router runs one replica per node so each node's
+        HAProxy calls its co-located router."""
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+
+        app = build_openai_app(LLMServingArgs(llm_configs=[llm_config]))
+        router = app._ingress_request_router._bound_deployment
+
+        assert router._deployment_config.num_replicas_per_node is True
+        assert router._replica_config.max_replicas_per_node == 1
+        assert router._deployment_config.max_ongoing_requests == 1000
+
     def test_direct_streaming_user_request_router_config_wins(
         self, llm_config, disable_placement_bundles, monkeypatch
     ):

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1818,6 +1818,13 @@ def override_deployment_info(
 
             ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
 
+        elif options.get("num_replicas") == "per_node":
+            # One replica per node: the controller tracks the schedulable node
+            # count. Pin max_replicas_per_node to 1 to enforce the spread.
+            options["num_replicas"] = None
+            options["num_replicas_per_node"] = True
+            options["max_replicas_per_node"] = 1
+
         # What to pass to info.update
         override_options = {}
 

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -644,6 +644,37 @@ def handle_num_replicas_auto(
     return max_ongoing_requests, autoscaling_config
 
 
+def handle_num_replicas_per_node(
+    autoscaling_config,
+    gang_scheduling_config,
+    max_replicas_per_node,
+):
+    """Validate options for num_replicas="per_node" and return the pinned
+    max_replicas_per_node.
+
+    One replica per node is enforced by pinning max_replicas_per_node to 1.
+    The mode does not autoscale and does not support gang scheduling, so it is
+    rejected when combined with either.
+    """
+    if autoscaling_config not in [DEFAULT.VALUE, None]:
+        raise ValueError(
+            'num_replicas="per_node" is not allowed when autoscaling_config '
+            "is provided."
+        )
+    if gang_scheduling_config not in [DEFAULT.VALUE, None]:
+        raise ValueError(
+            'num_replicas="per_node" is not supported with gang_scheduling_config.'
+        )
+    if max_replicas_per_node in [DEFAULT.VALUE, None]:
+        return 1
+    if max_replicas_per_node != 1:
+        raise ValueError(
+            'num_replicas="per_node" runs one replica per node, so '
+            f"max_replicas_per_node must be unset or 1, got {max_replicas_per_node}."
+        )
+    return max_replicas_per_node
+
+
 class ReplicaConfig:
     """Internal datastructure wrapping config options for a deployment's replicas.
 

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -126,6 +126,9 @@ class DeploymentConfig(BaseModel):
     Args:
         num_replicas: The number of processes to start up that
             handles requests to this deployment. Defaults to 1.
+        num_replicas_per_node: When True, the controller keeps the target
+            replica count equal to the number of schedulable nodes, running
+            one replica per node. Set by num_replicas="per_node".
         max_ongoing_requests: The maximum number of queries
             that is sent to a replica of this deployment without receiving
             a response. Defaults to 5.
@@ -161,6 +164,9 @@ class DeploymentConfig(BaseModel):
 
     num_replicas: Optional[NonNegativeInt] = Field(
         default=1, update_type=DeploymentOptionUpdateType.LightWeight
+    )
+    num_replicas_per_node: bool = Field(
+        default=False, update_type=DeploymentOptionUpdateType.LightWeight
     )
     max_ongoing_requests: PositiveInt = Field(
         default=DEFAULT_MAX_ONGOING_REQUESTS,

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -406,6 +406,35 @@ class DeploymentScheduler(ABC):
         self._head_node_id = head_node_id
         self._create_placement_group_fn = create_placement_group_fn
 
+    def get_num_schedulable_nodes(self, deployment_id: DeploymentID) -> int:
+        """Number of active nodes that can host one replica of this deployment.
+
+        Used by num_replicas="per_node" to size the deployment to the nodes it
+        can actually be placed on. A node counts when its total resources fit
+        the replica's resource request, so a resource-less head node is
+        excluded while a single schedulable node still yields one replica.
+        Falls back to the active node count for a deployment whose resource
+        request the scheduler has not recorded yet (the first deploy, before
+        on_deployment_deployed).
+
+        Does not account for label selectors; a per-node deployment constrained
+        by node labels may over-count.
+        """
+        active_node_ids = self._cluster_node_info_cache.get_active_node_ids()
+        info = self._deployments.get(deployment_id)
+        if info is None or info.actor_resources is None:
+            return len(active_node_ids)
+
+        required = info.required_resources
+        total_resources = self._cluster_node_info_cache.get_total_resources_per_node()
+        return sum(
+            1
+            for node_id in active_node_ids
+            if AvailableNodeResources(total_resources.get(node_id, {})).can_fit(
+                required
+            )
+        )
+
     def on_deployment_created(
         self,
         deployment_id: DeploymentID,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3514,7 +3514,14 @@ class DeploymentState:
             f"{self._target_state.info.to_dict() if self._target_state.info is not None else None}"
         )
 
-        if deployment_info.deployment_config.autoscaling_config:
+        if deployment_info.deployment_config.num_replicas_per_node:
+            # One replica per node: seed the target with the current schedulable
+            # node count. reconcile_num_replicas_per_node keeps it in sync.
+            self._autoscaling_state_manager.deregister_deployment(self._id)
+            target_num_replicas = len(
+                self._cluster_node_info_cache.get_active_node_ids()
+            )
+        elif deployment_info.deployment_config.autoscaling_config:
             target_num_replicas = self._autoscaling_state_manager.register_deployment(
                 self._id, deployment_info, self._target_state.target_num_replicas
             )
@@ -3646,6 +3653,27 @@ class DeploymentState:
         """Set the target state for the deployment to the provided info."""
         self._set_target_state(
             self._target_state.info, target_num_replicas, updated_via_api=True
+        )
+
+    def reconcile_num_replicas_per_node(self, num_schedulable_nodes: int) -> None:
+        """Keep a num_replicas="per_node" deployment at one replica per node.
+
+        Sets the target replica count to the number of schedulable nodes,
+        recomputed each control loop as nodes join or leave. No-op for
+        deployments that don't use per-node mode or that are being deleted.
+        """
+        if self._target_state.deleting:
+            return
+        if not self._target_state.info.deployment_config.num_replicas_per_node:
+            return
+        if self._target_state.target_num_replicas == num_schedulable_nodes:
+            return
+
+        old_num = self._target_state.target_num_replicas
+        self._set_target_state(self._target_state.info, num_schedulable_nodes)
+        logger.info(
+            f"Adjusting {self._id} from {old_num} to {num_schedulable_nodes} "
+            "replicas to match the number of schedulable nodes."
         )
 
     def _stop_or_update_outdated_version_replicas(
@@ -5948,6 +5976,12 @@ class DeploymentStateManager:
 
         # STEP 3: Reserve gang placement groups
         gang_placement_groups = self._reserve_gang_placement_groups()
+
+        # STEP 3.5: Reconcile num_replicas="per_node" deployments to the
+        # current schedulable node count so they run one replica per node.
+        num_schedulable_nodes = len(self._cluster_node_info_cache.get_active_node_ids())
+        for deployment_state in self._deployment_states.values():
+            deployment_state.reconcile_num_replicas_per_node(num_schedulable_nodes)
 
         # STEP 4: Scale replicas
         for deployment_id, deployment_state in self._deployment_states.items():

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3518,8 +3518,8 @@ class DeploymentState:
             # One replica per node: seed the target with the current schedulable
             # node count. reconcile_num_replicas_per_node keeps it in sync.
             self._autoscaling_state_manager.deregister_deployment(self._id)
-            target_num_replicas = len(
-                self._cluster_node_info_cache.get_active_node_ids()
+            target_num_replicas = self._deployment_scheduler.get_num_schedulable_nodes(
+                self._id
             )
         elif deployment_info.deployment_config.autoscaling_config:
             target_num_replicas = self._autoscaling_state_manager.register_deployment(
@@ -3655,17 +3655,21 @@ class DeploymentState:
             self._target_state.info, target_num_replicas, updated_via_api=True
         )
 
-    def reconcile_num_replicas_per_node(self, num_schedulable_nodes: int) -> None:
+    def reconcile_num_replicas_per_node(self) -> None:
         """Keep a num_replicas="per_node" deployment at one replica per node.
 
-        Sets the target replica count to the number of schedulable nodes,
-        recomputed each control loop as nodes join or leave. No-op for
-        deployments that don't use per-node mode or that are being deleted.
+        Sets the target replica count to the number of nodes the replica can be
+        scheduled on, recomputed each control loop as nodes join or leave. No-op
+        for deployments that don't use per-node mode or that are being deleted.
         """
         if self._target_state.deleting:
             return
         if not self._target_state.info.deployment_config.num_replicas_per_node:
             return
+
+        num_schedulable_nodes = self._deployment_scheduler.get_num_schedulable_nodes(
+            self._id
+        )
         if self._target_state.target_num_replicas == num_schedulable_nodes:
             return
 
@@ -5977,11 +5981,10 @@ class DeploymentStateManager:
         # STEP 3: Reserve gang placement groups
         gang_placement_groups = self._reserve_gang_placement_groups()
 
-        # STEP 3.5: Reconcile num_replicas="per_node" deployments to the
-        # current schedulable node count so they run one replica per node.
-        num_schedulable_nodes = len(self._cluster_node_info_cache.get_active_node_ids())
+        # STEP 3.5: Reconcile num_replicas="per_node" deployments to the current
+        # count of nodes the replica can be scheduled on, one replica per node.
         for deployment_state in self._deployment_states.values():
-            deployment_state.reconcile_num_replicas_per_node(num_schedulable_nodes)
+            deployment_state.reconcile_num_replicas_per_node()
 
         # STEP 4: Scale replicas
         for deployment_id, deployment_state in self._deployment_states.items():

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -16,6 +16,7 @@ from ray.serve._private.config import (
     DeploymentConfig,
     ReplicaConfig,
     handle_num_replicas_auto,
+    handle_num_replicas_per_node,
 )
 from ray.serve._private.constants import (
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
@@ -662,24 +663,9 @@ def deployment(
 
         ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
     elif num_replicas_per_node:
-        if autoscaling_config not in [DEFAULT.VALUE, None]:
-            raise ValueError(
-                'num_replicas="per_node" is not allowed when autoscaling_config '
-                "is provided."
-            )
-        if gang_scheduling_config not in [DEFAULT.VALUE, None]:
-            raise ValueError(
-                'num_replicas="per_node" is not supported with gang_scheduling_config.'
-            )
-        # One replica per node is enforced by pinning max_replicas_per_node to 1.
-        if max_replicas_per_node in [DEFAULT.VALUE, None]:
-            max_replicas_per_node = 1
-        elif max_replicas_per_node != 1:
-            raise ValueError(
-                'num_replicas="per_node" runs one replica per node, so '
-                "max_replicas_per_node must be unset or 1, got "
-                f"{max_replicas_per_node}."
-            )
+        max_replicas_per_node = handle_num_replicas_per_node(
+            autoscaling_config, gang_scheduling_config, max_replicas_per_node
+        )
         num_replicas = None
 
     # NOTE: The user_configured_option_names should be the first thing that's

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -561,7 +561,9 @@ def deployment(
             If not provided, the name of the class or function is used.
         version: Removed. Specifying this argument raises a ValueError.
         num_replicas: Number of replicas to run that handle requests to
-            this deployment. Defaults to 1.
+            this deployment. Defaults to 1. Set to "auto" for a default
+            autoscaling configuration, or "per_node" to run exactly one
+            replica on every schedulable node (scales as nodes join or leave).
         ray_actor_options: Options to pass to the Ray Actor decorator, such as
             resource requirements. Valid options are: `accelerator_type`, `memory`,
             `num_cpus`, `num_gpus`, `resources`, `runtime_env`, and `label_selector`.
@@ -651,6 +653,7 @@ def deployment(
             "gang_scheduling_config is provided. Use "
             "gang_scheduling_config.gang_placement_strategy instead."
         )
+    num_replicas_per_node = num_replicas == "per_node"
     if num_replicas == "auto":
         num_replicas = None
         max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
@@ -658,6 +661,26 @@ def deployment(
         )
 
         ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
+    elif num_replicas_per_node:
+        if autoscaling_config not in [DEFAULT.VALUE, None]:
+            raise ValueError(
+                'num_replicas="per_node" is not allowed when autoscaling_config '
+                "is provided."
+            )
+        if gang_scheduling_config not in [DEFAULT.VALUE, None]:
+            raise ValueError(
+                'num_replicas="per_node" is not supported with gang_scheduling_config.'
+            )
+        # One replica per node is enforced by pinning max_replicas_per_node to 1.
+        if max_replicas_per_node in [DEFAULT.VALUE, None]:
+            max_replicas_per_node = 1
+        elif max_replicas_per_node != 1:
+            raise ValueError(
+                'num_replicas="per_node" runs one replica per node, so '
+                "max_replicas_per_node must be unset or 1, got "
+                f"{max_replicas_per_node}."
+            )
+        num_replicas = None
 
     # NOTE: The user_configured_option_names should be the first thing that's
     # defined in this function. It depends on the locals() dictionary storing
@@ -666,7 +689,8 @@ def deployment(
     user_configured_option_names = [
         option
         for option, value in locals().items()
-        if option != "_func_or_class" and value is not DEFAULT.VALUE
+        if option not in ("_func_or_class", "num_replicas_per_node")
+        and value is not DEFAULT.VALUE
     ]
 
     # Num of replicas should not be 0.
@@ -688,6 +712,7 @@ def deployment(
 
     deployment_config = DeploymentConfig.from_default(
         num_replicas=num_replicas if num_replicas is not None else 1,
+        num_replicas_per_node=num_replicas_per_node,
         user_config=user_config,
         max_ongoing_requests=max_ongoing_requests,
         max_queued_requests=max_queued_requests,

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -7,6 +7,7 @@ from ray.serve._private.config import (
     ReplicaConfig,
     RequestRouterConfig,
     handle_num_replicas_auto,
+    handle_num_replicas_per_node,
 )
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import DEFAULT, Default
@@ -270,33 +271,16 @@ class Deployment:
         if max_ongoing_requests is None:
             raise ValueError("`max_ongoing_requests` must be non-null, got None.")
 
-        num_replicas_per_node = num_replicas == "per_node"
         if num_replicas == "auto":
             max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
                 max_ongoing_requests, autoscaling_config
             )
 
             ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
-        elif num_replicas_per_node:
-            if autoscaling_config not in [DEFAULT.VALUE, None]:
-                raise ValueError(
-                    'num_replicas="per_node" is not allowed when autoscaling_config '
-                    "is provided."
-                )
-            if gang_scheduling_config not in [DEFAULT.VALUE, None]:
-                raise ValueError(
-                    'num_replicas="per_node" is not supported with '
-                    "gang_scheduling_config."
-                )
-            # One replica per node is enforced by pinning max_replicas_per_node to 1.
-            if max_replicas_per_node in [DEFAULT.VALUE, None]:
-                max_replicas_per_node = 1
-            elif max_replicas_per_node != 1:
-                raise ValueError(
-                    'num_replicas="per_node" runs one replica per node, so '
-                    "max_replicas_per_node must be unset or 1, got "
-                    f"{max_replicas_per_node}."
-                )
+        elif num_replicas == "per_node":
+            max_replicas_per_node = handle_num_replicas_per_node(
+                autoscaling_config, gang_scheduling_config, max_replicas_per_node
+            )
 
         # NOTE: The user_configured_option_names should be the first thing that's
         # defined in this method. It depends on the locals() dictionary storing
@@ -305,8 +289,7 @@ class Deployment:
         user_configured_option_names = [
             option
             for option, value in locals().items()
-            if option
-            not in {"self", "func_or_class", "_internal", "num_replicas_per_node"}
+            if option not in {"self", "func_or_class", "_internal"}
             and value is not DEFAULT.VALUE
         ]
 
@@ -332,7 +315,7 @@ class Deployment:
         if num_replicas == 0:
             raise ValueError("num_replicas is expected to larger than 0")
 
-        if num_replicas_per_node:
+        if num_replicas == "per_node":
             new_deployment_config.num_replicas_per_node = True
         elif num_replicas not in [DEFAULT.VALUE, None]:
             # An explicit int or "auto" clears per-node mode.

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -270,12 +270,33 @@ class Deployment:
         if max_ongoing_requests is None:
             raise ValueError("`max_ongoing_requests` must be non-null, got None.")
 
+        num_replicas_per_node = num_replicas == "per_node"
         if num_replicas == "auto":
             max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
                 max_ongoing_requests, autoscaling_config
             )
 
             ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
+        elif num_replicas_per_node:
+            if autoscaling_config not in [DEFAULT.VALUE, None]:
+                raise ValueError(
+                    'num_replicas="per_node" is not allowed when autoscaling_config '
+                    "is provided."
+                )
+            if gang_scheduling_config not in [DEFAULT.VALUE, None]:
+                raise ValueError(
+                    'num_replicas="per_node" is not supported with '
+                    "gang_scheduling_config."
+                )
+            # One replica per node is enforced by pinning max_replicas_per_node to 1.
+            if max_replicas_per_node in [DEFAULT.VALUE, None]:
+                max_replicas_per_node = 1
+            elif max_replicas_per_node != 1:
+                raise ValueError(
+                    'num_replicas="per_node" runs one replica per node, so '
+                    "max_replicas_per_node must be unset or 1, got "
+                    f"{max_replicas_per_node}."
+                )
 
         # NOTE: The user_configured_option_names should be the first thing that's
         # defined in this method. It depends on the locals() dictionary storing
@@ -284,7 +305,8 @@ class Deployment:
         user_configured_option_names = [
             option
             for option, value in locals().items()
-            if option not in {"self", "func_or_class", "_internal"}
+            if option
+            not in {"self", "func_or_class", "_internal", "num_replicas_per_node"}
             and value is not DEFAULT.VALUE
         ]
 
@@ -310,8 +332,13 @@ class Deployment:
         if num_replicas == 0:
             raise ValueError("num_replicas is expected to larger than 0")
 
-        if num_replicas not in [DEFAULT.VALUE, None, "auto"]:
-            new_deployment_config.num_replicas = num_replicas
+        if num_replicas_per_node:
+            new_deployment_config.num_replicas_per_node = True
+        elif num_replicas not in [DEFAULT.VALUE, None]:
+            # An explicit int or "auto" clears per-node mode.
+            new_deployment_config.num_replicas_per_node = False
+            if num_replicas != "auto":
+                new_deployment_config.num_replicas = num_replicas
 
         if user_config is not DEFAULT.VALUE:
             new_deployment_config.user_config = user_config

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -322,7 +322,8 @@ class DeploymentSchema(BaseModel):
         description=(
             "The number of processes that handle requests to this "
             "deployment. Uses a default if null. Can also be set to "
-            "`auto` for a default autoscaling configuration."
+            "`auto` for a default autoscaling configuration, or `per_node` "
+            "to run one replica on every schedulable node."
         ),
     )
     max_ongoing_requests: int = Field(
@@ -494,11 +495,20 @@ class DeploymentSchema(BaseModel):
                     "Manually setting num_replicas is not allowed "
                     "when autoscaling_config is provided."
                 )
+        # `num_replicas="per_node"` runs one replica per node and does not
+        # autoscale, so it cannot be paired with an autoscaling config
+        elif num_replicas == "per_node":
+            if autoscaling_config not in [None, DEFAULT.VALUE]:
+                raise ValueError(
+                    'num_replicas="per_node" is not allowed when '
+                    "autoscaling_config is provided."
+                )
         # A null `num_replicas` or `num_replicas="auto"` can be paired
         # with a non-null autoscaling_config
         elif num_replicas not in ["auto", None, DEFAULT.VALUE]:
             raise ValueError(
-                f'`num_replicas` must be an int or "auto", but got: {num_replicas}'
+                '`num_replicas` must be an int, "auto", or "per_node", but got: '
+                f"{num_replicas}"
             )
 
         return values
@@ -682,6 +692,8 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         schema.autoscaling_config = (
             info.deployment_config.autoscaling_config.model_dump()
         )
+    elif info.deployment_config.num_replicas_per_node:
+        schema.num_replicas = "per_node"
     else:
         schema.num_replicas = info.deployment_config.num_replicas
 

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -205,6 +205,43 @@ class TestDeploymentConfig:
         with pytest.raises(ValidationError):
             b.num_replicas = -1
 
+    def test_num_replicas_per_node(self):
+        """num_replicas="per_node" sets the flag and pins one replica per node."""
+        # Default is off, and it survives a proto round-trip.
+        assert DeploymentConfig().num_replicas_per_node is False
+        dc = DeploymentConfig(num_replicas_per_node=True)
+        roundtripped = DeploymentConfig.from_proto_bytes(dc.to_proto_bytes())
+        assert roundtripped.num_replicas_per_node is True
+
+        # The decorator translates the string and pins max_replicas_per_node=1.
+        @serve.deployment(num_replicas="per_node")
+        class D:
+            pass
+
+        assert D._deployment_config.num_replicas_per_node is True
+        assert D._replica_config.max_replicas_per_node == 1
+
+        # .options() can switch back to a fixed replica count.
+        fixed = D.options(num_replicas=2)
+        assert fixed._deployment_config.num_replicas_per_node is False
+        assert fixed._deployment_config.num_replicas == 2
+
+    def test_num_replicas_per_node_invalid_combinations(self):
+        with pytest.raises(ValueError, match="autoscaling_config"):
+
+            @serve.deployment(
+                num_replicas="per_node",
+                autoscaling_config={"min_replicas": 1, "max_replicas": 2},
+            )
+            class A:
+                pass
+
+        with pytest.raises(ValueError, match="max_replicas_per_node"):
+
+            @serve.deployment(num_replicas="per_node", max_replicas_per_node=2)
+            class B:
+                pass
+
     def test_from_default(self):
         """Check from_default() method behavior."""
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4389,6 +4389,45 @@ def test_get_active_node_ids_none(mock_deployment_state_manager):
     assert None not in dsm.get_active_node_ids()
 
 
+def test_num_replicas_per_node_tracks_node_count(mock_deployment_state_manager):
+    """A num_replicas="per_node" deployment targets one replica per schedulable node."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    # The fixture starts with a single node, so deploy seeds the target at 1.
+    dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas_per_node=True)[0])
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    assert ds.target_num_replicas == 1
+
+    # A node joins: the control loop bumps the target to match.
+    cluster_node_info_cache.add_node(NodeID.from_random().hex())
+    dsm.update()
+    assert ds.target_num_replicas == 2
+
+    # A node starts draining: it drops out of the schedulable set.
+    draining = next(iter(cluster_node_info_cache.alive_node_ids))
+    cluster_node_info_cache.draining_nodes = {draining: 1}
+    dsm.update()
+    assert ds.target_num_replicas == 1
+
+
+def test_num_replicas_per_node_only_affects_per_node_deployments(
+    mock_deployment_state_manager,
+):
+    """A fixed-num_replicas deployment ignores node-set changes."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas=2)[0])
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    dsm.update()
+    assert ds.target_num_replicas == 2
+
+    cluster_node_info_cache.add_node(NodeID.from_random().hex())
+    dsm.update()
+    assert ds.target_num_replicas == 2
+
+
 def test_get_deployment_ids(mock_deployment_state_manager):
     create_dsm, _, _, _ = mock_deployment_state_manager
     dsm = create_dsm()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4389,25 +4389,55 @@ def test_get_active_node_ids_none(mock_deployment_state_manager):
     assert None not in dsm.get_active_node_ids()
 
 
+def _add_node_with_cpu(cluster_node_info_cache, node_id: str, cpu: float) -> None:
+    cluster_node_info_cache.add_node(node_id, resources={"CPU": cpu})
+
+
 def test_num_replicas_per_node_tracks_node_count(mock_deployment_state_manager):
     """A num_replicas="per_node" deployment targets one replica per schedulable node."""
     create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
     dsm: DeploymentStateManager = create_dsm()
 
-    # The fixture starts with a single node, so deploy seeds the target at 1.
+    # Give the fixture's initial node capacity for the (1 CPU) replica.
+    node_1 = next(iter(cluster_node_info_cache.alive_node_ids))
+    cluster_node_info_cache.total_resources_per_node[node_1] = {"CPU": 4}
+
+    # One schedulable node at deploy time, so the target starts at 1.
     dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas_per_node=True)[0])
     ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    dsm.update()
     assert ds.target_num_replicas == 1
 
     # A node joins: the control loop bumps the target to match.
-    cluster_node_info_cache.add_node(NodeID.from_random().hex())
+    node_2 = NodeID.from_random().hex()
+    _add_node_with_cpu(cluster_node_info_cache, node_2, 4)
     dsm.update()
     assert ds.target_num_replicas == 2
 
     # A node starts draining: it drops out of the schedulable set.
-    draining = next(iter(cluster_node_info_cache.alive_node_ids))
-    cluster_node_info_cache.draining_nodes = {draining: 1}
+    cluster_node_info_cache.draining_nodes = {node_2: 1}
     dsm.update()
+    assert ds.target_num_replicas == 1
+
+
+def test_num_replicas_per_node_excludes_nodes_without_capacity(
+    mock_deployment_state_manager,
+):
+    """Nodes that can't fit the replica (e.g. a resource-less head) aren't counted."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    # Fixture's initial node has no CPU (like a head node with no task resources).
+    head = next(iter(cluster_node_info_cache.alive_node_ids))
+    cluster_node_info_cache.total_resources_per_node[head] = {"CPU": 0}
+    worker = NodeID.from_random().hex()
+    _add_node_with_cpu(cluster_node_info_cache, worker, 4)
+
+    dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas_per_node=True)[0])
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    dsm.update()
+
+    # Only the worker can host the 1-CPU replica; the 0-CPU node is excluded.
     assert ds.target_num_replicas == 1
 
 
@@ -4423,7 +4453,7 @@ def test_num_replicas_per_node_only_affects_per_node_deployments(
     dsm.update()
     assert ds.target_num_replicas == 2
 
-    cluster_node_info_cache.add_node(NodeID.from_random().hex())
+    _add_node_with_cpu(cluster_node_info_cache, NodeID.from_random().hex(), 4)
     dsm.update()
     assert ds.target_num_replicas == 2
 

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -362,6 +362,19 @@ class TestDeploymentSchema:
         with pytest.raises(ValueError):
             DeploymentSchema.model_validate(deployment_schema)
 
+    def test_num_replicas_per_node(self):
+        deployment_schema = self.get_minimal_deployment_schema()
+
+        deployment_schema["num_replicas"] = "per_node"
+        deployment_schema["autoscaling_config"] = None
+        DeploymentSchema.model_validate(deployment_schema)
+
+        # per_node cannot be combined with an autoscaling config.
+        deployment_schema["num_replicas"] = "per_node"
+        deployment_schema["autoscaling_config"] = {"max_replicas": 99}
+        with pytest.raises(ValueError):
+            DeploymentSchema.model_validate(deployment_schema)
+
     def test_extra_fields_invalid_deployment_schema(self):
         # Undefined fields should be forbidden in the schema
 

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -249,6 +249,11 @@ message DeploymentConfig {
   // rolling upgrade) is distinguishable from an explicit value. When unset,
   // the Python side falls back to DEFAULT_ROLLING_UPDATE_PERCENTAGE (0.2).
   optional double rolling_update_percentage = 23;
+
+  // When true (num_replicas="per_node"), the controller keeps the target
+  // replica count equal to the number of schedulable nodes, running one
+  // replica per node. Mutually exclusive with autoscaling_config.
+  bool num_replicas_per_node = 24;
 }
 
 // Deployment language.


### PR DESCRIPTION
## What

Runs the Serve LLM direct-streaming ingress request router one replica per node by setting it to `num_replicas="per_node"`.

```python
serve.deployment(LLMRouter, num_replicas="per_node", max_ongoing_requests=1000)
```

This replaces the previous single global router pinned at `num_replicas=1`. `max_replicas_per_node` is pinned to 1 automatically by the mode, and `max_ongoing_requests` stays raised above the Serve default so the on-path router does not throttle ingress.

## Why

The ingress request router was a single global replica. It was a throughput bottleneck for every node's ingress and a shared failure domain. Running one router per node scales routing capacity with ingress, keeps the `/internal/route` hop on-node so each node's HAProxy calls its co-located router, and isolates a router failure to its own node.

## Stacking

Stacked on #64724, which adds the `num_replicas="per_node"` deployment mode. This PR is the motivating consumer of that mode. Only the final commit, `[serve.llm] Run the direct-streaming ingress router one per node`, belongs to this PR. The earlier commits are #64724 and will drop out of the diff once it merges.

## Testing

`test_builder_ingress.py` asserts the built router deployment has `num_replicas_per_node` set, `max_replicas_per_node=1`, and the raised `max_ongoing_requests`.
