### PR TITLE
[core] Add per-call RetryOnTimeoutPolicy to RetryableGrpcClient; opt in GetClusterId

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3044,7 +3044,10 @@ cdef class GcsClient:
 
     def __cinit__(self, address: str,
                   cluster_id: Optional[str] = None):
-        # For timeout (DEADLINE_EXCEEDED): retries once with timeout_ms.
+        # For timeout (DEADLINE_EXCEEDED): the cluster-ID fetch inside connect
+        # retries with bounded per-attempt deadlines and jittered backoff until
+        # the timeout_ms budget is exhausted (see RetryOnTimeoutPolicy on
+        # GcsRpcClient::GetClusterId), then raises.
         #
         # For other RpcError (UNAVAILABLE, UNKNOWN): retries indefinitely until it
         # thinks GCS is down and kills the whole process.

--- a/src/ray/gcs_rpc_client/gcs_client.cc
+++ b/src/ray/gcs_rpc_client/gcs_client.cc
@@ -200,10 +200,20 @@ Status GcsClient::FetchClusterId(int64_t timeout_ms) {
   if (!GetClusterId().IsNil()) {
     return Status::OK();
   }
+  // Connect() replaces a negative timeout with the connect-timeout config, so a
+  // non-positive budget here means a misconfiguration (it would silently make
+  // the fetch a no-op deadline). Fail loudly instead of guessing a value.
+  RAY_CHECK_GT(timeout_ms, static_cast<int64_t>(0))
+      << "FetchClusterId requires a positive timeout budget; check "
+         "gcs_rpc_server_connect_timeout_s.";
   rpc::GetClusterIdRequest request;
   rpc::GetClusterIdReply reply;
   RAY_LOG(DEBUG) << "Cluster ID is nil, getting cluster ID from GCS server.";
 
+  // GetClusterId carries a RetryOnTimeoutPolicy (see GcsRpcClient): timed-out
+  // attempts are retried with bounded per-attempt deadlines and jittered
+  // backoff within timeout_ms, so a read of this immutable value that lands on
+  // a momentarily backlogged GCS degrades to slow instead of fatal.
   Status s = client_context_->GetGcsRpcClient().SyncGetClusterId(
       std::move(request), &reply, timeout_ms);
   if (!s.ok()) {

--- a/src/ray/gcs_rpc_client/gcs_client.h
+++ b/src/ray/gcs_rpc_client/gcs_client.h
@@ -264,6 +264,13 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
  private:
   /// If client_call_manager_ does not have a cluster ID, fetches it from GCS. The
   /// fetched cluster ID is set to client_call_manager_.
+  ///
+  /// The underlying RPC retries timed-out attempts with bounded per-attempt
+  /// deadlines and jittered backoff within `timeout_ms` (see
+  /// RetryableGrpcClient::RetryOnTimeoutPolicy): a timed-out read of this
+  /// immutable value (e.g. queueing delay on a GCS busy with a node
+  /// registration storm) should degrade to slow, not fatal. `timeout_ms` must
+  /// be positive.
   Status FetchClusterId(int64_t timeout_ms);
 
   const UniqueID gcs_client_id_ = UniqueID::FromRandom();

--- a/src/ray/gcs_rpc_client/rpc_client.h
+++ b/src/ray/gcs_rpc_client/rpc_client.h
@@ -17,7 +17,9 @@
 #include <gtest/gtest_prod.h>
 
 #include <chrono>
+#include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -226,7 +228,9 @@ class GcsRpcClient {
       const std::string &call_name,
       Request &&request,
       const ClientCallback<Reply> &callback,
-      const int64_t timeout_ms) {
+      const int64_t timeout_ms,
+      std::optional<RetryableGrpcClient::RetryOnTimeoutPolicy> retry_on_timeout =
+          std::nullopt) {
     retryable_grpc_client_->template CallMethod<Service, Request, Reply>(
         prepare_async_function,
         std::move(grpc_client),
@@ -247,7 +251,8 @@ class GcsRpcClient {
             callback(status, std::move(reply));
           }
         },
-        timeout_ms);
+        timeout_ms,
+        retry_on_timeout);
   }
 
   /// Add job info to GCS Service.
@@ -325,11 +330,44 @@ class GcsRpcClient {
                              KillActorViaGcs,
                              actor_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
-  /// Register a client to GCS Service.
-  VOID_GCS_RPC_CLIENT_METHOD(NodeInfoGcsService,
-                             GetClusterId,
-                             node_info_grpc_client_,
-                             /*method_timeout_ms*/ -1, )
+  /// Fetch the cluster ID from GCS Service. Hand-written (the other methods use
+  /// VOID_GCS_RPC_CLIENT_METHOD) to attach a RetryOnTimeoutPolicy: every
+  /// client's Connect() blocks on this constant-value read, and during mass
+  /// cluster bring-up the GCS can be too backlogged to answer within one
+  /// deadline. Each attempt gets at most the connect timeout; timed-out
+  /// attempts are retried with jittered backoff until the caller's overall
+  /// timeout_ms budget is exhausted. Requires a finite positive timeout_ms.
+  void GetClusterId(GetClusterIdRequest &&request,
+                    const ClientCallback<GetClusterIdReply> &callback,
+                    const int64_t timeout_ms) {
+    invoke_async_method<NodeInfoGcsService,
+                        GetClusterIdRequest,
+                        GetClusterIdReply,
+                        /*handle_payload_status=*/true>(
+        &NodeInfoGcsService::Stub::PrepareAsyncGetClusterId,
+        node_info_grpc_client_,
+        "ray::rpc::NodeInfoGcsService.grpc_client.GetClusterId",
+        std::move(request),
+        callback,
+        timeout_ms,
+        RetryableGrpcClient::RetryOnTimeoutPolicy{
+            /*per_attempt_timeout_ms=*/::RayConfig::instance()
+                .gcs_rpc_server_connect_timeout_s() *
+            1000});
+  }
+  ray::Status SyncGetClusterId(GetClusterIdRequest &&request,
+                               GetClusterIdReply *reply_in,
+                               const int64_t timeout_ms) {
+    std::promise<Status> promise;
+    GetClusterId(
+        std::move(request),
+        [&promise, reply_in](const Status &status, const GetClusterIdReply &reply) {
+          reply_in->CopyFrom(reply);
+          promise.set_value(status);
+        },
+        timeout_ms);
+    return promise.get_future().get();
+  }
 
   /// Register a node to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(NodeInfoGcsService,

--- a/src/ray/rpc/retryable_grpc_client.cc
+++ b/src/ray/rpc/retryable_grpc_client.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <utility>
 
+#include "ray/asio/asio_util.h"
 #include "ray/util/exponential_backoff.h"
 
 namespace ray::rpc {
@@ -126,6 +127,27 @@ void RetryableGrpcClient::CheckChannelStatus(bool reset_timer) {
     RAY_LOG(FATAL) << "Not covered status: " << status;
   }
   }
+}
+
+void RetryableGrpcClient::RetryAfterJitteredBackoff(
+    std::shared_ptr<RetryableGrpcRequest> request, const ray::Status &status) {
+  // Full jitter: uniform in [0, min(base * 2^attempt, cap)]. When many clients
+  // time out on the same overloaded server at the same moment (e.g. mass
+  // cluster bring-up), decorrelating their retries matters more than the exact
+  // backoff value. The delay consumes the call's overall budget, so retries
+  // stay within timeout_ms; a retry that fires with (almost) no budget left
+  // makes one last short attempt and delivers TimedOut.
+  const uint64_t attempt = request->NextAttemptNumber();
+  const uint64_t backoff_cap_ms = ExponentialBackoff::GetBackoffMs(
+      attempt, kRetryOnTimeoutBackoffBaseMs, kRetryOnTimeoutBackoffMaxMs);
+  const int64_t delay_ms =
+      absl::Uniform<int64_t>(bit_gen_, 0, static_cast<int64_t>(backoff_cap_ms) + 1);
+  RAY_LOG(WARNING) << request->GetCallName() << " attempt " << attempt + 1
+                   << " timed out (" << status << "); retrying in " << delay_ms << " ms.";
+  execute_after(
+      io_context_,
+      [request = std::move(request)]() { request->CallMethod(); },
+      std::chrono::milliseconds(delay_ms));
 }
 
 void RetryableGrpcClient::Retry(std::shared_ptr<RetryableGrpcRequest> request) {

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -24,7 +25,9 @@
 #include <utility>
 
 #include "absl/container/btree_map.h"
+#include "absl/random/random.h"
 #include "absl/strings/str_format.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "ray/common/grpc_util.h"
 #include "ray/rpc/grpc_client.h"
@@ -79,6 +82,22 @@ namespace ray::rpc {
  * destructor is called and the client is shut down.
  */
 class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcClient> {
+ public:
+  /// Per-call policy: retry attempts that fail with TimedOut (DEADLINE_EXCEEDED)
+  /// using bounded per-attempt deadlines and jittered exponential backoff, until
+  /// the call's overall timeout_ms budget is exhausted. TimedOut is deliberately
+  /// not in IsGrpcRetryableStatus (it usually means the server is up but slow,
+  /// and blindly requeueing every timed-out call feeds an unbounded retry
+  /// queue), so this is per-call opt-in: use it only for cheap idempotent reads
+  /// whose timeout is more likely queueing delay on a busy server than payload
+  /// cost (e.g. NodeInfoGcsService.GetClusterId during mass cluster bring-up).
+  /// Requires the call to have a finite positive timeout_ms.
+  struct RetryOnTimeoutPolicy {
+    /// Deadline for each individual attempt; must be positive. The last attempt
+    /// is clamped to the remaining overall budget.
+    int64_t per_attempt_timeout_ms;
+  };
+
  private:
   /**
    * Represents a single retryable grpc request.
@@ -98,7 +117,8 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
         std::string call_name,
         Request request,
         ClientCallback<Reply> callback,
-        int64_t timeout_ms);
+        int64_t timeout_ms,
+        std::optional<RetryOnTimeoutPolicy> retry_on_timeout);
 
     RetryableGrpcRequest(const RetryableGrpcRequest &) = delete;
     RetryableGrpcRequest &operator=(const RetryableGrpcRequest &) = delete;
@@ -112,21 +132,67 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
 
     int64_t GetTimeoutMs() const { return timeout_ms_; }
 
+    /// Deadline for the next attempt: the full call timeout, or, when
+    /// retry_on_timeout is set, the per-attempt deadline clamped to the
+    /// remaining overall budget.
+    int64_t NextAttemptTimeoutMs() const {
+      if (!retry_on_timeout_.has_value()) {
+        return timeout_ms_;
+      }
+      const int64_t remaining_ms =
+          absl::ToInt64Milliseconds(overall_deadline_ - absl::Now());
+      return std::max<int64_t>(
+          1, std::min(retry_on_timeout_->per_attempt_timeout_ms, remaining_ms));
+    }
+
+    /// Whether a failed attempt should be retried under the retry_on_timeout
+    /// policy: the attempt timed out and overall budget remains.
+    bool ShouldRetryOnTimeout(const ray::Status &status) const {
+      return retry_on_timeout_.has_value() && status.IsTimedOut() &&
+             absl::Now() < overall_deadline_;
+    }
+
+    /// Returns the number of the attempt that just failed (0-based) and
+    /// advances the counter. Only used by the retry_on_timeout path.
+    uint64_t NextAttemptNumber() { return attempt_number_++; }
+
+    const std::string &GetCallName() const { return call_name_; }
+
    private:
     RetryableGrpcRequest(
         std::function<void(std::shared_ptr<RetryableGrpcRequest> request)> executor,
         std::function<void(ray::Status)> failure_callback,
+        std::string call_name,
         size_t request_bytes,
-        int64_t timeout_ms)
+        int64_t timeout_ms,
+        std::optional<RetryOnTimeoutPolicy> retry_on_timeout)
         : executor_(std::move(executor)),
           failure_callback_(std::move(failure_callback)),
+          call_name_(std::move(call_name)),
           request_bytes_(request_bytes),
-          timeout_ms_(timeout_ms) {}
+          timeout_ms_(timeout_ms),
+          retry_on_timeout_(retry_on_timeout),
+          overall_deadline_(timeout_ms > 0 ? absl::Now() + absl::Milliseconds(timeout_ms)
+                                           : absl::InfiniteFuture()) {
+      if (retry_on_timeout_.has_value()) {
+        RAY_CHECK_GT(timeout_ms, static_cast<int64_t>(0))
+            << call_name_
+            << ": RetryOnTimeoutPolicy requires a finite positive overall timeout.";
+        RAY_CHECK_GT(retry_on_timeout_->per_attempt_timeout_ms, static_cast<int64_t>(0))
+            << call_name_ << ": per_attempt_timeout_ms must be positive.";
+      }
+    }
 
     std::function<void(std::shared_ptr<RetryableGrpcRequest> request)> executor_;
     std::function<void(ray::Status)> failure_callback_;
+    const std::string call_name_;
     const size_t request_bytes_;
     const int64_t timeout_ms_;
+    const std::optional<RetryOnTimeoutPolicy> retry_on_timeout_;
+    /// Absolute deadline for the whole call including retries.
+    const absl::Time overall_deadline_;
+    /// Number of attempts sent so far under the retry_on_timeout policy.
+    uint64_t attempt_number_ = 0;
   };
 
  public:
@@ -161,9 +227,15 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
                   std::string call_name,
                   Request request,
                   ClientCallback<Reply> callback,
-                  int64_t timeout_ms);
+                  int64_t timeout_ms,
+                  std::optional<RetryOnTimeoutPolicy> retry_on_timeout = std::nullopt);
 
   void Retry(std::shared_ptr<RetryableGrpcRequest> request);
+
+  /// Re-sends a request whose attempt failed with TimedOut (see
+  /// RetryOnTimeoutPolicy) after a jittered exponential backoff delay.
+  void RetryAfterJitteredBackoff(std::shared_ptr<RetryableGrpcRequest> request,
+                                 const ray::Status &status);
 
   // Return the number of active (pending or inflight) requests.
   size_t NumActiveRequests() const { return num_active_requests_; }
@@ -229,6 +301,16 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
   // Total number of bytes of pending requests.
   size_t pending_requests_bytes_ = 0;
 
+  // Backoff parameters for RetryOnTimeoutPolicy retries: full jitter over an
+  // exponentially growing cap. Small relative to any realistic call budget;
+  // the point is decorrelating retries from many clients that timed out on the
+  // same overloaded server at the same moment.
+  static constexpr uint64_t kRetryOnTimeoutBackoffBaseMs = 100;
+  static constexpr uint64_t kRetryOnTimeoutBackoffMaxMs = 2000;
+  // Jitter source for RetryOnTimeoutPolicy backoff; only used on the
+  // io_context thread.
+  absl::BitGen bit_gen_;
+
   // Number of retries while the server is unavailable across all requests. Reset to 0
   // when the server is available.
   uint32_t attempt_number_ = 0;
@@ -244,7 +326,8 @@ void RetryableGrpcClient::CallMethod(
     std::string call_name,
     Request request,
     ClientCallback<Reply> callback,
-    int64_t timeout_ms) {
+    int64_t timeout_ms,
+    std::optional<RetryOnTimeoutPolicy> retry_on_timeout) {
   num_active_requests_++;
   RetryableGrpcRequest::Create(weak_from_this(),
                                std::move(prepare_async_function),
@@ -252,7 +335,8 @@ void RetryableGrpcClient::CallMethod(
                                std::move(call_name),
                                std::move(request),
                                std::move(callback),
-                               timeout_ms)
+                               timeout_ms,
+                               retry_on_timeout)
       ->CallMethod();
 }
 
@@ -265,7 +349,8 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
     std::string call_name,
     Request request,
     ClientCallback<Reply> callback,
-    int64_t timeout_ms) {
+    int64_t timeout_ms,
+    std::optional<RetryOnTimeoutPolicy> retry_on_timeout) {
   RAY_CHECK(callback != nullptr);
   RAY_CHECK(grpc_client.get() != nullptr);
 
@@ -274,7 +359,7 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
   auto executor = [weak_retryable_grpc_client = std::move(weak_retryable_grpc_client),
                    prepare_async_function = std::move(prepare_async_function),
                    grpc_client = std::move(grpc_client),
-                   call_name = std::move(call_name),
+                   call_name,
                    request = std::move(request),
                    callback](std::shared_ptr<RetryableGrpcClient::RetryableGrpcRequest>
                                  retryable_grpc_request) {
@@ -284,6 +369,12 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
         [weak_retryable_grpc_client, retryable_grpc_request, callback](
             const ray::Status &status, Reply &&reply) {
           auto retryable_grpc_client = weak_retryable_grpc_client.lock();
+          if (retryable_grpc_client && !status.ok() &&
+              retryable_grpc_request->ShouldRetryOnTimeout(status)) {
+            retryable_grpc_client->RetryAfterJitteredBackoff(retryable_grpc_request,
+                                                             status);
+            return;
+          }
           if (status.ok() || !IsGrpcRetryableStatus(status) || !retryable_grpc_client) {
             callback(status, std::move(reply));
             if (retryable_grpc_client) {
@@ -294,7 +385,7 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
           retryable_grpc_client->Retry(retryable_grpc_request);
         },
         call_name,
-        retryable_grpc_request->GetTimeoutMs());
+        retryable_grpc_request->NextAttemptTimeoutMs());
   };
 
   auto failure_callback = [weak_retryable_grpc_client,
@@ -309,8 +400,12 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
   return std::shared_ptr<RetryableGrpcClient::RetryableGrpcRequest>(
       // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot
       // invoke private constructors.
-      new RetryableGrpcClient::RetryableGrpcRequest(
-          std::move(executor), std::move(failure_callback), request_bytes, timeout_ms));
+      new RetryableGrpcClient::RetryableGrpcRequest(std::move(executor),
+                                                    std::move(failure_callback),
+                                                    std::move(call_name),
+                                                    request_bytes,
+                                                    timeout_ms,
+                                                    retry_on_timeout));
 }
 
 }  // namespace ray::rpc

--- a/src/ray/rpc/tests/BUILD.bazel
+++ b/src/ray/rpc/tests/BUILD.bazel
@@ -38,6 +38,22 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "retryable_grpc_client_test",
+    size = "small",
+    srcs = [
+        "retryable_grpc_client_test.cc",
+    ],
+    tags = ["team:core"],
+    deps = [
+        ":grpc_test_common",
+        "//src/ray/protobuf:test_service_cc_grpc",
+        "//src/ray/rpc:grpc_client",
+        "//src/ray/rpc:grpc_server",
+        "//src/ray/rpc:retryable_grpc_client",
+    ],
+)
+
+ray_cc_test(
     name = "metrics_agent_client_test",
     size = "small",
     srcs = [

--- a/src/ray/rpc/tests/retryable_grpc_client_test.cc
+++ b/src/ray/rpc/tests/retryable_grpc_client_test.cc
@@ -1,0 +1,152 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/rpc/retryable_grpc_client.h"
+
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <thread>
+
+#include "gtest/gtest.h"
+#include "ray/rpc/grpc_client.h"
+#include "ray/rpc/grpc_server.h"
+#include "ray/rpc/tests/grpc_test_common.h"
+
+namespace ray {
+namespace rpc {
+
+// Exercises RetryableGrpcClient::RetryOnTimeoutPolicy against a real server
+// whose handler can be frozen: while frozen, every attempt fails with
+// DEADLINE_EXCEEDED client-side.
+class RetryableGrpcClientTimeoutRetryFixture : public ::testing::Test {
+ public:
+  void SetUp() override {
+    handler_io_service_thread_ = std::make_unique<std::thread>([this]() {
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+          handler_io_service_work_(handler_io_service_.get_executor());
+      handler_io_service_.run();
+    });
+    grpc_server_.reset(new GrpcServer("test-retry-on-timeout", 0, true));
+    grpc_server_->RegisterService(
+        std::make_unique<TestGrpcService>(handler_io_service_, test_service_handler_),
+        false);
+    grpc_server_->Run();
+    while (grpc_server_->GetPort() == 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    client_thread_ = std::make_unique<std::thread>([this]() {
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+          client_io_service_work_(client_io_service_.get_executor());
+      client_io_service_.run();
+    });
+    client_call_manager_.reset(
+        new ClientCallManager(client_io_service_, false, /*local_address=*/""));
+    grpc_client_.reset(new GrpcClient<TestService>(
+        "127.0.0.1", grpc_server_->GetPort(), *client_call_manager_));
+    retryable_grpc_client_ = RetryableGrpcClient::Create(
+        grpc_client_->Channel(),
+        client_io_service_,
+        /*max_pending_requests_bytes=*/
+        std::numeric_limits<uint64_t>::max(),
+        /*check_channel_status_interval_milliseconds=*/100,
+        /*server_reconnect_timeout_base_seconds=*/60,
+        /*server_reconnect_timeout_max_seconds=*/60,
+        /*server_unavailable_timeout_callback=*/[]() {},
+        /*server_name=*/"test-server");
+  }
+
+  void TearDown() override {
+    test_service_handler_.frozen = false;
+    retryable_grpc_client_.reset();
+    grpc_client_.reset();
+    client_call_manager_.reset();
+    client_io_service_.stop();
+    if (client_thread_->joinable()) {
+      client_thread_->join();
+    }
+    grpc_server_->Shutdown();
+    handler_io_service_.stop();
+    if (handler_io_service_thread_->joinable()) {
+      handler_io_service_thread_->join();
+    }
+  }
+
+  // Sends a Ping under the given retry-on-timeout policy and blocks for the
+  // final status.
+  Status PingWithRetryOnTimeout(int64_t timeout_ms, int64_t per_attempt_timeout_ms) {
+    std::promise<Status> promise;
+    retryable_grpc_client_->CallMethod<TestService, PingRequest, PingReply>(
+        &TestService::Stub::PrepareAsyncPing,
+        grpc_client_,
+        "TestService.grpc_client.Ping",
+        PingRequest(),
+        [&promise](const Status &status, PingReply &&reply) {
+          promise.set_value(status);
+        },
+        timeout_ms,
+        RetryableGrpcClient::RetryOnTimeoutPolicy{per_attempt_timeout_ms});
+    return promise.get_future().get();
+  }
+
+ protected:
+  // Server.
+  TestServiceHandler test_service_handler_;
+  instrumented_io_context handler_io_service_;
+  std::unique_ptr<std::thread> handler_io_service_thread_;
+  std::unique_ptr<GrpcServer> grpc_server_;
+  // Client.
+  instrumented_io_context client_io_service_;
+  std::unique_ptr<std::thread> client_thread_;
+  std::unique_ptr<ClientCallManager> client_call_manager_;
+  std::shared_ptr<GrpcClient<TestService>> grpc_client_;
+  std::shared_ptr<RetryableGrpcClient> retryable_grpc_client_;
+};
+
+TEST_F(RetryableGrpcClientTimeoutRetryFixture, RetriesTimedOutAttemptsUntilSuccess) {
+  // Freeze the handler so early attempts exceed their 500 ms per-attempt
+  // deadline, then unfreeze after ~1.5 s: a later attempt inside the 20 s
+  // overall budget must succeed. Without the policy the first DEADLINE_EXCEEDED
+  // would be final.
+  test_service_handler_.frozen = true;
+  std::thread unfreezer([this]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    test_service_handler_.frozen = false;
+  });
+  const Status status =
+      PingWithRetryOnTimeout(/*timeout_ms=*/20000, /*per_attempt_timeout_ms=*/500);
+  unfreezer.join();
+  ASSERT_TRUE(status.ok()) << status;
+  ASSERT_GE(test_service_handler_.request_count, 2);
+}
+
+TEST_F(RetryableGrpcClientTimeoutRetryFixture, DeliversTimedOutWhenBudgetExhausted) {
+  // Handler stays frozen: every attempt times out and the final status must be
+  // TimedOut, delivered no earlier than the overall budget.
+  test_service_handler_.frozen = true;
+  const auto start = std::chrono::steady_clock::now();
+  const Status status =
+      PingWithRetryOnTimeout(/*timeout_ms=*/1500, /*per_attempt_timeout_ms=*/400);
+  const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - start)
+                              .count();
+  ASSERT_TRUE(status.IsTimedOut()) << status;
+  // Slightly under the 1500 ms budget to tolerate clock-source skew between
+  // the test's steady_clock and the client's absl::Now deadline.
+  ASSERT_GE(elapsed_ms, 1400);
+}
+
+}  // namespace rpc
+}  // namespace ray


### PR DESCRIPTION
## Why are these changes needed?

A `DEADLINE_EXCEEDED` on the cluster-ID fetch maps to `TimedOut`, which `IsGrpcRetryableStatus` deliberately never retries (that predicate feeds an unbounded retry queue). The fetch was a single all-or-nothing RPC with the whole connect budget as its deadline (30s on the Python standalone client path), so one deadline spent queueing on a GCS busy with a node registration storm was fatal to the connecting process — observed as fleet-wide bring-up deaths at 400 nodes on Ray 2.56.

**Fix: generalize the existing retry infrastructure instead of adding a bespoke loop.** `RetryableGrpcClient::CallMethod` gains an opt-in per-call `RetryOnTimeoutPolicy`:

- Each attempt gets a bounded per-attempt deadline, clamped to an **absolute overall deadline** derived from the call's `timeout_ms` — so retries can never exceed the caller's budget.
- A timed-out attempt is re-sent after a **full-jitter exponential backoff** delay (uniform in `[0, min(100ms·2^attempt, 2s)]`). Jitter is the point: hundreds of clients that timed out on the same overloaded server at the same moment must not re-fire in lockstep.
- Non-timeout errors keep the existing semantics (UNAVAILABLE/UNKNOWN → reconnect queue; everything else fails fast). Calls without the policy are unchanged.

`GcsRpcClient::GetClusterId` is the only opt-in (hand-written instead of the `VOID_GCS_RPC_CLIENT_METHOD` macro to attach the policy), with per-attempt deadline `gcs_rpc_server_connect_timeout_s`. `GcsClient::FetchClusterId` shrinks back to a single sync call; it now `RAY_CHECK`s a non-positive budget instead of silently normalizing it (an invalid budget is an operator error and should fail loudly), and its final-failure `Disconnect()` behavior is unchanged. With the C++ default 5s budget this stays effectively a single attempt; the Python 30s budget becomes ~6 chances to land in a queue gap.

An earlier revision implemented this as a hand-rolled attempt-counting loop inside `FetchClusterId` with a test-only virtual seam; this revision replaces that with the per-call policy in `RetryableGrpcClient` so there is one retry mechanism, it is reusable, and it adds jitter.

Companion PR (server-side half of the same incident, independently mergeable/revertable): #64845.

## Related issue number

None found — searched open PRs/issues for GetClusterId / connect retry before opening. Not a duplicate of in-flight work.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit on the changed files.
- [x] Testing strategy — new `//src/ray/rpc/tests:retryable_grpc_client_test` exercises the policy against a real gRPC server with a freezable handler: `RetriesTimedOutAttemptsUntilSuccess` (attempts time out while frozen; a later attempt succeeds after unfreeze; ≥2 requests observed server-side) and `DeliversTimedOutWhenBudgetExhausted` (handler stays frozen; final status is TimedOut, delivered no earlier than the overall budget). Ran locally (macOS, `--dynamic_mode=off`): passes, along with `//src/ray/gcs_rpc_client/tests:gcs_client_test`, `gcs_client_reconnection_test`, `gcs_client_injectable_test`, `accessor_test`. (`global_state_accessor_test` fails on my machine because it hardcodes port 6379, which a local redis service occupies — pre-existing, unrelated.)

Per the repo's AI contribution policy: AI assistance was used to develop this change; every changed line was reviewed and the tests above were run locally.