### PR TITLE
[Data] Add fill_null expression method

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -823,6 +823,34 @@ class Expr(ABC):
 
         return cast_udf(self)
 
+    def fill_null(self, fill_value: Any) -> "UDFExpr":
+        """Replace null values with ``fill_value``.
+
+        Args:
+            fill_value: The value used to replace nulls. Must be compatible
+                with the expression's type.
+
+        Returns:
+            A UDFExpr that replaces null values with ``fill_value``.
+
+        Example:
+            >>> from ray.data.expressions import col
+            >>> import ray
+            >>> ds = ray.data.from_items([{"x": 1}, {"x": None}])
+            >>> ds = ds.with_column("x_filled", col("x").fill_null(0))
+            >>> # Result: x_filled = [1, 0]
+        """
+
+        @pyarrow_udf(return_dtype=self.data_type)
+        def fill_null_udf(arr: pyarrow.Array) -> pyarrow.Array:
+            if pyarrow.types.is_null(arr.type):
+                # An all-null column has the null Arrow type, which pc.fill_null
+                # would return unchanged; cast it to the fill value's type first.
+                arr = arr.cast(pyarrow.scalar(fill_value).type)
+            return pc.fill_null(arr, fill_value)
+
+        return fill_null_udf(self)
+
     @property
     def arr(self) -> "_ArrayNamespace":
         """Access array operations for this expression."""

--- a/python/ray/data/tests/expressions/test_predicate.py
+++ b/python/ray/data/tests/expressions/test_predicate.py
@@ -54,6 +54,32 @@ class TestPredicateIntegration:
         )
         assert rows_same(result, expected)
 
+    def test_fill_null_with_dataset(self, ray_start_regular_shared):
+        """Test fill_null expression with Ray Dataset."""
+        ds = ray.data.from_items(
+            [
+                {"value": 10, "name": "Alice"},
+                {"value": None, "name": None},
+                {"value": 30, "name": "Charlie"},
+            ]
+        )
+
+        result = (
+            ds.with_column("value_filled", col("value").fill_null(0))
+            .with_column("name_filled", col("name").fill_null("unknown"))
+            .to_pandas()
+        )
+
+        expected = pd.DataFrame(
+            {
+                "value": [10, None, 30],
+                "name": ["Alice", None, "Charlie"],
+                "value_filled": [10, 0, 30],
+                "name_filled": ["Alice", "unknown", "Charlie"],
+            }
+        )
+        assert rows_same(result, expected)
+
     def test_membership_predicates_with_dataset(self, ray_start_regular_shared):
         """Test membership predicate expressions with Ray Dataset."""
         ds = ray.data.from_items(

--- a/python/ray/data/tests/unit/expressions/test_predicate.py
+++ b/python/ray/data/tests/unit/expressions/test_predicate.py
@@ -2,6 +2,7 @@
 
 This module tests:
 - Null predicates: is_null(), is_not_null()
+- Null replacement: fill_null()
 - Membership predicates: is_in(), not_in()
 """
 
@@ -9,7 +10,7 @@ import pandas as pd
 import pytest
 
 from ray.data._internal.planner.plan_expression.expression_evaluator import eval_expr
-from ray.data.expressions import BinaryExpr, Operation, UnaryExpr, col, lit
+from ray.data.expressions import BinaryExpr, Operation, UDFExpr, UnaryExpr, col, lit
 
 # ──────────────────────────────────────
 # Null Predicate Operations
@@ -100,6 +101,46 @@ class TestIsNotNull:
 
         assert expr1.structurally_equals(expr2)
         assert not expr1.structurally_equals(expr3)
+
+
+class TestFillNull:
+    """Tests for fill_null()."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Sample data with null values."""
+        return pd.DataFrame(
+            {
+                "value": [1.0, None, 3.0, None, 5.0],
+                "name": ["Alice", None, "Charlie", "Diana", None],
+            }
+        )
+
+    def test_fill_null_numeric(self, sample_data):
+        """Test fill_null on a numeric column."""
+        expr = col("value").fill_null(0)
+        assert isinstance(expr, UDFExpr)
+        result = eval_expr(expr, sample_data)
+        assert result.tolist() == [1.0, 0.0, 3.0, 0.0, 5.0]
+
+    def test_fill_null_string(self, sample_data):
+        """Test fill_null on a string column."""
+        expr = col("name").fill_null("unknown")
+        result = eval_expr(expr, sample_data)
+        assert result.tolist() == ["Alice", "unknown", "Charlie", "Diana", "unknown"]
+
+    def test_fill_null_no_nulls_unchanged(self):
+        """Test fill_null leaves columns without nulls unchanged."""
+        data = pd.DataFrame({"value": [1, 2, 3]})
+        result = eval_expr(col("value").fill_null(9), data)
+        assert result.tolist() == [1, 2, 3]
+
+    def test_fill_null_all_null_column(self):
+        """Test fill_null on an all-null column (null-typed Arrow array)."""
+        data = pd.DataFrame({"value": [None, None, None]})
+        expr = col("value").fill_null(0)
+        result = eval_expr(expr, data)
+        assert result.tolist() == [0, 0, 0]
 
 
 class TestNullPredicateCombinations:


### PR DESCRIPTION
## Description

Adds **`Expr.fill_null(fill_value)`** to replace null values via `pc.fill_null`.

All-null columns are a special case: they carry the null Arrow type, which `pc.fill_null` would return unchanged, so the array is cast to the fill value's type first.

```python
from ray.data.expressions import col

ds = ds.with_column("value_filled", col("value").fill_null(0))
ds = ds.with_column("name_filled", col("name").fill_null("unknown"))
```

## Related issues

Related to #58674 (Null Handling: `fill_null`). A previous attempt (#63908) was auto-closed by the stale bot without review feedback; this is a fresh implementation on current master.

## Additional information

Unit tests (numeric / string / no-op / all-null column via `eval_expr`) plus a dataset integration test. Lint (black + ruff) clean.
