### PR TITLE
[serve] Fix TraceContextManager leaking OpenTelemetry context (attach without detach)

### DIFF
--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -94,6 +94,9 @@ class TraceContextManager:
         self.trace_name = trace_name
         self.span_kind = span_kind
         self.trace_context = trace_context
+        # Detach token for the OpenTelemetry context attached in __enter__.
+        # Only set on the sampled path (where we actually attach/push).
+        self._token = None
 
         self.is_tracing_enabled = is_tracing_enabled()
 
@@ -112,7 +115,7 @@ class TraceContextManager:
             if not self.span.get_span_context().trace_flags.sampled:
                 return self
             new_ctx = set_span_in_context(self.span)
-            set_trace_context(new_ctx)
+            self._token = set_trace_context(new_ctx)
             _append_trace_stack(self.span)
             set_span_name(self.trace_name)
 
@@ -126,7 +129,10 @@ class TraceContextManager:
             # be reported as errors in the trace. They cause noise
             # in the trace and are not meaningful to the user.
             self.span.end()
-            _pop_trace_stack()
+            # Only detach/pop what we actually attached/pushed (sampled path).
+            if self._token is not None:
+                detach_trace_context(self._token)
+                _pop_trace_stack()
 
         return False
 

--- a/python/ray/serve/tests/test_tracing_utils.py
+++ b/python/ray/serve/tests/test_tracing_utils.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import sys
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from threading import Thread
 from typing import Set
@@ -32,6 +33,7 @@ from ray.serve._private.test_utils import (
 from ray.serve._private.tracing_utils import (
     DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
     TRACE_STACK,
+    TraceContextManager,
     _append_trace_stack,
     _load_span_processors,
     _validate_tracing_exporter,
@@ -48,8 +50,13 @@ from ray.tests.conftest import *  # noqa
 
 try:
     from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
-    from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
+    from opentelemetry.sdk.trace.sampling import (
+        ALWAYS_OFF,
+        ALWAYS_ON,
+        ParentBasedTraceIdRatio,
+    )
     from opentelemetry.trace.propagation.tracecontext import (
         TraceContextTextMapPropagator,
     )
@@ -918,6 +925,97 @@ def test_append_trace_stack_multithread():
         task.join()
 
     assert len(passing) == number_of_tasks
+
+
+@contextmanager
+def enable_tracing_with_sampler(sampler):
+    """Enable Serve tracing with a deterministic sampler for unit tests.
+
+    Uses a locally-constructed TracerProvider (never the process-global one,
+    which OpenTelemetry only allows to be set once) so the sampling decision is
+    fully deterministic and independent of the trace id. ALWAYS_ON/ALWAYS_OFF
+    avoid any RNG/trace-id-based flakiness. Also isolates TRACE_STACK so the
+    test does not leak into other tests.
+    """
+    provider = TracerProvider(sampler=sampler)
+    tracer = provider.get_tracer("test_trace_context_manager")
+    stack_token = TRACE_STACK.set([])
+    with patch(
+        "ray.serve._private.tracing_utils.is_tracing_enabled", return_value=True
+    ), patch("ray.serve._private.tracing_utils._tracer", tracer):
+        try:
+            yield
+        finally:
+            TRACE_STACK.reset(stack_token)
+
+
+def test_trace_context_manager_restores_context_on_exit():
+    """TraceContextManager must detach the OpenTelemetry context it attaches.
+
+    Regression test: __enter__ calls set_trace_context (OTel context.attach)
+    and must save the token so __exit__ can detach it. Without the detach, the
+    current context is never restored, so a sibling span created after an inner
+    span's block exits is mis-parented under the already-ended inner span
+    instead of under the still-open outer span. This mirrors the correct
+    BatchTraceContextManager attach/detach pattern in the same module.
+    """
+    with enable_tracing_with_sampler(ALWAYS_ON):
+        before = get_trace_context()
+
+        with TraceContextManager("outer") as outer_cm:
+            outer_span_id = outer_cm.span.get_span_context().span_id
+            # The current context resolves to the outer span while inside it.
+            assert (
+                trace.get_current_span(get_trace_context()).get_span_context().span_id
+                == outer_span_id
+            )
+
+            with TraceContextManager("inner") as inner_cm:
+                inner_span_id = inner_cm.span.get_span_context().span_id
+                assert inner_span_id != outer_span_id
+                assert (
+                    trace.get_current_span(get_trace_context())
+                    .get_span_context()
+                    .span_id
+                    == inner_span_id
+                )
+
+            # After the inner block exits, the current context must be restored
+            # to the outer span (not left pointing at the ended inner span).
+            assert (
+                trace.get_current_span(get_trace_context()).get_span_context().span_id
+                == outer_span_id
+            )
+
+        # After the outer block exits, the context is fully restored: no leak.
+        assert get_trace_context() == before
+        assert TRACE_STACK.get([]) == []
+
+
+def test_trace_context_manager_unsampled_leaves_stack_untouched():
+    """Unsampled spans must not touch the trace stack on enter or exit.
+
+    Regression test for the push/pop asymmetry: __enter__ early-returns before
+    pushing when the span is unsampled, so __exit__ must not pop. Popping
+    unconditionally removes an unrelated parent span from TRACE_STACK and
+    corrupts set_span_name/set_span_attributes/set_trace_status for that parent.
+    """
+    with enable_tracing_with_sampler(ALWAYS_OFF):
+        sentinel = FakeSpan()
+        TRACE_STACK.set([sentinel])
+        before = get_trace_context()
+
+        with TraceContextManager("unsampled") as cm:
+            # A span is created, but it is not sampled, so nothing is
+            # attached or pushed onto the stack.
+            assert cm.span is not None
+            assert not cm.span.get_span_context().trace_flags.sampled
+            assert TRACE_STACK.get([]) == [sentinel]
+
+        # Exiting must not pop the unrelated parent off the stack, nor detach
+        # any context (nothing was attached).
+        assert TRACE_STACK.get([]) == [sentinel]
+        assert get_trace_context() == before
 
 
 def test_batched_span_attached_to_first_request_trace():


### PR DESCRIPTION
## Why are these changes needed?

`TraceContextManager.__enter__` (used by every `@tracing_decorator_factory` span in `proxy.py`/`router.py` and by the replica's tracing context in `replica.py`) makes a span current via `set_trace_context()` — which internally calls OpenTelemetry `context.attach(...)` and returns a detach token. That token is discarded, and `__exit__` never calls `detach_trace_context(...)`.

Per the OpenTelemetry API, every `attach()` must be paired with a `detach(token)`; omitting the `detach` corrupts the current-context stack, so the attached context is never restored on exit. The sibling `BatchTraceContextManager` in the same module already does this correctly (`self._token = set_trace_context(...)` in `__enter__`, `detach_trace_context(self._token)` in `__exit__`) — the general `TraceContextManager` simply omitted both halves.

### Failing scenario (tracing enabled + sampled)

A request enters proxy span `P` (`send_request_to_replica`) — attach `P`, current = `P`. Inside, router span `R` (`route_to_replica`) is created as a child of `P` (correct) — attach `R`, current = `R`. When `R`'s block exits, `R.span.end()` runs and `R` is popped from the trace stack, but `R` is **never detached**, so `get_current()` still returns `R`. Any span or `create_propagated_context()` produced afterward inside `P` (e.g. the context propagated to the replica, or a second sequential downstream call) reads the current context as `R` and is parented under the already-ended sibling `R` instead of under `P` — producing a wrong trace tree and leaking context across the proxy→replica boundary.

There is also a related push/pop asymmetry: `__enter__` only pushes onto the trace stack on the sampled path (it early-returns for unsampled spans), but `__exit__` popped **unconditionally** whenever `self.span is not None`, removing an unrelated parent span from the stack and corrupting `set_span_name`/`set_span_attributes`/`set_trace_status` for that parent.

### The fix

Mirrors the correct `BatchTraceContextManager` pattern:
- Initialize `self._token = None` in `__init__`.
- Save the token in `__enter__` (`self._token = set_trace_context(new_ctx)`), only set on the sampled path.
- In `__exit__`, always end the span, but `detach_trace_context(...)` and `_pop_trace_stack()` only when `self._token is not None`.

Gating the pop on the same condition also fixes the push/pop asymmetry (the unsampled path pushes nothing, so it must pop nothing). `detach_trace_context` is already defined in this module, so no new import is needed.

## Related issue number

N/A

## Checks

Adds regression tests in `python/ray/serve/tests/test_tracing_utils.py`:
- `test_trace_context_manager_restores_context_on_exit`: with full sampling, after a nested inner `TraceContextManager` block exits, the current context resolves back to the outer span (not the ended inner span), and after the outer block exits the context is fully restored to its baseline with an empty trace stack.
- `test_trace_context_manager_unsampled_leaves_stack_untouched`: an unsampled span leaves `TRACE_STACK` untouched on both enter and exit.

Both tests use `ALWAYS_ON`/`ALWAYS_OFF` samplers for a deterministic sampling decision. Both fail on the pre-fix code and pass after the fix.