### PR TITLE
[Serve] Fix serve.ingress(FastAPI()) pickling under FastAPI >= 0.137 (cannot pickle '_thread.lock')

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -289,11 +289,31 @@ def copy_class_metadata(wrapper_cls, target_cls) -> None:
     wrapper_cls.__wrapped__ = target_cls
 
 
+def _register_thread_lock_serializer(serialization_context):
+    """Make threading locks cloudpickle-serializable.
+
+    FastAPI >= 0.137 embeds a threading.Lock in the ASGI app object, which cloudpickle
+    cannot serialize ("cannot pickle '_thread.lock' object"). serve.ingress(app) pickles
+    the app to freeze it (and again to ship it to replicas), so both fail. A lock carries
+    no transferable state and the app is frozen/shipped before it serves any request, so
+    reconstruct a fresh, unlocked lock on deserialization.
+    """
+    import threading
+
+    for lock_factory in (threading.Lock, threading.RLock):
+        serialization_context._register_cloudpickle_serializer(
+            type(lock_factory()),
+            custom_serializer=lambda lock: None,
+            custom_deserializer=lambda _serialized, factory=lock_factory: factory(),
+        )
+
+
 def ensure_serialization_context():
     """Ensure the serialization addons on registered, even when Ray has not
     been started."""
     ctx = StandaloneSerializationContext()
     ray.util.serialization_addons.apply(ctx)
+    _register_thread_lock_serializer(ctx)
 
 
 def msgpack_serialize(obj):

--- a/python/ray/serve/tests/unit/test_serialization.py
+++ b/python/ray/serve/tests/unit/test_serialization.py
@@ -1,0 +1,37 @@
+import sys
+import threading
+
+import pytest
+
+from ray import cloudpickle
+from ray.serve._private.utils import ensure_serialization_context
+
+
+def test_thread_lock_serializer_round_trips():
+    """FastAPI >= 0.137 embeds a threading.Lock in the ASGI app object, breaking
+    serve.ingress(app) with 'cannot pickle _thread.lock'. The addon serializer must let
+    an object holding a lock round-trip through cloudpickle, reconstructing a fresh,
+    usable lock (locks carry no transferable state).
+    """
+    ensure_serialization_context()
+
+    class Holder:
+        def __init__(self):
+            self.lock = threading.Lock()
+            self.rlock = threading.RLock()
+            self.value = 7
+
+    restored = cloudpickle.loads(cloudpickle.dumps(Holder()))
+
+    assert restored.value == 7
+    assert isinstance(restored.lock, type(threading.Lock()))
+    assert isinstance(restored.rlock, type(threading.RLock()))
+    # The reconstructed locks are fresh and usable.
+    assert restored.lock.acquire(blocking=False)
+    restored.lock.release()
+    assert restored.rlock.acquire(blocking=False)
+    restored.rlock.release()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Under **FastAPI >= 0.137**, deploying a pre-built ASGI app fails at deploy time:

```
TypeError: cannot pickle '_thread.lock' object
  ray/serve/api.py -> pickle_dumps(app, "Failed to serialize the ASGI app.")
```

FastAPI 0.137's app object now embeds a `threading.Lock`. `serve.ingress(app)` cloudpickles the app twice — once to *freeze* it at decoration time (so later mutations to the user's app don't leak into the deployment) and again to *ship* it to replica actors — and both fail on the unpicklable lock. This breaks every `serve.ingress(FastAPI())` deployment that passes a pre-built app, and turns the `test_api` suite red: `test_ingress_wrapper_preserves_metadata`, `test_ingress_async_init`, `test_ingress_sync_init_subclass_raises`, `test_ingress_sync_init_via_mixin_subclass_raises`, `test_ingress_async_init_subclass_allowed`, `test_deploy_application_basic`.

## What this PR does

Register a cloudpickle serializer for `threading.Lock` / `RLock` in Serve's `ensure_serialization_context()` (`python/ray/serve/_private/utils.py`). A lock carries no transferable state, and the app is frozen/shipped before it serves any request, so serializing the lock to nothing and reconstructing a fresh, unlocked lock on deserialization is safe. Both the freeze and the ship then succeed, with no change to the `serve.ingress` API.

### Why register it in Serve and not in the shared `serialization_addons`

The natural-looking home is `ray/util/serialization_addons.py` (next to the Starlette `State` serializer). But `apply()` there is invoked by Ray's **core** serialization context (`ray/_private/serialization.py`), so a lock serializer registered there applies to **all** Ray serialization and silently defeats the non-serializable guards other libraries rely on — e.g. Ray Train's `inspect_serializability` (`test_torch_trainer.py::test_nonserializable_train_function` deliberately captures a `threading.Lock` and expects a `TypeError`; a global lock serializer makes it ship a fresh lock to the worker instead). Registering in Serve's own `ensure_serialization_context()` scopes the behavior change to Serve, where making the ingress app picklable is exactly what we want.

## Alternatives considered

Root trigger is #63722 (Starlette 1.0.1 security bump), which left `fastapi>=0.133.0` unbounded so the serve test env resolves it to 0.137. Repo/CI-wide options:
- **Pin the version** — `fastapi<0.137` in `python/requirements.txt` + recompile `requirements_compiled*.txt` (matches #42740 / #42682 / #25604).
- **Close the hermeticity gap** — the base test image installs deps without `-c requirements_compiled.txt`, so the pinned 0.133 isn't enforced for this shard.

This PR takes the serve-scoped serialization approach so Serve keeps working *on* FastAPI 0.137, and composes with either.

## Related issue number

Part of the FastAPI >= 0.137 upgrade fallout (same wave as #64245 / #64246 / #64475 / #64531), introduced by #63722. This covers the `serve.ingress` app-pickling facet.

## Checks

- Added `python/ray/serve/tests/unit/test_serialization_addons.py`: asserts a lock-holding object round-trips through cloudpickle after `ensure_serialization_context()`, and both the reconstructed `Lock` and `RLock` are fresh and usable.
- Verified locally that `cloudpickle.dumps(threading.Lock())` raises the exact `cannot pickle '_thread.lock' object` before this change and round-trips after.