### PR TITLE
docs: Fix minor typos (compatability, initalize)

### DIFF
--- a/python/ray/_common/signature.py
+++ b/python/ray/_common/signature.py
@@ -24,7 +24,7 @@ def get_signature(func: Any) -> inspect.Signature:
     it is relatively stable. Future versions of Python may allow overloading
     the inspect 'isfunction' and 'ismethod' functions / create ABC for Python
     functions. Until then, it appears that Cython won't do anything about
-    compatability with the inspect module.
+    compatibility with the inspect module.
 
     Args:
         func: The function whose signature should be checked.

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -157,7 +157,7 @@ def test_default_config(shutdown_only):
     )
     ray.shutdown()
 
-    # Make sure config is not initalized if spilling is not enabled..
+    # Make sure config is not initialized if spilling is not enabled..
     ray.init(
         num_cpus=0,
         object_store_memory=75 * 1024 * 1024,

--- a/rllib/core/models/catalog.py
+++ b/rllib/core/models/catalog.py
@@ -284,7 +284,7 @@ class Catalog:
             # TODO (Artur): Maybe check for original spaces here
             # input_space is a 1D Box
             if isinstance(observation_space, Box) and len(observation_space.shape) == 1:
-                # In order to guarantee backward compatability with old configs,
+                # In order to guarantee backward compatibility with old configs,
                 # we need to check if no latent dim was set and simply reuse the last
                 # fcnet hidden dim for that purpose.
                 hidden_layer_dims = model_config_dict["fcnet_hiddens"][:-1]


### PR DESCRIPTION
Fixes minor typos in comments across the python and rllib packages.