### PR TITLE
[serve] Push-based replica health: replicas self-check and report over existing channels; pull probes become the fallback

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -822,6 +822,10 @@ class RequestMetadata:
     # Whether it is a direct ingress request
     is_direct_ingress: bool = False
 
+    # Whether the caller can consume ReplicaHealthFrame system messages
+    # interleaved on the response stream (unary rejection-protocol calls only).
+    supports_health_frames: bool = False
+
     # By reference or value
     _by_reference: bool = True
     _on_separate_loop: bool = True
@@ -902,6 +906,19 @@ class TargetCapacityDirection(str, Enum):
 
     UP = "UP"
     DOWN = "DOWN"
+
+
+@dataclass(frozen=True)
+class ReplicaHealthFrame:
+    """Self-health system message a replica interleaves on an open response stream.
+
+    Lets long-running requests keep carrying fresh health to the router (which
+    folds it into its handle metric report) without any standalone RPC.
+    """
+
+    healthy: bool
+    health_checked_at: float
+    health_consecutive_failures: Optional[int] = None
 
 
 @dataclass(frozen=True)

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -926,6 +926,12 @@ class ReplicaQueueLengthInfo:
     accepted: bool
     num_ongoing_requests: int
     # Replica self-health piggyback (None = sender does not carry health).
+    # Whether this replica will interleave ReplicaHealthFrame messages on
+    # the response stream for this request. Lets the router skip arming a
+    # frame pump when health already rides reports (idle pumps at high
+    # fan-in cost real driver memory).
+    will_send_health_frames: bool = False
+
     healthy: Optional[bool] = None
     health_checked_at: Optional[float] = None
     health_consecutive_failures: Optional[int] = None

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from starlette.types import Scope
 
@@ -908,6 +908,10 @@ class TargetCapacityDirection(str, Enum):
 class ReplicaQueueLengthInfo:
     accepted: bool
     num_ongoing_requests: int
+    # Replica self-health piggyback (None = sender does not carry health).
+    healthy: Optional[bool] = None
+    health_checked_at: Optional[float] = None
+    health_consecutive_failures: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -1020,6 +1024,9 @@ class HandleMetricReport:
         str, Dict[str, TimeSeries]
     ]  # replica key = ReplicaID.to_full_id_str()
     timestamp: float
+    # Latest response-carried replica self-health, keyed by replica unique id:
+    # (checked_at, healthy, consecutive_failures).
+    replica_health: Optional[Dict[str, Tuple[float, bool, Optional[int]]]] = None
 
     @property
     def total_requests(self) -> float:

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1065,6 +1065,7 @@ class ReplicaMetricReport:
     # controller then falls back to pull probes).
     healthy: Optional[bool] = None
     health_checked_at: Optional[float] = None
+    health_consecutive_failures: Optional[int] = None
 
 
 @dataclass

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1061,6 +1061,10 @@ class ReplicaMetricReport:
     aggregated_metrics: Dict[str, float]
     metrics: Dict[str, TimeSeries]
     timestamp: float
+    # Replica-pushed self-health (None = sender does not push health; the
+    # controller then falls back to pull probes).
+    healthy: Optional[bool] = None
+    health_checked_at: Optional[float] = None
 
 
 @dataclass

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -400,17 +400,22 @@ class ServeController:
                 replica_metric_report.health_checked_at
                 or replica_metric_report.timestamp,
                 replica_metric_report.healthy,
+                replica_metric_report.health_consecutive_failures,
             )
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_metric_report
         )
 
     def record_replica_health(
-        self, replica_unique_id: str, checked_at: float, healthy: bool
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
     ):
         """Self-health heartbeat from replicas that do not push metric reports."""
         self._replica_health_push_registry.record(
-            replica_unique_id, checked_at, healthy
+            replica_unique_id, checked_at, healthy, consecutive_failures
         )
 
     def record_autoscaling_metrics_from_handle(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -61,6 +61,7 @@ from ray.serve._private.default_impl import (
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_state import (
     DeploymentStateManager,
+    ReplicaHealthPushRegistry,
 )
 from ray.serve._private.endpoint_state import EndpointState
 from ray.serve._private.exceptions import ExternalScalerDisabledError
@@ -254,6 +255,7 @@ class ServeController:
         ]
 
         self.autoscaling_state_manager = AutoscalingStateManager()
+        self._replica_health_push_registry = ReplicaHealthPushRegistry()
         self.deployment_state_manager = DeploymentStateManager(
             self.kv_store,
             self.long_poll_host,
@@ -261,6 +263,7 @@ class ServeController:
             get_all_live_placement_group_names(),
             self.cluster_node_info_cache,
             self.autoscaling_state_manager,
+            health_push_registry=self._replica_health_push_registry,
         )
 
         # Manage all applications' state
@@ -391,8 +394,23 @@ class ServeController:
         )
         # Track in health metrics
         self._health_metrics_tracker.record_replica_metrics_delay(latency_ms)
+        if replica_metric_report.healthy is not None:
+            self._replica_health_push_registry.record(
+                replica_metric_report.replica_id.unique_id,
+                replica_metric_report.health_checked_at
+                or replica_metric_report.timestamp,
+                replica_metric_report.healthy,
+            )
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_metric_report
+        )
+
+    def record_replica_health(
+        self, replica_unique_id: str, checked_at: float, healthy: bool
+    ):
+        """Self-health heartbeat from replicas that do not push metric reports."""
+        self._replica_health_push_registry.record(
+            replica_unique_id, checked_at, healthy
         )
 
     def record_autoscaling_metrics_from_handle(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -440,6 +440,15 @@ class ServeController:
         )
         # Track in health metrics
         self._health_metrics_tracker.record_handle_metrics_delay(latency_ms)
+        if handle_metric_report.replica_health:
+            for _rid, (
+                _checked_at,
+                _healthy,
+                _failures,
+            ) in handle_metric_report.replica_health.items():
+                self._replica_health_push_registry.record(
+                    _rid, _checked_at, _healthy, _failures
+                )
         self.autoscaling_state_manager.record_request_metrics_for_handle(
             handle_metric_report
         )

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -639,6 +639,14 @@ class ServeController:
             dsm_duration = time.time() - dsm_update_start_time
             self.dsm_update_duration_gauge_s.set(dsm_duration)
             self._health_metrics_tracker.record_dsm_update_duration(dsm_duration)
+            try:
+                _gs = self._replica_health_push_registry.gap_stats()
+                self._health_metrics_tracker.push_checks_recorded = _gs["count"]
+                self._health_metrics_tracker.push_check_gap_p50_s = _gs["p50_s"]
+                self._health_metrics_tracker.push_check_gap_p99_s = _gs["p99_s"]
+                self._health_metrics_tracker.push_check_gap_max_s = _gs["max_s"]
+            except Exception:
+                pass
             if not self.done_recovering_event.is_set() and not any_recovering:
                 self.done_recovering_event.set()
                 if num_loops > 0:

--- a/python/ray/serve/_private/controller_health_metrics_tracker.py
+++ b/python/ray/serve/_private/controller_health_metrics_tracker.py
@@ -50,6 +50,13 @@ class ControllerHealthMetricsTracker:
     num_control_loops: int = 0
     last_control_loop_time: float = 0.0
 
+    # Replica self-check intervals observed via health pushes (set by the
+    # controller loop from the push registry).
+    push_checks_recorded: int = 0
+    push_check_gap_p50_s: float = 0.0
+    push_check_gap_p99_s: float = 0.0
+    push_check_gap_max_s: float = 0.0
+
     def record_loop_duration(self, duration: float):
         self.loop_durations.append(duration)
 
@@ -145,4 +152,8 @@ class ControllerHealthMetricsTracker:
             handle_metrics_delay_ms=handle_delay_stats,
             replica_metrics_delay_ms=replica_delay_stats,
             process_memory_mb=process_memory_mb,
+            push_checks_recorded=self.push_checks_recorded,
+            push_check_gap_p50_s=self.push_check_gap_p50_s,
+            push_check_gap_p99_s=self.push_check_gap_p99_s,
+            push_check_gap_max_s=self.push_check_gap_max_s,
         )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -715,15 +715,27 @@ class ReplicaHealthPushRegistry:
     _PRUNE_MAX_AGE_S = 600.0
 
     def __init__(self):
-        self._state: Dict[str, Tuple[float, bool]] = {}
+        self._state: Dict[str, Tuple[float, bool, Optional[int]]] = {}
 
-    def record(self, replica_unique_id: str, checked_at: float, healthy: bool):
+    def record(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ):
         if len(self._state) > self._PRUNE_THRESHOLD:
             cutoff = time.time() - self._PRUNE_MAX_AGE_S
             self._state = {k: v for k, v in self._state.items() if v[0] >= cutoff}
-        self._state[replica_unique_id] = (checked_at, healthy)
+        self._state[replica_unique_id] = (
+            checked_at,
+            healthy,
+            consecutive_failures,
+        )
 
-    def get(self, replica_unique_id: str) -> Optional[Tuple[float, bool]]:
+    def get(
+        self, replica_unique_id: str
+    ) -> Optional[Tuple[float, bool, Optional[int]]]:
         return self._state.get(replica_unique_id)
 
 
@@ -816,8 +828,9 @@ class ActorReplicaWrapper:
         self._outbound_deployments: Optional[List[DeploymentID]] = None
 
         # Latest replica-pushed self-health, consumed by check_health().
-        self._pushed_health: Optional[Tuple[float, bool]] = None
+        self._pushed_health: Optional[Tuple[float, bool, Optional[int]]] = None
         self._last_consumed_push_ts: float = 0.0
+        self._last_push_consume_time: float = 0.0
 
         # Histogram to track routing stats delay from replica to controller
         self._routing_stats_delay_histogram = metrics.Histogram(
@@ -1654,6 +1667,12 @@ class ActorReplicaWrapper:
             # There's already an active health check.
             return False
 
+        # Pushed health is flowing -- probe only once it goes stale.
+        if time.time() - self._last_push_consume_time < max(
+            self.health_check_period_s * 1.5, 1.0
+        ):
+            return False
+
         # If there's no active health check, kick off another and reset
         # the timer if it's been long enough since the last health
         # check. Add some randomness to avoid synchronizing across all
@@ -1696,10 +1715,15 @@ class ActorReplicaWrapper:
         )
         return time_since_last > randomized_period
 
-    def record_pushed_health(self, checked_at: float, healthy: bool) -> None:
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ) -> None:
         """Stash the replica's latest pushed self-health observation."""
         if checked_at > self._last_consumed_push_ts:
-            self._pushed_health = (checked_at, healthy)
+            self._pushed_health = (checked_at, healthy, consecutive_failures)
 
     def _take_fresh_pushed_health(self) -> Optional[bool]:
         """Consume the pushed self-health observation, if fresh.
@@ -1709,14 +1733,16 @@ class ActorReplicaWrapper:
         """
         if self._pushed_health is None:
             return None
-        checked_at, healthy = self._pushed_health
+        checked_at, healthy, consecutive_failures = self._pushed_health
         self._pushed_health = None
         self._last_consumed_push_ts = checked_at
-        if time.time() - checked_at > self.health_check_period_s:
+        # Freshness window: 1.5x the period with a 1s floor -- push->ingest->
+        # consume latency must not flip sub-second periods onto the pull path
+        # (two interleaved observers would double-count flaky checks).
+        if time.time() - checked_at > max(self.health_check_period_s * 1.5, 1.0):
             return None
-        if healthy:
-            self._last_health_check_time = time.time()
-        return healthy
+        self._last_push_consume_time = time.time()
+        return healthy, consecutive_failures
 
     def check_health(self) -> bool:
         """Check if the actor is healthy.
@@ -1731,12 +1757,16 @@ class ActorReplicaWrapper:
         pushed = self._take_fresh_pushed_health()
         response: ReplicaHealthCheckResponse = self._check_active_health_check()
         if response is ReplicaHealthCheckResponse.NONE and pushed is not None:
-            # No pull probe resolved this tick; use the pushed observation.
-            response = (
-                ReplicaHealthCheckResponse.SUCCEEDED
-                if pushed
-                else ReplicaHealthCheckResponse.APP_FAILURE
-            )
+            # No pull probe resolved this tick; use the pushed observation. The
+            # replica reports its own consecutive-failure count, so mirror it
+            # (robust to dropped/coalesced pushes) before the standard handling.
+            pushed_healthy, pushed_failures = pushed
+            if pushed_healthy:
+                response = ReplicaHealthCheckResponse.SUCCEEDED
+            else:
+                if pushed_failures is not None:
+                    self._consecutive_health_check_failures = pushed_failures - 1
+                response = ReplicaHealthCheckResponse.APP_FAILURE
         if response is ReplicaHealthCheckResponse.NONE:
             # No info; don't update replica health.
             pass
@@ -2124,9 +2154,14 @@ class DeploymentReplica:
             self._actor.force_stop()
         return False
 
-    def record_pushed_health(self, checked_at: float, healthy: bool) -> None:
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ) -> None:
         """Stash the replica's pushed self-health for the next health check."""
-        self._actor.record_pushed_health(checked_at, healthy)
+        self._actor.record_pushed_health(checked_at, healthy, consecutive_failures)
 
     def check_health(self) -> bool:
         """Check if the replica is healthy.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -44,6 +44,7 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
+    DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_LATENCY_BUCKET_MS,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_PERIOD_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_TIMEOUT_S,
@@ -704,6 +705,11 @@ def print_verbose_scaling_log():
     logger.error(f"Scaling information\n{json.dumps(debug_info, indent=2)}")
 
 
+def _push_freshness_window_s(health_check_period_s: float) -> float:
+    """How long a pushed health result stays fresh enough to stand in for a probe."""
+    return max(health_check_period_s * 1.5, 1.0)
+
+
 class ReplicaHealthPushRegistry:
     """Latest self-health pushed by each replica, keyed by replica unique id.
 
@@ -715,6 +721,15 @@ class ReplicaHealthPushRegistry:
     _PRUNE_MAX_AGE_S = 600.0
     _GAP_BUCKET_S = 0.25
     _GAP_NBUCKETS = 240  # 60s range
+    # Most tracked replicas going stale at once is the signature of
+    # controller-side ingest lag, not mass replica failure. Deferring the pull
+    # fallback then avoids a probe storm that would deepen the lag and can
+    # cascade into false kills; the cap bounds it so a real mass outage still
+    # surfaces.
+    _STALL_MIN_TRACKED = 64
+    _STALL_STALE_FRACTION = 0.5
+    _STALL_MAX_DEFER_S = 120.0
+    _STALL_CHECK_TTL_S = 1.0
 
     def __init__(self):
         # replica_unique_id -> (checked_at, received_at, healthy, consecutive_failures)
@@ -724,6 +739,9 @@ class ReplicaHealthPushRegistry:
         self._gap_hist = [0] * self._GAP_NBUCKETS
         self._gap_count = 0
         self._gap_max_s = 0.0
+        self._stall_checked_at: float = 0.0
+        self._stall_flag: bool = False
+        self._stall_since: Optional[float] = None
 
     def record(
         self,
@@ -757,6 +775,44 @@ class ReplicaHealthPushRegistry:
         self, replica_unique_id: str
     ) -> Optional[Tuple[float, float, bool, Optional[int]]]:
         return self._state.get(replica_unique_id)
+
+    def stale_counts(self, freshness_window_s: float) -> Tuple[int, int]:
+        """(stale, total) tracked replicas whose last push arrived too long ago."""
+        cutoff = time.time() - freshness_window_s
+        stale = sum(1 for v in self._state.values() if v[1] < cutoff)
+        return stale, len(self._state)
+
+    def systemic_stall(self) -> bool:
+        """True while pushes for most tracked replicas are stale at once.
+
+        Cached for ~1s (called once per swept replica). Bounded by
+        _STALL_MAX_DEFER_S per episode so a genuine mass outage still falls
+        through to pull probes.
+        """
+        now = time.time()
+        if now - self._stall_checked_at > self._STALL_CHECK_TTL_S:
+            self._stall_checked_at = now
+            stale, total = self.stale_counts(
+                _push_freshness_window_s(DEFAULT_HEALTH_CHECK_PERIOD_S)
+            )
+            self._stall_flag = (
+                total >= self._STALL_MIN_TRACKED
+                and stale >= total * self._STALL_STALE_FRACTION
+            )
+            if not self._stall_flag:
+                self._stall_since = None
+            elif self._stall_since is None:
+                self._stall_since = now
+                logger.warning(
+                    f"Pushed health went stale for {stale}/{total} replicas at "
+                    "once; treating as controller-side ingest lag and deferring "
+                    f"fallback probes for up to {self._STALL_MAX_DEFER_S}s."
+                )
+        return (
+            self._stall_flag
+            and self._stall_since is not None
+            and time.time() - self._stall_since < self._STALL_MAX_DEFER_S
+        )
 
     def gap_stats(self) -> Dict[str, float]:
         """Percentiles of the replicas' actual self-check intervals."""
@@ -1709,8 +1765,8 @@ class ActorReplicaWrapper:
             return False
 
         # Pushed health is flowing -- probe only once it goes stale.
-        if time.time() - self._last_push_consume_time < max(
-            self.health_check_period_s * 1.5, 1.0
+        if time.time() - self._last_push_consume_time < _push_freshness_window_s(
+            self.health_check_period_s
         ):
             return False
 
@@ -1791,10 +1847,20 @@ class ActorReplicaWrapper:
         # consume latency must not flip sub-second periods onto the pull path
         # (two interleaved observers would double-count flaky checks). Measured
         # against the controller-clock arrival time, immune to replica clock skew.
-        if time.time() - received_at > max(self.health_check_period_s * 1.5, 1.0):
+        if time.time() - received_at > _push_freshness_window_s(
+            self.health_check_period_s
+        ):
             return None
         self._last_push_consume_time = time.time()
         return healthy, consecutive_failures
+
+    def defer_push_fallback_probe(self) -> None:
+        """Hold the push-staleness probe gate closed for another window.
+
+        Used when staleness is systemic (controller ingest lag): probing every
+        replica at once would amplify the lag and can cascade into false kills.
+        """
+        self._last_push_consume_time = time.time()
 
     def check_health(self) -> bool:
         """Check if the actor is healthy.
@@ -2224,6 +2290,9 @@ class DeploymentReplica:
         self._actor.record_pushed_health(
             checked_at, received_at, healthy, consecutive_failures
         )
+
+    def defer_push_fallback_probe(self) -> None:
+        self._actor.defer_push_fallback_probe()
 
     def check_health(self) -> bool:
         """Check if the replica is healthy.
@@ -4798,6 +4867,8 @@ class DeploymentState:
         """Hand the replica's latest pushed self-health to its wrapper."""
         if self._health_push_registry is None:
             return
+        if self._health_push_registry.systemic_stall():
+            replica.defer_push_fallback_probe()
         pushed = self._health_push_registry.get(replica.replica_id.unique_id)
         if pushed is not None:
             replica.record_pushed_health(*pushed)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -715,7 +715,8 @@ class ReplicaHealthPushRegistry:
     _PRUNE_MAX_AGE_S = 600.0
 
     def __init__(self):
-        self._state: Dict[str, Tuple[float, bool, Optional[int]]] = {}
+        # replica_unique_id -> (checked_at, received_at, healthy, consecutive_failures)
+        self._state: Dict[str, Tuple[float, float, bool, Optional[int]]] = {}
 
     def record(
         self,
@@ -724,18 +725,22 @@ class ReplicaHealthPushRegistry:
         healthy: bool,
         consecutive_failures: Optional[int] = None,
     ):
+        prev = self._state.get(replica_unique_id)
+        if prev is not None and checked_at <= prev[0]:
+            return  # A delayed report must not clobber a newer observation.
         if len(self._state) > self._PRUNE_THRESHOLD:
             cutoff = time.time() - self._PRUNE_MAX_AGE_S
             self._state = {k: v for k, v in self._state.items() if v[0] >= cutoff}
         self._state[replica_unique_id] = (
             checked_at,
+            time.time(),
             healthy,
             consecutive_failures,
         )
 
     def get(
         self, replica_unique_id: str
-    ) -> Optional[Tuple[float, bool, Optional[int]]]:
+    ) -> Optional[Tuple[float, float, bool, Optional[int]]]:
         return self._state.get(replica_unique_id)
 
 
@@ -828,7 +833,7 @@ class ActorReplicaWrapper:
         self._outbound_deployments: Optional[List[DeploymentID]] = None
 
         # Latest replica-pushed self-health, consumed by check_health().
-        self._pushed_health: Optional[Tuple[float, bool, Optional[int]]] = None
+        self._pushed_health: Optional[Tuple[float, float, bool, Optional[int]]] = None
         self._last_consumed_push_ts: float = 0.0
         self._last_push_consume_time: float = 0.0
 
@@ -1718,12 +1723,22 @@ class ActorReplicaWrapper:
     def record_pushed_health(
         self,
         checked_at: float,
+        received_at: float,
         healthy: bool,
         consecutive_failures: Optional[int] = None,
     ) -> None:
-        """Stash the replica's latest pushed self-health observation."""
+        """Stash the replica's latest pushed self-health observation.
+
+        checked_at is replica-clock (used only for ordering/dedupe);
+        received_at is controller-clock (used for freshness, immune to skew).
+        """
         if checked_at > self._last_consumed_push_ts:
-            self._pushed_health = (checked_at, healthy, consecutive_failures)
+            self._pushed_health = (
+                checked_at,
+                received_at,
+                healthy,
+                consecutive_failures,
+            )
 
     def _take_fresh_pushed_health(self) -> Optional[bool]:
         """Consume the pushed self-health observation, if fresh.
@@ -1733,13 +1748,14 @@ class ActorReplicaWrapper:
         """
         if self._pushed_health is None:
             return None
-        checked_at, healthy, consecutive_failures = self._pushed_health
+        checked_at, received_at, healthy, consecutive_failures = self._pushed_health
         self._pushed_health = None
         self._last_consumed_push_ts = checked_at
         # Freshness window: 1.5x the period with a 1s floor -- push->ingest->
         # consume latency must not flip sub-second periods onto the pull path
-        # (two interleaved observers would double-count flaky checks).
-        if time.time() - checked_at > max(self.health_check_period_s * 1.5, 1.0):
+        # (two interleaved observers would double-count flaky checks). Measured
+        # against the controller-clock arrival time, immune to replica clock skew.
+        if time.time() - received_at > max(self.health_check_period_s * 1.5, 1.0):
             return None
         self._last_push_consume_time = time.time()
         return healthy, consecutive_failures
@@ -1754,8 +1770,15 @@ class ActorReplicaWrapper:
             2) Determining the replica health based on the health check results.
             3) Kicking off a new health check if needed.
         """
-        pushed = self._take_fresh_pushed_health()
         response: ReplicaHealthCheckResponse = self._check_active_health_check()
+        # Consume the pushed observation only when no pull probe resolved this
+        # tick -- otherwise leave it stashed so a fresh push is never discarded
+        # in favor of an older in-flight probe result.
+        pushed = (
+            self._take_fresh_pushed_health()
+            if response is ReplicaHealthCheckResponse.NONE
+            else None
+        )
         if response is ReplicaHealthCheckResponse.NONE and pushed is not None:
             # No pull probe resolved this tick; use the pushed observation. The
             # replica reports its own consecutive-failure count, so mirror it
@@ -2157,11 +2180,14 @@ class DeploymentReplica:
     def record_pushed_health(
         self,
         checked_at: float,
+        received_at: float,
         healthy: bool,
         consecutive_failures: Optional[int] = None,
     ) -> None:
         """Stash the replica's pushed self-health for the next health check."""
-        self._actor.record_pushed_health(checked_at, healthy, consecutive_failures)
+        self._actor.record_pushed_health(
+            checked_at, received_at, healthy, consecutive_failures
+        )
 
     def check_health(self) -> bool:
         """Check if the replica is healthy.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,6 +10,8 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
+from functools import reduce
+from operator import xor
 from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 import ray
@@ -3035,6 +3037,7 @@ class DeploymentState:
         self._autoscaling_state_manager = autoscaling_state_manager
         self._health_push_registry = health_push_registry
         self._push_probes_deferred: bool = False
+        self._last_rank_membership_fingerprint: Optional[int] = None
         self._push_stall_since: Optional[float] = None
         self._push_stall_stale: int = 0
         self._push_stall_total: int = 0
@@ -4993,8 +4996,19 @@ class DeploymentState:
         # if we delay the rank reassignment, the rank system will be in an invalid state
         # for a longer period of time. Abrar made this decision because he is not confident
         # about how rollouts work in the deployment state machine.
+        self._maybe_check_rank_consistency()
+
+    def _maybe_check_rank_consistency(self) -> None:
+        """Run the rank-consistency pass only when replica membership changed.
+
+        The pass is O(N) with heavy constants (id lists, per-node grouping,
+        reassignment managers) and used to run on every control-loop tick in
+        steady state -- at 16K replicas it monopolized the controller loop and
+        starved metric-report ingest. Rank consistency can only be violated by
+        membership changes, so a cheap fingerprint gates it.
+        """
         active_replicas = self._replicas.get()
-        if (
+        if not (
             active_replicas
             and self._curr_status_info.status == DeploymentStatus.HEALTHY
             # Skip consistency check if there are STARTING replicas. During node
@@ -5003,14 +5017,23 @@ class DeploymentState:
             # with STARTING replicas causes "active keys without ranks" error.
             and self._replicas.count(states=[ReplicaState.STARTING]) == 0
         ):
-            replicas_to_reconfigure = (
-                self._rank_manager.check_rank_consistency_and_reassign_minimally(
-                    active_replicas,
-                )
+            return
+        fingerprint = reduce(
+            xor,
+            (hash(r.replica_id.unique_id) for r in active_replicas),
+            len(active_replicas),
+        )
+        if fingerprint == self._last_rank_membership_fingerprint:
+            return
+        replicas_to_reconfigure = (
+            self._rank_manager.check_rank_consistency_and_reassign_minimally(
+                active_replicas,
             )
+        )
 
-            # Reconfigure replicas that had their ranks reassigned
-            self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
+        # Reconfigure replicas that had their ranks reassigned
+        self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
+        self._last_rank_membership_fingerprint = fingerprint
 
     def _handle_deployment_actor_failed_health_check(
         self,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -704,6 +704,29 @@ def print_verbose_scaling_log():
     logger.error(f"Scaling information\n{json.dumps(debug_info, indent=2)}")
 
 
+class ReplicaHealthPushRegistry:
+    """Latest self-health pushed by each replica, keyed by replica unique id.
+
+    Written by the controller ingest path; consumed by the reconcile sweep. A
+    fresh healthy push lets the sweep skip firing a pull probe.
+    """
+
+    _PRUNE_THRESHOLD = 65536
+    _PRUNE_MAX_AGE_S = 600.0
+
+    def __init__(self):
+        self._state: Dict[str, Tuple[float, bool]] = {}
+
+    def record(self, replica_unique_id: str, checked_at: float, healthy: bool):
+        if len(self._state) > self._PRUNE_THRESHOLD:
+            cutoff = time.time() - self._PRUNE_MAX_AGE_S
+            self._state = {k: v for k, v in self._state.items() if v[0] >= cutoff}
+        self._state[replica_unique_id] = (checked_at, healthy)
+
+    def get(self, replica_unique_id: str) -> Optional[Tuple[float, bool]]:
+        return self._state.get(replica_unique_id)
+
+
 class ActorReplicaWrapper:
     """Wraps a Ray actor for a deployment replica.
 
@@ -791,6 +814,10 @@ class ActorReplicaWrapper:
 
         # Outbound deployments polling state
         self._outbound_deployments: Optional[List[DeploymentID]] = None
+
+        # Latest replica-pushed self-health, consumed by check_health().
+        self._pushed_health: Optional[Tuple[float, bool]] = None
+        self._last_consumed_push_ts: float = 0.0
 
         # Histogram to track routing stats delay from replica to controller
         self._routing_stats_delay_histogram = metrics.Histogram(
@@ -1669,6 +1696,28 @@ class ActorReplicaWrapper:
         )
         return time_since_last > randomized_period
 
+    def record_pushed_health(self, checked_at: float, healthy: bool) -> None:
+        """Stash the replica's latest pushed self-health observation."""
+        if checked_at > self._last_consumed_push_ts:
+            self._pushed_health = (checked_at, healthy)
+
+    def _take_fresh_pushed_health(self) -> Optional[bool]:
+        """Consume the pushed self-health observation, if fresh.
+
+        A fresh healthy observation defers the next pull probe; stale ones are
+        dropped so the pull path remains the fallback.
+        """
+        if self._pushed_health is None:
+            return None
+        checked_at, healthy = self._pushed_health
+        self._pushed_health = None
+        self._last_consumed_push_ts = checked_at
+        if time.time() - checked_at > self.health_check_period_s:
+            return None
+        if healthy:
+            self._last_health_check_time = time.time()
+        return healthy
+
     def check_health(self) -> bool:
         """Check if the actor is healthy.
 
@@ -1679,7 +1728,15 @@ class ActorReplicaWrapper:
             2) Determining the replica health based on the health check results.
             3) Kicking off a new health check if needed.
         """
+        pushed = self._take_fresh_pushed_health()
         response: ReplicaHealthCheckResponse = self._check_active_health_check()
+        if response is ReplicaHealthCheckResponse.NONE and pushed is not None:
+            # No pull probe resolved this tick; use the pushed observation.
+            response = (
+                ReplicaHealthCheckResponse.SUCCEEDED
+                if pushed
+                else ReplicaHealthCheckResponse.APP_FAILURE
+            )
         if response is ReplicaHealthCheckResponse.NONE:
             # No info; don't update replica health.
             pass
@@ -2066,6 +2123,10 @@ class DeploymentReplica:
             )
             self._actor.force_stop()
         return False
+
+    def record_pushed_health(self, checked_at: float, healthy: bool) -> None:
+        """Stash the replica's pushed self-health for the next health check."""
+        self._actor.record_pushed_health(checked_at, healthy)
 
     def check_health(self) -> bool:
         """Check if the replica is healthy.
@@ -2840,12 +2901,14 @@ class DeploymentState:
         deployment_scheduler: DeploymentScheduler,
         cluster_node_info_cache: ClusterNodeInfoCache,
         autoscaling_state_manager: AutoscalingStateManager,
+        health_push_registry: Optional[ReplicaHealthPushRegistry] = None,
     ):
         self._id = id
         self._long_poll_host: LongPollHost = long_poll_host
         self._deployment_scheduler = deployment_scheduler
         self._cluster_node_info_cache = cluster_node_info_cache
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._health_push_registry = health_push_registry
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
@@ -4634,6 +4697,14 @@ class DeploymentState:
         graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
         self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
 
+    def _apply_pushed_health(self, replica: "DeploymentReplica") -> None:
+        """Hand the replica's latest pushed self-health to its wrapper."""
+        if self._health_push_registry is None:
+            return
+        pushed = self._health_push_registry.get(replica.replica_id.unique_id)
+        if pushed is not None:
+            replica.record_pushed_health(*pushed)
+
     def check_and_update_replicas(self):
         """
         Check current state of all DeploymentReplica being tracked, and compare
@@ -4656,6 +4727,8 @@ class DeploymentState:
                 for st in (ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION)
                 for replica in self._replicas.get([st])
             ]
+            for replica, _ in pairs:
+                self._apply_pushed_health(replica)
             healths = [replica.check_health() for replica, _ in pairs]
             for (replica, st), is_healthy in zip(pairs, healths):
                 self._record_health_check_metrics(replica)
@@ -4687,6 +4760,7 @@ class DeploymentState:
             for replica in self._replicas.pop(
                 states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
             ):
+                self._apply_pushed_health(replica)
                 is_healthy = replica.check_health()
                 self._record_health_check_metrics(replica)
                 if is_healthy:
@@ -5513,6 +5587,7 @@ class DeploymentStateManager:
         autoscaling_state_manager: AutoscalingStateManager,
         head_node_id_override: Optional[str] = None,
         create_placement_group_fn_override: Optional[Callable] = None,
+        health_push_registry: Optional[ReplicaHealthPushRegistry] = None,
     ):
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
@@ -5523,6 +5598,7 @@ class DeploymentStateManager:
             create_placement_group_fn_override,
         )
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._health_push_registry = health_push_registry
 
         self._shutting_down = False
 
@@ -5575,6 +5651,7 @@ class DeploymentStateManager:
             self._deployment_scheduler,
             self._cluster_node_info_cache,
             self._autoscaling_state_manager,
+            health_push_registry=self._health_push_registry,
         )
 
     def _map_actor_names_to_deployment(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -729,8 +729,9 @@ class ReplicaHealthPushRegistry:
         if prev is not None and checked_at <= prev[0]:
             return  # A delayed report must not clobber a newer observation.
         if len(self._state) > self._PRUNE_THRESHOLD:
+            # Age by controller-clock arrival time (v[1]), immune to replica skew.
             cutoff = time.time() - self._PRUNE_MAX_AGE_S
-            self._state = {k: v for k, v in self._state.items() if v[0] >= cutoff}
+            self._state = {k: v for k, v in self._state.items() if v[1] >= cutoff}
         self._state[replica_unique_id] = (
             checked_at,
             time.time(),

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -713,10 +713,17 @@ class ReplicaHealthPushRegistry:
 
     _PRUNE_THRESHOLD = 65536
     _PRUNE_MAX_AGE_S = 600.0
+    _GAP_BUCKET_S = 0.25
+    _GAP_NBUCKETS = 240  # 60s range
 
     def __init__(self):
         # replica_unique_id -> (checked_at, received_at, healthy, consecutive_failures)
         self._state: Dict[str, Tuple[float, float, bool, Optional[int]]] = {}
+        # Gap between a replica's consecutive accepted checked_at values = its
+        # actual self-check interval (same clock per replica, skew-free).
+        self._gap_hist = [0] * self._GAP_NBUCKETS
+        self._gap_count = 0
+        self._gap_max_s = 0.0
 
     def record(
         self,
@@ -728,6 +735,13 @@ class ReplicaHealthPushRegistry:
         prev = self._state.get(replica_unique_id)
         if prev is not None and checked_at <= prev[0]:
             return  # A delayed report must not clobber a newer observation.
+        if prev is not None:
+            gap = checked_at - prev[0]
+            b = int(gap / self._GAP_BUCKET_S)
+            self._gap_hist[b if b < self._GAP_NBUCKETS else self._GAP_NBUCKETS - 1] += 1
+            self._gap_count += 1
+            if gap > self._gap_max_s:
+                self._gap_max_s = gap
         if len(self._state) > self._PRUNE_THRESHOLD:
             # Age by controller-clock arrival time (v[1]), immune to replica skew.
             cutoff = time.time() - self._PRUNE_MAX_AGE_S
@@ -743,6 +757,27 @@ class ReplicaHealthPushRegistry:
         self, replica_unique_id: str
     ) -> Optional[Tuple[float, float, bool, Optional[int]]]:
         return self._state.get(replica_unique_id)
+
+    def gap_stats(self) -> Dict[str, float]:
+        """Percentiles of the replicas' actual self-check intervals."""
+
+        def pct(p):
+            if self._gap_count <= 0:
+                return 0.0
+            target = p * self._gap_count
+            cum = 0
+            for i, c in enumerate(self._gap_hist):
+                cum += c
+                if cum >= target:
+                    return (i + 1) * self._GAP_BUCKET_S
+            return self._GAP_NBUCKETS * self._GAP_BUCKET_S
+
+        return {
+            "count": self._gap_count,
+            "p50_s": pct(0.50),
+            "p99_s": pct(0.99),
+            "max_s": self._gap_max_s,
+        }
 
 
 class ActorReplicaWrapper:

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -44,7 +44,6 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
-    DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_LATENCY_BUCKET_MS,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_PERIOD_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_TIMEOUT_S,
@@ -710,6 +709,16 @@ def _push_freshness_window_s(health_check_period_s: float) -> float:
     return max(health_check_period_s * 1.5, 1.0)
 
 
+# Most of a deployment's pushed health going stale at once (by its own
+# configured period) is the signature of controller-side ingest lag, not mass
+# replica failure. Deferring the pull fallback then avoids a probe storm that
+# would deepen the lag and can cascade into false kills; the cap bounds it so
+# a real mass outage still surfaces.
+HEALTH_PUSH_STALL_MIN_TRACKED = 64
+HEALTH_PUSH_STALL_STALE_FRACTION = 0.5
+HEALTH_PUSH_STALL_MAX_DEFER_S = 120.0
+
+
 class ReplicaHealthPushRegistry:
     """Latest self-health pushed by each replica, keyed by replica unique id.
 
@@ -721,15 +730,6 @@ class ReplicaHealthPushRegistry:
     _PRUNE_MAX_AGE_S = 600.0
     _GAP_BUCKET_S = 0.25
     _GAP_NBUCKETS = 240  # 60s range
-    # Most tracked replicas going stale at once is the signature of
-    # controller-side ingest lag, not mass replica failure. Deferring the pull
-    # fallback then avoids a probe storm that would deepen the lag and can
-    # cascade into false kills; the cap bounds it so a real mass outage still
-    # surfaces.
-    _STALL_MIN_TRACKED = 64
-    _STALL_STALE_FRACTION = 0.5
-    _STALL_MAX_DEFER_S = 120.0
-    _STALL_CHECK_TTL_S = 1.0
 
     def __init__(self):
         # replica_unique_id -> (checked_at, received_at, healthy, consecutive_failures)
@@ -739,9 +739,6 @@ class ReplicaHealthPushRegistry:
         self._gap_hist = [0] * self._GAP_NBUCKETS
         self._gap_count = 0
         self._gap_max_s = 0.0
-        self._stall_checked_at: float = 0.0
-        self._stall_flag: bool = False
-        self._stall_since: Optional[float] = None
 
     def record(
         self,
@@ -775,44 +772,6 @@ class ReplicaHealthPushRegistry:
         self, replica_unique_id: str
     ) -> Optional[Tuple[float, float, bool, Optional[int]]]:
         return self._state.get(replica_unique_id)
-
-    def stale_counts(self, freshness_window_s: float) -> Tuple[int, int]:
-        """(stale, total) tracked replicas whose last push arrived too long ago."""
-        cutoff = time.time() - freshness_window_s
-        stale = sum(1 for v in self._state.values() if v[1] < cutoff)
-        return stale, len(self._state)
-
-    def systemic_stall(self) -> bool:
-        """True while pushes for most tracked replicas are stale at once.
-
-        Cached for ~1s (called once per swept replica). Bounded by
-        _STALL_MAX_DEFER_S per episode so a genuine mass outage still falls
-        through to pull probes.
-        """
-        now = time.time()
-        if now - self._stall_checked_at > self._STALL_CHECK_TTL_S:
-            self._stall_checked_at = now
-            stale, total = self.stale_counts(
-                _push_freshness_window_s(DEFAULT_HEALTH_CHECK_PERIOD_S)
-            )
-            self._stall_flag = (
-                total >= self._STALL_MIN_TRACKED
-                and stale >= total * self._STALL_STALE_FRACTION
-            )
-            if not self._stall_flag:
-                self._stall_since = None
-            elif self._stall_since is None:
-                self._stall_since = now
-                logger.warning(
-                    f"Pushed health went stale for {stale}/{total} replicas at "
-                    "once; treating as controller-side ingest lag and deferring "
-                    f"fallback probes for up to {self._STALL_MAX_DEFER_S}s."
-                )
-        return (
-            self._stall_flag
-            and self._stall_since is not None
-            and time.time() - self._stall_since < self._STALL_MAX_DEFER_S
-        )
 
     def gap_stats(self) -> Dict[str, float]:
         """Percentiles of the replicas' actual self-check intervals."""
@@ -3075,6 +3034,11 @@ class DeploymentState:
         self._cluster_node_info_cache = cluster_node_info_cache
         self._autoscaling_state_manager = autoscaling_state_manager
         self._health_push_registry = health_push_registry
+        self._push_probes_deferred: bool = False
+        self._push_stall_since: Optional[float] = None
+        self._push_stall_stale: int = 0
+        self._push_stall_total: int = 0
+        self._push_stall_window_s: float = 0.0
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
@@ -4863,15 +4827,53 @@ class DeploymentState:
         graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
         self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
 
+    def _finalize_push_stall_verdict(self) -> None:
+        """Set next sweep's probe-deferral from this sweep's staleness tally.
+
+        Most of this deployment's pushed health going stale at once (by its own
+        window) reads as controller-side ingest lag, so fallback probes are
+        deferred -- bounded by HEALTH_PUSH_STALL_MAX_DEFER_S per episode so a
+        genuine mass outage still falls through to probes.
+        """
+        stale, total = self._push_stall_stale, self._push_stall_total
+        if (
+            total < HEALTH_PUSH_STALL_MIN_TRACKED
+            or stale < total * HEALTH_PUSH_STALL_STALE_FRACTION
+        ):
+            self._push_stall_since = None
+            self._push_probes_deferred = False
+            return
+        now = time.time()
+        if self._push_stall_since is None:
+            self._push_stall_since = now
+            logger.warning(
+                f"Pushed health went stale for {stale}/{total} replicas of "
+                f"{self._id} at once; treating as controller-side ingest lag "
+                "and deferring fallback probes for up to "
+                f"{HEALTH_PUSH_STALL_MAX_DEFER_S}s."
+            )
+        self._push_probes_deferred = (
+            now - self._push_stall_since < HEALTH_PUSH_STALL_MAX_DEFER_S
+        )
+
     def _apply_pushed_health(self, replica: "DeploymentReplica") -> None:
-        """Hand the replica's latest pushed self-health to its wrapper."""
+        """Hand the replica's latest pushed self-health to its wrapper.
+
+        Tallies push staleness for this deployment's stall verdict and, while
+        the previous sweep's verdict says staleness is systemic, keeps the
+        replica's probe gate closed.
+        """
         if self._health_push_registry is None:
             return
-        if self._health_push_registry.systemic_stall():
+        if self._push_probes_deferred:
             replica.defer_push_fallback_probe()
         pushed = self._health_push_registry.get(replica.replica_id.unique_id)
-        if pushed is not None:
-            replica.record_pushed_health(*pushed)
+        if pushed is None:
+            return
+        self._push_stall_total += 1
+        if time.time() - pushed[1] > self._push_stall_window_s:
+            self._push_stall_stale += 1
+        replica.record_pushed_health(*pushed)
 
     def check_and_update_replicas(self):
         """
@@ -4879,6 +4881,13 @@ class DeploymentState:
         with state container from previous update() cycle to see if any state
         transition happened.
         """
+        self._finalize_push_stall_verdict()
+        self._push_stall_stale = 0
+        self._push_stall_total = 0
+        if self._target_state.info is not None:
+            self._push_stall_window_s = _push_freshness_window_s(
+                self._target_state.info.deployment_config.health_check_period_s
+            )
 
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -400,6 +400,7 @@ class ReplicaMetricsManager:
         self._self_health_checked_at: Optional[float] = None
         self._eval_self_health_fn: Optional[Callable] = None
         self._self_health_timeout_s: float = 0.0
+        self._self_health_period_s: float = 0.0
         self._pushing_metric_reports = False
         self._self_consecutive_failures = 0
         self._pending_health_push_ref: Optional[ObjectRef] = None
@@ -690,6 +691,7 @@ class ReplicaMetricsManager:
         """
         self._eval_self_health_fn = eval_fn
         self._self_health_timeout_s = timeout_s
+        self._self_health_period_s = period_s
         self._metrics_pusher.start()
         self._metrics_pusher.register_or_update_task(
             self.PUSH_SELF_HEALTH_TASK_NAME,
@@ -717,8 +719,16 @@ class ReplicaMetricsManager:
         self._self_healthy = healthy
         self._self_health_checked_at = time.time()
 
-        if self._pushing_metric_reports:
-            # Health rides on the metric report pushes.
+        if (
+            self._pushing_metric_reports
+            and self._autoscaling_config is not None
+            and self._autoscaling_config.metrics_interval_s
+            <= self._self_health_period_s
+        ):
+            # Metric-report pushes carry health at least as often as it is
+            # evaluated; a separate heartbeat would be redundant. When the
+            # metric cadence is slower than the health period, heartbeat
+            # anyway so freshness at the controller never lapses.
             return
         with self._metrics_push_lock:
             if self._pending_health_push_ref is not None:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -85,6 +85,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
     RECONFIGURE_METHOD,
     RECORD_REPLICA_METADATA_METHOD,
+    REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     REQUEST_LATENCY_BUCKETS_MS,
     REQUEST_ROUTING_STATS_METHOD,
     SERVE_CONTROLLER_NAME,
@@ -358,6 +359,7 @@ class ReplicaMetricsManager:
 
     PUSH_METRICS_TO_CONTROLLER_TASK_NAME = "push_metrics_to_controller"
     RECORD_METRICS_TASK_NAME = "record_metrics"
+    PUSH_SELF_HEALTH_TASK_NAME = "push_self_health"
     SET_REPLICA_REQUEST_METRIC_GAUGE_TASK_NAME = "set_replica_request_metric_gauge"
 
     def __init__(
@@ -390,6 +392,17 @@ class ReplicaMetricsManager:
         # Tracks in-flight metrics push to controller. Skip if new one is sent.
         self._pending_metrics_push_ref: Optional[ObjectRef] = None
         self._metrics_push_lock = threading.Lock()
+
+        # Self-health push state: the latest local health-check result rides on
+        # metric report pushes, or on a lightweight heartbeat when this replica
+        # does not push metric reports.
+        self._self_healthy: Optional[bool] = None
+        self._self_health_checked_at: Optional[float] = None
+        self._eval_self_health_fn: Optional[Callable] = None
+        self._self_health_timeout_s: float = 0.0
+        self._pushing_metric_reports = False
+        self._self_consecutive_failures = 0
+        self._pending_health_push_ref: Optional[ObjectRef] = None
 
         # If the interval is set to 0, eagerly sets all metrics.
         self._cached_metrics_enabled = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS != 0
@@ -648,6 +661,7 @@ class ReplicaMetricsManager:
 
     def start_metrics_pusher(self):
         self._metrics_pusher.start()
+        self._pushing_metric_reports = True
 
         # Push autoscaling metrics to the controller periodically.
         self._metrics_pusher.register_or_update_task(
@@ -665,6 +679,59 @@ class ReplicaMetricsManager:
             self._add_autoscaling_metrics_point_async,
             min(record_interval_s, self._autoscaling_config.metrics_interval_s),
         )
+
+    def start_self_health_pusher(
+        self, eval_fn: Callable, period_s: float, timeout_s: float
+    ):
+        """Periodically run the local health check and push the result.
+
+        eval_fn is an async callable that raises when unhealthy (the replica's
+        own check_health).
+        """
+        self._eval_self_health_fn = eval_fn
+        self._self_health_timeout_s = timeout_s
+        self._metrics_pusher.start()
+        self._metrics_pusher.register_or_update_task(
+            self.PUSH_SELF_HEALTH_TASK_NAME,
+            self._eval_and_push_self_health,
+            period_s,
+        )
+
+    async def _eval_and_push_self_health(self):
+        if self._self_consecutive_failures >= REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD:
+            # Latched: the controller will replace this replica; stop re-running
+            # the user check (parity with pull probes, which cease at the
+            # threshold) but keep reporting unhealthy.
+            healthy = False
+        else:
+            healthy = True
+            try:
+                await asyncio.wait_for(
+                    self._eval_self_health_fn(), timeout=self._self_health_timeout_s
+                )
+            except Exception:
+                healthy = False
+            self._self_consecutive_failures = (
+                0 if healthy else self._self_consecutive_failures + 1
+            )
+        self._self_healthy = healthy
+        self._self_health_checked_at = time.time()
+
+        if self._pushing_metric_reports:
+            # Health rides on the metric report pushes.
+            return
+        with self._metrics_push_lock:
+            if self._pending_health_push_ref is not None:
+                if not check_obj_ref_ready_nowait(self._pending_health_push_ref):
+                    return  # Previous heartbeat still in flight.
+            self._pending_health_push_ref = (
+                self._controller_handle.record_replica_health.remote(
+                    self._replica_id.unique_id,
+                    self._self_health_checked_at,
+                    healthy,
+                    self._self_consecutive_failures,
+                )
+            )
 
     def should_collect_ongoing_requests(self) -> bool:
         """Determine if replicas should collect ongoing request metrics.
@@ -948,6 +1015,9 @@ class ReplicaMetricsManager:
             timestamp=time.time(),
             aggregated_metrics=new_aggregated_metrics,
             metrics=new_metrics,
+            healthy=self._self_healthy,
+            health_checked_at=self._self_health_checked_at,
+            health_consecutive_failures=self._self_consecutive_failures,
         )
         with self._metrics_push_lock:
             if self._pending_metrics_push_ref is not None:
@@ -1076,6 +1146,11 @@ class Replica:
 
         # Guards against calling the user's callable constructor multiple times.
         self._user_callable_initialized = False
+        # Self-health task state: once active, check_health() serves the cached
+        # result instead of re-running the user check.
+        self._self_health_active = False
+        self._self_health_evaluated = False
+        self._last_self_health_error: Optional[str] = None
         self._user_callable_initialized_lock = asyncio.Lock()
         self._initialization_latency: Optional[float] = None
 
@@ -1876,6 +1951,9 @@ class Replica:
             # an initial health check. If an initial health check fails,
             # consider it an initialization failure.
             await self.check_health()
+            # From here on the periodic self-health task is the sole caller of
+            # the user health check; remote probes read its cached result.
+            self._start_self_health_pusher()
         except Exception:
             raise RuntimeError(traceback.format_exc()) from None
 
@@ -1903,6 +1981,8 @@ class Replica:
             self._metrics_manager.set_autoscaling_config(
                 deployment_config.autoscaling_config
             )
+            if self._user_callable_initialized:
+                self._start_self_health_pusher()
             self._metrics_manager.set_max_ongoing_requests(
                 deployment_config.max_ongoing_requests
             )
@@ -2138,7 +2218,16 @@ class Replica:
             extra={"log_to_stderr": False},
         )
 
-    async def check_health(self):
+    def _start_self_health_pusher(self):
+        """Push local health on the deployment's health-check cadence."""
+        self._self_health_active = True
+        self._metrics_manager.start_self_health_pusher(
+            self._run_user_health_check,
+            self._deployment_config.health_check_period_s,
+            self._deployment_config.health_check_timeout_s,
+        )
+
+    async def _run_user_health_check(self):
         try:
             # Runs the user-defined check_health on the user code loop if defined.
             # Otherwise, if the background watchdog has detected the user loop is
@@ -2152,7 +2241,21 @@ class Replica:
         except Exception as e:
             logger.warning("Replica health check failed.")
             self._healthy = False
+            self._last_self_health_error = repr(e)
             raise e from None
+        finally:
+            self._self_health_evaluated = True
+
+    async def check_health(self):
+        # While the self-health task is the active observer, serve its cached
+        # result -- concurrent callers must not re-run the user health check.
+        if self._self_health_active and self._self_health_evaluated:
+            if not self._healthy:
+                raise RuntimeError(
+                    self._last_self_health_error or "Replica self health check failed."
+                )
+            return
+        await self._run_user_health_check()
 
     async def record_routing_stats(self) -> Dict[str, Any]:
         try:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1903,11 +1903,18 @@ class Replica:
             request_metadata, ray_trace_ctx
         ) as status_code_callback:
             async with self._start_request(request_metadata):
+                # Binding for this request's lifetime: the router arms its
+                # frame pump only when frames are declared.
+                sends_frames = (
+                    request_metadata.supports_health_frames
+                    and not self._metrics_manager.health_already_carried()
+                )
                 yield ReplicaQueueLengthInfo(
                     accepted=True,
                     # NOTE(edoakes): `_wrap_request` will increment the number
                     # of ongoing requests to include this one, so re-fetch the value.
                     num_ongoing_requests=self.get_num_ongoing_requests(),
+                    will_send_health_frames=sends_frames,
                     **self._health_kwargs(),
                 )
 
@@ -1928,7 +1935,7 @@ class Replica:
                             request_kwargs,
                         ):
                             yield result
-                    elif request_metadata.supports_health_frames:
+                    elif sends_frames:
                         async for result in self._call_unary_with_health_frames(
                             request_metadata, request_args, request_kwargs
                         ):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -683,6 +683,16 @@ class ReplicaMetricsManager:
             min(record_interval_s, self._autoscaling_config.metrics_interval_s),
         )
 
+    def reports_carry_health(self) -> bool:
+        """Metric-report pushes already carry health at least as often as it
+        is evaluated; frames/heartbeats would be redundant."""
+        return (
+            self._pushing_metric_reports
+            and self._autoscaling_config is not None
+            and self._autoscaling_config.metrics_interval_s
+            <= self._self_health_period_s
+        )
+
     def self_health_frame(self) -> Optional["ReplicaHealthFrame"]:
         """Latest self-check as a stream frame; None before the first check."""
         if self._self_health_checked_at is None:
@@ -746,16 +756,10 @@ class ReplicaMetricsManager:
         self._self_healthy = healthy
         self._self_health_checked_at = time.time()
 
-        if (
-            self._pushing_metric_reports
-            and self._autoscaling_config is not None
-            and self._autoscaling_config.metrics_interval_s
-            <= self._self_health_period_s
-        ):
-            # Metric-report pushes carry health at least as often as it is
-            # evaluated; a separate heartbeat would be redundant. When the
-            # metric cadence is slower than the health period, heartbeat
-            # anyway so freshness at the controller never lapses.
+        if self.reports_carry_health():
+            # When the metric cadence is slower than the health period, fall
+            # through and heartbeat so freshness at the controller never
+            # lapses.
             return
         if (
             self._autoscaling_config is not None
@@ -1919,6 +1923,11 @@ class Replica:
                 done, _ = await asyncio.wait({user_task}, timeout=interval_s or None)
                 if done:
                     break
+                if self._metrics_manager.reports_carry_health():
+                    # Metric reports already carry health; don't duplicate it
+                    # on the stream (checked per tick: mode can change while
+                    # a request is held).
+                    continue
                 frame = self._metrics_manager.self_health_frame()
                 if frame is not None and frame.health_checked_at > last_sent_checked_at:
                     last_sent_checked_at = frame.health_checked_at

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -47,9 +47,9 @@ from ray.serve import metrics
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
     DeploymentID,
+    ReplicaHealthFrame,
     ReplicaID,
     ReplicaMetricReport,
-    ReplicaHealthFrame,
     ReplicaQueueLengthInfo,
     RequestMetadata,
     RequestProtocol,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -49,6 +49,7 @@ from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,
     ReplicaMetricReport,
+    ReplicaHealthFrame,
     ReplicaQueueLengthInfo,
     RequestMetadata,
     RequestProtocol,
@@ -681,6 +682,21 @@ class ReplicaMetricsManager:
             self._add_autoscaling_metrics_point_async,
             min(record_interval_s, self._autoscaling_config.metrics_interval_s),
         )
+
+    def self_health_frame(self) -> Optional["ReplicaHealthFrame"]:
+        """Latest self-check as a stream frame; None before the first check."""
+        if self._self_health_checked_at is None:
+            return None
+        healthy, checked_at, failures = self.self_health_snapshot()
+        return ReplicaHealthFrame(
+            healthy=healthy,
+            health_checked_at=checked_at,
+            health_consecutive_failures=failures,
+        )
+
+    @property
+    def self_health_period_s(self) -> float:
+        return self._self_health_period_s
 
     def self_health_snapshot(self):
         """(healthy, checked_at, consecutive_failures) from the local self-check;
@@ -1870,12 +1886,47 @@ class Replica:
                             request_kwargs,
                         ):
                             yield result
+                    elif request_metadata.supports_health_frames:
+                        async for result in self._call_unary_with_health_frames(
+                            request_metadata, request_args, request_kwargs
+                        ):
+                            yield result
                     else:
                         yield await self._user_callable_wrapper.call_user_method(
                             request_metadata, request_args, request_kwargs
                         )
                 except Exception as e:
                     self._raise_user_exception(e, request_metadata)
+
+    async def _call_unary_with_health_frames(
+        self, request_metadata: RequestMetadata, request_args, request_kwargs
+    ):
+        """Run a unary user call, yielding ReplicaHealthFrame while it's pending.
+
+        Keeps long-held requests carrying fresh self-health over the already-open
+        response stream so the router's handle report stays current and no
+        standalone heartbeat RPC is needed. The final yield is always the result.
+        """
+        user_task = asyncio.ensure_future(
+            self._user_callable_wrapper.call_user_method(
+                request_metadata, request_args, request_kwargs
+            )
+        )
+        interval_s = self._metrics_manager.self_health_period_s
+        last_sent_checked_at = 0.0
+        try:
+            while True:
+                done, _ = await asyncio.wait({user_task}, timeout=interval_s or None)
+                if done:
+                    break
+                frame = self._metrics_manager.self_health_frame()
+                if frame is not None and frame.health_checked_at > last_sent_checked_at:
+                    last_sent_checked_at = frame.health_checked_at
+                    yield frame
+        finally:
+            if not user_task.done():
+                user_task.cancel()
+        yield user_task.result()
 
     async def _on_initialized(self):
         await self._maybe_start_direct_ingress_servers()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2229,11 +2229,12 @@ class Replica:
         )
 
     def _start_self_health_pusher(self):
-        """Push local health on the deployment's health-check cadence."""
+        """Evaluate at half the health-check period so every replica is checked
+        well within the configured period despite scheduling jitter."""
         self._self_health_active = True
         self._metrics_manager.start_self_health_pusher(
             self._run_user_health_check,
-            self._deployment_config.health_check_period_s,
+            self._deployment_config.health_check_period_s * 0.5,
             self._deployment_config.health_check_timeout_s,
         )
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -403,6 +403,7 @@ class ReplicaMetricsManager:
         self._self_health_period_s: float = 0.0
         self._pushing_metric_reports = False
         self._self_consecutive_failures = 0
+        self._last_health_carried_ts: Optional[float] = None
         self._pending_health_push_ref: Optional[ObjectRef] = None
 
         # If the interval is set to 0, eagerly sets all metrics.
@@ -681,6 +682,16 @@ class ReplicaMetricsManager:
             min(record_interval_s, self._autoscaling_config.metrics_interval_s),
         )
 
+    def self_health_snapshot(self):
+        """(healthy, checked_at, consecutive_failures) from the local self-check;
+        stamps that health is being carried on a response."""
+        self._last_health_carried_ts = time.time()
+        return (
+            self._self_healthy,
+            self._self_health_checked_at,
+            self._self_consecutive_failures,
+        )
+
     def start_self_health_pusher(
         self, eval_fn: Callable, period_s: float, timeout_s: float
     ):
@@ -729,6 +740,15 @@ class ReplicaMetricsManager:
             # evaluated; a separate heartbeat would be redundant. When the
             # metric cadence is slower than the health period, heartbeat
             # anyway so freshness at the controller never lapses.
+            return
+        if (
+            self._autoscaling_config is not None
+            and RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
+            and self._last_health_carried_ts is not None
+            and time.time() - self._last_health_carried_ts < self._self_health_period_s
+        ):
+            # Health rode recent responses and the handles forward it on
+            # their metric reports; no separate heartbeat needed.
             return
         with self._metrics_push_lock:
             if self._pending_health_push_ref is not None:
@@ -1778,6 +1798,17 @@ class Replica:
             raise e
         raise wrapped_exception from e
 
+    def _health_kwargs(self) -> Dict[str, Any]:
+        """Self-health fields piggybacked on the response queue-length info."""
+        healthy, checked_at, failures = self._metrics_manager.self_health_snapshot()
+        if checked_at is None:
+            return {}
+        return {
+            "healthy": healthy,
+            "health_checked_at": checked_at,
+            "health_consecutive_failures": failures,
+        }
+
     async def handle_request_with_rejection(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
     ):
@@ -1789,7 +1820,9 @@ class Replica:
                 f"{request_metadata.request_id}.",
                 extra={"log_to_stderr": False},
             )
-            yield ReplicaQueueLengthInfo(False, self.get_num_ongoing_requests())
+            yield ReplicaQueueLengthInfo(
+                False, self.get_num_ongoing_requests(), **self._health_kwargs()
+            )
             return
 
         # Check if the replica has capacity for the request.
@@ -1800,7 +1833,9 @@ class Replica:
                 f"rejecting request {request_metadata.request_id}.",
                 extra={"log_to_stderr": False},
             )
-            yield ReplicaQueueLengthInfo(False, self.get_num_ongoing_requests())
+            yield ReplicaQueueLengthInfo(
+                False, self.get_num_ongoing_requests(), **self._health_kwargs()
+            )
             return
 
         request_args, request_kwargs, ray_trace_ctx = self._unpack_proxy_args(
@@ -1815,6 +1850,7 @@ class Replica:
                     # NOTE(edoakes): `_wrap_request` will increment the number
                     # of ongoing requests to include this one, so re-fetch the value.
                     num_ongoing_requests=self.get_num_ongoing_requests(),
+                    **self._health_kwargs(),
                 )
 
                 try:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -405,6 +405,7 @@ class ReplicaMetricsManager:
         self._pushing_metric_reports = False
         self._self_consecutive_failures = 0
         self._last_health_carried_ts: Optional[float] = None
+        self._last_health_reported_via_handle_ts: Optional[float] = None
         self._pending_health_push_ref: Optional[ObjectRef] = None
 
         # If the interval is set to 0, eagerly sets all metrics.
@@ -693,6 +694,36 @@ class ReplicaMetricsManager:
             <= self._self_health_period_s
         )
 
+    def health_already_carried(self) -> bool:
+        """Health is already riding metric reports or this replica's own
+        handle metric reports; frames would duplicate it."""
+        return self.reports_carry_health() or (
+            self._last_health_reported_via_handle_ts is not None
+            and time.time() - self._last_health_reported_via_handle_ts
+            < self._self_health_period_s
+        )
+
+    def self_health_report_entry(
+        self,
+    ) -> Optional[Tuple[str, Tuple[float, bool, Optional[int]]]]:
+        """Registry-shaped entry for this replica's own handle metric reports.
+
+        None while metric reports already carry health (no double delivery) or
+        before the first self-check. Consumption counts as handle-carried for
+        heartbeat suppression.
+        """
+        if self._self_health_checked_at is None or self.reports_carry_health():
+            return None
+        self._last_health_reported_via_handle_ts = time.time()
+        return (
+            self._replica_id.unique_id,
+            (
+                self._self_health_checked_at,
+                self._self_healthy,
+                self._self_consecutive_failures,
+            ),
+        )
+
     def self_health_frame(self) -> Optional["ReplicaHealthFrame"]:
         """Latest self-check as a stream frame; None before the first check."""
         if self._self_health_checked_at is None:
@@ -769,6 +800,13 @@ class ReplicaMetricsManager:
         ):
             # Health rode recent responses and the handles forward it on
             # their metric reports; no separate heartbeat needed.
+            return
+        if (
+            self._last_health_reported_via_handle_ts is not None
+            and time.time() - self._last_health_reported_via_handle_ts
+            < self._self_health_period_s
+        ):
+            # This replica's own handle metric reports carried its health.
             return
         with self._metrics_push_lock:
             if self._pending_health_push_ref is not None:
@@ -1923,10 +1961,10 @@ class Replica:
                 done, _ = await asyncio.wait({user_task}, timeout=interval_s or None)
                 if done:
                     break
-                if self._metrics_manager.reports_carry_health():
-                    # Metric reports already carry health; don't duplicate it
-                    # on the stream (checked per tick: mode can change while
-                    # a request is held).
+                if self._metrics_manager.health_already_carried():
+                    # Metric or handle reports already carry health; don't
+                    # duplicate it on the stream (checked per tick: mode can
+                    # change while a request is held).
                     continue
                 frame = self._metrics_manager.self_health_frame()
                 if frame is not None and frame.health_checked_at > last_sent_checked_at:
@@ -2332,6 +2370,10 @@ class Replica:
             self._run_user_health_check,
             self._deployment_config.health_check_period_s * 0.5,
             self._deployment_config.health_check_timeout_s,
+        )
+        # Routers in this process fold our health into their handle reports.
+        ray.serve.context._set_self_health_report_provider(
+            self._metrics_manager.self_health_report_entry
         )
 
     async def _run_user_health_check(self):

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -193,6 +193,9 @@ class ActorReplicaResult(ReplicaResult):
         self._frame_pump_task = loop.create_task(self._pump_health_frames())
 
     async def _pump_health_frames(self):
+        # Created by _maybe_start_frame_pump before this task starts.
+        outcome = self._pump_outcome
+        assert outcome is not None
         try:
             while True:
                 obj_ref = await self._obj_ref_gen.__anext__()
@@ -201,23 +204,25 @@ class ActorReplicaResult(ReplicaResult):
                 except Exception:
                     # The exception belongs to the request; consumers surface it
                     # when they fetch the ref.
-                    self._settle_pump(obj_ref)
+                    self._settle_pump(outcome, obj_ref)
                     return
                 if isinstance(value, ReplicaHealthFrame):
                     self._record_health_frame(value)
                     continue
-                self._settle_pump(obj_ref)
+                self._settle_pump(outcome, obj_ref)
                 return
         except BaseException as e:
-            if not self._pump_outcome.done():
-                self._pump_outcome.set_exception(e)
+            if not outcome.done():
+                outcome.set_exception(e)
             if isinstance(e, asyncio.CancelledError):
                 raise
 
-    def _settle_pump(self, obj_ref: ray.ObjectRef) -> None:
+    def _settle_pump(
+        self, outcome: concurrent.futures.Future, obj_ref: ray.ObjectRef
+    ) -> None:
         with self._object_ref_or_gen_sync_lock:
             self._obj_ref = obj_ref
-        self._pump_outcome.set_result(obj_ref)
+        outcome.set_result(obj_ref)
 
     def _record_health_frame(self, frame: ReplicaHealthFrame) -> None:
         if self._on_health_frame is None:
@@ -356,8 +361,11 @@ class ActorReplicaResult(ReplicaResult):
             return self._obj_ref
 
         # The background frame pump owns the stream; wait for it to settle.
+        # (The locked section above guarantees one of _obj_ref/_pump_outcome.)
+        pump_outcome = self._pump_outcome
+        assert pump_outcome is not None
         try:
-            return self._pump_outcome.result(
+            return pump_outcome.result(
                 timeout=calculate_remaining_timeout(
                     timeout_s=timeout_s,
                     start_time_s=start_time_s,

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -16,6 +16,7 @@ import ray
 from ray.exceptions import ActorUnavailableError, RayTaskError, TaskCancelledError
 from ray.serve._private.common import (
     OBJ_REF_NOT_SUPPORTED_ERROR,
+    ReplicaHealthFrame,
     ReplicaQueueLengthInfo,
     RequestMetadata,
 )
@@ -62,6 +63,13 @@ class ReplicaResult(ABC):
     def add_done_callback(self, callback: Callable):
         raise NotImplementedError
 
+    def set_health_frame_listener(self, on_frame: Callable) -> None:
+        """Record ReplicaHealthFrame system messages from the response stream.
+
+        Default: transport doesn't carry frames; no-op.
+        """
+        pass
+
     @abstractmethod
     def cancel(self):
         raise NotImplementedError
@@ -96,6 +104,15 @@ class ActorReplicaResult(ReplicaResult):
         self._object_ref_or_gen_sync_lock = threading.Lock()
         self._with_rejection = with_rejection
         self._rejection_response = None
+        self._health_frames_possible: bool = (
+            with_rejection
+            and not metadata.is_streaming
+            and getattr(metadata, "supports_health_frames", False)
+        )
+        self._on_health_frame: Optional[Callable] = None
+        self._frame_pump_task: Optional[asyncio.Task] = None
+        self._pump_outcome: Optional[concurrent.futures.Future] = None
+        self._consumption_started: bool = False
 
         if isinstance(obj_ref_or_gen, ray.ObjectRefGenerator):
             self._obj_ref_gen = obj_ref_or_gen
@@ -139,6 +156,76 @@ class ActorReplicaResult(ReplicaResult):
             return async_wrapper
         else:
             return wrapper
+
+    # Delay before the background frame pump takes over an unresolved response
+    # stream. Responses that resolve faster never start the pump.
+    _FRAME_PUMP_DELAY_S = 2.0
+
+    def set_health_frame_listener(self, on_frame: Callable) -> None:
+        """Record ReplicaHealthFrame system messages from the response stream.
+
+        Long-running requests are drained by a background pump that starts only
+        if the response hasn't resolved after a short delay, so fast requests
+        never pay for it. Must be called after the rejection response has been
+        consumed (the pump owns all remaining stream items once it starts).
+        """
+        if not self._health_frames_possible:
+            return
+        self._on_health_frame = on_frame
+        loop = asyncio.get_running_loop()
+        loop.call_later(self._FRAME_PUMP_DELAY_S, self._maybe_start_frame_pump, loop)
+
+    def _maybe_start_frame_pump(self, loop: asyncio.AbstractEventLoop) -> None:
+        # Non-blocking: if another consumer holds the lock it owns the stream
+        # (and filters frames itself); never block the event loop on it.
+        if not self._object_ref_or_gen_sync_lock.acquire(blocking=False):
+            return
+        try:
+            if (
+                self._obj_ref is not None
+                or self._consumption_started
+                or self._pump_outcome is not None
+            ):
+                return
+            self._pump_outcome = concurrent.futures.Future()
+        finally:
+            self._object_ref_or_gen_sync_lock.release()
+        self._frame_pump_task = loop.create_task(self._pump_health_frames())
+
+    async def _pump_health_frames(self):
+        try:
+            while True:
+                obj_ref = await self._obj_ref_gen.__anext__()
+                try:
+                    value = await obj_ref
+                except Exception:
+                    # The exception belongs to the request; consumers surface it
+                    # when they fetch the ref.
+                    self._settle_pump(obj_ref)
+                    return
+                if isinstance(value, ReplicaHealthFrame):
+                    self._record_health_frame(value)
+                    continue
+                self._settle_pump(obj_ref)
+                return
+        except BaseException as e:
+            if not self._pump_outcome.done():
+                self._pump_outcome.set_exception(e)
+            if isinstance(e, asyncio.CancelledError):
+                raise
+
+    def _settle_pump(self, obj_ref: ray.ObjectRef) -> None:
+        with self._object_ref_or_gen_sync_lock:
+            self._obj_ref = obj_ref
+        self._pump_outcome.set_result(obj_ref)
+
+    def _record_health_frame(self, frame: ReplicaHealthFrame) -> None:
+        if self._on_health_frame is None:
+            return
+        try:
+            self._on_health_frame(frame)
+        except Exception:
+            logger.warning("Health frame listener failed.", exc_info=True)
 
     @_process_response
     async def get_rejection_response(self) -> Optional[ReplicaQueueLengthInfo]:
@@ -231,15 +318,54 @@ class ActorReplicaResult(ReplicaResult):
         # object ref cached in order to avoid calling `__next__()` to
         # resolve to the underlying object ref more than once.
         # See: https://github.com/ray-project/ray/issues/43879.
+        start_time_s = time.time()
         with self._object_ref_or_gen_sync_lock:
-            if self._obj_ref is None:
-                obj_ref = self._obj_ref_gen._next_sync(timeout_s=timeout_s)  # type: ignore[union-attr]
-                if obj_ref.is_nil():
-                    raise TimeoutError("Timed out resolving to ObjectRef.")
+            self._consumption_started = True
+            if self._obj_ref is None and self._pump_outcome is None:
+                while True:
+                    remaining_timeout_s = calculate_remaining_timeout(
+                        timeout_s=timeout_s,
+                        start_time_s=start_time_s,
+                        curr_time_s=time.time(),
+                    )
+                    obj_ref = self._obj_ref_gen._next_sync(timeout_s=remaining_timeout_s)  # type: ignore[union-attr]
+                    if obj_ref.is_nil():
+                        raise TimeoutError("Timed out resolving to ObjectRef.")
 
-                self._obj_ref = obj_ref
+                    if not self._health_frames_possible:
+                        self._obj_ref = obj_ref
+                        break
 
-        return self._obj_ref
+                    # Skip health-frame system messages to reach the result.
+                    try:
+                        value = ray.get(obj_ref, timeout=remaining_timeout_s)
+                    except ray.exceptions.GetTimeoutError:
+                        raise TimeoutError("Timed out resolving to ObjectRef.")
+                    except Exception:
+                        # The exception belongs to the request; consumers
+                        # surface it when they fetch the ref.
+                        self._obj_ref = obj_ref
+                        break
+                    if isinstance(value, ReplicaHealthFrame):
+                        self._record_health_frame(value)
+                        continue
+                    self._obj_ref = obj_ref
+                    break
+
+        if self._obj_ref is not None:
+            return self._obj_ref
+
+        # The background frame pump owns the stream; wait for it to settle.
+        try:
+            return self._pump_outcome.result(
+                timeout=calculate_remaining_timeout(
+                    timeout_s=timeout_s,
+                    start_time_s=start_time_s,
+                    curr_time_s=time.time(),
+                )
+            )
+        except concurrent.futures.TimeoutError:
+            raise TimeoutError("Timed out resolving to ObjectRef.")
 
     async def to_object_ref_async(self) -> ray.ObjectRef:
         assert (
@@ -267,12 +393,33 @@ class ActorReplicaResult(ReplicaResult):
             if self._obj_ref is not None:
                 return self._obj_ref
 
+            # The background frame pump owns the stream; wait for it to settle.
+            if self._pump_outcome is not None:
+                return await asyncio.wrap_future(self._pump_outcome)
+
             acquired = self._object_ref_or_gen_sync_lock.acquire(blocking=False)
             if acquired:
                 try:
+                    self._consumption_started = True
                     # Double-check under lock
                     if self._obj_ref is None:
-                        self._obj_ref = await self._obj_ref_gen.__anext__()  # type: ignore[union-attr]
+                        while True:
+                            obj_ref = await self._obj_ref_gen.__anext__()  # type: ignore[union-attr]
+                            if not self._health_frames_possible:
+                                break
+                            # Skip health-frame system messages to reach the
+                            # result.
+                            try:
+                                value = await obj_ref
+                            except Exception:
+                                # The exception belongs to the request;
+                                # consumers surface it when they fetch the ref.
+                                break
+                            if isinstance(value, ReplicaHealthFrame):
+                                self._record_health_frame(value)
+                                continue
+                            break
+                        self._obj_ref = obj_ref
                     return self._obj_ref
                 finally:
                     self._object_ref_or_gen_sync_lock.release()

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -193,12 +193,14 @@ class ActorReplicaResult(ReplicaResult):
         self._frame_pump_task = loop.create_task(self._pump_health_frames())
 
     async def _pump_health_frames(self):
-        # Created by _maybe_start_frame_pump before this task starts.
+        # Created by _maybe_start_frame_pump before this task starts; the gen
+        # always exists for rejection-protocol results.
         outcome = self._pump_outcome
-        assert outcome is not None
+        gen = self._obj_ref_gen
+        assert outcome is not None and gen is not None
         try:
             while True:
-                obj_ref = await self._obj_ref_gen.__anext__()
+                obj_ref = await gen.__anext__()
                 try:
                     value = await obj_ref
                 except Exception:

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -3,7 +3,7 @@ import logging
 import pickle
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Optional, Set, Tuple, Union
 
 import grpc
@@ -101,6 +101,7 @@ class ActorReplicaWrapper(ReplicaWrapper):
         self, pr: PendingRequest, *, with_rejection: bool
     ) -> ActorReplicaResult:
         """Send the request to a Python replica."""
+        metadata = pr.metadata
         if with_rejection:
             # Call a separate handler that may reject the request.
             # This handler is *always* a streaming call and the first message will
@@ -108,17 +109,23 @@ class ActorReplicaWrapper(ReplicaWrapper):
             method = self._actor_handle.handle_request_with_rejection.options(
                 num_returns="streaming"
             )
-        elif pr.metadata.is_streaming:
+            if not (
+                metadata.is_streaming
+                or metadata.is_http_request
+                or metadata.is_grpc_request
+            ):
+                # Actor-transport unary calls can consume ReplicaHealthFrame
+                # system messages interleaved on the response stream.
+                metadata = replace(metadata, supports_health_frames=True)
+        elif metadata.is_streaming:
             method = self._actor_handle.handle_request_streaming.options(
                 num_returns="streaming"
             )
         else:
             method = self._actor_handle.handle_request
 
-        obj_ref_gen = method.remote(pickle.dumps(pr.metadata), *pr.args, **pr.kwargs)
-        return ActorReplicaResult(
-            obj_ref_gen, pr.metadata, with_rejection=with_rejection
-        )
+        obj_ref_gen = method.remote(pickle.dumps(metadata), *pr.args, **pr.kwargs)
+        return ActorReplicaResult(obj_ref_gen, metadata, with_rejection=with_rejection)
 
 
 class gRPCReplicaWrapper(ReplicaWrapper):

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -101,6 +101,11 @@ from ray.util import metrics
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
+# Stop re-sending a replica's health on handle reports once it has gone this
+# long without a refresh; the controller already has it.
+_REPORT_HEALTH_MAX_AGE_S = 30.0
+
+
 class RouterMetricsManager:
     """Manages metrics for the router."""
 
@@ -285,7 +290,14 @@ class RouterMetricsManager:
         """Downstream replicas' carried health, plus the host replica's own
         (when this router lives inside a replica) -- so a handle-owning
         replica's health rides reports that already flow."""
-        health = dict(self._replica_health)
+        # Entries not refreshed recently are already at the controller
+        # (deduped on arrival) -- re-sending them just bloats every report.
+        horizon = time.time() - _REPORT_HEALTH_MAX_AGE_S
+        health = {
+            uid: rec[:3]
+            for uid, rec in self._replica_health.items()
+            if rec[3] >= horizon
+        }
         provider = ray.serve.context._get_self_health_report_provider()
         if provider is not None:
             try:
@@ -307,13 +319,18 @@ class RouterMetricsManager:
         healthy: bool,
         consecutive_failures: Optional[int],
     ):
-        """Keep the newest response-carried self-health per replica."""
+        """Keep the newest response-carried self-health per replica.
+
+        The router-clock recording time rides along so reports can age-prune
+        without cross-clock comparisons against replica-local checked_at.
+        """
         prev = self._replica_health.get(replica_unique_id)
         if prev is None or checked_at > prev[0]:
             self._replica_health[replica_unique_id] = (
                 checked_at,
                 healthy,
                 consecutive_failures,
+                time.time(),
             )
 
     def _update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
@@ -1112,14 +1129,15 @@ class AsyncioRouter:
             )
             if queue_info.accepted:
                 replica_unique_id = replica.replica_id.unique_id
-                result.set_health_frame_listener(
-                    lambda frame: self._metrics_manager.record_replica_health(
-                        replica_unique_id,
-                        frame.health_checked_at,
-                        frame.healthy,
-                        frame.health_consecutive_failures,
+                if getattr(queue_info, "will_send_health_frames", False):
+                    result.set_health_frame_listener(
+                        lambda frame: self._metrics_manager.record_replica_health(
+                            replica_unique_id,
+                            frame.health_checked_at,
+                            frame.healthy,
+                            frame.health_consecutive_failures,
+                        )
                     )
-                )
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
                 self._register_decrement_queue_len_cache_callback(
                     result, replica.replica_id

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -124,6 +124,9 @@ class RouterMetricsManager:
         self._self_actor_id = self_actor_id
         self._handle_source = handle_source
         self._controller_handle = controller_handle
+        # Latest response-carried replica self-health, keyed by replica
+        # unique id: (checked_at, healthy, consecutive_failures).
+        self._replica_health: Dict[str, Tuple[float, bool, Optional[int]]] = {}
 
         # Exported metrics
         self.num_router_requests = router_requests_counter
@@ -276,6 +279,22 @@ class RouterMetricsManager:
             # is correctly decremented in this case.
             self.dec_num_queued_requests()
 
+    def record_replica_health(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int],
+    ):
+        """Keep the newest response-carried self-health per replica."""
+        prev = self._replica_health.get(replica_unique_id)
+        if prev is None or checked_at > prev[0]:
+            self._replica_health[replica_unique_id] = (
+                checked_at,
+                healthy,
+                consecutive_failures,
+            )
+
     def _update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
         """Prune list of replica ids in self.num_queries_sent_to_replicas.
 
@@ -284,6 +303,10 @@ class RouterMetricsManager:
         """
 
         running_replica_set = {replica.replica_id for replica in running_replicas}
+        unique_ids = {r.replica_id.unique_id for r in running_replicas}
+        self._replica_health = {
+            k: v for k, v in self._replica_health.items() if k in unique_ids
+        }
         with self._queries_lock:
             self.num_requests_sent_to_replicas = defaultdict(
                 int,
@@ -533,6 +556,7 @@ class RouterMetricsManager:
                 RUNNING_REQUESTS_KEY: running_requests,
             },
             timestamp=timestamp,
+            replica_health=dict(self._replica_health) or None,
         )
 
         return handle_metric_report
@@ -1055,6 +1079,13 @@ class AsyncioRouter:
                 return result
 
             queue_info = await result.get_rejection_response()
+            if queue_info.health_checked_at is not None:
+                self._metrics_manager.record_replica_health(
+                    replica.replica_id.unique_id,
+                    queue_info.health_checked_at,
+                    queue_info.healthy,
+                    queue_info.health_consecutive_failures,
+                )
             self.request_router.on_new_queue_len_info(
                 replica.replica_id, queue_info.num_ongoing_requests
             )

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1090,6 +1090,15 @@ class AsyncioRouter:
                 replica.replica_id, queue_info.num_ongoing_requests
             )
             if queue_info.accepted:
+                replica_unique_id = replica.replica_id.unique_id
+                result.set_health_frame_listener(
+                    lambda frame: self._metrics_manager.record_replica_health(
+                        replica_unique_id,
+                        frame.health_checked_at,
+                        frame.healthy,
+                        frame.health_consecutive_failures,
+                    )
+                )
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
                 self._register_decrement_queue_len_cache_callback(
                     result, replica.replica_id

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -279,6 +279,27 @@ class RouterMetricsManager:
             # is correctly decremented in this case.
             self.dec_num_queued_requests()
 
+    def _replica_health_for_report(
+        self,
+    ) -> Optional[Dict[str, Tuple[float, bool, Optional[int]]]]:
+        """Downstream replicas' carried health, plus the host replica's own
+        (when this router lives inside a replica) -- so a handle-owning
+        replica's health rides reports that already flow."""
+        health = dict(self._replica_health)
+        provider = ray.serve.context._get_self_health_report_provider()
+        if provider is not None:
+            try:
+                self_entry = provider()
+                if self_entry is not None:
+                    health[self_entry[0]] = self_entry[1]
+            except Exception:
+                # Never let health merging break the metrics report path.
+                logger.warning(
+                    "Failed to attach self-health to handle report.",
+                    exc_info=True,
+                )
+        return health or None
+
     def record_replica_health(
         self,
         replica_unique_id: str,
@@ -556,7 +577,7 @@ class RouterMetricsManager:
                 RUNNING_REQUESTS_KEY: running_requests,
             },
             timestamp=timestamp,
-            replica_health=dict(self._replica_health) or None,
+            replica_health=self._replica_health_for_report(),
         )
 
         return handle_metric_report

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -779,9 +779,13 @@ class MockReplicaActorWrapper:
         return self.healthy
 
     def record_pushed_health(
-        self, checked_at: float, healthy: bool, consecutive_failures=None
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures=None,
     ):
-        self.pushed_health = (checked_at, healthy, consecutive_failures)
+        self.pushed_health = (checked_at, received_at, healthy, consecutive_failures)
 
     def get_routing_stats(self) -> Dict[str, Any]:
         return {}

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -778,6 +778,9 @@ class MockReplicaActorWrapper:
         self.health_check_called = True
         return self.healthy
 
+    def record_pushed_health(self, checked_at: float, healthy: bool):
+        self.pushed_health = (checked_at, healthy)
+
     def get_routing_stats(self) -> Dict[str, Any]:
         return {}
 

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -778,8 +778,10 @@ class MockReplicaActorWrapper:
         self.health_check_called = True
         return self.healthy
 
-    def record_pushed_health(self, checked_at: float, healthy: bool):
-        self.pushed_health = (checked_at, healthy)
+    def record_pushed_health(
+        self, checked_at: float, healthy: bool, consecutive_failures=None
+    ):
+        self.pushed_health = (checked_at, healthy, consecutive_failures)
 
     def get_routing_stats(self) -> Dict[str, Any]:
         return {}

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -42,6 +42,22 @@ _global_client: ServeControllerClient = None
 # handle is unusable and must not be reused. See #64647.
 _global_client_job_id: Optional[str] = None
 
+# Set inside replica processes once the self-health task runs: returns
+# (replica_unique_id, (checked_at, healthy, consecutive_failures)) or None.
+# Routers living in the same process fold it into their handle metric
+# reports, so a handle-owning replica's health rides messages that already
+# flow -- no standalone RPC.
+_self_health_report_provider: Optional[Callable] = None
+
+
+def _set_self_health_report_provider(provider: Optional[Callable]) -> None:
+    global _self_health_report_provider
+    _self_health_report_provider = provider
+
+
+def _get_self_health_report_provider() -> Optional[Callable]:
+    return _self_health_report_provider
+
 
 @DeveloperAPI
 @dataclass

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1641,6 +1641,20 @@ class ControllerHealthMetrics(BaseModel):
         default=0.0, description="When the controller started (epoch seconds)."
     )
     uptime_s: float = Field(default=0.0, description="Controller uptime in seconds.")
+
+    # Replica self-check intervals observed via health pushes.
+    push_checks_recorded: int = Field(
+        default=0, description="Replica self-check intervals observed via pushes."
+    )
+    push_check_gap_p50_s: float = Field(
+        default=0.0, description="Median replica self-check interval."
+    )
+    push_check_gap_p99_s: float = Field(
+        default=0.0, description="p99 replica self-check interval."
+    )
+    push_check_gap_max_s: float = Field(
+        default=0.0, description="Max replica self-check interval."
+    )
     last_control_loop_time: float = Field(
         default=0.0,
         description="Time of the last control loop execution (epoch seconds).",

--- a/python/ray/serve/tests/test_healthcheck.py
+++ b/python/ray/serve/tests/test_healthcheck.py
@@ -5,7 +5,11 @@ import pytest
 
 import ray
 from ray import serve
-from ray._common.test_utils import async_wait_for_condition, wait_for_condition
+from ray._common.test_utils import (
+    SignalActor,
+    async_wait_for_condition,
+    wait_for_condition,
+)
 from ray.exceptions import RayError
 from ray.serve._private.common import DeploymentStatus
 from ray.serve._private.constants import (
@@ -484,6 +488,65 @@ def test_gang_health_check_restarts_gang(serve_instance):
     }
     assert len(old_gang_ids) == gang_size
     assert old_gang_ids.isdisjoint(final_replicas.keys())
+
+
+def test_health_frames_on_held_request(serve_instance):
+    """A held (long-running) unary request keeps carrying fresh health to the
+    router over the open response stream, with no standalone RPC.
+
+    The router-side per-replica health map only advances via response-carried
+    health or stream frames; with the single request held open, any advance
+    past the admission-time entry proves the frame path end to end.
+    """
+    signal = SignalActor.remote()
+
+    @serve.deployment(
+        health_check_period_s=1,
+        max_ongoing_requests=10,
+        autoscaling_config={
+            "min_replicas": 1,
+            "max_replicas": 2,
+            "target_ongoing_requests": 10,
+        },
+    )
+    class Held:
+        async def __call__(self):
+            await signal.wait.remote()
+            return "ok"
+
+    handle = serve.run(Held.bind())
+    response = handle.remote()
+    wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 1)
+
+    router = handle._router
+    metrics_manager = getattr(router, "_asyncio_router", router)._metrics_manager
+
+    def _newest_checked_at() -> float:
+        return max(
+            (rec[0] for rec in metrics_manager._replica_health.values()),
+            default=0.0,
+        )
+
+    # Admission carried the first result; frames must advance it while held.
+    wait_for_condition(lambda: _newest_checked_at() > 0)
+    admission_checked_at = _newest_checked_at()
+    wait_for_condition(lambda: _newest_checked_at() > admission_checked_at, timeout=30)
+
+    # The self-check results also reach the controller's push registry.
+    controller = serve_instance._controller
+    wait_for_condition(
+        lambda: (
+            ray.get(controller.get_health_metrics.remote()).get("push_checks_recorded")
+            or 0
+        )
+        > 0,
+        timeout=30,
+    )
+
+    # Frames must not corrupt the user-visible response.
+    assert ray.get(signal.cur_num_waiters.remote()) == 1
+    ray.get(signal.send.remote())
+    assert response.result(timeout_s=30) == "ok"
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9941,6 +9941,61 @@ class TestPushSystemicStallGuard:
         assert not wrapper._should_start_new_health_check()
 
 
+class TestRankConsistencyMembershipGate:
+    """The rank-consistency pass runs only when replica membership changes."""
+
+    def _ds(self, uids):
+        from ray.serve._private.common import DeploymentStatus
+
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        replicas = []
+        for uid in uids:
+            r = Mock()
+            r.replica_id.unique_id = uid
+            replicas.append(r)
+        ds._replicas = Mock()
+        ds._replicas.get.return_value = replicas
+        ds._replicas.count.return_value = 0
+        ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
+        ds._rank_manager = Mock()
+        ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
+        ds._reconfigure_replicas_with_new_ranks = Mock()
+        ds._last_rank_membership_fingerprint = None
+        return ds
+
+    def test_runs_once_then_skips_for_same_membership(self):
+        ds = self._ds(["a", "b", "c"])
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 1
+        )
+
+    def test_membership_change_reruns(self):
+        ds = self._ds(["a", "b", "c"])
+        ds._maybe_check_rank_consistency()
+        new = []
+        for uid in ["a", "b", "d"]:
+            r = Mock()
+            r.replica_id.unique_id = uid
+            new.append(r)
+        ds._replicas.get.return_value = new
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 2
+        )
+
+    def test_starting_replicas_skip_entirely(self):
+        ds = self._ds(["a", "b"])
+        ds._replicas.count.return_value = 1
+        ds._maybe_check_rank_consistency()
+        ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
+        assert ds._last_rank_membership_fingerprint is None
+
+
 class TestPushedHealthReviewRegressions:
     """Regressions for the agent-review findings on the push-health PR."""
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9846,6 +9846,66 @@ class TestPushedHealth:
         assert w._consecutive_health_check_failures == 0
 
 
+class TestPushSystemicStallGuard:
+    """Mass push staleness reads as controller-side lag: defer fallback probes,
+    bounded so a genuine mass outage still surfaces."""
+
+    def _registry_with(self, n, stale_n, age_s=60.0):
+        from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
+
+        registry = ReplicaHealthPushRegistry()
+        now = time.time()
+        for i in range(n):
+            received_at = now - age_s if i < stale_n else now
+            registry._state[f"r{i}"] = (now - age_s, received_at, True, 0)
+        return registry
+
+    def test_below_min_tracked_never_systemic(self):
+        registry = self._registry_with(n=63, stale_n=63)
+        assert not registry.systemic_stall()
+
+    def test_minority_stale_not_systemic(self):
+        registry = self._registry_with(n=100, stale_n=49)
+        assert not registry.systemic_stall()
+
+    def test_majority_stale_is_systemic(self):
+        registry = self._registry_with(n=100, stale_n=80)
+        assert registry.systemic_stall()
+
+    def test_defer_is_bounded(self):
+        registry = self._registry_with(n=100, stale_n=100)
+        assert registry.systemic_stall()
+        # Once the stall has lasted past the cap, probes must resume.
+        registry._stall_since = time.time() - registry._STALL_MAX_DEFER_S - 1
+        assert not registry.systemic_stall()
+
+    def test_recovery_clears_stall(self):
+        registry = self._registry_with(n=100, stale_n=100)
+        assert registry.systemic_stall()
+        registry._state = self._registry_with(n=100, stale_n=0)._state
+        registry._stall_checked_at = 0.0  # bypass the ~1s verdict cache
+        assert not registry.systemic_stall()
+        assert registry._stall_since is None
+
+    def test_verdict_cached_between_checks(self):
+        registry = self._registry_with(n=100, stale_n=100)
+        assert registry.systemic_stall()
+        # State recovers, but within the cache TTL the verdict holds.
+        registry._state = self._registry_with(n=100, stale_n=0)._state
+        assert registry.systemic_stall()
+
+    def test_stale_counts(self):
+        registry = self._registry_with(n=10, stale_n=4)
+        stale, total = registry.stale_counts(30.0)
+        assert (stale, total) == (4, 10)
+
+    def test_defer_holds_wrapper_probe_gate(self):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._last_push_consume_time = 0.0
+        wrapper.defer_push_fallback_probe()
+        assert not wrapper._should_start_new_health_check()
+
+
 class TestPushedHealthReviewRegressions:
     """Regressions for the agent-review findings on the push-health PR."""
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9788,6 +9788,7 @@ class TestPushedHealth:
         w._replica_id = "test_replica"
         w._pushed_health = None
         w._last_consumed_push_ts = 0.0
+        w._last_push_consume_time = 0.0
         w._version = SimpleNamespace(
             deployment_config=SimpleNamespace(health_check_period_s=10.0)
         )
@@ -9800,7 +9801,7 @@ class TestPushedHealth:
         assert w.check_health() is True
         w._actor_handle.check_health.remote.assert_not_called()
         assert w._health_check_ref is None
-        assert w._last_health_check_time > 0.0
+        assert w._last_push_consume_time > 0.0  # probe gated while pushes flow
 
     def test_stale_push_falls_back_to_pull_probe(self):
         w = self._wrapper()
@@ -9827,6 +9828,13 @@ class TestPushedHealth:
         w.check_health()
         assert w._consecutive_health_check_failures == 1
 
+    def test_pushed_count_is_mirrored(self):
+        w = self._wrapper()
+        w.record_pushed_health(time.time(), False, 7)
+        w.check_health()
+        assert w._consecutive_health_check_failures == 7
+        assert w._healthy is False
+
     def test_healthy_push_resets_failure_count(self):
         w = self._wrapper()
         w.record_pushed_health(time.time(), False)
@@ -9846,7 +9854,7 @@ def test_apply_pushed_health_hands_off_to_wrapper():
     rep.replica_id.unique_id = "r1"
     ds._health_push_registry.record("r1", 123.0, True)
     DeploymentState._apply_pushed_health(ds, rep)
-    rep.record_pushed_health.assert_called_once_with(123.0, True)
+    rep.record_pushed_health.assert_called_once_with(123.0, True, None)
 
     rep2 = Mock()
     rep2.replica_id.unique_id = "r2"

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9797,7 +9797,8 @@ class TestPushedHealth:
     def test_fresh_healthy_push_defers_pull_probe(self):
         w = self._wrapper()
         w._last_health_check_time = 0.0  # probe would fire without the push
-        w.record_pushed_health(time.time(), True)
+        now = time.time()
+        w.record_pushed_health(now, now, True)
         assert w.check_health() is True
         w._actor_handle.check_health.remote.assert_not_called()
         assert w._health_check_ref is None
@@ -9806,7 +9807,7 @@ class TestPushedHealth:
     def test_stale_push_falls_back_to_pull_probe(self):
         w = self._wrapper()
         w._last_health_check_time = 0.0
-        w.record_pushed_health(time.time() - 60.0, True)
+        w.record_pushed_health(time.time() - 60.0, time.time() - 60.0, True)
         assert w.check_health() is True
         w._actor_handle.check_health.remote.assert_called_once()
 
@@ -9814,7 +9815,7 @@ class TestPushedHealth:
         w = self._wrapper()
         threshold = ds_mod.REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
         for i in range(threshold):
-            w.record_pushed_health(time.time() + i * 1e-3, False)
+            w.record_pushed_health(time.time() + i * 1e-3, time.time(), False)
             w.check_health()
         assert w._healthy is False
         assert w._consecutive_health_check_failures == threshold
@@ -9822,27 +9823,52 @@ class TestPushedHealth:
     def test_push_deduped_by_timestamp(self):
         w = self._wrapper()
         ts = time.time()
-        w.record_pushed_health(ts, False)
+        w.record_pushed_health(ts, ts, False)
         w.check_health()
-        w.record_pushed_health(ts, False)  # same observation again
+        w.record_pushed_health(ts, ts, False)  # same observation again
         w.check_health()
         assert w._consecutive_health_check_failures == 1
 
     def test_pushed_count_is_mirrored(self):
         w = self._wrapper()
-        w.record_pushed_health(time.time(), False, 7)
+        w.record_pushed_health(time.time(), time.time(), False, 7)
         w.check_health()
         assert w._consecutive_health_check_failures == 7
         assert w._healthy is False
 
     def test_healthy_push_resets_failure_count(self):
         w = self._wrapper()
-        w.record_pushed_health(time.time(), False)
+        w.record_pushed_health(time.time(), time.time(), False)
         w.check_health()
         assert w._consecutive_health_check_failures == 1
-        w.record_pushed_health(time.time() + 1e-3, True)
+        w.record_pushed_health(time.time() + 1e-3, time.time(), True)
         assert w.check_health() is True
         assert w._consecutive_health_check_failures == 0
+
+
+class TestPushedHealthReviewRegressions:
+    """Regressions for the agent-review findings on the push-health PR."""
+
+    def test_registry_rejects_out_of_order_reports(self):
+        r = ReplicaHealthPushRegistry()
+        r.record("r1", checked_at=200.0, healthy=True)
+        r.record("r1", checked_at=100.0, healthy=False)  # delayed older report
+        checked_at, _received_at, healthy, _cnt = r.get("r1")
+        assert checked_at == 200.0 and healthy is True
+
+    def test_resolved_probe_does_not_discard_fresh_push(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        # An in-flight probe resolves SUCCEEDED this tick...
+        w._health_check_ref = "probe_ref"
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        monkeypatch.setattr(ds_mod.ray, "get", lambda r: None)
+        now = time.time()
+        w.record_pushed_health(now, now, False, 1)
+        assert w.check_health() is True  # probe result wins this tick
+        assert w._pushed_health is not None  # ...but the push stays stashed
+        # Next tick (no probe): the push is consumed.
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 1
 
 
 def test_apply_pushed_health_hands_off_to_wrapper():
@@ -9854,7 +9880,8 @@ def test_apply_pushed_health_hands_off_to_wrapper():
     rep.replica_id.unique_id = "r1"
     ds._health_push_registry.record("r1", 123.0, True)
     DeploymentState._apply_pushed_health(ds, rep)
-    rep.record_pushed_health.assert_called_once_with(123.0, True, None)
+    args = rep.record_pushed_health.call_args.args
+    assert args[0] == 123.0 and args[2] is True and args[3] is None
 
     rep2 = Mock()
     rep2.replica_id.unique_id = "r2"

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9847,57 +9847,92 @@ class TestPushedHealth:
 
 
 class TestPushSystemicStallGuard:
-    """Mass push staleness reads as controller-side lag: defer fallback probes,
-    bounded so a genuine mass outage still surfaces."""
+    """Most of a deployment's pushed health going stale at once (by its own
+    window) reads as controller-side lag: defer fallback probes, bounded so a
+    genuine mass outage still surfaces."""
 
-    def _registry_with(self, n, stale_n, age_s=60.0):
+    def _ds(self, window_s=15.0):
         from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
 
-        registry = ReplicaHealthPushRegistry()
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        ds._health_push_registry = ReplicaHealthPushRegistry()
+        ds._push_probes_deferred = False
+        ds._push_stall_since = None
+        ds._push_stall_stale = 0
+        ds._push_stall_total = 0
+        ds._push_stall_window_s = window_s
+        ds._id = "test-deployment"
+        return ds
+
+    def _seed(self, ds, n, stale_n, age_s=60.0):
         now = time.time()
         for i in range(n):
             received_at = now - age_s if i < stale_n else now
-            registry._state[f"r{i}"] = (now - age_s, received_at, True, 0)
-        return registry
+            ds._health_push_registry._state[f"r{i}"] = (
+                now - age_s,
+                received_at,
+                True,
+                0,
+            )
 
-    def test_below_min_tracked_never_systemic(self):
-        registry = self._registry_with(n=63, stale_n=63)
-        assert not registry.systemic_stall()
+    def _sweep(self, ds, n):
+        for i in range(n):
+            replica = Mock()
+            replica.replica_id.unique_id = f"r{i}"
+            ds._apply_pushed_health(replica)
 
-    def test_minority_stale_not_systemic(self):
-        registry = self._registry_with(n=100, stale_n=49)
-        assert not registry.systemic_stall()
+    def _tally_and_verdict(self, ds, n, stale_n):
+        self._seed(ds, n, stale_n)
+        self._sweep(ds, n)
+        ds._finalize_push_stall_verdict()
 
-    def test_majority_stale_is_systemic(self):
-        registry = self._registry_with(n=100, stale_n=80)
-        assert registry.systemic_stall()
+    def test_majority_stale_defers_next_sweep(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=80)
+        assert (ds._push_stall_stale, ds._push_stall_total) == (80, 100)
+        assert ds._push_probes_deferred
+        # Next sweep: every replica's probe gate is held closed.
+        replica = Mock()
+        replica.replica_id.unique_id = "r0"
+        ds._apply_pushed_health(replica)
+        replica.defer_push_fallback_probe.assert_called_once()
 
-    def test_defer_is_bounded(self):
-        registry = self._registry_with(n=100, stale_n=100)
-        assert registry.systemic_stall()
-        # Once the stall has lasted past the cap, probes must resume.
-        registry._stall_since = time.time() - registry._STALL_MAX_DEFER_S - 1
-        assert not registry.systemic_stall()
+    def test_below_min_tracked_never_defers(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=63, stale_n=63)
+        assert not ds._push_probes_deferred
 
-    def test_recovery_clears_stall(self):
-        registry = self._registry_with(n=100, stale_n=100)
-        assert registry.systemic_stall()
-        registry._state = self._registry_with(n=100, stale_n=0)._state
-        registry._stall_checked_at = 0.0  # bypass the ~1s verdict cache
-        assert not registry.systemic_stall()
-        assert registry._stall_since is None
+    def test_minority_stale_does_not_defer(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=49)
+        assert not ds._push_probes_deferred
 
-    def test_verdict_cached_between_checks(self):
-        registry = self._registry_with(n=100, stale_n=100)
-        assert registry.systemic_stall()
-        # State recovers, but within the cache TTL the verdict holds.
-        registry._state = self._registry_with(n=100, stale_n=0)._state
-        assert registry.systemic_stall()
+    def test_long_period_deployment_not_stale_by_its_own_window(self):
+        # Entries 60s old are fresh for a deployment whose configured window
+        # exceeds that (cursor review: the verdict must use the deployment's
+        # own period, not the default).
+        ds = self._ds(window_s=90.0)
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_stall_stale == 0
+        assert not ds._push_probes_deferred
 
-    def test_stale_counts(self):
-        registry = self._registry_with(n=10, stale_n=4)
-        stale, total = registry.stale_counts(30.0)
-        assert (stale, total) == (4, 10)
+    def test_defer_is_bounded_per_episode(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_probes_deferred
+        ds._push_stall_since = time.time() - ds_mod.HEALTH_PUSH_STALL_MAX_DEFER_S - 1
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+
+    def test_recovery_clears_the_episode(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_probes_deferred
+        ds._push_stall_stale = 0
+        ds._push_stall_total = 100
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+        assert ds._push_stall_since is None
 
     def test_defer_holds_wrapper_probe_gate(self):
         wrapper = TestPushedHealth()._wrapper()
@@ -9936,6 +9971,10 @@ def test_apply_pushed_health_hands_off_to_wrapper():
     entries or registry leave the pull path untouched."""
     ds = DeploymentState.__new__(DeploymentState)
     ds._health_push_registry = ReplicaHealthPushRegistry()
+    ds._push_probes_deferred = False
+    ds._push_stall_stale = 0
+    ds._push_stall_total = 0
+    ds._push_stall_window_s = 15.0
     rep = Mock()
     rep.replica_id.unique_id = "r1"
     ds._health_push_registry.record("r1", 123.0, True)

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1,10 +1,13 @@
 import sys
+import time
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+import ray.serve._private.deployment_state as ds_mod
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray._raylet import NodeID
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
@@ -49,6 +52,7 @@ from ray.serve._private.deployment_state import (
     DeploymentState,
     DeploymentStateManager,
     DeploymentVersion,
+    ReplicaHealthPushRegistry,
     ReplicaStartupStatus,
     ReplicaStateContainer,
 )
@@ -9767,3 +9771,88 @@ def test_ingress_membership_version_ignores_non_ingress_deployment(
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestPushedHealth:
+    """Replica-pushed self-health short-circuits the pull probe; stale or absent
+    pushes fall back to the pull path unchanged."""
+
+    def _wrapper(self):
+        w = ActorReplicaWrapper.__new__(ActorReplicaWrapper)
+        w._actor_handle = Mock()
+        w._actor_handle.check_health.remote.return_value = "probe_ref"
+        w._health_check_ref = None
+        w._last_health_check_time = time.time()
+        w._consecutive_health_check_failures = 0
+        w._healthy = True
+        w._replica_id = "test_replica"
+        w._pushed_health = None
+        w._last_consumed_push_ts = 0.0
+        w._version = SimpleNamespace(
+            deployment_config=SimpleNamespace(health_check_period_s=10.0)
+        )
+        return w
+
+    def test_fresh_healthy_push_defers_pull_probe(self):
+        w = self._wrapper()
+        w._last_health_check_time = 0.0  # probe would fire without the push
+        w.record_pushed_health(time.time(), True)
+        assert w.check_health() is True
+        w._actor_handle.check_health.remote.assert_not_called()
+        assert w._health_check_ref is None
+        assert w._last_health_check_time > 0.0
+
+    def test_stale_push_falls_back_to_pull_probe(self):
+        w = self._wrapper()
+        w._last_health_check_time = 0.0
+        w.record_pushed_health(time.time() - 60.0, True)
+        assert w.check_health() is True
+        w._actor_handle.check_health.remote.assert_called_once()
+
+    def test_unhealthy_pushes_count_toward_threshold(self):
+        w = self._wrapper()
+        threshold = ds_mod.REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+        for i in range(threshold):
+            w.record_pushed_health(time.time() + i * 1e-3, False)
+            w.check_health()
+        assert w._healthy is False
+        assert w._consecutive_health_check_failures == threshold
+
+    def test_push_deduped_by_timestamp(self):
+        w = self._wrapper()
+        ts = time.time()
+        w.record_pushed_health(ts, False)
+        w.check_health()
+        w.record_pushed_health(ts, False)  # same observation again
+        w.check_health()
+        assert w._consecutive_health_check_failures == 1
+
+    def test_healthy_push_resets_failure_count(self):
+        w = self._wrapper()
+        w.record_pushed_health(time.time(), False)
+        w.check_health()
+        assert w._consecutive_health_check_failures == 1
+        w.record_pushed_health(time.time() + 1e-3, True)
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 0
+
+
+def test_apply_pushed_health_hands_off_to_wrapper():
+    """DeploymentState routes registry entries to the replica wrapper; absent
+    entries or registry leave the pull path untouched."""
+    ds = DeploymentState.__new__(DeploymentState)
+    ds._health_push_registry = ReplicaHealthPushRegistry()
+    rep = Mock()
+    rep.replica_id.unique_id = "r1"
+    ds._health_push_registry.record("r1", 123.0, True)
+    DeploymentState._apply_pushed_health(ds, rep)
+    rep.record_pushed_health.assert_called_once_with(123.0, True)
+
+    rep2 = Mock()
+    rep2.replica_id.unique_id = "r2"
+    DeploymentState._apply_pushed_health(ds, rep2)
+    rep2.record_pushed_health.assert_not_called()
+
+    ds._health_push_registry = None
+    DeploymentState._apply_pushed_health(ds, rep2)
+    rep2.record_pushed_health.assert_not_called()

--- a/python/ray/serve/tests/unit/test_health_frames.py
+++ b/python/ray/serve/tests/unit/test_health_frames.py
@@ -22,9 +22,13 @@ def _metadata(**kwargs):
 class _FakeManager:
     """Just enough of ReplicaMetricsManager for the frame generator."""
 
-    def __init__(self, period_s=0.02):
+    def __init__(self, period_s=0.02, carries=False):
         self._self_health_period_s = period_s
         self.snapshot = (True, None, 0)
+        self.carries = carries
+
+    def reports_carry_health(self):
+        return self.carries
 
     @property
     def self_health_period_s(self):
@@ -115,6 +119,24 @@ class TestUnaryWithHealthFrames:
             return "r"
 
         asyncio.get_running_loop().call_later(0.1, release.set)
+        items = await _drain(
+            Replica._call_unary_with_health_frames(
+                _fake_replica(manager, user), _metadata(), (), {}
+            )
+        )
+        assert items == ["r"]
+
+    @pytest.mark.asyncio
+    async def test_no_frames_while_reports_carry_health(self):
+        manager = _FakeManager(carries=True)
+        manager.snapshot = (True, 100.0, 0)
+        release = asyncio.Event()
+
+        async def user():
+            await release.wait()
+            return "r"
+
+        asyncio.get_running_loop().call_later(0.15, release.set)
         items = await _drain(
             Replica._call_unary_with_health_frames(
                 _fake_replica(manager, user), _metadata(), (), {}

--- a/python/ray/serve/tests/unit/test_health_frames.py
+++ b/python/ray/serve/tests/unit/test_health_frames.py
@@ -30,6 +30,9 @@ class _FakeManager:
     def reports_carry_health(self):
         return self.carries
 
+    def health_already_carried(self):
+        return self.carries
+
     @property
     def self_health_period_s(self):
         return self._self_health_period_s

--- a/python/ray/serve/tests/unit/test_health_frames.py
+++ b/python/ray/serve/tests/unit/test_health_frames.py
@@ -1,0 +1,304 @@
+import asyncio
+import pickle
+import sys
+import threading
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from ray.serve._private.common import ReplicaHealthFrame
+from ray.serve._private.replica import Replica
+from ray.serve._private.replica_result import ActorReplicaResult
+from ray.serve._private.request_router.common import PendingRequest
+
+
+def _metadata(**kwargs):
+    from ray.serve._private.common import RequestMetadata
+
+    return RequestMetadata(request_id="r", internal_request_id="i", **kwargs)
+
+
+class _FakeManager:
+    """Just enough of ReplicaMetricsManager for the frame generator."""
+
+    def __init__(self, period_s=0.02):
+        self._self_health_period_s = period_s
+        self.snapshot = (True, None, 0)
+
+    @property
+    def self_health_period_s(self):
+        return self._self_health_period_s
+
+    def self_health_frame(self):
+        healthy, checked_at, failures = self.snapshot
+        if checked_at is None:
+            return None
+        return ReplicaHealthFrame(
+            healthy=healthy,
+            health_checked_at=checked_at,
+            health_consecutive_failures=failures,
+        )
+
+
+def _fake_replica(manager, user_coro_fn):
+    return SimpleNamespace(
+        _metrics_manager=manager,
+        _user_callable_wrapper=SimpleNamespace(
+            call_user_method=lambda md, args, kwargs: user_coro_fn()
+        ),
+    )
+
+
+async def _drain(gen):
+    items = []
+    async for item in gen:
+        items.append(item)
+    return items
+
+
+class TestUnaryWithHealthFrames:
+    """Replica-side generator: frames interleave while the user call is pending."""
+
+    @pytest.mark.asyncio
+    async def test_frames_then_result(self):
+        manager = _FakeManager()
+        release = asyncio.Event()
+
+        async def user():
+            await release.wait()
+            return "result"
+
+        replica = _fake_replica(manager, user)
+        manager.snapshot = (True, 100.0, 0)
+
+        async def release_later():
+            await asyncio.sleep(0.1)
+            manager.snapshot = (True, 101.0, 0)
+            await asyncio.sleep(0.1)
+            release.set()
+
+        task = asyncio.ensure_future(release_later())
+        items = await _drain(
+            Replica._call_unary_with_health_frames(replica, _metadata(), (), {})
+        )
+        await task
+
+        assert items[-1] == "result"
+        frames = [i for i in items[:-1] if isinstance(i, ReplicaHealthFrame)]
+        assert len(items[:-1]) == len(frames) >= 2
+        # Throttled: one frame per distinct checked_at, in order.
+        assert [f.health_checked_at for f in frames] == [100.0, 101.0]
+
+    @pytest.mark.asyncio
+    async def test_fast_request_yields_only_result(self):
+        manager = _FakeManager(period_s=10.0)
+        manager.snapshot = (True, 100.0, 0)
+
+        async def user():
+            return "fast"
+
+        items = await _drain(
+            Replica._call_unary_with_health_frames(
+                _fake_replica(manager, user), _metadata(), (), {}
+            )
+        )
+        assert items == ["fast"]
+
+    @pytest.mark.asyncio
+    async def test_no_frames_before_first_self_check(self):
+        manager = _FakeManager()  # snapshot checked_at is None
+        release = asyncio.Event()
+
+        async def user():
+            await release.wait()
+            return "r"
+
+        asyncio.get_running_loop().call_later(0.1, release.set)
+        items = await _drain(
+            Replica._call_unary_with_health_frames(
+                _fake_replica(manager, user), _metadata(), (), {}
+            )
+        )
+        assert items == ["r"]
+
+    @pytest.mark.asyncio
+    async def test_user_exception_propagates(self):
+        manager = _FakeManager()
+
+        async def user():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            await _drain(
+                Replica._call_unary_with_health_frames(
+                    _fake_replica(manager, user), _metadata(), (), {}
+                )
+            )
+
+
+class _FakeGen:
+    """Stands in for a ray ObjectRefGenerator: __anext__ pops awaitable 'refs'."""
+
+    def __init__(self, futures):
+        self._futures = list(futures)
+
+    async def __anext__(self):
+        if not self._futures:
+            raise StopAsyncIteration
+        fut = self._futures.pop(0)
+        # Yield control like a real gen so pending futures can be filled.
+        while not fut.done():
+            await asyncio.sleep(0.01)
+        return fut
+
+
+def _done_future(value=None, exception=None):
+    fut = asyncio.get_running_loop().create_future()
+    if exception is not None:
+        fut.set_exception(exception)
+    else:
+        fut.set_result(value)
+    return fut
+
+
+def _result_wrapper(gen, frames_possible=True):
+    r = ActorReplicaResult.__new__(ActorReplicaResult)
+    r._obj_ref = None
+    r._obj_ref_gen = gen
+    r._is_streaming = False
+    r._request_id = "r"
+    r._object_ref_or_gen_sync_lock = threading.Lock()
+    r._with_rejection = True
+    r._rejection_response = None
+    r._health_frames_possible = frames_possible
+    r._on_health_frame = None
+    r._frame_pump_task = None
+    r._pump_outcome = None
+    r._consumption_started = False
+    return r
+
+
+class TestFramePump:
+    """Router-side pump: drains frames in the background, then holds the result."""
+
+    @pytest.mark.asyncio
+    async def test_pump_records_frames_and_get_async_returns_result(self):
+        frame1 = ReplicaHealthFrame(healthy=True, health_checked_at=1.0)
+        frame2 = ReplicaHealthFrame(healthy=False, health_checked_at=2.0)
+        gen = _FakeGen(
+            [_done_future(frame1), _done_future(frame2), _done_future("result")]
+        )
+        r = _result_wrapper(gen)
+        seen = []
+        r._on_health_frame = seen.append
+
+        r._maybe_start_frame_pump(asyncio.get_running_loop())
+        assert r._pump_outcome is not None
+        assert (await r.get_async()) == "result"
+        assert seen == [frame1, frame2]
+
+    @pytest.mark.asyncio
+    async def test_pump_settles_error_ref_and_get_async_raises(self):
+        gen = _FakeGen(
+            [
+                _done_future(ReplicaHealthFrame(healthy=True, health_checked_at=1.0)),
+                _done_future(exception=ValueError("boom")),
+            ]
+        )
+        r = _result_wrapper(gen)
+        r._maybe_start_frame_pump(asyncio.get_running_loop())
+        with pytest.raises(ValueError, match="boom"):
+            await r.get_async()
+
+    @pytest.mark.asyncio
+    async def test_to_object_ref_async_waits_on_pump(self):
+        result_fut = asyncio.get_running_loop().create_future()
+        gen = _FakeGen([result_fut])
+        r = _result_wrapper(gen)
+        r._maybe_start_frame_pump(asyncio.get_running_loop())
+        asyncio.get_running_loop().call_later(0.05, result_fut.set_result, "late")
+        ref = await r.to_object_ref_async()
+        assert (await ref) == "late"
+
+    @pytest.mark.asyncio
+    async def test_direct_consumption_filters_frames_without_pump(self):
+        frame = ReplicaHealthFrame(healthy=True, health_checked_at=1.0)
+        gen = _FakeGen([_done_future(frame), _done_future("direct")])
+        r = _result_wrapper(gen)
+        seen = []
+        r._on_health_frame = seen.append
+        assert (await r.get_async()) == "direct"
+        assert seen == [frame]
+        # Consumption marked; a late pump start must be a no-op.
+        r._maybe_start_frame_pump(asyncio.get_running_loop())
+        assert r._pump_outcome is None
+
+    @pytest.mark.asyncio
+    async def test_listener_noop_when_frames_not_possible(self):
+        gen = _FakeGen([_done_future("x")])
+        r = _result_wrapper(gen, frames_possible=False)
+        r.set_health_frame_listener(lambda f: None)
+        assert r._on_health_frame is None
+        assert (await r.get_async()) == "x"
+
+
+class TestSupportsHealthFramesGate:
+    """The actor transport advertises frame support for unary rejection calls only."""
+
+    def _send(self, metadata, with_rejection=True):
+        # Resolve the module fresh: other unit suites reload serve modules,
+        # so a collection-time import can go stale.
+        import importlib
+
+        replica_wrapper_mod = importlib.import_module(
+            "ray.serve._private.request_router.replica_wrapper"
+        )
+        captured = {}
+
+        def remote(pickled_md, *args, **kwargs):
+            captured["metadata"] = pickle.loads(pickled_md)
+            return "obj_ref_gen"
+
+        endpoint = SimpleNamespace(remote=remote)
+        handle = SimpleNamespace(
+            handle_request_with_rejection=SimpleNamespace(options=lambda **kw: endpoint),
+            handle_request_streaming=SimpleNamespace(options=lambda **kw: endpoint),
+            handle_request=endpoint,
+        )
+        wrapper = replica_wrapper_mod.ActorReplicaWrapper(handle)
+        rr = mock.MagicMock()
+        # Patch the name where the method actually resolves it (its own
+        # __globals__) -- other unit suites shuffle module identities, so
+        # patching the sys.modules entry can miss.
+        with mock.patch.dict(
+            wrapper.send_request_python.__func__.__globals__,
+            {"ActorReplicaResult": rr},
+        ):
+            wrapper.send_request_python(
+                PendingRequest(args=[], kwargs={}, metadata=metadata),
+                with_rejection=with_rejection,
+            )
+            constructed_md = rr.call_args.args[1]
+        return captured["metadata"], constructed_md
+
+    # async: PendingRequest's future field needs a running event loop.
+    @pytest.mark.asyncio
+    async def test_unary_rejection_sets_flag(self):
+        sent, constructed = self._send(_metadata())
+        assert sent.supports_health_frames
+        assert constructed.supports_health_frames
+
+    @pytest.mark.asyncio
+    async def test_streaming_rejection_does_not(self):
+        sent, _ = self._send(_metadata(is_streaming=True))
+        assert not sent.supports_health_frames
+
+    @pytest.mark.asyncio
+    async def test_no_rejection_does_not(self):
+        sent, _ = self._send(_metadata(), with_rejection=False)
+        assert not sent.supports_health_frames
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/tests/unit/test_health_frames.py
+++ b/python/ray/serve/tests/unit/test_health_frames.py
@@ -262,7 +262,9 @@ class TestSupportsHealthFramesGate:
 
         endpoint = SimpleNamespace(remote=remote)
         handle = SimpleNamespace(
-            handle_request_with_rejection=SimpleNamespace(options=lambda **kw: endpoint),
+            handle_request_with_rejection=SimpleNamespace(
+                options=lambda **kw: endpoint
+            ),
             handle_request_streaming=SimpleNamespace(options=lambda **kw: endpoint),
             handle_request=endpoint,
         )

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1360,3 +1360,113 @@ class TestCythonImplementationEdgeCases:
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestSelfHealthPush:
+    """The replica-side self-health task stores the local result and heartbeats
+    it to the controller only when metric report pushes are not carrying it."""
+
+    def _manager(self, pushing_reports=False):
+        import threading
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import ReplicaMetricsManager
+
+        m = ReplicaMetricsManager.__new__(ReplicaMetricsManager)
+        m._self_healthy = None
+        m._self_health_checked_at = None
+        m._self_health_timeout_s = 1.0
+        m._pushing_metric_reports = pushing_reports
+        m._pending_health_push_ref = None
+        m._self_consecutive_failures = 0
+        m._metrics_push_lock = threading.Lock()
+        m._controller_handle = Mock()
+        m._replica_id = SimpleNamespace(unique_id="r1")
+        return m
+
+    @pytest.mark.asyncio
+    async def test_healthy_eval_heartbeats(self):
+        m = self._manager()
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is True
+        args = m._controller_handle.record_replica_health.remote.call_args.args
+        assert args[0] == "r1" and args[2] is True
+
+    @pytest.mark.asyncio
+    async def test_failing_eval_heartbeats_unhealthy(self):
+        m = self._manager()
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        assert (
+            m._controller_handle.record_replica_health.remote.call_args.args[2] is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_hanging_eval_times_out_unhealthy(self):
+        m = self._manager()
+        m._self_health_timeout_s = 0.05
+
+        async def hang():
+            await asyncio.sleep(10)
+
+        m._eval_self_health_fn = hang
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_metric_reports_carry_health(self):
+        m = self._manager(pushing_reports=True)
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is True
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_latches_unhealthy_at_threshold(self):
+        from ray.serve._private.constants import (
+            REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
+        )
+
+        m = self._manager(pushing_reports=True)
+        evals = []
+
+        async def bad():
+            evals.append(1)
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        for _ in range(REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD + 2):
+            await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        # The user check stops running at the threshold; pushes continue.
+        assert len(evals) == REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_in_flight_heartbeat_skips_next(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        m = self._manager()
+        m._pending_health_push_ref = "in_flight"
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: False)
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1384,6 +1384,7 @@ class TestSelfHealthPush:
         m._self_health_period_s = 10.0
         m._pending_health_push_ref = None
         m._self_consecutive_failures = 0
+        m._last_health_carried_ts = None
         m._metrics_push_lock = threading.Lock()
         m._controller_handle = Mock()
         m._replica_id = SimpleNamespace(unique_id="r1")
@@ -1503,6 +1504,43 @@ class TestSelfHealthPush:
         assert stats["count"] == 9
         assert 4.75 <= stats["p99_s"] <= 5.25
         assert stats["max_s"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_health_rides_responses(self, monkeypatch):
+        import time as time_mod
+        from types import SimpleNamespace
+
+        import ray.serve._private.replica as replica_mod
+
+        monkeypatch.setattr(
+            replica_mod, "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE", True
+        )
+        m = self._manager()
+        m._autoscaling_config = SimpleNamespace(metrics_interval_s=10.0)
+        m._last_health_carried_ts = time_mod.time()  # responses carried it
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+        # Traffic stopped long ago -> heartbeat resumes.
+        m._last_health_carried_ts = time_mod.time() - 60.0
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_called_once()
+
+    def test_router_keeps_newest_response_carried_health(self):
+        from ray.serve._private.router import RouterMetricsManager
+
+        rm = RouterMetricsManager.__new__(RouterMetricsManager)
+        rm._replica_health = {}
+        rm.record_replica_health("r1", 200.0, True, 0)
+        rm.record_replica_health("r1", 100.0, False, 2)  # delayed older
+        assert rm._replica_health["r1"] == (200.0, True, 0)
+        rm.record_replica_health("r1", 300.0, False, 1)
+        assert rm._replica_health["r1"] == (300.0, False, 1)
 
     @pytest.mark.asyncio
     async def test_in_flight_heartbeat_skips_next(self, monkeypatch):

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1475,6 +1475,35 @@ class TestSelfHealthPush:
         await m._eval_and_push_self_health()
         m._controller_handle.record_replica_health.remote.assert_called_once()
 
+    def test_self_check_runs_at_half_the_period(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica
+
+        r = Replica.__new__(Replica)
+        r._metrics_manager = Mock()
+        r._deployment_config = SimpleNamespace(
+            health_check_period_s=10.0, health_check_timeout_s=30.0
+        )
+        r._self_health_active = False
+        Replica._start_self_health_pusher(r)
+        args = r._metrics_manager.start_self_health_pusher.call_args.args
+        assert args[1] == 5.0  # half the period
+        assert args[2] == 30.0
+
+    def test_registry_tracks_self_check_intervals(self):
+        from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
+
+        r = ReplicaHealthPushRegistry()
+        t0 = 1000.0
+        for i in range(10):
+            r.record("r1", t0 + i * 5.0, True)
+        stats = r.gap_stats()
+        assert stats["count"] == 9
+        assert 4.75 <= stats["p99_s"] <= 5.25
+        assert stats["max_s"] == 5.0
+
     @pytest.mark.asyncio
     async def test_in_flight_heartbeat_skips_next(self, monkeypatch):
         import ray.serve._private.replica as replica_mod

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1378,6 +1378,10 @@ class TestSelfHealthPush:
         m._self_health_checked_at = None
         m._self_health_timeout_s = 1.0
         m._pushing_metric_reports = pushing_reports
+        m._autoscaling_config = (
+            SimpleNamespace(metrics_interval_s=10.0) if pushing_reports else None
+        )
+        m._self_health_period_s = 10.0
         m._pending_health_push_ref = None
         m._self_consecutive_failures = 0
         m._metrics_push_lock = threading.Lock()
@@ -1455,6 +1459,21 @@ class TestSelfHealthPush:
         assert m._self_healthy is False
         # The user check stops running at the threshold; pushes continue.
         assert len(evals) == REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_heartbeats_when_metric_pushes_too_infrequent(self):
+        from types import SimpleNamespace
+
+        m = self._manager(pushing_reports=True)
+        m._autoscaling_config = SimpleNamespace(metrics_interval_s=30.0)
+        m._self_health_period_s = 10.0  # health evaluated 3x per metric push
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_in_flight_heartbeat_skips_next(self, monkeypatch):

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1358,6 +1358,108 @@ class TestCythonImplementationEdgeCases:
         assert result[0].value == pytest.approx(1e-10, rel=1e-6)
 
 
+class TestSelfHealthReportEntry:
+    """A handle-owning replica's health rides its own handle metric reports;
+    frames and heartbeats stay quiet while that carries."""
+
+    def _manager(self, pushing_reports=False):
+        return TestSelfHealthPush()._manager(pushing_reports=pushing_reports)
+
+    def test_none_before_first_check(self):
+        m = self._manager()
+        assert m.self_health_report_entry() is None
+
+    def test_entry_after_check(self):
+        m = self._manager()
+        m._self_healthy = True
+        m._self_health_checked_at = 123.0
+        m._self_consecutive_failures = 0
+        uid, (checked_at, healthy, failures) = m.self_health_report_entry()
+        assert uid == "r1" and checked_at == 123.0 and healthy and failures == 0
+        assert m._last_health_reported_via_handle_ts is not None
+
+    def test_none_while_reports_carry_health(self):
+        m = self._manager(pushing_reports=True)
+        m._self_health_checked_at = 123.0
+        assert m.reports_carry_health()
+        assert m.self_health_report_entry() is None
+
+    def test_consumption_counts_as_carried(self):
+        m = self._manager()
+        m._self_health_checked_at = 123.0
+        assert not m.health_already_carried()
+        assert m.self_health_report_entry() is not None
+        assert m.health_already_carried()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_suppressed_after_report_consumption(self):
+        m = self._manager()
+        m._self_health_checked_at = 123.0
+        assert m.self_health_report_entry() is not None
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+
+class TestRouterSelfHealthMerge:
+    """The router folds the host replica's own health into its handle report."""
+
+    def _metrics_manager(self):
+        from ray.serve._private.router import RouterMetricsManager
+
+        mm = RouterMetricsManager.__new__(RouterMetricsManager)
+        mm._replica_health = {"downstream": (1.0, True, 0)}
+        return mm
+
+    def test_no_provider_passthrough(self):
+        import ray.serve.context as ctx
+
+        ctx._set_self_health_report_provider(None)
+        mm = self._metrics_manager()
+        assert mm._replica_health_for_report() == {"downstream": (1.0, True, 0)}
+
+    def test_provider_entry_merged(self):
+        import ray.serve.context as ctx
+
+        try:
+            ctx._set_self_health_report_provider(
+                lambda: ("self_replica", (2.0, False, 3))
+            )
+            mm = self._metrics_manager()
+            report = mm._replica_health_for_report()
+            assert report["downstream"] == (1.0, True, 0)
+            assert report["self_replica"] == (2.0, False, 3)
+        finally:
+            ctx._set_self_health_report_provider(None)
+
+    def test_provider_none_result_passthrough(self):
+        import ray.serve.context as ctx
+
+        try:
+            ctx._set_self_health_report_provider(lambda: None)
+            mm = self._metrics_manager()
+            assert mm._replica_health_for_report() == {"downstream": (1.0, True, 0)}
+        finally:
+            ctx._set_self_health_report_provider(None)
+
+    def test_empty_map_with_self_entry_still_reports(self):
+        import ray.serve.context as ctx
+
+        try:
+            ctx._set_self_health_report_provider(
+                lambda: ("self_replica", (2.0, True, 0))
+            )
+            mm = self._metrics_manager()
+            mm._replica_health = {}
+            assert mm._replica_health_for_report() == {"self_replica": (2.0, True, 0)}
+        finally:
+            ctx._set_self_health_report_provider(None)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
 
@@ -1385,6 +1487,7 @@ class TestSelfHealthPush:
         m._pending_health_push_ref = None
         m._self_consecutive_failures = 0
         m._last_health_carried_ts = None
+        m._last_health_reported_via_handle_ts = None
         m._metrics_push_lock = threading.Lock()
         m._controller_handle = Mock()
         m._replica_id = SimpleNamespace(unique_id="r1")
@@ -1488,10 +1591,17 @@ class TestSelfHealthPush:
             health_check_period_s=10.0, health_check_timeout_s=30.0
         )
         r._self_health_active = False
-        Replica._start_self_health_pusher(r)
-        args = r._metrics_manager.start_self_health_pusher.call_args.args
-        assert args[1] == 5.0  # half the period
-        assert args[2] == 30.0
+        try:
+            Replica._start_self_health_pusher(r)
+            args = r._metrics_manager.start_self_health_pusher.call_args.args
+            assert args[1] == 5.0  # half the period
+            assert args[2] == 30.0
+        finally:
+            # _start_self_health_pusher publishes the process-global provider;
+            # leaving the Mock there pollutes later tests.
+            import ray.serve.context as ctx
+
+            ctx._set_self_health_report_provider(None)
 
     def test_registry_tracks_self_check_intervals(self):
         from ray.serve._private.deployment_state import ReplicaHealthPushRegistry

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1412,7 +1412,9 @@ class TestRouterSelfHealthMerge:
         from ray.serve._private.router import RouterMetricsManager
 
         mm = RouterMetricsManager.__new__(RouterMetricsManager)
-        mm._replica_health = {"downstream": (1.0, True, 0)}
+        import time as _time
+
+        mm._replica_health = {"downstream": (1.0, True, 0, _time.time())}
         return mm
 
     def test_no_provider_passthrough(self):
@@ -1648,9 +1650,9 @@ class TestSelfHealthPush:
         rm._replica_health = {}
         rm.record_replica_health("r1", 200.0, True, 0)
         rm.record_replica_health("r1", 100.0, False, 2)  # delayed older
-        assert rm._replica_health["r1"] == (200.0, True, 0)
+        assert rm._replica_health["r1"][:3] == (200.0, True, 0)
         rm.record_replica_health("r1", 300.0, False, 1)
-        assert rm._replica_health["r1"] == (300.0, False, 1)
+        assert rm._replica_health["r1"][:3] == (300.0, False, 1)
 
     @pytest.mark.asyncio
     async def test_in_flight_heartbeat_skips_next(self, monkeypatch):


### PR DESCRIPTION
## Why

Controller-side health checking is a per-replica **pull**: every `health_check_period_s` the controller submits an actor call to each replica and polls the result. The submission alone costs ~0.5 ms of controller event-loop time per replica (Cython/GIL-bound — not parallelizable client-side), so at 10–20K replicas the controller spends multiple seconds of every period just asking replicas how they feel, and can no longer meet the period at all.

This PR inverts the direction: **replicas check themselves and report the result; the controller only probes when it hasn't heard anything recently.** Pull is the fallback, not a mode — there are no new feature flags.

## Design

**Replica side.** Each replica runs its own periodic health check (the same user-defined `check_health`, under the same `health_check_timeout_s`) on a timer at **half the health-check period** (5 s at the default 10 s), so results are always fresher than the period. After `consecutive_failures` reaches the unhealthy threshold the replica latches (stops re-running the user check, keeps reporting unhealthy). While the self-check task is active, remote `check_health` probes are served from the cached result — the user check always has a single sequential caller, preserving exact call-count semantics.

**How results reach the controller.** Health rides channels that already exist; which one depends on the deployment's metrics mode:

- **HAProxy / direct ingress enabled** — these replicas already push autoscaling metric reports to the controller; `healthy / health_checked_at / health_consecutive_failures` piggyback on them. *Zero additional messages.*
- **HAProxy disabled (handle-collection mode, the default)** — replicas don't push metric reports. Instead, a replica attaches its latest self-check result to the responses it sends over the open request channel, back to the **specific router routing to it** (`ReplicaQueueLengthInfo`). Each router keeps the newest result per replica and folds a `replica_health` map into the handle metric report it already sends; the controller ingests the map. *Zero additional messages while traffic is flowing — the controller never hears from replicas directly, only via the handle reports that already describe them.*
- **Heartbeat RPC** (`record_replica_health`) — only when neither channel has carried the result within a period (idle replicas, no traffic). Skips while a previous heartbeat is in flight.
- **Pull probes** — unchanged, and still the universal fallback: stale/absent pushes (crash, old replica version, dropped messages) re-enable today's probe path, which also surfaces `RayActorError` exactly as before.

**Controller side.** A `ReplicaHealthPushRegistry` collects observations: ordered per replica by replica-local `checked_at` (out-of-order and duplicate deliveries across multiple handles are dropped), freshness judged on controller-clock arrival time (immune to clock skew), size-capped with arrival-order pruning. During the reconcile sweep, a fresh observation is handed to the existing wrapper state machine as `SUCCEEDED`/`APP_FAILURE` — the downstream unhealthy/restart logic is untouched. The replica pushes its own consecutive-failure count and the controller mirrors it, so counting is immune to dropped or sampled observations. A pushed result is consumed only when no in-flight probe resolved this tick (a slow stale probe can never overwrite a newer push), and fresh pushes suppress starting new probes.

## Semantics preserved

- `health_check_period_s`, `health_check_timeout_s`, and the unhealthy threshold keep their meanings; failure/recovery transitions fire at the same counts.
- Replica crash detection is unchanged (pushes stop → probe → `RayActorError`).
- Mixed versions are safe in both directions: old replicas never push (controller pulls as today); failed pushes to an old controller are caught and logged, pull continues.

## Observability

`ControllerHealthMetrics` (alpha) gains `push_checks_recorded` and `push_check_gap_{p50,p99,max}_s` — percentiles of the per-replica gap between consecutively recorded self-check timestamps, i.e. direct confirmation of how often every replica is actually being health-checked.

## Benchmark

Pinned 8192-replica controller benchmark (controller-scaling opts, reconcile fraction 0.5), push vs pull on identical trees:

| | pull | push | Δ |
|---|---|---|---|
| control loop mean | 147 ms | **84.6 ms** | −42% |
| loops/sec | 2.45 | **4.22** | +72% |

The controller absorbed ~3.2k pushed observations/s in steady state with per-replica observation gaps at the self-check cadence (~5 s); larger-N and HAProxy-enabled runs in progress.

## Testing

- Unit: registry (ordering, dedupe, skew, pruning, gap stats), wrapper consume/mirroring/probe-gating, self-check task (cadence, latch, heartbeat suppression), router capture/prune, report/handle plumbing.
- Integration: full `test_healthcheck.py` parity through the push path (12/12), including exact user-check call counts, nonconsecutive-failure counting, and deploy-time failure semantics.

## Follow-ups

- Push user-defined routing stats over the same channels.
- Long-held requests: yield health frames on the open response stream so the handle-carried path stays fresh when no new responses flow (in progress).
- Internal-gRPC transport queue-info doesn't carry the health fields yet; those replicas use heartbeat/pull.
- For heartbeat-heavy deployments at extreme scale, per-node aggregation (HAProxy manager) can fan in observations before they reach the controller.