### PR TITLE
[doc] sphinx-fix: reclassify unknown-document and docutils-inline-markup as judgment

### DIFF
--- a/doc/.claude/skills/sphinx-fix/rules.yaml
+++ b/doc/.claude/skills/sphinx-fix/rules.yaml
@@ -114,7 +114,7 @@ rules:
   - id: unknown-document
     title: "{doc}/toctree reference to an unknown document"
     tier: 3
-    safety: mechanical
+    safety: judgment
     match: any
     categories:
       - ref.doc
@@ -219,7 +219,7 @@ rules:
   - id: docutils-inline-markup
     title: "Unbalanced inline emphasis/strong markup"
     tier: 3
-    safety: mechanical
+    safety: judgment
     match: any
     categories:
       - docutils

--- a/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/docutils_inline_markup.txt
@@ -5,11 +5,11 @@ Findings (2):
     [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
           msg:    Inline emphasis start-string without end-string.
           fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
-          safety: mechanical
+          safety: judgment (needs your call)
     [T3] docutils-inline-markup  doc/source/data/api/doc/ray.data.ReaderFormat.rst:74:<autosummary>:1
           msg:    Inline strong start-string without end-string.
           fix:    Balance or escape the marker in the source docstring, not in the generated stub: wrap literals in double backticks (``*args``, ``**kwargs``), or escape a standalone asterisk (\*).
-          safety: mechanical
+          safety: judgment (needs your call)
 
 Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
 

--- a/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
+++ b/doc/.claude/skills/sphinx-fix/tests/golden/unknown_document.txt
@@ -5,7 +5,7 @@ Findings (1):
     [T3] unknown-document  doc/source/serve/llm/examples.md:17
           msg:    unknown document: '/_collections/serve/tutorials/deployment-serve-llm/npu-ascend/README'
           fix:    Repoint to the correct document: a path relative to the referencing page, or an absolute path from doc/source with a leading slash. Remove the reference if the target is gone. Grep the bare stem across doc/ to find every caller.
-          safety: mechanical
+          safety: judgment (needs your call)
 
 Unclassified (0) — no rule matched; resolve with the user, then file a skill-improvement ticket to add a rule:
 


### PR DESCRIPTION
## Why are these changes needed?

Two `sphinx-fix` rules — `unknown-document` and `docutils-inline-markup` — are tagged `safety: mechanical` in `doc/.claude/skills/sphinx-fix/rules.yaml`, but neither ships a `fix_template`. In the skill, `mechanical` means the report offers a `Suggested:` rewrite to apply after confirming the target, and mechanical rules carry a `fix_template` to produce it (for example, `myst-xref-ambiguous`). With no template, both rules instead require the human to locate and decide the fix — the definition of `judgment`:

- `unknown-document`: the tool extracts the *broken* target but not the *correct* one. Repointing versus removing the reference is a decision.
- `docutils-inline-markup`: its own notes say the message doesn't carry the offending text, so the human must locate the unbalanced marker.

This change:

- Flips `safety: mechanical` → `judgment` on both rules.
- Regenerates `tests/golden/unknown_document.txt` and `tests/golden/docutils_inline_markup.txt`, which now carry the `(needs your call)` annotation.
- `python doc/.claude/skills/sphinx-fix/sphinx_fix.py --selftest` passes (16 fixtures, 15 rules, 4 suppressions).

## Related issue number

## Checks

- [x] I've signed off every commit (`git commit -s`).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
