### PR TITLE
[serve] Freeze GC after replica initialization by default

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -618,6 +618,12 @@ RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS = get_env_bool(
 # Used for gc.set_threshold() when proxy GC optimizations are enabled.
 RAY_SERVE_PROXY_GC_THRESHOLD = get_env_int("RAY_SERVE_PROXY_GC_THRESHOLD", 700)
 
+# Feature flag to run gc.collect() + gc.freeze() at the end of replica
+# initialization. Objects allocated during startup are long-lived, so freezing
+# them excludes them from future GC scans, reducing GC pauses / tail latency in
+# the request path. Set to 0 to disable (e.g. if memory usage is a concern).
+RAY_SERVE_FREEZE_GC_ON_STARTUP = get_env_bool("RAY_SERVE_FREEZE_GC_ON_STARTUP", "1")
+
 # Interval at which cached metrics will be exported using the Ray metric API.
 # Set to `0` to disable caching entirely.
 RAY_SERVE_METRICS_EXPORT_INTERVAL_MS = get_env_int(

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1042,6 +1042,7 @@ if RAY_SERVE_THROUGHPUT_OPTIMIZED:
     RAY_SERVE_ENABLE_DIRECT_INGRESS = get_env_bool(
         "RAY_SERVE_ENABLE_DIRECT_INGRESS", "1"
     )
+    RAY_SERVE_FREEZE_GC_ON_STARTUP = get_env_bool("RAY_SERVE_FREEZE_GC_ON_STARTUP", "1")
 
 if RAY_SERVE_ENABLE_HA_PROXY:
     # Direct ingress must be enabled if HAProxy is enabled.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -39,6 +39,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH,
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
+    RAY_SERVE_FREEZE_GC_ON_STARTUP,
     RAY_SERVE_LOG_TO_STDERR,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
@@ -325,6 +326,8 @@ class ServeController:
             msg += "  • Router running in main thread (not separate)\n"
         if not RAY_SERVE_LOG_TO_STDERR:
             msg += "  • Log to stderr disabled\n"
+        if RAY_SERVE_FREEZE_GC_ON_STARTUP:
+            msg += "  • Garbage collector is frozen on startup\n"
         msg += f"  • Request path log buffer size: {RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE}\n"
         logger.info(msg)
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1815,7 +1815,8 @@ class Replica:
             # When controller restarts, it will call this method again.
             async with self._user_callable_initialized_lock:
                 self._initialization_start_time = time.time()
-                if not self._user_callable_initialized:
+                is_first_init = not self._user_callable_initialized
+                if is_first_init:
                     self._user_callable_asgi_app = (
                         await self._user_callable_wrapper.initialize_callable()
                     )
@@ -1860,6 +1861,16 @@ class Replica:
                         deployment_config.user_config,
                         rank=rank,
                     )
+
+                if is_first_init and RAY_SERVE_FREEZE_GC_ON_STARTUP:
+                    # User code initialization is complete, including the first
+                    # reconfigure call (if a user_config was provided). Collect
+                    # garbage and freeze the GC: startup objects are long-lived,
+                    # so excluding them from future GC scans reduces GC pauses
+                    # in the request path. Any allocations after this point
+                    # will be from user requests.
+                    gc.collect()
+                    gc.freeze()
 
             # A new replica should not be considered healthy until it passes
             # an initial health check. If an initial health check fails,
@@ -3845,13 +3856,6 @@ class UserCallableWrapper:
         self._user_autoscaling_stats = getattr(
             self._callable, "record_autoscaling_stats", None
         )
-
-        if RAY_SERVE_FREEZE_GC_ON_STARTUP:
-            # At this point, the user code has finished initializing.
-            # We can now collect garbage and freeze the garbage collector.
-            # Any allocations after this point will be from user requests.
-            gc.collect()
-            gc.freeze()
 
         logger.info(
             "Finished initializing replica.",

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import errno
 import functools
+import gc
 import inspect
 import logging
 import math
@@ -67,6 +68,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT,
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
+    RAY_SERVE_FREEZE_GC_ON_STARTUP,
     RAY_SERVE_HAPROXY_METRICS_ENABLED,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S,
@@ -3843,6 +3845,13 @@ class UserCallableWrapper:
         self._user_autoscaling_stats = getattr(
             self._callable, "record_autoscaling_stats", None
         )
+
+        if RAY_SERVE_FREEZE_GC_ON_STARTUP:
+            # At this point, the user code has finished initializing.
+            # We can now collect garbage and freeze the garbage collector.
+            # Any allocations after this point will be from user requests.
+            gc.collect()
+            gc.freeze()
 
         logger.info(
             "Finished initializing replica.",


### PR DESCRIPTION
## Description

Adds `RAY_SERVE_FREEZE_GC_ON_STARTUP` (default: `1`). When enabled, each Serve replica runs `gc.collect()` + `gc.freeze()` once at the end of replica initialization (`Replica.initialize`) — after `__init__`, ASGI app setup, and the initial `reconfigure(user_config)` call (if any) have completed. A first-init guard ensures runtime `reconfigure` calls (user_config updates) and controller-restart re-initializations never re-freeze.

Objects allocated during replica startup (imports, model weights, framework state) are long-lived, so freezing them moves them to the GC's permanent generation and excludes them from all future collection scans. This reduces GC pauses in the request path, mirroring the proxy-side GC optimizations that already exist (`RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS`). In load tests of this behavior, tail latency (p95/p99) dropped substantially at high request concurrency and throughput stayed flat instead of degrading. The controller also logs a bullet in the throughput-optimized settings message when the flag is on.

**Behavior change note:** this is on by default for all Serve deployments. A full `gc.collect()` runs before freezing, so startup garbage is reclaimed first and only surviving objects are frozen. Frozen objects are still freed by refcounting, but cycles among them are permanently excluded from cyclic GC. The frozen set is fixed once at startup, so any resulting RSS increase is one-time and bounded — it does not compound across config updates. Opt out with `RAY_SERVE_FREEZE_GC_ON_STARTUP=0` (e.g. for deployments that routinely replace initialization-time state).

### Perf changes
<img width="1234" height="226" alt="Screenshot 2026-07-14 at 23 23 21" src="https://github.com/user-attachments/assets/52d750e4-1513-4a3b-ad83-48d1e026321d" />

