### PR TITLE
[ci/doc] Green the API-doc consistency check across all libraries

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -64,6 +64,10 @@ TEAM_API_CONFIGS = {
             "ray.data._internal.execution.interfaces.execution_options.ExecutionResources",
             "ray.data._internal.logical.operators.n_ary_operator.MixStoppingCondition",
             "ray.data._internal.random_config.RandomSeedConfig",
+            # Same pattern under ray.data.llm: the @PublicAPI Processor is
+            # re-exported through ray.data.llm (documented in data/api/llm.rst)
+            # while its implementation lives under ray.llm._internal.
+            "ray.llm._internal.batch.processor.base.Processor",
         },
         # Canonical names intentionally documented in more than one place. Each
         # is listed both in the generated ray.data.Dataset.rst method table
@@ -371,18 +375,25 @@ def _mock_uninstalled_backends(ray_checkout_dir: str):
     """
     from sphinx.ext.autodoc.mock import mock
 
-    doc_source = os.path.join(ray_checkout_dir, "doc", "source")
+    doc_source = os.path.abspath(os.path.join(ray_checkout_dir, "doc", "source"))
     sys.path.insert(0, doc_source)
     try:
         from api_mock_imports import absent_mock_modules
+
+        modules_to_mock = absent_mock_modules()
     finally:
         sys.path.remove(doc_source)
+        # api_mock_imports is checkout-specific and unqualified, so a copy left
+        # in sys.modules would be reused by a later invocation with a different
+        # ray_checkout_dir even after doc_source leaves sys.path. Evict it so
+        # each invocation re-imports from its own checkout.
+        sys.modules.pop("api_mock_imports", None)
 
     # Mock only the genuinely-absent optional backends, not the full
     # autodoc_mock_imports list: shadowing an installed library (e.g. pandas)
     # would make resolve()'s ``import ray.data`` fail and mass-flag every data
     # entry as unresolved. ray.* is never mocked.
-    with mock(absent_mock_modules()):
+    with mock(modules_to_mock):
         yield
 
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -374,11 +374,15 @@ def _mock_uninstalled_backends(ray_checkout_dir: str):
     doc_source = os.path.join(ray_checkout_dir, "doc", "source")
     sys.path.insert(0, doc_source)
     try:
-        from api_mock_imports import THIRD_PARTY_MOCK_MODULES
+        from api_mock_imports import absent_mock_modules
     finally:
         sys.path.remove(doc_source)
 
-    with mock(THIRD_PARTY_MOCK_MODULES):
+    # Mock only the genuinely-absent optional backends, not the full
+    # autodoc_mock_imports list: shadowing an installed library (e.g. pandas)
+    # would make resolve()'s ``import ray.data`` fail and mass-flag every data
+    # entry as unresolved. ray.* is never mocked.
+    with mock(absent_mock_modules()):
         yield
 
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -1,4 +1,6 @@
+import os
 import sys
+from contextlib import contextmanager
 
 import click
 
@@ -34,14 +36,58 @@ TEAM_API_CONFIGS = {
         "tracked_doc_debt": {
             # not sure what to do
             "ray.data.dataset.MaterializedDataset",
+            # Deprecated but still documented. Remove from the docs, or move to a
+            # deprecated-only page, then drop these.
+            "ray.data.aggregate.AggregateFn",
+            "ray.data.dataset.Dataset.iter_tf_batches",
+            "ray.data.read_api.read_unity_catalog",
+            # Private-named accessor classes documented under expressions.rst
+            # "Expression namespaces". Document the public accessor surface, or
+            # promote these to public names, then drop them.
+            "ray.data.namespace_expressions.arr_namespace._ArrayNamespace",
+            "ray.data.namespace_expressions.dt_namespace._DatetimeNamespace",
+            "ray.data.namespace_expressions.list_namespace._ListNamespace",
+            "ray.data.namespace_expressions.string_namespace._StringNamespace",
+            "ray.data.namespace_expressions.struct_namespace._StructNamespace",
         },
-        # Canonical names intentionally documented in more than one place:
-        # to_arrow_refs / to_numpy_refs / to_pandas_refs appear on both the
-        # Dataset API page (dataset.rst) and the saving-data page (saving_data.rst).
+        # Documented public APIs whose canonical name resolves under a private
+        # (._internal.) module: the class is re-exported from ray.data.__all__
+        # while its implementation lives in _internal. They resolve fine and are
+        # correctly documented; only the resolve check's private-name heuristic
+        # flags them. doc_only_whitelist exempts them from that check
+        # (split_resolvable_and_broken_doc_apis) without touching the
+        # must-be-documented check. Permanent (implementation location, not debt).
+        "doc_only_whitelist": {
+            "ray.data._internal.compute.ActorPoolStrategy",
+            "ray.data._internal.compute.TaskPoolStrategy",
+            "ray.data._internal.execution.interfaces.execution_options.ExecutionOptions",
+            "ray.data._internal.execution.interfaces.execution_options.ExecutionResources",
+            "ray.data._internal.logical.operators.n_ary_operator.MixStoppingCondition",
+            "ray.data._internal.random_config.RandomSeedConfig",
+        },
+        # Canonical names intentionally documented in more than one place. Each
+        # is listed both in the generated ray.data.Dataset.rst method table
+        # (included by dataset.rst) and in saving_data.rst's save-topic grouping.
+        # to_arrow_refs / to_numpy_refs / to_pandas_refs are the original three;
+        # the to_* / write_* conversion and write methods are the same pattern.
         "intentional_duplicate_apis": {
             "ray.data.dataset.Dataset.to_arrow_refs",
             "ray.data.dataset.Dataset.to_numpy_refs",
             "ray.data.dataset.Dataset.to_pandas_refs",
+            "ray.data.dataset.Dataset.to_daft",
+            "ray.data.dataset.Dataset.to_dask",
+            "ray.data.dataset.Dataset.to_mars",
+            "ray.data.dataset.Dataset.to_modin",
+            "ray.data.dataset.Dataset.to_pandas",
+            "ray.data.dataset.Dataset.to_spark",
+            "ray.data.dataset.Dataset.write_csv",
+            "ray.data.dataset.Dataset.write_iceberg",
+            "ray.data.dataset.Dataset.write_images",
+            "ray.data.dataset.Dataset.write_json",
+            "ray.data.dataset.Dataset.write_mongo",
+            "ray.data.dataset.Dataset.write_numpy",
+            "ray.data.dataset.Dataset.write_parquet",
+            "ray.data.dataset.Dataset.write_tfrecords",
         },
     },
     "serve": {
@@ -120,12 +166,78 @@ TEAM_API_CONFIGS = {
         "tracked_doc_debt": {
             # TODO(ml-team): deprecate these APIs
             "ray.tune.utils.log.Verbosity",
+            # Documented dunder on a public class; flagged non-public. Document
+            # the class-level behavior instead of the dunder, then drop this.
+            "ray.tune.stopper.stopper.Stopper.__call__",
+        },
+        # Documented in more than one place (scheduler overview and the
+        # per-scheduler page).
+        "intentional_duplicate_apis": {
+            "ray.tune.schedulers.async_hyperband.AsyncHyperBandScheduler",
         },
     },
     "rllib": {
         "head_modules": {"ray.rllib"},
         "head_doc_file": "doc/source/rllib/package_ref/index.rst",
         "white_list_apis": set(),
+        # RLlib carries the largest un-triaged surface. These are parked as
+        # tracked debt to green the now-honest check; each still wants a real
+        # resolution from the RLlib team (fix the doc entry, deprecate, or
+        # de-annotate). Grouped by failure mode.
+        "tracked_doc_debt": {
+            # Documented autosummary entries that don't resolve to a live object:
+            # instance attributes with no class-level object, and malformed
+            # entries whose module path is doubled (a full-path name written
+            # under a matching .. currentmodule::). Fix the source pages (or the
+            # check's name handling), then drop these.
+            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.module_class",
+            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.observation_space",
+            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.action_space",
+            "ray.rllib.core.rl_module.rl_module.RLModuleSpec.model_config",
+            "ray.rllib.core.rl_module.rl_module.RLModule.observation_space",
+            "ray.rllib.core.rl_module.rl_module.RLModule.action_space",
+            "ray.rllib.core.rl_module.rl_module.RLModule.inference_only",
+            "ray.rllib.core.rl_module.rl_module.RLModule.model_config",
+            "ray.rllib.env.external.rllink.ray.rllib.env.external.rllink.RLlink",
+            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.inference_only_api.InferenceOnlyAPI",
+            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.q_net_api.QNetAPI",
+            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.self_supervised_loss_api.SelfSupervisedLossAPI",
+            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.target_network_api.TargetNetworkAPI",
+            "ray.rllib.core.rl_module.apis.ray.rllib.core.rl_module.apis.value_function_api.ValueFunctionAPI",
+            "ray.rllib.connectors.connector_v2.ray.rllib.connectors.connector_v2.ConnectorV2",
+            "ray.rllib.connectors.connector_v2.ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2",
+            "ray.rllib.connectors.env_to_module.observation_preprocessor.ray.rllib.connectors.env_to_module.observation_preprocessor.SingleAgentObservationPreprocessor",
+            "ray.rllib.connectors.env_to_module.observation_preprocessor.ray.rllib.connectors.env_to_module.observation_preprocessor.MultiAgentObservationPreprocessor",
+            # Documented private / dunder members flagged non-public. Document
+            # the public surface instead, then drop these.
+            "ray.rllib.core.learner.learner.Learner._check_is_built",
+            "ray.rllib.core.learner.learner.Learner._make_module",
+            "ray.rllib.core.learner.learner.Learner._check_registered_optimizer",
+            "ray.rllib.core.learner.learner.Learner._set_optimizer_lr",
+            "ray.rllib.core.learner.learner.Learner._get_clip_function",
+            "ray.rllib.utils.schedules.scheduler.Scheduler._create_tensor_variable",
+            "ray.rllib.core.rl_module.rl_module.RLModule._forward",
+            "ray.rllib.core.rl_module.rl_module.RLModule._forward_exploration",
+            "ray.rllib.core.rl_module.rl_module.RLModule._forward_inference",
+            "ray.rllib.core.rl_module.rl_module.RLModule._forward_train",
+            "ray.rllib.offline.offline_data.OfflineData.__init__",
+            "ray.rllib.offline.offline_prelearner.OfflinePreLearner.__init__",
+            "ray.rllib.offline.offline_prelearner.OfflinePreLearner.__call__",
+            "ray.rllib.offline.offline_prelearner.OfflinePreLearner._map_to_episodes",
+            "ray.rllib.offline.offline_prelearner.OfflinePreLearner._map_sample_batch_to_episode",
+            "ray.rllib.offline.offline_prelearner.OfflinePreLearner._should_module_be_updated",
+            "ray.rllib.env.multi_agent_episode.MultiAgentEpisode.__len__",
+            "ray.rllib.env.single_agent_episode.SingleAgentEpisode.__len__",
+        },
+        # Documented in more than one place (a hand-written topic page plus the
+        # generated class stub).
+        "intentional_duplicate_apis": {
+            "ray.rllib.algorithms.algorithm_config.AlgorithmConfig.build_learner",
+            "ray.rllib.algorithms.algorithm_config.AlgorithmConfig.build_learner_group",
+            "ray.rllib.algorithms.algorithm_config.AlgorithmConfig.learners",
+            "ray.rllib.utils.checkpoints.Checkpointable.restore_from_path",
+            "ray.rllib.utils.checkpoints.Checkpointable.save_to_path",
+        },
     },
 }
 
@@ -238,6 +350,38 @@ def _check_team(ray_checkout_dir: str, team: str) -> bool:
     return passed
 
 
+@contextmanager
+def _mock_uninstalled_backends(ray_checkout_dir: str):
+    """Mock the third-party backends the docbuild image doesn't install.
+
+    The check imports documented names for real (``API.resolve`` /
+    ``get_canonical_name`` on the doc side, ``Module.get_apis`` on the code
+    side). Optional-dependency modules such as ``ray.data.llm`` /
+    ``ray.serve.llm`` / ``ray.train.lightning`` eagerly import backends like
+    vLLM, transformers, torch, or pytorch_lightning, which are absent on the CPU
+    docbuild runner. Without this they read as unresolved even though the
+    rendered docs -- built under the same mocks via conf.py's
+    ``autodoc_mock_imports`` -- show them fine. This mirrors that mock so the
+    check sees the same API surface the render produces.
+
+    Only third-party modules are mocked; ``ray.*`` is imported for real, so the
+    resolve/dedup policy keeps its teeth on Ray's own symbols. The mock list is
+    read from doc/source/api_mock_imports.py, the single source of truth shared
+    with conf.py.
+    """
+    from sphinx.ext.autodoc.mock import mock
+
+    doc_source = os.path.join(ray_checkout_dir, "doc", "source")
+    sys.path.insert(0, doc_source)
+    try:
+        from api_mock_imports import THIRD_PARTY_MOCK_MODULES
+    finally:
+        sys.path.remove(doc_source)
+
+    with mock(THIRD_PARTY_MOCK_MODULES):
+        yield
+
+
 @click.command()
 @click.argument("ray_checkout_dir", required=True, type=str)
 @click.argument(
@@ -248,23 +392,25 @@ def main(ray_checkout_dir: str, team: str) -> None:
     This script checks for annotated classes and functions in a module, and finds
     discrepancies between the annotations and the documentation.
     """
-    if team != "ALL":
-        if not _check_team(ray_checkout_dir, team):
-            exit(1)
-        return
+    with _mock_uninstalled_backends(ray_checkout_dir):
+        if team != "ALL":
+            if not _check_team(ray_checkout_dir, team):
+                exit(1)
+            return
 
-    all_pass = True
-    # Needs to do core first, otherwise, the APIs in other teams may be covered by core.
-    # This is due to the side effect of "importlib" and walking through the modules.
-    if not _check_team(ray_checkout_dir, "core"):
-        all_pass = False
-    for team in TEAM_API_CONFIGS:
-        if team == "core":
-            continue
-        if not _check_team(ray_checkout_dir, team):
+        all_pass = True
+        # Needs to do core first, otherwise, the APIs in other teams may be
+        # covered by core. This is due to the side effect of "importlib" and
+        # walking through the modules.
+        if not _check_team(ray_checkout_dir, "core"):
             all_pass = False
-    if not all_pass:
-        exit(1)
+        for team in TEAM_API_CONFIGS:
+            if team == "core":
+                continue
+            if not _check_team(ray_checkout_dir, team):
+                all_pass = False
+        if not all_pass:
+            exit(1)
 
 
 if __name__ == "__main__":

--- a/doc/source/api_mock_imports.py
+++ b/doc/source/api_mock_imports.py
@@ -1,0 +1,79 @@
+"""Single source of truth for modules mocked during API doc generation.
+
+Three consumers import from here so they agree on what "not installed in the
+docbuild image" means:
+
+- ``conf.py`` -- Sphinx ``autodoc_mock_imports`` for the full ``make html``
+  build.
+- ``api_autogen.py`` -- the standalone autosummary stub generator.
+- ``ci/ray_ci/doc`` -- the API/doc consistency check, whose ``resolve()`` walk
+  imports documented names directly (bypassing Sphinx), so it must apply the
+  same mocks or an optional-dependency API (for example ``ray.data.llm.*``,
+  which pulls in the vLLM/SGLang batch stack) reads as "does not resolve".
+
+Keep this module free of imports and side effects: it is imported both by the
+Sphinx config and by a plain-``python`` CI script.
+"""
+
+# Third-party libraries absent from the docbuild image. Safe for any consumer to
+# mock, including the consistency check (which imports Ray for real). Do NOT add
+# ``ray.*`` here: the check resolves Ray's own symbols against real objects, and
+# a mock answers any getattr -- mocking a ``ray.*`` path would blind the
+# resolve/dedup policy to deleted or renamed Ray APIs under it.
+THIRD_PARTY_MOCK_MODULES = [
+    "aiohttp",
+    "async_timeout",
+    "backoff",
+    "cachetools",
+    "comet_ml",
+    "composer",
+    "cupy",
+    "dask",
+    "datasets",
+    "fastapi",
+    "filelock",
+    "fsspec",
+    "google",
+    "grpc",
+    "gymnasium",
+    "horovod",
+    "huggingface",
+    "httpx",
+    "joblib",
+    "lightgbm",
+    "lightgbm_ray",
+    "mlflow",
+    "nevergrad",
+    "pandas",
+    "pytorch_lightning",
+    "scipy",
+    "setproctitle",
+    "skimage",
+    "sklearn",
+    "starlette",
+    "tensorflow",
+    "torch",
+    "torchvision",
+    "transformers",
+    "tree",
+    "typer",
+    "uvicorn",
+    "wandb",
+    "watchfiles",
+    "openai",
+    "xgboost",
+    "xgboost_ray",
+    "psutil",
+    "colorama",
+    "vllm",
+]
+
+# Compiled/generated Ray modules that are absent only when docs build against a
+# source checkout without a built Ray. The consistency check runs against an
+# installed Ray wheel where these are present, so it must NOT mock them; only the
+# Sphinx build adds these.
+BUILD_ONLY_MOCK_MODULES = [
+    "ray._raylet",
+    "ray.core.generated",
+    "ray.serve.generated",
+]

--- a/doc/source/api_mock_imports.py
+++ b/doc/source/api_mock_imports.py
@@ -77,3 +77,28 @@ BUILD_ONLY_MOCK_MODULES = [
     "ray.core.generated",
     "ray.serve.generated",
 ]
+
+
+def absent_mock_modules():
+    """Return the THIRD_PARTY_MOCK_MODULES that aren't importable here.
+
+    conf.py mocks every entry because Sphinx autodoc tolerates -- and sometimes
+    needs (e.g. tensorflow) -- shadowing an installed library. The raw-import
+    consumers (the standalone stub generator and the ci/ray_ci/doc consistency
+    check) must NOT shadow an installed library: mocking e.g. pandas, which is
+    installed in the docbuild image and imported by ray.data, makes a plain
+    importlib / autosummary ``import ray.data`` fail. So they mock only the
+    genuinely-absent modules -- all that's needed to make optional-dependency
+    modules (ray.data.llm, ray.serve.llm, ray.train.lightning, ...) importable.
+    """
+    import importlib.util
+
+    absent = []
+    for name in THIRD_PARTY_MOCK_MODULES:
+        try:
+            if importlib.util.find_spec(name) is None:
+                absent.append(name)
+        except (ImportError, ValueError):
+            # A parent package that itself isn't importable: treat as absent.
+            absent.append(name)
+    return absent

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -769,58 +769,14 @@ autosummary_filename_map = {
 # pyarrow are installed, so they are not mocked. tensorflow is also installed (a
 # direct requirements-doc entry), but importing it for real breaks the autodoc
 # import of ray.rllib.algorithms.algorithm at build time, so it stays mocked.
-autodoc_mock_imports = [
-    "aiohttp",
-    "async_timeout",
-    "backoff",
-    "cachetools",
-    "comet_ml",
-    "composer",
-    "cupy",
-    "dask",
-    "datasets",
-    "fastapi",
-    "filelock",
-    "fsspec",
-    "google",
-    "grpc",
-    "gymnasium",
-    "horovod",
-    "huggingface",
-    "httpx",
-    "joblib",
-    "lightgbm",
-    "lightgbm_ray",
-    "mlflow",
-    "nevergrad",
-    "pandas",
-    "pytorch_lightning",
-    "scipy",
-    "setproctitle",
-    "skimage",
-    "sklearn",
-    "starlette",
-    "tensorflow",
-    "torch",
-    "torchvision",
-    "transformers",
-    "tree",
-    "typer",
-    "uvicorn",
-    "wandb",
-    "watchfiles",
-    "openai",
-    "xgboost",
-    "xgboost_ray",
-    "psutil",
-    "colorama",
-    "grpc",
-    "vllm",
-    # Internal compiled modules
-    "ray._raylet",
-    "ray.core.generated",
-    "ray.serve.generated",
-]
+# The mock list is shared with the API/doc consistency check (ci/ray_ci/doc)
+# via api_mock_imports.py so the check, which imports documented names directly
+# (bypassing Sphinx), applies the same mocks this render does. THIRD_PARTY_MOCK
+# covers uninstalled third-party libraries; BUILD_ONLY_MOCK covers Ray's
+# compiled/generated modules, which are absent only in a source-checkout build.
+from api_mock_imports import BUILD_ONLY_MOCK_MODULES, THIRD_PARTY_MOCK_MODULES
+
+autodoc_mock_imports = THIRD_PARTY_MOCK_MODULES + BUILD_ONLY_MOCK_MODULES
 
 for mock_target in autodoc_mock_imports:
     if mock_target in sys.modules:


### PR DESCRIPTION
## Why

The API-doc consistency check (`ci/ray_ci/doc`) gained reverse-resolution and dedup policies, but it runs **only on premerge PRs, never postmerge**, so master drifted red undetected: any PR that touches a file mapping to this job now fails on pre-existing discrepancies across **data, serve, train, tune, and rllib**. This greens the check for all libraries on the existing `make -C doc/ html` path, so those PRs stop tripping over debt they didn't introduce.

This is deliberately the **whitelist + mock half**. Decoupling stub generation from the full render is a separate change that builds on this.

## What

### Mock uninstalled backends

The check imports documented names directly (`resolve()` / `Module.get_apis()`), bypassing Sphinx. Optional-dependency modules — `ray.data.llm`, `ray.serve.llm`, `ray.train.lightning` / `xgboost` / `lightgbm`, `ray.tune.integration.*` — eagerly import vLLM / transformers / torch / pytorch_lightning, which are absent on the CPU docbuild runner, so they read as *unresolved* even though the render shows them fine (it mocks the same libs via `autodoc_mock_imports`).

A new side-effect-free `doc/source/api_mock_imports.py` holds the mock list as the single source of truth, imported by both `conf.py` and the check, split into `THIRD_PARTY_MOCK_MODULES` (safe for the check) and `BUILD_ONLY_MOCK_MODULES` (`ray.*` compiled/generated, render-only). The check applies the third-party mocks via `sphinx.ext.autodoc.mock.mock()`. **`ray.*` is never mocked**, so the resolve/dedup policy keeps its teeth on Ray's own symbols. This alone clears **all serve and train failures** and the optional-dep tail of data and tune.

### Whitelist the rest by intent

- **`intentional_duplicate_apis`** — canonical names cross-listed on purpose: data `Dataset.to_*` / `write_*` (class stub + saving-data page), tune `AsyncHyperBandScheduler`, rllib `AlgorithmConfig.build_learner*` / `Checkpointable.save_to_path` etc.
- **`doc_only_whitelist`** (data) — public APIs re-exported from `_internal` (`ActorPoolStrategy`, `ExecutionOptions`, …) that resolve fine but trip the private-name heuristic. Exempted from the resolve check only.
- **`tracked_doc_debt`** — genuine debt owed a document-or-deprecate decision: data's deprecated + private-named accessors, tune's `Stopper.__call__`, and RLlib's larger surface (unresolved/malformed autosummary entries and documented private/dunder members). RLlib's entries are **parked to unblock CI; each still wants a real fix from the RLlib team** (fix the doc entry, deprecate, or de-annotate) and is commented as such.

Per-team result: serve/train clear via mock alone; data/tune via mock + a few entries; rllib via whitelisting (it imports fine, so the mock doesn't apply); core was already clean.

## Verification

- `pre-commit run --files` passes on all changed files (ruff, black, Ray import-order, Ray docstyle, semgrep, not-real-mock-methods).
- `py_compile` on the changed modules; `TEAM_API_CONFIGS` inspected via AST for the expected per-team counts.
- The in-image `python ci/ray_ci/doc/cmd_check_api_discrepancy.py <checkout> ALL` run is the decisive gate — it runs as this PR's `doc: check API doc consistency` premerge job. One thing that run confirms and local static checks can't: that the mocked optional-dep modules resolve to *public* objects (not deprecated/private canonicals).

## Not a duplicate

Part of the API-ref consistency workstream; no competing PR. The whitelist-split change it builds on already merged. No open PR greens the check for these teams.

## AI assistance

AI assistance was used to author these changes; every changed line was reviewed by the submitter.
