### PR TITLE
[Core] Debug test_task_metric to patch TTL env var instead of passing in system config

### DIFF
--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -11,12 +11,6 @@ from ray._common.test_utils import (
 )
 from ray._private.test_utils import run_string_as_driver_nonblocking
 
-METRIC_CONFIG = {
-    "_system_config": {
-        "metrics_report_interval_ms": 100,
-    }
-}
-
 
 def raw_metrics(info):
     metrics_page = build_address("localhost", info["metrics_export_port"])
@@ -40,8 +34,9 @@ def resources_by_state(info) -> dict:
         return {}
 
 
-def test_resources_metrics(shutdown_only):
-    info = ray.init(num_cpus=4, num_gpus=2, resources={"a": 3}, **METRIC_CONFIG)
+def test_resources_metrics(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=4, num_gpus=2, resources={"a": 3})
 
     driver = """
 import ray

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -11,15 +11,10 @@ from ray._common.test_utils import (
 )
 from ray._private.test_utils import raw_metric_timeseries
 
-METRIC_CONFIG = {
-    "_system_config": {
-        "metrics_report_interval_ms": 100,
-    }
-}
 
-
-def test_unintentional_worker_failures_metric(shutdown_only):
-    context = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_unintentional_worker_failures_metric(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    context = ray.init(num_cpus=2)
 
     @ray.remote
     class Actor:

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -18,12 +18,6 @@ from ray._private.test_utils import (
     wait_for_dashboard_agent_available,
 )
 
-SLOW_METRIC_CONFIG = {
-    "_system_config": {
-        "metrics_report_interval_ms": 3000,
-    }
-}
-
 
 def tasks_by_state(info, timeseries: PrometheusTimeseries, flush: bool = False) -> dict:
     if flush:
@@ -666,10 +660,10 @@ ray.get([a.f.remote() for _ in range(40)])
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
-def test_metrics_export_now(shutdown_only, ray_start_cluster):
+def test_metrics_export_now(monkeypatch, shutdown_only, ray_start_cluster):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "3000")
     cluster = ray_start_cluster
     cluster.add_node(
-        **SLOW_METRIC_CONFIG,
         num_cpus=2,
     )
     wait_for_dashboard_agent_available(cluster)

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -1,4 +1,3 @@
-import copy
 import multiprocessing
 import sys
 from collections import defaultdict
@@ -18,12 +17,6 @@ from ray._private.test_utils import (
     wait_for_assertion,
     wait_for_dashboard_agent_available,
 )
-
-METRIC_CONFIG = {
-    "_system_config": {
-        "metrics_report_interval_ms": 100,
-    }
-}
 
 SLOW_METRIC_CONFIG = {
     "_system_config": {
@@ -69,8 +62,9 @@ def tasks_breakdown(info, key_fn, timeseries: PrometheusTimeseries) -> dict:
 
 # TODO(ekl) in all these tests, we use run_string_as_driver_nonblocking to work around
 # stats reporting issues if Ray is repeatedly restarted in unit tests.
-def test_task_basic(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_basic(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
 
     driver = """
 import time
@@ -119,7 +113,7 @@ ray.get(refs + [c.remote() for _ in range(8)])
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
-def test_task_custom_name_metrics(shutdown_only):
+def test_task_custom_name_metrics(monkeypatch, shutdown_only):
     """Verify that custom task names set via .options(name=...) are used in metrics.
 
     This tests that RUNNING tasks use the custom name consistently with
@@ -127,7 +121,8 @@ def test_task_custom_name_metrics(shutdown_only):
     the function name (FunctionDescriptor->CallString()) but FINISHED/FAILED used
     the custom name (TaskSpec::GetName()).
     """
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
 
     driver = """
 import ray
@@ -172,8 +167,9 @@ ray.get(a)
     proc.kill()
 
 
-def test_task_job_ids(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_job_ids(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -214,8 +210,9 @@ ray.get(a)
         proc.kill()
 
 
-def test_task_nested(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_nested(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -267,8 +264,9 @@ ray.get(w)
     proc.kill()
 
 
-def test_task_nested_wait(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_nested_wait(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -370,8 +368,9 @@ def test_task_fetch_args(ray_start_cluster):
     assert p.exitcode == 0
 
 
-def test_task_wait_on_deps(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_wait_on_deps(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -408,8 +407,9 @@ ray.get(a)
     proc.kill()
 
 
-def test_actor_tasks_queued(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_actor_tasks_queued(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -446,8 +446,9 @@ ray.get(z)
     proc.kill()
 
 
-def test_task_finish(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_finish(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -485,8 +486,9 @@ time.sleep(999)
     proc.kill()
 
 
-def test_task_retry(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_retry(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -538,8 +540,9 @@ time.sleep(999)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows. Timing out.")
-def test_actor_task_retry(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_actor_task_retry(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -592,8 +595,9 @@ time.sleep(999)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
-def test_task_failure(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_task_failure(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -628,8 +632,9 @@ time.sleep(999)
     proc.kill()
 
 
-def test_concurrent_actor_tasks(shutdown_only):
-    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+def test_concurrent_actor_tasks(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -702,8 +707,9 @@ ray.get(a)
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on macos")
-def test_pull_manager_stats(shutdown_only):
-    info = ray.init(num_cpus=2, object_store_memory=100_000_000, **METRIC_CONFIG)
+def test_pull_manager_stats(monkeypatch, shutdown_only):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2, object_store_memory=100_000_000)
     timeseries = PrometheusTimeseries()
     driver = """
 import ray
@@ -770,7 +776,8 @@ def test_stale_view_cleanup_when_job_exits(monkeypatch, shutdown_only):
     timeseries = PrometheusTimeseries()
     with monkeypatch.context() as m:
         m.setenv(RAY_WORKER_TIMEOUT_S, 5)
-        info = ray.init(num_cpus=2, **METRIC_CONFIG)
+        m.setenv("RAY_metrics_report_interval_ms", "100")
+        info = ray.init(num_cpus=2)
         print(info)
 
         driver = """
@@ -788,6 +795,7 @@ ray.get(g.remote())
     """
 
         proc = run_string_as_driver_nonblocking(driver)
+        print(f"Process pid: {proc.pid} is running.")
         expected = {
             "RUNNING": 1.0,
         }
@@ -808,11 +816,10 @@ ray.get(g.remote())
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows. Timing out.")
-def test_metrics_batch(shutdown_only):
+def test_metrics_batch(monkeypatch, shutdown_only):
     """Verify metrics_report_batch_size works correctly without data loss."""
-    config_copy = copy.deepcopy(METRIC_CONFIG)
-    config_copy["_system_config"].update({"metrics_report_batch_size": 1})
-    info = ray.init(num_cpus=2, **config_copy)
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
+    info = ray.init(num_cpus=2, _system_config={"metrics_report_batch_size": 1})
     timeseries = PrometheusTimeseries()
     driver = """
 import ray

--- a/python/ray/tests/test_task_metrics_reconstruction.py
+++ b/python/ray/tests/test_task_metrics_reconstruction.py
@@ -8,19 +8,19 @@ from ray._common.test_utils import (
     PrometheusTimeseries,
     wait_for_condition,
 )
-from ray.tests.test_task_metrics import METRIC_CONFIG, tasks_by_all
+from ray.tests.test_task_metrics import tasks_by_all
 
 
 # Copied from similar test in test_reconstruction_2.py.
 @pytest.mark.skipif(sys.platform == "win32", reason="No multi-node on Windows.")
-def test_task_reconstruction(ray_start_cluster):
+def test_task_reconstruction(monkeypatch, ray_start_cluster):
+    monkeypatch.setenv("RAY_metrics_report_interval_ms", "100")
     timeseries = PrometheusTimeseries()
     cluster = ray_start_cluster
 
     # Head node with no resources.
     cluster.add_node(
         num_cpus=0,
-        **METRIC_CONFIG,
     )
     info = ray.init(address=cluster.address)
 


### PR DESCRIPTION
## Description
`test_task_metrics` is currently failing premerg on master due to `test_stale_view_cleanup_when_job_exits` timeout. The issue was related to our recent change in https://github.com/ray-project/ray/pull/64633/changes where guage metrics are now cleared via TTL instead of each time we query the prometheus endpoint. By changing to this new scheme, a failed job's task metrics will only be cleared when the TTL expires. Unfortunately, the default evaluated TTL value is the same length as the timeout of the test, causing the test to timeout waiting for the metrics to be cleared. 

The original test attempt to take care of this issue by passing in a custom system config with a shorter TTL. However, the system config is only passed to the raylet. All other processes on the host will still read from the env var. Thus we patch the env var instead.

## Related issues

## Additional information
