### PR TITLE
[RLlib] Fix API-doc consistency check for the new reverse/dedup policies

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -183,64 +183,44 @@ TEAM_API_CONFIGS = {
     "rllib": {
         "head_modules": {"ray.rllib"},
         "head_doc_file": "doc/source/rllib/package_ref/index.rst",
-        "white_list_apis": set(),
-        # RLlib carries the largest un-triaged surface. These are parked as
-        # tracked debt to green the now-honest check; each still wants a real
-        # resolution from the RLlib team (fix the doc entry, deprecate, or
-        # de-annotate). Grouped by failure mode.
-        "tracked_doc_debt": {
-            # Documented autosummary entries that don't resolve to a live object:
-            # instance attributes with no class-level object, and malformed
-            # entries whose module path is doubled (a full-path name written
-            # under a matching .. currentmodule::). Fix the source pages (or the
-            # check's name handling), then drop these.
-            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.module_class",
-            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.observation_space",
-            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.action_space",
-            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.model_config",
-            "ray.rllib.core.rl_module.rl_module.RLModule.observation_space",
-            "ray.rllib.core.rl_module.rl_module.RLModule.action_space",
-            "ray.rllib.core.rl_module.rl_module.RLModule.inference_only",
-            "ray.rllib.core.rl_module.rl_module.RLModule.model_config",
-            "ray.rllib.env.external.rllink.ray.rllib.env.external.rllink.RLlink",
-            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.inference_only_api.InferenceOnlyAPI",
-            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.q_net_api.QNetAPI",
-            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.self_supervised_loss_api.SelfSupervisedLossAPI",
-            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.target_network_api.TargetNetworkAPI",
-            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.value_function_api.ValueFunctionAPI",
-            "ray.rllib.connectors.connector_v2.ray.rllib.connectors.connector_v2.ConnectorV2",
-            "ray.rllib.connectors.connector_v2.ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2",
-            "ray.rllib.connectors.env_to_module.observation_preprocessor.ray.rllib.connectors.env_to_module.observation_preprocessor.SingleAgentObservationPreprocessor",
-            "ray.rllib.connectors.env_to_module.observation_preprocessor.ray.rllib.connectors.env_to_module.observation_preprocessor.MultiAgentObservationPreprocessor",
-            # Documented private / dunder members flagged non-public. Document
-            # the public surface instead, then drop these.
-            "ray.rllib.core.learner.learner.Learner._check_is_built",
-            "ray.rllib.core.learner.learner.Learner._make_module",
-            "ray.rllib.core.learner.learner.Learner._check_registered_optimizer",
-            "ray.rllib.core.learner.learner.Learner._set_optimizer_lr",
-            "ray.rllib.core.learner.learner.Learner._get_clip_function",
-            "ray.rllib.utils.schedules.scheduler.Scheduler._create_tensor_variable",
+        # Private-by-name methods RLlib intentionally documents as the public
+        # override contract: users subclass RLModule / Learner and implement
+        # these to define custom forward and module-construction behavior.
+        "white_list_apis": {
             "ray.rllib.core.rl_module.rl_module.RLModule._forward",
             "ray.rllib.core.rl_module.rl_module.RLModule._forward_exploration",
             "ray.rllib.core.rl_module.rl_module.RLModule._forward_inference",
             "ray.rllib.core.rl_module.rl_module.RLModule._forward_train",
+            "ray.rllib.core.learner.learner.Learner._make_module",
+            # OfflinePreLearner / OfflineData methods documented as the
+            # offline-RL customization surface in rllib-offline.rst (which has a
+            # worked example of overriding _map_to_episodes).
             "ray.rllib.offline.offline_data.OfflineData.__init__",
-            "ray.rllib.offline.offline_prelearner.OfflinePreLearner.__init__",
             "ray.rllib.offline.offline_prelearner.OfflinePreLearner.__call__",
             "ray.rllib.offline.offline_prelearner.OfflinePreLearner._map_to_episodes",
-            "ray.rllib.offline.offline_prelearner.OfflinePreLearner._map_sample_batch_to_episode",
-            "ray.rllib.offline.offline_prelearner.OfflinePreLearner._should_module_be_updated",
-            "ray.rllib.env.multi_agent_episode.MultiAgentEpisode.__len__",
-            "ray.rllib.env.single_agent_episode.SingleAgentEpisode.__len__",
         },
-        # Documented in more than one place (a hand-written topic page plus the
-        # generated class stub).
+        # RLModule instance attributes (observation_space, action_space,
+        # inference_only, model_config) are assigned in setup(), not declared on
+        # the class, so the checker's import-walk resolves them to None and
+        # treats them as unresolved. They are legitimately documented via
+        # autosummary, so exempt them from the doc-resolves-to-code check only.
+        "doc_only_whitelist": {
+            "ray.rllib.core.rl_module.rl_module.RLModule.observation_space",
+            "ray.rllib.core.rl_module.rl_module.RLModule.action_space",
+            "ray.rllib.core.rl_module.rl_module.RLModule.inference_only",
+            "ray.rllib.core.rl_module.rl_module.RLModule.model_config",
+        },
+        # Canonical names intentionally documented in more than one place:
+        # build_learner / build_learner_group / learners appear on both the
+        # AlgorithmConfig page (algorithm-config.rst) and the learner/offline
+        # pages; save_to_path / restore_from_path are inherited from
+        # Checkpointable and shown on each Checkpointable subclass's API page.
         "intentional_duplicate_apis": {
             "ray.rllib.algorithms.algorithm_config.AlgorithmConfig.build_learner",
             "ray.rllib.algorithms.algorithm_config.AlgorithmConfig.build_learner_group",
             "ray.rllib.algorithms.algorithm_config.AlgorithmConfig.learners",
-            "ray.rllib.utils.checkpoints.Checkpointable.restore_from_path",
             "ray.rllib.utils.checkpoints.Checkpointable.save_to_path",
+            "ray.rllib.utils.checkpoints.Checkpointable.restore_from_path",
         },
     },
 }

--- a/doc/source/rllib/package_ref/connector-v2.rst
+++ b/doc/source/rllib/package_ref/connector-v2.rst
@@ -10,7 +10,7 @@ ConnectorV2 API
 rllib.connectors.connector_v2.ConnectorV2
 -----------------------------------------
 
-.. autoclass:: ray.rllib.connectors.connector_v2.ConnectorV2
+.. autoclass:: ConnectorV2
     :special-members: __call__
     :members:
 
@@ -18,7 +18,9 @@ rllib.connectors.connector_v2.ConnectorV2
 rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2
 ----------------------------------------------------------
 
-.. autoclass:: ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2
+.. currentmodule:: ray.rllib.connectors.connector_pipeline_v2
+
+.. autoclass:: ConnectorPipelineV2
     :members:
 
 
@@ -30,7 +32,7 @@ Observation preprocessors
 rllib.connectors.env_to_module.observation_preprocessor.SingleAgentObservationPreprocessor
 ------------------------------------------------------------------------------------------
 
-.. autoclass:: ray.rllib.connectors.env_to_module.observation_preprocessor.SingleAgentObservationPreprocessor
+.. autoclass:: SingleAgentObservationPreprocessor
 
     .. automethod:: recompute_output_observation_space
     .. automethod:: preprocess
@@ -39,7 +41,7 @@ rllib.connectors.env_to_module.observation_preprocessor.SingleAgentObservationPr
 rllib.connectors.env_to_module.observation_preprocessor.MultiAgentObservationPreprocessor
 -----------------------------------------------------------------------------------------
 
-.. autoclass:: ray.rllib.connectors.env_to_module.observation_preprocessor.MultiAgentObservationPreprocessor
+.. autoclass:: MultiAgentObservationPreprocessor
 
     .. automethod:: recompute_output_observation_space
     .. automethod:: preprocess

--- a/doc/source/rllib/package_ref/env/external.rst
+++ b/doc/source/rllib/package_ref/env/external.rst
@@ -10,7 +10,7 @@ ray.rllib.env.external.rllink.RLlink
 
 .. currentmodule:: ray.rllib.env.external.rllink
 
-.. autoclass:: ray.rllib.env.external.rllink.RLlink
+.. autoclass:: RLlink
 
 .. autosummary::
    :nosignatures:

--- a/doc/source/rllib/package_ref/env/multi_agent_episode.rst
+++ b/doc/source/rllib/package_ref/env/multi_agent_episode.rst
@@ -27,7 +27,6 @@ Getting basic information
     :nosignatures:
     :toctree: env/
 
-    ~MultiAgentEpisode.__len__
     ~MultiAgentEpisode.get_return
     ~MultiAgentEpisode.get_duration_s
     ~MultiAgentEpisode.is_done

--- a/doc/source/rllib/package_ref/env/single_agent_episode.rst
+++ b/doc/source/rllib/package_ref/env/single_agent_episode.rst
@@ -27,7 +27,6 @@ Getting basic information
     :nosignatures:
     :toctree: env/
 
-    ~SingleAgentEpisode.__len__
     ~SingleAgentEpisode.get_return
     ~SingleAgentEpisode.get_duration_s
     ~SingleAgentEpisode.is_done

--- a/doc/source/rllib/package_ref/learner.rst
+++ b/doc/source/rllib/package_ref/learner.rst
@@ -61,7 +61,6 @@ Constructing a Learner
 
     Learner
     Learner.build
-    Learner._check_is_built
     Learner._make_module
 
 
@@ -114,8 +113,6 @@ Configuring optimizers
     Learner.get_parameters
     Learner.get_param_ref
     Learner.filter_param_dict_for_optimizer
-    Learner._check_registered_optimizer
-    Learner._set_optimizer_lr
 
 
 Gradient computation
@@ -129,7 +126,6 @@ Gradient computation
     Learner.postprocess_gradients
     Learner.postprocess_gradients_for_module
     Learner.apply_gradients
-    Learner._get_clip_function
 
 Saving and restoring
 --------------------

--- a/doc/source/rllib/package_ref/offline.rst
+++ b/doc/source/rllib/package_ref/offline.rst
@@ -47,6 +47,7 @@ Constructing OfflineData
     :toctree: doc/
 
     OfflineData
+    OfflineData.__init__
 
 Sampling from Offline Data
 --------------------------
@@ -78,3 +79,5 @@ Transforming Data with an OfflinePreLearner
     :toctree: doc/
 
     SCHEMA
+    OfflinePreLearner.__call__
+    OfflinePreLearner._map_to_episodes

--- a/doc/source/rllib/package_ref/offline.rst
+++ b/doc/source/rllib/package_ref/offline.rst
@@ -47,7 +47,6 @@ Constructing OfflineData
     :toctree: doc/
 
     OfflineData
-    OfflineData.__init__
 
 Sampling from Offline Data
 --------------------------
@@ -70,7 +69,6 @@ Constructing an OfflinePreLearner
     :toctree: doc/
 
     OfflinePreLearner
-    OfflinePreLearner.__init__
 
 Transforming Data with an OfflinePreLearner
 -------------------------------------------
@@ -80,7 +78,3 @@ Transforming Data with an OfflinePreLearner
     :toctree: doc/
 
     SCHEMA
-    OfflinePreLearner.__call__
-    OfflinePreLearner._map_to_episodes
-    OfflinePreLearner._map_sample_batch_to_episode
-    OfflinePreLearner._should_module_be_updated

--- a/doc/source/rllib/package_ref/rl_modules.rst
+++ b/doc/source/rllib/package_ref/rl_modules.rst
@@ -192,19 +192,21 @@ Saving and restoring
 Additional RLModule APIs
 ------------------------
 
-.. currentmodule:: ray.rllib.core.rl_module.apis
-
 InferenceOnlyAPI
 ++++++++++++++++
 
-.. autoclass:: inference_only_api.InferenceOnlyAPI
+.. currentmodule:: ray.rllib.core.rl_module.apis.inference_only_api
+
+.. autoclass:: InferenceOnlyAPI
 
     .. automethod:: get_non_inference_attributes
 
 QNetAPI
 +++++++
 
-.. autoclass:: q_net_api.QNetAPI
+.. currentmodule:: ray.rllib.core.rl_module.apis.q_net_api
+
+.. autoclass:: QNetAPI
 
     .. automethod:: compute_q_values
     .. automethod:: compute_advantage_distribution
@@ -212,14 +214,18 @@ QNetAPI
 SelfSupervisedLossAPI
 +++++++++++++++++++++
 
-.. autoclass:: self_supervised_loss_api.SelfSupervisedLossAPI
+.. currentmodule:: ray.rllib.core.rl_module.apis.self_supervised_loss_api
+
+.. autoclass:: SelfSupervisedLossAPI
 
     .. automethod:: compute_self_supervised_loss
 
 TargetNetworkAPI
 ++++++++++++++++
 
-.. autoclass:: target_network_api.TargetNetworkAPI
+.. currentmodule:: ray.rllib.core.rl_module.apis.target_network_api
+
+.. autoclass:: TargetNetworkAPI
 
     .. automethod:: make_target_networks
     .. automethod:: get_target_network_pairs
@@ -228,6 +234,8 @@ TargetNetworkAPI
 ValueFunctionAPI
 ++++++++++++++++
 
-.. autoclass:: value_function_api.ValueFunctionAPI
+.. currentmodule:: ray.rllib.core.rl_module.apis.value_function_api
+
+.. autoclass:: ValueFunctionAPI
 
     .. automethod:: compute_values

--- a/doc/source/rllib/package_ref/rl_modules.rst
+++ b/doc/source/rllib/package_ref/rl_modules.rst
@@ -19,12 +19,24 @@ Single RLModuleSpec
 
     RLModuleSpec
     RLModuleSpec.build
-    RLModuleSpec.module_class
-    RLModuleSpec.observation_space
-    RLModuleSpec.action_space
-    RLModuleSpec.inference_only
-    RLModuleSpec.learner_only
-    RLModuleSpec.model_config
+
+.. autoattribute:: ray.rllib.core.rl_module.rl_module.RLModuleSpec.module_class
+    :no-index:
+
+.. autoattribute:: ray.rllib.core.rl_module.rl_module.RLModuleSpec.observation_space
+    :no-index:
+
+.. autoattribute:: ray.rllib.core.rl_module.rl_module.RLModuleSpec.action_space
+    :no-index:
+
+.. autoattribute:: ray.rllib.core.rl_module.rl_module.RLModuleSpec.inference_only
+    :no-index:
+
+.. autoattribute:: ray.rllib.core.rl_module.rl_module.RLModuleSpec.learner_only
+    :no-index:
+
+.. autoattribute:: ray.rllib.core.rl_module.rl_module.RLModuleSpec.model_config
+    :no-index:
 
 MultiRLModuleSpec
 +++++++++++++++++
@@ -185,14 +197,14 @@ Additional RLModule APIs
 InferenceOnlyAPI
 ++++++++++++++++
 
-.. autoclass:: ray.rllib.core.rl_module.apis.inference_only_api.InferenceOnlyAPI
+.. autoclass:: inference_only_api.InferenceOnlyAPI
 
     .. automethod:: get_non_inference_attributes
 
 QNetAPI
 +++++++
 
-.. autoclass:: ray.rllib.core.rl_module.apis.q_net_api.QNetAPI
+.. autoclass:: q_net_api.QNetAPI
 
     .. automethod:: compute_q_values
     .. automethod:: compute_advantage_distribution
@@ -200,14 +212,14 @@ QNetAPI
 SelfSupervisedLossAPI
 +++++++++++++++++++++
 
-.. autoclass:: ray.rllib.core.rl_module.apis.self_supervised_loss_api.SelfSupervisedLossAPI
+.. autoclass:: self_supervised_loss_api.SelfSupervisedLossAPI
 
     .. automethod:: compute_self_supervised_loss
 
 TargetNetworkAPI
 ++++++++++++++++
 
-.. autoclass:: ray.rllib.core.rl_module.apis.target_network_api.TargetNetworkAPI
+.. autoclass:: target_network_api.TargetNetworkAPI
 
     .. automethod:: make_target_networks
     .. automethod:: get_target_network_pairs
@@ -216,6 +228,6 @@ TargetNetworkAPI
 ValueFunctionAPI
 ++++++++++++++++
 
-.. autoclass:: ray.rllib.core.rl_module.apis.value_function_api.ValueFunctionAPI
+.. autoclass:: value_function_api.ValueFunctionAPI
 
     .. automethod:: compute_values

--- a/doc/source/rllib/package_ref/utils.rst
+++ b/doc/source/rllib/package_ref/utils.rst
@@ -80,7 +80,6 @@ For example:
     Scheduler.validate
     Scheduler.get_current_value
     Scheduler.update
-    Scheduler._create_tensor_variable
 
 
 Framework Utilities


### PR DESCRIPTION
#64420 added reverse (documented-must-resolve-to-public) and dedup (documented-exactly-once) policies to the API-doc consistency check, and #64783/#64786 populated per-team exemptions for every team except RLlib (whose white_list_apis was left empty). The stricter check now flags ~30 pre-existing RLlib doc entries, failing the "doc: check API doc consistency" premerge job on every PR that merges current master.

This fixes the RLlib side:

Unresolved doc entries:
- De-double autoclass targets that combined `.. currentmodule::` with a fully-qualified name (RLlink, ConnectorV2, ConnectorPipelineV2, the observation preprocessors, and the RLModule `apis` classes) by making the autoclass argument relative to its currentmodule.
- RLModuleSpec dataclass fields -> `.. autoattribute:: ... :no-index:` (mirrors the existing MultiRLModuleSpec block).
- RLModule instance attributes (observation_space, action_space, inference_only, model_config) are assigned in setup(), not on the class, so they resolve to None; exempt them via doc_only_whitelist.

Documented private/dunder objects:
- Whitelist the intentional override contract (RLModule._forward*, Learner._make_module).
- Remove doc entries for internal helpers (Learner._check_is_built / _check_registered_optimizer / _set_optimizer_lr / _get_clip_function, Scheduler._create_tensor_variable, OfflineData/OfflinePreLearner privates, SingleAgentEpisode/MultiAgentEpisode.__len__).

Duplicate documentation:
- Mark intentional cross-page duplicates as intentional_duplicate_apis (AlgorithmConfig.build_learner / build_learner_group / learners; Checkpointable.save_to_path / restore_from_path, inherited and shown on each subclass page).
