### PR TITLE
[Data] Add min and max to the list expression namespace

### DIFF
--- a/python/ray/data/namespace_expressions/list_namespace.py
+++ b/python/ray/data/namespace_expressions/list_namespace.py
@@ -333,3 +333,101 @@ class _ListNamespace:
             )
 
         return _list_flatten(self._expr)
+
+    def min(self) -> "UDFExpr":
+        """Get the minimum element of each list.
+
+        Nulls within a list are ignored. Empty and all-null lists yield null,
+        as do null list rows.
+
+        Returns:
+            UDFExpr with the per-row minimum (same type as the list elements).
+
+        Example:
+            >>> from ray.data.expressions import col
+            >>> # [[3,1,2],[5],[]] -> [1, 5, None]
+            >>> expr = col("items").list.min()  # doctest: +SKIP
+        """
+        return self._reduce_elements("min")
+
+    def max(self) -> "UDFExpr":
+        """Get the maximum element of each list.
+
+        Nulls within a list are ignored. Empty and all-null lists yield null,
+        as do null list rows.
+
+        Returns:
+            UDFExpr with the per-row maximum (same type as the list elements).
+
+        Example:
+            >>> from ray.data.expressions import col
+            >>> # [[3,1,2],[5],[]] -> [3, 5, None]
+            >>> expr = col("items").list.max()  # doctest: +SKIP
+        """
+        return self._reduce_elements("max")
+
+    def _reduce_elements(self, agg: Literal["min", "max"]) -> "UDFExpr":
+        """Reduce each list to a scalar with the given group-by aggregation."""
+        return_dtype = DataType(object)
+        if self._expr.data_type.is_arrow_type():
+            arrow_type = self._expr.data_type.to_arrow_dtype()
+            if _is_list_like(arrow_type):
+                return_dtype = DataType.from_arrow(arrow_type.value_type)
+
+        @pyarrow_udf(return_dtype=return_dtype)
+        def _list_reduce(arr: pyarrow.Array) -> pyarrow.Array:
+            # Approach:
+            # 1) Normalize fixed_size_list -> list for list_* kernels
+            #    (null rows are filled so flatten/parent_indices stay aligned).
+            # 2) Flatten to (row_index, value) pairs and group-by aggregate.
+            # 3) Scatter per-group results back onto the full row range; rows
+            #    without values (empty/all-null lists) stay null.
+            arr = _ensure_array(arr)
+
+            if not _is_list_like(arr.type):
+                raise TypeError(f"list.{agg}() requires a list column.")
+
+            null_mask = arr.is_null() if arr.null_count else None
+            if pyarrow.types.is_fixed_size_list(arr.type):
+                child_type = arr.type.value_type
+                if null_mask is not None:
+                    filler_values = pyarrow.nulls(
+                        len(arr) * arr.type.list_size, type=child_type
+                    )
+                    filler = pyarrow.FixedSizeListArray.from_arrays(
+                        filler_values, arr.type.list_size
+                    )
+                    arr = pc.if_else(null_mask, filler, arr)
+                arr = arr.cast(pyarrow.list_(child_type))
+
+            n_rows = len(arr)
+            values = pc.list_flatten(arr)
+            out_type = values.type
+            if len(values) == 0:
+                return pyarrow.nulls(n_rows, type=out_type)
+
+            row_indices = pc.list_parent_indices(arr)
+            grouped = (
+                pyarrow.table({"row": row_indices, "value": values})
+                .group_by("row")
+                .aggregate([("value", agg)])
+            )
+            row_sequence = pyarrow.array(
+                np.arange(n_rows, dtype=np.int64), type=pyarrow.int64()
+            )
+            positions = pc.index_in(row_sequence, value_set=grouped.column("row"))
+            result = pc.if_else(
+                pc.is_null(positions),
+                pyarrow.nulls(n_rows, type=out_type),
+                pc.take(
+                    grouped.column(f"value_{agg}").combine_chunks(),
+                    pc.fill_null(positions, 0),
+                ),
+            )
+            if null_mask is not None:
+                result = pc.if_else(
+                    null_mask, pyarrow.nulls(n_rows, type=out_type), result
+                )
+            return result
+
+        return _list_reduce(self._expr)

--- a/python/ray/data/tests/expressions/test_namespace_list.py
+++ b/python/ray/data/tests/expressions/test_namespace_list.py
@@ -176,6 +176,89 @@ class TestListNamespace:
         )
         assert result_table.select(["flattened"]).combine_chunks().equals(expected)
 
+    def test_list_min_max(self, ray_start_regular_shared, dataset_format):
+        """Test list.min() and list.max() per-row reductions."""
+        data = [
+            {"items": [3, 1, 2]},
+            {"items": [5]},
+            {"items": []},  # empty lists yield null
+        ]
+        ds = _create_dataset(data, dataset_format)
+        rows = (
+            ds.with_column("mn", col("items").list.min())
+            .with_column("mx", col("items").list.max())
+            .take_all()
+        )
+        assert [row["mn"] for row in rows] == [1, 5, None]
+        assert [row["mx"] for row in rows] == [3, 5, None]
+
+    def test_list_min_max_ignores_nulls(self, ray_start_regular_shared, dataset_format):
+        """Test that nulls within lists are ignored, and null rows stay null."""
+        if dataset_format != "arrow":
+            pytest.skip("Null list rows only preserved via Arrow tables.")
+        table = pa.table(
+            {
+                "items": pa.array(
+                    [[4, None, 2], None, [None]], type=pa.list_(pa.int64())
+                ),
+            }
+        )
+        ds = _create_dataset(None, dataset_format, arrow_table=table)
+        rows = (
+            ds.with_column("mn", col("items").list.min())
+            .with_column("mx", col("items").list.max())
+            .take_all()
+        )
+        assert [row["mn"] for row in rows] == [2, None, None]
+        assert [row["mx"] for row in rows] == [4, None, None]
+
+    def test_list_min_max_strings(self, ray_start_regular_shared, dataset_format):
+        """Test list.min()/max() on string elements (ordinal comparison)."""
+        data = [
+            {"items": ["banana", "apple"]},
+            {"items": ["zebra"]},
+        ]
+        ds = _create_dataset(data, dataset_format)
+        rows = (
+            ds.with_column("mn", col("items").list.min())
+            .with_column("mx", col("items").list.max())
+            .take_all()
+        )
+        assert [row["mn"] for row in rows] == ["apple", "zebra"]
+        assert [row["mx"] for row in rows] == ["banana", "zebra"]
+
+    def test_list_min_max_fixed_size_list_with_null(
+        self, ray_start_regular_shared, dataset_format
+    ):
+        """Test list.min()/max() on fixed_size_list with null entries."""
+        if dataset_format != "arrow":
+            pytest.skip("FixedSizeList type only available via Arrow tables.")
+        table = pa.table(
+            {
+                "items": pa.array(
+                    [[1, 2], None, [3, 4]],
+                    type=pa.list_(pa.int64(), 2),
+                ),
+            }
+        )
+        ds = _create_dataset(None, dataset_format, arrow_table=table)
+        rows = (
+            ds.with_column("mn", col("items").list.min())
+            .with_column("mx", col("items").list.max())
+            .take_all()
+        )
+        assert [row["mn"] for row in rows] == [1, None, 3]
+        assert [row["mx"] for row in rows] == [2, None, 4]
+
+    def test_list_min_max_non_list_raises(
+        self, ray_start_regular_shared, dataset_format
+    ):
+        """Test that list.min() on a non-list column raises an error."""
+        data = [{"value": 1}]
+        ds = _create_dataset(data, dataset_format)
+        with pytest.raises((RayTaskError, TypeError)):
+            ds.with_column("bad", col("value").list.min()).take_all()
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description

Adds **`list.min()`** and **`list.max()`** per-row reductions to the list expression namespace.

Implementation mirrors the group-by pattern of the in-flight `list.sum()`/`list.mean()` PR: flatten each list to `(row, value)` pairs, group-by aggregate, then scatter results back onto the full row range. Semantics:

- Nulls **within** a list are ignored (`[4, None, 2]` → min `2`).
- Empty lists, all-null lists, and null list rows yield null.
- Element type is preserved (int lists → int result, string lists work ordinally).
- `fixed_size_list` columns are normalized to `list` first, with null rows filled so `list_flatten`/`list_parent_indices` stay aligned.

```python
from ray.data.expressions import col

ds = ds.with_column("mn", col("items").list.min())
ds = ds.with_column("mx", col("items").list.max())
```

## Related issues

Related to #58674 (list Aggregations). Complements #61087, which covers `sum`/`mean`; this PR deliberately doesn't touch shared code (e.g. `_list_sort`) to stay conflict-free with it.

## Additional information

Tests cover int/float/string elements, nulls-in-list, null rows, empty lists, `fixed_size_list` with null entries, and the non-list error path, parametrized over pandas/arrow dataset formats. Lint (black + ruff) clean.
