### PR TITLE
[dashboard] Aggregate OTLP histogram deltas directly and ingest metric reports off the event loop

### DIFF
--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -1,9 +1,10 @@
+import bisect
 import logging
 import os
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 from urllib.parse import unquote
 
 from opentelemetry import metrics
@@ -19,6 +20,97 @@ from ray._private.telemetry.metric_types import MetricType
 logger = logging.getLogger(__name__)
 
 NAMESPACE = "ray"
+
+
+class _HistogramDef:
+    """Static definition of a histogram metric: boundaries and midpoints."""
+
+    __slots__ = ("description", "boundaries", "midpoints")
+
+    def __init__(self, description: str, boundaries: List[float]):
+        self.description = description
+        self.boundaries = list(boundaries)
+        self.midpoints = _histogram_bucket_midpoints(boundaries)
+
+
+class _HistogramData:
+    """Accumulated histogram aggregation for one label set.
+
+    ``bucket_counts`` holds per-bucket (non-cumulative) counts, with the
+    implicit +Inf bucket as the last element.
+    """
+
+    __slots__ = ("bucket_counts", "sum")
+
+    def __init__(self, num_buckets: int):
+        self.bucket_counts = [0] * num_buckets
+        self.sum = 0.0
+
+
+def _histogram_bucket_midpoints(buckets: List[float]) -> List[float]:
+    """Approximate midpoints for each histogram bucket, including +Inf."""
+    midpoints = []
+    for i in range(len(buckets)):
+        if i == 0:
+            lower_bound = 0.0 if buckets[0] > 0 else buckets[0] * 2.0
+            midpoints.append((lower_bound + buckets[0]) / 2.0)
+        else:
+            midpoints.append((buckets[i] + buckets[i - 1]) / 2.0)
+    # Approximated mid point for Inf+ bucket. Inf+ bucket is an implicit bucket
+    # that is not part of buckets.
+    midpoints.append(1.0 if buckets[-1] <= 0 else buckets[-1] * 2.0)
+    return midpoints
+
+
+class _HistogramPrometheusCollector:
+    """prometheus_client collector rendering the accumulated histogram states.
+
+    Histograms are aggregated directly into per-bucket counts (see
+    ``record_histogram_aggregated_batch``) instead of going through
+    OpenTelemetry SDK instruments, so this collector renders the same
+    ``<ns>_<name>_bucket/_count/_sum`` families the SDK's Prometheus reader
+    would have produced.
+    """
+
+    def collect(self):
+        from prometheus_client.core import HistogramMetricFamily
+
+        with OpenTelemetryMetricRecorder._histogram_lock:
+            defs = dict(OpenTelemetryMetricRecorder._histogram_defs)
+            states = {
+                name: {
+                    tag_set: (list(data.bucket_counts), data.sum)
+                    for tag_set, data in by_tags.items()
+                }
+                for name, by_tags in OpenTelemetryMetricRecorder._histogram_states.items()
+            }
+
+        for name, hist_def in defs.items():
+            by_tags = states.get(name)
+            if not by_tags:
+                continue
+            # Keep a single label schema per metric, padding missing keys, to
+            # match the observable-metric export behavior.
+            label_keys = sorted({k for tag_set in by_tags for k, _ in tag_set})
+            family = HistogramMetricFamily(
+                f"{NAMESPACE}_{name}",
+                hist_def.description,
+                labels=label_keys,
+            )
+            le_labels = [str(float(b)) for b in hist_def.boundaries] + ["+Inf"]
+            for tag_set, (bucket_counts, sum_value) in by_tags.items():
+                tags = dict(tag_set)
+                cumulative = 0
+                buckets = []
+                for le, count in zip(le_labels, bucket_counts):
+                    cumulative += count
+                    buckets.append((le, cumulative))
+                family.add_metric(
+                    [tags.get(k, "") for k in label_keys],
+                    buckets=buckets,
+                    sum_value=sum_value,
+                )
+            yield family
 
 
 def _get_service_name(default_name: str) -> str:
@@ -45,6 +137,15 @@ class OpenTelemetryMetricRecorder:
 
     _metrics_initialized = False
     _metrics_initialized_lock = threading.Lock()
+
+    # Histogram aggregation state is shared across recorder instances (all
+    # instances in a process share the global meter provider and Prometheus
+    # registry), guarded by its own lock.
+    _histogram_lock = threading.Lock()
+    # metric name -> _HistogramDef
+    _histogram_defs: Dict[str, _HistogramDef] = {}
+    # metric name -> {frozenset(tag items) -> _HistogramData}
+    _histogram_states: Dict[str, Dict[frozenset, _HistogramData]] = {}
 
     def __init__(self, gauge_metric_ttl_seconds: Optional[float] = None):
         self._lock = threading.Lock()
@@ -188,6 +289,10 @@ class OpenTelemetryMetricRecorder:
                 metric_readers=[prometheus_reader],
             )
             metrics.set_meter_provider(provider)
+
+            from prometheus_client import REGISTRY
+
+            REGISTRY.register(_HistogramPrometheusCollector())
             OpenTelemetryMetricRecorder._metrics_initialized = True
 
     def register_gauge_metric(self, name: str, description: str) -> None:
@@ -257,6 +362,10 @@ class OpenTelemetryMetricRecorder:
     ) -> None:
         """
         Register a histogram metric with the given name and description.
+
+        Histograms are aggregated directly into shared per-bucket counts and
+        rendered by ``_HistogramPrometheusCollector``. They do not go through
+        an OpenTelemetry SDK instrument.
         """
         with self._lock:
             if name in self._registered_instruments:
@@ -267,31 +376,12 @@ class OpenTelemetryMetricRecorder:
                 # registered multiple times.
                 return
 
-            instrument = self.meter.create_histogram(
-                name=f"{NAMESPACE}_{name}",
-                description=description,
-                unit="1",
-                explicit_bucket_boundaries_advisory=buckets,
-            )
-            self._registered_instruments[name] = instrument
-
-            # calculate the bucket midpoints; this is used for converting histogram
-            # internal representation to approximated histogram data points.
-            for i in range(len(buckets)):
-                if i == 0:
-                    lower_bound = 0.0 if buckets[0] > 0 else buckets[0] * 2.0
-                    self._histogram_bucket_midpoints[name].append(
-                        (lower_bound + buckets[0]) / 2.0
-                    )
-                else:
-                    self._histogram_bucket_midpoints[name].append(
-                        (buckets[i] + buckets[i - 1]) / 2.0
-                    )
-            # Approximated mid point for Inf+ bucket. Inf+ bucket is an implicit bucket
-            # that is not part of buckets.
-            self._histogram_bucket_midpoints[name].append(
-                1.0 if buckets[-1] <= 0 else buckets[-1] * 2.0
-            )
+            hist_def = _HistogramDef(description, buckets)
+            with OpenTelemetryMetricRecorder._histogram_lock:
+                OpenTelemetryMetricRecorder._histogram_defs.setdefault(name, hist_def)
+                OpenTelemetryMetricRecorder._histogram_states.setdefault(name, {})
+            self._registered_instruments[name] = hist_def
+            self._histogram_bucket_midpoints[name] = list(hist_def.midpoints)
 
     def get_histogram_bucket_midpoints(self, name: str) -> List[float]:
         """
@@ -333,9 +423,9 @@ class OpenTelemetryMetricRecorder:
                     self._sum_observations_by_name[name].get(tag_key, 0) + value
                 )
             else:
-                # Histogram - record the value synchronously.
-                instrument = self._registered_instruments.get(name)
-                if isinstance(instrument, metrics.Histogram):
+                # Histogram - accumulate the single observation into the shared
+                # aggregation state.
+                if name in OpenTelemetryMetricRecorder._histogram_defs:
                     # Filter out high cardinality labels.
                     filtered_tags = {
                         k: v
@@ -345,11 +435,24 @@ class OpenTelemetryMetricRecorder:
                             name
                         )
                     }
-                    instrument.record(value, attributes=filtered_tags)
+                    self._observe_histogram(name, filtered_tags, value)
                 else:
                     logger.warning(
                         f"Metric {name} is not registered or unsupported type."
                     )
+
+    def _observe_histogram(self, name: str, filtered_tags: dict, value: float) -> None:
+        """Accumulate one observation with its true value into the shared state."""
+        with OpenTelemetryMetricRecorder._histogram_lock:
+            hist_def = OpenTelemetryMetricRecorder._histogram_defs[name]
+            states = OpenTelemetryMetricRecorder._histogram_states[name]
+            tag_key = frozenset(filtered_tags.items())
+            data = states.get(tag_key)
+            if data is None:
+                data = states[tag_key] = _HistogramData(len(hist_def.midpoints))
+            bucket_index = bisect.bisect_left(hist_def.boundaries, value)
+            data.bucket_counts[bucket_index] += 1
+            data.sum += value
 
     def record_histogram_aggregated_batch(
         self,
@@ -359,21 +462,22 @@ class OpenTelemetryMetricRecorder:
         """
         Record pre-aggregated histogram data for multiple data points in a single batch.
 
-        This method takes pre-aggregated bucket counts and reconstructs individual
-        observations using bucket midpoints. It acquires the lock once and performs
-        all record() calls for ALL data points, minimizing lock contention.
+        Each data point's per-bucket delta counts are added directly to the
+        shared aggregation state, so the cost is O(data points x buckets)
+        regardless of how many observations the buckets represent.
 
         Note: The histogram sum value will be an approximation since we use bucket midpoints instead of actual values.
         """
-        with self._lock:
-            instrument = self._registered_instruments.get(name)
-            if not isinstance(instrument, metrics.Histogram):
+        with OpenTelemetryMetricRecorder._histogram_lock:
+            hist_def = OpenTelemetryMetricRecorder._histogram_defs.get(name)
+            if hist_def is None:
                 logger.warning(
                     f"Metric {name} is not a registered histogram, skipping recording."
                 )
                 return
 
-            bucket_midpoints = self._histogram_bucket_midpoints[name]
+            bucket_midpoints = hist_def.midpoints
+            states = OpenTelemetryMetricRecorder._histogram_states[name]
             high_cardinality_labels = (
                 MetricCardinality.get_high_cardinality_labels_to_drop(name)
             )
@@ -388,13 +492,16 @@ class OpenTelemetryMetricRecorder:
                 filtered_tags = {
                     k: v for k, v in tags.items() if k not in high_cardinality_labels
                 }
+                tag_key = frozenset(filtered_tags.items())
+                data = states.get(tag_key)
+                if data is None:
+                    data = states[tag_key] = _HistogramData(len(bucket_midpoints))
 
                 for i, bucket_count in enumerate(bucket_counts):
                     if bucket_count == 0:
                         continue
-                    midpoint = bucket_midpoints[i]
-                    for _ in range(bucket_count):
-                        instrument.record(midpoint, attributes=filtered_tags)
+                    data.bucket_counts[i] += bucket_count
+                    data.sum += bucket_count * bucket_midpoints[i]
 
     def record_and_export(self, records: List[Record], global_tags=None):
         """

--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -23,14 +23,16 @@ NAMESPACE = "ray"
 
 
 class _HistogramDef:
-    """Static definition of a histogram metric: boundaries and midpoints."""
+    """Static definition of a histogram metric: boundaries, midpoints, and the
+    precomputed Prometheus ``le`` labels (boundaries plus the implicit +Inf)."""
 
-    __slots__ = ("description", "boundaries", "midpoints")
+    __slots__ = ("description", "boundaries", "midpoints", "le_labels")
 
     def __init__(self, description: str, boundaries: List[float]):
         self.description = description
         self.boundaries = list(boundaries)
         self.midpoints = _histogram_bucket_midpoints(boundaries)
+        self.le_labels = [str(float(b)) for b in self.boundaries] + ["+Inf"]
 
 
 class _HistogramData:
@@ -97,12 +99,11 @@ class _HistogramPrometheusCollector:
                 hist_def.description,
                 labels=label_keys,
             )
-            le_labels = [str(float(b)) for b in hist_def.boundaries] + ["+Inf"]
             for tag_set, (bucket_counts, sum_value) in by_tags.items():
                 tags = dict(tag_set)
                 cumulative = 0
                 buckets = []
-                for le, count in zip(le_labels, bucket_counts):
+                for le, count in zip(hist_def.le_labels, bucket_counts):
                     cumulative += count
                     buckets.append((le, cumulative))
                 family.add_metric(
@@ -156,7 +157,6 @@ class OpenTelemetryMetricRecorder:
         self._gauge_observations_by_name = defaultdict(dict)
         self._counter_observations_by_name = defaultdict(dict)
         self._sum_observations_by_name = defaultdict(dict)
-        self._histogram_bucket_midpoints = defaultdict(list)
         self._gauge_metric_ttl_s = self._resolve_gauge_ttl_seconds(
             gauge_metric_ttl_seconds
         )
@@ -365,29 +365,27 @@ class OpenTelemetryMetricRecorder:
 
         Histograms are aggregated directly into shared per-bucket counts and
         rendered by ``_HistogramPrometheusCollector``. They do not go through
-        an OpenTelemetry SDK instrument.
+        an OpenTelemetry SDK instrument, so their registry is the process-wide
+        ``_histogram_defs`` rather than the per-instance ``_registered_instruments``.
         """
-        with self._lock:
-            if name in self._registered_instruments:
+        with OpenTelemetryMetricRecorder._histogram_lock:
+            if name in OpenTelemetryMetricRecorder._histogram_defs:
                 # Histogram with the same name is already registered. This is a common
                 # case when metrics are exported from multiple Ray components (e.g.,
                 # raylet, worker, etc.) running in the same node. Since each component
                 # may export metrics with the same name, the same metric might be
                 # registered multiple times.
                 return
-
-            hist_def = _HistogramDef(description, buckets)
-            with OpenTelemetryMetricRecorder._histogram_lock:
-                OpenTelemetryMetricRecorder._histogram_defs.setdefault(name, hist_def)
-                OpenTelemetryMetricRecorder._histogram_states.setdefault(name, {})
-            self._registered_instruments[name] = hist_def
-            self._histogram_bucket_midpoints[name] = list(hist_def.midpoints)
+            OpenTelemetryMetricRecorder._histogram_defs[name] = _HistogramDef(
+                description, buckets
+            )
+            OpenTelemetryMetricRecorder._histogram_states[name] = {}
 
     def get_histogram_bucket_midpoints(self, name: str) -> List[float]:
         """
         Get the bucket midpoints for a histogram metric with the given name.
         """
-        return self._histogram_bucket_midpoints[name]
+        return OpenTelemetryMetricRecorder._histogram_defs[name].midpoints
 
     def set_metric_value(self, name: str, tags: dict, value: float):
         """
@@ -441,15 +439,26 @@ class OpenTelemetryMetricRecorder:
                         f"Metric {name} is not registered or unsupported type."
                     )
 
+    @staticmethod
+    def _get_or_create_histogram_data(states, filtered_tags, num_buckets):
+        """Returns the accumulation for one label set, creating it if absent.
+
+        Callers must hold ``_histogram_lock``.
+        """
+        tag_key = frozenset(filtered_tags.items())
+        data = states.get(tag_key)
+        if data is None:
+            data = states[tag_key] = _HistogramData(num_buckets)
+        return data
+
     def _observe_histogram(self, name: str, filtered_tags: dict, value: float) -> None:
         """Accumulate one observation with its true value into the shared state."""
         with OpenTelemetryMetricRecorder._histogram_lock:
             hist_def = OpenTelemetryMetricRecorder._histogram_defs[name]
             states = OpenTelemetryMetricRecorder._histogram_states[name]
-            tag_key = frozenset(filtered_tags.items())
-            data = states.get(tag_key)
-            if data is None:
-                data = states[tag_key] = _HistogramData(len(hist_def.midpoints))
+            data = self._get_or_create_histogram_data(
+                states, filtered_tags, len(hist_def.midpoints)
+            )
             bucket_index = bisect.bisect_left(hist_def.boundaries, value)
             data.bucket_counts[bucket_index] += 1
             data.sum += value
@@ -492,10 +501,9 @@ class OpenTelemetryMetricRecorder:
                 filtered_tags = {
                     k: v for k, v in tags.items() if k not in high_cardinality_labels
                 }
-                tag_key = frozenset(filtered_tags.items())
-                data = states.get(tag_key)
-                if data is None:
-                    data = states[tag_key] = _HistogramData(len(bucket_midpoints))
+                data = self._get_or_create_histogram_data(
+                    states, filtered_tags, len(bucket_midpoints)
+                )
 
                 for i, bucket_count in enumerate(bucket_counts):
                     if bucket_count == 0:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -545,8 +545,9 @@ class ReporterAgent(
             max_workers=RAY_DASHBOARD_REPORTER_AGENT_TPE_MAX_WORKERS,
             thread_name_prefix="reporter_agent_executor",
         )
-        # Single worker so OTLP metric reports from other Ray components are
-        # ingested in arrival order without blocking the event loop.
+        # Ingest OTLP metric reports off the event loop. max_workers must stay 1:
+        # gauge writes are last-writer-wins, so concurrent reports for the same
+        # series must be serialized in arrival order to keep the newest value.
         self._otlp_ingest_executor = ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix="reporter_agent_otlp_ingest",

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -545,6 +545,12 @@ class ReporterAgent(
             max_workers=RAY_DASHBOARD_REPORTER_AGENT_TPE_MAX_WORKERS,
             thread_name_prefix="reporter_agent_executor",
         )
+        # Single worker so OTLP metric reports from other Ray components are
+        # ingested in arrival order without blocking the event loop.
+        self._otlp_ingest_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="reporter_agent_otlp_ingest",
+        )
         self._gcs_pid = None
         self._gcs_proc = None
 
@@ -764,7 +770,18 @@ class ReporterAgent(
         components running in the same node (e.g., raylet, worker, etc.). This method
         implements an interface of `metrics_service_pb2_grpc.MetricsServiceServicer` (https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/metrics/v1/metrics_service.proto#L30),
         which is the default open-telemetry metrics service interface.
+
+        The request is ingested on a dedicated thread so a metric-heavy report
+        does not block the agent's event loop and back up other reporters.
         """
+        await get_or_create_event_loop().run_in_executor(
+            self._otlp_ingest_executor, self._ingest_exported_metrics, request
+        )
+        return metrics_service_pb2.ExportMetricsServiceResponse()
+
+    def _ingest_exported_metrics(
+        self, request: metrics_service_pb2.ExportMetricsServiceRequest
+    ) -> None:
         for resource_metrics in request.resource_metrics:
             for scope_metrics in resource_metrics.scope_metrics:
                 for metric in scope_metrics.metrics:
@@ -772,8 +789,6 @@ class ReporterAgent(
                         self._export_histogram_data(metric)
                     else:
                         self._export_number_data(metric)
-
-        return metrics_service_pb2.ExportMetricsServiceResponse()
 
     @staticmethod
     def _get_cpu_percent(in_k8s: bool):

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -256,6 +256,42 @@ def enable_profiling():
     os.environ.pop("RAY_DASHBOARD_ENABLE_PROFILING", None)
 
 
+def test_export_ingests_off_event_loop():
+    """Export hands the request to the ingest executor and still records all metrics."""
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+        ExportMetricsServiceRequest,
+    )
+
+    request = ExportMetricsServiceRequest()
+    scope_metrics = request.resource_metrics.add().scope_metrics.add()
+
+    gauge_metric = scope_metrics.metrics.add()
+    gauge_metric.name = "test_gauge"
+    gauge_point = gauge_metric.gauge.data_points.add()
+    gauge_point.as_double = 3.0
+
+    hist_metric = scope_metrics.metrics.add()
+    hist_metric.name = "test_histogram"
+    hist_point = hist_metric.histogram.data_points.add()
+    hist_point.count = 1
+    hist_point.explicit_bounds.extend([1.0])
+    hist_point.bucket_counts.extend([1, 0])
+
+    agent = object.__new__(ReporterAgent)
+    agent._open_telemetry_metric_recorder = MagicMock()
+    agent._otlp_ingest_executor = ThreadPoolExecutor(max_workers=1)
+
+    asyncio.run(ReporterAgent.Export(agent, request, None))
+
+    recorder = agent._open_telemetry_metric_recorder
+    recorder.register_gauge_metric.assert_called_once_with("test_gauge", "")
+    recorder.set_metric_value.assert_called_once_with("test_gauge", {}, 3.0)
+    recorder.record_histogram_aggregated_batch.assert_called_once()
+
+
 @pytest.fixture
 def enable_grpc_metrics_collection():
     os.environ["RAY_enable_grpc_metrics_collection_for"] = "gcs"

--- a/python/ray/tests/test_open_telemetry_metric_recorder.py
+++ b/python/ray/tests/test_open_telemetry_metric_recorder.py
@@ -224,7 +224,7 @@ def test_register_histogram_metric(
     recorder.register_histogram_metric(
         name="test_histogram", description="Test Histogram", buckets=[1.0, 2.0, 3.0]
     )
-    assert "test_histogram" in recorder._registered_instruments
+    assert "test_histogram" in OpenTelemetryMetricRecorder._histogram_defs
     recorder.set_metric_value(
         name="test_histogram",
         tags={"label_key": "label_value"},

--- a/python/ray/tests/test_open_telemetry_metric_recorder.py
+++ b/python/ray/tests/test_open_telemetry_metric_recorder.py
@@ -3,14 +3,32 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-from opentelemetry.metrics import NoOpHistogram
+from prometheus_client import CollectorRegistry, generate_latest
 
 from ray._private.metrics_agent import Gauge, Record
 from ray._private.telemetry.metric_types import MetricType
 from ray._private.telemetry.open_telemetry_metric_recorder import (
     OpenTelemetryMetricRecorder,
     _get_service_name,
+    _HistogramPrometheusCollector,
 )
+
+
+@pytest.fixture
+def clean_histogram_state():
+    """Clears the recorder's process-wide histogram aggregation state."""
+    OpenTelemetryMetricRecorder._histogram_defs.clear()
+    OpenTelemetryMetricRecorder._histogram_states.clear()
+    yield
+    OpenTelemetryMetricRecorder._histogram_defs.clear()
+    OpenTelemetryMetricRecorder._histogram_states.clear()
+
+
+def _histogram_exposition() -> str:
+    """Renders the shared histogram state through a private registry."""
+    registry = CollectorRegistry()
+    registry.register(_HistogramPrometheusCollector())
+    return generate_latest(registry).decode()
 
 
 def _gauge_values(recorder):
@@ -194,16 +212,14 @@ def test_register_sum_metric(
 @patch("opentelemetry.metrics.set_meter_provider")
 @patch("opentelemetry.metrics.get_meter")
 def test_register_histogram_metric(
-    mock_get_meter, mock_set_meter_provider, mock_logger_warning
+    mock_get_meter, mock_set_meter_provider, mock_logger_warning, clean_histogram_state
 ):
     """
     Test the register_histogram_metric method of OpenTelemetryMetricRecorder.
     - Test that it registers a histogram metric with the correct name and description.
     - Test that a value can be set for the histogram metric successfully without warnings.
     """
-    mock_meter = MagicMock()
-    mock_meter.create_histogram.return_value = NoOpHistogram(name="test_histogram")
-    mock_get_meter.return_value = mock_meter
+    mock_get_meter.return_value = MagicMock()
     recorder = OpenTelemetryMetricRecorder()
     recorder.register_histogram_metric(
         name="test_histogram", description="Test Histogram", buckets=[1.0, 2.0, 3.0]
@@ -216,7 +232,13 @@ def test_register_histogram_metric(
     )
     mock_logger_warning.assert_not_called()
 
-    mock_meter.create_histogram.return_value = NoOpHistogram(name="neg_histogram")
+    # The single observation lands in the +Inf bucket with its true value.
+    data = OpenTelemetryMetricRecorder._histogram_states["test_histogram"][
+        frozenset({"label_key": "label_value"}.items())
+    ]
+    assert data.bucket_counts == [0, 0, 0, 1]
+    assert data.sum == pytest.approx(10.0)
+
     recorder.register_histogram_metric(
         name="neg_histogram",
         description="Histogram with negative first boundary",
@@ -315,20 +337,15 @@ def test_record_and_export(mock_get_meter, mock_set_meter_provider):
 @patch("opentelemetry.metrics.set_meter_provider")
 @patch("opentelemetry.metrics.get_meter")
 def test_record_histogram_aggregated_batch(
-    mock_get_meter, mock_set_meter_provider, mock_logger_warning
+    mock_get_meter, mock_set_meter_provider, mock_logger_warning, clean_histogram_state
 ):
     """
     Test the record_histogram_aggregated_batch method of OpenTelemetryMetricRecorder.
-    - Test that it records histogram data for multiple data points in a single batch.
-    - Test that it calls instrument.record() for each observation.
+    - Test that per-bucket delta counts accumulate across batches.
+    - Test that the sum is approximated from bucket midpoints.
     - Test that it warns if the histogram is not registered.
     """
-    mock_meter = MagicMock()
-    real_histogram = NoOpHistogram(name="test_histogram")
-    mock_histogram = MagicMock(wraps=real_histogram, spec=real_histogram)
-    mock_meter.create_histogram.return_value = mock_histogram
-    mock_get_meter.return_value = mock_meter
-
+    mock_get_meter.return_value = MagicMock()
     recorder = OpenTelemetryMetricRecorder()
 
     # Test warning when histogram not registered
@@ -341,19 +358,13 @@ def test_record_histogram_aggregated_batch(
     )
     mock_logger_warning.reset_mock()
 
-    # Register histogram
+    # Register histogram. Bucket midpoints are [0.5, 5.5, 55.0, 200.0].
     recorder.register_histogram_metric(
         name="test_histogram",
         description="Test Histogram",
         buckets=[1.0, 10.0, 100.0],
     )
 
-    # Record batch data - 2 data points with different tags
-    # bucket_counts: [2, 3, 0, 1] means:
-    #   2 observations in bucket 0-1 (midpoint 0.5)
-    #   3 observations in bucket 1-10 (midpoint 5.5)
-    #   0 observations in bucket 10-100 (midpoint 55.0)
-    #   1 observation in bucket 100-Inf+ (midpoint 200.0)
     recorder.record_histogram_aggregated_batch(
         name="test_histogram",
         data_points=[
@@ -361,15 +372,33 @@ def test_record_histogram_aggregated_batch(
             {"tags": {"endpoint": "/api/v2"}, "bucket_counts": [1, 0, 1, 0]},
         ],
     )
+    # A second batch for the same label set accumulates on top of the first.
+    recorder.record_histogram_aggregated_batch(
+        name="test_histogram",
+        data_points=[
+            {"tags": {"endpoint": "/api/v1"}, "bucket_counts": [0, 1, 0, 0]},
+        ],
+    )
 
-    # Verify record() was called the correct number of times
-    # First data point: 2 + 3 + 0 + 1 = 6 calls
-    # Second data point: 1 + 0 + 1 + 0 = 2 calls
-    # Total: 8 calls
-    assert mock_histogram.record.call_count == 8
+    states = OpenTelemetryMetricRecorder._histogram_states["test_histogram"]
+    v1 = states[frozenset({"endpoint": "/api/v1"}.items())]
+    v2 = states[frozenset({"endpoint": "/api/v2"}.items())]
+    assert v1.bucket_counts == [2, 4, 0, 1]
+    assert v1.sum == pytest.approx(2 * 0.5 + 4 * 5.5 + 1 * 200.0)
+    assert v2.bucket_counts == [1, 0, 1, 0]
+    assert v2.sum == pytest.approx(0.5 + 55.0)
 
     # No warnings should be logged for registered histogram
     mock_logger_warning.assert_not_called()
+
+    # The Prometheus collector renders cumulative buckets, count and sum.
+    exposition = _histogram_exposition()
+    assert 'ray_test_histogram_bucket{endpoint="/api/v1",le="1.0"} 2.0' in exposition
+    assert 'ray_test_histogram_bucket{endpoint="/api/v1",le="10.0"} 6.0' in exposition
+    assert 'ray_test_histogram_bucket{endpoint="/api/v1",le="100.0"} 6.0' in exposition
+    assert 'ray_test_histogram_bucket{endpoint="/api/v1",le="+Inf"} 7.0' in exposition
+    assert 'ray_test_histogram_count{endpoint="/api/v1"} 7.0' in exposition
+    assert 'ray_test_histogram_count{endpoint="/api/v2"} 2.0' in exposition
 
 
 @patch("opentelemetry.metrics.set_meter_provider")


### PR DESCRIPTION
## Why are these changes needed?

When `RAY_enable_open_telemetry=1` (the default since #56432), worker processes push OTLP metric deltas to the dashboard agent every 10s, and the agent re-records them into OpenTelemetry SDK instruments. For histograms, `record_histogram_aggregated_batch` replays every observation individually: a data point whose buckets sum to N costs N `instrument.record()` calls of Python. A vLLM or Serve workload that observes histograms per token or per request makes this the dominant cost on the agent: one 10s push with 100k observations takes ~300 ms of event-loop time, and several reporting processes multiply it.

Because the `Export` gRPC handler runs this work directly on the agent's asyncio event loop, heavy pushes back up every other reporter on the node. The scrape path contends on the same SDK state, so `/metrics` latency grows from ~15 ms to multiple seconds and eventually fails with `MetricsTimeoutError` (HTTP 500). Worker-side `PeriodicExportingMetricReader` cycles (10s interval, 5s timeout) then stall behind the slow agent, so exported values freeze for minutes under exactly the load that autoscalers need metrics for. This is the root cause behind `ray_vllm_*` and `ray_serve_*` series going stale for 100 to 200s on loaded nodes while node-level metrics stay fresh, which breaks any `rate()`-based query over worker metrics. It is also the underlying condition behind recent metrics-timeout test deflaking (#64866, #64867).

Local reproduction (16-core host confined to 4 CPUs, 6 actors observing histograms in a tight loop):

| | before | after |
|---|---|---|
| `/metrics` scrape latency under load | 3 to 10 s, intermittent HTTP 500 (`MetricsTimeoutError`) | at most 71 ms, no errors |
| exposed counter staleness | up to 11.6 s with stretched scrape gaps | at most 8.1 s, bounded by the 10 s push interval |
| counter monotonicity | regressed under concurrent collects | monotonic |
| one push with 100k histogram observations | 308 ms | 0.05 ms |

## Changes

1. `open_telemetry_metric_recorder.py`: histograms are aggregated directly. `record_histogram_aggregated_batch` adds each data point's per-bucket delta counts to a shared aggregation state, so the cost is O(data points x buckets) regardless of how many observations the buckets represent. A `prometheus_client` collector renders the same `ray_<name>_bucket/_count/_sum` families the SDK reader produced, with the same label padding and `le` formatting. Single observations recorded through `set_metric_value` accumulate into the same state using their true value.
2. `reporter_agent.py`: the `Export` handler hands the request to a dedicated single-thread executor, so metric ingestion no longer blocks the agent's event loop and reports stay ordered.

The worker-side behavior of dropping a harvested delta when an export exceeds the 5s timeout (opentelemetry-cpp `PeriodicExportingMetricReader`) is unchanged. With agent ingestion no longer the bottleneck, that path is not hit under the reproduced load. Left for follow-up along with surfacing export stalls, which are currently silenced by `RAY_disable_open_telemetry_sdk_log=true`.

## Related issue number

## Checks

- [x] I've signed off every commit
- [x] I've run pre-commit checks (`black`, `ruff`) on the changed files
- [x] Unit tests:
  - `pytest python/ray/tests/test_open_telemetry_metric_recorder.py` (14 passed)
  - `pytest python/ray/dashboard/modules/reporter/tests/test_reporter.py -k "export_histogram_data_normalizes or export_ingests_off_event_loop"` (2 passed)

AI assistance was used for this change. Duplicate-work check: no open PRs touch `record_histogram_aggregated_batch`, the OTLP `Export` handler, or agent metric ingestion (`gh pr list --search` on 2026-07-20). The submitter has reviewed every changed line and run the tests above locally, plus the before/after load reproduction.
