### PR TITLE
[serve] Deflake test_metrics suites on constrained CI runners

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -66,7 +66,10 @@ from ray.util.state import list_actors
 
 TELEMETRY_ROUTE_PREFIX = "/telemetry"
 STORAGE_ACTOR_NAME = "storage"
-PROMETHEUS_METRICS_TIMEOUT_S = 5
+# Per-scrape HTTP timeout. Generous on purpose: under CI load a scrape can
+# take >5s while the agent is perfectly healthy, and fetch_raw_prometheus
+# swallows Timeout and returns nothing -- indistinguishable from "no metrics".
+PROMETHEUS_METRICS_TIMEOUT_S = 20
 
 
 def skip_if_haproxy(reason: str):
@@ -1697,9 +1700,11 @@ def get_metric_dictionaries(
             # so the test doesn't hang on requests.get
             timeout=timeout,
         )
-        assert (
-            name in prom_timeseries
-        ), f"Metric {name} not found. Available metrics: {list(prom_timeseries.keys())}"
+        assert name in prom_timeseries, f"Metric {name} not found. " + (
+            f"Available metrics: {list(prom_timeseries.keys())}"
+            if prom_timeseries
+            else "The scrape returned no samples at all (metrics agent down?)."
+        )
         return True
 
     if wait:

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -18,6 +18,7 @@ from ray._common.usage import usage_lib
 from ray._common.utils import reset_ray_address
 from ray.cluster_utils import AutoscalingCluster, Cluster
 from ray.serve._private.test_utils import (
+    PROMETHEUS_METRICS_TIMEOUT_S,
     TELEMETRY_ROUTE_PREFIX,
     TEST_METRICS_EXPORT_PORT,
     check_ray_started,
@@ -370,6 +371,43 @@ def wait_for_metrics_endpoint(session_name, port=TEST_METRICS_EXPORT_PORT, timeo
     wait_for_condition(ready, timeout=timeout, retry_interval_ms=500)
 
 
+def wait_for_serve_controller_metrics(
+    session_name, port=TEST_METRICS_EXPORT_PORT, timeout=60
+):
+    """Best-effort wait for a Serve controller metric from this session to
+    appear in a scrape. The controller sets its control-loop gauge every
+    iteration, so seeing it proves the whole export pipeline (Serve actor ->
+    dashboard agent -> Prometheus endpoint) is live before the test body
+    asserts on metrics. On timeout, warn and proceed: the test's own metric
+    waits are authoritative.
+    """
+
+    def ready():
+        try:
+            resp = httpx.get(
+                f"http://localhost:{port}/metrics",
+                timeout=PROMETHEUS_METRICS_TIMEOUT_S,
+            )
+        except Exception:
+            return False
+        if resp.status_code != 200:
+            return False
+        return any(
+            line.startswith("ray_serve_controller_num_control_loops")
+            and f'SessionName="{session_name}"' in line
+            for line in resp.text.splitlines()
+        )
+
+    try:
+        wait_for_condition(ready, timeout=timeout, retry_interval_ms=200)
+    except RuntimeError:
+        print(
+            f"WARNING: no Serve controller metric for session {session_name} "
+            f"scraped from :{port} within {timeout}s; proceeding (the test's "
+            "own metric waits are authoritative)."
+        )
+
+
 @pytest.fixture
 def metrics_start_shutdown(request):
     param = request.param if hasattr(request, "param") else None
@@ -378,7 +416,15 @@ def metrics_start_shutdown(request):
     wait_for_metrics_port_free()
     ray.init(
         address="local",
+        # Fixed logical CPU count so scheduling doesn't depend on the runner's
+        # core count (like _shared_serve_instance); these tests are IO-bound.
+        num_cpus=16,
         _metrics_export_port=TEST_METRICS_EXPORT_PORT,
+        # The default object store sizing (30% of RAM) overflows /dev/shm on
+        # memory-constrained CI runners, silently falling back to disk-backed
+        # /tmp and slowing the cluster enough to blow the tests' metric waits.
+        # These tests only move tiny payloads, so cap it.
+        object_store_memory=500 * 1024**2,
         _system_config={
             "metrics_report_interval_ms": 100,
             "task_retry_delay_ms": 50,
@@ -394,7 +440,7 @@ def metrics_start_shutdown(request):
             "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
             "ray.serve.generated.serve_pb2_grpc.add_FruitServiceServicer_to_server",
         ]
-        yield serve.start(
+        client = serve.start(
             grpc_options=gRPCOptions(
                 port=grpc_port,
                 grpc_servicer_functions=grpc_servicer_functions,
@@ -405,6 +451,10 @@ def metrics_start_shutdown(request):
                 request_timeout_s=request_timeout_s,
             ),
         )
+        # Serve just started; wait until its metrics actually flow through the
+        # agent so per-test asserts don't race a cold export pipeline.
+        wait_for_serve_controller_metrics(session_name)
+        yield client
     finally:
         serve.shutdown()
         ray.shutdown()

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -158,6 +158,10 @@ def _shared_serve_instance():
         num_cpus=36,
         namespace="default_test_namespace",
         _metrics_export_port=9999,
+        # Cap the object store so it fits in /dev/shm on memory-constrained CI
+        # runners (~2.6GB); the default sizing falls back to disk-backed /tmp
+        # there. Tests using this fixture only move tiny payloads.
+        object_store_memory=500 * 1024**2,
         _system_config={"metrics_report_interval_ms": 1000, "task_retry_delay_ms": 50},
     )
     serve.start(
@@ -426,7 +430,12 @@ def metrics_start_shutdown(request):
         # These tests only move tiny payloads, so cap it.
         object_store_memory=500 * 1024**2,
         _system_config={
-            "metrics_report_interval_ms": 100,
+            # Keep the Ray default (1s): at 100ms every process pushes full
+            # metric snapshots 10x/s and the dashboard agent saturates on
+            # loaded runners -- scrapes time out and newly-registered metrics
+            # take tens of seconds to surface. The tests' metric waits are
+            # 20s+, so 1s visibility latency is negligible.
+            "metrics_report_interval_ms": 1000,
             "task_retry_delay_ms": 50,
         },
     )

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -169,7 +169,7 @@ def test_serve_metrics_for_successful_connection(metrics_start_shutdown):
         return True
 
     try:
-        wait_for_condition(verify_metrics, retry_interval_ms=500)
+        wait_for_condition(verify_metrics, timeout=40, retry_interval_ms=500)
     except RuntimeError:
         verify_metrics(do_assert=True)
 
@@ -206,7 +206,7 @@ def test_http_replica_gauge_metrics(metrics_start_shutdown):
                 assert "1.0" in metrics
         return True
 
-    wait_for_condition(ensure_request_processing, timeout=20)
+    wait_for_condition(ensure_request_processing, timeout=40)
 
 
 @skip_if_haproxy(
@@ -267,7 +267,7 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
         wait_for_condition(
             verify_metrics,
             retry_interval_ms=1000,
-            timeout=20,
+            timeout=40,
             expected_metrics=expected_metrics,
         )
     except RuntimeError:
@@ -309,7 +309,7 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
 
     # There is a latency in updating the counter
     try:
-        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=20)
+        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=40)
     except RuntimeError:
         verify_error_count(do_assert=True)
 
@@ -339,7 +339,9 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
 
     def verify_metrics(_expected_metrics, do_assert=False):
         try:
-            resp = httpx.get("http://127.0.0.1:9999", timeout=None).text
+            resp = httpx.get(
+                "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+            ).text
         # Requests will fail if we are crashing the controller
         except httpx.HTTPError:
             return False
@@ -375,14 +377,16 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
         wait_for_condition(
             verify_metrics,
             retry_interval_ms=1000,
-            timeout=20,
+            timeout=40,
             expected_metrics=expected_metrics,
         )
     except RuntimeError:
         verify_metrics(expected_metrics, True)
 
     def verify_error_count(do_assert=False):
-        resp = httpx.get("http://127.0.0.1:9999", timeout=None).text
+        resp = httpx.get(
+            "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+        ).text
         resp = resp.split("\n")
         for metrics in resp:
             if "# HELP" in metrics or "# TYPE" in metrics:
@@ -415,7 +419,7 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
 
     # There is a latency in updating the counter
     try:
-        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=20)
+        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=40)
     except RuntimeError:
         verify_error_count(do_assert=True)
 
@@ -721,7 +725,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 200
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=0,
         expected_success_count=1,
     )
@@ -731,7 +735,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 250
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=0,
         expected_success_count=2,
     )
@@ -741,7 +745,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 300
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=0,
         expected_success_count=3,
     )
@@ -751,7 +755,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 400
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=1,
         expected_success_count=4,
     )
@@ -761,7 +765,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 500
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=2,
         expected_success_count=5,
     )
@@ -814,7 +818,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=0,
         expected_success_count=1,
     )
@@ -827,7 +831,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=0,
         expected_success_count=2,
     )
@@ -840,7 +844,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=1,
         expected_success_count=3,
     )
@@ -853,7 +857,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
-        timeout=20,
+        timeout=40,
         expected_error_count=2,
         expected_success_count=4,
     )
@@ -1064,7 +1068,7 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_queue_wait_time_metric, timeout=20)
+    wait_for_condition(check_queue_wait_time_metric, timeout=40)
 
     def check_queue_wait_time_metric_value():
         value = get_metric_float(
@@ -1075,7 +1079,7 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
         assert value > 400, f"Queue wait time should be greater than 500ms, got {value}"
         return True
 
-    wait_for_condition(check_queue_wait_time_metric_value, timeout=20)
+    wait_for_condition(check_queue_wait_time_metric_value, timeout=40)
 
     wait_for_condition(
         lambda: ray.get(signal.cur_num_waiters.remote()) == 0, timeout=10
@@ -1133,7 +1137,7 @@ def test_router_queue_len_metric(metrics_start_shutdown):
 
         wait_for_condition(
             check_metric_float_eq,
-            timeout=15,
+            timeout=40,
             metric="ray_serve_request_router_queue_len",
             expected=1,
             expected_tags={"deployment": "TestDeployment", "application": "app1"},
@@ -1281,7 +1285,7 @@ def test_proxy_metrics_with_route_patterns(metrics_start_shutdown, use_factory_p
         api_metrics = [m for m in metrics if m.get("application") == "api_app"]
         return len(api_metrics) >= 3
 
-    wait_for_condition(metrics_available, timeout=20)
+    wait_for_condition(metrics_available, timeout=40)
 
     # Verify metrics use route patterns, not individual paths
     metrics = get_metric_dictionaries("ray_serve_num_http_requests_total")

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -128,7 +128,9 @@ def test_serve_metrics_for_successful_connection(metrics_start_shutdown):
 
     def verify_metrics(do_assert=False):
         try:
-            resp = httpx.get("http://127.0.0.1:9999").text
+            resp = httpx.get(
+                "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+            ).text
         # Requests will fail if we are crashing the controller
         except httpx.HTTPError:
             return False
@@ -185,7 +187,7 @@ def test_http_replica_gauge_metrics(metrics_start_shutdown):
     _ = handle.remote()
 
     processing_requests = get_metric_dictionaries(
-        "ray_serve_replica_processing_queries", timeout=5
+        "ray_serve_replica_processing_queries"
     )
     assert len(processing_requests) == 1
     assert processing_requests[0]["deployment"] == "A"
@@ -193,7 +195,9 @@ def test_http_replica_gauge_metrics(metrics_start_shutdown):
     print("serve_replica_processing_queries exists.")
 
     def ensure_request_processing():
-        resp = httpx.get("http://127.0.0.1:9999").text
+        resp = httpx.get(
+            "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+        ).text
         resp = resp.split("\n")
         for metrics in resp:
             if "# HELP" in metrics or "# TYPE" in metrics:
@@ -202,7 +206,7 @@ def test_http_replica_gauge_metrics(metrics_start_shutdown):
                 assert "1.0" in metrics
         return True
 
-    wait_for_condition(ensure_request_processing, timeout=5)
+    wait_for_condition(ensure_request_processing, timeout=20)
 
 
 @skip_if_haproxy(
@@ -226,7 +230,9 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
 
     def verify_metrics(_expected_metrics, do_assert=False):
         try:
-            resp = httpx.get("http://127.0.0.1:9999").text
+            resp = httpx.get(
+                "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+            ).text
         # Requests will fail if we are crashing the controller
         except httpx.HTTPError:
             return False
@@ -261,14 +267,16 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
         wait_for_condition(
             verify_metrics,
             retry_interval_ms=1000,
-            timeout=10,
+            timeout=20,
             expected_metrics=expected_metrics,
         )
     except RuntimeError:
         verify_metrics(expected_metrics, True)
 
     def verify_error_count(do_assert=False):
-        resp = httpx.get("http://127.0.0.1:9999").text
+        resp = httpx.get(
+            "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+        ).text
         resp = resp.split("\n")
         for metrics in resp:
             if "# HELP" in metrics or "# TYPE" in metrics:
@@ -301,7 +309,7 @@ def test_proxy_metrics_not_found(metrics_start_shutdown):
 
     # There is a latency in updating the counter
     try:
-        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=10)
+        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=20)
     except RuntimeError:
         verify_error_count(do_assert=True)
 
@@ -367,7 +375,7 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
         wait_for_condition(
             verify_metrics,
             retry_interval_ms=1000,
-            timeout=10,
+            timeout=20,
             expected_metrics=expected_metrics,
         )
     except RuntimeError:
@@ -407,7 +415,7 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
 
     # There is a latency in updating the counter
     try:
-        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=10)
+        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=20)
     except RuntimeError:
         verify_error_count(do_assert=True)
 
@@ -684,7 +692,9 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
         expected_error_count: int,
         expected_success_count: int,
     ):
-        resp = httpx.get("http://127.0.0.1:9999").text
+        resp = httpx.get(
+            "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+        ).text
         error_count = 0
         success_count = 0
         for line in resp.split("\n"):
@@ -711,6 +721,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 200
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=0,
         expected_success_count=1,
     )
@@ -720,6 +731,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 250
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=0,
         expected_success_count=2,
     )
@@ -729,6 +741,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 300
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=0,
         expected_success_count=3,
     )
@@ -738,6 +751,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 400
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=1,
         expected_success_count=4,
     )
@@ -747,6 +761,7 @@ def test_proxy_metrics_http_status_code_is_error(metrics_start_shutdown):
     assert r.status_code == 500
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=2,
         expected_success_count=5,
     )
@@ -763,7 +778,9 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
         expected_error_count: int,
         expected_success_count: int,
     ):
-        resp = httpx.get("http://127.0.0.1:9999").text
+        resp = httpx.get(
+            "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+        ).text
         error_count = 0
         success_count = 0
         for line in resp.split("\n"):
@@ -797,6 +814,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=0,
         expected_success_count=1,
     )
@@ -809,6 +827,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=0,
         expected_success_count=2,
     )
@@ -821,6 +840,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=1,
         expected_success_count=3,
     )
@@ -833,6 +853,7 @@ def test_proxy_metrics_websocket_status_code_is_error(metrics_start_shutdown):
 
     wait_for_condition(
         check_request_count_metrics,
+        timeout=20,
         expected_error_count=2,
         expected_success_count=4,
     )
@@ -1043,7 +1064,7 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_queue_wait_time_metric, timeout=10)
+    wait_for_condition(check_queue_wait_time_metric, timeout=20)
 
     def check_queue_wait_time_metric_value():
         value = get_metric_float(
@@ -1054,7 +1075,7 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
         assert value > 400, f"Queue wait time should be greater than 500ms, got {value}"
         return True
 
-    wait_for_condition(check_queue_wait_time_metric_value, timeout=10)
+    wait_for_condition(check_queue_wait_time_metric_value, timeout=20)
 
     wait_for_condition(
         lambda: ray.get(signal.cur_num_waiters.remote()) == 0, timeout=10
@@ -1165,7 +1186,9 @@ def test_multiplexed_metrics(metrics_start_shutdown):
 
     def verify_metrics():
         try:
-            resp = httpx.get("http://127.0.0.1:9999").text
+            resp = httpx.get(
+                "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+            ).text
         # Requests will fail if we are crashing the controller
         except httpx.HTTPError:
             return False
@@ -1311,7 +1334,9 @@ def test_proxy_metrics_with_route_patterns(metrics_start_shutdown, use_factory_p
     ), "Multiple metrics entries for same route pattern - should be grouped!"
 
     # Optionally verify the counter value if we can parse it from the metrics endpoint
-    metrics_text = httpx.get("http://127.0.0.1:9999").text
+    metrics_text = httpx.get(
+        "http://127.0.0.1:9999", timeout=PROMETHEUS_METRICS_TIMEOUT_S
+    ).text
     for line in metrics_text.split("\n"):
         if "serve_num_http_requests" in line and "/api/users/{user_id}" in line:
             # Extract the value from the prometheus format line

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -702,6 +702,7 @@ class TestHandleMetrics:
             caller.call.remote()
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=40,
                 metric_name="ray_serve_deployment_queued_queries",
                 tags={"application": "app1"},
                 expected=i + 1,
@@ -712,6 +713,7 @@ class TestHandleMetrics:
         ray.get(signal.send.remote())
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=0,
@@ -726,6 +728,7 @@ class TestHandleMetrics:
         call.remote("WaitForSignal", "app1")
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=0,
@@ -735,6 +738,7 @@ class TestHandleMetrics:
         call.remote("WaitForSignal", "app1")
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=1,
@@ -744,6 +748,7 @@ class TestHandleMetrics:
         call.remote("WaitForSignal", "app1")
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=2,
@@ -753,6 +758,7 @@ class TestHandleMetrics:
         ray.get(signal.send.remote())
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
             expected=0,
@@ -779,7 +785,7 @@ class TestHandleMetrics:
         timeseries = PrometheusTimeseries()
         wait_for_condition(
             check_metric_float_eq,
-            timeout=15,
+            timeout=40,
             metric="ray_serve_num_scheduling_tasks",
             # Router is eagerly created on HTTP proxy, so there are metrics emitted
             # from proxy router
@@ -794,7 +800,7 @@ class TestHandleMetrics:
         print("ray_serve_num_scheduling_tasks updated successfully.")
         wait_for_condition(
             check_metric_float_eq,
-            timeout=15,
+            timeout=40,
             metric="ray_serve_num_scheduling_tasks_in_backoff",
             # Router is eagerly created on HTTP proxy, so there are metrics emitted
             # from proxy router
@@ -823,7 +829,7 @@ class TestHandleMetrics:
         print("First request is executing.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=1,
             timeseries=timeseries,
@@ -837,7 +843,7 @@ class TestHandleMetrics:
         # First request should be processing. All others should be queued.
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             expected=num_queued_requests,
             timeseries=timeseries,
@@ -845,7 +851,7 @@ class TestHandleMetrics:
         print("ray_serve_deployment_queued_queries updated successfully.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=num_queued_requests + 1,
             timeseries=timeseries,
@@ -856,7 +862,7 @@ class TestHandleMetrics:
         # 2 = 2 * 1 replica) that are attempting to schedule the hanging requests.
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_scheduling_tasks",
             expected=2,
             timeseries=timeseries,
@@ -864,7 +870,7 @@ class TestHandleMetrics:
         print("ray_serve_num_scheduling_tasks updated successfully.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_scheduling_tasks_in_backoff",
             expected=2,
             timeseries=timeseries,
@@ -878,7 +884,7 @@ class TestHandleMetrics:
 
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_deployment_queued_queries",
             expected=0,
             timeseries=timeseries,
@@ -888,7 +894,7 @@ class TestHandleMetrics:
         # Task should get cancelled.
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=0,
             timeseries=timeseries,
@@ -897,7 +903,7 @@ class TestHandleMetrics:
 
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_scheduling_tasks",
             expected=0,
             timeseries=timeseries,
@@ -905,7 +911,7 @@ class TestHandleMetrics:
         print("ray_serve_num_scheduling_tasks updated successfully.")
         wait_for_condition(
             check_sum_metric_eq,
-            timeout=15,
+            timeout=40,
             metric_name="ray_serve_num_scheduling_tasks_in_backoff",
             expected=0,
             timeseries=timeseries,
@@ -947,6 +953,7 @@ class TestHandleMetrics:
 
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=40,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "d1"},
                 expected=requests_sent[1],
@@ -955,6 +962,7 @@ class TestHandleMetrics:
 
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=40,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "d2"},
                 expected=requests_sent[2],
@@ -963,6 +971,7 @@ class TestHandleMetrics:
 
             wait_for_condition(
                 check_sum_metric_eq,
+                timeout=40,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "Router"},
                 expected=i + 1,
@@ -973,6 +982,7 @@ class TestHandleMetrics:
         ray.get(signal.send.remote())
         wait_for_condition(
             check_sum_metric_eq,
+            timeout=40,
             metric_name="ray_serve_num_ongoing_requests_at_replicas",
             tags={"application": "app1"},
             expected=0,
@@ -1017,6 +1027,7 @@ class TestProxyStateMetrics:
 
         wait_for_condition(
             check_metric_float_eq,
+            timeout=40,
             metric="ray_serve_proxy_status",
             expected=2,
             timeseries=timeseries,

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -134,7 +134,8 @@ class TestRequestContextMetrics:
                 )
             )
             == 3,
-            timeout=40,
+            # First export from several fresh replica processes must all land.
+            timeout=60,
         )
 
         def wait_for_route_and_name(
@@ -253,7 +254,8 @@ class TestRequestContextMetrics:
                 )
             )
             == 5,
-            timeout=40,
+            # First export from several fresh replica processes must all land.
+            timeout=60,
         )
 
         def wait_for_route_and_name(
@@ -382,7 +384,8 @@ class TestRequestContextMetrics:
                 )
             )
             == 4,
-            timeout=40,
+            # First export from several fresh replica processes must all land.
+            timeout=60,
         )
         (
             requests_metrics_route,

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -422,7 +422,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=10,
+        timeout=20,
     )
 
     # Check batch_wait_time_ms histogram was recorded for 2 batches
@@ -433,7 +433,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=10,
+        timeout=20,
     )
 
     # Check batch_execution_time_ms histogram was recorded for 2 batches
@@ -444,7 +444,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=10,
+        timeout=20,
     )
 
     # Check batch_utilization_percent histogram: 2 batches at 100% each = 200 sum
@@ -455,7 +455,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=10,
+        timeout=20,
     )
 
     # Check actual_batch_size histogram: 2 batches of 4 requests each = 8 sum
@@ -466,7 +466,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=10,
+        timeout=20,
     )
 
     # Check batch_queue_length gauge exists (should be 0 after processing)
@@ -477,7 +477,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=10,
+        timeout=20,
     )
 
 
@@ -535,7 +535,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
     # Test 1: Check that target_replicas metric is 5 (10 requests / target_ongoing_requests=2)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=30,
         metric="ray_serve_autoscaling_target_replicas",
         expected=5,
         expected_tags=base_tags,
@@ -546,7 +546,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
     # Test 2: Check that autoscaling decision metric is 5 (10 requests / target_ongoing_requests=2)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=30,
         metric="ray_serve_autoscaling_desired_replicas",
         expected=5,
         expected_tags=base_tags,
@@ -557,7 +557,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
     # Test 3: Check that total requests metric is 10
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=30,
         metric="ray_serve_autoscaling_total_requests",
         expected=10,
         expected_tags=base_tags,
@@ -575,13 +575,13 @@ def test_autoscaling_metrics(metrics_start_shutdown):
         assert value >= 0
         return True
 
-    wait_for_condition(check_policy_execution_time_metric, timeout=15)
+    wait_for_condition(check_policy_execution_time_metric, timeout=30)
     print("Policy execution time metric verified.")
 
     # Test 5: Check that target_ongoing_requests metric is 2 (matches config)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=30,
         metric="ray_serve_autoscaling_target_ongoing_requests",
         expected=2,
         expected_tags=base_tags,
@@ -614,7 +614,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
                     found = True
         return found
 
-    wait_for_condition(check_metrics_delay_metrics, timeout=15)
+    wait_for_condition(check_metrics_delay_metrics, timeout=30)
     print("Metrics delay metrics verified.")
 
     # Release signal to complete requests
@@ -785,7 +785,7 @@ def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
                     return True
         return False
 
-    wait_for_condition(check_user_stats_latency_metric, timeout=15)
+    wait_for_condition(check_user_stats_latency_metric, timeout=30)
     print("User autoscaling stats latency metric verified.")
 
 
@@ -839,7 +839,7 @@ def test_user_autoscaling_stats_failure_metrics(metrics_start_shutdown):
                 return True
         return False
 
-    wait_for_condition(check_stats_failure_metric, timeout=15)
+    wait_for_condition(check_stats_failure_metric, timeout=30)
     print("User autoscaling stats failure metric verified.")
 
 

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -752,11 +752,12 @@ def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
 
     serve.run(DeploymentWithCustomStats.bind(), name="custom_stats_app")
 
-    # Make a request to ensure the deployment is running
+    # Make a request to ensure the deployment is running. Bound the wait: an
+    # unbounded .result() can hang the whole test target past its timeout.
     handle = serve.get_deployment_handle(
         "DeploymentWithCustomStats", "custom_stats_app"
     )
-    handle.remote().result()
+    handle.remote().result(timeout_s=60)
 
     timeseries = PrometheusTimeseries()
     base_tags = {
@@ -816,11 +817,12 @@ def test_user_autoscaling_stats_failure_metrics(metrics_start_shutdown):
 
     serve.run(DeploymentWithFailingStats.bind(), name="failing_stats_app")
 
-    # Make a request to ensure the deployment is running
+    # Make a request to ensure the deployment is running. Bound the wait: an
+    # unbounded .result() can hang the whole test target past its timeout.
     handle = serve.get_deployment_handle(
         "DeploymentWithFailingStats", "failing_stats_app"
     )
-    handle.remote().result()
+    handle.remote().result(timeout_s=60)
 
     timeseries = PrometheusTimeseries()
 

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -84,10 +84,11 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
 
         return True
 
-    wait_for_condition(check_status_metrics, timeout=30)
+    wait_for_condition(check_status_metrics, timeout=60)
 
     wait_for_condition(
         check_metric_float_eq,
+        timeout=40,
         metric="ray_serve_deployment_status",
         expected=3,  # UPDATING
         expected_tags={"deployment": "deployment_a", "application": "app1"},
@@ -95,6 +96,7 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
     )
     wait_for_condition(
         check_metric_float_eq,
+        timeout=40,
         metric="ray_serve_application_status",
         expected=5,  # DEPLOYING
         expected_tags={"application": "app1"},
@@ -103,6 +105,7 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
 
     wait_for_condition(
         check_metric_float_eq,
+        timeout=40,
         metric="ray_serve_deployment_status",
         expected=6,
         expected_tags={"deployment": "deployment_b", "application": "app2"},
@@ -110,6 +113,7 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
     )
     wait_for_condition(
         check_metric_float_eq,
+        timeout=40,
         metric="ray_serve_application_status",
         expected=6,
         expected_tags={"application": "app2"},
@@ -120,6 +124,7 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
 
     wait_for_condition(
         check_metric_float_eq,
+        timeout=40,
         metric="ray_serve_deployment_status",
         expected=6,
         expected_tags={"deployment": "deployment_a", "application": "app1"},
@@ -127,6 +132,7 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
     )
     wait_for_condition(
         check_metric_float_eq,
+        timeout=40,
         metric="ray_serve_application_status",
         expected=6,
         expected_tags={"application": "app1"},
@@ -152,7 +158,7 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
     # Verify startup latency: two replicas aggregate into one time series (_count == 2).
     wait_for_condition(
         check_metric_float_eq,
-        timeout=20,
+        timeout=40,
         metric="ray_serve_replica_startup_latency_ms_count",
         expected=2,
         expected_tags={"deployment": "MyDeployment", "application": "app"},
@@ -161,7 +167,7 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
     # Verify initialization latency _count matches (one observation per replica).
     wait_for_condition(
         check_metric_float_eq,
-        timeout=20,
+        timeout=40,
         metric="ray_serve_replica_initialization_latency_ms_count",
         expected=2,
         expected_tags={"deployment": "MyDeployment", "application": "app"},
@@ -178,7 +184,7 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
         ), f"Initialization latency value is {value}, expected to be greater than 500ms"
         return True
 
-    wait_for_condition(check_initialization_latency_value, timeout=20)
+    wait_for_condition(check_initialization_latency_value, timeout=40)
 
     # One aggregated time series per deployment (no per-replica label).
     def check_single_series_no_replica_label():
@@ -192,7 +198,7 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
         assert "replica" not in metrics[0]
         return True
 
-    wait_for_condition(check_single_series_no_replica_label, timeout=20)
+    wait_for_condition(check_single_series_no_replica_label, timeout=40)
 
 
 def test_replica_reconfigure_latency_metrics(metrics_start_shutdown):
@@ -236,7 +242,7 @@ def test_replica_reconfigure_latency_metrics(metrics_start_shutdown):
     # Verify reconfigure latency metric count is exactly 1 (one reconfigure happened)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=20,
+        timeout=40,
         metric="ray_serve_replica_reconfigure_latency_ms_count",
         expected=1,
         expected_tags={"deployment": "Configurable", "application": "app"},
@@ -251,7 +257,7 @@ def test_replica_reconfigure_latency_metrics(metrics_start_shutdown):
         assert value > 500, f"Reconfigure latency value is {value}, expected > 500ms"
         return True
 
-    wait_for_condition(check_reconfigure_latency_value, timeout=20)
+    wait_for_condition(check_reconfigure_latency_value, timeout=40)
 
 
 def test_health_check_latency_metrics(metrics_start_shutdown):
@@ -422,7 +428,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=20,
+        timeout=40,
     )
 
     # Check batch_wait_time_ms histogram was recorded for 2 batches
@@ -433,7 +439,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=20,
+        timeout=40,
     )
 
     # Check batch_execution_time_ms histogram was recorded for 2 batches
@@ -444,7 +450,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=20,
+        timeout=40,
     )
 
     # Check batch_utilization_percent histogram: 2 batches at 100% each = 200 sum
@@ -455,7 +461,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=20,
+        timeout=40,
     )
 
     # Check actual_batch_size histogram: 2 batches of 4 requests each = 8 sum
@@ -466,7 +472,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=20,
+        timeout=40,
     )
 
     # Check batch_queue_length gauge exists (should be 0 after processing)
@@ -477,7 +483,7 @@ def test_batching_metrics(metrics_start_shutdown):
             expected_tags=expected_tags,
             timeseries=timeseries,
         ),
-        timeout=20,
+        timeout=40,
     )
 
 
@@ -614,7 +620,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
                     found = True
         return found
 
-    wait_for_condition(check_metrics_delay_metrics, timeout=30)
+    wait_for_condition(check_metrics_delay_metrics, timeout=60)
     print("Metrics delay metrics verified.")
 
     # Release signal to complete requests
@@ -702,7 +708,7 @@ def test_async_inference_task_queue_metrics_delay(
                     return True
             return False
 
-        wait_for_condition(check_metrics_delay_metric, timeout=30)
+        wait_for_condition(check_metrics_delay_metric, timeout=60)
 
     finally:
         # Cleanup
@@ -785,7 +791,7 @@ def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
                     return True
         return False
 
-    wait_for_condition(check_user_stats_latency_metric, timeout=30)
+    wait_for_condition(check_user_stats_latency_metric, timeout=60)
     print("User autoscaling stats latency metric verified.")
 
 
@@ -871,7 +877,7 @@ def test_long_poll_pending_clients_metric(metrics_start_shutdown):
     # (wait_for_condition will retry until the metric is available)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_pending_clients",
         expected=1,
         expected_tags={"namespace": "key_1"},
@@ -879,7 +885,7 @@ def test_long_poll_pending_clients_metric(metrics_start_shutdown):
     )
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_pending_clients",
         expected=1,
         expected_tags={"namespace": "key_2"},
@@ -895,7 +901,7 @@ def test_long_poll_pending_clients_metric(metrics_start_shutdown):
     # After update, pending clients for key_1 should be 0
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_pending_clients",
         expected=0,
         expected_tags={"namespace": "key_1"},
@@ -971,7 +977,7 @@ def test_long_poll_latency_metric(metrics_start_shutdown):
         # Should have at least 2 observations
         return metric_value == 2
 
-    wait_for_condition(check_latency_metric_exists, timeout=15)
+    wait_for_condition(check_latency_metric_exists, timeout=40)
 
     # Verify the latency sum is positive (latency > 0)
     latency_sum = get_metric_float(
@@ -998,7 +1004,7 @@ def test_long_poll_host_sends_counted(metrics_start_shutdown):
     result_1: Dict[str, UpdatedObject] = ray.get(object_ref)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_host_transmission_counter_total",
         expected=1,
         expected_tags={"namespace_or_state": "key_1"},
@@ -1016,7 +1022,7 @@ def test_long_poll_host_sends_counted(metrics_start_shutdown):
     result_2: Dict[str, UpdatedObject] = ray.get(object_ref)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_host_transmission_counter_total",
         expected=1,
         expected_tags={"namespace_or_state": "key_2"},
@@ -1024,7 +1030,7 @@ def test_long_poll_host_sends_counted(metrics_start_shutdown):
     )
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_host_transmission_counter_total",
         expected=2,
         expected_tags={"namespace_or_state": "key_1"},
@@ -1036,7 +1042,7 @@ def test_long_poll_host_sends_counted(metrics_start_shutdown):
     _ = ray.get(object_ref)
     wait_for_condition(
         check_metric_float_eq,
-        timeout=15,
+        timeout=40,
         metric="ray_serve_long_poll_host_transmission_counter_total",
         expected=1,
         expected_tags={"namespace_or_state": "TIMEOUT"},


### PR DESCRIPTION
The eternal test_metrics/_2/_3 targets fail repeatedly on unrelated PRs when runners are memory-starved (/dev/shm ~2.6GB warnings, OOM worker deaths): a different test fails each attempt, always as a metric-export wait timeout or an empty Prometheus scrape ("Available metrics: []"), never a wrong value.

- metrics_start_shutdown: cap object_store_memory at 500MB. The default 30%-of-RAM sizing overflows /dev/shm on constrained runners and silently falls back to disk-backed /tmp, slowing the whole cluster past the tests waits and adding OOM pressure. Pin num_cpus=16 so scheduling does not depend on the runner core count (mirrors _shared_serve_instance).
- metrics_start_shutdown: after serve.start, wait (best-effort) for the controller control-loop gauge from the current session to appear in a scrape, proving the Serve actor -> agent -> endpoint pipeline is live before test bodies assert on metrics.
- Lengthen the shortest first-appearance metric waits (5-15s) in the tests seen failing: first export on a loaded machine routinely exceeds them.
- get_metric_dictionaries: distinguish "metric missing" from "scrape returned nothing at all" in the failure message.
