### PR TITLE
[ci/doc] Split API-doc whitelist into permanent exemptions and tracked debt

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -6,17 +6,34 @@ from ci.ray_ci.doc.api import API
 from ci.ray_ci.doc.autodoc import Autodoc
 from ci.ray_ci.doc.module import Module
 
+# Each team config carries two exemption lists. Both feed the "every
+# @PublicAPI symbol must be documented" check identically (they're unioned at
+# check time), but they mean different things to a human reading the file:
+#
+#   white_list_apis  -- Permanent, intentional exemptions. These symbols are
+#                       correctly absent from the team autosummary and are
+#                       expected to stay on this list: documented elsewhere, an
+#                       intentional alias, or genuinely un-deprecatable. Not
+#                       doc debt.
+#   tracked_doc_debt  -- Known documentation debt: @PublicAPI symbols still
+#                       owed a document-or-deprecate decision. Clearing an entry
+#                       means the decision was made and acted on (documented,
+#                       deprecated, or the erroneous annotation removed).
+#
+# Because both sets are unioned, moving an entry between them never changes
+# what the check accepts -- only whether a reviewer reads it as "correct and
+# permanent" or "we still owe a decision here".
 TEAM_API_CONFIGS = {
     "data": {
         "head_modules": {"ray.data", "ray.data.grouped_data"},
         "head_doc_file": "doc/source/data/api/api.rst",
-        # List of APIs that are not following our API policy, and we will be fixing, or
-        # we cannot deprecate them although we want to
         "white_list_apis": {
-            # not sure what to do
-            "ray.data.dataset.MaterializedDataset",
             # special case where we cannot deprecate although we want to
             "ray.data.random_access_dataset.RandomAccessDataset",
+        },
+        "tracked_doc_debt": {
+            # not sure what to do
+            "ray.data.dataset.MaterializedDataset",
         },
         # Canonical names intentionally documented in more than one place:
         # to_arrow_refs / to_numpy_refs / to_pandas_refs appear on both the
@@ -30,7 +47,8 @@ TEAM_API_CONFIGS = {
     "serve": {
         "head_modules": {"ray.serve"},
         "head_doc_file": "doc/source/serve/api/index.md",
-        "white_list_apis": {
+        "white_list_apis": set(),
+        "tracked_doc_debt": {
             # private versions of request router APIs
             "ray.serve._private.common.ReplicaID",
             "ray.serve._private.request_router.common.PendingRequest",
@@ -45,7 +63,8 @@ TEAM_API_CONFIGS = {
     "core": {
         "head_modules": {"ray"},
         "head_doc_file": "doc/source/ray-core/api/index.rst",
-        "white_list_apis": {
+        "white_list_apis": set(),
+        "tracked_doc_debt": {
             # These APIs will be documented in near future
             "ray.util.scheduling_strategies.DoesNotExist",
             "ray.util.scheduling_strategies.Exists",
@@ -97,6 +116,8 @@ TEAM_API_CONFIGS = {
         "white_list_apis": {
             # Already documented as ray.tune.search.ConcurrencyLimiter
             "ray.tune.search.searcher.ConcurrencyLimiter",
+        },
+        "tracked_doc_debt": {
             # TODO(ml-team): deprecate these APIs
             "ray.tune.utils.log.Verbosity",
         },
@@ -127,8 +148,12 @@ def _check_team(ray_checkout_dir: str, team: str) -> bool:
     doc_apis = autodoc.get_apis()
     api_in_docs = {api.get_canonical_name() for api in doc_apis}
 
-    # Load the white list APIs
-    white_list_apis = config["white_list_apis"]
+    # Load the white list APIs. Permanent exemptions and tracked doc debt are
+    # kept in separate config keys for readability; the check treats them the
+    # same, so union them here.
+    white_list_apis = config["white_list_apis"] | config.get(
+        "tracked_doc_debt", set()
+    )
 
     passed = True
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -151,9 +151,7 @@ def _check_team(ray_checkout_dir: str, team: str) -> bool:
     # Load the white list APIs. Permanent exemptions and tracked doc debt are
     # kept in separate config keys for readability; the check treats them the
     # same, so union them here.
-    white_list_apis = config["white_list_apis"] | config.get(
-        "tracked_doc_debt", set()
-    )
+    white_list_apis = config["white_list_apis"] | config.get("tracked_doc_debt", set())
 
     passed = True
 

--- a/ci/ray_ci/doc/test_cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/test_cmd_check_api_discrepancy.py
@@ -18,6 +18,7 @@ def _run_check_team(
     autosummary_entries,
     autoclass_entries=(),
     white_list_apis=frozenset(),
+    tracked_doc_debt=frozenset(),
     doc_only_whitelist=frozenset(),
     intentional_duplicate_apis=frozenset(),
 ):
@@ -41,6 +42,7 @@ def _run_check_team(
             "head_modules": {_MOCK},
             "head_doc_file": "head.rst",
             "white_list_apis": set(white_list_apis),
+            "tracked_doc_debt": set(tracked_doc_debt),
             "doc_only_whitelist": set(doc_only_whitelist),
             "intentional_duplicate_apis": set(intentional_duplicate_apis),
         }
@@ -63,6 +65,18 @@ def test_undocumented_public_api_fails(monkeypatch):
         monkeypatch,
         autosummary_entries=[],
         autoclass_entries=["MockClass"],
+    )
+
+
+def test_undocumented_public_api_passes_when_tracked_as_debt(monkeypatch):
+    # The same undocumented public API is allowed when carried in
+    # tracked_doc_debt, exactly as if it were in white_list_apis: the two keys
+    # are unioned into the coverage whitelist.
+    assert _run_check_team(
+        monkeypatch,
+        autosummary_entries=[],
+        autoclass_entries=["MockClass"],
+        tracked_doc_debt={_CANONICAL_W00T},
     )
 
 


### PR DESCRIPTION
## Why are these changes needed?

The per-team `white_list_apis` sets in `ci/ray_ci/doc/cmd_check_api_discrepancy.py` are the accepted-exceptions list for the "every `@PublicAPI` symbol must be documented" check. Today one flat set per team mixes two very different kinds of exemption:

- **Permanent, intentional** — deprecated APIs documented in a separate file (Train's `deprecated.rst`), an intentional alias (Tune's `ConcurrencyLimiter`), a symbol that genuinely can't be deprecated (Data's `RandomAccessDataset`).
- **Doc debt** — `@PublicAPI` symbols still owed a document-or-deprecate decision, several parked behind `TODO`s for a long time.

Reading one flat set, you can't tell "correct and permanent" from "we forgot" without opening each comment.

## What this changes

Split each team's exemptions into two keys — `white_list_apis` (permanent) and `tracked_doc_debt` (owed a decision) — and union them at check time. The set the check accepts is **unchanged**; this is purely a legibility change so a reviewer, and tooling, can tell the two halves apart.

Current split: **7 permanent** (Train 5, Data 1, Tune 1) and **22 tracked debt** (Core 12, Serve 8, Data 1, Tune 1).

Follow-up to #64783, which fixed the empty RLlib whitelist crashing this check.

A separate effort is routing each team's `tracked_doc_debt` entries to their owners for the document-or-deprecate decisions; clearing an entry (documenting it, deprecating it, or removing an erroneous public annotation) then removes it from the list.

## Related issue number

Follow-up to #64783.

## Checks

- [x] I've signed off every commit (`git commit -s`) to certify the DCO.
- [x] Unit tests pass: `bazel test //ci/ray_ci/doc:test_cmd_check_api_discrepancy` (9 passed, incl. a new test that a `tracked_doc_debt` entry is honored identically to a `white_list_apis` entry).
- [x] Behavior-preserving: verified each team's effective whitelist (`white_list_apis | tracked_doc_debt`) is byte-for-byte unchanged from before the split.
