### PR TITLE
[serve] Cache per-tick replica id walks behind a container mutation version

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -3,7 +3,18 @@ import logging
 import math
 import time
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
@@ -93,7 +104,7 @@ class DeploymentAutoscalingState:
         # user defined policy returns a dictionary of state that is persisted between autoscaling decisions
         # content of the dictionary is determined by the user defined policy
         self._policy_state: Optional[Dict[str, Any]] = None
-        self._running_replicas: List[ReplicaID] = []
+        self._running_replicas: Sequence[ReplicaID] = []
         self._cached_running_replica_strs: Set[str] = set()
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
@@ -208,8 +219,12 @@ class DeploymentAutoscalingState:
             self._target_capacity,
         )
 
-    def update_running_replica_ids(self, running_replicas: List[ReplicaID]):
+    def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
+        if running_replicas is self._running_replicas:
+            # Identity means DeploymentState handed back its memoized tuple, so the
+            # running-replica ids are unchanged and the derived str set still matches.
+            return
         self._running_replicas = running_replicas
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -395,7 +410,9 @@ class DeploymentAutoscalingState:
             app_name=self._deployment_id.app_name,
             current_num_replicas=len(self._running_replicas),
             target_num_replicas=curr_target_num_replicas,
-            running_replicas=self._running_replicas,
+            # Copy: _running_replicas holds the memoized tuple from
+            # get_running_replica_ids(), and this is a stable public List[ReplicaID].
+            running_replicas=list(self._running_replicas),
             total_num_requests=self.get_total_num_requests,
             capacity_adjusted_min_replicas=self.get_num_replicas_lower_bound(),
             capacity_adjusted_max_replicas=self.get_num_replicas_upper_bound(),
@@ -1013,7 +1030,7 @@ class ApplicationAutoscalingState:
             }
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         self._deployment_autoscaling_states[deployment_id].update_running_replica_ids(
             running_replicas
@@ -1183,7 +1200,7 @@ class AutoscalingStateManager:
         )
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         app_state = self._app_autoscaling_states.get(deployment_id.app_name)
         if app_state:

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -3,7 +3,19 @@ import logging
 import math
 import time
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
@@ -91,7 +103,7 @@ class DeploymentAutoscalingState:
         # user defined policy returns a dictionary of state that is persisted between autoscaling decisions
         # content of the dictionary is determined by the user defined policy
         self._policy_state: Optional[Dict[str, Any]] = None
-        self._running_replicas: List[ReplicaID] = []
+        self._running_replicas: Sequence[ReplicaID] = []
         self._cached_running_replica_strs: Set[str] = set()
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
@@ -206,8 +218,12 @@ class DeploymentAutoscalingState:
             self._target_capacity,
         )
 
-    def update_running_replica_ids(self, running_replicas: List[ReplicaID]):
+    def update_running_replica_ids(self, running_replicas: Sequence[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
+        if running_replicas is self._running_replicas:
+            # Identity means DeploymentState handed back its memoized tuple, so the
+            # running-replica ids are unchanged and the derived str set still matches.
+            return
         self._running_replicas = running_replicas
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -279,7 +295,9 @@ class DeploymentAutoscalingState:
         """Records task queue length from QueueMonitor for async inference."""
         self._total_pending_async_requests = report.queue_length
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
+    def drop_stale_handle_metrics(
+        self, alive_serve_actor_ids: AbstractSet[str]
+    ) -> None:
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -395,7 +413,9 @@ class DeploymentAutoscalingState:
             app_name=self._deployment_id.app_name,
             current_num_replicas=len(self._running_replicas),
             target_num_replicas=curr_target_num_replicas,
-            running_replicas=self._running_replicas,
+            # Copy: _running_replicas holds the memoized tuple from
+            # get_running_replica_ids(), and this is a stable public List[ReplicaID].
+            running_replicas=list(self._running_replicas),
             total_num_requests=self.get_total_num_requests,
             capacity_adjusted_min_replicas=self.get_num_replicas_lower_bound(),
             capacity_adjusted_max_replicas=self.get_num_replicas_upper_bound(),
@@ -884,7 +904,7 @@ class ApplicationAutoscalingState:
             }
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         self._deployment_autoscaling_states[deployment_id].update_running_replica_ids(
             running_replicas
@@ -951,7 +971,7 @@ class ApplicationAutoscalingState:
                 report.deployment_id
             ].record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]):
+    def drop_stale_handle_metrics(self, alive_serve_actor_ids: AbstractSet[str]):
         """Drops handle metrics that are no longer valid.
 
         This includes handles that live on Serve Proxy or replica actors
@@ -1054,7 +1074,7 @@ class AutoscalingStateManager:
         )
 
     def update_running_replica_ids(
-        self, deployment_id: DeploymentID, running_replicas: List[ReplicaID]
+        self, deployment_id: DeploymentID, running_replicas: Sequence[ReplicaID]
     ):
         app_state = self._app_autoscaling_states.get(deployment_id.app_name)
         if app_state:
@@ -1142,6 +1162,8 @@ class AutoscalingStateManager:
         if app_state:
             app_state.record_async_inference_task_queue_metrics(report)
 
-    def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
+    def drop_stale_handle_metrics(
+        self, alive_serve_actor_ids: AbstractSet[str]
+    ) -> None:
         for app_state in self._app_autoscaling_states.values():
             app_state.drop_stale_handle_metrics(alive_serve_actor_ids)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -533,7 +533,9 @@ class ServeController:
         Controller decides where proxy actors should run
         (head node and nodes with deployment replicas).
         """
-        new_proxy_nodes = self.deployment_state_manager.get_active_node_ids()
+        # Copy: get_active_node_ids() returns a shared frozenset, and `frozenset - set`
+        # stays frozen, so the .add() below would raise without this.
+        new_proxy_nodes = set(self.deployment_state_manager.get_active_node_ids())
         new_proxy_nodes = new_proxy_nodes - set(
             self.cluster_node_info_cache.get_draining_nodes()
         )

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -547,7 +547,9 @@ class ServeController:
         Controller decides where proxy actors should run
         (head node and nodes with deployment replicas).
         """
-        new_proxy_nodes = self.deployment_state_manager.get_active_node_ids()
+        # Copy: get_active_node_ids() returns a shared frozenset, and `frozenset - set`
+        # stays frozen, so the .add() below would raise without this.
+        new_proxy_nodes = set(self.deployment_state_manager.get_active_node_ids())
         new_proxy_nodes = new_proxy_nodes - set(
             self.cluster_node_info_cache.get_draining_nodes()
         )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,7 +10,17 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 import ray
 from ray import ObjectRef, cloudpickle
@@ -2172,6 +2182,37 @@ class DeploymentReplica:
         return self._actor.get_outbound_deployments()
 
 
+def _memoized_walk(obj, memo_attr: str, token, compute):
+    """Return compute() memoized on *token* in obj.<memo_attr>.
+
+    token=None means "uncacheable right now": recompute and drop the memo.
+    Callers must treat returned collections as immutable (they are shared).
+    """
+    # No getattr default: a misspelled memo_attr must raise here rather than have
+    # setattr silently create a second memo the real attribute never sees.
+    memo = getattr(obj, memo_attr)
+    if token is not None and memo is not None and memo[0] == token:
+        return memo[1]
+    result = compute()
+    setattr(obj, memo_attr, None if token is None else (token, result))
+    return result
+
+
+# One odd multiplier per state. A hash of (replica_id, state) will not do: the tuple
+# hash makes term(r, A) - term(r, B) nearly independent of r, so two replicas swapping
+# states in one tick cancel out. Multiplying keeps that difference proportional to
+# hash(replica_id). Terms are ~128 bits, so each add/pop/remove is a small bigint add;
+# masking to 64 would reintroduce the cancellation, as the multiplier difference is even.
+_STATE_MULTIPLIERS = {
+    state: (2 * i + 1) * 0x9E3779B97F4A7C15 for i, state in enumerate(ReplicaState)
+}
+
+
+def _membership_term(replica_id: ReplicaID, state: ReplicaState) -> int:
+    """One fingerprint term -- add() adds it, pop()/remove() subtract the same value."""
+    return hash(replica_id) * _STATE_MULTIPLIERS[state]
+
+
 class ReplicaStateContainer:
     """Container for mapping ReplicaStates to lists of DeploymentReplicas."""
 
@@ -2182,6 +2223,21 @@ class ReplicaStateContainer:
         # Incremental (state, version) counts for O(1) version-filtered count()
         # (maintained on add/pop/remove) -> replaces the per-tick O(N) version scan.
         self._sv_counts: Dict[tuple, int] = defaultdict(int)
+        # Running sum of per-replica terms. The memo key is the membership_fingerprint
+        # property, which pairs this with the replica count.
+        self._membership_fingerprint: int = 0
+
+    @property
+    def membership_fingerprint(self) -> Tuple[int, int]:
+        """Fingerprint of the {replica id -> state} content, for memo keys.
+
+        Terms are summed, so popping a replica and re-adding it under the SAME state
+        cancels -- which is what the gang health pass and the drain pass do every tick --
+        while arrivals, departures and real state transitions do not. The exact replica
+        count rides along, so only equal-size contents can collide: equality means
+        "almost certainly unchanged", not proof.
+        """
+        return len(self._replica_id_index), self._membership_fingerprint
 
     def __getstate__(self):
         # Exclude the callback to keep the container picklable (the callback
@@ -2205,6 +2261,7 @@ class ReplicaStateContainer:
         self._replicas[state].append(replica)
         self._replica_id_index[replica.replica_id] = replica
         self._sv_counts[(state, replica.version)] += 1
+        self._membership_fingerprint += _membership_term(replica.replica_id, state)
         if self._on_replica_state_change and state != old_state:
             self._on_replica_state_change(old_state, state)
 
@@ -2296,8 +2353,11 @@ class ReplicaStateContainer:
 
             self._replicas[state] = remaining
             replicas.extend(popped)
-            for _r in popped:
-                self._sv_counts[(state, _r.version)] -= 1
+            for replica in popped:
+                self._sv_counts[(state, replica.version)] -= 1
+                self._membership_fingerprint -= _membership_term(
+                    replica.replica_id, state
+                )
 
         for replica in replicas:
             self._replica_id_index.pop(replica.replica_id, None)
@@ -2368,6 +2428,9 @@ class ReplicaStateContainer:
                 if remaining_to_find > 0 and replica.replica_id in replica_ids:
                     removed.append(replica)
                     self._sv_counts[(state, replica.version)] -= 1
+                    self._membership_fingerprint -= _membership_term(
+                        replica.replica_id, state
+                    )
                     self._replica_id_index.pop(replica.replica_id, None)
                     remaining_to_find -= 1
                     found_any = True
@@ -2934,7 +2997,11 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_ids: Optional[Set[str]] = None
+        self._last_rank_membership_fp: Optional[Tuple[int, int]] = None
+        # (token, result) memos for per-tick id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._running_replica_ids_memo = None
+        self._active_node_ids_memo = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -3311,16 +3378,50 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        return {replica.actor_id for replica in self._replicas.get()}
+    def _membership_cache_token(self) -> Optional[Tuple[int, int]]:
+        """Per-deployment memo token, or None while uncacheable.
 
-    def get_running_replica_ids(self) -> List[ReplicaID]:
-        return [
-            replica.replica_id
-            for replica in self._replicas.get(
-                [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+        The fingerprint covers which replica is in which state, not the replicas' own
+        fields -- and these walks read actor_id/actor_node_id, which check_ready() fills
+        in in place for STARTING, UPDATING and RECOVERING replicas. So disable caching
+        while any of the three exist.
+        """
+        if (
+            self._replicas.count(
+                states=[
+                    ReplicaState.STARTING,
+                    ReplicaState.UPDATING,
+                    ReplicaState.RECOVERING,
+                ]
             )
-        ]
+            > 0
+        ):
+            return None
+        return self._replicas.membership_fingerprint
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(replica.actor_id for replica in self._replicas.get()),
+        )
+
+    def get_running_replica_ids(self) -> Tuple[ReplicaID, ...]:
+        # Keyed on the fingerprint rather than the shared token: this walk reads only
+        # replica_id, which never changes after construction, so it has no check_ready()
+        # dependency and stays cached through rollouts.
+        return _memoized_walk(
+            self,
+            "_running_replica_ids_memo",
+            self._replicas.membership_fingerprint,
+            lambda: tuple(
+                replica.replica_id
+                for replica in self._replicas.get(
+                    [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                )
+            ),
+        )
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -3357,7 +3458,7 @@ class DeploymentState:
             - recovering_replicas
         )
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Get the node ids of all running replicas in this deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
@@ -3372,11 +3473,16 @@ class DeploymentState:
             # node before all the replicas are migrated.
             ReplicaState.PENDING_MIGRATION,
         ]
-        return {
-            replica.actor_node_id
-            for replica in self._replicas.get(active_states)
-            if replica.actor_node_id is not None
-        }
+        return _memoized_walk(
+            self,
+            "_active_node_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                replica.actor_node_id
+                for replica in self._replicas.get(active_states)
+                if replica.actor_node_id is not None
+            ),
+        )
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
@@ -4981,7 +5087,10 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so the active replica-id set gates it.
+        replica-id set changes, so the container's (id, state) fingerprint gates it.
+        It is finer than that set, so state transitions re-run the pass as well. That is
+        safe because a replica cannot run without a rank, so everything the pass sees
+        under a HEALTHY deployment holds one.
         """
         # O(1) guards first -- `get()` below copies the whole replica list, and these
         # two rule out the busiest ticks (rollouts, migrations) without paying for it.
@@ -4994,11 +5103,12 @@ class DeploymentState:
             or self._replicas.count(states=[ReplicaState.STARTING]) != 0
         ):
             return
+        fp = self._replicas.membership_fingerprint
+        if fp == self._last_rank_membership_fp:
+            return
         active_replicas = self._replicas.get()
         if not active_replicas:
-            return
-        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
-        if active_replica_ids == self._last_rank_membership_ids:
+            self._last_rank_membership_fp = fp
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -5007,7 +5117,7 @@ class DeploymentState:
         )
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        self._last_rank_membership_ids = active_replica_ids
+        self._last_rank_membership_fp = fp
 
     def _handle_deployment_actor_failed_health_check(
         self,
@@ -5780,6 +5890,9 @@ class DeploymentStateManager:
         self._shutdown_tier_started_at: Optional[float] = None
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # (key, result) memos for cross-deployment id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._active_node_ids_memo = None
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
         # reconcile on it, skipping the O(replicas) pass on ticks with no change.
@@ -6208,12 +6321,34 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids = set()
-        for ds in self._deployment_states.values():
-            alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+    def _membership_cache_key(self) -> Optional[tuple]:
+        """Combined per-deployment token, or None if any deployment is uncacheable.
 
-        return alive_replica_actor_ids
+        Adding or removing a deployment changes the tuple, so that is covered too. One
+        STARTING replica disarms this cluster-wide, but the per-deployment memos still
+        hit inside compute(), so it degrades to a union per deployment, not a walk per
+        replica."""
+        parts = []
+        for deployment_id, ds in self._deployment_states.items():
+            token = ds._membership_cache_token()
+            if token is None:
+                return None
+            parts.append((deployment_id, token))
+        return tuple(parts)
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        def compute():
+            alive_replica_actor_ids = set()
+            for ds in self._deployment_states.values():
+                alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+            return frozenset(alive_replica_actor_ids)
+
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_key(),
+            compute,
+        )
 
     def get_deployment_ids(self) -> List[DeploymentID]:
         return list(self._deployment_states.keys())
@@ -6640,16 +6775,22 @@ class DeploymentStateManager:
             return
         self._deployment_states[deployment_id].record_request_routing_info(info)
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Return set of node ids with running replicas of any deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
         head node should have active proxies.
         """
-        node_ids = set()
-        for deployment_state in self._deployment_states.values():
-            node_ids.update(deployment_state.get_active_node_ids())
-        return node_ids
+
+        def compute():
+            node_ids = set()
+            for deployment_state in self._deployment_states.values():
+                node_ids.update(deployment_state.get_active_node_ids())
+            return frozenset(node_ids)
+
+        return _memoized_walk(
+            self, "_active_node_ids_memo", self._membership_cache_key(), compute
+        )
 
     def get_ingress_membership_version(self) -> int:
         """Monotonic counter of ingress running-replica-set changes (node/ports

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Deque,
     Dict,
+    FrozenSet,
     Iterable,
     List,
     Mapping,
@@ -2246,6 +2247,37 @@ class DeploymentReplica:
         return self._actor.get_outbound_deployments()
 
 
+def _memoized_walk(obj, memo_attr: str, token, compute):
+    """Return compute() memoized on *token* in obj.<memo_attr>.
+
+    token=None means "uncacheable right now": recompute and drop the memo.
+    Callers must treat returned collections as immutable (they are shared).
+    """
+    # No getattr default: a misspelled memo_attr must raise here rather than have
+    # setattr silently create a second memo the real attribute never sees.
+    memo = getattr(obj, memo_attr)
+    if token is not None and memo is not None and memo[0] == token:
+        return memo[1]
+    result = compute()
+    setattr(obj, memo_attr, None if token is None else (token, result))
+    return result
+
+
+# One odd multiplier per state. A hash of (replica_id, state) will not do: the tuple
+# hash makes term(r, A) - term(r, B) nearly independent of r, so two replicas swapping
+# states in one tick cancel out. Multiplying keeps that difference proportional to
+# hash(replica_id). Terms are ~128 bits, so each add/pop/remove is a small bigint add;
+# masking to 64 would reintroduce the cancellation, as the multiplier difference is even.
+_STATE_MULTIPLIERS = {
+    state: (2 * i + 1) * 0x9E3779B97F4A7C15 for i, state in enumerate(ReplicaState)
+}
+
+
+def _membership_term(replica_id: ReplicaID, state: ReplicaState) -> int:
+    """One fingerprint term -- add() adds it, pop()/remove() subtract the same value."""
+    return hash(replica_id) * _STATE_MULTIPLIERS[state]
+
+
 class ReplicaStateContainer:
     """Container for mapping ReplicaStates to lists of DeploymentReplicas."""
 
@@ -2256,6 +2288,21 @@ class ReplicaStateContainer:
         # Incremental (state, version) counts for O(1) version-filtered count()
         # (maintained on add/pop/remove) -> replaces the per-tick O(N) version scan.
         self._sv_counts: Dict[tuple, int] = defaultdict(int)
+        # Running sum of per-replica terms. The memo key is the membership_fingerprint
+        # property, which pairs this with the replica count.
+        self._membership_fingerprint: int = 0
+
+    @property
+    def membership_fingerprint(self) -> Tuple[int, int]:
+        """Fingerprint of the {replica id -> state} content, for memo keys.
+
+        Terms are summed, so popping a replica and re-adding it under the SAME state
+        cancels -- which is what the gang health pass and the drain pass do every tick --
+        while arrivals, departures and real state transitions do not. The exact replica
+        count rides along, so only equal-size contents can collide: equality means
+        "almost certainly unchanged", not proof.
+        """
+        return len(self._replica_id_index), self._membership_fingerprint
 
     def __getstate__(self):
         # Exclude the callback to keep the container picklable (the callback
@@ -2279,6 +2326,7 @@ class ReplicaStateContainer:
         self._replicas[state].append(replica)
         self._replica_id_index[replica.replica_id] = replica
         self._sv_counts[(state, replica.version)] += 1
+        self._membership_fingerprint += _membership_term(replica.replica_id, state)
         if self._on_replica_state_change and state != old_state:
             self._on_replica_state_change(old_state, state)
 
@@ -2370,8 +2418,11 @@ class ReplicaStateContainer:
 
             self._replicas[state] = remaining
             replicas.extend(popped)
-            for _r in popped:
-                self._sv_counts[(state, _r.version)] -= 1
+            for replica in popped:
+                self._sv_counts[(state, replica.version)] -= 1
+                self._membership_fingerprint -= _membership_term(
+                    replica.replica_id, state
+                )
 
         for replica in replicas:
             self._replica_id_index.pop(replica.replica_id, None)
@@ -2442,6 +2493,9 @@ class ReplicaStateContainer:
                 if remaining_to_find > 0 and replica.replica_id in replica_ids:
                     removed.append(replica)
                     self._sv_counts[(state, replica.version)] -= 1
+                    self._membership_fingerprint -= _membership_term(
+                        replica.replica_id, state
+                    )
                     self._replica_id_index.pop(replica.replica_id, None)
                     remaining_to_find -= 1
                     found_any = True
@@ -3008,7 +3062,11 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_ids: Optional[Set[str]] = None
+        self._last_rank_membership_fp: Optional[Tuple[int, int]] = None
+        # (token, result) memos for per-tick id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._running_replica_ids_memo = None
+        self._active_node_ids_memo = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -3413,16 +3471,52 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        return {r.actor_id for r in self._replicas.get() if r.actor_id is not None}
+    def _membership_cache_token(self) -> Optional[Tuple[int, int]]:
+        """Per-deployment memo token, or None while uncacheable.
 
-    def get_running_replica_ids(self) -> List[ReplicaID]:
-        return [
-            replica.replica_id
-            for replica in self._replicas.get(
-                [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+        The fingerprint covers which replica is in which state, not the replicas' own
+        fields -- and these walks read actor_id/actor_node_id, which check_ready() fills
+        in in place for STARTING, UPDATING and RECOVERING replicas. So disable caching
+        while any of the three exist.
+        """
+        if (
+            self._replicas.count(
+                states=[
+                    ReplicaState.STARTING,
+                    ReplicaState.UPDATING,
+                    ReplicaState.RECOVERING,
+                ]
             )
-        ]
+            > 0
+        ):
+            return None
+        return self._replicas.membership_fingerprint
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                r.actor_id for r in self._replicas.get() if r.actor_id is not None
+            ),
+        )
+
+    def get_running_replica_ids(self) -> Tuple[ReplicaID, ...]:
+        # Keyed on the fingerprint rather than the shared token: this walk reads only
+        # replica_id, which never changes after construction, so it has no check_ready()
+        # dependency and stays cached through rollouts.
+        return _memoized_walk(
+            self,
+            "_running_replica_ids_memo",
+            self._replicas.membership_fingerprint,
+            lambda: tuple(
+                replica.replica_id
+                for replica in self._replicas.get(
+                    [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                )
+            ),
+        )
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -3462,7 +3556,7 @@ class DeploymentState:
             - recovering_replicas
         )
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Get the node ids of all running replicas in this deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
@@ -3477,11 +3571,16 @@ class DeploymentState:
             # node before all the replicas are migrated.
             ReplicaState.PENDING_MIGRATION,
         ]
-        return {
-            replica.actor_node_id
-            for replica in self._replicas.get(active_states)
-            if replica.actor_node_id is not None
-        }
+        return _memoized_walk(
+            self,
+            "_active_node_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                replica.actor_node_id
+                for replica in self._replicas.get(active_states)
+                if replica.actor_node_id is not None
+            ),
+        )
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
@@ -5148,7 +5247,10 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so the active replica-id set gates it.
+        replica-id set changes, so the container's (id, state) fingerprint gates it.
+        It is finer than that set, so state transitions re-run the pass as well. That is
+        safe because a replica cannot run without a rank, so everything the pass sees
+        under a HEALTHY deployment holds one.
         """
         # O(1) guards first -- `get()` below copies the whole replica list, and these
         # two rule out the busiest ticks (rollouts, migrations) without paying for it.
@@ -5161,11 +5263,12 @@ class DeploymentState:
             or self._replicas.count(states=[ReplicaState.STARTING]) != 0
         ):
             return
+        fp = self._replicas.membership_fingerprint
+        if fp == self._last_rank_membership_fp:
+            return
         active_replicas = self._replicas.get()
         if not active_replicas:
-            return
-        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
-        if active_replica_ids == self._last_rank_membership_ids:
+            self._last_rank_membership_fp = fp
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -5174,7 +5277,7 @@ class DeploymentState:
         )
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        self._last_rank_membership_ids = active_replica_ids
+        self._last_rank_membership_fp = fp
 
     def _handle_deployment_actor_failed_health_check(
         self,
@@ -5958,6 +6061,9 @@ class DeploymentStateManager:
         self._shutdown_tier_started_at: Optional[float] = None
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # (key, result) memos for cross-deployment id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._active_node_ids_memo = None
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
         # reconcile on it, skipping the O(replicas) pass on ticks with no change.
@@ -6393,12 +6499,39 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids: Set[str] = set()
-        for ds in self._deployment_states.values():
-            alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+    def _membership_cache_key(self) -> Optional[tuple]:
+        """Combined per-deployment token, or None if any deployment is uncacheable.
 
-        return alive_replica_actor_ids
+        Adding or removing a deployment changes the tuple, so that is covered too. One
+        STARTING replica disarms this cluster-wide, but the per-deployment memos still
+        hit inside compute(), so it degrades to a union per deployment, not a walk per
+        replica."""
+        parts = []
+        for deployment_id, ds in self._deployment_states.items():
+            token = ds._membership_cache_token()
+            if token is None:
+                return None
+            # get_active_node_ids filters on this flag, and it can flip with no replica
+            # churn to bump the token: it is not part of DeploymentVersion.
+            info = ds.target_info
+            parts.append(
+                (deployment_id, token, info is not None and info.ingress_request_router)
+            )
+        return tuple(parts)
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        def compute():
+            alive_replica_actor_ids: Set[str] = set()
+            for ds in self._deployment_states.values():
+                alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+            return frozenset(alive_replica_actor_ids)
+
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_key(),
+            compute,
+        )
 
     def get_deployment_ids(self) -> List[DeploymentID]:
         return list(self._deployment_states.keys())
@@ -6836,7 +6969,7 @@ class DeploymentStateManager:
             return
         self._deployment_states[deployment_id].record_request_routing_info(info)
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Return set of node ids with running replicas of any deployment.
 
         This is used to determine which nodes should have active proxies. Ingress
@@ -6844,13 +6977,19 @@ class DeploymentStateManager:
         counting them here would make a proxy node retain itself after all application
         replicas on the node have stopped.
         """
-        node_ids = set()
-        for deployment_state in self._deployment_states.values():
-            info = deployment_state.target_info
-            if info is not None and info.ingress_request_router:
-                continue
-            node_ids.update(deployment_state.get_active_node_ids())
-        return node_ids
+
+        def compute():
+            node_ids = set()
+            for deployment_state in self._deployment_states.values():
+                info = deployment_state.target_info
+                if info is not None and info.ingress_request_router:
+                    continue
+                node_ids.update(deployment_state.get_active_node_ids())
+            return frozenset(node_ids)
+
+        return _memoized_walk(
+            self, "_active_node_ids_memo", self._membership_cache_key(), compute
+        )
 
     def get_ingress_membership_version(self) -> int:
         """Monotonic counter of ingress running-replica-set changes (node/ports

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -394,6 +394,97 @@ class TestReplicaStateContainer:
             states=[ReplicaState.STOPPING],
         ) == [r1]
 
+    def test_membership_fingerprint_ignores_rebucketing_churn(self):
+        """The health and migration passes pop a whole bucket and re-add it every
+        tick. Only a real change of the {replica id -> state} content may show up."""
+        c = ReplicaStateContainer()
+        r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.RUNNING, r2)
+        settled = c.membership_fingerprint
+
+        # The migration pass: pop the bucket, re-add each replica to the state it
+        # came from. Order within a bucket is not membership.
+        for r in reversed(c.pop(states=[ReplicaState.RUNNING])):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == settled
+
+        # The in-place health path re-buckets a single replica: remove + re-add.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.RUNNING, r1)
+        assert c.membership_fingerprint == settled
+
+        # A real state transition, an arrival and a departure each change it.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.STOPPING, r1)
+        transitioned = c.membership_fingerprint
+        assert transitioned != settled
+
+        c.add(ReplicaState.RUNNING, replica(deployment_version("1")))
+        arrived = c.membership_fingerprint
+        assert arrived not in (settled, transitioned)
+
+        c.remove({r2.replica_id})
+        assert c.membership_fingerprint not in (settled, transitioned, arrived)
+
+    def test_paired_state_swap_changes_the_fingerprint(self):
+        """A drain tick moves one replica into a state as another moves out, so the
+        counts are unchanged and only the terms can tell the two apart."""
+        for _ in range(32):
+            c = ReplicaStateContainer()
+            r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+            c.add(ReplicaState.RUNNING, r1)
+            c.add(ReplicaState.PENDING_MIGRATION, r2)
+            before = c.membership_fingerprint
+
+            c.remove({r1.replica_id, r2.replica_id})
+            c.add(ReplicaState.PENDING_MIGRATION, r1)
+            c.add(ReplicaState.RUNNING, r2)
+            assert c.membership_fingerprint != before
+
+    def test_membership_terms_do_not_cancel_across_replicas(self):
+        """The swap above is only caught if term(r, A) - term(r, B) differs per replica.
+        Hashing (replica_id, state) as a tuple collapses it to a handful of values, which
+        makes a paired swap invisible for a large fraction of replica pairs."""
+        deltas = {
+            ds_mod._membership_term(r.replica_id, ReplicaState.RUNNING)
+            - ds_mod._membership_term(r.replica_id, ReplicaState.PENDING_MIGRATION)
+            for r in (replica(deployment_version("1")) for _ in range(64))
+        }
+        assert len(deltas) == 64
+
+    def test_membership_fingerprint_matches_a_recompute(self):
+        """The fingerprint is maintained incrementally, so pin it to ground truth: a
+        future bucket write that forgot to update it would silently make both the memos
+        and the rank gate skip real work."""
+
+        def recomputed(c):
+            return len(c._replica_id_index), sum(
+                ds_mod._membership_term(r.replica_id, state)
+                for state, replicas in c._replicas.items()
+                for r in replicas
+            )
+
+        c = ReplicaStateContainer()
+        r1, r2, r3 = (replica(deployment_version("1")) for _ in range(3))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.STARTING, r2)
+        c.add(ReplicaState.RUNNING, r3)
+        assert c.membership_fingerprint == recomputed(c)
+
+        for r in c.pop(states=[ReplicaState.RUNNING]):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.remove({r1.replica_id})
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.pop(states=[ReplicaState.STARTING])
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.add(ReplicaState.STOPPING, r1)
+        assert c.membership_fingerprint == recomputed(c)
+
 
 def _mock_deployment_actor_wrapper(deployment_id, code_version: str, name: str):
     """Create a MockDeploymentActorWrapper for container tests."""
@@ -10693,6 +10784,187 @@ class TestRankConsistencyMembershipGate:
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
         assert ds._rank_manager.consistency_calls == 0
+
+    def test_draining_elsewhere_does_not_rerun_the_pass(
+        self, rank_gate_dsm, mock_deployment_state_manager
+    ):
+        """A node draining elsewhere in the cluster churns the buckets every tick
+        without changing membership; the O(N) pass must still be gated off."""
+        dsm, ds, rank_manager, _ = rank_gate_dsm
+        _, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+        node = NodeID.from_random().hex()
+        cluster_node_info_cache.add_node(node)
+        before = rank_manager.consistency_calls
+
+        cluster_node_info_cache.draining_nodes = {node: 60 * 1000}
+        for _ in range(5):
+            bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+            dsm.update()
+            # pop() installs a fresh bucket list, so this witnesses the churn rather
+            # than assuming it -- otherwise the assertion below could hold vacuously.
+            assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+            # The gate's first guard is HEALTHY: a status flip would make this
+            # pass for the wrong reason.
+            assert ds._curr_status_info.status == DeploymentStatus.HEALTHY
+        assert rank_manager.consistency_calls == before
+
+
+def test_running_replica_ids_stay_cached_during_a_rollout(
+    mock_deployment_state_manager,
+):
+    """The running-id walk reads only replica_id, so unlike the other two it does not
+    need the STARTING/UPDATING/RECOVERING disarm -- and staying cached through a rollout
+    is what keeps the autoscaler from rebuilding its id-string set every tick."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=2, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v)])
+
+    # Scale up: the third replica stays STARTING, which disarms the shared token.
+    info, _ = deployment_info(num_replicas=3, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.update()
+    assert ds._replicas.count(states=[ReplicaState.STARTING]) == 1
+    assert ds._membership_cache_token() is None
+
+    running, alive = ds.get_running_replica_ids(), ds.get_alive_replica_actor_ids()
+    for _ in range(3):
+        dsm.update()
+        assert ds.get_running_replica_ids() is running
+        # The other walks read actor_id/actor_node_id, so they stay disarmed.
+        assert ds.get_alive_replica_actor_ids() is not alive
+
+
+def test_steady_state_ticks_do_not_change_the_fingerprint(
+    mock_deployment_state_manager,
+):
+    """The memo's whole value: an idle tick must not mutate the container."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=8, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.save_checkpoint()
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=8, by_state=[(ReplicaState.RUNNING, 8, v)])
+    for _ in range(3):
+        dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(20):
+        dsm.update()
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+
+
+def test_draining_elsewhere_does_not_invalidate_the_memo(
+    mock_deployment_state_manager,
+):
+    """A node draining elsewhere in the cluster makes the migration pass pop the
+    whole RUNNING bucket and re-add it every tick, membership unchanged."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    node, draining_node = NodeID.from_random().hex(), NodeID.from_random().hex()
+    cluster_node_info_cache.add_node(node)
+    cluster_node_info_cache.add_node(draining_node)
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=4, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for r in ds._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_node_id(node)
+        r._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+    # None of these replicas is on the draining node, so none of them moves.
+    cluster_node_info_cache.draining_nodes = {draining_node: 60 * 1000}
+    dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    # The controller and proxy read the manager-level getters, which key on the
+    # per-deployment tokens.
+    dsm_alive, dsm_nodes = dsm.get_alive_replica_actor_ids(), dsm.get_active_node_ids()
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list, so this witnesses the churn the test
+        # is about -- without it the assertions below could pass vacuously.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+        assert dsm.get_alive_replica_actor_ids() is dsm_alive
+        assert dsm.get_active_node_ids() is dsm_nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+
+def test_gang_health_churn_does_not_invalidate_the_memo(mock_deployment_state_manager):
+    """Gang deployments health-check through the pop-and-re-add path, so their
+    buckets churn on every tick with membership unchanged."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    deployment_id = DeploymentID(name="gang_memo", app_name="app")
+    info, v = deployment_info(
+        num_replicas=4,
+        version="v1",
+        gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+    )
+    dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+        return_value={
+            deployment_id: GangReservationResult(
+                success=True,
+                gang_pgs=[Mock(name="pg-0"), Mock(name="pg-1")],
+                gang_ids=["g0", "g1"],
+                gang_pg_names=["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"],
+            )
+        }
+    )
+    dsm.deploy(deployment_id, info)
+    ds = dsm._get_deployment_state_for_testing(deployment_id)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+    assert ds._is_gang_deployment, "the churn path under test is the gang one"
+
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list: the churn is real, not assumed.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -394,6 +394,97 @@ class TestReplicaStateContainer:
             states=[ReplicaState.STOPPING],
         ) == [r1]
 
+    def test_membership_fingerprint_ignores_rebucketing_churn(self):
+        """The health and migration passes pop a whole bucket and re-add it every
+        tick. Only a real change of the {replica id -> state} content may show up."""
+        c = ReplicaStateContainer()
+        r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.RUNNING, r2)
+        settled = c.membership_fingerprint
+
+        # The migration pass: pop the bucket, re-add each replica to the state it
+        # came from. Order within a bucket is not membership.
+        for r in reversed(c.pop(states=[ReplicaState.RUNNING])):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == settled
+
+        # The in-place health path re-buckets a single replica: remove + re-add.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.RUNNING, r1)
+        assert c.membership_fingerprint == settled
+
+        # A real state transition, an arrival and a departure each change it.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.STOPPING, r1)
+        transitioned = c.membership_fingerprint
+        assert transitioned != settled
+
+        c.add(ReplicaState.RUNNING, replica(deployment_version("1")))
+        arrived = c.membership_fingerprint
+        assert arrived not in (settled, transitioned)
+
+        c.remove({r2.replica_id})
+        assert c.membership_fingerprint not in (settled, transitioned, arrived)
+
+    def test_paired_state_swap_changes_the_fingerprint(self):
+        """A drain tick moves one replica into a state as another moves out, so the
+        counts are unchanged and only the terms can tell the two apart."""
+        for _ in range(32):
+            c = ReplicaStateContainer()
+            r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+            c.add(ReplicaState.RUNNING, r1)
+            c.add(ReplicaState.PENDING_MIGRATION, r2)
+            before = c.membership_fingerprint
+
+            c.remove({r1.replica_id, r2.replica_id})
+            c.add(ReplicaState.PENDING_MIGRATION, r1)
+            c.add(ReplicaState.RUNNING, r2)
+            assert c.membership_fingerprint != before
+
+    def test_membership_terms_do_not_cancel_across_replicas(self):
+        """The swap above is only caught if term(r, A) - term(r, B) differs per replica.
+        Hashing (replica_id, state) as a tuple collapses it to a handful of values, which
+        makes a paired swap invisible for a large fraction of replica pairs."""
+        deltas = {
+            ds_mod._membership_term(r.replica_id, ReplicaState.RUNNING)
+            - ds_mod._membership_term(r.replica_id, ReplicaState.PENDING_MIGRATION)
+            for r in (replica(deployment_version("1")) for _ in range(64))
+        }
+        assert len(deltas) == 64
+
+    def test_membership_fingerprint_matches_a_recompute(self):
+        """The fingerprint is maintained incrementally, so pin it to ground truth: a
+        future bucket write that forgot to update it would silently make both the memos
+        and the rank gate skip real work."""
+
+        def recomputed(c):
+            return len(c._replica_id_index), sum(
+                ds_mod._membership_term(r.replica_id, state)
+                for state, replicas in c._replicas.items()
+                for r in replicas
+            )
+
+        c = ReplicaStateContainer()
+        r1, r2, r3 = (replica(deployment_version("1")) for _ in range(3))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.STARTING, r2)
+        c.add(ReplicaState.RUNNING, r3)
+        assert c.membership_fingerprint == recomputed(c)
+
+        for r in c.pop(states=[ReplicaState.RUNNING]):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.remove({r1.replica_id})
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.pop(states=[ReplicaState.STARTING])
+        assert c.membership_fingerprint == recomputed(c)
+
+        c.add(ReplicaState.STOPPING, r1)
+        assert c.membership_fingerprint == recomputed(c)
+
 
 def _mock_deployment_actor_wrapper(deployment_id, code_version: str, name: str):
     """Create a MockDeploymentActorWrapper for container tests."""
@@ -4463,6 +4554,34 @@ def test_get_active_node_ids_handles_undeployed_state(
     dsm._deployment_states[undeployed_id] = undeployed_state
 
     assert undeployed_state.target_info is None
+    assert dsm.get_active_node_ids() == set()
+
+
+def test_active_node_ids_memo_tracks_ingress_request_router_flag(
+    mock_deployment_state_manager,
+):
+    """The memo key must cover the flag the filter reads: it can flip with no replica
+    churn to move the fingerprint, so a key blind to it serves the pre-flip node set."""
+    node = NodeID.from_random().hex()
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    cluster_node_info_cache.add_node(node)
+    info, v1 = deployment_info(version="1", num_replicas=1)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    replica = ds._replicas.get()[0]
+    replica._actor.set_node_id(node)
+    replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
+    # Armed (nothing STARTING/UPDATING/RECOVERING) and populated, so a later read
+    # would be served from the memo.
+    assert ds._membership_cache_token() is not None
+    assert dsm.get_active_node_ids() == {node}
+    fingerprint = ds._replicas.membership_fingerprint
+    ds.target_info.ingress_request_router = True
+    assert ds._replicas.membership_fingerprint == fingerprint
     assert dsm.get_active_node_ids() == set()
 
 
@@ -10671,6 +10790,187 @@ class TestRankConsistencyMembershipGate:
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
         assert ds._rank_manager.consistency_calls == 0
+
+    def test_draining_elsewhere_does_not_rerun_the_pass(
+        self, rank_gate_dsm, mock_deployment_state_manager
+    ):
+        """A node draining elsewhere in the cluster churns the buckets every tick
+        without changing membership; the O(N) pass must still be gated off."""
+        dsm, ds, rank_manager, _ = rank_gate_dsm
+        _, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+        node = NodeID.from_random().hex()
+        cluster_node_info_cache.add_node(node)
+        before = rank_manager.consistency_calls
+
+        cluster_node_info_cache.draining_nodes = {node: 60 * 1000}
+        for _ in range(5):
+            bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+            dsm.update()
+            # pop() installs a fresh bucket list, so this witnesses the churn rather
+            # than assuming it -- otherwise the assertion below could hold vacuously.
+            assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+            # The gate's first guard is HEALTHY: a status flip would make this
+            # pass for the wrong reason.
+            assert ds._curr_status_info.status == DeploymentStatus.HEALTHY
+        assert rank_manager.consistency_calls == before
+
+
+def test_running_replica_ids_stay_cached_during_a_rollout(
+    mock_deployment_state_manager,
+):
+    """The running-id walk reads only replica_id, so unlike the other two it does not
+    need the STARTING/UPDATING/RECOVERING disarm -- and staying cached through a rollout
+    is what keeps the autoscaler from rebuilding its id-string set every tick."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=2, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v)])
+
+    # Scale up: the third replica stays STARTING, which disarms the shared token.
+    info, _ = deployment_info(num_replicas=3, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.update()
+    assert ds._replicas.count(states=[ReplicaState.STARTING]) == 1
+    assert ds._membership_cache_token() is None
+
+    running, alive = ds.get_running_replica_ids(), ds.get_alive_replica_actor_ids()
+    for _ in range(3):
+        dsm.update()
+        assert ds.get_running_replica_ids() is running
+        # The other walks read actor_id/actor_node_id, so they stay disarmed.
+        assert ds.get_alive_replica_actor_ids() is not alive
+
+
+def test_steady_state_ticks_do_not_change_the_fingerprint(
+    mock_deployment_state_manager,
+):
+    """The memo's whole value: an idle tick must not mutate the container."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=8, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.save_checkpoint()
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=8, by_state=[(ReplicaState.RUNNING, 8, v)])
+    for _ in range(3):
+        dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(20):
+        dsm.update()
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+
+
+def test_draining_elsewhere_does_not_invalidate_the_memo(
+    mock_deployment_state_manager,
+):
+    """A node draining elsewhere in the cluster makes the migration pass pop the
+    whole RUNNING bucket and re-add it every tick, membership unchanged."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    node, draining_node = NodeID.from_random().hex(), NodeID.from_random().hex()
+    cluster_node_info_cache.add_node(node)
+    cluster_node_info_cache.add_node(draining_node)
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=4, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for r in ds._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_node_id(node)
+        r._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+    # None of these replicas is on the draining node, so none of them moves.
+    cluster_node_info_cache.draining_nodes = {draining_node: 60 * 1000}
+    dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    # The controller and proxy read the manager-level getters, which key on the
+    # per-deployment tokens.
+    dsm_alive, dsm_nodes = dsm.get_alive_replica_actor_ids(), dsm.get_active_node_ids()
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list, so this witnesses the churn the test
+        # is about -- without it the assertions below could pass vacuously.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+        assert dsm.get_alive_replica_actor_ids() is dsm_alive
+        assert dsm.get_active_node_ids() is dsm_nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+
+def test_gang_health_churn_does_not_invalidate_the_memo(mock_deployment_state_manager):
+    """Gang deployments health-check through the pop-and-re-add path, so their
+    buckets churn on every tick with membership unchanged."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    deployment_id = DeploymentID(name="gang_memo", app_name="app")
+    info, v = deployment_info(
+        num_replicas=4,
+        version="v1",
+        gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+    )
+    dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+        return_value={
+            deployment_id: GangReservationResult(
+                success=True,
+                gang_pgs=[Mock(name="pg-0"), Mock(name="pg-1")],
+                gang_ids=["g0", "g1"],
+                gang_pg_names=["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"],
+            )
+        }
+    )
+    dsm.deploy(deployment_id, info)
+    ds = dsm._get_deployment_state_for_testing(deployment_id)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+    assert ds._is_gang_deployment, "the churn path under test is the gang one"
+
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list: the churn is real, not assumed.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
 
 
 @pytest.mark.parametrize("aggregation_function, expected", [("max", 8), ("min", 2)])


### PR DESCRIPTION
Stacked on [#64911](https://github.com/ray-project/ray/pull/64911)

## Why

The Serve controller runs a control loop, and on every single tick it walked the full list of replicas five separate times just to rebuild lists of IDs — which replica actors are alive, which nodes have replicas on them, which replicas are running, the autoscaler's set of running replica IDs, and the rank gate's membership key. At 16K replicas those five walks dominated the loop. A CPU profile showed the loop wasn't slow because of any one expensive operation; it was slow because it kept recomputing the same five answers, and meanwhile the controller was too busy to ingest the metric reports its replicas were sending it.

The observation. Those answers only change when replica membership changes. In steady state, membership doesn't change for hours. So the walks can be computed once and cached until membership actually moves.

The mechanism. The replica container now maintains a cheap key describing its own contents, and each of those derived collections is cached against that key. When the key is unchanged, the cached answer is returned without touching a single replica.

## What

* `ReplicaStateContainer` gains a membership key: the summed per-replica hash of its
`{replica id -> state}` content, maintained incrementally on `add`/`pop`/`remove`, and
returned paired with the exact replica count. It is a hash of the content rather than a
counter of mutations because the health and migration passes pop a whole bucket and
re-add every replica to the state it came from: gang deployments take that path on
**every** tick, and every other deployment takes it whenever any node in the cluster is
draining, which is 5 mutations per otherwise-idle tick at 4 replicas. A counter reads
that churn as a membership change and gives back none of the win. Summing per-replica
terms makes pop-and-re-add cancel exactly, while a real arrival, departure or state
transition still changes it.
* Unlike #64911's id-set comparison, which was exact, this is a hash: two memberships
of the same size collide with probability ~2^-64. The pairing with the exact count
removes every collision where cardinality differs. The asymmetry worth knowing is that
a stale memo self-corrects on the next real membership change, whereas a skipped rank
pass would not, which is why the count is carried and why the fingerprint is pinned to
a full recompute in the tests.
* The derived collections memoize on that key at both `DeploymentState` and
`DeploymentStateManager` level, through one shared `_memoized_walk` helper.
* Caching disarms while any STARTING, UPDATING or RECOVERING replicas exist: the
startup check calls `check_ready()` for all three, and that rewrites
`actor_id`/`node_id` in place without a container mutation. During ramp, rollout and
recovery every getter recomputes exactly as before; the cache engages only at steady
state, which is where the waste was.
* The autoscaler skips its id-set rebuild when handed the same (cached) list object it
already processed. That is safe because `_running_replicas` and
`_cached_running_replica_strs` are only ever written together and both start empty, so
the pair cannot desync — note that re-registering a deployment reuses the existing
`DeploymentAutoscalingState` rather than presenting a new list object.
* [#64911](https://github.com/ray-project/ray/pull/64911)'s membership key and its
error backoff both become this key — no walk at all, and the gate's check now sits
before the `get()` list copy instead of after it.

Two deliberate deltas from the gate as it stands in #64911: the empty-membership early
return now caches before returning, and the errored-pass path clears the key.

Cached collections are shared objects, so the getters return them frozen
(`FrozenSet`/`Tuple`) and the one caller that needs a mutable set copies at its own
boundary; every other caller only reads them.

## Results

Isolated microbench of the three `DeploymentState` walks at 16K replicas:
3.23 ms → 0.008 ms per tick (real `DeploymentReplica` property chains cost
more than the benchmark stand-ins, so live savings are larger).

On the full harness (16K replicas, single deployment, pinned, steady state,
36 samples): control loop 352.6 ms → 42.9 ms, deployment-state update
253.8 ms → 17.1 ms, 1.36 → 4.99 loops/s — and the first run on this
harness to place all 16,384 replicas and complete cleanly; without this change
the controller starves its own report ingest at that scale. (Composite numbers
measured with the push-health stack on top; isolated this-PR-vs-base cells on the
same harness are running and will replace this table before review.)

## Testing

* The key changes only on a real membership change: empty pop/remove do not change it,
nor does popping a bucket and re-adding every replica to the state it came from, while
a transition, an arrival and a departure each do. A separate test recomputes the key
from every bucket and asserts it matches after a mixed add/pop/remove/re-bucket
sequence, so a future bucket write that forgets to maintain it fails loudly.
* Getters memoize and invalidate on mutation; STARTING/UPDATING/RECOVERING disarms
caching; autoscaler identity-skip (same object skipped, new object rebuilt).
* Churn coverage, since that is what a counter got wrong: the memos and #64911's rank
gate both hold across ticks with a node draining elsewhere in the cluster, and across
steady-state ticks of a gang deployment. Each of these witnesses the churn through
bucket-list identity so none can pass vacuously, and each is verified to fail if the
key's per-replica terms are made non-cancelling.
* An errored pass drops the previously validated key, so a membership it validated
before a failure is rechecked rather than skipped forever.
* `test_deployment_state.py` + `test_autoscaling_policy.py`: 287 tests, green under the
default env and all four CI env variants (`_with_pack_scheduling`, `_metr_disab`,
`_metr_agg_at_controller`, `_metr_agg_at_controller_and_replicas`).

<img width="1248" height="728" alt="perf_A7_loop_haproxy_on" src="https://github.com/user-attachments/assets/3f058741-eff5-4607-a9c3-6f8852c192a4" />
