### PR TITLE
[Chore] Disable gemini code review bot for draft PR

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -7,4 +7,5 @@ code_review:
     help: false
     summary: false
     code_review: true
+    include_drafts: false
 ignore_patterns: []


### PR DESCRIPTION
## Description

Disable the Gemini code review bot for draft PRs. It's unnecessary to review a PR while it's still in draft.

Doc: https://docs.cloud.google.com/gemini/docs/code-review/customize-repo-review#schema

## Related issues
N/A

## Additional information
