### PR TITLE
[doc] Move API type hints out of the signature into the Parameters list

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -530,8 +530,13 @@ texinfo_documents = [
 # Python methods should be presented in source code order
 autodoc_member_order = "bysource"
 
-# Better typehint formatting (see custom.css)
-autodoc_typehints = "signature"
+# Move type hints out of the signature and into the Parameters description list
+# (see custom.css), so signatures stay short and scannable while each parameter
+# still shows its type. "documented" scopes the description-side types to params
+# that already have a docstring entry, which keeps their prose descriptions and
+# preserves short type names.
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
 
 
 def filter_out_undoc_class_members(member_name, class_name, module_name):


### PR DESCRIPTION
## Context: two proposals for the same problem

The API reference signatures are hard to parse today. With
`autodoc_typehints = "signature"`, every parameter's full type annotation
renders inline in the signature, so an API with many parameters or long
union/callable types produces a dense, hard-to-scan signature block.

There are two ways to address this, and this PR is one of a pair so reviewers
can compare the rendered result side by side:

- **Add information** — #64778: keep types in the signature *and* also add them
  to the Parameters list (`autodoc_typehints = "both"`).
- **Move information** — this PR: take types *out* of the signature and show
  them only in the Parameters list (`autodoc_typehints = "description"`).

The docs team's preference is to move the information, for the cleanest
complete render.

## What changed

`doc/source/conf.py`: `autodoc_typehints = "description"` plus
`autodoc_typehints_description_target = "documented"`. The signature now shows
only parameter names and defaults; each parameter's type moves into the
Parameters list as `name (ShortType) - description`. Return types move to a
`Return type:` field in the description.

This matches the rendering used by projects such as pandas
(https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html), where the
signature stays short and the type detail lives in the Parameters table.

The `"documented"` target is load-bearing: with the default `"all"` target,
the description mode drops parameter descriptions and renders verbose
`Optional[...]`/`Union[...]` spellings instead of the short PEP 604 names.

## Tradeoff: undocumented parameters lose their type

The `"documented"` target has a real cost, raised in review and worth stating
plainly. Because `"description"` strips every annotation out of the signature
and `"documented"` only re-injects a type for parameters that already have a
docstring entry, any parameter that's annotated but *not* documented renders
with no type at all. Those parameters show their type in the signature today
and would lose it under this change.

A static pass over Ray's `@PublicAPI` surface at master (replicating napoleon's
`Args:` -> `:param:` handling, and sourcing `__init__` params from the class
docstring under the default `autoclass_content = "class"`) puts this at roughly
**21% of annotated public-API parameters (549/2,609)**, concentrated in Serve
(~52%) and Tune (~43%). It isn't limited to obscure internals: the entire
`tune.uniform` / `tune.randint` / `tune.loguniform` search-space API has prose
docstrings with no `Args:` section, so those parameters would drop their types.

This is the key axis for comparing the two proposals. The companion #64778
(`"both"`) never drops a type, at the cost of longer signatures. This PR
(`"description"`/`"documented"`) buys short signatures at the cost of erasing
types from the undocumented tail. That's a defensible product stance — "show a
type only where the parameter is documented, and treat the gap as pressure to
document" — but it should be an explicit decision, and it argues for pairing the
render change with a docstring-coverage effort. A third lever, the
`sphinx-autodoc-typehints` extension's `always_document_param_types`, would keep
a type row even for undocumented parameters.

## Not a duplicate

No open PR or issue changes `autodoc_typehints` other than the companion
proposal #64778, which is deliberately the alternative approach.

## Testing

Rendering was validated in an isolated Sphinx 8.2.3 build (matching the docs
lock) on a class mirroring a real Ray API signature and docstring: the
signature renders with names and defaults only, and the Parameters list shows
short type names with descriptions preserved. Full-site verification is left to
this PR's Read the Docs preview build (the docs build runs
`fail_on_warning: true`).

## AI assistance

This change was prepared with AI assistance (Claude Code). The change and its
verification were reviewed by the submitter.

