### PR TITLE
[doc] Fix navbar logo overhang stealing the first sidebar link's click

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -246,6 +246,11 @@ li.active-link {
 /* Ray logo */
 .navbar-brand.logo > svg {
   width: 120px;
+  /* The SVG ships with width="400" height="201"; without an explicit height here
+     the box keeps the 201px attribute height while only the width is overridden,
+     leaving ~140px of empty clickable logo box overhanging the sidebar (it steals
+     the first API nav link's clicks). height:auto scales height from the viewBox. */
+  height: auto;
 }
 .navbar-brand.logo > svg path#ray-text {
   fill: var(--pst-color-text-base);


### PR DESCRIPTION
## What & why

On any tab, clicking the **first** sidebar entry navigates to the docs **landing page** instead of the intended location.

This is **not a broken link** — every href resolves correctly (top-nav "APIs" → `apis/index`, the "select a library" body list → `data/api/api.html`, and the client-side sidebar fragment → `data/api/api.html`, all confirmed on live `/en/master/`). The click was being **intercepted**.

The Ray logo SVG (`_static/img/ray_logo.svg`) ships with `width="400" height="201"`. `custom.css` set only `width: 120px` on it, so the height fell back to the `201` attribute and the `<a class="navbar-brand logo">` box rendered **120×201px**. The visible wordmark is only the top ~60px; the remaining ~140px is empty but still part of the clickable anchor, and it overhangs the top of the sidebar. Because the logo links to the landing page, that invisible overhang swallowed the "Ray Data" click.

## Fix

Add `height: auto` so the box tracks the SVG's viewBox aspect ratio → **120 × ~60px** (`120 × 201/400 = 60.3`). The visible logo is unchanged; only the dead clickable area is removed, so the first sidebar link works again.

```css
.navbar-brand.logo > svg {
  width: 120px;
  height: auto;   /* added */
}
```

## Not a duplicate

Searched open PRs/issues — nothing on the navbar logo / `custom.css` / sidebar-click overlap:
- `gh pr list --search "navbar logo"`, `--search "custom.css sidebar"` → none
- `gh issue list --search "logo sidebar nav overlap"` → none

## Testing

CSS-only change; no automated test surface.
- **Lint:** `doc/source/` is globally excluded in `.pre-commit-config.yaml` (top-level `exclude`), so no formatter/linter gates this file. Confirmed the real `pre-commit run prettier --files doc/source/_static/css/custom.css` reports *"no files to check (Skipped)"*. The edit is prettier-clean regardless.
- **Root cause isolation:** confirmed the deployed `/en/master/` `custom.css` is exactly the width-only rule (the live culprit) and that all hrefs already resolve correctly, pinning the bug to the oversized clickable box rather than routing.
- **Math check:** `width:120px` + `height:auto` + `viewBox="0 0 400 201"` → 60.3px box, removing the ~140px overhang.
- **Recommended before merge (visual):** local docs build, then click the first "Ray Data" entry in the APIs sidebar and confirm it lands on `data/api/api.html`.

## AI assistance

AI assistance (Claude Code) was used to analyze and implement this change. The human submitter identified the root cause — the logo element overlapping the nav link — and is reviewing the change before it's marked ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
