### PR TITLE
[core][build] Fix TSAN false-positive data races in RocksDB GCS backend

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -126,6 +126,13 @@ build:tsan --copt -Wno-uninitialized
 build:tsan --linkopt -fsanitize=thread
 build:tsan --cxxopt="-D_RAY_TSAN_BUILD"
 build:tsan --no//:jemalloc_flag
+# RocksDB is a static library built by an out-of-band CMake action
+# (bazel/rocksdb.BUILD via rules_foreign_cc), so the --copt/--per_file_copt
+# above never reach it. Propagate a define that the RocksDB build reads to
+# turn on its native WITH_TSAN option (-fsanitize=thread), so ThreadSanitizer
+# can observe RocksDB's lock-free synchronization instead of reporting false
+# races on its uninstrumented memtable skiplist.
+build:tsan --define=ray_rocksdb_tsan=true
 # This config is only for running TSAN with LLVM toolchain on Linux.
 build:tsan-clang --config=tsan
 build:tsan-clang --config=llvm

--- a/bazel/rocksdb.BUILD
+++ b/bazel/rocksdb.BUILD
@@ -8,47 +8,69 @@ filegroup(
     ),
 )
 
+# Set by `--config=tsan` (see .bazelrc). RocksDB is compiled by an
+# out-of-band CMake action, so Bazel's `--copt -fsanitize=thread` never
+# reaches it. Under this config we instead flip RocksDB's own `WITH_TSAN`
+# CMake option, which adds `-fsanitize=thread` to its compile/link flags.
+# Without this, a TSAN-instrumented GCS test links an *un*instrumented
+# librocksdb.a, and ThreadSanitizer reports false data races inside
+# RocksDB's lock-free memtable skiplist (it cannot see the acquire/release
+# atomics that synchronize concurrent memtable writers and readers).
+config_setting(
+    name = "tsan_build",
+    values = {"define": "ray_rocksdb_tsan=true"},
+)
+
+# Static-only build. No shared lib, no shell tools, no benchmarks,
+# no tests — librocksdb.a is the only artifact GCS links against.
+_CACHE_ENTRIES = {
+    "ROCKSDB_BUILD_SHARED": "OFF",
+    "WITH_TESTS": "OFF",
+    "WITH_BENCHMARK_TOOLS": "OFF",
+    "WITH_TOOLS": "OFF",
+    "WITH_CORE_TOOLS": "OFF",
+    "WITH_TRACE_TOOLS": "OFF",
+    "WITH_EXAMPLES": "OFF",
+    "WITH_GFLAGS": "OFF",
+
+    # No compression deps for the initial cut — the REP's tuning
+    # table calls for LZ4 on cold levels, which can be enabled in a
+    # follow-up once the link footprint is measured against the
+    # tradeoff.
+    "WITH_SNAPPY": "OFF",
+    "WITH_LZ4": "OFF",
+    "WITH_ZSTD": "OFF",
+    "WITH_ZLIB": "OFF",
+    "WITH_BZ2": "OFF",
+
+    # Ray vendors its own jemalloc; mixing them is out of scope here.
+    "WITH_JEMALLOC": "OFF",
+    "WITH_LIBURING": "OFF",
+    "WITH_NUMA": "OFF",
+    "WITH_TBB": "OFF",
+
+    # CMake's GNUInstallDirs picks lib64/ on 64-bit Linux but lib/ on
+    # macOS/BSD. Pinning to lib/ keeps the out_static_libs path
+    # portable across platforms.
+    "CMAKE_INSTALL_LIBDIR": "lib",
+
+    "PORTABLE": "ON",
+    "FAIL_ON_WARNINGS": "OFF",
+    "USE_RTTI": "1",
+    "ROCKSDB_INSTALL_ON_WINDOWS": "OFF",
+    "WITH_RUNTIME_DEBUG": "OFF",
+}
+
 cmake(
     name = "rocksdb",
-    cache_entries = {
-        # Static-only build. No shared lib, no shell tools, no benchmarks,
-        # no tests — librocksdb.a is the only artifact GCS links against.
-        "ROCKSDB_BUILD_SHARED": "OFF",
-        "WITH_TESTS": "OFF",
-        "WITH_BENCHMARK_TOOLS": "OFF",
-        "WITH_TOOLS": "OFF",
-        "WITH_CORE_TOOLS": "OFF",
-        "WITH_TRACE_TOOLS": "OFF",
-        "WITH_EXAMPLES": "OFF",
-        "WITH_GFLAGS": "OFF",
-
-        # No compression deps for the initial cut — the REP's tuning
-        # table calls for LZ4 on cold levels, which can be enabled in a
-        # follow-up once the link footprint is measured against the
-        # tradeoff.
-        "WITH_SNAPPY": "OFF",
-        "WITH_LZ4": "OFF",
-        "WITH_ZSTD": "OFF",
-        "WITH_ZLIB": "OFF",
-        "WITH_BZ2": "OFF",
-
-        # Ray vendors its own jemalloc; mixing them is out of scope here.
-        "WITH_JEMALLOC": "OFF",
-        "WITH_LIBURING": "OFF",
-        "WITH_NUMA": "OFF",
-        "WITH_TBB": "OFF",
-
-        # CMake's GNUInstallDirs picks lib64/ on 64-bit Linux but lib/ on
-        # macOS/BSD. Pinning to lib/ keeps the out_static_libs path
-        # portable across platforms.
-        "CMAKE_INSTALL_LIBDIR": "lib",
-
-        "PORTABLE": "ON",
-        "FAIL_ON_WARNINGS": "OFF",
-        "USE_RTTI": "1",
-        "ROCKSDB_INSTALL_ON_WINDOWS": "OFF",
-        "WITH_RUNTIME_DEBUG": "OFF",
-    },
+    cache_entries = select({
+        # Under `--config=tsan`, build RocksDB with its native TSAN
+        # instrumentation so ThreadSanitizer understands its lock-free
+        # internals. `PORTABLE=ON` above keeps `-fsanitize=thread`
+        # compatible with the pie/relocation flags RocksDB adds here.
+        ":tsan_build": dict(_CACHE_ENTRIES, WITH_TSAN = "ON"),
+        "//conditions:default": _CACHE_ENTRIES,
+    }),
     generate_args = ["-G Ninja"],
     lib_source = ":all_srcs",
     out_static_libs = ["librocksdb.a"],

--- a/bazel/rocksdb.BUILD
+++ b/bazel/rocksdb.BUILD
@@ -53,7 +53,6 @@ _CACHE_ENTRIES = {
     # macOS/BSD. Pinning to lib/ keeps the out_static_libs path
     # portable across platforms.
     "CMAKE_INSTALL_LIBDIR": "lib",
-
     "PORTABLE": "ON",
     "FAIL_ON_WARNINGS": "OFF",
     "USE_RTTI": "1",
@@ -61,14 +60,20 @@ _CACHE_ENTRIES = {
     "WITH_RUNTIME_DEBUG": "OFF",
 }
 
+# Same as _CACHE_ENTRIES, but with RocksDB's native TSAN instrumentation
+# turned on. Used under `--config=tsan` so ThreadSanitizer understands
+# RocksDB's lock-free internals. `PORTABLE=ON` above keeps
+# `-fsanitize=thread` compatible with the pie/relocation flags RocksDB
+# adds when WITH_TSAN is set.
+_TSAN_CACHE_ENTRIES = dict(
+    _CACHE_ENTRIES,
+    WITH_TSAN = "ON",
+)
+
 cmake(
     name = "rocksdb",
     cache_entries = select({
-        # Under `--config=tsan`, build RocksDB with its native TSAN
-        # instrumentation so ThreadSanitizer understands its lock-free
-        # internals. `PORTABLE=ON` above keeps `-fsanitize=thread`
-        # compatible with the pie/relocation flags RocksDB adds here.
-        ":tsan_build": dict(_CACHE_ENTRIES, WITH_TSAN = "ON"),
+        ":tsan_build": _TSAN_CACHE_ENTRIES,
         "//conditions:default": _CACHE_ENTRIES,
     }),
     generate_args = ["-G Ninja"],


### PR DESCRIPTION
## Why are these changes needed?

After #63657 merged, the C++ ThreadSanitizer (TSAN) build started reporting data races in the embedded RocksDB GCS backend tests:

- `//src/ray/gcs/store_client/tests:rocksdb_store_client_test`
- `//src/ray/gcs/store_client/tests:rocksdb_concurrency_test`
- `//src/ray/gcs/store_client/tests:rocksdb_parity_test`

The reported races are **inside RocksDB itself**, e.g.:

```
WARNING: ThreadSanitizer: data race
  Write of size 2 by thread T180:
    #1 rocksdb::MemTable::Add(...)                       // memcpy of key bytes
  Previous read of size 2 by thread T182:
    #1 rocksdb::BytewiseComparatorImpl::Compare(...)     // memcmp during a Get
```

### Root cause

RocksDB is built as a static library by an **out-of-band CMake action** (`bazel/rocksdb.BUILD` via `rules_foreign_cc`). Bazel's `--copt -fsanitize=thread` and `--per_file_copt` from the `tsan` config only apply to Bazel-compiled `cc_library` targets — they never reach the CMake build. As a result, a TSAN-instrumented GCS test links an **un-instrumented** `librocksdb.a`.

TSAN can intercept the plain `memcpy`/`memcmp` on the key/value bytes inside RocksDB's lock-free memtable skiplist, but it **cannot see the acquire/release atomics** RocksDB uses to publish and observe those bytes (that synchronizing code is uninstrumented). Missing those happens-before edges, TSAN reports false races.

Concurrent `Put`/`Get` across the store client's I/O offload pool is a fully supported RocksDB operation, so these are false positives, not real races. `report_atomic_races=0` (already set in the `tsan` config) does not suppress them because the racing accesses are byte-wise `memcpy`/`memcmp`, not atomic operations.

### Fix

Build RocksDB with its native `WITH_TSAN` CMake option under the `tsan` config. RocksDB's `CMakeLists.txt` handles `WITH_TSAN` by adding `-fsanitize=thread` to its own compile/link flags — the RocksDB-blessed way to run it under TSAN. With RocksDB instrumented, ThreadSanitizer understands its synchronization and the false positives disappear.

- `.bazelrc`: `--config=tsan` now sets `--define=ray_rocksdb_tsan=true`.
- `bazel/rocksdb.BUILD`: a `config_setting` reads that define and a `cache_entries` `select()` flips `WITH_TSAN=ON` only for TSAN builds.

Non-TSAN builds are unaffected: the define is only set by `--config=tsan`, and `WITH_TSAN` stays off in the default `select()` branch. `--config=tsan-clang` inherits the define via `--config=tsan`.

### Verification

Reproduced and verified with the same toolchain CI uses (`--config=tsan-clang`, clang 14, libc++). All three previously-failing tests were built under TSAN and run (ASLR disabled via `setarch -R`, `TSAN_OPTIONS=report_atomic_races=0`, matching CI):

| RocksDB build (clang-14 TSAN, identical otherwise) | Data races | Result |
| --- | --- | --- |
| **Without this fix** (uninstrumented `librocksdb.a`) | **10** | **FAILED** (TSAN exits 66) |
| **With this fix** (`WITH_TSAN=ON`) | **0** | **PASSED** |

The negative-control run (fix disabled via `--define=ray_rocksdb_tsan=false`) reproduces the exact races from the report — `rocksdb::MemTable::Add` (memcpy) racing `rocksdb::BytewiseComparatorImpl::Compare` (memcmp) in the memtable skiplist:

```
SUMMARY: ThreadSanitizer: data race in __interceptor_memcmp
  #1 rocksdb::(anonymous namespace)::BytewiseComparatorImpl::Compare(...) comparator.cc
  #1 rocksdb::MemTable::Add(...)
```

With the fix, the same runs are clean:

```
rocksdb_store_client_test   : 0 data races, [  PASSED  ] 12 tests
rocksdb_concurrency_test    : 0 data races, [  PASSED  ]  4 tests
rocksdb_parity_test         : 0 data races, [  PASSED  ]  2 tests
```

This confirms the fix both eliminates the reported races and that removing it reproduces them — i.e. the instrumentation is the cause of the change.

## Related issue number

Follow-up to #63657.

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

