### PR TITLE
[Data][2.56.1] Fix TensorDtype.__from_arrow__ crash on empty tensor columns (#64767)

### DIFF
--- a/python/ray/data/_internal/tensor_extensions/pandas.py
+++ b/python/ray/data/_internal/tensor_extensions/pandas.py
@@ -468,9 +468,21 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         # For ARROW_NATIVE format (pa.fixed_shape_tensor), to_numpy() flattens the
         # inner tensor dimensions (e.g. shape (3,2,2,2) becomes (3,8)). Stack to collapse the object array into a real numeric array and then reshape to match the dimensions of the tensor from the metadata
         if self.element_shape and all(s is not None for s in self.element_shape):
-            if values.dtype == object:
-                values = np.stack(values)
-            values = values.reshape((-1,) + self.element_shape)
+            # Reshape with the explicit row count rather than -1: an empty column
+            # (num_rows == 0), or per-row tensors with a zero-size dimension (e.g.
+            # element_shape (0,)), make the flat array size 0, and numpy cannot
+            # infer a -1 dimension from a size-0 array ("cannot reshape array of
+            # size 0 into shape (0)"). See
+            # https://github.com/ray-project/ray/issues/64766.
+            num_rows = len(array)
+            if num_rows == 0:
+                # np.stack requires at least one array and reshape is a no-op
+                # here, so build the correctly typed empty buffer directly.
+                values = np.empty((0,) + self.element_shape, dtype=self._dtype)
+            else:
+                if values.dtype == object:
+                    values = np.stack(values)
+                values = values.reshape((num_rows,) + self.element_shape)
 
         return TensorArray(values)
 

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -626,6 +626,35 @@ def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
     pd.testing.assert_frame_equal(ds_df, expected_df)
 
 
+@pytest.mark.parametrize("element_shape", [(0,), (0, 2)])
+def test_tensors_in_tables_pandas_roundtrip_empty_elements(
+    ray_start_regular_shared,
+    enable_automatic_tensor_extension_cast,
+    tensor_format_context,
+    element_shape,
+):
+    # Regression test for https://github.com/ray-project/ray/issues/64766: a
+    # fixed-shape tensor column whose per-row tensors are empty (element_shape
+    # contains a 0) must round-trip through to_pandas. Previously
+    # TensorDtype.__from_arrow__ reshaped with a -1 dimension, which numpy
+    # cannot infer from a size-0 array ("cannot reshape array of size 0 into
+    # shape (0)").
+    num_rows = 3
+    ds = ray.data.from_items(
+        [{"pts": np.zeros(element_shape, dtype=np.float32)} for _ in range(num_rows)]
+    )
+    df = ds.to_pandas()
+    assert len(df) == num_rows
+    # Empty tensors must round-trip as empty. The V1/V2 Ray tensor extension
+    # preserves the exact element shape; the native pa.fixed_shape_tensor path
+    # may report a flattened shape, so assert emptiness rather than exact shape.
+    assert all(np.asarray(v).size == 0 for v in df["pts"])
+
+    # A fully empty block (num_rows == 0) must also round-trip.
+    empty_df = ds.filter(lambda row: False).to_pandas()
+    assert len(empty_df) == 0
+
+
 def test_tensors_in_tables_parquet_roundtrip(
     ray_start_regular_shared, tmp_path, tensor_format_context
 ):


### PR DESCRIPTION
Cherry-pick of #64767 onto the `releases/2.56.1` branch.

## Why are these changes needed?
Fixes a 2.56 regression where converting tensor-extension columns to pandas crashed on zero-size tensor elements. Replaces numpy's `-1` dimension inference with an explicit row count and builds the buffer directly for empty arrays instead of using `np.stack`.

## Related issue number
Cherry-pick of #64767

## Checks
Cherry-pick applied cleanly (no conflicts). DCO sign-off added.
🤖 Generated with [Claude Code](https://claude.com/claude-code)