### PR TITLE
[Data] Enable memory-safety best practices in video object detection benchmark (#64125) (cherry-pick 2.56.1)

### DIFF
--- a/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
@@ -97,6 +97,10 @@ def run_pipeline():
         ExtractImageFeatures,
         batch_size=BATCH_SIZE,
         num_gpus=1.0,
+        # Ray Data can't prevent OOMs if you don't set `memory` for high-memory UDFs
+        # like this one. We chose this value because it was the max USS we observed in
+        # previous nightly test runs.
+        memory=3_529_273_344,  # ~3.5 GB
     )
     ds = ds.flat_map(explode_features)
     ds = ds.map(crop_image)


### PR DESCRIPTION
Cherry-pick of #64125 onto `releases/2.56.1`.

Original PR: https://github.com/ray-project/ray/pull/64125

## Summary
Enables the opt-in memory-safety best practices for the video object detection multimodal benchmark so it exercises (and validates) the OOM guardrails we recommend to users. Specifically, it sets `memory=3_529_273_344` (~3.5 GB) on the high-memory `ExtractImageFeatures` UDF (the max USS observed in previous nightly runs), since Ray Data can't prevent OOMs unless `memory` is set for high-memory UDFs.

## Cherry-pick notes
One conflict resolved in `release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py`: the `isolate_read_workers` / `default_map_logical_memory_enabled` `DataContext` settings that #64125 adds are already present on the branch (introduced by the earlier cherry-pick of #64298, using the `DataContext.get_current()` accessor). Kept the branch's `get_current()` form; the net change from this cherry-pick is the `memory=3_529_273_344` argument on the `ExtractImageFeatures` `map_batches` call.
