### PR TITLE
[ci] Route API reference pages and autodoc machinery to the API-surface checks

### DIFF
--- a/.buildkite/BUILD.bazel
+++ b/.buildkite/BUILD.bazel
@@ -1,6 +1,10 @@
 load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
+# Consumed by //ci/pipeline:test_doc_api_rules_sync, which reads the doc_api
+# rule out of this file to keep it in sync with the API-page set.
+exports_files(["test.rules.txt"])
+
 py_binary(
     name = "copy_files",
     srcs = ["copy_files.py"],

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -34,8 +34,17 @@ steps:
       - doc
       - skip-on-premerge
 
+  # The two API checks below carry no `if:` guard on purpose. Their trigger set
+  # is defined entirely by tags: the library code tags, plus "doc_api" for the
+  # API reference pages and the autodoc machinery that decides what those pages
+  # contain (see test.rules.txt). Tag selection and Buildkite `if:` are separate
+  # passes -- tags choose which steps are emitted, `if:` can only suppress an
+  # already-emitted step -- so a label guard here could only ever subtract from
+  # a trigger set the rules already compute correctly. In particular these steps
+  # are deliberately NOT gated on "docs-go": that label exists to skip the
+  # per-team doc example execution on a content-only PR, and an API reference
+  # page edit is exactly the content-only change these checks must still cover.
   - label: ":book: doc: check API annotations"
-    if: '!(build.pull_request.labels includes "docs-go")'
     tags:
       - oss
       - core_python
@@ -49,7 +58,7 @@ steps:
       - llm
       - rllib
       - rllib_gpu
-      - doc
+      - doc_api
     key: doc_api_annotations
     instance_type: medium
     depends_on: docbuild
@@ -58,7 +67,6 @@ steps:
       - bash ci/lint/lint.sh api_annotations
 
   - label: ":book: doc: check API doc consistency"
-    if: '!(build.pull_request.labels includes "docs-go")'
     tags:
       - oss
       - core_python
@@ -72,7 +80,7 @@ steps:
       - llm
       - rllib
       - rllib_gpu
-      - doc
+      - doc_api
     key: doc_api_policy_check
     instance_type: medium
     depends_on: docbuild

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -158,14 +158,16 @@ doc/source/custom_directives.py: doc doc_api
 doc/source/api_autogen.py: doc doc_api
 doc/source/api_mock_imports.py: doc doc_api
 .buildkite/doc.rayci.yml: doc doc_api
+# api_sidebar.py sits under doc/source/_ext/ but carries `tools` on top of the
+# dir rule's tags, because //ci/pipeline:test_doc_api_rules_sync is a ci_unit
+# target and ci_unit is selected by `tools`. This case is what keeps the drift
+# guard executing on an API_PATH_PREFIXES edit.
+doc/source/_ext/api_sidebar.py: doc doc_api tools
 # The autodoc machinery above emits doc_api so the two API-consistency checks
 # run on it: these files decide what the API reference contains. The rendering
 # half of the doc infra must NOT, or every Vale vocabulary tweak pays for a
-# docbuild plus both checks. These four are the guard on that boundary.
-.vale.ini: doc
-doc/rtd_doctor.py: doc
-doc/source/template_collections.py: doc
-.readthedocs.yaml: doc
+# docbuild plus both checks. The cases below, and the doc/*.py ones further
+# down, are the guard on that boundary.
 doc/source/template_collections.py: doc
 doc/source/preprocess_github_markdown.py: doc
 # Gallery configs are build inputs, not example inputs: they sit under the

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -137,14 +137,35 @@ doc/source/cluster/doc_code/slurm-basic.sh:
 # scripts build the docs, so they route to the `doc` build and validation only,
 # never to a library's doctest or example execution.
 .readthedocs.yaml: doc
+doc/source/data/api/api.rst: doc_api
+doc/source/serve/api/index.md: doc_api
+doc/source/ray-core/api/index.rst: doc_api
+doc/source/train/api/api.rst: doc_api
+doc/source/tune/api/api.rst: doc_api
+doc/source/rllib/package_ref/index.rst: doc_api
+doc/source/ray-observability/reference/api.rst: doc_api
+# A nested leaf page under an API dir must also emit doc_api: directory rules
+# match recursively, so a change to any page below the dir triggers the checks,
+# not just the top-level index. Guards against a rule or matcher change that
+# would only catch top-level pages.
+doc/source/rllib/package_ref/env/single_agent_episode.rst: doc_api
 .vale.ini: doc
 .vale/styles/config/vocabularies/Core/accept.txt: doc
-doc/requirements-doc.txt: doc
-doc/source/conf.py: doc
-doc/source/_ext/llms_txt.py: doc
-doc/source/custom_directives.py: doc
-doc/source/api_autogen.py: doc
-doc/source/api_mock_imports.py: doc
+doc/requirements-doc.txt: doc doc_api
+doc/source/conf.py: doc doc_api
+doc/source/_ext/llms_txt.py: doc doc_api
+doc/source/custom_directives.py: doc doc_api
+doc/source/api_autogen.py: doc doc_api
+doc/source/api_mock_imports.py: doc doc_api
+.buildkite/doc.rayci.yml: doc doc_api
+# The autodoc machinery above emits doc_api so the two API-consistency checks
+# run on it: these files decide what the API reference contains. The rendering
+# half of the doc infra must NOT, or every Vale vocabulary tweak pays for a
+# docbuild plus both checks. These four are the guard on that boundary.
+.vale.ini: doc
+doc/rtd_doctor.py: doc
+doc/source/template_collections.py: doc
+.readthedocs.yaml: doc
 doc/source/template_collections.py: doc
 doc/source/preprocess_github_markdown.py: doc
 # Gallery configs are build inputs, not example inputs: they sit under the
@@ -167,8 +188,8 @@ doc/source/llms_txt_summary.txt: doc
 # The shared notebook runner stays on the catch-all core step by design; see
 # the comment on the catch-all rule in test.rules.txt.
 doc/test_myst_doc.py: core_doc
-python/deplocks/docs/docbuild_depset_py3.10.lock: doc python_dependencies
-ci/raydepsets/configs/docs.depsets.yaml: doc python_dependencies
+python/deplocks/docs/docbuild_depset_py3.10.lock: doc doc_api python_dependencies
+ci/raydepsets/configs/docs.depsets.yaml: doc doc_api python_dependencies
 
 # === Release ===
 
@@ -184,6 +205,12 @@ ci/ci.sh: tools
 # Windows CI driver scripts trigger the Windows test steps, not just tools.
 ci/ray_ci/windows/build_base.sh: windows tools
 ci/ray_ci/windows/install_tools.sh: windows tools
+# The API-consistency checker's own source emits doc_api (re-run the API checks
+# it implements) on top of tools (its six ci_unit py_test targets run in the
+# tools-selected job). Other ci/ray_ci/ files still emit tools alone (tester.py
+# above).
+ci/ray_ci/doc/cmd_check_api_discrepancy.py: doc_api tools
+ci/ray_ci/doc/autodoc.py: doc_api tools
 
 # === Build Scripts ===
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -17,9 +17,38 @@
 ! core_python cpp core_cpp java workflow cgraphs_direct_transport dashboard
 ! ray_client runtime_env_container
 ! data dask serve ml tune train train_gpu llm rllib rllib_gpu rllib_directly
-! linux_wheels macos_wheels docker doc python_dependencies min_build tools windows
+! linux_wheels macos_wheels docker doc doc_api python_dependencies min_build tools windows
 ! release_tests spark_on_ray rocksdb_tests redis_tests
 ! core_doc data_doc ml_doc rllib_doc serve_doc
+
+# Per-team API reference pages. Editing these can change the documented public
+# API surface, so they must be able to trigger the API-consistency checks
+# ("doc: check API annotations" and "doc: check API doc consistency" in
+# doc.rayci.yml), which cross-check every @PublicAPI symbol against these
+# autosummary pages. Emit a dedicated "doc_api" tag, ahead of the narrative
+# prose skip rule below so these pages aren't swallowed as prose.
+#
+# This tag is the whole trigger mechanism for those two checks: they carry no
+# `if:` label guard, so what runs is decided here and nowhere else. Keep that
+# in mind when editing the rules below -- an API surface that stops emitting
+# doc_api stops being checked, silently.
+#
+# The six per-team dirs match the API-page set in doc/source/_ext/api_sidebar.py
+# (API_PATH_PREFIXES). ray-observability/reference/ is here too because the Ray
+# Core landing (ray-core/api/index.rst) toctrees into its api.rst, so those
+# pages are part of the Core API surface the check walks despite living outside
+# ray-core/api/. //ci/pipeline:test_doc_api_rules_sync enforces this alignment,
+# so adding a library's API dir to API_PATH_PREFIXES without adding it here (or
+# vice versa) fails CI.
+doc/source/data/api/
+doc/source/serve/api/
+doc/source/ray-core/api/
+doc/source/train/api/
+doc/source/tune/api/
+doc/source/rllib/package_ref/
+doc/source/ray-observability/reference/
+@ doc_api
+;
 
 # Documentation prose (.md and .rst) and static image assets do not block
 # premerge. A content-only change to narrative docs or a diagram swap triggers
@@ -120,10 +149,14 @@ python/deplocks/ci/macos_depset_py*
 @ macos_wheels python_dependencies
 ;
 
-# Short-circuit deps handling for docs-specific.
+# Short-circuit deps handling for docs-specific. These pin the resolved Sphinx
+# and autodoc/autosummary versions the docbuild image installs, so a lock
+# change can alter stub generation and therefore what the API-consistency
+# checks see. Emit `doc_api` as well so those checks run on a docs dependency
+# bump.
 python/deplocks/docs/*.lock
 ci/raydepsets/configs/docs.depsets.yaml
-@ doc python_dependencies
+@ doc doc_api python_dependencies
 ;
 
 # Raydepsets-generated lock files and raydepsets configs that drive
@@ -207,19 +240,59 @@ docker/
 @ doc
 ;
 
-# Documentation validation infra: the Sphinx config, the modules that config
-# imports, the in-repo build extensions, the doc-build helper scripts, the Vale
-# config, the doc pipeline definition, and the doc requirements all drive the
-# documentation build and validation. The `doc` tag is reserved for that build
-# machinery, not for the library example tests that happen to live in the docs.
-# These changes route here only, so they trigger the documentation build and
-# validation without running any library doctest or example execution.
+# Documentation validation infra, part 1 of 2: the autodoc machinery. These
+# files determine what the API reference *contains*, so a change here can alter
+# the documented public API surface just as an API page edit can. They emit
+# `doc_api` alongside `doc` so both the documentation build and the two
+# API-consistency checks run.
 #
-# The `doc/source/*.py` modules are enumerated one by one on purpose. A
-# `doc/source/*.py` pattern would NOT work: `*` in these patterns is fnmatch
-# and crosses `/`, so it would also swallow every example script under
-# `doc/source/<lib>/doc_code/` and stop those from reaching the per-library
-# rules below. Add a module here when `conf.py` grows a new import.
+# Why each one is autodoc machinery, not just build config:
+#   - conf.py             the autodoc, autosummary, and intersphinx
+#                         configuration, and the importer of the four modules
+#                         below
+#   - api_autogen.py      generates the autosummary stub .rst files that
+#                         `lint.sh api_policy_check` reads; `AUTOGEN_FILES` here
+#                         is what decides which stubs exist at all
+#   - api_mock_imports.py the mocked-module list; mocking a package changes
+#                         which symbols autodoc can resolve, and therefore what
+#                         the check sees as documented
+#   - custom_directives.py imported by conf.py and registers directives the API
+#                         templates render through
+#   - doc/source/_ext/    the in-repo Sphinx extensions, including
+#                         api_sidebar.py, whose `API_PATH_PREFIXES` is the
+#                         source of truth for "this page documents public API"
+#                         (//ci/pipeline:test_doc_api_rules_sync enforces that
+#                         alignment)
+#   - requirements-doc.txt pins Sphinx and the autodoc/autosummary extensions;
+#                         a version bump can change stub generation output
+#
+# The `doc/source/*.py` modules are enumerated one by one on purpose, here and
+# in part 2. A `doc/source/*.py` pattern would NOT work: `*` in these patterns
+# is fnmatch and crosses `/`, so it would also swallow every example script
+# under `doc/source/<lib>/doc_code/` and stop those from reaching the
+# per-library rules below. Add a module to one of these two blocks when
+# `conf.py` grows a new import -- part 1 if it can affect the API surface,
+# part 2 if it only affects rendering.
+doc/source/conf.py
+doc/source/api_autogen.py
+doc/source/api_mock_imports.py
+doc/source/custom_directives.py
+doc/source/_ext/
+doc/requirements-doc.txt
+# The doc pipeline definition declares the two API-consistency check steps. An
+# edit to those step definitions should exercise the steps it edits, so this
+# emits `doc_api` too. Without it, changing a check's command or image would
+# never run that check on the PR making the change.
+.buildkite/doc.rayci.yml
+@ doc doc_api
+;
+
+# Documentation validation infra, part 2 of 2: rendering and validation only.
+# These drive the documentation build but cannot change the documented API
+# surface, so they emit `doc` alone and deliberately do NOT pull in the two
+# API-consistency checks. They route here only, so they trigger the
+# documentation build and validation without running any library doctest or
+# example execution.
 #
 # The two `llms_txt` entries are routed ahead of the files existing: they land
 # with ray-project/ray#64458, which adds a hermetic Sphinx-extension test and
@@ -227,23 +300,16 @@ docker/
 # path is inert, and pre-routing them means that PR merges correctly scoped
 # rather than leaving the test on the `doc/*.py` catch-all, which would run Ray
 # Core's doctests and examples for a test that imports no Ray code.
-doc/source/conf.py
-doc/source/custom_directives.py
-doc/source/api_autogen.py
-doc/source/api_mock_imports.py
 doc/source/template_collections.py
 doc/source/preprocess_github_markdown.py
 doc/source/llms_txt_summary.txt
-doc/source/_ext/
 doc/load_doc_cache.py
 doc/update_cache_env.py
 doc/rtd_doctor.py
 doc/test_no_new_rst.py
 doc/test_llms_txt.py
-doc/requirements-doc.txt
 .vale.ini
 .vale/
-.buildkite/doc.rayci.yml
 # The three gallery configs are build inputs, not example inputs. They are
 # parsed by `custom_directives.py` (its `EXAMPLE_GALLERY_CONFIGS` names these
 # three) to generate the gallery pages; they contain no executable code and
@@ -405,6 +471,22 @@ ci/ray_ci/macos/macos_ci_build.sh
 # these into 'tools' only.
 ci/ray_ci/windows/
 @ windows tools
+;
+
+# The API-consistency checker's own source. Editing the checker (its walk, team
+# configs, or allowlists under ci/ray_ci/doc/) must re-run the two API checks it
+# implements, hence 'doc_api'. It keeps 'tools' as well: this directory declares
+# six ci_unit py_test targets of its own (test_api, test_autodoc, test_module,
+# test_build_cache, test_cmd_check_api_discrepancy, test_update_cache_env), and
+# the job that runs ci_unit is selected by 'tools'. Dropping 'tools' here would
+# mean editing the checker never runs the checker's own unit tests.
+#
+# This rule exists only to add 'doc_api' on top of what the general ci/ray_ci/
+# rule below already gives these files, so it must precede that rule (first
+# match wins). An API reference *page* change does not reach here: pages are
+# routed to 'doc_api' alone by the rule near the top of this file.
+ci/ray_ci/doc/
+@ doc_api tools
 ;
 
 ci/pipeline/

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -240,6 +240,20 @@ docker/
 @ doc
 ;
 
+# api_sidebar.py is autodoc machinery like the rest of doc/source/_ext/ below,
+# but it needs `tools` on top. Its `API_PATH_PREFIXES` is one half of the pair
+# that //ci/pipeline:test_doc_api_rules_sync compares; the other half is the
+# doc_api rule block at the top of this file. That test is a ci_unit target, and
+# ci_unit is selected by `tools`, not by `doc` or `doc_api`. Without `tools`
+# here the guard would run on an edit to the rules side (this file emits
+# `tools`) but not on an edit to the prefixes side -- so growing
+# API_PATH_PREFIXES without adding the matching rule, which is exactly the drift
+# the guard exists to catch, would never execute it. First match wins, so this
+# rule has to precede the doc/source/_ext/ directory entry in part 1.
+doc/source/_ext/api_sidebar.py
+@ doc doc_api tools
+;
+
 # Documentation validation infra, part 1 of 2: the autodoc machinery. These
 # files determine what the API reference *contains*, so a change here can alter
 # the documented public API surface just as an API page edit can. They emit

--- a/ci/pipeline/BUILD.bazel
+++ b/ci/pipeline/BUILD.bazel
@@ -1,6 +1,27 @@
-load("@rules_python//python:defs.bzl", "py_library")
+load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "determine_tests_to_run",
     srcs = ["determine_tests_to_run.py"],
+)
+
+py_test(
+    name = "test_doc_api_rules_sync",
+    size = "small",
+    srcs = [
+        "determine_tests_to_run.py",
+        "test_doc_api_rules_sync.py",
+    ],
+    data = [
+        "//:.rayciversion",
+        "//.buildkite:test.rules.txt",
+        "//doc:doc_source_modules",
+        "//doc:source/_ext/api_sidebar.py",
+    ],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [ci_require("pytest")],
 )

--- a/ci/pipeline/test_doc_api_rules_sync.py
+++ b/ci/pipeline/test_doc_api_rules_sync.py
@@ -1,0 +1,251 @@
+"""Keep the ``doc_api`` conditional-testing rule in sync with the API-page set.
+
+The ``doc_api`` tag in ``.buildkite/test.rules.txt`` selects the API-consistency
+CI checks ("doc: check API annotations" and "doc: check API doc consistency" in
+``.buildkite/doc.rayci.yml``). It covers two populations: the API reference
+pages, and the autodoc machinery that determines what those pages contain
+(``conf.py``, ``api_autogen.py``, ``api_mock_imports.py``, the in-repo Sphinx
+extensions, and the docs dependency locks).
+
+This test polices the first population only. Its directory list must track
+``API_PATH_PREFIXES`` in ``doc/source/_ext/api_sidebar.py``, which is the source
+of truth for "this page documents public API surface." Machinery directories are
+listed in ``_NON_PAGE_DOC_API_DIRS`` and skipped; machinery routed as individual
+files never reaches the comparison at all.
+
+If a library adds an API reference directory to one and not the other, the
+checks silently stop firing on the new pages (or a stale rule fires on pages
+that are no longer API surface). A hardcoded per-page test can't catch that: it
+asserts the paths it already lists, not the ones a reorg introduces. This test
+compares the two directory sets directly, so it fails when they drift, modulo a
+small set of documented, intentional exceptions.
+"""
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+from determine_tests_to_run import TagRuleSet
+
+_RAYCI_VERSION_FILE = ".rayciversion"
+_DOC_SOURCE = "doc/source/"
+
+# Intentional, documented divergences between API_PATH_PREFIXES and the doc_api
+# rule's directory list. Keep both sets short; every entry is a deliberate
+# decision, not a place to let drift hide.
+
+# In API_PATH_PREFIXES but deliberately NOT a doc_api trigger. The APIs landing
+# page (apis/index) is curated navigation, not an autosummary surface, so the
+# consistency check has nothing to validate there and shouldn't pay a docbuild
+# to run on edits to it.
+_ALLOWED_ONLY_IN_API_PREFIXES = {"apis/"}
+
+# In the doc_api rule but NOT in API_PATH_PREFIXES. Ray Core's api/index.rst
+# toctrees into ray-observability/reference/api.rst, so those pages are part of
+# the Core API surface the check walks even though they live outside
+# ray-core/api/.
+_ALLOWED_ONLY_IN_RULE = {"ray-observability/reference/"}
+
+# Directories routed to doc_api that are not API reference pages. The doc_api
+# tag covers two populations: the API reference pages (which this test keeps
+# aligned with API_PATH_PREFIXES) and the machinery that determines what those
+# pages contain. Only the first population participates in the comparison, so
+# machinery directories are excluded from it entirely rather than compared as
+# doc/source pages. Stored without a trailing slash to match TagRuleSet's
+# rule.dirs.
+#
+#   - ci/ray_ci/doc     the API-consistency checker's own source; emits doc_api
+#                       so editing the checker re-runs the checks it implements
+#   - doc/source/_ext   the in-repo Sphinx extensions. api_sidebar.py lives here
+#                       and *defines* API_PATH_PREFIXES, so it is the input to
+#                       this test's comparison, never a row in it. Comparing it
+#                       as a page would assert `_ext/` is an API path prefix,
+#                       which it is not.
+#
+# Machinery routed as individual files rather than directories (conf.py,
+# api_autogen.py, api_mock_imports.py, custom_directives.py,
+# requirements-doc.txt, doc.rayci.yml, the docs deplocks) needs no entry here:
+# TagRuleSet keeps files and patterns separate from dirs, and this test only
+# walks rule.dirs.
+_NON_PAGE_DOC_API_DIRS = {"ci/ray_ci/doc", "doc/source/_ext"}
+
+
+# conf.py imports that are deliberately NOT autodoc machinery, so they route to
+# `doc` alone and do not trigger the API-consistency checks. Every entry is a
+# judgment that this module cannot change what the API reference documents.
+#
+#   - template_collections  fetches example templates at build time; it affects
+#                           which template pages render, never which symbols
+#                           autodoc resolves
+#
+# Adding an entry here is the explicit way to say "this new conf.py import can't
+# affect the API surface." Leaving a genuinely API-affecting module out of the
+# doc_api rules and out of this list is what this test exists to prevent.
+_CONF_IMPORTS_NOT_API_MACHINERY = {"template_collections"}
+
+# Fail-closed floor for the conf.py import scan. The scan decides "is this a
+# local module" by checking whether the file exists under doc/source/, so it
+# degrades to an empty set -- and a vacuous pass -- if the test's data deps ever
+# stop delivering those files into the bazel sandbox. These four are conf.py's
+# current local imports; requiring them to be found turns that silent
+# degradation into a hard failure.
+#
+# If a legitimate refactor removes one of these imports, delete it from this set
+# in the same change. Do not delete the set.
+_MACHINERY_IMPORT_FLOOR = {
+    "api_autogen",
+    "api_mock_imports",
+    "custom_directives",
+    "template_collections",
+}
+
+
+def _find_ray_root() -> Path:
+    """Walk up from this file and cwd looking for .rayciversion."""
+    start = Path(__file__).resolve()
+    for parent in start.parents:
+        if (parent / _RAYCI_VERSION_FILE).exists():
+            return parent
+    if (Path.cwd() / _RAYCI_VERSION_FILE).exists():
+        return Path.cwd()
+    raise FileNotFoundError("Could not find Ray root (missing .rayciversion).")
+
+
+def _api_path_prefixes(root: Path) -> set:
+    """Read API_PATH_PREFIXES out of api_sidebar.py without importing it.
+
+    Importing the module pulls in Sphinx and bs4, which aren't available in the
+    CI tooling environment, so parse the assignment out of the AST instead.
+    """
+    source = (root / "doc" / "source" / "_ext" / "api_sidebar.py").read_text()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "API_PATH_PREFIXES"
+            for t in node.targets
+        ):
+            return set(ast.literal_eval(node.value))
+    raise AssertionError("API_PATH_PREFIXES not found in api_sidebar.py")
+
+
+def _doc_api_rule_dirs(root: Path) -> set:
+    """Directories that emit the ``doc_api`` tag in test.rules.txt, normalized
+    to be relative to doc/source/ so they compare against API_PATH_PREFIXES."""
+    rules = TagRuleSet((root / ".buildkite" / "test.rules.txt").read_text())
+    dirs = set()
+    for rule in rules.rules:
+        if "doc_api" not in rule.tags:
+            continue
+        for d in rule.dirs:  # stored without a trailing slash
+            if d in _NON_PAGE_DOC_API_DIRS:
+                # Not an API page (e.g. the checker's own source); intentionally
+                # outside the page<->API_PATH_PREFIXES alignment this test checks.
+                continue
+            assert d.startswith(_DOC_SOURCE), (
+                f"doc_api rule directory {d!r} is not under {_DOC_SOURCE!r}; the "
+                "sync check assumes API reference pages live under doc/source/."
+            )
+            dirs.add(d[len(_DOC_SOURCE) :] + "/")
+    return dirs
+
+
+def test_doc_api_rule_matches_api_path_prefixes():
+    root = _find_ray_root()
+
+    expected = _api_path_prefixes(root) - _ALLOWED_ONLY_IN_API_PREFIXES
+    actual = _doc_api_rule_dirs(root) - _ALLOWED_ONLY_IN_RULE
+
+    missing_from_rule = expected - actual
+    extra_in_rule = actual - expected
+
+    assert not missing_from_rule and not extra_in_rule, (
+        "The doc_api rule in .buildkite/test.rules.txt has drifted from "
+        "API_PATH_PREFIXES in doc/source/_ext/api_sidebar.py.\n"
+        f"  API pages with no doc_api rule (add these dirs to test.rules.txt so "
+        f"the API checks fire on them): {sorted(missing_from_rule)}\n"
+        f"  doc_api rule dirs not in API_PATH_PREFIXES (remove them, or, if the "
+        f"divergence is intentional, add them to the documented exception list "
+        f"in this test with a comment): {sorted(extra_in_rule)}"
+    )
+
+
+def _conf_py_local_imports(root: Path) -> set:
+    """Module names conf.py imports that resolve to a file under doc/source/.
+
+    Parsed out of the AST rather than imported: importing conf.py executes the
+    whole Sphinx configuration, which isn't available in the CI tooling image.
+
+    Membership is decided by the file existing under doc/source/, which means
+    this function is only correct when those files are present. Under bazel they
+    are present because //ci/pipeline:test_doc_api_rules_sync declares the
+    //doc:doc_source_modules glob as a data dep. _MACHINERY_IMPORT_FLOOR below
+    is the guard against that wiring silently regressing -- without it, a sandbox
+    missing the files would return an empty set and the test would pass
+    vacuously.
+    """
+    conf = root / "doc" / "source" / "conf.py"
+    names = set()
+    for node in ast.walk(ast.parse(conf.read_text())):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+    return {
+        name
+        for name in names
+        if (root / "doc" / "source" / (name.replace(".", "/") + ".py")).exists()
+    }
+
+
+def test_conf_py_imports_route_to_doc_api():
+    """Every local module conf.py imports is classified, not left to a catch-all.
+
+    The autodoc machinery block in test.rules.txt is a hand-enumerated list, and
+    a `doc/source/*.py` pattern can't replace it (fnmatch `*` crosses `/`, so it
+    would swallow every example script under doc/source/<lib>/doc_code/). That
+    makes the list drift-prone in a way that fails silently and badly: a new
+    conf.py import that nobody adds to the rules lands on the `doc/*.py`
+    catch-all, which emits `core_doc`. It would run Ray Core's doctests and
+    example tests, and never the documentation build or the API checks.
+
+    So require every local conf.py import to be either routed to `doc_api` or
+    named in _CONF_IMPORTS_NOT_API_MACHINERY as an explicit rendering-only
+    exception.
+    """
+    root = _find_ray_root()
+    rules = TagRuleSet((root / ".buildkite" / "test.rules.txt").read_text())
+
+    found = _conf_py_local_imports(root)
+    missing_floor = _MACHINERY_IMPORT_FLOOR - found
+    assert not missing_floor, (
+        "The conf.py import scan did not find these known local imports: "
+        f"{sorted(missing_floor)}.\n"
+        "Either the test's data deps stopped delivering doc/source/*.py into the "
+        "sandbox (check //doc:doc_source_modules in doc/BUILD.bazel and the data "
+        "attr of //ci/pipeline:test_doc_api_rules_sync), or conf.py legitimately "
+        "dropped the import and _MACHINERY_IMPORT_FLOOR needs updating in the "
+        "same change. Without this assertion an empty scan would pass vacuously."
+    )
+
+    unclassified = {}
+    for module in sorted(found):
+        if module in _CONF_IMPORTS_NOT_API_MACHINERY:
+            continue
+        path = f"doc/source/{module.replace('.', '/')}.py"
+        tags, _ = rules.match_tags(path)
+        if "doc_api" not in tags:
+            unclassified[path] = sorted(tags)
+
+    assert not unclassified, (
+        "conf.py imports these modules, but test.rules.txt does not route them "
+        "to doc_api, so editing them would not run the API-consistency "
+        "checks:\n"
+        + "\n".join(f"  {p} currently emits {t}" for p, t in unclassified.items())
+        + "\n\nAdd each one to the autodoc machinery block in "
+        ".buildkite/test.rules.txt, or, if it genuinely cannot affect the "
+        "documented API surface, to _CONF_IMPORTS_NOT_API_MACHINERY in this "
+        "test with a comment saying why."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -4,6 +4,22 @@ load("//bazel:python.bzl", "doctest", "doctest_each", "py_test_run_all_notebooks
 
 exports_files(["test_myst_doc.py"])
 
+# Consumed by //ci/pipeline:test_doc_api_rules_sync, which reads
+# API_PATH_PREFIXES out of api_sidebar.py to keep the doc_api page rules in sync.
+exports_files(["source/_ext/api_sidebar.py"])
+
+# The top-level doc/source modules, for the same test. It parses conf.py's
+# imports and resolves each against this directory to decide which ones are
+# local modules, so the whole glob has to reach the sandbox, not just conf.py:
+# a new machinery module is exactly the case the test exists to catch, and it
+# cannot be named in a data dep ahead of being written. The test's
+# _MACHINERY_IMPORT_FLOOR fails closed if this stops arriving.
+filegroup(
+    name = "doc_source_modules",
+    srcs = glob(["source/*.py"]),
+    visibility = ["//ci/pipeline:__pkg__"],
+)
+
 # --------------------------------------------------------------------
 # Tests from the doc directory.
 # Please keep these sorted alphabetically, but start with the


### PR DESCRIPTION
## The problem

Two premerge checks in `.buildkite/doc.rayci.yml` cross-check every `@PublicAPI` symbol against the autosummary pages that document it:

- `doc: check API annotations`
- `doc: check API doc consistency`

They currently run on the wrong set of changes, in both directions.

**They miss changes they should catch.** API reference pages are `.rst` and `.md`, so the leading prose-and-image skip rule in `test.rules.txt` matches them first. Editing `doc/source/data/api/api.rst` changes the documented public API surface and triggers **no premerge step at all**.

**They run on changes that can't affect the API surface.** Both steps carry the blanket `doc` tag. Since #64775 reserved `doc` for documentation validation, that tag now covers two unlike things: the autodoc machinery that decides what the API reference *contains*, and rendering config that can't change it. So a Vale vocabulary tweak pays for a `docbuild` plus both checks.

## The fix

Add a `doc_api` tag, and route to it everything that can change the documented API surface or how it's computed. Then take the blanket `doc` tag off the two steps.

| A change to | today | with this PR |
|---|---|---|
| An API reference page | **skip** | run |
| The checker's own source (`ci/ray_ci/doc/`) | **skip** | run |
| `conf.py`, `api_autogen.py`, `api_mock_imports.py`, `_ext/` | run | run |
| Docs dependency locks (`deplocks/docs/*.lock`) | run | run |
| Library Python source | run | run |
| `.vale.ini`, Vale vocabularies | run | **skip** |
| `rtd_doctor.py`, `template_collections.py` | run | **skip** |
| `.readthedocs.yaml`, gallery configs | run | **skip** |
| Narrative prose, images | skip | skip |

## What's in the diff

Three commits, 7 files.

1. **`a0b545cc3e`** declares `doc_api` and routes the six per-team API reference directories to it, ahead of the skip rule. Also splits the doc-build infra block in two: the autodoc machinery emits `doc doc_api`, the rendering-only half emits `doc` alone. Then drops the bare `doc` tag from both check steps.

2. **`e0d520381d`** adds two drift guards in `//ci/pipeline:test_doc_api_rules_sync`. Both `doc_api` lists are hand-maintained and fail *silently* when they drift — a missing entry means those paths quietly stop being checked. One guard keeps the page list aligned with `API_PATH_PREFIXES` in `doc/source/_ext/api_sidebar.py`. The other requires every local module `conf.py` imports to be routed to `doc_api` or named as an explicit rendering-only exception.

3. **`f3db137384`** routes `api_sidebar.py` to `tools` as well, so the first guard actually runs. It was one-directional before: `test.rules.txt` emits `tools`, so the guard fired on a rules-side edit, but `api_sidebar.py` didn't, so growing `API_PATH_PREFIXES` without the matching rule never executed it — the likelier mistake, and exactly the drift the guard exists to catch. Also removes four duplicated assertions.

Three details worth knowing, since each looks like an oversight otherwise:

- **`ci/ray_ci/doc/` keeps `tools` alongside `doc_api`.** It declares six `ci_unit` `py_test` targets and `tools` is what selects the job that runs them, so dropping it would mean editing the checker never runs the checker's own unit tests.
- **`doc.rayci.yml` also emits `doc_api`,** so editing a check's step definition exercises the check it defines.
- **`doc/source/ray-observability/reference/` is routed even though it sits outside `doc/source/*/api/`.** Ray Core's `api/index.rst` toctrees into its `api.rst`, so it's part of the Core API-surface walk.

## Testing

`test.rules.test.txt` gains cases for the API pages (including a nested leaf page, to pin recursive directory matching), the checker source, each machinery path, and negative cases asserting the rendering half still emits `doc` alone. **These are the real gate:** the `test-rules` step runs them through rayci's parser as exact set equality, so a passing case proves a path emits precisely those tags and nothing else.

Locally, against the in-repo reference engine (`ci/pipeline/determine_tests_to_run.py`):

- `check_rules()` passes; **115 of 115** replay cases pass.
- Across all 10,213 tracked files the routing change is **purely additive: 95 files gain tags, none lose any.**
- No executable asset (`.py`, `.ipynb`) lives under the routed API directories, so no library docs-example step loses coverage.

```
python -m pytest ci/pipeline/test_doc_api_rules_sync.py
```

## Two notes for reviewers

**One behavior change to sanity-check.** Neither check carries an `if:` guard now, including the `docs-go` one they had before. A content-only PR labeled `docs-go` that touches an API reference page will run both checks plus their `docbuild` dependency, where it previously skipped them. That's intended — `docs-go` exists to skip per-team doc *example execution*, and an API reference edit is exactly the content-only change these checks must still cover — but it's a real cost change for that workflow. `docs-go` keeps its role everywhere else: 12 per-team doc example steps across `core`, `data`, `llm`, `ml`, `rllib`, `serve`, and `linux_aarch64`, plus the `lint: validate docs-go scope` step that enforces the label is only used on doc-only PRs.

**This PR changed shape, so earlier comments describe an older design.** It began as a `docs-api-go` PR label that would re-enable the checks on a `docs-go` PR. That's removed: tag selection and Buildkite `if:` are separate passes, and `if:` can only suppress a step the tags already emitted, so with the routing correct the label could only ever subtract. Dropping the `if:` achieves the same thing with no label to create or remember. Consequently the earlier Gemini review and the 2026-08-04 comment above both reference a `docs-api-go` label that no longer exists. Everything else in that comment still stands, including its decision that `doc_code/` and `examples/` should *not* grow into `doc_api`.

🤖 Written with assistance from Claude Code.
