### PR TITLE
[core] Prioritize dead-worker eviction by exit type

### DIFF
--- a/src/ray/gcs/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_worker_manager.cc
@@ -348,8 +348,6 @@ void GcsWorkerManager::GetWorkerInfo(
 }
 
 void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_data) {
-  // Bucket dead workers by retention priority tier, each carrying its death time so we
-  // can seed the tiers in death order.
   std::array<std::vector<std::pair<uint64_t, WorkerID>>, kNumDeadWorkerTiers>
       dead_workers_bucket;
   for (const auto &[worker_id, data] : gcs_init_data.Workers()) {
@@ -360,7 +358,6 @@ void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_dat
           worker_id);
     }
   }
-  // Seed each tier oldest-first (by death time).
   for (size_t tier = 0; tier < kNumDeadWorkerTiers; ++tier) {
     std::sort(
         dead_workers_bucket[tier].begin(),
@@ -370,7 +367,6 @@ void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_dat
       dead_workers_by_tier_[tier].push_back(entry.second);
     }
   }
-  // Trim to the cap, draining the lowest-priority tiers first, in one batch delete.
   const size_t cap = RayConfig::instance().maximum_gcs_dead_worker_cached_count();
   const size_t total = TotalDeadWorkers();
   size_t overflow = total > cap ? total - cap : 0;

--- a/src/ray/gcs/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_worker_manager.cc
@@ -369,6 +369,10 @@ void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_dat
   }
   const size_t cap = RayConfig::instance().maximum_gcs_dead_worker_cached_count();
   const size_t total = TotalDeadWorkers();
+  // Steady-state trimming keeps the table at or below the cap, so `overflow` is
+  // normally 0 here. It can be positive only when the persisted (Redis FT) table
+  // was bounded to a larger cap than the current one — i.e. the operator lowered
+  // maximum_gcs_dead_worker_cached_count across a restart.
   size_t overflow = total > cap ? total - cap : 0;
   std::vector<WorkerID> to_evict;
   to_evict.reserve(overflow);

--- a/src/ray/gcs/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_worker_manager.cc
@@ -14,6 +14,7 @@
 
 #include "ray/gcs/gcs_worker_manager.h"
 
+#include <array>
 #include <limits>
 #include <memory>
 #include <string>
@@ -29,6 +30,11 @@ namespace {
 bool IsIntentionalWorkerFailure(rpc::WorkerExitType exit_type) {
   return exit_type == rpc::WorkerExitType::INTENDED_USER_EXIT ||
          exit_type == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT;
+}
+
+// Retention priority tier for a dead worker (lower index = evicted first)
+size_t DeadWorkerTier(rpc::WorkerExitType exit_type) {
+  return IsIntentionalWorkerFailure(exit_type) ? 0 : 1;
 }
 }  // namespace
 
@@ -103,7 +109,7 @@ void GcsWorkerManager::HandleReportWorkerFailure(
              worker_failure.set_node_id(worker_failure_data->worker_address().node_id());
              gcs_publisher_.PublishWorkerFailure(worker_id, std::move(worker_failure));
              if (!is_duplicate_death_report) {
-               TrimDeadWorkers(worker_id);
+               TrimDeadWorkers(worker_id, worker_failure_data->exit_type());
              }
            }
            GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
@@ -342,50 +348,66 @@ void GcsWorkerManager::GetWorkerInfo(
 }
 
 void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_data) {
-  std::vector<std::pair<WorkerID, uint64_t>> dead;
-  dead.reserve(gcs_init_data.Workers().size());
+  // Bucket dead workers by retention priority tier, each carrying its death time so we
+  // can seed the tiers in death order.
+  std::array<std::vector<std::pair<uint64_t, WorkerID>>, kNumDeadWorkerTiers>
+      dead_workers_bucket;
   for (const auto &[worker_id, data] : gcs_init_data.Workers()) {
     if (!data.is_alive()) {
-      dead.emplace_back(worker_id,
-                        data.end_time_ms() != 0
-                            ? data.end_time_ms()
-                            : static_cast<uint64_t>(data.timestamp() * 1000));
+      dead_workers_bucket[DeadWorkerTier(data.exit_type())].emplace_back(
+          data.end_time_ms() != 0 ? data.end_time_ms()
+                                  : static_cast<uint64_t>(data.timestamp() * 1000),
+          worker_id);
     }
   }
-  std::sort(dead.begin(), dead.end(), [](const auto &left, const auto &right) {
-    return left.second < right.second;
-  });
-  const size_t cap = RayConfig::instance().maximum_gcs_dead_worker_cached_count();
-  const size_t overflow = dead.size() > cap ? dead.size() - cap : 0;
-  // Drop the oldest rows beyond the cap from the table in one batch.
-  if (overflow > 0) {
-    std::vector<WorkerID> to_evict;
-    to_evict.reserve(overflow);
-    for (size_t i = 0; i < overflow; ++i) {
-      to_evict.push_back(dead[i].first);
+  // Seed each tier oldest-first (by death time).
+  for (size_t tier = 0; tier < kNumDeadWorkerTiers; ++tier) {
+    std::sort(
+        dead_workers_bucket[tier].begin(),
+        dead_workers_bucket[tier].end(),
+        [](const auto &left, const auto &right) { return left.first < right.first; });
+    for (const auto &entry : dead_workers_bucket[tier]) {
+      dead_workers_by_tier_[tier].push_back(entry.second);
     }
+  }
+  // Trim to the cap, draining the lowest-priority tiers first, in one batch delete.
+  const size_t cap = RayConfig::instance().maximum_gcs_dead_worker_cached_count();
+  const size_t total = TotalDeadWorkers();
+  size_t overflow = total > cap ? total - cap : 0;
+  std::vector<WorkerID> to_evict;
+  to_evict.reserve(overflow);
+  for (auto &tier : dead_workers_by_tier_) {
+    while (overflow > 0 && !tier.empty()) {
+      to_evict.push_back(tier.front());
+      tier.pop_front();
+      --overflow;
+    }
+    if (overflow == 0) {
+      break;
+    }
+  }
+  if (!to_evict.empty()) {
     gcs_table_storage_.WorkerTable().BatchDelete(to_evict,
                                                  {[](const auto &) {}, io_context_});
   }
-  // Seed the queue with the retained (newest `cap`) ids, oldest first.
-  for (size_t i = overflow; i < dead.size(); ++i) {
-    dead_worker_ids_queue_.push_back(dead[i].first);
-  }
 }
 
-void GcsWorkerManager::TrimDeadWorkers(const WorkerID &worker_id) {
-  const size_t cap = RayConfig::instance().maximum_gcs_dead_worker_cached_count();
-  if (cap == 0) {
-    gcs_table_storage_.WorkerTable().Delete(worker_id,
-                                            {[](const auto &) {}, io_context_});
+void GcsWorkerManager::TrimDeadWorkers(const WorkerID &worker_id,
+                                       rpc::WorkerExitType exit_type) {
+  dead_workers_by_tier_[DeadWorkerTier(exit_type)].push_back(worker_id);
+  if (TotalDeadWorkers() <=
+      RayConfig::instance().maximum_gcs_dead_worker_cached_count()) {
     return;
   }
-  if (dead_worker_ids_queue_.size() >= cap) {
-    const WorkerID evict_id = dead_worker_ids_queue_.front();
-    dead_worker_ids_queue_.pop_front();
-    gcs_table_storage_.WorkerTable().Delete(evict_id, {[](const auto &) {}, io_context_});
+  for (auto &tier : dead_workers_by_tier_) {
+    if (!tier.empty()) {
+      const WorkerID evict_id = tier.front();
+      tier.pop_front();
+      gcs_table_storage_.WorkerTable().Delete(evict_id,
+                                              {[](const auto &) {}, io_context_});
+      break;
+    }
   }
-  dead_worker_ids_queue_.push_back(worker_id);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_worker_manager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <array>
 #include <deque>
 #include <vector>
 
@@ -70,6 +71,7 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
   void SetUsageStatsClient(UsageStatsClient *usage_stats_client) {
     usage_stats_client_ = usage_stats_client;
   }
+
   /**
    * @brief Rebuilds the dead-worker id queue from the worker table on GCS startup and
    * trims it to the retention cap.
@@ -84,12 +86,13 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
                      Postable<void(std::optional<rpc::WorkerTableData>)> callback) const;
 
   /**
-   * @brief Records a newly dead worker and evicts the oldest one when the retention cap
-   * is exceeded.
+   * @brief Records a newly dead worker in its priority tier and, when the retention cap
+   * is exceeded, evicts the oldest worker from the lowest-priority tier first
    *
    * @param worker_id The id of the worker that just died.
+   * @param exit_type How the worker exited; determines its retention priority tier.
    */
-  void TrimDeadWorkers(const WorkerID &worker_id);
+  void TrimDeadWorkers(const WorkerID &worker_id, rpc::WorkerExitType exit_type);
 
   gcs::GcsTableStorage &gcs_table_storage_;
   instrumented_io_context &io_context_;
@@ -114,9 +117,24 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
       "due to system related errors.",
       /*unit=*/""};
 
-  /// Queue of dead worker ids in death order (oldest at front); bounds retention in the
-  /// worker table. Only accessed on io_context_.
-  std::deque<WorkerID> dead_worker_ids_queue_;
+  /// Total dead workers retained across all priority tiers
+  size_t TotalDeadWorkers() const {
+    size_t total = 0;
+    for (const auto &tier : dead_workers_by_tier_) {
+      total += tier.size();
+    }
+    return total;
+  }
+
+  /// Number of dead-worker retention priority tiers; lower index is evicted first
+  /// Right now, we only have two tiers:
+  //    0: INTENDED_SYSTEM_EXIT, INTENDED_USER_EXIT
+  //    1: USER_ERROR, SYSTEM_ERROR, NODE_OUT_OF_MEMORY
+  static constexpr size_t kNumDeadWorkerTiers = 2;
+
+  /// Dead worker ids bucketed by retention priority tier; each tier is FIFO (oldest at
+  /// front). Bounds retention in the worker table. Only accessed on io_context_.
+  std::array<std::deque<WorkerID>, kNumDeadWorkerTiers> dead_workers_by_tier_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/tests/gcs_worker_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_worker_manager_test.cc
@@ -399,7 +399,6 @@ TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
 )");
   auto worker_manager = GetWorkerManager();
 
-  // Seeds a dead row directly into the table (bypasses TrimDeadWorkers), for phase 1.
   auto add_dead_worker = [&](const WorkerID &id, uint64_t end_ms, rpc::WorkerExitType t) {
     rpc::WorkerTableData d;
     d.mutable_worker_address()->set_worker_id(id.Binary());
@@ -417,8 +416,6 @@ TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
     promise.get_future().get();
   };
 
-  // Reports a worker dead through the RPC path (goes through TrimDeadWorkers), for
-  // phase 2.
   auto report_worker_dead = [&](const WorkerID &id, rpc::WorkerExitType t) {
     rpc::ReportWorkerFailureRequest req;
     req.mutable_worker_failure()->mutable_worker_address()->set_worker_id(id.Binary());
@@ -470,8 +467,8 @@ TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
 
   auto after_restore = get_all_worker_ids();
   ASSERT_EQ(after_restore.size(), 3);
-  EXPECT_TRUE(contains(after_restore, failure1));  // failure kept
-  EXPECT_FALSE(contains(after_restore, idle[0]));  // oldest idle-kill trimmed first
+  EXPECT_TRUE(contains(after_restore, failure1));
+  EXPECT_FALSE(contains(after_restore, idle[0]));
   EXPECT_TRUE(contains(after_restore, idle[1]));
   EXPECT_TRUE(contains(after_restore, idle[2]));
 
@@ -483,9 +480,9 @@ TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
 
   auto after_deaths = get_all_worker_ids();
   ASSERT_EQ(after_deaths.size(), 3);
-  EXPECT_TRUE(contains(after_deaths, failure1));  // both failures survive the churn
+  EXPECT_TRUE(contains(after_deaths, failure1));
   EXPECT_TRUE(contains(after_deaths, failure2));
-  EXPECT_TRUE(contains(after_deaths, idle3));     // only the newest idle-kill remains
-  EXPECT_FALSE(contains(after_deaths, idle[1]));  // older idle-kills evicted to make room
+  EXPECT_TRUE(contains(after_deaths, idle3));
+  EXPECT_FALSE(contains(after_deaths, idle[1]));
   EXPECT_FALSE(contains(after_deaths, idle[2]));
 }

--- a/src/ray/gcs/tests/gcs_worker_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_worker_manager_test.cc
@@ -386,3 +386,106 @@ TEST_F(GcsWorkerManagerTest, TestRestoreDeadWorkerIdsQueue) {
   EXPECT_TRUE(contains(remaining, worker_ids[3]));
   EXPECT_TRUE(contains(remaining, worker_ids[4]));
 }
+
+TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
+  // cap = 3. Verifies failures outrank intentional exits in BOTH eviction paths:
+  //   Phase 1 - startup reconstruction (RestoreDeadWorkerIdsQueue)
+  //   Phase 2 - steady-state deaths      (TrimDeadWorkers)
+  RayConfig::instance().initialize(
+      R"(
+{
+"maximum_gcs_dead_worker_cached_count": 3
+}
+)");
+  auto worker_manager = GetWorkerManager();
+
+  // Seeds a dead row directly into the table (bypasses TrimDeadWorkers), for phase 1.
+  auto add_dead_worker = [&](const WorkerID &id, uint64_t end_ms, rpc::WorkerExitType t) {
+    rpc::WorkerTableData d;
+    d.mutable_worker_address()->set_worker_id(id.Binary());
+    d.set_is_alive(false);
+    d.set_end_time_ms(end_ms);
+    d.set_exit_type(t);
+    rpc::AddWorkerInfoRequest req;
+    req.mutable_worker_data()->CopyFrom(d);
+    rpc::AddWorkerInfoReply reply;
+    std::promise<void> promise;
+    auto callback = [&promise](Status status,
+                               std::function<void()> success,
+                               std::function<void()> failure) { promise.set_value(); };
+    worker_manager->HandleAddWorkerInfo(req, &reply, callback);
+    promise.get_future().get();
+  };
+
+  // Reports a worker dead through the RPC path (goes through TrimDeadWorkers), for
+  // phase 2.
+  auto report_worker_dead = [&](const WorkerID &id, rpc::WorkerExitType t) {
+    rpc::ReportWorkerFailureRequest req;
+    req.mutable_worker_failure()->mutable_worker_address()->set_worker_id(id.Binary());
+    req.mutable_worker_failure()->set_exit_type(t);
+    rpc::ReportWorkerFailureReply reply;
+    std::promise<void> promise;
+    auto callback = [&promise](Status status,
+                               std::function<void()> success,
+                               std::function<void()> failure) { promise.set_value(); };
+    worker_manager->HandleReportWorkerFailure(req, &reply, callback);
+    promise.get_future().get();
+  };
+
+  auto get_all_worker_ids = [&]() {
+    rpc::GetAllWorkerInfoRequest req;
+    rpc::GetAllWorkerInfoReply reply;
+    std::promise<void> promise;
+    auto callback = [&promise](Status status,
+                               std::function<void()> success,
+                               std::function<void()> failure) { promise.set_value(); };
+    worker_manager->HandleGetAllWorkerInfo(req, &reply, callback);
+    promise.get_future().get();
+    std::vector<std::string> ids;
+    for (const auto &d : reply.worker_table_data()) {
+      ids.push_back(d.worker_address().worker_id());
+    }
+    return ids;
+  };
+
+  auto contains = [](const std::vector<std::string> &ids, const WorkerID &id) {
+    for (const auto &w : ids) {
+      if (w == id.Binary()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Phase 1: restart / restore. Seed 1 failure + 3 idle-kills (total 4 > cap).
+  WorkerID failure1 = WorkerID::FromRandom();
+  add_dead_worker(failure1, /*end_ms=*/100, rpc::WorkerExitType::USER_ERROR);
+  std::vector<WorkerID> idle;
+  for (int i = 0; i < 3; i++) {
+    idle.push_back(WorkerID::FromRandom());
+    add_dead_worker(
+        idle.back(), /*end_ms=*/(i + 1) * 10, rpc::WorkerExitType::INTENDED_SYSTEM_EXIT);
+  }
+  worker_manager->RestoreDeadWorkerIdsQueue(LoadInitData());
+
+  auto after_restore = get_all_worker_ids();
+  ASSERT_EQ(after_restore.size(), 3);
+  EXPECT_TRUE(contains(after_restore, failure1));  // failure kept
+  EXPECT_FALSE(contains(after_restore, idle[0]));  // oldest idle-kill trimmed first
+  EXPECT_TRUE(contains(after_restore, idle[1]));
+  EXPECT_TRUE(contains(after_restore, idle[2]));
+
+  // Phase 2: keep running. A new failure + a new idle-kill arrive.
+  WorkerID failure2 = WorkerID::FromRandom();
+  report_worker_dead(failure2, rpc::WorkerExitType::USER_ERROR);
+  WorkerID idle3 = WorkerID::FromRandom();
+  report_worker_dead(idle3, rpc::WorkerExitType::INTENDED_SYSTEM_EXIT);
+
+  auto after_deaths = get_all_worker_ids();
+  ASSERT_EQ(after_deaths.size(), 3);
+  EXPECT_TRUE(contains(after_deaths, failure1));  // both failures survive the churn
+  EXPECT_TRUE(contains(after_deaths, failure2));
+  EXPECT_TRUE(contains(after_deaths, idle3));     // only the newest idle-kill remains
+  EXPECT_FALSE(contains(after_deaths, idle[1]));  // older idle-kills evicted to make room
+  EXPECT_FALSE(contains(after_deaths, idle[2]));
+}


### PR DESCRIPTION
## Description
This PR is a follow-up to the dead-worker retention cap (#64612). That PR bounds the GCS worker table with a plain FIFO: once the cap(`maximum_gcs_dead_worker_cached_count`) is hit, the *oldest* dead-worker entry is evicted, regardless of how the worker exited. 

The problem is that eviction order ignores entry value. When scheduling latency leaves workers idle long enough to be recycled, the table fills with recent, low-value INTENDED_SYSTEM_EXIT entries. Under FIFO, these push out older crash/OOM/user-error records — exactly the entries observability exists for. The cap protects memory, but at the cost of discarding the most useful data.

This PR makes the *same* cap value-aware: dead workers are evicted by retention priority, so routine exits are shed before failures. The memory bound is unchanged.

| Tier | `WorkerExitType` | Rationale |
|---|---|---|
| 0 — evicted first | `INTENDED_SYSTEM_EXIT`, `INTENDED_USER_EXIT` | idle-recycle, `ray.kill` — routine, low observability value |
| 1 — retained longest | `SYSTEM_ERROR`, `USER_ERROR`, `NODE_OUT_OF_MEMORY` | crash, user error, OOM — more valuable for observability |

## Related issues
Related to #64612 

## Additional information
- **Data Structure**: The single dead-worker FIFO becomes a bucket queue-- `std::array<std::deque<WorkerID>, kNumDeadWorkerTiers>`, one FIFO per tier, O(1) insert/evict
- **Precedent**: Mirrors `GcsTaskManager`'s existing priority-based GC for task events. Tiers are easy to extend via `kNumDeadWorkerTiers` + `DeadWorkerTier`
- **Testing**:  `GcsWorkerManagerTest.TestPriorityEviction`
