### PR TITLE
[core] Isolate NodeInfoGcsService.GetClusterId on a dedicated lightweight-reads io_context

### DIFF
--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -95,6 +95,9 @@ void GcsNodeManager::WriteNodeExportEvent(const rpc::GcsNodeInfo &node_info,
 void GcsNodeManager::HandleGetClusterId(rpc::GetClusterIdRequest request,
                                         rpc::GetClusterIdReply *reply,
                                         rpc::SendReplyCallback send_reply_callback) {
+  // Runs on the dedicated lightweight-reads io_context, concurrently with the
+  // node_manager io_context, so it must stay a lock-free read of the immutable
+  // `cluster_id_` and must not touch any other GcsNodeManager state.
   reply->set_cluster_id(cluster_id_.Binary());
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -425,6 +425,7 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
   gcs_node_manager_->Initialize(gcs_init_data);
   rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
       io_context_provider_.GetIOContext<GcsNodeManager>(),
+      io_context_provider_.GetIOContext<GcsLightweightRpcReads>(),
       *gcs_node_manager_,
       RayConfig::instance().gcs_max_active_rpcs_per_handler()));
 }

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -138,6 +138,12 @@ class GcsServer {
   static constexpr char kRedisStorage[] = "redis";
   static constexpr char kRocksDbStorage[] = "rocksdb";
 
+  /// Test-only: the io_context GcsNodeManager handlers are posted to. Lets
+  /// tests simulate a backlogged node_manager event loop.
+  instrumented_io_context &GetNodeManagerIOContextInTest() {
+    return io_context_provider_.GetIOContext<GcsNodeManager>();
+  }
+
   void UpdateGcsResourceManagerInTest(
       const NodeID &node_id,
       const syncer::ResourceViewSyncMessage &resource_view_sync_message) {

--- a/src/ray/gcs/gcs_server_io_context_policy.h
+++ b/src/ray/gcs/gcs_server_io_context_policy.h
@@ -42,6 +42,12 @@ struct IOContextMetadata {
   bool used_for_health_check;
 };
 
+/// Tag type keying the dedicated io_context that runs trivial, constant-time
+/// RPC read handlers (currently NodeInfoGcsService.GetClusterId). These
+/// handlers sit on every client's Connect() path and must never queue behind
+/// heavyweight control-plane handlers; see NodeInfoGrpcService.
+struct GcsLightweightRpcReads {};
+
 struct GcsServerIOContextPolicy {
   GcsServerIOContextPolicy() = delete;
 
@@ -64,6 +70,8 @@ struct GcsServerIOContextPolicy {
       return IndexOf("internal_kv_io_context");
     } else if constexpr (std::is_same_v<T, GcsNodeManager>) {
       return IndexOf("node_manager_io_context");
+    } else if constexpr (std::is_same_v<T, GcsLightweightRpcReads>) {
+      return IndexOf("lightweight_rpc_reads_io_context");
     } else {
       // default io context
       return -1;
@@ -74,7 +82,7 @@ struct GcsServerIOContextPolicy {
   // and a complete set of those returned from GetDedicatedIOContextIndex. Or you
   // can get runtime crashes when accessing a missing name, or get leaks by
   // creating unused threads.
-  constexpr static std::array<IOContextMetadata, 7> kAllDedicatedIOContexts{{
+  constexpr static std::array<IOContextMetadata, 8> kAllDedicatedIOContexts{{
       // task_io_context only runs GcsTaskManager, which ingests and serves
       // task-state events (observability) and drops events under load by design.
       // It is not on the GCS control plane, so a backlog here (e.g. under a
@@ -97,6 +105,11 @@ struct GcsServerIOContextPolicy {
        /*enable_lag_probe=*/true,
        /*used_for_health_check=*/true},
       {"node_manager_io_context",
+       /*enable_lag_probe=*/true,
+       /*used_for_health_check=*/true},
+      // Only runs constant-time RPC read handlers (GetClusterId), which sit on
+      // every client's Connect() path — hence health-check critical.
+      {"lightweight_rpc_reads_io_context",
        /*enable_lag_probe=*/true,
        /*used_for_health_check=*/true},
   }};

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -49,10 +49,15 @@ void NodeInfoGrpcService::InitServerCallFactories(
     GrpcServerMetrics &server_metrics) {
   // We only allow one cluster ID in the lifetime of a client.
   // So, if a client connects, it should not have a pre-existing different ID.
-  RPC_SERVICE_HANDLER_CUSTOM_AUTH(NodeInfoGcsService,
-                                  GetClusterId,
-                                  max_active_rpcs_per_handler_,
-                                  ClusterIdAuthType::EMPTY_AUTH);
+  // GetClusterId runs on the dedicated lightweight-reads io_context: every
+  // client's Connect() blocks on it, and dispatching it through the
+  // (single-threaded) node_manager io_context lets mass RegisterNode /
+  // GetAllNodeInfo storms delay a constant-value read past client deadlines.
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH_IN_IO_CONTEXT(NodeInfoGcsService,
+                                                GetClusterId,
+                                                max_active_rpcs_per_handler_,
+                                                ClusterIdAuthType::EMPTY_AUTH,
+                                                lightweight_reads_io_service_);
   RPC_SERVICE_HANDLER(NodeInfoGcsService, RegisterNode, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER_WITH_GRPC_PEER(
       NodeInfoGcsService, UnregisterNode, max_active_rpcs_per_handler_)

--- a/src/ray/gcs/grpc_services.h
+++ b/src/ray/gcs/grpc_services.h
@@ -65,10 +65,15 @@ class ActorInfoGrpcService : public GrpcService {
 
 class NodeInfoGrpcService : public GrpcService {
  public:
+  /// \param lightweight_reads_io_service Dedicated io_context for trivial,
+  /// constant-time read handlers (GetClusterId) so they cannot queue behind
+  /// heavyweight handlers (RegisterNode, GetAllNodeInfo, ...) on \p io_service.
   explicit NodeInfoGrpcService(instrumented_io_context &io_service,
+                               instrumented_io_context &lightweight_reads_io_service,
                                NodeInfoGcsServiceHandler &service_handler,
                                int64_t max_active_rpcs_per_handler)
       : GrpcService(io_service),
+        lightweight_reads_io_service_(lightweight_reads_io_service),
         service_handler_(service_handler),
         max_active_rpcs_per_handler_(max_active_rpcs_per_handler) {}
 
@@ -84,6 +89,7 @@ class NodeInfoGrpcService : public GrpcService {
 
  private:
   NodeInfoGcsService::AsyncService service_;
+  instrumented_io_context &lightweight_reads_io_service_;
   NodeInfoGcsServiceHandler &service_handler_;
   int64_t max_active_rpcs_per_handler_;
 };

--- a/src/ray/gcs/tests/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/tests/gcs_server_rpc_test.cc
@@ -604,4 +604,28 @@ TEST_F(GcsServerTest, HealthCheckReflectsMainIOContextHealth) {
                                   std::chrono::seconds(30)));
 }
 
+TEST_F(GcsServerTest, GetClusterIdNotDelayedByNodeManagerIoContextBacklog) {
+  // Occupy the (single-threaded) node_manager io_context with a task that
+  // waits until released, simulating an event loop backlogged behind mass
+  // RegisterNode / GetAllNodeInfo storms. GetClusterId is posted to the
+  // dedicated lightweight-reads io_context, so a 2s deadline must still
+  // suffice. Pre-fix (GetClusterId shared the node_manager io_context), this
+  // call fails with DEADLINE_EXCEEDED.
+  std::promise<void> release;
+  // Captured by value: the blocking task may still be waking up when this test
+  // returns and destroys `release`.
+  std::shared_future<void> released = release.get_future().share();
+  gcs_server_->GetNodeManagerIOContextInTest().post([released]() { released.wait(); },
+                                                    "BlockNodeManagerIOContextForTest");
+
+  rpc::GetClusterIdRequest request;
+  rpc::GetClusterIdReply reply;
+  auto status =
+      client_->SyncGetClusterId(std::move(request), &reply, /*timeout_ms=*/2000);
+  release.set_value();
+
+  ASSERT_TRUE(status.ok()) << status;
+  ASSERT_FALSE(ClusterID::FromBinary(reply.cluster_id()).IsNil());
+}
+
 }  // namespace ray

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -32,8 +32,16 @@ namespace ray {
 namespace rpc {
 /// \param MAX_ACTIVE_RPCS Maximum number of RPCs to handle at the same time. -1 means no
 /// limit.
-#define _RPC_SERVICE_HANDLER(                                                      \
-    SERVICE, HANDLER, MAX_ACTIVE_RPCS, AUTH_TYPE, RECORD_METRICS, PASS_GRPC_PEER)  \
+/// \param IO_CONTEXT The io_context the handler is posted to. All handlers of a
+/// service normally share the service's main_service_; pass a different
+/// io_context to isolate a handler from queueing behind the others.
+#define _RPC_SERVICE_HANDLER_IN_IO_CONTEXT(SERVICE,                                \
+                                           HANDLER,                                \
+                                           MAX_ACTIVE_RPCS,                        \
+                                           AUTH_TYPE,                              \
+                                           RECORD_METRICS,                         \
+                                           PASS_GRPC_PEER,                         \
+                                           IO_CONTEXT)                             \
   std::unique_ptr<ServerCallFactory> HANDLER##_call_factory(                       \
       new ServerCallFactoryImpl<SERVICE,                                           \
                                 SERVICE##Handler,                                  \
@@ -46,7 +54,7 @@ namespace rpc {
           service_handler_,                                                        \
           &SERVICE##Handler::Handle##HANDLER,                                      \
           cq,                                                                      \
-          main_service_,                                                           \
+          IO_CONTEXT,                                                              \
           #SERVICE ".grpc_server." #HANDLER,                                       \
           AUTH_TYPE == ClusterIdAuthType::NO_AUTH ? ClusterID::Nil() : cluster_id, \
           auth_token,                                                              \
@@ -54,6 +62,16 @@ namespace rpc {
           RECORD_METRICS,                                                          \
           server_metrics));                                                        \
   server_call_factories->emplace_back(std::move(HANDLER##_call_factory));
+
+#define _RPC_SERVICE_HANDLER(                                                     \
+    SERVICE, HANDLER, MAX_ACTIVE_RPCS, AUTH_TYPE, RECORD_METRICS, PASS_GRPC_PEER) \
+  _RPC_SERVICE_HANDLER_IN_IO_CONTEXT(SERVICE,                                     \
+                                     HANDLER,                                     \
+                                     MAX_ACTIVE_RPCS,                             \
+                                     AUTH_TYPE,                                   \
+                                     RECORD_METRICS,                              \
+                                     PASS_GRPC_PEER,                              \
+                                     main_service_)
 
 /// Define a RPC service handler with gRPC server metrics enabled.
 #define RPC_SERVICE_HANDLER(SERVICE, HANDLER, MAX_ACTIVE_RPCS) \
@@ -79,6 +97,16 @@ namespace rpc {
 #define RPC_SERVICE_HANDLER_CUSTOM_AUTH_SERVER_METRICS_DISABLED( \
     SERVICE, HANDLER, MAX_ACTIVE_RPCS, AUTH_TYPE)                \
   _RPC_SERVICE_HANDLER(SERVICE, HANDLER, MAX_ACTIVE_RPCS, AUTH_TYPE, false, false)
+
+/// Like RPC_SERVICE_HANDLER_CUSTOM_AUTH, but posts the handler to an explicit
+/// io_context instead of the service's main_service_. Use this to isolate a
+/// cheap, latency-sensitive handler (e.g. NodeInfoGcsService.GetClusterId, a
+/// constant-time read on every client's Connect() path) from queueing behind
+/// heavyweight handlers that share the service's io_context.
+#define RPC_SERVICE_HANDLER_CUSTOM_AUTH_IN_IO_CONTEXT(        \
+    SERVICE, HANDLER, MAX_ACTIVE_RPCS, AUTH_TYPE, IO_CONTEXT) \
+  _RPC_SERVICE_HANDLER_IN_IO_CONTEXT(                         \
+      SERVICE, HANDLER, MAX_ACTIVE_RPCS, AUTH_TYPE, true, false, IO_CONTEXT)
 
 class GrpcService;
 

--- a/src/ray/rpc/tests/grpc_server_client_test.cc
+++ b/src/ray/rpc/tests/grpc_server_client_test.cc
@@ -251,5 +251,95 @@ TEST_F(TestGrpcServerClientFixture, TestTimeoutMacro) {
   }
 }
 
+// Fixture for handlers bound to a dedicated io_context via
+// RPC_SERVICE_HANDLER_CUSTOM_AUTH_IN_IO_CONTEXT: the service's main io_context
+// is constructed but its event loop is NEVER run, so any reply proves the
+// handler was posted to the dedicated io_context instead of the service's.
+class TestGrpcServerDedicatedIoContextFixture : public ::testing::Test {
+ public:
+  void SetUp() override {
+    grpc_server_.reset(new GrpcServer("test-dedicated-io-context", 0, true));
+    grpc_server_->RegisterService(
+        std::make_unique<TestGrpcServiceWithDedicatedIoContext>(
+            main_handler_io_service_, dedicated_io_service_, test_service_handler_),
+        false);
+    grpc_server_->Run();
+    while (grpc_server_->GetPort() == 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    dedicated_thread_ = std::make_unique<std::thread>([this]() {
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+          dedicated_io_service_work_(dedicated_io_service_.get_executor());
+      dedicated_io_service_.run();
+    });
+
+    client_thread_ = std::make_unique<std::thread>([this]() {
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+          client_io_service_work_(client_io_service_.get_executor());
+      client_io_service_.run();
+    });
+    client_call_manager_.reset(
+        new ClientCallManager(client_io_service_, false, /*local_address=*/""));
+    grpc_client_.reset(new GrpcClient<TestService>(
+        "127.0.0.1", grpc_server_->GetPort(), *client_call_manager_));
+  }
+
+  void TearDown() override {
+    grpc_client_.reset();
+    client_call_manager_.reset();
+    client_io_service_.stop();
+    if (client_thread_->joinable()) {
+      client_thread_->join();
+    }
+    dedicated_io_service_.stop();
+    if (dedicated_thread_->joinable()) {
+      dedicated_thread_->join();
+    }
+    grpc_server_->Shutdown();
+  }
+
+  // Sends a Ping and waits for the reply with a bounded deadline; returns
+  // whether the reply arrived in time.
+  bool PingAndWait(int64_t deadline_ms) {
+    PingRequest request;
+    std::atomic<bool> done(false);
+    Ping(request, [&done](const Status &status, const PingReply &reply) {
+      RAY_LOG(INFO) << "Ping replied, status=" << status;
+      ASSERT_TRUE(status.ok()) << status;
+      done = true;
+    });
+    for (int waited_ms = 0; waited_ms < deadline_ms; waited_ms += 10) {
+      if (done) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return done;
+  }
+
+ protected:
+  VOID_RPC_CLIENT_METHOD(TestService, Ping, grpc_client_, /*method_timeout_ms*/ -1, )
+  // Server; NOTE: main_handler_io_service_ is intentionally never run.
+  TestServiceHandler test_service_handler_;
+  instrumented_io_context main_handler_io_service_;
+  instrumented_io_context dedicated_io_service_;
+  std::unique_ptr<std::thread> dedicated_thread_;
+  std::unique_ptr<GrpcServer> grpc_server_;
+  // Client
+  instrumented_io_context client_io_service_;
+  std::unique_ptr<std::thread> client_thread_;
+  std::unique_ptr<ClientCallManager> client_call_manager_;
+  std::unique_ptr<GrpcClient<TestService>> grpc_client_;
+};
+
+TEST_F(TestGrpcServerDedicatedIoContextFixture,
+       DedicatedIoContextHandlerRepliesWhileServiceIoContextNeverRuns) {
+  // The service's main io_context has no thread running it; only a handler
+  // posted to the dedicated io_context can produce a reply.
+  ASSERT_TRUE(PingAndWait(/*deadline_ms=*/10000));
+  ASSERT_EQ(test_service_handler_.request_count, 1);
+}
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/rpc/tests/grpc_test_common.h
+++ b/src/ray/rpc/tests/grpc_test_common.h
@@ -106,5 +106,42 @@ class TestGrpcService : public GrpcService {
   TestServiceHandler &service_handler_;
 };
 
+/// Same as TestGrpcService, but Ping is posted to a separate dedicated
+/// io_context (RPC_SERVICE_HANDLER_CUSTOM_AUTH_IN_IO_CONTEXT) instead of the
+/// service's main io_context.
+class TestGrpcServiceWithDedicatedIoContext : public GrpcService {
+ public:
+  TestGrpcServiceWithDedicatedIoContext(instrumented_io_context &handler_io_service,
+                                        instrumented_io_context &dedicated_io_service,
+                                        TestServiceHandler &handler)
+      : GrpcService(handler_io_service),
+        dedicated_io_service_(dedicated_io_service),
+        service_handler_(handler) {}
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+      const ClusterID &cluster_id,
+      std::shared_ptr<const AuthenticationToken> auth_token,
+      GrpcServerMetrics &server_metrics) override {
+    RPC_SERVICE_HANDLER_CUSTOM_AUTH_IN_IO_CONTEXT(TestService,
+                                                  Ping,
+                                                  /*max_active_rpcs=*/1,
+                                                  ClusterIdAuthType::NO_AUTH,
+                                                  dedicated_io_service_);
+  }
+
+ private:
+  /// The grpc async service object.
+  TestService::AsyncService service_;
+  /// The io_context Ping is posted to; never the service's main io_context.
+  instrumented_io_context &dedicated_io_service_;
+  /// The service handler that actually handle the requests.
+  TestServiceHandler &service_handler_;
+};
+
 }  // namespace rpc
 }  // namespace ray


### PR DESCRIPTION
## Why are these changes needed?

`GetClusterId` is a lock-free read of an immutable value (`gcs_node_manager.cc`), but its handler is posted to the single-threaded `node_manager_io_context` shared with `RegisterNode`, `GetAllNodeInfo`, `CheckAlive`, etc. During mass node registration the loop's queue delay exceeds client deadlines, and `DEADLINE_EXCEEDED` maps to `TimedOut` which `IsGrpcRetryableStatus` deliberately never retries — so every connecting process's cluster-ID fetch dies on a constant-value read:

```
[gcs_client.cc] Failed to get cluster ID from GCS server: TimedOut: RPC error: Deadline Exceeded
```

We hit this as a full cluster bring-up collapse at 400 nodes (~60k potential worker processes) on Ray 2.56. `gcs_server_rpc_server_thread_num` cannot help (it only sizes completion-queue polling threads, which never run handlers).

**Fix: isolate on an existing axis instead of adding dispatch machinery.** The GCS already isolates workloads with dedicated io_contexts (`GcsServerIOContextPolicy`). This PR adds a `lightweight_rpc_reads_io_context` entry there, plus a small `RPC_SERVICE_HANDLER_CUSTOM_AUTH_IN_IO_CONTEXT` macro variant that posts one handler to an explicit io_context (`_RPC_SERVICE_HANDLER` now delegates with the service's `main_service_`, so all other handlers are unchanged). `GetClusterId` is the only opt-in; `CheckAlive` — which is starved by the same storms and causes false node-death — can follow in a later PR.

An earlier revision of this PR ran the handler inline on the gRPC polling thread. That worked, but it created a new hazard class: any future inline handler that gets slow stalls completion-queue polling for the whole server — exactly the failure mode of #55904, reverted in #59448. A dedicated io_context gets identical starvation immunity while a slow handler hurts only itself, and it reuses the GCS's existing isolation pattern (~10-line server diff instead of a new template axis through `ServerCallImpl`).

The new io_context is lag-probed and health-check-critical (it sits on every client's `Connect()` path).

Companion PR (client-side half, independently mergeable/revertable): #64847.

## Related issue number

None found — searched open PRs/issues for GetClusterId / io_context starvation before opening (closest, orthogonal: #64422 GCS passive-mode refactor). Not a duplicate of in-flight work.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit on the changed files.
- [x] Testing strategy:
  - New `//src/ray/rpc/tests:grpc_server_client_test` case `DedicatedIoContextHandlerRepliesWhileServiceIoContextNeverRuns`: the service's main io_context is never run; only a handler posted to the dedicated io_context can reply.
  - New `//src/ray/gcs/tests:gcs_server_rpc_test` case `GetClusterIdNotDelayedByNodeManagerIoContextBacklog`: blocks the node_manager io_context with a task that waits until released and asserts a 2s-deadline `SyncGetClusterId` still succeeds (fails with DEADLINE_EXCEEDED pre-fix).
  - Ran locally (macOS, `--dynamic_mode=off`): both targets pass.

Per the repo's AI contribution policy: AI assistance was used to develop this change; every changed line was reviewed and the tests above were run locally.