### PR TITLE
[Data] Bump size for `test_unique_e2e`

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -478,7 +478,7 @@ py_test(
 
 py_test(
     name = "test_unique_e2e",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_unique_e2e.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
`test_unique_e2e` has been failing semi-consistently.
<img width="1606" height="91" alt="image" src="https://github.com/user-attachments/assets/a9a81769-3b7b-4f8f-9300-633695768698" />

I looked at the failures and successes. The failures timedout, and the successes emit a warning that the test execution time goes close to the timeout.
```
[2026-07-16T03:03:59Z] //python/ray/data:test_unique_e2e                                        PASSED in 55.1s
--
  | [2026-07-16T03:03:59Z]   WARNING: //python/ray/data:test_unique_e2e: Test execution time (55.1s excluding execution overhead) outside of range for SHORT tests. Consider setting timeout="moderate" or size="medium".
  | [2026-07-16T03:03:59Z]
```

To prevent this flakiness, I'm bumping the timeout.