### PR TITLE
[ci] read pip-freeze via single-file image read, not full extraction

### DIFF
--- a/ci/ray_ci/automation/crane_lib.py
+++ b/ci/ray_ci/automation/crane_lib.py
@@ -10,7 +10,7 @@ import platform
 import subprocess
 import tarfile
 import tempfile
-from typing import List
+from typing import List, Optional
 
 import runfiles
 
@@ -114,6 +114,90 @@ def _extract_tar_to_dir(tar_path: str, output_dir: str) -> None:
                 logger.warning(f"Skipping path on different drive: {m.name}")
                 continue
             tf.extract(m, path=output_dir)
+
+
+def _strip_leading_dot_slash(name: str) -> str:
+    """Strip a single literal leading "./" from a tar member name.
+
+    Uses an explicit prefix check rather than str.lstrip("./"), which would
+    strip a *set* of leading '.'/'/' characters and conflate distinct names
+    (e.g. ".hidden" -> "hidden").
+    """
+    return name[2:] if name.startswith("./") else name
+
+
+def _read_member_from_tar(tar_path: str, path_in_image: str) -> Optional[bytes]:
+    """
+    Read the bytes of a single regular-file member from a tar, without
+    extracting the archive.
+
+    This deliberately avoids tarfile's hardlink/symlink resolution (which
+    `crane export` tars trigger for deduplicated files such as the identical
+    ``.dist-info/INSTALLER`` files, and which aborts a full extraction with a
+    ``KeyError: "linkname ... not found"``). Only the requested member is read,
+    and only if it is a regular file.
+
+    Args:
+        tar_path: Path to the tar file.
+        path_in_image: Member name to read (e.g. "home/ray/pip-freeze.txt",
+            with no leading slash -- matching crane export tar member names).
+
+    Returns:
+        The member's bytes, or None if it is absent or not a regular file.
+    """
+    normalized = _strip_leading_dot_slash(path_in_image)
+    with tarfile.open(tar_path, mode="r:*") as tf:
+        # Match on the normalized name so a "./"-prefixed archive is handled the
+        # same as a bare one, and let the last match win so the top image
+        # layer's copy takes precedence over any shadowed lower-layer entry.
+        member = None
+        for m in tf:
+            if _strip_leading_dot_slash(m.name) == normalized:
+                member = m
+        if member is None or not member.isfile():
+            return None
+        extracted = tf.extractfile(member)
+        if extracted is None:
+            return None
+        return extracted.read()
+
+
+def read_file_from_image(tag: str, path_in_image: str) -> Optional[bytes]:
+    """
+    Export a container image and read a single file from its filesystem.
+
+    Equivalent to ``crane export <tag>`` followed by reading one path out of
+    the resulting tar -- but without extracting the whole filesystem, so it is
+    immune to the hardlink-resolution failures that break a full extraction of
+    `crane export` tars (see _read_member_from_tar). No docker daemon required.
+
+    Args:
+        tag: Image reference to export.
+        path_in_image: File to read, as a tar member name with no leading slash
+            (e.g. "home/ray/pip-freeze.txt").
+
+    Returns:
+        The file's bytes, or None if the file is absent from the image.
+
+    Raises:
+        CraneError: If the crane export or the tar read fails.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tar_path = os.path.join(tmpdir, "image.tar")
+        crane_cmd = [_crane_binary(), "export", tag, tar_path]
+        logger.info(f"Running: {' '.join(crane_cmd)}")
+
+        try:
+            subprocess.check_call(crane_cmd, env=os.environ)
+        except subprocess.CalledProcessError as e:
+            raise CraneError(f"crane export failed (rc={e.returncode})")
+        except FileNotFoundError:
+            raise CraneError(f"Crane binary not found at {crane_cmd[0]}")
+
+        try:
+            return _read_member_from_tar(tar_path, path_in_image)
+        except Exception as e:
+            raise CraneError(f"reading {path_in_image} from image tar failed: {e}")
 
 
 def call_crane_copy(source: str, destination: str) -> None:

--- a/ci/ray_ci/automation/push_ray_image.py
+++ b/ci/ray_ci/automation/push_ray_image.py
@@ -1,14 +1,12 @@
 import logging
 import os
-import shutil
 import sys
-import tempfile
 from datetime import datetime
 from typing import List
 
 import click
 
-from ci.ray_ci.automation.crane_lib import CraneError, call_crane_export
+from ci.ray_ci.automation.crane_lib import CraneError, read_file_from_image
 from ci.ray_ci.automation.image_tags_lib import (
     ImageTagsError,
     copy_image,
@@ -219,8 +217,8 @@ def _export_pip_freeze(src_ref: str, ctx: RayImagePushContext) -> str:
     """
     Export the image's pip-freeze.txt and stage it as a Buildkite artifact.
 
-    Uses `crane export` (no docker daemon) to pull the image filesystem, reads
-    PIP_FREEZE_PATH_IN_IMAGE out of it, and copies it under
+    Reads PIP_FREEZE_PATH_IN_IMAGE straight out of the image via crane (no
+    docker daemon, no full-filesystem extraction) and writes it under
     ARTIFACT_MOUNT_IMAGE_INFO_DIR using ctx.pip_freeze_artifact_filename().
 
     Runs independently of whether images are pushed (dry_run), so the shipped
@@ -234,29 +232,37 @@ def _export_pip_freeze(src_ref: str, ctx: RayImagePushContext) -> str:
             export / filesystem staging fails (CraneError / OSError are wrapped,
             mirroring _copy_image's handling of ImageTagsError).
     """
+    logger.info(f"Exporting pip freeze from {src_ref}")
     try:
-        with tempfile.TemporaryDirectory() as export_dir:
-            logger.info(f"Exporting pip freeze from {src_ref}")
-            call_crane_export(src_ref, export_dir)
-
-            freeze_src = os.path.join(export_dir, PIP_FREEZE_PATH_IN_IMAGE)
-            if not os.path.exists(freeze_src):
-                raise PushRayImageError(
-                    f"pip-freeze.txt not found in image {src_ref} "
-                    f"at /{PIP_FREEZE_PATH_IN_IMAGE}"
-                )
-
-            os.makedirs(ARTIFACT_MOUNT_IMAGE_INFO_DIR, exist_ok=True)
-            dest = os.path.join(
-                ARTIFACT_MOUNT_IMAGE_INFO_DIR, ctx.pip_freeze_artifact_filename()
-            )
-            shutil.copyfile(freeze_src, dest)
-            logger.info(f"Staged pip freeze Buildkite artifact at {dest}")
-            return dest
+        content = read_file_from_image(src_ref, PIP_FREEZE_PATH_IN_IMAGE)
     except (CraneError, OSError) as e:
+        # OSError covers e.g. a non-executable crane binary (PermissionError)
+        # or a full disk while exporting (TemporaryDirectory); wrap it like the
+        # staging step below, per this function's contract.
         raise PushRayImageError(
             f"Failed to export pip-freeze from {src_ref}: {e}"
         ) from e
+
+    if content is None:
+        raise PushRayImageError(
+            f"pip-freeze.txt not found in image {src_ref} "
+            f"at /{PIP_FREEZE_PATH_IN_IMAGE}"
+        )
+
+    try:
+        os.makedirs(ARTIFACT_MOUNT_IMAGE_INFO_DIR, exist_ok=True)
+        dest = os.path.join(
+            ARTIFACT_MOUNT_IMAGE_INFO_DIR, ctx.pip_freeze_artifact_filename()
+        )
+        with open(dest, "wb") as f:
+            f.write(content)
+    except OSError as e:
+        raise PushRayImageError(
+            f"Failed to stage pip-freeze from {src_ref}: {e}"
+        ) from e
+
+    logger.info(f"Staged pip freeze Buildkite artifact at {dest}")
+    return dest
 
 
 def _should_upload(pipeline_id: str, branch: str, rayci_schedule: str) -> bool:

--- a/ci/ray_ci/automation/test_crane_lib.py
+++ b/ci/ray_ci/automation/test_crane_lib.py
@@ -10,10 +10,12 @@ import requests
 from ci.ray_ci.automation.crane_lib import (
     CraneError,
     _crane_binary,
+    _read_member_from_tar,
     call_crane_copy,
     call_crane_export,
     call_crane_index,
     call_crane_manifest,
+    read_file_from_image,
 )
 from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401, F811
 
@@ -151,6 +153,129 @@ class TestCraneExportIntegration:
             assert os.path.lexists(
                 os.path.join(out_dir, "bin", "sh")
             ) or os.path.lexists(os.path.join(out_dir, "bin", "ash"))
+
+
+class TestReadFileFromImage:
+    """Tests for reading a single file out of an image tar."""
+
+    def _write_tar_with_hardlink(self, tar_path, freeze_content=b"ray==2.56.0\n"):
+        """
+        Build a tar shaped like a `crane export` archive: the pip-freeze file
+        plus a pair of identical files deduplicated into a hardlink. A full
+        tarfile extraction of this trips the "linkname ... not found" failure
+        we saw on CI; reading a single member must not.
+        """
+        import io
+        import tarfile
+
+        with tarfile.open(tar_path, mode="w") as tf:
+            # Canonical regular file that the hardlink target points at, but
+            # placed AFTER the hardlink so streaming link resolution fails.
+            link_name = "home/ray/anaconda3/pkg_b/INSTALLER"
+            link_target = "home/ray/anaconda3/pkg_a/INSTALLER"
+
+            hardlink = tarfile.TarInfo(link_name)
+            hardlink.type = tarfile.LNKTYPE
+            hardlink.linkname = link_target
+            tf.addfile(hardlink)
+
+            freeze = tarfile.TarInfo("home/ray/pip-freeze.txt")
+            freeze.size = len(freeze_content)
+            tf.addfile(freeze, io.BytesIO(freeze_content))
+
+            installer = b"pip\n"
+            target = tarfile.TarInfo(link_target)
+            target.size = len(installer)
+            tf.addfile(target, io.BytesIO(installer))
+
+    def test_read_member_survives_unextractable_hardlinks(self):
+        from ci.ray_ci.automation.crane_lib import _extract_tar_to_dir
+
+        freeze = b"ray==2.56.0\nnumpy==1.26.4\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tar_path = os.path.join(tmpdir, "image.tar")
+            self._write_tar_with_hardlink(tar_path, freeze)
+
+            # Sanity check: a full extraction of this tar reproduces the CI
+            # failure (the whole reason for reading a single member instead).
+            with pytest.raises(Exception, match="linkname"):
+                _extract_tar_to_dir(tar_path, os.path.join(tmpdir, "full"))
+
+            content = _read_member_from_tar(tar_path, "home/ray/pip-freeze.txt")
+            assert content == freeze
+
+    def test_read_member_absent_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tar_path = os.path.join(tmpdir, "image.tar")
+            self._write_tar_with_hardlink(tar_path)
+
+            assert _read_member_from_tar(tar_path, "home/ray/missing.txt") is None
+
+    def _write_tar_with_files(self, tar_path, files):
+        """Write a tar with the given {member_name: bytes} contents."""
+        import io
+        import tarfile
+
+        with tarfile.open(tar_path, mode="w") as tf:
+            for name, content in files.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(content)
+                tf.addfile(info, io.BytesIO(content))
+
+    def test_read_member_matches_dot_slash_prefixed_name(self):
+        # crane/tar archives sometimes store members as "./path"; a request for
+        # "path" must still find it via the normalization fallback.
+        want = b"ray==2.56.0\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tar_path = os.path.join(tmpdir, "image.tar")
+            self._write_tar_with_files(tar_path, {"./home/ray/pip-freeze.txt": want})
+
+            assert _read_member_from_tar(tar_path, "home/ray/pip-freeze.txt") == want
+
+    def test_read_member_does_not_conflate_leading_dot_names(self):
+        # ".home/ray/x" and "home/ray/x" are DISTINCT members; the old
+        # lstrip("./") normalization wrongly collapsed them. Requesting the
+        # dotless name must not return the leading-dot member's bytes.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tar_path = os.path.join(tmpdir, "image.tar")
+            self._write_tar_with_files(
+                tar_path, {".home/ray/x": b"dot-file-contents\n"}
+            )
+
+            assert _read_member_from_tar(tar_path, "home/ray/x") is None
+
+    @mock.patch("ci.ray_ci.automation.crane_lib.subprocess.check_call")
+    @mock.patch("ci.ray_ci.automation.crane_lib._crane_binary")
+    def test_read_file_from_image_exports_then_reads(self, mock_bin, mock_check_call):
+        mock_bin.return_value = "/usr/bin/crane"
+        freeze = b"ray==2.56.0\n"
+
+        # Stand in for `crane export <tag> <tar_path>` by writing the tar the
+        # command's 4th arg points at.
+        def fake_export(cmd, env=None):
+            self._write_tar_with_hardlink(cmd[3], freeze)
+
+        mock_check_call.side_effect = fake_export
+
+        content = read_file_from_image("some-repo:tag", "home/ray/pip-freeze.txt")
+        assert content == freeze
+        assert mock_check_call.call_count == 1
+        assert mock_check_call.call_args[0][0][:3] == [
+            "/usr/bin/crane",
+            "export",
+            "some-repo:tag",
+        ]
+
+    @mock.patch("ci.ray_ci.automation.crane_lib.subprocess.check_call")
+    @mock.patch("ci.ray_ci.automation.crane_lib._crane_binary")
+    def test_read_file_from_image_wraps_export_failure(self, mock_bin, mock_check_call):
+        import subprocess
+
+        mock_bin.return_value = "/usr/bin/crane"
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, "crane")
+
+        with pytest.raises(CraneError, match="crane export failed"):
+            read_file_from_image("some-repo:tag", "home/ray/pip-freeze.txt")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -657,20 +657,14 @@ class TestPipFreezeArtifact:
             == "ray-extra:2.56.0.d7951f-extra-py311-cpu-aarch64_pip-freeze.txt"
         )
 
-    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_export")
-    def test_export_pip_freeze_writes_artifact(self, mock_export, tmp_path):
-        import os
+    @mock.patch("ci.ray_ci.automation.push_ray_image.read_file_from_image")
+    def test_export_pip_freeze_writes_artifact(self, mock_read, tmp_path):
+        from ci.ray_ci.automation.push_ray_image import (
+            PIP_FREEZE_PATH_IN_IMAGE,
+            _export_pip_freeze,
+        )
 
-        from ci.ray_ci.automation.push_ray_image import _export_pip_freeze
-
-        # Simulate crane export laying down the image filesystem.
-        def fake_export(src_ref, export_dir):
-            freeze = os.path.join(export_dir, "home", "ray", "pip-freeze.txt")
-            os.makedirs(os.path.dirname(freeze), exist_ok=True)
-            with open(freeze, "w") as f:
-                f.write("ray==2.56.0\nnumpy==1.26.4\n")
-
-        mock_export.side_effect = fake_export
+        mock_read.return_value = b"ray==2.56.0\nnumpy==1.26.4\n"
 
         artifact_dir = tmp_path / "image-info"
         with mock.patch(
@@ -690,19 +684,19 @@ class TestPipFreezeArtifact:
         expected = artifact_dir / "ray:2.56.0.d7951f-py310-cpu_pip-freeze.txt"
         assert dest == str(expected)
         assert expected.read_text() == "ray==2.56.0\nnumpy==1.26.4\n"
-        mock_export.assert_called_once_with(
-            "work-repo:build123-ray-py3.10-cpu", mock.ANY
+        mock_read.assert_called_once_with(
+            "work-repo:build123-ray-py3.10-cpu", PIP_FREEZE_PATH_IN_IMAGE
         )
 
-    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_export")
-    def test_export_pip_freeze_missing_file_raises(self, mock_export, tmp_path):
+    @mock.patch("ci.ray_ci.automation.push_ray_image.read_file_from_image")
+    def test_export_pip_freeze_missing_file_raises(self, mock_read, tmp_path):
         from ci.ray_ci.automation.push_ray_image import (
             PushRayImageError,
             _export_pip_freeze,
         )
 
-        # crane export "succeeds" but produces no pip-freeze.txt.
-        mock_export.side_effect = lambda src_ref, export_dir: None
+        # crane export "succeeds" but the image has no pip-freeze.txt.
+        mock_read.return_value = None
 
         with mock.patch(
             "ci.ray_ci.automation.push_ray_image.ARTIFACT_MOUNT_IMAGE_INFO_DIR",
@@ -712,8 +706,8 @@ class TestPipFreezeArtifact:
             with pytest.raises(PushRayImageError, match="pip-freeze.txt not found"):
                 _export_pip_freeze("work-repo:tag", ctx)
 
-    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_export")
-    def test_export_pip_freeze_wraps_crane_error(self, mock_export, tmp_path):
+    @mock.patch("ci.ray_ci.automation.push_ray_image.read_file_from_image")
+    def test_export_pip_freeze_wraps_crane_error(self, mock_read, tmp_path):
         from ci.ray_ci.automation.crane_lib import CraneError
         from ci.ray_ci.automation.push_ray_image import (
             PushRayImageError,
@@ -722,7 +716,28 @@ class TestPipFreezeArtifact:
 
         # crane export itself fails -> wrapped as PushRayImageError (mirrors how
         # _copy_image wraps ImageTagsError), not propagated as a raw CraneError.
-        mock_export.side_effect = CraneError("crane export failed (rc=1)")
+        mock_read.side_effect = CraneError("crane export failed (rc=1)")
+
+        with mock.patch(
+            "ci.ray_ci.automation.push_ray_image.ARTIFACT_MOUNT_IMAGE_INFO_DIR",
+            str(tmp_path / "image-info"),
+        ):
+            ctx = make_ctx(platform="cpu", branch="releases/2.56.0")
+            with pytest.raises(PushRayImageError, match="Failed to export pip-freeze"):
+                _export_pip_freeze("work-repo:tag", ctx)
+
+    @mock.patch("ci.ray_ci.automation.push_ray_image.read_file_from_image")
+    def test_export_pip_freeze_wraps_os_error(self, mock_read, tmp_path):
+        from ci.ray_ci.automation.push_ray_image import (
+            PushRayImageError,
+            _export_pip_freeze,
+        )
+
+        # An OSError from the export/read path (e.g. non-executable crane binary
+        # -> PermissionError, or a full disk -> TemporaryDirectory) must be
+        # wrapped as PushRayImageError, not escape raw. Guards the docstring's
+        # "CraneError / OSError are wrapped" contract.
+        mock_read.side_effect = PermissionError("crane: permission denied")
 
         with mock.patch(
             "ci.ray_ci.automation.push_ray_image.ARTIFACT_MOUNT_IMAGE_INFO_DIR",


### PR DESCRIPTION
## Description
The postmerge `:crane: publish` step's pip-freeze export (added in #64455) crashed at runtime with `KeyError: "linkname ... not found"`. Root cause: `crane_lib.call_crane_export` extracts the **entire** image filesystem, and Python's `tarfile` aborts when it hits the hardlinked, deduplicated `.dist-info/INSTALLER` files that `crane export` tars contain. The failure was non-fatal (the export is best-effort, so publishing still succeeded), but the pip-freeze artifact was never produced — observed on postmerge build 18526.

This change stops extracting the whole filesystem and instead reads just the one file we need straight out of the image tar, which is immune to the hardlink-resolution problem by construction.

## Related issues
None.

## Additional information
**Implementation**
- New `crane_lib.read_file_from_image(tag, path)` + `_read_member_from_tar(tar_path, path)`: export the image, then read a single **regular-file** member via `tarfile.extractfile` — no hardlink/symlink resolution, no multi-hundred-MB filesystem write.
- `push_ray_image._export_pip_freeze` now calls `read_file_from_image` and writes the bytes to the artifact path. Error handling is unchanged in spirit: `(CraneError, OSError)` are wrapped as `PushRayImageError`, and the call site remains best-effort so a failure here can never break image publishing.
- `_strip_leading_dot_slash` normalizes a literal leading `"./"` for the member-name fallback (avoids the `str.lstrip` char-set pitfall).

**Testing** (`bazel test //ci/ray_ci/automation:test_crane_lib //ci/ray_ci/automation:test_push_ray_image`)
- A crafted-tar regression test asserts a **full** extraction still trips `linkname ... not found` (proving it models the CI failure) while the single-member read returns the file.
- Plus: absent-file → `None`, `./`-prefixed member match, no conflation of leading-dot names, export-failure (`CraneError`/`OSError`) wrapping, and the updated `_export_pip_freeze` read path.