### PR TITLE
[core] clarify KubeRay autoscaler restartPolicy requirement

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.md
+++ b/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.md
@@ -252,6 +252,14 @@ The [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1
 
 * **`enableInTreeAutoscaling`**: By setting `enableInTreeAutoscaling: true`, the KubeRay operator automatically configures an autoscaling sidecar container for the Ray head Pod.
 * **`minReplicas` / `maxReplicas` / `replicas`**: Set the `minReplicas` and `maxReplicas` fields to define the range for `replicas` in an autoscaling `workerGroup`. Typically, you would initialize both `replicas` and `minReplicas` with the same value during the deployment of an autoscaling cluster. Subsequently, the Ray Autoscaler adjusts the `replicas` field as it adds or removes Pods from the cluster.
+* **`restartPolicy`**: Autoscaler V1 and V2 both require `restartPolicy: Never` on all worker groups.
+
+  ```yaml
+  workerGroupSpecs:
+  - template:
+      spec:
+        restartPolicy: Never
+  ```
 
 ### 2. Scale-up and scale-down speed
 


### PR DESCRIPTION
## Description

The current KubeRay autoscaler document already covers the `restartPolicy: Never` requirement for autoscaler v2, but that is also required for v1 as well, otherwise pods won't be able to be reclaimed by idle termination. This PR makes it clear.