### PR TITLE
Advertise real data_parallel_size for KV-aware routing workers

### DIFF
--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
@@ -289,7 +289,7 @@ class KVRouterActor:
                 # scoring in the selection service.
                 "max_num_batched_tokens": kv_event_metadata["max_num_batched_tokens"],
                 "data_parallel_start_rank": dp_rank,
-                "data_parallel_size": kv_event_metadata.get("data_parallel_size", 1),
+                "data_parallel_size": kv_event_metadata.get("data_parallel_size") or 1,
                 "kv_events_endpoints": {dp_rank: kv_event_metadata["endpoint"]},
                 # The listener dials this on a sequence gap (slow-joiner) to replay
                 # the events it missed before its SUB connected; without it those

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/kv_aware_actor.py
@@ -289,8 +289,7 @@ class KVRouterActor:
                 # scoring in the selection service.
                 "max_num_batched_tokens": kv_event_metadata["max_num_batched_tokens"],
                 "data_parallel_start_rank": dp_rank,
-                # TODO (jeffreywang): Support KV-aware routing for data parallel deployments.
-                "data_parallel_size": 1,
+                "data_parallel_size": kv_event_metadata.get("data_parallel_size", 1),
                 "kv_events_endpoints": {dp_rank: kv_event_metadata["endpoint"]},
                 # The listener dials this on a sequence gap (slow-joiner) to replay
                 # the events it missed before its SUB connected; without it those

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/vllm/kv_events.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/vllm/kv_events.py
@@ -115,6 +115,7 @@ def get_kv_event_routing_stats(
         "block_size": block_size,
         "max_num_batched_tokens": max_num_batched_tokens,
         "dp_rank": llm_config.engine_kwargs.get("data_parallel_rank") or 0,
+        "data_parallel_size": llm_config.engine_kwargs.get("data_parallel_size", 1),
         "replay_endpoint": _get_node_routable_endpoint(
             llm_config, kv_events_config["replay_endpoint"]
         ),

--- a/python/ray/llm/_internal/serve/routing_policies/kv_aware/vllm/kv_events.py
+++ b/python/ray/llm/_internal/serve/routing_policies/kv_aware/vllm/kv_events.py
@@ -115,7 +115,7 @@ def get_kv_event_routing_stats(
         "block_size": block_size,
         "max_num_batched_tokens": max_num_batched_tokens,
         "dp_rank": llm_config.engine_kwargs.get("data_parallel_rank") or 0,
-        "data_parallel_size": llm_config.engine_kwargs.get("data_parallel_size", 1),
+        "data_parallel_size": llm_config.engine_kwargs.get("data_parallel_size") or 1,
         "replay_endpoint": _get_node_routable_endpoint(
             llm_config, kv_events_config["replay_endpoint"]
         ),

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/kv/test_kv_events.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/kv/test_kv_events.py
@@ -103,9 +103,25 @@ class TestConfigureKvEvents:
                 "block_size": 16,
                 "max_num_batched_tokens": 4096,
                 "dp_rank": 0,
+                "data_parallel_size": 1,
                 "replay_endpoint": f"tcp://{node_ip}:6557",
             }
         }
+
+    def test_routing_stats_advertise_data_parallel_size(self, ray_instance):
+        """A DP deployment's configured data_parallel_size is advertised so the
+        selection service learns the worker's real DP group size, not a default
+        of 1 (which would misrepresent a DP-rank worker as a standalone one)."""
+        llm_config = make_kv_aware_llm_config(
+            engine_kwargs={"data_parallel_rank": 2, "data_parallel_size": 4}
+        )
+        configure_kv_events_for_kv_routing(llm_config)
+
+        stats = get_kv_event_routing_stats(
+            llm_config, block_size=16, max_num_batched_tokens=4096
+        )
+        assert stats["kv_event_metadata"]["dp_rank"] == 2
+        assert stats["kv_event_metadata"]["data_parallel_size"] == 4
 
     def test_routing_stats_empty_without_kv_events(self):
         """Nothing to advertise when KV-cache events are not enabled."""


### PR DESCRIPTION
## Why are these changes needed?

`KVRouterActor._upsert_worker` hardcoded `data_parallel_size` to `1` for every registered worker, regardless of the deployment's actual configured DP group size. A replica correctly reports its own `dp_rank` (e.g. `2`) while always claiming a group size of `1` — an internally inconsistent pair of facts sent to the selection service (a worker can't be "rank 2 of a group of size 1").

`get_kv_event_routing_stats` now advertises the deployment's real `data_parallel_size` (read from `engine_kwargs`, defaulting to `1` for non-DP deployments — consistent with how it's already read elsewhere, e.g. `dp_server.py`), and `_upsert_worker` forwards it instead of the literal `1`.

This addresses the `# TODO (jeffreywang): Support KV-aware routing for data parallel deployments.` left in `kv_aware_actor.py`, part of the "Data-parallel deployments" item tracked under #64389 (Milestone 2).

**Scope note:** this fixes the internal-consistency bug in what Ray reports to Dynamo about DP topology. It does not by itself validate that the selection service's routing decisions become fully DP-topology-aware — that depends on Dynamo-side behavior and would need GPU validation I don't currently have access to.

## Not a duplicate

I checked #64389's comment thread before starting: the only other actively-claimed item there is "Support Anthropic SDK" (assigned informally to another contributor). This specific `data_parallel_size` gap wasn't claimed or in progress anywhere I could find (no open PR references it).

## Testing

- Added `test_routing_stats_advertise_data_parallel_size` in `test_kv_events.py`, asserting a configured `data_parallel_rank=2, data_parallel_size=4` flows through `get_kv_event_routing_stats` correctly.
- Updated the existing `test_routing_stats_advertise_endpoint` (exact-dict-equality) to include the new `data_parallel_size` key so it stays accurate.
- Verified both by manual trace against the implementation (dict-merge semantics of `update_engine_kwargs`, `is_kv_aware` resolution, and the exact key lookups) rather than a local run — my current environment doesn't have a working native build of Ray's compiled core, so I couldn't `import ray` locally. Happy to fix up anything CI surfaces.

cc @jeffreywang88 — flagging you directly since you own #64389 and left the original TODO this closes.