### PR TITLE
[ci/doc] Add diff-scoped @PublicAPI parameter-coverage check

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -35,6 +35,24 @@ steps:
     commands:
       - ./ci/lint/lint.sh pre_commit_pydoclint
 
+  # Diff-scoped @PublicAPI parameter-coverage check: fails when a PR adds a new
+  # public API, or a new parameter on an existing one, without a docstring
+  # Args: entry. Pre-existing gaps are grandfathered. Static (no docbuild), so
+  # it runs in the lint group. `soft_fail: true` keeps it visible but
+  # non-blocking during the warn phase; remove `soft_fail` to make it a
+  # required check once the false-positive rate is confirmed low.
+  - label: ":lint-roller: lint: API param coverage"
+    key: api-param-coverage
+    tags:
+      - oss
+      - lint
+      - always
+    depends_on:
+      - forge
+    soft_fail: true
+    commands:
+      - ./ci/lint/lint.sh api_param_coverage --blocking
+
   # Scope guard for the "docs-go" label: runs only when the label is present,
   # and fails unless the PR is content-only (changes under doc/, excluding
   # BUILD files). This is the check the label cannot turn off, so the label

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -140,6 +140,18 @@ api_policy_check() {
   PYTHONPATH="$(pwd)${PYTHONPATH:+:$PYTHONPATH}" python ci/ray_ci/doc/cmd_check_api_discrepancy.py /ray "$@"
 }
 
+api_param_coverage() {
+  # Static, diff-scoped check: fail a PR that adds a new @PublicAPI callable, or
+  # a new parameter on an existing one, without a docstring Args: entry.
+  # Pre-existing gaps are grandfathered. Parses source only, so no Ray build or
+  # install is needed. Non-blocking by default; pass --blocking to gate.
+  echo "--- Check new-parameter documentation coverage"
+  local base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+  git fetch --depth=500 origin "${base_branch}" >/dev/null 2>&1 || true
+  PYTHONPATH="$(pwd)${PYTHONPATH:+:$PYTHONPATH}" python ci/ray_ci/doc/cmd_check_api_param_coverage.py \
+    "$(pwd)" --base-ref "origin/${base_branch}" "$@"
+}
+
 documentation_style() {
   ./ci/lint/check-documentation-style.sh
 }

--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -125,7 +125,10 @@ py_test(
 py_test(
     name = "test_api_param_coverage",
     size = "small",
-    srcs = ["test_api_param_coverage.py"],
+    srcs = [
+        "cmd_check_api_param_coverage.py",
+        "test_api_param_coverage.py",
+    ],
     exec_compatible_with = ["//bazel:py3"],
     tags = [
         "ci_unit",

--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -11,7 +11,6 @@ py_binary(
     name = "cmd_check_api_param_coverage",
     srcs = ["cmd_check_api_param_coverage.py"],
     deps = [
-        ci_require("click"),
         ":doc",
     ],
 )

--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -8,6 +8,15 @@ py_binary(
 )
 
 py_binary(
+    name = "cmd_check_api_param_coverage",
+    srcs = ["cmd_check_api_param_coverage.py"],
+    deps = [
+        ci_require("click"),
+        ":doc",
+    ],
+)
+
+py_binary(
     name = "cmd_build",
     srcs = ["cmd_build.py"],
     exec_compatible_with = ["//bazel:py3"],
@@ -110,6 +119,21 @@ py_test(
     deps = [
         ":doc",
         ci_require("click"),
+        ci_require("pytest"),
+    ],
+)
+
+py_test(
+    name = "test_api_param_coverage",
+    size = "small",
+    srcs = ["test_api_param_coverage.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":doc",
         ci_require("pytest"),
     ],
 )

--- a/ci/ray_ci/doc/api_param_coverage.py
+++ b/ci/ray_ci/doc/api_param_coverage.py
@@ -142,9 +142,15 @@ def signature_params(func: _FuncNode) -> List[str]:
 
 
 def _base_names(classdef: ast.ClassDef) -> List[str]:
-    """Simple names of a class's declared bases."""
+    """Simple names of a class's declared bases.
+
+    Unwraps subscripted bases so a generic parent (``class C(Base[T])``) still
+    resolves for docstring inheritance.
+    """
     names = []
     for b in classdef.bases:
+        if isinstance(b, ast.Subscript):
+            b = b.value
         if isinstance(b, ast.Name):
             names.append(b.id)
         elif isinstance(b, ast.Attribute):

--- a/ci/ray_ci/doc/api_param_coverage.py
+++ b/ci/ray_ci/doc/api_param_coverage.py
@@ -1,0 +1,335 @@
+"""
+Static, diff-scoped parameter-coverage check for Ray's public API surface.
+
+Fails when a pull request adds a new ``@PublicAPI`` callable, or a new
+parameter to an existing one, without a matching entry in the docstring
+``Args:`` block. The intent is "no new debt": pre-existing undocumented
+parameters are grandfathered, and only newly-undocumented parameters on the
+changed public surface are reported.
+
+This is the ``@PublicAPI``-aware, diff-scoped custom check (no baseline file)
+that sits alongside ``cmd_check_api_discrepancy.py`` in the same doc-guard
+family. Unlike that check, it works entirely from source via ``ast`` and needs
+no Ray build or import environment: it parses the base-branch and working-tree
+versions of the changed files and diffs their undocumented-parameter sets.
+
+Only *presence* is checked. A parameter counts as documented if its name
+appears in an ``Args:`` / ``Arguments:`` block (or, for ``__init__``, in the
+class docstring, matching Ray's default ``autoclass_content="class"``); the
+description prose is not inspected. Empty-description detection is out of scope
+(it needs ``numpydoc.validate`` or a custom rule).
+
+The parsing and docstring-inheritance logic mirrors the standing-gap audit in
+anyscale/docs (``strategy/doc-infra-backlog/scripts/typeless-param-audit.py``);
+this is its forward-looking, diff-scoped counterpart.
+"""
+import ast
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+# Google-style "Args:"/"Arguments:" section headers.
+_GOOGLE_SECTION = re.compile(
+    r"^\s*(Args|Arguments|Keyword Args|Keyword Arguments)\s*:\s*$", re.M
+)
+# A documented param line: "    name (type): ..." or "    name: ...".
+_GOOGLE_PARAM = re.compile(r"^\s+([*]{0,2}[A-Za-z_]\w*)\s*(\(|:)")
+# Section headers that end an Args block.
+_NEXT_SECTION = re.compile(
+    r"^\s*(Returns|Return|Yields|Raises|Examples?|Example|Note|Notes|Warning|"
+    r"Warnings|See Also|References|Attributes|Todo)\s*:\s*$",
+    re.M,
+)
+
+
+def documented_params(docstring: Optional[str]) -> Set[str]:
+    """Return the set of parameter names documented in a docstring's Args section(s)."""
+    if not docstring:
+        return set()
+    documented = set()
+    in_args = False
+    args_indent = None
+    for line in docstring.splitlines():
+        if _GOOGLE_SECTION.match(line):
+            in_args = True
+            args_indent = None
+            continue
+        if in_args:
+            if line.strip() == "":
+                continue
+            if _NEXT_SECTION.match(line):
+                in_args = False
+                continue
+            indent = len(line) - len(line.lstrip())
+            if args_indent is None:
+                args_indent = indent
+            m = _GOOGLE_PARAM.match(line)
+            if m and indent <= args_indent + 1:
+                documented.add(m.group(1).lstrip("*"))
+    return documented
+
+
+def has_publicapi_decorator(node: ast.AST) -> bool:
+    """Whether a class/function node carries an ``@PublicAPI`` decorator.
+
+    Matches bare ``@PublicAPI`` and called ``@PublicAPI(...)`` forms, and both
+    ``PublicAPI`` (imported name) and ``annotations.PublicAPI`` (attribute)
+    spellings. Only ``@PublicAPI`` counts; ``@DeveloperAPI`` and ``@Deprecated``
+    are not part of the rendered public API surface.
+    """
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        name = None
+        if isinstance(target, ast.Name):
+            name = target.id
+        elif isinstance(target, ast.Attribute):
+            name = target.attr
+        if name == "PublicAPI":
+            return True
+    return False
+
+
+def signature_params(func: ast.AST) -> List[str]:
+    """Return every named signature parameter, in order.
+
+    Excludes ``self``/``cls`` and the ``*args``/``**kwargs`` catch-alls (which
+    are not conventionally documented per-name). All remaining positional,
+    positional-only, and keyword-only parameters are included regardless of
+    whether they carry a type annotation, per the confirmed all-params scope.
+    """
+    a = func.args
+    posonly = getattr(a, "posonlyargs", [])
+    return [
+        arg.arg
+        for arg in (posonly + a.args + a.kwonlyargs)
+        if arg.arg not in ("self", "cls")
+    ]
+
+
+def _base_names(classdef: ast.ClassDef) -> List[str]:
+    """Simple names of a class's declared bases."""
+    names = []
+    for b in classdef.bases:
+        if isinstance(b, ast.Name):
+            names.append(b.id)
+        elif isinstance(b, ast.Attribute):
+            names.append(b.attr)
+    return names
+
+
+@dataclass
+class ClassIndex:
+    """Docstring-inheritance index, keyed by simple class name.
+
+    Sphinx's default ``autodoc_inherit_docstrings=True`` means a method with no
+    own docstring inherits its base's docstring, and ``__init__`` params are
+    documented on the class docstring under ``autoclass_content="class"``. This
+    index lets the check subtract out params that are documented on a base, so
+    an override with no own docstring is not flagged when a base documents the
+    parameter. Best-effort: base classes are resolved by simple name, so
+    external, aliased, or dynamically-built bases are not seen.
+    """
+
+    bases: Dict[str, List[str]] = field(default_factory=lambda: defaultdict(list))
+    # class -> {method -> documented-param set}, only for methods with an OWN
+    # docstring (key present == has own doc, which stops getdoc's MRO walk).
+    method_own: Dict[str, Dict[str, Set[str]]] = field(
+        default_factory=lambda: defaultdict(dict)
+    )
+    class_doc: Dict[str, Set[str]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+
+    def inherited_method_params(
+        self, class_name: str, method_name: str, _seen=None
+    ) -> Set[str]:
+        """Params an override with no own docstring recovers from a base method."""
+        if _seen is None:
+            _seen = set()
+        for base in self.bases.get(class_name, []):
+            if base in _seen:
+                continue
+            _seen.add(base)
+            if method_name in self.method_own.get(base, {}):
+                return set(self.method_own[base][method_name])
+            got = self.inherited_method_params(base, method_name, _seen)
+            if got:
+                return got
+        return set()
+
+    def inherited_class_params(self, class_name: str, _seen=None) -> Set[str]:
+        """Params a class with no own docstring recovers from a base class docstring."""
+        if _seen is None:
+            _seen = set()
+        for base in self.bases.get(class_name, []):
+            if base in _seen:
+                continue
+            _seen.add(base)
+            if base in self.class_doc:
+                return set(self.class_doc[base])
+            got = self.inherited_class_params(base, _seen)
+            if got:
+                return got
+        return set()
+
+
+def build_class_index(files: Iterable[Tuple[str, str]]) -> ClassIndex:
+    """Build a :class:`ClassIndex` from ``(path, source)`` pairs.
+
+    Walks every class in every file (public or not) so docstring inheritance
+    can be resolved. Same simple-name collisions across modules are merged
+    (union of documented params, concatenated bases). Files that fail to parse
+    are skipped.
+    """
+    index = ClassIndex()
+    for _path, source in files:
+        try:
+            tree = ast.parse(source)
+        except (SyntaxError, ValueError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            cn = node.name
+            for b in _base_names(node):
+                if b not in index.bases[cn]:
+                    index.bases[cn].append(b)
+            cdoc = ast.get_docstring(node)
+            if cdoc:
+                index.class_doc[cn] |= documented_params(cdoc)
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    mdoc = ast.get_docstring(sub)
+                    if mdoc is not None:  # own docstring -> stops MRO walk
+                        index.method_own[cn].setdefault(sub.name, set())
+                        index.method_own[cn][sub.name] |= documented_params(mdoc)
+    return index
+
+
+@dataclass
+class Callable_:
+    """A public callable's coverage state at one tree revision."""
+
+    qualname: str
+    lineno: int
+    signature: List[str]
+    undocumented: Set[str]
+
+
+def _undocumented_for_func(
+    func: ast.AST,
+    qual: str,
+    index: ClassIndex,
+    class_doc_node: Optional[ast.ClassDef],
+) -> Optional[Callable_]:
+    """Coverage state for one function/method, or None if it is not in scope.
+
+    Out of scope: private names other than ``__init__``, and callables with no
+    signature parameters (nothing to document).
+    """
+    if func.name.startswith("_") and func.name != "__init__":
+        return None
+    sig = signature_params(func)
+    if not sig:
+        return None
+
+    own_doc = ast.get_docstring(func)
+    documented = documented_params(own_doc)
+    if func.name == "__init__" and class_doc_node is not None:
+        documented |= documented_params(ast.get_docstring(class_doc_node))
+
+    # Docstring-inheritance recovery for methods of a class.
+    if "." in qual:
+        class_name = qual.split(".", 1)[0]
+        if own_doc is None:
+            documented |= index.inherited_method_params(class_name, func.name)
+        if func.name == "__init__" and (
+            class_doc_node is None or ast.get_docstring(class_doc_node) is None
+        ):
+            documented |= index.inherited_class_params(class_name)
+
+    undocumented = {p for p in sig if p not in documented}
+    return Callable_(
+        qualname=qual, lineno=func.lineno, signature=sig, undocumented=undocumented
+    )
+
+
+def public_callables(source: str, index: ClassIndex) -> Dict[str, Callable_]:
+    """Map ``qualname -> Callable_`` for the public callables defined in ``source``.
+
+    Public callables are module-level functions decorated ``@PublicAPI`` and the
+    methods of ``@PublicAPI`` classes. ``qualname`` is ``func`` for a
+    module-level function and ``Class.method`` for a method, which is a stable
+    key across revisions of the same file.
+    """
+    out: Dict[str, Callable_] = {}
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return out
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if has_publicapi_decorator(node):
+                c = _undocumented_for_func(node, node.name, index, None)
+                if c is not None:
+                    out[c.qualname] = c
+        elif isinstance(node, ast.ClassDef) and has_publicapi_decorator(node):
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    c = _undocumented_for_func(
+                        sub, f"{node.name}.{sub.name}", index, node
+                    )
+                    if c is not None:
+                        out[c.qualname] = c
+    return out
+
+
+@dataclass
+class Violation:
+    """A newly-undocumented parameter set on one public callable."""
+
+    path: str
+    qualname: str
+    lineno: int
+    params: List[str]  # newly-undocumented, sorted
+
+
+def new_violations_for_file(
+    path: str,
+    base_source: Optional[str],
+    head_source: str,
+    base_index: ClassIndex,
+    head_index: ClassIndex,
+) -> List[Violation]:
+    """Newly-undocumented params in one file, comparing base to head.
+
+    A parameter is a *new* violation when it is undocumented at head and was not
+    already undocumented at base for the same callable. This grandfathers
+    pre-existing gaps and fires only on new public callables, newly-added
+    params, and doc entries removed from an existing param. ``base_source`` is
+    ``None`` when the file did not exist at the base revision (every head gap is
+    then new).
+    """
+    head = public_callables(head_source, head_index)
+    base = (
+        public_callables(base_source, base_index) if base_source is not None else {}
+    )
+
+    violations: List[Violation] = []
+    for qual, head_c in head.items():
+        base_c = base.get(qual)
+        already = base_c.undocumented if base_c is not None else set()
+        new_params = sorted(head_c.undocumented - already)
+        if new_params:
+            violations.append(
+                Violation(
+                    path=path,
+                    qualname=qual,
+                    lineno=head_c.lineno,
+                    params=new_params,
+                )
+            )
+    violations.sort(key=lambda v: (v.path, v.lineno, v.qualname))
+    return violations

--- a/ci/ray_ci/doc/api_param_coverage.py
+++ b/ci/ray_ci/doc/api_param_coverage.py
@@ -27,7 +27,9 @@ import ast
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
+
+_FuncNode = Union[ast.FunctionDef, ast.AsyncFunctionDef]
 
 # Google-style "Args:"/"Arguments:" section headers.
 _GOOGLE_SECTION = re.compile(
@@ -64,13 +66,20 @@ def documented_params(docstring: Optional[str]) -> Set[str]:
             indent = len(line) - len(line.lstrip())
             if args_indent is None:
                 args_indent = indent
+            elif indent < args_indent:
+                # Dedent below the first param's indent ends the Args block,
+                # even without an explicit next-section header.
+                in_args = False
+                continue
             m = _GOOGLE_PARAM.match(line)
             if m and indent <= args_indent + 1:
                 documented.add(m.group(1).lstrip("*"))
     return documented
 
 
-def has_publicapi_decorator(node: ast.AST) -> bool:
+def has_publicapi_decorator(
+    node: Union[ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef]
+) -> bool:
     """Whether a class/function node carries an ``@PublicAPI`` decorator.
 
     Matches bare ``@PublicAPI`` and called ``@PublicAPI(...)`` forms, and both
@@ -90,7 +99,7 @@ def has_publicapi_decorator(node: ast.AST) -> bool:
     return False
 
 
-def signature_params(func: ast.AST) -> List[str]:
+def signature_params(func: _FuncNode) -> List[str]:
     """Return every named signature parameter, in order.
 
     Excludes ``self``/``cls`` and the ``*args``/``**kwargs`` catch-alls (which
@@ -218,7 +227,7 @@ class Callable_:
 
 
 def _undocumented_for_func(
-    func: ast.AST,
+    func: _FuncNode,
     qual: str,
     index: ClassIndex,
     class_doc_node: Optional[ast.ClassDef],

--- a/ci/ray_ci/doc/api_param_coverage.py
+++ b/ci/ray_ci/doc/api_param_coverage.py
@@ -99,6 +99,31 @@ def has_publicapi_decorator(
     return False
 
 
+# Annotations that take a callable back out of the rendered public surface even
+# when it sits on an ``@PublicAPI`` class.
+_NON_PUBLIC_ANNOTATIONS = frozenset({"DeveloperAPI", "Deprecated"})
+
+
+def has_non_public_annotation(node: _FuncNode) -> bool:
+    """Whether a method carries its own non-public API annotation.
+
+    A method of an ``@PublicAPI`` class inherits public scope from the class, but
+    an explicit ``@DeveloperAPI`` or ``@Deprecated`` on the method overrides that:
+    the callable is not part of the rendered public API surface, so its
+    parameters are out of scope for this check.
+    """
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        name = None
+        if isinstance(target, ast.Name):
+            name = target.id
+        elif isinstance(target, ast.Attribute):
+            name = target.attr
+        if name in _NON_PUBLIC_ANNOTATIONS:
+            return True
+    return False
+
+
 def signature_params(func: _FuncNode) -> List[str]:
     """Return every named signature parameter, in order.
 
@@ -266,8 +291,9 @@ def public_callables(source: str, index: ClassIndex) -> Dict[str, Callable_]:
     """Map ``qualname -> Callable_`` for the public callables defined in ``source``.
 
     Public callables are module-level functions decorated ``@PublicAPI`` and the
-    methods of ``@PublicAPI`` classes. ``qualname`` is ``func`` for a
-    module-level function and ``Class.method`` for a method, which is a stable
+    methods of ``@PublicAPI`` classes, excluding methods that carry their own
+    ``@DeveloperAPI`` or ``@Deprecated`` annotation. ``qualname`` is ``func`` for
+    a module-level function and ``Class.method`` for a method, which is a stable
     key across revisions of the same file.
     """
     out: Dict[str, Callable_] = {}
@@ -285,6 +311,13 @@ def public_callables(source: str, index: ClassIndex) -> Dict[str, Callable_]:
         elif isinstance(node, ast.ClassDef) and has_publicapi_decorator(node):
             for sub in node.body:
                 if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    # A method inherits public scope from its class, but its own
+                    # @DeveloperAPI/@Deprecated takes it back out. An explicit
+                    # @PublicAPI on the method wins over both.
+                    if has_non_public_annotation(sub) and not has_publicapi_decorator(
+                        sub
+                    ):
+                        continue
                     c = _undocumented_for_func(
                         sub, f"{node.name}.{sub.name}", index, node
                     )

--- a/ci/ray_ci/doc/api_param_coverage.py
+++ b/ci/ray_ci/doc/api_param_coverage.py
@@ -146,9 +146,7 @@ class ClassIndex:
     method_own: Dict[str, Dict[str, Set[str]]] = field(
         default_factory=lambda: defaultdict(dict)
     )
-    class_doc: Dict[str, Set[str]] = field(
-        default_factory=lambda: defaultdict(set)
-    )
+    class_doc: Dict[str, Set[str]] = field(default_factory=lambda: defaultdict(set))
 
     def inherited_method_params(
         self, class_name: str, method_name: str, _seen=None
@@ -322,9 +320,7 @@ def new_violations_for_file(
     then new).
     """
     head = public_callables(head_source, head_index)
-    base = (
-        public_callables(base_source, base_index) if base_source is not None else {}
-    )
+    base = public_callables(base_source, base_index) if base_source is not None else {}
 
     violations: List[Violation] = []
     for qual, head_c in head.items():

--- a/ci/ray_ci/doc/cmd_check_api_param_coverage.py
+++ b/ci/ray_ci/doc/cmd_check_api_param_coverage.py
@@ -1,9 +1,8 @@
+import argparse
 import os
 import subprocess
 import sys
 from typing import Dict, List, Optional, Tuple
-
-import click
 
 from ci.ray_ci.doc.api_param_coverage import (
     Violation,
@@ -151,30 +150,48 @@ def find_violations(checkout_dir: str, base_ref: str) -> Tuple[List[Violation], 
     return violations, base
 
 
-@click.command()
-@click.argument("ray_checkout_dir", required=True, type=str)
-@click.option(
-    "--base-ref",
-    default="origin/master",
-    show_default=True,
-    help="Git ref for the pull-request base branch.",
-)
-@click.option(
-    "--blocking/--no-blocking",
-    default=False,
-    show_default=True,
-    help=(
-        "Exit non-zero on violations. Starts non-blocking (warn only) so the "
-        "false-positive rate can be confirmed before the check becomes required."
-    ),
-)
-def main(ray_checkout_dir: str, base_ref: str, blocking: bool) -> None:
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse the command line.
+
+    Uses the standard library only: this check runs in the plain lint container,
+    which has no third-party dependencies installed.
     """
-    Fail a pull request that adds a new @PublicAPI callable, or a new parameter
-    on an existing one, without a docstring Args: entry. Pre-existing gaps are
-    grandfathered; only newly-undocumented params on the changed public surface
-    are reported. Static: parses source, no Ray build or import needed.
-    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail a pull request that adds a new @PublicAPI callable, or a new "
+            "parameter on an existing one, without a docstring Args: entry. "
+            "Pre-existing gaps are grandfathered; only newly-undocumented params "
+            "on the changed public surface are reported. Static: parses source, "
+            "no Ray build or import needed."
+        )
+    )
+    parser.add_argument(
+        "ray_checkout_dir",
+        help="Path to the Ray checkout to scan.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/master",
+        help="Git ref for the pull-request base branch. (default: origin/master)",
+    )
+    parser.add_argument(
+        "--blocking",
+        action="store_true",
+        help=(
+            "Exit non-zero on violations. Off by default (warn only) so the "
+            "false-positive rate can be confirmed before the check becomes "
+            "required."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = _parse_args(argv)
+    ray_checkout_dir = args.ray_checkout_dir
+    base_ref = args.base_ref
+    blocking = args.blocking
+
     try:
         violations, base = find_violations(ray_checkout_dir, base_ref)
     except RuntimeError as e:

--- a/ci/ray_ci/doc/cmd_check_api_param_coverage.py
+++ b/ci/ray_ci/doc/cmd_check_api_param_coverage.py
@@ -42,9 +42,12 @@ def _changed_python_files(checkout_dir: str, base: str) -> List[str]:
     Skips deleted files (no head content to check) and the non-API paths in
     ``_SKIP_SEGMENTS``.
     """
-    out = _git(
-        checkout_dir, "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"
-    )
+    try:
+        out = _git(
+            checkout_dir, "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"could not list changed files: {e}")
     files = []
     for line in out.splitlines():
         path = line.strip()
@@ -70,7 +73,11 @@ def _iter_source_files(checkout_dir: str):
     """Yield ``(repo_rel_path, source)`` for every in-scope working-tree file."""
     root = os.path.join(checkout_dir, _SOURCE_ROOT)
     for dirpath, _dirs, filenames in os.walk(root):
-        if any(seg in f"/{dirpath}" for seg in _SKIP_SEGMENTS):
+        # Match skip segments against the repo-relative path, not the absolute
+        # one: a checkout dir that itself contains a skip segment (e.g. a path
+        # under ".../test/...") would otherwise skip every file.
+        rel_dirpath = os.path.relpath(dirpath, checkout_dir)
+        if any(seg in f"/{rel_dirpath}" for seg in _SKIP_SEGMENTS):
             continue
         for fn in filenames:
             if not fn.endswith(".py"):

--- a/ci/ray_ci/doc/cmd_check_api_param_coverage.py
+++ b/ci/ray_ci/doc/cmd_check_api_param_coverage.py
@@ -1,0 +1,215 @@
+import os
+import subprocess
+import sys
+from typing import Dict, List, Optional, Tuple
+
+import click
+
+from ci.ray_ci.doc.api_param_coverage import (
+    Violation,
+    build_class_index,
+    new_violations_for_file,
+)
+
+# Only the Python API surface is in scope. Mirror the audit's skip list so
+# tests, examples, and vendored code never enter the index or the diff.
+_SOURCE_ROOT = "python/ray"
+_SKIP_SEGMENTS = (
+    "/tests",
+    "/test",
+    "/examples",
+    "/_private/thirdparty",
+    "/dashboard/client",
+)
+
+
+def _git(checkout_dir: str, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", "-C", checkout_dir, *args], text=True, stderr=subprocess.DEVNULL
+    )
+
+
+def _merge_base(checkout_dir: str, base_ref: str) -> Optional[str]:
+    try:
+        return _git(checkout_dir, "merge-base", base_ref, "HEAD").strip() or None
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _changed_python_files(checkout_dir: str, base: str) -> List[str]:
+    """Repo-root-relative ``python/ray`` source files changed since ``base``.
+
+    Skips deleted files (no head content to check) and the non-API paths in
+    ``_SKIP_SEGMENTS``.
+    """
+    out = _git(
+        checkout_dir, "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"
+    )
+    files = []
+    for line in out.splitlines():
+        path = line.strip()
+        if not path.endswith(".py"):
+            continue
+        if not path.startswith(f"{_SOURCE_ROOT}/"):
+            continue
+        if any(seg in f"/{path}" for seg in _SKIP_SEGMENTS):
+            continue
+        files.append(path)
+    return files
+
+
+def _base_content(checkout_dir: str, base: str, path: str) -> Optional[str]:
+    """File content at the base revision, or None if it did not exist there."""
+    try:
+        return _git(checkout_dir, "show", f"{base}:{path}")
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _iter_source_files(checkout_dir: str):
+    """Yield ``(repo_rel_path, source)`` for every in-scope working-tree file."""
+    root = os.path.join(checkout_dir, _SOURCE_ROOT)
+    for dirpath, _dirs, filenames in os.walk(root):
+        if any(seg in f"/{dirpath}" for seg in _SKIP_SEGMENTS):
+            continue
+        for fn in filenames:
+            if not fn.endswith(".py"):
+                continue
+            abspath = os.path.join(dirpath, fn)
+            rel = os.path.relpath(abspath, checkout_dir)
+            try:
+                with open(abspath, encoding="utf-8") as f:
+                    yield rel, f.read()
+            except (OSError, UnicodeDecodeError):
+                continue
+
+
+def find_violations(checkout_dir: str, base_ref: str) -> Tuple[List[Violation], str]:
+    """Run the diff-scoped coverage check. Returns ``(violations, base_sha)``.
+
+    Raises RuntimeError when the base revision cannot be resolved (fail-closed
+    responsibility is left to the caller so it can honor the warn/blocking
+    posture).
+    """
+    base = _merge_base(checkout_dir, base_ref)
+    if base is None:
+        raise RuntimeError(
+            f"could not determine merge-base between {base_ref} and HEAD"
+        )
+
+    changed = _changed_python_files(checkout_dir, base)
+    if not changed:
+        return [], base
+
+    # Base content of the changed files, fetched once and reused for both the
+    # base index and the per-file comparison.
+    base_sources: Dict[str, Optional[str]] = {
+        path: _base_content(checkout_dir, base, path) for path in changed
+    }
+
+    # Head index: the working tree. Base index: the working tree with the
+    # changed files reverted to their base content (added files dropped). Only
+    # the changed files differ between the two trees, so this reconstructs the
+    # base tree accurately without a second checkout.
+    head_files = list(_iter_source_files(checkout_dir))
+    changed_set = set(changed)
+    base_files = []
+    for rel, source in head_files:
+        if rel in changed_set:
+            base_src = base_sources[rel]
+            if base_src is not None:
+                base_files.append((rel, base_src))
+        else:
+            base_files.append((rel, source))
+
+    head_index = build_class_index(head_files)
+    base_index = build_class_index(base_files)
+
+    head_by_path = dict(head_files)
+    violations: List[Violation] = []
+    for path in changed:
+        head_source = head_by_path.get(path)
+        if head_source is None:
+            continue
+        violations.extend(
+            new_violations_for_file(
+                path,
+                base_sources[path],
+                head_source,
+                base_index,
+                head_index,
+            )
+        )
+    violations.sort(key=lambda v: (v.path, v.lineno, v.qualname))
+    return violations, base
+
+
+@click.command()
+@click.argument("ray_checkout_dir", required=True, type=str)
+@click.option(
+    "--base-ref",
+    default="origin/master",
+    show_default=True,
+    help="Git ref for the pull-request base branch.",
+)
+@click.option(
+    "--blocking/--no-blocking",
+    default=False,
+    show_default=True,
+    help=(
+        "Exit non-zero on violations. Starts non-blocking (warn only) so the "
+        "false-positive rate can be confirmed before the check becomes required."
+    ),
+)
+def main(ray_checkout_dir: str, base_ref: str, blocking: bool) -> None:
+    """
+    Fail a pull request that adds a new @PublicAPI callable, or a new parameter
+    on an existing one, without a docstring Args: entry. Pre-existing gaps are
+    grandfathered; only newly-undocumented params on the changed public surface
+    are reported. Static: parses source, no Ray build or import needed.
+    """
+    try:
+        violations, base = find_violations(ray_checkout_dir, base_ref)
+    except RuntimeError as e:
+        # Fail-closed only when blocking; in warn mode a missing base branch
+        # must not break the build.
+        print(f"--- API param coverage: {e}", file=sys.stderr)
+        sys.exit(1 if blocking else 0)
+
+    print(
+        f"--- Checking new-parameter documentation coverage against {base[:12]}...",
+        file=sys.stderr,
+    )
+
+    if not violations:
+        print("No newly-undocumented public-API parameters. ", file=sys.stderr)
+        return
+
+    print(
+        "Public APIs with newly-undocumented parameters "
+        "(add an Args: entry for each):",
+        file=sys.stderr,
+    )
+    for v in violations:
+        params = ", ".join(v.params)
+        print(f"\t{v.path}:{v.lineno}  {v.qualname}  ->  {params}", file=sys.stderr)
+
+    total = sum(len(v.params) for v in violations)
+    print(
+        f"\n{total} newly-undocumented parameter(s) across {len(violations)} "
+        "public callable(s). Document each parameter in the callable's docstring "
+        "Args: block (for __init__, the class docstring). Pre-existing gaps are "
+        "grandfathered; this gate fires only on new or changed public API.",
+        file=sys.stderr,
+    )
+
+    if blocking:
+        sys.exit(1)
+    print(
+        "\n(non-blocking: reporting only. This check does not fail the build yet.)",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/doc/cmd_check_api_param_coverage.py
+++ b/ci/ray_ci/doc/cmd_check_api_param_coverage.py
@@ -23,9 +23,16 @@ _SKIP_SEGMENTS = (
 
 
 def _git(checkout_dir: str, *args: str) -> str:
+    # Decode as UTF-8 explicitly rather than relying on the locale default, so
+    # non-ASCII paths in git output survive on any platform.
     return subprocess.check_output(
-        ["git", "-C", checkout_dir, *args], text=True, stderr=subprocess.DEVNULL
+        ["git", "-C", checkout_dir, *args], encoding="utf-8", stderr=subprocess.DEVNULL
     )
+
+
+def _repo_rel(path: str, checkout_dir: str) -> str:
+    """Checkout-relative path with forward slashes, matching git's output."""
+    return os.path.relpath(path, checkout_dir).replace(os.sep, "/")
 
 
 def _merge_base(checkout_dir: str, base_ref: str) -> Optional[str]:
@@ -35,28 +42,49 @@ def _merge_base(checkout_dir: str, base_ref: str) -> Optional[str]:
         return None
 
 
-def _changed_python_files(checkout_dir: str, base: str) -> List[str]:
-    """Repo-root-relative ``python/ray`` source files changed since ``base``.
+def _in_scope(path: str) -> bool:
+    """Whether a repo-relative path is a ``python/ray`` API source file."""
+    return (
+        path.endswith(".py")
+        and path.startswith(f"{_SOURCE_ROOT}/")
+        and not any(seg in f"/{path}" for seg in _SKIP_SEGMENTS)
+    )
+
+
+def _changed_python_files(checkout_dir: str, base: str) -> List[Tuple[str, str]]:
+    """``(head_path, base_path)`` for ``python/ray`` sources changed since ``base``.
 
     Skips deleted files (no head content to check) and the non-API paths in
-    ``_SKIP_SEGMENTS``.
+    ``_SKIP_SEGMENTS``. Rename detection is on (``-M``): for a renamed or copied
+    file the two paths differ, so the base content is read from the old path
+    rather than being treated as a new file. Without this a rename would report
+    every pre-existing gap in the file as new debt.
     """
     try:
         out = _git(
-            checkout_dir, "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"
+            checkout_dir,
+            "diff",
+            "--name-status",
+            "-M",
+            "--diff-filter=d",
+            f"{base}...HEAD",
         )
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"could not list changed files: {e}")
     files = []
     for line in out.splitlines():
-        path = line.strip()
-        if not path.endswith(".py"):
+        fields = line.rstrip("\n").split("\t")
+        if len(fields) < 2:
             continue
-        if not path.startswith(f"{_SOURCE_ROOT}/"):
+        status = fields[0]
+        # Rename/copy entries carry both paths: "R100\told\tnew".
+        if status[:1] in ("R", "C") and len(fields) >= 3:
+            base_path, head_path = fields[1], fields[2]
+        else:
+            base_path = head_path = fields[1]
+        if not _in_scope(head_path):
             continue
-        if any(seg in f"/{path}" for seg in _SKIP_SEGMENTS):
-            continue
-        files.append(path)
+        files.append((head_path, base_path))
     return files
 
 
@@ -75,14 +103,14 @@ def _iter_source_files(checkout_dir: str):
         # Match skip segments against the repo-relative path, not the absolute
         # one: a checkout dir that itself contains a skip segment (e.g. a path
         # under ".../test/...") would otherwise skip every file.
-        rel_dirpath = os.path.relpath(dirpath, checkout_dir)
+        rel_dirpath = _repo_rel(dirpath, checkout_dir)
         if any(seg in f"/{rel_dirpath}" for seg in _SKIP_SEGMENTS):
             continue
         for fn in filenames:
             if not fn.endswith(".py"):
                 continue
             abspath = os.path.join(dirpath, fn)
-            rel = os.path.relpath(abspath, checkout_dir)
+            rel = _repo_rel(abspath, checkout_dir)
             try:
                 with open(abspath, encoding="utf-8") as f:
                     yield rel, f.read()
@@ -108,9 +136,11 @@ def find_violations(checkout_dir: str, base_ref: str) -> Tuple[List[Violation], 
         return [], base
 
     # Base content of the changed files, fetched once and reused for both the
-    # base index and the per-file comparison.
+    # base index and the per-file comparison. Keyed by head path, but read from
+    # the base path so a renamed file still compares against its old content.
     base_sources: Dict[str, Optional[str]] = {
-        path: _base_content(checkout_dir, base, path) for path in changed
+        head_path: _base_content(checkout_dir, base, base_path)
+        for head_path, base_path in changed
     }
 
     # Head index: the working tree. Base index: the working tree with the
@@ -118,7 +148,7 @@ def find_violations(checkout_dir: str, base_ref: str) -> Tuple[List[Violation], 
     # the changed files differ between the two trees, so this reconstructs the
     # base tree accurately without a second checkout.
     head_files = list(_iter_source_files(checkout_dir))
-    changed_set = set(changed)
+    changed_set = {head_path for head_path, _ in changed}
     base_files = []
     for rel, source in head_files:
         if rel in changed_set:
@@ -133,7 +163,7 @@ def find_violations(checkout_dir: str, base_ref: str) -> Tuple[List[Violation], 
 
     head_by_path = dict(head_files)
     violations: List[Violation] = []
-    for path in changed:
+    for path, _base_path in changed:
         head_source = head_by_path.get(path)
         if head_source is None:
             continue

--- a/ci/ray_ci/doc/test_api_param_coverage.py
+++ b/ci/ray_ci/doc/test_api_param_coverage.py
@@ -41,7 +41,7 @@ def test_documented_params_reads_args_block():
 
         Args:
             a: the a.
-            b (int): the b.
+            b (int): the b.  # noqa: this typed arg is intentional test data
 
         Returns:
             nothing.

--- a/ci/ray_ci/doc/test_api_param_coverage.py
+++ b/ci/ray_ci/doc/test_api_param_coverage.py
@@ -305,6 +305,88 @@ def test_multiple_callables_sorted_by_location():
     assert violations[0].lineno < violations[1].lineno
 
 
+def test_developer_api_method_of_public_class_ignored():
+    # Regression: a method of an @PublicAPI class that carries its own
+    # @DeveloperAPI is not part of the rendered public surface. Ray's
+    # Dataset.map_batches_internal (#64963) is the real-world case.
+    head = _src(
+        '''
+        @PublicAPI
+        class C:
+            """Summary."""
+
+            @DeveloperAPI
+            def method_internal(self, alpha, beta):
+                """Internal helper."""
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_deprecated_method_of_public_class_ignored():
+    head = _src(
+        '''
+        @PublicAPI
+        class C:
+            """Summary."""
+
+            @Deprecated
+            def old_method(self, alpha):
+                """Old."""
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_developer_api_call_form_on_method_ignored():
+    head = _src(
+        '''
+        @PublicAPI
+        class C:
+            """Summary."""
+
+            @DeveloperAPI(stability="alpha")
+            def method_internal(self, alpha):
+                """Internal helper."""
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_explicit_public_api_on_method_wins_over_developer_api():
+    # An explicit @PublicAPI on the method keeps it in scope even alongside
+    # @DeveloperAPI, so the more specific public annotation is not lost.
+    head = _src(
+        '''
+        @PublicAPI
+        class C:
+            """Summary."""
+
+            @DeveloperAPI
+            @PublicAPI
+            def method(self, alpha):
+                """Does a thing."""
+        '''
+    )
+    violations = _check(base=None, head=head)
+    assert len(violations) == 1
+    assert violations[0].qualname == "C.method"
+    assert violations[0].params == ["alpha"]
+
+
+def test_developer_api_module_function_still_ignored():
+    # Module-level scope is decided by @PublicAPI presence, so a @DeveloperAPI
+    # function was already out of scope; guard against the filter regressing it.
+    head = _src(
+        '''
+        @DeveloperAPI
+        def helper(alpha):
+            """Helper."""
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
 def test_syntax_error_source_yields_no_callables():
     assert public_callables("def broken(:", ClassIndex()) == {}
 

--- a/ci/ray_ci/doc/test_api_param_coverage.py
+++ b/ci/ray_ci/doc/test_api_param_coverage.py
@@ -1,0 +1,297 @@
+import sys
+import textwrap
+from typing import List
+
+import pytest
+
+from ci.ray_ci.doc.api_param_coverage import (
+    ClassIndex,
+    Violation,
+    build_class_index,
+    documented_params,
+    new_violations_for_file,
+    public_callables,
+    signature_params,
+)
+
+
+def _src(text: str) -> str:
+    return textwrap.dedent(text)
+
+
+def _check(base: str, head: str, extra_files=()) -> List[Violation]:
+    """New violations for one changed file, given before/after source.
+
+    ``extra_files`` supplies additional ``(path, source)`` pairs that populate
+    the class index (for docstring-inheritance cases). ``base=None`` models a
+    file that did not exist at the base revision.
+    """
+    files = list(extra_files) + [("python/ray/mod.py", head)]
+    index = build_class_index(files)
+    return new_violations_for_file("python/ray/mod.py", base, head, index, index)
+
+
+# --- documented_params / signature_params units -------------------------------
+
+
+def test_documented_params_reads_args_block():
+    doc = _src(
+        """
+        Summary.
+
+        Args:
+            a: the a.
+            b (int): the b.
+
+        Returns:
+            nothing.
+        """
+    )
+    assert documented_params(doc) == {"a", "b"}
+
+
+def test_documented_params_empty_without_args():
+    assert documented_params("Just a summary.") == set()
+    assert documented_params(None) == set()
+
+
+def test_signature_params_excludes_self_and_varargs():
+    tree = _src(
+        """
+        def f(self, a, b=1, *args, c, **kwargs):
+            pass
+        """
+    )
+    import ast
+
+    func = ast.parse(tree).body[0]
+    assert signature_params(func) == ["a", "b", "c"]
+
+
+# --- new_violations_for_file: core diff semantics -----------------------------
+
+
+def test_new_public_function_undocumented_param_fails():
+    head = _src(
+        '''
+        @PublicAPI
+        def new_api(alpha, beta):
+            """Summary."""
+        '''
+    )
+    violations = _check(base=None, head=head)
+    assert len(violations) == 1
+    assert violations[0].qualname == "new_api"
+    assert violations[0].params == ["alpha", "beta"]
+
+
+def test_new_public_function_documented_param_passes():
+    head = _src(
+        '''
+        @PublicAPI
+        def new_api(alpha, beta):
+            """Summary.
+
+            Args:
+                alpha: the alpha.
+                beta: the beta.
+            """
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_new_param_on_existing_api_fails():
+    base = _src(
+        '''
+        @PublicAPI
+        def api(alpha):
+            """Summary.
+
+            Args:
+                alpha: the alpha.
+            """
+        '''
+    )
+    head = _src(
+        '''
+        @PublicAPI
+        def api(alpha, beta):
+            """Summary.
+
+            Args:
+                alpha: the alpha.
+            """
+        '''
+    )
+    violations = _check(base=base, head=head)
+    assert len(violations) == 1
+    assert violations[0].params == ["beta"]
+
+
+def test_preexisting_gap_is_grandfathered():
+    # alpha was already undocumented at base; it must not fire.
+    base = _src(
+        '''
+        @PublicAPI
+        def api(alpha):
+            """Summary."""
+        '''
+    )
+    head = _src(
+        '''
+        @PublicAPI
+        def api(alpha):
+            """Summary, now with a body change but still no Args."""
+        '''
+    )
+    assert _check(base=base, head=head) == []
+
+
+def test_removing_doc_entry_for_existing_param_fails():
+    base = _src(
+        '''
+        @PublicAPI
+        def api(alpha):
+            """Summary.
+
+            Args:
+                alpha: the alpha.
+            """
+        '''
+    )
+    head = _src(
+        '''
+        @PublicAPI
+        def api(alpha):
+            """Summary."""
+        '''
+    )
+    violations = _check(base=base, head=head)
+    assert len(violations) == 1
+    assert violations[0].params == ["alpha"]
+
+
+def test_non_public_function_ignored():
+    head = _src(
+        '''
+        def not_public(alpha):
+            """Summary."""
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_private_function_ignored_even_if_public_api():
+    head = _src(
+        '''
+        @PublicAPI
+        def _private(alpha):
+            """Summary."""
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_publicapi_call_form_is_detected():
+    head = _src(
+        '''
+        @PublicAPI(stability="beta")
+        def api(alpha):
+            """Summary."""
+        '''
+    )
+    violations = _check(base=None, head=head)
+    assert len(violations) == 1
+    assert violations[0].params == ["alpha"]
+
+
+# --- class / __init__ / inheritance -------------------------------------------
+
+
+def test_init_documented_on_class_docstring_passes():
+    head = _src(
+        '''
+        @PublicAPI
+        class C:
+            """Summary.
+
+            Args:
+                alpha: the alpha.
+            """
+
+            def __init__(self, alpha):
+                pass
+        '''
+    )
+    assert _check(base=None, head=head) == []
+
+
+def test_method_of_public_class_undocumented_fails():
+    head = _src(
+        '''
+        @PublicAPI
+        class C:
+            """Summary."""
+
+            def method(self, alpha):
+                """Does a thing."""
+        '''
+    )
+    violations = _check(base=None, head=head)
+    assert len(violations) == 1
+    assert violations[0].qualname == "C.method"
+    assert violations[0].params == ["alpha"]
+
+
+def test_inherited_method_docstring_recovers_param():
+    # Override has no own docstring; the base class documents `alpha`, so
+    # Sphinx re-injects it and the check must not flag it.
+    base_class_file = (
+        "python/ray/base_mod.py",
+        _src(
+            '''
+            class Base:
+                def method(self, alpha):
+                    """Base.
+
+                    Args:
+                        alpha: the alpha.
+                    """
+            '''
+        ),
+    )
+    head = _src(
+        """
+        @PublicAPI
+        class Child(Base):
+            def method(self, alpha):
+                pass
+        """
+    )
+    assert _check(base=None, head=head, extra_files=[base_class_file]) == []
+
+
+def test_multiple_callables_sorted_by_location():
+    head = _src(
+        '''
+        @PublicAPI
+        def a_api(x):
+            """S."""
+
+        @PublicAPI
+        def b_api(y):
+            """S."""
+        '''
+    )
+    violations = _check(base=None, head=head)
+    assert [v.qualname for v in violations] == ["a_api", "b_api"]
+    assert violations[0].lineno < violations[1].lineno
+
+
+def test_syntax_error_source_yields_no_callables():
+    assert public_callables("def broken(:", ClassIndex()) == {}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/ci/ray_ci/doc/test_api_param_coverage.py
+++ b/ci/ray_ci/doc/test_api_param_coverage.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pytest
 
+from ci.ray_ci.doc import cmd_check_api_param_coverage as cmd
 from ci.ray_ci.doc.api_param_coverage import (
     ClassIndex,
     Violation,
@@ -385,6 +386,101 @@ def test_developer_api_module_function_still_ignored():
         '''
     )
     assert _check(base=None, head=head) == []
+
+
+def test_inherited_docstring_through_subscripted_base():
+    # A generic base (`class Impl(Base[T])`) must still resolve for docstring
+    # inheritance; otherwise the override is flagged for a documented param.
+    base_class_file = (
+        "python/ray/base_mod.py",
+        _src(
+            '''
+            class Base:
+                """Base.
+
+                Args:
+                    alpha: The alpha param.
+                """
+
+                def method(self, alpha):
+                    """Base method.
+
+                    Args:
+                        alpha: The alpha param.
+                    """
+            '''
+        ),
+    )
+    head = _src(
+        '''
+        @PublicAPI
+        class Impl(Base[T]):
+            """Impl."""
+
+            def method(self, alpha):
+                pass
+        '''
+    )
+    violations = _check(base=None, head=head, extra_files=[base_class_file])
+    assert violations == []
+
+
+# --- changed-file listing (rename detection) ----------------------------------
+
+
+def _fake_git(monkeypatch, output: str) -> None:
+    monkeypatch.setattr(cmd, "_git", lambda *a, **k: output)
+
+
+def test_changed_files_maps_rename_to_old_path(monkeypatch):
+    # A rename must compare against the old path's content. Treating it as a new
+    # file would report every pre-existing gap in it as new debt.
+    _fake_git(
+        monkeypatch,
+        "R100\tpython/ray/old_mod.py\tpython/ray/new_mod.py\n"
+        "M\tpython/ray/other.py\n",
+    )
+    assert cmd._changed_python_files("/repo", "base") == [
+        ("python/ray/new_mod.py", "python/ray/old_mod.py"),
+        ("python/ray/other.py", "python/ray/other.py"),
+    ]
+
+
+def test_changed_files_maps_copy_to_source_path(monkeypatch):
+    _fake_git(monkeypatch, "C75\tpython/ray/src.py\tpython/ray/copy.py\n")
+    assert cmd._changed_python_files("/repo", "base") == [
+        ("python/ray/copy.py", "python/ray/src.py")
+    ]
+
+
+def test_changed_files_added_and_modified_use_same_path(monkeypatch):
+    _fake_git(monkeypatch, "A\tpython/ray/added.py\nM\tpython/ray/mod.py\n")
+    assert cmd._changed_python_files("/repo", "base") == [
+        ("python/ray/added.py", "python/ray/added.py"),
+        ("python/ray/mod.py", "python/ray/mod.py"),
+    ]
+
+
+def test_changed_files_filters_out_of_scope_paths(monkeypatch):
+    _fake_git(
+        monkeypatch,
+        "M\tpython/ray/tests/test_thing.py\n"
+        "M\tpython/ray/mod.txt\n"
+        "M\tdoc/source/index.md\n"
+        "M\tpython/ray/keep.py\n",
+    )
+    assert cmd._changed_python_files("/repo", "base") == [
+        ("python/ray/keep.py", "python/ray/keep.py")
+    ]
+
+
+def test_changed_files_rename_out_of_scope_destination_skipped(monkeypatch):
+    # Scope is decided by the head path: a file renamed into tests/ drops out.
+    _fake_git(
+        monkeypatch,
+        "R100\tpython/ray/mod.py\tpython/ray/tests/test_mod.py\n",
+    )
+    assert cmd._changed_python_files("/repo", "base") == []
 
 
 def test_syntax_error_source_yields_no_callables():

--- a/ci/ray_ci/doc/test_api_param_coverage.py
+++ b/ci/ray_ci/doc/test_api_param_coverage.py
@@ -55,6 +55,22 @@ def test_documented_params_empty_without_args():
     assert documented_params(None) == set()
 
 
+def test_documented_params_stops_on_dedent():
+    # A dedented line below the first param's indent ends the Args block, so a
+    # "name:"-looking line in trailing prose is not counted as a param.
+    doc = _src(
+        """
+        Summary.
+
+        Args:
+            a: the a.
+
+          note: this trailing line is dedented and must not count.
+        """
+    )
+    assert documented_params(doc) == {"a"}
+
+
 def test_signature_params_excludes_self_and_varargs():
     tree = _src(
         """


### PR DESCRIPTION
## Why

Ray's public API reference accretes undocumented parameters over time: a new
`@PublicAPI` callable, or a new parameter on an existing one, can ship without a
docstring `Args:` entry, and nothing fails. This adds a **static, diff-scoped**
check that blocks *new* debt on the `@PublicAPI` surface while grandfathering the
standing backlog.

### What pydoclint already covers, and the gap it leaves

pydoclint (pinned at `0.8.3` in `.pre-commit-config.yaml`) already runs its
argument-completeness checks `DOC101`/`DOC103` repo-wide across `python/ray`,
against an **empty** `ci/lint/pydoclint-baseline.txt`. So that class of violation
is already fully enforced with zero grandfathering, and the tree is essentially
clean: a repo-wide run under the exact pre-commit config flags exactly **one**
callable, `_find_imported_submodules` in vendored
`python/ray/cloudpickle/cloudpickle.py`, which is private. The per-module
cleanups (#63500, #63509,
#63518, #63541, #63571, #63632, #63633, #63634, #63639) are what got it there.

The gap is `--skip-checking-short-docstrings`, which defaults to `True` and is not
overridden. It makes pydoclint skip any callable whose docstring is absent or is a
bare one-line summary with no sections. Those callables can gain parameters
indefinitely without any check firing.

Flipping that one flag is not a viable fix. Repo-wide with
`--skip-checking-short-docstrings=False`, `DOC101`/`DOC103` fire on **8,285**
callables across `python/ray` (public and private alike; 16,570 violations, since
each callable trips both codes) -- precisely the "baseline the size of the
codebase" that the config comment on master already says the team doesn't want,
and it has no `@PublicAPI` awareness to narrow it.

Measured on the `@PublicAPI` surface, the same unit for comparison: of 815 public
callables that take parameters, **230** have at least one undocumented parameter,
totalling **505** undocumented parameters. So the public surface is roughly 3% of
what a repo-wide flag flip would drag in.

**All 230 of them sit in pydoclint's blind spot** -- zero overlap with what
`DOC101`/`DOC103` catch today. That falls out of the numbers above without relying
on any modelling of pydoclint's "short docstring" rule: if any `@PublicAPI`
callable had a section-bearing docstring missing a param, pydoclint would already
report `DOC101` on it, and the only such callable in the tree is a private
cloudpickle function. The two checks partition the problem rather than duplicating
it.

This check therefore scopes exactly to the `@PublicAPI` surface with **no baseline
file**: it parses the base-branch and working-tree versions of the changed files
and diffs their undocumented-parameter sets, so it needs **no Ray build or import
environment**.

## What it does

- Enumerates the `@PublicAPI` callables changed by the PR (module-level
  `@PublicAPI` functions and methods of `@PublicAPI` classes). A method that
  carries its own `@DeveloperAPI` or `@Deprecated` is out of scope even on a
  public class, since it isn't part of the rendered surface; an explicit
  `@PublicAPI` on the method wins over both.
- For each, computes the signature parameters missing from the docstring
  `Args:`/`Arguments:` block (for `__init__`, also the class docstring, matching
  the default `autoclass_content="class"`), resolving docstring inheritance so an
  override with no own docstring isn't flagged when a base documents the param.
- Fails only on parameters that are **newly** undocumented versus the base
  branch. Pre-existing gaps are grandfathered; the gate fires on new public
  callables, newly-added params, and doc entries removed from an existing param.

**Scope and limits (intentional):** all signature params, not only annotated
ones. Presence only -- a param counts as documented if its name appears in
`Args:`; description prose is not inspected (empty-description detection would
need `numpydoc.validate` and is out of scope). Static source analysis, so it does
not confirm what the reference actually renders.

## Where it lives / rollout

Sits in the `ci/ray_ci/doc` guard family next to `cmd_check_api_discrepancy.py`,
and runs in the **lint group** (static, no docbuild). It starts as a
`soft_fail: true` step -- **visible but non-blocking** -- so the measured
false-positive rate above can be confirmed against live traffic before the check
gates anything. Flipping it to a required check is a one-line removal of
`soft_fail`.

One caveat for reviewers on the warn phase: the pipeline passes `--blocking` and
relies on `soft_fail` to absorb the exit code, so an environment failure (an
unfetched base branch, a shallow clone deeper than `--depth=500`) surfaces the
same way a finding does. Happy to drop `--blocking` from the pipeline command
instead, so the script's own warn mode carries the phase and infrastructure
errors stay distinguishable from real findings.

Because the check is AST-based, it matches only *directly* applied `@PublicAPI`
decorators, which lines up with the direct-annotation policy established in
#65196 and #65208.

## Testing

- `python -m pytest ci/ray_ci/doc/test_api_param_coverage.py` -- **28 passed**.
  Covers new API, new param, grandfathered gap, removed doc entry, non-public /
  private skips, `@PublicAPI(...)` call form, `__init__`-on-class-docstring,
  `Args:` block termination on dedent, docstring-inheritance recovery, and the
  `@DeveloperAPI`/`@Deprecated`-method scoping rule.
- End-to-end on the pydoclint blind spot, which is the case this check exists
  for: adding an undocumented `strict` param to `RayError.from_bytes` (a
  `@PublicAPI` method with no docstring) fired on exactly `strict`, while
  pydoclint under the pre-commit config reported no violations on the same file.
  `--blocking` exits 1; documenting the param cleared it.
- End-to-end on a case pydoclint *does* cover, to confirm agreement rather than
  contradiction: adding an undocumented `seed` param to `tune.loguniform` fired
  on exactly `seed` and correctly grandfathered the pre-existing gaps in the same
  file. pydoclint independently blocks this one at pre-commit.
- `shellcheck ci/lint/lint.sh` clean; `.buildkite/lint.rayci.yml` parses.
- Renaming `python/ray/exceptions.py` with no content change reported 22
  violations across 11 callables before rename detection was added, and reports
  none after. A rename that also adds an undocumented param still fires on
  exactly that param.

### False-positive rate, measured against real history

Replayed the check over the **200** most recent merged commits touching
`python/ray/**/*.py`, each evaluated against its own parent. **Two** fired (1%):

- #64963 flagged `Dataset.map_batches_internal` with 15 parameters. A genuine
  false positive: the method is `@DeveloperAPI`, but the check was pulling in
  every non-underscore method of an `@PublicAPI` class regardless of the method's
  own annotation. Fixed in this PR, with regression tests; the commit is clean on
  the replay now.
- #64519 flagged `mode`, a newly added and undocumented parameter on
  `Catalog.resolve` (`@PublicAPI(stability="alpha")`, one-line docstring). A true
  positive, and squarely the blind-spot class this check exists for. It correctly
  grandfathered the pre-existing `table` and `reader` gaps on the same callable.

Post-fix that is **one firing across 200 commits, and it is a real finding**.

### False-negative probe

Coverage was probed independently of the replay: for every `@PublicAPI` callable
on the surface, inject a new undocumented keyword parameter and assert the check
reports it. **815 callables probed, 0 misses** -- 585 that are currently fully
documented, plus the 230 that already carry gaps, which verifies that
grandfathering an existing gap doesn't mask a newly added parameter. Broken out
by shape: 176 module-level functions, 470 methods, 157 `__init__`, and 12 async
methods, with no misses in any group.

## Alternatives considered

- **Flip `--skip-checking-short-docstrings=False` repo-wide.** 8,285 callables, no
  `@PublicAPI` scoping. Rejected above.
- **A second pydoclint invocation with that flag plus its own baseline.**
  pre-commit is already diff-scoped, so this is closer than it looks, but it
  requires committing a baseline on the order of 8,000 entries and still gates all
  of `python/ray` rather than the rendered public surface.

## Relationship to other open work

No open PR builds a parameter-coverage gate. #64779 changes how type hints render
into the Parameters list, which is a separate deliverable and does not gate new
undocumented params.

## AI assistance

This change was developed with AI assistance. The submitter has reviewed every
changed line and run the tests above locally.
