### PR TITLE
[ci/doc] Fix rllib API-doc consistency check crashing on empty whitelist

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -104,7 +104,7 @@ TEAM_API_CONFIGS = {
     "rllib": {
         "head_modules": {"ray.rllib"},
         "head_doc_file": "doc/source/rllib/package_ref/index.rst",
-        "white_list_apis": {},
+        "white_list_apis": set(),
     },
 }
 


### PR DESCRIPTION
## Why are these changes needed?

The per-team API-doc consistency check (`ci/ray_ci/doc/cmd_check_api_discrepancy.py`) crashes on the `rllib` team:

```
File "ci/ray_ci/doc/cmd_check_api_discrepancy.py", line 166, in _check_team
    doc_only_whitelist = white_list_apis | config.get("doc_only_whitelist", set())
TypeError: unsupported operand type(s) for |: 'dict' and 'set'
```

The `rllib` config declared its empty whitelist as `{}`, which Python parses as an empty **dict**, not an empty set. Every other team uses a non-empty set literal, so `rllib` was the only team whose `white_list_apis` was a dict.

The mismatch stayed latent while `white_list_apis` was used only in `in` membership tests, where an empty dict and an empty set behave identically. The reverse/dedup policy work (#64420) added a `white_list_apis | config.get("doc_only_whitelist", set())` union, and `dict | set` raises `TypeError` — breaking the check for every doc-scoped PR that reaches the `rllib` team.

The fix declares the empty whitelist as `set()` so its type matches the other teams and the union operand.

## Related issue number

N/A — regression from #64420.

## Checks

- [x] I've signed off every commit (`git commit -s`).
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests.
- Testing Strategy
   - [x] Unit tests
