### PR TITLE
[Data] Remove incorrect `test_map_batches_actors_preserves_order`

### DIFF
--- a/python/ray/data/tests/test_map_batches.py
+++ b/python/ray/data/tests/test_map_batches.py
@@ -435,22 +435,6 @@ def test_map_batches_generator(
         ).take()
 
 
-def test_map_batches_actors_preserves_order(
-    shutdown_only, target_max_block_size_infinite_or_default
-):
-    class UDFClass:
-        def __call__(self, x):
-            return x
-
-    ray.shutdown()
-    ray.init(num_cpus=2)
-    # Test that actor compute model preserves block order.
-    ds = ray.data.range(10, override_num_blocks=5)
-    assert extract_values("id", ds.map_batches(UDFClass, concurrency=1).take()) == list(
-        range(10)
-    )
-
-
 @pytest.mark.parametrize(
     "num_rows,num_blocks,batch_size",
     [


### PR DESCRIPTION
`test_map_batches_actors_preserves_order` runs a simple pipeline with actors and asserts that outputs are ordered. This test is both incorrect and flaky. Ray Data doesn't make any guarantees about ordering by default, so I'm removing it.