### PR TITLE
[Data] Support Arrow string-view and binary-view arrays in custom serialization

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -362,17 +362,28 @@ def _is_binary(type_: "pyarrow.DataType") -> bool:
     )
 
 
+# Cached view-type checkers, resolved on first use; empty tuple on pyarrow < 16,
+# which doesn't have view types.
+_view_type_checkers: Optional[Tuple[Callable[["pyarrow.DataType"], bool], ...]] = None
+
+
 def _is_view(type_: "pyarrow.DataType") -> bool:
     """Whether the provided Array type is a variable-sized binary view type
     (string view, binary view). These types were added in Arrow 16.0.0."""
-    import pyarrow as pa
+    global _view_type_checkers
 
-    is_string_view = getattr(pa.types, "is_string_view", None)
-    is_binary_view = getattr(pa.types, "is_binary_view", None)
-    if is_string_view is None or is_binary_view is None:
-        # pyarrow < 16 doesn't have view types.
-        return False
-    return is_string_view(type_) or is_binary_view(type_)
+    if _view_type_checkers is None:
+        import pyarrow as pa
+
+        _view_type_checkers = tuple(
+            checker
+            for checker in (
+                getattr(pa.types, "is_string_view", None),
+                getattr(pa.types, "is_binary_view", None),
+            )
+            if checker is not None
+        )
+    return any(checker(type_) for checker in _view_type_checkers)
 
 
 def _null_array_to_array_payload(a: "pyarrow.NullArray") -> "PicklableArrayPayload":

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -315,6 +315,8 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
         return _primitive_array_to_array_payload(a)
     elif _is_binary(a.type):
         return _binary_array_to_array_payload(a)
+    elif _is_view(a.type):
+        return _view_array_to_array_payload(a)
     elif pa.types.is_list(a.type) or pa.types.is_large_list(a.type):
         return _list_array_to_array_payload(a)
     elif pa.types.is_fixed_size_list(a.type):
@@ -358,6 +360,19 @@ def _is_binary(type_: "pyarrow.DataType") -> bool:
         or pa.types.is_binary(type_)
         or pa.types.is_large_binary(type_)
     )
+
+
+def _is_view(type_: "pyarrow.DataType") -> bool:
+    """Whether the provided Array type is a variable-sized binary view type
+    (string view, binary view). These types were added in Arrow 16.0.0."""
+    import pyarrow as pa
+
+    is_string_view = getattr(pa.types, "is_string_view", None)
+    is_binary_view = getattr(pa.types, "is_binary_view", None)
+    if is_string_view is None or is_binary_view is None:
+        # pyarrow < 16 doesn't have view types.
+        return False
+    return is_string_view(type_) or is_binary_view(type_)
 
 
 def _null_array_to_array_payload(a: "pyarrow.NullArray") -> "PicklableArrayPayload":
@@ -430,6 +445,39 @@ def _binary_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload
         type=a.type,
         length=len(a),
         buffers=[bitmap_buf, offset_buf, data_buf],
+        null_count=a.null_count,
+        offset=0,
+        children=[],
+    )
+
+
+def _view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
+    """Serialize binary view (string view, binary view) arrays to
+    PicklableArrayPayload.
+    """
+    assert _is_view(a.type), a.type
+    # Buffer scheme: [bitmap, views, data_buffer_0, ..., data_buffer_n]
+    buffers = a.buffers()
+    assert len(buffers) >= 2, len(buffers)
+
+    # Copy bitmap buffer, if needed.
+    if a.null_count > 0:
+        bitmap_buf = _copy_bitpacked_buffer_if_needed(buffers[0], a.offset, len(a))
+    else:
+        bitmap_buf = None
+
+    # Copy the views buffer, if needed. Each view is a fixed-size 16-byte struct.
+    views_buf = buffers[1]
+    if views_buf is not None:
+        views_buf = _copy_normal_buffer_if_needed(views_buf, 16, a.offset, len(a))
+
+    # Variadic data buffers are passed through as-is: views store absolute
+    # (buffer index, offset) references into them, so they can't be truncated
+    # without rewriting every view.
+    return PicklableArrayPayload(
+        type=a.type,
+        length=len(a),
+        buffers=[bitmap_buf, views_buf, *buffers[2:]],
         null_count=a.null_count,
         offset=0,
         children=[],

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -65,6 +65,23 @@ def binary_array():
 
 
 @pytest.fixture
+def string_view_array():
+    # Mix of long (out-of-line), short (inlined in the view), and null values.
+    return pa.array(
+        ["foo" * 10, "bar", None, "quux" * 10, "inline"] * 200,
+        type=pa.string_view(),
+    )
+
+
+@pytest.fixture
+def binary_view_array():
+    return pa.array(
+        [b"foo" * 10, b"bar", None, b"quux" * 10] * 250,
+        type=pa.binary_view(),
+    )
+
+
+@pytest.fixture
 def fixed_size_binary_array():
     return pa.array([b"foo", b"bar", b"baz", None, b"qux"] * 200, type=pa.binary(3))
 
@@ -285,6 +302,17 @@ pytest_custom_serialization_arrays = [
     # Array of pickled objects
     (lazy_fixture("pickled_objects_array"), 0.1),
 ]
+
+if get_pyarrow_version() >= parse_version("16.0.0"):
+    # View types were added in Arrow 16.0.0. Variadic data buffers can't be
+    # truncated when slicing (views hold absolute offsets into them), so the
+    # serialized-size cap is looser than for regular string/binary arrays.
+    pytest_custom_serialization_arrays += [
+        # String view array
+        (lazy_fixture("string_view_array"), 1.0),
+        # Binary view array
+        (lazy_fixture("binary_view_array"), 1.0),
+    ]
 
 
 @pytest.mark.parametrize("data,cap_mult", pytest_custom_serialization_arrays)


### PR DESCRIPTION
## Why are these changes needed?

Ray's custom Arrow data serializer (`ray/_private/arrow_serialization.py`) has no handler for Arrow `string_view` / `binary_view` arrays (added in Arrow 16), so `_array_to_array_payload` raises `ValueError: Unhandled Arrow array type: string_view`.

Consequences today:
- **Under pytest** (`is_in_test()`): `ray.put()` / `ray.data.from_arrow_refs()` on any table containing a view column **crashes** with the error above.
- **Outside tests**: every such table silently falls back to whole-table Arrow IPC serialization — slower and defeats the zero-copy-slice truncation this serializer exists for.

Repro from the issue:
```python
import pyarrow as pa, ray
t = pa.table({"x": pa.array(["hello world, long string", "hi"], type=pa.string_view())})
ray.data.from_arrow_refs([ray.put(t)])  # crashes in pytest; IPC fallback otherwise
```

## What does this PR do?

Adds a dedicated payload handler for view arrays:
- **validity bitmap**: sliced/bit-shifted like all other array types
- **views buffer**: truncated to the slice using its fixed 16-byte-per-element width
- **variadic data buffers**: passed through as-is — views store absolute offsets into these buffers, so they cannot be truncated without rewriting every view

View types are detected with a `getattr` guard so pyarrow < 16 is unaffected.

Verified locally (pyarrow 24.0.0): full-array, sliced (including non-byte-aligned offsets with nulls), and table-reduce round-trips all succeed through the custom path with no IPC fallback, and the views buffer is properly truncated on slices.

## Related issue number

Fixes #59951

## Checks

- [x] I've signed off every commit (DCO)
- [x] I've run pre-commit hooks (black + ruff) on changed files
- [x] Unit tests added: `string_view_array` / `binary_view_array` cases in `python/ray/data/tests/test_arrow_serialization.py` (gated on pyarrow >= 16)
- [ ] Release tests N/A
