### PR TITLE
[Data] Bump test size for `test_webdataset`

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1895,7 +1895,7 @@ py_test(
 
 py_test(
     name = "test_webdataset",
-    size = "medium",
+    size = "large",
     srcs = ["tests/datasource/test_webdataset.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
`test_webdataset` occasionally fails or flakes. It's likely because the test runtime runs close to the timeout:
```
[2026-07-18T01:02:57Z] //python/ray/data:test_webdataset                                         FLAKY, failed in 1 out of 2 in 301.7s
--
  | [2026-07-18T01:02:57Z]   Stats over 2 runs: max = 301.7s, min = 280.1s, avg = 290.9s, dev = 10.8s

```

To immediately deflake our CI, I'm bumping the timeout.

Long term, we should see if we can speed up or refactor `test_webdataset`.