### PR TITLE
[core] Fix pgid cleanup leak in job supervisor 

### DIFF
--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -213,9 +213,16 @@ class JobSupervisor:
                 # Open a new subprocess to kill the child process when the parent
                 # process dies kill -s 0 parent_pid will succeed if the parent is
                 # alive. If it fails, SIGKILL the child process group and exit
+                #
+                # start_new_session=True detaches this watcher into its own
+                # session/process group. Otherwise it would inherit the supervisor
+                # actor's process group and the raylet's per-worker process-group
+                # cleanup (killpg on worker exit) would kill this watcher before it
+                # can reap the driver, potentially leaking the driver subprocess.
                 subprocess.Popen(
                     f"while kill -s 0 {parent_pid}; do sleep 1; done; kill -9 -{child_pgid}",  # noqa: E501
                     shell=True,
+                    start_new_session=True,
                     # Suppress output
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -44,7 +44,7 @@ from ray.dashboard.modules.job.tests.conftest import (
 )
 from ray.job_submission import JobErrorType, JobStatus
 from ray.tests.conftest import call_ray_start  # noqa: F401
-from ray.util.state import list_tasks
+from ray.util.state import get_actor, list_tasks
 
 import psutil
 
@@ -1057,7 +1057,9 @@ class TestAsyncAPI:
                 assert psutil.pid_exists(pid), "driver subprocess should be running"
 
             actor = job_manager._get_actor_for_job(job_id)
-            ray.kill(actor, no_restart=True)
+            supervisor_pid = get_actor(actor._actor_id.hex()).pid
+            kill_signal = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
+            os.kill(supervisor_pid, kill_signal)
             await async_wait_for_condition(
                 check_job_failed,
                 job_manager=job_manager,


### PR DESCRIPTION
In #64407 we flipped the default for process_group_cleanup_enabled to true. This caused test_kill_job_actor_in_before_driver_finish to start failing on mac because the driver was failing to be cleaned up. This is due to a couple things:

- In the test we call ray.kill on the supervisor actor, which triggers the legacy kill_child_processes_on_worker_exit. Even though the driver is spawned as a detached process from the supervisor actor, on linux we walk the /proc table which still records that the driver's parent process is the supervisor actor. Hence it was still getting cleaned up 
- On mac, kill_child_processes_on_worker_exit is unsupported (literally a noop) so what happens is that the the job supervisor actor does die but the child driver process doesn't get cleaned up. We do spawn an extra "watcher daemon" process to monitor the status of the job supervisor actor and if it goes down then it cleans up the driver, but it is NOT detached as well. So the watcher daemon gets cleaned up with the job supervisor actor since they share the same process group now, leaving the driver process alive.

The fix for this is to mark the watcher daemon thread as detached as well, it's just a one line shell script that polls the status of the supervisor actor so they already fate share together so it won't be leaked. 

I also updated test_job_manager.py to not use ray.kill(...) and instead os.kill to not trigger the extra cleanup path on linux. If we do this, the test without this fix also fails on linux. 
