### PR TITLE
fix(core): fold runtime-env hash instead of truncating to int

### DIFF
--- a/src/ray/common/scheduling/scheduling_class_util.cc
+++ b/src/ray/common/scheduling/scheduling_class_util.cc
@@ -204,9 +204,12 @@ int CalculateRuntimeEnvHash(const std::string &serialized_runtime_env) {
   // Fold the full 64-bit hash into a non-negative 31-bit key. A plain
   // static_cast<int>(hash) drops the upper 32 bits and can be negative, raising
   // silent worker-pool key collisions across different runtime envs (#64836).
-  size_t hash = std::hash<std::string>()(serialized_runtime_env);
-  hash ^= (hash >> 32);
-  return static_cast<int>(hash & 0x7fffffffULL);
+  //
+  // Widen to a fixed 64-bit integer before folding: size_t is 32-bit on some
+  // platforms, where `hash >> 32` would be undefined behavior.
+  const uint64_t hash = static_cast<uint64_t>(
+      std::hash<std::string>()(serialized_runtime_env));
+  return static_cast<int>((hash ^ (hash >> 32)) & 0x7fffffffULL);
 }
 
 }  // namespace ray

--- a/src/ray/common/scheduling/scheduling_class_util.cc
+++ b/src/ray/common/scheduling/scheduling_class_util.cc
@@ -201,8 +201,12 @@ int CalculateRuntimeEnvHash(const std::string &serialized_runtime_env) {
     // runtime envs.
     return 0;
   }
+  // Fold the full 64-bit hash into a non-negative 31-bit key. A plain
+  // static_cast<int>(hash) drops the upper 32 bits and can be negative, raising
+  // silent worker-pool key collisions across different runtime envs (#64836).
   size_t hash = std::hash<std::string>()(serialized_runtime_env);
-  return static_cast<int>(hash);
+  hash ^= (hash >> 32);
+  return static_cast<int>(hash & 0x7fffffffULL);
 }
 
 }  // namespace ray


### PR DESCRIPTION
## Description

`CalculateRuntimeEnvHash` previously did `return static_cast<int>(hash)` on a 64-bit `size_t` hash. That drops the upper 32 bits and can produce a negative key. The value is used as a worker-pool reuse key, so a low-bit collision can silently run a task under the wrong runtime env.

This folds with `hash ^ (hash >> 32)` and keeps a non-negative 31-bit key (`& 0x7fffffff`) so existing `int`-typed call sites stay compatible while using more of the original hash entropy.

## Related issues

Fixes #64836

## Additional information

Minimal change confined to `CalculateRuntimeEnvHash`; no API surface type widen (full `int64_t` migration left as follow-up if maintainers want it).
