### PR TITLE
[data] PR 1 of 2: Add write_delta APPEND/OVERWRITE/ERROR/IGNORE, part…

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -13,6 +13,10 @@ python/ray/data/_internal/datasource/binary_datasource.py
 python/ray/data/_internal/datasource/clickhouse_datasink.py
 python/ray/data/_internal/datasource/csv_datasink.py
 python/ray/data/_internal/datasource/csv_datasource.py
+python/ray/data/_internal/datasource/delta/committer.py
+python/ray/data/_internal/datasource/delta/datasink.py
+python/ray/data/_internal/datasource/delta/utils.py
+python/ray/data/_internal/datasource/delta/writer.py
 python/ray/data/_internal/datasource/delta_sharing_datasource.py
 python/ray/data/_internal/datasource/hudi_datasource.py
 python/ray/data/_internal/datasource/huggingface_datasource.py

--- a/python/ray/data/_internal/datasource/delta/__init__.py
+++ b/python/ray/data/_internal/datasource/delta/__init__.py
@@ -1,0 +1,9 @@
+"""Delta Lake write support for Ray Data."""
+
+from ray.data._internal.datasource.delta.datasink import DeltaDatasink
+from ray.data._internal.datasource.delta.utils import DeltaWriteResult
+
+__all__ = [
+    "DeltaDatasink",
+    "DeltaWriteResult",
+]

--- a/python/ray/data/_internal/datasource/delta/committer.py
+++ b/python/ray/data/_internal/datasource/delta/committer.py
@@ -1,0 +1,350 @@
+"""Transaction commit logic for Delta Lake datasink (MVP, APPEND only).
+
+This MVP build implements only the APPEND code paths -- ``create_table_with_files``
+for first-time writes and ``commit_to_existing_table`` for appends. PR 4 adds
+the OVERWRITE branch and PR 5 adds dynamic-partition overwrite.
+
+Delta Lake spec: https://delta.io/specification/
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import pyarrow as pa
+import pyarrow.fs as pa_fs
+import pyarrow.parquet as pq
+
+if TYPE_CHECKING:
+    from deltalake import DeltaTable
+    from deltalake.transaction import AddAction
+
+from ray.data._internal.datasource.delta.utils import (
+    convert_schema_to_delta,
+    get_file_info_with_retry,
+    infer_partition_type,
+    resolve_under_table_root,
+    to_pyarrow_schema,
+    validate_file_path,
+    validate_schema_type_compatibility,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CommitInputs:
+    """Inputs for commit operations."""
+
+    table_uri: str
+    mode: str
+    partition_cols: List[str]
+    storage_options: Dict[str, str]
+    write_kwargs: Dict[str, Any]
+    local_filesystem_root: Optional[str] = None
+
+
+def validate_file_actions(
+    file_actions: List["AddAction"],
+    filesystem: pa_fs.FileSystem,
+    local_filesystem_root: Optional[str] = None,
+) -> None:
+    """Validate file actions before committing."""
+    for action in file_actions:
+        validate_file_path(action.path)
+        if action.size == 0:
+            raise ValueError(f"File is empty: {action.path}")
+        phys = resolve_under_table_root(local_filesystem_root, action.path)
+        info = get_file_info_with_retry(filesystem, phys)
+        if info.type == pa_fs.FileType.NotFound:
+            raise ValueError(
+                f"File does not exist: {action.path} (relative to table root)"
+            )
+
+
+def infer_schema_from_files(
+    add_actions: List["AddAction"],
+    partition_cols: List[str],
+    filesystem: pa_fs.FileSystem,
+    provided_schema: Optional[pa.Schema],
+    local_filesystem_root: Optional[str] = None,
+) -> pa.Schema:
+    """Infer schema from the first Parquet file plus any partition cols."""
+    if provided_schema:
+        schema = provided_schema
+        for col in partition_cols:
+            if col not in schema.names:
+                col_type = pa.string()
+                for a in add_actions:
+                    pv = getattr(a, "partition_values", None) or {}
+                    if col in pv and pv[col] is not None:
+                        col_type = infer_partition_type(pv[col])
+                        break
+                schema = schema.append(pa.field(col, col_type))
+        return schema
+
+    if not add_actions:
+        raise ValueError("Cannot infer schema from empty file list")
+
+    first = next((a for a in add_actions if a and a.path), None)
+    if not first:
+        raise ValueError("No valid file actions found for schema inference")
+
+    try:
+        phys = resolve_under_table_root(local_filesystem_root, first.path)
+        with filesystem.open_input_file(phys) as f:
+            schema = pq.ParquetFile(f).schema_arrow
+    except Exception as e:
+        raise ValueError(f"Failed to read schema from {first.path}: {e}") from e
+
+    if len(schema) == 0:
+        raise ValueError(f"Cannot infer schema from file with no columns: {first.path}")
+
+    # Append partition columns to schema if missing.
+    for col in partition_cols:
+        if col in schema.names:
+            continue
+        col_type = pa.string()
+        for a in add_actions:
+            pv = getattr(a, "partition_values", None) or {}
+            if col in pv and pv[col] is not None:
+                col_type = infer_partition_type(pv[col])
+                break
+        schema = schema.append(pa.field(col, col_type))
+    return schema
+
+
+def create_table_with_files(
+    inputs: CommitInputs,
+    file_actions: List["AddAction"],
+    schema: Optional[pa.Schema],
+    filesystem: pa_fs.FileSystem,
+) -> None:
+    """Create a new Delta table and commit ``file_actions`` atomically."""
+    from deltalake.transaction import create_table_with_add_actions
+
+    if not file_actions:
+        if schema is None or len(schema) == 0:
+            raise ValueError(
+                "Cannot create a new Delta table with no files and no schema."
+            )
+        inferred = schema
+    else:
+        inferred = infer_schema_from_files(
+            file_actions,
+            inputs.partition_cols,
+            filesystem,
+            schema,
+            inputs.local_filesystem_root,
+        )
+    delta_schema = convert_schema_to_delta(inferred)
+
+    create_table_with_add_actions(
+        table_uri=inputs.table_uri,
+        schema=delta_schema,
+        add_actions=file_actions,
+        mode=inputs.mode,
+        partition_by=inputs.partition_cols or None,
+        name=inputs.write_kwargs.get("name"),
+        description=inputs.write_kwargs.get("description"),
+        configuration=inputs.write_kwargs.get("configuration"),
+        storage_options=inputs.storage_options,
+        commit_properties=inputs.write_kwargs.get("commit_properties"),
+    )
+
+
+def commit_to_existing_table(
+    inputs: CommitInputs,
+    table: "DeltaTable",
+    file_actions: List["AddAction"],
+    schema: Optional[pa.Schema],
+    filesystem: pa_fs.FileSystem,
+) -> None:
+    """Commit ``file_actions`` to an existing Delta table.
+
+    Supports APPEND and OVERWRITE. Static overwrite, and dynamic partition
+    overwrite of a single partition combination, replace the table's data
+    in a single atomic ``create_write_transaction`` call (using
+    ``partition_filters`` to scope the replace for dynamic mode). Dynamic
+    overwrite spanning more than one partition combination -- or touching a
+    NULL partition value, which ``partition_filters`` can't express -- falls
+    back to a separate ``table.delete()`` before the append; see
+    ``_build_single_partition_filter``.
+    """
+    existing_schema = to_pyarrow_schema(table.schema())
+    if file_actions:
+        incoming = infer_schema_from_files(
+            file_actions,
+            inputs.partition_cols,
+            filesystem,
+            schema,
+            inputs.local_filesystem_root,
+        )
+    else:
+        incoming = schema
+    if incoming is not None and len(incoming) > 0:
+        validate_schema_type_compatibility(existing_schema, incoming)
+
+    partition_filters = None
+    if inputs.mode == "overwrite":
+        partition_overwrite_mode = inputs.write_kwargs.get(
+            "partition_overwrite_mode", "static"
+        )
+        if partition_overwrite_mode not in ("static", "dynamic"):
+            raise ValueError(
+                f"Invalid partition_overwrite_mode '{partition_overwrite_mode}'. "
+                "Must be 'static' or 'dynamic'."
+            )
+        if partition_overwrite_mode == "dynamic" and inputs.partition_cols:
+            single_filter = _build_single_partition_filter(
+                file_actions, inputs.partition_cols
+            )
+            if single_filter is not None:
+                # Exactly one partition combination, no NULLs: delta-rs
+                # can replace it atomically in the same transaction as the
+                # append below, avoiding the delete-then-append race in
+                # the fallback branch.
+                partition_filters = single_filter
+                commit_mode = "overwrite"
+            else:
+                # Multiple distinct partition combinations in one write,
+                # a NULL partition value, or an empty write:
+                # create_write_transaction's partition_filters can't
+                # express an OR across combinations or a NULL match
+                # (verified empirically), so fall back to an explicit
+                # delete + append -- non-atomic, same as this whole
+                # overwrite path was before this fix.
+                pred = _build_partition_delete_predicate(
+                    file_actions, inputs.partition_cols, existing_schema
+                )
+                if pred:
+                    table.delete(pred)
+                # else: no partitions to replace (e.g. an empty write) --
+                # nothing to delete. Falling back to an unfiltered
+                # ``table.delete()`` here would wipe partitions the caller
+                # never asked to touch.
+                commit_mode = "append"
+        else:
+            # Static overwrite: let delta-rs replace the table's data in a
+            # single atomic transaction instead of a separate
+            # ``table.delete()`` followed by an append. The two-step form
+            # leaves the table permanently empty if the append half fails.
+            commit_mode = "overwrite"
+    else:
+        commit_mode = "append"
+
+    table.create_write_transaction(
+        actions=file_actions,
+        mode=commit_mode,
+        schema=table.schema(),
+        partition_by=inputs.partition_cols or None,
+        partition_filters=partition_filters,
+        commit_properties=inputs.write_kwargs.get("commit_properties"),
+    )
+
+
+def _build_single_partition_filter(
+    file_actions: List["AddAction"],
+    partition_cols: List[str],
+) -> Optional[List[Tuple[str, str, str]]]:
+    """Build a ``create_write_transaction``-compatible partition filter,
+    but only for the shape that API can actually express.
+
+    Empirically verified against ``deltalake``: ``create_write_transaction``
+    accepts a flat AND-only list of ``(col, "=", value)`` tuples (matched
+    against the partition value exactly as Delta stores it, e.g. ``"NaN"``
+    for float NaN), but does **not** accept an OR across several partition
+    combinations, nor a ``None``/NULL value. So this only returns a filter
+    when ``file_actions`` touches exactly one partition-value combination
+    and none of its values is NULL; otherwise returns ``None`` and the
+    caller must fall back to an explicit ``table.delete()``.
+    """
+    if not partition_cols or not file_actions:
+        return None
+    combos = set()
+    for action in file_actions:
+        pv = getattr(action, "partition_values", None) or {}
+        if not pv:
+            continue
+        combos.add(tuple(pv.get(col) for col in partition_cols))
+    if len(combos) != 1:
+        return None
+    (combo,) = combos
+    if any(v is None for v in combo):
+        return None
+    return [(col, "=", val) for col, val in zip(partition_cols, combo)]
+
+
+def _build_partition_delete_predicate(
+    file_actions: List["AddAction"],
+    partition_cols: List[str],
+    schema: Optional[pa.Schema] = None,
+) -> Optional[str]:
+    """Build a SQL delete predicate for partitions being overwritten."""
+    if not partition_cols or not file_actions:
+        return None
+
+    def quote_id(name: str) -> str:
+        return f"`{name.replace('`', '``')}`"
+
+    def fmt_val(val: Any) -> str:
+        if val is None:
+            return "NULL"
+        return "'" + str(val).replace("'", "''") + "'"
+
+    partition_col_types: Dict[str, pa.DataType] = {}
+    if schema:
+        for col in partition_cols:
+            if col in schema.names:
+                partition_col_types[col] = schema.field(col).type
+
+    partition_combinations = set()
+    for action in file_actions:
+        pv = getattr(action, "partition_values", None) or {}
+        if pv:
+            combo = tuple(pv.get(col) for col in partition_cols)
+            partition_combinations.add(combo)
+    if not partition_combinations:
+        return None
+
+    ors = []
+    for combo in partition_combinations:
+        ands = []
+        for i, col in enumerate(partition_cols):
+            val = combo[i]
+            if val is None:
+                ands.append(f"{quote_id(col)} IS NULL")
+            elif (
+                val == "NaN"
+                and partition_col_types.get(col) is not None
+                and pa.types.is_floating(partition_col_types[col])
+            ):
+                ands.append(f"{quote_id(col)} != {quote_id(col)}")
+            else:
+                ands.append(f"{quote_id(col)} = {fmt_val(val)}")
+        if ands:
+            ors.append("(" + " AND ".join(ands) + ")")
+    return " OR ".join(ors) if ors else None
+
+
+def validate_partition_columns_match_existing(
+    existing_table: "DeltaTable", partition_cols: List[str]
+) -> None:
+    """Ensure ``partition_cols`` is compatible with the existing table."""
+    existing = existing_table.metadata().partition_columns
+    if partition_cols:
+        if existing and existing != partition_cols:
+            raise ValueError(
+                f"Partition columns mismatch. Existing: {existing}, "
+                f"requested: {partition_cols}"
+            )
+        if not existing:
+            raise ValueError(
+                f"Partition columns provided {partition_cols} but table is "
+                "not partitioned."
+            )
+    elif existing:
+        raise ValueError(
+            f"Table is partitioned by {existing} but no partition columns "
+            "were provided."
+        )

--- a/python/ray/data/_internal/datasource/delta/datasink.py
+++ b/python/ray/data/_internal/datasource/delta/datasink.py
@@ -1,0 +1,635 @@
+"""Delta Lake datasink.
+
+``DeltaDatasink`` directly implements Ray Data's ``Datasink`` write lifecycle
+(``on_write_start`` -> workers' ``write`` -> ``on_write_complete`` ->
+``on_write_failed``) -- there is no generic multi-format adapter layer; this
+is the only concrete write path Delta needs.
+
+Supports ``SaveMode.{APPEND,OVERWRITE,ERROR,IGNORE}``. Partitioning and
+schema evolution are handled inline. UPSERT is not supported.
+
+Delta Lake: https://delta.io/
+"""
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple
+
+import pyarrow as pa
+import pyarrow.fs as pa_fs
+
+from ray.data._internal.datasource.delta.committer import (
+    CommitInputs,
+    commit_to_existing_table,
+    create_table_with_files,
+    validate_file_actions,
+    validate_partition_columns_match_existing,
+)
+from ray.data._internal.datasource.delta.fs import make_fs_config, worker_filesystem
+from ray.data._internal.datasource.delta.schema import (
+    SchemaPolicy,
+    evolve_schema,
+    existing_table_pyarrow_schema,
+    reconcile_worker_schemas,
+    validate_and_plan_evolution,
+)
+from ray.data._internal.datasource.delta.utils import (
+    DeltaWriteResult,
+    get_file_info_with_retry,
+    get_storage_options,
+    resolve_under_table_root,
+    try_get_deltatable,
+    types_compatible,
+    validate_partition_column_names,
+    validate_partition_columns_in_table,
+)
+from ray.data._internal.datasource.delta.writer import DeltaFileWriter
+from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.planner.plan_write_op import WRITE_UUID_KWARG_NAME
+from ray.data._internal.savemode import SaveMode
+from ray.data._internal.util import _check_import, _is_local_scheme
+from ray.data.block import Block, BlockAccessor
+from ray.data.datasource.datasink import Datasink, WriteResult
+
+_SUPPORTED_MODES = {
+    SaveMode.APPEND,
+    SaveMode.OVERWRITE,
+    SaveMode.ERROR,
+    SaveMode.IGNORE,
+}
+
+if TYPE_CHECKING:
+    from deltalake.transaction import AddAction
+
+logger = logging.getLogger(__name__)
+
+
+def _attach_written_paths(exc: BaseException, paths: List[str]) -> None:
+    """Append ``paths`` to ``exc._table_written_paths`` for orphan cleanup.
+
+    Used by both the worker write path and driver ``on_write_complete`` to
+    carry the list of files that were written (and therefore need best-effort
+    cleanup) to ``on_write_failed`` via the raised exception.
+
+    Setting an attribute can raise ``AttributeError`` for exceptions that use
+    ``__slots__`` without ``__dict__`` (some optimized / C-extension errors).
+    In that case we swallow it: failing to record orphan paths must never mask
+    the original error.
+    """
+    if not paths:
+        return
+    try:
+        existing = getattr(exc, "_table_written_paths", None) or []
+        # Dynamic attribute carried to on_write_failed for orphan cleanup;
+        # BaseException has no static slot for it.
+        exc._table_written_paths = list(existing) + list(paths)
+    except AttributeError:
+        pass
+
+
+def _unify_schemas(schemas: List[pa.Schema]) -> Optional[pa.Schema]:
+    """Type-promoted ``pa.unify_schemas``."""
+    if not schemas:
+        return None
+    from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
+
+    return unify_schemas(schemas, promote_types=True)
+
+
+class DeltaDatasink(Datasink[DeltaWriteResult]):
+    """Datasink for writing to Delta Lake tables."""
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        mode: Any = SaveMode.APPEND,
+        partition_cols: Optional[List[str]] = None,
+        filesystem: Optional[pa_fs.FileSystem] = None,
+        schema: Optional[pa.Schema] = None,
+        schema_mode: str = "error",
+        **write_kwargs,
+    ):
+        _check_import(self, module="deltalake", package="deltalake")
+
+        self.table_uri = path
+        self.mode = self._coerce_mode(mode)
+        self.partition_cols = validate_partition_column_names(
+            list(partition_cols or [])
+        )
+        # ``self.schema`` is live -- it may be adopted from the first input
+        # bundle in ``on_write_start`` and later reconciled/promoted in
+        # ``_aggregate_and_commit``. ``self._declared_schema`` is the frozen
+        # user-supplied value, used only as the schema-unification fallback
+        # when every block written was empty (see ``_aggregate_and_commit``).
+        self.schema = schema
+        self._declared_schema = schema
+        self.write_kwargs = dict(write_kwargs)
+        self._schema_policy = SchemaPolicy(mode=schema_mode.lower())
+
+        target = write_kwargs.get("target_file_size_bytes")
+        if target is not None and target <= 0:
+            raise ValueError("target_file_size_bytes must be > 0")
+        self._target_file_size_bytes: Optional[int] = target
+
+        self.storage_options = get_storage_options(
+            self.table_uri, write_kwargs.get("storage_options")
+        )
+        self._fs_config, self.filesystem = make_fs_config(
+            self.table_uri, filesystem, self.storage_options
+        )
+        self._local_filesystem_root = self._fs_config.local_filesystem_root
+
+        # Driver-side state.
+        self._skip_write: bool = False
+
+        # Worker-side state.
+        self._worker_fs: Optional[pa_fs.FileSystem] = None
+        self._writer: Optional[DeltaFileWriter] = None
+        self._task_write_uuid: Optional[str] = None
+        self._task_idx: int = 0
+        self._task_written_files: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Mode coercion.
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _coerce_mode(mode: Any) -> SaveMode:
+        if isinstance(mode, str):
+            try:
+                mode = SaveMode(mode.lower())
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid mode '{mode}'. Supported: "
+                    f"{sorted(m.value for m in _SUPPORTED_MODES)}"
+                ) from e
+        elif not isinstance(mode, SaveMode):
+            raise TypeError(f"Invalid mode type: {type(mode).__name__}")
+        if mode not in _SUPPORTED_MODES:
+            raise ValueError(
+                f"write_delta does not support mode={mode.value!r}. Supported: "
+                f"{sorted(m.value for m in _SUPPORTED_MODES)}"
+            )
+        return mode
+
+    # ------------------------------------------------------------------
+    # Pickling -- filesystem/writer are rebuilt on each worker, not shipped.
+    # ------------------------------------------------------------------
+    def __getstate__(self) -> dict:
+        d = self.__dict__.copy()
+        d.pop("filesystem", None)
+        d.pop("_worker_fs", None)
+        d.pop("_writer", None)
+        return d
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self.filesystem = None
+        self._worker_fs = None
+        self._writer = None
+
+    # ------------------------------------------------------------------
+    # Introspection.
+    # ------------------------------------------------------------------
+    def get_name(self) -> str:
+        return "Delta"
+
+    @property
+    def supports_distributed_writes(self) -> bool:
+        if _is_local_scheme(self.table_uri):
+            return False
+        u = self.table_uri.lower()
+        if u.startswith("file://") or "://" not in self.table_uri:
+            return False
+        return True
+
+    @staticmethod
+    def path_for_action(action: "AddAction") -> str:
+        # deltalake's ``AddAction`` exposes the relative path as ``.path``.
+        return action.path
+
+    # ------------------------------------------------------------------
+    # Driver lifecycle -- preflight.
+    # ------------------------------------------------------------------
+    def on_write_start(self, schema: Optional[pa.Schema] = None) -> None:
+        existing = try_get_deltatable(self.table_uri, self.storage_options)
+        self._table_existed_at_start = existing is not None
+
+        if existing is not None:
+            if not self.partition_cols:
+                self.partition_cols = list(existing.metadata().partition_columns) or []
+            else:
+                validate_partition_columns_match_existing(existing, self.partition_cols)
+
+            # Schema evolution is deferred to commit time in
+            # ``_aggregate_and_commit``, where the schema is fully
+            # reconciled across all workers (and available even when the
+            # caller didn't pass an explicit ``schema=`` and it's inferred
+            # from the data instead). Evolving here would be non-atomic
+            # with the write: if the tasks below fail, the table's schema
+            # would already have been permanently altered for nothing.
+
+        if self.mode == SaveMode.ERROR and existing is not None:
+            raise ValueError(
+                f"Delta table already exists at {self.table_uri}. "
+                "Use APPEND or OVERWRITE."
+            )
+
+        self._skip_write = self.mode == SaveMode.IGNORE and existing is not None
+
+        # Adopt Ray Data's own inferred schema only if the user didn't
+        # declare one explicitly.
+        if schema is not None and self.schema is None:
+            self.schema = schema
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle -- write.
+    # ------------------------------------------------------------------
+    def write(self, blocks: Iterable[Block], ctx: TaskContext) -> DeltaWriteResult:
+        self._start_task(ctx)
+
+        add_actions: List["AddAction"] = []
+        emitted_schemas: List[pa.Schema] = []
+        written_paths: List[str] = []
+
+        try:
+            for block in blocks:
+                arrow_table = BlockAccessor.for_block(block).to_arrow()
+                if arrow_table.num_rows == 0:
+                    continue
+                actions, emitted_schema = self._write_block(arrow_table)
+                if actions:
+                    add_actions.extend(actions)
+                    for action in actions:
+                        written_paths.append(self.path_for_action(action))
+                if emitted_schema is not None:
+                    emitted_schemas.append(emitted_schema)
+
+            tail_actions = self._finalize_task()
+            if tail_actions:
+                add_actions.extend(tail_actions)
+                for action in tail_actions:
+                    written_paths.append(self.path_for_action(action))
+
+            task_metadata: Dict[str, Any] = (
+                {"write_uuid": self._task_write_uuid} if self._task_write_uuid else {}
+            )
+        except Exception as e:
+            # Surface the orphan-path list to the driver via the exception so
+            # ``on_write_failed`` can clean it up. Include any in-flight paths
+            # the writer started but hadn't yet returned as completed actions
+            # (e.g. a Parquet file registered right before ``pq.write_table``
+            # raised mid-write) -- these never appear in ``written_paths`` and
+            # would otherwise be orphaned.
+            orphan_paths = list(set(written_paths) | self._task_written_files)
+            _attach_written_paths(e, orphan_paths)
+            raise
+
+        return DeltaWriteResult(
+            add_actions=add_actions,
+            emitted_schemas=emitted_schemas,
+            written_paths=written_paths,
+            task_id=getattr(ctx, "task_idx", None),
+            task_metadata=task_metadata,
+        )
+
+    def _start_task(self, ctx: TaskContext) -> None:
+        if self._skip_write:
+            return
+        if self._worker_fs is None:
+            self._worker_fs = worker_filesystem(self._fs_config)
+        if self._local_filesystem_root:
+            os.makedirs(self._local_filesystem_root, exist_ok=True)
+        ctx_kwargs = getattr(ctx, "kwargs", None) or {}
+        self._task_write_uuid = ctx_kwargs.get(WRITE_UUID_KWARG_NAME)
+        self._task_idx = int(getattr(ctx, "task_idx", 0) or 0)
+        self._task_written_files = set()
+        self._writer = DeltaFileWriter(
+            filesystem=self._worker_fs,
+            partition_cols=self.partition_cols,
+            write_uuid=self._task_write_uuid,
+            write_kwargs=self.write_kwargs,
+            written_files=self._task_written_files,
+            target_file_size_bytes=self._target_file_size_bytes,
+            local_filesystem_root=self._local_filesystem_root,
+        )
+
+    def _write_block(
+        self, arrow_table: pa.Table
+    ) -> Tuple[List["AddAction"], pa.Schema]:
+        if self._skip_write or self._writer is None:
+            return ([], arrow_table.schema)
+        try:
+            validate_partition_columns_in_table(self.partition_cols, arrow_table)
+            self._validate_block_against_declared_schema(arrow_table)
+            actions = self._writer.add_table(arrow_table, self._task_idx)
+        except Exception as e:
+            paths = list(self._task_written_files)
+            # Dynamic attribute the framework reads in on_write_failed to
+            # drive orphan-file cleanup.
+            e._table_written_paths = paths
+            self._cleanup_files_worker(paths)
+            raise
+        return (actions, arrow_table.schema)
+
+    def _validate_block_against_declared_schema(self, table: pa.Table) -> None:
+        """Raise if the incoming block is missing a declared schema column or
+        contains a type-incompatible value for an existing column.
+
+        Partition columns are exempt (they are stripped from the on-disk
+        payload by the writer). All-null columns against a nullable declared
+        type are also accepted.
+        """
+        schema = self.schema
+        if not schema:
+            return
+
+        table_cols: Set[str] = set(table.column_names)
+        missing: Set[str] = set(schema.names) - table_cols
+        if missing:
+            raise ValueError(
+                f"Missing columns: {sorted(missing)}. "
+                f"Table has: {sorted(table_cols)}"
+            )
+
+        for f in schema:
+            if f.name in table_cols and f.name not in self.partition_cols:
+                col = table[f.name]
+                # A pa.null()-typed column is null by construction -- no
+                # need to scan it to confirm.
+                if f.nullable and pa.types.is_null(col.type):
+                    continue
+                if not types_compatible(f.type, col.type):
+                    raise ValueError(
+                        f"Type mismatch for '{f.name}': "
+                        f"expected {f.type}, got {col.type}"
+                    )
+
+    def _finalize_task(self) -> List["AddAction"]:
+        if self._skip_write or self._writer is None:
+            return []
+        try:
+            return self._writer.flush(self._task_idx)
+        except Exception as e:
+            paths = list(self._task_written_files)
+            e._table_written_paths = paths
+            self._cleanup_files_worker(paths)
+            raise
+
+    # ------------------------------------------------------------------
+    # Driver lifecycle -- on_write_complete (aggregate, reconcile, commit).
+    # ------------------------------------------------------------------
+    def on_write_complete(self, write_result: WriteResult[DeltaWriteResult]) -> None:
+        returns = [r for r in (write_result.write_returns or []) if r is not None]
+        # Snapshot every path workers wrote *before* doing anything that can
+        # fail. If aggregation / dedup / schema reconciliation / commit raises
+        # below, those files are orphans (the commit is atomic and did not
+        # complete), so ``on_write_failed`` must clean them up. This
+        # complements the worker-side tracking, which only covers tasks that
+        # themselves failed -- not a driver-side commit failure after all
+        # workers succeeded.
+        all_written_paths: List[str] = []
+        for r in returns:
+            all_written_paths.extend(r.written_paths or [])
+
+        try:
+            self._aggregate_and_commit(returns)
+        except Exception as e:
+            _attach_written_paths(e, all_written_paths)
+            raise
+
+    def _aggregate_and_commit(self, returns: List[DeltaWriteResult]) -> None:
+        all_actions: List["AddAction"] = []
+        all_schemas: List[pa.Schema] = []
+        aggregated_write_uuid: Optional[str] = None
+        seen_paths: Set[str] = set()
+
+        for r in returns:
+            for action in r.add_actions:
+                path = self.path_for_action(action)
+                if path in seen_paths:
+                    raise ValueError(f"Duplicate file paths detected: {path}")
+                seen_paths.add(path)
+                all_actions.append(action)
+            if r.emitted_schemas:
+                all_schemas.extend(r.emitted_schemas)
+            uuid_val = r.task_metadata.get("write_uuid") if r.task_metadata else None
+            if uuid_val and aggregated_write_uuid is None:
+                aggregated_write_uuid = uuid_val
+
+        unified_schema = (
+            _unify_schemas(all_schemas) if all_schemas else self._declared_schema
+        )
+
+        # Driver-side schema reconciliation: fold the already-promoted union
+        # of every worker's schema into the existing table's schema (if any),
+        # so type promotions across workers + table are handled consistently.
+        if unified_schema is not None:
+            existing = try_get_deltatable(self.table_uri, self.storage_options)
+            existing_schema = (
+                existing_table_pyarrow_schema(existing) if existing else None
+            )
+
+            # Schema evolution happens here -- at commit time, using the
+            # fully worker-reconciled schema -- rather than in
+            # ``on_write_start`` (see comment there). This is also the only
+            # place ``schema_mode`` is enforced when the schema came from
+            # Ray's inference rather than an explicit ``schema=``. Skipped
+            # for ``IGNORE``-against-existing-table: that write is a
+            # complete no-op, and ``_write_block`` returns the block's
+            # Arrow schema even when ``self._skip_write`` short-circuits
+            # the actual file write, so ``unified_schema`` can be non-None
+            # here even though nothing was (or should be) written.
+            #
+            # Validate *before* calling ``reconcile_worker_schemas`` below:
+            # that helper unifies ``existing_schema`` and ``unified_schema``
+            # via PyArrow's ``unify_schemas``, which raises a raw, unfriendly
+            # ``ArrowTypeError`` for genuinely incompatible types (e.g.
+            # string vs int64). Checking compatibility ourselves first (via
+            # ``types_compatible``, a plain Python comparison) turns that
+            # into the same clean ``ValueError`` this validation has always
+            # produced for an explicit ``schema=``.
+            new_fields: List[Tuple[str, pa.DataType, bool]] = []
+            if existing is not None and not self._skip_write:
+                new_fields = validate_and_plan_evolution(
+                    self._schema_policy, existing_schema, unified_schema
+                )
+
+            merged = reconcile_worker_schemas([unified_schema], existing_schema)
+            if merged is not None:
+                self.schema = merged
+                if new_fields:
+                    # Residual non-atomicity, inherent to delta-rs's public
+                    # Python API rather than something this call ordering
+                    # can avoid: ``evolve_schema`` issues its own commit
+                    # (``DeltaTable.alter.add_columns``) that lands before
+                    # the data commit below. Passing the merged schema
+                    # directly to ``create_write_transaction`` instead
+                    # (avoiding the extra commit) does NOT work -- verified
+                    # empirically that its ``schema=`` argument does not
+                    # drive schema evolution; a schema wider than the
+                    # table's current one is silently ignored and the
+                    # extra column's data is dropped on read-back. So if
+                    # the data commit below fails after this succeeds, the
+                    # table permanently gains the new (nullable) column
+                    # with no corresponding data -- a schema-only,
+                    # backward-compatible state, not data loss or
+                    # corruption; the next successful write is unaffected.
+                    evolve_schema(existing, new_fields)
+
+        # Mode-specific commit. ``_coerce_mode`` at __init__ time guarantees
+        # ``self.mode`` is one of these four.
+        if self.mode in (SaveMode.APPEND, SaveMode.ERROR, SaveMode.IGNORE):
+            self._commit_append(all_actions)
+        elif self.mode == SaveMode.OVERWRITE:
+            self._commit_overwrite(all_actions)
+        else:
+            raise ValueError(f"Unsupported mode: {self.mode}")
+
+    def _commit_append(self, file_actions: List["AddAction"]) -> None:
+        # IGNORE against an existing table: the write tasks still ran, so
+        # workers wrote data files we are NOT going to commit. Delete them
+        # best-effort so they don't leak as orphans (they are unreferenced by
+        # the Delta log, hence invisible to readers but wasting storage).
+        if self._skip_write:
+            if file_actions:
+                self._cleanup_files_driver(
+                    [self.path_for_action(a) for a in file_actions]
+                )
+            return
+
+        existing = try_get_deltatable(self.table_uri, self.storage_options)
+        # Race: ERROR mode passed preflight because no table existed then,
+        # but a concurrent writer created one before our commit. Refuse to
+        # silently append to it (ERROR semantics: the table must not already
+        # exist).
+        if self.mode == SaveMode.ERROR and existing is not None:
+            raise ValueError(
+                f"Delta table at {self.table_uri} was created by a concurrent "
+                f"writer after this mode='error' write started; refusing to "
+                f"append. Re-run with mode='append' to add to the existing table."
+            )
+        inputs = CommitInputs(
+            table_uri=self.table_uri,
+            mode=SaveMode.APPEND.value,
+            partition_cols=self.partition_cols,
+            storage_options=self.storage_options,
+            write_kwargs=self.write_kwargs,
+            local_filesystem_root=self._local_filesystem_root,
+        )
+
+        if not file_actions:
+            # Empty APPEND: create empty table if needed; otherwise no-op.
+            if existing is None and self.schema is not None:
+                create_table_with_files(inputs, [], self.schema, self.filesystem)
+            return
+
+        validate_file_actions(
+            file_actions, self.filesystem, self._local_filesystem_root
+        )
+        if existing:
+            commit_to_existing_table(
+                inputs, existing, file_actions, self.schema, self.filesystem
+            )
+        else:
+            create_table_with_files(inputs, file_actions, self.schema, self.filesystem)
+
+    def _commit_overwrite(self, file_actions: List["AddAction"]) -> None:
+        if self._skip_write:
+            return
+
+        existing = try_get_deltatable(self.table_uri, self.storage_options)
+        inputs = CommitInputs(
+            table_uri=self.table_uri,
+            mode=SaveMode.OVERWRITE.value,
+            partition_cols=self.partition_cols,
+            storage_options=self.storage_options,
+            write_kwargs=self.write_kwargs,
+            local_filesystem_root=self._local_filesystem_root,
+        )
+
+        if not file_actions:
+            # OVERWRITE with no data. Static mode truncates the whole
+            # table (matches its "replace everything" semantics even when
+            # "everything" is empty). Dynamic mode's whole point is "only
+            # replace partitions present in the new data" -- an empty
+            # write has no partitions in it, so it correctly touches
+            # nothing (mirrors Spark's dynamic partitionOverwriteMode,
+            # which likewise no-ops on an empty write: there's no
+            # information available about which partition the caller
+            # meant to replace). This is intentional, not a bug -- see
+            # ``commit_to_existing_table``'s dynamic-overwrite branch,
+            # which resolves to ``commit_mode="append"`` with no actions
+            # here, i.e. a true no-op.
+            if existing is not None:
+                commit_to_existing_table(
+                    inputs, existing, [], self.schema, self.filesystem
+                )
+                return
+            if self.schema is not None:
+                create_table_with_files(inputs, [], self.schema, self.filesystem)
+            return
+
+        validate_file_actions(
+            file_actions, self.filesystem, self._local_filesystem_root
+        )
+        if existing:
+            # Either the table existed at start, or it appeared between
+            # preflight and commit; in both cases OVERWRITE delete+append is
+            # the correct outcome.
+            commit_to_existing_table(
+                inputs, existing, file_actions, self.schema, self.filesystem
+            )
+        else:
+            create_table_with_files(inputs, file_actions, self.schema, self.filesystem)
+
+    # ------------------------------------------------------------------
+    # Driver lifecycle -- on_write_failed (orphan cleanup).
+    # ------------------------------------------------------------------
+    def on_write_failed(self, error: Exception) -> None:
+        paths = list(getattr(error, "_table_written_paths", None) or [])
+        if not paths:
+            logger.error(
+                "Delta write failed for %s. Could not determine files to clean up.",
+                self.table_uri,
+            )
+            return
+        logger.warning(
+            "Delta write failed for %s. Cleaning up %d orphaned files.",
+            self.table_uri,
+            len(paths),
+        )
+        try:
+            self._cleanup_files_driver(paths)
+        except Exception as cleanup_error:  # noqa: BLE001
+            logger.warning(
+                "Cleanup raised %s; ignoring to avoid masking the primary error.",
+                cleanup_error,
+            )
+
+    # ------------------------------------------------------------------
+    # Cleanup helpers.
+    # ------------------------------------------------------------------
+    def _cleanup_files_driver(self, file_paths: List[str]) -> None:
+        fs = self.filesystem
+        for p in file_paths:
+            try:
+                phys = resolve_under_table_root(self._local_filesystem_root, p)
+                info = get_file_info_with_retry(fs, phys)
+                if info.type != pa_fs.FileType.NotFound:
+                    fs.delete_file(phys)
+            except Exception as e:
+                logger.warning("Failed to cleanup file %s: %s", p, e)
+
+    def _cleanup_files_worker(self, file_paths: List[str]) -> None:
+        fs = self._worker_fs
+        if fs is None:
+            return
+        for p in file_paths:
+            try:
+                phys = resolve_under_table_root(self._local_filesystem_root, p)
+                info = get_file_info_with_retry(fs, phys)
+                if info.type != pa_fs.FileType.NotFound:
+                    fs.delete_file(phys)
+            except Exception:
+                pass

--- a/python/ray/data/_internal/datasource/delta/fs.py
+++ b/python/ray/data/_internal/datasource/delta/fs.py
@@ -1,0 +1,89 @@
+"""Filesystem helpers for the Delta Lake datasink.
+
+This module isolates filesystem reconstruction so the datasink remains
+pickleable. The driver resolves a PyArrow filesystem once (either the
+explicit ``filesystem=`` the caller supplied, or one built from ``table_uri``
+via ``FileSystem.from_uri``); each worker rebuilds an equivalent filesystem
+from a small picklable config rather than pickling the filesystem object
+itself -- with one exception: an explicitly-supplied filesystem is carried
+through as-is, since PyArrow filesystems such as ``S3FileSystem`` are
+themselves picklable, and a caller-supplied filesystem may not be
+reconstructable from ``table_uri`` alone (e.g. a ``SubTreeFileSystem``
+rooted somewhere other than the table's own URI, or one carrying
+credentials the worker's ambient environment doesn't have).
+
+PyArrow filesystem: https://arrow.apache.org/docs/python/api/filesystems.html
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import pyarrow.fs as pa_fs
+
+
+@dataclass
+class _FsConfig:
+    """Picklable filesystem reconstruction record."""
+
+    table_uri: str
+    storage_options: Dict[str, str]
+    # Absolute directory for plain local ``table_uri`` values (from_uri path).
+    # Used to resolve Delta-relative file paths; see module docstring on
+    # ``make_fs_config``.
+    local_filesystem_root: Optional[str] = None
+    # Set only when the caller supplied an explicit filesystem. Carried to
+    # the worker as-is -- see module docstring.
+    explicit_filesystem: Optional[pa_fs.FileSystem] = None
+
+
+def make_fs_config(
+    table_uri: str,
+    filesystem: Optional[pa_fs.FileSystem],
+    storage_options: Dict[str, str],
+) -> Tuple[_FsConfig, pa_fs.FileSystem]:
+    """Return ``(picklable_config, driver_filesystem)``.
+
+    The driver uses the returned filesystem directly. The config travels on
+    the pickled datasink; workers call ``worker_filesystem(config)`` to
+    materialise their own filesystem instance.
+
+    For a **local** POSIX ``table_uri``, ``FileSystem.from_uri`` returns
+    ``(LocalFileSystem, base_path)``, but ``pq.write_table(..., path,
+    filesystem=fs)`` resolves *relative* ``path`` against the process working
+    directory, not ``base_path``. Callers therefore also record
+    ``local_filesystem_root=base_path`` and join it to Delta-relative paths
+    when writing, validating, and cleaning up files.
+    """
+    if filesystem is not None:
+        return (
+            _FsConfig(
+                table_uri=table_uri,
+                storage_options=dict(storage_options),
+                local_filesystem_root=None,
+                explicit_filesystem=filesystem,
+            ),
+            filesystem,
+        )
+    fs, path = pa_fs.FileSystem.from_uri(table_uri)
+    local_root = path if (path and isinstance(fs, pa_fs.LocalFileSystem)) else None
+    return (
+        _FsConfig(
+            table_uri=table_uri,
+            storage_options=dict(storage_options),
+            local_filesystem_root=local_root,
+        ),
+        fs,
+    )
+
+
+def worker_filesystem(config: _FsConfig) -> pa_fs.FileSystem:
+    """Materialise the filesystem on a worker from a picklable config.
+
+    Returns the explicitly-supplied filesystem as-is when there is one
+    (matching the driver exactly, including its root/credentials);
+    otherwise rebuilds a path-only filesystem from ``table_uri``.
+    """
+    if config.explicit_filesystem is not None:
+        return config.explicit_filesystem
+    fs, _ = pa_fs.FileSystem.from_uri(config.table_uri)
+    return fs

--- a/python/ray/data/_internal/datasource/delta/schema.py
+++ b/python/ray/data/_internal/datasource/delta/schema.py
@@ -1,0 +1,126 @@
+"""Schema reconciliation and evolution policies for the Delta Lake datasink.
+
+The framework's ``reconcile_schema`` hook lets the adapter decide what to do
+when worker schemas disagree with each other or with the existing table.
+Delta evolves at commit time (this module), in contrast with Iceberg which
+evolves pre-write.
+
+PyArrow schemas: https://arrow.apache.org/docs/python/api/datatypes.html
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+
+import pyarrow as pa
+
+if TYPE_CHECKING:
+    from deltalake import DeltaTable
+
+from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
+from ray.data._internal.datasource.delta.utils import (
+    to_pyarrow_schema,
+    types_compatible,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SchemaPolicy:
+    """Schema evolution policy.
+
+    * ``"error"`` (default) -- reject incoming data with new columns.
+    * ``"merge"`` -- add new columns to the existing table via
+      ``DeltaTable.alter.add_columns``.
+    """
+
+    mode: str = "error"
+
+
+def reconcile_worker_schemas(
+    worker_schemas: Sequence[pa.Schema],
+    existing_table_schema: Optional[pa.Schema],
+) -> Optional[pa.Schema]:
+    """Type-promoted union of every worker schema with the existing table."""
+    if not worker_schemas and not existing_table_schema:
+        return None
+    if worker_schemas and all(s == worker_schemas[0] for s in worker_schemas):
+        if existing_table_schema in (None, worker_schemas[0]):
+            return existing_table_schema or worker_schemas[0]
+    schemas = list(worker_schemas)
+    if existing_table_schema is not None:
+        schemas = [existing_table_schema] + schemas
+    return unify_schemas(schemas, promote_types=True) if schemas else None
+
+
+def validate_and_plan_evolution(
+    policy: SchemaPolicy,
+    existing_schema: pa.Schema,
+    incoming_schema: pa.Schema,
+) -> List[Tuple[str, pa.DataType, bool]]:
+    """Validate compatibility and return new fields to add (if any).
+
+    Raises ``ValueError`` if a column type mismatch is detected, or if the
+    incoming schema adds new columns and the policy is ``"error"``.
+    """
+    existing_cols = {f.name: f.type for f in existing_schema}
+    incoming_cols = {f.name: (f.type, f.nullable) for f in incoming_schema}
+
+    mismatches = []
+    for c, t in existing_cols.items():
+        if c in incoming_cols:
+            incoming_type = incoming_cols[c][0]
+            if pa.types.is_null(incoming_type):
+                existing_field = existing_schema.field(c)
+                if not existing_field.nullable:
+                    mismatches.append(c)
+            elif not types_compatible(t, incoming_type):
+                mismatches.append(c)
+
+    if mismatches:
+        raise ValueError(
+            f"Schema mismatch: type mismatches for existing columns: {mismatches}"
+        )
+
+    new_cols = [c for c in incoming_cols.keys() if c not in existing_cols]
+    if not new_cols:
+        return []
+
+    if policy.mode == "error":
+        raise ValueError(
+            f"New columns detected: {new_cols}. Schema evolution is disabled "
+            "by default. Set schema_mode='merge' to allow."
+        )
+    if policy.mode != "merge":
+        raise ValueError(
+            f"Invalid schema_mode '{policy.mode}'. Must be 'error' or 'merge'."
+        )
+    return [(c, incoming_cols[c][0], incoming_cols[c][1]) for c in new_cols]
+
+
+def evolve_schema(
+    existing_table: "DeltaTable", new_fields: List[Tuple[str, pa.DataType, bool]]
+) -> None:
+    """Add new columns to an existing Delta table."""
+    if not new_fields:
+        return
+    from ray.data._internal.datasource.delta.utils import convert_schema_to_delta
+
+    delta_fields = []
+    for name, pa_type, nullable in new_fields:
+        temp = pa.schema([pa.field(name, pa_type, nullable)])
+        delta_schema = convert_schema_to_delta(temp)
+        delta_fields.append(delta_schema.fields[0])
+
+    existing_table.alter.add_columns(delta_fields)
+    logger.info(
+        "Schema evolution: added %d columns: %s",
+        len(new_fields),
+        ", ".join(f[0] for f in new_fields),
+    )
+
+
+def existing_table_pyarrow_schema(existing_table: "DeltaTable") -> pa.Schema:
+    """Return the PyArrow schema of an existing Delta table."""
+    return to_pyarrow_schema(existing_table.schema())

--- a/python/ray/data/_internal/datasource/delta/utils.py
+++ b/python/ray/data/_internal/datasource/delta/utils.py
@@ -1,0 +1,556 @@
+"""Utility functions for Delta Lake datasource operations.
+
+Delta Lake: https://delta.io/
+delta-rs Python library: https://delta-io.github.io/delta-rs/python/
+"""
+
+import json
+import math
+import os
+import posixpath
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.fs as pa_fs
+
+if TYPE_CHECKING:
+    from deltalake import DeltaTable
+
+# ----------------------------------------------------------------------
+# Per-task write result.
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class DeltaWriteResult:
+    """Result a worker returns to the driver after a write task completes.
+
+    Attributes:
+        add_actions: ``deltalake.transaction.AddAction`` objects produced by
+            this task's writer.
+        emitted_schemas: PyArrow schema of every non-empty Arrow table the
+            worker processed in this task. Used by the driver for
+            type-promoted schema unification across workers.
+        written_paths: Best-effort list of relative paths written by this
+            task, used by ``on_write_failed`` to clean up orphans.
+        task_id: Worker task index (for logging / debugging).
+        task_metadata: Free-form metadata produced by this task -- carries
+            the per-write UUID used for idempotent commit retries.
+    """
+
+    add_actions: List[Any] = field(default_factory=list)
+    emitted_schemas: List[pa.Schema] = field(default_factory=list)
+    written_paths: List[str] = field(default_factory=list)
+    task_id: Optional[int] = None
+    task_metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+# ----------------------------------------------------------------------
+# Partitioning constants and helpers.
+# ----------------------------------------------------------------------
+
+MAX_PARTITION_PATH_LENGTH = 200
+MAX_PARTITION_COLUMNS = 10
+
+
+def build_partition_path(
+    cols: List[str], values: tuple
+) -> Tuple[str, Dict[str, Optional[str]]]:
+    """Build a Hive-style partition path (``col1=val1/col2=val2/``).
+
+    NULL values use ``__HIVE_DEFAULT_PARTITION__``; float NaN uses the
+    literal string ``"NaN"`` (distinct from string ``"NaN"``).
+    """
+    if not cols or not values:
+        return "", {}
+
+    parts = []
+    part_dict: Dict[str, Optional[str]] = {}
+    for col, val in zip(cols, values):
+        if val is None:
+            parts.append(f"{col}=__HIVE_DEFAULT_PARTITION__")
+            part_dict[col] = None
+        elif isinstance(val, float) and math.isnan(val):
+            parts.append(f"{col}=NaN")
+            part_dict[col] = "NaN"
+        else:
+            validate_partition_value(val)
+            encoded_val = urllib.parse.quote(str(val), safe="")
+            parts.append(f"{col}={encoded_val}")
+            part_dict[col] = str(val)
+
+    path = "/".join(parts) + "/"
+    if len(path) > MAX_PARTITION_PATH_LENGTH:
+        raise ValueError(f"Partition path too long: {len(path)} chars")
+    return path, part_dict
+
+
+def validate_partition_value(value: Any) -> None:
+    """Validate a partition value is safe for use in paths."""
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return
+    val_str = str(value)
+    if not val_str:
+        raise ValueError("Partition value cannot be empty string")
+    if ".." in val_str or "/" in val_str or "\\" in val_str:
+        raise ValueError(f"Partition value contains invalid characters: {value}")
+    if "\x00" in val_str:
+        raise ValueError(f"Partition value contains null byte: {value}")
+    if len(val_str) > MAX_PARTITION_PATH_LENGTH:
+        raise ValueError(f"Partition value too long ({len(val_str)} chars)")
+
+
+def validate_partition_column_names(cols: List[str]) -> List[str]:
+    """Validate partition column names."""
+    if not isinstance(cols, list):
+        raise ValueError(f"Partition columns must be a list, got {type(cols).__name__}")
+    if len(cols) > MAX_PARTITION_COLUMNS:
+        raise ValueError(f"Too many partition columns ({len(cols)})")
+    seen = set()
+    for col in cols:
+        if not isinstance(col, str) or not col.strip():
+            raise ValueError(f"Invalid partition column name: {col}")
+        if "/" in col or "\\" in col or ".." in col or "=" in col:
+            raise ValueError(f"Invalid characters in partition column name: {col}")
+        if col in seen:
+            raise ValueError(f"Duplicate partition column: {col}")
+        seen.add(col)
+    return cols
+
+
+def validate_partition_columns_in_table(cols: List[str], table: pa.Table) -> None:
+    """Validate partition columns exist in table with valid types."""
+    if not cols:
+        return
+    missing = [c for c in cols if c not in table.column_names]
+    if missing:
+        raise ValueError(f"Missing partition columns: {missing}")
+    for col in cols:
+        col_type = table.schema.field(col).type
+        if pa.types.is_nested(col_type):
+            raise ValueError(f"Partition column '{col}' has nested type {col_type}")
+        if pa.types.is_dictionary(col_type):
+            raise ValueError(f"Partition column '{col}' has dictionary type")
+
+
+def infer_partition_type(value: Any) -> pa.DataType:
+    """Infer PyArrow type from a partition value (best-effort)."""
+    if value is None:
+        return pa.string()
+    if isinstance(value, bool):
+        return pa.bool_()
+    if isinstance(value, int):
+        return pa.int64()
+    if isinstance(value, float):
+        return pa.float64()
+    if isinstance(value, str):
+        if value.lower() in ("true", "false"):
+            return pa.bool_()
+        try:
+            int(value)
+            if "." not in value and "e" not in value.lower():
+                return pa.int64()
+        except ValueError:
+            pass
+        try:
+            float(value)
+            return pa.float64()
+        except ValueError:
+            pass
+    return pa.string()
+
+
+# ----------------------------------------------------------------------
+# Path helpers.
+# ----------------------------------------------------------------------
+
+
+def safe_dirname(path: str) -> str:
+    """Get directory portion of path, handling URI schemes."""
+    if "://" in path:
+        scheme, rest = path.split("://", 1)
+        directory = posixpath.dirname(rest)
+        return f"{scheme}://{directory}" if directory else ""
+    return os.path.dirname(path)
+
+
+def resolve_under_table_root(table_root: Optional[str], rel_path: str) -> str:
+    """Join a Delta-relative path to an absolute local table directory.
+
+    When ``table_root`` is ``None`` (cloud / custom filesystem), ``rel_path``
+    is returned unchanged.
+    """
+    if not table_root:
+        return rel_path
+    return os.path.normpath(os.path.join(table_root, rel_path))
+
+
+def validate_file_path(path: str, max_length: int = 500) -> None:
+    """Validate file path is safe for use."""
+    if not isinstance(path, str):
+        raise ValueError(f"Path must be string, got {type(path).__name__}")
+    if not path or not path.strip():
+        raise ValueError("Path cannot be empty")
+    if ".." in path:
+        raise ValueError(f"Path contains '..': {path}")
+    if path.startswith("/"):
+        raise ValueError(f"Absolute path not allowed: {path}")
+    if len(path) > max_length:
+        raise ValueError(f"Path too long ({len(path)} chars): {path}")
+    if "\x00" in path:
+        raise ValueError(f"Path contains null byte: {path}")
+    for char in '<>:"|?*':
+        if char in path:
+            raise ValueError(f"Path contains invalid character '{char}': {path}")
+
+
+def get_file_info_with_retry(
+    fs: pa_fs.FileSystem, path: str, max_retries: int = 3, base_delay: float = 0.1
+) -> pa_fs.FileInfo:
+    """Get file info with retries and exponential backoff."""
+    from ray._common.retry import call_with_retry
+    from ray.data.context import DataContext
+
+    data_context = DataContext.get_current()
+    max_backoff_s = (
+        base_delay * (2 ** (max_retries - 1)) if max_retries > 1 else base_delay
+    )
+    return call_with_retry(
+        lambda: fs.get_file_info(path),
+        description=f"get file info for '{path}'",
+        match=data_context.retried_io_errors,
+        max_attempts=max_retries,
+        # call_with_retry caps backoff in whole seconds; round the sub-second
+        # computed value up so a small base_delay still yields a >=1s cap.
+        max_backoff_s=math.ceil(max_backoff_s),
+    )
+
+
+# ----------------------------------------------------------------------
+# Storage options (pass-through only; cloud auto-detection + explicit
+# filesystem construction are added in the follow-up PR).
+# ----------------------------------------------------------------------
+
+
+def get_storage_options(
+    path: str, provided: Optional[Dict[str, str]] = None
+) -> Dict[str, str]:
+    """Return storage options dict for the given path.
+
+    Pass-through only; caller-supplied options are returned unchanged.
+    """
+    return dict(provided or {})
+
+
+# ----------------------------------------------------------------------
+# DeltaTable helpers.
+# ----------------------------------------------------------------------
+
+
+def try_get_deltatable(
+    table_uri: str, storage_options: Optional[Dict[str, str]] = None
+) -> Optional["DeltaTable"]:
+    """Return DeltaTable if it exists, None otherwise."""
+    from deltalake import DeltaTable
+
+    try:
+        return DeltaTable(table_uri, storage_options=storage_options)
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        # deltalake raises TableNotFoundError (an optional import) when the
+        # table doesn't exist; treat that like a missing path. Anything else
+        # is a real error and must propagate.
+        if type(e).__name__ == "TableNotFoundError":
+            return None
+        raise
+
+
+# ----------------------------------------------------------------------
+# Type compatibility helpers.
+# ----------------------------------------------------------------------
+
+
+def _safe_type_check(t: pa.DataType, check_func) -> bool:
+    """Safely check type, handling arro3 types that don't have 'id' attribute."""
+    try:
+        return check_func(t)
+    except AttributeError:
+        if not hasattr(t, "id"):
+            try:
+                pa_type = pa.DataType._import_from_c(t._export_to_c())
+                return check_func(pa_type)
+            except (AttributeError, TypeError):
+                return False
+        raise
+
+
+def is_string_type(t: pa.DataType) -> bool:
+    return (
+        pa.types.is_string(t)
+        or pa.types.is_large_string(t)
+        or (hasattr(pa.types, "is_string_view") and pa.types.is_string_view(t))
+    )
+
+
+def is_binary_type(t: pa.DataType) -> bool:
+    return (
+        pa.types.is_binary(t)
+        or pa.types.is_large_binary(t)
+        or (hasattr(pa.types, "is_binary_view") and pa.types.is_binary_view(t))
+        or pa.types.is_fixed_size_binary(t)
+    )
+
+
+def is_date_type(t: pa.DataType) -> bool:
+    return pa.types.is_date32(t) or pa.types.is_date64(t)
+
+
+def is_numeric_type(t: pa.DataType) -> bool:
+    return pa.types.is_integer(t) or pa.types.is_floating(t) or pa.types.is_decimal(t)
+
+
+def is_temporal_type(t: pa.DataType) -> bool:
+    return pa.types.is_date(t) or pa.types.is_timestamp(t)
+
+
+def types_compatible(expected: pa.DataType, actual: pa.DataType) -> bool:
+    """Check if actual type can be written to expected type column."""
+    if expected == actual:
+        return True
+    if _safe_type_check(expected, pa.types.is_integer) and _safe_type_check(
+        actual, pa.types.is_integer
+    ):
+        if _safe_type_check(expected, pa.types.is_signed_integer) != _safe_type_check(
+            actual, pa.types.is_signed_integer
+        ):
+            return False
+        return getattr(actual, "bit_width", 64) <= getattr(expected, "bit_width", 64)
+    if _safe_type_check(expected, pa.types.is_floating) and _safe_type_check(
+        actual, pa.types.is_floating
+    ):
+        return True
+    if is_string_type(expected) and is_string_type(actual):
+        return True
+    if is_binary_type(expected) and is_binary_type(actual):
+        return True
+    if _safe_type_check(expected, pa.types.is_boolean) and _safe_type_check(
+        actual, pa.types.is_boolean
+    ):
+        return True
+    if is_date_type(expected) and is_date_type(actual):
+        return True
+    if _safe_type_check(expected, pa.types.is_timestamp) and _safe_type_check(
+        actual, pa.types.is_timestamp
+    ):
+        return getattr(expected, "tz", None) == getattr(actual, "tz", None)
+    if _safe_type_check(expected, pa.types.is_decimal) and _safe_type_check(
+        actual, pa.types.is_decimal
+    ):
+        return expected.precision == actual.precision and expected.scale == actual.scale
+    return False
+
+
+def validate_schema_type_compatibility(
+    existing_schema: pa.Schema, incoming_schema: pa.Schema
+) -> None:
+    """Validate that incoming schema is compatible with existing schema."""
+    existing_cols = {f.name: f.type for f in existing_schema}
+    incoming_cols = {f.name: f.type for f in incoming_schema}
+
+    mismatches = [
+        c
+        for c in existing_cols
+        if c in incoming_cols
+        and not types_compatible(existing_cols[c], incoming_cols[c])
+    ]
+    if mismatches:
+        raise ValueError(
+            f"Schema mismatch: type mismatches for existing columns: {mismatches}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Schema conversion (PyArrow <-> Delta Lake).
+# ----------------------------------------------------------------------
+
+
+def pyarrow_type_to_delta_type(pa_type: pa.DataType) -> str:
+    """Convert PyArrow type to Delta Lake type string."""
+    if pa.types.is_int8(pa_type):
+        return "byte"
+    if pa.types.is_int16(pa_type):
+        return "short"
+    if pa.types.is_int32(pa_type):
+        return "integer"
+    if pa.types.is_int64(pa_type):
+        return "long"
+    if pa.types.is_uint8(pa_type):
+        return "short"
+    if pa.types.is_uint16(pa_type):
+        return "integer"
+    if pa.types.is_uint32(pa_type):
+        return "long"
+    if pa.types.is_uint64(pa_type):
+        return "decimal(20,0)"
+    if pa.types.is_float16(pa_type) or pa.types.is_float32(pa_type):
+        return "float"
+    if pa.types.is_float64(pa_type):
+        return "double"
+    if is_string_type(pa_type):
+        return "string"
+    if is_binary_type(pa_type):
+        return "binary"
+    if pa.types.is_boolean(pa_type):
+        return "boolean"
+    if is_date_type(pa_type):
+        return "date"
+    if pa.types.is_timestamp(pa_type):
+        return "timestamp"
+    if pa.types.is_time(pa_type) or pa.types.is_null(pa_type):
+        return "string"
+    if pa.types.is_duration(pa_type):
+        return "long"
+    if pa.types.is_decimal(pa_type):
+        return f"decimal({pa_type.precision},{pa_type.scale})"
+    raise ValueError(f"Unsupported PyArrow type for Delta Lake: {pa_type}")
+
+
+def convert_schema_to_delta(schema: pa.Schema) -> Any:
+    """Convert PyArrow schema to Delta Lake schema."""
+    from deltalake import Schema as DeltaSchema
+
+    if schema is None:
+        raise ValueError("Cannot convert None schema to Delta Lake schema")
+
+    converted_fields = []
+    for schema_field in schema:
+        field_type = schema_field.type
+        if pa.types.is_timestamp(field_type) and field_type.unit != "us":
+            tz = field_type.tz if hasattr(field_type, "tz") else None
+            field_type = pa.timestamp("us", tz=tz)
+        converted_fields.append(
+            pa.field(
+                schema_field.name,
+                field_type,
+                schema_field.nullable,
+                schema_field.metadata,
+            )
+        )
+
+    converted_schema = pa.schema(converted_fields)
+
+    try:
+        return DeltaSchema.from_arrow(converted_schema)
+    except (ValueError, TypeError):
+        fields = [
+            {
+                "name": f.name,
+                "type": pyarrow_type_to_delta_type(f.type),
+                "nullable": f.nullable,
+                "metadata": {},
+            }
+            for f in converted_schema
+        ]
+        return DeltaSchema.from_json(json.dumps({"type": "struct", "fields": fields}))
+
+
+def to_pyarrow_schema(delta_schema: Any) -> pa.Schema:
+    """Convert Delta Lake schema to PyArrow schema."""
+    if delta_schema is None:
+        raise ValueError("Cannot convert None to PyArrow schema")
+    if isinstance(delta_schema, pa.Schema):
+        return delta_schema
+
+    out = None
+    if hasattr(delta_schema, "to_pyarrow"):
+        out = delta_schema.to_pyarrow()
+    elif hasattr(delta_schema, "to_arrow"):
+        # delta-rs newer builds expose to_arrow(); value may be arro3 Schema,
+        # not pa.Schema.
+        out = delta_schema.to_arrow()
+
+    if out is not None:
+        if isinstance(out, pa.Schema):
+            return out
+        # arro3 (and other Arrow C Data exporters): PyArrow accepts these in
+        # pa.schema().
+        try:
+            return pa.schema(out)
+        except (TypeError, ValueError):
+            pass
+
+    raise AttributeError(
+        f"Cannot convert {type(delta_schema).__name__} to PyArrow schema"
+    )
+
+
+# ----------------------------------------------------------------------
+# Parquet statistics for Delta file metadata.
+# ----------------------------------------------------------------------
+
+
+def _to_json_serializable(val: Any) -> Any:
+    import math
+    from decimal import Decimal
+
+    if val is None:
+        return None
+    if isinstance(val, Decimal):
+        return str(val)
+    if isinstance(val, float) and not math.isfinite(val):
+        return None
+    if hasattr(val, "isoformat"):
+        return val.isoformat()
+    return val
+
+
+def compute_parquet_statistics(table: pa.Table) -> str:
+    """Compute Delta Lake statistics JSON for a table.
+
+    Delta-rs expects per-column stats only for primitive (non-nested) types
+    and rejects flat-integer ``nullCount`` for struct / list / map columns
+    (it requires a recursive struct-shaped value for those). To keep the
+    implementation simple and conformant, we skip stats entirely for
+    nested columns -- delta-rs reads them as "no statistics available",
+    which is harmless and disables only the row-group skipping optimisation
+    for those columns.
+    """
+    stats: Dict[str, Any] = {"numRecords": table.num_rows}
+    null_counts: Dict[str, int] = {}
+    min_vals: Dict[str, Any] = {}
+    max_vals: Dict[str, Any] = {}
+
+    for i, col in enumerate(table.columns):
+        name = table.schema.field(i).name
+        col_type = col.type
+        if pa.types.is_nested(col_type):
+            # Skip stats for struct / list / map / fixed_size_list etc.
+            # Delta-rs expects nested null-counts for nested columns and
+            # rejects the flat integer form we'd otherwise emit.
+            continue
+        null_count = pc.sum(pc.is_null(col)).as_py()
+        if null_count is not None and null_count >= 0:
+            null_counts[name] = null_count
+        if (
+            is_numeric_type(col_type)
+            or is_string_type(col_type)
+            or is_temporal_type(col_type)
+        ):
+            min_val = _to_json_serializable(pc.min(col).as_py())
+            max_val = _to_json_serializable(pc.max(col).as_py())
+            if min_val is not None:
+                min_vals[name] = min_val
+            if max_val is not None:
+                max_vals[name] = max_val
+
+    if min_vals:
+        stats["minValues"] = min_vals
+    if max_vals:
+        stats["maxValues"] = max_vals
+    if null_counts:
+        stats["nullCount"] = null_counts
+    return json.dumps(stats)

--- a/python/ray/data/_internal/datasource/delta/writer.py
+++ b/python/ray/data/_internal/datasource/delta/writer.py
@@ -1,0 +1,389 @@
+"""Parquet writer for the Delta Lake datasink.
+
+Supports Hive-style partitioning and an optional buffered/large-file mode
+controlled by ``target_file_size_bytes``. Schema evolution is handled at the
+datasink level; cloud filesystem reconstruction at the fs level.
+
+PyArrow Parquet: https://arrow.apache.org/docs/python/parquet.html
+"""
+
+import logging
+import time
+import uuid
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.fs as pa_fs
+import pyarrow.parquet as pq
+
+from ray._common.retry import call_with_retry
+from ray.data._internal.datasource.delta.utils import (
+    build_partition_path,
+    compute_parquet_statistics,
+    get_file_info_with_retry,
+    resolve_under_table_root,
+    safe_dirname,
+    validate_file_path,
+    validate_partition_value,
+)
+from ray.data.context import DataContext
+
+# Standalone retry tunables for the Delta Parquet writer. Deliberately not
+# shared with ``ParquetDatasink`` (``write_parquet``'s own writer) -- this
+# datasink has no dependency on `write_parquet` internals.
+_WRITE_FILE_MAX_ATTEMPTS = 10
+_WRITE_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
+
+
+def build_uuid_filename(
+    write_uuid: Optional[str],
+    task_idx: int,
+    block_idx: int,
+    suffix: str = ".parquet",
+) -> str:
+    """Generate a stable, write-UUID-tagged filename.
+
+    The format is ``part-<uuid8>-<task:05d>-<block:05d>-<rand16>.parquet``.
+    """
+    uid = uuid.uuid4().hex[:16]
+    prefix = write_uuid or "00000000"
+    prefix = prefix[:8].ljust(8, "0")
+    return f"part-{prefix}-{task_idx:05d}-{block_idx:05d}-{uid}{suffix}"
+
+
+def write_parquet_with_retry(
+    table: pa.Table,
+    rel_path: str,
+    filesystem: pa_fs.FileSystem,
+    *,
+    compression: str = "snappy",
+    write_statistics: bool = True,
+    verify_size: bool = True,
+    extra_pq_kwargs: Optional[Dict[str, Any]] = None,
+    on_each_attempt: Optional[Callable[[], None]] = None,
+) -> int:
+    """Write a PyArrow table to ``rel_path`` with retry and size verification.
+
+    Returns the written file size in bytes. Raises if the file ends up empty
+    (treated as a transient failure and retried; final empty is a hard error).
+    """
+    extra = dict(extra_pq_kwargs or {})
+    ctx = DataContext.get_current()
+    result: Dict[str, int] = {"size": 0}
+
+    def _attempt() -> None:
+        if on_each_attempt is not None:
+            on_each_attempt()
+        pq.write_table(
+            table,
+            rel_path,
+            filesystem=filesystem,
+            compression=compression,
+            write_statistics=write_statistics,
+            **extra,
+        )
+        info = get_file_info_with_retry(filesystem, rel_path)
+        if verify_size and info.size == 0:
+            try:
+                filesystem.delete_file(rel_path)
+            except Exception:
+                pass
+            raise RuntimeError(f"Written file is empty: {rel_path}")
+        result["size"] = info.size
+
+    call_with_retry(
+        _attempt,
+        description=f"write Parquet file '{rel_path}'",
+        match=ctx.retried_io_errors,
+        max_attempts=_WRITE_FILE_MAX_ATTEMPTS,
+        max_backoff_s=_WRITE_FILE_RETRY_MAX_BACKOFF_SECONDS,
+    )
+    return result["size"]
+
+
+logger = logging.getLogger(__name__)
+
+_MAX_PARTITIONS = 10_000
+_VALID_COMPRESSIONS = {"snappy", "gzip", "brotli", "zstd", "lz4", "none"}
+
+
+def _import_add_action():
+    """Import AddAction from deltalake, handling different package layouts."""
+    for mod in ("deltalake.transaction", "deltalake", "deltalake.writer"):
+        try:
+            m = __import__(mod, fromlist=["AddAction"])
+            return m.AddAction
+        except Exception:
+            continue
+    raise ImportError(
+        "Could not import AddAction from deltalake. Install/upgrade deltalake."
+    )
+
+
+class DeltaFileWriter:
+    """Partition-aware buffered Parquet writer for Delta tables."""
+
+    def __init__(
+        self,
+        *,
+        filesystem: pa.fs.FileSystem,
+        partition_cols: List[str],
+        write_uuid: Optional[str],
+        write_kwargs: Dict[str, Any],
+        written_files: Set[str],
+        target_file_size_bytes: Optional[int] = None,
+        local_filesystem_root: Optional[str] = None,
+    ):
+        self.filesystem = filesystem
+        self.partition_cols = partition_cols
+        self.write_uuid = write_uuid
+        self.write_kwargs = write_kwargs
+        self.written_files = written_files
+        self._AddAction = _import_add_action()
+        self.target_file_size_bytes = target_file_size_bytes
+
+        # Per-task buffers keyed by partition values tuple.
+        self._buffers: DefaultDict[Tuple, List[pa.Table]] = defaultdict(list)
+        self._buffer_bytes: DefaultDict[Tuple, int] = defaultdict(int)
+        self._file_seq = 0
+        self._local_filesystem_root = local_filesystem_root
+
+        compression = self.write_kwargs.get("compression", "snappy")
+        if compression not in _VALID_COMPRESSIONS:
+            raise ValueError(
+                f"Invalid compression '{compression}'. "
+                f"Supported: {sorted(_VALID_COMPRESSIONS)}"
+            )
+        if self.target_file_size_bytes is not None and self.target_file_size_bytes <= 0:
+            raise ValueError("target_file_size_bytes must be > 0")
+
+    # ------------------------------------------------------------------
+    # Public API.
+    # ------------------------------------------------------------------
+    def add_table(self, table: pa.Table, task_idx: int) -> List[Any]:
+        """Push an Arrow table through the writer.
+
+        With ``target_file_size_bytes`` unset, one file per partition per
+        ``add_table`` call. Set, buffers per partition until threshold.
+        """
+        if len(table) == 0:
+            return []
+
+        if not self.target_file_size_bytes:
+            return self._write_immediate(table, task_idx)
+
+        # Buffered path.
+        parts = (
+            self.partition_table(table, self.partition_cols)
+            if self.partition_cols
+            else {(): table}
+        )
+        actions: List[Any] = []
+        for partition_values, partition_table in parts.items():
+            self._buffers[partition_values].append(partition_table)
+            self._buffer_bytes[partition_values] += getattr(
+                partition_table, "nbytes", 0
+            )
+            if self._buffer_bytes[partition_values] >= self.target_file_size_bytes:
+                actions.extend(self._flush_partition(partition_values, task_idx))
+        return actions
+
+    def flush(self, task_idx: int) -> List[Any]:
+        """Drain remaining buffered partitions and return their actions."""
+        actions: List[Any] = []
+        for partition_values in list(self._buffers.keys()):
+            actions.extend(self._flush_partition(partition_values, task_idx))
+        return actions
+
+    # ------------------------------------------------------------------
+    # Internal helpers.
+    # ------------------------------------------------------------------
+    def _write_immediate(self, table: pa.Table, task_idx: int) -> List[Any]:
+        self._file_seq += 1
+        if self.partition_cols:
+            parts = self.partition_table(table, self.partition_cols)
+            return [
+                a
+                for a in (
+                    self._write_partition(t, k, task_idx, self._file_seq)
+                    for k, t in parts.items()
+                )
+                if a is not None
+            ]
+        a = self._write_partition(table, (), task_idx, self._file_seq)
+        return [a] if a is not None else []
+
+    def _flush_partition(self, partition_values: Tuple, task_idx: int) -> List[Any]:
+        tables = self._buffers.get(partition_values)
+        if not tables:
+            return []
+        # Permissive promotion so buffered same-partition blocks with
+        # promotable type diffs (e.g. int32/int64) merge — matching the
+        # framework's permissive worker-schema unification, so buffered writes
+        # (target_file_size_bytes) behave the same as unbuffered ones.
+        merged = pa.concat_tables(tables, promote_options="permissive")
+        self._buffers[partition_values].clear()
+        self._buffer_bytes[partition_values] = 0
+        self._file_seq += 1
+        action = self._write_partition(
+            merged, partition_values, task_idx, self._file_seq
+        )
+        return [action] if action is not None else []
+
+    def partition_table(
+        self, table: pa.Table, cols: List[str]
+    ) -> Dict[Tuple, pa.Table]:
+        """Partition the table by ``cols`` using Arrow-native ops."""
+        if len(table) == 0:
+            return {}
+
+        if len(cols) == 1:
+            col = cols[0]
+            unique_vals = pc.unique(table[col])
+            if len(unique_vals) > _MAX_PARTITIONS:
+                raise ValueError(
+                    f"Too many partition values ({len(unique_vals)}). "
+                    f"Max: {_MAX_PARTITIONS}"
+                )
+            out: Dict[Tuple, pa.Table] = {}
+            for v in unique_vals:
+                vpy = v.as_py()
+                if vpy is not None and not (isinstance(vpy, float) and vpy != vpy):
+                    validate_partition_value(vpy)
+                if vpy is None:
+                    sub = table.filter(pc.is_null(table[col]))
+                elif (
+                    pa.types.is_floating(table[col].type)
+                    and isinstance(vpy, float)
+                    and vpy != vpy
+                ):
+                    sub = table.filter(pc.is_nan(table[col]))
+                else:
+                    sub = table.filter(pc.equal(table[col], v))
+                if len(sub) > 0:
+                    out[(vpy,)] = sub
+            return out
+
+        # Multi-column: struct + dictionary_encode (with fallback).
+        arrays = []
+        fields = []
+        for c in cols:
+            arr = table[c]
+            if isinstance(arr, pa.ChunkedArray):
+                arr = arr.combine_chunks()
+            arrays.append(arr)
+            fields.append(pa.field(c, table.schema.field(c).type, nullable=True))
+
+        struct_arr = pa.StructArray.from_arrays(arrays, fields=fields)
+        try:
+            enc = pc.dictionary_encode(struct_arr)
+            dictionary, indices = enc.dictionary, enc.indices
+            use_dictionary_keys = True
+        except pa.ArrowNotImplementedError:
+            # Manual grouping fallback for builds without struct dict_encode.
+            col_arrays = [table[c] for c in cols]
+            col_arrays = [
+                a.combine_chunks() if isinstance(a, pa.ChunkedArray) else a
+                for a in col_arrays
+            ]
+            groups: Dict[Tuple, List[int]] = {}
+            for i in range(len(table)):
+                key = tuple(
+                    arr[i].as_py() if arr[i].is_valid else None for arr in col_arrays
+                )
+                groups.setdefault(key, []).append(i)
+            if len(groups) > _MAX_PARTITIONS:
+                raise ValueError(
+                    f"Too many partition combinations ({len(groups)}). "
+                    f"Max: {_MAX_PARTITIONS}"
+                )
+            out = {}
+            for key, indices_list in groups.items():
+                sub = table.take(pa.array(indices_list))
+                if len(sub) > 0:
+                    out[key] = sub
+            return out
+
+        if len(dictionary) > _MAX_PARTITIONS:
+            raise ValueError(
+                f"Too many partition combinations ({len(dictionary)}). "
+                f"Max: {_MAX_PARTITIONS}"
+            )
+
+        out = {}
+        for dict_idx in range(len(dictionary)):
+            sub = table.filter(pc.equal(indices, dict_idx))
+            if len(sub) == 0:
+                continue
+            if use_dictionary_keys:
+                key_struct = dictionary[dict_idx]
+                key = tuple(
+                    key_struct[i].as_py() if key_struct[i].is_valid else None
+                    for i in range(len(cols))
+                )
+            else:
+                first = sub.slice(0, 1)
+                key = tuple(first[c][0].as_py() for c in cols)
+            out[key] = sub
+        return out
+
+    def _write_partition(
+        self, table: pa.Table, partition_values: Tuple, task_idx: int, block_idx: int
+    ) -> Optional[Any]:
+        if len(table) == 0:
+            return None
+        # Drop partition columns from the on-disk payload.
+        if self.partition_cols:
+            data_cols = [c for c in table.column_names if c not in self.partition_cols]
+            table = table.select(data_cols)
+
+        filename = self._filename(task_idx, block_idx)
+        partition_path, partition_dict = build_partition_path(
+            self.partition_cols, partition_values
+        )
+        rel_path = partition_path + filename
+
+        validate_file_path(rel_path)
+        self.written_files.add(rel_path)
+
+        size = self._write_parquet(table, rel_path)
+        stats = compute_parquet_statistics(table)
+
+        return self._AddAction(
+            path=rel_path,
+            size=size,
+            partition_values=partition_dict,
+            modification_time=int(time.time() * 1000),
+            data_change=True,
+            stats=stats,
+        )
+
+    def _filename(self, task_idx: int, block_idx: int) -> str:
+        return build_uuid_filename(self.write_uuid, task_idx, block_idx)
+
+    def _write_parquet(self, table: pa.Table, rel_path: str) -> int:
+        phys_path = resolve_under_table_root(self._local_filesystem_root, rel_path)
+        parent = safe_dirname(rel_path)
+        phys_parent = (
+            resolve_under_table_root(self._local_filesystem_root, parent)
+            if self._local_filesystem_root and parent
+            else parent
+        )
+
+        def _ensure_parent() -> None:
+            if phys_parent:
+                try:
+                    self.filesystem.create_dir(phys_parent, recursive=True)
+                except Exception:
+                    pass
+
+        return write_parquet_with_retry(
+            table,
+            phys_path,
+            self.filesystem,
+            compression=self.write_kwargs.get("compression", "snappy"),
+            write_statistics=self.write_kwargs.get("write_statistics", True),
+            on_each_attempt=_ensure_parent,
+        )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -41,6 +41,7 @@ from ray.data._internal.datasource.clickhouse_datasink import (
     SinkMode,
 )
 from ray.data._internal.datasource.csv_datasink import CSVDatasink
+from ray.data._internal.datasource.delta.datasink import DeltaDatasink
 from ray.data._internal.datasource.iceberg_datasink import IcebergDatasink
 from ray.data._internal.datasource.image_datasink import ImageDatasink
 from ray.data._internal.datasource.json_datasink import JSONDatasink
@@ -4734,6 +4735,69 @@ class Dataset:
             overwrite_kwargs=overwrite_kwargs,
         )
 
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
+
+    @ConsumptionAPI
+    @PublicAPI(stability="alpha", api_group=IOC_API_GROUP)
+    def write_delta(
+        self,
+        path: str,
+        *,
+        mode: str = "append",
+        partition_cols: Optional[List[str]] = None,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+        schema: Optional["pyarrow.Schema"] = None,
+        schema_mode: str = "error",
+        ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
+        **write_kwargs,
+    ) -> None:
+        """Writes the :class:`~ray.data.Dataset` to a Delta Lake table.
+
+        Examples:
+            >>> import ray
+            >>> ds = ray.data.range(100)
+            >>> ds.write_delta("/tmp/my-delta-table")  # doctest: +SKIP
+            >>> ds.write_delta("/tmp/my-delta-table", mode="overwrite")  # doctest: +SKIP
+
+        Args:
+            path: Path to the Delta table.
+            mode: Determines how to handle an existing table. One of
+                ``"append"`` (default), ``"overwrite"``, ``"error"``, or
+                ``"ignore"``. ``"error"`` raises if the table already exists;
+                ``"ignore"`` is a no-op if the table already exists.
+            partition_cols: Column names by which to partition the table.
+                Files are written in Hive partition style.
+            filesystem: The pyarrow filesystem implementation to write to.
+                By default, the filesystem is automatically selected based on
+                the scheme of ``path``.
+            schema: Explicit schema for the table. If not provided, the
+                schema is inferred from the first non-empty block written.
+            schema_mode: ``"error"`` (default) rejects incoming columns not
+                present in the existing table schema. ``"merge"`` adds them.
+            ray_remote_args: Kwargs passed to :func:`ray.remote` in the write
+                tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently.
+                By default, concurrency is dynamically decided based on the
+                available resources.
+            **write_kwargs: Additional keyword arguments passed through to
+                the underlying ``deltalake`` write, e.g. ``compression``,
+                ``write_statistics``, ``target_file_size_bytes``,
+                ``storage_options``.
+        """
+        datasink = DeltaDatasink(
+            path,
+            mode=mode,
+            partition_cols=partition_cols,
+            filesystem=filesystem,
+            schema=schema,
+            schema_mode=schema_mode,
+            **write_kwargs,
+        )
         self.write_datasink(
             datasink,
             ray_remote_args=ray_remote_args,

--- a/python/ray/data/tests/datasource/test_write_delta.py
+++ b/python/ray/data/tests/datasource/test_write_delta.py
@@ -1,0 +1,959 @@
+"""Tests for ``Dataset.write_delta`` -- core write path.
+
+Covers APPEND / OVERWRITE / ERROR / IGNORE modes, Hive-style partitioning
+(incl. dynamic partition overwrite and buffered writes), and schema
+evolution.
+
+Master's existing ``test_delta.py`` covers ``ray.data.read_delta`` and is
+not modified here.
+"""
+
+import os
+from typing import Any, Dict, List
+
+import pyarrow as pa
+import pytest
+from packaging.version import parse as parse_version
+
+import ray
+from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+try:
+    import deltalake as _deltalake_check  # noqa: F401
+except ImportError:
+    _deltalake_check = None
+
+_pa_version = get_pyarrow_version()
+# Use skipif (not importorskip) so tests are still collected and show up as
+# skipped with a clear reason when optional deps are missing.
+pytestmark = [
+    pytest.mark.skipif(
+        _deltalake_check is None,
+        reason="Missing optional dependency: pip install deltalake",
+    ),
+    pytest.mark.skipif(
+        _pa_version is None or _pa_version < parse_version("15.0.0"),
+        reason="deltalake requires pyarrow >= 15.0",
+    ),
+]
+
+
+@pytest.fixture
+def temp_delta_path(tmp_path):
+    """Clean per-test path for a Delta table."""
+    return os.path.join(str(tmp_path), "delta_table")
+
+
+def _write_append(rows: List[Dict[str, Any]], path: str, **kwargs) -> None:
+    ray.data.from_items(rows).write_delta(path, mode="append", **kwargs)
+
+
+def _read_all(path: str, **kwargs) -> List[Dict[str, Any]]:
+    return ray.data.read_delta(path, **kwargs).take_all()
+
+
+def _log_exists(path: str) -> bool:
+    return os.path.isdir(os.path.join(path, "_delta_log"))
+
+
+# ----------------------------------------------------------------------
+# APPEND.
+# ----------------------------------------------------------------------
+
+
+def test_append_to_new_path_creates_table(temp_delta_path):
+    rows = [{"id": i, "v": f"r{i}"} for i in range(5)]
+    _write_append(rows, temp_delta_path)
+    assert _log_exists(temp_delta_path)
+    assert sorted(_read_all(temp_delta_path), key=lambda r: r["id"]) == rows
+
+
+def test_append_to_existing_table_sums_rows(temp_delta_path):
+    first = [{"id": i, "v": f"a{i}"} for i in range(3)]
+    second = [{"id": i + 100, "v": f"b{i}"} for i in range(2)]
+    _write_append(first, temp_delta_path)
+    _write_append(second, temp_delta_path)
+    assert len(_read_all(temp_delta_path)) == 5
+
+
+def test_explicit_schema_round_trip(temp_delta_path):
+    schema = pa.schema([("id", pa.int64()), ("v", pa.string())])
+    rows = [{"id": 1, "v": "x"}, {"id": 2, "v": "y"}]
+    _write_append(rows, temp_delta_path, schema=schema)
+    out = _read_all(temp_delta_path)
+    assert len(out) == 2
+
+
+def test_append_empty_dataset_with_schema_creates_empty_table(temp_delta_path):
+    schema = pa.schema([("id", pa.int64())])
+    ray.data.from_items([], override_num_blocks=1).write_delta(
+        temp_delta_path, mode="append", schema=schema
+    )
+    # Table exists, no rows.
+    assert _log_exists(temp_delta_path)
+    assert _read_all(temp_delta_path) == []
+
+
+def test_append_empty_dataset_against_existing_table_is_noop(temp_delta_path):
+    """Regression test: a genuinely empty ``Dataset`` never triggers
+    ``on_write_start`` (see ``test_dynamic_overwrite_empty_dataset_is_a_noop``
+    for why), so ``_commit_append``'s empty-``file_actions`` branch must
+    re-check table existence at commit time rather than trust a driver-side
+    flag set only in ``on_write_start``. Before that fix this branch believed
+    the table didn't exist and tried to (re)create it in place of a no-op."""
+    schema = pa.schema([("id", pa.int64())])
+    _write_append([{"id": 1}, {"id": 2}], temp_delta_path)
+    ray.data.from_items([], override_num_blocks=1).write_delta(
+        temp_delta_path, mode="append", schema=schema
+    )
+    assert sorted(_read_all(temp_delta_path), key=lambda r: r["id"]) == [
+        {"id": 1},
+        {"id": 2},
+    ]
+
+
+def _delta_log_json_count(path: str) -> int:
+    """Count the *.json files inside _delta_log/ (one per Delta version)."""
+    log_dir = os.path.join(path, "_delta_log")
+    if not os.path.isdir(log_dir):
+        return 0
+    return sum(1 for f in os.listdir(log_dir) if f.endswith(".json"))
+
+
+def test_append_creates_one_delta_log_file_per_call(temp_delta_path):
+    _write_append([{"id": 1}], temp_delta_path)
+    assert _delta_log_json_count(temp_delta_path) == 1
+    assert os.path.isfile(
+        os.path.join(temp_delta_path, "_delta_log", "00000000000000000000.json")
+    )
+    _write_append([{"id": 2}], temp_delta_path)
+    assert _delta_log_json_count(temp_delta_path) == 2
+    assert os.path.isfile(
+        os.path.join(temp_delta_path, "_delta_log", "00000000000000000001.json")
+    )
+
+
+def test_multiple_blocks_commit_in_single_version(temp_delta_path):
+    """Multi-block, multi-task write must produce exactly one new Delta
+    log entry, even though every task writes its own file(s)."""
+    import json
+
+    rows = [{"id": i, "v": f"r{i}"} for i in range(20)]
+    ray.data.from_items(rows, override_num_blocks=4).write_delta(temp_delta_path)
+    assert _delta_log_json_count(temp_delta_path) == 1
+
+    log_path = os.path.join(temp_delta_path, "_delta_log", "00000000000000000000.json")
+    add_count = 0
+    with open(log_path) as f:
+        for line in f:
+            entry = json.loads(line)
+            if "add" in entry:
+                add_count += 1
+    assert add_count >= 4, f"Expected >=4 AddActions, got {add_count}"
+    assert len(_read_all(temp_delta_path)) == 20
+
+
+def test_upsert_mode_rejected(temp_delta_path):
+    """UPSERT is intentionally out of scope; the datasink must reject it."""
+    with pytest.raises(ValueError, match="does not support mode"):
+        ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode="upsert")
+
+
+# ----------------------------------------------------------------------
+# OVERWRITE / ERROR / IGNORE.
+# ----------------------------------------------------------------------
+
+
+def test_error_mode_against_existing_table_raises(temp_delta_path):
+    _write_append([{"id": 1}], temp_delta_path)
+    with pytest.raises(ValueError, match="already exists"):
+        ray.data.from_items([{"id": 2}]).write_delta(temp_delta_path, mode="error")
+
+
+def test_error_mode_against_new_path_succeeds(temp_delta_path):
+    ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode="error")
+    assert _log_exists(temp_delta_path)
+
+
+def test_ignore_mode_against_existing_table_is_noop(temp_delta_path):
+    _write_append([{"id": 1, "v": "first"}], temp_delta_path)
+    ray.data.from_items([{"id": 2, "v": "second"}]).write_delta(
+        temp_delta_path, mode="ignore"
+    )
+    # Only the original row should be present.
+    out = _read_all(temp_delta_path)
+    assert len(out) == 1
+    assert out[0]["v"] == "first"
+
+
+def test_ignore_mode_against_new_path_creates_table(temp_delta_path):
+    ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode="ignore")
+    assert _log_exists(temp_delta_path)
+
+
+def test_overwrite_replaces_existing_data(temp_delta_path):
+    _write_append([{"id": i, "v": "old"} for i in range(3)], temp_delta_path)
+    ray.data.from_items([{"id": i, "v": "new"} for i in range(2)]).write_delta(
+        temp_delta_path, mode="overwrite"
+    )
+    out = _read_all(temp_delta_path)
+    assert len(out) == 2
+    assert all(r["v"] == "new" for r in out)
+
+
+def test_static_overwrite_failure_does_not_delete_existing_data(
+    temp_delta_path, monkeypatch
+):
+    """Regression test: static overwrite must replace the table's data in a
+    single atomic transaction. Previously it did a separate `table.delete()`
+    followed by `create_write_transaction(mode="append")` -- if the second
+    call failed, the table was left permanently empty. Simulate that
+    failure and confirm the original data survives."""
+    from deltalake import DeltaTable
+
+    _write_append([{"id": 1, "v": "original"}], temp_delta_path)
+
+    def raise_on_commit(self, *args, **kwargs):
+        raise IOError("AWS Error NETWORK_CONNECTION: simulated failure")
+
+    monkeypatch.setattr(DeltaTable, "create_write_transaction", raise_on_commit)
+
+    with pytest.raises(Exception):
+        ray.data.from_items([{"id": 2, "v": "new"}]).write_delta(
+            temp_delta_path, mode="overwrite"
+        )
+
+    monkeypatch.undo()
+    out = _read_all(temp_delta_path)
+    assert out == [{"id": 1, "v": "original"}]
+
+
+def test_overwrite_creates_table_when_missing(temp_delta_path):
+    ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode="overwrite")
+    assert _log_exists(temp_delta_path)
+
+
+def test_overwrite_empty_dataset_truncates_table(temp_delta_path):
+    schema = pa.schema([("id", pa.int64())])
+    _write_append([{"id": 1}, {"id": 2}], temp_delta_path)
+    ray.data.from_items([], override_num_blocks=1).write_delta(
+        temp_delta_path, mode="overwrite", schema=schema
+    )
+    assert _read_all(temp_delta_path) == []
+
+
+def test_dynamic_overwrite_empty_dataset_is_a_noop(temp_delta_path):
+    """Dynamic partition overwrite only replaces partitions present in the
+    new data. An empty write has no partitions in it, so -- unlike static
+    overwrite -- it must leave all existing data untouched (mirrors Spark's
+    dynamic partitionOverwriteMode, which has no way to know which partition
+    an empty write meant to target).
+
+    Regression test: for a genuinely empty ``Dataset``, Ray Data never calls
+    ``on_write_start`` at all (zero blocks means zero write tasks means the
+    Write operator's first-bundle callback never fires), so a driver-side
+    flag set only in ``on_write_start`` is unreliable here. ``_commit_append``
+    / ``_commit_overwrite`` must instead rely on a fresh ``try_get_deltatable``
+    check made at commit time -- see ``datasink.py``."""
+    schema = pa.schema([("year", pa.int64()), ("id", pa.int64())])
+    rows_initial = [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
+    ray.data.from_items(rows_initial).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+    ray.data.from_items([], override_num_blocks=1).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["year"],
+        partition_overwrite_mode="dynamic",
+        schema=schema,
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == rows_initial
+
+
+def test_error_mode_race_table_appears_after_preflight(temp_delta_path, monkeypatch):
+    """If a table is created concurrently between preflight (sees no
+    table) and commit (sees one), ERROR mode must NOT silently append.
+    We assert *some* exception bubbles up rather than a silent success."""
+    from ray.data._internal.datasource.delta import (
+        datasink as _delta_datasink,
+        utils as _delta_utils,
+    )
+
+    real_get = _delta_utils.try_get_deltatable
+    n = {"calls": 0}
+
+    def racy_get(table_uri, storage_options=None):
+        n["calls"] += 1
+        if n["calls"] == 1:
+            return None
+        if not os.path.isdir(os.path.join(table_uri, "_delta_log")):
+            from deltalake import write_deltalake
+
+            write_deltalake(
+                table_uri,
+                pa.table({"id": pa.array([0], type=pa.int64())}),
+            )
+        return real_get(table_uri, storage_options)
+
+    monkeypatch.setattr(_delta_utils, "try_get_deltatable", racy_get)
+    monkeypatch.setattr(_delta_datasink, "try_get_deltatable", racy_get)
+
+    with pytest.raises(Exception):
+        ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode="error")
+
+
+# ----------------------------------------------------------------------
+# Partitioning + dynamic overwrite + buffered writes.
+# ----------------------------------------------------------------------
+
+
+def test_single_column_partition(temp_delta_path):
+    rows = [{"year": 2024, "id": i, "v": f"r{i}"} for i in range(3)] + [
+        {"year": 2025, "id": i, "v": f"r{i}"} for i in range(2)
+    ]
+    ray.data.from_items(rows).write_delta(temp_delta_path, partition_cols=["year"])
+    # Partition directories must exist.
+    assert os.path.isdir(os.path.join(temp_delta_path, "year=2024"))
+    assert os.path.isdir(os.path.join(temp_delta_path, "year=2025"))
+    out = _read_all(temp_delta_path)
+    assert len(out) == 5
+
+
+def test_multi_column_partition(temp_delta_path):
+    rows = [
+        {"year": 2024, "month": 1, "id": 1},
+        {"year": 2024, "month": 2, "id": 2},
+        {"year": 2025, "month": 1, "id": 3},
+    ]
+    ray.data.from_items(rows).write_delta(
+        temp_delta_path, partition_cols=["year", "month"]
+    )
+    assert os.path.isdir(os.path.join(temp_delta_path, "year=2024", "month=1"))
+    assert os.path.isdir(os.path.join(temp_delta_path, "year=2024", "month=2"))
+    assert os.path.isdir(os.path.join(temp_delta_path, "year=2025", "month=1"))
+
+
+def test_invalid_partition_column_name(temp_delta_path):
+    with pytest.raises(ValueError, match="Invalid characters in partition column"):
+        ray.data.from_items([{"a/b": 1}]).write_delta(
+            temp_delta_path, partition_cols=["a/b"]
+        )
+
+
+def test_partition_column_mismatch_with_existing_table(temp_delta_path):
+    ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+    with pytest.raises(ValueError, match="Partition columns mismatch"):
+        ray.data.from_items([{"year": 2024, "id": 2}]).write_delta(
+            temp_delta_path, partition_cols=["id"]
+        )
+
+
+def test_dynamic_partition_overwrite_only_replaces_affected_partitions(temp_delta_path):
+    rows_initial = [
+        {"year": 2024, "id": 1, "v": "a"},
+        {"year": 2024, "id": 2, "v": "b"},
+        {"year": 2025, "id": 3, "v": "c"},
+    ]
+    ray.data.from_items(rows_initial).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+    # Overwrite only 2024.
+    ray.data.from_items([{"year": 2024, "id": 99, "v": "new"}]).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["year"],
+        partition_overwrite_mode="dynamic",
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: (r["year"], r["id"]))
+    # 2025 partition should be intact; 2024 should have only the new row.
+    assert len(out) == 2
+    assert {r["year"] for r in out} == {2024, 2025}
+
+
+def test_dynamic_overwrite_skips_delete_when_predicate_unavailable(
+    temp_delta_path, monkeypatch
+):
+    """Regression test: when neither the atomic single-partition filter nor
+    the partition-scoped delete predicate can be built, dynamic partition
+    overwrite must skip the delete entirely rather than falling back to an
+    unconditional `table.delete()`, which would wipe partitions the write
+    never asked to touch."""
+    from ray.data._internal.datasource.delta import committer as _committer
+
+    rows_initial = [
+        {"year": 2024, "id": 1, "v": "a"},
+        {"year": 2025, "id": 2, "v": "b"},
+    ]
+    ray.data.from_items(rows_initial).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+
+    # Force past the atomic single-partition path too, so this exercises the
+    # delete()-based fallback specifically.
+    monkeypatch.setattr(
+        _committer, "_build_single_partition_filter", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        _committer, "_build_partition_delete_predicate", lambda *a, **kw: None
+    )
+
+    ray.data.from_items([{"year": 2024, "id": 99, "v": "new"}]).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["year"],
+        partition_overwrite_mode="dynamic",
+    )
+    out = _read_all(temp_delta_path)
+    # 2025 must survive -- the old code's unconditional table.delete() would
+    # have wiped it even though the write never touched that partition.
+    assert any(r["year"] == 2025 and r["id"] == 2 for r in out)
+
+
+def test_dynamic_overwrite_single_partition_is_atomic(temp_delta_path, monkeypatch):
+    """Regression test: when a dynamic overwrite touches exactly one
+    partition combination (the common case), it must replace that
+    partition's data in the SAME transaction as the append -- not a
+    separate `table.delete()` followed by a second commit, which would
+    leave the partition empty if the second commit failed."""
+    import deltalake
+
+    rows_initial = [
+        {"year": 2024, "id": 1, "v": "old"},
+        {"year": 2025, "id": 2, "v": "b"},
+    ]
+    ray.data.from_items(rows_initial).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+
+    delete_calls = {"n": 0}
+    real_delete = deltalake.DeltaTable.delete
+
+    def spy_delete(self, *args, **kwargs):
+        delete_calls["n"] += 1
+        return real_delete(self, *args, **kwargs)
+
+    monkeypatch.setattr(deltalake.DeltaTable, "delete", spy_delete)
+
+    ray.data.from_items([{"year": 2024, "id": 99, "v": "new"}]).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["year"],
+        partition_overwrite_mode="dynamic",
+    )
+    assert delete_calls["n"] == 0, "single-partition dynamic overwrite must be atomic"
+    out = sorted(_read_all(temp_delta_path), key=lambda r: (r["year"], r["id"]))
+    assert out == [
+        {"year": 2024, "id": 99, "v": "new"},
+        {"year": 2025, "id": 2, "v": "b"},
+    ]
+
+
+def test_dynamic_overwrite_multiple_partitions_in_one_write(temp_delta_path):
+    """Dynamic overwrite touching more than one distinct partition value in
+    a single write can't use the atomic single-partition path (delta-rs's
+    partition_filters doesn't support an OR across combinations); it must
+    still correctly replace every touched partition via the delete()
+    fallback, leaving untouched partitions alone."""
+    rows_initial = [
+        {"year": 2023, "id": 1, "v": "a"},
+        {"year": 2024, "id": 2, "v": "b"},
+        {"year": 2025, "id": 3, "v": "c"},
+    ]
+    ray.data.from_items(rows_initial).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+    ray.data.from_items(
+        [
+            {"year": 2024, "id": 99, "v": "new"},
+            {"year": 2025, "id": 100, "v": "new"},
+        ]
+    ).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["year"],
+        partition_overwrite_mode="dynamic",
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: (r["year"], r["id"]))
+    assert out == [
+        {"year": 2023, "id": 1, "v": "a"},
+        {"year": 2024, "id": 99, "v": "new"},
+        {"year": 2025, "id": 100, "v": "new"},
+    ]
+
+
+def test_dynamic_overwrite_null_partition_value(temp_delta_path):
+    """A NULL partition value can't be expressed in delta-rs's
+    partition_filters (verified empirically), so this must fall back to
+    the delete()-based path rather than erroring or silently no-op'ing."""
+    rows_initial = [
+        {"region": None, "id": 1, "v": "a"},
+        {"region": "us", "id": 2, "v": "b"},
+    ]
+    ray.data.from_items(rows_initial).write_delta(
+        temp_delta_path, partition_cols=["region"]
+    )
+    ray.data.from_items([{"region": None, "id": 99, "v": "new"}]).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["region"],
+        partition_overwrite_mode="dynamic",
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: (str(r["region"]), r["id"]))
+    assert out == [
+        {"region": None, "id": 99, "v": "new"},
+        {"region": "us", "id": 2, "v": "b"},
+    ]
+
+
+def test_static_partition_overwrite_replaces_everything(temp_delta_path):
+    ray.data.from_items([{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]).write_delta(
+        temp_delta_path, partition_cols=["year"]
+    )
+    ray.data.from_items([{"year": 2026, "id": 99}]).write_delta(
+        temp_delta_path,
+        mode="overwrite",
+        partition_cols=["year"],
+        partition_overwrite_mode="static",
+    )
+    out = _read_all(temp_delta_path)
+    assert len(out) == 1
+    assert out[0]["year"] == 2026
+
+
+def test_target_file_size_bytes_validates_positive(temp_delta_path):
+    with pytest.raises(ValueError, match="target_file_size_bytes must be > 0"):
+        ray.data.from_items([{"id": 1}]).write_delta(
+            temp_delta_path, target_file_size_bytes=0
+        )
+
+
+# ---- Partition edge cases & writer knobs ---------------------------------
+
+
+def test_partition_column_string(temp_delta_path):
+    rows = [
+        {"region": "us", "id": 1},
+        {"region": "eu", "id": 2},
+        {"region": "us", "id": 3},
+    ]
+    ray.data.from_items(rows).write_delta(temp_delta_path, partition_cols=["region"])
+    assert os.path.isdir(os.path.join(temp_delta_path, "region=us"))
+    assert os.path.isdir(os.path.join(temp_delta_path, "region=eu"))
+
+
+def test_partition_column_bool(temp_delta_path):
+    rows = [{"flag": True, "id": 1}, {"flag": False, "id": 2}]
+    ray.data.from_items(rows).write_delta(temp_delta_path, partition_cols=["flag"])
+    children = set(os.listdir(temp_delta_path))
+    children.discard("_delta_log")
+    assert any(d.lower().startswith("flag=true") for d in children)
+    assert any(d.lower().startswith("flag=false") for d in children)
+
+
+def test_multi_column_partition_round_trip_values(temp_delta_path):
+    rows = [
+        {"year": 2024, "month": 1, "id": 1},
+        {"year": 2024, "month": 2, "id": 2},
+        {"year": 2025, "month": 1, "id": 3},
+    ]
+    ray.data.from_items(rows).write_delta(
+        temp_delta_path, partition_cols=["year", "month"]
+    )
+    out = sorted(
+        _read_all(temp_delta_path), key=lambda r: (r["year"], r["month"], r["id"])
+    )
+    assert [(r["year"], r["month"], r["id"]) for r in out] == [
+        (2024, 1, 1),
+        (2024, 2, 2),
+        (2025, 1, 3),
+    ]
+
+
+def test_null_partition_value(temp_delta_path):
+    schema = pa.schema([("region", pa.string()), ("id", pa.int64())])
+    table = pa.table(
+        {"region": pa.array(["us", None, "eu"]), "id": pa.array([1, 2, 3])},
+        schema=schema,
+    )
+    ray.data.from_arrow(table).write_delta(
+        temp_delta_path, partition_cols=["region"], schema=schema
+    )
+    assert os.path.isdir(
+        os.path.join(temp_delta_path, "region=__HIVE_DEFAULT_PARTITION__")
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    null_row = next(r for r in out if r["id"] == 2)
+    assert null_row["region"] is None
+
+
+def test_nan_partition_value_distinct_from_string_nan(temp_delta_path):
+    schema = pa.schema([("v", pa.float64()), ("id", pa.int64())])
+    table = pa.table(
+        {"v": pa.array([1.5, float("nan"), 2.5]), "id": pa.array([1, 2, 3])},
+        schema=schema,
+    )
+    ray.data.from_arrow(table).write_delta(
+        temp_delta_path, partition_cols=["v"], schema=schema
+    )
+    assert os.path.isdir(os.path.join(temp_delta_path, "v=NaN"))
+
+
+def test_partition_column_dropped_from_on_disk_payload(temp_delta_path):
+    import pyarrow.parquet as pq
+
+    rows = [
+        {"year": 2024, "id": 1, "v": "a"},
+        {"year": 2025, "id": 2, "v": "b"},
+    ]
+    ray.data.from_items(rows).write_delta(temp_delta_path, partition_cols=["year"])
+    part_dir = os.path.join(temp_delta_path, "year=2024")
+    pq_files = [f for f in os.listdir(part_dir) if f.endswith(".parquet")]
+    assert pq_files, "expected at least one parquet file in partition dir"
+    on_disk_schema = pq.read_schema(os.path.join(part_dir, pq_files[0]))
+    assert "year" not in on_disk_schema.names
+    assert "id" in on_disk_schema.names and "v" in on_disk_schema.names
+
+
+@pytest.mark.parametrize("bad_value", ["a/b", "..", "", "x\x00y"])
+def test_invalid_partition_value_rejected(temp_delta_path, bad_value):
+    rows = [{"col": bad_value, "id": 1}]
+    with pytest.raises(ValueError):
+        ray.data.from_items(rows).write_delta(temp_delta_path, partition_cols=["col"])
+
+
+def test_max_partitions_cap(tmp_path, monkeypatch):
+    """Unit test the per-task partition cap directly on ``DeltaFileWriter``.
+
+    The cap is enforced inside ``partition_table`` which runs in a worker
+    process. A monkeypatch of ``_MAX_PARTITIONS`` at the test-process module
+    level does not propagate to those workers, so this test exercises the
+    cap by calling the writer directly in-process.
+    """
+    import pyarrow.fs as pa_fs
+
+    from ray.data._internal.datasource.delta import writer as _writer
+
+    monkeypatch.setattr(_writer, "_MAX_PARTITIONS", 4)
+
+    table_root = str(tmp_path / "delta")
+    os.makedirs(table_root, exist_ok=True)
+    w = _writer.DeltaFileWriter(
+        filesystem=pa_fs.LocalFileSystem(),
+        partition_cols=["col"],
+        write_uuid="test",
+        write_kwargs={},
+        written_files=set(),
+        local_filesystem_root=table_root,
+    )
+
+    table = pa.table({"col": pa.array([str(i) for i in range(6)])})
+    with pytest.raises(ValueError, match="Too many partition"):
+        w.partition_table(table, ["col"])
+
+
+def test_default_writer_one_file_per_partition_per_block(temp_delta_path):
+    import json
+
+    rows = [{"region": "us", "id": i} for i in range(3)] + [
+        {"region": "eu", "id": i} for i in range(2)
+    ]
+    ray.data.from_items(rows, override_num_blocks=1).write_delta(
+        temp_delta_path, partition_cols=["region"]
+    )
+    log = os.path.join(temp_delta_path, "_delta_log", "00000000000000000000.json")
+    add_count = 0
+    with open(log) as f:
+        for line in f:
+            if "add" in json.loads(line):
+                add_count += 1
+    assert add_count == 2, f"expected 2 AddActions (one per partition), got {add_count}"
+
+
+def test_target_file_size_bytes_buffers_and_flushes(temp_delta_path):
+    """With buffering enabled, a multi-block write to a single partition
+    should not produce one file per block -- the buffer merges them."""
+    import json
+
+    rows = [{"v": i} for i in range(200)]
+    ray.data.from_items(rows, override_num_blocks=4).write_delta(
+        temp_delta_path,
+        target_file_size_bytes=100_000,
+    )
+    log = os.path.join(temp_delta_path, "_delta_log", "00000000000000000000.json")
+    add_count = 0
+    with open(log) as f:
+        for line in f:
+            if "add" in json.loads(line):
+                add_count += 1
+    assert add_count <= 4
+    assert len(_read_all(temp_delta_path)) == 200
+
+
+@pytest.mark.parametrize(
+    "compression,should_raise",
+    [("snappy", False), ("zstd", False), ("not-a-codec", True)],
+)
+def test_compression_parametrize(temp_delta_path, compression, should_raise):
+    rows = [{"id": 1, "v": "x"}]
+    if should_raise:
+        with pytest.raises(ValueError, match="Invalid compression"):
+            ray.data.from_items(rows).write_delta(
+                temp_delta_path, compression=compression
+            )
+    else:
+        ray.data.from_items(rows).write_delta(temp_delta_path, compression=compression)
+        assert _read_all(temp_delta_path) == rows
+
+
+@pytest.mark.parametrize("write_statistics", [True, False])
+def test_write_statistics_parametrize(temp_delta_path, write_statistics):
+    rows = [{"id": i, "v": f"r{i}"} for i in range(4)]
+    ray.data.from_items(rows).write_delta(
+        temp_delta_path, write_statistics=write_statistics
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == rows
+
+
+def test_get_file_info_with_retry_retries_transient_failure(tmp_path):
+    """Regression test for the `writer.py` call-site fix: the post-write
+    size check must go through `get_file_info_with_retry` (which retries
+    transient I/O errors), not a bare `filesystem.get_file_info` call.
+
+    `write_parquet_with_retry`'s write happens through a real
+    `pyarrow.fs.FileSystem` (pq.write_table type-checks the `filesystem`
+    argument and rejects duck-typed wrappers), so this tests the retry
+    helper directly rather than through a distributed write -- the actual
+    Parquet write runs on a Ray worker in a separate process, where a
+    driver-process monkeypatch wouldn't be visible anyway.
+    """
+    import pyarrow.fs as pa_fs
+
+    from ray.data._internal.datasource.delta.utils import get_file_info_with_retry
+
+    real_fs = pa_fs.LocalFileSystem()
+    path = str(tmp_path / "probe.txt")
+    with open(path, "w") as f:
+        f.write("x")
+    calls = {"n": 0}
+    real_get_file_info = real_fs.get_file_info
+
+    class FlakyFs:
+        def get_file_info(self, p):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise IOError("AWS Error NETWORK_CONNECTION: simulated failure")
+            return real_get_file_info(p)
+
+    info = get_file_info_with_retry(FlakyFs(), path)
+    assert calls["n"] == 2
+    assert info.size > 0
+
+
+# ----------------------------------------------------------------------
+# Schema evolution.
+# ----------------------------------------------------------------------
+
+
+def test_schema_mode_error_rejects_new_column(temp_delta_path):
+    _write_append([{"id": 1, "v": "x"}], temp_delta_path)
+    schema_with_extra = pa.schema(
+        [("id", pa.int64()), ("v", pa.string()), ("extra", pa.string())]
+    )
+    with pytest.raises(ValueError, match="New columns detected"):
+        ray.data.from_items([{"id": 2, "v": "y", "extra": "z"}]).write_delta(
+            temp_delta_path, schema=schema_with_extra, schema_mode="error"
+        )
+
+
+def test_schema_mode_merge_adds_new_column(temp_delta_path):
+    _write_append([{"id": 1, "v": "x"}], temp_delta_path)
+    schema_with_extra = pa.schema(
+        [("id", pa.int64()), ("v", pa.string()), ("extra", pa.string())]
+    )
+    ray.data.from_items([{"id": 2, "v": "y", "extra": "z"}]).write_delta(
+        temp_delta_path, schema=schema_with_extra, schema_mode="merge"
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert len(out) == 2
+    assert "extra" in out[1]
+
+
+def test_invalid_schema_mode_value_rejected(temp_delta_path):
+    _write_append([{"id": 1}], temp_delta_path)
+    extra = pa.schema([("id", pa.int64()), ("x", pa.string())])
+    with pytest.raises(ValueError, match="Invalid schema_mode"):
+        ray.data.from_items([{"id": 2, "x": "v"}]).write_delta(
+            temp_delta_path, schema=extra, schema_mode="bogus"
+        )
+
+
+def test_existing_column_type_mismatch_rejected(temp_delta_path):
+    _write_append([{"id": 1, "v": "string"}], temp_delta_path)
+    mismatched = pa.schema([("id", pa.int64()), ("v", pa.int64())])
+    with pytest.raises(ValueError, match="type mismatches"):
+        ray.data.from_items([{"id": 2, "v": 99}]).write_delta(
+            temp_delta_path, schema=mismatched, schema_mode="merge"
+        )
+
+
+def test_schema_mode_error_rejects_new_column_when_schema_inferred(temp_delta_path):
+    """Regression test: schema_mode must be enforced even when the schema
+    comes from Ray's inference (no explicit `schema=`), not just when an
+    explicit schema is passed. Evolution now happens at commit time in
+    `_aggregate_and_commit`, using the worker-reconciled schema, rather than
+    only in `on_write_start` against an explicit `schema=`."""
+    _write_append([{"id": 1, "v": "x"}], temp_delta_path)
+    with pytest.raises(ValueError, match="New columns detected"):
+        ray.data.from_items([{"id": 2, "v": "y", "extra": "z"}]).write_delta(
+            temp_delta_path, mode="append"
+        )
+
+
+def test_schema_mode_merge_adds_new_column_when_schema_inferred(temp_delta_path):
+    _write_append([{"id": 1, "v": "x"}], temp_delta_path)
+    ray.data.from_items([{"id": 2, "v": "y", "extra": "z"}]).write_delta(
+        temp_delta_path, mode="append", schema_mode="merge"
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert len(out) == 2
+    assert out[1]["extra"] == "z"
+
+
+def test_ignore_mode_does_not_evolve_schema_of_existing_table(temp_delta_path):
+    """IGNORE mode against an existing table must be a complete no-op --
+    including not evolving the table's schema, even though workers still
+    emit an Arrow schema for the (discarded) incoming data."""
+    _write_append([{"id": 1, "v": "x"}], temp_delta_path)
+    ray.data.from_items([{"id": 2, "v": "y", "extra": "z"}]).write_delta(
+        temp_delta_path, mode="ignore", schema_mode="merge"
+    )
+    out = _read_all(temp_delta_path)
+    assert out == [{"id": 1, "v": "x"}]
+    assert "extra" not in out[0]
+
+
+# ---- Schema-evolution edge cases ------------------------------------------
+
+
+def test_block_missing_required_column_raises(temp_delta_path):
+    schema = pa.schema([("id", pa.int64()), ("v", pa.string())])
+    table = pa.table({"id": pa.array([1, 2], type=pa.int64())})  # missing "v"
+    with pytest.raises(ValueError, match="Missing columns"):
+        ray.data.from_arrow(table).write_delta(temp_delta_path, schema=schema)
+
+
+def test_all_null_column_writes_to_nullable_existing_column(temp_delta_path):
+    _write_append([{"id": 1, "v": "x"}], temp_delta_path)
+    table = pa.table(
+        {
+            "id": pa.array([2, 3], type=pa.int64()),
+            "v": pa.array([None, None], type=pa.null()),
+        }
+    )
+    ray.data.from_arrow(table).write_delta(temp_delta_path)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert len(out) == 3
+    assert all(r["v"] is None for r in out if r["id"] in (2, 3))
+
+
+def test_complex_types_round_trip(temp_delta_path):
+    schema = pa.schema(
+        [
+            ("id", pa.int64()),
+            ("tags", pa.list_(pa.string())),
+            ("nested", pa.struct([("a", pa.int64()), ("b", pa.string())])),
+        ]
+    )
+    table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "tags": pa.array([["x", "y"], ["z"]], type=pa.list_(pa.string())),
+            "nested": pa.array(
+                [{"a": 1, "b": "p"}, {"a": 2, "b": "q"}],
+                type=pa.struct([("a", pa.int64()), ("b", pa.string())]),
+            ),
+        },
+        schema=schema,
+    )
+    ray.data.from_arrow(table).write_delta(temp_delta_path, schema=schema)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert len(out) == 2
+    assert out[0]["tags"] == ["x", "y"]
+    assert out[0]["nested"] == {"a": 1, "b": "p"}
+    assert out[1]["nested"] == {"a": 2, "b": "q"}
+
+
+def test_non_microsecond_timestamp_units_coerced(temp_delta_path):
+    """Regression test: Delta Lake requires microsecond-precision
+    timestamps. Only `timestamp("s")` was previously coerced to
+    `timestamp("us")`; `ns`/`ms` inputs (common from pandas/PyArrow) must
+    be coerced too."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "ts_ns": pa.array([1_000_000_000, 2_000_000_000], type=pa.timestamp("ns")),
+            "ts_ms": pa.array([1_000, 2_000], type=pa.timestamp("ms")),
+        }
+    )
+    ray.data.from_arrow(table).write_delta(temp_delta_path)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert len(out) == 2
+
+
+def test_cross_worker_type_promotion_int32_int64(temp_delta_path):
+    """Two workers emit blocks with int32 and int64 columns named `v`.
+
+    Schema-reconciliation at commit time promotes to int64 (the wider
+    type). The per-block validator only fires when the user declared an
+    explicit schema, so we declare ``int64`` so that the narrower int32
+    block is accepted (narrower-into-wider is always compatible) and the
+    wider int64 block matches the declared type.
+    """
+    block_a = pa.table({"v": pa.array([1, 2, 3], type=pa.int32())})
+    block_b = pa.table({"v": pa.array([10, 20], type=pa.int64())})
+    declared = pa.schema([("v", pa.int64())])
+    ds = ray.data.from_arrow(block_a).union(ray.data.from_arrow(block_b))
+    ds.write_delta(temp_delta_path, schema=declared)
+    out = _read_all(temp_delta_path)
+    assert sorted(r["v"] for r in out) == [1, 2, 3, 10, 20]
+
+
+# ---- Filesystem plumbing ---------------------------------------------------
+
+
+def test_worker_filesystem_carries_explicit_filesystem_through_pickle():
+    """Regression test: an explicit `filesystem=` must reach the worker
+    exactly as given, not be silently dropped in favor of a
+    from_uri(table_uri) reconstruction (which would ignore the caller's
+    credentials or non-default rooting, e.g. a SubTreeFileSystem)."""
+    import pickle
+
+    import pyarrow.fs as pa_fs
+
+    from ray.data._internal.datasource.delta.fs import (
+        make_fs_config,
+        worker_filesystem,
+    )
+
+    explicit_fs = pa_fs.SubTreeFileSystem("/some/root", pa_fs.LocalFileSystem())
+    config, driver_fs = make_fs_config("s3://bucket/table", explicit_fs, {})
+    assert driver_fs is explicit_fs
+    assert config.local_filesystem_root is None
+
+    # Simulate shipping the config to a worker.
+    restored_config = pickle.loads(pickle.dumps(config))
+    worker_fs = worker_filesystem(restored_config)
+    assert isinstance(worker_fs, pa_fs.SubTreeFileSystem)
+    assert worker_fs.base_path == explicit_fs.base_path
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Add write_delta APPEND/OVERWRITE/ERROR/IGNORE, partitioning, schema evolution

Standalone Dataset.write_delta implementation: a single concrete DeltaDatasink(Datasink[DeltaWriteResult]) with no generic multi-format adapter framework. Supports APPEND, OVERWRITE (static + dynamic partition), ERROR, and IGNORE modes; Hive-style partitioning (target_file_size_bytes buffering, NULL/NaN handling); and schema evolution (schema_mode="error"|"merge", cross-worker type promotion).

UPSERT is intentionally out of scope. Cloud storage autodetection, commit idempotency, and orphan-file cleanup land in PR 2.