### PR TITLE
[Data] Add delta_timestamps (temporal windows) to read_lerobot

### DIFF
--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -112,9 +112,10 @@ class _LeRobotRoot(NamedTuple):
     ``meta/stats.json``, serialized to a JSON string.  Emitted verbatim on
     every row as the ``stats`` column"""
 
-    frame_tolerance_s: Optional[float]
+    frame_tolerance_s: float
     """Max seconds a decoded video frame's timestamp may differ from a row's
-    timestamp before it is rejected (passed to lerobot's ``decode_video_frames``)."""
+    timestamp before it is rejected (passed to lerobot's ``decode_video_frames``).
+    Resolved at construction: the caller's value, or ``0.5 / fps`` when unset."""
 
     delta_steps: Dict[str, List[int]]
     """``delta_timestamps`` resolved to integer frame offsets per feature key
@@ -279,22 +280,23 @@ def _non_camera_features(features: dict) -> Dict[str, tuple]:
 
 
 def _delta_targets(
-    global_index, ep_from, ep_to, steps
+    global_index, episode_from, episode_to, steps
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Resolve each frame offset to a clamped in-episode global index and whether
     it fell outside the episode (the pad mask).
 
-    Vectorized: ``global_index`` / ``ep_from`` / ``ep_to`` may be scalars or
-    ``(A,)`` arrays and ``steps`` a length-``S`` sequence, giving ``(S,)`` results
-    for a single anchor or ``(A, S)`` for an array of anchors. Same clamp/pad rule
-    as lerobot's ``DatasetReader._get_query_indices``, kept as a standalone numpy
-    helper because that method is bound to a torch-backed reader we don't build."""
-    g = np.asarray(global_index)[..., None]
-    lo = np.asarray(ep_from)[..., None]
-    hi = np.asarray(ep_to)[..., None]
-    j = g + np.asarray(steps)
-    pad = (j < lo) | (j >= hi)
-    return np.clip(j, lo, hi - 1), pad
+    Vectorized: ``global_index`` / ``episode_from`` / ``episode_to`` may be scalars
+    or ``(A,)`` arrays and ``steps`` a length-``S`` sequence, giving ``(S,)``
+    results for a single anchor or ``(A, S)`` for an array of anchors. Same
+    clamp/pad rule as lerobot's ``DatasetReader._get_query_indices``, kept as a
+    standalone numpy helper because that method is bound to a torch-backed reader
+    we don't build."""
+    anchor = np.asarray(global_index)[..., None]
+    low = np.asarray(episode_from)[..., None]
+    high = np.asarray(episode_to)[..., None]
+    target = anchor + np.asarray(steps)
+    pad = (target < low) | (target >= high)
+    return np.clip(target, low, high - 1), pad
 
 
 def _resolve_filesystem(
@@ -544,6 +546,11 @@ def _build_root(
     )
     row_size_bytes = _estimated_row_size_bytes(meta.features)
     stats_json = _stats_to_json(meta.stats)
+    # Resolve the video-frame timestamp tolerance now (needs fps): the caller's
+    # value, or half a frame interval (0.5 / fps) when unset.
+    resolved_frame_tolerance_s = (
+        frame_tolerance_s if frame_tolerance_s is not None else 0.5 / float(meta.fps)
+    )
 
     root_bundle = _LeRobotRoot(
         root=video_root_uri,
@@ -560,7 +567,7 @@ def _build_root(
         fps=meta.fps,
         storage_options=video_storage_options,
         stats_json=stats_json,
-        frame_tolerance_s=frame_tolerance_s,
+        frame_tolerance_s=resolved_frame_tolerance_s,
         delta_steps=delta_steps,
     )
     return root_bundle, episodes_table
@@ -678,17 +685,44 @@ class _DeltaSegment(NamedTuple):
     """Per-segment state for the delta (temporal-window) read path, built once by
     ``_prepare_delta_segment`` and reused across the segment's batches."""
 
-    seg_lo: int
+    segment_start: int
+    """Global frame index of the segment's first row. Convert a clamped global
+    index to its 0-based position in this segment's arrays via
+    ``index - segment_start`` (valid because a segment is a contiguous run of
+    whole episodes)."""
+
     global_idx: List[int]
-    ep_col: List[int]
+    """Per-row global frame index (the parquet ``index`` column), one entry per
+    segment row, in row order."""
+
+    episode_index_col: List[int]
+    """Per-row episode index (the ``episode_index`` column); maps a row to its
+    episode when routing a video frame to its ``(file, timestamp)``."""
+
     row_from: List[int]
+    """Per-row inclusive lower bound of the row's episode, as a global frame index.
+    Windows are clamped to ``[row_from, row_to)`` so they never cross into a
+    neighbouring episode."""
+
     row_to: List[int]
-    delta_video_keys: List[str]
-    nondelta_video_keys: List[str]
-    nondelta_image_keys: List[str]
+    """Per-row exclusive upper bound of the row's episode, as a global frame index
+    (see ``row_from``)."""
+
     pad_order: List[str]
-    tab_base: Dict[str, np.ndarray]
-    seg_images: Dict[str, np.ndarray]
+    """Windowed feature keys in the fixed order their ``{key}_is_pad`` mask
+    columns are appended to the block -- parquet columns (file order) then video
+    keys -- matching ``_build_schema``."""
+
+    tabular_base: Dict[str, np.ndarray]
+    """Each windowed tabular/scalar feature materialized once over the whole
+    segment as ``(n_seg, *shape)``, dtype preserved; the per-batch gather
+    fancy-indexes it with the clamped ``(A, S)`` positions."""
+
+    segment_images: Dict[str, np.ndarray]
+    """Each windowed in-parquet image camera decoded once for the whole segment
+    and stacked to ``(n_seg, H, W, C)``; gathered like ``tabular_base``.
+    Whole-segment (not per-batch) because a window near a batch edge reaches
+    adjacent rows."""
 
 
 def _read_lerobot_segment(
@@ -705,11 +739,6 @@ def _read_lerobot_segment(
     Reads the segment's parquet rows once, then emits Arrow batches sized from
     this root's estimated row size (so each batch targets one output block),
     decoding each batch's camera frames on demand via ``_build_batch``.
-
-    When ``root.delta_steps`` is set, each batch instead gathers a temporal
-    window per listed feature (``_build_delta_batch``), using per-segment
-    state from ``_prepare_delta_segment``; a window multiplies a row's size,
-    so the batch is shrunk by the widest window to keep blocks near target.
     """
     fs = root.fs
 
@@ -737,14 +766,8 @@ def _read_lerobot_segment(
     if root.video_keys:
         video_meta = _video_episode_meta(ep_slice, root.video_keys)
         cache = new_decoder_cache(root.storage_options)
-        # Per-frame timestamp tolerance for the video decoder. Default to half a
-        # frame interval (0.5 / fps); computed only when there are video cameras
-        # so image-only and tabular-only datasets never divide by fps.
-        tolerance_s = (
-            root.frame_tolerance_s
-            if root.frame_tolerance_s is not None
-            else 0.5 / float(root.fps)
-        )
+        # Video-decoder timestamp tolerance, resolved at construction.
+        tolerance_s = root.frame_tolerance_s
     else:
         video_meta = {}
         cache = None
@@ -753,11 +776,15 @@ def _read_lerobot_segment(
     if root.delta_steps:
         # Delta reads gather a window per feature; build the per-segment state once
         # and divide the batch by the widest window so blocks stay near target size.
-        dseg = _prepare_delta_segment(root, full, ep_slice)
-        max_t = max((len(s) for s in root.delta_steps.values()), default=1)
-        rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes) // max_t)
+        delta_segment = _prepare_delta_segment(root, full, ep_slice)
+        widest_window = max(
+            (len(steps) for steps in root.delta_steps.values()), default=1
+        )
+        rows_per_batch = max(
+            1, (max_block_bytes // root.row_size_bytes) // widest_window
+        )
     else:
-        dseg = None
+        delta_segment = None
         rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes))
 
     try:
@@ -778,16 +805,13 @@ def _read_lerobot_segment(
                     video_meta,
                     tolerance_s,
                     cache,
-                    dseg,
+                    delta_segment,
                 )
             else:
-                frame_buffers: dict = {}
-                if root.video_keys:
-                    frame_buffers.update(
-                        _decode_video_batch(root, batch, video_meta, tolerance_s, cache)
-                    )
-                if root.image_keys:
-                    frame_buffers.update(_decode_image_frames(root, batch))
+                frame_buffers = {
+                    **_decode_video_batch(root, batch, video_meta, tolerance_s, cache),
+                    **_decode_image_frames(root, batch),
+                }
                 yield _build_batch(
                     camera_keys,
                     batch,
@@ -810,32 +834,32 @@ def _prepare_delta_segment(
 
     Validates the invariant the gather relies on: the segment is a contiguous run
     of whole episodes in the global frame index (guaranteed by the
-    ``get_read_tasks`` delta guard). That lets a clamped global index ``j`` map to
-    row position ``j - seg_lo`` and guarantees every in-episode neighbour is
-    loaded; a split episode would silently corrupt windows, so fail loudly.
+    ``get_read_tasks`` delta guard). That lets a clamped global index map to row
+    position ``index - segment_start`` and guarantees every in-episode neighbour
+    is loaded; a split episode would silently corrupt windows, so fail loudly.
     """
     global_idx = full.column("index").to_pylist()
-    ep_col = full.column("episode_index").to_pylist()
-    ep_from = dict(
+    episode_index_col = full.column("episode_index").to_pylist()
+    from_by_episode = dict(
         zip(
             ep_slice.column("episode_index").to_pylist(),
             ep_slice.column("_global_from_index").to_pylist(),
         )
     )
-    ep_to = dict(
+    to_by_episode = dict(
         zip(
             ep_slice.column("episode_index").to_pylist(),
             ep_slice.column("_global_to_index").to_pylist(),
         )
     )
-    row_from = [ep_from[e] for e in ep_col]
-    row_to = [ep_to[e] for e in ep_col]
+    row_from = [from_by_episode[episode] for episode in episode_index_col]
+    row_to = [to_by_episode[episode] for episode in episode_index_col]
 
-    seg_lo, seg_hi = global_idx[0], global_idx[-1] + 1
+    segment_start, segment_end = global_idx[0], global_idx[-1] + 1
     if (
-        len(global_idx) != seg_hi - seg_lo
-        or min(row_from) < seg_lo
-        or max(row_to) > seg_hi
+        len(global_idx) != segment_end - segment_start
+        or min(row_from) < segment_start
+        or max(row_to) > segment_end
     ):
         raise RuntimeError(
             "delta_timestamps requires contiguous whole-episode read segments, "
@@ -861,7 +885,7 @@ def _prepare_delta_segment(
     # so stacked windows match the schema: list columns (fixed or variable) flatten
     # to (n_rows, dim) via the value array -- which keeps e.g. float32 that
     # to_pylist would widen to float64 -- and scalar columns stay 1-D.
-    tab_base: Dict[str, np.ndarray] = {}
+    tabular_base: Dict[str, np.ndarray] = {}
     for name in delta_tabular_keys:
         col = full.column(name).combine_chunks()
         if (
@@ -870,28 +894,23 @@ def _prepare_delta_segment(
             or pa.types.is_large_list(col.type)
         ):
             flat = col.flatten().to_numpy(zero_copy_only=False)
-            tab_base[name] = flat.reshape(len(col), -1)
+            tabular_base[name] = flat.reshape(len(col), -1)
         else:
-            tab_base[name] = col.to_numpy(zero_copy_only=False)
+            tabular_base[name] = col.to_numpy(zero_copy_only=False)
     return _DeltaSegment(
-        seg_lo=seg_lo,
+        segment_start=segment_start,
         global_idx=global_idx,
-        ep_col=ep_col,
+        episode_index_col=episode_index_col,
         row_from=row_from,
         row_to=row_to,
-        delta_video_keys=[vk for vk in root.video_keys if vk in delta_steps],
-        nondelta_video_keys=[vk for vk in root.video_keys if vk not in delta_steps],
-        nondelta_image_keys=[ik for ik in root.image_keys if ik not in delta_steps],
         pad_order=pad_order,
-        tab_base=tab_base,
+        tabular_base=tabular_base,
         # Stack each decoded image camera to one (n_seg, H, W, C) array so a batch
         # can gather its windows by fancy-indexing with the (A, S) positions.
-        seg_images={
-            k: np.stack(v)
-            for k, v in (
-                _decode_image_frames(root, full, keys=delta_image_keys)
-                if delta_image_keys
-                else {}
+        segment_images={
+            image_key: np.stack(frames)
+            for image_key, frames in _decode_image_frames(
+                root, full, keys=delta_image_keys
             ).items()
         },
     )
@@ -906,7 +925,7 @@ def _build_delta_batch(
     video_meta: dict,
     tolerance_s: Optional[float],
     cache: Any,
-    dseg: _DeltaSegment,
+    delta_segment: _DeltaSegment,
 ) -> pa.Table:
     """Assemble one temporal-window output batch.
 
@@ -922,59 +941,56 @@ def _build_delta_batch(
 
     delta_steps = root.delta_steps
     image_set = set(root.image_keys)
+    # Route cameras into windowed vs. one-frame-per-row.
+    delta_video_keys = [vk for vk in root.video_keys if vk in delta_steps]
+    nondelta_video_keys = [vk for vk in root.video_keys if vk not in delta_steps]
+    nondelta_image_keys = [ik for ik in root.image_keys if ik not in delta_steps]
     anchors = range(batch_start, batch_start + batch.num_rows)
     pad_buffers: dict = {}
 
     # Per-anchor clamped target positions + pad mask, computed once per distinct
-    # offset list and shared across keys that use it. A clamped global index j is
-    # at row position j - seg_lo (the segment is contiguous; see
-    # _prepare_delta_segment).
+    # offset list and shared across keys that use it.
     targets_cache: Dict[tuple, tuple] = {}
 
     def _targets_for(steps):
         cached = targets_cache.get(steps)
         if cached is None:
-            b0, b1 = batch_start, batch_start + batch.num_rows
+            batch_end = batch_start + batch.num_rows
             clamped, pad = _delta_targets(
-                np.asarray(dseg.global_idx[b0:b1]),
-                np.asarray(dseg.row_from[b0:b1]),
-                np.asarray(dseg.row_to[b0:b1]),
+                np.asarray(delta_segment.global_idx[batch_start:batch_end]),
+                np.asarray(delta_segment.row_from[batch_start:batch_end]),
+                np.asarray(delta_segment.row_to[batch_start:batch_end]),
                 steps,
             )
-            # (A, S) row positions + pad mask; a clamped global index j is at row
-            # position j - seg_lo (the segment is contiguous).
-            cached = targets_cache[steps] = (clamped - dseg.seg_lo, pad)
+            # (A, S) row positions + pad mask; a clamped global index is at row
+            # position ``index - segment_start`` (the segment is contiguous).
+            cached = targets_cache[steps] = (
+                clamped - delta_segment.segment_start,
+                pad,
+            )
         return cached
 
     # Decode all cameras up front, then assemble columns in schema order.
-    nd_video_fb = (
-        _decode_video_batch(
-            root, batch, video_meta, tolerance_s, cache, keys=dseg.nondelta_video_keys
-        )
-        if dseg.nondelta_video_keys
-        else {}
+    nondelta_video_frames = _decode_video_batch(
+        root, batch, video_meta, tolerance_s, cache, keys=nondelta_video_keys
     )
-    nd_image_fb = (
-        _decode_image_frames(root, batch, keys=dseg.nondelta_image_keys)
-        if dseg.nondelta_image_keys
-        else {}
-    )
-    delta_video_fb: dict = {}
-    for vk in dseg.delta_video_keys:
+    nondelta_image_frames = _decode_image_frames(root, batch, keys=nondelta_image_keys)
+    delta_video_frames: dict = {}
+    for vk in delta_video_keys:
         frames, pads = _decode_video_delta(
             root,
             anchors,
-            dseg.global_idx,
-            dseg.row_from,
-            dseg.row_to,
-            dseg.ep_col,
+            delta_segment.global_idx,
+            delta_segment.row_from,
+            delta_segment.row_to,
+            delta_segment.episode_index_col,
             video_meta,
             vk,
             delta_steps[vk],
             tolerance_s,
             cache,
         )
-        delta_video_fb[vk] = frames
+        delta_video_frames[vk] = frames
         pad_buffers[vk] = pads
 
     columns: dict = {}
@@ -984,20 +1000,20 @@ def _build_delta_batch(
         if name in image_set:
             if name in delta_steps:
                 positions, pad = _targets_for(tuple(delta_steps[name]))
-                # seg_images[name]: (n_seg, H, W, C); [positions] -> (A, S, H, W, C).
+                # segment_images[name]: (n_seg, H, W, C); [positions] -> (A, S, H, W, C).
                 columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                    list(dseg.seg_images[name][positions])
+                    list(delta_segment.segment_images[name][positions])
                 )
                 pad_buffers[name] = list(pad)
             else:
                 columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                    nd_image_fb[name]
+                    nondelta_image_frames[name]
                 )
         elif name in delta_steps:
             positions, pad = _targets_for(tuple(delta_steps[name]))
-            # tab_base[name]: (n_seg, *shape); [positions] -> (A, S, *shape).
+            # tabular_base[name]: (n_seg, *shape); [positions] -> (A, S, *shape).
             columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                list(dseg.tab_base[name][positions])
+                list(delta_segment.tabular_base[name][positions])
             )
             pad_buffers[name] = list(pad)
         else:
@@ -1005,8 +1021,10 @@ def _build_delta_batch(
 
     # 2. Video columns (not in the parquet), in root.video_keys order.
     for vk in root.video_keys:
-        buf = delta_video_fb[vk] if vk in delta_steps else nd_video_fb[vk]
-        columns[vk] = ArrowVariableShapedTensorArray.from_numpy(buf)
+        video_frames = (
+            delta_video_frames[vk] if vk in delta_steps else nondelta_video_frames[vk]
+        )
+        columns[vk] = ArrowVariableShapedTensorArray.from_numpy(video_frames)
 
     # 3. Per-dataset constants.
     columns["task"] = pa.array(task_list, type=pa.string()).dictionary_encode()
@@ -1018,12 +1036,60 @@ def _build_delta_batch(
     ).dictionary_encode()
 
     # 4. Pad masks, in the schema's fixed order.
-    for name in dseg.pad_order:
+    for name in delta_segment.pad_order:
         columns[f"{name}_is_pad"] = ArrowVariableShapedTensorArray.from_numpy(
             pad_buffers[name]
         )
 
     return pa.table(columns)
+
+
+def _decode_frames_by_file(
+    root: _LeRobotRoot,
+    vk: str,
+    file_requests: Dict[tuple, List[tuple]],
+    tolerance_s: float,
+    cache: Any,
+) -> dict:
+    """Decode video frames for one camera, grouped by physical file.
+
+    ``file_requests`` maps ``(chunk_index, file_index)`` to
+    ``[(slot, timestamp), ...]``; each file's timestamps are decoded once through
+    the shared per-segment ``cache`` (a file's decoder is reused, not reopened).
+    Returns ``{slot: HWC uint8 frame}`` -- ``slot`` is an opaque key (a row index,
+    or an ``(anchor, step)`` pair) so both the per-row and windowed callers can
+    reshape the result."""
+    # Imported here, not at module top, so ``import ray.data`` stays lerobot-free
+    # until video is actually decoded on a worker.
+    from lerobot.datasets.video_utils import decode_video_frames_torchcodec
+
+    assert root.video_path is not None
+    frames_by_slot: dict = {}
+    for (chunk, fi), requests in file_requests.items():
+        # Full URI (with protocol) so torchcodec detects cloud vs local.
+        vpath = (
+            f"{root.root}/"
+            f"{root.video_path.format(video_key=vk, chunk_index=chunk, file_index=fi)}"
+        )
+        # lerobot returns a torch.Tensor (N, C, H, W) normalized to float32 in
+        # [0, 1]; rescale to uint8. .cpu() first -- a CUDA tensor can't convert
+        # directly (decode is CPU-only today, so this is a no-op guard).
+        frames = decode_video_frames_torchcodec(
+            vpath,
+            [timestamp for _, timestamp in requests],
+            tolerance_s,
+            decoder_cache=cache,
+        )
+        arr = frames.permute(0, 2, 3, 1).contiguous().cpu().numpy()
+        if arr.dtype != np.uint8:
+            if arr.dtype.kind == "f":
+                # Undo lerobot's /255; round so pixels survive the round-trip.
+                arr = (arr * 255.0).round().clip(0, 255).astype(np.uint8)
+            else:
+                arr = arr.astype(np.uint8)
+        for i, (slot, _timestamp) in enumerate(requests):
+            frames_by_slot[slot] = arr[i]
+    return frames_by_slot
 
 
 def _decode_video_delta(
@@ -1032,7 +1098,7 @@ def _decode_video_delta(
     global_idx: List[int],
     row_from: List[int],
     row_to: List[int],
-    ep_col: List[int],
+    episode_index_col: List[int],
     video_meta: dict,
     vk: str,
     steps: List[int],
@@ -1041,54 +1107,43 @@ def _decode_video_delta(
 ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
     """Decode a temporal window of video frames per anchor for one video key.
 
-    For each anchor, resolves the ``steps`` offsets to in-episode timestamps
-    (clamping at the episode bounds), decodes them from the shared per-segment
-    decoder ``cache`` (grouping requests per file so each decoder is hit once),
-    and returns ``([per-anchor (T, H, W, C) uint8], [per-anchor (T,) bool pad])``.
+    Resolves each anchor's ``steps`` offsets to in-episode timestamps (clamped to
+    the episode), decodes them via ``_decode_frames_by_file``, then stacks the
+    window per anchor. Returns ``([per-anchor (T, H, W, C) uint8], [per-anchor
+    (T,) bool pad])``.
     """
-    from lerobot.datasets.video_utils import decode_video_frames_torchcodec
-
-    assert root.video_path is not None
     fps = float(root.fps)
     ep_info = video_meta[vk]
     n_steps = len(steps)
 
     pads: List[np.ndarray] = []
-    # (chunk, file_index) -> list of (anchor_slot, step_slot, timestamp)
+    # (chunk, fi) -> [((anchor, step), timestamp), ...]
     file_requests: Dict[tuple, list] = {}
-    for a, p in enumerate(anchors):
-        g, rf, rt = global_idx[p], row_from[p], row_to[p]
-        chunk, fi, from_ts = ep_info[ep_col[p]]
-        targets, pad = _delta_targets(g, rf, rt, steps)
-        for k, j in enumerate(targets):
-            # int(j) keeps ts a Python float, so lerobot's torch.tensor(timestamps)
-            # is float32 and matches the decoder's loaded_ts (cdist needs one dtype);
-            # a numpy int64 here would make ts float64 and raise in cdist.
-            ts = from_ts + (int(j) - rf) / fps
-            file_requests.setdefault((chunk, fi), []).append((a, k, ts))
+    for anchor_idx, position in enumerate(anchors):
+        episode_start = row_from[position]
+        chunk, fi, from_ts = ep_info[episode_index_col[position]]
+        targets, pad = _delta_targets(
+            global_idx[position], episode_start, row_to[position], steps
+        )
+        for step_idx, target in enumerate(targets):
+            # int(target) keeps the timestamp a Python float so lerobot's
+            # torch.tensor(timestamps) is float32 and matches the decoder's
+            # loaded_ts (cdist needs one dtype).
+            file_requests.setdefault((chunk, fi), []).append(
+                (
+                    (anchor_idx, step_idx),
+                    from_ts + (int(target) - episode_start) / fps,
+                )
+            )
         pads.append(np.asarray(pad, dtype=bool))
 
-    # (T, H, W, C) accumulator per anchor, filled slot by slot as files decode.
-    frames_per_anchor: List[List[Any]] = [[None] * n_steps for _ in anchors]
-    for (chunk, fi), reqs in file_requests.items():
-        vpath = (
-            f"{root.root}/"
-            f"{root.video_path.format(video_key=vk, chunk_index=chunk, file_index=fi)}"
+    frames = _decode_frames_by_file(root, vk, file_requests, tolerance_s, cache)
+    stacked = [
+        np.stack(
+            [frames[(anchor_idx, step_idx)] for step_idx in range(n_steps)], axis=0
         )
-        timestamps = [ts for _, _, ts in reqs]
-        frames = decode_video_frames_torchcodec(
-            vpath, timestamps, tolerance_s, decoder_cache=cache
-        )
-        arr = frames.permute(0, 2, 3, 1).contiguous().cpu().numpy()
-        if arr.dtype != np.uint8:
-            if arr.dtype.kind == "f":
-                arr = (arr * 255.0).round().clip(0, 255).astype(np.uint8)
-            else:
-                arr = arr.astype(np.uint8)
-        for out_i, (a, k, _ts) in enumerate(reqs):
-            frames_per_anchor[a][k] = arr[out_i]
-
-    stacked = [np.stack(slots, axis=0) for slots in frames_per_anchor]
+        for anchor_idx in range(len(anchors))
+    ]
     return stacked, pads
 
 
@@ -1114,59 +1169,25 @@ def _decode_video_batch(
     cache: Any,
     keys: Optional[List[str]] = None,
 ) -> dict:
-    """Decode one batch's video frames to HWC uint8 arrays aligned to the
-    batch's row order.
-
-    Groups rows by video file and decodes each file's timestamps from the
-    shared (per-segment) decoder ``cache``, so a file's decoder is reused
-    across batches instead of being reopened. Returns
-    ``{video_key: list[np.ndarray HWC uint8]}``. ``keys`` restricts decoding to a
-    subset of ``root.video_keys`` (used by the delta path to skip windowed keys).
-    """
-    # Imported here, not at module top, so ``import ray.data`` stays
-    # lerobot-free until video is actually decoded on a worker.
-    from lerobot.datasets.video_utils import decode_video_frames_torchcodec
-
-    assert root.video_path is not None
+    """Decode one batch's video frames to HWC uint8 arrays, one per row, aligned
+    to the batch's row order. Returns ``{video_key: list[np.ndarray HWC uint8]}``.
+    ``keys`` restricts decoding to a subset of ``root.video_keys`` (the delta path
+    passes its non-windowed keys); an empty key set returns ``{}``."""
+    keys = root.video_keys if keys is None else keys
+    if not keys:
+        return {}
     n = batch.num_rows
     ep_idx_col = batch.column("episode_index").to_pylist()
     ts_col = batch.column("timestamp").to_pylist()
     out: dict = {}
-    for vk in keys if keys is not None else root.video_keys:
+    for vk in keys:
         ep_info = video_meta[vk]
-        file_to_rows: dict = {}
+        file_requests: Dict[tuple, list] = {}  # (chunk, fi) -> [(row, ts), ...]
         for r in range(n):
             chunk, fi, from_t = ep_info[ep_idx_col[r]]
-            file_to_rows.setdefault((chunk, fi), []).append((r, from_t + ts_col[r]))
-        frames_by_row: List[Any] = [None] * n
-        for (chunk, fi), rows_and_ts in file_to_rows.items():
-            # Full URI (with protocol) so torchcodec detects cloud vs local.
-            vpath = (
-                f"{root.root}/"
-                f"{root.video_path.format(video_key=vk, chunk_index=chunk, file_index=fi)}"
-            )
-            row_indices = [r for r, _ in rows_and_ts]
-            timestamps = [t for _, t in rows_and_ts]
-            # lerobot returns a torch.Tensor (N, C, H, W) normalized to
-            # float32 in [0, 1], so we rescale to uint8 below.
-            frames = decode_video_frames_torchcodec(
-                vpath, timestamps, tolerance_s, decoder_cache=cache
-            )
-            # .cpu() before the numpy conversion (a CUDA tensor can't
-            # convert directly). Decode is CPU-only today, so this is a
-            # no-op guard, not an active GPU->host move.
-            arr = frames.permute(0, 2, 3, 1).contiguous().cpu().numpy()
-            if arr.dtype != np.uint8:
-                if arr.dtype.kind == "f":
-                    # Undo lerobot's /255 normalization; round rather than
-                    # truncate so pixel values survive the uint8 -> float32
-                    # -> uint8 round-trip exactly.
-                    arr = (arr * 255.0).round().clip(0, 255).astype(np.uint8)
-                else:
-                    arr = arr.astype(np.uint8)
-            for i, r in enumerate(row_indices):
-                frames_by_row[r] = arr[i]
-        out[vk] = frames_by_row
+            file_requests.setdefault((chunk, fi), []).append((r, from_t + ts_col[r]))
+        frames = _decode_frames_by_file(root, vk, file_requests, tolerance_s, cache)
+        out[vk] = [frames[r] for r in range(n)]
     return out
 
 
@@ -1180,15 +1201,19 @@ def _decode_image_frames(
     there is no separate file or timestamp matching: each row already holds
     its own encoded frame. Returns ``{image_key: list[np.ndarray HWC uint8]}``
     aligned to ``full``'s row order. ``keys`` restricts decoding to a subset of
-    ``root.image_keys`` (used by the delta path to skip windowed keys).
+    ``root.image_keys`` (used by the delta path to skip windowed keys); an empty
+    key set returns ``{}`` without importing image libraries.
     """
+    keys = root.image_keys if keys is None else keys
+    if not keys:
+        return {}
 
     import io
 
     from PIL import Image
 
     decoded: dict = {}
-    for ik in keys if keys is not None else root.image_keys:
+    for ik in keys:
         frames: List[Any] = []
         for cell in full.column(ik).to_pylist():
             data = cell.get("bytes") if isinstance(cell, dict) else cell

--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -276,15 +276,23 @@ def _non_camera_features(features: dict) -> Dict[str, tuple]:
 def _delta_targets(
     global_index, episode_from, episode_to, steps
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Resolve each frame offset to a clamped in-episode global index and whether
-    it fell outside the episode (the pad mask).
+    """Pick the neighbouring frames at the given ``steps`` offsets, staying inside
+    the anchor frame's episode.
+
+    For an anchor at global frame ``global_index`` whose episode spans
+    ``[episode_from, episode_to)``, each offset ``s`` points at frame
+    ``global_index + s``. Offsets that land outside the episode are clamped back
+    to the nearest in-episode frame and flagged in the returned ``pad`` mask.
+
+    Example: anchor 14 in episode ``[10, 15)`` with ``steps=[-1, 0, 1]`` gives raw
+    targets ``[13, 14, 15]``; 15 is past the episode end, so it returns targets
+    ``[13, 14, 14]`` with pad ``[False, False, True]``.
 
     Vectorized: ``global_index`` / ``episode_from`` / ``episode_to`` may be scalars
-    or ``(A,)`` arrays and ``steps`` a length-``S`` sequence, giving ``(S,)``
-    results for a single anchor or ``(A, S)`` for an array of anchors. Same
-    clamp/pad rule as lerobot's ``DatasetReader._get_query_indices``, kept as a
-    standalone numpy helper because that method is bound to a torch-backed reader
-    we don't build."""
+    (``(S,)`` result) or ``(A,)`` arrays (``(A, S)`` result). Mirrors lerobot's
+    ``DatasetReader._get_query_indices`` clamp/pad rule, reimplemented here because
+    that method is bound to a torch reader we don't build.
+    """
     anchor = np.asarray(global_index)[..., None]
     low = np.asarray(episode_from)[..., None]
     high = np.asarray(episode_to)[..., None]

--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -738,6 +738,23 @@ def _read_lerobot_task(
         )
 
 
+class _DeltaSegment(NamedTuple):
+    """Per-segment state for the delta (temporal-window) read path, built once by
+    :func:`_prepare_delta_segment` and reused across the segment's batches."""
+
+    seg_lo: int
+    global_idx: List[int]
+    ep_col: List[int]
+    row_from: List[int]
+    row_to: List[int]
+    delta_video_keys: List[str]
+    nondelta_video_keys: List[str]
+    nondelta_image_keys: List[str]
+    pad_order: List[str]
+    tab_base: Dict[str, np.ndarray]
+    seg_images: Dict[str, list]
+
+
 def _read_lerobot_segment(
     root: _LeRobotRoot,
     start: int,
@@ -749,17 +766,15 @@ def _read_lerobot_segment(
 ) -> Iterator[pa.Table]:
     """Stream decoded rows for one ``[start, end)`` range within a single root.
 
-    Reads the segment's parquet rows, then emits Arrow batches sized from
+    Reads the segment's parquet rows once, then emits Arrow batches sized from
     this root's estimated row size (so each batch targets one output block),
-    decoding each batch's camera frames on demand.
-    """
-    if root.delta_steps:
-        # Temporal-window reads go through the episode-aligned delta path.
-        yield from _read_lerobot_segment_delta(
-            root, start, end, dataset_index, parquet_segs, ep_slice, max_block_bytes
-        )
-        return
+    decoding each batch's camera frames on demand via :func:`_build_batch`.
 
+    When ``root.delta_steps`` is set, each batch instead gathers a temporal
+    window per listed feature (:func:`_build_delta_batch`), using per-segment
+    state from :func:`_prepare_delta_segment`; a window multiplies a row's size,
+    so the batch is shrunk by the widest window to keep blocks near target.
+    """
     fs = root.fs
 
     # Read all parquet rows for this segment (predicate pushdown on index).
@@ -774,22 +789,6 @@ def _read_lerobot_segment(
     n_rows = full.num_rows
     camera_keys = root.video_keys + root.image_keys
 
-    if root.video_keys:
-        video_meta = _video_episode_meta(ep_slice, root.video_keys)
-        cache = new_decoder_cache(root.storage_options)
-        # Per-frame timestamp tolerance for the video decoder, needed only
-        # when there are video cameras. Default to half a frame interval
-        # (0.5 / fps). Computed inside this branch -- not unconditionally --
-        # so image-only and tabular-only datasets never divide by fps.
-        if root.frame_tolerance_s is not None:
-            tolerance_s = root.frame_tolerance_s
-        else:
-            tolerance_s = 0.5 / float(root.fps)
-    else:
-        video_meta = {}
-        cache = None
-        tolerance_s = None
-
     task_idx_pylist = full.column("task_index").to_pylist()
     missing_tasks = {ti for ti in task_idx_pylist if ti not in root.tasks_dict}
     if missing_tasks:
@@ -799,73 +798,83 @@ def _read_lerobot_segment(
             f"tasks metadata are inconsistent."
         )
 
-    # Size batches from this root's row size
-    rows_per_batch = max(1, max_block_bytes // (root.row_size_bytes))
+    if root.video_keys:
+        video_meta = _video_episode_meta(ep_slice, root.video_keys)
+        cache = new_decoder_cache(root.storage_options)
+        # Per-frame timestamp tolerance for the video decoder. Default to half a
+        # frame interval (0.5 / fps); computed only when there are video cameras
+        # so image-only and tabular-only datasets never divide by fps.
+        tolerance_s = (
+            root.frame_tolerance_s
+            if root.frame_tolerance_s is not None
+            else 0.5 / float(root.fps)
+        )
+    else:
+        video_meta = {}
+        cache = None
+        tolerance_s = None
+
+    # Delta reads gather a window per feature; build the per-segment state once
+    # and divide the batch by the widest window so blocks stay near target size.
+    dseg = _prepare_delta_segment(root, full, ep_slice) if root.delta_steps else None
+    max_t = max((len(s) for s in root.delta_steps.values()), default=1)
+    rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes) // max_t)
     try:
         for batch_start in range(0, n_rows, rows_per_batch):
             batch_end = min(batch_start + rows_per_batch, n_rows)
             batch = full.slice(batch_start, batch_end - batch_start)
-            frame_buffers: dict = {}
-            if root.video_keys:
-                frame_buffers.update(
-                    _decode_video_batch(root, batch, video_meta, tolerance_s, cache)
-                )
-            if root.image_keys:
-                frame_buffers.update(_decode_image_frames(root, batch))
             task_list = [
                 root.tasks_dict[task_idx_pylist[i]]
                 for i in range(batch_start, batch_end)
             ]
-            yield _build_batch(
-                camera_keys,
-                batch,
-                frame_buffers,
-                task_list,
-                dataset_index,
-                root.stats_json,
-            )
+            if dseg is not None:
+                yield _build_delta_batch(
+                    root,
+                    batch,
+                    batch_start,
+                    dataset_index,
+                    task_list,
+                    video_meta,
+                    tolerance_s,
+                    cache,
+                    dseg,
+                )
+            else:
+                frame_buffers: dict = {}
+                if root.video_keys:
+                    frame_buffers.update(
+                        _decode_video_batch(root, batch, video_meta, tolerance_s, cache)
+                    )
+                if root.image_keys:
+                    frame_buffers.update(_decode_image_frames(root, batch))
+                yield _build_batch(
+                    camera_keys,
+                    batch,
+                    frame_buffers,
+                    task_list,
+                    dataset_index,
+                    root.stats_json,
+                )
     finally:
         if cache is not None:
             cache.clear()
 
 
-def _read_lerobot_segment_delta(
-    root: _LeRobotRoot,
-    start: int,
-    end: int,
-    dataset_index: int,
-    parquet_segs: List[str],
-    ep_slice: pa.Table,
-    max_block_bytes: int,
-) -> Iterator[pa.Table]:
-    """Stream decoded rows for one ``[start, end)`` range with temporal windows.
+def _prepare_delta_segment(
+    root: _LeRobotRoot, full: pa.Table, ep_slice: pa.Table
+) -> _DeltaSegment:
+    """Build the per-segment state the delta gather reuses across batches:
+    per-row episode bounds (for clamping), key routing, and the segment-level
+    tabular / decoded-image buffers whose windows may span batch boundaries.
 
-    Like :func:`_read_lerobot_segment`, but every feature in ``root.delta_steps``
-    is gathered over its frame offsets -- clamped to the anchor frame's episode --
-    into a leading time dimension, and a boolean ``{key}_is_pad`` column is emitted
-    for it. Requires whole-episode segments (guaranteed by the ``get_read_tasks``
-    delta guard) so all neighbour rows lie within this segment's parquet read.
+    Validates the invariant the gather relies on: the segment is a contiguous run
+    of whole episodes in the global frame index (guaranteed by the
+    ``get_read_tasks`` delta guard). That lets a clamped global index ``j`` map to
+    row position ``j - seg_lo`` and guarantees every in-episode neighbour is
+    loaded; a split episode would silently corrupt windows, so fail loudly.
     """
-    from ray.data.extensions import ArrowVariableShapedTensorArray
-
-    fs = root.fs
-    filters = [("index", ">=", start), ("index", "<", end)]
-    pq_tables = []
-    for path in parquet_segs:
-        with fs.open(path, "rb") as f:
-            pq_tables.append(pq.read_table(f, filters=filters))
-    full = pa.concat_tables(pq_tables) if pq_tables else None
-    if full is None or full.num_rows == 0:
-        return
-    n_rows = full.num_rows
-
-    # Global frame index -> row position within this (contiguous, whole-episode)
-    # segment, so every clamped neighbour resolves to a loaded row.
     global_idx = full.column("index").to_pylist()
-    pos_of_global = {g: p for p, g in enumerate(global_idx)}
     ep_col = full.column("episode_index").to_pylist()
-
-    # Per-episode [from, to) bounds for clamping, expanded to per-row arrays.
     ep_from = dict(
         zip(
             ep_slice.column("episode_index").to_pylist(),
@@ -881,32 +890,22 @@ def _read_lerobot_segment_delta(
     row_from = [ep_from[e] for e in ep_col]
     row_to = [ep_to[e] for e in ep_col]
 
-    # Safety net: the delta path assumes whole-episode segments (see the
-    # get_read_tasks guard). If an episode were split, some clamped neighbour
-    # would fall outside this segment and KeyError below; fail loudly instead.
     seg_lo, seg_hi = global_idx[0], global_idx[-1] + 1
-    if min(row_from) < seg_lo or max(row_to) > seg_hi:
+    if (
+        len(global_idx) != seg_hi - seg_lo
+        or min(row_from) < seg_lo
+        or max(row_to) > seg_hi
+    ):
         raise RuntimeError(
-            "delta_timestamps requires whole-episode read segments, but this "
-            "segment splits an episode -- an internal invariant violation "
-            "(get_read_tasks caps parallelism when delta_timestamps is set)."
-        )
-
-    task_idx_pylist = full.column("task_index").to_pylist()
-    missing_tasks = {ti for ti in task_idx_pylist if ti not in root.tasks_dict}
-    if missing_tasks:
-        raise ValueError(
-            f"task_index values {sorted(missing_tasks)} are absent from the "
-            f"dataset's tasks metadata (meta/tasks.parquet); the data and "
-            f"tasks metadata are inconsistent."
+            "delta_timestamps requires contiguous whole-episode read segments, "
+            "but this segment splits an episode -- an internal invariant "
+            "violation (get_read_tasks caps parallelism when delta_timestamps "
+            "is set)."
         )
 
     delta_steps = root.delta_steps
     image_set = set(root.image_keys)
     delta_image_keys = [ik for ik in root.image_keys if ik in delta_steps]
-    nondelta_image_keys = [ik for ik in root.image_keys if ik not in delta_steps]
-    delta_video_keys = [vk for vk in root.video_keys if vk in delta_steps]
-    nondelta_video_keys = [vk for vk in root.video_keys if vk not in delta_steps]
     delta_tabular_keys = [
         name
         for name in full.column_names
@@ -917,158 +916,152 @@ def _read_lerobot_segment_delta(
     pad_order = [name for name in full.column_names if name in delta_steps] + [
         vk for vk in root.video_keys if vk in delta_steps
     ]
-
-    if root.video_keys:
-        video_meta = _video_episode_meta(ep_slice, root.video_keys)
-        cache = new_decoder_cache(root.storage_options)
-        tolerance_s = (
-            root.frame_tolerance_s
-            if root.frame_tolerance_s is not None
-            else 0.5 / float(root.fps)
-        )
-    else:
-        video_meta = {}
-        cache = None
-        tolerance_s = None
-
-    # Segment-level buffers reused across batches for gathers whose neighbours may
-    # cross batch boundaries: tabular columns (cheap) and decoded delta images.
-    tab_base = {
-        name: _column_to_numpy(full.column(name)) for name in delta_tabular_keys
-    }
-    seg_images = (
-        _decode_image_frames(root, full, keys=delta_image_keys)
-        if delta_image_keys
-        else {}
+    return _DeltaSegment(
+        seg_lo=seg_lo,
+        global_idx=global_idx,
+        ep_col=ep_col,
+        row_from=row_from,
+        row_to=row_to,
+        delta_video_keys=[vk for vk in root.video_keys if vk in delta_steps],
+        nondelta_video_keys=[vk for vk in root.video_keys if vk not in delta_steps],
+        nondelta_image_keys=[ik for ik in root.image_keys if ik not in delta_steps],
+        pad_order=pad_order,
+        tab_base={
+            name: _column_to_numpy(full.column(name)) for name in delta_tabular_keys
+        },
+        seg_images=(
+            _decode_image_frames(root, full, keys=delta_image_keys)
+            if delta_image_keys
+            else {}
+        ),
     )
 
-    def _gather_from_positions(source, positions):
-        return np.stack([source[i] for i in positions], axis=0)
 
-    # Each output row now carries up to ``max_T`` frames, so shrink the batch by
-    # the widest window to keep block sizes near the target.
-    max_t = max(len(s) for s in delta_steps.values())
-    rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes) // max_t)
-    try:
-        for batch_start in range(0, n_rows, rows_per_batch):
-            batch_end = min(batch_start + rows_per_batch, n_rows)
-            batch = full.slice(batch_start, batch_end - batch_start)
-            anchors = list(range(batch_start, batch_end))
+def _build_delta_batch(
+    root: _LeRobotRoot,
+    batch: pa.Table,
+    batch_start: int,
+    dataset_index: int,
+    task_list: List[str],
+    video_meta: dict,
+    tolerance_s: Optional[float],
+    cache: Any,
+    dseg: _DeltaSegment,
+) -> pa.Table:
+    """Assemble one temporal-window output batch.
 
-            # Per-anchor clamped target positions + pad masks, computed once per
-            # distinct step list and reused across the keys that share it.
-            targets_cache: Dict[tuple, tuple] = {}
+    Each feature in ``root.delta_steps`` is gathered over its offsets -- clamped
+    to the anchor's episode -- into a leading time dimension, with a boolean
+    ``{key}_is_pad`` mask; non-windowed columns pass through unchanged. Anchors
+    are ``batch``'s rows, at absolute segment positions
+    ``[batch_start, batch_start + len(batch))``. Column order matches
+    :func:`_build_schema`: parquet columns, then video keys, then
+    ``task`` / ``dataset_index`` / ``stats``, then the pad masks.
+    """
+    from ray.data.extensions import ArrowVariableShapedTensorArray
 
-            def _targets_for(step_key):
-                cached = targets_cache.get(step_key)
-                if cached is not None:
-                    return cached
-                positions_per_anchor = []
-                pad_per_anchor = []
-                steps = list(step_key)
-                for p in anchors:
-                    tgt, pad = _delta_targets(
-                        global_idx[p], row_from[p], row_to[p], steps
-                    )
-                    positions_per_anchor.append([pos_of_global[j] for j in tgt])
-                    pad_per_anchor.append(np.asarray(pad, dtype=bool))
-                targets_cache[step_key] = (positions_per_anchor, pad_per_anchor)
-                return targets_cache[step_key]
+    delta_steps = root.delta_steps
+    image_set = set(root.image_keys)
+    anchors = range(batch_start, batch_start + batch.num_rows)
+    pad_buffers: dict = {}
 
-            columns: dict = {}
-            pad_buffers: dict = {}
+    # Per-anchor clamped target positions + pad mask, computed once per distinct
+    # offset list and shared across keys that use it. A clamped global index j is
+    # at row position j - seg_lo (the segment is contiguous; see
+    # _prepare_delta_segment).
+    targets_cache: Dict[tuple, tuple] = {}
 
-            # Non-delta cameras: one frame per row (unchanged behaviour).
-            nd_video_fb = (
-                _decode_video_batch(
-                    root,
-                    batch,
-                    video_meta,
-                    tolerance_s,
-                    cache,
-                    keys=nondelta_video_keys,
+    def _targets_for(steps):
+        cached = targets_cache.get(steps)
+        if cached is None:
+            positions, pads = [], []
+            for p in anchors:
+                tgt, pad = _delta_targets(
+                    dseg.global_idx[p], dseg.row_from[p], dseg.row_to[p], list(steps)
                 )
-                if nondelta_video_keys
-                else {}
-            )
-            nd_image_fb = (
-                _decode_image_frames(root, batch, keys=nondelta_image_keys)
-                if nondelta_image_keys
-                else {}
-            )
+                positions.append([j - dseg.seg_lo for j in tgt])
+                pads.append(np.asarray(pad, dtype=bool))
+            cached = targets_cache[steps] = (positions, pads)
+        return cached
 
-            # Delta video: T frames per anchor from the shared decoder cache.
-            for vk in delta_video_keys:
-                frames, pads = _decode_video_delta(
-                    root,
-                    anchors,
-                    global_idx,
-                    row_from,
-                    row_to,
-                    ep_col,
-                    video_meta,
-                    vk,
-                    delta_steps[vk],
-                    tolerance_s,
-                    cache,
+    # Decode all cameras up front, then assemble columns in schema order.
+    nd_video_fb = (
+        _decode_video_batch(
+            root, batch, video_meta, tolerance_s, cache, keys=dseg.nondelta_video_keys
+        )
+        if dseg.nondelta_video_keys
+        else {}
+    )
+    nd_image_fb = (
+        _decode_image_frames(root, batch, keys=dseg.nondelta_image_keys)
+        if dseg.nondelta_image_keys
+        else {}
+    )
+    delta_video_fb: dict = {}
+    for vk in dseg.delta_video_keys:
+        frames, pads = _decode_video_delta(
+            root,
+            anchors,
+            dseg.global_idx,
+            dseg.row_from,
+            dseg.row_to,
+            dseg.ep_col,
+            video_meta,
+            vk,
+            delta_steps[vk],
+            tolerance_s,
+            cache,
+        )
+        delta_video_fb[vk] = frames
+        pad_buffers[vk] = pads
+
+    columns: dict = {}
+    # 1. Parquet columns, in file order: windowed image/tabular gathered from the
+    #    per-segment buffers, everything else passed through.
+    for name in batch.column_names:
+        if name in image_set:
+            if name in delta_steps:
+                positions, pad = _targets_for(tuple(delta_steps[name]))
+                src = dseg.seg_images[name]
+                columns[name] = ArrowVariableShapedTensorArray.from_numpy(
+                    [np.stack([src[i] for i in pos], axis=0) for pos in positions]
                 )
-                columns[vk] = ArrowVariableShapedTensorArray.from_numpy(frames)
-                pad_buffers[vk] = pads
-
-            # Parquet columns, in file order.
-            for name in full.column_names:
-                if name in image_set:
-                    if name in delta_steps:
-                        positions_per_anchor, pad_per_anchor = _targets_for(
-                            tuple(delta_steps[name])
-                        )
-                        src = seg_images[name]
-                        stacked = [
-                            _gather_from_positions(src, positions)
-                            for positions in positions_per_anchor
-                        ]
-                        columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                            stacked
-                        )
-                        pad_buffers[name] = pad_per_anchor
-                    else:
-                        columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                            nd_image_fb[name]
-                        )
-                elif name in delta_steps:
-                    positions_per_anchor, pad_per_anchor = _targets_for(
-                        tuple(delta_steps[name])
-                    )
-                    base = tab_base[name]
-                    stacked = [base[positions] for positions in positions_per_anchor]
-                    columns[name] = ArrowVariableShapedTensorArray.from_numpy(stacked)
-                    pad_buffers[name] = pad_per_anchor
-                else:
-                    columns[name] = batch.column(name)
-
-            # Non-parquet video columns, appended after the parquet columns.
-            for vk in nondelta_video_keys:
-                columns[vk] = ArrowVariableShapedTensorArray.from_numpy(nd_video_fb[vk])
-
-            task_list = [root.tasks_dict[task_idx_pylist[p]] for p in anchors]
-            columns["task"] = pa.array(task_list, type=pa.string()).dictionary_encode()
-            columns["dataset_index"] = pa.array(
-                [dataset_index] * len(anchors), type=pa.int32()
-            )
-            columns["stats"] = pa.array(
-                [root.stats_json] * len(anchors), type=pa.string()
-            ).dictionary_encode()
-
-            # Pad masks last, in the schema's fixed order.
-            for name in pad_order:
-                columns[f"{name}_is_pad"] = ArrowVariableShapedTensorArray.from_numpy(
-                    pad_buffers[name]
+                pad_buffers[name] = pad
+            else:
+                columns[name] = ArrowVariableShapedTensorArray.from_numpy(
+                    nd_image_fb[name]
                 )
+        elif name in delta_steps:
+            positions, pad = _targets_for(tuple(delta_steps[name]))
+            base = dseg.tab_base[name]
+            columns[name] = ArrowVariableShapedTensorArray.from_numpy(
+                [base[pos] for pos in positions]
+            )
+            pad_buffers[name] = pad
+        else:
+            columns[name] = batch.column(name)
 
-            yield pa.table(columns)
-    finally:
-        if cache is not None:
-            cache.clear()
+    # 2. Video columns (not in the parquet), in root.video_keys order.
+    for vk in root.video_keys:
+        buf = delta_video_fb[vk] if vk in delta_steps else nd_video_fb[vk]
+        columns[vk] = ArrowVariableShapedTensorArray.from_numpy(buf)
+
+    # 3. Per-dataset constants.
+    columns["task"] = pa.array(task_list, type=pa.string()).dictionary_encode()
+    columns["dataset_index"] = pa.array(
+        [dataset_index] * len(task_list), type=pa.int32()
+    )
+    columns["stats"] = pa.array(
+        [root.stats_json] * len(task_list), type=pa.string()
+    ).dictionary_encode()
+
+    # 4. Pad masks, in the schema's fixed order.
+    for name in dseg.pad_order:
+        columns[f"{name}_is_pad"] = ArrowVariableShapedTensorArray.from_numpy(
+            pad_buffers[name]
+        )
+
+    return pa.table(columns)
 
 
 def _decode_video_delta(

--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -49,6 +49,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Default frame-grid tolerance (seconds) for delta_timestamps offsets; matches
+# lerobot's ``LeRobotDataset(tolerance_s=1e-4)`` default. Overridable per read via
+# ``read_lerobot(delta_tolerance_s=...)``.
+_DEFAULT_DELTA_TOLERANCE_S = 1e-4
+
+
 class _LeRobotRoot(NamedTuple):
     """Per-root derived state for the LeRobot datasource built on the driver."""
 
@@ -58,7 +64,7 @@ class _LeRobotRoot(NamedTuple):
 
     fs: "fsspec.AbstractFileSystem"
     """Resolved fsspec filesystem for metadata + parquet I/O, built once on the
-    driver (see :func:`_resolve_filesystem`) and shipped to workers."""
+    driver (see ``_resolve_filesystem``) and shipped to workers."""
 
     fs_root: str
     """Dataset path relative to ``fs``'s root for path joining
@@ -121,7 +127,7 @@ class _LeRobotRoot(NamedTuple):
 class _ReadGranularity(str, enum.Enum):
     """How rows are grouped into base read tasks: one task per physical file
     (video-file group) or per episode. ``override_num_blocks`` splits/merges
-    from whichever base this selects (see :meth:`LeRobotDatasource._slice`)."""
+    from whichever base this selects (see ``LeRobotDatasource._slice``)."""
 
     FILE = "file"
     EPISODE = "episode"
@@ -172,11 +178,18 @@ def _build_schema(
             # Encoded-byte image struct -> decoded uint8 tensor (4-D if windowed).
             return pa.field(f.name, delta_frame_type if f.name in delta else frame_type)
         if f.name in delta:
-            # Tabular feature gains a leading time axis.
-            value_type, base_ndim = _delta_value_type_and_ndim(f.type)
+            # Tabular feature gains a leading time axis. A list column (fixed or
+            # variable) stacks to (T, dim) -> ndim 2 over its element type; a
+            # scalar column stacks to (T,) -> ndim 1 over its own type.
+            is_list = (
+                pa.types.is_fixed_size_list(f.type)
+                or pa.types.is_list(f.type)
+                or pa.types.is_large_list(f.type)
+            )
+            value_type = f.type.value_type if is_list else f.type
             return pa.field(
                 f.name,
-                ArrowVariableShapedTensorType(value_type, ndim=base_ndim + 1),
+                ArrowVariableShapedTensorType(value_type, ndim=2 if is_list else 1),
             )
         return f
 
@@ -263,81 +276,6 @@ def _non_camera_features(features: dict) -> Dict[str, tuple]:
         for k, v in features.items()
         if v.get("dtype") not in ("video", "image")
     }
-
-
-# Default frame-grid tolerance (seconds) for delta_timestamps offsets; matches
-# lerobot's ``LeRobotDataset(tolerance_s=1e-4)`` default. Overridable per read via
-# ``read_lerobot(delta_tolerance_s=...)``.
-_DEFAULT_DELTA_TOLERANCE_S = 1e-4
-
-
-def _convert_delta_timestamps(
-    delta_timestamps: Dict[str, List[float]],
-    fps: int,
-    feature_keys: set,
-    tolerance_s: float,
-) -> Dict[str, List[int]]:
-    """Validate ``delta_timestamps`` and convert its second offsets to integer
-    frame offsets, preserving order.
-
-    The frame-grid alignment check and the seconds->frames conversion are
-    delegated to lerobot (``check_delta_timestamps`` / ``get_delta_indices``) so
-    the semantics match ``lerobot.LeRobotDataset`` exactly. This adds the two
-    checks lerobot omits: each key must be a real feature, and no offset list may
-    be empty. Raises ``ValueError`` otherwise.
-    """
-    from lerobot.datasets.feature_utils import (
-        check_delta_timestamps,
-        get_delta_indices,
-    )
-
-    for key, offsets in delta_timestamps.items():
-        if key not in feature_keys:
-            raise ValueError(
-                f"delta_timestamps key {key!r} is not a feature of this dataset. "
-                f"Valid keys: {sorted(feature_keys)}."
-            )
-        if not offsets:
-            raise ValueError(
-                f"delta_timestamps[{key!r}] is empty; give at least one offset "
-                f"(in seconds), or drop the key."
-            )
-    # Raises ValueError listing any offset that is not a multiple of 1/fps within
-    # tolerance_s (each must map unambiguously to one frame).
-    check_delta_timestamps(delta_timestamps, fps, tolerance_s)
-    return get_delta_indices(delta_timestamps, fps)
-
-
-def _delta_value_type_and_ndim(pa_type: pa.DataType) -> Tuple[pa.DataType, int]:
-    """Value type and base ndim of a parquet column, for building its stacked
-    delta tensor type. A fixed/var-size list of scalars is a length-1 base
-    (``(dim,)``); a bare scalar is a length-0 base (``()``)."""
-    if (
-        pa.types.is_fixed_size_list(pa_type)
-        or pa.types.is_list(pa_type)
-        or (pa.types.is_large_list(pa_type))
-    ):
-        return pa_type.value_type, 1
-    return pa_type, 0
-
-
-def _column_to_numpy(col: pa.ChunkedArray) -> np.ndarray:
-    """Materialize a parquet column as a ``(n_rows, *base_shape)`` numpy array,
-    preserving the stored value dtype so stacked delta tensors match the schema.
-
-    Feature vectors have a uniform per-row length, so both fixed- and
-    variable-size list columns flatten to ``(n_rows, dim)`` via the value array
-    (which keeps e.g. float32, unlike ``to_pylist`` -> object -> float64)."""
-    chunked = col.combine_chunks() if isinstance(col, pa.ChunkedArray) else col
-    t = chunked.type
-    if (
-        pa.types.is_fixed_size_list(t)
-        or pa.types.is_list(t)
-        or pa.types.is_large_list(t)
-    ):
-        values = chunked.flatten().to_numpy(zero_copy_only=False)
-        return values.reshape(len(chunked), -1)
-    return chunked.to_numpy(zero_copy_only=False)
 
 
 def _delta_targets(
@@ -524,7 +462,7 @@ def _build_root(
             ``meta/`` only, so data and video paths are resolved against
             ``root``, not ``meta.root``.
         fs: Resolved fsspec filesystem for metadata and parquet I/O; captured on
-            the returned :class:`_LeRobotRoot` so workers reuse it.
+            the returned ``_LeRobotRoot`` so workers reuse it.
         fs_root: Dataset path relative to ``fs``'s root, for path joining.
         video_root_uri: Root URI for the by-URI video decode path (videos are
             streamed through torchcodec/fsspec, not through ``fs``).
@@ -541,7 +479,7 @@ def _build_root(
             ``check_delta_timestamps``.
 
     Returns:
-        A ``(root_bundle, episodes_table)`` tuple: the :class:`_LeRobotRoot`
+        A ``(root_bundle, episodes_table)`` tuple: the ``_LeRobotRoot``
         worker-shipped state, and the per-root episodes table (augmented with
         ``_global_from_index`` / ``_global_to_index``) kept on the driver for
         planning.
@@ -590,13 +528,18 @@ def _build_root(
     tasks_dict = dict(
         zip(meta.tasks["task_index"].astype(int).tolist(), meta.tasks.index.tolist())
     )
-    delta_steps = (
-        _convert_delta_timestamps(
-            delta_timestamps, meta.fps, set(meta.features), delta_tolerance_s
+    if delta_timestamps:
+        # Validate offsets align to the frame grid and convert seconds -> integer
+        # frame offsets; both delegated to lerobot so semantics match LeRobotDataset.
+        from lerobot.datasets.feature_utils import (
+            check_delta_timestamps,
+            get_delta_indices,
         )
-        if delta_timestamps
-        else {}
-    )
+
+        check_delta_timestamps(delta_timestamps, meta.fps, delta_tolerance_s)
+        delta_steps = get_delta_indices(delta_timestamps, meta.fps)
+    else:
+        delta_steps = {}
     schema = _build_schema(
         episodes_table,
         meta.data_path,
@@ -641,9 +584,9 @@ def _resolve_root(
     """Resolve one root into its read-task bundle + per-episode table.
 
     Runs the single-root pipeline: resolve the filesystem
-    (:func:`_resolve_filesystem`), load LeRobot metadata
-    (:func:`_load_lerobot_metadata`), and distill both (:func:`_build_root`) into
-    a slim :class:`_LeRobotRoot` (shipped to read tasks) and a per-episode Arrow
+    (``_resolve_filesystem``), load LeRobot metadata
+    (``_load_lerobot_metadata``), and distill both (``_build_root``) into
+    a slim ``_LeRobotRoot`` (shipped to read tasks) and a per-episode Arrow
     table (used for slicing). The upstream metadata is returned too, so the
     caller can run cross-root homogeneity checks and expose it via
     :attr:`LeRobotDatasource.meta`.
@@ -740,7 +683,7 @@ def _read_lerobot_task(
 
 class _DeltaSegment(NamedTuple):
     """Per-segment state for the delta (temporal-window) read path, built once by
-    :func:`_prepare_delta_segment` and reused across the segment's batches."""
+    ``_prepare_delta_segment`` and reused across the segment's batches."""
 
     seg_lo: int
     global_idx: List[int]
@@ -768,11 +711,11 @@ def _read_lerobot_segment(
 
     Reads the segment's parquet rows once, then emits Arrow batches sized from
     this root's estimated row size (so each batch targets one output block),
-    decoding each batch's camera frames on demand via :func:`_build_batch`.
+    decoding each batch's camera frames on demand via ``_build_batch``.
 
     When ``root.delta_steps`` is set, each batch instead gathers a temporal
-    window per listed feature (:func:`_build_delta_batch`), using per-segment
-    state from :func:`_prepare_delta_segment`; a window multiplies a row's size,
+    window per listed feature (``_build_delta_batch``), using per-segment
+    state from ``_prepare_delta_segment``; a window multiplies a row's size,
     so the batch is shrunk by the widest window to keep blocks near target.
     """
     fs = root.fs
@@ -814,11 +757,16 @@ def _read_lerobot_segment(
         cache = None
         tolerance_s = None
 
-    # Delta reads gather a window per feature; build the per-segment state once
-    # and divide the batch by the widest window so blocks stay near target size.
-    dseg = _prepare_delta_segment(root, full, ep_slice) if root.delta_steps else None
-    max_t = max((len(s) for s in root.delta_steps.values()), default=1)
-    rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes) // max_t)
+    if root.delta_steps:
+        # Delta reads gather a window per feature; build the per-segment state once
+        # and divide the batch by the widest window so blocks stay near target size.
+        dseg = _prepare_delta_segment(root, full, ep_slice)
+        max_t = max((len(s) for s in root.delta_steps.values()), default=1)
+        rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes) // max_t)
+    else:
+        dseg = None
+        rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes))
+
     try:
         for batch_start in range(0, n_rows, rows_per_batch):
             batch_end = min(batch_start + rows_per_batch, n_rows)
@@ -827,7 +775,7 @@ def _read_lerobot_segment(
                 root.tasks_dict[task_idx_pylist[i]]
                 for i in range(batch_start, batch_end)
             ]
-            if dseg is not None:
+            if root.delta_steps:
                 yield _build_delta_batch(
                     root,
                     batch,
@@ -916,6 +864,22 @@ def _prepare_delta_segment(
     pad_order = [name for name in full.column_names if name in delta_steps] + [
         vk for vk in root.video_keys if vk in delta_steps
     ]
+    # Materialize tabular delta columns to numpy once, preserving the stored dtype
+    # so stacked windows match the schema: list columns (fixed or variable) flatten
+    # to (n_rows, dim) via the value array -- which keeps e.g. float32 that
+    # to_pylist would widen to float64 -- and scalar columns stay 1-D.
+    tab_base: Dict[str, np.ndarray] = {}
+    for name in delta_tabular_keys:
+        col = full.column(name).combine_chunks()
+        if (
+            pa.types.is_fixed_size_list(col.type)
+            or pa.types.is_list(col.type)
+            or pa.types.is_large_list(col.type)
+        ):
+            flat = col.flatten().to_numpy(zero_copy_only=False)
+            tab_base[name] = flat.reshape(len(col), -1)
+        else:
+            tab_base[name] = col.to_numpy(zero_copy_only=False)
     return _DeltaSegment(
         seg_lo=seg_lo,
         global_idx=global_idx,
@@ -926,9 +890,7 @@ def _prepare_delta_segment(
         nondelta_video_keys=[vk for vk in root.video_keys if vk not in delta_steps],
         nondelta_image_keys=[ik for ik in root.image_keys if ik not in delta_steps],
         pad_order=pad_order,
-        tab_base={
-            name: _column_to_numpy(full.column(name)) for name in delta_tabular_keys
-        },
+        tab_base=tab_base,
         seg_images=(
             _decode_image_frames(root, full, keys=delta_image_keys)
             if delta_image_keys
@@ -955,7 +917,7 @@ def _build_delta_batch(
     ``{key}_is_pad`` mask; non-windowed columns pass through unchanged. Anchors
     are ``batch``'s rows, at absolute segment positions
     ``[batch_start, batch_start + len(batch))``. Column order matches
-    :func:`_build_schema`: parquet columns, then video keys, then
+    ``_build_schema``: parquet columns, then video keys, then
     ``task`` / ``dataset_index`` / ``stats``, then the pad masks.
     """
     from ray.data.extensions import ArrowVariableShapedTensorArray
@@ -1586,7 +1548,7 @@ class LeRobotDatasource(Datasource):
         Returns:
             A list of ``(global_from_index, global_to_index)`` tuples, one per
             contiguous file run (``_slice`` sorts them afterward). Same
-            ``(from, to)`` shape that :meth:`_slices_by_episode` returns one per
+            ``(from, to)`` shape that ``_slices_by_episode`` returns one per
             episode -- this just merges the adjacent episodes that share a file.
             Episodes that share a file but are NOT adjacent (an ``episodes``
             subset dropped the episode between them, or a non-standard layout
@@ -1741,11 +1703,12 @@ class LeRobotDatasource(Datasource):
 
         # delta_timestamps gathers a temporal window per frame, clamped to the
         # anchor's episode. That requires whole-episode read segments, so never
-        # split below the base (episode / file-group) ranges: cap parallelism at
-        # the base range count. See _read_lerobot_segment_delta and the note in
-        # ``read_lerobot``'s docstring for the parallelism trade-off.
+        # split below the base (episode / file-group) ranges.
         if self._delta_timestamps and parallelism > len(row_ranges):
-            parallelism = len(row_ranges)
+            raise ValueError(
+                f"Delta timestamps are enabled, but parallelism ({parallelism}) is greater than the number of row ranges ({len(row_ranges)}). "
+                f"Delta timestamps require whole-episode read segments, so parallelism must be less than or equal to the number of row ranges."
+            )
 
         groups: List[list]
         if parallelism > 0 and parallelism > len(row_ranges):

--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -279,29 +279,22 @@ def _non_camera_features(features: dict) -> Dict[str, tuple]:
 
 
 def _delta_targets(
-    global_index: int, ep_from: int, ep_to: int, steps: List[int]
-) -> Tuple[List[int], List[bool]]:
-    """For an anchor at ``global_index`` in episode ``[ep_from, ep_to)``, resolve
-    each frame offset to a clamped in-episode global index and whether it was
-    padded (fell outside the episode).
+    global_index, ep_from, ep_to, steps
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Resolve each frame offset to a clamped in-episode global index and whether
+    it fell outside the episode (the pad mask).
 
-    Same clamp/pad rule as lerobot's ``DatasetReader._get_query_indices``, kept as
-    a standalone numpy-side helper because that method is bound to a torch-backed
-    reader object we don't build here."""
-    targets: List[int] = []
-    pad: List[bool] = []
-    for step in steps:
-        j = global_index + step
-        if j < ep_from:
-            targets.append(ep_from)
-            pad.append(True)
-        elif j >= ep_to:
-            targets.append(ep_to - 1)
-            pad.append(True)
-        else:
-            targets.append(j)
-            pad.append(False)
-    return targets, pad
+    Vectorized: ``global_index`` / ``ep_from`` / ``ep_to`` may be scalars or
+    ``(A,)`` arrays and ``steps`` a length-``S`` sequence, giving ``(S,)`` results
+    for a single anchor or ``(A, S)`` for an array of anchors. Same clamp/pad rule
+    as lerobot's ``DatasetReader._get_query_indices``, kept as a standalone numpy
+    helper because that method is bound to a torch-backed reader we don't build."""
+    g = np.asarray(global_index)[..., None]
+    lo = np.asarray(ep_from)[..., None]
+    hi = np.asarray(ep_to)[..., None]
+    j = g + np.asarray(steps)
+    pad = (j < lo) | (j >= hi)
+    return np.clip(j, lo, hi - 1), pad
 
 
 def _resolve_filesystem(
@@ -695,7 +688,7 @@ class _DeltaSegment(NamedTuple):
     nondelta_image_keys: List[str]
     pad_order: List[str]
     tab_base: Dict[str, np.ndarray]
-    seg_images: Dict[str, list]
+    seg_images: Dict[str, np.ndarray]
 
 
 def _read_lerobot_segment(
@@ -891,11 +884,16 @@ def _prepare_delta_segment(
         nondelta_image_keys=[ik for ik in root.image_keys if ik not in delta_steps],
         pad_order=pad_order,
         tab_base=tab_base,
-        seg_images=(
-            _decode_image_frames(root, full, keys=delta_image_keys)
-            if delta_image_keys
-            else {}
-        ),
+        # Stack each decoded image camera to one (n_seg, H, W, C) array so a batch
+        # can gather its windows by fancy-indexing with the (A, S) positions.
+        seg_images={
+            k: np.stack(v)
+            for k, v in (
+                _decode_image_frames(root, full, keys=delta_image_keys)
+                if delta_image_keys
+                else {}
+            ).items()
+        },
     )
 
 
@@ -936,14 +934,16 @@ def _build_delta_batch(
     def _targets_for(steps):
         cached = targets_cache.get(steps)
         if cached is None:
-            positions, pads = [], []
-            for p in anchors:
-                tgt, pad = _delta_targets(
-                    dseg.global_idx[p], dseg.row_from[p], dseg.row_to[p], list(steps)
-                )
-                positions.append([j - dseg.seg_lo for j in tgt])
-                pads.append(np.asarray(pad, dtype=bool))
-            cached = targets_cache[steps] = (positions, pads)
+            b0, b1 = batch_start, batch_start + batch.num_rows
+            clamped, pad = _delta_targets(
+                np.asarray(dseg.global_idx[b0:b1]),
+                np.asarray(dseg.row_from[b0:b1]),
+                np.asarray(dseg.row_to[b0:b1]),
+                steps,
+            )
+            # (A, S) row positions + pad mask; a clamped global index j is at row
+            # position j - seg_lo (the segment is contiguous).
+            cached = targets_cache[steps] = (clamped - dseg.seg_lo, pad)
         return cached
 
     # Decode all cameras up front, then assemble columns in schema order.
@@ -984,22 +984,22 @@ def _build_delta_batch(
         if name in image_set:
             if name in delta_steps:
                 positions, pad = _targets_for(tuple(delta_steps[name]))
-                src = dseg.seg_images[name]
+                # seg_images[name]: (n_seg, H, W, C); [positions] -> (A, S, H, W, C).
                 columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                    [np.stack([src[i] for i in pos], axis=0) for pos in positions]
+                    list(dseg.seg_images[name][positions])
                 )
-                pad_buffers[name] = pad
+                pad_buffers[name] = list(pad)
             else:
                 columns[name] = ArrowVariableShapedTensorArray.from_numpy(
                     nd_image_fb[name]
                 )
         elif name in delta_steps:
             positions, pad = _targets_for(tuple(delta_steps[name]))
-            base = dseg.tab_base[name]
+            # tab_base[name]: (n_seg, *shape); [positions] -> (A, S, *shape).
             columns[name] = ArrowVariableShapedTensorArray.from_numpy(
-                [base[pos] for pos in positions]
+                list(dseg.tab_base[name][positions])
             )
-            pad_buffers[name] = pad
+            pad_buffers[name] = list(pad)
         else:
             columns[name] = batch.column(name)
 
@@ -1060,8 +1060,11 @@ def _decode_video_delta(
         g, rf, rt = global_idx[p], row_from[p], row_to[p]
         chunk, fi, from_ts = ep_info[ep_col[p]]
         targets, pad = _delta_targets(g, rf, rt, steps)
-        for k, (j, _padded) in enumerate(zip(targets, pad)):
-            ts = from_ts + (j - rf) / fps
+        for k, j in enumerate(targets):
+            # int(j) keeps ts a Python float, so lerobot's torch.tensor(timestamps)
+            # is float32 and matches the decoder's loaded_ts (cdist needs one dtype);
+            # a numpy int64 here would make ts float64 and raise in cdist.
+            ts = from_ts + (int(j) - rf) / fps
             file_requests.setdefault((chunk, fi), []).append((a, k, ts))
         pads.append(np.asarray(pad, dtype=bool))
 

--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -110,6 +110,13 @@ class _LeRobotRoot(NamedTuple):
     """Max seconds a decoded video frame's timestamp may differ from a row's
     timestamp before it is rejected (passed to lerobot's ``decode_video_frames``)."""
 
+    delta_steps: Dict[str, List[int]]
+    """``delta_timestamps`` resolved to integer frame offsets per feature key
+    (``round(offset * fps)``). Empty means no temporal windows are requested.
+    When non-empty, each listed feature is gathered over these offsets -- clamped
+    to the anchor frame's episode -- into a leading time dimension, and a companion
+    boolean ``{key}_is_pad`` column flags the offsets that fell outside the episode."""
+
 
 class _ReadGranularity(str, enum.Enum):
     """How rows are grouped into base read tasks: one task per physical file
@@ -132,17 +139,23 @@ def _build_schema(
     image_keys: List[str],
     fs: "fsspec.AbstractFileSystem",
     fs_root: str,
+    delta_steps: Optional[Dict[str, List[int]]] = None,
 ) -> pa.Schema:
     """Read the Arrow schema of the first data parquet file and produce the
     output schema: in-parquet ``image`` columns (HF ``struct<bytes, path>``) are
     replaced by decoded uint8 tensor columns, ``video`` columns are appended as
-    decoded tensors, plus ``task``, ``dataset_index`` and ``stats``."""
+    decoded tensors, plus ``task``, ``dataset_index`` and ``stats``.
+
+    When ``delta_steps`` is given, each listed feature gains a leading time
+    dimension (cameras become 4-D ``(T, H, W, C)`` tensors, tabular features gain
+    one axis) and a boolean ``{key}_is_pad`` tensor column is appended for it."""
 
     # Note(Artur): Imported here rather than at module top so importing this module stays
     # docs-build-safe: an eager ``ray.data.extensions`` import pulls in pandas' tensor
     # extension, whose class body breaks under the docs build's mocked pandas.
     from ray.data.extensions import ArrowVariableShapedTensorType
 
+    delta = delta_steps or {}
     ep = episodes_table.slice(0, 1).to_pylist()[0]
     path = (
         f"{fs_root}/"
@@ -152,14 +165,27 @@ def _build_schema(
         pq_schema = pq.read_schema(f)
     image_set = set(image_keys)
     frame_type = ArrowVariableShapedTensorType(pa.uint8(), ndim=3)
+    delta_frame_type = ArrowVariableShapedTensorType(pa.uint8(), ndim=4)
+
+    def _field_for(f: pa.Field) -> pa.Field:
+        if f.name in image_set:
+            # Encoded-byte image struct -> decoded uint8 tensor (4-D if windowed).
+            return pa.field(f.name, delta_frame_type if f.name in delta else frame_type)
+        if f.name in delta:
+            # Tabular feature gains a leading time axis.
+            value_type, base_ndim = _delta_value_type_and_ndim(f.type)
+            return pa.field(
+                f.name,
+                ArrowVariableShapedTensorType(value_type, ndim=base_ndim + 1),
+            )
+        return f
+
     # Image columns live in the parquet as encoded-byte structs; swap them for
     # the decoded-tensor type in place (preserving column order).
-    fields = [
-        pa.field(f.name, frame_type) if f.name in image_set else f for f in pq_schema
-    ]
+    fields = [_field_for(f) for f in pq_schema]
     # Video columns are not in the parquet; append them.
     for vk in video_keys:
-        fields.append(pa.field(vk, frame_type))
+        fields.append(pa.field(vk, delta_frame_type if vk in delta else frame_type))
     # task + stats are per-dataset constants repeated on every row, so they are
     # dictionary-encoded (one shared value per block + an int32 index per row)
     # instead of duplicating the (multi-KB) stats JSON on each row.
@@ -167,6 +193,16 @@ def _build_schema(
     fields.append(pa.field("task", dict_str))
     fields.append(pa.field("dataset_index", pa.int32()))
     fields.append(pa.field("stats", dict_str))
+    # Per-delta-key pad masks, appended last in a fixed order (parquet columns in
+    # file order, then video keys) so the schema matches the emitted block layout.
+    if delta:
+        pad_type = ArrowVariableShapedTensorType(pa.bool_(), ndim=1)
+        for f in pq_schema:
+            if f.name in delta:
+                fields.append(pa.field(f"{f.name}_is_pad", pad_type))
+        for vk in video_keys:
+            if vk in delta:
+                fields.append(pa.field(f"{vk}_is_pad", pad_type))
     return pa.schema(fields)
 
 
@@ -227,6 +263,107 @@ def _non_camera_features(features: dict) -> Dict[str, tuple]:
         for k, v in features.items()
         if v.get("dtype") not in ("video", "image")
     }
+
+
+# Default frame-grid tolerance (seconds) for delta_timestamps offsets; matches
+# lerobot's ``LeRobotDataset(tolerance_s=1e-4)`` default. Overridable per read via
+# ``read_lerobot(delta_tolerance_s=...)``.
+_DEFAULT_DELTA_TOLERANCE_S = 1e-4
+
+
+def _convert_delta_timestamps(
+    delta_timestamps: Dict[str, List[float]],
+    fps: int,
+    feature_keys: set,
+    tolerance_s: float,
+) -> Dict[str, List[int]]:
+    """Validate ``delta_timestamps`` and convert its second offsets to integer
+    frame offsets, preserving order.
+
+    The frame-grid alignment check and the seconds->frames conversion are
+    delegated to lerobot (``check_delta_timestamps`` / ``get_delta_indices``) so
+    the semantics match ``lerobot.LeRobotDataset`` exactly. This adds the two
+    checks lerobot omits: each key must be a real feature, and no offset list may
+    be empty. Raises ``ValueError`` otherwise.
+    """
+    from lerobot.datasets.feature_utils import (
+        check_delta_timestamps,
+        get_delta_indices,
+    )
+
+    for key, offsets in delta_timestamps.items():
+        if key not in feature_keys:
+            raise ValueError(
+                f"delta_timestamps key {key!r} is not a feature of this dataset. "
+                f"Valid keys: {sorted(feature_keys)}."
+            )
+        if not offsets:
+            raise ValueError(
+                f"delta_timestamps[{key!r}] is empty; give at least one offset "
+                f"(in seconds), or drop the key."
+            )
+    # Raises ValueError listing any offset that is not a multiple of 1/fps within
+    # tolerance_s (each must map unambiguously to one frame).
+    check_delta_timestamps(delta_timestamps, fps, tolerance_s)
+    return get_delta_indices(delta_timestamps, fps)
+
+
+def _delta_value_type_and_ndim(pa_type: pa.DataType) -> Tuple[pa.DataType, int]:
+    """Value type and base ndim of a parquet column, for building its stacked
+    delta tensor type. A fixed/var-size list of scalars is a length-1 base
+    (``(dim,)``); a bare scalar is a length-0 base (``()``)."""
+    if (
+        pa.types.is_fixed_size_list(pa_type)
+        or pa.types.is_list(pa_type)
+        or (pa.types.is_large_list(pa_type))
+    ):
+        return pa_type.value_type, 1
+    return pa_type, 0
+
+
+def _column_to_numpy(col: pa.ChunkedArray) -> np.ndarray:
+    """Materialize a parquet column as a ``(n_rows, *base_shape)`` numpy array,
+    preserving the stored value dtype so stacked delta tensors match the schema.
+
+    Feature vectors have a uniform per-row length, so both fixed- and
+    variable-size list columns flatten to ``(n_rows, dim)`` via the value array
+    (which keeps e.g. float32, unlike ``to_pylist`` -> object -> float64)."""
+    chunked = col.combine_chunks() if isinstance(col, pa.ChunkedArray) else col
+    t = chunked.type
+    if (
+        pa.types.is_fixed_size_list(t)
+        or pa.types.is_list(t)
+        or pa.types.is_large_list(t)
+    ):
+        values = chunked.flatten().to_numpy(zero_copy_only=False)
+        return values.reshape(len(chunked), -1)
+    return chunked.to_numpy(zero_copy_only=False)
+
+
+def _delta_targets(
+    global_index: int, ep_from: int, ep_to: int, steps: List[int]
+) -> Tuple[List[int], List[bool]]:
+    """For an anchor at ``global_index`` in episode ``[ep_from, ep_to)``, resolve
+    each frame offset to a clamped in-episode global index and whether it was
+    padded (fell outside the episode).
+
+    Same clamp/pad rule as lerobot's ``DatasetReader._get_query_indices``, kept as
+    a standalone numpy-side helper because that method is bound to a torch-backed
+    reader object we don't build here."""
+    targets: List[int] = []
+    pad: List[bool] = []
+    for step in steps:
+        j = global_index + step
+        if j < ep_from:
+            targets.append(ep_from)
+            pad.append(True)
+        elif j >= ep_to:
+            targets.append(ep_to - 1)
+            pad.append(True)
+        else:
+            targets.append(j)
+            pad.append(False)
+    return targets, pad
 
 
 def _resolve_filesystem(
@@ -372,6 +509,8 @@ def _build_root(
     video_root_uri: str,
     video_storage_options: Dict[str, Any],
     frame_tolerance_s: Optional[float] = None,
+    delta_timestamps: Optional[Dict[str, List[float]]] = None,
+    delta_tolerance_s: float = _DEFAULT_DELTA_TOLERANCE_S,
 ) -> Tuple[_LeRobotRoot, pa.Table]:
     """Compute the per-root derived state bundle for a lerobot
     ``LeRobotDatasetMetadata`` instance.
@@ -393,6 +532,13 @@ def _build_root(
         frame_tolerance_s: Max seconds a decoded frame's timestamp may differ
             from a row's before the frame is rejected; ``None`` uses the
             ``0.5 / fps`` default.
+        delta_timestamps: Optional ``{feature_key: [offsets_in_seconds]}``
+            temporal-window request, validated against ``meta.features`` and
+            converted to per-key integer frame steps via ``meta.fps``; ``None``
+            disables windowing.
+        delta_tolerance_s: Frame-grid tolerance (seconds) for the
+            ``delta_timestamps`` offset check; forwarded to lerobot's
+            ``check_delta_timestamps``.
 
     Returns:
         A ``(root_bundle, episodes_table)`` tuple: the :class:`_LeRobotRoot`
@@ -444,8 +590,21 @@ def _build_root(
     tasks_dict = dict(
         zip(meta.tasks["task_index"].astype(int).tolist(), meta.tasks.index.tolist())
     )
+    delta_steps = (
+        _convert_delta_timestamps(
+            delta_timestamps, meta.fps, set(meta.features), delta_tolerance_s
+        )
+        if delta_timestamps
+        else {}
+    )
     schema = _build_schema(
-        episodes_table, meta.data_path, meta.video_keys, meta.image_keys, fs, fs_root
+        episodes_table,
+        meta.data_path,
+        meta.video_keys,
+        meta.image_keys,
+        fs,
+        fs_root,
+        delta_steps=delta_steps,
     )
     row_size_bytes = _estimated_row_size_bytes(meta.features)
     stats_json = _stats_to_json(meta.stats)
@@ -466,6 +625,7 @@ def _build_root(
         storage_options=video_storage_options,
         stats_json=stats_json,
         frame_tolerance_s=frame_tolerance_s,
+        delta_steps=delta_steps,
     )
     return root_bundle, episodes_table
 
@@ -475,6 +635,8 @@ def _resolve_root(
     filesystem: Optional["pyarrow.fs.FileSystem | fsspec.AbstractFileSystem"],
     storage_options: Dict[str, Any],
     frame_tolerance_s: Optional[float],
+    delta_timestamps: Optional[Dict[str, List[float]]] = None,
+    delta_tolerance_s: float = _DEFAULT_DELTA_TOLERANCE_S,
 ) -> Tuple[_LeRobotRoot, pa.Table, "LeRobotDatasetMetadata"]:
     """Resolve one root into its read-task bundle + per-episode table.
 
@@ -498,6 +660,8 @@ def _resolve_root(
         video_uri,
         video_opts,
         frame_tolerance_s=frame_tolerance_s,
+        delta_timestamps=delta_timestamps,
+        delta_tolerance_s=delta_tolerance_s,
     )
     return built_root, built_episodes, meta
 
@@ -589,6 +753,13 @@ def _read_lerobot_segment(
     this root's estimated row size (so each batch targets one output block),
     decoding each batch's camera frames on demand.
     """
+    if root.delta_steps:
+        # Temporal-window reads go through the episode-aligned delta path.
+        yield from _read_lerobot_segment_delta(
+            root, start, end, dataset_index, parquet_segs, ep_slice, max_block_bytes
+        )
+        return
+
     fs = root.fs
 
     # Read all parquet rows for this segment (predicate pushdown on index).
@@ -658,6 +829,311 @@ def _read_lerobot_segment(
             cache.clear()
 
 
+def _read_lerobot_segment_delta(
+    root: _LeRobotRoot,
+    start: int,
+    end: int,
+    dataset_index: int,
+    parquet_segs: List[str],
+    ep_slice: pa.Table,
+    max_block_bytes: int,
+) -> Iterator[pa.Table]:
+    """Stream decoded rows for one ``[start, end)`` range with temporal windows.
+
+    Like :func:`_read_lerobot_segment`, but every feature in ``root.delta_steps``
+    is gathered over its frame offsets -- clamped to the anchor frame's episode --
+    into a leading time dimension, and a boolean ``{key}_is_pad`` column is emitted
+    for it. Requires whole-episode segments (guaranteed by the ``get_read_tasks``
+    delta guard) so all neighbour rows lie within this segment's parquet read.
+    """
+    from ray.data.extensions import ArrowVariableShapedTensorArray
+
+    fs = root.fs
+    filters = [("index", ">=", start), ("index", "<", end)]
+    pq_tables = []
+    for path in parquet_segs:
+        with fs.open(path, "rb") as f:
+            pq_tables.append(pq.read_table(f, filters=filters))
+    full = pa.concat_tables(pq_tables) if pq_tables else None
+    if full is None or full.num_rows == 0:
+        return
+    n_rows = full.num_rows
+
+    # Global frame index -> row position within this (contiguous, whole-episode)
+    # segment, so every clamped neighbour resolves to a loaded row.
+    global_idx = full.column("index").to_pylist()
+    pos_of_global = {g: p for p, g in enumerate(global_idx)}
+    ep_col = full.column("episode_index").to_pylist()
+
+    # Per-episode [from, to) bounds for clamping, expanded to per-row arrays.
+    ep_from = dict(
+        zip(
+            ep_slice.column("episode_index").to_pylist(),
+            ep_slice.column("_global_from_index").to_pylist(),
+        )
+    )
+    ep_to = dict(
+        zip(
+            ep_slice.column("episode_index").to_pylist(),
+            ep_slice.column("_global_to_index").to_pylist(),
+        )
+    )
+    row_from = [ep_from[e] for e in ep_col]
+    row_to = [ep_to[e] for e in ep_col]
+
+    # Safety net: the delta path assumes whole-episode segments (see the
+    # get_read_tasks guard). If an episode were split, some clamped neighbour
+    # would fall outside this segment and KeyError below; fail loudly instead.
+    seg_lo, seg_hi = global_idx[0], global_idx[-1] + 1
+    if min(row_from) < seg_lo or max(row_to) > seg_hi:
+        raise RuntimeError(
+            "delta_timestamps requires whole-episode read segments, but this "
+            "segment splits an episode -- an internal invariant violation "
+            "(get_read_tasks caps parallelism when delta_timestamps is set)."
+        )
+
+    task_idx_pylist = full.column("task_index").to_pylist()
+    missing_tasks = {ti for ti in task_idx_pylist if ti not in root.tasks_dict}
+    if missing_tasks:
+        raise ValueError(
+            f"task_index values {sorted(missing_tasks)} are absent from the "
+            f"dataset's tasks metadata (meta/tasks.parquet); the data and "
+            f"tasks metadata are inconsistent."
+        )
+
+    delta_steps = root.delta_steps
+    image_set = set(root.image_keys)
+    delta_image_keys = [ik for ik in root.image_keys if ik in delta_steps]
+    nondelta_image_keys = [ik for ik in root.image_keys if ik not in delta_steps]
+    delta_video_keys = [vk for vk in root.video_keys if vk in delta_steps]
+    nondelta_video_keys = [vk for vk in root.video_keys if vk not in delta_steps]
+    delta_tabular_keys = [
+        name
+        for name in full.column_names
+        if name in delta_steps and name not in image_set
+    ]
+    # Pad-mask columns are appended last, in the schema's fixed order: parquet
+    # columns (in file order), then video keys.
+    pad_order = [name for name in full.column_names if name in delta_steps] + [
+        vk for vk in root.video_keys if vk in delta_steps
+    ]
+
+    if root.video_keys:
+        video_meta = _video_episode_meta(ep_slice, root.video_keys)
+        cache = new_decoder_cache(root.storage_options)
+        tolerance_s = (
+            root.frame_tolerance_s
+            if root.frame_tolerance_s is not None
+            else 0.5 / float(root.fps)
+        )
+    else:
+        video_meta = {}
+        cache = None
+        tolerance_s = None
+
+    # Segment-level buffers reused across batches for gathers whose neighbours may
+    # cross batch boundaries: tabular columns (cheap) and decoded delta images.
+    tab_base = {
+        name: _column_to_numpy(full.column(name)) for name in delta_tabular_keys
+    }
+    seg_images = (
+        _decode_image_frames(root, full, keys=delta_image_keys)
+        if delta_image_keys
+        else {}
+    )
+
+    def _gather_from_positions(source, positions):
+        return np.stack([source[i] for i in positions], axis=0)
+
+    # Each output row now carries up to ``max_T`` frames, so shrink the batch by
+    # the widest window to keep block sizes near the target.
+    max_t = max(len(s) for s in delta_steps.values())
+    rows_per_batch = max(1, (max_block_bytes // root.row_size_bytes) // max_t)
+    try:
+        for batch_start in range(0, n_rows, rows_per_batch):
+            batch_end = min(batch_start + rows_per_batch, n_rows)
+            batch = full.slice(batch_start, batch_end - batch_start)
+            anchors = list(range(batch_start, batch_end))
+
+            # Per-anchor clamped target positions + pad masks, computed once per
+            # distinct step list and reused across the keys that share it.
+            targets_cache: Dict[tuple, tuple] = {}
+
+            def _targets_for(step_key):
+                cached = targets_cache.get(step_key)
+                if cached is not None:
+                    return cached
+                positions_per_anchor = []
+                pad_per_anchor = []
+                steps = list(step_key)
+                for p in anchors:
+                    tgt, pad = _delta_targets(
+                        global_idx[p], row_from[p], row_to[p], steps
+                    )
+                    positions_per_anchor.append([pos_of_global[j] for j in tgt])
+                    pad_per_anchor.append(np.asarray(pad, dtype=bool))
+                targets_cache[step_key] = (positions_per_anchor, pad_per_anchor)
+                return targets_cache[step_key]
+
+            columns: dict = {}
+            pad_buffers: dict = {}
+
+            # Non-delta cameras: one frame per row (unchanged behaviour).
+            nd_video_fb = (
+                _decode_video_batch(
+                    root,
+                    batch,
+                    video_meta,
+                    tolerance_s,
+                    cache,
+                    keys=nondelta_video_keys,
+                )
+                if nondelta_video_keys
+                else {}
+            )
+            nd_image_fb = (
+                _decode_image_frames(root, batch, keys=nondelta_image_keys)
+                if nondelta_image_keys
+                else {}
+            )
+
+            # Delta video: T frames per anchor from the shared decoder cache.
+            for vk in delta_video_keys:
+                frames, pads = _decode_video_delta(
+                    root,
+                    anchors,
+                    global_idx,
+                    row_from,
+                    row_to,
+                    ep_col,
+                    video_meta,
+                    vk,
+                    delta_steps[vk],
+                    tolerance_s,
+                    cache,
+                )
+                columns[vk] = ArrowVariableShapedTensorArray.from_numpy(frames)
+                pad_buffers[vk] = pads
+
+            # Parquet columns, in file order.
+            for name in full.column_names:
+                if name in image_set:
+                    if name in delta_steps:
+                        positions_per_anchor, pad_per_anchor = _targets_for(
+                            tuple(delta_steps[name])
+                        )
+                        src = seg_images[name]
+                        stacked = [
+                            _gather_from_positions(src, positions)
+                            for positions in positions_per_anchor
+                        ]
+                        columns[name] = ArrowVariableShapedTensorArray.from_numpy(
+                            stacked
+                        )
+                        pad_buffers[name] = pad_per_anchor
+                    else:
+                        columns[name] = ArrowVariableShapedTensorArray.from_numpy(
+                            nd_image_fb[name]
+                        )
+                elif name in delta_steps:
+                    positions_per_anchor, pad_per_anchor = _targets_for(
+                        tuple(delta_steps[name])
+                    )
+                    base = tab_base[name]
+                    stacked = [base[positions] for positions in positions_per_anchor]
+                    columns[name] = ArrowVariableShapedTensorArray.from_numpy(stacked)
+                    pad_buffers[name] = pad_per_anchor
+                else:
+                    columns[name] = batch.column(name)
+
+            # Non-parquet video columns, appended after the parquet columns.
+            for vk in nondelta_video_keys:
+                columns[vk] = ArrowVariableShapedTensorArray.from_numpy(nd_video_fb[vk])
+
+            task_list = [root.tasks_dict[task_idx_pylist[p]] for p in anchors]
+            columns["task"] = pa.array(task_list, type=pa.string()).dictionary_encode()
+            columns["dataset_index"] = pa.array(
+                [dataset_index] * len(anchors), type=pa.int32()
+            )
+            columns["stats"] = pa.array(
+                [root.stats_json] * len(anchors), type=pa.string()
+            ).dictionary_encode()
+
+            # Pad masks last, in the schema's fixed order.
+            for name in pad_order:
+                columns[f"{name}_is_pad"] = ArrowVariableShapedTensorArray.from_numpy(
+                    pad_buffers[name]
+                )
+
+            yield pa.table(columns)
+    finally:
+        if cache is not None:
+            cache.clear()
+
+
+def _decode_video_delta(
+    root: _LeRobotRoot,
+    anchors: List[int],
+    global_idx: List[int],
+    row_from: List[int],
+    row_to: List[int],
+    ep_col: List[int],
+    video_meta: dict,
+    vk: str,
+    steps: List[int],
+    tolerance_s: float,
+    cache: Any,
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Decode a temporal window of video frames per anchor for one video key.
+
+    For each anchor, resolves the ``steps`` offsets to in-episode timestamps
+    (clamping at the episode bounds), decodes them from the shared per-segment
+    decoder ``cache`` (grouping requests per file so each decoder is hit once),
+    and returns ``([per-anchor (T, H, W, C) uint8], [per-anchor (T,) bool pad])``.
+    """
+    from lerobot.datasets.video_utils import decode_video_frames_torchcodec
+
+    assert root.video_path is not None
+    fps = float(root.fps)
+    ep_info = video_meta[vk]
+    n_steps = len(steps)
+
+    pads: List[np.ndarray] = []
+    # (chunk, file_index) -> list of (anchor_slot, step_slot, timestamp)
+    file_requests: Dict[tuple, list] = {}
+    for a, p in enumerate(anchors):
+        g, rf, rt = global_idx[p], row_from[p], row_to[p]
+        chunk, fi, from_ts = ep_info[ep_col[p]]
+        targets, pad = _delta_targets(g, rf, rt, steps)
+        for k, (j, _padded) in enumerate(zip(targets, pad)):
+            ts = from_ts + (j - rf) / fps
+            file_requests.setdefault((chunk, fi), []).append((a, k, ts))
+        pads.append(np.asarray(pad, dtype=bool))
+
+    # (T, H, W, C) accumulator per anchor, filled slot by slot as files decode.
+    frames_per_anchor: List[List[Any]] = [[None] * n_steps for _ in anchors]
+    for (chunk, fi), reqs in file_requests.items():
+        vpath = (
+            f"{root.root}/"
+            f"{root.video_path.format(video_key=vk, chunk_index=chunk, file_index=fi)}"
+        )
+        timestamps = [ts for _, _, ts in reqs]
+        frames = decode_video_frames_torchcodec(
+            vpath, timestamps, tolerance_s, decoder_cache=cache
+        )
+        arr = frames.permute(0, 2, 3, 1).contiguous().cpu().numpy()
+        if arr.dtype != np.uint8:
+            if arr.dtype.kind == "f":
+                arr = (arr * 255.0).round().clip(0, 255).astype(np.uint8)
+            else:
+                arr = arr.astype(np.uint8)
+        for out_i, (a, k, _ts) in enumerate(reqs):
+            frames_per_anchor[a][k] = arr[out_i]
+
+    stacked = [np.stack(slots, axis=0) for slots in frames_per_anchor]
+    return stacked, pads
+
+
 def _video_episode_meta(episodes: pa.Table, video_keys: List[str]) -> dict:
     eps = episodes
     ep_idx = eps.column("episode_index").to_pylist()
@@ -678,6 +1154,7 @@ def _decode_video_batch(
     video_meta: dict,
     tolerance_s: float,
     cache: Any,
+    keys: Optional[List[str]] = None,
 ) -> dict:
     """Decode one batch's video frames to HWC uint8 arrays aligned to the
     batch's row order.
@@ -685,7 +1162,8 @@ def _decode_video_batch(
     Groups rows by video file and decodes each file's timestamps from the
     shared (per-segment) decoder ``cache``, so a file's decoder is reused
     across batches instead of being reopened. Returns
-    ``{video_key: list[np.ndarray HWC uint8]}``.
+    ``{video_key: list[np.ndarray HWC uint8]}``. ``keys`` restricts decoding to a
+    subset of ``root.video_keys`` (used by the delta path to skip windowed keys).
     """
     # Imported here, not at module top, so ``import ray.data`` stays
     # lerobot-free until video is actually decoded on a worker.
@@ -696,7 +1174,7 @@ def _decode_video_batch(
     ep_idx_col = batch.column("episode_index").to_pylist()
     ts_col = batch.column("timestamp").to_pylist()
     out: dict = {}
-    for vk in root.video_keys:
+    for vk in keys if keys is not None else root.video_keys:
         ep_info = video_meta[vk]
         file_to_rows: dict = {}
         for r in range(n):
@@ -734,14 +1212,17 @@ def _decode_video_batch(
     return out
 
 
-def _decode_image_frames(root: _LeRobotRoot, full: pa.Table) -> dict:
+def _decode_image_frames(
+    root: _LeRobotRoot, full: pa.Table, keys: Optional[List[str]] = None
+) -> dict:
     """Decode in-parquet image cameras to HWC uint8 frames, one per row.
 
     LeRobot stores ``dtype == 'image'`` cameras as HuggingFace ``Image``
     structs (``{bytes, path}``) inside the data parquet — so, unlike video,
     there is no separate file or timestamp matching: each row already holds
     its own encoded frame. Returns ``{image_key: list[np.ndarray HWC uint8]}``
-    aligned to ``full``'s row order.
+    aligned to ``full``'s row order. ``keys`` restricts decoding to a subset of
+    ``root.image_keys`` (used by the delta path to skip windowed keys).
     """
 
     import io
@@ -749,7 +1230,7 @@ def _decode_image_frames(root: _LeRobotRoot, full: pa.Table) -> dict:
     from PIL import Image
 
     decoded: dict = {}
-    for ik in root.image_keys:
+    for ik in keys if keys is not None else root.image_keys:
         frames: List[Any] = []
         for cell in full.column(ik).to_pylist():
             data = cell.get("bytes") if isinstance(cell, dict) else cell
@@ -888,6 +1369,8 @@ class LeRobotDatasource(Datasource):
         ] = None,
         storage_options: Optional[Dict[str, Any]] = None,
         frame_tolerance_s: Optional[float] = None,
+        delta_timestamps: Optional[Dict[str, List[float]]] = None,
+        delta_tolerance_s: float = _DEFAULT_DELTA_TOLERANCE_S,
     ):
         """Initialize LeRobot datasource.
 
@@ -923,9 +1406,21 @@ class LeRobotDatasource(Datasource):
                 (the default) uses ``0.5 / fps`` — half a frame interval, e.g.
                 ~0.05s at 10fps. Increase to tolerate timestamp jitter; decrease
                 for stricter alignment.
+            delta_timestamps: Optional ``{feature_key: [offsets_in_seconds]}``. For
+                each frame the listed feature is returned stacked over the offsets
+                (a new leading time dimension) plus a boolean ``{key}_is_pad``
+                column. Offsets are converted to frame steps via the dataset
+                ``fps`` and clamped to the anchor frame's episode; out-of-range
+                offsets are flagged in the pad mask. Setting this forces
+                **episode-aligned** reads (see :func:`ray.data.read_lerobot`).
+            delta_tolerance_s: Frame-grid tolerance (seconds) for
+                ``delta_timestamps`` offsets; an offset must be a multiple of
+                ``1 / fps`` within this tolerance. Defaults to ``1e-4`` (lerobot's
+                ``LeRobotDataset`` default).
         Raises:
-            ValueError: If ``frame_tolerance_s`` is non-positive, or if roots
-                have incompatible schemas.
+            ValueError: If ``frame_tolerance_s`` is non-positive, if a
+                ``delta_timestamps`` key is not a feature or an offset does not
+                align to the frame grid, or if roots have incompatible schemas.
         """
         super().__init__()
 
@@ -943,6 +1438,9 @@ class LeRobotDatasource(Datasource):
                 f"got {frame_tolerance_s!r}."
             )
         self._frame_tolerance_s: Optional[float] = frame_tolerance_s
+        # Validated + converted to per-root integer frame steps in ``_build_root``.
+        self._delta_timestamps: Optional[Dict[str, List[float]]] = delta_timestamps
+        self._delta_tolerance_s: float = delta_tolerance_s
 
         try:
             self._read_granularity = _ReadGranularity(read_granularity)
@@ -966,7 +1464,12 @@ class LeRobotDatasource(Datasource):
         self.original_metas: List["LeRobotDatasetMetadata"] = []
         for r in roots:
             built_root, built_episodes, meta = _resolve_root(
-                r, filesystem, self._storage_options, self._frame_tolerance_s
+                r,
+                filesystem,
+                self._storage_options,
+                self._frame_tolerance_s,
+                delta_timestamps=self._delta_timestamps,
+                delta_tolerance_s=self._delta_tolerance_s,
             )
             self.distilled_metas.append(built_root)
             self._episodes.append(built_episodes)
@@ -1242,6 +1745,14 @@ class LeRobotDatasource(Datasource):
         data_context: Optional[DataContext] = None,
     ) -> List[ReadTask]:
         row_ranges = self._slice()
+
+        # delta_timestamps gathers a temporal window per frame, clamped to the
+        # anchor's episode. That requires whole-episode read segments, so never
+        # split below the base (episode / file-group) ranges: cap parallelism at
+        # the base range count. See _read_lerobot_segment_delta and the note in
+        # ``read_lerobot``'s docstring for the parallelism trade-off.
+        if self._delta_timestamps and parallelism > len(row_ranges):
+            parallelism = len(row_ranges)
 
         groups: List[list]
         if parallelism > 0 and parallelism > len(row_ranges):

--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -49,12 +49,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Default frame-grid tolerance (seconds) for delta_timestamps offsets; matches
-# lerobot's ``LeRobotDataset(tolerance_s=1e-4)`` default. Overridable per read via
-# ``read_lerobot(delta_tolerance_s=...)``.
-_DEFAULT_DELTA_TOLERANCE_S = 1e-4
-
-
 class _LeRobotRoot(NamedTuple):
     """Per-root derived state for the LeRobot datasource built on the driver."""
 
@@ -443,7 +437,8 @@ def _build_root(
     video_storage_options: Dict[str, Any],
     frame_tolerance_s: Optional[float] = None,
     delta_timestamps: Optional[Dict[str, List[float]]] = None,
-    delta_tolerance_s: float = _DEFAULT_DELTA_TOLERANCE_S,
+    *,
+    delta_tolerance_s: float,
 ) -> Tuple[_LeRobotRoot, pa.Table]:
     """Compute the per-root derived state bundle for a lerobot
     ``LeRobotDatasetMetadata`` instance.
@@ -579,7 +574,8 @@ def _resolve_root(
     storage_options: Dict[str, Any],
     frame_tolerance_s: Optional[float],
     delta_timestamps: Optional[Dict[str, List[float]]] = None,
-    delta_tolerance_s: float = _DEFAULT_DELTA_TOLERANCE_S,
+    *,
+    delta_tolerance_s: float,
 ) -> Tuple[_LeRobotRoot, pa.Table, "LeRobotDatasetMetadata"]:
     """Resolve one root into its read-task bundle + per-episode table.
 
@@ -1353,7 +1349,7 @@ class LeRobotDatasource(Datasource):
         storage_options: Optional[Dict[str, Any]] = None,
         frame_tolerance_s: Optional[float] = None,
         delta_timestamps: Optional[Dict[str, List[float]]] = None,
-        delta_tolerance_s: float = _DEFAULT_DELTA_TOLERANCE_S,
+        delta_tolerance_s: float = 1e-4,
     ):
         """Initialize LeRobot datasource.
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2936,7 +2936,7 @@ def read_lerobot(
                a larger value raises ``ValueError``. Leaving it unset reads one
                task per episode / file group.
         delta_tolerance_s: Frame-grid tolerance in seconds for ``delta_timestamps``
-            offsets -- each offset must be a multiple of ``1 / fps`` within this
+            offsets. Each offset must be a multiple of ``1 / fps`` within this
             tolerance. Defaults to ``1e-4`` (matching lerobot's ``LeRobotDataset``).
             Ignored when ``delta_timestamps`` is ``None``.
         storage_options: fsspec storage options (e.g. credentials or a custom

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2918,10 +2918,10 @@ def read_lerobot(
             requesting a temporal window per frame. For each frame, the listed
             feature is returned stacked over the offsets -- a new leading time
             dimension (e.g. a camera frame becomes ``(T, H, W, C)``, an ``action``
-            vector becomes ``(T, action_dim)``) -- plus a boolean ``{key}_is_pad``
+            vector becomes ``(T, action_dim)``) and a boolean ``{key}_is_pad``
             column of shape ``(T,)``. Offsets are converted to frame steps via the
             dataset ``fps`` (each must align to the frame grid, i.e. be a multiple
-            of ``1 / fps``) and **clamped to the anchor frame's episode**: an
+            of ``1 / fps``) and clamped to the anchor frame's episode: an
             offset falling before the episode's first frame or after its last
             returns the nearest in-episode frame and sets ``is_pad`` ``True`` for
             that slot. Features not listed keep their single-frame output. ``None``
@@ -2930,13 +2930,11 @@ def read_lerobot(
             .. note::
                When ``delta_timestamps`` is set, reads are **episode-aligned**:
                each read task always covers whole episodes, so
-               ``override_num_blocks`` cannot split an episode across tasks and
-               parallelism is capped at the number of episodes (with
-               ``read_granularity="episode"``) or file groups (with ``"file"``).
-               A dataset that is a single very long episode therefore reads on one
-               task. This keeps temporal-window gathering local and correct;
-               splitting within an episode (reading a neighbour "halo") may be
-               added later.
+               ``override_num_blocks`` cannot split an episode across tasks. It
+               must not exceed the number of episodes (with
+               ``read_granularity="episode"``) or file groups (with ``"file"``) --
+               a larger value raises ``ValueError``. Leaving it unset reads one
+               task per episode / file group.
         delta_tolerance_s: Frame-grid tolerance in seconds for ``delta_timestamps``
             offsets -- each offset must be a multiple of ``1 / fps`` within this
             tolerance. Defaults to ``1e-4`` (matching lerobot's ``LeRobotDataset``).

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2814,6 +2814,8 @@ def read_lerobot(
         "pyarrow.fs.FileSystem | fsspec.spec.AbstractFileSystem"
     ] = None,
     frame_tolerance_s: Optional[float] = None,
+    delta_timestamps: Optional[Dict[str, List[float]]] = None,
+    delta_tolerance_s: float = 1e-4,
     storage_options: Optional[Dict[str, Any]] = None,
     num_cpus: Optional[float] = None,
     num_gpus: Optional[float] = None,
@@ -2865,6 +2867,18 @@ def read_lerobot(
         ...     ["/path/to/ds1", "/path/to/ds2"],
         ... )
 
+        Return a temporal window per frame -- here the last 3 image frames and the
+        next 2 actions, each stacked along a new leading time axis with a
+        companion ``*_is_pad`` mask:
+
+        >>> ds = ray.data.read_lerobot(  # doctest: +SKIP
+        ...     "s3://anonymous@ray-example-data/lerobot/libero-mini",
+        ...     delta_timestamps={
+        ...         "observation.images.image": [-0.2, -0.1, 0.0],
+        ...         "action": [0.0, 0.1],
+        ...     },
+        ... )
+
     Args:
         root: Path or URI to the dataset root (local, ``gs://``, ``s3://``),
             or a list of such paths to read multiple datasets as one.
@@ -2900,6 +2914,33 @@ def read_lerobot(
             default) uses ``0.5 / fps`` — half a frame interval, e.g. ~0.05s at
             10fps. Increase to tolerate timestamp jitter; decrease for stricter
             alignment.
+        delta_timestamps: Optional ``{feature_key: [offsets_in_seconds]}`` mapping
+            requesting a temporal window per frame. For each frame, the listed
+            feature is returned stacked over the offsets -- a new leading time
+            dimension (e.g. a camera frame becomes ``(T, H, W, C)``, an ``action``
+            vector becomes ``(T, action_dim)``) -- plus a boolean ``{key}_is_pad``
+            column of shape ``(T,)``. Offsets are converted to frame steps via the
+            dataset ``fps`` (each must align to the frame grid, i.e. be a multiple
+            of ``1 / fps``) and **clamped to the anchor frame's episode**: an
+            offset falling before the episode's first frame or after its last
+            returns the nearest in-episode frame and sets ``is_pad`` ``True`` for
+            that slot. Features not listed keep their single-frame output. ``None``
+            (the default) disables temporal windows.
+
+            .. note::
+               When ``delta_timestamps`` is set, reads are **episode-aligned**:
+               each read task always covers whole episodes, so
+               ``override_num_blocks`` cannot split an episode across tasks and
+               parallelism is capped at the number of episodes (with
+               ``read_granularity="episode"``) or file groups (with ``"file"``).
+               A dataset that is a single very long episode therefore reads on one
+               task. This keeps temporal-window gathering local and correct;
+               splitting within an episode (reading a neighbour "halo") may be
+               added later.
+        delta_tolerance_s: Frame-grid tolerance in seconds for ``delta_timestamps``
+            offsets -- each offset must be a multiple of ``1 / fps`` within this
+            tolerance. Defaults to ``1e-4`` (matching lerobot's ``LeRobotDataset``).
+            Ignored when ``delta_timestamps`` is ``None``.
         storage_options: fsspec storage options (e.g. credentials or a custom
             ``endpoint_url``). They supply the credentials for the by-URI video
             decode path -- videos are streamed directly through torchcodec /
@@ -2942,6 +2983,8 @@ def read_lerobot(
         filesystem=filesystem,
         storage_options=storage_options,
         frame_tolerance_s=frame_tolerance_s,
+        delta_timestamps=delta_timestamps,
+        delta_tolerance_s=delta_tolerance_s,
     )
     if override_num_blocks is None:
         # Default to one read task per video-file group. Ray's generic

--- a/python/ray/data/tests/datasource/test_lerobot.py
+++ b/python/ray/data/tests/datasource/test_lerobot.py
@@ -1210,18 +1210,20 @@ def test_delta_tolerance_s_configurable(
 def test_delta_targets_clamps_to_episode():
     from ray.data._internal.datasource.lerobot_datasource import _delta_targets
 
-    # Episode [10, 15): a look-back at the first frame is clamped + padded.
-    assert _delta_targets(10, 10, 15, [-1, 0, 1]) == (
-        [10, 10, 11],
-        [True, False, False],
+    # Episode [10, 15). Scalar anchor -> (S,) arrays.
+    tgt, pad = _delta_targets(10, 10, 15, [-1, 0, 1])  # look-back clamps + pads
+    assert list(tgt) == [10, 10, 11] and list(pad) == [True, False, False]
+    tgt, pad = _delta_targets(14, 10, 15, [0, 1, 2])  # look-ahead clamps + pads
+    assert list(tgt) == [14, 14, 14] and list(pad) == [False, True, True]
+    tgt, pad = _delta_targets(12, 10, 15, [-1, 0, 1])  # interior, no pad
+    assert list(tgt) == [11, 12, 13] and list(pad) == [False, False, False]
+
+    # Vectorized over anchors: (A,) anchors + (S,) steps -> (A, S).
+    tgt, pad = _delta_targets(
+        np.array([10, 14]), np.array([10, 10]), np.array([15, 15]), [-1, 0, 1]
     )
-    # A look-ahead at the last frame is clamped + padded.
-    assert _delta_targets(14, 10, 15, [0, 1, 2]) == ([14, 14, 14], [False, True, True])
-    # Fully interior: no padding.
-    assert _delta_targets(12, 10, 15, [-1, 0, 1]) == (
-        [11, 12, 13],
-        [False, False, False],
-    )
+    assert tgt.tolist() == [[10, 10, 11], [13, 14, 14]]
+    assert pad.tolist() == [[True, False, False], [False, False, True]]
 
 
 def test_build_schema_delta_adds_pad_columns(lerobot_dataset_no_video):

--- a/python/ray/data/tests/datasource/test_lerobot.py
+++ b/python/ray/data/tests/datasource/test_lerobot.py
@@ -1182,6 +1182,215 @@ def test_read_lerobot_episodes_multi_root(ray_start_regular_shared, tmp_path):
     assert {r["dataset_index"] for r in rows} == {0, 1}
 
 
+# ---------------------------------------------------------------------------
+# delta_timestamps (temporal windows, episode-aligned)
+# ---------------------------------------------------------------------------
+
+
+def test_convert_delta_timestamps_and_validation():
+    from ray.data._internal.datasource.lerobot_datasource import (
+        _convert_delta_timestamps,
+    )
+
+    keys = {"action", "state", "observation.image"}
+    tol = 1e-4
+    assert _convert_delta_timestamps(
+        {"action": [-0.2, -0.1, 0.0, 0.1]}, 10, keys, tol
+    ) == {"action": [-2, -1, 0, 1]}
+    with pytest.raises(ValueError, match="not a feature"):
+        _convert_delta_timestamps({"nope": [0.0]}, 10, keys, tol)
+    with pytest.raises(ValueError, match="tolerance"):  # lerobot's grid check
+        _convert_delta_timestamps({"action": [0.05]}, 10, keys, tol)  # 0.5 of a frame
+    with pytest.raises(ValueError, match="empty"):
+        _convert_delta_timestamps({"action": []}, 10, keys, tol)
+
+
+def test_delta_tolerance_s_configurable(
+    ray_start_regular_shared, lerobot_dataset_no_video
+):
+    """delta_tolerance_s widens/narrows the frame-grid check: an off-grid offset
+    rejected at the tight default is accepted (and rounded) at a looser value."""
+    from ray.data._internal.datasource.lerobot_datasource import (
+        _convert_delta_timestamps,
+    )
+
+    # 0.14s @ 10fps = 1.4 frames -> off-grid by 0.04s.
+    with pytest.raises(ValueError, match="tolerance"):
+        _convert_delta_timestamps({"action": [0.14]}, 10, {"action"}, 1e-4)
+    assert _convert_delta_timestamps({"action": [0.14]}, 10, {"action"}, 0.05) == {
+        "action": [1]
+    }
+    # The looser tolerance flows through read_lerobot end-to-end.
+    ds = ray.data.read_lerobot(
+        lerobot_dataset_no_video,
+        delta_timestamps={"action": [0.14]},
+        delta_tolerance_s=0.05,
+    )
+    assert np.asarray(ds.take(1)[0]["action"]).shape == (1, 2)
+
+
+def test_delta_targets_clamps_to_episode():
+    from ray.data._internal.datasource.lerobot_datasource import _delta_targets
+
+    # Episode [10, 15): a look-back at the first frame is clamped + padded.
+    assert _delta_targets(10, 10, 15, [-1, 0, 1]) == (
+        [10, 10, 11],
+        [True, False, False],
+    )
+    # A look-ahead at the last frame is clamped + padded.
+    assert _delta_targets(14, 10, 15, [0, 1, 2]) == ([14, 14, 14], [False, True, True])
+    # Fully interior: no padding.
+    assert _delta_targets(12, 10, 15, [-1, 0, 1]) == (
+        [11, 12, 13],
+        [False, False, False],
+    )
+
+
+def test_build_schema_delta_adds_pad_columns(lerobot_dataset_no_video):
+    from ray.data.datasource import LeRobotDatasource
+
+    src = LeRobotDatasource(
+        lerobot_dataset_no_video,
+        delta_timestamps={"action": [0.0, 0.1], "state": [-0.1, 0.0]},
+    )
+    names = src.distilled_metas[0].schema.names
+    assert "action_is_pad" in names and "state_is_pad" in names
+    # A non-windowed feature gets no pad mask.
+    assert "timestamp_is_pad" not in names
+
+
+def test_read_lerobot_delta_tabular(ray_start_regular_shared, lerobot_dataset_no_video):
+    """Tabular windows: ``action`` gathers [t, t+1] and ``state`` gathers
+    [t-1, t], each clamped to the anchor's episode with an is_pad mask."""
+    rows = ray.data.read_lerobot(
+        lerobot_dataset_no_video,
+        delta_timestamps={"action": [0.0, 0.1], "state": [-0.1, 0.0]},
+    ).take_all()
+    assert len(rows) == 15  # 3 episodes * 5 frames, row count unchanged
+
+    for row in rows:
+        i = row["index"]
+        ep_from, ep_to = (i // 5) * 5, (i // 5) * 5 + 5
+        action = np.asarray(row["action"])
+        state = np.asarray(row["state"])
+        action_pad = np.asarray(row["action_is_pad"])
+        state_pad = np.asarray(row["state_is_pad"])
+        assert action.shape == (2, 2) and state.shape == (2, 2)  # (T, dim)
+        assert action_pad.shape == (2,) and action_pad.dtype == bool
+
+        # Fixture: action[i] == [i, i+1]; window is [t, t+1] clamped to episode.
+        j_next = min(i + 1, ep_to - 1)
+        np.testing.assert_array_equal(action[0], [i, i + 1])
+        np.testing.assert_array_equal(action[1], [j_next, j_next + 1])
+        assert list(action_pad) == [False, i + 1 >= ep_to]
+
+        # Fixture: state[i] == [i*0.1, i*0.2]; window is [t-1, t] clamped.
+        j_prev = max(i - 1, ep_from)
+        np.testing.assert_allclose(state[0], [j_prev * 0.1, j_prev * 0.2], rtol=1e-6)
+        np.testing.assert_allclose(state[1], [i * 0.1, i * 0.2], rtol=1e-6)
+        assert list(state_pad) == [i - 1 < ep_from, False]
+
+
+def test_read_lerobot_delta_video(ray_start_regular_shared, lerobot_dataset):
+    """Video windows decode T frames per row into a (T, H, W, C) tensor with an
+    is_pad mask; at an episode boundary the clamped slot repeats the edge frame."""
+    rows = ray.data.read_lerobot(
+        lerobot_dataset,
+        delta_timestamps={"observation.image": [-0.1, 0.0, 0.1]},
+    ).take_all()
+    assert len(rows) == 15
+
+    for row in rows:
+        frames = np.asarray(row["observation.image"])
+        pad = np.asarray(row["observation.image_is_pad"])
+        assert frames.shape == (3, FRAME_H, FRAME_W, FRAME_C)
+        assert frames.dtype == np.uint8
+        assert pad.shape == (3,) and pad.dtype == bool
+
+        fr = row["index"] % 5  # within-episode frame index
+        # steps [-1, 0, 1]: look-back pads at frame 0, look-ahead pads at frame 4.
+        assert list(pad) == [fr == 0, False, fr == 4]
+        # A clamped slot repeats the anchor frame (same decoded timestamp).
+        if fr == 0:
+            np.testing.assert_array_equal(frames[0], frames[1])
+        if fr == 4:
+            np.testing.assert_array_equal(frames[2], frames[1])
+
+
+def test_read_lerobot_delta_image(ray_start_regular_shared, lerobot_dataset_image):
+    """Image-camera windows gather T decoded frames per row (lossless PNG), so
+    exact pixel values and episode clamping are assertable. Fixture encodes row
+    ``index`` i as a solid ``i % 256`` frame."""
+    rows = ray.data.read_lerobot(
+        lerobot_dataset_image,
+        delta_timestamps={"observation.image": [0.0, 0.1]},
+    ).take_all()
+    assert len(rows) == 15
+
+    for row in rows:
+        i = row["index"]
+        ep_to = (i // 5) * 5 + 5
+        frames = np.asarray(row["observation.image"])
+        pad = np.asarray(row["observation.image_is_pad"])
+        assert frames.shape == (2, FRAME_H, FRAME_W, FRAME_C)
+        j_next = min(i + 1, ep_to - 1)
+        assert (frames[0] == i % 256).all()  # anchor frame
+        assert (frames[1] == j_next % 256).all()  # next frame, clamped at episode end
+        assert list(pad) == [False, i + 1 >= ep_to]
+
+
+def test_read_lerobot_delta_non_windowed_keys_unchanged(
+    ray_start_regular_shared, lerobot_dataset_no_video
+):
+    """Features absent from delta_timestamps keep their single-frame output."""
+    row = ray.data.read_lerobot(
+        lerobot_dataset_no_video, delta_timestamps={"action": [0.0, 0.1]}
+    ).take_all()[0]
+    assert np.asarray(row["action"]).shape == (2, 2)  # windowed
+    assert np.asarray(row["state"]).shape == (2,)  # unchanged
+    assert "action_is_pad" in row and "state_is_pad" not in row
+
+
+def test_read_lerobot_delta_forces_episode_alignment(
+    ray_start_regular_shared, lerobot_dataset
+):
+    """delta_timestamps caps parallelism at whole-episode segments: even a huge
+    ``override_num_blocks`` cannot split an episode, so window gathers stay
+    local. Without delta the same request splits episodes into more tasks."""
+    from ray.data.datasource import LeRobotDatasource
+
+    delta = {"observation.image": [-0.1, 0.0, 0.1]}
+    src = LeRobotDatasource(
+        lerobot_dataset, read_granularity="episode", delta_timestamps=delta
+    )
+    assert len(src.get_read_tasks(1000)) == 3  # 3 episodes, never split
+
+    src_no_delta = LeRobotDatasource(lerobot_dataset, read_granularity="episode")
+    assert len(src_no_delta.get_read_tasks(1000)) > 3  # splits within episodes
+
+    # The read is still complete + correct under the cap.
+    rows = ray.data.read_lerobot(
+        lerobot_dataset,
+        read_granularity="episode",
+        delta_timestamps=delta,
+        override_num_blocks=1000,
+    ).take_all()
+    assert len(rows) == 15
+
+
+def test_read_lerobot_delta_invalid_raises(
+    ray_start_regular_shared, lerobot_dataset_no_video
+):
+    with pytest.raises(ValueError, match="tolerance"):
+        ray.data.read_lerobot(
+            lerobot_dataset_no_video, delta_timestamps={"action": [0.05]}
+        )
+    with pytest.raises(ValueError, match="not a feature"):
+        ray.data.read_lerobot(
+            lerobot_dataset_no_video, delta_timestamps={"missing": [0.0]}
+        )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/datasource/test_lerobot.py
+++ b/python/ray/data/tests/datasource/test_lerobot.py
@@ -1187,40 +1187,18 @@ def test_read_lerobot_episodes_multi_root(ray_start_regular_shared, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_convert_delta_timestamps_and_validation():
-    from ray.data._internal.datasource.lerobot_datasource import (
-        _convert_delta_timestamps,
-    )
-
-    keys = {"action", "state", "observation.image"}
-    tol = 1e-4
-    assert _convert_delta_timestamps(
-        {"action": [-0.2, -0.1, 0.0, 0.1]}, 10, keys, tol
-    ) == {"action": [-2, -1, 0, 1]}
-    with pytest.raises(ValueError, match="not a feature"):
-        _convert_delta_timestamps({"nope": [0.0]}, 10, keys, tol)
-    with pytest.raises(ValueError, match="tolerance"):  # lerobot's grid check
-        _convert_delta_timestamps({"action": [0.05]}, 10, keys, tol)  # 0.5 of a frame
-    with pytest.raises(ValueError, match="empty"):
-        _convert_delta_timestamps({"action": []}, 10, keys, tol)
-
-
 def test_delta_tolerance_s_configurable(
     ray_start_regular_shared, lerobot_dataset_no_video
 ):
     """delta_tolerance_s widens/narrows the frame-grid check: an off-grid offset
-    rejected at the tight default is accepted (and rounded) at a looser value."""
-    from ray.data._internal.datasource.lerobot_datasource import (
-        _convert_delta_timestamps,
-    )
-
-    # 0.14s @ 10fps = 1.4 frames -> off-grid by 0.04s.
+    (0.14s @ 10fps = 1.4 frames) is rejected at the tight default and accepted --
+    rounded to the nearest frame -- at a looser value."""
+    # Tight default tolerance rejects the off-grid offset.
     with pytest.raises(ValueError, match="tolerance"):
-        _convert_delta_timestamps({"action": [0.14]}, 10, {"action"}, 1e-4)
-    assert _convert_delta_timestamps({"action": [0.14]}, 10, {"action"}, 0.05) == {
-        "action": [1]
-    }
-    # The looser tolerance flows through read_lerobot end-to-end.
+        ray.data.read_lerobot(
+            lerobot_dataset_no_video, delta_timestamps={"action": [0.14]}
+        )
+    # A looser tolerance accepts it (rounds 1.4 -> 1 frame).
     ds = ray.data.read_lerobot(
         lerobot_dataset_no_video,
         delta_timestamps={"action": [0.14]},
@@ -1354,26 +1332,29 @@ def test_read_lerobot_delta_non_windowed_keys_unchanged(
 def test_read_lerobot_delta_forces_episode_alignment(
     ray_start_regular_shared, lerobot_dataset
 ):
-    """delta_timestamps caps parallelism at whole-episode segments: even a huge
-    ``override_num_blocks`` cannot split an episode, so window gathers stay
-    local. Without delta the same request splits episodes into more tasks."""
+    """delta_timestamps requires whole-episode read segments: a window can't be
+    gathered across a mid-episode split, so requesting more blocks than there are
+    base (episode / file-group) ranges raises. Without delta the same request
+    splits episodes freely."""
     from ray.data.datasource import LeRobotDatasource
 
     delta = {"observation.image": [-0.1, 0.0, 0.1]}
     src = LeRobotDatasource(
         lerobot_dataset, read_granularity="episode", delta_timestamps=delta
     )
-    assert len(src.get_read_tasks(1000)) == 3  # 3 episodes, never split
+    # One task per episode (3) needs no split -> fine.
+    assert len(src.get_read_tasks(3)) == 3
+    # More blocks than the 3 base ranges would split an episode -> rejected.
+    with pytest.raises(ValueError, match="row ranges"):
+        src.get_read_tasks(1000)
 
+    # Without delta the same over-request splits episodes into more tasks.
     src_no_delta = LeRobotDatasource(lerobot_dataset, read_granularity="episode")
-    assert len(src_no_delta.get_read_tasks(1000)) > 3  # splits within episodes
+    assert len(src_no_delta.get_read_tasks(1000)) > 3
 
-    # The read is still complete + correct under the cap.
+    # A default read (one task per episode) is complete + correct.
     rows = ray.data.read_lerobot(
-        lerobot_dataset,
-        read_granularity="episode",
-        delta_timestamps=delta,
-        override_num_blocks=1000,
+        lerobot_dataset, read_granularity="episode", delta_timestamps=delta
     ).take_all()
     assert len(rows) == 15
 
@@ -1384,10 +1365,6 @@ def test_read_lerobot_delta_invalid_raises(
     with pytest.raises(ValueError, match="tolerance"):
         ray.data.read_lerobot(
             lerobot_dataset_no_video, delta_timestamps={"action": [0.05]}
-        )
-    with pytest.raises(ValueError, match="not a feature"):
-        ray.data.read_lerobot(
-            lerobot_dataset_no_video, delta_timestamps={"missing": [0.0]}
         )
 
 

--- a/python/ray/data/tests/datasource/test_lerobot.py
+++ b/python/ray/data/tests/datasource/test_lerobot.py
@@ -1226,19 +1226,6 @@ def test_delta_targets_clamps_to_episode():
     assert pad.tolist() == [[True, False, False], [False, False, True]]
 
 
-def test_build_schema_delta_adds_pad_columns(lerobot_dataset_no_video):
-    from ray.data.datasource import LeRobotDatasource
-
-    src = LeRobotDatasource(
-        lerobot_dataset_no_video,
-        delta_timestamps={"action": [0.0, 0.1], "state": [-0.1, 0.0]},
-    )
-    names = src.distilled_metas[0].schema.names
-    assert "action_is_pad" in names and "state_is_pad" in names
-    # A non-windowed feature gets no pad mask.
-    assert "timestamp_is_pad" not in names
-
-
 def test_read_lerobot_delta_tabular(ray_start_regular_shared, lerobot_dataset_no_video):
     """Tabular windows: ``action`` gathers [t, t+1] and ``state`` gathers
     [t-1, t], each clamped to the anchor's episode with an is_pad mask."""
@@ -1250,13 +1237,13 @@ def test_read_lerobot_delta_tabular(ray_start_regular_shared, lerobot_dataset_no
 
     for row in rows:
         i = row["index"]
-        ep_from, ep_to = (i // 5) * 5, (i // 5) * 5 + 5
+        ep_from = (i // 5) * 5
+        ep_to = ep_from + 5
         action = np.asarray(row["action"])
         state = np.asarray(row["state"])
         action_pad = np.asarray(row["action_is_pad"])
         state_pad = np.asarray(row["state_is_pad"])
         assert action.shape == (2, 2) and state.shape == (2, 2)  # (T, dim)
-        assert action_pad.shape == (2,) and action_pad.dtype == bool
 
         # Fixture: action[i] == [i, i+1]; window is [t, t+1] clamped to episode.
         j_next = min(i + 1, ep_to - 1)


### PR DESCRIPTION
Follow-up for #63821 

Solves #64598 in part.

Adds a `delta_timestamps` argument to `ray.data.read_lerobot`, mirroring lerobot's LeRobotDataset: for each frame, every listed feature is returned stacked over a set of relative time offsets (a new leading time dimension) plus a boolean `{key}_is_pad` mask.

In this PR, we mirror the ergonomics of hugginface's lerobot dataset for "delta_stimestamps":
Offsets are given in seconds, converted to integer frame steps via the dataset fps (each must align to the frame grid), and clamped to the anchor frame's episode; out-of-range offsets return the nearest in-episode frame and are flagged in the pad mask. Video windows are gathered by timestamp from the shared per-segment decoder (introduced in initial lerobot PR). Tabular/image windows gather neighbour rows within the segment. Features not listed keep their single-frame output.

When delta_timestamps is set, reads are episode-aligned: get_read_tasks caps parallelism at whole-episode (file-group / episode) segments so every window is gathered locally, so override_num_blocks cannot split an episode. Splitting within an episode (a neighbour "halo") is left as a (possible) follow-up. We are going this path for now to make the solution robust and simple.

To review, I recommend taking a look at the unittests first.