### PR TITLE
[RLlib] Require MultiRLModuleSpec.rl_module_specs to be a dict.

### DIFF
--- a/doc/source/rllib/rl-modules.rst
+++ b/doc/source/rllib/rl-modules.rst
@@ -369,13 +369,20 @@ tell RLlib to use the particular module class and constructor arguments:
             config = (
                 PPOConfig()
                 .environment(MultiAgentCartPole, env_config={"num_agents": 2})
+                .multi_agent(
+                    # Both agents (0 and 1) map to the same policy, so they share
+                    # a single RLModule.
+                    policies={"p0"},
+                    policy_mapping_fn=lambda agent_id, episode, **kw: "p0",
+                )
                 .rl_module(
                     rl_module_spec=MultiRLModuleSpec(
-                        # All agents (0 and 1) use the same (single) RLModule.
-                        rl_module_specs=RLModuleSpec(
-                            module_class=MyRLModuleClass,
-                            model_config={"some_key": "some_setting"},
-                        )
+                        rl_module_specs={
+                            "p0": RLModuleSpec(
+                                module_class=MyRLModuleClass,
+                                model_config={"some_key": "some_setting"},
+                            ),
+                        },
                     ),
                 )
             )

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4682,37 +4682,21 @@ class AlgorithmConfig(_Config):
             # Default is single-agent but the user has provided a multi-agent spec
             # so the use-case is multi-agent.
             if isinstance(default_rl_module_spec, RLModuleSpec):
-                # The individual (single-agent) module specs are defined by the user
-                # in the currently setup MultiRLModuleSpec -> Use that
-                # RLModuleSpec.
-                if isinstance(current_rl_module_spec.rl_module_specs, RLModuleSpec):
-                    single_agent_spec = single_agent_rl_module_spec or (
-                        current_rl_module_spec.rl_module_specs
+                # Use the individual module specs defined by the user in the
+                # currently set up MultiRLModuleSpec, falling back to the provided
+                # or default RLModuleSpec for any ModuleID missing from it.
+                single_agent_spec = (
+                    single_agent_rl_module_spec or default_rl_module_spec
+                )
+                single_agent_spec.inference_only = inference_only
+                module_specs = {
+                    k: copy.deepcopy(
+                        current_rl_module_spec.rl_module_specs.get(k, single_agent_spec)
                     )
-                    single_agent_spec.inference_only = inference_only
-                    module_specs = {
-                        k: copy.deepcopy(single_agent_spec) for k in policy_dict.keys()
-                    }
-
-                # The individual (single-agent) module specs have not been configured
-                # via this AlgorithmConfig object -> Use provided single-agent spec or
-                # the default spec (which is also a RLModuleSpec in this
-                # case).
-                else:
-                    single_agent_spec = (
-                        single_agent_rl_module_spec or default_rl_module_spec
-                    )
-                    single_agent_spec.inference_only = inference_only
-                    module_specs = {
-                        k: copy.deepcopy(
-                            current_rl_module_spec.rl_module_specs.get(
-                                k, single_agent_spec
-                            )
-                        )
-                        for k in (
-                            policy_dict | current_rl_module_spec.rl_module_specs
-                        ).keys()
-                    }
+                    for k in (
+                        policy_dict | current_rl_module_spec.rl_module_specs
+                    ).keys()
+                }
 
                 # Now construct the proper MultiRLModuleSpec.
                 # We need to infer the multi-agent class from `current_rl_module_spec`
@@ -4728,33 +4712,17 @@ class AlgorithmConfig(_Config):
             # Default is multi-agent and user wants to override it -> Don't use the
             # default.
             else:
-                # User provided an override RLModuleSpec -> Use this to
-                # construct the individual RLModules within the MultiRLModuleSpec.
-                if single_agent_rl_module_spec is not None:
-                    pass
-                # User has NOT provided an override RLModuleSpec.
-                else:
-                    # But the currently setup multi-agent spec has a SingleAgentRLModule
-                    # spec defined -> Use that to construct the individual RLModules
-                    # within the MultiRLModuleSpec.
-                    if isinstance(current_rl_module_spec.rl_module_specs, RLModuleSpec):
-                        # The individual module specs are not given, it is given as one
-                        # RLModuleSpec to be re-used for all
-                        single_agent_rl_module_spec = (
-                            current_rl_module_spec.rl_module_specs
-                        )
-                    # The currently set up multi-agent spec has NO
-                    # RLModuleSpec in it -> Error (there is no way we can
-                    # infer this information from anywhere at this point).
-                    else:
-                        raise ValueError(
-                            "We have a MultiRLModuleSpec "
-                            f"({current_rl_module_spec}), but no "
-                            "`RLModuleSpec`s to compile the individual "
-                            "RLModules' specs! Use "
-                            "`AlgorithmConfig.get_multi_rl_module_spec("
-                            "policy_dict=.., rl_module_spec=..)`."
-                        )
+                # Without an override RLModuleSpec, there is no single RLModuleSpec
+                # to reuse for all modules in this multi-agent default setup.
+                if single_agent_rl_module_spec is None:
+                    raise ValueError(
+                        "We have a MultiRLModuleSpec "
+                        f"({current_rl_module_spec}), but no "
+                        "`RLModuleSpec`s to compile the individual "
+                        "RLModules' specs! Use "
+                        "`AlgorithmConfig.get_multi_rl_module_spec("
+                        "policy_dict=.., rl_module_spec=..)`."
+                    )
 
                 single_agent_rl_module_spec.inference_only = inference_only
 
@@ -4782,16 +4750,6 @@ class AlgorithmConfig(_Config):
             if module_spec.module_class is None:
                 if isinstance(default_rl_module_spec, RLModuleSpec):
                     module_spec.module_class = default_rl_module_spec.module_class
-                elif isinstance(default_rl_module_spec.rl_module_specs, RLModuleSpec):
-                    module_class = default_rl_module_spec.rl_module_specs.module_class
-                    # This should be already checked in validate() but we check it
-                    # again here just in case
-                    if module_class is None:
-                        raise ValueError(
-                            "The default rl_module spec cannot have an empty "
-                            "module_class under its RLModuleSpec."
-                        )
-                    module_spec.module_class = module_class
                 elif module_id in default_rl_module_spec.rl_module_specs:
                     module_spec.module_class = default_rl_module_spec.rl_module_specs[
                         module_id
@@ -4806,9 +4764,6 @@ class AlgorithmConfig(_Config):
             if module_spec.catalog_class is None:
                 if isinstance(default_rl_module_spec, RLModuleSpec):
                     module_spec.catalog_class = default_rl_module_spec.catalog_class
-                elif isinstance(default_rl_module_spec.rl_module_specs, RLModuleSpec):
-                    catalog_class = default_rl_module_spec.rl_module_specs.catalog_class
-                    module_spec.catalog_class = catalog_class
                 elif module_id in default_rl_module_spec.rl_module_specs:
                     module_spec.catalog_class = default_rl_module_spec.rl_module_specs[
                         module_id

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -13,6 +13,7 @@ from ray.rllib.core.rl_module.multi_rl_module import (
     MultiRLModuleSpec,
 )
 from ray.rllib.core.rl_module.rl_module import RLModule, RLModuleSpec
+from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.utils.test_utils import check
 
 
@@ -37,6 +38,29 @@ class TestAlgorithmConfig(unittest.TestCase):
         self.assertTrue(algo.config.train_batch_size == 3000)
         algo.train()
         algo.stop()
+
+    def test_multi_agent_shared_module(self):
+        """Multiple agents sharing a single RLModule via a one-entry spec dict."""
+        config = (
+            PPOConfig()
+            .environment(MultiAgentCartPole, env_config={"num_agents": 2})
+            .env_runners(num_env_runners=0)
+            .multi_agent(
+                policies={"p0"},
+                policy_mapping_fn=lambda agent_id, *args, **kwargs: "p0",
+            )
+            .rl_module(
+                rl_module_spec=MultiRLModuleSpec(
+                    rl_module_specs={"p0": RLModuleSpec()},
+                ),
+            )
+        )
+        algo = config.build_algo()
+        try:
+            self.assertEqual(set(algo.env_runner.module.keys()), {"p0"})
+            algo.train()
+        finally:
+            algo.stop()
 
     def test_freezing_of_algo_config(self):
         """Tests, whether freezing an AlgorithmConfig actually works as expected."""
@@ -427,7 +451,7 @@ class TestAlgorithmConfig(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            "Module_specs cannot be None",
+            "must be a dict",
             lambda: config.rl_module_spec,
         )
 

--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -549,7 +549,7 @@ class MultiRLModuleSpec:
     model_config: Optional[dict] = None
     #: A dictionary mapping ModuleIDs to the RLModuleSpec used for each individual
     #: module.
-    rl_module_specs: Dict[ModuleID, RLModuleSpec] = None
+    rl_module_specs: Optional[Dict[ModuleID, RLModuleSpec]] = None
 
     # TODO (sven): Deprecate these in favor of using the pure Checkpointable APIs for
     #  loading and saving state.

--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -547,10 +547,9 @@ class MultiRLModuleSpec:
     #: network components that only live inside the MultiRLModule and don't have
     #: their own ModuleID and own RLModule within `self._rl_modules`.
     model_config: Optional[dict] = None
-    #: The module specs for each individual module. It can be either
-    #: an RLModuleSpec used for all module_ids or a dictionary mapping from module
-    #: IDs to RLModuleSpecs for each individual module.
-    rl_module_specs: Union[RLModuleSpec, Dict[ModuleID, RLModuleSpec]] = None
+    #: A dictionary mapping ModuleIDs to the RLModuleSpec used for each individual
+    #: module.
+    rl_module_specs: Dict[ModuleID, RLModuleSpec] = None
 
     # TODO (sven): Deprecate these in favor of using the pure Checkpointable APIs for
     #  loading and saving state.
@@ -558,7 +557,7 @@ class MultiRLModuleSpec:
     modules_to_load: Optional[Set[ModuleID]] = None
 
     # Deprecated: Do not use anymore.
-    module_specs: Optional[Union[RLModuleSpec, Dict[ModuleID, RLModuleSpec]]] = None
+    module_specs: Optional[Dict[ModuleID, RLModuleSpec]] = None
 
     def __post_init__(self):
         if self.module_specs is not None:
@@ -567,11 +566,13 @@ class MultiRLModuleSpec:
                 new="MultiRLModuleSpec(rl_module_specs=..)",
                 error=True,
             )
-        if self.rl_module_specs is None:
+        if not isinstance(self.rl_module_specs, dict):
             raise ValueError(
-                "Module_specs cannot be None. It should be either a "
-                "RLModuleSpec or a dictionary mapping from module IDs to "
-                "RLModuleSpecs for each individual module."
+                "`MultiRLModuleSpec.rl_module_specs` must be a dict mapping ModuleIDs "
+                "to RLModuleSpecs. To use one RLModule for all agents, pass your "
+                "`RLModuleSpec` directly to `config.rl_module(rl_module_spec=..)`, "
+                "which RLlib replicates across your policies; to configure modules "
+                'individually, pass a dict, e.g. `{"my_module": RLModuleSpec(..)}`.'
             )
         self.module_specs = self.rl_module_specs
         # Figure out global inference_only setting.

--- a/rllib/core/rl_module/tests/test_rl_module_specs.py
+++ b/rllib/core/rl_module/tests/test_rl_module_specs.py
@@ -233,6 +233,11 @@ class TestRLModuleSpecs(unittest.TestCase):
             marl_spec_1.rl_module_specs["agent_2"].model_config, "I'm new!"
         )
 
+    def test_multi_rl_module_spec_requires_dict(self):
+        """`MultiRLModuleSpec.rl_module_specs` must be a dict, not a single spec."""
+        with self.assertRaisesRegex(ValueError, "must be a dict"):
+            MultiRLModuleSpec(rl_module_specs=RLModuleSpec())
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
`MultiRLModuleSpec.rl_module_specs` previously accepted either a single `RLModuleSpec` (reused for all module IDs) or a dict mapping ModuleIDs to RLModuleSpecs. The single-spec form raised at construction and only duplicated what passing a bare `RLModuleSpec` to `config.rl_module(rl_module_spec=..)` already does. Require a dict and raise an actionable error otherwise, and switch the shared-policy RLModule docs example to the dict form.

Trying to be clever with this "easy of use feature" lead to the following issue which this also closes #63616

