### PR TITLE
[Core] Fix spurious OwnerDiedError during graceful raylet shutdown

### DIFF
--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -42,9 +42,10 @@ class IObjectDirectory {
   virtual ~IObjectDirectory() {}
 
   /// Signal that the owning node is shutting down. After this call,
-  /// object-location subscription failures are no longer marked as
-  /// OWNER_DIED, since such failures are caused by our own client
-  /// teardown rather than a genuine remote owner death.
+  /// object-location subscription failures caused by local client
+  /// teardown are no longer surfaced as fatal remote-owner failures
+  /// to dependent tasks. Genuine owner deaths are still detected via
+  /// the GCS worker/node-death path.
   virtual void MarkShuttingDown() {}
 
   /// Handle the removal of an object manager node. This updates the

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -41,6 +41,12 @@ class IObjectDirectory {
  public:
   virtual ~IObjectDirectory() {}
 
+  /// Signal that the owning node is shutting down. After this call,
+  /// object-location subscription failures are no longer marked as
+  /// OWNER_DIED, since such failures are caused by our own client
+  /// teardown rather than a genuine remote owner death.
+  virtual void MarkShuttingDown() {}
+
   /// Handle the removal of an object manager node. This updates the
   /// locations of all subscribed objects that have the removed node as a
   /// location, and fires the subscribed callbacks for those objects.

--- a/src/ray/object_manager/ownership_object_directory.cc
+++ b/src/ray/object_manager/ownership_object_directory.cc
@@ -342,8 +342,23 @@ void OwnershipBasedObjectDirectory::SubscribeObjectLocations(
                                                   const Status &status) {
       const auto obj_id = ObjectID::FromBinary(object_id_binary);
       if (!status.ok()) {
-        RAY_LOG(INFO).WithField(obj_id) << "Owner of object died: " << status.ToString();
-        mark_as_failed_(obj_id, rpc::ErrorType::OWNER_DIED);
+        if (is_shutting_down_) {
+          // We are shutting down, so this long-poll failure is caused by our
+          // own gRPC client being torn down, not a genuine remote owner death.
+          // Do not mark OWNER_DIED (which is fatal/non-retryable). Real owner
+          // deaths are still detected by the GCS node/worker-death path and
+          // re-evaluated when the dependent task is retried on a live node.
+          RAY_LOG(INFO).WithField(obj_id).WithField(
+              WorkerID::FromBinary(owner_address.worker_id()))
+              << "Current node is shutting down; aborting SubscribeObjectLocations "
+                 "and suppressing OWNER_DIED (local gRPC teardown, not a real owner "
+                 "death): "
+              << status.ToString();
+        } else {
+          RAY_LOG(INFO).WithField(obj_id)
+              << "Owner of object died: " << status.ToString();
+          mark_as_failed_(obj_id, rpc::ErrorType::OWNER_DIED);
+        }
       } else {
         // Owner is still alive but published a failure because the ref was deleted.
         RAY_LOG(INFO).WithField(obj_id)

--- a/src/ray/object_manager/ownership_object_directory.cc
+++ b/src/ray/object_manager/ownership_object_directory.cc
@@ -345,14 +345,12 @@ void OwnershipBasedObjectDirectory::SubscribeObjectLocations(
         if (is_shutting_down_) {
           // We are shutting down, so this long-poll failure is caused by our
           // own gRPC client being torn down, not a genuine remote owner death.
-          // Do not mark OWNER_DIED (which is fatal/non-retryable). Real owner
-          // deaths are still detected by the GCS node/worker-death path and
-          // re-evaluated when the dependent task is retried on a live node.
+          // Leave failure classification to the GCS node/worker-death path and
+          // let dependent tasks be retried on a live node.
           RAY_LOG(INFO).WithField(obj_id).WithField(
               WorkerID::FromBinary(owner_address.worker_id()))
               << "Current node is shutting down; aborting SubscribeObjectLocations "
-                 "and suppressing OWNER_DIED (local gRPC teardown, not a real owner "
-                 "death): "
+                 "for the object location subscription: "
               << status.ToString();
         } else {
           RAY_LOG(INFO).WithField(obj_id)

--- a/src/ray/object_manager/ownership_object_directory.h
+++ b/src/ray/object_manager/ownership_object_directory.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -80,6 +81,13 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
 
   std::string DebugString() const override;
 
+  /// Signal that the owning node is shutting down. After this call,
+  /// object-location subscription failures are no longer marked as
+  /// OWNER_DIED, since such failures are caused by our own client
+  /// teardown rather than a genuine remote owner death. Other signals
+  /// (e.g. OBJECT_DELETED) and location updates still flow.
+  void MarkShuttingDown() override { is_shutting_down_ = true; }
+
  private:
   friend class OwnershipBasedObjectDirectoryTest;
 
@@ -133,6 +141,13 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
 
   /// A set of in-flight UpdateObjectLocationBatch requests.
   absl::flat_hash_set<WorkerID> in_flight_requests_;
+
+  /// Whether this node is shutting down. When true, object-location
+  /// subscription failures are not marked as OWNER_DIED, to avoid
+  /// misclassifying local client teardown as remote owner death. Atomic
+  /// because it can be set from the shutdown path (e.g. agent-monitor thread)
+  /// while the pubsub failure callback reads it on the main service thread.
+  std::atomic<bool> is_shutting_down_ = false;
 
   /// Get or create the rpc client in the worker_rpc_clients.
   std::shared_ptr<rpc::CoreWorkerClientInterface> GetClient(

--- a/src/ray/object_manager/ownership_object_directory.h
+++ b/src/ray/object_manager/ownership_object_directory.h
@@ -82,10 +82,10 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
   std::string DebugString() const override;
 
   /// Signal that the owning node is shutting down. After this call,
-  /// object-location subscription failures are no longer marked as
-  /// OWNER_DIED, since such failures are caused by our own client
-  /// teardown rather than a genuine remote owner death. Other signals
-  /// (e.g. OBJECT_DELETED) and location updates still flow.
+  /// object-location subscription failures caused by local client
+  /// teardown are no longer surfaced as fatal remote-owner failures
+  /// to dependent tasks. Other signals (e.g. object deletion) and
+  /// location updates still flow.
   void MarkShuttingDown() override { is_shutting_down_ = true; }
 
  private:
@@ -143,10 +143,11 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
   absl::flat_hash_set<WorkerID> in_flight_requests_;
 
   /// Whether this node is shutting down. When true, object-location
-  /// subscription failures are not marked as OWNER_DIED, to avoid
-  /// misclassifying local client teardown as remote owner death. Atomic
-  /// because it can be set from the shutdown path (e.g. agent-monitor thread)
-  /// while the pubsub failure callback reads it on the main service thread.
+  /// subscription failures are no longer surfaced as fatal remote-owner
+  /// failures, to avoid misclassifying local client teardown as remote
+  /// owner death. Atomic because it can be set from the shutdown path
+  /// (e.g. agent-monitor thread) while the pubsub failure callback
+  /// reads it on the main service thread.
   std::atomic<bool> is_shutting_down_ = false;
 
   /// Get or create the rpc client in the worker_rpc_clients.

--- a/src/ray/object_manager/tests/ownership_object_directory_test.cc
+++ b/src/ray/object_manager/tests/ownership_object_directory_test.cc
@@ -97,6 +97,26 @@ class MockGcsClientNodeAccessor : public gcs::NodeInfoAccessor {
   bool IsNodeDead(const NodeID &node_id) const override { return false; }
 };
 
+// A subscriber that captures the failure callback per subscribed key so tests
+// can simulate a subscription (long-poll) failure.
+class CapturingSubscriber : public pubsub::FakeSubscriber {
+ public:
+  void Subscribe(
+      std::unique_ptr<rpc::SubMessage> sub_message,
+      rpc::ChannelType channel_type,
+      const rpc::Address &owner_address,
+      const std::optional<std::string> &key_id,
+      pubsub::SubscribeDoneCallback subscribe_done_callback,
+      pubsub::SubscriptionItemCallback subscription_callback,
+      pubsub::SubscriptionFailureCallback subscription_failure_callback) override {
+    if (key_id.has_value()) {
+      failure_callbacks[*key_id] = std::move(subscription_failure_callback);
+    }
+  }
+
+  absl::flat_hash_map<std::string, pubsub::SubscriptionFailureCallback> failure_callbacks;
+};
+
 class MockGcsClient : public gcs::GcsClient {
  public:
   MockGcsClient(gcs::GcsClientOptions options,
@@ -127,7 +147,7 @@ class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
                  /*fetch_cluster_id_if_nil=*/false),
         gcs_client_mock_(
             new MockGcsClient(options_, std::make_unique<MockGcsClientNodeAccessor>())),
-        subscriber_(std::make_shared<pubsub::FakeSubscriber>()),
+        subscriber_(std::make_shared<CapturingSubscriber>()),
         owner_client(std::make_shared<MockWorkerClient>()),
         client_pool([&](const rpc::Address &addr) { return owner_client; }) {
     RayConfig::instance().initialize(R"({"max_object_report_batch_size": 20})");
@@ -145,6 +165,7 @@ class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
 
   void MarkAsFailed(const ObjectID &object_id, const rpc::ErrorType &error_type) {
     RAY_LOG(INFO) << "Object Failed";
+    mark_as_failed_calls.emplace_back(object_id, error_type);
   }
 
   ObjectInfo CreateNewObjectInfo(const WorkerID &worker_id) {
@@ -200,11 +221,12 @@ class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
   instrumented_io_context io_service_;
   gcs::GcsClientOptions options_;
   std::shared_ptr<gcs::GcsClient> gcs_client_mock_;
-  std::shared_ptr<pubsub::FakeSubscriber> subscriber_;
+  std::shared_ptr<CapturingSubscriber> subscriber_;
   std::shared_ptr<MockWorkerClient> owner_client;
   rpc::CoreWorkerClientPool client_pool;
   std::unique_ptr<OwnershipBasedObjectDirectory> obod_;
   std::unordered_set<ObjectID> used_ids_;
+  std::vector<std::pair<ObjectID, rpc::ErrorType>> mark_as_failed_calls;
   const NodeID current_node_id = NodeID::FromRandom();
 };
 
@@ -544,6 +566,65 @@ TEST_F(OwnershipBasedObjectDirectoryTest, TestNotifyOnUpdate) {
 
   // Make sure metadata is cleaned up properly.
   AssertNoLeak();
+}
+
+// When the node is shutting down, an object-location subscription failure is
+// caused by our own gRPC client teardown (not a real remote owner death), so
+// the object must NOT be marked OWNER_DIED.
+TEST_F(OwnershipBasedObjectDirectoryTest, OwnerDiedSuppressedDuringShutdown) {
+  const auto object_id = ObjectID::FromRandom();
+  rpc::Address owner_address;
+  owner_address.set_worker_id(WorkerID::FromRandom().Binary());
+  owner_address.set_node_id(NodeID::FromRandom().Binary());
+
+  obod_->SubscribeObjectLocations(UniqueID::FromRandom(),
+                                  object_id,
+                                  owner_address,
+                                  [](const ObjectID &,
+                                     const std::unordered_set<NodeID> &,
+                                     const std::string &,
+                                     const NodeID &,
+                                     bool,
+                                     size_t) {});
+
+  auto it = subscriber_->failure_callbacks.find(object_id.Binary());
+  ASSERT_NE(it, subscriber_->failure_callbacks.end());
+
+  // Begin shutdown, then simulate the local gRPC client teardown failing the
+  // long-poll.
+  obod_->MarkShuttingDown();
+  it->second(object_id.Binary(), Status::Disconnected("GRPC client is shut down."));
+
+  // Owner (driver) is alive; no fatal OWNER_DIED should be produced.
+  ASSERT_TRUE(mark_as_failed_calls.empty());
+}
+
+// When NOT shutting down, a subscription failure is treated as a genuine owner
+// death and the object is marked OWNER_DIED (pre-existing behavior).
+TEST_F(OwnershipBasedObjectDirectoryTest, OwnerDiedMarkedWhenNotShuttingDown) {
+  const auto object_id = ObjectID::FromRandom();
+  rpc::Address owner_address;
+  owner_address.set_worker_id(WorkerID::FromRandom().Binary());
+  owner_address.set_node_id(NodeID::FromRandom().Binary());
+
+  obod_->SubscribeObjectLocations(UniqueID::FromRandom(),
+                                  object_id,
+                                  owner_address,
+                                  [](const ObjectID &,
+                                     const std::unordered_set<NodeID> &,
+                                     const std::string &,
+                                     const NodeID &,
+                                     bool,
+                                     size_t) {});
+
+  auto it = subscriber_->failure_callbacks.find(object_id.Binary());
+  ASSERT_NE(it, subscriber_->failure_callbacks.end());
+
+  it->second(object_id.Binary(), Status::Disconnected("GRPC client is shut down."));
+
+  ASSERT_EQ(mark_as_failed_calls.size(), 1);
+  ASSERT_EQ(mark_as_failed_calls[0].first, object_id);
+  ASSERT_EQ(mark_as_failed_calls[0].second, rpc::ErrorType::OWNER_DIED);
 }
 
 }  // namespace ray

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -465,6 +465,7 @@ int main(int argc, char *argv[]) {
       [raylet_node_id,
        &shutting_down,
        &node_manager,
+       &object_directory,
        &main_service,
        &raylet_socket_name,
        &gcs_client,
@@ -477,6 +478,17 @@ int main(int argc, char *argv[]) {
         }
         RAY_LOG(INFO) << "Raylet graceful shutdown triggered with death info: "
                       << node_death_info.DebugString();
+
+        // Signal shutdown to the object directory as early as possible, before
+        // UnregisterSelf and any client teardown. Otherwise, object-location
+        // subscription long-polls failed during shutdown (because our own gRPC
+        // client is being torn down) would be misclassified as the remote owner
+        // dying, surfacing as spurious OwnerDiedError on dependent tasks.
+        // object_directory may not be constructed yet if SIGTERM arrives during
+        // early startup (before the AsyncGetInternalConfig callback runs).
+        if (object_directory != nullptr) {
+          object_directory->MarkShuttingDown();
+        }
 
         auto unregister_done_callback = [&main_service,
                                          &raylet_socket_name,
@@ -780,6 +792,14 @@ int main(int argc, char *argv[]) {
         [&](const ray::ObjectID &obj_id, const ray::rpc::ErrorType &error_type) {
           object_manager->MarkObjectFailed(obj_id, error_type);
         });
+
+    // Catch up: if SIGTERM arrived before this callback ran,
+    // shutdown_raylet_gracefully skipped MarkShuttingDown() because
+    // object_directory was still null. Set it now so teardown-caused
+    // subscription failures are not misclassified as OWNER_DIED.
+    if (shutting_down.load()) {
+      object_directory->MarkShuttingDown();
+    }
 
     auto object_store_runner = std::make_unique<ray::ObjectStoreRunner>(
         object_manager_config,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -795,8 +795,8 @@ int main(int argc, char *argv[]) {
 
     // Catch up: if SIGTERM arrived before this callback ran,
     // shutdown_raylet_gracefully skipped MarkShuttingDown() because
-    // object_directory was still null. Set it now so teardown-caused
-    // subscription failures are not misclassified as OWNER_DIED.
+    // object_directory was still null. Set it now so teardown-induced
+    // subscription failures are not misclassified as remote owner deaths.
     if (shutting_down.load()) {
       object_directory->MarkShuttingDown();
     }


### PR DESCRIPTION
## Summary

A running job fails with `OwnerDiedError`, but the object's owner is the driver, which is still alive — so the "owner died" report is wrong.

**Cause:** during graceful raylet shutdown, an in-flight object-location long-poll fails because the raylet's *own* gRPC client is being torn down, but the object directory treats any such failure as `OWNER_DIED` (fatal, non-retryable).

**Fix:** mark the object directory as shutting down at the start of shutdown and skip the `OWNER_DIED` marking while set, so a local teardown is no longer misreported as a remote owner death.

## Root cause

Observed failure — a Ray Data job aborted. The reported "owner" is the **driver**, which stayed alive; the preempted node was the **worker** running the failing `MapBatches->Write` task. (IPs redacted; trailing user frames omitted.)

> The final `Underlying failure: ...` line is a **local debug log we added**, not stock Ray output — it exposes the long-poll status at the point the object is marked `OWNER_DIED`. Stock Ray only prints the generic "The object's owner has exited", which is what made this hard to diagnose.

```text
2026-07-20 16:22:35,553    INFO streaming_executor.py:294 -- ⚠️  Dataset dataset_5_0 execution failed
2026-07-20 16:22:35,581    ERROR exceptions.py:73 -- Exception occurred in Ray Data or Ray Core internal code. If you continue to see this error, please open an issue on the Ray project GitHub page with the full stack trace below: https://github.com/ray-project/ray/issues/new/choose
2026-07-20 16:22:35,581    ERROR exceptions.py:81 -- Full stack trace:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ray/data/exceptions.py", line 49, in handle_trace
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/plan.py", line 469, in execute
    bundle = execute_to_ref_bundle(
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/legacy_compat.py", line 115, in execute_to_ref_bundle
    ref_bundle = RefBundle.merge_ref_bundles(bundles)
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/interfaces/ref_bundle.py", line 335, in merge_ref_bundles
    bundles = list(bundles)
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/interfaces/executor.py", line 34, in __next__
    return self.get_next()
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/streaming_executor.py", line 673, in get_next
    bundle = state.get_output_blocking(output_split_idx)
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/streaming_executor_state.py", line 320, in get_output_blocking
    raise self._exception
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/streaming_executor.py", line 343, in run
    continue_sched = self._scheduling_loop_step(self._topology)
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/streaming_executor.py", line 416, in _scheduling_loop_step
    num_errored_blocks = process_completed_tasks(
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/streaming_executor_state.py", line 514, in process_completed_tasks
    raise e from None
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/streaming_executor_state.py", line 478, in process_completed_tasks
    bytes_read = task.on_data_ready(
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/interfaces/physical_operator.py", line 241, in on_data_ready
    raise ex from None
  File "/usr/local/lib/python3.10/dist-packages/ray/data/_internal/execution/interfaces/physical_operator.py", line 231, in on_data_ready
    ray.get(self._pending_block_ref)
  File "/usr/local/lib/python3.10/dist-packages/ray/_private/worker.py", line 1023, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(OwnerDiedError): ray::MapBatches(_cast_vector_parquet_batch)->Write() (pid=23655, ip=<worker-node-ip>)
  At least one of the input arguments for this task could not be computed:
ray.exceptions.OwnerDiedError: Failed to retrieve object de7f2e113ad05a71ef65db3164a319f33c857aa30200000002000000.

The object's owner has exited. This is the Python worker that first created the ObjectRef via `.remote()` or `ray.put()`. Check cluster logs (`.../logs/*02000000ffff...ffff*` at IP address <head-node-ip>) for more information about the Python worker failure.

Underlying failure: Owner of object died (pubsub long-poll failed). owner_worker_id=02000000ffffffffffffffffffffffffffffffffffffffffffffffff owner_address=<head-node-ip>:10004 status=Disconnected: GRPC client is shut down.
```

`owner_worker_id=02000000ffff...` is the **driver** worker ID (JobID padded with `ff`) — the "owner" is the driver, which never exited, confirming the misclassification.

**Causal chain:**

1. A busy worker node is preempted while tasks on it still depend on remotely-owned objects, so object-location long-polls are active when `shutdown_raylet_gracefully` runs.
2. During shutdown the long-poll is failed by the local gRPC client teardown with `Status::Disconnected("GRPC client is shut down.")` (`src/ray/rpc/retryable_grpc_client.cc`) — a local signal, not a remote owner death. (An in-flight request instead sees `UNAVAILABLE`/`CANCELLED`, via the same path.)
3. The pubsub `Subscriber` treats any non-OK long-poll status as "publisher dead" and fires the object directory's failure callback.
4. That callback unconditionally does `mark_as_failed_(obj_id, OWNER_DIED)` (`src/ray/object_manager/ownership_object_directory.cc`) → `MarkObjectFailed` writes an `OWNER_DIED` sentinel into plasma → the task's `ray.get` raises the fatal `OwnerDiedError` → the job aborts.

## Fix

- Add `IObjectDirectory::MarkShuttingDown()` (default no-op), overridden by `OwnershipBasedObjectDirectory` to set `is_shutting_down_`.
- In the object-location failure callback, when shutting down, skip only `mark_as_failed_(OWNER_DIED)`. `OBJECT_DELETED` and location updates still run — the guard is scoped to the fatal action, and keys on "shutting down" (not the status code, so it also covers `UNAVAILABLE`/`CANCELLED`).
- `NodeManager::MarkShuttingDown()` forwards to the object directory; `main.cc` calls it at the very start of `shutdown_raylet_gracefully`, before `UnregisterSelf` and any teardown, so the flag is set before the failure fires.

**Why it's safe:** genuine owner deaths are still detected by the authoritative GCS node/worker-death path and re-evaluated when the task is retried on a live node, so nothing is lost. Skipping the mark just leaves the task waiting; it is killed as the node finishes shutting down and retried elsewhere.

## Test plan

- [x] Added `OwnerDiedSuppressedDuringShutdown` / `OwnerDiedMarkedWhenNotShuttingDown`; `bazel test //src/ray/object_manager/tests:ownership_object_directory_test` passes (11/11). On macOS/arm64 add `--dynamic_mode=off` to dodge an unrelated external upb link error; Linux CI is unaffected.
- [ ] Repro validation: confirm via log that `is_shutting_down_ == true` when the long-poll fails and no `OwnerDiedError` is raised.

## Notes

- **Follow-up (separate PR):** `FutureResolver` (`src/ray/core_worker/future_resolver.cc`) has the same pattern via `GetObjectStatus` during worker shutdown; it needs its own shutdown signal and is not yet confirmed to trigger, so it's handled separately.
