### PR TITLE
[Data][2.56.1] Fix Arrow-backed to_pandas regressions: opt-out flag + int/float block overflow (#64768)

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -297,9 +297,14 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 return None
             return pd.ArrowDtype(t)
 
+        # Gated on enable_arrow_backed_pandas_conversion so callers can restore the
+        # pre-2.56 numpy conversion (standard Arrow types -> numpy dtypes). See
+        # https://github.com/ray-project/ray/issues/64765.
         df = self._table.to_pandas(
             ignore_metadata=ctx.pandas_block_ignore_metadata,
-            types_mapper=_types_mapper,
+            types_mapper=(
+                _types_mapper if ctx.enable_arrow_backed_pandas_conversion else None
+            ),
         )
         if ctx.enable_tensor_extension_casting:
             df = _cast_tensor_columns_to_ndarrays(df, arrow_schema=self._table.schema)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -46,6 +46,10 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 # Max number of samples used to estimate the Pandas block size.
 _PANDAS_SIZE_BYTES_MAX_SAMPLE_COUNT = 200
+# Largest integer magnitude float64 can represent exactly. Beyond this, integers
+# are not uniquely representable, so an "integral" float may not equal the
+# intended value.
+FLOAT64_MAX_INTEGER_VALUE = 2**53
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +63,99 @@ def lazy_import_pandas():
 
         _pandas = pandas
     return _pandas
+
+
+def _reconcile_arrow_backed_int_float_columns(
+    tables: List["pandas.DataFrame"],
+) -> List["pandas.DataFrame"]:
+    """Reconcile columns typed integer in some blocks and float in others.
+
+    Per-block pyarrow inference can type the same column as ``int64`` in some
+    blocks and ``double`` in others (e.g. a block whose values are all null infers
+    ``double``). ``pandas.concat`` then promotes to ``double`` with a *checked*
+    cast, which raises ``ArrowInvalid`` for ``int64`` values above ``2**53``. When
+    the float-typed blocks hold only null / integral values, cast them back to the
+    integer type so the concat stays lossless and cannot overflow. Blocks with
+    genuine fractional values are left untouched (pandas promotes as usual).
+
+    Reconciliation only happens when it is provably lossless (integral values
+    within both ``+-2**53`` and the target integer type's range). When it is not
+    lossless — e.g. a column mixes true ``int64`` values above ``2**53`` with
+    fractional float values — the blocks are left as-is and the subsequent
+    ``pandas.concat`` still raises ``ArrowInvalid`` on the checked ``int64`` ->
+    ``double`` promotion, exactly as before.
+
+    Only affects Arrow-backed (``pd.ArrowDtype``) columns; a no-op otherwise.
+    See https://github.com/ray-project/ray/issues/64765.
+    """
+    import pyarrow as pa
+
+    pandas = lazy_import_pandas()
+    if len(tables) < 2:
+        return tables
+
+    common_columns = set(tables[0].columns)
+    for table in tables[1:]:
+        common_columns &= set(table.columns)
+
+    # column -> integer ArrowDtype to cast the float-typed blocks to.
+    casts = {}
+    for column in common_columns:
+        dtypes = [table[column].dtype for table in tables]
+        if not all(isinstance(dtype, pandas.ArrowDtype) for dtype in dtypes):
+            continue
+        arrow_types = [dtype.pyarrow_dtype for dtype in dtypes]
+        int_types = [t for t in arrow_types if pa.types.is_integer(t)]
+        float_columns = [
+            table[column]
+            for table in tables
+            if pa.types.is_floating(table[column].dtype.pyarrow_dtype)
+        ]
+        if not int_types or not float_columns:
+            continue
+        # Downcast the float blocks to the widest integer type present among the
+        # int blocks, but only when every non-null float value can be recovered
+        # exactly as that integer type. A value must be:
+        #   - integral, and
+        #   - within +-2**53 (beyond that float64 cannot represent every integer,
+        #     so an "integral" float may not equal the intended value), and
+        #   - within the target type's range (bit width and signedness), so the
+        #     cast cannot overflow, wrap, or produce an invalid value.
+        # Otherwise leave the blocks for pandas' usual (float) promotion.
+        target_type = max(int_types, key=lambda t: t.bit_width)
+        if pa.types.is_unsigned_integer(target_type):
+            type_min, type_max = 0, 2**target_type.bit_width - 1
+        else:
+            type_min = -(2 ** (target_type.bit_width - 1))
+            type_max = 2 ** (target_type.bit_width - 1) - 1
+        lo = max(type_min, -FLOAT64_MAX_INTEGER_VALUE)
+        hi = min(type_max, FLOAT64_MAX_INTEGER_VALUE)
+        lossless = True
+        for column_values in float_columns:
+            non_null = column_values.dropna()
+            if non_null.empty:
+                continue
+            values = non_null.to_numpy(dtype="float64", na_value=np.nan)
+            is_integral = np.mod(values, 1) == 0
+            in_range = (values >= lo) & (values <= hi)
+            if not np.all(is_integral & in_range):
+                lossless = False
+                break
+        if lossless:
+            casts[column] = pandas.ArrowDtype(target_type)
+
+    if not casts:
+        return tables
+
+    reconciled = []
+    for table in tables:
+        replace = {
+            column: table[column].astype(target)
+            for column, target in casts.items()
+            if pa.types.is_floating(table[column].dtype.pyarrow_dtype)
+        }
+        reconciled.append(table.assign(**replace) if replace else table)
+    return reconciled
 
 
 def _from_pandas_safe(df: "pandas.DataFrame") -> "pyarrow.Table":
@@ -361,6 +458,7 @@ class PandasBlockBuilder(TableBlockBuilder):
         )
 
         if len(tables) > 1:
+            tables = _reconcile_arrow_backed_int_float_columns(tables)
             df = pandas.concat(tables, ignore_index=True)
             df.reset_index(drop=True, inplace=True)
         else:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -71,6 +71,10 @@ DEFAULT_PANDAS_BLOCK_IGNORE_METADATA = env_bool(
     "RAY_DATA_PANDAS_BLOCK_IGNORE_METADATA", False
 )
 
+DEFAULT_ENABLE_ARROW_BACKED_PANDAS_CONVERSION = env_bool(
+    "RAY_DATA_ENABLE_ARROW_BACKED_PANDAS_CONVERSION", True
+)
+
 DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
     "RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT", True
 )
@@ -660,6 +664,12 @@ class DataContext:
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
         pandas_block_ignore_metadata: Whether to ignore pandas metadata when converting
             between Arrow and pandas formats for better type inference.
+        enable_arrow_backed_pandas_conversion: Whether ``BlockAccessor.to_pandas``
+            maps standard Arrow types to pandas Arrow-backed dtypes
+            (``pd.ArrowDtype``). When ``False``, standard Arrow types convert to
+            numpy dtypes (the pre-2.56 behavior). Set to ``False`` if pandas UDFs
+            assign multi-dimensional arrays into columns or rely on numpy-only
+            operations (e.g. ``%``) that Arrow-backed columns do not implement.
         batch_to_block_arrow_format: Whether to convert Pandas batches to Arrow blocks by default when calling `BlockAccessor.batch_to_block`.
         gpu_shuffle_num_actors: Number of GPU actors (ranks) for GPU shuffle. Defaults
             to total GPUs available in the cluster.
@@ -854,6 +864,10 @@ class DataContext:
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
 
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
+
+    enable_arrow_backed_pandas_conversion: bool = (
+        DEFAULT_ENABLE_ARROW_BACKED_PANDAS_CONVERSION
+    )
 
     batch_to_block_arrow_format: bool = DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT
 

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -347,5 +347,86 @@ def test_arrow_block_to_pandas_preserves_arrow_types_through_roundtrip(
     assert roundtripped.to_pydict() == {"x": expected_values}
 
 
+def test_arrow_block_to_pandas_opt_out_numpy_dtypes(restore_data_context):
+    # https://github.com/ray-project/ray/issues/64765: opting out restores the
+    # pre-2.56 numpy conversion, so standard Arrow types no longer become
+    # pd.ArrowDtype. This unblocks pandas UDFs that assign multi-dimensional
+    # arrays into columns or rely on numpy-only ops these columns do not support.
+    ctx = DataContext.get_current()
+    table = pa.table({"x": pa.array([1, 2, 3], pa.int64())})
+
+    ctx.enable_arrow_backed_pandas_conversion = True
+    on = ArrowBlockAccessor(table).to_pandas()
+    assert isinstance(on.dtypes["x"], pd.ArrowDtype)
+    assert on.dtypes["x"] == pd.ArrowDtype(pa.int64())
+
+    ctx.enable_arrow_backed_pandas_conversion = False
+    off = ArrowBlockAccessor(table).to_pandas()
+    assert not isinstance(off.dtypes["x"], pd.ArrowDtype)
+    assert off.dtypes["x"] == np.dtype("int64")
+
+
+def test_to_pandas_reconciles_int_and_float_blocks(ray_start_regular_shared):
+    # https://github.com/ray-project/ray/issues/64765 (symptom B): to_pandas must
+    # not overflow when the same column is int64 in some blocks and double in
+    # others (e.g. a block whose values are all null infers double). The int64
+    # values are preserved exactly, without lossy float widening.
+    big = 1782750729409928627  # > 2**53, not exactly representable as float64
+    ds = ray.data.from_arrow(
+        [
+            pa.table({"ts": pa.array([big], pa.int64())}),
+            pa.table({"ts": pa.array([None], pa.float64())}),
+        ]
+    )
+    df = ds.to_pandas()
+    assert len(df) == 2
+    assert df["ts"].dropna().tolist() == [big]
+
+
+def test_to_pandas_does_not_downcast_large_floats(ray_start_regular_shared):
+    # https://github.com/ray-project/ray/issues/64765: a float column above 2**53
+    # must not be silently downcast to int during int/float block reconciliation.
+    # float64 cannot represent every integer past 2**53, so an "integral" float may
+    # not equal the intended value; such blocks are left float-backed rather than
+    # coerced to an int with false exactness.
+    big_float = float(2**53 + 2)  # integral and exactly representable, but > 2**53
+    ds = ray.data.from_arrow(
+        [
+            pa.table({"v": pa.array([3], pa.int64())}),
+            pa.table({"v": pa.array([big_float], pa.float64())}),
+        ]
+    )
+    df = ds.to_pandas()
+    assert len(df) == 2
+    assert pa.types.is_floating(df["v"].dtype.pyarrow_dtype)
+
+
+@pytest.mark.parametrize(
+    "int_type, float_value",
+    [
+        (pa.int32(), 3.0e9),  # integral and < 2**53, but exceeds int32 max
+        (pa.uint32(), -5.0),  # integral, but negative does not fit unsigned
+        (pa.uint8(), 300.0),  # integral, but exceeds uint8 max
+    ],
+)
+def test_to_pandas_does_not_downcast_out_of_range_floats(
+    ray_start_regular_shared, int_type, float_value
+):
+    # https://github.com/ray-project/ray/issues/64765: float blocks are downcast
+    # to the int blocks' type only when values fit that type's range (bit width
+    # and signedness). Out-of-range or wrong-sign integral floats must stay
+    # float-backed rather than overflow, wrap, or become invalid.
+    ds = ray.data.from_arrow(
+        [
+            pa.table({"v": pa.array([3], int_type)}),
+            pa.table({"v": pa.array([float_value], pa.float64())}),
+        ]
+    )
+    df = ds.to_pandas()
+    assert len(df) == 2
+    assert pa.types.is_floating(df["v"].dtype.pyarrow_dtype)
+    assert float_value in df["v"].dropna().tolist()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Cherry-pick of #64768 onto the `releases/2.56.1` branch.

## Why are these changes needed?
Fixes two Ray Data `to_pandas` regressions introduced in 2.56:
1. Adds `DataContext.enable_arrow_backed_pandas_conversion` (env `RAY_DATA_ENABLE_ARROW_BACKED_PANDAS_CONVERSION`, default `True`) as an opt-out for Arrow-backed pandas conversion.
2. Reconciles divergent numeric column types before concatenation to prevent int64/double[pyarrow] overflow crashes.

## Related issue number
Cherry-pick of #64768

## Checks
Cherry-pick applied cleanly (no conflicts). DCO sign-off added.
🤖 Generated with [Claude Code](https://claude.com/claude-code)