### PR TITLE
[doc] Wrap long fully-qualified names in autosummary API index tables

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -358,7 +358,10 @@ table.autosummary .row-odd {
   background-color: var(--pst-color-surface);
 }
 
-/* Ensure that long function names get elided and show ellipses to not overflow their bounding boxes  */
+/* Wrap long fully-qualified names so they stay within the fixed-width first
+* column instead of being clipped. The theme sets white-space: nowrap on these
+* code spans, which disables line breaking, so overflow-wrap alone is inert;
+* reset white-space to normal so break-word can wrap the dotted path. */
 table.autosummary tr > td:first-child > p > a > code {
   max-width: 100%;
   width: fit-content;
@@ -366,8 +369,8 @@ table.autosummary tr > td:first-child > p > a > code {
 }
 table.autosummary tr > td:first-child > p > a > code > span {
   display: block;
-  overflow: clip;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 /* RTD footer container makes the parent */


### PR DESCRIPTION
## What

Long fully-qualified names in the first column of `autosummary` tables on API index pages (for example `ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy` on the [Core scheduling API page](https://docs.ray.io/en/master/ray-core/api/scheduling.html)) are clipped with an ellipsis, so the module path is truncated and unreadable.

This changes the name-cell styling in `doc/source/_static/css/custom.css` so long names **wrap** within the fixed-width first column instead of being cut off.

## Why

The name-cell span was styled with `overflow: clip; text-overflow: ellipsis`. Swapping that for `overflow-wrap: break-word` alone does **not** fix it: the span also inherits `white-space: nowrap` from the theme, which disables line breaking outright, so `overflow-wrap` is inert. The fix also resets `white-space: normal` so the dotted path can wrap. Short names that already fit are unaffected.

## How it was verified

No unit test covers rendered CSS, so I verified the rendered result with a Playwright probe that measures the offending name cell on the live `/en/master` scheduling page, then injects the candidate CSS via `addStyleTag` and re-measures:

- **Before** (deployed CSS): span `scrollWidth` 531px vs `clientWidth` 305px → horizontally clipped; `clientHeight` 23px (single line); `white-space: nowrap`.
- **After** (this change): `scrollWidth` == `clientWidth` (305px) → no clipping; `clientHeight` 46px (wraps to two lines); full name rendered.

I also confirmed `overflow-wrap: break-word` without `white-space: normal` leaves the text on one line (still clipped), which is why both properties are needed.

## Notes

- **Not a duplicate.** Related to #42303 (open); no open PR addresses it (`gh pr list --search "42303 in:body"` and `--search "autosummary overflow"` both empty). #42303 asks to shorten the displayed names to the leaf symbol; this PR instead keeps the fully-qualified path but makes it wrap and stay readable, so it resolves the truncation without dropping the module context. Happy to switch to the `~`-prefix short-name approach instead if that's preferred.
- Docs-only, `doc`-tagged change (single CSS file); no runtime or API surface touched.
- AI assistance (Claude Code) was used to investigate and author this change; I reviewed every changed line.
