### PR TITLE
[ci/doc] Exempt override hooks from the API-doc private-name rule

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -216,6 +216,25 @@ class API:
 
         return name_has_underscore or is_internal
 
+    @staticmethod
+    def _is_override_hook(obj: object) -> bool:
+        """
+        A leading underscore carries two meanings in Python. PEP 8 uses it for
+        "non-public"; but with no ``protected`` keyword the same underscore also
+        marks a template-method override hook -- a public, non-overridable
+        wrapper delegates to a protected, user-overridable method (for example
+        ``RLModule.forward_train`` delegating to the documented, subclassable
+        ``_forward_train``). An override hook is a declared public extension
+        point, not a private leak, so its underscore should not read as private.
+
+        The ``@OverrideToImplementCustomLogic`` decorators tag such methods by
+        setting ``__is_overridden__``; the *presence* of the attribute is the
+        intent signal (its boolean value tracks a separate runtime concern).
+        Read the attribute generically so the shared check needs no per-team
+        import.
+        """
+        return hasattr(obj, "__is_overridden__")
+
     def is_public(self) -> bool:
         """
         Check if this API is public. Public APIs are those that are annotated as public
@@ -310,7 +329,13 @@ class API:
                 annotation_type=annotation_type,
                 code_type=api.code_type,
             )
-            if resolved_api.is_deprecated() or resolved_api._is_private_name():
+            # Override hooks are public extension points despite their leading
+            # underscore, so the private-name rule does not apply to them; a
+            # deprecated annotation still does.
+            is_private = resolved_api._is_private_name() and not API._is_override_hook(
+                obj
+            )
+            if resolved_api.is_deprecated() or is_private:
                 non_public.append(canonical_name)
 
         return unresolved, non_public

--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -11,6 +11,12 @@ _SPHINX_AUTOCLASS_HEADER = ".. autoclass::"
 # example ~module.api_name will render only api_name
 _SPHINX_AUTODOC_SHORTNAME = "~"
 
+# Attribute set by RLlib's @OverrideToImplementCustomLogic decorators to tag a
+# method as a template-method override hook. Its presence marks an intentional
+# public extension point, so an underscore-named object carrying it is exempt
+# from the private-name rule.
+_OVERRIDE_HOOK_MARKER = "__is_overridden__"
+
 
 class AnnotationType(Enum):
     PUBLIC_API = "PublicAPI"
@@ -233,7 +239,7 @@ class API:
         Read the attribute generically so the shared check needs no per-team
         import.
         """
-        return hasattr(obj, "__is_overridden__")
+        return hasattr(obj, _OVERRIDE_HOOK_MARKER)
 
     def is_public(self) -> bool:
         """

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -213,17 +213,16 @@ TEAM_API_CONFIGS = {
             "ray.rllib.connectors.env_to_module.observation_preprocessor.ray.rllib.connectors.env_to_module.observation_preprocessor.SingleAgentObservationPreprocessor",
             "ray.rllib.connectors.env_to_module.observation_preprocessor.ray.rllib.connectors.env_to_module.observation_preprocessor.MultiAgentObservationPreprocessor",
             # Documented private / dunder members flagged non-public. Document
-            # the public surface instead, then drop these.
+            # the public surface instead, then drop these. The documented
+            # override hooks that used to sit here (RLModule._forward*) are now
+            # exempted by their @OverrideToImplementCustomLogic marker in
+            # API.split_resolvable_and_broken_doc_apis, so they need no entry.
             "ray.rllib.core.learner.learner.Learner._check_is_built",
             "ray.rllib.core.learner.learner.Learner._make_module",
             "ray.rllib.core.learner.learner.Learner._check_registered_optimizer",
             "ray.rllib.core.learner.learner.Learner._set_optimizer_lr",
             "ray.rllib.core.learner.learner.Learner._get_clip_function",
             "ray.rllib.utils.schedules.scheduler.Scheduler._create_tensor_variable",
-            "ray.rllib.core.rl_module.rl_module.RLModule._forward",
-            "ray.rllib.core.rl_module.rl_module.RLModule._forward_exploration",
-            "ray.rllib.core.rl_module.rl_module.RLModule._forward_inference",
-            "ray.rllib.core.rl_module.rl_module.RLModule._forward_train",
             "ray.rllib.offline.offline_data.OfflineData.__init__",
             "ray.rllib.offline.offline_prelearner.OfflinePreLearner.__init__",
             "ray.rllib.offline.offline_prelearner.OfflinePreLearner.__call__",

--- a/ci/ray_ci/doc/mock/mock_module.py
+++ b/ci/ray_ci/doc/mock/mock_module.py
@@ -25,6 +25,15 @@ def Deprecated(*args, **kwargs):
     return wrap
 
 
+def OverrideToImplementCustomLogic(obj):
+    # Mirrors rllib.utils.annotations.OverrideToImplementCustomLogic: tags a
+    # method as a template-method override hook by setting __is_overridden__.
+    # The API check reads the attribute generically, so the test fixture does
+    # not import RLlib.
+    obj.__is_overridden__ = False
+    return obj
+
+
 @PublicAPI
 class MockClass:
     """
@@ -36,6 +45,23 @@ class MockClass:
         A method that is documented (for example in an autosummary) but is not
         itself annotated -- it is public by virtue of its annotated class.
         The check must accept it as long as it resolves.
+        """
+        pass
+
+    @OverrideToImplementCustomLogic
+    def _mock_forward(self):
+        """
+        A documented override hook: underscore-named but a declared public
+        extension point. The check must accept it despite the leading
+        underscore because it carries the override-hook marker.
+        """
+        pass
+
+    def _mock_private(self):
+        """
+        A plain underscore-named method with no override-hook marker. The check
+        must still flag it as non-public -- the exemption must not weaken
+        detection of genuinely private symbols.
         """
         pass
 

--- a/ci/ray_ci/doc/mock/mock_module.py
+++ b/ci/ray_ci/doc/mock/mock_module.py
@@ -1,4 +1,4 @@
-from ci.ray_ci.doc.api import AnnotationType
+from ci.ray_ci.doc.api import _OVERRIDE_HOOK_MARKER, AnnotationType
 
 
 def PublicAPI(*args, **kwargs):
@@ -27,10 +27,10 @@ def Deprecated(*args, **kwargs):
 
 def OverrideToImplementCustomLogic(obj):
     # Mirrors rllib.utils.annotations.OverrideToImplementCustomLogic: tags a
-    # method as a template-method override hook by setting __is_overridden__.
+    # method as a template-method override hook by setting the override marker.
     # The API check reads the attribute generically, so the test fixture does
     # not import RLlib.
-    obj.__is_overridden__ = False
+    setattr(obj, _OVERRIDE_HOOK_MARKER, False)
     return obj
 
 

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -303,6 +303,23 @@ def test_split_resolvable_flags_private_documented_name():
     assert non_public == []
 
 
+def test_split_resolvable_exempts_override_hook():
+    # A documented, underscore-named method tagged as an override hook is a
+    # public extension point, so it is not flagged non-public. A sibling
+    # underscore method with no marker still is -- the exemption must not weaken
+    # detection of genuinely private symbols.
+    unresolved, non_public = API.split_resolvable_and_broken_doc_apis(
+        [
+            _doc_api(f"{_MOCK}.MockClass._mock_forward"),
+            _doc_api(f"{_MOCK}.MockClass._mock_private"),
+        ],
+        set(),
+    )
+
+    assert unresolved == []
+    assert non_public == [f"{_MOCK}.MockClass._mock_private"]
+
+
 def test_find_duplicate_doc_apis():
     # mock_w00t appears twice, MockClass once. Names canonicalize first, so the
     # duplicate is reported under the canonical name.


### PR DESCRIPTION
## Why

The API-doc consistency check (`ci/ray_ci/doc/api.py`, `cmd_check_api_discrepancy.py`) flags any documented API whose canonical name is private, where `_is_private_name()` treats a leading-underscore final segment as private. That heuristic conflates the two meanings a single leading underscore carries in Python. PEP 8 uses it for "non-public / no stability guarantee," which is what the check wants to catch. But with no `protected` keyword, the same underscore also marks a **template-method override hook**: a public, non-overridable wrapper that delegates to a protected, user-overridable method. That hook is an intentional, documented extension point, not a private leak.

RLlib relies on this pattern. `RLModule._forward`, `_forward_exploration`, `_forward_inference`, and `_forward_train` are documented in `doc/source/rllib/package_ref/rl_modules.rst` ("Override these private methods to define your custom model's forward behavior"). Users call the public `forward_train` and override `_forward_train`. The check flags all four as non-public purely because of the leading underscore, even though they resolve cleanly and are the documented contract for subclassing a `@PublicAPI(stability="beta")` class. They were parked in the RLlib `tracked_doc_debt` list to green the check, which records the exception by name and grows with every new documented override hook.

## What

Teach the check to exempt an underscore-named object from the private-name rule when it carries the `__is_overridden__` marker that `@OverrideToImplementCustomLogic` (and the `_CallToSuperRecommended` variant) sets. A method tagged as an intentional override hook is a declared public extension point, so its leading underscore should not read as "private." This keys the exemption off an explicit, machine-readable signal of intent instead of a hand-maintained name list.

- **`ci/ray_ci/doc/api.py`** — add `API._is_override_hook(obj)` and apply it in `split_resolvable_and_broken_doc_apis`. The exemption reads the attribute generically (`hasattr(obj, "__is_overridden__")`), so the shared check needs no RLlib import. It affects only the non-public classification; the unresolved-name and duplicate-documentation checks are unchanged. A `@Deprecated` annotation is still fatal, and a plain `_helper` with no marker still fails.
- **`ci/ray_ci/doc/cmd_check_api_discrepancy.py`** — retire the four `RLModule._forward*` entries from the RLlib tracked-doc-debt list, now covered by the marker exemption. The genuine private/dunder entries stay.
- **`ci/ray_ci/doc/mock/mock_module.py`, `test_api.py`** — add coverage for a documented underscore method that is / isn't tagged as an override hook.

Note on the signal: the decorators set `__is_overridden__ = False` on the base method, and `is_overridden()` returns `True` by default for undecorated objects, so the intent signal is the *presence* of the attribute, not its value.

## Checks

- `ci/ray_ci/doc/test_api.py` and `ci/ray_ci/doc/test_cmd_check_api_discrepancy.py` pass locally.
- Full pre-commit suite (ruff/black/import-order/docstyle/semgrep) passes.
- The `doc: check API doc consistency` premerge job is the authoritative gate.

## Related

Overlaps the RLlib config block edited by #64807 (short-term whitelist + `.rst` fixes) — this exemption makes the four `_forward*` debt entries dead, so once it lands the RLlib side is covered regardless of merge order. The classification function is also touched by the analogous Data `__all__` signal-over-whitelist change; whichever merges second rebases.
