### PR TITLE
[serve] Cache merged autoscaling-metrics timeseries across controller ticks

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -250,7 +250,9 @@ class DeploymentAutoscalingState:
         ):
             return
         self._membership_dirty = False
-        self._running_replicas = running_replicas
+        # Copy: this list is handed to user policies via `AutoscalingContext`, and the
+        # fast path above compares against it.
+        self._running_replicas = list(running_replicas)
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -242,17 +242,27 @@ class DeploymentAutoscalingState:
     def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
         # Called every control loop tick; membership is usually unchanged, so skip the
-        # set/dict rebuilds and keep the merge cache valid. Compared element-wise because
-        # the caller memoizes a tuple; a preceding stop forces the rebuild via the flag.
+        # set/dict rebuilds and keep the merge cache valid. Identity is the common case
+        # (the caller memoizes); the element-wise compare covers a caller that does not,
+        # and a preceding stop forces the rebuild via the flag.
         if not self._membership_dirty and (
-            len(running_replicas) == len(self._running_replicas)
-            and all(a == b for a, b in zip(running_replicas, self._running_replicas))
+            running_replicas is self._running_replicas
+            or (
+                len(running_replicas) == len(self._running_replicas)
+                and all(
+                    a == b for a, b in zip(running_replicas, self._running_replicas)
+                )
+            )
         ):
             return
         self._membership_dirty = False
-        # Copy: this list is handed to user policies via `AutoscalingContext`, and the
-        # fast path above compares against it.
-        self._running_replicas = list(running_replicas)
+        # A tuple is aliased so the identity check above can hit; a list caller may keep
+        # mutating what it passed, so that has to be copied.
+        self._running_replicas = (
+            running_replicas
+            if isinstance(running_replicas, tuple)
+            else list(running_replicas)
+        )
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -206,10 +206,12 @@ class DeploymentAutoscalingState:
         return self.apply_bounds(target_num_replicas)
 
     def on_replica_stopped(self, replica_id: ReplicaID):
-        if replica_id in self._replica_metrics:
-            del self._replica_metrics[replica_id]
-            if self._running_replica_running_requests.pop(replica_id, None) is not None:
-                self._metrics_version += 1
+        self._replica_metrics.pop(replica_id, None)
+        # Defensive: keep a late report from re-adding the stopped replica
+        # before the next membership update.
+        self._running_replica_id_set.discard(replica_id)
+        if self._running_replica_running_requests.pop(replica_id, None) is not None:
+            self._metrics_version += 1
 
     def get_num_replicas_lower_bound(self) -> int:
         if self._config.initial_replicas is not None and (
@@ -303,9 +305,12 @@ class DeploymentAutoscalingState:
                     self._running_replica_running_requests[
                         replica_id
                     ] = replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
-                else:
+                    self._metrics_version += 1
+                elif (
                     self._running_replica_running_requests.pop(replica_id, None)
-                self._metrics_version += 1
+                    is not None
+                ):
+                    self._metrics_version += 1
 
     def record_request_metrics_for_handle(
         self,

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -105,7 +105,17 @@ class DeploymentAutoscalingState:
         # content of the dictionary is determined by the user defined policy
         self._policy_state: Optional[Dict[str, Any]] = None
         self._running_replicas: Sequence[ReplicaID] = []
+        self._running_replica_id_set: Set[ReplicaID] = set()
         self._cached_running_replica_strs: Set[str] = set()
+        # Running-requests series per running replica, kept in sync as reports
+        # arrive so each control loop tick doesn't rescan every replica.
+        self._running_replica_running_requests: Dict[ReplicaID, TimeSeries] = {}
+        # Bumped whenever the inputs to the merged ongoing-requests timeseries
+        # change (replica/handle reports, running set); gates the merge cache.
+        self._metrics_version: int = 0
+        self._merged_ongoing_requests_version: int = -1
+        self._merged_ongoing_requests_timeseries: TimeSeries = []
+        self._merged_ongoing_requests_window_start: Optional[float] = None
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
         # Track timestamps of last scale up and scale down events
@@ -198,6 +208,8 @@ class DeploymentAutoscalingState:
     def on_replica_stopped(self, replica_id: ReplicaID):
         if replica_id in self._replica_metrics:
             del self._replica_metrics[replica_id]
+            if self._running_replica_running_requests.pop(replica_id, None) is not None:
+                self._metrics_version += 1
 
     def get_num_replicas_lower_bound(self) -> int:
         if self._config.initial_replicas is not None and (
@@ -221,14 +233,25 @@ class DeploymentAutoscalingState:
 
     def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
-        if running_replicas is self._running_replicas:
-            # Identity means DeploymentState handed back its memoized tuple, so the
-            # running-replica ids are unchanged and the derived str set still matches.
+        # Called every control loop tick; membership is usually unchanged, so skip the
+        # O(replicas) rebuild and keep the merge cache valid. Compared element-wise
+        # because the caller memoizes a tuple, which never equals a stored list.
+        if len(running_replicas) == len(self._running_replicas) and all(
+            a == b for a, b in zip(running_replicas, self._running_replicas)
+        ):
             return
         self._running_replicas = running_replicas
+        self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
         }
+        self._running_replica_running_requests = {
+            replica_id: self._replica_metrics[replica_id].metrics[RUNNING_REQUESTS_KEY]
+            for replica_id in running_replicas
+            if replica_id in self._replica_metrics
+            and RUNNING_REQUESTS_KEY in self._replica_metrics[replica_id].metrics
+        }
+        self._metrics_version += 1
 
     def record_scale_up(self):
         """Record a scale up event by updating the timestamp."""
@@ -274,6 +297,15 @@ class DeploymentAutoscalingState:
             or send_timestamp > self._replica_metrics[replica_id].timestamp
         ):
             self._replica_metrics[replica_id] = replica_metric_report
+            # Only reports from running replicas feed the merged timeseries.
+            if replica_id in self._running_replica_id_set:
+                if RUNNING_REQUESTS_KEY in replica_metric_report.metrics:
+                    self._running_replica_running_requests[
+                        replica_id
+                    ] = replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
+                else:
+                    self._running_replica_running_requests.pop(replica_id, None)
+                self._metrics_version += 1
 
     def record_request_metrics_for_handle(
         self,
@@ -289,6 +321,7 @@ class DeploymentAutoscalingState:
             or send_timestamp > self._handle_requests[handle_id].timestamp
         ):
             self._handle_requests[handle_id] = handle_metric_report
+            self._metrics_version += 1
 
     def record_async_inference_task_queue_metrics(
         self, report: AsyncInferenceTaskQueueMetricReport
@@ -317,6 +350,7 @@ class DeploymentAutoscalingState:
                 and handle_metric.actor_id not in alive_serve_actor_ids
             ):
                 del self._handle_requests[handle_id]
+                self._metrics_version += 1
                 if handle_metric.total_requests > 0:
                     logger.debug(
                         f"Dropping metrics for handle '{handle_id}' because the Serve "
@@ -328,6 +362,7 @@ class DeploymentAutoscalingState:
             # proxies that have been shut down.
             elif time.time() - handle_metric.timestamp >= timeout_s:
                 del self._handle_requests[handle_id]
+                self._metrics_version += 1
                 if handle_metric.total_requests > 0:
                     actor_id = handle_metric.actor_id
                     actor_info = f"on actor '{actor_id}' " if actor_id else ""
@@ -433,19 +468,7 @@ class DeploymentAutoscalingState:
         Returns:
             List of timeseries data.
         """
-        timeseries_list = []
-
-        for replica_id in self._running_replicas:
-            replica_metric_report = self._replica_metrics.get(replica_id, None)
-            if (
-                replica_metric_report is not None
-                and RUNNING_REQUESTS_KEY in replica_metric_report.metrics
-            ):
-                timeseries_list.append(
-                    replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
-                )
-
-        return timeseries_list
+        return list(self._running_replica_running_requests.values())
 
     def _collect_handle_queued_requests(self) -> List[TimeSeries]:
         """Collect queued requests timeseries from all handles.
@@ -521,8 +544,42 @@ class DeploymentAutoscalingState:
         if not timeseries_list:
             return 0.0
 
+        merged_timeseries, window_start = self._merge_timeseries(timeseries_list)
+        return self._aggregate_merged_timeseries(merged_timeseries, window_start)
+
+    def _merge_timeseries(
+        self,
+        timeseries_list: List[TimeSeries],
+    ) -> Tuple[TimeSeries, Optional[float]]:
+        """Merge timeseries into an instantaneous total plus aligned window start.
+
+        Depends only on the input series (not the current time), so the result
+        can be cached until the underlying metrics change.
+        """
         # Use instantaneous merge approach - no arbitrary windowing needed
         merged_timeseries = merge_instantaneous_total(timeseries_list)
+        # Exclude early "partial" period: when series have misaligned start times,
+        # late-starting series are implicitly 0 before their first data point, which
+        # undercounts the total and biases aggregations. Start the window at the
+        # timestamp when all series have contributed at least one point.
+        # Use max(aligned_start, merged[0].timestamp) because merge rounds timestamps
+        # to 10ms; if aligned_start is before the first merged point, the gap would
+        # be treated as 0 and bias the average downward.
+        window_start = None
+        if merged_timeseries:
+            non_empty_series = [ts for ts in timeseries_list if ts]
+            if len(non_empty_series) > 1:
+                aligned_start = max(ts[0].timestamp for ts in non_empty_series)
+                if aligned_start <= merged_timeseries[-1].timestamp:
+                    window_start = max(aligned_start, merged_timeseries[0].timestamp)
+        return merged_timeseries, window_start
+
+    def _aggregate_merged_timeseries(
+        self,
+        merged_timeseries: TimeSeries,
+        window_start: Optional[float],
+    ) -> float:
+        """Time-weighted aggregate of a merged timeseries, valid through now."""
         if merged_timeseries:
             # assume that the last recorded metric is valid for last_window_s seconds
             last_metric_time = merged_timeseries[-1].timestamp
@@ -534,20 +591,6 @@ class DeploymentAutoscalingState:
             # between replicas and controller. Also add a small epsilon to avoid division by zero
             if last_window_s <= 0:
                 last_window_s = 1e-3
-
-            # Exclude early "partial" period: when series have misaligned start times,
-            # late-starting series are implicitly 0 before their first data point, which
-            # undercounts the total and biases aggregations. Start the window at the
-            # timestamp when all series have contributed at least one point.
-            # Use max(aligned_start, merged[0].timestamp) because merge rounds timestamps
-            # to 10ms; if aligned_start is before the first merged point, the gap would
-            # be treated as 0 and bias the average downward.
-            window_start = None
-            non_empty_series = [ts for ts in timeseries_list if ts]
-            if len(non_empty_series) > 1:
-                aligned_start = max(ts[0].timestamp for ts in non_empty_series)
-                if aligned_start <= merged_timeseries[-1].timestamp:
-                    window_start = max(aligned_start, merged_timeseries[0].timestamp)
 
             # Calculate the aggregated metric value
             value = aggregate_timeseries(
@@ -624,35 +667,46 @@ class DeploymentAutoscalingState:
             Total number of requests (average running + queued) calculated from
             timeseries data aggregation.
         """
-        # Collect replica-based running requests (returns List[TimeSeries])
-        replica_timeseries = self._collect_replica_running_requests()
-        metrics_collected_on_replicas = len(replica_timeseries) > 0
+        # The merged total depends only on the recorded reports and running
+        # set, so it's rebuilt only when those change; the time-dependent
+        # aggregation below runs on every call.
+        if self._merged_ongoing_requests_version != self._metrics_version:
+            # Collect replica-based running requests (returns List[TimeSeries])
+            replica_timeseries = self._collect_replica_running_requests()
+            metrics_collected_on_replicas = len(replica_timeseries) > 0
 
-        # Collect queued requests from handles (returns List[TimeSeries])
-        queued_timeseries = self._collect_handle_queued_requests()
+            # Collect queued requests from handles (returns List[TimeSeries])
+            queued_timeseries = self._collect_handle_queued_requests()
 
-        if not metrics_collected_on_replicas:
-            # Collect handle-based running requests if not collected on replicas
-            handle_timeseries = self._collect_handle_running_requests()
-        else:
-            handle_timeseries = []
+            if not metrics_collected_on_replicas:
+                # Collect handle-based running requests if not collected on replicas
+                handle_timeseries = self._collect_handle_running_requests()
+            else:
+                handle_timeseries = []
 
-        # Collect all timeseries for ongoing requests
-        ongoing_requests_timeseries = []
+            # Collect all timeseries for ongoing requests
+            ongoing_requests_timeseries = []
 
-        # Add replica timeseries
-        ongoing_requests_timeseries.extend(replica_timeseries)
+            # Add replica timeseries
+            ongoing_requests_timeseries.extend(replica_timeseries)
 
-        # Add handle timeseries if replica metrics weren't collected
-        if not metrics_collected_on_replicas:
-            ongoing_requests_timeseries.extend(handle_timeseries)
+            # Add handle timeseries if replica metrics weren't collected
+            if not metrics_collected_on_replicas:
+                ongoing_requests_timeseries.extend(handle_timeseries)
 
-        # Add queued timeseries
-        ongoing_requests_timeseries.extend(queued_timeseries)
+            # Add queued timeseries
+            ongoing_requests_timeseries.extend(queued_timeseries)
+
+            (
+                self._merged_ongoing_requests_timeseries,
+                self._merged_ongoing_requests_window_start,
+            ) = self._merge_timeseries(ongoing_requests_timeseries)
+            self._merged_ongoing_requests_version = self._metrics_version
 
         # Aggregate and add running requests to total
-        ongoing_requests = self._merge_and_aggregate_timeseries(
-            ongoing_requests_timeseries
+        ongoing_requests = self._aggregate_merged_timeseries(
+            self._merged_ongoing_requests_timeseries,
+            self._merged_ongoing_requests_window_start,
         )
 
         return ongoing_requests

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -216,6 +216,10 @@ class DeploymentAutoscalingState:
         # feeds policy inputs, so flag the divergence for the equality fast path.
         if replica_id in self._running_replica_id_set:
             self._running_replica_id_set.remove(replica_id)
+            # Simple mode filters on the string set, so drop it there too: otherwise a
+            # late report re-inserts itself into _replica_metrics and only that path
+            # counts it.
+            self._cached_running_replica_strs.discard(replica_id.to_full_id_str())
             self._membership_dirty = True
         if self._running_requests_by_replica.pop(replica_id, None) is not None:
             self._metrics_version += 1
@@ -244,26 +248,19 @@ class DeploymentAutoscalingState:
         """Update cached set of running replica IDs for this deployment."""
         # Called every control loop tick; membership is usually unchanged, so skip the
         # set/dict rebuilds and keep the merge cache valid. Identity is the common case
-        # (the caller memoizes); the element-wise compare covers a caller that does not,
-        # and a preceding stop forces the rebuild via the flag.
+        # (the caller memoizes); the value compare covers a caller that does not, and a
+        # preceding stop forces the rebuild via the flag. Comparing tuples rather than
+        # zipping keeps the walk in C, where it short-circuits on element identity.
         if not self._membership_dirty and (
             running_replicas is self._running_replicas
-            or (
-                len(running_replicas) == len(self._running_replicas)
-                and all(
-                    a == b for a, b in zip(running_replicas, self._running_replicas)
-                )
-            )
+            or tuple(running_replicas) == self._running_replicas
         ):
             return
         self._membership_dirty = False
-        # A tuple is aliased so the identity check above can hit; a list caller may keep
-        # mutating what it passed, so that has to be copied.
-        self._running_replicas = (
-            running_replicas
-            if isinstance(running_replicas, tuple)
-            else list(running_replicas)
-        )
+        # Stored as a tuple: tuple() hands back a tuple unchanged, so a caller that
+        # memoizes keeps hitting the identity check above, while a list caller gets a
+        # copy that its own mutations cannot reach.
+        self._running_replicas = tuple(running_replicas)
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -906,8 +903,9 @@ class DeploymentAutoscalingState:
                 continue
 
             for metric_name, timeseries in replica_metric_report.metrics.items():
-                # Extract values from TimeStampedValue list
-                raw_metrics[metric_name][replica_id] = timeseries
+                # Copy: the merge cache reads these lists, so a policy mutating what it
+                # is handed here would corrupt the cached total invisibly.
+                raw_metrics[metric_name][replica_id] = list(timeseries)
 
         return dict(raw_metrics)
 

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -251,7 +251,9 @@ class DeploymentAutoscalingState:
         ):
             return
         self._membership_dirty = False
-        self._running_replicas = running_replicas
+        # Copy: this list is handed to user policies via `AutoscalingContext`, and the
+        # fast path above compares against it.
+        self._running_replicas = list(running_replicas)
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -106,7 +106,17 @@ class DeploymentAutoscalingState:
         # content of the dictionary is determined by the user defined policy
         self._policy_state: Optional[Dict[str, Any]] = None
         self._running_replicas: Sequence[ReplicaID] = []
+        self._running_replica_id_set: Set[ReplicaID] = set()
         self._cached_running_replica_strs: Set[str] = set()
+        # Running-requests series per running replica, kept in sync as reports
+        # arrive so each control loop tick doesn't rescan every replica.
+        self._running_replica_running_requests: Dict[ReplicaID, TimeSeries] = {}
+        # Bumped whenever the inputs to the merged ongoing-requests timeseries
+        # change (replica/handle reports, running set); gates the merge cache.
+        self._metrics_version: int = 0
+        self._merged_ongoing_requests_version: int = -1
+        self._merged_ongoing_requests_timeseries: TimeSeries = []
+        self._merged_ongoing_requests_window_start: Optional[float] = None
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
         # Track timestamps of last scale up and scale down events
@@ -199,6 +209,8 @@ class DeploymentAutoscalingState:
     def on_replica_stopped(self, replica_id: ReplicaID):
         if replica_id in self._replica_metrics:
             del self._replica_metrics[replica_id]
+            if self._running_replica_running_requests.pop(replica_id, None) is not None:
+                self._metrics_version += 1
 
     def get_num_replicas_lower_bound(self) -> int:
         if self._config.initial_replicas is not None and (
@@ -222,14 +234,25 @@ class DeploymentAutoscalingState:
 
     def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
-        if running_replicas is self._running_replicas:
-            # Identity means DeploymentState handed back its memoized tuple, so the
-            # running-replica ids are unchanged and the derived str set still matches.
+        # Called every control loop tick; membership is usually unchanged, so skip the
+        # O(replicas) rebuild and keep the merge cache valid. Compared element-wise
+        # because the caller memoizes a tuple, which never equals a stored list.
+        if len(running_replicas) == len(self._running_replicas) and all(
+            a == b for a, b in zip(running_replicas, self._running_replicas)
+        ):
             return
         self._running_replicas = running_replicas
+        self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
         }
+        self._running_replica_running_requests = {
+            replica_id: self._replica_metrics[replica_id].metrics[RUNNING_REQUESTS_KEY]
+            for replica_id in running_replicas
+            if replica_id in self._replica_metrics
+            and RUNNING_REQUESTS_KEY in self._replica_metrics[replica_id].metrics
+        }
+        self._metrics_version += 1
 
     def record_scale_up(self):
         """Record a scale up event by updating the timestamp."""
@@ -275,6 +298,15 @@ class DeploymentAutoscalingState:
             or send_timestamp > self._replica_metrics[replica_id].timestamp
         ):
             self._replica_metrics[replica_id] = replica_metric_report
+            # Only reports from running replicas feed the merged timeseries.
+            if replica_id in self._running_replica_id_set:
+                if RUNNING_REQUESTS_KEY in replica_metric_report.metrics:
+                    self._running_replica_running_requests[
+                        replica_id
+                    ] = replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
+                else:
+                    self._running_replica_running_requests.pop(replica_id, None)
+                self._metrics_version += 1
 
     def record_request_metrics_for_handle(
         self,
@@ -290,6 +322,7 @@ class DeploymentAutoscalingState:
             or send_timestamp > self._handle_requests[handle_id].timestamp
         ):
             self._handle_requests[handle_id] = handle_metric_report
+            self._metrics_version += 1
 
     def record_async_inference_task_queue_metrics(
         self, report: AsyncInferenceTaskQueueMetricReport
@@ -320,6 +353,7 @@ class DeploymentAutoscalingState:
                 and handle_metric.actor_id not in alive_serve_actor_ids
             ):
                 del self._handle_requests[handle_id]
+                self._metrics_version += 1
                 if handle_metric.total_requests > 0:
                     logger.debug(
                         f"Dropping metrics for handle '{handle_id}' because the Serve "
@@ -331,6 +365,7 @@ class DeploymentAutoscalingState:
             # proxies that have been shut down.
             elif time.time() - handle_metric.timestamp >= timeout_s:
                 del self._handle_requests[handle_id]
+                self._metrics_version += 1
                 if handle_metric.total_requests > 0:
                     actor_id = handle_metric.actor_id
                     actor_info = f"on actor '{actor_id}' " if actor_id else ""
@@ -436,19 +471,7 @@ class DeploymentAutoscalingState:
         Returns:
             List of timeseries data.
         """
-        timeseries_list = []
-
-        for replica_id in self._running_replicas:
-            replica_metric_report = self._replica_metrics.get(replica_id, None)
-            if (
-                replica_metric_report is not None
-                and RUNNING_REQUESTS_KEY in replica_metric_report.metrics
-            ):
-                timeseries_list.append(
-                    replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
-                )
-
-        return timeseries_list
+        return list(self._running_replica_running_requests.values())
 
     def _collect_handle_queued_requests(self) -> List[TimeSeries]:
         """Collect queued requests timeseries from all handles.
@@ -524,8 +547,42 @@ class DeploymentAutoscalingState:
         if not timeseries_list:
             return 0.0
 
+        merged_timeseries, window_start = self._merge_timeseries(timeseries_list)
+        return self._aggregate_merged_timeseries(merged_timeseries, window_start)
+
+    def _merge_timeseries(
+        self,
+        timeseries_list: List[TimeSeries],
+    ) -> Tuple[TimeSeries, Optional[float]]:
+        """Merge timeseries into an instantaneous total plus aligned window start.
+
+        Depends only on the input series (not the current time), so the result
+        can be cached until the underlying metrics change.
+        """
         # Use instantaneous merge approach - no arbitrary windowing needed
         merged_timeseries = merge_instantaneous_total(timeseries_list)
+        # Exclude early "partial" period: when series have misaligned start times,
+        # late-starting series are implicitly 0 before their first data point, which
+        # undercounts the total and biases aggregations. Start the window at the
+        # timestamp when all series have contributed at least one point.
+        # Use max(aligned_start, merged[0].timestamp) because merge rounds timestamps
+        # to 10ms; if aligned_start is before the first merged point, the gap would
+        # be treated as 0 and bias the average downward.
+        window_start = None
+        if merged_timeseries:
+            non_empty_series = [ts for ts in timeseries_list if ts]
+            if len(non_empty_series) > 1:
+                aligned_start = max(ts[0].timestamp for ts in non_empty_series)
+                if aligned_start <= merged_timeseries[-1].timestamp:
+                    window_start = max(aligned_start, merged_timeseries[0].timestamp)
+        return merged_timeseries, window_start
+
+    def _aggregate_merged_timeseries(
+        self,
+        merged_timeseries: TimeSeries,
+        window_start: Optional[float],
+    ) -> float:
+        """Time-weighted aggregate of a merged timeseries, valid through now."""
         if merged_timeseries:
             # assume that the last recorded metric is valid for last_window_s seconds
             last_metric_time = merged_timeseries[-1].timestamp
@@ -537,20 +594,6 @@ class DeploymentAutoscalingState:
             # between replicas and controller. Also add a small epsilon to avoid division by zero
             if last_window_s <= 0:
                 last_window_s = 1e-3
-
-            # Exclude early "partial" period: when series have misaligned start times,
-            # late-starting series are implicitly 0 before their first data point, which
-            # undercounts the total and biases aggregations. Start the window at the
-            # timestamp when all series have contributed at least one point.
-            # Use max(aligned_start, merged[0].timestamp) because merge rounds timestamps
-            # to 10ms; if aligned_start is before the first merged point, the gap would
-            # be treated as 0 and bias the average downward.
-            window_start = None
-            non_empty_series = [ts for ts in timeseries_list if ts]
-            if len(non_empty_series) > 1:
-                aligned_start = max(ts[0].timestamp for ts in non_empty_series)
-                if aligned_start <= merged_timeseries[-1].timestamp:
-                    window_start = max(aligned_start, merged_timeseries[0].timestamp)
 
             # Calculate the aggregated metric value
             value = aggregate_timeseries(
@@ -627,35 +670,46 @@ class DeploymentAutoscalingState:
             Total number of requests (average running + queued) calculated from
             timeseries data aggregation.
         """
-        # Collect replica-based running requests (returns List[TimeSeries])
-        replica_timeseries = self._collect_replica_running_requests()
-        metrics_collected_on_replicas = len(replica_timeseries) > 0
+        # The merged total depends only on the recorded reports and running
+        # set, so it's rebuilt only when those change; the time-dependent
+        # aggregation below runs on every call.
+        if self._merged_ongoing_requests_version != self._metrics_version:
+            # Collect replica-based running requests (returns List[TimeSeries])
+            replica_timeseries = self._collect_replica_running_requests()
+            metrics_collected_on_replicas = len(replica_timeseries) > 0
 
-        # Collect queued requests from handles (returns List[TimeSeries])
-        queued_timeseries = self._collect_handle_queued_requests()
+            # Collect queued requests from handles (returns List[TimeSeries])
+            queued_timeseries = self._collect_handle_queued_requests()
 
-        if not metrics_collected_on_replicas:
-            # Collect handle-based running requests if not collected on replicas
-            handle_timeseries = self._collect_handle_running_requests()
-        else:
-            handle_timeseries = []
+            if not metrics_collected_on_replicas:
+                # Collect handle-based running requests if not collected on replicas
+                handle_timeseries = self._collect_handle_running_requests()
+            else:
+                handle_timeseries = []
 
-        # Collect all timeseries for ongoing requests
-        ongoing_requests_timeseries = []
+            # Collect all timeseries for ongoing requests
+            ongoing_requests_timeseries = []
 
-        # Add replica timeseries
-        ongoing_requests_timeseries.extend(replica_timeseries)
+            # Add replica timeseries
+            ongoing_requests_timeseries.extend(replica_timeseries)
 
-        # Add handle timeseries if replica metrics weren't collected
-        if not metrics_collected_on_replicas:
-            ongoing_requests_timeseries.extend(handle_timeseries)
+            # Add handle timeseries if replica metrics weren't collected
+            if not metrics_collected_on_replicas:
+                ongoing_requests_timeseries.extend(handle_timeseries)
 
-        # Add queued timeseries
-        ongoing_requests_timeseries.extend(queued_timeseries)
+            # Add queued timeseries
+            ongoing_requests_timeseries.extend(queued_timeseries)
+
+            (
+                self._merged_ongoing_requests_timeseries,
+                self._merged_ongoing_requests_window_start,
+            ) = self._merge_timeseries(ongoing_requests_timeseries)
+            self._merged_ongoing_requests_version = self._metrics_version
 
         # Aggregate and add running requests to total
-        ongoing_requests = self._merge_and_aggregate_timeseries(
-            ongoing_requests_timeseries
+        ongoing_requests = self._aggregate_merged_timeseries(
+            self._merged_ongoing_requests_timeseries,
+            self._merged_ongoing_requests_window_start,
         )
 
         return ongoing_requests

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -3,7 +3,19 @@ import logging
 import math
 import time
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
@@ -93,7 +105,7 @@ class DeploymentAutoscalingState:
         # user defined policy returns a dictionary of state that is persisted between autoscaling decisions
         # content of the dictionary is determined by the user defined policy
         self._policy_state: Optional[Dict[str, Any]] = None
-        self._running_replicas: List[ReplicaID] = []
+        self._running_replicas: Sequence[ReplicaID] = []
         self._cached_running_replica_strs: Set[str] = set()
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
@@ -208,8 +220,12 @@ class DeploymentAutoscalingState:
             self._target_capacity,
         )
 
-    def update_running_replica_ids(self, running_replicas: List[ReplicaID]):
+    def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
+        if running_replicas is self._running_replicas:
+            # Identity means DeploymentState handed back its memoized tuple, so the
+            # running-replica ids are unchanged and the derived str set still matches.
+            return
         self._running_replicas = running_replicas
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -281,7 +297,9 @@ class DeploymentAutoscalingState:
         """Records task queue length from QueueMonitor for async inference."""
         self._total_pending_async_requests = report.queue_length
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
+    def drop_stale_handle_metrics(
+        self, alive_serve_actor_ids: AbstractSet[str]
+    ) -> None:
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -395,7 +413,9 @@ class DeploymentAutoscalingState:
             app_name=self._deployment_id.app_name,
             current_num_replicas=len(self._running_replicas),
             target_num_replicas=curr_target_num_replicas,
-            running_replicas=self._running_replicas,
+            # Copy: _running_replicas holds the memoized tuple from
+            # get_running_replica_ids(), and this is a stable public List[ReplicaID].
+            running_replicas=list(self._running_replicas),
             total_num_requests=self.get_total_num_requests,
             capacity_adjusted_min_replicas=self.get_num_replicas_lower_bound(),
             capacity_adjusted_max_replicas=self.get_num_replicas_upper_bound(),
@@ -1013,7 +1033,7 @@ class ApplicationAutoscalingState:
             }
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         self._deployment_autoscaling_states[deployment_id].update_running_replica_ids(
             running_replicas
@@ -1080,7 +1100,7 @@ class ApplicationAutoscalingState:
                 report.deployment_id
             ].record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]):
+    def drop_stale_handle_metrics(self, alive_serve_actor_ids: AbstractSet[str]):
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -1183,7 +1203,7 @@ class AutoscalingStateManager:
         )
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         app_state = self._app_autoscaling_states.get(deployment_id.app_name)
         if app_state:
@@ -1271,6 +1291,8 @@ class AutoscalingStateManager:
         if app_state:
             app_state.record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
+    def drop_stale_handle_metrics(
+        self, alive_serve_actor_ids: AbstractSet[str]
+    ) -> None:
         for app_state in self._app_autoscaling_states.values():
             app_state.drop_stale_handle_metrics(alive_serve_actor_ids)

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -106,10 +106,13 @@ class DeploymentAutoscalingState:
         self._policy_state: Optional[Dict[str, Any]] = None
         self._running_replicas: Sequence[ReplicaID] = []
         self._running_replica_id_set: Set[ReplicaID] = set()
+        # Set when a stop drops a replica that `_running_replicas` still lists, so
+        # the next membership update can't take the unchanged-list fast path.
+        self._membership_dirty: bool = False
         self._cached_running_replica_strs: Set[str] = set()
         # Running-requests series per running replica, kept in sync as reports
         # arrive so each control loop tick doesn't rescan every replica.
-        self._running_replica_running_requests: Dict[ReplicaID, TimeSeries] = {}
+        self._running_requests_by_replica: Dict[ReplicaID, TimeSeries] = {}
         # Bumped whenever the inputs to the merged ongoing-requests timeseries
         # change (replica/handle reports, running set); gates the merge cache.
         self._metrics_version: int = 0
@@ -207,10 +210,13 @@ class DeploymentAutoscalingState:
 
     def on_replica_stopped(self, replica_id: ReplicaID):
         self._replica_metrics.pop(replica_id, None)
-        # Defensive: keep a late report from re-adding the stopped replica
-        # before the next membership update.
-        self._running_replica_id_set.discard(replica_id)
-        if self._running_replica_running_requests.pop(replica_id, None) is not None:
+        # Defensive: keep a late report from re-adding the stopped replica before
+        # the next membership update. `_running_replicas` still lists it because it
+        # feeds policy inputs, so flag the divergence for the equality fast path.
+        if replica_id in self._running_replica_id_set:
+            self._running_replica_id_set.remove(replica_id)
+            self._membership_dirty = True
+        if self._running_requests_by_replica.pop(replica_id, None) is not None:
             self._metrics_version += 1
 
     def get_num_replicas_lower_bound(self) -> int:
@@ -236,18 +242,20 @@ class DeploymentAutoscalingState:
     def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
         # Called every control loop tick; membership is usually unchanged, so skip the
-        # O(replicas) rebuild and keep the merge cache valid. Compared element-wise
-        # because the caller memoizes a tuple, which never equals a stored list.
-        if len(running_replicas) == len(self._running_replicas) and all(
-            a == b for a, b in zip(running_replicas, self._running_replicas)
+        # set/dict rebuilds and keep the merge cache valid. Compared element-wise because
+        # the caller memoizes a tuple; a preceding stop forces the rebuild via the flag.
+        if not self._membership_dirty and (
+            len(running_replicas) == len(self._running_replicas)
+            and all(a == b for a, b in zip(running_replicas, self._running_replicas))
         ):
             return
+        self._membership_dirty = False
         self._running_replicas = running_replicas
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
         }
-        self._running_replica_running_requests = {
+        self._running_requests_by_replica = {
             replica_id: self._replica_metrics[replica_id].metrics[RUNNING_REQUESTS_KEY]
             for replica_id in running_replicas
             if replica_id in self._replica_metrics
@@ -302,13 +310,12 @@ class DeploymentAutoscalingState:
             # Only reports from running replicas feed the merged timeseries.
             if replica_id in self._running_replica_id_set:
                 if RUNNING_REQUESTS_KEY in replica_metric_report.metrics:
-                    self._running_replica_running_requests[
+                    self._running_requests_by_replica[
                         replica_id
                     ] = replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
                     self._metrics_version += 1
                 elif (
-                    self._running_replica_running_requests.pop(replica_id, None)
-                    is not None
+                    self._running_requests_by_replica.pop(replica_id, None) is not None
                 ):
                     self._metrics_version += 1
 
@@ -473,7 +480,7 @@ class DeploymentAutoscalingState:
         Returns:
             List of timeseries data.
         """
-        return list(self._running_replica_running_requests.values())
+        return list(self._running_requests_by_replica.values())
 
     def _collect_handle_queued_requests(self) -> List[TimeSeries]:
         """Collect queued requests timeseries from all handles.
@@ -702,10 +709,11 @@ class DeploymentAutoscalingState:
             # Add queued timeseries
             ongoing_requests_timeseries.extend(queued_timeseries)
 
-            (
-                self._merged_ongoing_requests_timeseries,
-                self._merged_ongoing_requests_window_start,
-            ) = self._merge_timeseries(ongoing_requests_timeseries)
+            merged, window_start = self._merge_timeseries(ongoing_requests_timeseries)
+            # Copy: a single-series merge returns that input list by reference, and
+            # the cache outlives the tick that built it.
+            self._merged_ongoing_requests_timeseries = list(merged)
+            self._merged_ongoing_requests_window_start = window_start
             self._merged_ongoing_requests_version = self._metrics_version
 
         # Aggregate and add running requests to total

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -3,7 +3,18 @@ import logging
 import math
 import time
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
@@ -93,7 +104,7 @@ class DeploymentAutoscalingState:
         # user defined policy returns a dictionary of state that is persisted between autoscaling decisions
         # content of the dictionary is determined by the user defined policy
         self._policy_state: Optional[Dict[str, Any]] = None
-        self._running_replicas: List[ReplicaID] = []
+        self._running_replicas: Sequence[ReplicaID] = []
         self._cached_running_replica_strs: Set[str] = set()
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
@@ -208,8 +219,12 @@ class DeploymentAutoscalingState:
             self._target_capacity,
         )
 
-    def update_running_replica_ids(self, running_replicas: List[ReplicaID]):
+    def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
+        if running_replicas is self._running_replicas:
+            # Identity means DeploymentState handed back its memoized tuple, so the
+            # running-replica ids are unchanged and the derived str set still matches.
+            return
         self._running_replicas = running_replicas
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -395,7 +410,9 @@ class DeploymentAutoscalingState:
             app_name=self._deployment_id.app_name,
             current_num_replicas=len(self._running_replicas),
             target_num_replicas=curr_target_num_replicas,
-            running_replicas=self._running_replicas,
+            # Copy: _running_replicas holds the memoized tuple from
+            # get_running_replica_ids(), and this is a stable public List[ReplicaID].
+            running_replicas=list(self._running_replicas),
             total_num_requests=self.get_total_num_requests,
             capacity_adjusted_min_replicas=self.get_num_replicas_lower_bound(),
             capacity_adjusted_max_replicas=self.get_num_replicas_upper_bound(),
@@ -1013,7 +1030,7 @@ class ApplicationAutoscalingState:
             }
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         self._deployment_autoscaling_states[deployment_id].update_running_replica_ids(
             running_replicas
@@ -1183,7 +1200,7 @@ class AutoscalingStateManager:
         )
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         app_state = self._app_autoscaling_states.get(deployment_id.app_name)
         if app_state:

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -107,10 +107,13 @@ class DeploymentAutoscalingState:
         self._policy_state: Optional[Dict[str, Any]] = None
         self._running_replicas: Sequence[ReplicaID] = []
         self._running_replica_id_set: Set[ReplicaID] = set()
+        # Set when a stop drops a replica that `_running_replicas` still lists, so
+        # the next membership update can't take the unchanged-list fast path.
+        self._membership_dirty: bool = False
         self._cached_running_replica_strs: Set[str] = set()
         # Running-requests series per running replica, kept in sync as reports
         # arrive so each control loop tick doesn't rescan every replica.
-        self._running_replica_running_requests: Dict[ReplicaID, TimeSeries] = {}
+        self._running_requests_by_replica: Dict[ReplicaID, TimeSeries] = {}
         # Bumped whenever the inputs to the merged ongoing-requests timeseries
         # change (replica/handle reports, running set); gates the merge cache.
         self._metrics_version: int = 0
@@ -208,10 +211,13 @@ class DeploymentAutoscalingState:
 
     def on_replica_stopped(self, replica_id: ReplicaID):
         self._replica_metrics.pop(replica_id, None)
-        # Defensive: keep a late report from re-adding the stopped replica
-        # before the next membership update.
-        self._running_replica_id_set.discard(replica_id)
-        if self._running_replica_running_requests.pop(replica_id, None) is not None:
+        # Defensive: keep a late report from re-adding the stopped replica before
+        # the next membership update. `_running_replicas` still lists it because it
+        # feeds policy inputs, so flag the divergence for the equality fast path.
+        if replica_id in self._running_replica_id_set:
+            self._running_replica_id_set.remove(replica_id)
+            self._membership_dirty = True
+        if self._running_requests_by_replica.pop(replica_id, None) is not None:
             self._metrics_version += 1
 
     def get_num_replicas_lower_bound(self) -> int:
@@ -237,18 +243,20 @@ class DeploymentAutoscalingState:
     def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
         # Called every control loop tick; membership is usually unchanged, so skip the
-        # O(replicas) rebuild and keep the merge cache valid. Compared element-wise
-        # because the caller memoizes a tuple, which never equals a stored list.
-        if len(running_replicas) == len(self._running_replicas) and all(
-            a == b for a, b in zip(running_replicas, self._running_replicas)
+        # set/dict rebuilds and keep the merge cache valid. Compared element-wise because
+        # the caller memoizes a tuple; a preceding stop forces the rebuild via the flag.
+        if not self._membership_dirty and (
+            len(running_replicas) == len(self._running_replicas)
+            and all(a == b for a, b in zip(running_replicas, self._running_replicas))
         ):
             return
+        self._membership_dirty = False
         self._running_replicas = running_replicas
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
         }
-        self._running_replica_running_requests = {
+        self._running_requests_by_replica = {
             replica_id: self._replica_metrics[replica_id].metrics[RUNNING_REQUESTS_KEY]
             for replica_id in running_replicas
             if replica_id in self._replica_metrics
@@ -303,13 +311,12 @@ class DeploymentAutoscalingState:
             # Only reports from running replicas feed the merged timeseries.
             if replica_id in self._running_replica_id_set:
                 if RUNNING_REQUESTS_KEY in replica_metric_report.metrics:
-                    self._running_replica_running_requests[
+                    self._running_requests_by_replica[
                         replica_id
                     ] = replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
                     self._metrics_version += 1
                 elif (
-                    self._running_replica_running_requests.pop(replica_id, None)
-                    is not None
+                    self._running_requests_by_replica.pop(replica_id, None) is not None
                 ):
                     self._metrics_version += 1
 
@@ -476,7 +483,7 @@ class DeploymentAutoscalingState:
         Returns:
             List of timeseries data.
         """
-        return list(self._running_replica_running_requests.values())
+        return list(self._running_requests_by_replica.values())
 
     def _collect_handle_queued_requests(self) -> List[TimeSeries]:
         """Collect queued requests timeseries from all handles.
@@ -705,10 +712,11 @@ class DeploymentAutoscalingState:
             # Add queued timeseries
             ongoing_requests_timeseries.extend(queued_timeseries)
 
-            (
-                self._merged_ongoing_requests_timeseries,
-                self._merged_ongoing_requests_window_start,
-            ) = self._merge_timeseries(ongoing_requests_timeseries)
+            merged, window_start = self._merge_timeseries(ongoing_requests_timeseries)
+            # Copy: a single-series merge returns that input list by reference, and
+            # the cache outlives the tick that built it.
+            self._merged_ongoing_requests_timeseries = list(merged)
+            self._merged_ongoing_requests_window_start = window_start
             self._merged_ongoing_requests_version = self._metrics_version
 
         # Aggregate and add running requests to total

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -207,10 +207,12 @@ class DeploymentAutoscalingState:
         return self.apply_bounds(target_num_replicas)
 
     def on_replica_stopped(self, replica_id: ReplicaID):
-        if replica_id in self._replica_metrics:
-            del self._replica_metrics[replica_id]
-            if self._running_replica_running_requests.pop(replica_id, None) is not None:
-                self._metrics_version += 1
+        self._replica_metrics.pop(replica_id, None)
+        # Defensive: keep a late report from re-adding the stopped replica
+        # before the next membership update.
+        self._running_replica_id_set.discard(replica_id)
+        if self._running_replica_running_requests.pop(replica_id, None) is not None:
+            self._metrics_version += 1
 
     def get_num_replicas_lower_bound(self) -> int:
         if self._config.initial_replicas is not None and (
@@ -304,9 +306,12 @@ class DeploymentAutoscalingState:
                     self._running_replica_running_requests[
                         replica_id
                     ] = replica_metric_report.metrics[RUNNING_REQUESTS_KEY]
-                else:
+                    self._metrics_version += 1
+                elif (
                     self._running_replica_running_requests.pop(replica_id, None)
-                self._metrics_version += 1
+                    is not None
+                ):
+                    self._metrics_version += 1
 
     def record_request_metrics_for_handle(
         self,

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -243,17 +243,27 @@ class DeploymentAutoscalingState:
     def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
         # Called every control loop tick; membership is usually unchanged, so skip the
-        # set/dict rebuilds and keep the merge cache valid. Compared element-wise because
-        # the caller memoizes a tuple; a preceding stop forces the rebuild via the flag.
+        # set/dict rebuilds and keep the merge cache valid. Identity is the common case
+        # (the caller memoizes); the element-wise compare covers a caller that does not,
+        # and a preceding stop forces the rebuild via the flag.
         if not self._membership_dirty and (
-            len(running_replicas) == len(self._running_replicas)
-            and all(a == b for a, b in zip(running_replicas, self._running_replicas))
+            running_replicas is self._running_replicas
+            or (
+                len(running_replicas) == len(self._running_replicas)
+                and all(
+                    a == b for a, b in zip(running_replicas, self._running_replicas)
+                )
+            )
         ):
             return
         self._membership_dirty = False
-        # Copy: this list is handed to user policies via `AutoscalingContext`, and the
-        # fast path above compares against it.
-        self._running_replicas = list(running_replicas)
+        # A tuple is aliased so the identity check above can hit; a list caller may keep
+        # mutating what it passed, so that has to be copied.
+        self._running_replicas = (
+            running_replicas
+            if isinstance(running_replicas, tuple)
+            else list(running_replicas)
+        )
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -215,6 +215,10 @@ class DeploymentAutoscalingState:
         # feeds policy inputs, so flag the divergence for the equality fast path.
         if replica_id in self._running_replica_id_set:
             self._running_replica_id_set.remove(replica_id)
+            # Simple mode filters on the string set, so drop it there too: otherwise a
+            # late report re-inserts itself into _replica_metrics and only that path
+            # counts it.
+            self._cached_running_replica_strs.discard(replica_id.to_full_id_str())
             self._membership_dirty = True
         if self._running_requests_by_replica.pop(replica_id, None) is not None:
             self._metrics_version += 1
@@ -243,26 +247,19 @@ class DeploymentAutoscalingState:
         """Update cached set of running replica IDs for this deployment."""
         # Called every control loop tick; membership is usually unchanged, so skip the
         # set/dict rebuilds and keep the merge cache valid. Identity is the common case
-        # (the caller memoizes); the element-wise compare covers a caller that does not,
-        # and a preceding stop forces the rebuild via the flag.
+        # (the caller memoizes); the value compare covers a caller that does not, and a
+        # preceding stop forces the rebuild via the flag. Comparing tuples rather than
+        # zipping keeps the walk in C, where it short-circuits on element identity.
         if not self._membership_dirty and (
             running_replicas is self._running_replicas
-            or (
-                len(running_replicas) == len(self._running_replicas)
-                and all(
-                    a == b for a, b in zip(running_replicas, self._running_replicas)
-                )
-            )
+            or tuple(running_replicas) == self._running_replicas
         ):
             return
         self._membership_dirty = False
-        # A tuple is aliased so the identity check above can hit; a list caller may keep
-        # mutating what it passed, so that has to be copied.
-        self._running_replicas = (
-            running_replicas
-            if isinstance(running_replicas, tuple)
-            else list(running_replicas)
-        )
+        # Stored as a tuple: tuple() hands back a tuple unchanged, so a caller that
+        # memoizes keeps hitting the identity check above, while a list caller gets a
+        # copy that its own mutations cannot reach.
+        self._running_replicas = tuple(running_replicas)
         self._running_replica_id_set = set(running_replicas)
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -903,8 +900,9 @@ class DeploymentAutoscalingState:
                 continue
 
             for metric_name, timeseries in replica_metric_report.metrics.items():
-                # Extract values from TimeStampedValue list
-                raw_metrics[metric_name][replica_id] = timeseries
+                # Copy: the merge cache reads these lists, so a policy mutating what it
+                # is handed here would corrupt the cached total invisibly.
+                raw_metrics[metric_name][replica_id] = list(timeseries)
 
         return dict(raw_metrics)
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -553,7 +553,9 @@ class ServeController:
         Controller decides where proxy actors should run
         (head node and nodes with deployment replicas).
         """
-        new_proxy_nodes = self.deployment_state_manager.get_active_node_ids()
+        # Copy: get_active_node_ids() returns a shared frozenset, and `frozenset - set`
+        # stays frozen, so the .add() below would raise without this.
+        new_proxy_nodes = set(self.deployment_state_manager.get_active_node_ids())
         new_proxy_nodes = new_proxy_nodes - set(
             self.cluster_node_info_cache.get_draining_nodes()
         )

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -533,7 +533,9 @@ class ServeController:
         Controller decides where proxy actors should run
         (head node and nodes with deployment replicas).
         """
-        new_proxy_nodes = self.deployment_state_manager.get_active_node_ids()
+        # Copy: get_active_node_ids() returns a shared frozenset, and `frozenset - set`
+        # stays frozen, so the .add() below would raise without this.
+        new_proxy_nodes = set(self.deployment_state_manager.get_active_node_ids())
         new_proxy_nodes = new_proxy_nodes - set(
             self.cluster_node_info_cache.get_draining_nodes()
         )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Deque,
     Dict,
+    FrozenSet,
     Iterable,
     List,
     Mapping,
@@ -2246,6 +2247,37 @@ class DeploymentReplica:
         return self._actor.get_outbound_deployments()
 
 
+def _memoized_walk(obj, memo_attr: str, token, compute):
+    """Return compute() memoized on *token* in obj.<memo_attr>.
+
+    token=None means "uncacheable right now": recompute and drop the memo.
+    Callers must treat returned collections as immutable (they are shared).
+    """
+    # No getattr default: a misspelled memo_attr must raise here rather than have
+    # setattr silently create a second memo the real attribute never sees.
+    memo = getattr(obj, memo_attr)
+    if token is not None and memo is not None and memo[0] == token:
+        return memo[1]
+    result = compute()
+    setattr(obj, memo_attr, None if token is None else (token, result))
+    return result
+
+
+# One odd multiplier per state. A hash of (replica_id, state) will not do: the tuple
+# hash makes term(r, A) - term(r, B) nearly independent of r, so two replicas swapping
+# states in one tick cancel out. Multiplying keeps that difference proportional to
+# hash(replica_id). Terms are ~128 bits, so each add/pop/remove is a small bigint add;
+# masking to 64 would reintroduce the cancellation, as the multiplier difference is even.
+_STATE_MULTIPLIERS = {
+    state: (2 * i + 1) * 0x9E3779B97F4A7C15 for i, state in enumerate(ReplicaState)
+}
+
+
+def _membership_term(replica_id: ReplicaID, state: ReplicaState) -> int:
+    """One fingerprint term -- add() adds it, pop()/remove() subtract the same value."""
+    return hash(replica_id) * _STATE_MULTIPLIERS[state]
+
+
 class ReplicaStateContainer:
     """Container for mapping ReplicaStates to lists of DeploymentReplicas."""
 
@@ -2256,6 +2288,21 @@ class ReplicaStateContainer:
         # Incremental (state, version) counts for O(1) version-filtered count()
         # (maintained on add/pop/remove) -> replaces the per-tick O(N) version scan.
         self._sv_counts: Dict[tuple, int] = defaultdict(int)
+        # Running sum of per-replica terms. The memo key is the membership_fingerprint
+        # property, which pairs this with the replica count.
+        self._membership_fingerprint: int = 0
+
+    @property
+    def membership_fingerprint(self) -> Tuple[int, int]:
+        """Fingerprint of the {replica id -> state} content, for memo keys.
+
+        Terms are summed, so popping a replica and re-adding it under the SAME state
+        cancels -- which is what the gang health pass and the drain pass do every tick --
+        while arrivals, departures and real state transitions do not. The exact replica
+        count rides along, so only equal-size contents can collide: equality means
+        "almost certainly unchanged", not proof.
+        """
+        return len(self._replica_id_index), self._membership_fingerprint
 
     def __getstate__(self):
         # Exclude the callback to keep the container picklable (the callback
@@ -2279,6 +2326,7 @@ class ReplicaStateContainer:
         self._replicas[state].append(replica)
         self._replica_id_index[replica.replica_id] = replica
         self._sv_counts[(state, replica.version)] += 1
+        self._membership_fingerprint += _membership_term(replica.replica_id, state)
         if self._on_replica_state_change and state != old_state:
             self._on_replica_state_change(old_state, state)
 
@@ -2370,8 +2418,11 @@ class ReplicaStateContainer:
 
             self._replicas[state] = remaining
             replicas.extend(popped)
-            for _r in popped:
-                self._sv_counts[(state, _r.version)] -= 1
+            for replica in popped:
+                self._sv_counts[(state, replica.version)] -= 1
+                self._membership_fingerprint -= _membership_term(
+                    replica.replica_id, state
+                )
 
         for replica in replicas:
             self._replica_id_index.pop(replica.replica_id, None)
@@ -2442,6 +2493,9 @@ class ReplicaStateContainer:
                 if remaining_to_find > 0 and replica.replica_id in replica_ids:
                     removed.append(replica)
                     self._sv_counts[(state, replica.version)] -= 1
+                    self._membership_fingerprint -= _membership_term(
+                        replica.replica_id, state
+                    )
                     self._replica_id_index.pop(replica.replica_id, None)
                     remaining_to_find -= 1
                     found_any = True
@@ -3008,7 +3062,11 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_ids: Optional[Set[str]] = None
+        self._last_rank_membership_fp: Optional[Tuple[int, int]] = None
+        # (token, result) memos for per-tick id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._running_replica_ids_memo = None
+        self._active_node_ids_memo = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -3413,16 +3471,52 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        return {r.actor_id for r in self._replicas.get() if r.actor_id is not None}
+    def _membership_cache_token(self) -> Optional[Tuple[int, int]]:
+        """Per-deployment memo token, or None while uncacheable.
 
-    def get_running_replica_ids(self) -> List[ReplicaID]:
-        return [
-            replica.replica_id
-            for replica in self._replicas.get(
-                [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+        The fingerprint covers which replica is in which state, not the replicas' own
+        fields -- and these walks read actor_id/actor_node_id, which check_ready() fills
+        in in place for STARTING, UPDATING and RECOVERING replicas. So disable caching
+        while any of the three exist.
+        """
+        if (
+            self._replicas.count(
+                states=[
+                    ReplicaState.STARTING,
+                    ReplicaState.UPDATING,
+                    ReplicaState.RECOVERING,
+                ]
             )
-        ]
+            > 0
+        ):
+            return None
+        return self._replicas.membership_fingerprint
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                r.actor_id for r in self._replicas.get() if r.actor_id is not None
+            ),
+        )
+
+    def get_running_replica_ids(self) -> Tuple[ReplicaID, ...]:
+        # Keyed on the fingerprint rather than the shared token: this walk reads only
+        # replica_id, which never changes after construction, so it has no check_ready()
+        # dependency and stays cached through rollouts.
+        return _memoized_walk(
+            self,
+            "_running_replica_ids_memo",
+            self._replicas.membership_fingerprint,
+            lambda: tuple(
+                replica.replica_id
+                for replica in self._replicas.get(
+                    [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                )
+            ),
+        )
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -3462,7 +3556,7 @@ class DeploymentState:
             - recovering_replicas
         )
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Get the node ids of all running replicas in this deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
@@ -3477,11 +3571,16 @@ class DeploymentState:
             # node before all the replicas are migrated.
             ReplicaState.PENDING_MIGRATION,
         ]
-        return {
-            replica.actor_node_id
-            for replica in self._replicas.get(active_states)
-            if replica.actor_node_id is not None
-        }
+        return _memoized_walk(
+            self,
+            "_active_node_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                replica.actor_node_id
+                for replica in self._replicas.get(active_states)
+                if replica.actor_node_id is not None
+            ),
+        )
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
@@ -5148,7 +5247,10 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so the active replica-id set gates it.
+        replica-id set changes, so the container's (id, state) fingerprint gates it.
+        It is finer than that set, so state transitions re-run the pass as well. That is
+        safe because a replica cannot run without a rank, so everything the pass sees
+        under a HEALTHY deployment holds one.
         """
         # O(1) guards first -- `get()` below copies the whole replica list, and these
         # two rule out the busiest ticks (rollouts, migrations) without paying for it.
@@ -5161,11 +5263,12 @@ class DeploymentState:
             or self._replicas.count(states=[ReplicaState.STARTING]) != 0
         ):
             return
+        fp = self._replicas.membership_fingerprint
+        if fp == self._last_rank_membership_fp:
+            return
         active_replicas = self._replicas.get()
         if not active_replicas:
-            return
-        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
-        if active_replica_ids == self._last_rank_membership_ids:
+            self._last_rank_membership_fp = fp
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -5174,7 +5277,7 @@ class DeploymentState:
         )
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        self._last_rank_membership_ids = active_replica_ids
+        self._last_rank_membership_fp = fp
 
     def _handle_deployment_actor_failed_health_check(
         self,
@@ -5958,6 +6061,9 @@ class DeploymentStateManager:
         self._shutdown_tier_started_at: Optional[float] = None
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # (key, result) memos for cross-deployment id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._active_node_ids_memo = None
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
         # reconcile on it, skipping the O(replicas) pass on ticks with no change.
@@ -6393,12 +6499,34 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids: Set[str] = set()
-        for ds in self._deployment_states.values():
-            alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+    def _membership_cache_key(self) -> Optional[tuple]:
+        """Combined per-deployment token, or None if any deployment is uncacheable.
 
-        return alive_replica_actor_ids
+        Adding or removing a deployment changes the tuple, so that is covered too. One
+        STARTING replica disarms this cluster-wide, but the per-deployment memos still
+        hit inside compute(), so it degrades to a union per deployment, not a walk per
+        replica."""
+        parts = []
+        for deployment_id, ds in self._deployment_states.items():
+            token = ds._membership_cache_token()
+            if token is None:
+                return None
+            parts.append((deployment_id, token))
+        return tuple(parts)
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        def compute():
+            alive_replica_actor_ids: Set[str] = set()
+            for ds in self._deployment_states.values():
+                alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+            return frozenset(alive_replica_actor_ids)
+
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_key(),
+            compute,
+        )
 
     def get_deployment_ids(self) -> List[DeploymentID]:
         return list(self._deployment_states.keys())
@@ -6836,16 +6964,22 @@ class DeploymentStateManager:
             return
         self._deployment_states[deployment_id].record_request_routing_info(info)
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Return set of node ids with running replicas of any deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
         head node should have active proxies.
         """
-        node_ids = set()
-        for deployment_state in self._deployment_states.values():
-            node_ids.update(deployment_state.get_active_node_ids())
-        return node_ids
+
+        def compute():
+            node_ids = set()
+            for deployment_state in self._deployment_states.values():
+                node_ids.update(deployment_state.get_active_node_ids())
+            return frozenset(node_ids)
+
+        return _memoized_walk(
+            self, "_active_node_ids_memo", self._membership_cache_key(), compute
+        )
 
     def get_ingress_membership_version(self) -> int:
         """Monotonic counter of ingress running-replica-set changes (node/ports

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,7 +10,17 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 import ray
 from ray import ObjectRef, cloudpickle
@@ -2172,6 +2182,37 @@ class DeploymentReplica:
         return self._actor.get_outbound_deployments()
 
 
+def _memoized_walk(obj, memo_attr: str, token, compute):
+    """Return compute() memoized on *token* in obj.<memo_attr>.
+
+    token=None means "uncacheable right now": recompute and drop the memo.
+    Callers must treat returned collections as immutable (they are shared).
+    """
+    # No getattr default: a misspelled memo_attr must raise here rather than have
+    # setattr silently create a second memo the real attribute never sees.
+    memo = getattr(obj, memo_attr)
+    if token is not None and memo is not None and memo[0] == token:
+        return memo[1]
+    result = compute()
+    setattr(obj, memo_attr, None if token is None else (token, result))
+    return result
+
+
+# One odd multiplier per state. A hash of (replica_id, state) will not do: the tuple
+# hash makes term(r, A) - term(r, B) nearly independent of r, so two replicas swapping
+# states in one tick cancel out. Multiplying keeps that difference proportional to
+# hash(replica_id). Terms are ~128 bits, so each add/pop/remove is a small bigint add;
+# masking to 64 would reintroduce the cancellation, as the multiplier difference is even.
+_STATE_MULTIPLIERS = {
+    state: (2 * i + 1) * 0x9E3779B97F4A7C15 for i, state in enumerate(ReplicaState)
+}
+
+
+def _membership_term(replica_id: ReplicaID, state: ReplicaState) -> int:
+    """One fingerprint term -- add() adds it, pop()/remove() subtract the same value."""
+    return hash(replica_id) * _STATE_MULTIPLIERS[state]
+
+
 class ReplicaStateContainer:
     """Container for mapping ReplicaStates to lists of DeploymentReplicas."""
 
@@ -2182,6 +2223,21 @@ class ReplicaStateContainer:
         # Incremental (state, version) counts for O(1) version-filtered count()
         # (maintained on add/pop/remove) -> replaces the per-tick O(N) version scan.
         self._sv_counts: Dict[tuple, int] = defaultdict(int)
+        # Running sum of per-replica terms. The memo key is the membership_fingerprint
+        # property, which pairs this with the replica count.
+        self._membership_fingerprint: int = 0
+
+    @property
+    def membership_fingerprint(self) -> Tuple[int, int]:
+        """Fingerprint of the {replica id -> state} content, for memo keys.
+
+        Terms are summed, so popping a replica and re-adding it under the SAME state
+        cancels -- which is what the gang health pass and the drain pass do every tick --
+        while arrivals, departures and real state transitions do not. The exact replica
+        count rides along, so only equal-size contents can collide: equality means
+        "almost certainly unchanged", not proof.
+        """
+        return len(self._replica_id_index), self._membership_fingerprint
 
     def __getstate__(self):
         # Exclude the callback to keep the container picklable (the callback
@@ -2205,6 +2261,7 @@ class ReplicaStateContainer:
         self._replicas[state].append(replica)
         self._replica_id_index[replica.replica_id] = replica
         self._sv_counts[(state, replica.version)] += 1
+        self._membership_fingerprint += _membership_term(replica.replica_id, state)
         if self._on_replica_state_change and state != old_state:
             self._on_replica_state_change(old_state, state)
 
@@ -2296,8 +2353,11 @@ class ReplicaStateContainer:
 
             self._replicas[state] = remaining
             replicas.extend(popped)
-            for _r in popped:
-                self._sv_counts[(state, _r.version)] -= 1
+            for replica in popped:
+                self._sv_counts[(state, replica.version)] -= 1
+                self._membership_fingerprint -= _membership_term(
+                    replica.replica_id, state
+                )
 
         for replica in replicas:
             self._replica_id_index.pop(replica.replica_id, None)
@@ -2368,6 +2428,9 @@ class ReplicaStateContainer:
                 if remaining_to_find > 0 and replica.replica_id in replica_ids:
                     removed.append(replica)
                     self._sv_counts[(state, replica.version)] -= 1
+                    self._membership_fingerprint -= _membership_term(
+                        replica.replica_id, state
+                    )
                     self._replica_id_index.pop(replica.replica_id, None)
                     remaining_to_find -= 1
                     found_any = True
@@ -2934,7 +2997,11 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_ids: Optional[Set[str]] = None
+        self._last_rank_membership_fp: Optional[Tuple[int, int]] = None
+        # (token, result) memos for per-tick id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._running_replica_ids_memo = None
+        self._active_node_ids_memo = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -3311,16 +3378,50 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        return {replica.actor_id for replica in self._replicas.get()}
+    def _membership_cache_token(self) -> Optional[Tuple[int, int]]:
+        """Per-deployment memo token, or None while uncacheable.
 
-    def get_running_replica_ids(self) -> List[ReplicaID]:
-        return [
-            replica.replica_id
-            for replica in self._replicas.get(
-                [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+        The fingerprint covers which replica is in which state, not the replicas' own
+        fields -- and these walks read actor_id/actor_node_id, which check_ready() fills
+        in in place for STARTING, UPDATING and RECOVERING replicas. So disable caching
+        while any of the three exist.
+        """
+        if (
+            self._replicas.count(
+                states=[
+                    ReplicaState.STARTING,
+                    ReplicaState.UPDATING,
+                    ReplicaState.RECOVERING,
+                ]
             )
-        ]
+            > 0
+        ):
+            return None
+        return self._replicas.membership_fingerprint
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(replica.actor_id for replica in self._replicas.get()),
+        )
+
+    def get_running_replica_ids(self) -> Tuple[ReplicaID, ...]:
+        # Keyed on the fingerprint rather than the shared token: this walk reads only
+        # replica_id, which never changes after construction, so it has no check_ready()
+        # dependency and stays cached through rollouts.
+        return _memoized_walk(
+            self,
+            "_running_replica_ids_memo",
+            self._replicas.membership_fingerprint,
+            lambda: tuple(
+                replica.replica_id
+                for replica in self._replicas.get(
+                    [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                )
+            ),
+        )
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -3357,7 +3458,7 @@ class DeploymentState:
             - recovering_replicas
         )
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Get the node ids of all running replicas in this deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
@@ -3372,11 +3473,16 @@ class DeploymentState:
             # node before all the replicas are migrated.
             ReplicaState.PENDING_MIGRATION,
         ]
-        return {
-            replica.actor_node_id
-            for replica in self._replicas.get(active_states)
-            if replica.actor_node_id is not None
-        }
+        return _memoized_walk(
+            self,
+            "_active_node_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                replica.actor_node_id
+                for replica in self._replicas.get(active_states)
+                if replica.actor_node_id is not None
+            ),
+        )
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
@@ -4981,7 +5087,10 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so the active replica-id set gates it.
+        replica-id set changes, so the container's (id, state) fingerprint gates it.
+        It is finer than that set, so state transitions re-run the pass as well. That is
+        safe because a replica cannot run without a rank, so everything the pass sees
+        under a HEALTHY deployment holds one.
         """
         # O(1) guards first -- `get()` below copies the whole replica list, and these
         # two rule out the busiest ticks (rollouts, migrations) without paying for it.
@@ -4994,11 +5103,12 @@ class DeploymentState:
             or self._replicas.count(states=[ReplicaState.STARTING]) != 0
         ):
             return
+        fp = self._replicas.membership_fingerprint
+        if fp == self._last_rank_membership_fp:
+            return
         active_replicas = self._replicas.get()
         if not active_replicas:
-            return
-        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
-        if active_replica_ids == self._last_rank_membership_ids:
+            self._last_rank_membership_fp = fp
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -5007,7 +5117,7 @@ class DeploymentState:
         )
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        self._last_rank_membership_ids = active_replica_ids
+        self._last_rank_membership_fp = fp
 
     def _handle_deployment_actor_failed_health_check(
         self,
@@ -5780,6 +5890,9 @@ class DeploymentStateManager:
         self._shutdown_tier_started_at: Optional[float] = None
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # (key, result) memos for cross-deployment id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._active_node_ids_memo = None
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
         # reconcile on it, skipping the O(replicas) pass on ticks with no change.
@@ -6208,12 +6321,34 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids = set()
-        for ds in self._deployment_states.values():
-            alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+    def _membership_cache_key(self) -> Optional[tuple]:
+        """Combined per-deployment token, or None if any deployment is uncacheable.
 
-        return alive_replica_actor_ids
+        Adding or removing a deployment changes the tuple, so that is covered too. One
+        STARTING replica disarms this cluster-wide, but the per-deployment memos still
+        hit inside compute(), so it degrades to a union per deployment, not a walk per
+        replica."""
+        parts = []
+        for deployment_id, ds in self._deployment_states.items():
+            token = ds._membership_cache_token()
+            if token is None:
+                return None
+            parts.append((deployment_id, token))
+        return tuple(parts)
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        def compute():
+            alive_replica_actor_ids = set()
+            for ds in self._deployment_states.values():
+                alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+            return frozenset(alive_replica_actor_ids)
+
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_key(),
+            compute,
+        )
 
     def get_deployment_ids(self) -> List[DeploymentID]:
         return list(self._deployment_states.keys())
@@ -6640,16 +6775,22 @@ class DeploymentStateManager:
             return
         self._deployment_states[deployment_id].record_request_routing_info(info)
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Return set of node ids with running replicas of any deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
         head node should have active proxies.
         """
-        node_ids = set()
-        for deployment_state in self._deployment_states.values():
-            node_ids.update(deployment_state.get_active_node_ids())
-        return node_ids
+
+        def compute():
+            node_ids = set()
+            for deployment_state in self._deployment_states.values():
+                node_ids.update(deployment_state.get_active_node_ids())
+            return frozenset(node_ids)
+
+        return _memoized_walk(
+            self, "_active_node_ids_memo", self._membership_cache_key(), compute
+        )
 
     def get_ingress_membership_version(self) -> int:
         """Monotonic counter of ingress running-replica-set changes (node/ports

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1678,6 +1678,26 @@ class TestMergedTimeseriesCache:
 
         assert state.get_total_num_requests() == pytest.approx(10.0)
 
+    def test_membership_survives_caller_list_mutation(self):
+        """`_running_replicas` is handed to user policies through
+        `AutoscalingContext`, so a policy mutating it in place must not make a real
+        membership change look like a no-op to the unchanged-list fast path."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        r2 = ReplicaID(unique_id="r2", deployment_id=state._deployment_id)
+        now = time.time()
+
+        running = [r1, r2]
+        state.update_running_replica_ids(running)
+        self._record_replica(state, r1, 5.0, now)
+        self._record_replica(state, r2, 5.0, now)
+        assert state.get_total_num_requests() == pytest.approx(10.0)
+
+        running.pop()
+        state.update_running_replica_ids([r1])
+
+        assert state.get_total_num_requests() == pytest.approx(5.0)
+
     def test_dropping_stale_handle_metrics_lowers_total(self):
         """Dropping a handle's metrics has to invalidate the cached merge."""
         state = self._create_state()

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1659,6 +1659,26 @@ class TestMergedTimeseriesCache:
         self._record_replica(state, r1, 7.0, now)
         assert state.get_total_num_requests() == pytest.approx(5.0)
 
+    def test_late_report_from_stopped_replica_is_excluded_in_simple_mode(self):
+        """Aggregate mode filters on the id set and simple mode on the string set, so a
+        stop has to drop the replica from both or the late report inflates one path."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        r2 = ReplicaID(unique_id="r2", deployment_id=state._deployment_id)
+        now = time.time()
+
+        state.update_running_replica_ids([r1, r2])
+        self._record_replica(state, r1, 5.0, now)
+        self._record_replica(state, r2, 5.0, now)
+        assert state._calculate_total_requests_simple_mode() == pytest.approx(10.0)
+
+        state.on_replica_stopped(r1)
+        # Racing report re-inserts r1 into _replica_metrics.
+        self._record_replica(state, r1, 7.0, now)
+
+        assert state._calculate_total_requests_simple_mode() == pytest.approx(5.0)
+        assert state._calculate_total_requests_aggregate_mode() == pytest.approx(5.0)
+
     def test_stop_then_unchanged_membership_update_rebuilds(self):
         """on_replica_stopped diverges the running set from `_running_replicas`, so
         the next update has to rebuild even though the list is unchanged."""

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1698,6 +1698,21 @@ class TestMergedTimeseriesCache:
 
         assert state.get_total_num_requests() == pytest.approx(5.0)
 
+    def test_unchanged_membership_as_tuple_takes_fast_path(self):
+        """`get_running_replica_ids()` memoizes and returns a tuple, which never compares
+        equal to the list stored here, so the fast path has to compare element-wise or the
+        merge cache is invalidated on every tick."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        r2 = ReplicaID(unique_id="r2", deployment_id=state._deployment_id)
+
+        state.update_running_replica_ids([r1, r2])
+        version = state._metrics_version
+
+        state.update_running_replica_ids((r1, r2))
+
+        assert state._metrics_version == version
+
     def test_dropping_stale_handle_metrics_lowers_total(self):
         """Dropping a handle's metrics has to invalidate the cached merge."""
         state = self._create_state()

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1,11 +1,20 @@
 import math
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from ray.serve._private.autoscaling_state import DeploymentAutoscalingState
-from ray.serve._private.common import DeploymentID, ReplicaID, TimeStampedValue
+from ray.serve._private.common import (
+    RUNNING_REQUESTS_KEY,
+    DeploymentHandleSource,
+    DeploymentID,
+    HandleMetricReport,
+    ReplicaID,
+    ReplicaMetricReport,
+    TimeStampedValue,
+)
 from ray.serve._private.constants import (
     CONTROL_LOOP_INTERVAL_S,
     SERVE_AUTOSCALING_DECISION_COUNTERS_KEY,
@@ -1569,6 +1578,128 @@ class TestAppLevelPolicyStateIsolation:
         assert final_state[d2][SERVE_AUTOSCALING_DECISION_TIMESTAMP_KEY] == fake_now
         # user state remains intact
         assert final_state[d2]["counter"] == 5
+
+
+class TestMergedTimeseriesCache:
+    """The merged ongoing-requests timeseries is cached across control loop ticks,
+    so every mutation of its inputs has to invalidate it."""
+
+    @pytest.fixture(autouse=True)
+    def aggregate_at_controller(self):
+        """The cache only exists on the controller-side aggregation path."""
+        with patch.object(
+            DeploymentAutoscalingState,
+            "_should_aggregate_metrics_at_controller",
+            return_value=True,
+        ):
+            yield
+
+    def _create_state(self) -> DeploymentAutoscalingState:
+        state = DeploymentAutoscalingState(DeploymentID(name="test", app_name="app"))
+
+        info = MagicMock()
+        info.deployment_config.autoscaling_config = AutoscalingConfig(
+            min_replicas=1,
+            max_replicas=10,
+        )
+        info.deployment_config.gang_scheduling_config = None
+        info.target_capacity = None
+        info.target_capacity_direction = None
+        info.config_changed.return_value = False
+
+        state.register(info, curr_target_num_replicas=1)
+        return state
+
+    def _record_replica(
+        self,
+        state: DeploymentAutoscalingState,
+        replica_id: ReplicaID,
+        value: float,
+        timestamp: float,
+    ):
+        state.record_request_metrics_for_replica(
+            ReplicaMetricReport(
+                replica_id=replica_id,
+                aggregated_metrics={RUNNING_REQUESTS_KEY: value},
+                metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp, value)]},
+                timestamp=timestamp,
+            )
+        )
+
+    def test_report_after_unchanged_membership_update(self):
+        """A report arriving after the unchanged-list fast path must reach the total."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        now = time.time()
+
+        state.update_running_replica_ids([r1])
+        # Equal (but distinct) list: takes the fast path.
+        state.update_running_replica_ids([r1])
+        # Populate the cache so the report below has to invalidate it.
+        assert state.get_total_num_requests() == 0.0
+        self._record_replica(state, r1, 5.0, now)
+
+        assert state.get_total_num_requests() == pytest.approx(5.0)
+
+    def test_late_report_from_stopped_replica_is_excluded(self):
+        """A report racing on_replica_stopped must not inflate the total."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        r2 = ReplicaID(unique_id="r2", deployment_id=state._deployment_id)
+        now = time.time()
+
+        state.update_running_replica_ids([r1, r2])
+        self._record_replica(state, r1, 5.0, now)
+        self._record_replica(state, r2, 5.0, now)
+        assert state.get_total_num_requests() == pytest.approx(10.0)
+
+        state.on_replica_stopped(r1)
+        assert state.get_total_num_requests() == pytest.approx(5.0)
+
+        self._record_replica(state, r1, 7.0, now)
+        assert state.get_total_num_requests() == pytest.approx(5.0)
+
+    def test_stop_then_unchanged_membership_update_rebuilds(self):
+        """on_replica_stopped diverges the running set from `_running_replicas`, so
+        the next update has to rebuild even though the list is unchanged."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        r2 = ReplicaID(unique_id="r2", deployment_id=state._deployment_id)
+        now = time.time()
+
+        running = [r1, r2]
+        state.update_running_replica_ids(running)
+        self._record_replica(state, r1, 5.0, now)
+        self._record_replica(state, r2, 5.0, now)
+
+        state.on_replica_stopped(r1)
+        state.update_running_replica_ids(running)
+        self._record_replica(state, r1, 5.0, now)
+
+        assert state.get_total_num_requests() == pytest.approx(10.0)
+
+    def test_dropping_stale_handle_metrics_lowers_total(self):
+        """Dropping a handle's metrics has to invalidate the cached merge."""
+        state = self._create_state()
+        now = time.time()
+
+        state.record_request_metrics_for_handle(
+            HandleMetricReport(
+                deployment_id=state._deployment_id,
+                handle_id="h1",
+                actor_id="dead_actor",
+                handle_source=DeploymentHandleSource.PROXY,
+                aggregated_queued_requests=3.0,
+                queued_requests=[TimeStampedValue(now, 3.0)],
+                aggregated_metrics={},
+                metrics={},
+                timestamp=now,
+            )
+        )
+        assert state.get_total_num_requests() == pytest.approx(3.0)
+
+        state.drop_stale_handle_metrics(alive_serve_actor_ids=set())
+        assert state.get_total_num_requests() == 0.0
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1713,6 +1713,30 @@ class TestMergedTimeseriesCache:
 
         assert state._metrics_version == version
 
+    def test_repeated_memoized_tuple_is_aliased(self):
+        """The caller memoizes and hands back the same tuple while membership is
+        unchanged; aliasing it keeps the check O(1) instead of walking every replica."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        memo = (r1,)
+
+        state.update_running_replica_ids(memo)
+        version = state._metrics_version
+        state.update_running_replica_ids(memo)
+
+        assert state._metrics_version == version
+        assert state._running_replicas is memo
+
+    def test_caller_list_is_copied_not_aliased(self):
+        """A list caller may keep mutating what it passed, so it must not be aliased."""
+        state = self._create_state()
+        r1 = ReplicaID(unique_id="r1", deployment_id=state._deployment_id)
+        passed = [r1]
+
+        state.update_running_replica_ids(passed)
+
+        assert state._running_replicas is not passed
+
     def test_dropping_stale_handle_metrics_lowers_total(self):
         """Dropping a handle's metrics has to invalidate the cached merge."""
         state = self._create_state()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -394,6 +394,97 @@ class TestReplicaStateContainer:
             states=[ReplicaState.STOPPING],
         ) == [r1]
 
+    def test_membership_fingerprint_ignores_rebucketing_churn(self):
+        """The health and migration passes pop a whole bucket and re-add it every
+        tick. Only a real change of the {replica id -> state} content may show up."""
+        c = ReplicaStateContainer()
+        r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.RUNNING, r2)
+        settled = c.membership_fingerprint
+
+        # The migration pass: pop the bucket, re-add each replica to the state it
+        # came from. Order within a bucket is not membership.
+        for r in reversed(c.pop(states=[ReplicaState.RUNNING])):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == settled
+
+        # The in-place health path re-buckets a single replica: remove + re-add.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.RUNNING, r1)
+        assert c.membership_fingerprint == settled
+
+        # A real state transition, an arrival and a departure each change it.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.STOPPING, r1)
+        transitioned = c.membership_fingerprint
+        assert transitioned != settled
+
+        c.add(ReplicaState.RUNNING, replica(deployment_version("1")))
+        arrived = c.membership_fingerprint
+        assert arrived not in (settled, transitioned)
+
+        c.remove({r2.replica_id})
+        assert c.membership_fingerprint not in (settled, transitioned, arrived)
+
+    def test_paired_state_swap_changes_the_fingerprint(self):
+        """A drain tick moves one replica into a state as another moves out, so the
+        counts are unchanged and only the terms can tell the two apart."""
+        for _ in range(32):
+            c = ReplicaStateContainer()
+            r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+            c.add(ReplicaState.RUNNING, r1)
+            c.add(ReplicaState.PENDING_MIGRATION, r2)
+            before = c.membership_fingerprint
+
+            c.remove({r1.replica_id, r2.replica_id})
+            c.add(ReplicaState.PENDING_MIGRATION, r1)
+            c.add(ReplicaState.RUNNING, r2)
+            assert c.membership_fingerprint != before
+
+    def test_membership_terms_do_not_cancel_across_replicas(self):
+        """The swap above is only caught if term(r, A) - term(r, B) differs per replica.
+        Hashing (replica_id, state) as a tuple collapses it to a handful of values, which
+        makes a paired swap invisible for a large fraction of replica pairs."""
+        deltas = {
+            ds_mod._membership_term(r.replica_id, ReplicaState.RUNNING)
+            - ds_mod._membership_term(r.replica_id, ReplicaState.PENDING_MIGRATION)
+            for r in (replica(deployment_version("1")) for _ in range(64))
+        }
+        assert len(deltas) == 64
+
+    def test_membership_fingerprint_matches_a_recompute(self):
+        """The fingerprint is maintained incrementally, so pin it to ground truth: a
+        future bucket write that forgot to update it would silently make both the memos
+        and the rank gate skip real work."""
+
+        def recomputed(c):
+            return len(c._replica_id_index), sum(
+                ds_mod._membership_term(r.replica_id, state)
+                for state, replicas in c._replicas.items()
+                for r in replicas
+            )
+
+        c = ReplicaStateContainer()
+        r1, r2, r3 = (replica(deployment_version("1")) for _ in range(3))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.STARTING, r2)
+        c.add(ReplicaState.RUNNING, r3)
+        assert c.membership_fingerprint == recomputed(c)
+
+        for r in c.pop(states=[ReplicaState.RUNNING]):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.remove({r1.replica_id})
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.pop(states=[ReplicaState.STARTING])
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.add(ReplicaState.STOPPING, r1)
+        assert c.membership_fingerprint == recomputed(c)
+
 
 def _mock_deployment_actor_wrapper(deployment_id, code_version: str, name: str):
     """Create a MockDeploymentActorWrapper for container tests."""
@@ -10693,6 +10784,187 @@ class TestRankConsistencyMembershipGate:
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
         assert ds._rank_manager.consistency_calls == 0
+
+    def test_draining_elsewhere_does_not_rerun_the_pass(
+        self, rank_gate_dsm, mock_deployment_state_manager
+    ):
+        """A node draining elsewhere in the cluster churns the buckets every tick
+        without changing membership; the O(N) pass must still be gated off."""
+        dsm, ds, rank_manager, _ = rank_gate_dsm
+        _, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+        node = NodeID.from_random().hex()
+        cluster_node_info_cache.add_node(node)
+        before = rank_manager.consistency_calls
+
+        cluster_node_info_cache.draining_nodes = {node: 60 * 1000}
+        for _ in range(5):
+            bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+            dsm.update()
+            # pop() installs a fresh bucket list, so this witnesses the churn rather
+            # than assuming it -- otherwise the assertion below could hold vacuously.
+            assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+            # The gate's first guard is HEALTHY: a status flip would make this
+            # pass for the wrong reason.
+            assert ds._curr_status_info.status == DeploymentStatus.HEALTHY
+        assert rank_manager.consistency_calls == before
+
+
+def test_running_replica_ids_stay_cached_during_a_rollout(
+    mock_deployment_state_manager,
+):
+    """The running-id walk reads only replica_id, so unlike the other two it does not
+    need the STARTING/UPDATING/RECOVERING disarm -- and staying cached through a rollout
+    is what keeps the autoscaler from rebuilding its id-string set every tick."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=2, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v)])
+
+    # Scale up: the third replica stays STARTING, which disarms the shared token.
+    info, _ = deployment_info(num_replicas=3, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.update()
+    assert ds._replicas.count(states=[ReplicaState.STARTING]) == 1
+    assert ds._membership_cache_token() is None
+
+    running, alive = ds.get_running_replica_ids(), ds.get_alive_replica_actor_ids()
+    for _ in range(3):
+        dsm.update()
+        assert ds.get_running_replica_ids() is running
+        # The other walks read actor_id/actor_node_id, so they stay disarmed.
+        assert ds.get_alive_replica_actor_ids() is not alive
+
+
+def test_steady_state_ticks_do_not_change_the_fingerprint(
+    mock_deployment_state_manager,
+):
+    """The memo's whole value: an idle tick must not mutate the container."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=8, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.save_checkpoint()
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=8, by_state=[(ReplicaState.RUNNING, 8, v)])
+    for _ in range(3):
+        dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(20):
+        dsm.update()
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+
+
+def test_draining_elsewhere_does_not_invalidate_the_memo(
+    mock_deployment_state_manager,
+):
+    """A node draining elsewhere in the cluster makes the migration pass pop the
+    whole RUNNING bucket and re-add it every tick, membership unchanged."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    node, draining_node = NodeID.from_random().hex(), NodeID.from_random().hex()
+    cluster_node_info_cache.add_node(node)
+    cluster_node_info_cache.add_node(draining_node)
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=4, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for r in ds._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_node_id(node)
+        r._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+    # None of these replicas is on the draining node, so none of them moves.
+    cluster_node_info_cache.draining_nodes = {draining_node: 60 * 1000}
+    dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    # The controller and proxy read the manager-level getters, which key on the
+    # per-deployment tokens.
+    dsm_alive, dsm_nodes = dsm.get_alive_replica_actor_ids(), dsm.get_active_node_ids()
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list, so this witnesses the churn the test
+        # is about -- without it the assertions below could pass vacuously.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+        assert dsm.get_alive_replica_actor_ids() is dsm_alive
+        assert dsm.get_active_node_ids() is dsm_nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+
+def test_gang_health_churn_does_not_invalidate_the_memo(mock_deployment_state_manager):
+    """Gang deployments health-check through the pop-and-re-add path, so their
+    buckets churn on every tick with membership unchanged."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    deployment_id = DeploymentID(name="gang_memo", app_name="app")
+    info, v = deployment_info(
+        num_replicas=4,
+        version="v1",
+        gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+    )
+    dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+        return_value={
+            deployment_id: GangReservationResult(
+                success=True,
+                gang_pgs=[Mock(name="pg-0"), Mock(name="pg-1")],
+                gang_ids=["g0", "g1"],
+                gang_pg_names=["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"],
+            )
+        }
+    )
+    dsm.deploy(deployment_id, info)
+    ds = dsm._get_deployment_state_for_testing(deployment_id)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+    assert ds._is_gang_deployment, "the churn path under test is the gang one"
+
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list: the churn is real, not assumed.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

With direct ingress enabled (`RAY_SERVE_ENABLE_DIRECT_INGRESS`, forced on by `RAY_SERVE_ENABLE_HA_PROXY`), autoscaling metrics use aggregate mode: the controller merges raw per-replica timeseries instead of summing pre-aggregated values. This path re-collected every running replica's series and re-ran the k-way merge on **every control loop tick**, even when no new metric report had arrived — O(replicas × points) per tick. The work runs under `ApplicationStateManager.update()` → `app.autoscale()` → `get_total_num_requests()`, so it shows up as application-state update time.

In pinned controller benchmarks at 4096 replicas this made the application state update ~7x more expensive with direct ingress on (~90 ms/loop vs ~12.6 ms off). The slow loop starves metric-report ingest (report processing delays of 3–11 s at 4K), and at 8192 replicas the lag crosses the 20 s handle-metrics eviction threshold.

This PR makes the recomputation proportional to what actually changed, with no behavior change:

- **Version the merge inputs.** A `_metrics_version` counter is bumped only when the inputs to the merged ongoing-requests timeseries change (replica/handle report accepted, replica stopped, stale handle dropped, running set changed). The merged timeseries and its aligned window start are rebuilt only when the version moves; the time-dependent aggregation (`last_window_s`, time-weighted average) still runs on every call. To enable this, `_merge_and_aggregate_timeseries` is split into `_merge_timeseries` (time-independent, cacheable) and `_aggregate_merged_timeseries` (per-call); the moved code is unchanged and the original function remains as a composition for its other callers.
- **Incremental collect.** A `running replica → running-requests series` dict is kept in sync as reports arrive, so the per-tick collect is `list(dict.values())` instead of an O(replicas) rescan.
- **Skip no-op membership updates.** `update_running_replica_ids` is called every tick with an unchanged list; it now early-returns instead of rebuilding the O(replicas) `to_full_id_str()` set each time (cheap check: the list holds the same `ReplicaID` objects, so `==` hits the identity fast path).

Repeated `get_total_num_requests` calls within one tick (e.g. the autoscaling log line) now also reuse the cached merge, and the persistent merged buffer removes ~20K short-lived objects per tick of GC churn at 4096 replicas.

Microbenchmark (controller-tick reproduction: 1 app, autoscaled deployment, direct-ingress report topology, reports arriving at the default 10 s push cadence; mean application-state update per tick):

### Performance

Controller-side microbench (mock DSM, direct-ingress/HA-on shape, one deployment,
`asm_update` p50 per control-loop tick, devbox, same session):

| N | shape | base | this PR | speedup |
|---|---|---|---|---|
| 4096 | reports every metrics interval | 7.75 ms | 6.50 ms | 1.19x |
| 4096 | no new reports | 7.78 ms | 0.80 ms | 9.7x |
| 8192 | reports every metrics interval | 15.72 ms | 12.6 ms | 1.25x |

n=3 per 4096 point, n=2 per 8192 point. The no-new-reports row is the best case:
every accepted replica or handle report bumps `_metrics_version`, so at 4096
replicas under live load the cross-tick cache misses on most ticks.

The always-on win is the intra-tick dedup, independent of report arrival rate.
`AutoscalingContext.total_num_requests` is a property that re-invokes the
callable on every access (`config.py:162-165`), and it is wired directly to
`get_total_num_requests` (`autoscaling_state.py:447`). A rescaling tick reads it
from `autoscaling_policy.py:334`, again through `running_requests`
(`config.py:177`), and again in the autoscaling log f-string
(`deployment_state.py:3676`) -- 2-3 full merges per rescaling tick collapsed to
one.

### Behavior change

Reports now feed the merged series only for replicas in the running set, so a
report arriving after `on_replica_stopped` is dropped from it. Previously it
would have been merged, because `_running_replicas` still listed the replica.
This matches the existing intent for aggregated metrics -- stale reports from
stopped replicas are filtered to avoid inflating the total -- but it is a
semantic change riding along with the caching, so it is called out here and
pinned by `test_late_report_from_stopped_replica_is_excluded`.
Testing:
- Existing unit suites pass: `test_application_state.py`, `test_autoscaling_policy.py`, `test_metrics_utils.py`, `test_deployment_state.py` (435 tests), run in both default and `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER=1` modes.
- Differential fuzzer: 19k randomized report/membership/stop/drop sequences comparing the cached path against the pre-change computation with a frozen clock, requiring exact float equality — zero mismatches.
<img width="1248" height="728" alt="perf_A8_loop_haproxy_on" src="https://github.com/user-attachments/assets/22ef2b3b-d98d-48bd-acbd-93eeac5a9b34" />
