### PR TITLE
[serve] Deflake `test_metrics_*` timeouts

### DIFF
--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -550,7 +550,9 @@ def test_proxy_disconnect_http_metrics(metrics_start_shutdown):
     conn.close()  # Forcefully close the connection
     ray.get(signal.send.remote(clear=True))
 
-    num_errors = get_metric_dictionaries("ray_serve_num_http_error_requests_total")
+    num_errors = get_metric_dictionaries(
+        "ray_serve_num_http_error_requests_total", timeout=60
+    )
     assert len(num_errors) == 1
     assert num_errors[0]["route"] == "/disconnect"
     assert num_errors[0]["error_code"] == "499"
@@ -602,7 +604,9 @@ def test_proxy_disconnect_grpc_metrics(metrics_start_shutdown):
     thread.join()
     ray.get(signal.send.remote(clear=True))
 
-    num_errors = get_metric_dictionaries("ray_serve_num_grpc_error_requests_total")
+    num_errors = get_metric_dictionaries(
+        "ray_serve_num_grpc_error_requests_total", timeout=60
+    )
     assert len(num_errors) == 1
     assert num_errors[0]["route"] == "disconnect"
     assert num_errors[0]["error_code"] == grpc.StatusCode.CANCELLED.name
@@ -1016,14 +1020,18 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
 
     handle = serve.run(SlowDeployment.bind(), name="app1", route_prefix="/slow")
 
-    futures = [handle.remote() for _ in range(2)]
+    # Submit the second request only after the first reaches the replica, else
+    # the router can dispatch both before either's queue-length update lands.
+    first = handle.remote()
     wait_for_condition(
         lambda: ray.get(signal.cur_num_waiters.remote()) == 1, timeout=10
     )
+    second = handle.remote()
 
     time.sleep(0.5)
     ray.get(signal.send.remote())
-    [f.result() for f in futures]
+    first.result()
+    second.result()
 
     timeseries = PrometheusTimeseries()
 
@@ -1112,7 +1120,7 @@ def test_router_queue_len_metric(metrics_start_shutdown):
 
         wait_for_condition(
             check_metric_float_eq,
-            timeout=15,
+            timeout=30,
             metric="ray_serve_request_router_queue_len",
             expected=1,
             expected_tags={"deployment": "TestDeployment", "application": "app1"},
@@ -1485,7 +1493,7 @@ def _check_controller_high_cardinality_metric_tags(include_high_cardinality: boo
         return True
 
     try:
-        wait_for_condition(check_controller_metric_tags, timeout=60)
+        wait_for_condition(check_controller_metric_tags, timeout=120)
     finally:
         ray.get(signal.send.remote())
 
@@ -1612,7 +1620,7 @@ def test_routing_stats_error_metric(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_exception_error_metric, timeout=30)
+    wait_for_condition(check_exception_error_metric, timeout=60)
     print("Exception error metric verified.")
 
     # Now test timeout case
@@ -1638,7 +1646,7 @@ def test_routing_stats_error_metric(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_timeout_error_metric, timeout=30)
+    wait_for_condition(check_timeout_error_metric, timeout=60)
     print("Timeout error metric verified.")
 
     ray.get(signal.send.remote(clear=True))

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -653,7 +653,7 @@ class TestRequestContextMetrics:
                 ),
             )
             == 1,
-            timeout=40,
+            timeout=60,
         )
 
         counter_metrics = get_metric_dictionaries(
@@ -702,6 +702,7 @@ class TestHandleMetrics:
             caller.call.remote()
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=30,
                 metric_name="ray_serve_deployment_queued_queries",
                 tags={"application": "app1"},
                 expected=i + 1,
@@ -712,6 +713,7 @@ class TestHandleMetrics:
         ray.get(signal.send.remote())
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=0,
@@ -726,6 +728,7 @@ class TestHandleMetrics:
         call.remote("WaitForSignal", "app1")
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=0,
@@ -735,6 +738,7 @@ class TestHandleMetrics:
         call.remote("WaitForSignal", "app1")
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=1,
@@ -744,6 +748,7 @@ class TestHandleMetrics:
         call.remote("WaitForSignal", "app1")
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=2,
@@ -753,6 +758,7 @@ class TestHandleMetrics:
         ray.get(signal.send.remote())
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=0,
@@ -779,7 +785,7 @@ class TestHandleMetrics:
         timeseries = PrometheusTimeseries()
         wait_for_condition(
             check_metric_float_eq,
-            timeout=15,
+            timeout=30,
             metric="ray_serve_num_scheduling_tasks",
             # Router is eagerly created on HTTP proxy, so there are metrics emitted
             # from proxy router
@@ -794,7 +800,7 @@ class TestHandleMetrics:
         print("ray_serve_num_scheduling_tasks updated successfully.")
         wait_for_condition(
             check_metric_float_eq,
-            timeout=15,
+            timeout=30,
             metric="ray_serve_num_scheduling_tasks_in_backoff",
             # Router is eagerly created on HTTP proxy, so there are metrics emitted
             # from proxy router
@@ -823,7 +829,7 @@ class TestHandleMetrics:
         print("First request is executing.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=1,
             timeseries=timeseries,
@@ -837,7 +843,7 @@ class TestHandleMetrics:
         # First request should be processing. All others should be queued.
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             expected=num_queued_requests,
             timeseries=timeseries,
@@ -845,7 +851,7 @@ class TestHandleMetrics:
         print("ray_serve_deployment_queued_queries updated successfully.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=num_queued_requests + 1,
             timeseries=timeseries,
@@ -856,7 +862,7 @@ class TestHandleMetrics:
         # 2 = 2 * 1 replica) that are attempting to schedule the hanging requests.
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_scheduling_tasks",
             expected=2,
             timeseries=timeseries,
@@ -864,7 +870,7 @@ class TestHandleMetrics:
         print("ray_serve_num_scheduling_tasks updated successfully.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_scheduling_tasks_in_backoff",
             expected=2,
             timeseries=timeseries,
@@ -878,7 +884,7 @@ class TestHandleMetrics:
 
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_deployment_queued_queries",
             expected=0,
             timeseries=timeseries,
@@ -888,7 +894,7 @@ class TestHandleMetrics:
         # Task should get cancelled.
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=0,
             timeseries=timeseries,
@@ -897,7 +903,7 @@ class TestHandleMetrics:
 
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_scheduling_tasks",
             expected=0,
             timeseries=timeseries,
@@ -905,7 +911,7 @@ class TestHandleMetrics:
         print("ray_serve_num_scheduling_tasks updated successfully.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=30,
             metric_name="ray_serve_num_scheduling_tasks_in_backoff",
             expected=0,
             timeseries=timeseries,
@@ -947,6 +953,7 @@ class TestHandleMetrics:
 
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=30,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "d1"},
                 expected=requests_sent[1],
@@ -955,6 +962,7 @@ class TestHandleMetrics:
 
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=30,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "d2"},
                 expected=requests_sent[2],
@@ -963,6 +971,7 @@ class TestHandleMetrics:
 
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=30,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "Router"},
                 expected=i + 1,
@@ -973,6 +982,7 @@ class TestHandleMetrics:
         ray.get(signal.send.remote())
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=30,
             metric_name="ray_serve_num_ongoing_requests_at_replicas",
             tags={"application": "app1"},
             expected=0,
@@ -1017,6 +1027,7 @@ class TestProxyStateMetrics:
 
         wait_for_condition(
             check_metric_float_eq,
+            timeout=30,
             metric="ray_serve_proxy_status",
             expected=2,
             timeseries=timeseries,

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -764,6 +764,7 @@ def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
             "ray_serve_user_autoscaling_stats_latency_ms_sum",
             expected_tags=base_tags,
             timeseries=timeseries,
+            timeout=5,
         )
         if value >= 0:
             # Verify replica tag exists
@@ -785,7 +786,7 @@ def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
                     return True
         return False
 
-    wait_for_condition(check_user_stats_latency_metric, timeout=15)
+    wait_for_condition(check_user_stats_latency_metric, timeout=60)
     print("User autoscaling stats latency metric verified.")
 
 
@@ -1099,7 +1100,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_proxy_main_loop_metrics, timeout=30)
+    wait_for_condition(check_proxy_main_loop_metrics, timeout=60)
     print("Proxy main loop monitoring metrics verified.")
 
     # Test 1a: Check proxy router loop metrics
@@ -1118,7 +1119,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
         return False
 
     if RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP:
-        wait_for_condition(check_proxy_router_loop_metrics, timeout=30)
+        wait_for_condition(check_proxy_router_loop_metrics, timeout=60)
         print("Proxy router loop monitoring metrics verified.")
     else:
         print("Proxy router loop monitoring metrics not verified.")
@@ -1143,7 +1144,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_replica_main_loop_metrics, timeout=30)
+    wait_for_condition(check_replica_main_loop_metrics, timeout=60)
     print("Replica main loop monitoring metrics verified.")
 
     # Test 3: Check replica user_code loop metrics (enabled by default)
@@ -1167,7 +1168,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
         return False
 
     if RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD:
-        wait_for_condition(check_replica_user_code_loop_metrics, timeout=30)
+        wait_for_condition(check_replica_user_code_loop_metrics, timeout=60)
         print("Replica user_code loop monitoring metrics verified.")
     else:
         print("Replica user_code loop monitoring metrics not verified.")
@@ -1188,7 +1189,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
         return False
 
     if RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP:
-        wait_for_condition(check_router_loop_metrics, timeout=30)
+        wait_for_condition(check_router_loop_metrics, timeout=60)
         print("Router loop monitoring metrics verified.")
     else:
         print("Router loop monitoring metrics not verified.")
@@ -1221,7 +1222,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             expected_pairs.add(("proxy", "router"))
         return expected_pairs.issubset(component_loop_pairs)
 
-    wait_for_condition(check_scheduling_latency_metric, timeout=30)
+    wait_for_condition(check_scheduling_latency_metric, timeout=60)
     print("Scheduling latency histogram metrics verified.")
 
     # Test 6: Check that tasks gauge exists
@@ -1251,7 +1252,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             expected_pairs.add(("proxy", "router"))
         return expected_pairs.issubset(component_loop_pairs)
 
-    wait_for_condition(check_tasks_gauge_metric, timeout=30)
+    wait_for_condition(check_tasks_gauge_metric, timeout=60)
     print("Event loop tasks gauge metrics verified.")
 
 

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -535,7 +535,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
     # Test 1: Check that target_replicas metric is 5 (10 requests / target_ongoing_requests=2)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=30,
         metric="ray_serve_autoscaling_target_replicas",
         expected=5,
         expected_tags=base_tags,


### PR DESCRIPTION
## Summary
`test_user_autoscaling_stats_metrics` and `test_event_loop_monitoring_metrics` flaked in postmerge CI with `wait_for_condition` timeout errors. The same nested-timeout-budget pattern was then found across `test_metrics.py` and `test_metrics_2.py` too.

**Root cause**
- This CI step runs 3 test shards concurrently on one host (`--parallelism-per-worker 3`, no CPU limit). Most failures are outer `wait_for_condition` timeouts too tight for that contention — some via a nested-budget bug (an inner fetch's own timeout meets or exceeds the outer timeout, so one slow attempt burns the whole retry budget).
- One failure (`test_queue_wait_time_metric`) was **not** a timing issue — a genuine race where two simultaneous requests could both get dispatched by the router before either's queue-length cache update committed.

## Fix
- `test_metrics_3.py`: `get_metric_float(..., timeout=5)`; `wait_for_condition` timeouts 15s/30s→60s.
- `test_metrics_2.py`: all 19 `check_sum_metric_eq` call sites given `timeout=30`; 3 `check_metric_float_eq` nested-budget fixes; `test_serve_metrics_outside_serve` 40s→60s.
- `test_metrics.py`
  - `check_metric_float_eq` nested-budget fix in `test_router_queue_len_metric`
  - `test_controller_high_cardinality_metric_tags` 60s→120s (60s was already confirmed insufficient)
  -  `test_routing_stats_error_metric` 30s→60s
  - Explicit `timeout=60` added to two previously-bare `get_metric_dictionaries` calls
  - `test_queue_wait_time_metric` fixed by serializing two request submissions instead of changing any timeout.

## Alternatives considered
- Reduce CI parallelism / bigger instance: broad blast radius across the whole `serve_python_tests` step.
- Bump bazel `size`: no-op, already medium with explicit long timeout, and `size` doesn't reserve CPU regardless of level.

## Test plan
- [ ] Run premerge CI 3 times and all of them should pass.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
