### PR TITLE
[doc] Add a documentation CI steps overview to the PR CI guide

### DIFF
--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -39,6 +39,22 @@ If you're a committer, add the `go` label to your PR once it's ready, then merge
 
 If you're an external contributor, adding the `go` label and enabling auto-merge both require write access, so a committer runs the full suite and merges when your PR is ready.
 
+## Documentation CI steps
+
+When your PR changes documentation, an additional set of steps runs alongside `microcheck`. Ray builds the docs in three places that share one Sphinx configuration.
+
+* **The Sphinx build.** `make -C doc/ html` generates the HTML with warnings treated as errors, so any Sphinx warning fails the build.
+* **The Read the Docs render gate.** Read the Docs runs the same Sphinx build on your PR and reports the `docs/readthedocs.com:anyscale-ray` check. Because the build fails on any warning, this check is the effective render gate for documentation changes. A PR that changes no documentation files skips the preview build, so the check reports green without rebuilding.
+* **The Buildkite doc steps.** These run when your PR changes doc-affecting files, selected by the `doc` test tag.
+
+The Buildkite doc steps are:
+
+* **API annotation and consistency checks** verify that the documented API surface matches the `@PublicAPI` annotations in the code. The consistency check builds the docs as part of its run. See [Running the API consistency check locally](#running-the-api-consistency-check-locally).
+* **Per-team doc tests** run the code examples in each library's docstrings and user guides. These execute the `doctest`, `testcode`, and `literalinclude` examples described in [How to write code snippets](writing-code-snippets.md). Each library, including core, data, ml, rllib, serve, and llm, owns its own doc-tests step.
+* **Always-on lints** run on every PR, not just documentation changes: a ban on new `.rst` files, since new pages must be MyST Markdown, a README check, and a documentation style linter.
+
+Two heavier steps don't run on your PR. The `doc: build` step, which also uploads a build cache, and `linkcheck` run on the `master` branch after merge, not premerge. For how to build and preview the docs on your own machine, see [Contributing to the Ray documentation](docs.md).
+
 ## Running the API consistency check locally
 
 The `doc: check API doc consistency` premerge step (the `api_policy_check` function in `ci/lint/lint.sh`) runs `ci/ray_ci/doc/cmd_check_api_discrepancy.py`, which compares each team's documented API surface against the annotated (`@PublicAPI`/`@DeveloperAPI`/`@Deprecated`) surface in the code. It imports Ray's own symbols for real, so it needs an environment where Ray installs and imports. This is the opposite of the docs *build* environment, which deliberately doesn't install Ray (see [Building the Ray documentation](docs.md)). The optional third-party backends that some surfaces pull in at import time (for example the vLLM and SGLang stack behind `ray.data.llm` and `ray.serve.llm`, or the deep-learning backends behind `ray.train`, `ray.tune`, and `ray.rllib`) don't have to be installed: the check mocks any that are absent, reading the list from `doc/source/api_mock_imports.py`, the same source of truth the docs build uses for `autodoc_mock_imports`.

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -38,3 +38,34 @@ If microcheck passes, you'll see a green checkmark on your PR. If it fails, you'
 If you're a committer, add the `go` label to your PR once it's ready, then merge after the full suite passes. Clicking **Enable auto-merge** does both in one step: it adds the `go` label and merges the PR automatically once the suite passes. Pushing a new commit disables auto-merge, so re-enable it afterward. When you review an external contributor's PR, add the `go` label for them, since they can't add it themselves.
 
 If you're an external contributor, adding the `go` label and enabling auto-merge both require write access, so a committer runs the full suite and merges when your PR is ready.
+
+## Running the API consistency check locally
+
+The `doc: check API doc consistency` premerge step (the `api_policy_check` function in `ci/lint/lint.sh`) runs `ci/ray_ci/doc/cmd_check_api_discrepancy.py`, which compares each team's documented API surface against the annotated (`@PublicAPI`/`@DeveloperAPI`/`@Deprecated`) surface in the code. It imports Ray's own symbols for real, so it needs an environment where Ray installs and imports. This is the opposite of the docs *build* environment, which deliberately doesn't install Ray (see [Building the Ray documentation](docs.md)). The optional third-party backends that some surfaces pull in at import time (for example the vLLM and SGLang stack behind `ray.data.llm` and `ray.serve.llm`, or the deep-learning backends behind `ray.train`, `ray.tune`, and `ray.rllib`) don't have to be installed: the check mocks any that are absent, reading the list from `doc/source/api_mock_imports.py`, the same source of truth the docs build uses for `autodoc_mock_imports`.
+
+### The faithful environment: the docbuild image
+
+CI runs this check inside the `docbuild` image (`ci/docker/doc.build.Dockerfile`). The image builds on the prebuilt `ray-core` and `oss-ci-base_build` base images, which supply Ray and the real ML libraries the walk imports (for example `pandas`, `torch`, and `transformers`), then installs the docs dependency lock (`python/deplocks/docs/docbuild_depset_py<version>.lock`) on top. Because the real libraries come from the base images and the lock is pinned to Linux wheels, the only fully faithful local reproduction is the Linux docbuild image (via Docker) or a CI run on your branch.
+
+### A lightweight local approximation
+
+For quick iteration on the checker itself, a Python 3.11 virtual environment with a nightly Ray wheel is usually enough. Because the check mocks the absent optional backends, you generally don't need to install `pandas`, `torch`, `transformers`, and the rest by hand. Install a backend for real only when you want the check to walk that library's true surface rather than a mock.
+
+```bash
+uv venv --python 3.11 ~/.virtualenvs/ray-apiref
+# The wheel URL below is macOS arm64 / Python 3.11. Adjust it for your OS, architecture, and Python version.
+uv pip install --python ~/.virtualenvs/ray-apiref/bin/python \
+  "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl"
+# Link your checkout's Python files over the wheel so the check walks your local @PublicAPI changes, not the wheel's:
+~/.virtualenvs/ray-apiref/bin/python python/ray/setup-dev.py --yes
+
+# Run the check against your checkout (PYTHONPATH so the checker imports from your tree):
+PYTHONPATH="$(pwd)" ~/.virtualenvs/ray-apiref/bin/python \
+  ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
+```
+
+Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) or omit the argument to check all of them.
+
+```{warning}
+`setup-dev.py` links your checkout's Python packages over the wheel, so the walked `@PublicAPI` surface reflects your local changes. The rest of the wheel (compiled extensions and generated code) is still the nightly build, cut at a different commit than your checkout, so treat a clean local run as a fast iteration signal rather than a definitive result. For sign-off, rely on the CI run in the docbuild image.
+```


### PR DESCRIPTION
## Summary

Adds a "Documentation CI steps" section to the PR CI guide describing what runs when a PR changes docs:

- The three build surfaces that share one Sphinx configuration: the `make -C doc/ html` Sphinx build, the Read the Docs render gate, and the Buildkite doc steps.
- The Buildkite doc steps themselves: the API annotation and consistency checks, the per-team doc tests, and the always-on lints.
- Which steps run post-merge rather than on your PR (`doc: build` and `linkcheck`).

Descriptive overview only; it links to the existing "How to write code snippets" and "Contributing to the Ray documentation" pages rather than duplicating them.

## Stacked on #64450

This branch is built on top of #64450 (*Add a guide for running the API consistency check locally*), and the new overview links to that section. GitHub shows both commits here; the net-new change in this PR is the top commit (`[doc] Add a documentation CI steps overview to the PR CI guide`). Merge #64450 first; this then rebases onto `master` cleanly and the diff reduces to the single commit.

## Why this isn't a duplicate

Checked open PRs with `gh pr list --repo ray-project/ray --state open`. Only #64450 (the branch this stacks on) touches `doc/source/ray-contribute/ci.md`.

## Testing

Prose-only addition to an existing MyST page. Verified the two cross-file links (`writing-code-snippets.md`, `docs.md`) and the intra-page anchor to the API-consistency section resolve. The Read the Docs render gate exercises this page in CI.

## AI assistance

Drafted with AI assistance (Claude Code) and reviewed by the submitter.
