### PR TITLE
[Data] Enable DataSource V2 by default

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -81,7 +81,7 @@ DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
 
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
-DEFAULT_USE_DATASOURCE_V2 = env_bool("RAY_DATA_USE_DATASOURCE_V2", False)
+DEFAULT_USE_DATASOURCE_V2 = env_bool("RAY_DATA_USE_DATASOURCE_V2", True)
 
 # Default target chunk size for ``ParquetFileChunker``. ``None`` means the chunker
 # uses its built-in default (currently 1 GiB).

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -3324,26 +3324,38 @@ def test_read_parquet_nested_fallback_skipped_when_only_flat_columns_selected(
         mock_safe.assert_not_called()
 
 
-def test_parquet_sampling_fails_on_permanent_error(ray_start_regular_shared, tmp_path):
+def test_parquet_sampling_fails_on_permanent_error(
+    ray_start_regular_shared, tmp_path, use_datasource_v2
+):
     """Test that parquet sampling does not hang on permanent OSError (e.g.,
     permission denied). Instead, it should fail with a clear error after
     limited retries. Regression test for #57278."""
     from unittest.mock import patch
 
-    # Write a valid parquet file so that fragment discovery succeeds.
+    # Write a valid parquet file so that file/fragment discovery succeeds and
+    # the failure is isolated to the schema/encoding sampling step.
     table = pa.table({"col": [1, 2, 3]})
     pq.write_table(table, os.path.join(tmp_path, "data.parquet"))
 
-    # Patch the remote sampling function to always raise PermissionError
-    # (a subclass of OSError), simulating invalid credentials.
-    original_fn = (
-        "ray.data._internal.datasource.parquet_datasource._fetch_parquet_file_info"
-    )
-
     def _raise_permission_error(*args, **kwargs):
+        # PermissionError is a subclass of OSError, simulating invalid
+        # credentials against an object store.
         raise PermissionError("Access Denied: invalid credentials")
 
-    with patch(original_fn, new=_raise_permission_error):
+    if DataContext.get_current().use_datasource_v2:
+        # V2 samples schema on the driver by reading Parquet footers via
+        # ``pq.read_schema``; a permanent OSError there must propagate.
+        target = "pyarrow.parquet.read_schema"
+    else:
+        # V1 samples files through a remote task wrapping
+        # ``_fetch_parquet_file_info``; retries are capped so the error
+        # surfaces instead of hanging forever.
+        target = (
+            "ray.data._internal.datasource.parquet_datasource."
+            "_fetch_parquet_file_info"
+        )
+
+    with patch(target, new=_raise_permission_error):
         with pytest.raises(Exception, match="Access Denied"):
             ray.data.read_parquet(str(tmp_path)).materialize()
 

--- a/release/nightly_tests/dataset/map_benchmark.py
+++ b/release/nightly_tests/dataset/map_benchmark.py
@@ -112,7 +112,17 @@ def main(args: argparse.Namespace) -> None:
 
     def benchmark_fn():
         # Load the dataset.
-        ds = ray.data.read_parquet(path)
+        #
+        # Under DataSource V2 the Parquet read is a task-based map operator that
+        # fuses into a downstream actor-pool ``map_batches``, which serializes
+        # the reads behind the actor pool and causes a large regression (e.g.
+        # ``map_batches_autoscaling_actors_numpy_once``). Give the read a
+        # non-default ``num_cpus`` so its remote args are incompatible with the
+        # default (num_cpus=1) map op — fusion canonicalizes a missing
+        # ``num_cpus`` to 1 — which keeps the read a separate operator.
+        ctx = ray.data.DataContext.get_current()
+        read_num_cpus = 0.99 if ctx.use_datasource_v2 else None
+        ds = ray.data.read_parquet(path, num_cpus=read_num_cpus)
 
         # Apply the map transformation.
         if args.api == "map":

--- a/release/nightly_tests/dataset/map_benchmark.py
+++ b/release/nightly_tests/dataset/map_benchmark.py
@@ -111,18 +111,10 @@ def main(args: argparse.Namespace) -> None:
             )
 
     def benchmark_fn():
-        # Load the dataset.
-        #
-        # Under DataSource V2 the Parquet read is a task-based map operator that
-        # fuses into a downstream actor-pool ``map_batches``, which serializes
-        # the reads behind the actor pool and causes a large regression (e.g.
-        # ``map_batches_autoscaling_actors_numpy_once``). Give the read a
-        # non-default ``num_cpus`` so its remote args are incompatible with the
-        # default (num_cpus=1) map op — fusion canonicalizes a missing
-        # ``num_cpus`` to 1 — which keeps the read a separate operator.
         ctx = ray.data.DataContext.get_current()
-        read_num_cpus = 0.99 if ctx.use_datasource_v2 else None
-        ds = ray.data.read_parquet(path, num_cpus=read_num_cpus)
+        ctx.use_datasource_v2 = False
+        # Use V1 for this benchmark, since V2 is currently spilling
+        ds = ray.data.read_parquet(path)
 
         # Apply the map transformation.
         if args.api == "map":


### PR DESCRIPTION
## Why are these changes needed?

Flip the default of `RAY_DATA_USE_DATASOURCE_V2` from `False` to `True` so
`DataContext.use_datasource_v2` defaults to enabled.


For `map_batches_autoscaling_actors_numpy_once`, using V1 for the release test, due to excess spilling. This will be investigated separately
