### PR TITLE
[Data] Prevent output backpressure from starving lineage reconstruction

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3794,6 +3794,23 @@ cdef class CoreWorker:
 
         return result
 
+    def get_local_queued_generator_resubmit_task_ids(self):
+        cdef:
+            c_vector[CTaskID] task_ids
+            c_vector[CTaskID].iterator it
+
+        with nogil:
+            task_ids = (CCoreWorkerProcess.GetCoreWorker().
+                        GetLocalQueuedGeneratorResubmitTaskIds())
+
+        result = []
+        it = task_ids.begin()
+        while it != task_ids.end():
+            result.append(TaskID(dereference(it).Binary()))
+            postincrement(it)
+
+        return result
+
     def get_local_object_locations(self, object_refs):
         cdef:
             c_vector[optional[CObjectLocation]] results

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -9,9 +9,10 @@ import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import ray
+import ray._private.worker
 from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import ActorPoolInfo
 from ray.data._internal.execution.backpressure_policy import BackpressurePolicy
 from ray.data._internal.execution.block_ref_counter import BlockRefCounter
@@ -123,13 +124,74 @@ class IdleDetector:
         logger.warning(msg)
 
 
+def _get_local_queued_generator_resubmit_task_ids() -> List[ray.TaskID]:
+    """Streaming generators submitted by this worker that Ray Core has queued for
+    resubmission by lineage reconstruction. Local (no RPC), but locks the task
+    submitter, so avoid calling it on hot paths when it is not needed."""
+    core_worker = ray._private.worker.global_worker.core_worker
+    return core_worker.get_local_queued_generator_resubmit_task_ids()
+
+
+class ReconstructionBypassLane:
+    """One operator's allowance to read past output backpressure, for a single
+    scheduling round.
+
+    Vended by :meth:`OutputBackpressureGuard.reconstruction_bypass_lane`. The
+    allowance is a block count shared by all of the operator's generators that
+    lineage reconstruction has queued for resubmit; ordinary tasks are never
+    eligible. That task-scoped eligibility is why this exception can't simply
+    widen the operator-level byte budget that ``should_unblock`` relaxes —
+    doing so would let every task on the operator read past backpressure.
+    """
+
+    def __init__(
+        self,
+        blocks: int,
+        queued_generator_resubmit_task_ids: Set[ray.TaskID],
+    ):
+        self._remaining_blocks = blocks
+        self._queued_generator_resubmit_task_ids = queued_generator_resubmit_task_ids
+
+    def try_drain(self, task: DataOpTask, metadata_fetcher: "MetadataFetcher") -> bool:
+        """Read up to the remaining allowance from ``task``, one block at a time.
+
+        Returns False without reading anything when ``task`` is not a
+        reconstruction-critical generator or the allowance is already spent; the
+        caller then falls back to the operator's normal output byte budget.
+        """
+        if self._remaining_blocks <= 0 or not self._is_eligible(task):
+            return False
+        while self._remaining_blocks > 0:
+            # ``on_data_ready(1, ...)`` reads a single block. Stop as soon as
+            # there is no more ready output (drained, pending emits, or nothing
+            # buffered yet) so we never spin the full allowance for nothing.
+            if task.on_data_ready(1, metadata_fetcher) == 0:
+                break
+            self._remaining_blocks -= 1
+        return True
+
+    def _is_eligible(self, task: OpTask) -> bool:
+        """Whether ``task`` is a generator that reconstruction is waiting on."""
+        return (
+            isinstance(task, DataOpTask)
+            and task.get_task_id() in self._queued_generator_resubmit_task_ids
+        )
+
+
 class OutputBackpressureGuard:
     """Escape hatch for streaming output backpressure.
 
-    When backpressure policies collectively allow 0 bytes of task output to be
-    read for an operator, the pipeline can deadlock if downstream is also
-    starved (no active tasks, no queued inputs). This guard inspects the
-    topology and resource state and decides whether to unblock the backpressure.
+    Owns every exception to output backpressure, of which there are two:
+
+    - Operator-scoped (:meth:`should_unblock`): when backpressure policies
+      collectively allow 0 bytes of task output to be read for an operator, the
+      pipeline can deadlock if downstream is also starved (no active tasks, no
+      queued inputs), so the budget is relaxed to 1 byte.
+    - Task-scoped (:meth:`reconstruction_bypass_lane`): a fully-backpressured
+      operator starves the one streaming generator that Ray Core's lineage
+      reconstruction is waiting on to finish, stalling replay. That generator
+      gets a small block allowance past backpressure while its siblings stay
+      throttled.
 
     The guard owns per-operator idle-detection state across the lifetime of
     a single executor, so it must be constructed once and reused across
@@ -140,6 +202,54 @@ class OutputBackpressureGuard:
         self._topology = topology
         self._resource_manager = resource_manager
         self._idle_detector = IdleDetector()
+
+    def order_ready_tasks(
+        self,
+        ready_tasks: List[OpTask],
+        queued_generator_resubmit_task_ids: Set[ray.TaskID],
+    ) -> List[OpTask]:
+        """Order an operator's ready tasks for consumption, reconstruction first.
+
+        Generators that reconstruction has queued for resubmit go first, so they
+        claim the operator's output budget (including any single block
+        ``should_unblock`` frees for liveness) before ordinary tasks, instead of
+        being starved and blocking replay. Remaining ties use deterministic
+        task-index order so that, when backpressure caps an operator's reads,
+        fewer tasks finish quickly and yield resources rather than all tasks
+        emitting blocks together.
+        """
+        if not queued_generator_resubmit_task_ids:
+            return sorted(ready_tasks, key=lambda task: task.task_index())
+        return sorted(
+            ready_tasks,
+            key=lambda task: (
+                task.get_task_id() not in queued_generator_resubmit_task_ids
+                if isinstance(task, DataOpTask)
+                else True,
+                task.task_index(),
+            ),
+        )
+
+    def reconstruction_bypass_lane(
+        self,
+        op: PhysicalOperator,
+        op_output_budget: Optional[int],
+        queued_generator_resubmit_task_ids: Set[ray.TaskID],
+    ) -> ReconstructionBypassLane:
+        """The block allowance ``op``'s reconstruction-critical generators may
+        read past output backpressure this round.
+
+        Only granted while the operator is effectively fully backpressured: a
+        budget of 0, or the 1 byte ``should_unblock`` bumped it to (with which
+        ordinary tasks still can't make meaningful progress).
+        """
+        fully_backpressured = op_output_budget is not None and op_output_budget <= 1
+        blocks = (
+            op.data_context.lineage_reconstruction_backpressure_bypass_blocks
+            if fully_backpressured and queued_generator_resubmit_task_ids
+            else 0
+        )
+        return ReconstructionBypassLane(blocks, queued_generator_resubmit_task_ids)
 
     def should_unblock(self, op: PhysicalOperator) -> bool:
         """Return True if output backpressure should be relaxed for ``op``
@@ -605,9 +715,10 @@ def process_completed_tasks(
         backpressure_policies: The backpressure policies to use.
         max_errored_blocks: Max number of errored blocks to allow,
             unlimited if negative.
-        output_backpressure_guard: Escape hatch for streaming output
-            backpressure. Bumps a fully-throttled output limit (0 bytes) to
-            1 byte when the guard signals a stall.
+        output_backpressure_guard: Owns the exceptions to output backpressure:
+            bumps a fully-throttled output limit (0 bytes) to 1 byte when it
+            signals a stall, orders each operator's ready tasks, and vends the
+            per-operator lineage-reconstruction bypass lane.
         metadata_fetcher: Resolves pulled (block_ref, meta_ref) pairs into
             emitted RefBundles. The threaded fetcher defers metadata fetches to
             a background thread (emitting in per-op order as they become ready);
@@ -704,11 +815,8 @@ def process_completed_tasks(
             timeout=WAIT_FOR_TASK_COMPLETION_TIMEOUT_S,
         )
 
-        # Organize tasks by the operator they belong to, and sort them by task index.
-        # So that we'll process them in a deterministic order.
-        # This is because backpressure policies may limit the number of blocks to read
-        # per operator. In this case, we want to have fewer tasks finish quickly and
-        # yield resources, instead of having all tasks output blocks together.
+        # Organize ready tasks by operator; the guard then orders each operator's
+        # tasks for consumption (reconstruction priority + deterministic index).
         ready_tasks_by_op = defaultdict(list)
         for ref in ready:
             state, task = active_tasks[ref]
@@ -724,24 +832,44 @@ def process_completed_tasks(
         #   to the background fetcher by ``submit``; emission and the postponed
         #   done-callback happen in ``emit_ready_and_fire_done_callbacks``, preserving the per-op,
         #   per-task, per-pair emission order.
+
+        # Gated on there being a finite output read budget somewhere: only an
+        # output-limited operator can starve a reconstruction-critical generator,
+        # and this lookup takes Ray Core's task submitter lock.
+        queued_generator_resubmit_task_ids = (
+            set(_get_local_queued_generator_resubmit_task_ids())
+            if remaining_output_budget
+            else set()
+        )
         for state, ready_tasks in ready_tasks_by_op.items():
-            # TODO elaborate why sorting (helps preserve_order case)
-            ready_tasks = sorted(ready_tasks, key=lambda t: t.task_index())
+            ready_tasks = output_backpressure_guard.order_ready_tasks(
+                ready_tasks, queued_generator_resubmit_task_ids
+            )
+            bypass_lane = output_backpressure_guard.reconstruction_bypass_lane(
+                state.op,
+                remaining_output_budget.get(state),
+                queued_generator_resubmit_task_ids,
+            )
             op_data_tasks: List[DataOpTask] = []
             try:
                 for task in ready_tasks:
                     if isinstance(task, DataOpTask):
                         try:
-                            bytes_read = task.on_data_ready(
-                                remaining_output_budget.get(state, None),
-                                metadata_fetcher,
-                            )
-                            op_data_tasks.append(task)
-                            if state in remaining_output_budget:
-                                # Clamp remaining output budget at 0
-                                remaining_output_budget[state] = max(
-                                    remaining_output_budget[state] - bytes_read, 0
+                            # Reconstruction-critical generators drain through
+                            # the bypass lane, leaving the operator's (zeroed)
+                            # byte budget untouched so ordinary tasks stay
+                            # backpressured. Everything else reads against it.
+                            if not bypass_lane.try_drain(task, metadata_fetcher):
+                                bytes_read = task.on_data_ready(
+                                    remaining_output_budget.get(state, None),
+                                    metadata_fetcher,
                                 )
+                                if state in remaining_output_budget:
+                                    # Clamp remaining output budget at 0
+                                    remaining_output_budget[state] = max(
+                                        remaining_output_budget[state] - bytes_read, 0
+                                    )
+                            op_data_tasks.append(task)
                         except Exception as e:
                             _record_errored_block(e, state.op.name)
                     else:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -365,6 +365,16 @@ DEFAULT_DOWNSTREAM_CAPACITY_BACKPRESSURE_RATIO: float = env_float(
 )
 
 
+# Max blocks per operator per scheduling round that a lineage-reconstruction
+# generator may read past output backpressure. Larger values drain the
+# reconstruction-critical generator faster (shorter recovery) at the cost of a
+# higher transient object-store footprint. Set to 0 to disable the bypass
+# (accepts backpressure-induced stalls but avoids extra object-store footprint).
+DEFAULT_LINEAGE_RECONSTRUCTION_BACKPRESSURE_BYPASS_BLOCKS: int = env_integer(
+    "RAY_DATA_LINEAGE_RECONSTRUCTION_BACKPRESSURE_BYPASS_BLOCKS", 1
+)
+
+
 @DeveloperAPI
 @dataclass
 class IcebergConfig:
@@ -766,6 +776,12 @@ class DataContext:
             later. If `None`, this backpressure policy is disabled.
         enable_dynamic_output_queue_size_backpressure: Whether to cap the concurrency
             of an operator based on its and downstream operators' queue size.
+        lineage_reconstruction_backpressure_bypass_blocks: Max blocks per operator
+            per scheduling round that a streaming generator queued for
+            lineage-reconstruction resubmit may read past output backpressure, so
+            replay keeps pace instead of stalling. Larger values shorten
+            recovery at the cost of a higher transient object-store footprint.
+            Set to 0 to disable the bypass.
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
         pandas_block_ignore_metadata: Whether to ignore pandas metadata when converting
             between Arrow and pandas formats for better type inference.
@@ -980,6 +996,10 @@ class DataContext:
 
     enable_dynamic_output_queue_size_backpressure: bool = (
         DEFAULT_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE
+    )
+
+    lineage_reconstruction_backpressure_bypass_blocks: int = (
+        DEFAULT_LINEAGE_RECONSTRUCTION_BACKPRESSURE_BYPASS_BLOCKS
     )
 
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -168,10 +168,15 @@ def test_disallow_non_unique_operators(ray_start_regular_shared):
         )
 
 
-def _make_disabled_guard() -> MagicMock:
-    """Return a stub guard whose escape hatch never fires."""
-    guard = MagicMock(spec=OutputBackpressureGuard)
-    guard.should_unblock.return_value = False
+def _make_disabled_guard() -> OutputBackpressureGuard:
+    """Return a real guard whose operator-level escape hatch never fires.
+
+    Only ``should_unblock`` is stubbed out; task ordering and the
+    lineage-reconstruction bypass lane stay real, so callers exercise the
+    actual policy instead of a mock's return values.
+    """
+    guard = OutputBackpressureGuard({}, MagicMock())
+    guard.should_unblock = MagicMock(return_value=False)
     return guard
 
 
@@ -351,6 +356,211 @@ def test_process_completed_tasks_inline(sleep_task_ref, ray_start_regular_shared
     _process_completed_tasks_sync(topo, [], 0, _make_disabled_guard())
     update_operator_states(topo)
     o2.mark_execution_finished.assert_called_once()
+
+
+class _FakeDataOpTask(DataOpTask):
+    """Minimal ``DataOpTask`` stand-in recording the byte budget of every read."""
+
+    def __init__(self, task_index, task_id, bytes_read, waitable=None, calls=None):
+        self._task_index = task_index
+        self._task_id = task_id
+        self._bytes_read = bytes_read
+        self._waitable = waitable
+        self.calls = calls if calls is not None else []
+
+    def get_waitable(self):
+        return self._waitable
+
+    def get_task_id(self):
+        return self._task_id
+
+    def on_data_ready(self, max_bytes_to_read, metadata_fetcher):
+        self.calls.append((self._task_id, max_bytes_to_read))
+        return self._bytes_read
+
+
+class _ZeroOutputBudgetPolicy:
+    """Simulate output backpressure preventing ordinary task-output reads."""
+
+    @property
+    def name(self):
+        return "ZeroOutputBudget"
+
+    def max_task_output_bytes_to_read(self, op):
+        return 0
+
+
+def _make_op(bypass_blocks: int) -> MagicMock:
+    op = MagicMock()
+    op.data_context.lineage_reconstruction_backpressure_bypass_blocks = bypass_blocks
+    return op
+
+
+def _guard() -> OutputBackpressureGuard:
+    """A guard for exercising its stateless task-ordering / bypass-lane policy.
+
+    ``order_ready_tasks`` and ``reconstruction_bypass_lane`` take the queued
+    generator set as an argument, so no per-round setup is needed.
+    """
+    return OutputBackpressureGuard({}, MagicMock())
+
+
+def test_process_completed_tasks_skips_core_worker_query_when_nothing_is_output_limited(
+    ray_start_regular_shared,
+):
+    # The lookup is local but takes Ray Core's task submitter lock, so it is
+    # only issued when some operator has a finite output read budget. With no
+    # limiting policy there is no budget, so even with a ready task the query
+    # must be skipped.
+    task = _FakeDataOpTask(0, "normal", bytes_read=0, waitable=ray.put("normal"))
+    op = MagicMock()
+    op.get_active_tasks.return_value = [task]
+    op.has_next.return_value = False
+    state = MagicMock()
+    state.op = op
+    topology = {op: state}
+
+    with patch(
+        "ray.data._internal.execution.streaming_executor_state."
+        "_get_local_queued_generator_resubmit_task_ids",
+    ) as mock_query:
+        _process_completed_tasks_sync(
+            topology,
+            [],
+            max_errored_blocks=0,
+            output_backpressure_guard=_make_disabled_guard(),
+        )
+    mock_query.assert_not_called()
+    # The task is still read, with no byte budget applied.
+    assert task.calls == [("normal", None)]
+
+
+def test_order_ready_tasks_puts_queued_generators_first():
+    gen = _FakeDataOpTask(2, "gen", bytes_read=10)
+    normal = _FakeDataOpTask(0, "normal", bytes_read=10)
+    meta = MagicMock(spec=MetadataOpTask)
+    meta.task_index.return_value = 1
+
+    # The queued-for-resubmit generator claims the operator's output budget
+    # first, even though its task index is highest. Non-data tasks (no task ID)
+    # are ordered without being probed for eligibility.
+    assert _guard().order_ready_tasks([normal, meta, gen], {"gen"}) == [
+        gen,
+        normal,
+        meta,
+    ]
+
+    # With nothing queued, ordering falls back to plain task-index order.
+    assert _guard().order_ready_tasks([gen, meta, normal], set()) == [
+        normal,
+        meta,
+        gen,
+    ]
+
+
+@pytest.mark.parametrize("op_output_budget", [0, 1])
+def test_reconstruction_bypass_lane_granted_when_fully_backpressured(op_output_budget):
+    # Budget 0 is full backpressure; budget 1 is what ``should_unblock`` bumps it
+    # to, which is still too little for an ordinary task to make progress.
+    gen = _FakeDataOpTask(0, "gen", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(_make_op(3), op_output_budget, {"gen"})
+    assert lane.try_drain(gen, metadata_fetcher=None)
+    # Drained one block at a time so the bypass stays bounded.
+    assert gen.calls == [("gen", 1)] * 3
+
+
+@pytest.mark.parametrize("op_output_budget", [None, 2, 1024])
+def test_no_reconstruction_bypass_lane_when_output_budget_allows_progress(
+    op_output_budget,
+):
+    gen = _FakeDataOpTask(0, "gen", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(_make_op(3), op_output_budget, {"gen"})
+    assert not lane.try_drain(gen, metadata_fetcher=None)
+    assert gen.calls == []
+
+
+def test_reconstruction_bypass_lane_disabled_by_zero_bypass_blocks():
+    gen = _FakeDataOpTask(0, "gen", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(_make_op(0), 0, {"gen"})
+    assert not lane.try_drain(gen, metadata_fetcher=None)
+    assert gen.calls == []
+
+
+def test_reconstruction_bypass_lane_ignores_ordinary_tasks():
+    normal = _FakeDataOpTask(0, "normal", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(_make_op(3), 0, {"gen"})
+    assert not lane.try_drain(normal, metadata_fetcher=None)
+    assert normal.calls == []
+
+
+def test_reconstruction_bypass_lane_stops_when_generator_has_no_ready_output():
+    # The lane pulls one block at a time up to the configured cap, but stops as
+    # soon as ``on_data_ready`` reports 0 bytes read (generator drained / pending
+    # emits / nothing buffered), so it never spins the full cap for nothing.
+    gen = _FakeDataOpTask(0, "gen", bytes_read=0)
+    lane = _guard().reconstruction_bypass_lane(_make_op(100), 0, {"gen"})
+    assert lane.try_drain(gen, metadata_fetcher=None)
+    assert gen.calls == [("gen", 1)]
+
+
+def test_reconstruction_bypass_lane_budget_is_shared_per_operator():
+    # ``lineage_reconstruction_backpressure_bypass_blocks`` is a per-operator
+    # budget shared across that operator's queued-for-resubmit generators, NOT
+    # granted N-per-task: with two queued generators and a cap of 3, the total
+    # is 3 bypass reads, not 6.
+    gen_a = _FakeDataOpTask(0, "gen_a", bytes_read=10)
+    gen_b = _FakeDataOpTask(1, "gen_b", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(_make_op(3), 0, {"gen_a", "gen_b"})
+
+    assert lane.try_drain(gen_a, metadata_fetcher=None)
+    assert gen_a.calls == [("gen_a", 1)] * 3
+    # gen_b finds the shared allowance exhausted and falls back to the
+    # operator's (zeroed) byte budget.
+    assert not lane.try_drain(gen_b, metadata_fetcher=None)
+    assert gen_b.calls == []
+
+
+@pytest.mark.parametrize("bypass_blocks", [1, 3])
+def test_process_completed_tasks_drains_queued_generator_resubmit_tasks_under_backpressure(
+    ray_start_regular_shared, bypass_blocks
+):
+    calls = []
+    normal_task = _FakeDataOpTask(
+        0, "normal", bytes_read=0, waitable=ray.put("normal"), calls=calls
+    )
+    queued_resubmit_task = _FakeDataOpTask(
+        1,
+        "queued_resubmit",
+        bytes_read=10,
+        waitable=ray.put("queued_resubmit"),
+        calls=calls,
+    )
+
+    op = _make_op(bypass_blocks)
+    op.get_active_tasks.return_value = [normal_task, queued_resubmit_task]
+    op.has_next.return_value = False
+
+    state = MagicMock()
+    state.op = op
+    topology = {op: state}
+
+    with patch(
+        "ray.data._internal.execution.streaming_executor_state."
+        "_get_local_queued_generator_resubmit_task_ids",
+        return_value=["queued_resubmit"],
+    ) as mock_get_queued_generator_resubmit_task_ids:
+        _process_completed_tasks_sync(
+            topology,
+            [_ZeroOutputBudgetPolicy()],
+            max_errored_blocks=0,
+            output_backpressure_guard=_make_disabled_guard(),
+        )
+
+    # The queued-for-resubmit generator is ordered first and drains through the
+    # guard's bypass lane; the ordinary task is still visited but stays
+    # backpressured on the operator's untouched byte budget of 0.
+    mock_get_queued_generator_resubmit_task_ids.assert_called_once()
+    assert calls == [("queued_resubmit", 1)] * bypass_blocks + [("normal", 0)]
 
 
 def test_update_operator_states_drains_upstream(ray_start_regular_shared):

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -76,7 +76,11 @@ from ray.data.block import BlockAccessor, BlockMetadataWithSchema, TaskExecWorke
 from ray.data.context import EXECUTION_CALLBACKS_ENV_VAR, DataContext
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.conftest import noop_counter
-from ray.data.tests.util import fetcher_has_pending_work
+from ray.data.tests.util import (
+    FakeDataOpTask,
+    fetcher_has_pending_work,
+    make_backpressured_op,
+)
 from ray.exceptions import GetTimeoutError
 
 
@@ -358,27 +362,6 @@ def test_process_completed_tasks_inline(sleep_task_ref, ray_start_regular_shared
     o2.mark_execution_finished.assert_called_once()
 
 
-class _FakeDataOpTask(DataOpTask):
-    """Minimal ``DataOpTask`` stand-in recording the byte budget of every read."""
-
-    def __init__(self, task_index, task_id, bytes_read, waitable=None, calls=None):
-        self._task_index = task_index
-        self._task_id = task_id
-        self._bytes_read = bytes_read
-        self._waitable = waitable
-        self.calls = calls if calls is not None else []
-
-    def get_waitable(self):
-        return self._waitable
-
-    def get_task_id(self):
-        return self._task_id
-
-    def on_data_ready(self, max_bytes_to_read, metadata_fetcher):
-        self.calls.append((self._task_id, max_bytes_to_read))
-        return self._bytes_read
-
-
 class _ZeroOutputBudgetPolicy:
     """Simulate output backpressure preventing ordinary task-output reads."""
 
@@ -390,21 +373,6 @@ class _ZeroOutputBudgetPolicy:
         return 0
 
 
-def _make_op(bypass_blocks: int) -> MagicMock:
-    op = MagicMock()
-    op.data_context.lineage_reconstruction_backpressure_bypass_blocks = bypass_blocks
-    return op
-
-
-def _guard() -> OutputBackpressureGuard:
-    """A guard for exercising its stateless task-ordering / bypass-lane policy.
-
-    ``order_ready_tasks`` and ``reconstruction_bypass_lane`` take the queued
-    generator set as an argument, so no per-round setup is needed.
-    """
-    return OutputBackpressureGuard({}, MagicMock())
-
-
 def test_process_completed_tasks_skips_core_worker_query_when_nothing_is_output_limited(
     ray_start_regular_shared,
 ):
@@ -412,7 +380,7 @@ def test_process_completed_tasks_skips_core_worker_query_when_nothing_is_output_
     # only issued when some operator has a finite output read budget. With no
     # limiting policy there is no budget, so even with a ready task the query
     # must be skipped.
-    task = _FakeDataOpTask(0, "normal", bytes_read=0, waitable=ray.put("normal"))
+    task = FakeDataOpTask(0, "normal", bytes_read=0, waitable=ray.put("normal"))
     op = MagicMock()
     op.get_active_tasks.return_value = [task]
     op.has_next.return_value = False
@@ -435,100 +403,15 @@ def test_process_completed_tasks_skips_core_worker_query_when_nothing_is_output_
     assert task.calls == [("normal", None)]
 
 
-def test_order_ready_tasks_puts_queued_generators_first():
-    gen = _FakeDataOpTask(2, "gen", bytes_read=10)
-    normal = _FakeDataOpTask(0, "normal", bytes_read=10)
-    meta = MagicMock(spec=MetadataOpTask)
-    meta.task_index.return_value = 1
-
-    # The queued-for-resubmit generator claims the operator's output budget
-    # first, even though its task index is highest. Non-data tasks (no task ID)
-    # are ordered without being probed for eligibility.
-    assert _guard().order_ready_tasks([normal, meta, gen], {"gen"}) == [
-        gen,
-        normal,
-        meta,
-    ]
-
-    # With nothing queued, ordering falls back to plain task-index order.
-    assert _guard().order_ready_tasks([gen, meta, normal], set()) == [
-        normal,
-        meta,
-        gen,
-    ]
-
-
-@pytest.mark.parametrize("op_output_budget", [0, 1])
-def test_reconstruction_bypass_lane_granted_when_fully_backpressured(op_output_budget):
-    # Budget 0 is full backpressure; budget 1 is what ``should_unblock`` bumps it
-    # to, which is still too little for an ordinary task to make progress.
-    gen = _FakeDataOpTask(0, "gen", bytes_read=10)
-    lane = _guard().reconstruction_bypass_lane(_make_op(3), op_output_budget, {"gen"})
-    assert lane.try_drain(gen, metadata_fetcher=None)
-    # Drained one block at a time so the bypass stays bounded.
-    assert gen.calls == [("gen", 1)] * 3
-
-
-@pytest.mark.parametrize("op_output_budget", [None, 2, 1024])
-def test_no_reconstruction_bypass_lane_when_output_budget_allows_progress(
-    op_output_budget,
-):
-    gen = _FakeDataOpTask(0, "gen", bytes_read=10)
-    lane = _guard().reconstruction_bypass_lane(_make_op(3), op_output_budget, {"gen"})
-    assert not lane.try_drain(gen, metadata_fetcher=None)
-    assert gen.calls == []
-
-
-def test_reconstruction_bypass_lane_disabled_by_zero_bypass_blocks():
-    gen = _FakeDataOpTask(0, "gen", bytes_read=10)
-    lane = _guard().reconstruction_bypass_lane(_make_op(0), 0, {"gen"})
-    assert not lane.try_drain(gen, metadata_fetcher=None)
-    assert gen.calls == []
-
-
-def test_reconstruction_bypass_lane_ignores_ordinary_tasks():
-    normal = _FakeDataOpTask(0, "normal", bytes_read=10)
-    lane = _guard().reconstruction_bypass_lane(_make_op(3), 0, {"gen"})
-    assert not lane.try_drain(normal, metadata_fetcher=None)
-    assert normal.calls == []
-
-
-def test_reconstruction_bypass_lane_stops_when_generator_has_no_ready_output():
-    # The lane pulls one block at a time up to the configured cap, but stops as
-    # soon as ``on_data_ready`` reports 0 bytes read (generator drained / pending
-    # emits / nothing buffered), so it never spins the full cap for nothing.
-    gen = _FakeDataOpTask(0, "gen", bytes_read=0)
-    lane = _guard().reconstruction_bypass_lane(_make_op(100), 0, {"gen"})
-    assert lane.try_drain(gen, metadata_fetcher=None)
-    assert gen.calls == [("gen", 1)]
-
-
-def test_reconstruction_bypass_lane_budget_is_shared_per_operator():
-    # ``lineage_reconstruction_backpressure_bypass_blocks`` is a per-operator
-    # budget shared across that operator's queued-for-resubmit generators, NOT
-    # granted N-per-task: with two queued generators and a cap of 3, the total
-    # is 3 bypass reads, not 6.
-    gen_a = _FakeDataOpTask(0, "gen_a", bytes_read=10)
-    gen_b = _FakeDataOpTask(1, "gen_b", bytes_read=10)
-    lane = _guard().reconstruction_bypass_lane(_make_op(3), 0, {"gen_a", "gen_b"})
-
-    assert lane.try_drain(gen_a, metadata_fetcher=None)
-    assert gen_a.calls == [("gen_a", 1)] * 3
-    # gen_b finds the shared allowance exhausted and falls back to the
-    # operator's (zeroed) byte budget.
-    assert not lane.try_drain(gen_b, metadata_fetcher=None)
-    assert gen_b.calls == []
-
-
 @pytest.mark.parametrize("bypass_blocks", [1, 3])
 def test_process_completed_tasks_drains_queued_generator_resubmit_tasks_under_backpressure(
     ray_start_regular_shared, bypass_blocks
 ):
     calls = []
-    normal_task = _FakeDataOpTask(
+    normal_task = FakeDataOpTask(
         0, "normal", bytes_read=0, waitable=ray.put("normal"), calls=calls
     )
-    queued_resubmit_task = _FakeDataOpTask(
+    queued_resubmit_task = FakeDataOpTask(
         1,
         "queued_resubmit",
         bytes_read=10,
@@ -536,7 +419,7 @@ def test_process_completed_tasks_drains_queued_generator_resubmit_tasks_under_ba
         calls=calls,
     )
 
-    op = _make_op(bypass_blocks)
+    op = make_backpressured_op(bypass_blocks)
     op.get_active_tasks.return_value = [normal_task, queued_resubmit_task]
     op.has_next.return_value = False
 

--- a/python/ray/data/tests/unit/test_output_backpressure_guard.py
+++ b/python/ray/data/tests/unit/test_output_backpressure_guard.py
@@ -1,0 +1,115 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from ray.data._internal.execution.interfaces.physical_operator import MetadataOpTask
+from ray.data._internal.execution.streaming_executor_state import (
+    OutputBackpressureGuard,
+)
+from ray.data.tests.util import FakeDataOpTask, make_backpressured_op
+
+
+def _guard() -> OutputBackpressureGuard:
+    """A guard for exercising its stateless task-ordering / bypass-lane policy.
+
+    ``order_ready_tasks`` and ``reconstruction_bypass_lane`` take the queued
+    generator set as an argument, so no per-round setup is needed.
+    """
+    return OutputBackpressureGuard({}, MagicMock())
+
+
+def test_order_ready_tasks_puts_queued_generators_first():
+    gen = FakeDataOpTask(2, "gen", bytes_read=10)
+    normal = FakeDataOpTask(0, "normal", bytes_read=10)
+    meta = MagicMock(spec=MetadataOpTask)
+    meta.task_index.return_value = 1
+
+    # The queued-for-resubmit generator claims the operator's output budget
+    # first, even though its task index is highest. Non-data tasks (no task ID)
+    # are ordered without being probed for eligibility.
+    assert _guard().order_ready_tasks([normal, meta, gen], {"gen"}) == [
+        gen,
+        normal,
+        meta,
+    ]
+
+    # With nothing queued, ordering falls back to plain task-index order.
+    assert _guard().order_ready_tasks([gen, meta, normal], set()) == [
+        normal,
+        meta,
+        gen,
+    ]
+
+
+@pytest.mark.parametrize("op_output_budget", [0, 1])
+def test_reconstruction_bypass_lane_granted_when_fully_backpressured(op_output_budget):
+    # Budget 0 is full backpressure; budget 1 is what ``should_unblock`` bumps it
+    # to, which is still too little for an ordinary task to make progress.
+    gen = FakeDataOpTask(0, "gen", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(
+        make_backpressured_op(3), op_output_budget, {"gen"}
+    )
+    assert lane.try_drain(gen, metadata_fetcher=None)
+    # Drained one block at a time so the bypass stays bounded.
+    assert gen.calls == [("gen", 1)] * 3
+
+
+@pytest.mark.parametrize("op_output_budget", [None, 2, 1024])
+def test_no_reconstruction_bypass_lane_when_output_budget_allows_progress(
+    op_output_budget,
+):
+    gen = FakeDataOpTask(0, "gen", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(
+        make_backpressured_op(3), op_output_budget, {"gen"}
+    )
+    assert not lane.try_drain(gen, metadata_fetcher=None)
+    assert gen.calls == []
+
+
+def test_reconstruction_bypass_lane_disabled_by_zero_bypass_blocks():
+    gen = FakeDataOpTask(0, "gen", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(make_backpressured_op(0), 0, {"gen"})
+    assert not lane.try_drain(gen, metadata_fetcher=None)
+    assert gen.calls == []
+
+
+def test_reconstruction_bypass_lane_ignores_ordinary_tasks():
+    normal = FakeDataOpTask(0, "normal", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(make_backpressured_op(3), 0, {"gen"})
+    assert not lane.try_drain(normal, metadata_fetcher=None)
+    assert normal.calls == []
+
+
+def test_reconstruction_bypass_lane_stops_when_generator_has_no_ready_output():
+    # The lane pulls one block at a time up to the configured cap, but stops as
+    # soon as ``on_data_ready`` reports 0 bytes read (generator drained / pending
+    # emits / nothing buffered), so it never spins the full cap for nothing.
+    gen = FakeDataOpTask(0, "gen", bytes_read=0)
+    lane = _guard().reconstruction_bypass_lane(make_backpressured_op(100), 0, {"gen"})
+    assert lane.try_drain(gen, metadata_fetcher=None)
+    assert gen.calls == [("gen", 1)]
+
+
+def test_reconstruction_bypass_lane_budget_is_shared_per_operator():
+    # ``lineage_reconstruction_backpressure_bypass_blocks`` is a per-operator
+    # budget shared across that operator's queued-for-resubmit generators, NOT
+    # granted N-per-task: with two queued generators and a cap of 3, the total
+    # is 3 bypass reads, not 6.
+    gen_a = FakeDataOpTask(0, "gen_a", bytes_read=10)
+    gen_b = FakeDataOpTask(1, "gen_b", bytes_read=10)
+    lane = _guard().reconstruction_bypass_lane(
+        make_backpressured_op(3), 0, {"gen_a", "gen_b"}
+    )
+
+    assert lane.try_drain(gen_a, metadata_fetcher=None)
+    assert gen_a.calls == [("gen_a", 1)] * 3
+    # gen_b finds the shared allowance exhausted and falls back to the
+    # operator's (zeroed) byte budget.
+    assert not lane.try_drain(gen_b, metadata_fetcher=None)
+    assert gen_b.calls == []
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from contextlib import contextmanager
 from typing import Any, Callable, Iterable, List, Optional
+from unittest.mock import MagicMock
 
 import pandas as pd
 
@@ -213,3 +214,38 @@ def _take_outputs(op: PhysicalOperator) -> List[Any]:
         assert ref.owns_blocks, ref
         _get_blocks(ref, output)
     return output
+
+
+class FakeDataOpTask(DataOpTask):
+    """Minimal ``DataOpTask`` stand-in for output-backpressure scheduling tests.
+
+    Records the byte budget passed to every ``on_data_ready`` call in ``calls``
+    (a list of ``(task_id, max_bytes_to_read)`` tuples) and returns a fixed
+    ``bytes_read``, so tests can assert exactly how each task was read without a
+    real generator.
+    """
+
+    def __init__(self, task_index, task_id, bytes_read, waitable=None, calls=None):
+        self._task_index = task_index
+        self._task_id = task_id
+        self._bytes_read = bytes_read
+        self._waitable = waitable
+        self.calls = calls if calls is not None else []
+
+    def get_waitable(self):
+        return self._waitable
+
+    def get_task_id(self):
+        return self._task_id
+
+    def on_data_ready(self, max_bytes_to_read, metadata_fetcher):
+        self.calls.append((self._task_id, max_bytes_to_read))
+        return self._bytes_read
+
+
+def make_backpressured_op(bypass_blocks: int) -> MagicMock:
+    """A mock operator whose data context caps the lineage-reconstruction bypass
+    lane at ``bypass_blocks`` blocks."""
+    op = MagicMock()
+    op.data_context.lineage_reconstruction_backpressure_bypass_blocks = bypass_blocks
+    return op

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -415,6 +415,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         unordered_map[CLineageReconstructionTask, uint64_t] \
             GetLocalOngoingLineageReconstructionTasks() const
 
+        c_vector[CTaskID] GetLocalQueuedGeneratorResubmitTaskIds() const
+
     cdef cppclass CCoreWorkerOptions "ray::core::CoreWorkerOptions":
         CWorkerType worker_type
         CLanguage language

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4242,6 +4242,13 @@ CoreWorker::GetLocalOngoingLineageReconstructionTasks() const {
   return task_manager_->GetOngoingLineageReconstructionTasks(*actor_manager_);
 }
 
+std::vector<TaskID> CoreWorker::GetLocalQueuedGeneratorResubmitTaskIds() const {
+  auto result = normal_task_submitter_->GetQueuedGeneratorResubmitTaskIds();
+  auto actor_task_ids = actor_task_submitter_->GetQueuedGeneratorResubmitTaskIds();
+  result.insert(result.end(), actor_task_ids.begin(), actor_task_ids.end());
+  return result;
+}
+
 Status CoreWorker::GetLocalObjectLocations(
     const std::vector<ObjectID> &object_ids,
     std::vector<std::optional<ObjectLocation>> *results) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -831,6 +831,10 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   std::unordered_map<rpc::LineageReconstructionTask, uint64_t>
   GetLocalOngoingLineageReconstructionTasks() const;
 
+  /// Return locally submitted running streaming generator tasks that have a queued
+  /// resubmission for lineage reconstruction. No RPCs are made in this method.
+  std::vector<TaskID> GetLocalQueuedGeneratorResubmitTaskIds() const;
+
   /// Get the locations of a list objects. Locations that failed to be retrieved
   /// will be returned as nullptrs.
   ///

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -833,6 +833,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Return locally submitted running streaming generator tasks that have a queued
   /// resubmission for lineage reconstruction. No RPCs are made in this method.
+  /// \return The task IDs of those streaming generators.
   std::vector<TaskID> GetLocalQueuedGeneratorResubmitTaskIds() const;
 
   /// Get the locations of a list objects. Locations that failed to be retrieved

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -1098,5 +1098,11 @@ bool ActorTaskSubmitter::QueueGeneratorForResubmit(const TaskSpecification &spec
   return true;
 }
 
+std::vector<TaskID> ActorTaskSubmitter::GetQueuedGeneratorResubmitTaskIds() const {
+  absl::MutexLock lock(&mu_);
+  return std::vector<TaskID>(generators_to_resubmit_.begin(),
+                             generators_to_resubmit_.end());
+}
+
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -250,6 +250,7 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
 
   /// Return running streaming generator tasks that have a queued resubmission for
   /// lineage reconstruction once their current attempt finishes.
+  /// \return The task IDs of those streaming generators.
   std::vector<TaskID> GetQueuedGeneratorResubmitTaskIds() const;
 
  private:

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -246,6 +247,10 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   /// \return true if the task is still executing and the submitter agrees to resubmit
   /// when it finishes. false case is a TODO.
   bool QueueGeneratorForResubmit(const TaskSpecification &spec);
+
+  /// Return running streaming generator tasks that have a queued resubmission for
+  /// lineage reconstruction once their current attempt finishes.
+  std::vector<TaskID> GetQueuedGeneratorResubmitTaskIds() const;
 
  private:
   struct PendingTaskWaitingForDeathInfo {

--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -831,6 +831,12 @@ bool NormalTaskSubmitter::QueueGeneratorForResubmit(const TaskSpecification &spe
   return true;
 }
 
+std::vector<TaskID> NormalTaskSubmitter::GetQueuedGeneratorResubmitTaskIds() const {
+  absl::MutexLock lock(&mu_);
+  return std::vector<TaskID>(generators_to_resubmit_.begin(),
+                             generators_to_resubmit_.end());
+}
+
 ClusterSizeBasedLeaseRequestRateLimiter::ClusterSizeBasedLeaseRequestRateLimiter(
     size_t min_concurrent_lease_limit)
     : min_concurrent_lease_cap_(min_concurrent_lease_limit), num_alive_nodes_(0) {}

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -150,6 +150,7 @@ class NormalTaskSubmitter {
 
   /// Return running streaming generator tasks that have a queued resubmission for
   /// lineage reconstruction once their current attempt finishes.
+  /// \return The task IDs of those streaming generators.
   std::vector<TaskID> GetQueuedGeneratorResubmitTaskIds() const;
 
   /// Check that the scheduling_key_entries_ hashmap is empty by calling the private

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -148,6 +148,10 @@ class NormalTaskSubmitter {
   /// when it finishes. false if the user cancelled the task.
   bool QueueGeneratorForResubmit(const TaskSpecification &spec);
 
+  /// Return running streaming generator tasks that have a queued resubmission for
+  /// lineage reconstruction once their current attempt finishes.
+  std::vector<TaskID> GetQueuedGeneratorResubmitTaskIds() const;
+
   /// Check that the scheduling_key_entries_ hashmap is empty by calling the private
   /// CheckNoSchedulingKeyEntries function after acquiring the lock.
   bool CheckNoSchedulingKeyEntriesPublic() {
@@ -276,7 +280,7 @@ class NormalTaskSubmitter {
   const WorkerType worker_type_;
 
   // Protects task submission state below.
-  absl::Mutex mu_;
+  mutable absl::Mutex mu_;
 
   std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool_;
 


### PR DESCRIPTION
## Description

On preemptible / elastic clusters (spot workers preempted often), Ray Data
pipelines that rely on lineage reconstruction can collapse to **near-zero
goodput** after a recoverable object loss. The streaming generator that
reconstruction is waiting on is starved by its own operator's output
backpressure — which is in turn caused by the very downstream task that is
blocked on that reconstruction.

Consider a typical elastic-resource pipeline (worker pods can be preempted at
any time):

```text
read_parquet ──► map_batches A ──► map_batches B ──► write_parquet
                 (streaming gen)     (actor)

  A_task_k  yields intermediate block A1
                     │
                     ▼
  B_task    consumes A1, produces B1
                     │
              node preempted
                     ▼
              B1 is LOST  ──►  lineage reconstruction of B1 needs A1,
                               and A1 was produced by A_task_k
```

### The starvation cycle

`A_task_k`'s original attempt is **still running**, so Ray Core queues it for
resubmit (replay) and waits for the current attempt to return. For that attempt
to return, Ray Data must keep reading `A_task_k`'s streaming output. But Ray
Data applies output read budgets **per operator**, and under backpressure the
budget for operator `A` is `0`:

```text
        ┌─────────────────────────────────────────────────────────────┐
        │                                                             │
        ▼                                                             │
  downstream write task is PENDING on B1                              │
  (waiting for B1 to be reconstructed)                                │
        │                                                             │
        │  can't consume from B → B backs up → A backs up             │
        ▼                                                             │
  output backpressure clamps A's read budget → 0                      │
        │                                                             │
        ▼                                                             │
  A_task_k (needed for replay) is starved of reads                    │
        │                                                             │
        ▼                                                             │
  A_task_k's current attempt cannot finish                            │
        │                                                             │
        ▼                                                             │
  replay stays queued → A1 and B1 not reconstructed  ─────────────────┘
```

This is **not a permanent deadlock** in the general case: Ray Data's existing
output-backpressure escape hatch (`OutputBackpressureGuard.should_unblock`)
periodically releases a single block. But its forward progress is only nominal —
it fires on a ~10s idle-detection interval, and it releases the budget to *any*
ready task, not specifically the generator replay is queued behind. How badly
this bites depends on the resource regime:

- **Elastic CPU** (spare capacity downstream): the drip does eventually
  reconstruct, but ~1 block / 10s loses the race against sustained preemption —
  goodput collapses.
- **Constrained accelerators** (e.g. a lowest-priority job whose GPUs are
  preempted, with none free to reschedule on): the released block is often not
  the reconstruction-critical generator, and even when it is, that block has
  **nowhere to go** — surviving GPU actors are starved waiting for inputs and no
  new actors can be scheduled. The released blocks instead pile up in the object
  store, which *tightens* the very backpressure starving the generator. Here the
  "one block per round" safety net produces no real forward progress and the
  pipeline effectively **hangs** — the same cycle, surfacing as a full halt.

### Root cause

Ray Data computes output read budgets at the **operator** level and treats all
of an operator's ready tasks identically. It has no way to tell that one
specific streaming generator is the one Ray Core is waiting on for
reconstruction, so under backpressure that generator is starved along with
everything else. Ray Core cannot resolve this alone either — it does not observe
or control Ray Data's per-operator output-read policy.

## Fix

Give Ray Data a minimal, bounded feedback path from Ray Core's reconstruction
state. All of it lands in `OutputBackpressureGuard`, which already owns the one
existing exception to output backpressure:

1. **Expose the signal from Core.** Add
   `CoreWorker::GetLocalQueuedGeneratorResubmitTaskIds()` (aggregating new
   `GetQueuedGeneratorResubmitTaskIds()` accessors on the normal and actor task
   submitters), surfaced to Python via
   `CoreWorker.get_local_queued_generator_resubmit_task_ids()`. It returns the
   locally-submitted streaming generators reconstruction has queued for resubmit.
   Local (no RPC) but takes the submitter lock, so it is only queried when at
   least one operator has a finite output read budget.

2. **Prioritize the reconstruction-critical generator.**
   `OutputBackpressureGuard.order_ready_tasks` orders an operator's ready tasks
   so queued generators come first, then by task index (deterministic; falls
   back to plain task-index order when nothing is queued).

3. **Grant a bounded bypass lane.** For a fully-backpressured operator the guard
   vends a `ReconstructionBypassLane` worth
   `DataContext.lineage_reconstruction_backpressure_bypass_blocks` blocks (env
   `RAY_DATA_LINEAGE_RECONSTRUCTION_BACKPRESSURE_BYPASS_BLOCKS`, default `1`, `0`
   disables), shared across that operator's queued generators. The lane reads one
   block at a time, stops early once the generator has nothing ready, and
   **never touches the operator's byte budget** — so ordinary tasks on the same
   operator stay fully backpressured.

This breaks the cycle: `A_task_k` is drained a bounded number of blocks per
round, its current attempt can finish, replay proceeds, `A1` and then `B1` are
reconstructed, and recovery keeps pace with the preemption rate.

Keeping this in the guard (rather than the scheduling loop) puts both
backpressure exceptions in one place. The lane stays a **separate** mechanism
from `should_unblock` because eligibility is **task-scoped**: widening the
operator-level byte budget would let *every* task on the operator read past
backpressure, not just the one generator reconstruction is blocked on.