### PR TITLE
[Data] Deduplicate Iceberg read task state

### DIFF
--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -5,12 +5,14 @@ Module to read an iceberg table into a Ray Dataset, by using the Ray Datasource 
 import heapq
 import itertools
 import logging
+from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pyarrow as pa
 from packaging import version
 
+import ray
 from ray.data._internal.arrow_block import _BATCH_SIZE_PRESERVING_STUB_COL_NAME
 from ray.data._internal.datasource.parquet_datasource import (
     PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
@@ -157,6 +159,24 @@ def _estimate_inmemory_file_size(
         on_disk_size = data_file.file_size_in_bytes
 
     return int(on_disk_size * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT)
+
+
+@dataclass(frozen=True)
+class _IcebergReadTaskSharedState:
+    table_io: "FileIO"
+    table_metadata: "TableMetadata"
+    row_filter: "BooleanExpression"
+    case_sensitive: bool
+    limit: Optional[int]
+    schema: "Schema"
+    empty_projection: bool
+    read_file_tasks_sequentially: bool
+
+
+def _resolve_shared_read_state(
+    state_ref: "ray.ObjectRef",
+) -> _IcebergReadTaskSharedState:
+    return ray.get(state_ref)
 
 
 class _IcebergExpressionVisitor(
@@ -358,6 +378,24 @@ def _get_read_task(
             # schema we report and every other reader's stub.
             table = BlockAccessor.for_block(table).select([])
         yield table
+
+
+def _get_read_task_from_shared_state(
+    tasks: Iterable["FileScanTask"],
+    state_ref: "ray.ObjectRef",
+) -> Iterable[Block]:
+    state = _resolve_shared_read_state(state_ref)
+    yield from _get_read_task(
+        tasks=tasks,
+        table_io=state.table_io,
+        table_metadata=state.table_metadata,
+        row_filter=state.row_filter,
+        case_sensitive=state.case_sensitive,
+        limit=state.limit,
+        schema=state.schema,
+        empty_projection=state.empty_projection,
+        read_file_tasks_sequentially=state.read_file_tasks_sequentially,
+    )
 
 
 @DeveloperAPI
@@ -626,18 +664,28 @@ class IcebergDatasource(Datasource):
             logger.warning(
                 f"Reducing the parallelism to {parallelism}, as that is the number of files"
             )
-
-        # Get required properties for reading tasks - table IO, table metadata,
-        # row filter, case sensitivity,limit and projected schema to pass
-        # them directly to `_get_read_task` to avoid capture of `self` reference
-        # within the closure carrying substantial overhead invoking these tasks
+        # Store state shared by all read tasks once in the object store. Capturing
+        # this state in every task duplicates table metadata and projected schema,
+        # which can make large Iceberg scans expensive to construct and spill.
         #
         # See https://github.com/ray-project/ray/issues/49107 for more context
-        table_io = self.table.io
-        table_metadata = self.table.metadata
         row_filter = self._get_combined_filter()
         case_sensitive = self._scan_kwargs.get("case_sensitive", True)
         limit = self._scan_kwargs.get("limit")
+        state_ref = ray.put(
+            _IcebergReadTaskSharedState(
+                table_io=self.table.io,
+                table_metadata=self.table.metadata,
+                row_filter=row_filter,
+                case_sensitive=case_sensitive,
+                limit=limit,
+                schema=projected_schema,
+                empty_projection=empty_projection,
+                read_file_tasks_sequentially=(
+                    data_context.iceberg_config.read_file_tasks_sequentially
+                ),
+            )
+        )
 
         # Manifests record how many rows each file holds, which is only still an
         # exact count if every surviving row matches the filter. PyIceberg puts
@@ -660,17 +708,8 @@ class IcebergDatasource(Datasource):
         )
 
         get_read_task = partial(
-            _get_read_task,
-            table_io=table_io,
-            table_metadata=table_metadata,
-            row_filter=row_filter,
-            case_sensitive=case_sensitive,
-            limit=limit,
-            schema=projected_schema,
-            empty_projection=empty_projection,
-            read_file_tasks_sequentially=(
-                data_context.iceberg_config.read_file_tasks_sequentially
-            ),
+            _get_read_task_from_shared_state,
+            state_ref=state_ref,
         )
 
         read_tasks = []

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -5,12 +5,14 @@ Module to read an iceberg table into a Ray Dataset, by using the Ray Datasource 
 import heapq
 import itertools
 import logging
+from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pyarrow as pa
 from packaging import version
 
+import ray
 from ray.data._internal.planner.plan_expression.expression_visitors import _ExprVisitor
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockMetadata
@@ -83,6 +85,22 @@ if TYPE_CHECKING:
     from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _IcebergReadTaskSharedState:
+    table_io: "FileIO"
+    table_metadata: "TableMetadata"
+    row_filter: "BooleanExpression"
+    case_sensitive: bool
+    limit: Optional[int]
+    schema: "Schema"
+
+
+def _resolve_shared_read_state(
+    state_ref: "ray.ObjectRef",
+) -> _IcebergReadTaskSharedState:
+    return ray.get(state_ref)
 
 
 class _IcebergExpressionVisitor(
@@ -256,6 +274,22 @@ def _get_read_task(
             yield table
 
     yield from _generate_tables()
+
+
+def _get_read_task_from_shared_state(
+    tasks: Iterable["FileScanTask"],
+    state_ref: "ray.ObjectRef",
+) -> Iterable[Block]:
+    state = _resolve_shared_read_state(state_ref)
+    yield from _get_read_task(
+        tasks=tasks,
+        table_io=state.table_io,
+        table_metadata=state.table_metadata,
+        row_filter=state.row_filter,
+        case_sensitive=state.case_sensitive,
+        limit=state.limit,
+        schema=state.schema,
+    )
 
 
 @DeveloperAPI
@@ -454,27 +488,25 @@ class IcebergDatasource(Datasource):
             logger.warning(
                 f"Reducing the parallelism to {parallelism}, as that is the number of files"
             )
-
-        # Get required properties for reading tasks - table IO, table metadata,
-        # row filter, case sensitivity,limit and projected schema to pass
-        # them directly to `_get_read_task` to avoid capture of `self` reference
-        # within the closure carrying substantial overhead invoking these tasks
+        # Store state shared by all read tasks once in the object store. Capturing
+        # this state in every task duplicates table metadata and projected schema,
+        # which can make large Iceberg scans expensive to construct and spill.
         #
         # See https://github.com/ray-project/ray/issues/49107 for more context
-        table_io = self.table.io
-        table_metadata = self.table.metadata
-        row_filter = self._get_combined_filter()
-        case_sensitive = self._scan_kwargs.get("case_sensitive", True)
-        limit = self._scan_kwargs.get("limit")
+        state_ref = ray.put(
+            _IcebergReadTaskSharedState(
+                table_io=self.table.io,
+                table_metadata=self.table.metadata,
+                row_filter=self._get_combined_filter(),
+                case_sensitive=self._scan_kwargs.get("case_sensitive", True),
+                limit=self._scan_kwargs.get("limit"),
+                schema=projected_schema,
+            )
+        )
 
         get_read_task = partial(
-            _get_read_task,
-            table_io=table_io,
-            table_metadata=table_metadata,
-            row_filter=row_filter,
-            case_sensitive=case_sensitive,
-            limit=limit,
-            schema=projected_schema,
+            _get_read_task_from_shared_state,
+            state_ref=state_ref,
         )
 
         read_tasks = []

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -2,7 +2,6 @@ import os
 import random
 from types import SimpleNamespace
 from typing import Any, Dict, Generator, List, Tuple, Type
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -29,7 +28,6 @@ from ray.data._internal.datasource.iceberg_datasource import (
     IcebergDatasource,
     _estimate_inmemory_file_size,
     _get_read_task,
-    _IcebergReadTaskSharedState,
 )
 from ray.data._internal.datasource.parquet_datasource import (
     PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
@@ -485,31 +483,26 @@ def test_empty_projection_has_zero_size_estimate():
     get_pyarrow_version() < parse_version("14.0.0"),
     reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
-def test_get_read_tasks_share_scan_state():
+def test_read_task_remains_compact_with_large_table_metadata():
+    shared_metadata = "x" * (1024 * 1024)
+    catalog = pyi_catalog.load_catalog(**_CATALOG_KWARGS)
+    table = catalog.load_table(f"{_DB_NAME}.{_TABLE_NAME}")
+    with table.transaction() as transaction:
+        transaction.set_properties({"ray.test.large_metadata": shared_metadata})
+
     iceberg_ds = IcebergDatasource(
         table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
         catalog_kwargs=_CATALOG_KWARGS.copy(),
     )
-    state_ref = ray.put(None)
+    read_task_ref = ray.put(iceberg_ds.get_read_tasks(1)[0])
 
-    with (
-        patch(
-            "ray.data._internal.datasource.iceberg_datasource.ray.put",
-            return_value=state_ref,
-        ) as put,
-        patch(
-            "ray.data._internal.datasource.iceberg_datasource._get_read_task_from_shared_state",
-            return_value=[],
-        ) as read,
-    ):
-        read_tasks = iceberg_ds.get_read_tasks(5)
-        for read_task in read_tasks:
-            list(read_task())
+    read_task_size = ray.experimental.get_local_object_locations([read_task_ref])[
+        read_task_ref
+    ]["object_size"]
+    assert read_task_size < len(shared_metadata) // 2
 
-    put.assert_called_once()
-    assert isinstance(put.call_args.args[0], _IcebergReadTaskSharedState)
-    assert read.call_count == len(read_tasks)
-    assert all(call.kwargs["state_ref"] == state_ref for call in read.call_args_list)
+    read_task = ray.get(read_task_ref)
+    assert sum(block.num_rows for block in read_task()) == 101
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -2,6 +2,7 @@ import os
 import random
 from types import SimpleNamespace
 from typing import Any, Dict, Generator, List, Tuple, Type
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -28,6 +29,7 @@ from ray.data._internal.datasource.iceberg_datasource import (
     IcebergDatasource,
     _estimate_inmemory_file_size,
     _get_read_task,
+    _IcebergReadTaskSharedState,
 )
 from ray.data._internal.datasource.parquet_datasource import (
     PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
@@ -477,6 +479,37 @@ def test_empty_projection_has_zero_size_estimate():
 
     assert iceberg_ds.estimate_inmemory_data_size() == 0
     assert all(task.metadata.size_bytes == 0 for task in iceberg_ds.get_read_tasks(3))
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_get_read_tasks_share_scan_state():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+    state_ref = ray.put(None)
+
+    with (
+        patch(
+            "ray.data._internal.datasource.iceberg_datasource.ray.put",
+            return_value=state_ref,
+        ) as put,
+        patch(
+            "ray.data._internal.datasource.iceberg_datasource._get_read_task_from_shared_state",
+            return_value=[],
+        ) as read,
+    ):
+        read_tasks = iceberg_ds.get_read_tasks(5)
+        for read_task in read_tasks:
+            list(read_task())
+
+    put.assert_called_once()
+    assert isinstance(put.call_args.args[0], _IcebergReadTaskSharedState)
+    assert read.call_count == len(read_tasks)
+    assert all(call.kwargs["state_ref"] == state_ref for call in read.call_args_list)
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -1,6 +1,7 @@
 import os
 import random
 from typing import Any, Dict, Generator, List, Tuple, Type
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -21,7 +22,10 @@ from pyiceberg.transforms import IdentityTransform
 
 import ray
 from ray.data import read_iceberg
-from ray.data._internal.datasource.iceberg_datasource import IcebergDatasource
+from ray.data._internal.datasource.iceberg_datasource import (
+    IcebergDatasource,
+    _IcebergReadTaskSharedState,
+)
 from ray.data._internal.logical.operators import Filter, Project
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
@@ -203,6 +207,37 @@ def test_get_read_tasks():
     read_tasks = iceberg_ds.get_read_tasks(5)
     assert len(read_tasks) == 5
     assert all(len(rt.metadata.input_files) == 2 for rt in read_tasks)
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_get_read_tasks_share_scan_state():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+    state_ref = ray.put(None)
+
+    with (
+        patch(
+            "ray.data._internal.datasource.iceberg_datasource.ray.put",
+            return_value=state_ref,
+        ) as put,
+        patch(
+            "ray.data._internal.datasource.iceberg_datasource._get_read_task_from_shared_state",
+            return_value=[],
+        ) as read,
+    ):
+        read_tasks = iceberg_ds.get_read_tasks(5)
+        for read_task in read_tasks:
+            list(read_task())
+
+    put.assert_called_once()
+    assert isinstance(put.call_args.args[0], _IcebergReadTaskSharedState)
+    assert read.call_count == len(read_tasks)
+    assert all(call.kwargs["state_ref"] == state_ref for call in read.call_args_list)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
*I used CODEX to analyze this problem and create this PR. I've reviewed the code and tests and stand by them. This summary is written completely by a human (me) other than very light copy editing by an LLM.*

The problem I ran into was that with 50000 Iceberg read tasks the driver was serializing 50000 copies of the same information as it serialized the tasks into its object store.  This PR replaces those copies with an `ObjectRef` to the same information in Ray's distributed object store and the workers fetch that data when needed.

This ended up being a meaningful performance gain in driver-side task construction and serialization at scale, see the benchmarking section below.  In my production use case it reduced the Iceberg read-task construction and serialization from over an hour to less than one minute.


CODEX generated summary follows:
-----
Large Iceberg scans currently serialize the same PyIceberg scan state into every Ray `ReadTask`. On a production-shaped scan with 50,000 read tasks, that repeated metadata prevented Ray from finishing task construction, delayed autoscaling indefinitely, and projected far beyond the head node's object-store capacity.

This change stores the immutable scan state once in Ray's object store. Each read task now carries only its file chunk and the shared `ObjectRef`; the worker resolves that reference before calling the existing Iceberg read implementation. Read semantics, planning, projection, filtering, and delete handling are unchanged.

## Why this is not duplicate work

[ray-project/ray#49054](https://github.com/ray-project/ray/pull/49054) fixed [ray-project/ray#49107](https://github.com/ray-project/ray/issues/49107) by removing the datasource's `self` reference from each read closure. The replacement partial still captures table IO, full table metadata, the row filter, and the projected schema in every task. Searches of open PRs for that issue, `IcebergDatasource.get_read_tasks`, Iceberg `ObjectRef`, `table_metadata`, serialized Iceberg reads, and Iceberg object-store usage found no PR addressing that residual duplication. [ray-project/ray#61753](https://github.com/ray-project/ray/pull/61753) touches this datasource for unrelated checkpoint filtering.

## Benchmark
A controlled single-node benchmark isolated the driver-side work changed by this PR. It created a real local Iceberg table with 1,028 fields, projected 290 fields, and replicated a planned FileScanTask to produce different task counts. For each count, the benchmark constructed the ReadTasks and stored each with ray.put, matching plan_read_op.py. Object sizes were measured through get_local_object_locations.

The patched totals include both the serialized ReadTasks and the single shared-state object.

| Read tasks | Base object-store bytes | Patched object-store bytes | Reduction |
| ---: | ---: | ---: | ---: |
| 100 | 30.45 MB | 12.35 MB | 59.5% |
| 1,000 | 304.54 MB | 122.40 MB | 59.8% |
| 5,000 | 1.523 GB | 611.52 MB | 59.8% |

  At 1,000 tasks, median task construction and serialization time across three runs fell from 2.55 seconds to 0.46 seconds, a 5.5x improvement.

  The local fixture’s shared state was 117 KB, substantially smaller than the production workload’s metadata. It therefore demonstrates the scaling behavior without reproducing the production-sized state.

On the production-shaped scan, the serialized size of one read task fell from approximately 1.63 MiB to 106 KiB. The patched implementation constructed all 50,000 tasks in 50.10 seconds, submitted the reads, and allowed autoscaling to begin. The stock implementation did not finish task construction or submit a read. Iceberg planning remained approximately 100 seconds in both cases, as expected; this change targets task serialization and construction rather than file planning.

## Tests

```text
.venv/bin/pytest -q python/ray/data/tests/datasource/test_iceberg.py --tb=short
# 55 passed

PATH="$PWD/.venv/bin:/opt/homebrew/bin:/usr/bin:/bin" bazel test //python/ray/data:test_iceberg \
  --test_output=errors --nocache_test_results --action_env=PATH \
  --test_env=VIRTUAL_ENV="$PWD/.venv"
# PASSED

pre-commit run --files \
  python/ray/data/_internal/datasource/iceberg_datasource.py \
  python/ray/data/tests/datasource/test_iceberg.py
# All applicable hooks passed
```

AI assistance was used to investigate the bottleneck, prototype the change, implement the patch, and draft tests and this description. This PR is a draft pending the human submitter's line-by-line review before review is requested.
