### PR TITLE
[serve] Fix type regression in RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -761,10 +761,8 @@ RAY_SERVE_HAPROXY_STARTUP_TIMEOUT_S = int(
 # HAProxy close-spread-time. Drains the old worker's idle connections over this
 # window at soft-stop so they migrate to the reloaded config instead of lingering
 # until hard-stop-after. None omits it.
-RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S = (
-    int(os.environ.get("RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S"))
-    if os.environ.get("RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S")
-    else None
+RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S = get_env_int(
+    "RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S", None
 )
 
 # Minimum spacing between HAProxy reloads. Broadcasts arriving inside


### PR DESCRIPTION
#63996 added int(os.environ.get("RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S")) guarded by a separate os.environ.get() truthiness check. The two independent lookups mean neither mypy nor pyrefly can narrow the value to non-None, so int(str | None) fails both checkers -- which currently turns the serve type-check lint shard red for every Serve PR (the mypy/pyrefly serve hooks run --all-files).

Read the env var once into a local so the truthiness guard narrows it; runtime behavior is identical (single lookup, same empty-string -> None handling). Restores the serve allowlist to green.

Related to #64643