### PR TITLE
[core] Removing unused constants from constants.h

### DIFF
--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -35,12 +35,6 @@ constexpr int kObjectIdIndexSize = 32;
 static_assert(kObjectIdIndexSize % CHAR_BIT == 0,
               "ObjectID prefix not a multiple of bytes");
 
-/// Raylet exit code on plasma store socket error.
-constexpr int kRayletStoreErrorExitCode = 100;
-
-/// Prefix for the object table keys in redis.
-constexpr char kObjectTablePrefix[] = "ObjectTable";
-
 constexpr char kClusterIdKey[] = "ray_cluster_id";
 constexpr char kAuthTokenKey[] = "authorization";
 constexpr char kBearerPrefix[] = "Bearer ";
@@ -49,10 +43,6 @@ constexpr char kWorkerDynamicOptionPlaceholder[] =
     "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER";
 
 constexpr char kNodeManagerPortPlaceholder[] = "RAY_NODE_MANAGER_PORT_PLACEHOLDER";
-
-/// Public DNS address which is is used to connect and get local IP.
-constexpr char kPublicDNSServerIp[] = "8.8.8.8";
-constexpr int kPublicDNSServerPort = 53;
 
 constexpr char kEnvVarKeyJobId[] = "RAY_JOB_ID";
 constexpr char kEnvVarKeyRayletPid[] = "RAY_RAYLET_PID";


### PR DESCRIPTION
## Description
A very simple PR removing unused constants from common/constants.h. 

## Related issues
N/A

## Additional information
- checked if the constants were being used across the codebase with the Search functionality in VSCode.
- verified this with Claude Code by asking it to look for any instances that uses these constants.
