### PR TITLE
[Core] Fix typos in ActorPool comments

### DIFF
--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -98,7 +98,7 @@ class ActorPool:
                 [2, 4, 6, 8]
         """
         # Ignore/Cancel all the previous submissions
-        # by calling `has_next` and `gen_next` repeteadly.
+        # by calling `has_next` and `gen_next` repeatedly.
         while self.has_next():
             try:
                 self.get_next(timeout=0, ignore_if_timedout=True)
@@ -155,7 +155,7 @@ class ActorPool:
                 [6, 8, 4, 2]
         """
         # Ignore/Cancel all the previous submissions
-        # by calling `has_next` and `gen_next_unordered` repeteadly.
+        # by calling `has_next` and `gen_next_unordered` repeatedly.
         while self.has_next():
             try:
                 self.get_next_unordered(timeout=0)


### PR DESCRIPTION
## Description

Fix two misspellings of "repeatedly" in `python/ray/util/actor_pool.py`.

This change only updates comments and does not affect code behavior.

## Related issues

N/A

## Additional information

Tests were not run because this is a comment-only change.