### PR TITLE
[Data] Bound Iceberg read task memory

### DIFF
--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -258,24 +258,37 @@ def _get_read_task(
     def _generate_tables() -> Iterable[pa.Table]:
         if version.parse(pyiceberg.__version__) >= version.parse("0.9.0"):
             # Modern implementation using ArrowScan (PyIceberg 0.9.0+)
-            from pyiceberg.io.pyarrow import ArrowScan
+            from pyiceberg.io.pyarrow import ArrowScan, schema_to_pyarrow
 
-            # Initialize scanner with Iceberg metadata and query parameters
-            scanner = ArrowScan(
-                table_metadata=table_metadata,
-                io=table_io,
-                row_filter=row_filter,
-                projected_schema=schema,
-                case_sensitive=case_sensitive,
-                limit=limit,
-            )
+            def _create_scanner(scan_limit: Optional[int]) -> ArrowScan:
+                return ArrowScan(
+                    table_metadata=table_metadata,
+                    io=table_io,
+                    row_filter=row_filter,
+                    projected_schema=schema,
+                    case_sensitive=case_sensitive,
+                    limit=scan_limit,
+                )
 
-            # Convert scanned data to Arrow Table format
-            result_table = scanner.to_table(tasks=tasks)
+            target_schema = schema_to_pyarrow(schema, include_field_ids=False)
+            rows_remaining = limit
+            scanner = _create_scanner(None) if rows_remaining is None else None
+            for task in tasks:
+                if rows_remaining is not None and rows_remaining <= 0:
+                    break
 
-            # Stream results as RecordBatches for memory efficiency
-            for batch in result_table.to_batches():
-                yield pa.Table.from_batches([batch])
+                # Scan one file at a time. ArrowScan.to_record_batches() materializes
+                # all batches for each FileScanTask in its thread pool, so passing the
+                # full task chunk can retain several files before yielding any output.
+                # Singleton calls can reread delete files shared by multiple data
+                # files, but avoid relying on PyIceberg's private scan APIs.
+                if rows_remaining is not None:
+                    scanner = _create_scanner(rows_remaining)
+                assert scanner is not None
+                for batch in scanner.to_record_batches(tasks=(task,)):
+                    if rows_remaining is not None:
+                        rows_remaining -= len(batch)
+                    yield pa.Table.from_batches([batch.cast(target_schema)])
 
         else:
             # Legacy implementation using project_table (PyIceberg <0.9.0)

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 # Field ID for the fabricated stub field, see ``_get_empty_projection_schema``.
 # Iceberg matches columns by ID, so this must not be a real column's: colliding
 # with a non-boolean column raises ``ResolveError``, and with a boolean column

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -251,6 +251,7 @@ def _get_read_task(
     limit: Optional[int],
     schema: "Schema",
     empty_projection: bool = False,
+    read_file_tasks_sequentially: bool = True,
 ) -> Iterable[Block]:
     # Determine the PyIceberg version to handle backward compatibility
     import pyiceberg
@@ -269,6 +270,12 @@ def _get_read_task(
                     case_sensitive=case_sensitive,
                     limit=scan_limit,
                 )
+
+            if not read_file_tasks_sequentially:
+                result_table = _create_scanner(limit).to_table(tasks=tasks)
+                for batch in result_table.to_batches():
+                    yield pa.Table.from_batches([batch])
+                return
 
             target_schema = schema_to_pyarrow(schema, include_field_ids=False)
             rows_remaining = limit
@@ -541,6 +548,10 @@ class IcebergDatasource(Datasource):
         from pyiceberg.io import pyarrow as pyi_pa_io
         from pyiceberg.manifest import DataFileContent
 
+        from ray.data.context import DataContext
+
+        data_context = data_context or DataContext.get_current()
+
         # Get the PyIceberg scan
         data_scan = self._get_data_scan()
         # Get the plan files in this query
@@ -612,6 +623,9 @@ class IcebergDatasource(Datasource):
             limit=limit,
             schema=projected_schema,
             empty_projection=empty_projection,
+            read_file_tasks_sequentially=(
+                data_context.iceberg_config.read_file_tasks_sequentially
+            ),
         )
 
         read_tasks = []

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -217,24 +217,37 @@ def _get_read_task(
     def _generate_tables() -> Iterable[pa.Table]:
         if version.parse(pyiceberg.__version__) >= version.parse("0.9.0"):
             # Modern implementation using ArrowScan (PyIceberg 0.9.0+)
-            from pyiceberg.io.pyarrow import ArrowScan
+            from pyiceberg.io.pyarrow import ArrowScan, schema_to_pyarrow
 
-            # Initialize scanner with Iceberg metadata and query parameters
-            scanner = ArrowScan(
-                table_metadata=table_metadata,
-                io=table_io,
-                row_filter=row_filter,
-                projected_schema=schema,
-                case_sensitive=case_sensitive,
-                limit=limit,
-            )
+            def _create_scanner(scan_limit: Optional[int]) -> ArrowScan:
+                return ArrowScan(
+                    table_metadata=table_metadata,
+                    io=table_io,
+                    row_filter=row_filter,
+                    projected_schema=schema,
+                    case_sensitive=case_sensitive,
+                    limit=scan_limit,
+                )
 
-            # Convert scanned data to Arrow Table format
-            result_table = scanner.to_table(tasks=tasks)
+            target_schema = schema_to_pyarrow(schema, include_field_ids=False)
+            rows_remaining = limit
+            scanner = _create_scanner(None) if rows_remaining is None else None
+            for task in tasks:
+                if rows_remaining is not None and rows_remaining <= 0:
+                    break
 
-            # Stream results as RecordBatches for memory efficiency
-            for batch in result_table.to_batches():
-                yield pa.Table.from_batches([batch])
+                # Scan one file at a time. ArrowScan.to_record_batches() materializes
+                # all batches for each FileScanTask in its thread pool, so passing the
+                # full task chunk can retain several files before yielding any output.
+                # Singleton calls can reread delete files shared by multiple data
+                # files, but avoid relying on PyIceberg's private scan APIs.
+                if rows_remaining is not None:
+                    scanner = _create_scanner(rows_remaining)
+                assert scanner is not None
+                for batch in scanner.to_record_batches(tasks=(task,)):
+                    if rows_remaining is not None:
+                        rows_remaining -= len(batch)
+                    yield pa.Table.from_batches([batch.cast(target_schema)])
 
         else:
             # Legacy implementation using project_table (PyIceberg <0.9.0)

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -413,6 +413,10 @@ class IcebergConfig:
         catalog_retried_errors: A list of substrings of error messages that
             should trigger a retry for Iceberg catalog operations. Includes common
             HTTP error codes and connection errors.
+        read_file_tasks_sequentially: Whether each Ray read task processes files
+            one at a time. Defaults to ``True`` to limit memory use. Set to
+            ``False`` for higher throughput when a task has many small files and
+            their combined input comfortably fits in memory.
     """
 
     write_file_max_attempts: int = DEFAULT_ICEBERG_WRITE_FILE_MAX_ATTEMPTS
@@ -422,6 +426,7 @@ class IcebergConfig:
     catalog_retried_errors: List[str] = field(
         default_factory=lambda: list(DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS)
     )
+    read_file_tasks_sequentially: bool = True
 
 
 @DeveloperAPI

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -266,6 +266,37 @@ def test_get_read_task_streams_files_and_preserves_limit(monkeypatch):
         next(tables)
 
 
+def test_get_read_tasks_can_disable_bounded_memory(monkeypatch):
+    from pyiceberg.io import pyarrow as pyi_pa_io
+
+    from ray.data.context import DataContext
+
+    scanned_task_counts = []
+
+    class FakeArrowScan:
+        def __init__(self, **kwargs):
+            pass
+
+        def to_table(self, tasks):
+            scanned_task_counts.append(len(tuple(tasks)))
+            return pa.table({"value": [1]})
+
+    monkeypatch.setattr(pyi_pa_io, "ArrowScan", FakeArrowScan)
+
+    data_context = DataContext()
+    data_context.iceberg_config.read_file_tasks_sequentially = False
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+    expected_task_count = len(iceberg_ds.plan_files)
+
+    read_task = iceberg_ds.get_read_tasks(1, data_context=data_context)[0]
+
+    assert [table.to_pydict() for table in read_task()] == [{"value": [1]}]
+    assert scanned_task_counts == [expected_task_count]
+
+
 def test_get_read_task_normalizes_batch_schemas(monkeypatch):
     from pyiceberg.io import pyarrow as pyi_pa_io
 

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -22,7 +22,10 @@ from pyiceberg.transforms import IdentityTransform
 import ray
 from ray.data import read_iceberg
 from ray.data._internal.arrow_block import _BATCH_SIZE_PRESERVING_STUB_COL_NAME
-from ray.data._internal.datasource.iceberg_datasource import IcebergDatasource
+from ray.data._internal.datasource.iceberg_datasource import (
+    IcebergDatasource,
+    _get_read_task,
+)
 from ray.data._internal.logical.operators import Filter, Project
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
@@ -204,6 +207,130 @@ def test_get_read_tasks():
     read_tasks = iceberg_ds.get_read_tasks(5)
     assert len(read_tasks) == 5
     assert all(len(rt.metadata.input_files) == 2 for rt in read_tasks)
+
+
+def test_get_read_task_streams_files_and_preserves_limit(monkeypatch):
+    from pyiceberg.io import pyarrow as pyi_pa_io
+
+    batches = {
+        "file-1": pa.record_batch({"value": [1, 2, 3, 4]}),
+        "file-2": pa.record_batch({"value": [5, 6, 7, 8]}),
+    }
+    scanned_files = []
+    scanner_limits = []
+
+    class FakeArrowScan:
+        def __init__(self, **kwargs):
+            self._limit = kwargs["limit"]
+            scanner_limits.append(self._limit)
+
+        def to_record_batches(self, tasks):
+            (task,) = tasks
+            scanned_files.append(task)
+            batch = batches[task]
+            if self._limit is not None:
+                batch = batch.slice(0, self._limit)
+            yield batch
+
+    monkeypatch.setattr(pyi_pa_io, "ArrowScan", FakeArrowScan)
+
+    schema = pyi_schema.Schema(
+        pyi_types.NestedField(
+            field_id=1,
+            name="value",
+            field_type=pyi_types.LongType(),
+            required=False,
+        )
+    )
+
+    tables = iter(
+        _get_read_task(
+            tasks=("file-1", "file-2"),
+            table_io=object(),
+            table_metadata=object(),
+            row_filter=object(),
+            case_sensitive=True,
+            limit=5,
+            schema=schema,
+        )
+    )
+
+    assert next(tables).column("value").to_pylist() == [1, 2, 3, 4]
+    assert scanned_files == ["file-1"]
+    assert scanner_limits == [5]
+
+    assert next(tables).column("value").to_pylist() == [5]
+    assert scanned_files == ["file-1", "file-2"]
+    assert scanner_limits == [5, 1]
+    with pytest.raises(StopIteration):
+        next(tables)
+
+
+def test_get_read_task_normalizes_batch_schemas(monkeypatch):
+    from pyiceberg.io import pyarrow as pyi_pa_io
+
+    batches = {
+        "small-offsets": pa.record_batch(
+            {
+                "string": pa.array(["a"], type=pa.string()),
+                "list": pa.array([["b"]], type=pa.list_(pa.string())),
+            }
+        ),
+        "large-offsets": pa.record_batch(
+            {
+                "string": pa.array(["c"], type=pa.large_string()),
+                "list": pa.array([["d"]], type=pa.large_list(pa.large_string())),
+            }
+        ),
+    }
+
+    class FakeArrowScan:
+        def __init__(self, **kwargs):
+            pass
+
+        def to_record_batches(self, tasks):
+            (task,) = tasks
+            yield batches[task]
+
+    monkeypatch.setattr(pyi_pa_io, "ArrowScan", FakeArrowScan)
+
+    schema = pyi_schema.Schema(
+        pyi_types.NestedField(
+            field_id=1,
+            name="string",
+            field_type=pyi_types.StringType(),
+            required=False,
+        ),
+        pyi_types.NestedField(
+            field_id=2,
+            name="list",
+            field_type=pyi_types.ListType(
+                element_id=3,
+                element=pyi_types.StringType(),
+                element_required=False,
+            ),
+            required=False,
+        ),
+    )
+    expected_schema = pyi_pa_io.schema_to_pyarrow(schema, include_field_ids=False)
+
+    tables = list(
+        _get_read_task(
+            tasks=("small-offsets", "large-offsets"),
+            table_io=object(),
+            table_metadata=object(),
+            row_filter=object(),
+            case_sensitive=True,
+            limit=None,
+            schema=schema,
+        )
+    )
+
+    assert [table.schema for table in tables] == [expected_schema, expected_schema]
+    assert [table.to_pydict() for table in tables] == [
+        {"string": ["a"], "list": [["b"]]},
+        {"string": ["c"], "list": [["d"]]},
+    ]
 
 
 @pytest.mark.skipif(
@@ -567,7 +694,7 @@ def test_read_basic():
     table: pa.Table = pa.concat_tables((ray.get(ref) for ref in ray_ds.to_arrow_refs()))
 
     expected_schema = pa.schema(
-        [pa.field("col_a", pa.int32()), pa.field("col_b", pa.string())]
+        [pa.field("col_a", pa.int32()), pa.field("col_b", pa.large_string())]
     )
     assert table.schema.equals(expected_schema)
 

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -21,7 +21,10 @@ from pyiceberg.transforms import IdentityTransform
 
 import ray
 from ray.data import read_iceberg
-from ray.data._internal.datasource.iceberg_datasource import IcebergDatasource
+from ray.data._internal.datasource.iceberg_datasource import (
+    IcebergDatasource,
+    _get_read_task,
+)
 from ray.data._internal.logical.operators import Filter, Project
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
@@ -205,6 +208,130 @@ def test_get_read_tasks():
     assert all(len(rt.metadata.input_files) == 2 for rt in read_tasks)
 
 
+def test_get_read_task_streams_files_and_preserves_limit(monkeypatch):
+    from pyiceberg.io import pyarrow as pyi_pa_io
+
+    batches = {
+        "file-1": pa.record_batch({"value": [1, 2, 3, 4]}),
+        "file-2": pa.record_batch({"value": [5, 6, 7, 8]}),
+    }
+    scanned_files = []
+    scanner_limits = []
+
+    class FakeArrowScan:
+        def __init__(self, **kwargs):
+            self._limit = kwargs["limit"]
+            scanner_limits.append(self._limit)
+
+        def to_record_batches(self, tasks):
+            (task,) = tasks
+            scanned_files.append(task)
+            batch = batches[task]
+            if self._limit is not None:
+                batch = batch.slice(0, self._limit)
+            yield batch
+
+    monkeypatch.setattr(pyi_pa_io, "ArrowScan", FakeArrowScan)
+
+    schema = pyi_schema.Schema(
+        pyi_types.NestedField(
+            field_id=1,
+            name="value",
+            field_type=pyi_types.LongType(),
+            required=False,
+        )
+    )
+
+    tables = iter(
+        _get_read_task(
+            tasks=("file-1", "file-2"),
+            table_io=object(),
+            table_metadata=object(),
+            row_filter=object(),
+            case_sensitive=True,
+            limit=5,
+            schema=schema,
+        )
+    )
+
+    assert next(tables).column("value").to_pylist() == [1, 2, 3, 4]
+    assert scanned_files == ["file-1"]
+    assert scanner_limits == [5]
+
+    assert next(tables).column("value").to_pylist() == [5]
+    assert scanned_files == ["file-1", "file-2"]
+    assert scanner_limits == [5, 1]
+    with pytest.raises(StopIteration):
+        next(tables)
+
+
+def test_get_read_task_normalizes_batch_schemas(monkeypatch):
+    from pyiceberg.io import pyarrow as pyi_pa_io
+
+    batches = {
+        "small-offsets": pa.record_batch(
+            {
+                "string": pa.array(["a"], type=pa.string()),
+                "list": pa.array([["b"]], type=pa.list_(pa.string())),
+            }
+        ),
+        "large-offsets": pa.record_batch(
+            {
+                "string": pa.array(["c"], type=pa.large_string()),
+                "list": pa.array([["d"]], type=pa.large_list(pa.large_string())),
+            }
+        ),
+    }
+
+    class FakeArrowScan:
+        def __init__(self, **kwargs):
+            pass
+
+        def to_record_batches(self, tasks):
+            (task,) = tasks
+            yield batches[task]
+
+    monkeypatch.setattr(pyi_pa_io, "ArrowScan", FakeArrowScan)
+
+    schema = pyi_schema.Schema(
+        pyi_types.NestedField(
+            field_id=1,
+            name="string",
+            field_type=pyi_types.StringType(),
+            required=False,
+        ),
+        pyi_types.NestedField(
+            field_id=2,
+            name="list",
+            field_type=pyi_types.ListType(
+                element_id=3,
+                element=pyi_types.StringType(),
+                element_required=False,
+            ),
+            required=False,
+        ),
+    )
+    expected_schema = pyi_pa_io.schema_to_pyarrow(schema, include_field_ids=False)
+
+    tables = list(
+        _get_read_task(
+            tasks=("small-offsets", "large-offsets"),
+            table_io=object(),
+            table_metadata=object(),
+            row_filter=object(),
+            case_sensitive=True,
+            limit=None,
+            schema=schema,
+        )
+    )
+
+    assert [table.schema for table in tables] == [expected_schema, expected_schema]
+    assert [table.to_pydict() for table in tables] == [
+        {"string": ["a"], "list": [["b"]]},
+        {"string": ["c"], "list": [["d"]]},
+    ]
+
+
 @pytest.mark.skipif(
     get_pyarrow_version() < parse_version("14.0.0"),
     reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
@@ -240,7 +367,7 @@ def test_read_basic():
     table: pa.Table = pa.concat_tables((ray.get(ref) for ref in ray_ds.to_arrow_refs()))
 
     expected_schema = pa.schema(
-        [pa.field("col_a", pa.int32()), pa.field("col_b", pa.string())]
+        [pa.field("col_a", pa.int32()), pa.field("col_b", pa.large_string())]
     )
     assert table.schema.equals(expected_schema)
 


### PR DESCRIPTION
*I used CODEX to analyze this problem and create this PR. I've reviewed the code and tests and stand by them. This summary is written completely by a human (me) other than very light copy editing by an LLM.*

Currently `_generate_tables()` scans all files associated with the `FileScanTask`s to produce one Arrow table and then yields the results in batches.  The implication is that the memory consumption is what's needed to process all FileScanTasks at once.

This change processes one `FileScanTask` at a time and yields the result in batches.  This reduces the memory consumption to a function of the largest requirement for any single FileScanTask.

This can be a meaningful benefit at scale when multiple files are processed per Ray task.

UPDATE: @abhishekverma-ray points out in a comment that this subtly changes the PyArrow field data type, with respect to width of offsets.  Before, the use `to_table()` allowed for promotion to `large_string / large_list` when needed.  But with this PR's use of `to_record_batches()` that needs to always happen.   An alternative idea would be to keep using `to_table` but yield back results at the file level.  That reduces the memory footprint relative to the current behavior, which processes all files at once, but take more memory than the current approach in this PR which is to yield back at the batch level.

I will defer to the guidance of the project maintainers on what the best tradeoff is here between the memory and the breaking(?) change of the returned types.

CODEX generated summary follows:
-----
Ray's Iceberg reader passes every `FileScanTask` assigned to a Ray read task into one PyIceberg `ArrowScan`. PyIceberg materializes the files in its executor before Ray can consume the resulting batches, so transient worker memory scales with the number and size of files assigned to that task. In our production-shaped workload, workers OOMed before downstream processing made meaningful progress.

By default, this change calls PyIceberg's public `to_record_batches()` API separately for each `FileScanTask`. That bounds the Ray task's high-water mark to one file, preserves the task-wide row limit, and casts every result to the projected Iceberg schema so blocks do not alternate between small- and large-offset Arrow types. PyIceberg still materializes a complete file before Ray receives its batches, so this is a file-level—not batch-level—memory bound.

`DataContext.iceberg_config.read_file_tasks_sequentially` defaults to `True` for that bounded behavior. Setting it to `False` restores the prior `to_table(tasks=tasks)` path, including PyIceberg's within-task cross-file parallelism and shared delete-file reuse. Disable it when a task has many small files, their combined input comfortably fits in memory, and throughput matters more than the memory bound.

## Results

A local six-file Iceberg benchmark scanned 12 million rows: two million rows per file with eight random `int64` columns. Peak process memory fell from 1.855 GiB to approximately 650 MiB, a 65% reduction (2.85x lower), with the same output rows and no measurable hot-cache slowdown.

As an end-to-end validation, the original reader OOMed after roughly 242 completed read tasks. The bounded reader, combined with an explicit 5 GiB Ray task-memory reservation, reached 2,343 completed reads with zero failures; peak worker-node memory was 102.5/160 GiB. The local benchmark isolates this code change; the cluster result validates the reader together with separate scheduling configuration.

## Testing

- `/Users/aniskodedossett/development/ray/.venv/bin/pytest -q python/ray/data/tests/datasource/test_iceberg.py -k 'get_read_task or read_basic'` — 5 passed, 52 deselected
- `pre-commit run --files python/ray/data/_internal/datasource/iceberg_datasource.py python/ray/data/context.py python/ray/data/tests/datasource/test_iceberg.py` — passed
- `git diff --check` — passed

I searched open `ray-project/ray` pull requests for Iceberg memory, `read_iceberg` memory, and `ArrowScan` Iceberg changes and found no active duplicate.

AI assistance was used to investigate, implement, test, benchmark, and draft this PR. The submitter must review every changed line and validate the results before requesting upstream review.
