### PR TITLE
[Data] Add assume_timezone and tz_convert to the datetime expression namespace

### DIFF
--- a/python/ray/data/namespace_expressions/dt_namespace.py
+++ b/python/ray/data/namespace_expressions/dt_namespace.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING, Literal
 import pyarrow.compute as pc
 
 from ray.data.datatype import DataType
-from ray.data.expressions import _create_pyarrow_compute_udf
+from ray.data.expressions import _create_pyarrow_compute_udf, pyarrow_udf
 
 if TYPE_CHECKING:
-    from ray.data.expressions import Expr, PyArrowComputeUDFExpr
+    import pyarrow
+
+    from ray.data.expressions import Expr, PyArrowComputeUDFExpr, UDFExpr
 
 TemporalUnit = Literal[
     "year",
@@ -85,3 +87,75 @@ class _DatetimeNamespace:
         return _create_pyarrow_compute_udf(pc.round_temporal, self._expr.data_type)(
             self._expr, multiple=1, unit=unit
         )
+
+    # timezone operations
+
+    def _timestamp_dtype_with_tz(self, tz: str) -> DataType:
+        """Return this expression's timestamp DataType re-tagged with ``tz``.
+
+        Falls back to the expression's current data type when it is not a
+        timestamp (the underlying compute call will then raise a clear error).
+        """
+        import pyarrow as pa
+
+        dtype = self._expr.data_type
+        if dtype.is_arrow_type():
+            arrow_type = dtype.to_arrow_dtype()
+            if pa.types.is_timestamp(arrow_type):
+                return DataType.from_arrow(pa.timestamp(arrow_type.unit, tz=tz))
+        return dtype
+
+    def assume_timezone(
+        self,
+        timezone: str,
+        *,
+        ambiguous: Literal["raise", "earliest", "latest"] = "raise",
+        nonexistent: Literal["raise", "earliest", "latest"] = "raise",
+    ) -> "PyArrowComputeUDFExpr":
+        """Localize timezone-naive timestamps to the given timezone.
+
+        Args:
+            timezone: Timezone to assume for the timestamps, e.g. ``"UTC"``
+                or ``"America/New_York"``.
+            ambiguous: How to handle timestamps that are ambiguous in the
+                assumed timezone (DST fall-back), one of ``"raise"``,
+                ``"earliest"``, or ``"latest"``.
+            nonexistent: How to handle timestamps that don't exist in the
+                assumed timezone (DST spring-forward), one of ``"raise"``,
+                ``"earliest"``, or ``"latest"``.
+
+        Returns:
+            Expression producing timezone-aware timestamps.
+        """
+        return _create_pyarrow_compute_udf(
+            pc.assume_timezone, self._timestamp_dtype_with_tz(timezone)
+        )(self._expr, timezone=timezone, ambiguous=ambiguous, nonexistent=nonexistent)
+
+    def tz_convert(self, target_tz: str) -> "UDFExpr":
+        """Convert timezone-aware timestamps to another timezone.
+
+        The stored instant is unchanged; only the timezone metadata used for
+        display and component extraction changes.
+
+        Args:
+            target_tz: Target timezone, e.g. ``"Europe/London"``.
+
+        Returns:
+            Expression producing timestamps in the target timezone.
+        """
+        import pyarrow as pa
+
+        @pyarrow_udf(return_dtype=self._timestamp_dtype_with_tz(target_tz))
+        def _tz_convert(arr: "pyarrow.Array") -> "pyarrow.Array":
+            if not pa.types.is_timestamp(arr.type):
+                raise TypeError(
+                    f"dt.tz_convert() requires a timestamp column, got {arr.type}."
+                )
+            if arr.type.tz is None:
+                raise ValueError(
+                    "dt.tz_convert() requires timezone-aware timestamps; use "
+                    "dt.assume_timezone() to localize naive timestamps first."
+                )
+            return pc.cast(arr, pa.timestamp(arr.type.unit, tz=target_tz))
+
+        return _tz_convert(self._expr)

--- a/python/ray/data/tests/expressions/test_namespace_datetime.py
+++ b/python/ray/data/tests/expressions/test_namespace_datetime.py
@@ -74,6 +74,96 @@ class TestDatetimeNamespace:
         with pytest.raises(Exception):
             ds.with_column("year", col("value").dt.year()).to_pandas()
 
+    def test_dt_assume_timezone(self, ray_start_regular_shared):
+        """Test localizing naive timestamps with assume_timezone."""
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [pd.Timestamp("2024-01-01 00:00:00")], type=pa.timestamp("us")
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+
+        result = ds.with_column(
+            "ts_utc", col("ts").dt.assume_timezone("UTC")
+        ).to_pandas()
+
+        assert str(result["ts_utc"].dt.tz) == "UTC"
+        assert result["ts_utc"].iloc[0] == pd.Timestamp("2024-01-01", tz="UTC")
+
+    def test_dt_assume_timezone_ambiguous(self, ray_start_regular_shared):
+        """Test assume_timezone with an ambiguous DST fall-back timestamp."""
+        # 2024-11-03 01:30 occurs twice in America/New_York (DST fall-back).
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [pd.Timestamp("2024-11-03 01:30:00")], type=pa.timestamp("us")
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+
+        result = ds.with_column(
+            "ts_ny",
+            col("ts").dt.assume_timezone("America/New_York", ambiguous="earliest"),
+        ).to_pandas()
+
+        assert str(result["ts_ny"].dt.tz) == "America/New_York"
+
+    def test_dt_tz_convert(self, ray_start_regular_shared):
+        """Test converting timezone-aware timestamps to another timezone."""
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [pd.Timestamp("2024-01-01 00:00:00")],
+                    type=pa.timestamp("us", tz="UTC"),
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+
+        result = ds.with_column(
+            "ts_ny", col("ts").dt.tz_convert("America/New_York")
+        ).to_pandas()
+
+        assert str(result["ts_ny"].dt.tz) == "America/New_York"
+        # The instant is unchanged: UTC midnight is 19:00 the previous day in NY.
+        assert result["ts_ny"].iloc[0].hour == 19
+
+    def test_dt_tz_convert_naive_raises(self, ray_start_regular_shared):
+        """Test that tz_convert on naive timestamps raises a clear error."""
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [pd.Timestamp("2024-01-01 00:00:00")], type=pa.timestamp("us")
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+
+        with pytest.raises(Exception, match="assume_timezone"):
+            ds.with_column("bad", col("ts").dt.tz_convert("UTC")).to_pandas()
+
+    def test_dt_assume_timezone_then_convert(self, ray_start_regular_shared):
+        """Test chaining assume_timezone and tz_convert."""
+        table = pa.table(
+            {
+                "ts": pa.array(
+                    [pd.Timestamp("2024-01-01 00:00:00")], type=pa.timestamp("us")
+                )
+            }
+        )
+        ds = ray.data.from_arrow(table)
+
+        result = ds.with_column(
+            "ts_sh",
+            col("ts").dt.assume_timezone("UTC").dt.tz_convert("Asia/Shanghai"),
+        ).to_pandas()
+
+        # UTC midnight is 08:00 in Shanghai (UTC+8).
+        assert result["ts_sh"].iloc[0].hour == 8
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description

Adds timezone operations to the `.dt` expression namespace:

- **`assume_timezone(timezone, *, ambiguous="raise", nonexistent="raise")`** — localize timezone-naive timestamps via `pc.assume_timezone`, with DST ambiguous/nonexistent handling exposed.
- **`tz_convert(target_tz)`** — convert timezone-aware timestamps to another timezone. The stored instant is unchanged (metadata-only cast). Calling it on naive timestamps raises a clear error pointing users to `assume_timezone()`.

Both re-tag the return dtype as `timestamp(unit, tz)` so downstream schema inference stays correct.

```python
from ray.data.expressions import col

ds = ds.with_column(
    "ts_local",
    col("ts").dt.assume_timezone("UTC").dt.tz_convert("America/New_York"),
)
```

## Related issues

Related to #58674 (fills the `.dt` Timezone row: `assume_timezone`, `tz_convert`). A previous attempt (#63822) was auto-closed by the stale bot without review feedback; this is a fresh implementation on current master.

## Additional information

Tested end-to-end (naive→aware localization, DST-ambiguous timestamps with `ambiguous="earliest"`, instant preservation across conversion, chained assume+convert, and the naive-input error path). Lint (black + ruff) clean.
