### PR TITLE
[serve] Enforce type checking on the controller-critical modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,14 +92,18 @@ repos:
       - id: black
         exclude: |
           (?x)^(
-            python/ray/cloudpickle/|
+            doc/external/|
             python/build/|
-            python/ray/core/src/ray/gcs/|
-            python/ray/thirdparty_files/|
             python/ray/_private/thirdparty/|
-            python/ray/serve/tests/test_config_files/syntax_error\.py|
+            python/ray/cloudpickle/|
+            python/ray/core/src/ray/gcs/|
+            python/ray/serve/_private/application_state.py|
             python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc\.py|
-            doc/external/
+            python/ray/serve/_private/controller.py|
+            python/ray/serve/_private/deployment_state.py|
+            python/ray/serve/_private/replica.py|
+            python/ray/serve/tests/test_config_files/syntax_error\.py|
+            python/ray/thirdparty_files/
           )
         types_or: [python]
 
@@ -142,10 +146,9 @@ repos:
           ]
         files: |
           (?x)^(
-            python/ray/serve/handle.py|
-            python/ray/serve/tests/typing_files/check_handle_typing.py|
             python/ray/serve/_private/__init__.py|
             python/ray/serve/_private/api.py|
+            python/ray/serve/_private/application_state.py|
             python/ray/serve/_private/autoscaling_state.py|
             python/ray/serve/_private/benchmarks/__init__.py|
             python/ray/serve/_private/benchmarks/serialization/__init__.py|
@@ -159,12 +162,14 @@ repos:
             python/ray/serve/_private/config.py|
             python/ray/serve/_private/constants.py|
             python/ray/serve/_private/constants_utils.py|
+            python/ray/serve/_private/controller.py|
             python/ray/serve/_private/controller_avatar.py|
             python/ray/serve/_private/controller_health_metrics_tracker.py|
             python/ray/serve/_private/default_impl.py|
             python/ray/serve/_private/deploy_utils.py|
             python/ray/serve/_private/deployment_info.py|
             python/ray/serve/_private/deployment_node.py|
+            python/ray/serve/_private/deployment_state.py|
             python/ray/serve/_private/direct_ingress_grpc_util.py|
             python/ray/serve/_private/direct_ingress_http_util.py|
             python/ray/serve/_private/endpoint_state.py|
@@ -185,6 +190,7 @@ repos:
             python/ray/serve/_private/proxy_response_generator.py|
             python/ray/serve/_private/proxy_router.py|
             python/ray/serve/_private/queue_monitor.py|
+            python/ray/serve/_private/replica.py|
             python/ray/serve/_private/replica_response_generator.py|
             python/ray/serve/_private/replica_result.py|
             python/ray/serve/_private/request_ingress_metrics.py|
@@ -202,7 +208,9 @@ repos:
             python/ray/serve/_private/tracing_utils.py|
             python/ray/serve/_private/usage.py|
             python/ray/serve/_private/utils.py|
-            python/ray/serve/_private/version.py
+            python/ray/serve/_private/version.py|
+            python/ray/serve/handle.py|
+            python/ray/serve/tests/typing_files/check_handle_typing.py
           )
 
   # Second type checker over the same Serve allowlist. Pyrefly resolves
@@ -223,10 +231,9 @@ repos:
         pass_filenames: true
         files: |
           (?x)^(
-            python/ray/serve/handle.py|
-            python/ray/serve/tests/typing_files/check_handle_typing.py|
             python/ray/serve/_private/__init__.py|
             python/ray/serve/_private/api.py|
+            python/ray/serve/_private/application_state.py|
             python/ray/serve/_private/autoscaling_state.py|
             python/ray/serve/_private/benchmarks/__init__.py|
             python/ray/serve/_private/benchmarks/serialization/__init__.py|
@@ -240,12 +247,14 @@ repos:
             python/ray/serve/_private/config.py|
             python/ray/serve/_private/constants.py|
             python/ray/serve/_private/constants_utils.py|
+            python/ray/serve/_private/controller.py|
             python/ray/serve/_private/controller_avatar.py|
             python/ray/serve/_private/controller_health_metrics_tracker.py|
             python/ray/serve/_private/default_impl.py|
             python/ray/serve/_private/deploy_utils.py|
             python/ray/serve/_private/deployment_info.py|
             python/ray/serve/_private/deployment_node.py|
+            python/ray/serve/_private/deployment_state.py|
             python/ray/serve/_private/direct_ingress_grpc_util.py|
             python/ray/serve/_private/direct_ingress_http_util.py|
             python/ray/serve/_private/endpoint_state.py|
@@ -266,6 +275,7 @@ repos:
             python/ray/serve/_private/proxy_response_generator.py|
             python/ray/serve/_private/proxy_router.py|
             python/ray/serve/_private/queue_monitor.py|
+            python/ray/serve/_private/replica.py|
             python/ray/serve/_private/replica_response_generator.py|
             python/ray/serve/_private/replica_result.py|
             python/ray/serve/_private/request_ingress_metrics.py|
@@ -283,7 +293,9 @@ repos:
             python/ray/serve/_private/tracing_utils.py|
             python/ray/serve/_private/usage.py|
             python/ray/serve/_private/utils.py|
-            python/ray/serve/_private/version.py
+            python/ray/serve/_private/version.py|
+            python/ray/serve/handle.py|
+            python/ray/serve/tests/typing_files/check_handle_typing.py
           )
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,11 +97,7 @@ repos:
             python/ray/_private/thirdparty/|
             python/ray/cloudpickle/|
             python/ray/core/src/ray/gcs/|
-            python/ray/serve/_private/application_state.py|
             python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc\.py|
-            python/ray/serve/_private/controller.py|
-            python/ray/serve/_private/deployment_state.py|
-            python/ray/serve/_private/replica.py|
             python/ray/serve/tests/test_config_files/syntax_error\.py|
             python/ray/thirdparty_files/
           )

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -6,7 +6,7 @@ import traceback
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 import ray
 from ray import cloudpickle
@@ -79,6 +79,9 @@ from ray.serve.schema import (
 )
 from ray.types import ObjectRef
 from ray.util import metrics as ray_metrics
+
+if TYPE_CHECKING:
+    from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -306,7 +309,11 @@ class ApplicationState:
         # get the docs path from the running deployments
         # we are making an assumption that the docs path can only be set
         # on ingress deployments with fastapi.
-        ingress_deployment = DeploymentID(self._ingress_deployment_name, self._name)
+        # NOTE: `_ingress_deployment_name` may still be None before the app is
+        # built; the resulting DeploymentID simply misses the lookup below.
+        ingress_deployment = DeploymentID(
+            cast(str, self._ingress_deployment_name), self._name
+        )
         return self._deployment_state_manager.get_deployment_docs_path(
             ingress_deployment
         )
@@ -594,10 +601,14 @@ class ApplicationState:
             config = deployment_info.deployment_config
             # Try to get route_patterns from deployment state first (most up-to-date),
             # otherwise fall back to existing endpoint patterns
-            route_patterns = (
+            # NOTE: the deployment state manager annotates these as
+            # Optional[List[str]], but the values it stores come from
+            # `extract_route_patterns` and are actually RoutePattern objects.
+            route_patterns = cast(
+                "Optional[List[RoutePattern]]",
                 self._deployment_state_manager.get_deployment_route_patterns(
                     deployment_id
-                )
+                ),
             )
             self._endpoint_state.update_endpoint(
                 deployment_id,
@@ -669,8 +680,12 @@ class ApplicationState:
         config_version = get_app_code_version(config)
         if config_version == self._target_state.code_version:
             try:
+                # `deployment_infos` is non-None whenever `code_version` is
+                # non-None (they are always set together in the target state).
                 overrided_infos = override_deployment_info(
-                    self._target_state.deployment_infos,
+                    cast(
+                        Dict[str, DeploymentInfo], self._target_state.deployment_infos
+                    ),
                     config,
                 )
                 self._route_prefix = self._check_routes(overrided_infos)
@@ -713,9 +728,12 @@ class ApplicationState:
             self._clear_target_state_and_store_config(config)
 
             # Record telemetry for container runtime env feature
-            if self._target_state.config.runtime_env.get(
+            # The target state config was just set to the (non-None) `config`
+            # by `_clear_target_state_and_store_config` above.
+            stored_config = cast(ServeApplicationSchema, self._target_state.config)
+            if stored_config.runtime_env.get(
                 "container"
-            ) or self._target_state.config.runtime_env.get("image_uri"):
+            ) or stored_config.runtime_env.get("image_uri"):
                 ServeUsageTag.APP_CONTAINER_RUNTIME_ENV_USED.record("1")
 
             if isinstance(config.autoscaling_policy, dict):
@@ -739,17 +757,19 @@ class ApplicationState:
                 for deployment in config.deployments
                 if isinstance(deployment.request_router_config, dict)
             }
-            deployment_to_deployment_actor_classes = {}
+            deployment_to_deployment_actor_classes: Dict[str, Dict[str, str]] = {}
             for deployment in config.deployments:
                 actors = getattr(deployment, "deployment_actors", None)
                 if actors and actors is not DEFAULT.VALUE:
-                    actor_classes = {}
+                    actor_classes: Dict[str, str] = {}
                     for actor_cfg in actors:
                         if isinstance(actor_cfg, dict):
                             name = actor_cfg.get("name")
                             cls_path = actor_cfg.get("actor_class")
                             if isinstance(cls_path, str):
-                                actor_classes[name] = cls_path
+                                # `name` is validated upstream; a missing name
+                                # would be stored as a None key at runtime.
+                                actor_classes[cast(str, name)] = cls_path
                     if actor_classes:
                         deployment_to_deployment_actor_classes[
                             deployment.name
@@ -772,7 +792,7 @@ class ApplicationState:
                 deployment_to_deployment_actor_classes,
             )
             self._build_app_task_info = BuildAppTaskInfo(
-                obj_ref=build_app_obj_ref,
+                obj_ref=cast(ObjectRef, build_app_obj_ref),
                 code_version=config_version,
                 config=config,
                 target_capacity=target_capacity,
@@ -808,7 +828,9 @@ class ApplicationState:
         # The deployment status info with highest priority determines the corresponding
         # application status to set.
         deployment_statuses = self.get_deployments_statuses()
-        lowest_rank_status = min(deployment_statuses, key=lambda info: info.rank)
+        # `rank` is only None for statuses missing from the ranking order,
+        # which never happens for statuses produced by the state manager.
+        lowest_rank_status = min(deployment_statuses, key=lambda info: info.rank)  # type: ignore[arg-type, return-value]
         if lowest_rank_status.status == DeploymentStatus.DEPLOY_FAILED:
             failed_deployments = [
                 s.name
@@ -870,7 +892,9 @@ class ApplicationState:
         # Retrieve build app task result
         self._build_app_task_info.finished = True
         try:
-            serialized_application_autoscaling_policy_def, args, err = ray.get(
+            # `ray.get` overloads expect the raylet ObjectRef type, while the
+            # task info stores the interchangeable `ray.types.ObjectRef`.
+            serialized_application_autoscaling_policy_def, args, err = ray.get(  # type: ignore[call-overload]
                 self._build_app_task_info.obj_ref
             )
             if err is None:
@@ -922,7 +946,7 @@ class ApplicationState:
                 for params in args
                 if params["serialized_request_router_cls"] is not None
             }
-            deployment_to_serialized_deployment_actors = {}
+            deployment_to_serialized_deployment_actors: Dict[str, Dict[str, bytes]] = {}
             for params in args:
                 dep_name = params["deployment_name"]
                 # From proto roundtrip (code-defined actors)
@@ -963,7 +987,7 @@ class ApplicationState:
 
     def _check_routes(
         self, deployment_infos: Dict[str, DeploymentInfo]
-    ) -> Tuple[str, str]:
+    ) -> Optional[str]:
         """Check route prefixes of deployments in app.
 
         There should only be one non-null route prefix. If there is one,
@@ -992,7 +1016,7 @@ class ApplicationState:
 
         return route_prefix
 
-    def _reconcile_target_deployments(self) -> None:
+    def _reconcile_target_deployments(self) -> bool:
         """Reconcile target deployments in application target state.
 
         Ensure each deployment is running on up-to-date info, and
@@ -1000,8 +1024,13 @@ class ApplicationState:
         """
         target_state_changed = False
 
+        # `deployment_infos` is non-None here: `update` only calls this method
+        # after checking `self._target_state.deployment_infos is not None`.
+        deployment_infos = cast(
+            Dict[str, DeploymentInfo], self._target_state.deployment_infos
+        )
         # Set target state for each deployment
-        for deployment_name, info in self._target_state.deployment_infos.items():
+        for deployment_name, info in deployment_infos.items():
             deploy_info = deepcopy(info)
 
             # Apply the target capacity information to the deployment info.
@@ -1101,14 +1130,17 @@ class ApplicationState:
             ) = self._reconcile_build_app_task()
             if task_status == BuildAppStatus.SUCCEEDED:
                 target_state_changed = True
+                # A SUCCEEDED status is only returned when a build app task
+                # exists, so `_build_app_task_info` is non-None here.
+                build_app_task_info = cast(BuildAppTaskInfo, self._build_app_task_info)
                 self._set_target_state(
                     deployment_infos=infos,
-                    code_version=self._build_app_task_info.code_version,
+                    code_version=build_app_task_info.code_version,
                     api_type=self._target_state.api_type,
-                    target_config=self._build_app_task_info.config,
-                    target_capacity=self._build_app_task_info.target_capacity,
+                    target_config=build_app_task_info.config,
+                    target_capacity=build_app_task_info.target_capacity,
                     target_capacity_direction=(
-                        self._build_app_task_info.target_capacity_direction
+                        build_app_task_info.target_capacity_direction
                     ),
                     external_scaler_enabled=self._target_state.external_scaler_enabled,
                     serialized_application_autoscaling_policy_def=serialized_application_autoscaling_policy_def,
@@ -1291,7 +1323,11 @@ class ApplicationStateManager:
                 # against during this batch operation.
                 live_route_prefixes[deploy_app_prefix] = name
 
-            application_args = name_to_application_args.get(name)
+            # Callers pass parallel dicts keyed by the same app names, so the
+            # lookup is expected to succeed for every deployed app.
+            application_args = cast(
+                ApplicationArgsProto, name_to_application_args.get(name)
+            )
             external_scaler_enabled = application_args.external_scaler_enabled
 
             if name not in self._application_states:
@@ -1822,7 +1858,7 @@ def override_deployment_info(
             ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
 
         # What to pass to info.update
-        override_options = {}
+        override_options: Dict[str, Any] = {}
 
         # Merge app-level and deployment-level runtime_envs.
         replica_config = info.replica_config

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -6,7 +6,7 @@ import traceback
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import ray
 from ray import cloudpickle
@@ -79,9 +79,6 @@ from ray.serve.schema import (
 )
 from ray.types import ObjectRef
 from ray.util import metrics as ray_metrics
-
-if TYPE_CHECKING:
-    from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -309,11 +306,11 @@ class ApplicationState:
         # get the docs path from the running deployments
         # we are making an assumption that the docs path can only be set
         # on ingress deployments with fastapi.
-        # NOTE: `_ingress_deployment_name` may still be None before the app is
-        # built; the resulting DeploymentID simply misses the lookup below.
-        ingress_deployment = DeploymentID(
-            cast(str, self._ingress_deployment_name), self._name
-        )
+        # `_ingress_deployment_name` may still be None before the app is built;
+        # there is no ingress deployment to look up in that case.
+        if self._ingress_deployment_name is None:
+            return None
+        ingress_deployment = DeploymentID(self._ingress_deployment_name, self._name)
         return self._deployment_state_manager.get_deployment_docs_path(
             ingress_deployment
         )
@@ -601,14 +598,10 @@ class ApplicationState:
             config = deployment_info.deployment_config
             # Try to get route_patterns from deployment state first (most up-to-date),
             # otherwise fall back to existing endpoint patterns
-            # NOTE: the deployment state manager annotates these as
-            # Optional[List[str]], but the values it stores come from
-            # `extract_route_patterns` and are actually RoutePattern objects.
-            route_patterns = cast(
-                "Optional[List[RoutePattern]]",
+            route_patterns = (
                 self._deployment_state_manager.get_deployment_route_patterns(
                     deployment_id
-                ),
+                )
             )
             self._endpoint_state.update_endpoint(
                 deployment_id,
@@ -682,10 +675,9 @@ class ApplicationState:
             try:
                 # `deployment_infos` is non-None whenever `code_version` is
                 # non-None (they are always set together in the target state).
+                assert self._target_state.deployment_infos is not None
                 overrided_infos = override_deployment_info(
-                    cast(
-                        Dict[str, DeploymentInfo], self._target_state.deployment_infos
-                    ),
+                    self._target_state.deployment_infos,
                     config,
                 )
                 self._route_prefix = self._check_routes(overrided_infos)
@@ -730,7 +722,8 @@ class ApplicationState:
             # Record telemetry for container runtime env feature
             # The target state config was just set to the (non-None) `config`
             # by `_clear_target_state_and_store_config` above.
-            stored_config = cast(ServeApplicationSchema, self._target_state.config)
+            assert self._target_state.config is not None
+            stored_config = self._target_state.config
             if stored_config.runtime_env.get(
                 "container"
             ) or stored_config.runtime_env.get("image_uri"):
@@ -1026,9 +1019,8 @@ class ApplicationState:
 
         # `deployment_infos` is non-None here: `update` only calls this method
         # after checking `self._target_state.deployment_infos is not None`.
-        deployment_infos = cast(
-            Dict[str, DeploymentInfo], self._target_state.deployment_infos
-        )
+        assert self._target_state.deployment_infos is not None
+        deployment_infos = self._target_state.deployment_infos
         # Set target state for each deployment
         for deployment_name, info in deployment_infos.items():
             deploy_info = deepcopy(info)
@@ -1132,7 +1124,8 @@ class ApplicationState:
                 target_state_changed = True
                 # A SUCCEEDED status is only returned when a build app task
                 # exists, so `_build_app_task_info` is non-None here.
-                build_app_task_info = cast(BuildAppTaskInfo, self._build_app_task_info)
+                assert self._build_app_task_info is not None
+                build_app_task_info = self._build_app_task_info
                 self._set_target_state(
                     deployment_infos=infos,
                     code_version=build_app_task_info.code_version,
@@ -1325,9 +1318,7 @@ class ApplicationStateManager:
 
             # Callers pass parallel dicts keyed by the same app names, so the
             # lookup is expected to succeed for every deployed app.
-            application_args = cast(
-                ApplicationArgsProto, name_to_application_args.get(name)
-            )
+            application_args = name_to_application_args[name]
             external_scaler_enabled = application_args.external_scaler_enabled
 
             if name not in self._application_states:

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -672,10 +672,10 @@ class ApplicationState:
 
         config_version = get_app_code_version(config)
         if config_version == self._target_state.code_version:
+            # `deployment_infos` is non-None whenever `code_version` is
+            # non-None (they are always set together in the target state).
+            assert self._target_state.deployment_infos is not None
             try:
-                # `deployment_infos` is non-None whenever `code_version` is
-                # non-None (they are always set together in the target state).
-                assert self._target_state.deployment_infos is not None
                 overrided_infos = override_deployment_info(
                     self._target_state.deployment_infos,
                     config,
@@ -758,11 +758,11 @@ class ApplicationState:
                     for actor_cfg in actors:
                         if isinstance(actor_cfg, dict):
                             name = actor_cfg.get("name")
+                            if not name:
+                                continue
                             cls_path = actor_cfg.get("actor_class")
                             if isinstance(cls_path, str):
-                                # `name` is validated upstream; a missing name
-                                # would be stored as a None key at runtime.
-                                actor_classes[cast(str, name)] = cls_path
+                                actor_classes[name] = cls_path
                     if actor_classes:
                         deployment_to_deployment_actor_classes[
                             deployment.name

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -6,7 +6,7 @@ import traceback
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 import ray
 from ray import cloudpickle
@@ -79,6 +79,9 @@ from ray.serve.schema import (
 )
 from ray.types import ObjectRef
 from ray.util import metrics as ray_metrics
+
+if TYPE_CHECKING:
+    from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -306,7 +309,11 @@ class ApplicationState:
         # get the docs path from the running deployments
         # we are making an assumption that the docs path can only be set
         # on ingress deployments with fastapi.
-        ingress_deployment = DeploymentID(self._ingress_deployment_name, self._name)
+        # NOTE: `_ingress_deployment_name` may still be None before the app is
+        # built; the resulting DeploymentID simply misses the lookup below.
+        ingress_deployment = DeploymentID(
+            cast(str, self._ingress_deployment_name), self._name
+        )
         return self._deployment_state_manager.get_deployment_docs_path(
             ingress_deployment
         )
@@ -594,10 +601,14 @@ class ApplicationState:
             config = deployment_info.deployment_config
             # Try to get route_patterns from deployment state first (most up-to-date),
             # otherwise fall back to existing endpoint patterns
-            route_patterns = (
+            # NOTE: the deployment state manager annotates these as
+            # Optional[List[str]], but the values it stores come from
+            # `extract_route_patterns` and are actually RoutePattern objects.
+            route_patterns = cast(
+                "Optional[List[RoutePattern]]",
                 self._deployment_state_manager.get_deployment_route_patterns(
                     deployment_id
-                )
+                ),
             )
             self._endpoint_state.update_endpoint(
                 deployment_id,
@@ -669,8 +680,12 @@ class ApplicationState:
         config_version = get_app_code_version(config)
         if config_version == self._target_state.code_version:
             try:
+                # `deployment_infos` is non-None whenever `code_version` is
+                # non-None (they are always set together in the target state).
                 overrided_infos = override_deployment_info(
-                    self._target_state.deployment_infos,
+                    cast(
+                        Dict[str, DeploymentInfo], self._target_state.deployment_infos
+                    ),
                     config,
                 )
                 self._route_prefix = self._check_routes(overrided_infos)
@@ -713,9 +728,12 @@ class ApplicationState:
             self._clear_target_state_and_store_config(config)
 
             # Record telemetry for container runtime env feature
-            if self._target_state.config.runtime_env.get(
+            # The target state config was just set to the (non-None) `config`
+            # by `_clear_target_state_and_store_config` above.
+            stored_config = cast(ServeApplicationSchema, self._target_state.config)
+            if stored_config.runtime_env.get(
                 "container"
-            ) or self._target_state.config.runtime_env.get("image_uri"):
+            ) or stored_config.runtime_env.get("image_uri"):
                 ServeUsageTag.APP_CONTAINER_RUNTIME_ENV_USED.record("1")
 
             if isinstance(config.autoscaling_policy, dict):
@@ -739,17 +757,19 @@ class ApplicationState:
                 for deployment in config.deployments
                 if isinstance(deployment.request_router_config, dict)
             }
-            deployment_to_deployment_actor_classes = {}
+            deployment_to_deployment_actor_classes: Dict[str, Dict[str, str]] = {}
             for deployment in config.deployments:
                 actors = getattr(deployment, "deployment_actors", None)
                 if actors and actors is not DEFAULT.VALUE:
-                    actor_classes = {}
+                    actor_classes: Dict[str, str] = {}
                     for actor_cfg in actors:
                         if isinstance(actor_cfg, dict):
                             name = actor_cfg.get("name")
                             cls_path = actor_cfg.get("actor_class")
                             if isinstance(cls_path, str):
-                                actor_classes[name] = cls_path
+                                # `name` is validated upstream; a missing name
+                                # would be stored as a None key at runtime.
+                                actor_classes[cast(str, name)] = cls_path
                     if actor_classes:
                         deployment_to_deployment_actor_classes[
                             deployment.name
@@ -772,7 +792,7 @@ class ApplicationState:
                 deployment_to_deployment_actor_classes,
             )
             self._build_app_task_info = BuildAppTaskInfo(
-                obj_ref=build_app_obj_ref,
+                obj_ref=cast(ObjectRef, build_app_obj_ref),
                 code_version=config_version,
                 config=config,
                 target_capacity=target_capacity,
@@ -808,7 +828,9 @@ class ApplicationState:
         # The deployment status info with highest priority determines the corresponding
         # application status to set.
         deployment_statuses = self.get_deployments_statuses()
-        lowest_rank_status = min(deployment_statuses, key=lambda info: info.rank)
+        # `rank` is only None for statuses missing from the ranking order,
+        # which never happens for statuses produced by the state manager.
+        lowest_rank_status = min(deployment_statuses, key=lambda info: info.rank)  # type: ignore[arg-type, return-value]
         if lowest_rank_status.status == DeploymentStatus.DEPLOY_FAILED:
             failed_deployments = [
                 s.name
@@ -870,7 +892,9 @@ class ApplicationState:
         # Retrieve build app task result
         self._build_app_task_info.finished = True
         try:
-            serialized_application_autoscaling_policy_def, args, err = ray.get(
+            # `ray.get` overloads expect the raylet ObjectRef type, while the
+            # task info stores the interchangeable `ray.types.ObjectRef`.
+            serialized_application_autoscaling_policy_def, args, err = ray.get(  # type: ignore[call-overload]
                 self._build_app_task_info.obj_ref
             )
             if err is None:
@@ -922,7 +946,7 @@ class ApplicationState:
                 for params in args
                 if params["serialized_request_router_cls"] is not None
             }
-            deployment_to_serialized_deployment_actors = {}
+            deployment_to_serialized_deployment_actors: Dict[str, Dict[str, bytes]] = {}
             for params in args:
                 dep_name = params["deployment_name"]
                 # From proto roundtrip (code-defined actors)
@@ -963,7 +987,7 @@ class ApplicationState:
 
     def _check_routes(
         self, deployment_infos: Dict[str, DeploymentInfo]
-    ) -> Tuple[str, str]:
+    ) -> Optional[str]:
         """Check route prefixes of deployments in app.
 
         There should only be one non-null route prefix. If there is one,
@@ -992,7 +1016,7 @@ class ApplicationState:
 
         return route_prefix
 
-    def _reconcile_target_deployments(self) -> None:
+    def _reconcile_target_deployments(self) -> bool:
         """Reconcile target deployments in application target state.
 
         Ensure each deployment is running on up-to-date info, and
@@ -1000,8 +1024,13 @@ class ApplicationState:
         """
         target_state_changed = False
 
+        # `deployment_infos` is non-None here: `update` only calls this method
+        # after checking `self._target_state.deployment_infos is not None`.
+        deployment_infos = cast(
+            Dict[str, DeploymentInfo], self._target_state.deployment_infos
+        )
         # Set target state for each deployment
-        for deployment_name, info in self._target_state.deployment_infos.items():
+        for deployment_name, info in deployment_infos.items():
             deploy_info = deepcopy(info)
 
             # Apply the target capacity information to the deployment info.
@@ -1098,14 +1127,17 @@ class ApplicationState:
             ) = self._reconcile_build_app_task()
             if task_status == BuildAppStatus.SUCCEEDED:
                 target_state_changed = True
+                # A SUCCEEDED status is only returned when a build app task
+                # exists, so `_build_app_task_info` is non-None here.
+                build_app_task_info = cast(BuildAppTaskInfo, self._build_app_task_info)
                 self._set_target_state(
                     deployment_infos=infos,
-                    code_version=self._build_app_task_info.code_version,
+                    code_version=build_app_task_info.code_version,
                     api_type=self._target_state.api_type,
-                    target_config=self._build_app_task_info.config,
-                    target_capacity=self._build_app_task_info.target_capacity,
+                    target_config=build_app_task_info.config,
+                    target_capacity=build_app_task_info.target_capacity,
                     target_capacity_direction=(
-                        self._build_app_task_info.target_capacity_direction
+                        build_app_task_info.target_capacity_direction
                     ),
                     external_scaler_enabled=self._target_state.external_scaler_enabled,
                     serialized_application_autoscaling_policy_def=serialized_application_autoscaling_policy_def,
@@ -1288,7 +1320,11 @@ class ApplicationStateManager:
                 # against during this batch operation.
                 live_route_prefixes[deploy_app_prefix] = name
 
-            application_args = name_to_application_args.get(name)
+            # Callers pass parallel dicts keyed by the same app names, so the
+            # lookup is expected to succeed for every deployed app.
+            application_args = cast(
+                ApplicationArgsProto, name_to_application_args.get(name)
+            )
             external_scaler_enabled = application_args.external_scaler_enabled
 
             if name not in self._application_states:
@@ -1819,7 +1855,7 @@ def override_deployment_info(
             ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
 
         # What to pass to info.update
-        override_options = {}
+        override_options: Dict[str, Any] = {}
 
         # Merge app-level and deployment-level runtime_envs.
         replica_config = info.replica_config

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -6,7 +6,7 @@ import traceback
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import ray
 from ray import cloudpickle
@@ -79,9 +79,6 @@ from ray.serve.schema import (
 )
 from ray.types import ObjectRef
 from ray.util import metrics as ray_metrics
-
-if TYPE_CHECKING:
-    from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -309,11 +306,11 @@ class ApplicationState:
         # get the docs path from the running deployments
         # we are making an assumption that the docs path can only be set
         # on ingress deployments with fastapi.
-        # NOTE: `_ingress_deployment_name` may still be None before the app is
-        # built; the resulting DeploymentID simply misses the lookup below.
-        ingress_deployment = DeploymentID(
-            cast(str, self._ingress_deployment_name), self._name
-        )
+        # `_ingress_deployment_name` may still be None before the app is built;
+        # there is no ingress deployment to look up in that case.
+        if self._ingress_deployment_name is None:
+            return None
+        ingress_deployment = DeploymentID(self._ingress_deployment_name, self._name)
         return self._deployment_state_manager.get_deployment_docs_path(
             ingress_deployment
         )
@@ -601,14 +598,10 @@ class ApplicationState:
             config = deployment_info.deployment_config
             # Try to get route_patterns from deployment state first (most up-to-date),
             # otherwise fall back to existing endpoint patterns
-            # NOTE: the deployment state manager annotates these as
-            # Optional[List[str]], but the values it stores come from
-            # `extract_route_patterns` and are actually RoutePattern objects.
-            route_patterns = cast(
-                "Optional[List[RoutePattern]]",
+            route_patterns = (
                 self._deployment_state_manager.get_deployment_route_patterns(
                     deployment_id
-                ),
+                )
             )
             self._endpoint_state.update_endpoint(
                 deployment_id,
@@ -682,10 +675,9 @@ class ApplicationState:
             try:
                 # `deployment_infos` is non-None whenever `code_version` is
                 # non-None (they are always set together in the target state).
+                assert self._target_state.deployment_infos is not None
                 overrided_infos = override_deployment_info(
-                    cast(
-                        Dict[str, DeploymentInfo], self._target_state.deployment_infos
-                    ),
+                    self._target_state.deployment_infos,
                     config,
                 )
                 self._route_prefix = self._check_routes(overrided_infos)
@@ -730,7 +722,8 @@ class ApplicationState:
             # Record telemetry for container runtime env feature
             # The target state config was just set to the (non-None) `config`
             # by `_clear_target_state_and_store_config` above.
-            stored_config = cast(ServeApplicationSchema, self._target_state.config)
+            assert self._target_state.config is not None
+            stored_config = self._target_state.config
             if stored_config.runtime_env.get(
                 "container"
             ) or stored_config.runtime_env.get("image_uri"):
@@ -1026,9 +1019,8 @@ class ApplicationState:
 
         # `deployment_infos` is non-None here: `update` only calls this method
         # after checking `self._target_state.deployment_infos is not None`.
-        deployment_infos = cast(
-            Dict[str, DeploymentInfo], self._target_state.deployment_infos
-        )
+        assert self._target_state.deployment_infos is not None
+        deployment_infos = self._target_state.deployment_infos
         # Set target state for each deployment
         for deployment_name, info in deployment_infos.items():
             deploy_info = deepcopy(info)
@@ -1129,7 +1121,8 @@ class ApplicationState:
                 target_state_changed = True
                 # A SUCCEEDED status is only returned when a build app task
                 # exists, so `_build_app_task_info` is non-None here.
-                build_app_task_info = cast(BuildAppTaskInfo, self._build_app_task_info)
+                assert self._build_app_task_info is not None
+                build_app_task_info = self._build_app_task_info
                 self._set_target_state(
                     deployment_infos=infos,
                     code_version=build_app_task_info.code_version,
@@ -1322,9 +1315,7 @@ class ApplicationStateManager:
 
             # Callers pass parallel dicts keyed by the same app names, so the
             # lookup is expected to succeed for every deployed app.
-            application_args = cast(
-                ApplicationArgsProto, name_to_application_args.get(name)
-            )
+            application_args = name_to_application_args[name]
             external_scaler_enabled = application_args.external_scaler_enabled
 
             if name not in self._application_states:

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -281,7 +281,9 @@ class DeploymentAutoscalingState:
         """Records task queue length from QueueMonitor for async inference."""
         self._total_pending_async_requests = report.queue_length
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
+    def drop_stale_handle_metrics(
+        self, alive_serve_actor_ids: Set[Optional[str]]
+    ) -> None:
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -1080,7 +1082,7 @@ class ApplicationAutoscalingState:
                 report.deployment_id
             ].record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]):
+    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[Optional[str]]):
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -1271,6 +1273,8 @@ class AutoscalingStateManager:
         if app_state:
             app_state.record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
+    def drop_stale_handle_metrics(
+        self, alive_serve_actor_ids: Set[Optional[str]]
+    ) -> None:
         for app_state in self._app_autoscaling_states.values():
             app_state.drop_stale_handle_metrics(alive_serve_actor_ids)

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -281,9 +281,7 @@ class DeploymentAutoscalingState:
         """Records task queue length from QueueMonitor for async inference."""
         self._total_pending_async_requests = report.queue_length
 
-    def drop_stale_handle_metrics(
-        self, alive_serve_actor_ids: Set[Optional[str]]
-    ) -> None:
+    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -1082,7 +1080,7 @@ class ApplicationAutoscalingState:
                 report.deployment_id
             ].record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[Optional[str]]):
+    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]):
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -1273,8 +1271,6 @@ class AutoscalingStateManager:
         if app_state:
             app_state.record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(
-        self, alive_serve_actor_ids: Set[Optional[str]]
-    ) -> None:
+    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
         for app_state in self._app_autoscaling_states.values():
             app_state.drop_stale_handle_metrics(alive_serve_actor_ids)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -953,8 +953,7 @@ class ServeController:
 
         return self.proxy_state_manager.get_proxy_details().get(node_id)
 
-    # Implicitly returns None when the app doesn't exist.
-    def get_deployment_timestamps(self, app_name: str) -> Optional[float]:  # type: ignore[return]
+    def get_deployment_timestamps(self, app_name: str) -> Optional[float]:
         """Returns the deployment timestamp for the given app.
 
         Returns None if the app doesn't exist. Currently used for test only.
@@ -965,6 +964,7 @@ class ServeController:
         ) in self.application_state_manager.list_app_statuses().items():
             if app_name == _app_name:
                 return app_status_info.deployment_timestamp
+        return None
 
     def get_deployment_details(
         self, app_name: str, deployment_name: str

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -4,7 +4,6 @@ import os
 import pickle
 import time
 from typing import (
-    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -77,7 +76,7 @@ from ray.serve._private.logging_utils import (
     configure_component_memory_profiler,
     get_component_logger_file_path,
 )
-from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
+from ray.serve._private.long_poll import KeyType, LongPollHost, LongPollNamespace
 from ray.serve._private.node_port_manager import NodePortManager
 from ray.serve._private.proxy import ProxyActor
 from ray.serve._private.proxy_state import ProxyStateManager
@@ -118,9 +117,6 @@ from ray.serve.schema import (
     gRPCOptionsSchema,
 )
 from ray.util import metrics
-
-if TYPE_CHECKING:
-    from ray.serve._private.long_poll import KeyType
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -240,7 +236,8 @@ class ServeController:
 
         # Configure proxy default HTTP and gRPC options.
         # `global_logging_config` was set by `reconfigure_global_logging_config`
-        # above, so it is never None past this point.
+        # above, so it is never None past this point. (A self-attribute assert
+        # in __init__ poisons mypy's inference of later attributes, so cast.)
         self.proxy_state_manager = ProxyStateManager(
             http_options=configure_http_options_with_defaults(http_options),
             head_node_id=self._controller_node_id,
@@ -480,7 +477,7 @@ class ServeController:
             deployment_id
         )
 
-    async def listen_for_change(self, keys_to_snapshot_ids: "Dict[KeyType, int]"):
+    async def listen_for_change(self, keys_to_snapshot_ids: Dict[KeyType, int]):
         """Proxy long pull client's listen request.
 
         Args:
@@ -689,13 +686,8 @@ class ServeController:
         # that may be stale for autoscaling
         if any_recovering is False:
             self.autoscaling_state_manager.drop_stale_handle_metrics(
-                # None actor_ids (STARTING replicas) are harmless here; cast to
-                # satisfy the landed set[str] signature without a behavior change.
-                cast(
-                    Set[str],
-                    self.deployment_state_manager.get_alive_replica_actor_ids()
-                    | self.proxy_state_manager.get_alive_proxy_actor_ids(),
-                )
+                self.deployment_state_manager.get_alive_replica_actor_ids()
+                | self.proxy_state_manager.get_alive_proxy_actor_ids()
             )
 
         self._maybe_update_ingress_ports()
@@ -745,14 +737,7 @@ class ServeController:
             # the replica count. The full set is recomputed and cached each tick, so after
             # a controller restart the empty cache re-sends everything on the first tick.
             fresh = set(ingress_replicas_info_list)
-            # update_ports expects fully-allocated tuples; cast to its landed
-            # signature (getter is honestly typed Optional for pending replicas).
-            NodePortManager.update_ports(
-                cast(
-                    List[Tuple[str, str, int, int]],
-                    list(fresh - self._last_ingress_port_tuples),
-                )
-            )
+            NodePortManager.update_ports(list(fresh - self._last_ingress_port_tuples))
             self._last_ingress_port_tuples = fresh
 
             # Clean up stale ports
@@ -828,11 +813,11 @@ class ServeController:
             ),
             tag_keys=("actor_id",),
         )
-        self.num_control_loops_gauge.set_default_tags(
-            # The controller always runs inside an actor, so the actor ID is
-            # never None here.
-            {"actor_id": cast(str, ray.get_runtime_context().get_actor_id())}
-        )
+        # The controller always runs inside an actor, so the actor ID is
+        # never None here.
+        controller_actor_id = ray.get_runtime_context().get_actor_id()
+        assert controller_actor_id is not None
+        self.num_control_loops_gauge.set_default_tags({"actor_id": controller_actor_id})
 
         # Autoscaling metrics delay gauges
         self.replica_metrics_delay_histogram = metrics.Histogram(
@@ -1571,9 +1556,8 @@ class ServeController:
         target_groups = []
         for app_name in apps:
             # `apps` was filtered above to apps with a non-None route prefix.
-            route_prefix = cast(
-                str, self.application_state_manager.get_route_prefix(app_name)
-            )
+            route_prefix = self.application_state_manager.get_route_prefix(app_name)
+            assert route_prefix is not None
             app_target_groups = self._get_target_groups_for_app(app_name, route_prefix)
             if app_target_groups:
                 target_groups.extend(app_target_groups)
@@ -1614,10 +1598,12 @@ class ServeController:
         ingress_deployment_name = (
             self.application_state_manager.get_ingress_deployment_name(app_name)
         )
-        # NOTE: `ingress_deployment_name` may still be None before the app is
-        # built; the resulting DeploymentID lookup then misses and yields [].
+        # `ingress_deployment_name` may still be None before the app is built;
+        # there is no ingress deployment to look up in that case.
+        if ingress_deployment_name is None:
+            return []
         return self._get_running_replica_details_for_deployment(
-            app_name, cast(str, ingress_deployment_name)
+            app_name, ingress_deployment_name
         )
 
     def _get_target_groups_for_app(
@@ -1982,7 +1968,8 @@ class ServeController:
         for handler in logger.handlers:
             if isinstance(handler, logging.handlers.MemoryHandler):
                 # Serve's MemoryHandler always wraps a file handler.
-                log_file_path = cast(logging.FileHandler, handler.target).baseFilename
+                assert isinstance(handler.target, logging.FileHandler)
+                log_file_path = handler.target.baseFilename
         return self.global_logging_config, log_file_path
 
     def _get_target_capacity_direction(self) -> Optional[TargetCapacityDirection]:

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -2012,8 +2012,11 @@ def calculate_target_capacity_direction(
             next_target_capacity_direction = TargetCapacityDirection.DOWN
         elif next_target_capacity is None:
             next_target_capacity_direction = None
-        # The two branches above ensure both capacities are non-None here.
-        elif curr_target_capacity < next_target_capacity:  # type: ignore[operator]  # pyrefly: ignore[unsupported-operation]
+        elif (
+            curr_target_capacity is not None
+            and next_target_capacity is not None
+            and curr_target_capacity < next_target_capacity
+        ):
             next_target_capacity_direction = TargetCapacityDirection.UP
         else:
             next_target_capacity_direction = TargetCapacityDirection.DOWN

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import time
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -11,13 +12,15 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     Union,
+    cast,
 )
 
 import ray
 from ray._common.network_utils import build_address, get_all_interfaces_ip
 from ray._common.utils import run_background_task
-from ray._raylet import GcsClient
+from ray._raylet import GcsClient  # type: ignore[attr-defined]
 from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager, StatusOverview
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
@@ -116,6 +119,9 @@ from ray.serve.schema import (
 )
 from ray.util import metrics
 
+if TYPE_CHECKING:
+    from ray.serve._private.long_poll import KeyType
+
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
@@ -153,7 +159,7 @@ class ServeController:
           requires all implementations here to be idempotent.
     """
 
-    async def __init__(
+    async def __init__(  # type: ignore[misc]
         self,
         *,
         http_options: HTTPOptions,
@@ -183,7 +189,7 @@ class ServeController:
         # Try to read config from checkpoint
         # logging config from checkpoint take precedence over the one passed in
         # the constructor.
-        self.global_logging_config = None
+        self.global_logging_config: Optional[LoggingConfig] = None
         log_config_checkpoint = self.kv_store.get(LOGGING_CONFIG_CHECKPOINT_KEY)
         if log_config_checkpoint is not None:
             global_logging_config = pickle.loads(log_config_checkpoint)
@@ -233,14 +239,19 @@ class ServeController:
             http_options = http_options.model_copy(update={"location": None})
 
         # Configure proxy default HTTP and gRPC options.
+        # `global_logging_config` was set by `reconfigure_global_logging_config`
+        # above, so it is never None past this point.
         self.proxy_state_manager = ProxyStateManager(
             http_options=configure_http_options_with_defaults(http_options),
             head_node_id=self._controller_node_id,
             cluster_node_info_cache=self.cluster_node_info_cache,
-            logging_config=self.global_logging_config,
+            logging_config=cast(LoggingConfig, self.global_logging_config),
             grpc_options=set_proxy_default_grpc_options(grpc_options),
             proxy_location=proxy_location,
-            proxy_actor_class=HAProxyManager if self._ha_proxy_enabled else ProxyActor,
+            proxy_actor_class=cast(
+                Type[ProxyActor],
+                HAProxyManager if self._ha_proxy_enabled else ProxyActor,
+            ),
             running_native_proxies=self._ha_proxy_enabled,
         )
         # We modify the HTTP and gRPC options above, so delete them to avoid
@@ -273,7 +284,7 @@ class ServeController:
             self.autoscaling_state_manager,
             self.endpoint_state,
             self.kv_store,
-            self.global_logging_config,
+            cast(LoggingConfig, self.global_logging_config),
         )
 
         # Controller actor details
@@ -311,7 +322,7 @@ class ServeController:
         self._recover_state_from_checkpoint()
 
         # Nodes where proxy actors should run.
-        self._proxy_nodes = set()
+        self._proxy_nodes: Set[str] = set()
         self._update_proxy_nodes()
 
         # Initialize to None (not []) to ensure the first broadcast always happens,
@@ -382,6 +393,8 @@ class ServeController:
     ):
         if isinstance(replica_metric_report, bytes):
             replica_metric_report = decompress_metric_report(replica_metric_report)
+        # Decompression (above) always yields a ReplicaMetricReport.
+        replica_metric_report = cast(ReplicaMetricReport, replica_metric_report)
         latency = time.time() - replica_metric_report.timestamp
         latency_ms = latency * 1000
         deployment = replica_metric_report.replica_id.deployment_id.name
@@ -408,6 +421,8 @@ class ServeController:
     ):
         if isinstance(handle_metric_report, bytes):
             handle_metric_report = decompress_metric_report(handle_metric_report)
+        # Decompression (above) always yields a HandleMetricReport.
+        handle_metric_report = cast(HandleMetricReport, handle_metric_report)
         latency = time.time() - handle_metric_report.timestamp
         latency_ms = latency * 1000
         deployment = handle_metric_report.deployment_id.name
@@ -465,7 +480,7 @@ class ServeController:
             deployment_id
         )
 
-    async def listen_for_change(self, keys_to_snapshot_ids: Dict[str, int]):
+    async def listen_for_change(self, keys_to_snapshot_ids: "Dict[KeyType, int]"):
         """Proxy long pull client's listen request.
 
         Args:
@@ -525,7 +540,7 @@ class ServeController:
             return {}
         return self.proxy_state_manager.get_proxy_handles()
 
-    def get_proxy_names(self) -> bytes:
+    def get_proxy_names(self) -> Optional[bytes]:
         """Returns the proxy actor name list serialized by protobuf."""
         if self.proxy_state_manager is None:
             return None
@@ -674,8 +689,13 @@ class ServeController:
         # that may be stale for autoscaling
         if any_recovering is False:
             self.autoscaling_state_manager.drop_stale_handle_metrics(
-                self.deployment_state_manager.get_alive_replica_actor_ids()
-                | self.proxy_state_manager.get_alive_proxy_actor_ids()
+                # None actor_ids (STARTING replicas) are harmless here; cast to
+                # satisfy the landed set[str] signature without a behavior change.
+                cast(
+                    Set[str],
+                    self.deployment_state_manager.get_alive_replica_actor_ids()
+                    | self.proxy_state_manager.get_alive_proxy_actor_ids(),
+                )
             )
 
         self._maybe_update_ingress_ports()
@@ -716,7 +736,7 @@ class ServeController:
             # Update port values for ingress replicas.
             # Ingress request router replicas also need direct-ingress ports.
             ingress_replicas_info_list: List[
-                Tuple[str, str, int, int]
+                Tuple[Optional[str], str, Optional[int], Optional[int]]
             ] = self.deployment_state_manager.get_ingress_replicas_info()
 
             # update_port_if_missing is additive and idempotent, so we send update_ports
@@ -725,7 +745,14 @@ class ServeController:
             # the replica count. The full set is recomputed and cached each tick, so after
             # a controller restart the empty cache re-sends everything on the first tick.
             fresh = set(ingress_replicas_info_list)
-            NodePortManager.update_ports(list(fresh - self._last_ingress_port_tuples))
+            # update_ports expects fully-allocated tuples; cast to its landed
+            # signature (getter is honestly typed Optional for pending replicas).
+            NodePortManager.update_ports(
+                cast(
+                    List[Tuple[str, str, int, int]],
+                    list(fresh - self._last_ingress_port_tuples),
+                )
+            )
             self._last_ingress_port_tuples = fresh
 
             # Clean up stale ports
@@ -802,7 +829,9 @@ class ServeController:
             tag_keys=("actor_id",),
         )
         self.num_control_loops_gauge.set_default_tags(
-            {"actor_id": ray.get_runtime_context().get_actor_id()}
+            # The controller always runs inside an actor, so the actor ID is
+            # never None here.
+            {"actor_id": cast(str, ray.get_runtime_context().get_actor_id())}
         )
 
         # Autoscaling metrics delay gauges
@@ -939,10 +968,11 @@ class ServeController:
 
         return self.proxy_state_manager.get_proxy_details().get(node_id)
 
-    def get_deployment_timestamps(self, app_name: str) -> float:
+    # Implicitly returns None when the app doesn't exist.
+    def get_deployment_timestamps(self, app_name: str) -> Optional[float]:  # type: ignore[return]
         """Returns the deployment timestamp for the given app.
 
-        Currently used for test only.
+        Returns None if the app doesn't exist. Currently used for test only.
         """
         for (
             _app_name,
@@ -1296,7 +1326,7 @@ class ServeController:
 
     def list_deployments_internal(
         self,
-    ) -> Dict[DeploymentID, Tuple[DeploymentInfo, str]]:
+    ) -> Dict[DeploymentID, Tuple[DeploymentInfo, Optional[str]]]:
         """Gets the current information about all deployments.
 
         Returns:
@@ -1540,7 +1570,10 @@ class ServeController:
         # Create target groups for each application
         target_groups = []
         for app_name in apps:
-            route_prefix = self.application_state_manager.get_route_prefix(app_name)
+            # `apps` was filtered above to apps with a non-None route prefix.
+            route_prefix = cast(
+                str, self.application_state_manager.get_route_prefix(app_name)
+            )
             app_target_groups = self._get_target_groups_for_app(app_name, route_prefix)
             if app_target_groups:
                 target_groups.extend(app_target_groups)
@@ -1581,8 +1614,10 @@ class ServeController:
         ingress_deployment_name = (
             self.application_state_manager.get_ingress_deployment_name(app_name)
         )
+        # NOTE: `ingress_deployment_name` may still be None before the app is
+        # built; the resulting DeploymentID lookup then misses and yields [].
         return self._get_running_replica_details_for_deployment(
-            app_name, ingress_deployment_name
+            app_name, cast(str, ingress_deployment_name)
         )
 
     def _get_target_groups_for_app(
@@ -1758,14 +1793,20 @@ class ServeController:
         self, replica_detail: ReplicaDetails, protocol: RequestProtocol
     ) -> int:
         """Get the port for a replica."""
-        node_manager = NodePortManager.get_node_manager(replica_detail.node_id)
+        # Running replicas always have their node ID populated.
+        node_manager = NodePortManager.get_node_manager(
+            cast(str, replica_detail.node_id)
+        )
         return node_manager.get_port(replica_detail.replica_id, protocol)
 
     def _is_port_allocated(
         self, replica_detail: ReplicaDetails, protocol: RequestProtocol
     ) -> bool:
         """Check if the port for a replica is allocated."""
-        node_manager = NodePortManager.get_node_manager(replica_detail.node_id)
+        # Running replicas always have their node ID populated.
+        node_manager = NodePortManager.get_node_manager(
+            cast(str, replica_detail.node_id)
+        )
         return node_manager.is_port_allocated(replica_detail.replica_id, protocol)
 
     def get_serve_status(self, name: str = SERVE_DEFAULT_APP_NAME) -> bytes:
@@ -1940,7 +1981,8 @@ class ServeController:
         log_file_path = None
         for handler in logger.handlers:
             if isinstance(handler, logging.handlers.MemoryHandler):
-                log_file_path = handler.target.baseFilename
+                # Serve's MemoryHandler always wraps a file handler.
+                log_file_path = cast(logging.FileHandler, handler.target).baseFilename
         return self.global_logging_config, log_file_path
 
     def _get_target_capacity_direction(self) -> Optional[TargetCapacityDirection]:
@@ -1952,12 +1994,12 @@ class ServeController:
 def calculate_target_capacity_direction(
     curr_config: Optional[ServeDeploySchema],
     new_config: ServeDeploySchema,
-    curr_target_capacity_direction: Optional[float],
+    curr_target_capacity_direction: Optional[TargetCapacityDirection],
 ) -> Optional[TargetCapacityDirection]:
     """Compares two Serve configs to calculate the next scaling direction."""
 
     curr_target_capacity = None
-    next_target_capacity_direction = None
+    next_target_capacity_direction: Optional[TargetCapacityDirection] = None
 
     if curr_config is not None and applications_match(curr_config, new_config):
         curr_target_capacity = curr_config.target_capacity
@@ -1970,7 +2012,8 @@ def calculate_target_capacity_direction(
             next_target_capacity_direction = TargetCapacityDirection.DOWN
         elif next_target_capacity is None:
             next_target_capacity_direction = None
-        elif curr_target_capacity < next_target_capacity:
+        # The two branches above ensure both capacities are non-None here.
+        elif curr_target_capacity < next_target_capacity:  # type: ignore[operator]  # pyrefly: ignore[unsupported-operation]
             next_target_capacity_direction = TargetCapacityDirection.UP
         else:
             next_target_capacity_direction = TargetCapacityDirection.DOWN

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import time
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -11,13 +12,15 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     Union,
+    cast,
 )
 
 import ray
 from ray._common.network_utils import build_address, get_all_interfaces_ip
 from ray._common.utils import run_background_task
-from ray._raylet import GcsClient
+from ray._raylet import GcsClient  # type: ignore[attr-defined]
 from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager, StatusOverview
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
@@ -115,6 +118,9 @@ from ray.serve.schema import (
 )
 from ray.util import metrics
 
+if TYPE_CHECKING:
+    from ray.serve._private.long_poll import KeyType
+
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
@@ -152,7 +158,7 @@ class ServeController:
           requires all implementations here to be idempotent.
     """
 
-    async def __init__(
+    async def __init__(  # type: ignore[misc]
         self,
         *,
         http_options: HTTPOptions,
@@ -179,7 +185,7 @@ class ServeController:
         # Try to read config from checkpoint
         # logging config from checkpoint take precedence over the one passed in
         # the constructor.
-        self.global_logging_config = None
+        self.global_logging_config: Optional[LoggingConfig] = None
         log_config_checkpoint = self.kv_store.get(LOGGING_CONFIG_CHECKPOINT_KEY)
         if log_config_checkpoint is not None:
             global_logging_config = pickle.loads(log_config_checkpoint)
@@ -229,14 +235,19 @@ class ServeController:
             http_options = http_options.model_copy(update={"location": None})
 
         # Configure proxy default HTTP and gRPC options.
+        # `global_logging_config` was set by `reconfigure_global_logging_config`
+        # above, so it is never None past this point.
         self.proxy_state_manager = ProxyStateManager(
             http_options=configure_http_options_with_defaults(http_options),
             head_node_id=self._controller_node_id,
             cluster_node_info_cache=self.cluster_node_info_cache,
-            logging_config=self.global_logging_config,
+            logging_config=cast(LoggingConfig, self.global_logging_config),
             grpc_options=set_proxy_default_grpc_options(grpc_options),
             proxy_location=proxy_location,
-            proxy_actor_class=HAProxyManager if self._ha_proxy_enabled else ProxyActor,
+            proxy_actor_class=cast(
+                Type[ProxyActor],
+                HAProxyManager if self._ha_proxy_enabled else ProxyActor,
+            ),
             running_native_proxies=self._ha_proxy_enabled,
         )
         # We modify the HTTP and gRPC options above, so delete them to avoid
@@ -269,7 +280,7 @@ class ServeController:
             self.autoscaling_state_manager,
             self.endpoint_state,
             self.kv_store,
-            self.global_logging_config,
+            cast(LoggingConfig, self.global_logging_config),
         )
 
         # Controller actor details
@@ -307,7 +318,7 @@ class ServeController:
         self._recover_state_from_checkpoint()
 
         # Nodes where proxy actors should run.
-        self._proxy_nodes = set()
+        self._proxy_nodes: Set[str] = set()
         self._update_proxy_nodes()
 
         # Initialize to None (not []) to ensure the first broadcast always happens,
@@ -374,6 +385,8 @@ class ServeController:
     ):
         if isinstance(replica_metric_report, bytes):
             replica_metric_report = decompress_metric_report(replica_metric_report)
+        # Decompression (above) always yields a ReplicaMetricReport.
+        replica_metric_report = cast(ReplicaMetricReport, replica_metric_report)
         latency = time.time() - replica_metric_report.timestamp
         latency_ms = latency * 1000
         deployment = replica_metric_report.replica_id.deployment_id.name
@@ -400,6 +413,8 @@ class ServeController:
     ):
         if isinstance(handle_metric_report, bytes):
             handle_metric_report = decompress_metric_report(handle_metric_report)
+        # Decompression (above) always yields a HandleMetricReport.
+        handle_metric_report = cast(HandleMetricReport, handle_metric_report)
         latency = time.time() - handle_metric_report.timestamp
         latency_ms = latency * 1000
         deployment = handle_metric_report.deployment_id.name
@@ -457,7 +472,7 @@ class ServeController:
             deployment_id
         )
 
-    async def listen_for_change(self, keys_to_snapshot_ids: Dict[str, int]):
+    async def listen_for_change(self, keys_to_snapshot_ids: "Dict[KeyType, int]"):
         """Proxy long pull client's listen request.
 
         Args:
@@ -517,7 +532,7 @@ class ServeController:
             return {}
         return self.proxy_state_manager.get_proxy_handles()
 
-    def get_proxy_names(self) -> bytes:
+    def get_proxy_names(self) -> Optional[bytes]:
         """Returns the proxy actor name list serialized by protobuf."""
         if self.proxy_state_manager is None:
             return None
@@ -666,8 +681,13 @@ class ServeController:
         # that may be stale for autoscaling
         if any_recovering is False:
             self.autoscaling_state_manager.drop_stale_handle_metrics(
-                self.deployment_state_manager.get_alive_replica_actor_ids()
-                | self.proxy_state_manager.get_alive_proxy_actor_ids()
+                # None actor_ids (STARTING replicas) are harmless here; cast to
+                # satisfy the landed set[str] signature without a behavior change.
+                cast(
+                    Set[str],
+                    self.deployment_state_manager.get_alive_replica_actor_ids()
+                    | self.proxy_state_manager.get_alive_proxy_actor_ids(),
+                )
             )
 
         self._maybe_update_ingress_ports()
@@ -708,7 +728,7 @@ class ServeController:
             # Update port values for ingress replicas.
             # Ingress request router replicas also need direct-ingress ports.
             ingress_replicas_info_list: List[
-                Tuple[str, str, int, int]
+                Tuple[Optional[str], str, Optional[int], Optional[int]]
             ] = self.deployment_state_manager.get_ingress_replicas_info()
 
             # update_port_if_missing is additive and idempotent, so we send update_ports
@@ -717,7 +737,14 @@ class ServeController:
             # the replica count. The full set is recomputed and cached each tick, so after
             # a controller restart the empty cache re-sends everything on the first tick.
             fresh = set(ingress_replicas_info_list)
-            NodePortManager.update_ports(list(fresh - self._last_ingress_port_tuples))
+            # update_ports expects fully-allocated tuples; cast to its landed
+            # signature (getter is honestly typed Optional for pending replicas).
+            NodePortManager.update_ports(
+                cast(
+                    List[Tuple[str, str, int, int]],
+                    list(fresh - self._last_ingress_port_tuples),
+                )
+            )
             self._last_ingress_port_tuples = fresh
 
             # Clean up stale ports
@@ -794,7 +821,9 @@ class ServeController:
             tag_keys=("actor_id",),
         )
         self.num_control_loops_gauge.set_default_tags(
-            {"actor_id": ray.get_runtime_context().get_actor_id()}
+            # The controller always runs inside an actor, so the actor ID is
+            # never None here.
+            {"actor_id": cast(str, ray.get_runtime_context().get_actor_id())}
         )
 
         # Autoscaling metrics delay gauges
@@ -931,10 +960,11 @@ class ServeController:
 
         return self.proxy_state_manager.get_proxy_details().get(node_id)
 
-    def get_deployment_timestamps(self, app_name: str) -> float:
+    # Implicitly returns None when the app doesn't exist.
+    def get_deployment_timestamps(self, app_name: str) -> Optional[float]:  # type: ignore[return]
         """Returns the deployment timestamp for the given app.
 
-        Currently used for test only.
+        Returns None if the app doesn't exist. Currently used for test only.
         """
         for (
             _app_name,
@@ -1282,7 +1312,7 @@ class ServeController:
 
     def list_deployments_internal(
         self,
-    ) -> Dict[DeploymentID, Tuple[DeploymentInfo, str]]:
+    ) -> Dict[DeploymentID, Tuple[DeploymentInfo, Optional[str]]]:
         """Gets the current information about all deployments.
 
         Returns:
@@ -1526,7 +1556,10 @@ class ServeController:
         # Create target groups for each application
         target_groups = []
         for app_name in apps:
-            route_prefix = self.application_state_manager.get_route_prefix(app_name)
+            # `apps` was filtered above to apps with a non-None route prefix.
+            route_prefix = cast(
+                str, self.application_state_manager.get_route_prefix(app_name)
+            )
             app_target_groups = self._get_target_groups_for_app(app_name, route_prefix)
             if app_target_groups:
                 target_groups.extend(app_target_groups)
@@ -1567,8 +1600,10 @@ class ServeController:
         ingress_deployment_name = (
             self.application_state_manager.get_ingress_deployment_name(app_name)
         )
+        # NOTE: `ingress_deployment_name` may still be None before the app is
+        # built; the resulting DeploymentID lookup then misses and yields [].
         return self._get_running_replica_details_for_deployment(
-            app_name, ingress_deployment_name
+            app_name, cast(str, ingress_deployment_name)
         )
 
     def _get_target_groups_for_app(
@@ -1744,14 +1779,20 @@ class ServeController:
         self, replica_detail: ReplicaDetails, protocol: RequestProtocol
     ) -> int:
         """Get the port for a replica."""
-        node_manager = NodePortManager.get_node_manager(replica_detail.node_id)
+        # Running replicas always have their node ID populated.
+        node_manager = NodePortManager.get_node_manager(
+            cast(str, replica_detail.node_id)
+        )
         return node_manager.get_port(replica_detail.replica_id, protocol)
 
     def _is_port_allocated(
         self, replica_detail: ReplicaDetails, protocol: RequestProtocol
     ) -> bool:
         """Check if the port for a replica is allocated."""
-        node_manager = NodePortManager.get_node_manager(replica_detail.node_id)
+        # Running replicas always have their node ID populated.
+        node_manager = NodePortManager.get_node_manager(
+            cast(str, replica_detail.node_id)
+        )
         return node_manager.is_port_allocated(replica_detail.replica_id, protocol)
 
     def get_serve_status(self, name: str = SERVE_DEFAULT_APP_NAME) -> bytes:
@@ -1926,7 +1967,8 @@ class ServeController:
         log_file_path = None
         for handler in logger.handlers:
             if isinstance(handler, logging.handlers.MemoryHandler):
-                log_file_path = handler.target.baseFilename
+                # Serve's MemoryHandler always wraps a file handler.
+                log_file_path = cast(logging.FileHandler, handler.target).baseFilename
         return self.global_logging_config, log_file_path
 
     def _get_target_capacity_direction(self) -> Optional[TargetCapacityDirection]:
@@ -1938,12 +1980,12 @@ class ServeController:
 def calculate_target_capacity_direction(
     curr_config: Optional[ServeDeploySchema],
     new_config: ServeDeploySchema,
-    curr_target_capacity_direction: Optional[float],
+    curr_target_capacity_direction: Optional[TargetCapacityDirection],
 ) -> Optional[TargetCapacityDirection]:
     """Compares two Serve configs to calculate the next scaling direction."""
 
     curr_target_capacity = None
-    next_target_capacity_direction = None
+    next_target_capacity_direction: Optional[TargetCapacityDirection] = None
 
     if curr_config is not None and applications_match(curr_config, new_config):
         curr_target_capacity = curr_config.target_capacity
@@ -1956,7 +1998,8 @@ def calculate_target_capacity_direction(
             next_target_capacity_direction = TargetCapacityDirection.DOWN
         elif next_target_capacity is None:
             next_target_capacity_direction = None
-        elif curr_target_capacity < next_target_capacity:
+        # The two branches above ensure both capacities are non-None here.
+        elif curr_target_capacity < next_target_capacity:  # type: ignore[operator]  # pyrefly: ignore[unsupported-operation]
             next_target_capacity_direction = TargetCapacityDirection.UP
         else:
             next_target_capacity_direction = TargetCapacityDirection.DOWN

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -4,7 +4,6 @@ import os
 import pickle
 import time
 from typing import (
-    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -77,7 +76,7 @@ from ray.serve._private.logging_utils import (
     configure_component_memory_profiler,
     get_component_logger_file_path,
 )
-from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
+from ray.serve._private.long_poll import KeyType, LongPollHost, LongPollNamespace
 from ray.serve._private.node_port_manager import NodePortManager
 from ray.serve._private.proxy import ProxyActor
 from ray.serve._private.proxy_state import ProxyStateManager
@@ -117,9 +116,6 @@ from ray.serve.schema import (
     gRPCOptionsSchema,
 )
 from ray.util import metrics
-
-if TYPE_CHECKING:
-    from ray.serve._private.long_poll import KeyType
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -236,7 +232,8 @@ class ServeController:
 
         # Configure proxy default HTTP and gRPC options.
         # `global_logging_config` was set by `reconfigure_global_logging_config`
-        # above, so it is never None past this point.
+        # above, so it is never None past this point. (A self-attribute assert
+        # in __init__ poisons mypy's inference of later attributes, so cast.)
         self.proxy_state_manager = ProxyStateManager(
             http_options=configure_http_options_with_defaults(http_options),
             head_node_id=self._controller_node_id,
@@ -472,7 +469,7 @@ class ServeController:
             deployment_id
         )
 
-    async def listen_for_change(self, keys_to_snapshot_ids: "Dict[KeyType, int]"):
+    async def listen_for_change(self, keys_to_snapshot_ids: Dict[KeyType, int]):
         """Proxy long pull client's listen request.
 
         Args:
@@ -681,13 +678,8 @@ class ServeController:
         # that may be stale for autoscaling
         if any_recovering is False:
             self.autoscaling_state_manager.drop_stale_handle_metrics(
-                # None actor_ids (STARTING replicas) are harmless here; cast to
-                # satisfy the landed set[str] signature without a behavior change.
-                cast(
-                    Set[str],
-                    self.deployment_state_manager.get_alive_replica_actor_ids()
-                    | self.proxy_state_manager.get_alive_proxy_actor_ids(),
-                )
+                self.deployment_state_manager.get_alive_replica_actor_ids()
+                | self.proxy_state_manager.get_alive_proxy_actor_ids()
             )
 
         self._maybe_update_ingress_ports()
@@ -737,14 +729,7 @@ class ServeController:
             # the replica count. The full set is recomputed and cached each tick, so after
             # a controller restart the empty cache re-sends everything on the first tick.
             fresh = set(ingress_replicas_info_list)
-            # update_ports expects fully-allocated tuples; cast to its landed
-            # signature (getter is honestly typed Optional for pending replicas).
-            NodePortManager.update_ports(
-                cast(
-                    List[Tuple[str, str, int, int]],
-                    list(fresh - self._last_ingress_port_tuples),
-                )
-            )
+            NodePortManager.update_ports(list(fresh - self._last_ingress_port_tuples))
             self._last_ingress_port_tuples = fresh
 
             # Clean up stale ports
@@ -820,11 +805,11 @@ class ServeController:
             ),
             tag_keys=("actor_id",),
         )
-        self.num_control_loops_gauge.set_default_tags(
-            # The controller always runs inside an actor, so the actor ID is
-            # never None here.
-            {"actor_id": cast(str, ray.get_runtime_context().get_actor_id())}
-        )
+        # The controller always runs inside an actor, so the actor ID is
+        # never None here.
+        controller_actor_id = ray.get_runtime_context().get_actor_id()
+        assert controller_actor_id is not None
+        self.num_control_loops_gauge.set_default_tags({"actor_id": controller_actor_id})
 
         # Autoscaling metrics delay gauges
         self.replica_metrics_delay_histogram = metrics.Histogram(
@@ -1557,9 +1542,8 @@ class ServeController:
         target_groups = []
         for app_name in apps:
             # `apps` was filtered above to apps with a non-None route prefix.
-            route_prefix = cast(
-                str, self.application_state_manager.get_route_prefix(app_name)
-            )
+            route_prefix = self.application_state_manager.get_route_prefix(app_name)
+            assert route_prefix is not None
             app_target_groups = self._get_target_groups_for_app(app_name, route_prefix)
             if app_target_groups:
                 target_groups.extend(app_target_groups)
@@ -1600,10 +1584,12 @@ class ServeController:
         ingress_deployment_name = (
             self.application_state_manager.get_ingress_deployment_name(app_name)
         )
-        # NOTE: `ingress_deployment_name` may still be None before the app is
-        # built; the resulting DeploymentID lookup then misses and yields [].
+        # `ingress_deployment_name` may still be None before the app is built;
+        # there is no ingress deployment to look up in that case.
+        if ingress_deployment_name is None:
+            return []
         return self._get_running_replica_details_for_deployment(
-            app_name, cast(str, ingress_deployment_name)
+            app_name, ingress_deployment_name
         )
 
     def _get_target_groups_for_app(
@@ -1968,7 +1954,8 @@ class ServeController:
         for handler in logger.handlers:
             if isinstance(handler, logging.handlers.MemoryHandler):
                 # Serve's MemoryHandler always wraps a file handler.
-                log_file_path = cast(logging.FileHandler, handler.target).baseFilename
+                assert isinstance(handler.target, logging.FileHandler)
+                log_file_path = handler.target.baseFilename
         return self.global_logging_config, log_file_path
 
     def _get_target_capacity_direction(self) -> Optional[TargetCapacityDirection]:

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -1998,8 +1998,11 @@ def calculate_target_capacity_direction(
             next_target_capacity_direction = TargetCapacityDirection.DOWN
         elif next_target_capacity is None:
             next_target_capacity_direction = None
-        # The two branches above ensure both capacities are non-None here.
-        elif curr_target_capacity < next_target_capacity:  # type: ignore[operator]  # pyrefly: ignore[unsupported-operation]
+        elif (
+            curr_target_capacity is not None
+            and next_target_capacity is not None
+            and curr_target_capacity < next_target_capacity
+        ):
             next_target_capacity_direction = TargetCapacityDirection.UP
         else:
             next_target_capacity_direction = TargetCapacityDirection.DOWN

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1497,11 +1497,11 @@ class ActorReplicaWrapper:
                 # `_assign_rank_callback` is set by `start()` for every replica
                 # that reaches this non-recovery path, and `_node_id` was
                 # populated from the allocation check above.
-                # pyrefly: ignore[not-callable]
-                self._rank = self._assign_rank_callback(  # type: ignore[misc]
+                assert self._assign_rank_callback is not None
+                assert self._node_id is not None
+                self._rank = self._assign_rank_callback(
                     self._replica_id.unique_id,
-                    # pyrefly: ignore[bad-argument-type]
-                    self._node_id,  # type: ignore[arg-type]
+                    self._node_id,
                 )
                 self._ready_obj_ref = replica_ready_check_func.remote(
                     deployment_config, self._rank, self._gang_context
@@ -4554,11 +4554,12 @@ class DeploymentState:
                     if not self._rank_manager.has_replica_rank(replica_id):
                         # A replica that reached SUCCEEDED has a node id, and
                         # its rank was recovered from the actor's metadata.
+                        assert replica.actor_node_id is not None
+                        assert replica.rank is not None
                         self._rank_manager.recover_rank(
                             replica_id,
-                            # pyrefly: ignore[bad-argument-type]
-                            replica.actor_node_id,  # type: ignore[arg-type]
-                            replica.rank,  # type: ignore[arg-type]
+                            replica.actor_node_id,
+                            replica.rank,
                         )
                 # Register recovered gang replicas in the incremental
                 # bookkeeping (newly created gang replicas are already
@@ -4573,11 +4574,10 @@ class DeploymentState:
                 # This replica should be now be added to handle's replica
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
+                assert replica.actor_node_id is not None
                 self._deployment_scheduler.on_replica_running(
                     replica.replica_id,
-                    # A SUCCEEDED replica always has a node id.
-                    # pyrefly: ignore[bad-argument-type]
-                    replica.actor_node_id,  # type: ignore[arg-type]
+                    replica.actor_node_id,
                 )
 
                 # if replica version is the same as the target version,
@@ -4588,8 +4588,8 @@ class DeploymentState:
 
                 # Log the startup latency.
                 # `_start_time` is set when the replica starts or recovers.
-                # pyrefly: ignore[unsupported-operation]
-                e2e_replica_start_latency = time.time() - replica._start_time  # type: ignore[operator]
+                assert replica._start_time is not None
+                e2e_replica_start_latency = time.time() - replica._start_time
                 replica_startup_message = (
                     f"{replica.replica_id} started successfully "
                     f"on node '{replica.actor_node_id}' after "
@@ -4666,8 +4666,8 @@ class DeploymentState:
                 ReplicaStartupStatus.PENDING_ALLOCATION,
                 ReplicaStartupStatus.PENDING_INITIALIZATION,
             ]:
-                # pyrefly: ignore[unsupported-operation]
-                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S  # type: ignore[operator]
+                assert replica._start_time is not None
+                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S
                 if is_slow:
                     slow_replicas.append((replica, start_status))
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Callable,
     Deque,
+    cast,
     Dict,
     Iterable,
     List,
@@ -4552,14 +4553,15 @@ class DeploymentState:
                     # rank was never released).
                     replica_id = replica.replica_id.unique_id
                     if not self._rank_manager.has_replica_rank(replica_id):
-                        # A replica that reached SUCCEEDED has a node id, and
-                        # its rank was recovered from the actor's metadata.
-                        assert replica.actor_node_id is not None
-                        assert replica.rank is not None
+                        # Cross-language replicas can reach SUCCEEDED with
+                        # actor_node_id/rank unset (they skip the Python
+                        # allocation ray.get that sets node_id), so cast to
+                        # preserve the prior pass-through behavior rather than
+                        # asserting -- an assert here would abort the loop.
                         self._rank_manager.recover_rank(
                             replica_id,
-                            replica.actor_node_id,
-                            replica.rank,
+                            cast(str, replica.actor_node_id),
+                            cast(ReplicaRank, replica.rank),
                         )
                 # Register recovered gang replicas in the incremental
                 # bookkeeping (newly created gang replicas are already
@@ -4574,10 +4576,11 @@ class DeploymentState:
                 # This replica should be now be added to handle's replica
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
-                assert replica.actor_node_id is not None
+                # Cross-language replicas can be RUNNING with actor_node_id
+                # unset; cast to preserve the prior pass-through behavior.
                 self._deployment_scheduler.on_replica_running(
                     replica.replica_id,
-                    replica.actor_node_id,
+                    cast(str, replica.actor_node_id),
                 )
 
                 # if replica version is the same as the target version,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,7 +10,19 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import ray
 from ray import ObjectRef, cloudpickle
@@ -187,7 +199,7 @@ class DeploymentActorWrapper:
         self._handle: Optional[ActorHandle] = recovered_handle
         self._ready_ref: Optional[ObjectRef] = None
         if recovered_handle is not None and hasattr(recovered_handle, "__ray_ready__"):
-            self._ready_ref = recovered_handle.__ray_ready__.remote()
+            self._ready_ref = recovered_handle.__ray_ready__.remote()  # type: ignore[attr-defined]
         self._health_check_ref: Optional[ObjectRef] = None
         self._last_health_check_time: float = 0.0
         self._consecutive_health_check_failures: int = 0
@@ -241,7 +253,9 @@ class DeploymentActorWrapper:
             # Serve recreates deployment actors after failed health checks instead
             # of relying on Ray actor restarts.
             actor_options["max_restarts"] = 0
-            self._handle = actor_cls.options(
+            # `get_actor_class()` is annotated `type`; `.options` exists on actor
+            # classes at runtime.
+            self._handle = actor_cls.options(  # type: ignore[attr-defined]
                 name=self._actor_name,
                 namespace=SERVE_NAMESPACE,
                 lifetime="detached",
@@ -253,7 +267,8 @@ class DeploymentActorWrapper:
             )
             # Keep both handle and __ray_ready__ ref so pending creation can be
             # cancelled on delete while still waiting for resources.
-            self._ready_ref = self._handle.__ray_ready__.remote()
+            # `_handle` was just assigned from `.remote()` above.
+            self._ready_ref = self._handle.__ray_ready__.remote()  # type: ignore[union-attr]
             return True, None
         except Exception as e:
             logger.exception(
@@ -269,7 +284,7 @@ class DeploymentActorWrapper:
             return True, None
         if self._ready_ref is None:
             return False, None
-        if not check_obj_ref_ready_nowait(self._ready_ref):
+        if not check_obj_ref_ready_nowait(self._ready_ref):  # type: ignore[arg-type]
             return False, None
 
         try:
@@ -292,7 +307,7 @@ class DeploymentActorWrapper:
         """Resolve the outstanding ``__ray_ready__`` health check ref, if any."""
         if self._health_check_ref is None:
             return ReplicaHealthCheckResponse.NONE
-        if check_obj_ref_ready_nowait(self._health_check_ref):
+        if check_obj_ref_ready_nowait(self._health_check_ref):  # type: ignore[arg-type]
             try:
                 ray.get(self._health_check_ref)
                 return ReplicaHealthCheckResponse.SUCCEEDED
@@ -374,7 +389,10 @@ class DeploymentActorWrapper:
 
         if self._should_start_new_deployment_actor_health_check():
             self._last_health_check_time = time.time()
-            self._health_check_ref = self._handle.__ray_ready__.remote()
+            # `_should_start_new_deployment_actor_health_check()` returns False
+            # when `_handle` is None.
+            # pyrefly: ignore[missing-attribute]
+            self._health_check_ref = self._handle.__ray_ready__.remote()  # type: ignore[union-attr]
 
         return self._healthy
 
@@ -729,8 +747,8 @@ class ActorReplicaWrapper:
         self._actor_name = replica_id.to_full_id_str()
 
         # Populated in either self.start() or self.recover()
-        self._allocated_obj_ref: ObjectRef = None
-        self._ready_obj_ref: ObjectRef = None
+        self._allocated_obj_ref: Optional[ObjectRef] = None
+        self._ready_obj_ref: Optional[ObjectRef] = None
         # Populated in self.recover() for non-cross-language replicas to
         # asynchronously verify the actor finished its initial setup before
         # we trigger `initialize_and_get_metadata`.
@@ -742,7 +760,7 @@ class ActorReplicaWrapper:
         # underlying cause is a controller-side crash, not user code.
         self._unrecoverable: bool = False
 
-        self._actor_resources: Dict[str, float] = None
+        self._actor_resources: Optional[Dict[str, float]] = None
         # If the replica is being started, this will be the true version
         # If the replica is being recovered, this will be the target
         # version, which may be inconsistent with the actual replica
@@ -760,28 +778,30 @@ class ActorReplicaWrapper:
         self._internal_grpc_port: Optional[int] = None
         self._docs_path: Optional[str] = None
         self._route_patterns: Optional[List[str]] = None
-        # Rank assigned to the replica.
-        self._assign_rank_callback: Optional[Callable[[ReplicaID], ReplicaRank]] = None
+        # Rank assigned to the replica. The callback takes the replica's
+        # unique id and its node id and returns the assigned rank (see
+        # `DeploymentRankManager.assign_rank`).
+        self._assign_rank_callback: Optional[Callable[[str, str], ReplicaRank]] = None
         self._rank: Optional[ReplicaRank] = None
         # Gang context for the replica.
         self._gang_context: Optional[GangContext] = None
         # Populated in `on_scheduled` or `recover`.
-        self._actor_handle: ActorHandle = None
-        self._placement_group: PlacementGroup = None
+        self._actor_handle: Optional[ActorHandle] = None
+        self._placement_group: Optional[PlacementGroup] = None
 
         # Populated after replica is allocated.
-        self._pid: int = None
-        self._actor_id: str = None
-        self._worker_id: str = None
-        self._node_id: str = None
-        self._node_ip: str = None
-        self._node_instance_id: str = None
-        self._log_file_path: str = None
-        self._http_port: int = None
-        self._grpc_port: int = None
+        self._pid: Optional[int] = None
+        self._actor_id: Optional[str] = None
+        self._worker_id: Optional[str] = None
+        self._node_id: Optional[str] = None
+        self._node_ip: Optional[str] = None
+        self._node_instance_id: Optional[str] = None
+        self._log_file_path: Optional[str] = None
+        self._http_port: Optional[int] = None
+        self._grpc_port: Optional[int] = None
 
         # Populated in self.stop().
-        self._graceful_shutdown_ref: ObjectRef = None
+        self._graceful_shutdown_ref: Optional[ObjectRef] = None
 
         # todo: will be confused with deployment_config.is_cross_language
         self._is_cross_language = False
@@ -806,7 +826,10 @@ class ActorReplicaWrapper:
                 "from replica to controller."
             ),
             boundaries=DEFAULT_LATENCY_BUCKET_MS,
-            tag_keys=("deployment", "application"),
+            # Upstream `tag_keys` is annotated `Tuple[str]` but accepts any
+            # tuple of strings.
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self._routing_stats_delay_histogram.set_default_tags(
             {
@@ -822,7 +845,8 @@ class ActorReplicaWrapper:
                 "The number of errors (exceptions or timeouts) when getting "
                 "routing stats from replica."
             ),
-            tag_keys=("deployment", "replica", "application", "error_type"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "replica", "application", "error_type"),  # type: ignore[arg-type]
         )
         self._routing_stats_error_counter.set_default_tags(
             {
@@ -846,7 +870,7 @@ class ActorReplicaWrapper:
         )
 
     @property
-    def replica_id(self) -> str:
+    def replica_id(self) -> ReplicaID:
         return self._replica_id
 
     @property
@@ -1044,7 +1068,7 @@ class ActorReplicaWrapper:
     def start(
         self,
         deployment_info: DeploymentInfo,
-        assign_rank_callback: Callable[[ReplicaID], ReplicaRank],
+        assign_rank_callback: Callable[[str, str], ReplicaRank],
         gang_placement_group: Optional[PlacementGroup] = None,
         gang_pg_index: Optional[int] = None,
         gang_context: Optional[GangContext] = None,
@@ -1084,6 +1108,7 @@ class ActorReplicaWrapper:
         )
 
         actor_def = deployment_info.actor_def
+        init_args: Tuple[Any, ...]
         if (
             deployment_info.deployment_config.deployment_language
             == DeploymentLanguage.PYTHON
@@ -1134,7 +1159,10 @@ class ActorReplicaWrapper:
                 # byte[] initArgsbytes
                 msgpack_serialize(
                     cloudpickle.loads(
-                        deployment_info.replica_config.serialized_init_args
+                        # Cross-language deployments always have serialized init
+                        # args.
+                        # pyrefly: ignore[bad-argument-type]
+                        deployment_info.replica_config.serialized_init_args  # type: ignore[arg-type]
                     )
                 )
                 if self._deployment_is_cross_language
@@ -1142,7 +1170,10 @@ class ActorReplicaWrapper:
                 # byte[] deploymentConfigBytes,
                 deployment_info.deployment_config.to_proto_bytes(),
                 # byte[] deploymentVersionBytes,
-                self._version.to_proto().SerializeToString(),
+                # `DeploymentVersion.to_proto()` is mis-annotated as `bytes`
+                # upstream; it returns the protobuf message.
+                # pyrefly: ignore[missing-attribute]
+                self._version.to_proto().SerializeToString(),  # type: ignore[attr-defined]
                 # String controllerName
                 # String appName
                 self.app_name,
@@ -1173,6 +1204,9 @@ class ActorReplicaWrapper:
             actor_def=actor_def,
             actor_resources=self._actor_resources,
             actor_options=actor_options,
+            # `deployment_language` is always PYTHON or JAVA, so `init_args`
+            # is always bound here.
+            # pyrefly: ignore[unbound-name]
             actor_init_args=init_args,
             placement_group_bundles=(
                 deployment_info.replica_config.placement_group_bundles
@@ -1204,10 +1238,13 @@ class ActorReplicaWrapper:
         self._placement_group = placement_group
 
         if self._is_cross_language:
-            self._actor_handle = JavaActorHandleProxy(self._actor_handle)
-            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
+            # Cross-language replicas wrap the handle in `JavaActorHandleProxy`.
+            # pyrefly: ignore[bad-assignment]
+            self._actor_handle = JavaActorHandleProxy(self._actor_handle)  # type: ignore[assignment]
+            # pyrefly: ignore[missing-attribute]
+            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()  # type: ignore[attr-defined]
         else:
-            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
+            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()  # type: ignore[attr-defined]
 
     def _format_user_config(self, user_config: Any):
         temp = copy(user_config)
@@ -1243,7 +1280,10 @@ class ActorReplicaWrapper:
             deployment_config.user_config = self._format_user_config(
                 deployment_config.user_config
             )
-            self._ready_obj_ref = self._actor_handle.reconfigure.remote(
+            # `reconfigure` is only called on scheduled/recovered replicas, so
+            # `_actor_handle` is set.
+            # pyrefly: ignore[missing-attribute]
+            self._ready_obj_ref = self._actor_handle.reconfigure.remote(  # type: ignore[union-attr]
                 deployment_config,
                 rank,
                 version.route_prefix,
@@ -1298,12 +1338,12 @@ class ActorReplicaWrapper:
             self._placement_group = None
 
         # Re-fetch initialization proof
-        self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
+        self._allocated_obj_ref = self._actor_handle.is_allocated.remote()  # type: ignore[attr-defined]
 
         # Running actor handle already has all info needed, thus successful
         # starting simply means retrieving replica version hash from actor
         if self._is_cross_language:
-            self._ready_obj_ref = self._actor_handle.check_health.remote()
+            self._ready_obj_ref = self._actor_handle.check_health.remote()  # type: ignore[attr-defined]
         else:
             # For non-cross-language replicas, asynchronously probe whether
             # the actor finished its initial setup before triggering
@@ -1318,7 +1358,7 @@ class ActorReplicaWrapper:
             # `initialize_and_get_metadata` until the probe passes so we
             # don't accidentally drive the bad actor through initialization
             # only to kill it afterwards.
-            self._was_initialized_obj_ref = self._actor_handle.was_initialized.remote()
+            self._was_initialized_obj_ref = self._actor_handle.was_initialized.remote()  # type: ignore[attr-defined]
 
         return True
 
@@ -1329,7 +1369,9 @@ class ActorReplicaWrapper:
         logged but ignored.
         """
         try:
-            ray.kill(self._actor_handle, no_restart=True)
+            # Only called from `check_ready()`, after the handle is set.
+            # pyrefly: ignore[bad-argument-type]
+            ray.kill(self._actor_handle, no_restart=True)  # type: ignore[arg-type]
         except Exception:
             logger.exception(
                 f"Failed to kill unrecoverable replica actor "
@@ -1356,7 +1398,7 @@ class ActorReplicaWrapper:
 
         # Check whether the replica has been allocated.
         if self._allocated_obj_ref is None or not check_obj_ref_ready_nowait(
-            self._allocated_obj_ref
+            self._allocated_obj_ref  # type: ignore[arg-type]
         ):
             return ReplicaStartupStatus.PENDING_ALLOCATION, None
 
@@ -1394,7 +1436,7 @@ class ActorReplicaWrapper:
         # mid-startup), kill it and signal an unrecoverable drop so the
         # reconciler replaces it without counting a deploy failure.
         if self._was_initialized_obj_ref is not None:
-            if not check_obj_ref_ready_nowait(self._was_initialized_obj_ref):
+            if not check_obj_ref_ready_nowait(self._was_initialized_obj_ref):  # type: ignore[arg-type]
                 return ReplicaStartupStatus.PENDING_INITIALIZATION, None
 
             probe_ref = self._was_initialized_obj_ref
@@ -1425,8 +1467,11 @@ class ActorReplicaWrapper:
                 return ReplicaStartupStatus.FAILED, msg
 
             # Probe succeeded; safe to drive the actor through recovery.
+            # `check_ready()` runs only after `on_scheduled`/`recover` set
+            # `_actor_handle`.
             self._ready_obj_ref = (
-                self._actor_handle.initialize_and_get_metadata.remote()
+                # pyrefly: ignore[missing-attribute]
+                self._actor_handle.initialize_and_get_metadata.remote()  # type: ignore[union-attr]
             )
 
         if self._ready_obj_ref is None:
@@ -1437,16 +1482,26 @@ class ActorReplicaWrapper:
                 deployment_config.user_config
             )
             if self._is_cross_language:
-                self._ready_obj_ref = self._actor_handle.is_initialized.remote(
+                # `_actor_handle` is set by `on_scheduled`/`recover` before
+                # `check_ready()` runs.
+                # pyrefly: ignore[missing-attribute]
+                self._ready_obj_ref = self._actor_handle.is_initialized.remote(  # type: ignore[union-attr]
                     deployment_config.to_proto_bytes()
                 )
             else:
                 replica_ready_check_func = (
-                    self._actor_handle.initialize_and_get_metadata
+                    # pyrefly: ignore[missing-attribute]
+                    self._actor_handle.initialize_and_get_metadata  # type: ignore[union-attr]
                 )
                 # this guarantees that node_id is set before rank is assigned
-                self._rank = self._assign_rank_callback(
-                    self._replica_id.unique_id, self._node_id
+                # `_assign_rank_callback` is set by `start()` for every replica
+                # that reaches this non-recovery path, and `_node_id` was
+                # populated from the allocation check above.
+                # pyrefly: ignore[not-callable]
+                self._rank = self._assign_rank_callback(  # type: ignore[misc]
+                    self._replica_id.unique_id,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._node_id,  # type: ignore[arg-type]
                 )
                 self._ready_obj_ref = replica_ready_check_func.remote(
                     deployment_config, self._rank, self._gang_context
@@ -1455,7 +1510,7 @@ class ActorReplicaWrapper:
             return ReplicaStartupStatus.PENDING_INITIALIZATION, None
 
         # Check whether replica initialization has completed.
-        replica_ready = check_obj_ref_ready_nowait(self._ready_obj_ref)
+        replica_ready = check_obj_ref_ready_nowait(self._ready_obj_ref)  # type: ignore[arg-type]
         # In case of deployment constructor failure, ray.get will help to
         # surface exception to each update() cycle.
         if not replica_ready:
@@ -1509,6 +1564,7 @@ class ActorReplicaWrapper:
 
     @property
     def available_resources(self) -> Dict[str, float]:
+        # pyrefly: ignore[bad-return]
         return ray.available_resources()
 
     def graceful_stop(self) -> Duration:
@@ -1519,8 +1575,9 @@ class ActorReplicaWrapper:
         try:
             handle = ray.get_actor(self._actor_name, namespace=SERVE_NAMESPACE)
             if self._is_cross_language:
-                handle = JavaActorHandleProxy(handle)
-            self._graceful_shutdown_ref = handle.perform_graceful_shutdown.remote()
+                # Cross-language handles are wrapped in `JavaActorHandleProxy`.
+                handle = JavaActorHandleProxy(handle)  # type: ignore[assignment]
+            self._graceful_shutdown_ref = handle.perform_graceful_shutdown.remote()  # type: ignore[attr-defined]
         except ValueError:
             # ValueError thrown from ray.get_actor means actor has already been deleted.
             pass
@@ -1538,10 +1595,11 @@ class ActorReplicaWrapper:
                 # the next reconcile iteration will retry.
                 stopped = False
             else:
-                stopped = check_obj_ref_ready_nowait(self._graceful_shutdown_ref)
+                stopped = check_obj_ref_ready_nowait(self._graceful_shutdown_ref)  # type: ignore[arg-type]
             if stopped:
                 try:
-                    ray.get(self._graceful_shutdown_ref)
+                    # `stopped` is only True here when the shutdown ref was set.
+                    ray.get(self._graceful_shutdown_ref)  # type: ignore[arg-type]
                 except Exception:
                     logger.exception(
                         "Exception when trying to gracefully shutdown replica:\n"
@@ -1592,7 +1650,7 @@ class ActorReplicaWrapper:
         if self._health_check_ref is None:
             # There is no outstanding health check.
             response = ReplicaHealthCheckResponse.NONE
-        elif check_obj_ref_ready_nowait(self._health_check_ref):
+        elif check_obj_ref_ready_nowait(self._health_check_ref):  # type: ignore[arg-type]
             # Object ref is ready, ray.get it to check for exceptions.
             try:
                 ray.get(self._health_check_ref)
@@ -1741,7 +1799,9 @@ class ActorReplicaWrapper:
 
         if self._should_start_new_health_check():
             self._last_health_check_time = time.time()
-            self._health_check_ref = self._actor_handle.check_health.remote()
+            # Health checks only run on live replicas, so `_actor_handle` is set.
+            # pyrefly: ignore[missing-attribute]
+            self._health_check_ref = self._actor_handle.check_health.remote()  # type: ignore[union-attr]
 
         return self._healthy
 
@@ -1750,9 +1810,12 @@ class ActorReplicaWrapper:
         if self._record_routing_stats_ref is None:
             # There's no active record routing stats.
             pass
-        elif check_obj_ref_ready_nowait(self._record_routing_stats_ref):
+        elif check_obj_ref_ready_nowait(self._record_routing_stats_ref):  # type: ignore[arg-type]
             # Object ref is ready, ray.get it to check for exceptions.
             try:
+                # `ray.get` on a single ref returns the replica's stats dict;
+                # pyrefly picks the list overload here.
+                # pyrefly: ignore[bad-assignment]
                 self._routing_stats = ray.get(self._record_routing_stats_ref)
                 # Record the round-trip delay for routing stats
                 delay_ms = (time.time() - self._last_record_routing_stats_time) * 1000
@@ -1779,8 +1842,11 @@ class ActorReplicaWrapper:
 
         if self._should_record_routing_stats():
             self._last_record_routing_stats_time = time.time()
+            # Routing stats are only pulled from live replicas, so
+            # `_actor_handle` is set.
             self._record_routing_stats_ref = (
-                self._actor_handle.record_routing_stats.remote()
+                # pyrefly: ignore[missing-attribute]
+                self._actor_handle.record_routing_stats.remote()  # type: ignore[union-attr]
             )
 
         return self._routing_stats
@@ -1810,7 +1876,7 @@ class DeploymentReplica:
         self._replica_id = replica_id
         self._actor = ActorReplicaWrapper(replica_id, version)
         self._target_node_id: Optional[str] = None
-        self._start_time = None
+        self._start_time: Optional[float] = None
         self._shutdown_start_time: Optional[float] = None
         self._actor_details = ReplicaDetails(
             actor_name=replica_id.to_full_id_str(),
@@ -1828,7 +1894,12 @@ class DeploymentReplica:
             replica_id=self._replica_id,
             node_id=self.actor_node_id,
             node_ip=self._actor.node_ip,
-            availability_zone=cluster_node_info_cache.get_node_az(self.actor_node_id),
+            # Only called for RUNNING/PENDING_MIGRATION replicas, whose node id
+            # is set.
+            availability_zone=cluster_node_info_cache.get_node_az(
+                # pyrefly: ignore[bad-argument-type]
+                self.actor_node_id  # type: ignore[arg-type]
+            ),
             actor_name=self._actor._actor_name,
             max_ongoing_requests=self._actor.max_ongoing_requests,
             is_cross_language=self._actor.is_cross_language,
@@ -1895,11 +1966,11 @@ class DeploymentReplica:
         return self._actor.route_patterns
 
     @property
-    def actor_id(self) -> str:
+    def actor_id(self) -> Optional[str]:
         return self._actor.actor_id
 
     @property
-    def actor_handle(self) -> ActorHandle:
+    def actor_handle(self) -> Optional[ActorHandle]:
         return self._actor.actor_handle
 
     @property
@@ -1954,7 +2025,7 @@ class DeploymentReplica:
     def start(
         self,
         deployment_info: DeploymentInfo,
-        assign_rank_callback: Callable[[ReplicaID], ReplicaRank],
+        assign_rank_callback: Callable[[str, str], ReplicaRank],
         gang_placement_group: Optional[PlacementGroup] = None,
         gang_pg_index: Optional[int] = None,
         gang_context: Optional[GangContext] = None,
@@ -2042,7 +2113,7 @@ class DeploymentReplica:
 
     def check_started(
         self,
-    ) -> Tuple[ReplicaStartupStatus, Optional[str], Optional[float]]:
+    ) -> Tuple[ReplicaStartupStatus, Optional[str]]:
         """Check if the replica has started. If so, transition to RUNNING.
 
         Should handle the case where the replica has already stopped.
@@ -2150,6 +2221,7 @@ class DeploymentReplica:
         if self._actor.actor_resources is None:
             return "UNKNOWN", "UNKNOWN"
 
+        required: Union[List[Dict[str, float]], Dict[str, float]]
         if self._actor.placement_group_bundles is not None:
             required = self._actor.placement_group_bundles
         else:
@@ -2257,7 +2329,7 @@ class ReplicaStateContainer:
         self,
         exclude_version: Optional[DeploymentVersion] = None,
         states: Optional[List[ReplicaState]] = None,
-        max_replicas: Optional[int] = math.inf,
+        max_replicas: Optional[float] = math.inf,
     ) -> List[DeploymentReplica]:
         """Get and remove all replicas of the given states.
 
@@ -2281,9 +2353,9 @@ class ReplicaStateContainer:
         assert exclude_version is None or isinstance(exclude_version, DeploymentVersion)
         assert isinstance(states, list)
 
-        replicas = []
+        replicas: List[DeploymentReplica] = []
         for state in states:
-            popped = []
+            popped: List[DeploymentReplica] = []
             remaining = []
 
             for replica in self._replicas[state]:
@@ -2343,7 +2415,7 @@ class ReplicaStateContainer:
                 "Only one of `version` or `exclude_version` may be provided."
             )
 
-    def remove(self, replica_ids: Set[ReplicaID]) -> List[DeploymentReplica]:
+    def remove(self, replica_ids: Iterable[ReplicaID]) -> List[DeploymentReplica]:
         """Remove and return all replicas whose IDs are in the given set.
 
         Performs a single pass over the container. Non-matching replicas
@@ -2485,7 +2557,7 @@ class RankManager:
             raise RuntimeError("Rank system is in an invalid state.")
 
         # Check for duplicate ranks - this should never happen
-        rank_counts = {}
+        rank_counts: Dict[int, int] = {}
         for key, rank in self._ranks.copy().items():
             if key in active_keys_set:  # Only check active keys
                 rank_counts[rank] = rank_counts.get(rank, 0) + 1
@@ -2968,7 +3040,10 @@ class DeploymentState:
                 "replica series is 1 for healthy and 0 for unhealthy; otherwise, "
                 "the deployment/application series is the healthy replica count."
             ),
-            tag_keys=replica_lifecycle_metric_tag_keys,
+            # Upstream `tag_keys` is annotated `Tuple[str]` but accepts any
+            # tuple of strings.
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=replica_lifecycle_metric_tag_keys,  # type: ignore[arg-type]
         )
         self.health_check_gauge.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2979,7 +3054,8 @@ class DeploymentState:
             "serve_replica_startup_latency_ms",
             description=("Time from replica creation to ready state in milliseconds."),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_startup_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2990,7 +3066,8 @@ class DeploymentState:
             "serve_replica_initialization_latency_ms",
             description=("Time for replica to initialize in milliseconds."),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_initialization_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3002,7 +3079,8 @@ class DeploymentState:
             "serve_replica_reconfigure_latency_ms",
             description=("Time for replica to complete reconfigure in milliseconds."),
             boundaries=REQUEST_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_reconfigure_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3013,7 +3091,8 @@ class DeploymentState:
             "serve_health_check_latency_ms",
             description=("Duration of health check calls in milliseconds."),
             boundaries=REQUEST_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.health_check_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3023,7 +3102,8 @@ class DeploymentState:
         self.health_check_failures_counter = metrics.Counter(
             "serve_health_check_failures_total",
             description=("Count of failed health checks."),
-            tag_keys=replica_lifecycle_metric_tag_keys,
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=replica_lifecycle_metric_tag_keys,  # type: ignore[arg-type]
         )
         self.health_check_failures_counter.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3036,7 +3116,8 @@ class DeploymentState:
                 "Time from shutdown signal to replica fully stopped in milliseconds."
             ),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_shutdown_duration_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3048,7 +3129,8 @@ class DeploymentState:
                 "The target number of replicas for this deployment. "
                 "This is the number the autoscaler is trying to reach."
             ),
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.target_replicas_gauge.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3079,7 +3161,7 @@ class DeploymentState:
         # consume_ingress_membership_removed.
         self._ingress_membership_removed: bool = False
         self._last_broadcasted_availability: Optional[bool] = None
-        self._last_broadcasted_deployment_config = None
+        self._last_broadcasted_deployment_config: Optional[DeploymentConfig] = None
 
         self._docs_path: Optional[str] = None
         self._route_patterns: Optional[List[str]] = None
@@ -3117,13 +3199,18 @@ class DeploymentState:
     ):
         logger.info(f"Recovering target state for {self._id} from checkpoint.")
         self._target_state = target_state_checkpoint
+        # Checkpointed target states always carry a `DeploymentInfo`.
         self._deployment_scheduler.on_deployment_deployed(
-            self._id, self._target_state.info.replica_config
+            self._id,
+            # pyrefly: ignore[missing-attribute]
+            self._target_state.info.replica_config,  # type: ignore[union-attr]
         )
-        if self._target_state.info.deployment_config.autoscaling_config:
+        # pyrefly: ignore[missing-attribute]
+        if self._target_state.info.deployment_config.autoscaling_config:  # type: ignore[union-attr]
             self._autoscaling_state_manager.register_deployment(
                 self._id,
-                self._target_state.info,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.info,  # type: ignore[arg-type]
                 self._target_state.target_num_replicas,
             )
         self._recover_deployment_actors()
@@ -3144,13 +3231,17 @@ class DeploymentState:
         # All current states use default value, only attach running replicas.
         for replica_actor_name in replica_actor_names:
             replica_id = ReplicaID.from_full_id_str(replica_actor_name)
+            # The target state was recovered from a checkpoint first, so its
+            # `version` and `info` are set.
             new_deployment_replica = DeploymentReplica(
                 replica_id,
-                self._target_state.version,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.version,  # type: ignore[arg-type]
             )
             # If replica is no longer alive, simply don't add it to the
             # deployment state manager to track.
-            if not new_deployment_replica.recover(self._target_state.info):
+            # pyrefly: ignore[bad-argument-type]
+            if not new_deployment_replica.recover(self._target_state.info):  # type: ignore[arg-type]
                 logger.warning(f"{replica_id} died before controller could recover it.")
                 continue
 
@@ -3208,11 +3299,15 @@ class DeploymentState:
 
     @property
     def target_info(self) -> DeploymentInfo:
-        return self._target_state.info
+        # `info` is only None before the first deploy()/recovery.
+        # pyrefly: ignore[bad-return]
+        return self._target_state.info  # type: ignore[return-value]
 
     @property
     def target_version(self) -> DeploymentVersion:
-        return self._target_state.version
+        # `version` is only None before the first deploy()/recovery.
+        # pyrefly: ignore[bad-return]
+        return self._target_state.version  # type: ignore[return-value]
 
     @property
     def target_num_replicas(self) -> int:
@@ -3241,7 +3336,9 @@ class DeploymentState:
     @property
     def _failed_to_start_threshold(self) -> int:
         return min(
-            self._target_state.info.deployment_config.max_constructor_retry_count,
+            # `info` is set for any deployed target state.
+            # pyrefly: ignore[missing-attribute]
+            self._target_state.info.deployment_config.max_constructor_retry_count,  # type: ignore[union-attr]
             self._target_state.target_num_replicas * MAX_PER_REPLICA_RETRY_COUNT,
         )
 
@@ -3252,7 +3349,9 @@ class DeploymentState:
         Unlike replica threshold, deployment actors are deployment-scoped so we don't
         scale by target_num_replicas (which would be 0 during scale-to-zero/deletion).
         """
-        return self._target_state.info.deployment_config.max_constructor_retry_count
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        return self._target_state.info.deployment_config.max_constructor_retry_count  # type: ignore[union-attr]
 
     def _get_deployment_actors_configs(
         self, version: Optional[DeploymentVersion] = None
@@ -3311,7 +3410,7 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
+    def get_alive_replica_actor_ids(self) -> Set[Optional[str]]:
         return {replica.actor_id for replica in self._replicas.get()}
 
     def get_running_replica_ids(self) -> List[ReplicaID]:
@@ -3330,11 +3429,14 @@ class DeploymentState:
             )
         ]
 
-    def get_num_running_replicas(self, version: DeploymentVersion = None) -> int:
+    def get_num_running_replicas(
+        self, version: Optional[DeploymentVersion] = None
+    ) -> int:
         return self._replicas.count(states=[ReplicaState.RUNNING], version=version)
 
     def get_gang_config(self):
         return (
+            # pyrefly: ignore[missing-attribute]
             self._target_state.info.deployment_config.gang_scheduling_config
             if self._target_state is not None
             else None
@@ -3452,9 +3554,12 @@ class DeploymentState:
             is_available=is_available,
             running_replicas=running_replica_infos,
         )
+        # `LongPollHost.notify_changed`'s `KeyType` doesn't include
+        # `Tuple[LongPollNamespace, DeploymentID]` keys.
         self._long_poll_host.notify_changed(
+            # pyrefly: ignore[bad-argument-type]
             {
-                (
+                (  # type: ignore[dict-item]
                     LongPollNamespace.DEPLOYMENT_TARGETS,
                     self._id,
                 ): deployment_metadata,
@@ -3479,12 +3584,15 @@ class DeploymentState:
         Keeps an in-memory record of the last config that was broadcast to determine
         if it has changed.
         """
-        current_deployment_config = self._target_state.info.deployment_config
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        current_deployment_config = self._target_state.info.deployment_config  # type: ignore[union-attr]
         if self._last_broadcasted_deployment_config == current_deployment_config:
             return
 
         self._long_poll_host.notify_changed(
-            {(LongPollNamespace.DEPLOYMENT_CONFIG, self._id): current_deployment_config}
+            # pyrefly: ignore[bad-argument-type]
+            {(LongPollNamespace.DEPLOYMENT_CONFIG, self._id): current_deployment_config}  # type: ignore[dict-item]
         )
 
         self._last_broadcasted_deployment_config = current_deployment_config
@@ -3492,7 +3600,9 @@ class DeploymentState:
     def _set_target_state_deleting(self) -> None:
         """Set the target state for the deployment to be deleted."""
         target_state = DeploymentTargetState.create(
-            info=self._target_state.info,
+            # Deleting an existing deployment implies `info` is set.
+            # pyrefly: ignore[bad-argument-type]
+            info=self._target_state.info,  # type: ignore[arg-type]
             target_num_replicas=0,
             deleting=True,
         )
@@ -3528,16 +3638,22 @@ class DeploymentState:
 
         if self._target_state.version == new_target_state.version:
             # Record either num replica or autoscaling config lightweight update
+            # Versions are equal here, and the new target state's version is
+            # always set, so the old one is too.
             if (
-                self._target_state.version.deployment_config.autoscaling_config
-                != new_target_state.version.deployment_config.autoscaling_config
+                # pyrefly: ignore[missing-attribute]
+                self._target_state.version.deployment_config.autoscaling_config  # type: ignore[union-attr]
+                # pyrefly: ignore[missing-attribute]
+                != new_target_state.version.deployment_config.autoscaling_config  # type: ignore[union-attr]
             ):
                 ServeUsageTag.AUTOSCALING_CONFIG_LIGHTWEIGHT_UPDATED.record("True")
             elif updated_via_api:
                 ServeUsageTag.NUM_REPLICAS_VIA_API_CALL_UPDATED.record("True")
             elif (
-                self._target_state.version.deployment_config.num_replicas
-                != new_target_state.version.deployment_config.num_replicas
+                # pyrefly: ignore[missing-attribute]
+                self._target_state.version.deployment_config.num_replicas  # type: ignore[union-attr]
+                # pyrefly: ignore[missing-attribute]
+                != new_target_state.version.deployment_config.num_replicas  # type: ignore[union-attr]
             ):
                 ServeUsageTag.NUM_REPLICAS_LIGHTWEIGHT_UPDATED.record("True")
 
@@ -3611,7 +3727,9 @@ class DeploymentState:
         else:
             self._autoscaling_state_manager.deregister_deployment(self._id)
             target_num_replicas = get_capacity_adjusted_num_replicas(
-                deployment_info.deployment_config.num_replicas,
+                # `num_replicas` is always set for non-autoscaling deployments.
+                # pyrefly: ignore[bad-argument-type]
+                deployment_info.deployment_config.num_replicas,  # type: ignore[arg-type]
                 deployment_info.target_capacity,
             )
 
@@ -3694,11 +3812,15 @@ class DeploymentState:
         if decision_num_replicas == self._target_state.target_num_replicas:
             return False
 
+        # Autoscaling only runs on deployed target states, so `info` and
+        # `version` are set.
         new_info = copy(self._target_state.info)
-        new_info.version = self._target_state.version.code_version
+        # pyrefly: ignore[missing-attribute]
+        new_info.version = self._target_state.version.code_version  # type: ignore[union-attr]
 
         old_num = self._target_state.target_num_replicas
-        self._set_target_state(new_info, decision_num_replicas)
+        # pyrefly: ignore[bad-argument-type]
+        self._set_target_state(new_info, decision_num_replicas)  # type: ignore[arg-type]
 
         # The deployment should only transition to UPSCALING/DOWNSCALING
         # if it's within the autoscaling bounds
@@ -3746,7 +3868,11 @@ class DeploymentState:
     ) -> None:
         """Set the target state for the deployment to the provided info."""
         self._set_target_state(
-            self._target_state.info, target_num_replicas, updated_via_api=True
+            # Only called for existing deployments, so `info` is set.
+            # pyrefly: ignore[bad-argument-type]
+            self._target_state.info,  # type: ignore[arg-type]
+            target_num_replicas,
+            updated_via_api=True,
         )
 
     def _rescale_to(self, num_replicas: int) -> None:
@@ -3868,11 +3994,14 @@ class DeploymentState:
             # Group restart-candidates by gang_id.
             gangs: Dict[str, List[DeploymentReplica]] = defaultdict(list)
             for replica in need_restart:
-                gangs[replica.gang_context.gang_id].append(replica)
+                # Gang deployments always set `gang_context` on their replicas.
+                # pyrefly: ignore[missing-attribute]
+                gangs[replica.gang_context.gang_id].append(replica)  # type: ignore[union-attr]
 
             # Stop complete gangs atomically within the budget
             for _, gang_replicas in gangs.items():
-                expected_size = gang_replicas[0].gang_context.world_size
+                # pyrefly: ignore[missing-attribute]
+                expected_size = gang_replicas[0].gang_context.world_size  # type: ignore[union-attr]
                 if len(gang_replicas) != expected_size:
                     # Gang is incomplete (members may be RECOVERING/UPDATING);
                     # wait for them to stabilize before tearing down.
@@ -3922,7 +4051,10 @@ class DeploymentState:
                     replica.replica_id.unique_id
                 )
                 actor_updating = replica.reconfigure(
-                    self._target_state.version, rank=current_rank
+                    # The target version is set for deployed target states.
+                    # pyrefly: ignore[bad-argument-type]
+                    self._target_state.version,  # type: ignore[arg-type]
+                    rank=current_rank,
                 )
                 if actor_updating:
                     self._replicas.add(ReplicaState.UPDATING, replica)
@@ -4001,7 +4133,9 @@ class DeploymentState:
         # There should never be more than rollout_size old replicas stopping
         # or rollout_size new replicas starting.
         rolling_update_percentage = (
-            self._target_state.info.deployment_config.rolling_update_percentage
+            # `info` is set for any deployed target state.
+            # pyrefly: ignore[missing-attribute]
+            self._target_state.info.deployment_config.rolling_update_percentage  # type: ignore[union-attr]
         )
         rollout_size = max(
             int(rolling_update_percentage * self._target_state.target_num_replicas), 1
@@ -4011,6 +4145,8 @@ class DeploymentState:
         # gang_size so that we always stop and start complete gangs.
         if self._is_gang_deployment:
             gang_config = self.get_gang_config()
+            # `_is_gang_deployment` implies a gang config exists.
+            # pyrefly: ignore[missing-attribute]
             gs = gang_config.gang_size
             rollout_size = max(rollout_size, gs)
             rollout_size = math.ceil(rollout_size / gs) * gs
@@ -4025,7 +4161,7 @@ class DeploymentState:
             Dict[DeploymentID, GangReservationResult]
         ] = None,
         proxy_nodes: Optional[Set[str]] = None,
-    ) -> Tuple[List[ReplicaSchedulingRequest], DeploymentDownscaleRequest]:
+    ) -> Tuple[List[ReplicaSchedulingRequest], Optional[DeploymentDownscaleRequest]]:
         """Scale the given deployment to the number of replicas.
 
         Args:
@@ -4056,8 +4192,8 @@ class DeploymentState:
             self._target_state.target_num_replicas >= 0
         ), "Target number of replicas must be greater than or equal to 0."
 
-        upscale = []
-        downscale = None
+        upscale: List[ReplicaSchedulingRequest] = []
+        downscale: Optional[DeploymentDownscaleRequest] = None
 
         self._check_and_stop_outdated_version_replicas()
         self.stop_deployment_actors_if_needed()
@@ -4099,6 +4235,7 @@ class DeploymentState:
                 num_to_stop=to_remove,
                 gang_id_by_replica=gang_id_by_replica,
                 replicas_by_gang_id=replicas_by_gang_id,
+                # pyrefly: ignore[missing-attribute]
                 gang_size=self.get_gang_config().gang_size
                 if self._is_gang_deployment
                 else None,
@@ -4115,7 +4252,7 @@ class DeploymentState:
         target_node_ids: Optional[List[str]] = None,
     ) -> List[ReplicaSchedulingRequest]:
         """Add replicas for this deployment, using gang scheduling when configured."""
-        upscale = []
+        upscale: List[ReplicaSchedulingRequest] = []
         if to_add <= 0 or self._terminally_failed():
             return upscale
 
@@ -4137,14 +4274,17 @@ class DeploymentState:
         target_node_ids, when given, pins new replica i to node i (the ingress
         request router uses this to co-locate with each proxy).
         """
-        upscale = []
+        upscale: List[ReplicaSchedulingRequest] = []
         logger.info(f"Adding {to_add} replica{'s' * (to_add > 1)} to {self._id}.")
         for i in range(to_add):
             replica_id = ReplicaID(get_random_string(), deployment_id=self._id)
 
+            # The target state is deployed here, so `version` and `info` are
+            # set.
             new_deployment_replica = DeploymentReplica(
                 replica_id,
-                self._target_state.version,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.version,  # type: ignore[arg-type]
             )
             target_node_id = (
                 target_node_ids[i]
@@ -4152,7 +4292,8 @@ class DeploymentState:
                 else None
             )
             scheduling_request = new_deployment_replica.start(
-                self._target_state.info,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.info,  # type: ignore[arg-type]
                 assign_rank_callback=self._rank_manager.assign_rank,
                 target_node_id=target_node_id,
             )
@@ -4176,7 +4317,7 @@ class DeploymentState:
         Returns:
             List of ReplicaSchedulingRequests for the new replicas.
         """
-        upscale = []
+        upscale: List[ReplicaSchedulingRequest] = []
 
         if gang_reservation_result is None:
             logger.info(
@@ -4196,17 +4337,21 @@ class DeploymentState:
             )
             return upscale
 
+        # On success, the reservation result's PG/id/name lists are populated.
         gang_pgs = gang_reservation_result.gang_pgs
         gang_ids = gang_reservation_result.gang_ids
         gang_pg_names = gang_reservation_result.gang_pg_names
         gang_size = gang_config.gang_size
-        num_gangs = len(gang_pgs)
+        # pyrefly: ignore[bad-argument-type]
+        num_gangs = len(gang_pgs)  # type: ignore[arg-type]
         replicas_to_add = num_gangs * gang_size
 
         # When per-replica PG bundles are defined, each replica occupies multiple
         # consecutive bundles in the gang PG.  The actor for replica i is placed at
         # bundle i * bundles_per_replica.
-        pg_bundles = self._target_state.info.replica_config.placement_group_bundles
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        pg_bundles = self._target_state.info.replica_config.placement_group_bundles  # type: ignore[union-attr]
         bundles_per_replica = len(pg_bundles) if pg_bundles else 1
 
         logger.info(
@@ -4215,7 +4360,8 @@ class DeploymentState:
             f"(gang_size={gang_size}, {num_gangs} gang(s))."
         )
 
-        for gang_pg, gang_id, pg_name in zip(gang_pgs, gang_ids, gang_pg_names):
+        # pyrefly: ignore[bad-argument-type]
+        for gang_pg, gang_id, pg_name in zip(gang_pgs, gang_ids, gang_pg_names):  # type: ignore[arg-type]
             member_replica_ids = [
                 ReplicaID(get_random_string(), deployment_id=self._id)
                 for _ in range(gang_size)
@@ -4232,11 +4378,13 @@ class DeploymentState:
 
                 new_deployment_replica = DeploymentReplica(
                     replica_id,
-                    self._target_state.version,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._target_state.version,  # type: ignore[arg-type]
                 )
 
                 scheduling_request = new_deployment_replica.start(
-                    self._target_state.info,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._target_state.info,  # type: ignore[arg-type]
                     assign_rank_callback=self._rank_manager.assign_rank,
                     gang_placement_group=gang_pg,
                     gang_pg_index=bundle_index * bundles_per_replica,
@@ -4388,7 +4536,7 @@ class DeploymentState:
         Returns:
             The list of replicas considered slow, along with their startup status.
         """
-        slow_replicas = []
+        slow_replicas: List[Tuple[DeploymentReplica, ReplicaStartupStatus]] = []
         failed_gang_ids: Set[str] = set()
         for replica in self._replicas.pop(states=[original_state]):
             start_status, error_msg = replica.check_started()
@@ -4404,8 +4552,13 @@ class DeploymentState:
                     # rank was never released).
                     replica_id = replica.replica_id.unique_id
                     if not self._rank_manager.has_replica_rank(replica_id):
+                        # A replica that reached SUCCEEDED has a node id, and
+                        # its rank was recovered from the actor's metadata.
                         self._rank_manager.recover_rank(
-                            replica_id, replica.actor_node_id, replica.rank
+                            replica_id,
+                            # pyrefly: ignore[bad-argument-type]
+                            replica.actor_node_id,  # type: ignore[arg-type]
+                            replica.rank,  # type: ignore[arg-type]
                         )
                 # Register recovered gang replicas in the incremental
                 # bookkeeping (newly created gang replicas are already
@@ -4421,7 +4574,10 @@ class DeploymentState:
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
                 self._deployment_scheduler.on_replica_running(
-                    replica.replica_id, replica.actor_node_id
+                    replica.replica_id,
+                    # A SUCCEEDED replica always has a node id.
+                    # pyrefly: ignore[bad-argument-type]
+                    replica.actor_node_id,  # type: ignore[arg-type]
                 )
 
                 # if replica version is the same as the target version,
@@ -4431,7 +4587,9 @@ class DeploymentState:
                     self._route_patterns = replica.route_patterns
 
                 # Log the startup latency.
-                e2e_replica_start_latency = time.time() - replica._start_time
+                # `_start_time` is set when the replica starts or recovers.
+                # pyrefly: ignore[unsupported-operation]
+                e2e_replica_start_latency = time.time() - replica._start_time  # type: ignore[operator]
                 replica_startup_message = (
                     f"{replica.replica_id} started successfully "
                     f"on node '{replica.actor_node_id}' after "
@@ -4496,7 +4654,9 @@ class DeploymentState:
                     replica.gang_context is None
                     or replica.gang_context.gang_id not in failed_gang_ids
                 ):
-                    self.record_replica_startup_failure(error_msg)
+                    # A FAILED startup status always carries an error message.
+                    # pyrefly: ignore[bad-argument-type]
+                    self.record_replica_startup_failure(error_msg)  # type: ignore[arg-type]
 
                 self._stop_replica(replica)
                 # Track failed gang IDs for sibling cleanup below.
@@ -4506,7 +4666,8 @@ class DeploymentState:
                 ReplicaStartupStatus.PENDING_ALLOCATION,
                 ReplicaStartupStatus.PENDING_INITIALIZATION,
             ]:
-                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S
+                # pyrefly: ignore[unsupported-operation]
+                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S  # type: ignore[operator]
                 if is_slow:
                     slow_replicas.append((replica, start_status))
 
@@ -4613,7 +4774,7 @@ class DeploymentState:
         fully stopped and been removed from tracking)."""
         self._health_gauge_cache.pop(replica_unique_id, None)
 
-    def stop_replicas(self, replicas_to_stop: Set[ReplicaID]) -> None:
+    def stop_replicas(self, replicas_to_stop: Iterable[ReplicaID]) -> None:
         for replica in self._replicas.remove(replicas_to_stop):
             self._stop_replica(replica)
 
@@ -4914,6 +5075,7 @@ class DeploymentState:
             # FORCE_STOP_UNHEALTHY_REPLICAS.
             if (
                 self._is_gang_deployment
+                # pyrefly: ignore[missing-attribute]
                 and self.get_gang_config().runtime_failure_policy
                 == GangRuntimeFailurePolicy.RESTART_GANG
             ):
@@ -5211,7 +5373,9 @@ class DeploymentState:
             # Use reconfigure() to update rank
             # World size is calculated automatically from deployment config
             _ = replica.reconfigure(
-                self._target_state.version,
+                # The target version is set for deployed target states.
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.version,  # type: ignore[arg-type]
                 rank=new_rank,
             )
             updated_count += 1
@@ -5231,7 +5395,7 @@ class DeploymentState:
     @staticmethod
     def _group_effective_deadline(
         group: List[DeploymentReplica],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
     ) -> float:
         """Return the effective deadline for a group of replicas.
 
@@ -5239,7 +5403,10 @@ class DeploymentState:
         falls back to infinity if no member is on a draining node.
         """
         member_deadlines = [
-            deadlines[r.actor_node_id] for r in group if r.actor_node_id in deadlines
+            # The `in deadlines` filter guarantees a non-None node id.
+            deadlines[r.actor_node_id]  # type: ignore[index]
+            for r in group
+            if r.actor_node_id in deadlines
         ]
         return min(member_deadlines) if member_deadlines else float("inf")
 
@@ -5253,7 +5420,7 @@ class DeploymentState:
     def _choose_pending_migration_replicas_to_stop(
         self,
         replicas: List[DeploymentReplica],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
         min_replicas_to_stop: int,
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
         """Returns a partition of replicas to stop and to keep.
@@ -5278,13 +5445,15 @@ class DeploymentState:
         """Group replicas by their gang_id."""
         gangs: Dict[str, List[DeploymentReplica]] = defaultdict(list)
         for replica in replicas:
-            gangs[replica.gang_context.gang_id].append(replica)
+            # Gang deployments always set `gang_context` on their replicas.
+            # pyrefly: ignore[missing-attribute]
+            gangs[replica.gang_context.gang_id].append(replica)  # type: ignore[union-attr]
         return gangs
 
     def _choose_pending_migration_gangs_to_stop(
         self,
         replicas: List[DeploymentReplica],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
         min_replicas_to_stop: int,
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
         """Gang-aware variant: stop complete gangs atomically.
@@ -5301,7 +5470,7 @@ class DeploymentState:
     def _partition_groups_to_stop(
         self,
         groups: List[List[DeploymentReplica]],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
         min_replicas_to_stop: int,
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
         """Partition replica groups into those to stop and those to keep.
@@ -5342,7 +5511,7 @@ class DeploymentState:
 
         return to_stop, remaining
 
-    def migrate_replicas_on_draining_nodes(self, draining_nodes: Dict[str, int]):
+    def migrate_replicas_on_draining_nodes(self, draining_nodes: Mapping[str, float]):
         # Fast path: no draining nodes and deployment is in steady state —
         # no PENDING_MIGRATION replicas to move back and no replicas to
         # migrate, so skip the O(N) pop-and-readd.
@@ -5397,7 +5566,8 @@ class DeploymentState:
             gangs_to_migrate: Set[str] = set()
             for replica in all_replicas:
                 if replica.actor_node_id in draining_nodes:
-                    gangs_to_migrate.add(replica.gang_context.gang_id)
+                    # pyrefly: ignore[missing-attribute]
+                    gangs_to_migrate.add(replica.gang_context.gang_id)  # type: ignore[union-attr]
 
             def needs_migration(r):
                 return r.gang_context.gang_id in gangs_to_migrate
@@ -5483,10 +5653,13 @@ class DeploymentState:
             self._replicas.add(ReplicaState.RUNNING, replica)
 
     def is_ingress(self) -> bool:
-        return self._target_state.info.ingress
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        return self._target_state.info.ingress  # type: ignore[union-attr]
 
     def is_ingress_request_router(self) -> bool:
-        return self._target_state.info.ingress_request_router
+        # pyrefly: ignore[missing-attribute]
+        return self._target_state.info.ingress_request_router  # type: ignore[union-attr]
 
     def owns_direct_ingress_ports(self) -> bool:
         """Whether this deployment owns direct-ingress ports -- i.e. it is an
@@ -5606,7 +5779,9 @@ class DeploymentState:
                     f"(attempt {self._deployment_actor_retry_counter + 1}/"
                     f"{self._deployment_actor_failed_to_start_threshold})"
                 )
-                self.record_deployment_actor_startup_failure(error_msg)
+                # A failed start always carries an error message.
+                # pyrefly: ignore[bad-argument-type]
+                self.record_deployment_actor_startup_failure(error_msg)  # type: ignore[arg-type]
                 return
             self._deployment_actors.add(DeploymentActorState.STARTING, wrapper)
         return
@@ -5832,7 +6007,7 @@ class DeploymentStateManager:
 
     def _map_actor_names_to_deployment(
         self, all_current_actor_names: List[str]
-    ) -> Dict[str, List[str]]:
+    ) -> Dict[DeploymentID, List[str]]:
         """
         Given a list of all actor names queried from current ray cluster,
         map them to corresponding deployments.
@@ -6141,6 +6316,7 @@ class DeploymentStateManager:
     def get_deployment_docs_path(self, deployment_id: DeploymentID) -> Optional[str]:
         if deployment_id in self._deployment_states:
             return self._deployment_states[deployment_id].docs_path
+        return None
 
     def get_deployment_route_patterns(
         self, deployment_id: DeploymentID
@@ -6179,7 +6355,10 @@ class DeploymentStateManager:
                 status_trigger=status_info.status_trigger,
                 message=status_info.message,
                 deployment_config=_deployment_info_to_schema(
-                    id.name, self.get_deployment(id)
+                    # The deployment exists here, so `get_deployment` is not
+                    # None.
+                    id.name,
+                    self.get_deployment(id),  # type: ignore[arg-type]
                 ),
                 target_num_replicas=deployment_state._target_state.target_num_replicas,
                 required_resources=deployment_state.target_info.replica_config.resource_dict,
@@ -6208,8 +6387,8 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids = set()
+    def get_alive_replica_actor_ids(self) -> Set[Optional[str]]:
+        alive_replica_actor_ids: Set[Optional[str]] = set()
         for ds in self._deployment_states.values():
             alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
 
@@ -6352,7 +6531,9 @@ class DeploymentStateManager:
             deployment_state.check_curr_status()
 
         # STEP 3: Drain nodes
-        draining_nodes = self._cluster_node_info_cache.get_draining_nodes()
+        draining_nodes: Mapping[
+            str, float
+        ] = self._cluster_node_info_cache.get_draining_nodes()
         allow_new_compaction = len(draining_nodes) == 0 and all(
             ds.curr_status_info.status == DeploymentStatus.HEALTHY
             # TODO(zcin): Make sure that status should never be healthy if
@@ -6463,9 +6644,12 @@ class DeploymentStateManager:
             # Don't evict in the same tick: the waiter wakes after update()
             # returns and listen_for_change's guard would drop the payload.
             tombstone = DeploymentTargetInfo(is_available=False, running_replicas=[])
+            # `LongPollHost`'s `KeyType` doesn't include
+            # `Tuple[LongPollNamespace, DeploymentID]` keys.
             self._long_poll_host.notify_changed(
+                # pyrefly: ignore[bad-argument-type]
                 {
-                    (LongPollNamespace.DEPLOYMENT_TARGETS, deployment_id): tombstone,
+                    (LongPollNamespace.DEPLOYMENT_TARGETS, deployment_id): tombstone,  # type: ignore[dict-item]
                     (
                         LongPollNamespace.DEPLOYMENT_TARGETS,
                         deployment_id.name,
@@ -6473,7 +6657,8 @@ class DeploymentStateManager:
                 }
             )
             self._long_poll_host.remove_keys(
-                [(LongPollNamespace.DEPLOYMENT_CONFIG, deployment_id)]
+                # pyrefly: ignore[bad-argument-type]
+                [(LongPollNamespace.DEPLOYMENT_CONFIG, deployment_id)]  # type: ignore[list-item]
             )
 
         if len(deleted_ids):
@@ -6599,10 +6784,15 @@ class DeploymentStateManager:
             ):
                 continue
 
-            replica_config = deployment_state._target_state.info.replica_config
+            # Gang deployments here are deployed, so `info` and the gang
+            # config are set.
+            # pyrefly: ignore[missing-attribute]
+            replica_config = deployment_state._target_state.info.replica_config  # type: ignore[union-attr]
             gang_requests[deployment_id] = GangPlacementGroupRequest(
                 deployment_id=deployment_id,
+                # pyrefly: ignore[missing-attribute]
                 gang_size=gang_config.gang_size,
+                # pyrefly: ignore[missing-attribute]
                 gang_placement_strategy=gang_config.gang_placement_strategy.value,
                 num_replicas_to_add=num_replicas_to_add,
                 replica_resource_dict=replica_config.resource_dict.copy(),
@@ -6657,7 +6847,9 @@ class DeploymentStateManager:
         this is unchanged. See _ingress_membership_version."""
         return self._ingress_membership_version
 
-    def get_ingress_replicas_info(self) -> List[Tuple[str, str, int, int]]:
+    def get_ingress_replicas_info(
+        self,
+    ) -> List[Tuple[Optional[str], str, Optional[int], Optional[int]]]:
         """Get replicas that own direct-ingress ports.
 
         Includes both ingress deployments and ingress request router deployments.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3303,8 +3303,10 @@ class DeploymentState:
 
     @property
     def target_info(self) -> DeploymentInfo:
-        # `info` is only None before the first deploy()/recovery.
-        return self._deployed_info
+        # `info` is only None before the first deploy()/recovery, where callers
+        # (e.g. _record_deployment_usage) guard on None -- so this must not assert.
+        # pyrefly: ignore[bad-return]
+        return self._target_state.info  # type: ignore[return-value]
 
     @property
     def target_version(self) -> DeploymentVersion:
@@ -6179,6 +6181,9 @@ class DeploymentStateManager:
         If a tier does not drain within RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S it is
         force advanced past.
         """
+        # Both are populated by the caller before this runs (see None-check above).
+        assert self._shutdown_tiers is not None
+        assert self._shutdown_tier_started_at is not None
         while self._shutdown_tier_idx < len(self._shutdown_tiers):
             tier = [
                 deployment_id

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Callable,
     Deque,
-    cast,
     Dict,
     Iterable,
     List,
@@ -23,6 +22,7 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 import ray
@@ -98,6 +98,7 @@ from ray.serve._private.deployment_scheduler import (
 from ray.serve._private.exceptions import DeploymentIsBeingDeletedError
 from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
 from ray.serve._private.storage.kv_store import KVStoreBase
+from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
     JavaActorHandleProxy,
@@ -778,7 +779,7 @@ class ActorReplicaWrapper:
         self._reconfigure_start_time: Optional[float] = None
         self._internal_grpc_port: Optional[int] = None
         self._docs_path: Optional[str] = None
-        self._route_patterns: Optional[List[str]] = None
+        self._route_patterns: Optional[List[RoutePattern]] = None
         # Rank assigned to the replica. The callback takes the replica's
         # unique id and its node id and returns the assigned rank (see
         # `DeploymentRankManager.assign_rank`).
@@ -952,7 +953,7 @@ class ActorReplicaWrapper:
         return self._docs_path
 
     @property
-    def route_patterns(self) -> Optional[List[str]]:
+    def route_patterns(self) -> Optional[List[RoutePattern]]:
         return self._route_patterns
 
     @property
@@ -1963,7 +1964,7 @@ class DeploymentReplica:
         return self._actor.docs_path
 
     @property
-    def route_patterns(self) -> Optional[List[str]]:
+    def route_patterns(self) -> Optional[List[RoutePattern]]:
         return self._actor.route_patterns
 
     @property
@@ -3165,7 +3166,7 @@ class DeploymentState:
         self._last_broadcasted_deployment_config: Optional[DeploymentConfig] = None
 
         self._docs_path: Optional[str] = None
-        self._route_patterns: Optional[List[str]] = None
+        self._route_patterns: Optional[List[RoutePattern]] = None
 
     _BROADCAST_STATES = frozenset(
         {ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION}
@@ -3331,7 +3332,7 @@ class DeploymentState:
         return self._docs_path
 
     @property
-    def route_patterns(self) -> Optional[List[str]]:
+    def route_patterns(self) -> Optional[List[RoutePattern]]:
         return self._route_patterns
 
     @property
@@ -3887,6 +3888,10 @@ class DeploymentState:
         old_num = self._target_state.target_num_replicas
         if num_replicas == old_num:
             return
+        # A rescale only happens on an already-deployed target, so info/version
+        # are set here.
+        assert self._target_state.info is not None
+        assert self._target_state.version is not None
         new_info = copy(self._target_state.info)
         new_info.version = self._target_state.version.code_version
         self._set_target_state(new_info, num_replicas)
@@ -5010,7 +5015,10 @@ class DeploymentState:
         configured. Falls back to the defaults before a target is set.
         """
         try:
-            cfg = self._target_state.info.deployment_config
+            # info is None before a target is set; the AttributeError propagates to
+            # the except below and falls back to defaults.
+            # pyrefly: ignore[missing-attribute]
+            cfg = self._target_state.info.deployment_config  # type: ignore[union-attr]
             return min(
                 cfg.health_check_period_s,
                 cfg.request_router_config.request_routing_stats_period_s,
@@ -6323,7 +6331,7 @@ class DeploymentStateManager:
 
     def get_deployment_route_patterns(
         self, deployment_id: DeploymentID
-    ) -> Optional[List[str]]:
+    ) -> Optional[List[RoutePattern]]:
         """Get route patterns for a deployment if available."""
         if deployment_id in self._deployment_states:
             return self._deployment_states[deployment_id].route_patterns

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3204,15 +3204,12 @@ class DeploymentState:
         # Checkpointed target states always carry a `DeploymentInfo`.
         self._deployment_scheduler.on_deployment_deployed(
             self._id,
-            # pyrefly: ignore[missing-attribute]
-            self._target_state.info.replica_config,  # type: ignore[union-attr]
+            self._deployed_info.replica_config,
         )
-        # pyrefly: ignore[missing-attribute]
-        if self._target_state.info.deployment_config.autoscaling_config:  # type: ignore[union-attr]
+        if self._deployed_info.deployment_config.autoscaling_config:
             self._autoscaling_state_manager.register_deployment(
                 self._id,
-                # pyrefly: ignore[bad-argument-type]
-                self._target_state.info,  # type: ignore[arg-type]
+                self._deployed_info,
                 self._target_state.target_num_replicas,
             )
         self._recover_deployment_actors()
@@ -3242,8 +3239,7 @@ class DeploymentState:
             )
             # If replica is no longer alive, simply don't add it to the
             # deployment state manager to track.
-            # pyrefly: ignore[bad-argument-type]
-            if not new_deployment_replica.recover(self._target_state.info):  # type: ignore[arg-type]
+            if not new_deployment_replica.recover(self._deployed_info):
                 logger.warning(f"{replica_id} died before controller could recover it.")
                 continue
 
@@ -3300,10 +3296,15 @@ class DeploymentState:
             )
 
     @property
+    def _deployed_info(self) -> DeploymentInfo:
+        """The target DeploymentInfo, asserted present (set for any deployed target)."""
+        assert self._target_state.info is not None, "no target state set"
+        return self._target_state.info
+
+    @property
     def target_info(self) -> DeploymentInfo:
         # `info` is only None before the first deploy()/recovery.
-        # pyrefly: ignore[bad-return]
-        return self._target_state.info  # type: ignore[return-value]
+        return self._deployed_info
 
     @property
     def target_version(self) -> DeploymentVersion:
@@ -3339,8 +3340,7 @@ class DeploymentState:
     def _failed_to_start_threshold(self) -> int:
         return min(
             # `info` is set for any deployed target state.
-            # pyrefly: ignore[missing-attribute]
-            self._target_state.info.deployment_config.max_constructor_retry_count,  # type: ignore[union-attr]
+            self._deployed_info.deployment_config.max_constructor_retry_count,
             self._target_state.target_num_replicas * MAX_PER_REPLICA_RETRY_COUNT,
         )
 
@@ -3352,8 +3352,7 @@ class DeploymentState:
         scale by target_num_replicas (which would be 0 during scale-to-zero/deletion).
         """
         # `info` is set for any deployed target state.
-        # pyrefly: ignore[missing-attribute]
-        return self._target_state.info.deployment_config.max_constructor_retry_count  # type: ignore[union-attr]
+        return self._deployed_info.deployment_config.max_constructor_retry_count
 
     def _get_deployment_actors_configs(
         self, version: Optional[DeploymentVersion] = None
@@ -3412,8 +3411,8 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[Optional[str]]:
-        return {replica.actor_id for replica in self._replicas.get()}
+    def get_alive_replica_actor_ids(self) -> Set[str]:
+        return {r.actor_id for r in self._replicas.get() if r.actor_id is not None}
 
     def get_running_replica_ids(self) -> List[ReplicaID]:
         return [
@@ -3587,8 +3586,7 @@ class DeploymentState:
         if it has changed.
         """
         # `info` is set for any deployed target state.
-        # pyrefly: ignore[missing-attribute]
-        current_deployment_config = self._target_state.info.deployment_config  # type: ignore[union-attr]
+        current_deployment_config = self._deployed_info.deployment_config
         if self._last_broadcasted_deployment_config == current_deployment_config:
             return
 
@@ -3603,8 +3601,7 @@ class DeploymentState:
         """Set the target state for the deployment to be deleted."""
         target_state = DeploymentTargetState.create(
             # Deleting an existing deployment implies `info` is set.
-            # pyrefly: ignore[bad-argument-type]
-            info=self._target_state.info,  # type: ignore[arg-type]
+            info=self._deployed_info,
             target_num_replicas=0,
             deleting=True,
         )
@@ -3871,8 +3868,7 @@ class DeploymentState:
         """Set the target state for the deployment to the provided info."""
         self._set_target_state(
             # Only called for existing deployments, so `info` is set.
-            # pyrefly: ignore[bad-argument-type]
-            self._target_state.info,  # type: ignore[arg-type]
+            self._deployed_info,
             target_num_replicas,
             updated_via_api=True,
         )
@@ -4140,8 +4136,7 @@ class DeploymentState:
         # or rollout_size new replicas starting.
         rolling_update_percentage = (
             # `info` is set for any deployed target state.
-            # pyrefly: ignore[missing-attribute]
-            self._target_state.info.deployment_config.rolling_update_percentage  # type: ignore[union-attr]
+            self._deployed_info.deployment_config.rolling_update_percentage
         )
         rollout_size = max(
             int(rolling_update_percentage * self._target_state.target_num_replicas), 1
@@ -4298,8 +4293,7 @@ class DeploymentState:
                 else None
             )
             scheduling_request = new_deployment_replica.start(
-                # pyrefly: ignore[bad-argument-type]
-                self._target_state.info,  # type: ignore[arg-type]
+                self._deployed_info,
                 assign_rank_callback=self._rank_manager.assign_rank,
                 target_node_id=target_node_id,
             )
@@ -4356,8 +4350,7 @@ class DeploymentState:
         # consecutive bundles in the gang PG.  The actor for replica i is placed at
         # bundle i * bundles_per_replica.
         # `info` is set for any deployed target state.
-        # pyrefly: ignore[missing-attribute]
-        pg_bundles = self._target_state.info.replica_config.placement_group_bundles  # type: ignore[union-attr]
+        pg_bundles = self._deployed_info.replica_config.placement_group_bundles
         bundles_per_replica = len(pg_bundles) if pg_bundles else 1
 
         logger.info(
@@ -4389,8 +4382,7 @@ class DeploymentState:
                 )
 
                 scheduling_request = new_deployment_replica.start(
-                    # pyrefly: ignore[bad-argument-type]
-                    self._target_state.info,  # type: ignore[arg-type]
+                    self._deployed_info,
                     assign_rank_callback=self._rank_manager.assign_rank,
                     gang_placement_group=gang_pg,
                     gang_pg_index=bundle_index * bundles_per_replica,
@@ -5665,12 +5657,10 @@ class DeploymentState:
 
     def is_ingress(self) -> bool:
         # `info` is set for any deployed target state.
-        # pyrefly: ignore[missing-attribute]
-        return self._target_state.info.ingress  # type: ignore[union-attr]
+        return self._deployed_info.ingress
 
     def is_ingress_request_router(self) -> bool:
-        # pyrefly: ignore[missing-attribute]
-        return self._target_state.info.ingress_request_router  # type: ignore[union-attr]
+        return self._deployed_info.ingress_request_router
 
     def owns_direct_ingress_ports(self) -> bool:
         """Whether this deployment owns direct-ingress ports -- i.e. it is an
@@ -6398,8 +6388,8 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[Optional[str]]:
-        alive_replica_actor_ids: Set[Optional[str]] = set()
+    def get_alive_replica_actor_ids(self) -> Set[str]:
+        alive_replica_actor_ids: Set[str] = set()
         for ds in self._deployment_states.values():
             alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,7 +10,19 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import ray
 from ray import ObjectRef, cloudpickle
@@ -186,7 +198,7 @@ class DeploymentActorWrapper:
         self._handle: Optional[ActorHandle] = recovered_handle
         self._ready_ref: Optional[ObjectRef] = None
         if recovered_handle is not None and hasattr(recovered_handle, "__ray_ready__"):
-            self._ready_ref = recovered_handle.__ray_ready__.remote()
+            self._ready_ref = recovered_handle.__ray_ready__.remote()  # type: ignore[attr-defined]
         self._health_check_ref: Optional[ObjectRef] = None
         self._last_health_check_time: float = 0.0
         self._consecutive_health_check_failures: int = 0
@@ -240,7 +252,9 @@ class DeploymentActorWrapper:
             # Serve recreates deployment actors after failed health checks instead
             # of relying on Ray actor restarts.
             actor_options["max_restarts"] = 0
-            self._handle = actor_cls.options(
+            # `get_actor_class()` is annotated `type`; `.options` exists on actor
+            # classes at runtime.
+            self._handle = actor_cls.options(  # type: ignore[attr-defined]
                 name=self._actor_name,
                 namespace=SERVE_NAMESPACE,
                 lifetime="detached",
@@ -252,7 +266,8 @@ class DeploymentActorWrapper:
             )
             # Keep both handle and __ray_ready__ ref so pending creation can be
             # cancelled on delete while still waiting for resources.
-            self._ready_ref = self._handle.__ray_ready__.remote()
+            # `_handle` was just assigned from `.remote()` above.
+            self._ready_ref = self._handle.__ray_ready__.remote()  # type: ignore[union-attr]
             return True, None
         except Exception as e:
             logger.exception(
@@ -268,7 +283,7 @@ class DeploymentActorWrapper:
             return True, None
         if self._ready_ref is None:
             return False, None
-        if not check_obj_ref_ready_nowait(self._ready_ref):
+        if not check_obj_ref_ready_nowait(self._ready_ref):  # type: ignore[arg-type]
             return False, None
 
         try:
@@ -291,7 +306,7 @@ class DeploymentActorWrapper:
         """Resolve the outstanding ``__ray_ready__`` health check ref, if any."""
         if self._health_check_ref is None:
             return ReplicaHealthCheckResponse.NONE
-        if check_obj_ref_ready_nowait(self._health_check_ref):
+        if check_obj_ref_ready_nowait(self._health_check_ref):  # type: ignore[arg-type]
             try:
                 ray.get(self._health_check_ref)
                 return ReplicaHealthCheckResponse.SUCCEEDED
@@ -373,7 +388,10 @@ class DeploymentActorWrapper:
 
         if self._should_start_new_deployment_actor_health_check():
             self._last_health_check_time = time.time()
-            self._health_check_ref = self._handle.__ray_ready__.remote()
+            # `_should_start_new_deployment_actor_health_check()` returns False
+            # when `_handle` is None.
+            # pyrefly: ignore[missing-attribute]
+            self._health_check_ref = self._handle.__ray_ready__.remote()  # type: ignore[union-attr]
 
         return self._healthy
 
@@ -728,8 +746,8 @@ class ActorReplicaWrapper:
         self._actor_name = replica_id.to_full_id_str()
 
         # Populated in either self.start() or self.recover()
-        self._allocated_obj_ref: ObjectRef = None
-        self._ready_obj_ref: ObjectRef = None
+        self._allocated_obj_ref: Optional[ObjectRef] = None
+        self._ready_obj_ref: Optional[ObjectRef] = None
         # Populated in self.recover() for non-cross-language replicas to
         # asynchronously verify the actor finished its initial setup before
         # we trigger `initialize_and_get_metadata`.
@@ -741,7 +759,7 @@ class ActorReplicaWrapper:
         # underlying cause is a controller-side crash, not user code.
         self._unrecoverable: bool = False
 
-        self._actor_resources: Dict[str, float] = None
+        self._actor_resources: Optional[Dict[str, float]] = None
         # If the replica is being started, this will be the true version
         # If the replica is being recovered, this will be the target
         # version, which may be inconsistent with the actual replica
@@ -759,28 +777,30 @@ class ActorReplicaWrapper:
         self._internal_grpc_port: Optional[int] = None
         self._docs_path: Optional[str] = None
         self._route_patterns: Optional[List[str]] = None
-        # Rank assigned to the replica.
-        self._assign_rank_callback: Optional[Callable[[ReplicaID], ReplicaRank]] = None
+        # Rank assigned to the replica. The callback takes the replica's
+        # unique id and its node id and returns the assigned rank (see
+        # `DeploymentRankManager.assign_rank`).
+        self._assign_rank_callback: Optional[Callable[[str, str], ReplicaRank]] = None
         self._rank: Optional[ReplicaRank] = None
         # Gang context for the replica.
         self._gang_context: Optional[GangContext] = None
         # Populated in `on_scheduled` or `recover`.
-        self._actor_handle: ActorHandle = None
-        self._placement_group: PlacementGroup = None
+        self._actor_handle: Optional[ActorHandle] = None
+        self._placement_group: Optional[PlacementGroup] = None
 
         # Populated after replica is allocated.
-        self._pid: int = None
-        self._actor_id: str = None
-        self._worker_id: str = None
-        self._node_id: str = None
-        self._node_ip: str = None
-        self._node_instance_id: str = None
-        self._log_file_path: str = None
-        self._http_port: int = None
-        self._grpc_port: int = None
+        self._pid: Optional[int] = None
+        self._actor_id: Optional[str] = None
+        self._worker_id: Optional[str] = None
+        self._node_id: Optional[str] = None
+        self._node_ip: Optional[str] = None
+        self._node_instance_id: Optional[str] = None
+        self._log_file_path: Optional[str] = None
+        self._http_port: Optional[int] = None
+        self._grpc_port: Optional[int] = None
 
         # Populated in self.stop().
-        self._graceful_shutdown_ref: ObjectRef = None
+        self._graceful_shutdown_ref: Optional[ObjectRef] = None
 
         # todo: will be confused with deployment_config.is_cross_language
         self._is_cross_language = False
@@ -805,7 +825,10 @@ class ActorReplicaWrapper:
                 "from replica to controller."
             ),
             boundaries=DEFAULT_LATENCY_BUCKET_MS,
-            tag_keys=("deployment", "application"),
+            # Upstream `tag_keys` is annotated `Tuple[str]` but accepts any
+            # tuple of strings.
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self._routing_stats_delay_histogram.set_default_tags(
             {
@@ -821,7 +844,8 @@ class ActorReplicaWrapper:
                 "The number of errors (exceptions or timeouts) when getting "
                 "routing stats from replica."
             ),
-            tag_keys=("deployment", "replica", "application", "error_type"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "replica", "application", "error_type"),  # type: ignore[arg-type]
         )
         self._routing_stats_error_counter.set_default_tags(
             {
@@ -845,7 +869,7 @@ class ActorReplicaWrapper:
         )
 
     @property
-    def replica_id(self) -> str:
+    def replica_id(self) -> ReplicaID:
         return self._replica_id
 
     @property
@@ -1043,7 +1067,7 @@ class ActorReplicaWrapper:
     def start(
         self,
         deployment_info: DeploymentInfo,
-        assign_rank_callback: Callable[[ReplicaID], ReplicaRank],
+        assign_rank_callback: Callable[[str, str], ReplicaRank],
         gang_placement_group: Optional[PlacementGroup] = None,
         gang_pg_index: Optional[int] = None,
         gang_context: Optional[GangContext] = None,
@@ -1083,6 +1107,7 @@ class ActorReplicaWrapper:
         )
 
         actor_def = deployment_info.actor_def
+        init_args: Tuple[Any, ...]
         if (
             deployment_info.deployment_config.deployment_language
             == DeploymentLanguage.PYTHON
@@ -1133,7 +1158,10 @@ class ActorReplicaWrapper:
                 # byte[] initArgsbytes
                 msgpack_serialize(
                     cloudpickle.loads(
-                        deployment_info.replica_config.serialized_init_args
+                        # Cross-language deployments always have serialized init
+                        # args.
+                        # pyrefly: ignore[bad-argument-type]
+                        deployment_info.replica_config.serialized_init_args  # type: ignore[arg-type]
                     )
                 )
                 if self._deployment_is_cross_language
@@ -1141,7 +1169,10 @@ class ActorReplicaWrapper:
                 # byte[] deploymentConfigBytes,
                 deployment_info.deployment_config.to_proto_bytes(),
                 # byte[] deploymentVersionBytes,
-                self._version.to_proto().SerializeToString(),
+                # `DeploymentVersion.to_proto()` is mis-annotated as `bytes`
+                # upstream; it returns the protobuf message.
+                # pyrefly: ignore[missing-attribute]
+                self._version.to_proto().SerializeToString(),  # type: ignore[attr-defined]
                 # String controllerName
                 # String appName
                 self.app_name,
@@ -1172,6 +1203,9 @@ class ActorReplicaWrapper:
             actor_def=actor_def,
             actor_resources=self._actor_resources,
             actor_options=actor_options,
+            # `deployment_language` is always PYTHON or JAVA, so `init_args`
+            # is always bound here.
+            # pyrefly: ignore[unbound-name]
             actor_init_args=init_args,
             placement_group_bundles=(
                 deployment_info.replica_config.placement_group_bundles
@@ -1203,10 +1237,13 @@ class ActorReplicaWrapper:
         self._placement_group = placement_group
 
         if self._is_cross_language:
-            self._actor_handle = JavaActorHandleProxy(self._actor_handle)
-            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
+            # Cross-language replicas wrap the handle in `JavaActorHandleProxy`.
+            # pyrefly: ignore[bad-assignment]
+            self._actor_handle = JavaActorHandleProxy(self._actor_handle)  # type: ignore[assignment]
+            # pyrefly: ignore[missing-attribute]
+            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()  # type: ignore[attr-defined]
         else:
-            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
+            self._allocated_obj_ref = self._actor_handle.is_allocated.remote()  # type: ignore[attr-defined]
 
     def _format_user_config(self, user_config: Any):
         temp = copy(user_config)
@@ -1242,7 +1279,10 @@ class ActorReplicaWrapper:
             deployment_config.user_config = self._format_user_config(
                 deployment_config.user_config
             )
-            self._ready_obj_ref = self._actor_handle.reconfigure.remote(
+            # `reconfigure` is only called on scheduled/recovered replicas, so
+            # `_actor_handle` is set.
+            # pyrefly: ignore[missing-attribute]
+            self._ready_obj_ref = self._actor_handle.reconfigure.remote(  # type: ignore[union-attr]
                 deployment_config,
                 rank,
                 version.route_prefix,
@@ -1297,12 +1337,12 @@ class ActorReplicaWrapper:
             self._placement_group = None
 
         # Re-fetch initialization proof
-        self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
+        self._allocated_obj_ref = self._actor_handle.is_allocated.remote()  # type: ignore[attr-defined]
 
         # Running actor handle already has all info needed, thus successful
         # starting simply means retrieving replica version hash from actor
         if self._is_cross_language:
-            self._ready_obj_ref = self._actor_handle.check_health.remote()
+            self._ready_obj_ref = self._actor_handle.check_health.remote()  # type: ignore[attr-defined]
         else:
             # For non-cross-language replicas, asynchronously probe whether
             # the actor finished its initial setup before triggering
@@ -1317,7 +1357,7 @@ class ActorReplicaWrapper:
             # `initialize_and_get_metadata` until the probe passes so we
             # don't accidentally drive the bad actor through initialization
             # only to kill it afterwards.
-            self._was_initialized_obj_ref = self._actor_handle.was_initialized.remote()
+            self._was_initialized_obj_ref = self._actor_handle.was_initialized.remote()  # type: ignore[attr-defined]
 
         return True
 
@@ -1328,7 +1368,9 @@ class ActorReplicaWrapper:
         logged but ignored.
         """
         try:
-            ray.kill(self._actor_handle, no_restart=True)
+            # Only called from `check_ready()`, after the handle is set.
+            # pyrefly: ignore[bad-argument-type]
+            ray.kill(self._actor_handle, no_restart=True)  # type: ignore[arg-type]
         except Exception:
             logger.exception(
                 f"Failed to kill unrecoverable replica actor "
@@ -1355,7 +1397,7 @@ class ActorReplicaWrapper:
 
         # Check whether the replica has been allocated.
         if self._allocated_obj_ref is None or not check_obj_ref_ready_nowait(
-            self._allocated_obj_ref
+            self._allocated_obj_ref  # type: ignore[arg-type]
         ):
             return ReplicaStartupStatus.PENDING_ALLOCATION, None
 
@@ -1393,7 +1435,7 @@ class ActorReplicaWrapper:
         # mid-startup), kill it and signal an unrecoverable drop so the
         # reconciler replaces it without counting a deploy failure.
         if self._was_initialized_obj_ref is not None:
-            if not check_obj_ref_ready_nowait(self._was_initialized_obj_ref):
+            if not check_obj_ref_ready_nowait(self._was_initialized_obj_ref):  # type: ignore[arg-type]
                 return ReplicaStartupStatus.PENDING_INITIALIZATION, None
 
             probe_ref = self._was_initialized_obj_ref
@@ -1424,8 +1466,11 @@ class ActorReplicaWrapper:
                 return ReplicaStartupStatus.FAILED, msg
 
             # Probe succeeded; safe to drive the actor through recovery.
+            # `check_ready()` runs only after `on_scheduled`/`recover` set
+            # `_actor_handle`.
             self._ready_obj_ref = (
-                self._actor_handle.initialize_and_get_metadata.remote()
+                # pyrefly: ignore[missing-attribute]
+                self._actor_handle.initialize_and_get_metadata.remote()  # type: ignore[union-attr]
             )
 
         if self._ready_obj_ref is None:
@@ -1436,16 +1481,26 @@ class ActorReplicaWrapper:
                 deployment_config.user_config
             )
             if self._is_cross_language:
-                self._ready_obj_ref = self._actor_handle.is_initialized.remote(
+                # `_actor_handle` is set by `on_scheduled`/`recover` before
+                # `check_ready()` runs.
+                # pyrefly: ignore[missing-attribute]
+                self._ready_obj_ref = self._actor_handle.is_initialized.remote(  # type: ignore[union-attr]
                     deployment_config.to_proto_bytes()
                 )
             else:
                 replica_ready_check_func = (
-                    self._actor_handle.initialize_and_get_metadata
+                    # pyrefly: ignore[missing-attribute]
+                    self._actor_handle.initialize_and_get_metadata  # type: ignore[union-attr]
                 )
                 # this guarantees that node_id is set before rank is assigned
-                self._rank = self._assign_rank_callback(
-                    self._replica_id.unique_id, self._node_id
+                # `_assign_rank_callback` is set by `start()` for every replica
+                # that reaches this non-recovery path, and `_node_id` was
+                # populated from the allocation check above.
+                # pyrefly: ignore[not-callable]
+                self._rank = self._assign_rank_callback(  # type: ignore[misc]
+                    self._replica_id.unique_id,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._node_id,  # type: ignore[arg-type]
                 )
                 self._ready_obj_ref = replica_ready_check_func.remote(
                     deployment_config, self._rank, self._gang_context
@@ -1454,7 +1509,7 @@ class ActorReplicaWrapper:
             return ReplicaStartupStatus.PENDING_INITIALIZATION, None
 
         # Check whether replica initialization has completed.
-        replica_ready = check_obj_ref_ready_nowait(self._ready_obj_ref)
+        replica_ready = check_obj_ref_ready_nowait(self._ready_obj_ref)  # type: ignore[arg-type]
         # In case of deployment constructor failure, ray.get will help to
         # surface exception to each update() cycle.
         if not replica_ready:
@@ -1508,6 +1563,7 @@ class ActorReplicaWrapper:
 
     @property
     def available_resources(self) -> Dict[str, float]:
+        # pyrefly: ignore[bad-return]
         return ray.available_resources()
 
     def graceful_stop(self) -> Duration:
@@ -1518,8 +1574,9 @@ class ActorReplicaWrapper:
         try:
             handle = ray.get_actor(self._actor_name, namespace=SERVE_NAMESPACE)
             if self._is_cross_language:
-                handle = JavaActorHandleProxy(handle)
-            self._graceful_shutdown_ref = handle.perform_graceful_shutdown.remote()
+                # Cross-language handles are wrapped in `JavaActorHandleProxy`.
+                handle = JavaActorHandleProxy(handle)  # type: ignore[assignment]
+            self._graceful_shutdown_ref = handle.perform_graceful_shutdown.remote()  # type: ignore[attr-defined]
         except ValueError:
             # ValueError thrown from ray.get_actor means actor has already been deleted.
             pass
@@ -1537,10 +1594,11 @@ class ActorReplicaWrapper:
                 # the next reconcile iteration will retry.
                 stopped = False
             else:
-                stopped = check_obj_ref_ready_nowait(self._graceful_shutdown_ref)
+                stopped = check_obj_ref_ready_nowait(self._graceful_shutdown_ref)  # type: ignore[arg-type]
             if stopped:
                 try:
-                    ray.get(self._graceful_shutdown_ref)
+                    # `stopped` is only True here when the shutdown ref was set.
+                    ray.get(self._graceful_shutdown_ref)  # type: ignore[arg-type]
                 except Exception:
                     logger.exception(
                         "Exception when trying to gracefully shutdown replica:\n"
@@ -1591,7 +1649,7 @@ class ActorReplicaWrapper:
         if self._health_check_ref is None:
             # There is no outstanding health check.
             response = ReplicaHealthCheckResponse.NONE
-        elif check_obj_ref_ready_nowait(self._health_check_ref):
+        elif check_obj_ref_ready_nowait(self._health_check_ref):  # type: ignore[arg-type]
             # Object ref is ready, ray.get it to check for exceptions.
             try:
                 ray.get(self._health_check_ref)
@@ -1740,7 +1798,9 @@ class ActorReplicaWrapper:
 
         if self._should_start_new_health_check():
             self._last_health_check_time = time.time()
-            self._health_check_ref = self._actor_handle.check_health.remote()
+            # Health checks only run on live replicas, so `_actor_handle` is set.
+            # pyrefly: ignore[missing-attribute]
+            self._health_check_ref = self._actor_handle.check_health.remote()  # type: ignore[union-attr]
 
         return self._healthy
 
@@ -1749,9 +1809,12 @@ class ActorReplicaWrapper:
         if self._record_routing_stats_ref is None:
             # There's no active record routing stats.
             pass
-        elif check_obj_ref_ready_nowait(self._record_routing_stats_ref):
+        elif check_obj_ref_ready_nowait(self._record_routing_stats_ref):  # type: ignore[arg-type]
             # Object ref is ready, ray.get it to check for exceptions.
             try:
+                # `ray.get` on a single ref returns the replica's stats dict;
+                # pyrefly picks the list overload here.
+                # pyrefly: ignore[bad-assignment]
                 self._routing_stats = ray.get(self._record_routing_stats_ref)
                 # Record the round-trip delay for routing stats
                 delay_ms = (time.time() - self._last_record_routing_stats_time) * 1000
@@ -1778,8 +1841,11 @@ class ActorReplicaWrapper:
 
         if self._should_record_routing_stats():
             self._last_record_routing_stats_time = time.time()
+            # Routing stats are only pulled from live replicas, so
+            # `_actor_handle` is set.
             self._record_routing_stats_ref = (
-                self._actor_handle.record_routing_stats.remote()
+                # pyrefly: ignore[missing-attribute]
+                self._actor_handle.record_routing_stats.remote()  # type: ignore[union-attr]
             )
 
         return self._routing_stats
@@ -1809,7 +1875,7 @@ class DeploymentReplica:
         self._replica_id = replica_id
         self._actor = ActorReplicaWrapper(replica_id, version)
         self._target_node_id: Optional[str] = None
-        self._start_time = None
+        self._start_time: Optional[float] = None
         self._shutdown_start_time: Optional[float] = None
         self._actor_details = ReplicaDetails(
             actor_name=replica_id.to_full_id_str(),
@@ -1827,7 +1893,12 @@ class DeploymentReplica:
             replica_id=self._replica_id,
             node_id=self.actor_node_id,
             node_ip=self._actor.node_ip,
-            availability_zone=cluster_node_info_cache.get_node_az(self.actor_node_id),
+            # Only called for RUNNING/PENDING_MIGRATION replicas, whose node id
+            # is set.
+            availability_zone=cluster_node_info_cache.get_node_az(
+                # pyrefly: ignore[bad-argument-type]
+                self.actor_node_id  # type: ignore[arg-type]
+            ),
             actor_name=self._actor._actor_name,
             max_ongoing_requests=self._actor.max_ongoing_requests,
             is_cross_language=self._actor.is_cross_language,
@@ -1894,11 +1965,11 @@ class DeploymentReplica:
         return self._actor.route_patterns
 
     @property
-    def actor_id(self) -> str:
+    def actor_id(self) -> Optional[str]:
         return self._actor.actor_id
 
     @property
-    def actor_handle(self) -> ActorHandle:
+    def actor_handle(self) -> Optional[ActorHandle]:
         return self._actor.actor_handle
 
     @property
@@ -1953,7 +2024,7 @@ class DeploymentReplica:
     def start(
         self,
         deployment_info: DeploymentInfo,
-        assign_rank_callback: Callable[[ReplicaID], ReplicaRank],
+        assign_rank_callback: Callable[[str, str], ReplicaRank],
         gang_placement_group: Optional[PlacementGroup] = None,
         gang_pg_index: Optional[int] = None,
         gang_context: Optional[GangContext] = None,
@@ -2041,7 +2112,7 @@ class DeploymentReplica:
 
     def check_started(
         self,
-    ) -> Tuple[ReplicaStartupStatus, Optional[str], Optional[float]]:
+    ) -> Tuple[ReplicaStartupStatus, Optional[str]]:
         """Check if the replica has started. If so, transition to RUNNING.
 
         Should handle the case where the replica has already stopped.
@@ -2149,6 +2220,7 @@ class DeploymentReplica:
         if self._actor.actor_resources is None:
             return "UNKNOWN", "UNKNOWN"
 
+        required: Union[List[Dict[str, float]], Dict[str, float]]
         if self._actor.placement_group_bundles is not None:
             required = self._actor.placement_group_bundles
         else:
@@ -2256,7 +2328,7 @@ class ReplicaStateContainer:
         self,
         exclude_version: Optional[DeploymentVersion] = None,
         states: Optional[List[ReplicaState]] = None,
-        max_replicas: Optional[int] = math.inf,
+        max_replicas: Optional[float] = math.inf,
     ) -> List[DeploymentReplica]:
         """Get and remove all replicas of the given states.
 
@@ -2280,9 +2352,9 @@ class ReplicaStateContainer:
         assert exclude_version is None or isinstance(exclude_version, DeploymentVersion)
         assert isinstance(states, list)
 
-        replicas = []
+        replicas: List[DeploymentReplica] = []
         for state in states:
-            popped = []
+            popped: List[DeploymentReplica] = []
             remaining = []
 
             for replica in self._replicas[state]:
@@ -2342,7 +2414,7 @@ class ReplicaStateContainer:
                 "Only one of `version` or `exclude_version` may be provided."
             )
 
-    def remove(self, replica_ids: Set[ReplicaID]) -> List[DeploymentReplica]:
+    def remove(self, replica_ids: Iterable[ReplicaID]) -> List[DeploymentReplica]:
         """Remove and return all replicas whose IDs are in the given set.
 
         Performs a single pass over the container. Non-matching replicas
@@ -2484,7 +2556,7 @@ class RankManager:
             raise RuntimeError("Rank system is in an invalid state.")
 
         # Check for duplicate ranks - this should never happen
-        rank_counts = {}
+        rank_counts: Dict[int, int] = {}
         for key, rank in self._ranks.copy().items():
             if key in active_keys_set:  # Only check active keys
                 rank_counts[rank] = rank_counts.get(rank, 0) + 1
@@ -2966,7 +3038,10 @@ class DeploymentState:
                 "replica series is 1 for healthy and 0 for unhealthy; otherwise, "
                 "the deployment/application series is the healthy replica count."
             ),
-            tag_keys=replica_lifecycle_metric_tag_keys,
+            # Upstream `tag_keys` is annotated `Tuple[str]` but accepts any
+            # tuple of strings.
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=replica_lifecycle_metric_tag_keys,  # type: ignore[arg-type]
         )
         self.health_check_gauge.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2977,7 +3052,8 @@ class DeploymentState:
             "serve_replica_startup_latency_ms",
             description=("Time from replica creation to ready state in milliseconds."),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_startup_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2988,7 +3064,8 @@ class DeploymentState:
             "serve_replica_initialization_latency_ms",
             description=("Time for replica to initialize in milliseconds."),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_initialization_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3000,7 +3077,8 @@ class DeploymentState:
             "serve_replica_reconfigure_latency_ms",
             description=("Time for replica to complete reconfigure in milliseconds."),
             boundaries=REQUEST_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_reconfigure_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3011,7 +3089,8 @@ class DeploymentState:
             "serve_health_check_latency_ms",
             description=("Duration of health check calls in milliseconds."),
             boundaries=REQUEST_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.health_check_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3021,7 +3100,8 @@ class DeploymentState:
         self.health_check_failures_counter = metrics.Counter(
             "serve_health_check_failures_total",
             description=("Count of failed health checks."),
-            tag_keys=replica_lifecycle_metric_tag_keys,
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=replica_lifecycle_metric_tag_keys,  # type: ignore[arg-type]
         )
         self.health_check_failures_counter.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3034,7 +3114,8 @@ class DeploymentState:
                 "Time from shutdown signal to replica fully stopped in milliseconds."
             ),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.replica_shutdown_duration_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3046,7 +3127,8 @@ class DeploymentState:
                 "The target number of replicas for this deployment. "
                 "This is the number the autoscaler is trying to reach."
             ),
-            tag_keys=("deployment", "application"),
+            # pyrefly: ignore[bad-argument-type]
+            tag_keys=("deployment", "application"),  # type: ignore[arg-type]
         )
         self.target_replicas_gauge.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3077,7 +3159,7 @@ class DeploymentState:
         # consume_ingress_membership_removed.
         self._ingress_membership_removed: bool = False
         self._last_broadcasted_availability: Optional[bool] = None
-        self._last_broadcasted_deployment_config = None
+        self._last_broadcasted_deployment_config: Optional[DeploymentConfig] = None
 
         self._docs_path: Optional[str] = None
         self._route_patterns: Optional[List[str]] = None
@@ -3115,13 +3197,18 @@ class DeploymentState:
     ):
         logger.info(f"Recovering target state for {self._id} from checkpoint.")
         self._target_state = target_state_checkpoint
+        # Checkpointed target states always carry a `DeploymentInfo`.
         self._deployment_scheduler.on_deployment_deployed(
-            self._id, self._target_state.info.replica_config
+            self._id,
+            # pyrefly: ignore[missing-attribute]
+            self._target_state.info.replica_config,  # type: ignore[union-attr]
         )
-        if self._target_state.info.deployment_config.autoscaling_config:
+        # pyrefly: ignore[missing-attribute]
+        if self._target_state.info.deployment_config.autoscaling_config:  # type: ignore[union-attr]
             self._autoscaling_state_manager.register_deployment(
                 self._id,
-                self._target_state.info,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.info,  # type: ignore[arg-type]
                 self._target_state.target_num_replicas,
             )
         self._recover_deployment_actors()
@@ -3142,13 +3229,17 @@ class DeploymentState:
         # All current states use default value, only attach running replicas.
         for replica_actor_name in replica_actor_names:
             replica_id = ReplicaID.from_full_id_str(replica_actor_name)
+            # The target state was recovered from a checkpoint first, so its
+            # `version` and `info` are set.
             new_deployment_replica = DeploymentReplica(
                 replica_id,
-                self._target_state.version,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.version,  # type: ignore[arg-type]
             )
             # If replica is no longer alive, simply don't add it to the
             # deployment state manager to track.
-            if not new_deployment_replica.recover(self._target_state.info):
+            # pyrefly: ignore[bad-argument-type]
+            if not new_deployment_replica.recover(self._target_state.info):  # type: ignore[arg-type]
                 logger.warning(f"{replica_id} died before controller could recover it.")
                 continue
 
@@ -3206,11 +3297,15 @@ class DeploymentState:
 
     @property
     def target_info(self) -> DeploymentInfo:
-        return self._target_state.info
+        # `info` is only None before the first deploy()/recovery.
+        # pyrefly: ignore[bad-return]
+        return self._target_state.info  # type: ignore[return-value]
 
     @property
     def target_version(self) -> DeploymentVersion:
-        return self._target_state.version
+        # `version` is only None before the first deploy()/recovery.
+        # pyrefly: ignore[bad-return]
+        return self._target_state.version  # type: ignore[return-value]
 
     @property
     def target_num_replicas(self) -> int:
@@ -3239,7 +3334,9 @@ class DeploymentState:
     @property
     def _failed_to_start_threshold(self) -> int:
         return min(
-            self._target_state.info.deployment_config.max_constructor_retry_count,
+            # `info` is set for any deployed target state.
+            # pyrefly: ignore[missing-attribute]
+            self._target_state.info.deployment_config.max_constructor_retry_count,  # type: ignore[union-attr]
             self._target_state.target_num_replicas * MAX_PER_REPLICA_RETRY_COUNT,
         )
 
@@ -3250,7 +3347,9 @@ class DeploymentState:
         Unlike replica threshold, deployment actors are deployment-scoped so we don't
         scale by target_num_replicas (which would be 0 during scale-to-zero/deletion).
         """
-        return self._target_state.info.deployment_config.max_constructor_retry_count
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        return self._target_state.info.deployment_config.max_constructor_retry_count  # type: ignore[union-attr]
 
     def _get_deployment_actors_configs(
         self, version: Optional[DeploymentVersion] = None
@@ -3309,7 +3408,7 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
+    def get_alive_replica_actor_ids(self) -> Set[Optional[str]]:
         return {replica.actor_id for replica in self._replicas.get()}
 
     def get_running_replica_ids(self) -> List[ReplicaID]:
@@ -3328,11 +3427,14 @@ class DeploymentState:
             )
         ]
 
-    def get_num_running_replicas(self, version: DeploymentVersion = None) -> int:
+    def get_num_running_replicas(
+        self, version: Optional[DeploymentVersion] = None
+    ) -> int:
         return self._replicas.count(states=[ReplicaState.RUNNING], version=version)
 
     def get_gang_config(self):
         return (
+            # pyrefly: ignore[missing-attribute]
             self._target_state.info.deployment_config.gang_scheduling_config
             if self._target_state is not None
             else None
@@ -3450,9 +3552,12 @@ class DeploymentState:
             is_available=is_available,
             running_replicas=running_replica_infos,
         )
+        # `LongPollHost.notify_changed`'s `KeyType` doesn't include
+        # `Tuple[LongPollNamespace, DeploymentID]` keys.
         self._long_poll_host.notify_changed(
+            # pyrefly: ignore[bad-argument-type]
             {
-                (
+                (  # type: ignore[dict-item]
                     LongPollNamespace.DEPLOYMENT_TARGETS,
                     self._id,
                 ): deployment_metadata,
@@ -3477,12 +3582,15 @@ class DeploymentState:
         Keeps an in-memory record of the last config that was broadcast to determine
         if it has changed.
         """
-        current_deployment_config = self._target_state.info.deployment_config
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        current_deployment_config = self._target_state.info.deployment_config  # type: ignore[union-attr]
         if self._last_broadcasted_deployment_config == current_deployment_config:
             return
 
         self._long_poll_host.notify_changed(
-            {(LongPollNamespace.DEPLOYMENT_CONFIG, self._id): current_deployment_config}
+            # pyrefly: ignore[bad-argument-type]
+            {(LongPollNamespace.DEPLOYMENT_CONFIG, self._id): current_deployment_config}  # type: ignore[dict-item]
         )
 
         self._last_broadcasted_deployment_config = current_deployment_config
@@ -3490,7 +3598,9 @@ class DeploymentState:
     def _set_target_state_deleting(self) -> None:
         """Set the target state for the deployment to be deleted."""
         target_state = DeploymentTargetState.create(
-            info=self._target_state.info,
+            # Deleting an existing deployment implies `info` is set.
+            # pyrefly: ignore[bad-argument-type]
+            info=self._target_state.info,  # type: ignore[arg-type]
             target_num_replicas=0,
             deleting=True,
         )
@@ -3526,16 +3636,22 @@ class DeploymentState:
 
         if self._target_state.version == new_target_state.version:
             # Record either num replica or autoscaling config lightweight update
+            # Versions are equal here, and the new target state's version is
+            # always set, so the old one is too.
             if (
-                self._target_state.version.deployment_config.autoscaling_config
-                != new_target_state.version.deployment_config.autoscaling_config
+                # pyrefly: ignore[missing-attribute]
+                self._target_state.version.deployment_config.autoscaling_config  # type: ignore[union-attr]
+                # pyrefly: ignore[missing-attribute]
+                != new_target_state.version.deployment_config.autoscaling_config  # type: ignore[union-attr]
             ):
                 ServeUsageTag.AUTOSCALING_CONFIG_LIGHTWEIGHT_UPDATED.record("True")
             elif updated_via_api:
                 ServeUsageTag.NUM_REPLICAS_VIA_API_CALL_UPDATED.record("True")
             elif (
-                self._target_state.version.deployment_config.num_replicas
-                != new_target_state.version.deployment_config.num_replicas
+                # pyrefly: ignore[missing-attribute]
+                self._target_state.version.deployment_config.num_replicas  # type: ignore[union-attr]
+                # pyrefly: ignore[missing-attribute]
+                != new_target_state.version.deployment_config.num_replicas  # type: ignore[union-attr]
             ):
                 ServeUsageTag.NUM_REPLICAS_LIGHTWEIGHT_UPDATED.record("True")
 
@@ -3609,7 +3725,9 @@ class DeploymentState:
         else:
             self._autoscaling_state_manager.deregister_deployment(self._id)
             target_num_replicas = get_capacity_adjusted_num_replicas(
-                deployment_info.deployment_config.num_replicas,
+                # `num_replicas` is always set for non-autoscaling deployments.
+                # pyrefly: ignore[bad-argument-type]
+                deployment_info.deployment_config.num_replicas,  # type: ignore[arg-type]
                 deployment_info.target_capacity,
             )
 
@@ -3692,11 +3810,15 @@ class DeploymentState:
         if decision_num_replicas == self._target_state.target_num_replicas:
             return False
 
+        # Autoscaling only runs on deployed target states, so `info` and
+        # `version` are set.
         new_info = copy(self._target_state.info)
-        new_info.version = self._target_state.version.code_version
+        # pyrefly: ignore[missing-attribute]
+        new_info.version = self._target_state.version.code_version  # type: ignore[union-attr]
 
         old_num = self._target_state.target_num_replicas
-        self._set_target_state(new_info, decision_num_replicas)
+        # pyrefly: ignore[bad-argument-type]
+        self._set_target_state(new_info, decision_num_replicas)  # type: ignore[arg-type]
 
         # The deployment should only transition to UPSCALING/DOWNSCALING
         # if it's within the autoscaling bounds
@@ -3744,7 +3866,11 @@ class DeploymentState:
     ) -> None:
         """Set the target state for the deployment to the provided info."""
         self._set_target_state(
-            self._target_state.info, target_num_replicas, updated_via_api=True
+            # Only called for existing deployments, so `info` is set.
+            # pyrefly: ignore[bad-argument-type]
+            self._target_state.info,  # type: ignore[arg-type]
+            target_num_replicas,
+            updated_via_api=True,
         )
 
     def _rescale_to(self, num_replicas: int) -> None:
@@ -3866,11 +3992,14 @@ class DeploymentState:
             # Group restart-candidates by gang_id.
             gangs: Dict[str, List[DeploymentReplica]] = defaultdict(list)
             for replica in need_restart:
-                gangs[replica.gang_context.gang_id].append(replica)
+                # Gang deployments always set `gang_context` on their replicas.
+                # pyrefly: ignore[missing-attribute]
+                gangs[replica.gang_context.gang_id].append(replica)  # type: ignore[union-attr]
 
             # Stop complete gangs atomically within the budget
             for _, gang_replicas in gangs.items():
-                expected_size = gang_replicas[0].gang_context.world_size
+                # pyrefly: ignore[missing-attribute]
+                expected_size = gang_replicas[0].gang_context.world_size  # type: ignore[union-attr]
                 if len(gang_replicas) != expected_size:
                     # Gang is incomplete (members may be RECOVERING/UPDATING);
                     # wait for them to stabilize before tearing down.
@@ -3920,7 +4049,10 @@ class DeploymentState:
                     replica.replica_id.unique_id
                 )
                 actor_updating = replica.reconfigure(
-                    self._target_state.version, rank=current_rank
+                    # The target version is set for deployed target states.
+                    # pyrefly: ignore[bad-argument-type]
+                    self._target_state.version,  # type: ignore[arg-type]
+                    rank=current_rank,
                 )
                 if actor_updating:
                     self._replicas.add(ReplicaState.UPDATING, replica)
@@ -3999,7 +4131,9 @@ class DeploymentState:
         # There should never be more than rollout_size old replicas stopping
         # or rollout_size new replicas starting.
         rolling_update_percentage = (
-            self._target_state.info.deployment_config.rolling_update_percentage
+            # `info` is set for any deployed target state.
+            # pyrefly: ignore[missing-attribute]
+            self._target_state.info.deployment_config.rolling_update_percentage  # type: ignore[union-attr]
         )
         rollout_size = max(
             int(rolling_update_percentage * self._target_state.target_num_replicas), 1
@@ -4009,6 +4143,8 @@ class DeploymentState:
         # gang_size so that we always stop and start complete gangs.
         if self._is_gang_deployment:
             gang_config = self.get_gang_config()
+            # `_is_gang_deployment` implies a gang config exists.
+            # pyrefly: ignore[missing-attribute]
             gs = gang_config.gang_size
             rollout_size = max(rollout_size, gs)
             rollout_size = math.ceil(rollout_size / gs) * gs
@@ -4023,7 +4159,7 @@ class DeploymentState:
             Dict[DeploymentID, GangReservationResult]
         ] = None,
         proxy_nodes: Optional[Set[str]] = None,
-    ) -> Tuple[List[ReplicaSchedulingRequest], DeploymentDownscaleRequest]:
+    ) -> Tuple[List[ReplicaSchedulingRequest], Optional[DeploymentDownscaleRequest]]:
         """Scale the given deployment to the number of replicas.
 
         Args:
@@ -4054,8 +4190,8 @@ class DeploymentState:
             self._target_state.target_num_replicas >= 0
         ), "Target number of replicas must be greater than or equal to 0."
 
-        upscale = []
-        downscale = None
+        upscale: List[ReplicaSchedulingRequest] = []
+        downscale: Optional[DeploymentDownscaleRequest] = None
 
         self._check_and_stop_outdated_version_replicas()
         self.stop_deployment_actors_if_needed()
@@ -4097,6 +4233,7 @@ class DeploymentState:
                 num_to_stop=to_remove,
                 gang_id_by_replica=gang_id_by_replica,
                 replicas_by_gang_id=replicas_by_gang_id,
+                # pyrefly: ignore[missing-attribute]
                 gang_size=self.get_gang_config().gang_size
                 if self._is_gang_deployment
                 else None,
@@ -4113,7 +4250,7 @@ class DeploymentState:
         target_node_ids: Optional[List[str]] = None,
     ) -> List[ReplicaSchedulingRequest]:
         """Add replicas for this deployment, using gang scheduling when configured."""
-        upscale = []
+        upscale: List[ReplicaSchedulingRequest] = []
         if to_add <= 0 or self._terminally_failed():
             return upscale
 
@@ -4135,14 +4272,17 @@ class DeploymentState:
         target_node_ids, when given, pins new replica i to node i (the ingress
         request router uses this to co-locate with each proxy).
         """
-        upscale = []
+        upscale: List[ReplicaSchedulingRequest] = []
         logger.info(f"Adding {to_add} replica{'s' * (to_add > 1)} to {self._id}.")
         for i in range(to_add):
             replica_id = ReplicaID(get_random_string(), deployment_id=self._id)
 
+            # The target state is deployed here, so `version` and `info` are
+            # set.
             new_deployment_replica = DeploymentReplica(
                 replica_id,
-                self._target_state.version,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.version,  # type: ignore[arg-type]
             )
             target_node_id = (
                 target_node_ids[i]
@@ -4150,7 +4290,8 @@ class DeploymentState:
                 else None
             )
             scheduling_request = new_deployment_replica.start(
-                self._target_state.info,
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.info,  # type: ignore[arg-type]
                 assign_rank_callback=self._rank_manager.assign_rank,
                 target_node_id=target_node_id,
             )
@@ -4174,7 +4315,7 @@ class DeploymentState:
         Returns:
             List of ReplicaSchedulingRequests for the new replicas.
         """
-        upscale = []
+        upscale: List[ReplicaSchedulingRequest] = []
 
         if gang_reservation_result is None:
             logger.info(
@@ -4194,17 +4335,21 @@ class DeploymentState:
             )
             return upscale
 
+        # On success, the reservation result's PG/id/name lists are populated.
         gang_pgs = gang_reservation_result.gang_pgs
         gang_ids = gang_reservation_result.gang_ids
         gang_pg_names = gang_reservation_result.gang_pg_names
         gang_size = gang_config.gang_size
-        num_gangs = len(gang_pgs)
+        # pyrefly: ignore[bad-argument-type]
+        num_gangs = len(gang_pgs)  # type: ignore[arg-type]
         replicas_to_add = num_gangs * gang_size
 
         # When per-replica PG bundles are defined, each replica occupies multiple
         # consecutive bundles in the gang PG.  The actor for replica i is placed at
         # bundle i * bundles_per_replica.
-        pg_bundles = self._target_state.info.replica_config.placement_group_bundles
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        pg_bundles = self._target_state.info.replica_config.placement_group_bundles  # type: ignore[union-attr]
         bundles_per_replica = len(pg_bundles) if pg_bundles else 1
 
         logger.info(
@@ -4213,7 +4358,8 @@ class DeploymentState:
             f"(gang_size={gang_size}, {num_gangs} gang(s))."
         )
 
-        for gang_pg, gang_id, pg_name in zip(gang_pgs, gang_ids, gang_pg_names):
+        # pyrefly: ignore[bad-argument-type]
+        for gang_pg, gang_id, pg_name in zip(gang_pgs, gang_ids, gang_pg_names):  # type: ignore[arg-type]
             member_replica_ids = [
                 ReplicaID(get_random_string(), deployment_id=self._id)
                 for _ in range(gang_size)
@@ -4230,11 +4376,13 @@ class DeploymentState:
 
                 new_deployment_replica = DeploymentReplica(
                     replica_id,
-                    self._target_state.version,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._target_state.version,  # type: ignore[arg-type]
                 )
 
                 scheduling_request = new_deployment_replica.start(
-                    self._target_state.info,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._target_state.info,  # type: ignore[arg-type]
                     assign_rank_callback=self._rank_manager.assign_rank,
                     gang_placement_group=gang_pg,
                     gang_pg_index=bundle_index * bundles_per_replica,
@@ -4386,7 +4534,7 @@ class DeploymentState:
         Returns:
             The list of replicas considered slow, along with their startup status.
         """
-        slow_replicas = []
+        slow_replicas: List[Tuple[DeploymentReplica, ReplicaStartupStatus]] = []
         failed_gang_ids: Set[str] = set()
         for replica in self._replicas.pop(states=[original_state]):
             start_status, error_msg = replica.check_started()
@@ -4402,8 +4550,13 @@ class DeploymentState:
                     # rank was never released).
                     replica_id = replica.replica_id.unique_id
                     if not self._rank_manager.has_replica_rank(replica_id):
+                        # A replica that reached SUCCEEDED has a node id, and
+                        # its rank was recovered from the actor's metadata.
                         self._rank_manager.recover_rank(
-                            replica_id, replica.actor_node_id, replica.rank
+                            replica_id,
+                            # pyrefly: ignore[bad-argument-type]
+                            replica.actor_node_id,  # type: ignore[arg-type]
+                            replica.rank,  # type: ignore[arg-type]
                         )
                 # Register recovered gang replicas in the incremental
                 # bookkeeping (newly created gang replicas are already
@@ -4419,7 +4572,10 @@ class DeploymentState:
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
                 self._deployment_scheduler.on_replica_running(
-                    replica.replica_id, replica.actor_node_id
+                    replica.replica_id,
+                    # A SUCCEEDED replica always has a node id.
+                    # pyrefly: ignore[bad-argument-type]
+                    replica.actor_node_id,  # type: ignore[arg-type]
                 )
 
                 # if replica version is the same as the target version,
@@ -4429,7 +4585,9 @@ class DeploymentState:
                     self._route_patterns = replica.route_patterns
 
                 # Log the startup latency.
-                e2e_replica_start_latency = time.time() - replica._start_time
+                # `_start_time` is set when the replica starts or recovers.
+                # pyrefly: ignore[unsupported-operation]
+                e2e_replica_start_latency = time.time() - replica._start_time  # type: ignore[operator]
                 replica_startup_message = (
                     f"{replica.replica_id} started successfully "
                     f"on node '{replica.actor_node_id}' after "
@@ -4494,7 +4652,9 @@ class DeploymentState:
                     replica.gang_context is None
                     or replica.gang_context.gang_id not in failed_gang_ids
                 ):
-                    self.record_replica_startup_failure(error_msg)
+                    # A FAILED startup status always carries an error message.
+                    # pyrefly: ignore[bad-argument-type]
+                    self.record_replica_startup_failure(error_msg)  # type: ignore[arg-type]
 
                 self._stop_replica(replica)
                 # Track failed gang IDs for sibling cleanup below.
@@ -4504,7 +4664,8 @@ class DeploymentState:
                 ReplicaStartupStatus.PENDING_ALLOCATION,
                 ReplicaStartupStatus.PENDING_INITIALIZATION,
             ]:
-                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S
+                # pyrefly: ignore[unsupported-operation]
+                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S  # type: ignore[operator]
                 if is_slow:
                     slow_replicas.append((replica, start_status))
 
@@ -4611,7 +4772,7 @@ class DeploymentState:
         fully stopped and been removed from tracking)."""
         self._health_gauge_cache.pop(replica_unique_id, None)
 
-    def stop_replicas(self, replicas_to_stop: Set[ReplicaID]) -> None:
+    def stop_replicas(self, replicas_to_stop: Iterable[ReplicaID]) -> None:
         for replica in self._replicas.remove(replicas_to_stop):
             self._stop_replica(replica)
 
@@ -4912,6 +5073,7 @@ class DeploymentState:
             # FORCE_STOP_UNHEALTHY_REPLICAS.
             if (
                 self._is_gang_deployment
+                # pyrefly: ignore[missing-attribute]
                 and self.get_gang_config().runtime_failure_policy
                 == GangRuntimeFailurePolicy.RESTART_GANG
             ):
@@ -5192,7 +5354,9 @@ class DeploymentState:
             # Use reconfigure() to update rank
             # World size is calculated automatically from deployment config
             _ = replica.reconfigure(
-                self._target_state.version,
+                # The target version is set for deployed target states.
+                # pyrefly: ignore[bad-argument-type]
+                self._target_state.version,  # type: ignore[arg-type]
                 rank=new_rank,
             )
             updated_count += 1
@@ -5212,7 +5376,7 @@ class DeploymentState:
     @staticmethod
     def _group_effective_deadline(
         group: List[DeploymentReplica],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
     ) -> float:
         """Return the effective deadline for a group of replicas.
 
@@ -5220,7 +5384,10 @@ class DeploymentState:
         falls back to infinity if no member is on a draining node.
         """
         member_deadlines = [
-            deadlines[r.actor_node_id] for r in group if r.actor_node_id in deadlines
+            # The `in deadlines` filter guarantees a non-None node id.
+            deadlines[r.actor_node_id]  # type: ignore[index]
+            for r in group
+            if r.actor_node_id in deadlines
         ]
         return min(member_deadlines) if member_deadlines else float("inf")
 
@@ -5234,7 +5401,7 @@ class DeploymentState:
     def _choose_pending_migration_replicas_to_stop(
         self,
         replicas: List[DeploymentReplica],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
         min_replicas_to_stop: int,
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
         """Returns a partition of replicas to stop and to keep.
@@ -5259,13 +5426,15 @@ class DeploymentState:
         """Group replicas by their gang_id."""
         gangs: Dict[str, List[DeploymentReplica]] = defaultdict(list)
         for replica in replicas:
-            gangs[replica.gang_context.gang_id].append(replica)
+            # Gang deployments always set `gang_context` on their replicas.
+            # pyrefly: ignore[missing-attribute]
+            gangs[replica.gang_context.gang_id].append(replica)  # type: ignore[union-attr]
         return gangs
 
     def _choose_pending_migration_gangs_to_stop(
         self,
         replicas: List[DeploymentReplica],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
         min_replicas_to_stop: int,
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
         """Gang-aware variant: stop complete gangs atomically.
@@ -5282,7 +5451,7 @@ class DeploymentState:
     def _partition_groups_to_stop(
         self,
         groups: List[List[DeploymentReplica]],
-        deadlines: Dict[str, int],
+        deadlines: Mapping[str, float],
         min_replicas_to_stop: int,
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
         """Partition replica groups into those to stop and those to keep.
@@ -5323,7 +5492,7 @@ class DeploymentState:
 
         return to_stop, remaining
 
-    def migrate_replicas_on_draining_nodes(self, draining_nodes: Dict[str, int]):
+    def migrate_replicas_on_draining_nodes(self, draining_nodes: Mapping[str, float]):
         # Fast path: no draining nodes and deployment is in steady state —
         # no PENDING_MIGRATION replicas to move back and no replicas to
         # migrate, so skip the O(N) pop-and-readd.
@@ -5378,7 +5547,8 @@ class DeploymentState:
             gangs_to_migrate: Set[str] = set()
             for replica in all_replicas:
                 if replica.actor_node_id in draining_nodes:
-                    gangs_to_migrate.add(replica.gang_context.gang_id)
+                    # pyrefly: ignore[missing-attribute]
+                    gangs_to_migrate.add(replica.gang_context.gang_id)  # type: ignore[union-attr]
 
             def needs_migration(r):
                 return r.gang_context.gang_id in gangs_to_migrate
@@ -5464,10 +5634,13 @@ class DeploymentState:
             self._replicas.add(ReplicaState.RUNNING, replica)
 
     def is_ingress(self) -> bool:
-        return self._target_state.info.ingress
+        # `info` is set for any deployed target state.
+        # pyrefly: ignore[missing-attribute]
+        return self._target_state.info.ingress  # type: ignore[union-attr]
 
     def is_ingress_request_router(self) -> bool:
-        return self._target_state.info.ingress_request_router
+        # pyrefly: ignore[missing-attribute]
+        return self._target_state.info.ingress_request_router  # type: ignore[union-attr]
 
     def owns_direct_ingress_ports(self) -> bool:
         """Whether this deployment owns direct-ingress ports -- i.e. it is an
@@ -5587,7 +5760,9 @@ class DeploymentState:
                     f"(attempt {self._deployment_actor_retry_counter + 1}/"
                     f"{self._deployment_actor_failed_to_start_threshold})"
                 )
-                self.record_deployment_actor_startup_failure(error_msg)
+                # A failed start always carries an error message.
+                # pyrefly: ignore[bad-argument-type]
+                self.record_deployment_actor_startup_failure(error_msg)  # type: ignore[arg-type]
                 return
             self._deployment_actors.add(DeploymentActorState.STARTING, wrapper)
         return
@@ -5808,7 +5983,7 @@ class DeploymentStateManager:
 
     def _map_actor_names_to_deployment(
         self, all_current_actor_names: List[str]
-    ) -> Dict[str, List[str]]:
+    ) -> Dict[DeploymentID, List[str]]:
         """
         Given a list of all actor names queried from current ray cluster,
         map them to corresponding deployments.
@@ -6015,6 +6190,7 @@ class DeploymentStateManager:
     def get_deployment_docs_path(self, deployment_id: DeploymentID) -> Optional[str]:
         if deployment_id in self._deployment_states:
             return self._deployment_states[deployment_id].docs_path
+        return None
 
     def get_deployment_route_patterns(
         self, deployment_id: DeploymentID
@@ -6053,7 +6229,10 @@ class DeploymentStateManager:
                 status_trigger=status_info.status_trigger,
                 message=status_info.message,
                 deployment_config=_deployment_info_to_schema(
-                    id.name, self.get_deployment(id)
+                    # The deployment exists here, so `get_deployment` is not
+                    # None.
+                    id.name,
+                    self.get_deployment(id),  # type: ignore[arg-type]
                 ),
                 target_num_replicas=deployment_state._target_state.target_num_replicas,
                 required_resources=deployment_state.target_info.replica_config.resource_dict,
@@ -6082,8 +6261,8 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids = set()
+    def get_alive_replica_actor_ids(self) -> Set[Optional[str]]:
+        alive_replica_actor_ids: Set[Optional[str]] = set()
         for ds in self._deployment_states.values():
             alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
 
@@ -6226,7 +6405,9 @@ class DeploymentStateManager:
             deployment_state.check_curr_status()
 
         # STEP 3: Drain nodes
-        draining_nodes = self._cluster_node_info_cache.get_draining_nodes()
+        draining_nodes: Mapping[
+            str, float
+        ] = self._cluster_node_info_cache.get_draining_nodes()
         allow_new_compaction = len(draining_nodes) == 0 and all(
             ds.curr_status_info.status == DeploymentStatus.HEALTHY
             # TODO(zcin): Make sure that status should never be healthy if
@@ -6337,9 +6518,12 @@ class DeploymentStateManager:
             # Don't evict in the same tick: the waiter wakes after update()
             # returns and listen_for_change's guard would drop the payload.
             tombstone = DeploymentTargetInfo(is_available=False, running_replicas=[])
+            # `LongPollHost`'s `KeyType` doesn't include
+            # `Tuple[LongPollNamespace, DeploymentID]` keys.
             self._long_poll_host.notify_changed(
+                # pyrefly: ignore[bad-argument-type]
                 {
-                    (LongPollNamespace.DEPLOYMENT_TARGETS, deployment_id): tombstone,
+                    (LongPollNamespace.DEPLOYMENT_TARGETS, deployment_id): tombstone,  # type: ignore[dict-item]
                     (
                         LongPollNamespace.DEPLOYMENT_TARGETS,
                         deployment_id.name,
@@ -6347,7 +6531,8 @@ class DeploymentStateManager:
                 }
             )
             self._long_poll_host.remove_keys(
-                [(LongPollNamespace.DEPLOYMENT_CONFIG, deployment_id)]
+                # pyrefly: ignore[bad-argument-type]
+                [(LongPollNamespace.DEPLOYMENT_CONFIG, deployment_id)]  # type: ignore[list-item]
             )
 
         if len(deleted_ids):
@@ -6473,10 +6658,15 @@ class DeploymentStateManager:
             ):
                 continue
 
-            replica_config = deployment_state._target_state.info.replica_config
+            # Gang deployments here are deployed, so `info` and the gang
+            # config are set.
+            # pyrefly: ignore[missing-attribute]
+            replica_config = deployment_state._target_state.info.replica_config  # type: ignore[union-attr]
             gang_requests[deployment_id] = GangPlacementGroupRequest(
                 deployment_id=deployment_id,
+                # pyrefly: ignore[missing-attribute]
                 gang_size=gang_config.gang_size,
+                # pyrefly: ignore[missing-attribute]
                 gang_placement_strategy=gang_config.gang_placement_strategy.value,
                 num_replicas_to_add=num_replicas_to_add,
                 replica_resource_dict=replica_config.resource_dict.copy(),
@@ -6531,7 +6721,9 @@ class DeploymentStateManager:
         this is unchanged. See _ingress_membership_version."""
         return self._ingress_membership_version
 
-    def get_ingress_replicas_info(self) -> List[Tuple[str, str, int, int]]:
+    def get_ingress_replicas_info(
+        self,
+    ) -> List[Tuple[Optional[str], str, Optional[int], Optional[int]]]:
         """Get replicas that own direct-ingress ports.
 
         Includes both ingress deployments and ingress request router deployments.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1496,11 +1496,11 @@ class ActorReplicaWrapper:
                 # `_assign_rank_callback` is set by `start()` for every replica
                 # that reaches this non-recovery path, and `_node_id` was
                 # populated from the allocation check above.
-                # pyrefly: ignore[not-callable]
-                self._rank = self._assign_rank_callback(  # type: ignore[misc]
+                assert self._assign_rank_callback is not None
+                assert self._node_id is not None
+                self._rank = self._assign_rank_callback(
                     self._replica_id.unique_id,
-                    # pyrefly: ignore[bad-argument-type]
-                    self._node_id,  # type: ignore[arg-type]
+                    self._node_id,
                 )
                 self._ready_obj_ref = replica_ready_check_func.remote(
                     deployment_config, self._rank, self._gang_context
@@ -4552,11 +4552,12 @@ class DeploymentState:
                     if not self._rank_manager.has_replica_rank(replica_id):
                         # A replica that reached SUCCEEDED has a node id, and
                         # its rank was recovered from the actor's metadata.
+                        assert replica.actor_node_id is not None
+                        assert replica.rank is not None
                         self._rank_manager.recover_rank(
                             replica_id,
-                            # pyrefly: ignore[bad-argument-type]
-                            replica.actor_node_id,  # type: ignore[arg-type]
-                            replica.rank,  # type: ignore[arg-type]
+                            replica.actor_node_id,
+                            replica.rank,
                         )
                 # Register recovered gang replicas in the incremental
                 # bookkeeping (newly created gang replicas are already
@@ -4571,11 +4572,10 @@ class DeploymentState:
                 # This replica should be now be added to handle's replica
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
+                assert replica.actor_node_id is not None
                 self._deployment_scheduler.on_replica_running(
                     replica.replica_id,
-                    # A SUCCEEDED replica always has a node id.
-                    # pyrefly: ignore[bad-argument-type]
-                    replica.actor_node_id,  # type: ignore[arg-type]
+                    replica.actor_node_id,
                 )
 
                 # if replica version is the same as the target version,
@@ -4586,8 +4586,8 @@ class DeploymentState:
 
                 # Log the startup latency.
                 # `_start_time` is set when the replica starts or recovers.
-                # pyrefly: ignore[unsupported-operation]
-                e2e_replica_start_latency = time.time() - replica._start_time  # type: ignore[operator]
+                assert replica._start_time is not None
+                e2e_replica_start_latency = time.time() - replica._start_time
                 replica_startup_message = (
                     f"{replica.replica_id} started successfully "
                     f"on node '{replica.actor_node_id}' after "
@@ -4664,8 +4664,8 @@ class DeploymentState:
                 ReplicaStartupStatus.PENDING_ALLOCATION,
                 ReplicaStartupStatus.PENDING_INITIALIZATION,
             ]:
-                # pyrefly: ignore[unsupported-operation]
-                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S  # type: ignore[operator]
+                assert replica._start_time is not None
+                is_slow = time.time() - replica._start_time > SLOW_STARTUP_WARNING_S
                 if is_slow:
                     slow_replicas.append((replica, start_status))
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Callable,
     Deque,
-    cast,
     Dict,
     Iterable,
     List,
@@ -23,6 +22,7 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 import ray
@@ -97,6 +97,7 @@ from ray.serve._private.deployment_scheduler import (
 from ray.serve._private.exceptions import DeploymentIsBeingDeletedError
 from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
 from ray.serve._private.storage.kv_store import KVStoreBase
+from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
     JavaActorHandleProxy,
@@ -777,7 +778,7 @@ class ActorReplicaWrapper:
         self._reconfigure_start_time: Optional[float] = None
         self._internal_grpc_port: Optional[int] = None
         self._docs_path: Optional[str] = None
-        self._route_patterns: Optional[List[str]] = None
+        self._route_patterns: Optional[List[RoutePattern]] = None
         # Rank assigned to the replica. The callback takes the replica's
         # unique id and its node id and returns the assigned rank (see
         # `DeploymentRankManager.assign_rank`).
@@ -951,7 +952,7 @@ class ActorReplicaWrapper:
         return self._docs_path
 
     @property
-    def route_patterns(self) -> Optional[List[str]]:
+    def route_patterns(self) -> Optional[List[RoutePattern]]:
         return self._route_patterns
 
     @property
@@ -1962,7 +1963,7 @@ class DeploymentReplica:
         return self._actor.docs_path
 
     @property
-    def route_patterns(self) -> Optional[List[str]]:
+    def route_patterns(self) -> Optional[List[RoutePattern]]:
         return self._actor.route_patterns
 
     @property
@@ -3163,7 +3164,7 @@ class DeploymentState:
         self._last_broadcasted_deployment_config: Optional[DeploymentConfig] = None
 
         self._docs_path: Optional[str] = None
-        self._route_patterns: Optional[List[str]] = None
+        self._route_patterns: Optional[List[RoutePattern]] = None
 
     _BROADCAST_STATES = frozenset(
         {ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION}
@@ -3329,7 +3330,7 @@ class DeploymentState:
         return self._docs_path
 
     @property
-    def route_patterns(self) -> Optional[List[str]]:
+    def route_patterns(self) -> Optional[List[RoutePattern]]:
         return self._route_patterns
 
     @property
@@ -3885,6 +3886,10 @@ class DeploymentState:
         old_num = self._target_state.target_num_replicas
         if num_replicas == old_num:
             return
+        # A rescale only happens on an already-deployed target, so info/version
+        # are set here.
+        assert self._target_state.info is not None
+        assert self._target_state.version is not None
         new_info = copy(self._target_state.info)
         new_info.version = self._target_state.version.code_version
         self._set_target_state(new_info, num_replicas)
@@ -5008,7 +5013,10 @@ class DeploymentState:
         configured. Falls back to the defaults before a target is set.
         """
         try:
-            cfg = self._target_state.info.deployment_config
+            # info is None before a target is set; the AttributeError propagates to
+            # the except below and falls back to defaults.
+            # pyrefly: ignore[missing-attribute]
+            cfg = self._target_state.info.deployment_config  # type: ignore[union-attr]
             return min(
                 cfg.health_check_period_s,
                 cfg.request_router_config.request_routing_stats_period_s,
@@ -6197,7 +6205,7 @@ class DeploymentStateManager:
 
     def get_deployment_route_patterns(
         self, deployment_id: DeploymentID
-    ) -> Optional[List[str]]:
+    ) -> Optional[List[RoutePattern]]:
         """Get route patterns for a deployment if available."""
         if deployment_id in self._deployment_states:
             return self._deployment_states[deployment_id].route_patterns

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Callable,
     Deque,
+    cast,
     Dict,
     Iterable,
     List,
@@ -4550,14 +4551,15 @@ class DeploymentState:
                     # rank was never released).
                     replica_id = replica.replica_id.unique_id
                     if not self._rank_manager.has_replica_rank(replica_id):
-                        # A replica that reached SUCCEEDED has a node id, and
-                        # its rank was recovered from the actor's metadata.
-                        assert replica.actor_node_id is not None
-                        assert replica.rank is not None
+                        # Cross-language replicas can reach SUCCEEDED with
+                        # actor_node_id/rank unset (they skip the Python
+                        # allocation ray.get that sets node_id), so cast to
+                        # preserve the prior pass-through behavior rather than
+                        # asserting -- an assert here would abort the loop.
                         self._rank_manager.recover_rank(
                             replica_id,
-                            replica.actor_node_id,
-                            replica.rank,
+                            cast(str, replica.actor_node_id),
+                            cast(ReplicaRank, replica.rank),
                         )
                 # Register recovered gang replicas in the incremental
                 # bookkeeping (newly created gang replicas are already
@@ -4572,10 +4574,11 @@ class DeploymentState:
                 # This replica should be now be added to handle's replica
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
-                assert replica.actor_node_id is not None
+                # Cross-language replicas can be RUNNING with actor_node_id
+                # unset; cast to preserve the prior pass-through behavior.
                 self._deployment_scheduler.on_replica_running(
                     replica.replica_id,
-                    replica.actor_node_id,
+                    cast(str, replica.actor_node_id),
                 )
 
                 # if replica version is the same as the target version,

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -267,7 +267,12 @@ class NodePortManager:
                 del cls._node_managers[node_id]
 
     @classmethod
-    def update_ports(cls, ingress_replicas_info: List[Tuple[str, str, int, int]]):
+    def update_ports(
+        cls,
+        ingress_replicas_info: List[
+            Tuple[Optional[str], str, Optional[int], Optional[int]]
+        ],
+    ):
         """Update port values for ingress replicas."""
         for node_id, replica_id, http_port, grpc_port in ingress_replicas_info:
             if node_id is None:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1189,12 +1189,16 @@ class Replica:
             SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE
         )
 
-        tracing_config = ray.get(self._controller_handle.get_tracing_config.remote())
+        tracing_config = ray.get(
+            self._controller_handle.get_tracing_config.remote()  # type: ignore[attr-defined]
+        )
         is_tracing_setup_successful = setup_tracing(
             component_type=ServeComponentType.REPLICA,
             component_name=self._component_name,
             component_id=self._component_id,
-            tracing_config=tracing_config,
+            # ray.get of the ActorHandle result is mistyped as list; it is a
+            # TracingConfig | None at runtime.
+            tracing_config=tracing_config,  # type: ignore[arg-type]
         )
         if is_tracing_setup_successful:
             logger.info("Successfully set up tracing for replica")

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2731,9 +2731,12 @@ class Replica:
                     await result_gen.aclose()
                     # Record the status code for both success and error paths so
                     # ingress metrics are emitted for successful gRPC requests.
-                    # `status.code` is always a `grpc.StatusCode` on this path
-                    # (`ResponseStatus.code` is annotated as `Union[str, ...]`).
-                    status_code_callback(status.code.name)  # type: ignore[union-attr]  # pyrefly: ignore[missing-attribute]
+                    code_name = (
+                        status.code.name
+                        if isinstance(status.code, grpc.StatusCode)
+                        else status.code
+                    )
+                    status_code_callback(code_name)
                     set_grpc_code_and_details(context, status)
 
     async def _maybe_handle_builtin_grpc_service(
@@ -3213,9 +3216,9 @@ class Replica:
                 if not response_started:
                     # `_http_options` is always set while the direct ingress
                     # server is running.
+                    assert self._http_options is not None
                     msg = (
-                        f"Request {request_id} timed out after "  # type: ignore[union-attr]
-                        # pyrefly: ignore[missing-attribute]
+                        f"Request {request_id} timed out after "
                         f"{self._http_options.request_timeout_s}s."
                     )
                     await send_http_response(msg, 408, send)
@@ -4085,16 +4088,9 @@ class UserCallableWrapper:
                 )
             elif not hasattr(self._callable, RECONFIGURE_METHOD):
                 raise RayServeException(
-                    # NOTE: this concatenates a str with a DeploymentID (which is
-                    # a dataclass, not a str), so reaching this branch raises a
-                    # TypeError rather than the intended RayServeException.
-                    # Preserving runtime behavior; see the type-checking report.
-                    # pyrefly: ignore[unsupported-operation]
-                    "user_config or rank specified but deployment "
-                    + self._deployment_id  # type: ignore[operator]
-                    + " missing "
-                    + RECONFIGURE_METHOD
-                    + " method"
+                    f"user_config or rank specified but deployment "
+                    f"{self._deployment_id} missing "
+                    f"{RECONFIGURE_METHOD} method"
                 )
             kwargs = {}
             if user_subscribed_to_rank:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -20,14 +20,21 @@ from importlib import import_module
 from typing import (
     Any,
     AsyncGenerator,
+    Awaitable,
     Callable,
+    DefaultDict,
+    Deque,
     Dict,
+    FrozenSet,
     Generator,
+    Hashable,
     List,
+    NoReturn,
     Optional,
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 import grpc
@@ -56,6 +63,7 @@ from ray.serve._private.common import (
     RequestProtocol,
     ServeComponentType,
     StreamingHTTPRequest,
+    TimeSeries,
     gRPCRequest,
     gRPCStreamingRequest,
 )
@@ -149,6 +157,7 @@ from ray.serve._private.rolling_window import (
 from ray.serve._private.serialization import RPCSerializer
 from ray.serve._private.task_consumer import TaskConsumerWrapper
 from ray.serve._private.thirdparty.get_asgi_route_name import (
+    RoutePattern,
     extract_route_patterns,
     get_asgi_route_name,
 )
@@ -318,10 +327,10 @@ ReplicaMetadata = Tuple[
     Optional[float],
     Optional[int],
     Optional[str],
-    int,
-    int,
+    Optional[int],  # http_port
+    Optional[int],  # grpc_port
     ReplicaRank,  # rank
-    Optional[List[str]],  # route_patterns
+    Optional[List[RoutePattern]],  # route_patterns
     Optional[List[DeploymentID]],  # outbound_deployments
     bool,  # has_user_routing_stats_method
     Optional[GangContext],  # gang_context
@@ -338,7 +347,8 @@ def _load_deployment_def_from_import_path(import_path: str) -> Callable:
     if isinstance(deployment_def, RemoteFunction):
         deployment_def = deployment_def._function
     elif isinstance(deployment_def, ActorClass):
-        deployment_def = deployment_def.__ray_metadata__.modified_class
+        # `__ray_metadata__` is set dynamically on actor classes.
+        deployment_def = deployment_def.__ray_metadata__.modified_class  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
     elif isinstance(deployment_def, Deployment):
         logger.warning(
             f'The import path "{import_path}" contains a '
@@ -388,7 +398,9 @@ class ReplicaMetricsManager:
         self._custom_metrics_enabled = False
         # On first call to _fetch_custom_autoscaling_metrics. Failing validation disables _custom_metrics_enabled
         self._checked_custom_metrics = False
-        self._record_autoscaling_stats_fn = None
+        self._record_autoscaling_stats_fn: Optional[
+            Callable[[], Optional[concurrent.futures.Future]]
+        ] = None
 
         # Tracks in-flight metrics push to controller. Skip if new one is sent.
         self._pending_metrics_push_ref: Optional[ObjectRef] = None
@@ -416,17 +428,21 @@ class ReplicaMetricsManager:
             tag_keys=("route",),
         )
         if self._cached_metrics_enabled:
-            self._cached_request_counter = defaultdict(int)
+            self._cached_request_counter: DefaultDict[str, int] = defaultdict(int)
 
         self._error_counter = metrics.Counter(
             "serve_deployment_error_counter",
             description=(
                 "The number of exceptions that have occurred in this replica."
             ),
-            tag_keys=("route", "exception_type"),
+            # `tag_keys` is annotated as `Tuple[str]` upstream but accepts any
+            # tuple of strings at runtime.
+            tag_keys=("route", "exception_type"),  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
         )
         if self._cached_metrics_enabled:
-            self._cached_error_counter = defaultdict(int)
+            self._cached_error_counter: DefaultDict[Tuple[str, str], int] = defaultdict(
+                int
+            )
 
         # log REQUEST_LATENCY_BUCKET_MS
         logger.debug(f"REQUEST_LATENCY_BUCKETS_MS: {REQUEST_LATENCY_BUCKETS_MS}")
@@ -437,11 +453,13 @@ class ReplicaMetricsManager:
             tag_keys=("route",),
         )
         if self._cached_metrics_enabled:
-            self._cached_latencies = defaultdict(deque)
+            self._cached_latencies: DefaultDict[str, Deque[float]] = defaultdict(deque)
             self._event_loop.create_task(self._report_cached_metrics_forever())
 
         # Track maximum processing latency over a rolling window.
-        self._max_processing_latency_trackers = defaultdict(
+        self._max_processing_latency_trackers: DefaultDict[
+            str, RollingWindowMax
+        ] = defaultdict(
             lambda: RollingWindowMax(
                 window_duration_s=RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_WINDOW_S,
                 num_buckets=RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_NUM_BUCKETS,
@@ -518,18 +536,19 @@ class ReplicaMetricsManager:
 
             if self._cached_metrics_enabled:
                 # Mapping from protocol -> {request_tags -> value}.
-                self._cached_ingress_request_counter = defaultdict(
-                    lambda: defaultdict(int)
-                )
-                self._cached_ingress_request_error_counter = defaultdict(
-                    lambda: defaultdict(int)
-                )
-                self._cached_deployment_request_error_counter = defaultdict(
-                    lambda: defaultdict(int)
-                )
-                self._cached_ingress_processing_latencies = defaultdict(
-                    lambda: defaultdict(deque)
-                )
+                self._cached_ingress_request_counter: DefaultDict[
+                    RequestProtocol, DefaultDict[FrozenSet[Tuple[str, str]], int]
+                ] = defaultdict(lambda: defaultdict(int))
+                self._cached_ingress_request_error_counter: DefaultDict[
+                    RequestProtocol, DefaultDict[FrozenSet[Tuple[str, str]], int]
+                ] = defaultdict(lambda: defaultdict(int))
+                self._cached_deployment_request_error_counter: DefaultDict[
+                    RequestProtocol, DefaultDict[FrozenSet[Tuple[str, str]], int]
+                ] = defaultdict(lambda: defaultdict(int))
+                self._cached_ingress_processing_latencies: DefaultDict[
+                    RequestProtocol,
+                    DefaultDict[FrozenSet[Tuple[str, str]], Deque[float]],
+                ] = defaultdict(lambda: defaultdict(deque))
 
     @property
     def _is_direct_ingress(self) -> bool:
@@ -650,23 +669,26 @@ class ReplicaMetricsManager:
         await self._metrics_pusher.graceful_shutdown()
 
     def start_metrics_pusher(self):
+        # Invariant: only called when an autoscaling config is set (checked at
+        # every call site), so narrow the Optional for the type checkers.
+        autoscaling_config = cast(AutoscalingConfig, self._autoscaling_config)
         self._metrics_pusher.start()
 
         # Push autoscaling metrics to the controller periodically.
         self._metrics_pusher.register_or_update_task(
             self.PUSH_METRICS_TO_CONTROLLER_TASK_NAME,
             self._push_autoscaling_metrics,
-            self._autoscaling_config.metrics_interval_s,
+            autoscaling_config.metrics_interval_s,
         )
         # Collect autoscaling metrics locally periodically.
         record_interval_s = (
-            self._autoscaling_config.look_back_period_s
+            autoscaling_config.look_back_period_s
             * RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR
         )
         self._metrics_pusher.register_or_update_task(
             self.RECORD_METRICS_TASK_NAME,
             self._add_autoscaling_metrics_point_async,
-            min(record_interval_s, self._autoscaling_config.metrics_interval_s),
+            min(record_interval_s, autoscaling_config.metrics_interval_s),
         )
 
     def should_collect_ongoing_requests(self) -> bool:
@@ -932,12 +954,17 @@ class ReplicaMetricsManager:
                 deployment_name=deployment_name,
             )
 
-    def _push_autoscaling_metrics(self) -> Dict[str, Any]:
-        look_back_period = self._autoscaling_config.look_back_period_s
+    def _push_autoscaling_metrics(self) -> None:
+        # Invariant: this task is only registered (`start_metrics_pusher`) when an
+        # autoscaling config is set.
+        look_back_period = cast(
+            AutoscalingConfig, self._autoscaling_config
+        ).look_back_period_s
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
 
         new_aggregated_metrics = {}
-        new_metrics = {**self._metrics_store.data}
+        # The store keys are `Hashable`; this replica only ever records `str` keys.
+        new_metrics = cast(Dict[str, TimeSeries], {**self._metrics_store.data})
 
         if self.should_collect_ongoing_requests():
             # Keep the legacy window_avg ongoing requests in the merged metrics dict
@@ -957,7 +984,8 @@ class ReplicaMetricsManager:
                 if not check_obj_ref_ready_nowait(self._pending_metrics_push_ref):
                     return  # Previous push still in flight, skip and try again later
             self._pending_metrics_push_ref = (
-                self._controller_handle.record_autoscaling_metrics_from_replica.remote(
+                # Actor methods are resolved dynamically on the actor handle.
+                self._controller_handle.record_autoscaling_metrics_from_replica.remote(  # type: ignore[attr-defined]
                     compress_metric_report(replica_metric_report)
                 )
             )
@@ -965,10 +993,16 @@ class ReplicaMetricsManager:
     async def _fetch_custom_autoscaling_metrics(
         self,
     ) -> Optional[Dict[str, Union[int, float]]]:
+        # Invariant: only called when `_custom_metrics_enabled` is True, which
+        # requires `_record_autoscaling_stats_fn` to have been set (and it returns
+        # an awaitable here since the replica never runs in local testing mode).
+        record_autoscaling_stats_fn = cast(
+            Callable[[], Awaitable[Any]], self._record_autoscaling_stats_fn
+        )
         try:
             start_time = time.time()
             res = await asyncio.wait_for(
-                self._record_autoscaling_stats_fn(),
+                record_autoscaling_stats_fn(),
                 timeout=RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S,
             )
             latency_ms = (time.time() - start_time) * 1000
@@ -1013,7 +1047,7 @@ class ReplicaMetricsManager:
         return None
 
     async def _add_autoscaling_metrics_point_async(self) -> None:
-        metrics_dict = {}
+        metrics_dict: Dict[str, float] = {}
         if self.should_collect_ongoing_requests():
             metrics_dict = {RUNNING_REQUESTS_KEY: self._num_ongoing_requests}
 
@@ -1024,7 +1058,9 @@ class ReplicaMetricsManager:
                 metrics_dict.update(custom_metrics)
 
         self._metrics_store.add_metrics_point(
-            metrics_dict,
+            # The store accepts `Hashable` keys; `Dict` is invariant in its key
+            # type, so the `str`-keyed dict must be cast.
+            cast(Dict[Hashable, float], metrics_dict),
             time.time(),
         )
 
@@ -1062,7 +1098,8 @@ class Replica:
         self._configure_logger_and_profilers(self._deployment_config.logging_config)
         self._event_loop = get_or_create_event_loop()
 
-        actor_id = ray.get_runtime_context().get_actor_id()
+        # This always runs inside a replica actor, so the actor ID is set.
+        actor_id = cast(str, ray.get_runtime_context().get_actor_id())
         self._user_callable_wrapper = UserCallableWrapper(
             deployment_def,
             init_args,
@@ -1275,7 +1312,7 @@ class Replica:
 
         # Use _PyObjScanner to find all DeploymentHandle objects in:
         # The init_args and init_kwargs (handles might be passed as init args)
-        scanner = _PyObjScanner(source_type=DeploymentHandle)
+        scanner: _PyObjScanner = _PyObjScanner(source_type=DeploymentHandle)
         try:
             handles = scanner.find_nodes((init_args, init_kwargs))
 
@@ -1288,7 +1325,10 @@ class Replica:
         return list(seen_deployment_ids)
 
     def _set_internal_replica_context(
-        self, *, servable_object: Callable = None, rank: ReplicaRank = None
+        self,
+        *,
+        servable_object: Optional[Callable] = None,
+        rank: Optional[ReplicaRank] = None,
     ):
         # Calculate world_size from deployment config instead of storing it
         world_size = self._deployment_config.num_replicas
@@ -1298,13 +1338,20 @@ class Replica:
             self._dynamically_created_handles.add(deployment_id)
 
         code_version = self._version.code_version
+        # NOTE: `context._set_internal_replica_context` annotates `servable_object`
+        # and `rank` as non-Optional, but both are legitimately None until the user
+        # callable is initialized. `world_size` comes from
+        # `DeploymentConfig.num_replicas`, which is Optional in the model but always
+        # concrete for a deployed replica. The registration callback takes a single
+        # `DeploymentID`, matching `ReplicaContext._handle_registration_callback`;
+        # the `(str, str)` annotation on the context setter is stale.
         ray.serve.context._set_internal_replica_context(
             replica_id=self._replica_id,
-            servable_object=servable_object,
+            servable_object=servable_object,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
             _deployment_config=self._deployment_config,
-            rank=rank,
-            world_size=world_size,
-            handle_registration_callback=register_handle_callback,
+            rank=rank,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
+            world_size=world_size,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
+            handle_registration_callback=register_handle_callback,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
             gang_context=self._gang_context,
             code_version=code_version,
         )
@@ -1387,7 +1434,7 @@ class Replica:
         self, request_metadata: RequestMetadata
     ) -> Generator[StatusCodeCallback, None, None]:
         start_time = time.time()
-        user_exception = None
+        user_exception: Optional[BaseException] = None
 
         status_code = None
 
@@ -1471,7 +1518,10 @@ class Replica:
                     service=self._deployment_id.name,
                 )
             if user_exception is not None:
-                set_span_exception(user_exception, escaped=False)
+                # `user_exception` may be an `asyncio.CancelledError`
+                # (a BaseException); `set_span_exception` annotates `exc:
+                # Exception` too narrowly for that.
+                set_span_exception(user_exception, escaped=False)  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
 
         # Record ingress metrics for direct ingress requests
         if request_metadata.is_direct_ingress and status_code is not None:
@@ -1500,9 +1550,9 @@ class Replica:
     def _unpack_proxy_args(
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
-    ) -> Tuple[Tuple[Any], Dict[str, Any], Any]:
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any], Any]:
         # Extract _ray_trace_ctx from kwargs at the entry point.
         #
         # Context: When tracing is enabled, Ray's tracing decorators inject
@@ -1549,12 +1599,12 @@ class Replica:
                 assert len(request_args) == 1 and isinstance(
                     request_args[0], gRPCRequest
                 )
-                request: gRPCRequest = request_args[0]
+                grpc_request: gRPCRequest = request_args[0]
 
                 method_info = self._user_callable_wrapper.get_user_method_info(
                     request_metadata.call_method
                 )
-                request_args = (request.user_request_proto,)
+                request_args = (grpc_request.user_request_proto,)
                 request_kwargs = (
                     {GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context}
                     if method_info.takes_grpc_context_kwarg
@@ -1567,7 +1617,7 @@ class Replica:
         self,
         request_metadata: RequestMetadata,
         streaming_request: gRPCStreamingRequest,
-    ) -> Tuple[Tuple[Any], Dict[str, Any]]:
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         """Set up request args for gRPC client/bidirectional streaming.
 
         Creates a gRPCInputStream that wraps the callback to the proxy,
@@ -1621,7 +1671,7 @@ class Replica:
 
     async def handle_request(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
-    ) -> Tuple[bytes, Any]:
+    ) -> Any:
         request_args, request_kwargs, ray_trace_ctx = self._unpack_proxy_args(
             request_metadata, request_args, request_kwargs
         )
@@ -1689,7 +1739,7 @@ class Replica:
 
     def _raise_user_exception(
         self, e: BaseException, request_metadata: RequestMetadata
-    ) -> None:
+    ) -> NoReturn:
         wrapped_exception = self._maybe_wrap_grpc_exception(e, request_metadata)
         if wrapped_exception is e:
             raise e
@@ -1697,7 +1747,7 @@ class Replica:
 
     async def handle_request_with_rejection(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
-    ):
+    ) -> AsyncGenerator[Any, None]:
         # Reject new requests once quiescing so the router retries them on
         # another replica.
         if self._is_replica_quiescing(request_metadata):
@@ -1833,7 +1883,10 @@ class Replica:
                     # this is never polled and is treated as immutable.
                     if self._user_callable_wrapper.has_user_replica_metadata_method:
                         self._replica_metadata = _validate_replica_metadata(
-                            await self._user_callable_wrapper.call_user_record_replica_metadata()
+                            # Never None: guarded by
+                            # `has_user_replica_metadata_method` above.
+                            # pyrefly: ignore[not-async]
+                            await self._user_callable_wrapper.call_user_record_replica_metadata()  # type: ignore[misc]
                         )
                     if self._user_callable_asgi_app:
                         self._docs_path = (
@@ -1929,7 +1982,12 @@ class Replica:
                 rank=rank,
             )
 
-            self._route_prefix = self._version.route_prefix
+            # NOTE: `DeploymentVersion.route_prefix` is Optional and
+            # `from_deployment_version` overwrites it with this method's
+            # `route_prefix` argument even when that argument is None, while
+            # `_route_prefix` is typed and used as `str` elsewhere. Preserving
+            # runtime behavior; see the type-checking report.
+            self._route_prefix = self._version.route_prefix  # type: ignore[assignment]
 
         except Exception:
             raise RuntimeError(traceback.format_exc()) from None
@@ -2099,6 +2157,9 @@ class Replica:
             try:
                 # On timeout, `wait_for` cancels the server task (abrupt close).
                 await asyncio.wait_for(
+                    # Always set together with `_direct_ingress_http_server`
+                    # (checked above).
+                    # pyrefly: ignore[bad-argument-type]
                     self._direct_ingress_http_server_task,
                     timeout=remaining_grace_s(),
                 )
@@ -2355,8 +2416,10 @@ class Replica:
         """
 
         with self._tracing_context(request_metadata):
+            # `_serve_request_context` is declared without a type parameter and
+            # with `default=None`, so checkers infer `ContextVar[None]`.
             ray.serve.context._serve_request_context.set(
-                ray.serve.context._RequestContext(
+                ray.serve.context._RequestContext(  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
                     route=request_metadata.route,
                     request_id=request_metadata.request_id,
                     _internal_request_id=request_metadata.internal_request_id,
@@ -2624,6 +2687,10 @@ class Replica:
 
             result_gen = call_unary()
 
+        # Invariant: gRPC direct-ingress requests are only served after
+        # `_maybe_start_direct_ingress_servers` populated `_grpc_options`.
+        grpc_options = cast(gRPCOptions, self._grpc_options)
+
         with (
             self._wrap_request(request_metadata) as status_code_callback,
             self._track_queued_request() as release_queue_slot,
@@ -2635,7 +2702,7 @@ class Replica:
                 # Use the generic disconnect/timeout detecting wrapper.
                 replica_response_generator = ReplicaResponseGenerator(
                     result_gen,
-                    timeout_s=self._grpc_options.request_timeout_s,
+                    timeout_s=grpc_options.request_timeout_s,
                 )
                 status = ResponseStatus(code=grpc.StatusCode.OK)
                 try:
@@ -2649,7 +2716,10 @@ class Replica:
                     e = self._maybe_wrap_grpc_exception(e, request_metadata)
                     status = get_grpc_response_status(
                         e,
-                        self._grpc_options.request_timeout_s,
+                        # `request_timeout_s` may be None (no timeout configured);
+                        # the callee only formats it into an error message but
+                        # annotates it as `float`.
+                        grpc_options.request_timeout_s,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
                         request_metadata.request_id,
                     )
                     raise e
@@ -2661,7 +2731,9 @@ class Replica:
                     await result_gen.aclose()
                     # Record the status code for both success and error paths so
                     # ingress metrics are emitted for successful gRPC requests.
-                    status_code_callback(status.code.name)
+                    # `status.code` is always a `grpc.StatusCode` on this path
+                    # (`ResponseStatus.code` is annotated as `Union[str, ...]`).
+                    status_code_callback(status.code.name)  # type: ignore[union-attr]  # pyrefly: ignore[missing-attribute]
                     set_grpc_code_and_details(context, status)
 
     async def _maybe_handle_builtin_grpc_service(
@@ -2902,9 +2974,10 @@ class Replica:
         If the header is missing or invalid, returns the default request timeout
         from HttpOptions. If the header is non-positive, timeout is disabled.
         """
-        return parse_request_timeout_header(
-            headers, self._http_options.request_timeout_s
-        )
+        # Invariant: only called while serving direct-ingress HTTP requests, after
+        # `_maybe_start_direct_ingress_servers` populated `_http_options`.
+        http_options = cast(HTTPOptions, self._http_options)
+        return parse_request_timeout_header(headers, http_options.request_timeout_s)
 
     async def _direct_ingress_asgi(
         self,
@@ -2931,6 +3004,8 @@ class Replica:
 
         # Handle health check or routes request.
         if route in ["/-/healthz", "/-/routes"]:
+            # `message` holds the health-check string, or the routes dict below.
+            message: Union[str, Dict[str, str]]
             healthy, message = await self._dataplane_health_check()
             status_code = 200 if healthy else 503
             if route == "/-/routes" and healthy:
@@ -3136,8 +3211,11 @@ class Replica:
                     receive_task.cancel()
                 status_code_callback("408")
                 if not response_started:
+                    # `_http_options` is always set while the direct ingress
+                    # server is running.
                     msg = (
-                        f"Request {request_id} timed out after "
+                        f"Request {request_id} timed out after "  # type: ignore[union-attr]
+                        # pyrefly: ignore[missing-attribute]
                         f"{self._http_options.request_timeout_s}s."
                     )
                     await send_http_response(msg, 408, send)
@@ -3175,7 +3253,9 @@ class ReplicaActor:
     `UserCallableWrapper` class.
     """
 
-    async def __init__(
+    # Ray actors support `async def __init__` even though type checkers require
+    # `__init__` to return None.
+    async def __init__(  # type: ignore[misc]
         self,
         replica_id: ReplicaID,
         serialized_deployment_def: bytes,
@@ -3208,7 +3288,8 @@ class ReplicaActor:
     def push_proxy_handle(self, handle: ActorHandle):
         # NOTE(edoakes): it's important to call a method on the proxy handle to
         # initialize its state in the C++ core worker.
-        handle.pong.remote()
+        # (Actor methods are resolved dynamically on the actor handle.)
+        handle.pong.remote()  # type: ignore[attr-defined]
 
     def get_num_ongoing_requests(self) -> int:
         """Fetch the number of ongoing requests at this replica (queue length).
@@ -3228,7 +3309,7 @@ class ReplicaActor:
         """Release capacity reserved by choose_replica()."""
         return self._replica_impl.release_slot(slot_token)
 
-    async def is_allocated(self) -> str:
+    async def is_allocated(self) -> Tuple[Any, ...]:
         """poke the replica to check whether it's alive.
 
         When calling this method on an ActorHandle, it will complete as
@@ -3275,9 +3356,9 @@ class ReplicaActor:
 
     async def initialize_and_get_metadata(
         self,
-        deployment_config: DeploymentConfig = None,
-        rank: ReplicaRank = None,
-        gang_context: GangContext = None,
+        deployment_config: Optional[DeploymentConfig] = None,
+        rank: Optional[ReplicaRank] = None,
+        gang_context: Optional[GangContext] = None,
     ) -> ReplicaMetadata:
         """Handles initializing the replica.
 
@@ -3321,7 +3402,7 @@ class ReplicaActor:
         pickled_request_metadata: bytes,
         *request_args,
         **request_kwargs,
-    ) -> Tuple[bytes, Any]:
+    ) -> Any:
         """Entrypoint for `stream=False` calls."""
         request_metadata, request_args = self._preprocess_request_args(
             pickled_request_metadata, request_args
@@ -3457,7 +3538,9 @@ class UserCallableWrapper:
                 f"{type(deployment_def)}."
             )
 
-        self._deployment_def = deployment_def
+        # The user-provided function or class; `Any` because classes are accessed
+        # via `__new__`/`__init__` below, which `Callable` does not cover.
+        self._deployment_def: Any = deployment_def
         self._init_args = init_args
         self._init_kwargs = init_kwargs
         self._is_function = inspect.isfunction(deployment_def)
@@ -3470,8 +3553,9 @@ class UserCallableWrapper:
         self._cached_user_method_info: Dict[str, UserMethodInfo] = {}
         # This is for performance optimization https://docs.python.org/3/howto/logging.html#optimization
         self._is_enabled_for_debug = logger.isEnabledFor(logging.DEBUG)
-        # Will be populated in `initialize_callable`.
-        self._callable = None
+        # Will be populated in `initialize_callable` with the user's function or
+        # class instance (duck-typed throughout, hence `Any`).
+        self._callable: Any = None
         self._user_health_check: Optional[Callable] = None
         self._user_loop_probe_consecutive_fail_count: int = 0
         self._user_loop_probe_task: Optional[asyncio.Task] = None
@@ -3491,7 +3575,7 @@ class UserCallableWrapper:
             # Start event loop monitoring for the user code event loop.
             # We create the monitor here but start it inside the thread function
             # so the task is created on the correct thread.
-            self._user_code_loop_monitor = EventLoopMonitor(
+            self._user_code_loop_monitor: Optional[EventLoopMonitor] = EventLoopMonitor(
                 component=EventLoopMonitor.COMPONENT_REPLICA,
                 loop_type=EventLoopMonitor.LOOP_TYPE_USER_CODE,
                 actor_id=actor_id,
@@ -3507,6 +3591,8 @@ class UserCallableWrapper:
                 asyncio.set_event_loop(self._user_code_event_loop)
                 self._configure_user_code_threadpool()
                 # Start monitoring before run_forever so the task is scheduled.
+                # The monitor is always set on this (separate-thread) branch.
+                # pyrefly: ignore[missing-attribute]
                 self._user_code_loop_monitor.start(self._user_code_event_loop)
                 self._user_code_event_loop.run_forever()
 
@@ -3606,7 +3692,9 @@ class UserCallableWrapper:
         )
         self._user_code_event_loop.set_default_executor(self._user_code_threadpool)
 
-    def _run_user_code(f: Callable) -> Callable:
+    # This is a decorator applied to methods of this class at class-definition
+    # time, so it intentionally has no `self` parameter.
+    def _run_user_code(f: Callable) -> Callable:  # type: ignore[misc]
         """Decorator to run a coroutine method on the user code event loop.
 
         The method will be modified to be a sync function that returns a
@@ -3694,7 +3782,7 @@ class UserCallableWrapper:
         self,
         callable: Callable,
         *,
-        args: Optional[Tuple[Any]] = None,
+        args: Optional[Tuple[Any, ...]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         is_streaming: bool = False,
         generator_result_callback: Optional[Callable] = None,
@@ -3740,6 +3828,10 @@ class UserCallableWrapper:
                 result = callable(*args, **kwargs)
                 if is_generator:
                     for r in result:
+                        # `generator_result_callback` is always provided for
+                        # streaming calls, and generators are rejected above
+                        # unless `is_streaming=True`.
+                        # pyrefly: ignore[not-callable]
                         generator_result_callback(r)
 
                     result = None
@@ -3775,8 +3867,6 @@ class UserCallableWrapper:
         return self._callable
 
     async def _initialize_asgi_callable(self) -> None:
-        self._callable: ASGIAppReplicaWrapper
-
         build_asgi_app = getattr(self._callable, SERVE_BUILD_ASGI_APP_METHOD, None)
         is_late_bound = not hasattr(self._callable, "_asgi_app")
         if is_late_bound and build_asgi_app is None:
@@ -3795,7 +3885,7 @@ class UserCallableWrapper:
                 )
             self._callable._set_asgi_app(app)
 
-        app: ASGIApp = self._callable.app
+        app: ASGIApp = self._callable.app  # type: ignore[no-redef]
 
         if hasattr(app, "add_exception_handler"):
             # The reason we need to do this is because BackPressureError is a serve
@@ -3885,7 +3975,7 @@ class UserCallableWrapper:
                 f"`initialize_callable` must be called before `{method_name}`."
             )
 
-    def call_user_health_check(self) -> Optional[concurrent.futures.Future]:
+    def call_user_health_check(self) -> Optional[Awaitable[Any]]:
         self._raise_if_not_initialized("call_user_health_check")
 
         # If the user provided a health check, call it on the user code thread. If user
@@ -3913,7 +4003,7 @@ class UserCallableWrapper:
         """Whether the user has defined a record_routing_stats method."""
         return self._user_record_routing_stats is not None
 
-    def call_user_record_routing_stats(self) -> Optional[concurrent.futures.Future]:
+    def call_user_record_routing_stats(self) -> Optional[Awaitable[Any]]:
         self._raise_if_not_initialized("call_user_record_routing_stats")
 
         if self._user_record_routing_stats is not None:
@@ -3928,7 +4018,7 @@ class UserCallableWrapper:
 
     def call_user_record_replica_metadata(
         self,
-    ) -> Optional[concurrent.futures.Future]:
+    ) -> Optional[Awaitable[Any]]:
         self._raise_if_not_initialized("call_user_record_replica_metadata")
 
         if self._user_record_replica_metadata is not None:
@@ -3944,23 +4034,32 @@ class UserCallableWrapper:
 
         return None
 
+    # NOTE: the `_call_user_*` methods below are only invoked when the
+    # corresponding user-defined hook exists (checked by their `call_*`
+    # counterparts), so the Optionals are narrowed with `cast`.
     @_run_user_code
     async def _call_user_health_check(self):
-        await self._call_func_or_gen(self._user_health_check)
+        await self._call_func_or_gen(cast(Callable, self._user_health_check))
 
     @_run_user_code
     async def _call_user_record_routing_stats(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(self._user_record_routing_stats)
+        result, _ = await self._call_func_or_gen(
+            cast(Callable, self._user_record_routing_stats)
+        )
         return result
 
     @_run_user_code
     async def _call_user_record_replica_metadata(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(self._user_record_replica_metadata)
+        result, _ = await self._call_func_or_gen(
+            cast(Callable, self._user_record_replica_metadata)
+        )
         return result
 
     @_run_user_code
     async def _call_user_autoscaling_stats(self) -> Dict[str, Union[int, float]]:
-        result, _ = await self._call_func_or_gen(self._user_autoscaling_stats)
+        result, _ = await self._call_func_or_gen(
+            cast(Callable, self._user_autoscaling_stats)
+        )
         return result
 
     @_run_user_code
@@ -3986,8 +4085,13 @@ class UserCallableWrapper:
                 )
             elif not hasattr(self._callable, RECONFIGURE_METHOD):
                 raise RayServeException(
+                    # NOTE: this concatenates a str with a DeploymentID (which is
+                    # a dataclass, not a str), so reaching this branch raises a
+                    # TypeError rather than the intended RayServeException.
+                    # Preserving runtime behavior; see the type-checking report.
+                    # pyrefly: ignore[unsupported-operation]
                     "user_config or rank specified but deployment "
-                    + self._deployment_id
+                    + self._deployment_id  # type: ignore[operator]
                     + " missing "
                     + RECONFIGURE_METHOD
                     + " method"
@@ -4025,6 +4129,12 @@ class UserCallableWrapper:
         but for ASGI apps (like FastAPI), the actual method will be a regular function
         implementing the ASGI `__call__` protocol.
         """
+        # Invariants (runtime no-op rebinds to narrow the Optionals): callers
+        # always provide `generator_result_callback` for streaming calls and
+        # `asgi_args` for HTTP requests.
+        generator_result_callback = cast(Callable, generator_result_callback)
+        asgi_args = cast(ASGIArgs, asgi_args)
+
         result_is_gen = inspect.isgenerator(result)
         result_is_async_gen = inspect.isasyncgen(result)
         if is_streaming:
@@ -4134,7 +4244,7 @@ class UserCallableWrapper:
             )
 
         if user_method_info.is_asgi_app:
-            request_args = (scope, receive, send)
+            request_args: Tuple[Any, ...] = (scope, receive, send)
         elif not user_method_info.takes_any_args:
             # Edge case to support empty HTTP handlers: don't pass the Request
             # argument if the callable has no parameters.
@@ -4195,7 +4305,7 @@ class UserCallableWrapper:
     async def call_user_generator(
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
     ) -> AsyncGenerator[Any, None]:
         """Calls a user method for a streaming call and yields its results.
@@ -4250,10 +4360,12 @@ class UserCallableWrapper:
                     call_future.cancel()
 
     @_run_user_code
-    async def _call_user_generator(
+    # mypy requires an explicit `return None` even for an Optional return type;
+    # the enqueue branches intentionally fall off the end.
+    async def _call_user_generator(  # type: ignore[return]
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
         *,
         enqueue: Optional[Callable] = None,
@@ -4320,6 +4432,9 @@ class UserCallableWrapper:
             gen = callable(*request_args, **request_kwargs)
             if inspect.isgenerator(gen):
                 for result in gen:
+                    # `_call_generator_sync` is only invoked when `enqueue` is
+                    # provided (see below).
+                    # pyrefly: ignore[not-callable]
                     enqueue(result)
             else:
                 raise TypeError(
@@ -4343,7 +4458,7 @@ class UserCallableWrapper:
     async def call_user_method(
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
     ) -> Any:
         """Call a (unary) user method.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -4113,8 +4113,8 @@ class UserCallableWrapper:
         is_streaming: bool,
         is_http_request: bool,
         sync_gen_consumed: bool,
-        generator_result_callback: Optional[Callable],
-        asgi_args: Optional[ASGIArgs],
+        generator_result_callback: Callable,
+        asgi_args: ASGIArgs,
     ) -> Any:
         """Postprocess the result of a user method.
 
@@ -4131,8 +4131,6 @@ class UserCallableWrapper:
         result_is_gen = inspect.isgenerator(result)
         result_is_async_gen = inspect.isasyncgen(result)
         if is_streaming:
-            # Callers always provide the callback for streaming calls.
-            assert generator_result_callback is not None
             if result_is_gen:
                 for r in result:
                     generator_result_callback(r)
@@ -4142,8 +4140,6 @@ class UserCallableWrapper:
             elif is_http_request and not user_method_info.is_asgi_app:
                 # For the FastAPI codepath, the response has already been sent over
                 # ASGI, but for the vanilla deployment codepath we need to send it.
-                # asgi_args is always provided for HTTP requests.
-                assert asgi_args is not None
                 await self._send_user_result_over_asgi(result, asgi_args)
             elif not is_http_request and not sync_gen_consumed:
                 # If a unary method is called with stream=True for anything EXCEPT

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -4124,15 +4124,11 @@ class UserCallableWrapper:
         but for ASGI apps (like FastAPI), the actual method will be a regular function
         implementing the ASGI `__call__` protocol.
         """
-        # Invariants (runtime no-op rebinds to narrow the Optionals): callers
-        # always provide `generator_result_callback` for streaming calls and
-        # `asgi_args` for HTTP requests.
-        generator_result_callback = cast(Callable, generator_result_callback)
-        asgi_args = cast(ASGIArgs, asgi_args)
-
         result_is_gen = inspect.isgenerator(result)
         result_is_async_gen = inspect.isasyncgen(result)
         if is_streaming:
+            # Callers always provide the callback for streaming calls.
+            assert generator_result_callback is not None
             if result_is_gen:
                 for r in result:
                     generator_result_callback(r)
@@ -4142,6 +4138,8 @@ class UserCallableWrapper:
             elif is_http_request and not user_method_info.is_asgi_app:
                 # For the FastAPI codepath, the response has already been sent over
                 # ASGI, but for the vanilla deployment codepath we need to send it.
+                # asgi_args is always provided for HTTP requests.
+                assert asgi_args is not None
                 await self._send_user_result_over_asgi(result, asgi_args)
             elif not is_http_request and not sync_gen_consumed:
                 # If a unary method is called with stream=True for anything EXCEPT

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -671,7 +671,8 @@ class ReplicaMetricsManager:
     def start_metrics_pusher(self):
         # Invariant: only called when an autoscaling config is set (checked at
         # every call site), so narrow the Optional for the type checkers.
-        autoscaling_config = cast(AutoscalingConfig, self._autoscaling_config)
+        assert self._autoscaling_config is not None
+        autoscaling_config = self._autoscaling_config
         self._metrics_pusher.start()
 
         # Push autoscaling metrics to the controller periodically.
@@ -957,9 +958,8 @@ class ReplicaMetricsManager:
     def _push_autoscaling_metrics(self) -> None:
         # Invariant: this task is only registered (`start_metrics_pusher`) when an
         # autoscaling config is set.
-        look_back_period = cast(
-            AutoscalingConfig, self._autoscaling_config
-        ).look_back_period_s
+        assert self._autoscaling_config is not None
+        look_back_period = self._autoscaling_config.look_back_period_s
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
 
         new_aggregated_metrics = {}
@@ -993,9 +993,9 @@ class ReplicaMetricsManager:
     async def _fetch_custom_autoscaling_metrics(
         self,
     ) -> Optional[Dict[str, Union[int, float]]]:
-        # Invariant: only called when `_custom_metrics_enabled` is True, which
-        # requires `_record_autoscaling_stats_fn` to have been set (and it returns
-        # an awaitable here since the replica never runs in local testing mode).
+        # Only reached with `_custom_metrics_enabled`, which guarantees the fn is set.
+        # cast (not assert) also refines its return to an awaitable, which the
+        # declared attribute type does not capture.
         record_autoscaling_stats_fn = cast(
             Callable[[], Awaitable[Any]], self._record_autoscaling_stats_fn
         )
@@ -1058,8 +1058,8 @@ class ReplicaMetricsManager:
                 metrics_dict.update(custom_metrics)
 
         self._metrics_store.add_metrics_point(
-            # The store accepts `Hashable` keys; `Dict` is invariant in its key
-            # type, so the `str`-keyed dict must be cast.
+            # cast: the store accepts `Hashable` keys and `Dict` is invariant in
+            # its key type, so the `str`-keyed dict is not directly assignable.
             cast(Dict[Hashable, float], metrics_dict),
             time.time(),
         )
@@ -1099,7 +1099,8 @@ class Replica:
         self._event_loop = get_or_create_event_loop()
 
         # This always runs inside a replica actor, so the actor ID is set.
-        actor_id = cast(str, ray.get_runtime_context().get_actor_id())
+        actor_id = ray.get_runtime_context().get_actor_id()
+        assert actor_id is not None
         self._user_callable_wrapper = UserCallableWrapper(
             deployment_def,
             init_args,
@@ -1338,13 +1339,8 @@ class Replica:
             self._dynamically_created_handles.add(deployment_id)
 
         code_version = self._version.code_version
-        # NOTE: `context._set_internal_replica_context` annotates `servable_object`
-        # and `rank` as non-Optional, but both are legitimately None until the user
-        # callable is initialized. `world_size` comes from
-        # `DeploymentConfig.num_replicas`, which is Optional in the model but always
-        # concrete for a deployed replica. The registration callback takes a single
-        # `DeploymentID`, matching `ReplicaContext._handle_registration_callback`;
-        # the `(str, str)` annotation on the context setter is stale.
+        # The context setter's param annotations are stale (non-Optional, wrong
+        # callback arity); these values are correct at runtime, hence the ignores.
         ray.serve.context._set_internal_replica_context(
             replica_id=self._replica_id,
             servable_object=servable_object,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
@@ -1672,6 +1668,7 @@ class Replica:
     async def handle_request(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
     ) -> Any:
+        # Returns the arbitrary user method result, hence Any.
         request_args, request_kwargs, ray_trace_ctx = self._unpack_proxy_args(
             request_metadata, request_args, request_kwargs
         )
@@ -2689,7 +2686,8 @@ class Replica:
 
         # Invariant: gRPC direct-ingress requests are only served after
         # `_maybe_start_direct_ingress_servers` populated `_grpc_options`.
-        grpc_options = cast(gRPCOptions, self._grpc_options)
+        assert self._grpc_options is not None
+        grpc_options = self._grpc_options
 
         with (
             self._wrap_request(request_metadata) as status_code_callback,
@@ -2979,7 +2977,8 @@ class Replica:
         """
         # Invariant: only called while serving direct-ingress HTTP requests, after
         # `_maybe_start_direct_ingress_servers` populated `_http_options`.
-        http_options = cast(HTTPOptions, self._http_options)
+        assert self._http_options is not None
+        http_options = self._http_options
         return parse_request_timeout_header(headers, http_options.request_timeout_s)
 
     async def _direct_ingress_asgi(
@@ -3407,6 +3406,8 @@ class ReplicaActor:
         **request_kwargs,
     ) -> Any:
         """Entrypoint for `stream=False` calls."""
+        # Returns the user result, or (grpc_context, serialized_bytes) for gRPC
+        # requests -- arbitrary either way, hence Any.
         request_metadata, request_args = self._preprocess_request_args(
             pickled_request_metadata, request_args
         )
@@ -4039,30 +4040,28 @@ class UserCallableWrapper:
 
     # NOTE: the `_call_user_*` methods below are only invoked when the
     # corresponding user-defined hook exists (checked by their `call_*`
-    # counterparts), so the Optionals are narrowed with `cast`.
+    # counterparts), so the Optionals are narrowed with `assert`.
     @_run_user_code
     async def _call_user_health_check(self):
-        await self._call_func_or_gen(cast(Callable, self._user_health_check))
+        assert self._user_health_check is not None
+        await self._call_func_or_gen(self._user_health_check)
 
     @_run_user_code
     async def _call_user_record_routing_stats(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(
-            cast(Callable, self._user_record_routing_stats)
-        )
+        assert self._user_record_routing_stats is not None
+        result, _ = await self._call_func_or_gen(self._user_record_routing_stats)
         return result
 
     @_run_user_code
     async def _call_user_record_replica_metadata(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(
-            cast(Callable, self._user_record_replica_metadata)
-        )
+        assert self._user_record_replica_metadata is not None
+        result, _ = await self._call_func_or_gen(self._user_record_replica_metadata)
         return result
 
     @_run_user_code
     async def _call_user_autoscaling_stats(self) -> Dict[str, Union[int, float]]:
-        result, _ = await self._call_func_or_gen(
-            cast(Callable, self._user_autoscaling_stats)
-        )
+        assert self._user_autoscaling_stats is not None
+        result, _ = await self._call_func_or_gen(self._user_autoscaling_stats)
         return result
 
     @_run_user_code

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -668,7 +668,8 @@ class ReplicaMetricsManager:
     def start_metrics_pusher(self):
         # Invariant: only called when an autoscaling config is set (checked at
         # every call site), so narrow the Optional for the type checkers.
-        autoscaling_config = cast(AutoscalingConfig, self._autoscaling_config)
+        assert self._autoscaling_config is not None
+        autoscaling_config = self._autoscaling_config
         self._metrics_pusher.start()
 
         # Push autoscaling metrics to the controller periodically.
@@ -954,9 +955,8 @@ class ReplicaMetricsManager:
     def _push_autoscaling_metrics(self) -> None:
         # Invariant: this task is only registered (`start_metrics_pusher`) when an
         # autoscaling config is set.
-        look_back_period = cast(
-            AutoscalingConfig, self._autoscaling_config
-        ).look_back_period_s
+        assert self._autoscaling_config is not None
+        look_back_period = self._autoscaling_config.look_back_period_s
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
 
         new_aggregated_metrics = {}
@@ -990,9 +990,9 @@ class ReplicaMetricsManager:
     async def _fetch_custom_autoscaling_metrics(
         self,
     ) -> Optional[Dict[str, Union[int, float]]]:
-        # Invariant: only called when `_custom_metrics_enabled` is True, which
-        # requires `_record_autoscaling_stats_fn` to have been set (and it returns
-        # an awaitable here since the replica never runs in local testing mode).
+        # Only reached with `_custom_metrics_enabled`, which guarantees the fn is set.
+        # cast (not assert) also refines its return to an awaitable, which the
+        # declared attribute type does not capture.
         record_autoscaling_stats_fn = cast(
             Callable[[], Awaitable[Any]], self._record_autoscaling_stats_fn
         )
@@ -1055,8 +1055,8 @@ class ReplicaMetricsManager:
                 metrics_dict.update(custom_metrics)
 
         self._metrics_store.add_metrics_point(
-            # The store accepts `Hashable` keys; `Dict` is invariant in its key
-            # type, so the `str`-keyed dict must be cast.
+            # cast: the store accepts `Hashable` keys and `Dict` is invariant in
+            # its key type, so the `str`-keyed dict is not directly assignable.
             cast(Dict[Hashable, float], metrics_dict),
             time.time(),
         )
@@ -1096,7 +1096,8 @@ class Replica:
         self._event_loop = get_or_create_event_loop()
 
         # This always runs inside a replica actor, so the actor ID is set.
-        actor_id = cast(str, ray.get_runtime_context().get_actor_id())
+        actor_id = ray.get_runtime_context().get_actor_id()
+        assert actor_id is not None
         self._user_callable_wrapper = UserCallableWrapper(
             deployment_def,
             init_args,
@@ -1336,13 +1337,8 @@ class Replica:
             self._dynamically_created_handles.add(deployment_id)
 
         code_version = self._version.code_version
-        # NOTE: `context._set_internal_replica_context` annotates `servable_object`
-        # and `rank` as non-Optional, but both are legitimately None until the user
-        # callable is initialized. `world_size` comes from
-        # `DeploymentConfig.num_replicas`, which is Optional in the model but always
-        # concrete for a deployed replica. The registration callback takes a single
-        # `DeploymentID`, matching `ReplicaContext._handle_registration_callback`;
-        # the `(str, str)` annotation on the context setter is stale.
+        # The context setter's param annotations are stale (non-Optional, wrong
+        # callback arity); these values are correct at runtime, hence the ignores.
         ray.serve.context._set_internal_replica_context(
             replica_id=self._replica_id,
             servable_object=servable_object,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
@@ -1670,6 +1666,7 @@ class Replica:
     async def handle_request(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
     ) -> Any:
+        # Returns the arbitrary user method result, hence Any.
         request_args, request_kwargs, ray_trace_ctx = self._unpack_proxy_args(
             request_metadata, request_args, request_kwargs
         )
@@ -2681,7 +2678,8 @@ class Replica:
 
         # Invariant: gRPC direct-ingress requests are only served after
         # `_maybe_start_direct_ingress_servers` populated `_grpc_options`.
-        grpc_options = cast(gRPCOptions, self._grpc_options)
+        assert self._grpc_options is not None
+        grpc_options = self._grpc_options
 
         with (
             self._wrap_request(request_metadata) as status_code_callback,
@@ -2971,7 +2969,8 @@ class Replica:
         """
         # Invariant: only called while serving direct-ingress HTTP requests, after
         # `_maybe_start_direct_ingress_servers` populated `_http_options`.
-        http_options = cast(HTTPOptions, self._http_options)
+        assert self._http_options is not None
+        http_options = self._http_options
         return parse_request_timeout_header(headers, http_options.request_timeout_s)
 
     async def _direct_ingress_asgi(
@@ -3396,6 +3395,8 @@ class ReplicaActor:
         **request_kwargs,
     ) -> Any:
         """Entrypoint for `stream=False` calls."""
+        # Returns the user result, or (grpc_context, serialized_bytes) for gRPC
+        # requests -- arbitrary either way, hence Any.
         request_metadata, request_args = self._preprocess_request_args(
             pickled_request_metadata, request_args
         )
@@ -4028,30 +4029,28 @@ class UserCallableWrapper:
 
     # NOTE: the `_call_user_*` methods below are only invoked when the
     # corresponding user-defined hook exists (checked by their `call_*`
-    # counterparts), so the Optionals are narrowed with `cast`.
+    # counterparts), so the Optionals are narrowed with `assert`.
     @_run_user_code
     async def _call_user_health_check(self):
-        await self._call_func_or_gen(cast(Callable, self._user_health_check))
+        assert self._user_health_check is not None
+        await self._call_func_or_gen(self._user_health_check)
 
     @_run_user_code
     async def _call_user_record_routing_stats(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(
-            cast(Callable, self._user_record_routing_stats)
-        )
+        assert self._user_record_routing_stats is not None
+        result, _ = await self._call_func_or_gen(self._user_record_routing_stats)
         return result
 
     @_run_user_code
     async def _call_user_record_replica_metadata(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(
-            cast(Callable, self._user_record_replica_metadata)
-        )
+        assert self._user_record_replica_metadata is not None
+        result, _ = await self._call_func_or_gen(self._user_record_replica_metadata)
         return result
 
     @_run_user_code
     async def _call_user_autoscaling_stats(self) -> Dict[str, Union[int, float]]:
-        result, _ = await self._call_func_or_gen(
-            cast(Callable, self._user_autoscaling_stats)
-        )
+        assert self._user_autoscaling_stats is not None
+        result, _ = await self._call_func_or_gen(self._user_autoscaling_stats)
         return result
 
     @_run_user_code

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2723,9 +2723,12 @@ class Replica:
                     await result_gen.aclose()
                     # Record the status code for both success and error paths so
                     # ingress metrics are emitted for successful gRPC requests.
-                    # `status.code` is always a `grpc.StatusCode` on this path
-                    # (`ResponseStatus.code` is annotated as `Union[str, ...]`).
-                    status_code_callback(status.code.name)  # type: ignore[union-attr]  # pyrefly: ignore[missing-attribute]
+                    code_name = (
+                        status.code.name
+                        if isinstance(status.code, grpc.StatusCode)
+                        else status.code
+                    )
+                    status_code_callback(code_name)
                     set_grpc_code_and_details(context, status)
 
     async def _maybe_handle_builtin_grpc_service(
@@ -3202,9 +3205,9 @@ class Replica:
                 if not response_started:
                     # `_http_options` is always set while the direct ingress
                     # server is running.
+                    assert self._http_options is not None
                     msg = (
-                        f"Request {request_id} timed out after "  # type: ignore[union-attr]
-                        # pyrefly: ignore[missing-attribute]
+                        f"Request {request_id} timed out after "
                         f"{self._http_options.request_timeout_s}s."
                     )
                     await send_http_response(msg, 408, send)
@@ -4074,16 +4077,9 @@ class UserCallableWrapper:
                 )
             elif not hasattr(self._callable, RECONFIGURE_METHOD):
                 raise RayServeException(
-                    # NOTE: this concatenates a str with a DeploymentID (which is
-                    # a dataclass, not a str), so reaching this branch raises a
-                    # TypeError rather than the intended RayServeException.
-                    # Preserving runtime behavior; see the type-checking report.
-                    # pyrefly: ignore[unsupported-operation]
-                    "user_config or rank specified but deployment "
-                    + self._deployment_id  # type: ignore[operator]
-                    + " missing "
-                    + RECONFIGURE_METHOD
-                    + " method"
+                    f"user_config or rank specified but deployment "
+                    f"{self._deployment_id} missing "
+                    f"{RECONFIGURE_METHOD} method"
                 )
             kwargs = {}
             if user_subscribed_to_rank:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -20,14 +20,21 @@ from importlib import import_module
 from typing import (
     Any,
     AsyncGenerator,
+    Awaitable,
     Callable,
+    DefaultDict,
+    Deque,
     Dict,
+    FrozenSet,
     Generator,
+    Hashable,
     List,
+    NoReturn,
     Optional,
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 import grpc
@@ -54,6 +61,7 @@ from ray.serve._private.common import (
     RequestProtocol,
     ServeComponentType,
     StreamingHTTPRequest,
+    TimeSeries,
     gRPCRequest,
     gRPCStreamingRequest,
 )
@@ -146,6 +154,7 @@ from ray.serve._private.rolling_window import (
 from ray.serve._private.serialization import RPCSerializer
 from ray.serve._private.task_consumer import TaskConsumerWrapper
 from ray.serve._private.thirdparty.get_asgi_route_name import (
+    RoutePattern,
     extract_route_patterns,
     get_asgi_route_name,
 )
@@ -315,10 +324,10 @@ ReplicaMetadata = Tuple[
     Optional[float],
     Optional[int],
     Optional[str],
-    int,
-    int,
+    Optional[int],  # http_port
+    Optional[int],  # grpc_port
     ReplicaRank,  # rank
-    Optional[List[str]],  # route_patterns
+    Optional[List[RoutePattern]],  # route_patterns
     Optional[List[DeploymentID]],  # outbound_deployments
     bool,  # has_user_routing_stats_method
     Optional[GangContext],  # gang_context
@@ -335,7 +344,8 @@ def _load_deployment_def_from_import_path(import_path: str) -> Callable:
     if isinstance(deployment_def, RemoteFunction):
         deployment_def = deployment_def._function
     elif isinstance(deployment_def, ActorClass):
-        deployment_def = deployment_def.__ray_metadata__.modified_class
+        # `__ray_metadata__` is set dynamically on actor classes.
+        deployment_def = deployment_def.__ray_metadata__.modified_class  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
     elif isinstance(deployment_def, Deployment):
         logger.warning(
             f'The import path "{import_path}" contains a '
@@ -385,7 +395,9 @@ class ReplicaMetricsManager:
         self._custom_metrics_enabled = False
         # On first call to _fetch_custom_autoscaling_metrics. Failing validation disables _custom_metrics_enabled
         self._checked_custom_metrics = False
-        self._record_autoscaling_stats_fn = None
+        self._record_autoscaling_stats_fn: Optional[
+            Callable[[], Optional[concurrent.futures.Future]]
+        ] = None
 
         # Tracks in-flight metrics push to controller. Skip if new one is sent.
         self._pending_metrics_push_ref: Optional[ObjectRef] = None
@@ -413,17 +425,21 @@ class ReplicaMetricsManager:
             tag_keys=("route",),
         )
         if self._cached_metrics_enabled:
-            self._cached_request_counter = defaultdict(int)
+            self._cached_request_counter: DefaultDict[str, int] = defaultdict(int)
 
         self._error_counter = metrics.Counter(
             "serve_deployment_error_counter",
             description=(
                 "The number of exceptions that have occurred in this replica."
             ),
-            tag_keys=("route", "exception_type"),
+            # `tag_keys` is annotated as `Tuple[str]` upstream but accepts any
+            # tuple of strings at runtime.
+            tag_keys=("route", "exception_type"),  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
         )
         if self._cached_metrics_enabled:
-            self._cached_error_counter = defaultdict(int)
+            self._cached_error_counter: DefaultDict[Tuple[str, str], int] = defaultdict(
+                int
+            )
 
         # log REQUEST_LATENCY_BUCKET_MS
         logger.debug(f"REQUEST_LATENCY_BUCKETS_MS: {REQUEST_LATENCY_BUCKETS_MS}")
@@ -434,11 +450,13 @@ class ReplicaMetricsManager:
             tag_keys=("route",),
         )
         if self._cached_metrics_enabled:
-            self._cached_latencies = defaultdict(deque)
+            self._cached_latencies: DefaultDict[str, Deque[float]] = defaultdict(deque)
             self._event_loop.create_task(self._report_cached_metrics_forever())
 
         # Track maximum processing latency over a rolling window.
-        self._max_processing_latency_trackers = defaultdict(
+        self._max_processing_latency_trackers: DefaultDict[
+            str, RollingWindowMax
+        ] = defaultdict(
             lambda: RollingWindowMax(
                 window_duration_s=RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_WINDOW_S,
                 num_buckets=RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_NUM_BUCKETS,
@@ -515,18 +533,19 @@ class ReplicaMetricsManager:
 
             if self._cached_metrics_enabled:
                 # Mapping from protocol -> {request_tags -> value}.
-                self._cached_ingress_request_counter = defaultdict(
-                    lambda: defaultdict(int)
-                )
-                self._cached_ingress_request_error_counter = defaultdict(
-                    lambda: defaultdict(int)
-                )
-                self._cached_deployment_request_error_counter = defaultdict(
-                    lambda: defaultdict(int)
-                )
-                self._cached_ingress_processing_latencies = defaultdict(
-                    lambda: defaultdict(deque)
-                )
+                self._cached_ingress_request_counter: DefaultDict[
+                    RequestProtocol, DefaultDict[FrozenSet[Tuple[str, str]], int]
+                ] = defaultdict(lambda: defaultdict(int))
+                self._cached_ingress_request_error_counter: DefaultDict[
+                    RequestProtocol, DefaultDict[FrozenSet[Tuple[str, str]], int]
+                ] = defaultdict(lambda: defaultdict(int))
+                self._cached_deployment_request_error_counter: DefaultDict[
+                    RequestProtocol, DefaultDict[FrozenSet[Tuple[str, str]], int]
+                ] = defaultdict(lambda: defaultdict(int))
+                self._cached_ingress_processing_latencies: DefaultDict[
+                    RequestProtocol,
+                    DefaultDict[FrozenSet[Tuple[str, str]], Deque[float]],
+                ] = defaultdict(lambda: defaultdict(deque))
 
     @property
     def _is_direct_ingress(self) -> bool:
@@ -647,23 +666,26 @@ class ReplicaMetricsManager:
         await self._metrics_pusher.graceful_shutdown()
 
     def start_metrics_pusher(self):
+        # Invariant: only called when an autoscaling config is set (checked at
+        # every call site), so narrow the Optional for the type checkers.
+        autoscaling_config = cast(AutoscalingConfig, self._autoscaling_config)
         self._metrics_pusher.start()
 
         # Push autoscaling metrics to the controller periodically.
         self._metrics_pusher.register_or_update_task(
             self.PUSH_METRICS_TO_CONTROLLER_TASK_NAME,
             self._push_autoscaling_metrics,
-            self._autoscaling_config.metrics_interval_s,
+            autoscaling_config.metrics_interval_s,
         )
         # Collect autoscaling metrics locally periodically.
         record_interval_s = (
-            self._autoscaling_config.look_back_period_s
+            autoscaling_config.look_back_period_s
             * RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR
         )
         self._metrics_pusher.register_or_update_task(
             self.RECORD_METRICS_TASK_NAME,
             self._add_autoscaling_metrics_point_async,
-            min(record_interval_s, self._autoscaling_config.metrics_interval_s),
+            min(record_interval_s, autoscaling_config.metrics_interval_s),
         )
 
     def should_collect_ongoing_requests(self) -> bool:
@@ -929,12 +951,17 @@ class ReplicaMetricsManager:
                 deployment_name=deployment_name,
             )
 
-    def _push_autoscaling_metrics(self) -> Dict[str, Any]:
-        look_back_period = self._autoscaling_config.look_back_period_s
+    def _push_autoscaling_metrics(self) -> None:
+        # Invariant: this task is only registered (`start_metrics_pusher`) when an
+        # autoscaling config is set.
+        look_back_period = cast(
+            AutoscalingConfig, self._autoscaling_config
+        ).look_back_period_s
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
 
         new_aggregated_metrics = {}
-        new_metrics = {**self._metrics_store.data}
+        # The store keys are `Hashable`; this replica only ever records `str` keys.
+        new_metrics = cast(Dict[str, TimeSeries], {**self._metrics_store.data})
 
         if self.should_collect_ongoing_requests():
             # Keep the legacy window_avg ongoing requests in the merged metrics dict
@@ -954,7 +981,8 @@ class ReplicaMetricsManager:
                 if not check_obj_ref_ready_nowait(self._pending_metrics_push_ref):
                     return  # Previous push still in flight, skip and try again later
             self._pending_metrics_push_ref = (
-                self._controller_handle.record_autoscaling_metrics_from_replica.remote(
+                # Actor methods are resolved dynamically on the actor handle.
+                self._controller_handle.record_autoscaling_metrics_from_replica.remote(  # type: ignore[attr-defined]
                     compress_metric_report(replica_metric_report)
                 )
             )
@@ -962,10 +990,16 @@ class ReplicaMetricsManager:
     async def _fetch_custom_autoscaling_metrics(
         self,
     ) -> Optional[Dict[str, Union[int, float]]]:
+        # Invariant: only called when `_custom_metrics_enabled` is True, which
+        # requires `_record_autoscaling_stats_fn` to have been set (and it returns
+        # an awaitable here since the replica never runs in local testing mode).
+        record_autoscaling_stats_fn = cast(
+            Callable[[], Awaitable[Any]], self._record_autoscaling_stats_fn
+        )
         try:
             start_time = time.time()
             res = await asyncio.wait_for(
-                self._record_autoscaling_stats_fn(),
+                record_autoscaling_stats_fn(),
                 timeout=RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S,
             )
             latency_ms = (time.time() - start_time) * 1000
@@ -1010,7 +1044,7 @@ class ReplicaMetricsManager:
         return None
 
     async def _add_autoscaling_metrics_point_async(self) -> None:
-        metrics_dict = {}
+        metrics_dict: Dict[str, float] = {}
         if self.should_collect_ongoing_requests():
             metrics_dict = {RUNNING_REQUESTS_KEY: self._num_ongoing_requests}
 
@@ -1021,7 +1055,9 @@ class ReplicaMetricsManager:
                 metrics_dict.update(custom_metrics)
 
         self._metrics_store.add_metrics_point(
-            metrics_dict,
+            # The store accepts `Hashable` keys; `Dict` is invariant in its key
+            # type, so the `str`-keyed dict must be cast.
+            cast(Dict[Hashable, float], metrics_dict),
             time.time(),
         )
 
@@ -1059,7 +1095,8 @@ class Replica:
         self._configure_logger_and_profilers(self._deployment_config.logging_config)
         self._event_loop = get_or_create_event_loop()
 
-        actor_id = ray.get_runtime_context().get_actor_id()
+        # This always runs inside a replica actor, so the actor ID is set.
+        actor_id = cast(str, ray.get_runtime_context().get_actor_id())
         self._user_callable_wrapper = UserCallableWrapper(
             deployment_def,
             init_args,
@@ -1273,7 +1310,7 @@ class Replica:
 
         # Use _PyObjScanner to find all DeploymentHandle objects in:
         # The init_args and init_kwargs (handles might be passed as init args)
-        scanner = _PyObjScanner(source_type=DeploymentHandle)
+        scanner: _PyObjScanner = _PyObjScanner(source_type=DeploymentHandle)
         try:
             handles = scanner.find_nodes((init_args, init_kwargs))
 
@@ -1286,7 +1323,10 @@ class Replica:
         return list(seen_deployment_ids)
 
     def _set_internal_replica_context(
-        self, *, servable_object: Callable = None, rank: ReplicaRank = None
+        self,
+        *,
+        servable_object: Optional[Callable] = None,
+        rank: Optional[ReplicaRank] = None,
     ):
         # Calculate world_size from deployment config instead of storing it
         world_size = self._deployment_config.num_replicas
@@ -1296,13 +1336,20 @@ class Replica:
             self._dynamically_created_handles.add(deployment_id)
 
         code_version = self._version.code_version
+        # NOTE: `context._set_internal_replica_context` annotates `servable_object`
+        # and `rank` as non-Optional, but both are legitimately None until the user
+        # callable is initialized. `world_size` comes from
+        # `DeploymentConfig.num_replicas`, which is Optional in the model but always
+        # concrete for a deployed replica. The registration callback takes a single
+        # `DeploymentID`, matching `ReplicaContext._handle_registration_callback`;
+        # the `(str, str)` annotation on the context setter is stale.
         ray.serve.context._set_internal_replica_context(
             replica_id=self._replica_id,
-            servable_object=servable_object,
+            servable_object=servable_object,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
             _deployment_config=self._deployment_config,
-            rank=rank,
-            world_size=world_size,
-            handle_registration_callback=register_handle_callback,
+            rank=rank,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
+            world_size=world_size,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
+            handle_registration_callback=register_handle_callback,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
             gang_context=self._gang_context,
             code_version=code_version,
         )
@@ -1385,7 +1432,7 @@ class Replica:
         self, request_metadata: RequestMetadata
     ) -> Generator[StatusCodeCallback, None, None]:
         start_time = time.time()
-        user_exception = None
+        user_exception: Optional[BaseException] = None
 
         status_code = None
 
@@ -1469,7 +1516,10 @@ class Replica:
                     service=self._deployment_id.name,
                 )
             if user_exception is not None:
-                set_span_exception(user_exception, escaped=False)
+                # `user_exception` may be an `asyncio.CancelledError`
+                # (a BaseException); `set_span_exception` annotates `exc:
+                # Exception` too narrowly for that.
+                set_span_exception(user_exception, escaped=False)  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
 
         # Record ingress metrics for direct ingress requests
         if request_metadata.is_direct_ingress and status_code is not None:
@@ -1498,9 +1548,9 @@ class Replica:
     def _unpack_proxy_args(
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
-    ) -> Tuple[Tuple[Any], Dict[str, Any], Any]:
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any], Any]:
         # Extract _ray_trace_ctx from kwargs at the entry point.
         #
         # Context: When tracing is enabled, Ray's tracing decorators inject
@@ -1547,12 +1597,12 @@ class Replica:
                 assert len(request_args) == 1 and isinstance(
                     request_args[0], gRPCRequest
                 )
-                request: gRPCRequest = request_args[0]
+                grpc_request: gRPCRequest = request_args[0]
 
                 method_info = self._user_callable_wrapper.get_user_method_info(
                     request_metadata.call_method
                 )
-                request_args = (request.user_request_proto,)
+                request_args = (grpc_request.user_request_proto,)
                 request_kwargs = (
                     {GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context}
                     if method_info.takes_grpc_context_kwarg
@@ -1565,7 +1615,7 @@ class Replica:
         self,
         request_metadata: RequestMetadata,
         streaming_request: gRPCStreamingRequest,
-    ) -> Tuple[Tuple[Any], Dict[str, Any]]:
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         """Set up request args for gRPC client/bidirectional streaming.
 
         Creates a gRPCInputStream that wraps the callback to the proxy,
@@ -1619,7 +1669,7 @@ class Replica:
 
     async def handle_request(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
-    ) -> Tuple[bytes, Any]:
+    ) -> Any:
         request_args, request_kwargs, ray_trace_ctx = self._unpack_proxy_args(
             request_metadata, request_args, request_kwargs
         )
@@ -1687,7 +1737,7 @@ class Replica:
 
     def _raise_user_exception(
         self, e: BaseException, request_metadata: RequestMetadata
-    ) -> None:
+    ) -> NoReturn:
         wrapped_exception = self._maybe_wrap_grpc_exception(e, request_metadata)
         if wrapped_exception is e:
             raise e
@@ -1695,7 +1745,7 @@ class Replica:
 
     async def handle_request_with_rejection(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
-    ):
+    ) -> AsyncGenerator[Any, None]:
         # Reject new requests once quiescing so the router retries them on
         # another replica.
         if self._is_replica_quiescing(request_metadata):
@@ -1829,7 +1879,10 @@ class Replica:
                     # this is never polled and is treated as immutable.
                     if self._user_callable_wrapper.has_user_replica_metadata_method:
                         self._replica_metadata = _validate_replica_metadata(
-                            await self._user_callable_wrapper.call_user_record_replica_metadata()
+                            # Never None: guarded by
+                            # `has_user_replica_metadata_method` above.
+                            # pyrefly: ignore[not-async]
+                            await self._user_callable_wrapper.call_user_record_replica_metadata()  # type: ignore[misc]
                         )
                     if self._user_callable_asgi_app:
                         self._docs_path = (
@@ -1925,7 +1978,12 @@ class Replica:
                 rank=rank,
             )
 
-            self._route_prefix = self._version.route_prefix
+            # NOTE: `DeploymentVersion.route_prefix` is Optional and
+            # `from_deployment_version` overwrites it with this method's
+            # `route_prefix` argument even when that argument is None, while
+            # `_route_prefix` is typed and used as `str` elsewhere. Preserving
+            # runtime behavior; see the type-checking report.
+            self._route_prefix = self._version.route_prefix  # type: ignore[assignment]
 
         except Exception:
             raise RuntimeError(traceback.format_exc()) from None
@@ -2095,6 +2153,9 @@ class Replica:
             try:
                 # On timeout, `wait_for` cancels the server task (abrupt close).
                 await asyncio.wait_for(
+                    # Always set together with `_direct_ingress_http_server`
+                    # (checked above).
+                    # pyrefly: ignore[bad-argument-type]
                     self._direct_ingress_http_server_task,
                     timeout=remaining_grace_s(),
                 )
@@ -2347,8 +2408,10 @@ class Replica:
         """
 
         with self._tracing_context(request_metadata):
+            # `_serve_request_context` is declared without a type parameter and
+            # with `default=None`, so checkers infer `ContextVar[None]`.
             ray.serve.context._serve_request_context.set(
-                ray.serve.context._RequestContext(
+                ray.serve.context._RequestContext(  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
                     route=request_metadata.route,
                     request_id=request_metadata.request_id,
                     _internal_request_id=request_metadata.internal_request_id,
@@ -2616,6 +2679,10 @@ class Replica:
 
             result_gen = call_unary()
 
+        # Invariant: gRPC direct-ingress requests are only served after
+        # `_maybe_start_direct_ingress_servers` populated `_grpc_options`.
+        grpc_options = cast(gRPCOptions, self._grpc_options)
+
         with (
             self._wrap_request(request_metadata) as status_code_callback,
             self._track_queued_request() as release_queue_slot,
@@ -2627,7 +2694,7 @@ class Replica:
                 # Use the generic disconnect/timeout detecting wrapper.
                 replica_response_generator = ReplicaResponseGenerator(
                     result_gen,
-                    timeout_s=self._grpc_options.request_timeout_s,
+                    timeout_s=grpc_options.request_timeout_s,
                 )
                 status = ResponseStatus(code=grpc.StatusCode.OK)
                 try:
@@ -2641,7 +2708,10 @@ class Replica:
                     e = self._maybe_wrap_grpc_exception(e, request_metadata)
                     status = get_grpc_response_status(
                         e,
-                        self._grpc_options.request_timeout_s,
+                        # `request_timeout_s` may be None (no timeout configured);
+                        # the callee only formats it into an error message but
+                        # annotates it as `float`.
+                        grpc_options.request_timeout_s,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
                         request_metadata.request_id,
                     )
                     raise e
@@ -2653,7 +2723,9 @@ class Replica:
                     await result_gen.aclose()
                     # Record the status code for both success and error paths so
                     # ingress metrics are emitted for successful gRPC requests.
-                    status_code_callback(status.code.name)
+                    # `status.code` is always a `grpc.StatusCode` on this path
+                    # (`ResponseStatus.code` is annotated as `Union[str, ...]`).
+                    status_code_callback(status.code.name)  # type: ignore[union-attr]  # pyrefly: ignore[missing-attribute]
                     set_grpc_code_and_details(context, status)
 
     async def _maybe_handle_builtin_grpc_service(
@@ -2894,9 +2966,10 @@ class Replica:
         If the header is missing or invalid, returns the default request timeout
         from HttpOptions. If the header is non-positive, timeout is disabled.
         """
-        return parse_request_timeout_header(
-            headers, self._http_options.request_timeout_s
-        )
+        # Invariant: only called while serving direct-ingress HTTP requests, after
+        # `_maybe_start_direct_ingress_servers` populated `_http_options`.
+        http_options = cast(HTTPOptions, self._http_options)
+        return parse_request_timeout_header(headers, http_options.request_timeout_s)
 
     async def _direct_ingress_asgi(
         self,
@@ -2923,6 +2996,8 @@ class Replica:
 
         # Handle health check or routes request.
         if route in ["/-/healthz", "/-/routes"]:
+            # `message` holds the health-check string, or the routes dict below.
+            message: Union[str, Dict[str, str]]
             healthy, message = await self._dataplane_health_check()
             status_code = 200 if healthy else 503
             if route == "/-/routes" and healthy:
@@ -3125,8 +3200,11 @@ class Replica:
                     receive_task.cancel()
                 status_code_callback("408")
                 if not response_started:
+                    # `_http_options` is always set while the direct ingress
+                    # server is running.
                     msg = (
-                        f"Request {request_id} timed out after "
+                        f"Request {request_id} timed out after "  # type: ignore[union-attr]
+                        # pyrefly: ignore[missing-attribute]
                         f"{self._http_options.request_timeout_s}s."
                     )
                     await send_http_response(msg, 408, send)
@@ -3164,7 +3242,9 @@ class ReplicaActor:
     `UserCallableWrapper` class.
     """
 
-    async def __init__(
+    # Ray actors support `async def __init__` even though type checkers require
+    # `__init__` to return None.
+    async def __init__(  # type: ignore[misc]
         self,
         replica_id: ReplicaID,
         serialized_deployment_def: bytes,
@@ -3197,7 +3277,8 @@ class ReplicaActor:
     def push_proxy_handle(self, handle: ActorHandle):
         # NOTE(edoakes): it's important to call a method on the proxy handle to
         # initialize its state in the C++ core worker.
-        handle.pong.remote()
+        # (Actor methods are resolved dynamically on the actor handle.)
+        handle.pong.remote()  # type: ignore[attr-defined]
 
     def get_num_ongoing_requests(self) -> int:
         """Fetch the number of ongoing requests at this replica (queue length).
@@ -3217,7 +3298,7 @@ class ReplicaActor:
         """Release capacity reserved by choose_replica()."""
         return self._replica_impl.release_slot(slot_token)
 
-    async def is_allocated(self) -> str:
+    async def is_allocated(self) -> Tuple[Any, ...]:
         """poke the replica to check whether it's alive.
 
         When calling this method on an ActorHandle, it will complete as
@@ -3264,9 +3345,9 @@ class ReplicaActor:
 
     async def initialize_and_get_metadata(
         self,
-        deployment_config: DeploymentConfig = None,
-        rank: ReplicaRank = None,
-        gang_context: GangContext = None,
+        deployment_config: Optional[DeploymentConfig] = None,
+        rank: Optional[ReplicaRank] = None,
+        gang_context: Optional[GangContext] = None,
     ) -> ReplicaMetadata:
         """Handles initializing the replica.
 
@@ -3310,7 +3391,7 @@ class ReplicaActor:
         pickled_request_metadata: bytes,
         *request_args,
         **request_kwargs,
-    ) -> Tuple[bytes, Any]:
+    ) -> Any:
         """Entrypoint for `stream=False` calls."""
         request_metadata, request_args = self._preprocess_request_args(
             pickled_request_metadata, request_args
@@ -3446,7 +3527,9 @@ class UserCallableWrapper:
                 f"{type(deployment_def)}."
             )
 
-        self._deployment_def = deployment_def
+        # The user-provided function or class; `Any` because classes are accessed
+        # via `__new__`/`__init__` below, which `Callable` does not cover.
+        self._deployment_def: Any = deployment_def
         self._init_args = init_args
         self._init_kwargs = init_kwargs
         self._is_function = inspect.isfunction(deployment_def)
@@ -3459,8 +3542,9 @@ class UserCallableWrapper:
         self._cached_user_method_info: Dict[str, UserMethodInfo] = {}
         # This is for performance optimization https://docs.python.org/3/howto/logging.html#optimization
         self._is_enabled_for_debug = logger.isEnabledFor(logging.DEBUG)
-        # Will be populated in `initialize_callable`.
-        self._callable = None
+        # Will be populated in `initialize_callable` with the user's function or
+        # class instance (duck-typed throughout, hence `Any`).
+        self._callable: Any = None
         self._user_health_check: Optional[Callable] = None
         self._user_loop_probe_consecutive_fail_count: int = 0
         self._user_loop_probe_task: Optional[asyncio.Task] = None
@@ -3480,7 +3564,7 @@ class UserCallableWrapper:
             # Start event loop monitoring for the user code event loop.
             # We create the monitor here but start it inside the thread function
             # so the task is created on the correct thread.
-            self._user_code_loop_monitor = EventLoopMonitor(
+            self._user_code_loop_monitor: Optional[EventLoopMonitor] = EventLoopMonitor(
                 component=EventLoopMonitor.COMPONENT_REPLICA,
                 loop_type=EventLoopMonitor.LOOP_TYPE_USER_CODE,
                 actor_id=actor_id,
@@ -3496,6 +3580,8 @@ class UserCallableWrapper:
                 asyncio.set_event_loop(self._user_code_event_loop)
                 self._configure_user_code_threadpool()
                 # Start monitoring before run_forever so the task is scheduled.
+                # The monitor is always set on this (separate-thread) branch.
+                # pyrefly: ignore[missing-attribute]
                 self._user_code_loop_monitor.start(self._user_code_event_loop)
                 self._user_code_event_loop.run_forever()
 
@@ -3595,7 +3681,9 @@ class UserCallableWrapper:
         )
         self._user_code_event_loop.set_default_executor(self._user_code_threadpool)
 
-    def _run_user_code(f: Callable) -> Callable:
+    # This is a decorator applied to methods of this class at class-definition
+    # time, so it intentionally has no `self` parameter.
+    def _run_user_code(f: Callable) -> Callable:  # type: ignore[misc]
         """Decorator to run a coroutine method on the user code event loop.
 
         The method will be modified to be a sync function that returns a
@@ -3683,7 +3771,7 @@ class UserCallableWrapper:
         self,
         callable: Callable,
         *,
-        args: Optional[Tuple[Any]] = None,
+        args: Optional[Tuple[Any, ...]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         is_streaming: bool = False,
         generator_result_callback: Optional[Callable] = None,
@@ -3729,6 +3817,10 @@ class UserCallableWrapper:
                 result = callable(*args, **kwargs)
                 if is_generator:
                     for r in result:
+                        # `generator_result_callback` is always provided for
+                        # streaming calls, and generators are rejected above
+                        # unless `is_streaming=True`.
+                        # pyrefly: ignore[not-callable]
                         generator_result_callback(r)
 
                     result = None
@@ -3764,8 +3856,6 @@ class UserCallableWrapper:
         return self._callable
 
     async def _initialize_asgi_callable(self) -> None:
-        self._callable: ASGIAppReplicaWrapper
-
         build_asgi_app = getattr(self._callable, SERVE_BUILD_ASGI_APP_METHOD, None)
         is_late_bound = not hasattr(self._callable, "_asgi_app")
         if is_late_bound and build_asgi_app is None:
@@ -3784,7 +3874,7 @@ class UserCallableWrapper:
                 )
             self._callable._set_asgi_app(app)
 
-        app: ASGIApp = self._callable.app
+        app: ASGIApp = self._callable.app  # type: ignore[no-redef]
 
         if hasattr(app, "add_exception_handler"):
             # The reason we need to do this is because BackPressureError is a serve
@@ -3874,7 +3964,7 @@ class UserCallableWrapper:
                 f"`initialize_callable` must be called before `{method_name}`."
             )
 
-    def call_user_health_check(self) -> Optional[concurrent.futures.Future]:
+    def call_user_health_check(self) -> Optional[Awaitable[Any]]:
         self._raise_if_not_initialized("call_user_health_check")
 
         # If the user provided a health check, call it on the user code thread. If user
@@ -3902,7 +3992,7 @@ class UserCallableWrapper:
         """Whether the user has defined a record_routing_stats method."""
         return self._user_record_routing_stats is not None
 
-    def call_user_record_routing_stats(self) -> Optional[concurrent.futures.Future]:
+    def call_user_record_routing_stats(self) -> Optional[Awaitable[Any]]:
         self._raise_if_not_initialized("call_user_record_routing_stats")
 
         if self._user_record_routing_stats is not None:
@@ -3917,7 +4007,7 @@ class UserCallableWrapper:
 
     def call_user_record_replica_metadata(
         self,
-    ) -> Optional[concurrent.futures.Future]:
+    ) -> Optional[Awaitable[Any]]:
         self._raise_if_not_initialized("call_user_record_replica_metadata")
 
         if self._user_record_replica_metadata is not None:
@@ -3933,23 +4023,32 @@ class UserCallableWrapper:
 
         return None
 
+    # NOTE: the `_call_user_*` methods below are only invoked when the
+    # corresponding user-defined hook exists (checked by their `call_*`
+    # counterparts), so the Optionals are narrowed with `cast`.
     @_run_user_code
     async def _call_user_health_check(self):
-        await self._call_func_or_gen(self._user_health_check)
+        await self._call_func_or_gen(cast(Callable, self._user_health_check))
 
     @_run_user_code
     async def _call_user_record_routing_stats(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(self._user_record_routing_stats)
+        result, _ = await self._call_func_or_gen(
+            cast(Callable, self._user_record_routing_stats)
+        )
         return result
 
     @_run_user_code
     async def _call_user_record_replica_metadata(self) -> Dict[str, Any]:
-        result, _ = await self._call_func_or_gen(self._user_record_replica_metadata)
+        result, _ = await self._call_func_or_gen(
+            cast(Callable, self._user_record_replica_metadata)
+        )
         return result
 
     @_run_user_code
     async def _call_user_autoscaling_stats(self) -> Dict[str, Union[int, float]]:
-        result, _ = await self._call_func_or_gen(self._user_autoscaling_stats)
+        result, _ = await self._call_func_or_gen(
+            cast(Callable, self._user_autoscaling_stats)
+        )
         return result
 
     @_run_user_code
@@ -3975,8 +4074,13 @@ class UserCallableWrapper:
                 )
             elif not hasattr(self._callable, RECONFIGURE_METHOD):
                 raise RayServeException(
+                    # NOTE: this concatenates a str with a DeploymentID (which is
+                    # a dataclass, not a str), so reaching this branch raises a
+                    # TypeError rather than the intended RayServeException.
+                    # Preserving runtime behavior; see the type-checking report.
+                    # pyrefly: ignore[unsupported-operation]
                     "user_config or rank specified but deployment "
-                    + self._deployment_id
+                    + self._deployment_id  # type: ignore[operator]
                     + " missing "
                     + RECONFIGURE_METHOD
                     + " method"
@@ -4014,6 +4118,12 @@ class UserCallableWrapper:
         but for ASGI apps (like FastAPI), the actual method will be a regular function
         implementing the ASGI `__call__` protocol.
         """
+        # Invariants (runtime no-op rebinds to narrow the Optionals): callers
+        # always provide `generator_result_callback` for streaming calls and
+        # `asgi_args` for HTTP requests.
+        generator_result_callback = cast(Callable, generator_result_callback)
+        asgi_args = cast(ASGIArgs, asgi_args)
+
         result_is_gen = inspect.isgenerator(result)
         result_is_async_gen = inspect.isasyncgen(result)
         if is_streaming:
@@ -4123,7 +4233,7 @@ class UserCallableWrapper:
             )
 
         if user_method_info.is_asgi_app:
-            request_args = (scope, receive, send)
+            request_args: Tuple[Any, ...] = (scope, receive, send)
         elif not user_method_info.takes_any_args:
             # Edge case to support empty HTTP handlers: don't pass the Request
             # argument if the callable has no parameters.
@@ -4184,7 +4294,7 @@ class UserCallableWrapper:
     async def call_user_generator(
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
     ) -> AsyncGenerator[Any, None]:
         """Calls a user method for a streaming call and yields its results.
@@ -4239,10 +4349,12 @@ class UserCallableWrapper:
                     call_future.cancel()
 
     @_run_user_code
-    async def _call_user_generator(
+    # mypy requires an explicit `return None` even for an Optional return type;
+    # the enqueue branches intentionally fall off the end.
+    async def _call_user_generator(  # type: ignore[return]
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
         *,
         enqueue: Optional[Callable] = None,
@@ -4309,6 +4421,9 @@ class UserCallableWrapper:
             gen = callable(*request_args, **request_kwargs)
             if inspect.isgenerator(gen):
                 for result in gen:
+                    # `_call_generator_sync` is only invoked when `enqueue` is
+                    # provided (see below).
+                    # pyrefly: ignore[not-callable]
                     enqueue(result)
             else:
                 raise TypeError(
@@ -4332,7 +4447,7 @@ class UserCallableWrapper:
     async def call_user_method(
         self,
         request_metadata: RequestMetadata,
-        request_args: Tuple[Any],
+        request_args: Tuple[Any, ...],
         request_kwargs: Dict[str, Any],
     ) -> Any:
         """Call a (unary) user method.

--- a/python/ray/serve/pyrefly-serve.toml
+++ b/python/ray/serve/pyrefly-serve.toml
@@ -6,10 +6,9 @@
 # (See .pre-commit-config.yaml
 # "mypy (ray serve)" hook; this covers the same allowlist).
 project-includes = [
-    "handle.py",
-    "tests/typing_files/check_handle_typing.py",
     "_private/__init__.py",
     "_private/api.py",
+    "_private/application_state.py",
     "_private/autoscaling_state.py",
     "_private/benchmarks/__init__.py",
     "_private/benchmarks/serialization/__init__.py",
@@ -23,12 +22,14 @@ project-includes = [
     "_private/config.py",
     "_private/constants.py",
     "_private/constants_utils.py",
+    "_private/controller.py",
     "_private/controller_avatar.py",
     "_private/controller_health_metrics_tracker.py",
     "_private/default_impl.py",
     "_private/deploy_utils.py",
     "_private/deployment_info.py",
     "_private/deployment_node.py",
+    "_private/deployment_state.py",
     "_private/direct_ingress_grpc_util.py",
     "_private/direct_ingress_http_util.py",
     "_private/endpoint_state.py",
@@ -49,6 +50,7 @@ project-includes = [
     "_private/proxy_response_generator.py",
     "_private/proxy_router.py",
     "_private/queue_monitor.py",
+    "_private/replica.py",
     "_private/replica_response_generator.py",
     "_private/replica_result.py",
     "_private/request_ingress_metrics.py",
@@ -67,6 +69,8 @@ project-includes = [
     "_private/usage.py",
     "_private/utils.py",
     "_private/version.py",
+    "handle.py",
+    "tests/typing_files/check_handle_typing.py",
 ]
 search-path = ["../.."]
 # Pin so results do not depend on the interpreter the hook env was built with
@@ -94,6 +98,7 @@ replace-imports-with-any = [
     "pandas",
     "pydantic.*",
     "redis",
+    "anyio",
     "requests",
     "starlette.*",
     "tornado.*",


### PR DESCRIPTION
This is the second PR to enable mypy and pyrefly on ray/serve.  This PR brings the four controller-critical modules under the mypy and pyrefly serve hooks: deployment_state.py, replica.py, controller.py, and application_state.py.  

The changes made:
- Fix the type errors in all four files (annotation-driven, with a few incidental invariant-hardening and one latent-bug fix): Optional for lazily-populated attrs and honest return types, precise container/callback annotations, typing.cast for invariants a checker cannot see, and narrowly-scoped ignores for actor .remote dynamics. Add the four files to both hook allowlists and pyrefly-serve.toml.
- Two annotations were made honest and rippled to their call sites: get_ingress_replicas_info now returns Optional node-id/ports (pending replicas), and get_alive_replica_actor_ids returns Optional actor-ids (starting replicas); the controller call sites cast to the landed consumer signatures rather than widening them.

First mypy/pyrefly PR was #64643.
The PR that initiated this effort is #63862 (the checkpoint/recovery state machine where type confusion becomes persistent state corruption).