### PR TITLE
[serve][ci] Skip the full-suite HAProxy step on microcheck

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -213,6 +213,7 @@ steps:
     parallelism: 3
     tags:
       - serve
+      - skip-on-microcheck
     instance_type: large
     commands:
       # Full serve suite with HAProxy, minus tags owned by their own steps or images.


### PR DESCRIPTION
## Why are these changes needed?

Since #64210 the "serve: HAProxy tests" step contains every serve target (~203). That had two unintended effects on **microcheck**:

1. **It became microcheck's carrier step for the serve suite.** Microcheck designates one carrier step per selected test via `sorted(test_step_ids)[0]` (`release/ray_release/test.py`), so the HAProxy step displaced the regular default-env serve steps — e.g. microcheck build 50462 ran the full serve suite *only* under the HAProxy env, with no default-env serve step at all.
2. **It cannot finish there.** rayci clamps microcheck steps to `MaxParallelism = 1`, so one worker ran all ~203 targets serially, blew the 300-minute timeout (cancelled at 171/203 with zero failures, e.g. build 50386), and the timeout's exit status -1 is in rayci's automatic-retry list (limit 3) — the step's `|| exit 42` guard never runs on a timeout — burning ~20 hours of CI per affected PR.

This tags the step `skip-on-microcheck` (the same mechanism rllib uses for its heavy steps). Microcheck's serve coverage reverts to the regular serve steps — dedicated HAProxy targets (`test_haproxy*`, `unit/test_haproxy_*`) remain selectable there — and the full-suite-under-HAProxy sweep stays on premerge and postmerge, where `parallelism: 3` applies.

Verified by rendering the microcheck pipeline locally with rayci (pipeline ID `018f4f1e-…`): with this change the generated pipeline contains no HAProxy step and all regular serve steps remain; without it, the HAProxy step is present.