### PR TITLE
[RLlib] Deflake test_feature_importance's over-strict per-feature assertion

### DIFF
--- a/rllib/offline/tests/test_feature_importance.py
+++ b/rllib/offline/tests/test_feature_importance.py
@@ -32,8 +32,14 @@ class TestFeatureImportance(unittest.TestCase):
 
             estimate = evaluator.estimate(sample_batch)
 
-            # Check if the estimate is positive.
-            assert all(val > 0 for val in estimate.values())
+            # Feature importance is a mean of absolute action differences, so it is
+            # non-negative by construction. For an untrained policy a single
+            # low-influence feature can legitimately yield exactly 0 (permuting it
+            # flips no argmax action), which made the strict per-feature `> 0` check
+            # flaky. Require non-negativity for every feature and a positive total
+            # (perturbing features does change some actions).
+            assert all(val >= 0 for val in estimate.values())
+            assert sum(estimate.values()) > 0
 
     def test_feat_importance_estimate_on_dataset(self):
         # TODO (Kourosh): add a test for this


### PR DESCRIPTION
## Description

`test_feature_importance` asserted that every feature's permutation importance is strictly `> 0`. But that importance is a mean of absolute action differences (`np.mean(np.abs(perturbed_actions - ref_actions))`), so it is non-negative by construction, and for an untrained policy a single low-influence feature can legitimately be exactly `0` (permuting it flips no argmax action). The strict per-feature `> 0` check therefore failed on roughly half of runs (fails the first bazel attempt, passes on retry → FLAKY).

Fix (test-only): require non-negativity for every feature and a positive total. This is what the test actually means — perturbing features changes some actions — and is no longer flaky.

Example failing build (postmerge): https://buildkite.com/ray-project/postmerge/builds/18549#019f5c3e-1f92-41e8-9878-562cf4911061

Verified locally: green across 5 back-to-back runs (was ~50% flaky before).

## Related issues

None.

## Additional information

Found via the RLlib flaky-test tracker: https://flakey-tests.ray.io/?owner=rllib
