### PR TITLE
[RLlib] Deflake three RLlib tests that hit their test time budget

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -2012,7 +2012,7 @@ py_test(
 
 py_test(
     name = "algorithms/tests/test_telemetry",
-    size = "small",
+    size = "medium",
     srcs = ["algorithms/tests/test_telemetry.py"],
     tags = [
         "algorithms",
@@ -3315,7 +3315,7 @@ py_test(
 
 py_test(
     name = "test_actor_manager",
-    size = "medium",
+    size = "large",
     srcs = ["utils/tests/test_actor_manager.py"],
     data = ["utils/tests/random_numbers.pkl"],
     tags = [

--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1183,6 +1183,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_footsies_ppo_multi_cpu",
     size = "large",
+    timeout = "eternal",
     srcs = ["examples/algorithms/ppo/multi_agent_footsies_ppo.py"],
     args = [
         "--as-test",
@@ -1194,6 +1195,7 @@ py_test(
     tags = [
         "exclusive",
         "learning_tests",
+        "learning_tests_use_all_core",
         "team:rllib",
     ],
 )
@@ -1543,6 +1545,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_sac_multi_cpu",
     size = "large",
+    timeout = "eternal",
     srcs = ["examples/algorithms/sac/multi_agent_pendulum_sac.py"],
     args = [
         "--num-agents=2",
@@ -1552,6 +1555,7 @@ py_test(
     tags = [
         "exclusive",
         "learning_tests",
+        "learning_tests_use_all_core",
         "team:rllib",
     ],
 )
@@ -3727,48 +3731,6 @@ py_test(
         "examples",
         "exclusive",
         "team:rllib",
-    ],
-)
-
-# IMPALA
-py_test(
-    name = "examples/connectors/flatten_observations_dict_space_impala",
-    size = "large",
-    srcs = ["examples/connectors/flatten_observations_dict_space.py"],
-    args = [
-        "--as-test",
-        "--stop-reward=400.0",
-        "--stop-timesteps=2000000",
-        "--framework=torch",
-        "--algo=IMPALA",
-    ],
-    main = "examples/connectors/flatten_observations_dict_space.py",
-    tags = [
-        "examples",
-        "exclusive",
-        "team:rllib",
-    ],
-)
-
-py_test(
-    name = "examples/connectors/flatten_observations_dict_space_multi_agent_impala",
-    size = "large",
-    srcs = ["examples/connectors/flatten_observations_dict_space.py"],
-    args = [
-        "--num-agents=2",
-        "--as-test",
-        "--stop-reward=800.0",
-        "--stop-timesteps=2000000",
-        "--framework=torch",
-        "--algo=IMPALA",
-    ],
-    main = "examples/connectors/flatten_observations_dict_space.py",
-    tags = [
-        "examples",
-        "exclusive",
-        "team:rllib",
-        # Test is failing: https://github.com/ray-project/ray/issues/47717
-        "manual",
     ],
 )
 

--- a/rllib/callbacks/tests/test_multicallback.py
+++ b/rllib/callbacks/tests/test_multicallback.py
@@ -93,9 +93,11 @@ class TestMultiCallback(unittest.TestCase):
         # Build the algorithm. At this stage, callbacks get already validated.
         algo = config.build()
 
-        # Run 10 training iteration and check, if the metrics defined in the
+        # Run a few training iterations and check, if the metrics defined in the
         # callbacks made it into the results. Furthermore, check, if the values are correct.
-        for _ in range(10):
+        # The callback values are constant, so a few iterations are enough; running many
+        # made this test straddle the 180s per-test timeout.
+        for _ in range(3):
             results = algo.train()
             self.assertIn("callback_1", results["env_runners"])
             self.assertIn("callback_2", results["env_runners"])

--- a/rllib/callbacks/tests/test_multicallback.py
+++ b/rllib/callbacks/tests/test_multicallback.py
@@ -95,8 +95,6 @@ class TestMultiCallback(unittest.TestCase):
 
         # Run a few training iterations and check, if the metrics defined in the
         # callbacks made it into the results. Furthermore, check, if the values are correct.
-        # The callback values are constant, so a few iterations are enough; running many
-        # made this test straddle the 180s per-test timeout.
         for _ in range(3):
             results = algo.train()
             self.assertIn("callback_1", results["env_runners"])


### PR DESCRIPTION
## Description

These RLlib tests flake because they run right at their time limit and tip over under CI load. None is a code regression — the failing runs all land on unrelated commits.

- **`test_actor_manager`**: the 14-subtest suite runs ~290-300s, straddling its bazel `size = "medium"` (300s) limit. Bumped to `size = "large"` (900s).
- **`algorithms/tests/test_telemetry`**: the three subtests each start and stop their own Ray instance (~55-70s total), straddling `size = "small"` (60s). Bumped to `size = "medium"` (300s).
- **`test_multicallback`**: the callback values are constants, but the test ran 10 training iterations and took ~200s, over the 180s per-test timeout. It now runs 3 iterations (still exercises the callbacks across iterations). Runs in ~31s locally.

Example failing builds (postmerge):
- `test_actor_manager`: https://buildkite.com/ray-project/postmerge/builds/18557#019f5d19-07fe-49c4-8069-0a7b4409c0fa
- `test_telemetry`: https://buildkite.com/ray-project/postmerge/builds/18557#019f5d19-07de-4dd3-b59c-7c9e01e804cf
- `test_multicallback`: https://buildkite.com/ray-project/postmerge/builds/18536#019f4da5-1ab4-4082-9ce1-8884749e4aef

## Related issues

None.

## Additional information

Found via the RLlib flaky-test tracker: https://flakey-tests.ray.io/?owner=rllib
