### PR TITLE
[core] extend rocksdb timeout in tests

### DIFF
--- a/src/ray/gcs/store_client/tests/rocksdb_parity_test.cc
+++ b/src/ray/gcs/store_client/tests/rocksdb_parity_test.cc
@@ -47,6 +47,12 @@ fs::path UniqueDbPath() {
 
 class RocksDbStoreClientParityTest : public StoreClientTestBase {
  public:
+  RocksDbStoreClientParityTest() {
+    // RocksDB AsyncPut fsyncs the WAL before acking. 5000 sync puts can
+    // exceed the base fixture's 5s wait under ASAN / slow CI disks.
+    wait_pending_timeout_ = std::chrono::seconds(60);
+  }
+
   void InitStoreClient() override {
     db_path_ = UniqueDbPath();
     store_client_ = std::make_shared<RocksDbStoreClient>(*(io_service_pool_->Get()),


### PR DESCRIPTION
## Description

Fix the following RocksDbStoreClientParityTest.AsyncPutAndAsyncGetTest test by increasing the timeout.
```
[2026-07-16T05:56:16Z] [  FAILED  ] RocksDbStoreClientParityTest.AsyncPutAndAsyncGetTest (10351 ms)
--
  | [2026-07-16T05:56:16Z] [ RUN      ] RocksDbStoreClientParityTest.AsyncGetAllAndBatchDeleteTest
  | [2026-07-16T05:56:16Z] [2026-07-16 05:56:11,504 I 1325 1325] (rocksdb_parity_test) io_service_pool.cc:37: IOServicePool is running with 2 io_service.
  | [2026-07-16T05:56:16Z] bazel-out/k8-opt/bin/src/ray/gcs/store_client/tests/_virtual_includes/store_client_test_lib/ray/gcs/store_client/tests/store_client_test_base.h:253: Failure
  | [2026-07-16T05:56:16Z] Value of: WaitForCondition(condition, wait_pending_timeout_.count())
  | [2026-07-16T05:56:16Z]   Actual: false
  | [2026-07-16T05:56:16Z] Expected: true
  | [2026-07-16T05:56:16Z]
  | [2026-07-16T05:56:16Z] [2026-07-16 05:56:16,710 I 1325 1358] (rocksdb_parity_test) store_client_test_base.h:123: ReceivedKeys=4938
  | [2026-07-16T05:56:16Z] [2026-07-16 05:56:16,722 C 1325 1358] (rocksdb_parity_test) store_client_test_base.h:134:  An unexpected system state has occurred. You have likely discovered a bug in Ray. Please report this issue at https://github.com/ray-project/ray/issues and we'll work with you to fix it. Check failed: received_keys.size() == key_to_value_.size()
```
