### PR TITLE
[Doc][Serve][LLM] Document loading models from Azure storage

### DIFF
--- a/doc/source/serve/llm/user-guides/deployment-initialization.md
+++ b/doc/source/serve/llm/user-guides/deployment-initialization.md
@@ -127,7 +127,13 @@ Load models from S3, GCS, or Azure storage instead of Hugging Face. This is usef
 - Faster loading from cloud storage in the same region
 - Custom model formats or fine-tuned models
 
-### S3 bucket structure
+Select your cloud provider for backend-specific configuration:
+
+`````{tab-set}
+
+````{tab-item} S3
+
+**Bucket structure**
 
 Your S3 bucket should contain the model files in a Hugging Face-compatible structure:
 
@@ -145,7 +151,7 @@ $ aws s3 ls air-example-data/rayllm-ossci/meta-Llama-3.2-1B-Instruct/
 2025-03-25 11:37:53      54528 tokenizer_config.json
 ```
 
-### Configure S3 loading (YAML)
+**Configure with YAML**
 
 Use the `bucket_uri` parameter in `model_loading_config`:
 
@@ -172,9 +178,7 @@ Deploy with:
 serve deploy config.yaml
 ```
 
-### Configure S3 loading (Python API)
-
-You can also configure S3 loading with Python:
+**Configure with the Python API**
 
 ```python
 from ray import serve
@@ -197,57 +201,11 @@ app = build_openai_app({"llm_configs": [llm_config]})
 serve.run(app, blocking=True)
 ```
 
-### Configure GCS bucket loading (YAML)
+**Credentials**
 
-For Google Cloud Storage, use the `gs://` protocol:
+For private S3 buckets, configure AWS credentials.
 
-```yaml
-model_loading_config:
-  model_id: my_model
-  model_source:
-    bucket_uri: gs://my-gcs-bucket/path/to/model
-```
-
-### Configure Azure loading (YAML)
-
-For Azure Blob Storage or Azure Data Lake Storage (ADLS) Gen2, use the `azure://`
-or `abfss://` protocol. The URI must embed the container and storage account as
-`container@account.<domain>`:
-
-- `abfss://<container>@<account>.dfs.core.windows.net/path/to/model` (ADLS Gen2)
-- `azure://<container>@<account>.blob.core.windows.net/path/to/model` (Blob Storage)
-
-```yaml
-model_loading_config:
-  model_id: my_model
-  model_source:
-    bucket_uri: abfss://my-container@myaccount.dfs.core.windows.net/path/to/model
-```
-
-### Configure Azure loading (Python API)
-
-Configure the same Azure source with the Python API. Azure loading requires the
-`adlfs` and `azure-identity` packages on every node that loads the model. Ship
-them through `runtime_env` so Ray installs them on each node's download task, no
-image rebuild required:
-
-```python
-llm_config = LLMConfig(
-    model_loading_config=dict(
-        model_id="my_model",
-        model_source=dict(
-            bucket_uri="abfss://my-container@myaccount.dfs.core.windows.net/path/to/model"
-        ),
-    ),
-    runtime_env=dict(pip=["adlfs", "azure-identity"]),
-)
-```
-
-### S3 credentials
-
-For private S3 buckets, configure AWS credentials:
-
-1. **Option 1: Environment variables**
+Option 1: Environment variables
 
 ```python
 llm_config = LLMConfig(
@@ -266,12 +224,64 @@ llm_config = LLMConfig(
 )
 ```
 
-2. **Option 2: IAM roles** (recommended for production)
+Option 2: IAM roles (recommended for production)
 
 Use EC2 instance profiles or EKS service accounts with appropriate S3 read permissions.
 
+````
 
-### Azure credentials
+````{tab-item} GCS
+
+**Configure with YAML**
+
+For Google Cloud Storage, use the `gs://` protocol:
+
+```yaml
+model_loading_config:
+  model_id: my_model
+  model_source:
+    bucket_uri: gs://my-gcs-bucket/path/to/model
+```
+
+````
+
+````{tab-item} Azure
+
+For Azure Blob Storage or Azure Data Lake Storage (ADLS) Gen2, use the `azure://`
+or `abfss://` protocol. The URI must embed the container and storage account as
+`container@account.<domain>`:
+
+- `abfss://<container>@<account>.dfs.core.windows.net/path/to/model` (ADLS Gen2)
+- `azure://<container>@<account>.blob.core.windows.net/path/to/model` (Blob Storage)
+
+**Configure with YAML**
+
+```yaml
+model_loading_config:
+  model_id: my_model
+  model_source:
+    bucket_uri: abfss://my-container@myaccount.dfs.core.windows.net/path/to/model
+```
+
+**Configure with the Python API**
+
+Azure loading requires the `adlfs` and `azure-identity` packages on every node
+that loads the model. Ship them through `runtime_env` so Ray installs them on
+each node's download task, no image rebuild required:
+
+```python
+llm_config = LLMConfig(
+    model_loading_config=dict(
+        model_id="my_model",
+        model_source=dict(
+            bucket_uri="abfss://my-container@myaccount.dfs.core.windows.net/path/to/model"
+        ),
+    ),
+    runtime_env=dict(pip=["adlfs", "azure-identity"]),
+)
+```
+
+**Credentials**
 
 Azure authentication uses [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential),
 which resolves credentials from the standard Azure credential chain, in order:
@@ -301,6 +311,10 @@ llm_config = LLMConfig(
     ),
 )
 ```
+
+````
+
+`````
 
 
 ### S3 and RunAI Streamer

--- a/doc/source/serve/llm/user-guides/deployment-initialization.md
+++ b/doc/source/serve/llm/user-guides/deployment-initialization.md
@@ -284,14 +284,16 @@ llm_config = LLMConfig(
 **Credentials**
 
 Azure authentication uses [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential),
-which resolves credentials from the standard Azure credential chain, in order:
-environment variables, a workload identity, a managed identity, then the Azure
-CLI login. For production deployments on AKS, a workload identity or managed
-identity granted the **Storage Blob Data Reader** role on the container is
-recommended.
+which resolves credentials from the standard Azure credential chain. It tries
+several sources in order, including environment variables, a workload identity, a
+managed identity, and the Azure CLI login.
 
-To authenticate with a service principal, pass its credentials through
-`runtime_env` so they reach the replica and engine workers:
+For production deployments on AKS, use a [Microsoft Entra Workload
+ID](https://learn.microsoft.com/azure/aks/workload-identity-overview), or a
+managed identity, with the **Storage Blob Data Reader** role on the container.
+`DefaultAzureCredential` resolves either one automatically, so the deployment
+only needs the Azure packages. Uncomment the environment variables to fall back
+to a service principal when a workload or managed identity isn't available:
 
 ```python
 llm_config = LLMConfig(
@@ -303,11 +305,13 @@ llm_config = LLMConfig(
     ),
     runtime_env=dict(
         pip=["adlfs", "azure-identity"],
-        env_vars={
-            "AZURE_CLIENT_ID": os.environ["AZURE_CLIENT_ID"],
-            "AZURE_TENANT_ID": os.environ["AZURE_TENANT_ID"],
-            "AZURE_CLIENT_SECRET": os.environ["AZURE_CLIENT_SECRET"],
-        },
+        # A workload or managed identity resolves automatically and needs nothing here.
+        # Uncomment to fall back to a service principal instead:
+        # env_vars={
+        #     "AZURE_CLIENT_ID": os.environ["AZURE_CLIENT_ID"],
+        #     "AZURE_TENANT_ID": os.environ["AZURE_TENANT_ID"],
+        #     "AZURE_CLIENT_SECRET": os.environ["AZURE_CLIENT_SECRET"],
+        # },
     ),
 )
 ```
@@ -453,7 +457,7 @@ config = LLMConfig(
 - Verify bucket URI format (for example, `s3://bucket/path`, `gs://bucket/path`, or `abfss://container@account.dfs.core.windows.net/path`)
 - Check AWS/GCP/Azure credentials and regions are configured correctly
 - Ensure your IAM role, service account, or Azure identity has read access (`s3:GetObject`, `storage.objects.get`, or the **Storage Blob Data Reader** role)
-- For Azure, confirm `adlfs` and `azure-identity` are installed on every node
+- For Azure, confirm the `adlfs` and `azure-identity` Python packages are installed on every node
 - Verify the bucket exists and is accessible from your deployment region
 
 ### Model files not found

--- a/doc/source/serve/llm/user-guides/deployment-initialization.md
+++ b/doc/source/serve/llm/user-guides/deployment-initialization.md
@@ -121,7 +121,7 @@ serve.run(app, blocking=True)
 
 ## Model Loading from remote storage
 
-Load models from S3 or GCS buckets instead of Hugging Face. This is useful for:
+Load models from S3, GCS, or Azure storage instead of Hugging Face. This is useful for:
 
 - Private models not hosted on Hugging Face
 - Faster loading from cloud storage in the same region
@@ -208,6 +208,41 @@ model_loading_config:
     bucket_uri: gs://my-gcs-bucket/path/to/model
 ```
 
+### Configure Azure loading (YAML)
+
+For Azure Blob Storage or Azure Data Lake Storage (ADLS) Gen2, use the `azure://`
+or `abfss://` protocol. The URI must embed the container and storage account as
+`container@account.<domain>`:
+
+- `abfss://<container>@<account>.dfs.core.windows.net/path/to/model` (ADLS Gen2)
+- `azure://<container>@<account>.blob.core.windows.net/path/to/model` (Blob Storage)
+
+```yaml
+model_loading_config:
+  model_id: my_model
+  model_source:
+    bucket_uri: abfss://my-container@myaccount.dfs.core.windows.net/path/to/model
+```
+
+### Configure Azure loading (Python API)
+
+Configure the same Azure source with the Python API. Azure loading requires the
+`adlfs` and `azure-identity` packages on every node that loads the model. Ship
+them through `runtime_env` so Ray installs them on each node's download task, no
+image rebuild required:
+
+```python
+llm_config = LLMConfig(
+    model_loading_config=dict(
+        model_id="my_model",
+        model_source=dict(
+            bucket_uri="abfss://my-container@myaccount.dfs.core.windows.net/path/to/model"
+        ),
+    ),
+    runtime_env=dict(pip=["adlfs", "azure-identity"]),
+)
+```
+
 ### S3 credentials
 
 For private S3 buckets, configure AWS credentials:
@@ -236,6 +271,38 @@ llm_config = LLMConfig(
 Use EC2 instance profiles or EKS service accounts with appropriate S3 read permissions.
 
 
+### Azure credentials
+
+Azure authentication uses [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential),
+which resolves credentials from the standard Azure credential chain, in order:
+environment variables, a workload identity, a managed identity, then the Azure
+CLI login. For production deployments on AKS, a workload identity or managed
+identity granted the **Storage Blob Data Reader** role on the container is
+recommended.
+
+To authenticate with a service principal, pass its credentials through
+`runtime_env` so they reach the replica and engine workers:
+
+```python
+llm_config = LLMConfig(
+    model_loading_config=dict(
+        model_id="my_model",
+        model_source=dict(
+            bucket_uri="abfss://my-container@myaccount.dfs.core.windows.net/model"
+        )
+    ),
+    runtime_env=dict(
+        pip=["adlfs", "azure-identity"],
+        env_vars={
+            "AZURE_CLIENT_ID": os.environ["AZURE_CLIENT_ID"],
+            "AZURE_TENANT_ID": os.environ["AZURE_TENANT_ID"],
+            "AZURE_CLIENT_SECRET": os.environ["AZURE_CLIENT_SECRET"],
+        },
+    ),
+)
+```
+
+
 ### S3 and RunAI Streamer
 S3 can be combined with RunAI Streamer, an extension in vLLM that enables streaming the model weights directly from remote cloud storage into GPU memory, improving model load latency. More details can be found [here](https://docs.vllm.ai/en/stable/models/extensions/runai_model_streamer.html).
 
@@ -251,6 +318,26 @@ llm_config = LLMConfig(
         "load_format": "runai_streamer",
     },
     ...
+)
+```
+
+### RunAI Streamer from a local path
+
+When `load_format` is `runai_streamer`, Ray Serve LLM doesn't download the model. It passes `model_source` to the streamer, which reads it directly. The streamer supports a local path on each node in addition to remote object stores, and the set of supported remote schemes depends on your `runai-model-streamer` and vLLM versions. Use a local path when the weights are already staged on a volume mounted on every node or copied to local disk, such as weights pulled from another source before serving. Point `model_source` at the path, set `load_format` to `runai_streamer`, and tune the number of concurrent read streams with the `RUNAI_STREAMER_CONCURRENCY` environment variable:
+
+```python
+from ray.serve.llm import LLMConfig
+
+llm_config = LLMConfig(
+    model_loading_config={
+        "model_id": "my-model",
+        "model_source": "/path/to/model",
+    },
+    engine_kwargs={
+        "tensor_parallel_size": 16,
+        "load_format": "runai_streamer",
+    },
+    runtime_env={"env_vars": {"RUNAI_STREAMER_CONCURRENCY": "16"}},
 )
 ```
 
@@ -345,13 +432,14 @@ config = LLMConfig(
 
 - Install `hf_transfer`: `pip install hf_transfer`
 - Set `HF_HUB_ENABLE_HF_TRANSFER=1` in `runtime_env`
-- Consider moving the model to S3/GCS in your cloud region and using RunAI streamer, and use sharding for large models
+- Consider moving the model to S3, GCS, or Azure storage in your cloud region and using RunAI streamer, and use sharding for large models
 
-### S3/GCS access errors
+### Cloud storage access errors
 
-- Verify bucket URI format (for example, `s3://bucket/path` or `gs://bucket/path`)
-- Check AWS/GCP credentials and regions are configured correctly
-- Ensure your IAM role or service account has `s3:GetObject` or `storage.objects.get` permissions
+- Verify bucket URI format (for example, `s3://bucket/path`, `gs://bucket/path`, or `abfss://container@account.dfs.core.windows.net/path`)
+- Check AWS/GCP/Azure credentials and regions are configured correctly
+- Ensure your IAM role, service account, or Azure identity has read access (`s3:GetObject`, `storage.objects.get`, or the **Storage Blob Data Reader** role)
+- For Azure, confirm `adlfs` and `azure-identity` are installed on every node
 - Verify the bucket exists and is accessible from your deployment region
 
 ### Model files not found


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

Ray Serve LLM can load models from Azure Blob Storage and ADLS Gen2 today (`abfss://` and `azure://` are handled by the adlfs-backed pyarrow filesystem). Users deploying on AKS have no reference for the Azure URI format, the required packages, or how authentication resolves. This PR fills that documentation gap and adds an additional RunAI Streaming section that is vendor neutral for local downloading.

Validation:
- **Azure URIs (`abfss://` and `azure://`)** — exercised the list and download path against a real Azure storage account using Ray's own `_create_azure_filesystem` logic. Both schemes successfully listed the model directory and downloaded files.
- **`runtime_env` pip mechanism** — confirmed on a live Ray task that `runtime_env={"pip": ["adlfs", "azure-identity"]}` installs both packages into the download task environment, with no image rebuild.
- **`adlfs` requirement** — verified that pyarrow has no native Azure filesystem in the standard wheels (`pyarrow.fs.AzureFileSystem` raises `ImportError: not built with support`), which is why Azure loading requires `adlfs` while S3 and GCS do not.
- **`DefaultAzureCredential` chain** — introspected the live credential chain from `azure-identity`, confirming the resolution order (environment variables, workload identity, managed identity, then others such as the Azure CLI) and that the chain contains more sources than are listed in the docs.
- **Service-principal auth** — confirmed that the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` environment variables select `ClientSecretCredential`, and that `EnvironmentCredential` sits first in the chain, so setting them overrides a workload or managed identity.
- **RunAI local-path loading** — traced end to end: the Ray Serve LLM loader skips the download for streaming load formats (`STREAMING_LOAD_FORMATS` → `NodeModelDownloadable.NONE`) and passes `model_source` to vLLM verbatim; the vLLM `runai_streamer_loader` supports a local filesystem path; and the `runai-model-streamer` library reads `RUNAI_STREAMER_CONCURRENCY` from the environment.


## Related issues

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
