### PR TITLE
[docs][core] Document the embedded RocksDB GCS backend

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides.md
+++ b/doc/source/cluster/kubernetes/user-guides.md
@@ -20,6 +20,7 @@ user-guides/configuring-ippr
 user-guides/label-based-scheduling
 user-guides/kuberay-gcs-ft
 user-guides/kuberay-gcs-persistent-ft
+user-guides/kuberay-gcs-rocksdb-ft
 user-guides/gke-gcs-bucket
 user-guides/persist-kuberay-custom-resource-logs
 user-guides/persist-kuberay-operator-logs
@@ -59,6 +60,7 @@ To learn the basics of Ray on Kubernetes, we recommend taking a look at the {ref
 * {ref}`kuberay-tpu`
 * {ref}`kuberay-gcs-ft`
 * {ref}`kuberay-gcs-persistent-ft`
+* {ref}`kuberay-gcs-rocksdb-ft`
 * {ref}`persist-kuberay-custom-resource-logs`
 * {ref}`persist-kuberay-operator-logs`
 * {ref}`kuberay-pod-command`

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -17,7 +17,7 @@ See {ref}`Ray Serve end-to-end fault tolerance documentation <serve-e2e-ft-guide
 If you need fault tolerance for Redis as well, see {ref}`Tuning Redis for a
 Persistent Fault Tolerant GCS <kuberay-gcs-persistent-ft>`.
 
-To make the GCS fault tolerant without running Redis, see the experimental
+To make the GCS fault tolerant without running Redis, see the alpha
 {ref}`embedded RocksDB backend <kuberay-gcs-rocksdb-ft>`.
 ```
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -16,6 +16,9 @@ See {ref}`Ray Serve end-to-end fault tolerance documentation <serve-e2e-ft-guide
 ```{seealso}
 If you need fault tolerance for Redis as well, see {ref}`Tuning Redis for a
 Persistent Fault Tolerant GCS <kuberay-gcs-persistent-ft>`.
+
+To make the GCS fault tolerant without running Redis, see the experimental
+{ref}`embedded RocksDB backend <kuberay-gcs-rocksdb-ft>`.
 ```
 
 ## Use cases

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -19,6 +19,9 @@ Persistent Fault Tolerant GCS <kuberay-gcs-persistent-ft>`.
 
 To make the GCS fault tolerant without running Redis, see the alpha
 {ref}`embedded RocksDB backend <kuberay-gcs-rocksdb-ft>`.
+
+For the concepts, the Redis-vs-RocksDB trade-offs, and non-Kubernetes usage, see
+{ref}`fault-tolerance-gcs-rocksdb`.
 ```
 
 ## Use cases

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -58,6 +58,13 @@ Apply the following manifest. It creates a `PersistentVolumeClaim` for the GCS d
 RayCluster whose head mounts that claim and sets the two environment variables that enable the
 backend.
 
+```{admonition} Ray image version
+:class: note
+The embedded RocksDB backend isn't in a stable release yet, so the manifest uses the
+`rayproject/ray:nightly` image. Once a release ships with the backend, pin the image to that
+released version (for example, `rayproject/ray:X.Y.Z`) instead of `nightly`.
+```
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -81,7 +88,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:latest
+          image: rayproject/ray:nightly
           env:
           # Select the embedded RocksDB backend.
           - name: RAY_gcs_storage
@@ -106,7 +113,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:latest
+          image: rayproject/ray:nightly
           env:
           # Keep workers alive while the head Pod restarts and its volume
           # reattaches. Because this setup configures GCS fault tolerance

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -1,9 +1,9 @@
 (kuberay-gcs-rocksdb-ft)=
-# GCS fault tolerance with embedded RocksDB (experimental)
+# GCS fault tolerance with embedded RocksDB (alpha)
 
-```{admonition} Experimental
+```{admonition} Alpha
 :class: warning
-The embedded RocksDB GCS backend is experimental, and we're actively looking for feedback.
+The embedded RocksDB GCS backend is in alpha and may change before becoming stable.
 If you try it, please share your experience on [GitHub](https://github.com/ray-project/ray/issues).
 ```
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -104,6 +104,14 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:latest
+          env:
+          # Keep workers alive while the head Pod restarts and its volume
+          # reattaches. Because this setup configures GCS fault tolerance
+          # manually (not through gcsFaultToleranceOptions), KubeRay doesn't
+          # inject this timeout automatically, and the 60s default is usually
+          # too short for a PersistentVolume to detach and reattach.
+          - name: RAY_gcs_rpc_server_reconnect_timeout_s
+            value: "600"
 ```
 
 ```{admonition} Keep the mount path and the storage path in sync

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -44,9 +44,12 @@ For the officially supported, Redis-backed setup, see
 
 ```{admonition} Single writer
 :class: note
-The RocksDB database is embedded in the GCS process and is single-writer: exactly one head
-Pod may open the storage path at a time. Use a `ReadWriteOnce` volume and a single head
-replica, and never share a storage path between clusters.
+The RocksDB database is embedded in the GCS process and is single-writer: at most one GCS
+process may have the database open at any time, and two concurrent writers corrupt it. The
+simplest way to guarantee this on Kubernetes, and what this guide uses, is a `ReadWriteOnce`
+volume with a single head replica. Any other setup must still enforce a single active writer,
+so a storage path must never be opened by more than one Pod at a time, and must never be
+shared between clusters.
 ```
 
 ## Deploy a RayCluster with the RocksDB backend

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -14,9 +14,11 @@ tolerance <fault-tolerance-gcs>` fixes this by persisting the metadata to durabl
 The {ref}`Redis-backed setup <kuberay-gcs-ft>` does this with an external, highly available
 Redis instance that you deploy and operate alongside Ray. The **embedded RocksDB backend**
 persists GCS state to a local [RocksDB](https://rocksdb.org/) database on a Kubernetes
-`PersistentVolume` instead, so there's no Redis to run. When the head Pod restarts, it
-reattaches the same volume, reads the metadata back from disk, and workers reconnect while
-the GCS recovers.
+`PersistentVolume` instead, so there's no Redis to run. You opt in with
+`gcsFaultToleranceOptions.backend: rocksdb`, and KubeRay provisions the volume, mounts it on
+the head Pod, sets the required environment variables, and garbage-collects the volume with
+the cluster. When the head Pod restarts, it reattaches the same volume, reads the metadata
+back from disk, and workers reconnect while the GCS recovers.
 
 For the concepts, the Redis-vs-RocksDB trade-offs, and non-Kubernetes usage, see
 {ref}`fault-tolerance-gcs-rocksdb`.
@@ -28,60 +30,84 @@ For the officially supported, Redis-backed setup, see
 
 ## Prerequisites
 
-* KubeRay 1.3.0+
-* Linux worker nodes (the RocksDB backend is Linux only)
+* A KubeRay version with embedded RocksDB support. This backend is only on KubeRay master
+  (nightly) at the time of writing; it isn't in a stable KubeRay release yet. Once a release
+  ships with it, use that version.
+* A Ray image that contains the embedded RocksDB backend. It isn't in a stable Ray release
+  yet, so the manifest below uses `rayproject/ray:nightly`.
+* Linux worker nodes (the RocksDB backend is Linux only).
 * A `StorageClass` that provisions a durable volume which can reattach to the node that runs
-  the recovered head Pod
+  the recovered head Pod.
+
+## Enable the operator feature gate
+
+The embedded backend is alpha and gated behind the KubeRay `GCSFaultToleranceEmbeddedStorage`
+feature gate, which is **off by default**. Start the KubeRay operator with the gate enabled:
+
+```sh
+--feature-gates=GCSFaultToleranceEmbeddedStorage=true
+```
+
+Set this on the operator Deployment (for example through the Helm chart's `featureGates`
+value). Without it, KubeRay rejects any RayCluster that sets `backend: rocksdb` during
+validation.
 
 ## How it works
 
-* You mount a `PersistentVolume` on the head Pod and point the GCS at it with two environment
-  variables.
+* You set `gcsFaultToleranceOptions.backend: rocksdb` on the RayCluster. KubeRay provisions a
+  `PersistentVolumeClaim` named `{cluster}-gcs-pvc`, mounts it on the head Pod at `/data/gcs`,
+  and sets `RAY_gcs_storage=rocksdb` and `RAY_gcs_storage_path` automatically. You don't set
+  those environment variables yourself.
 * The GCS writes its state to a RocksDB database on that volume, syncing every mutating write
   to disk.
+* KubeRay injects `RAY_gcs_rpc_server_reconnect_timeout_s=600` into the worker Pods, exactly
+  as it does for the Redis backend, so workers wait for the head Pod to come back instead of
+  exiting during recovery.
 * If the head Pod dies and Kubernetes reschedules it, the new Pod reattaches the *same*
   volume and the GCS recovers from the on-disk database.
+* The operator-managed PVC is owned by the RayCluster, so by default Kubernetes
+  garbage-collects it when you delete the cluster. Set `deletionPolicy: Retain` to keep the
+  volume and its data after the cluster is gone.
 
 ```{admonition} Single writer
 :class: note
 The RocksDB database is embedded in the GCS process and is single-writer: at most one GCS
 process may have the database open at any time, and two concurrent writers corrupt it. The
-simplest way to guarantee this on Kubernetes, and what this guide uses, is a `ReadWriteOnce`
-volume with a single head replica. Any other setup must still enforce a single active writer,
-so a storage path must never be opened by more than one Pod at a time, and must never be
-shared between clusters.
+default `ReadWriteOnce` volume with a single head replica guarantees this. Any other setup
+must still enforce a single active writer, so a storage path must never be opened by more than
+one Pod at a time, and must never be shared between clusters.
 ```
 
 ## Deploy a RayCluster with the RocksDB backend
 
-Apply the following manifest. It creates a `PersistentVolumeClaim` for the GCS database and a
-RayCluster whose head mounts that claim and sets the two environment variables that enable the
-backend.
-
-```{admonition} Ray image version
-:class: note
-The embedded RocksDB backend isn't in a stable release yet, so the manifest uses the
-`rayproject/ray:nightly` image. Once a release ships with the backend, pin the image to that
-released version (for example, `rayproject/ray:X.Y.Z`) instead of `nightly`.
-```
+Apply the following manifest. Setting `gcsFaultToleranceOptions.backend: rocksdb` is all it
+takes to enable the backend; KubeRay handles the PVC, the mount, and the environment
+variables.
 
 ```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: ray-gcs-rocksdb
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: raycluster-rocksdb-ft
 spec:
+  gcsFaultToleranceOptions:
+    # Select the embedded RocksDB backend. KubeRay provisions a PVC, mounts it on
+    # the head Pod at /data/gcs, and sets RAY_gcs_storage / RAY_gcs_storage_path.
+    backend: rocksdb
+    storage:
+      # Operator-managed PVC. KubeRay creates `{cluster}-gcs-pvc` and garbage-collects
+      # it with the RayCluster. It's created once and not reconfigured in place; to
+      # change size, class, or access modes, delete the PVC and let KubeRay recreate it.
+      size: 10Gi
+      # storageClassName: ssd              # optional; defaults to the cluster's default StorageClass
+      # accessModes: [ReadWriteOnce]       # optional; ReadWriteOnce is the default and suits a
+      #                                    # single-head cluster (RocksDB is single-writer)
+      # subPath: clusters/my-ray/gcs       # optional; mount a subdirectory of the volume
+      # deletionPolicy: DeleteWithCluster  # optional; default. Set to Retain to keep the PVC
+      #                                    # (and its data) after the RayCluster is deleted.
+      # claimName: my-gcs-pvc              # optional; bring your own PVC instead of an
+      #                                    # operator-managed one (mutually exclusive with
+      #                                    # size / storageClassName / accessModes).
   headGroupSpec:
     rayStartParams: {}
     template:
@@ -89,20 +115,6 @@ spec:
         containers:
         - name: ray-head
           image: rayproject/ray:nightly
-          env:
-          # Select the embedded RocksDB backend.
-          - name: RAY_gcs_storage
-            value: rocksdb
-          # Store the RocksDB database on the mounted persistent volume.
-          - name: RAY_gcs_storage_path
-            value: /mnt/ray-gcs
-          volumeMounts:
-          - name: gcs-rocksdb
-            mountPath: /mnt/ray-gcs
-        volumes:
-        - name: gcs-rocksdb
-          persistentVolumeClaim:
-            claimName: ray-gcs-rocksdb
   workerGroupSpecs:
   - groupName: small-group
     replicas: 1
@@ -114,20 +126,21 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:nightly
-          env:
-          # Keep workers alive while the head Pod restarts and its volume
-          # reattaches. Because this setup configures GCS fault tolerance
-          # manually (not through gcsFaultToleranceOptions), KubeRay doesn't
-          # inject this timeout automatically, and the 60s default is usually
-          # too short for a PersistentVolume to detach and reattach.
-          - name: RAY_gcs_rpc_server_reconnect_timeout_s
-            value: "600"
 ```
 
-```{admonition} Keep the mount path and the storage path in sync
+```{admonition} Storage options
 :class: tip
-`RAY_gcs_storage_path` must match the container `mountPath` (`/mnt/ray-gcs` above). Ray fails
-fast at startup if `RAY_gcs_storage_path` is unset or points at a path that isn't writable.
+The fields under `storage` mirror the KubeRay API:
+
+* `size`, `storageClassName`, and `accessModes` describe the PVC that KubeRay provisions and
+  owns. It's created once; to change any of them, delete the PVC so KubeRay recreates it.
+* `subPath` mounts a subdirectory of the volume instead of its root.
+* `deletionPolicy` is `DeleteWithCluster` (default) or `Retain`. `Retain` omits the owner
+  reference so the PVC and its data outlive the cluster; a later cluster can recover the state
+  through `claimName` (or by reusing the same cluster name, which adopts the retained PVC).
+* `claimName` brings your own PVC and is mutually exclusive with `size`, `storageClassName`,
+  and `accessModes`. It's also how you persist GCS state across a RayService zero-downtime
+  upgrade: point every generation at the same claim.
 ```
 
 ```{admonition} Size the volume for throughput, not just capacity
@@ -146,6 +159,9 @@ Confirm the head Pod is running, then delete it to simulate a GCS crash and watc
 recreate it against the same volume:
 
 ```sh
+# Confirm KubeRay provisioned the operator-managed PVC.
+kubectl get pvc raycluster-rocksdb-ft-gcs-pvc
+
 # Wait for the head Pod to be ready.
 kubectl get pods -l ray.io/node-type=head
 
@@ -165,7 +181,15 @@ placement group creation are briefly unavailable, exactly as with the Redis back
 
 ```sh
 kubectl delete raycluster raycluster-rocksdb-ft
-kubectl delete pvc ray-gcs-rocksdb
+```
+
+Under the default `deletionPolicy: DeleteWithCluster`, KubeRay garbage-collects the
+operator-managed `raycluster-rocksdb-ft-gcs-pvc` PVC with the cluster, so there's no separate
+volume to delete. If you set `deletionPolicy: Retain` or brought your own PVC with
+`claimName`, delete the PVC manually when you no longer need the data:
+
+```sh
+kubectl delete pvc raycluster-rocksdb-ft-gcs-pvc
 ```
 
 ## Next steps

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -1,0 +1,147 @@
+(kuberay-gcs-rocksdb-ft)=
+# GCS fault tolerance with embedded RocksDB (experimental)
+
+```{admonition} Experimental
+:class: warning
+The embedded RocksDB GCS backend is experimental, and we're actively looking for feedback.
+If you try it, please share your experience on [GitHub](https://github.com/ray-project/ray/issues).
+```
+
+The Global Control Service (GCS) manages cluster-level metadata. By default it keeps that
+metadata in memory, so a GCS restart takes down the whole Ray cluster. {ref}`GCS fault
+tolerance <fault-tolerance-gcs>` fixes this by persisting the metadata to durable storage.
+
+The {ref}`Redis-backed setup <kuberay-gcs-ft>` does this with an external, highly available
+Redis instance that you deploy and operate alongside Ray. The **embedded RocksDB backend**
+persists GCS state to a local [RocksDB](https://rocksdb.org/) database on a Kubernetes
+`PersistentVolume` instead, so there's no Redis to run. When the head Pod restarts, it
+reattaches the same volume, reads the metadata back from disk, and workers reconnect while
+the GCS recovers.
+
+For the concepts, the Redis-vs-RocksDB trade-offs, and non-Kubernetes usage, see
+{ref}`fault-tolerance-gcs-rocksdb`.
+
+```{seealso}
+For the officially supported, Redis-backed setup, see
+{ref}`GCS fault tolerance in KubeRay <kuberay-gcs-ft>`.
+```
+
+## Prerequisites
+
+* KubeRay 1.3.0+
+* Linux worker nodes (the RocksDB backend is Linux only)
+* A `StorageClass` that provisions a durable volume which can reattach to the node that runs
+  the recovered head Pod
+
+## How it works
+
+* You mount a `PersistentVolume` on the head Pod and point the GCS at it with two environment
+  variables.
+* The GCS writes its state to a RocksDB database on that volume, syncing every mutating write
+  to disk.
+* If the head Pod dies and Kubernetes reschedules it, the new Pod reattaches the *same*
+  volume and the GCS recovers from the on-disk database.
+
+```{admonition} Single writer
+:class: note
+The RocksDB database is embedded in the GCS process and is single-writer: exactly one head
+Pod may open the storage path at a time. Use a `ReadWriteOnce` volume and a single head
+replica, and never share a storage path between clusters.
+```
+
+## Deploy a RayCluster with the RocksDB backend
+
+Apply the following manifest. It creates a `PersistentVolumeClaim` for the GCS database and a
+RayCluster whose head mounts that claim and sets the two environment variables that enable the
+backend.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ray-gcs-rocksdb
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-rocksdb-ft
+spec:
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:latest
+          env:
+          # Select the embedded RocksDB backend.
+          - name: RAY_gcs_storage
+            value: rocksdb
+          # Store the RocksDB database on the mounted persistent volume.
+          - name: RAY_gcs_storage_path
+            value: /mnt/ray-gcs
+          volumeMounts:
+          - name: gcs-rocksdb
+            mountPath: /mnt/ray-gcs
+        volumes:
+        - name: gcs-rocksdb
+          persistentVolumeClaim:
+            claimName: ray-gcs-rocksdb
+  workerGroupSpecs:
+  - groupName: small-group
+    replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:latest
+```
+
+```{admonition} Keep the mount path and the storage path in sync
+:class: tip
+`RAY_gcs_storage_path` must match the container `mountPath` (`/mnt/ray-gcs` above). Ray fails
+fast at startup if `RAY_gcs_storage_path` is unset or points at a path that isn't writable.
+```
+
+## Verify recovery
+
+Confirm the head Pod is running, then delete it to simulate a GCS crash and watch KubeRay
+recreate it against the same volume:
+
+```sh
+# Wait for the head Pod to be ready.
+kubectl get pods -l ray.io/node-type=head
+
+# Delete the head Pod to simulate a GCS/head failure.
+kubectl delete pod -l ray.io/node-type=head
+
+# KubeRay recreates the head Pod. It reattaches the same PersistentVolumeClaim
+# and the GCS recovers its state from the on-disk RocksDB database.
+kubectl get pods -l ray.io/node-type=head -w
+```
+
+Because the GCS metadata persisted to the volume, the recovered cluster keeps its state
+instead of starting fresh. During recovery, cluster-level operations such as actor and
+placement group creation are briefly unavailable, exactly as with the Redis backend.
+
+## Clean up
+
+```sh
+kubectl delete raycluster raycluster-rocksdb-ft
+kubectl delete pvc ray-gcs-rocksdb
+```
+
+## Next steps
+
+* {ref}`GCS fault tolerance concepts and tuning <fault-tolerance-gcs>`
+* {ref}`Redis-backed GCS fault tolerance <kuberay-gcs-ft>`
+* {ref}`Tuning Redis for a persistent fault tolerant GCS <kuberay-gcs-persistent-ft>`

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -123,6 +123,16 @@ spec:
 fast at startup if `RAY_gcs_storage_path` is unset or points at a path that isn't writable.
 ```
 
+```{admonition} Size the volume for throughput, not just capacity
+:class: warning
+On most cloud providers, a volume's IOPS and throughput scale with its provisioned size (for
+example, AWS `gp3` and GCP `pd-balanced` grant more baseline throughput to larger disks).
+Because the GCS syncs every mutating write to disk, an undersized volume can throttle GCS
+write latency even when it has plenty of free capacity. Provision the volume for the disk
+throughput your workload needs rather than for the metadata footprint alone, and consult your
+`StorageClass` and provider documentation for the size-to-throughput relationship.
+```
+
 ## Verify recovery
 
 Confirm the head Pod is running, then delete it to simulate a GCS crash and watch KubeRay

--- a/doc/source/ray-core/fault_tolerance/gcs.rst
+++ b/doc/source/ray-core/fault_tolerance/gcs.rst
@@ -9,7 +9,7 @@ By default, the GCS isn't fault tolerant because it stores all data in memory. I
 To enable GCS fault tolerance, back the GCS with durable storage so it can reload cluster metadata after a restart. Ray offers two backends:
 
 - **External Redis** (officially supported): the GCS persists its state to a highly available Redis instance, known as HA Redis.
-- **Embedded RocksDB** (experimental): the GCS persists its state to a local `RocksDB <https://rocksdb.org/>`__ database on a persistent volume, with no external datastore to run. See :ref:`fault-tolerance-gcs-rocksdb`.
+- **Embedded RocksDB** (alpha): the GCS persists its state to a local `RocksDB <https://rocksdb.org/>`__ database on a persistent volume, with no external datastore to run. See :ref:`fault-tolerance-gcs-rocksdb`.
 
 Either way, when the GCS restarts, it loads all the data back from the backing store and resumes regular functions.
 
@@ -76,13 +76,14 @@ the correct GCS. You need to ensure that at any time, only one GCS is alive.
 
 .. _fault-tolerance-gcs-rocksdb:
 
-Embedded RocksDB backend (experimental)
----------------------------------------
+Embedded RocksDB backend (alpha)
+--------------------------------
 
 .. note::
 
-  The embedded RocksDB backend is experimental. We're actively looking for feedback:
-  please share your experience on `GitHub <https://github.com/ray-project/ray/issues>`_.
+  The embedded RocksDB backend is in alpha and may change before becoming stable.
+  We're actively looking for feedback: please share your experience on
+  `GitHub <https://github.com/ray-project/ray/issues>`_.
 
 The Redis-backed setup above makes the GCS fault tolerant, but it also adds an external,
 highly available Redis instance that you have to deploy, secure, and operate. The *embedded
@@ -119,7 +120,7 @@ Redis or RocksDB?
      - Linux only
    * - Maturity
      - Officially supported (with KubeRay for Ray Serve)
-     - Experimental
+     - Alpha
 
 Choose the embedded RocksDB backend when you want GCS fault tolerance without running Redis,
 and you can attach a durable, reattachable volume, for example a Kubernetes ``PersistentVolume``,

--- a/doc/source/ray-core/fault_tolerance/gcs.rst
+++ b/doc/source/ray-core/fault_tolerance/gcs.rst
@@ -6,8 +6,12 @@ GCS Fault Tolerance
 The Global Control Service, or GCS, manages cluster-level metadata.
 It also provides a handful of cluster-level operations including :ref:`actor <ray-remote-classes>`, :ref:`placement groups <ray-placement-group-doc-ref>` and node management.
 By default, the GCS isn't fault tolerant because it stores all data in memory. If it fails, the entire Ray cluster fails.
-To enable GCS fault tolerance, you need a highly available Redis instance, known as HA Redis.
-Then, when the GCS restarts, it loads all the data from the Redis instance and resumes regular functions.
+To enable GCS fault tolerance, back the GCS with durable storage so it can reload cluster metadata after a restart. Ray offers two backends:
+
+- **External Redis** (officially supported): the GCS persists its state to a highly available Redis instance, known as HA Redis.
+- **Embedded RocksDB** (experimental): the GCS persists its state to a local `RocksDB <https://rocksdb.org/>`__ database on a persistent volume, with no external datastore to run. See :ref:`fault-tolerance-gcs-rocksdb`.
+
+Either way, when the GCS restarts, it loads all the data back from the backing store and resumes regular functions.
 
 During the recovery period, the following functions aren't available:
 
@@ -69,3 +73,92 @@ the correct GCS. You need to ensure that at any time, only one GCS is alive.
 .. note::
 
   You can also enable GCS fault tolerance when running Ray on `Anyscale <https://www.anyscale.com/>`_. See the Anyscale `documentation <https://docs.anyscale.com/platform/services/head-node-ft/>`_ for instructions.
+
+.. _fault-tolerance-gcs-rocksdb:
+
+Embedded RocksDB backend (experimental)
+---------------------------------------
+
+.. note::
+
+  The embedded RocksDB backend is experimental. We're actively looking for feedback:
+  please share your experience on `GitHub <https://github.com/ray-project/ray/issues>`_.
+
+The Redis-backed setup above makes the GCS fault tolerant, but it also adds an external,
+highly available Redis instance that you have to deploy, secure, and operate. The *embedded
+RocksDB backend* removes that dependency: the GCS persists its state to a local
+`RocksDB <https://rocksdb.org/>`__ database on a persistent volume instead of to Redis.
+There's no separate datastore to run, just a directory on durable storage.
+
+The recovery model is identical to Redis-backed fault tolerance. When the GCS restarts, it
+reads its state back from disk and resumes, and each raylet reconnects while it recovers.
+Only the *location* of the persisted state differs: a local RocksDB database instead of an
+external Redis instance.
+
+Redis or RocksDB?
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 33 33
+
+   * -
+     - External Redis
+     - Embedded RocksDB
+   * - Extra process to operate
+     - Yes (HA Redis)
+     - No
+   * - Where state lives
+     - External Redis instance
+     - Local RocksDB database on a persistent volume
+   * - Survives head node or Pod loss
+     - Yes, if Redis survives
+     - Yes, if the persistent volume survives and reattaches to the new head
+   * - Platform support
+     - All platforms
+     - Linux only
+   * - Maturity
+     - Officially supported (with KubeRay for Ray Serve)
+     - Experimental
+
+Choose the embedded RocksDB backend when you want GCS fault tolerance without running Redis,
+and you can attach a durable, reattachable volume, for example a Kubernetes ``PersistentVolume``,
+to whichever node runs the GCS.
+
+Enabling it
+~~~~~~~~~~~
+
+Set two environment variables before you start the head node:
+
+- ``RAY_gcs_storage=rocksdb`` selects the backend.
+- ``RAY_gcs_storage_path=<dir>`` points at a directory on a persistent volume where RocksDB
+  stores its files. This is required; Ray fails fast at startup if it's unset.
+
+.. code-block:: shell
+
+  RAY_gcs_storage=rocksdb RAY_gcs_storage_path=/mnt/ray-gcs ray start --head
+
+The directory must live on storage that survives a GCS (head) restart and that can be
+reattached to the node running the recovered GCS: the same durability requirement that HA
+Redis satisfies for the Redis backend.
+
+.. note::
+
+  The RocksDB database is embedded in the GCS process and is single-writer: exactly one GCS
+  may open the storage path at a time. Point every restart of a given cluster's head at the
+  *same* path, and never share a path between clusters.
+
+For a step-by-step Kubernetes walkthrough, see :ref:`kuberay-gcs-rocksdb-ft`.
+
+Advanced tuning
+~~~~~~~~~~~~~~~
+
+RocksDB I/O, including the write-ahead-log fsync that dominates write latency, runs on a
+dedicated thread pool so it never stalls the GCS event loop. Two environment variables tune
+it. The defaults suit the GCS metadata workload, and most users never change them:
+
+- ``RAY_gcs_rocksdb_io_pool_size`` (default ``4``): worker threads in the RocksDB I/O
+  offload pool.
+- ``RAY_gcs_rocksdb_strand_buckets`` (default ``64``): per-key ordering buckets. Single-key
+  operations are hashed into a bucket and serialized within it, while different buckets run
+  concurrently.


### PR DESCRIPTION
## Description

Adds user-facing documentation for the **alpha embedded RocksDB GCS
fault-tolerance backend** introduced in #63657. The RocksDB backend lets the GCS
persist its state to a local RocksDB database on a persistent volume instead of
requiring an external Redis instance, so there's no separate datastore to run.

The KubeRay how-to targets the **native** integration merged in
[ray-project/kuberay#5013](https://github.com/ray-project/kuberay/pull/5013),
which lets users opt in with `gcsFaultToleranceOptions.backend: rocksdb` and has
the operator provision, mount, and garbage-collect the persistent volume.

This is a **docs-only** PR (all changes map to the `doc` build tag). The goal is
to make the feature discoverable within the existing Ray fault-tolerance docs and
to collect early user feedback.

## What's included

- **`ray-core/fault_tolerance/gcs.rst`** — the canonical GCS fault-tolerance page.
  Introduces the two backends (external Redis vs. embedded RocksDB) up front and
  adds an "Embedded RocksDB backend (alpha)" section covering:
  - the recovery model (identical to Redis-backed FT; only the location of state differs),
  - a Redis-vs-RocksDB comparison table (when to use which),
  - how to enable it (`RAY_gcs_storage=rocksdb`, `RAY_gcs_storage_path`),
  - the single-writer constraint, and
  - advanced tuning knobs (`RAY_gcs_rocksdb_io_pool_size`, `RAY_gcs_rocksdb_strand_buckets`).
- **`cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md`** — a new
  step-by-step KubeRay how-to built on the native `gcsFaultToleranceOptions.backend:
  rocksdb` API from kuberay#5013. It covers:
  - opting in with `backend: rocksdb` (KubeRay provisions `{cluster}-gcs-pvc`,
    mounts it at `/data/gcs`, and sets `RAY_gcs_storage` / `RAY_gcs_storage_path`
    automatically),
  - enabling the alpha `GCSFaultToleranceEmbeddedStorage` operator feature gate
    (off by default),
  - the `storage` sub-fields (`size`, `storageClassName`, `accessModes`, `subPath`,
    `deletionPolicy`, and `claimName` for a bring-your-own PVC),
  - the operator-managed PVC lifecycle (`DeleteWithCluster` default vs. `Retain`),
  - the single-writer / `ReadWriteOnce` constraint and volume-throughput sizing, and
  - recovery verification by deleting the head Pod.

  KubeRay injects the worker `RAY_gcs_rpc_server_reconnect_timeout_s` timeout
  automatically (as with the Redis backend), so no manual env-var wiring is needed.
  It's wired into the KubeRay user-guides toctree and list.
- **`kuberay-gcs-ft.md`** — cross-links the new RocksDB how-to from the Redis page.

Content is authored to match the current docs organization: concept/tuning lives
in `gcs.rst`, the practical Kubernetes walkthrough lives under the KubeRay
user-guides, and the new page is discoverable via toctree, the guides list, and a
`{seealso}` cross-reference.

## Related issues

- Related to #63657 (embedded RocksDB GCS backend, REP-64).
- KubeRay counterpart: [ray-project/kuberay#5013](https://github.com/ray-project/kuberay/pull/5013) (merged), which adds native `gcsFaultToleranceOptions.backend: rocksdb` support.

## Additional information

- New page authored as MyST Markdown (`.md`) per the docs authoring rule; the only
  `.rst` touched is the pre-existing `gcs.rst` (editing existing `.rst` is allowed).
- The feature is branded as alpha (Ray's governed stability level) throughout, with a feedback callout.
- The native KubeRay support isn't in a stable KubeRay release yet (latest is v1.6.2),
  so the how-to notes it requires KubeRay master/nightly, and it keeps the
  `rayproject/ray:nightly` image because the Ray-side backend isn't in a stable Ray
  release either.

## Checks

- [x] I've signed off every commit (`git commit -s`) to meet the DCO requirement.
- [x] Docs-only change; verified all touched files map to the `doc` tag.
- [x] AI assistance was used to draft and revise these docs.
