### PR TITLE
[core] Fix driver SIGABRT + core dump when SIGTERM arrives during a slow graceful shutdown

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -897,13 +897,17 @@ def set_sigterm_handler(sigterm_handler):
         # SIGINT is Ctrl+C, SIGBREAK is Ctrl+Break.
         signal.signal(signal.SIGBREAK, sigterm_handler)
     else:
+        if not callable(sigterm_handler):
+            signal.signal(signal.SIGTERM, sigterm_handler)
+            return
 
         def sigterm_handler_wrapper(signum, frame):
             # abseil's failure signal handler (Ray registers SIGTERM with it)
             # has already armed a SIGALRM timer that SIGABRTs the process
             # after 3s. Cancel it, since handlers installed here recover into
             # a graceful shutdown that may legitimately take longer.
-            signal.alarm(0)
+            if hasattr(signal, "alarm"):
+                signal.alarm(0)
             sigterm_handler(signum, frame)
 
         signal.signal(signal.SIGTERM, sigterm_handler_wrapper)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -897,7 +897,16 @@ def set_sigterm_handler(sigterm_handler):
         # SIGINT is Ctrl+C, SIGBREAK is Ctrl+Break.
         signal.signal(signal.SIGBREAK, sigterm_handler)
     else:
-        signal.signal(signal.SIGTERM, sigterm_handler)
+
+        def sigterm_handler_wrapper(signum, frame):
+            # abseil's failure signal handler (Ray registers SIGTERM with it)
+            # has already armed a SIGALRM timer that SIGABRTs the process
+            # after 3s. Cancel it, since handlers installed here recover into
+            # a graceful shutdown that may legitimately take longer.
+            signal.alarm(0)
+            sigterm_handler(signum, frame)
+
+        signal.signal(signal.SIGTERM, sigterm_handler_wrapper)
 
 
 def try_to_symlink(symlink_path: str, target_path: str):

--- a/python/ray/tests/test_ray_shutdown.py
+++ b/python/ray/tests/test_ray_shutdown.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os
 import platform
+import select
 import signal
 import sys
 import time
@@ -568,11 +569,17 @@ time.sleep(60)
 """
     p = run_string_as_driver_nonblocking(driver)
     try:
-        for _ in range(30):
-            if p.stdout.readline().strip() == b"ready":
-                break
-        else:
-            raise AssertionError("Driver never became ready.")
+        # Bounded wait for readiness: poll stdout with select() so a hung
+        # driver fails the test instead of blocking readline() forever.
+        deadline = time.monotonic() + 60
+        while True:
+            remaining = deadline - time.monotonic()
+            assert remaining > 0, "Driver never became ready."
+            if select.select([p.stdout], [], [], remaining)[0]:
+                line = p.stdout.readline()
+                assert line, "Driver exited before becoming ready."
+                if line.strip() == b"ready":
+                    break
 
         p.send_signal(signal.SIGTERM)
         # Ray's SIGTERM handler recovers into a graceful exit with code

--- a/python/ray/tests/test_ray_shutdown.py
+++ b/python/ray/tests/test_ray_shutdown.py
@@ -540,5 +540,48 @@ def test_kill_actor_after_restart(shutdown_only):
     wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0)
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="POSIX signals only.")
+def test_sigterm_during_slow_graceful_exit_does_not_abort():
+    """Regression test for https://github.com/ray-project/ray/issues/64829.
+
+    Ray registers SIGTERM with abseil's failure signal handler, which arms a
+    3s SIGALRM abort timer before chaining into Ray's graceful SIGTERM
+    handler. If the graceful exit outlives that timer (e.g. a driver-owned
+    local node being torn down after a process-group SIGTERM, as on a Jupyter
+    kernel restart), the driver used to die with SIGABRT and dump core into
+    the working directory instead of exiting cleanly.
+    """
+    driver = """
+import atexit
+import time
+
+import ray
+
+ray.init(num_cpus=1)
+
+# Registered after ray.init() so it runs before Ray's atexit shutdown hook;
+# simulates a graceful exit that outlives abseil's 3s abort timer.
+atexit.register(time.sleep, 5)
+
+print("ready", flush=True)
+time.sleep(60)
+"""
+    p = run_string_as_driver_nonblocking(driver)
+    try:
+        for _ in range(30):
+            if p.stdout.readline().strip() == b"ready":
+                break
+        else:
+            raise AssertionError("Driver never became ready.")
+
+        p.send_signal(signal.SIGTERM)
+        # Ray's SIGTERM handler recovers into a graceful exit with code
+        # SIGTERM (15). Before the fix, abseil's abort timer killed the
+        # driver with SIGABRT ~3s after the SIGTERM (negative returncode).
+        assert p.wait(timeout=60) == signal.SIGTERM
+    finally:
+        p.kill()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_shutdown.py
+++ b/python/ray/tests/test_ray_shutdown.py
@@ -10,7 +10,7 @@ import pytest
 
 import ray
 from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private import ray_constants
+from ray._private import ray_constants, utils
 from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
 )
@@ -539,6 +539,53 @@ def test_kill_actor_after_restart(shutdown_only):
 
     ray.shutdown()
     wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0)
+
+
+@pytest.mark.parametrize("sigterm_handler", [signal.SIG_DFL, signal.SIG_IGN])
+def test_set_sigterm_handler_preserves_non_callable_handlers(
+    monkeypatch, sigterm_handler
+):
+    installed_handlers = []
+    monkeypatch.setattr(
+        signal,
+        "signal",
+        lambda signum, handler: installed_handlers.append((signum, handler)),
+    )
+
+    utils.set_sigterm_handler(sigterm_handler)
+
+    expected_signal = signal.SIGBREAK if sys.platform == "win32" else signal.SIGTERM
+    assert installed_handlers == [(expected_signal, sigterm_handler)]
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="POSIX signals only.")
+def test_set_sigterm_handler_cancels_alarm_before_calling_handler(monkeypatch):
+    installed_handlers = []
+    events = []
+    monkeypatch.setattr(
+        signal,
+        "signal",
+        lambda signum, handler: installed_handlers.append((signum, handler)),
+    )
+    monkeypatch.setattr(
+        signal, "alarm", lambda seconds: events.append(("alarm", seconds))
+    )
+
+    def handler(signum, frame):
+        events.append(("handler", signum, frame))
+
+    utils.set_sigterm_handler(handler)
+    assert len(installed_handlers) == 1
+
+    signum, installed_handler = installed_handlers[0]
+    frame = object()
+    installed_handler(signum, frame)
+
+    assert signum == signal.SIGTERM
+    assert events == [
+        ("alarm", 0),
+        ("handler", signal.SIGTERM, frame),
+    ]
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX signals only.")


### PR DESCRIPTION
## Description

On POSIX, Ray registers SIGTERM with abseil's failure signal handler:

https://github.com/ray-project/ray/blob/2a70ac4a39deeb354116086221c9e35dd918f1eb/src/ray/util/logging.cc#L437

Here, `logging.cc` sets only `call_previous_handler` and `writerfn` on the options struct, leaves every other option at its default — `alarm_on_failure_secs` defaults to **3 seconds** — and immediately passes it to `absl::InstallFailureSignalHandler`:

https://github.com/ray-project/ray/blob/2a70ac4a39deeb354116086221c9e35dd918f1eb/src/ray/util/logging.cc#L506-L509

So when SIGTERM arrives, abseil's handler runs first and arms a 3-second abort timer before chaining to the previous handler ([`absl/debugging/failure_signal_handler.cc#L405-L409`](https://github.com/abseil/abseil-cpp/blob/c34b1491291f7673fd758ea3aa08517231497b97/absl/debugging/failure_signal_handler.cc#L405-L409)):

```cpp
if (fsh_options.alarm_on_failure_secs > 0) {
  alarm(0);  // Cancel any existing alarms.
  signal(SIGALRM, ImmediateAbortSignalHandler);
  alarm(static_cast<unsigned int>(fsh_options.alarm_on_failure_secs));
}
```

The chained handler is Ray's Python SIGTERM handler, which recovers into a graceful `sys.exit()` that tears down the driver-owned local node. A Jupyter notebook kernel restart typically takes more than 3 seconds to clean up (the kernel's Ray daemons received the same process-group SIGTERM, so the driver stalls waiting on them while they die). So before the cleanup finishes, the alarm goes off and sends the ABORT signal — and that SIGABRT is what ends up creating the multi-GB core dump in the notebook's working directory on every restart.

**Fix:** cancel the pending alarm (`signal.alarm(0)`) before invoking any handler installed via `ray._private.utils.set_sigterm_handler()`. Every handler installed through that function recovers into a graceful shutdown, so this applies to exactly the affected code paths; abseil's abort-timer protection for genuine crash signals (SIGSEGV, etc.) is unaffected.

Includes a regression test: a driver whose exit outlives the 3s timer must exit gracefully with code 15 instead of being killed by SIGABRT.

## Related issues

Fixes #64829

## Additional information

**Verification** (the fix is pure Python; validated by applying this exact patch to the released 2.56.0 wheel):

- Repro from the issue: exit `-6` (SIGABRT) 3.0s after SIGTERM before the fix → clean exit `15` after (3/3 runs)
- `pytest python/ray/tests/test_ray_shutdown.py -k test_sigterm_during_slow_graceful_exit_does_not_abort`: fails (`-6`) before, passes after
- `pre-commit run --files python/ray/_private/utils.py python/ray/tests/test_ray_shutdown.py`: all hooks pass

**Duplicate-work check:** no linked PRs on #64829 and no open PRs found for this area.

**AI assistance disclosure:** prepared with AI assistance (Claude Code); the submitter reviewed every changed line and ran the repro and tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
