### PR TITLE
[Serve][LLM][Doc] Document az:// Azure Blob streaming with RunAI Streamer

### DIFF
--- a/doc/source/serve/llm/user-guides/deployment-initialization.md
+++ b/doc/source/serve/llm/user-guides/deployment-initialization.md
@@ -377,7 +377,7 @@ llm_config = LLMConfig(
 
 ### Azure Blob streaming with RunAI Streamer
 
-RunAI Streamer reads Azure Blob Storage natively through the `az://` scheme, streaming weights into GPU memory without staging them on disk first. This needs a `runai-model-streamer` and vLLM version that support `az://`, so confirm the versions bundled in your image.
+RunAI Streamer reads Azure Blob Storage natively through the `az://` scheme, streaming weights into GPU memory without staging them on disk first. This requires versions of `runai-model-streamer` and vLLM that support `az://`, so confirm the versions bundled in your image.
 
 Set `model_source` to an `az://<container>/<model>` URI and `load_format` to `runai_streamer`. The `AZURE_STORAGE_ACCOUNT_NAME` environment variable tells the streamer which storage account to read from. On AKS, bind the pod to a workload identity that holds the **Storage Blob Data Reader** role so the streamer authenticates with a Microsoft Entra ID token instead of a key.
 
@@ -397,7 +397,7 @@ llm_config = LLMConfig(
 )
 ```
 
-Unlike the `abfss://` and `azure://` bucket URIs, which download the model to disk before loading, the `az://` scheme streams directly from Blob into GPU memory.
+Unlike the `abfss://` and `azure://` schemes, which download the model to disk before loading, the `az://` scheme streams directly from Blob into GPU memory.
 
 For an end-to-end AKS walkthrough that provisions the cluster, workload identity, and Blob storage, and benchmarks streaming against download-then-load, see [Stream models from Azure Blob Storage into vLLM with the RunAI Model Streamer](https://blog.aks.azure.com/2026/07/13/runai-streamer-vllm).
 
@@ -480,11 +480,11 @@ config = LLMConfig(
 
 ### Cloud storage access errors
 
-- Verify bucket URI format (for example, `s3://bucket/path`, `gs://bucket/path`, or `abfss://container@account.dfs.core.windows.net/path`)
+- Verify bucket or container URI format (for example, `s3://bucket/path`, `gs://bucket/path`, or `abfss://container@account.dfs.core.windows.net/path`)
 - Check AWS/GCP/Azure credentials and regions are configured correctly
 - Ensure your IAM role, service account, or Azure identity has read access (`s3:GetObject`, `storage.objects.get`, or the **Storage Blob Data Reader** role)
 - For Azure, confirm the `adlfs` and `azure-identity` Python packages are installed on every node
-- Verify the bucket exists and is accessible from your deployment region
+- Verify the bucket or container exists and is accessible from your deployment region
 
 ### Model files not found
 

--- a/doc/source/serve/llm/user-guides/deployment-initialization.md
+++ b/doc/source/serve/llm/user-guides/deployment-initialization.md
@@ -321,8 +321,19 @@ llm_config = LLMConfig(
 `````
 
 
+## RunAI Streamer
+
+RunAI Streamer is a vLLM extension that streams model weights directly from remote storage into GPU memory, reducing model load latency.
+
+:::{note}
+These snippets are examples. Check the
+[RunAI Streamer docs](https://docs.vllm.ai/en/stable/models/extensions/runai_model_streamer.html)
+for S3, Azure, and GCS compatibility with your vLLM version.
+:::
+
 ### S3 and RunAI Streamer
-S3 can be combined with RunAI Streamer, an extension in vLLM that enables streaming the model weights directly from remote cloud storage into GPU memory, improving model load latency. More details can be found [here](https://docs.vllm.ai/en/stable/models/extensions/runai_model_streamer.html).
+
+Set `model_source` to an `s3://` URI and `load_format` to `runai_streamer`:
 
 ```python
 llm_config = LLMConfig(

--- a/doc/source/serve/llm/user-guides/deployment-initialization.md
+++ b/doc/source/serve/llm/user-guides/deployment-initialization.md
@@ -375,6 +375,32 @@ llm_config = LLMConfig(
 )
 ```
 
+### Azure Blob streaming with RunAI Streamer
+
+RunAI Streamer reads Azure Blob Storage natively through the `az://` scheme, streaming weights into GPU memory without staging them on disk first. This needs a `runai-model-streamer` and vLLM version that support `az://`, so confirm the versions bundled in your image.
+
+Set `model_source` to an `az://<container>/<model>` URI and `load_format` to `runai_streamer`. The `AZURE_STORAGE_ACCOUNT_NAME` environment variable tells the streamer which storage account to read from. On AKS, bind the pod to a workload identity that holds the **Storage Blob Data Reader** role so the streamer authenticates with a Microsoft Entra ID token instead of a key.
+
+```python
+from ray.serve.llm import LLMConfig
+
+llm_config = LLMConfig(
+    model_loading_config={
+        "model_id": "phi-4",
+        "model_source": "az://models/phi-4",
+    },
+    engine_kwargs={
+        "tensor_parallel_size": 1,
+        "load_format": "runai_streamer",
+    },
+    runtime_env={"env_vars": {"AZURE_STORAGE_ACCOUNT_NAME": "mystorageacct"}},
+)
+```
+
+Unlike the `abfss://` and `azure://` bucket URIs, which download the model to disk before loading, the `az://` scheme streams directly from Blob into GPU memory.
+
+For an end-to-end AKS walkthrough that provisions the cluster, workload identity, and Blob storage, and benchmarks streaming against download-then-load, see [Stream models from Azure Blob Storage into vLLM with the RunAI Model Streamer](https://blog.aks.azure.com/2026/07/13/runai-streamer-vllm).
+
 ## Additional Optimizations
 
 ### Torch Compile Cache


### PR DESCRIPTION
## Why are these changes needed?

Documents the vLLM-native `az://` Azure Blob streaming path for Ray Serve LLM. 
Adds an "Azure Blob streaming with RunAI Streamer" section to the deployment-initialization guide covering:
- the `az://<container>/<model>` URI form and `load_format: runai_streamer`
- the `AZURE_STORAGE_ACCOUNT_NAME` environment variable
- workload-identity auth on AKS (Storage Blob Data Reader, Microsoft Entra ID)
- how `az://` (streams directly from Blob into GPU memory) differs from the `abfss://` / `azure://` bucket URIs (download to disk first)
-link to the AKS end-to-end walkthrough and benchmarks

## Depends on #62962
The code that makes `az://` work is provided by #62962: 
`apply_checkpoint_info` reads the config the engine already loaded (`vllm_engine_config.model_config.hf_config`) instead of re-reading it with `transformers.AutoConfig` (which cannot read `az://`). 
Otherwise without #62962,`az://` + `runai_streamer` fails during engine start when `apply_checkpoint_info` calls `transformers.AutoConfig("az://...")`.

## Related 
This PR should merge after #62962.
- #64819 — Azure object-storage (`abfss://` / `azure://`) loading docs.

## Validation

- The `az://` scheme, `AZURE_STORAGE_ACCOUNT_NAME`, and `DefaultAzureCredential` / workload-identity auth were checked against the runai-model-streamer source and the AKS blog  (https://blog.aks.azure.com/2026/07/13/runai-streamer-vllm).
- The config-level behavior #62962 enables (a supplied `hf_config` short-circuits the `transformers` read) was confirmed on `ray 3.0.0.dev0`.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
