### PR TITLE
[serve] Coalesce health check and routing-stats pull into one RPC

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1719,7 +1719,19 @@ class ActorReplicaWrapper:
 
         if self._should_start_new_health_check():
             self._last_health_check_time = time.time()
-            self._health_check_ref = self._actor_handle.check_health.remote()
+            if self._should_record_routing_stats():
+                # Task submission dominates a probe's controller-side cost, so
+                # coalesce both probes into one RPC when both are due. The shared
+                # ref resolves each probe's slot independently; if the health
+                # check fails, the stats side sees the same error (stats really
+                # were not retrieved).
+                self._last_record_routing_stats_time = self._last_health_check_time
+                self._health_check_ref = (
+                    self._actor_handle.check_health_and_record_routing_stats.remote()
+                )
+                self._record_routing_stats_ref = self._health_check_ref
+            else:
+                self._health_check_ref = self._actor_handle.check_health.remote()
 
         return self._healthy
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2164,6 +2164,11 @@ class Replica:
             logger.warning("Replica record routing stats failed.")
             raise e from None
 
+    async def check_health_and_record_routing_stats(self) -> Dict[str, Any]:
+        """Both probes in one RPC; a health failure raises and drops the stats."""
+        await self.check_health()
+        return await self.record_routing_stats()
+
     @property
     def max_queued_requests(self) -> int:
         return self._deployment_config.max_queued_requests
@@ -3287,6 +3292,9 @@ class ReplicaActor:
 
     async def record_routing_stats(self) -> Dict[str, Any]:
         return await self._replica_impl.record_routing_stats()
+
+    async def check_health_and_record_routing_stats(self) -> Dict[str, Any]:
+        return await self._replica_impl.check_health_and_record_routing_stats()
 
     async def reconfigure(
         self, deployment_config, rank: ReplicaRank, route_prefix: Optional[str] = None

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1,10 +1,12 @@
 import sys
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+import ray.serve._private.deployment_state as ds_mod
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray._raylet import NodeID
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
@@ -9767,3 +9769,75 @@ def test_ingress_membership_version_ignores_non_ingress_deployment(
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestCombinedHealthRoutingProbe:
+    """When the health check and routing-stats pull are due together, one RPC covers
+    both; each probe's slot still resolves independently off the shared ref."""
+
+    def _wrapper(self, has_stats_method=True):
+        w = ActorReplicaWrapper.__new__(ActorReplicaWrapper)
+        w._actor_handle = Mock()
+        w._actor_handle.check_health.remote.return_value = "health_ref"
+        w._actor_handle.check_health_and_record_routing_stats.remote.return_value = (
+            "combined_ref"
+        )
+        w._actor_handle.record_routing_stats.remote.return_value = "stats_ref"
+        w._has_user_routing_stats_method = has_stats_method
+        w._health_check_ref = None
+        w._record_routing_stats_ref = None
+        w._last_health_check_time = 0.0
+        w._last_record_routing_stats_time = 0.0
+        w._consecutive_health_check_failures = 0
+        w._healthy = True
+        w._routing_stats = {}
+        w._replica_id = "test_replica"
+        w._routing_stats_delay_histogram = Mock()
+        w._routing_stats_error_counter = Mock()
+        w._version = SimpleNamespace(
+            deployment_config=SimpleNamespace(
+                health_check_period_s=10.0,
+                request_router_config=SimpleNamespace(
+                    request_routing_stats_period_s=10.0,
+                    request_routing_stats_timeout_s=30.0,
+                ),
+            )
+        )
+        return w
+
+    def test_fires_single_combined_rpc_when_both_due(self, monkeypatch):
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: False)
+        w = self._wrapper()
+        assert w.check_health() is True
+        assert w._health_check_ref == "combined_ref"
+        assert w._record_routing_stats_ref == "combined_ref"
+        w._actor_handle.check_health_and_record_routing_stats.remote.assert_called_once()
+        w._actor_handle.check_health.remote.assert_not_called()
+        w._actor_handle.record_routing_stats.remote.assert_not_called()
+        # The stats side must not double-fire while the shared ref is in flight.
+        w.get_routing_stats()
+        w._actor_handle.record_routing_stats.remote.assert_not_called()
+
+    def test_solo_health_when_stats_probe_in_flight(self):
+        w = self._wrapper()
+        w._record_routing_stats_ref = "in_flight"
+        w.check_health()
+        assert w._health_check_ref == "health_ref"
+        w._actor_handle.check_health_and_record_routing_stats.remote.assert_not_called()
+
+    def test_solo_health_without_user_stats_method(self):
+        w = self._wrapper(has_stats_method=False)
+        w.check_health()
+        assert w._health_check_ref == "health_ref"
+        assert w._record_routing_stats_ref is None
+
+    def test_combined_ref_resolves_each_probe_independently(self, monkeypatch):
+        w = self._wrapper()
+        w.check_health()
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        monkeypatch.setattr(ds_mod.ray, "get", lambda r: {"queue": 1})
+        assert w.check_health() is True  # resolves the health slot
+        assert w._health_check_ref is None
+        assert w._record_routing_stats_ref == "combined_ref"  # stats slot untouched
+        assert w.get_routing_stats() == {"queue": 1}  # resolves the stats slot
+        assert w._record_routing_stats_ref is None


### PR DESCRIPTION
## Why are these changes needed?

For deployments that implement the `record_routing_stats()` hook, the controller
fires two actor RPCs per replica probe cycle: `check_health` and
`record_routing_stats`. Task submission dominates the controller-side cost of a
probe — ~465 µs per `.remote()` (measured; ~70% inside the Cython/C++ submit
path, GIL-held, so it cannot be batched or threaded away client-side). At the
default configuration both probes share the same 10 s period, so at scale they
are almost always due together, and the second submission is pure overhead on
the single-threaded control loop.

This PR coalesces the two probes into one RPC when both are due: the replica
gains `check_health_and_record_routing_stats()` (runs the health check, then
returns the routing stats; a health failure raises and drops the stats), and
the controller fires it instead of two separate calls. The shared `ObjectRef`
fills both probe slots and each slot still resolves independently — timeout
bookkeeping, failure counting, and retry behavior for each probe are unchanged.

Scope: this only affects deployments with a user-defined
`record_routing_stats` method (the custom request-router stats feature). For
such deployments it halves probe submissions in steady state, cutting
controller loop cost where per-replica reconcile work is the bottleneck.
Deployments without the hook never fire a routing-stats probe and are
completely unaffected. The solo paths are preserved for the cases where only
one probe is due (e.g. the periods are configured differently or the probes
are out of phase).
