### PR TITLE
[ci] fix org_lzma_lzma download failures by using SourceForge redirector

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -219,10 +219,10 @@ def ray_deps_setup():
         sha256 = "06327c2ddc81e126a6d9a78b0be5014b976a2c0832f492dcfc4755d7facf6d33",
         strip_prefix = "xz-5.2.7",
         urls = [
-            "https://cfhcable.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
-            "https://superb-sea2.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
-            "https://ayera.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
-            "https://astuteinternet.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
+            # Use the SourceForge redirector, which picks a live mirror,
+            # instead of pinning specific mirrors that can go offline.
+            "https://downloads.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
+            "https://tukaani.org/xz/xz-5.2.7.tar.gz",
         ],
         build_file = "//thirdparty/patches:org_lzma_lzma.BUILD.bazel",
     )


### PR DESCRIPTION
All four pinned SourceForge mirrors for xz-5.2.7.tar.gz are currently unreachable (cfhcable times out; superb-sea2, ayera, and astuteinternet no longer resolve in DNS), which breaks every build that needs to fetch @org_lzma_lzma (e.g. premerge build 70468).

Replace the hardcoded mirror list with the canonical downloads.sourceforge.net redirector, which selects a live mirror automatically, plus tukaani.org (the xz project's own site) as a fallback. Both currently serve the tarball with the pinned sha256 unchanged.