### PR TITLE
[serve] Carry replica self-health on handle metric reports

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -210,6 +210,9 @@ class DeploymentAutoscalingState:
 
     def update_running_replica_ids(self, running_replicas: List[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
+        if running_replicas is self._running_replicas:
+            # Same (cached) list object -- membership unchanged, skip rebuild.
+            return
         self._running_replicas = running_replicas
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1061,6 +1061,11 @@ class ReplicaMetricReport:
     aggregated_metrics: Dict[str, float]
     metrics: Dict[str, TimeSeries]
     timestamp: float
+    # Replica-pushed self-health (None = sender does not push health; the
+    # controller then falls back to pull probes).
+    healthy: Optional[bool] = None
+    health_checked_at: Optional[float] = None
+    health_consecutive_failures: Optional[int] = None
 
 
 @dataclass

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from starlette.types import Scope
 
@@ -908,6 +908,10 @@ class TargetCapacityDirection(str, Enum):
 class ReplicaQueueLengthInfo:
     accepted: bool
     num_ongoing_requests: int
+    # Replica self-health piggyback (None = sender does not carry health).
+    healthy: Optional[bool] = None
+    health_checked_at: Optional[float] = None
+    health_consecutive_failures: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -1020,6 +1024,9 @@ class HandleMetricReport:
         str, Dict[str, TimeSeries]
     ]  # replica key = ReplicaID.to_full_id_str()
     timestamp: float
+    # Latest response-carried replica self-health, keyed by replica unique id:
+    # (checked_at, healthy, consecutive_failures).
+    replica_health: Optional[Dict[str, Tuple[float, bool, Optional[int]]]] = None
 
     @property
     def total_requests(self) -> float:

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -61,6 +61,7 @@ from ray.serve._private.default_impl import (
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_state import (
     DeploymentStateManager,
+    ReplicaHealthPushRegistry,
 )
 from ray.serve._private.endpoint_state import EndpointState
 from ray.serve._private.exceptions import ExternalScalerDisabledError
@@ -254,6 +255,7 @@ class ServeController:
         ]
 
         self.autoscaling_state_manager = AutoscalingStateManager()
+        self._replica_health_push_registry = ReplicaHealthPushRegistry()
         self.deployment_state_manager = DeploymentStateManager(
             self.kv_store,
             self.long_poll_host,
@@ -261,6 +263,7 @@ class ServeController:
             get_all_live_placement_group_names(),
             self.cluster_node_info_cache,
             self.autoscaling_state_manager,
+            health_push_registry=self._replica_health_push_registry,
         )
 
         # Manage all applications' state
@@ -391,8 +394,28 @@ class ServeController:
         )
         # Track in health metrics
         self._health_metrics_tracker.record_replica_metrics_delay(latency_ms)
+        if replica_metric_report.healthy is not None:
+            self._replica_health_push_registry.record(
+                replica_metric_report.replica_id.unique_id,
+                replica_metric_report.health_checked_at
+                or replica_metric_report.timestamp,
+                replica_metric_report.healthy,
+                replica_metric_report.health_consecutive_failures,
+            )
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_metric_report
+        )
+
+    def record_replica_health(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ):
+        """Self-health heartbeat from replicas that do not push metric reports."""
+        self._replica_health_push_registry.record(
+            replica_unique_id, checked_at, healthy, consecutive_failures
         )
 
     def record_autoscaling_metrics_from_handle(
@@ -616,6 +639,14 @@ class ServeController:
             dsm_duration = time.time() - dsm_update_start_time
             self.dsm_update_duration_gauge_s.set(dsm_duration)
             self._health_metrics_tracker.record_dsm_update_duration(dsm_duration)
+            try:
+                _gs = self._replica_health_push_registry.gap_stats()
+                self._health_metrics_tracker.push_checks_recorded = _gs["count"]
+                self._health_metrics_tracker.push_check_gap_p50_s = _gs["p50_s"]
+                self._health_metrics_tracker.push_check_gap_p99_s = _gs["p99_s"]
+                self._health_metrics_tracker.push_check_gap_max_s = _gs["max_s"]
+            except Exception:
+                pass
             if not self.done_recovering_event.is_set() and not any_recovering:
                 self.done_recovering_event.set()
                 if num_loops > 0:

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -440,6 +440,15 @@ class ServeController:
         )
         # Track in health metrics
         self._health_metrics_tracker.record_handle_metrics_delay(latency_ms)
+        if handle_metric_report.replica_health:
+            for _rid, (
+                _checked_at,
+                _healthy,
+                _failures,
+            ) in handle_metric_report.replica_health.items():
+                self._replica_health_push_registry.record(
+                    _rid, _checked_at, _healthy, _failures
+                )
         self.autoscaling_state_manager.record_request_metrics_for_handle(
             handle_metric_report
         )

--- a/python/ray/serve/_private/controller_health_metrics_tracker.py
+++ b/python/ray/serve/_private/controller_health_metrics_tracker.py
@@ -50,6 +50,13 @@ class ControllerHealthMetricsTracker:
     num_control_loops: int = 0
     last_control_loop_time: float = 0.0
 
+    # Replica self-check intervals observed via health pushes (set by the
+    # controller loop from the push registry).
+    push_checks_recorded: int = 0
+    push_check_gap_p50_s: float = 0.0
+    push_check_gap_p99_s: float = 0.0
+    push_check_gap_max_s: float = 0.0
+
     def record_loop_duration(self, duration: float):
         self.loop_durations.append(duration)
 
@@ -145,4 +152,8 @@ class ControllerHealthMetricsTracker:
             handle_metrics_delay_ms=handle_delay_stats,
             replica_metrics_delay_ms=replica_delay_stats,
             process_memory_mb=process_memory_mb,
+            push_checks_recorded=self.push_checks_recorded,
+            push_check_gap_p50_s=self.push_check_gap_p50_s,
+            push_check_gap_p99_s=self.push_check_gap_p99_s,
+            push_check_gap_max_s=self.push_check_gap_max_s,
         )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3113,6 +3113,7 @@ class DeploymentState:
         self._push_stall_since: Optional[float] = None
         self._push_stall_stale: int = 0
         self._push_stall_total: int = 0
+        self._push_stall_ticks: int = 0
         # Default to the stock period so pushes are not misread as stale on
         # deployments that have no target info yet (recovery, deletion).
         self._push_stall_window_s: float = _push_freshness_window_s(
@@ -4975,15 +4976,7 @@ class DeploymentState:
         self._outstanding_dirty_set = still
         n = container.count_state(ReplicaState.RUNNING)
         if n:
-            period = self._reconcile_sweep_period_s()
-            ticks = max(
-                1,
-                int(
-                    CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION
-                    * period
-                    / max(CONTROL_LOOP_INTERVAL_S, 1e-3)
-                ),
-            )
+            ticks = self._reconcile_sweep_ticks()
             slice_n = max(1, (n + ticks - 1) // ticks)
             start = self._dirty_set_rr_cursor % n
             sl = container.slice_state(ReplicaState.RUNNING, start, slice_n)
@@ -5017,10 +5010,42 @@ class DeploymentState:
                 DEFAULT_HEALTH_CHECK_PERIOD_S, DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S
             )
 
-    def _finalize_push_stall_verdict(self) -> None:
-        """Set next sweep's probe-deferral from this sweep's staleness tally.
+    def _reconcile_sweep_ticks(self) -> int:
+        """Control-loop ticks the dirty-set takes to sweep the RUNNING bucket
+        once (see _dirty_set_active_pairs)."""
+        return max(
+            1,
+            int(
+                CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION
+                * self._reconcile_sweep_period_s()
+                / max(CONTROL_LOOP_INTERVAL_S, 1e-3)
+            ),
+        )
 
-        Most of this deployment's pushed health going stale at once (by its own
+    def _advance_push_stall_window(self) -> None:
+        """Finalize the systemic-stall verdict once enough replicas have been
+        sampled across ticks (or a full sweep elapsed), then reset the tally.
+
+        Each tick only health-checks a dirty-set slice (~N/sweep_ticks), well
+        below the guard's min-tracked floor for all but the largest deployments;
+        accumulating across ticks lets the guard reach a deployment-representative
+        sample. A large deployment whose one-tick slice already exceeds the floor
+        still finalizes next tick, so engagement stays prompt where it matters.
+        """
+        self._push_stall_ticks += 1
+        if (
+            self._push_stall_total >= HEALTH_PUSH_STALL_MIN_TRACKED
+            or self._push_stall_ticks >= self._reconcile_sweep_ticks()
+        ):
+            self._finalize_push_stall_verdict()
+            self._push_stall_stale = 0
+            self._push_stall_total = 0
+            self._push_stall_ticks = 0
+
+    def _finalize_push_stall_verdict(self) -> None:
+        """Set probe-deferral from the accumulated staleness tally.
+
+        Most of this deployment's sampled pushes going stale at once (by its own
         window) reads as controller-side ingest lag, so fallback probes are
         deferred -- bounded by HEALTH_PUSH_STALL_MAX_DEFER_S per episode so a
         genuine mass outage still falls through to probes.
@@ -5071,9 +5096,7 @@ class DeploymentState:
         with state container from previous update() cycle to see if any state
         transition happened.
         """
-        self._finalize_push_stall_verdict()
-        self._push_stall_stale = 0
-        self._push_stall_total = 0
+        self._advance_push_stall_window()
         if self._target_state.info is not None:
             self._push_stall_window_s = _push_freshness_window_s(
                 self._target_state.info.deployment_config.health_check_period_s

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,8 +10,6 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from functools import reduce
-from operator import xor
 from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 import ray
@@ -2574,6 +2572,9 @@ class DeploymentRankManager:
         # Global rank manager (existing replica-level rank)
         self._replica_rank_manager = RankManager()
         self._fail_on_rank_error = fail_on_rank_error
+        # Whether the most recent rank op swallowed an error (fail_on_rank_error
+        # off). Read right after a call to decide whether its result is trustworthy.
+        self._last_rank_op_errored = False
 
         # Node rank manager (assigns rank IDs to nodes)
         self._node_rank_manager = RankManager()
@@ -2587,13 +2588,18 @@ class DeploymentRankManager:
     def _execute_with_error_handling(self, func, safe_default, *args, **kwargs):
         if self._fail_on_rank_error:
             # Let exceptions propagate
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+            self._last_rank_op_errored = False
+            return result
         else:
             # Catch exceptions and return safe default
             try:
-                return func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                self._last_rank_op_errored = False
+                return result
             except Exception as e:
                 logger.error(f"Error executing function {func.__name__}: {e}")
+                self._last_rank_op_errored = True
                 return safe_default
 
     def assign_rank(self, replica_id: str, node_id: str) -> ReplicaRank:
@@ -2921,7 +2927,7 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_fingerprint: Optional[int] = None
+        self._last_rank_membership_ids: Optional[Set[str]] = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -4869,7 +4875,7 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so a cheap fingerprint gates it.
+        membership changes, so the active replica-id set gates it.
         """
         active_replicas = self._replicas.get()
         if not (
@@ -4882,12 +4888,8 @@ class DeploymentState:
             and self._replicas.count(states=[ReplicaState.STARTING]) == 0
         ):
             return
-        fingerprint = reduce(
-            xor,
-            (hash(r.replica_id.unique_id) for r in active_replicas),
-            len(active_replicas),
-        )
-        if fingerprint == self._last_rank_membership_fingerprint:
+        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
+        if active_replica_ids == self._last_rank_membership_ids:
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -4897,7 +4899,10 @@ class DeploymentState:
 
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        self._last_rank_membership_fingerprint = fingerprint
+        if not self._rank_manager._last_rank_op_errored:
+            # Only mark this membership as checked if the pass did not swallow an
+            # error (fail_on_rank_error off); otherwise retry it next tick.
+            self._last_rank_membership_ids = active_replica_ids
 
     def _handle_deployment_actor_failed_health_check(
         self,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,6 +10,8 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
+from functools import reduce
+from operator import xor
 from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 import ray
@@ -2919,6 +2921,7 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
+        self._last_rank_membership_fingerprint: Optional[int] = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -4858,8 +4861,18 @@ class DeploymentState:
         # if we delay the rank reassignment, the rank system will be in an invalid state
         # for a longer period of time. Abrar made this decision because he is not confident
         # about how rollouts work in the deployment state machine.
+        self._maybe_check_rank_consistency()
+
+    def _maybe_check_rank_consistency(self) -> None:
+        """Run the rank-consistency pass only when replica membership changed.
+
+        The pass is O(N) with heavy constants and used to run on every
+        control-loop tick in steady state -- at 10K+ replicas it monopolizes
+        the controller loop. Rank consistency can only be violated by
+        membership changes, so a cheap fingerprint gates it.
+        """
         active_replicas = self._replicas.get()
-        if (
+        if not (
             active_replicas
             and self._curr_status_info.status == DeploymentStatus.HEALTHY
             # Skip consistency check if there are STARTING replicas. During node
@@ -4868,14 +4881,23 @@ class DeploymentState:
             # with STARTING replicas causes "active keys without ranks" error.
             and self._replicas.count(states=[ReplicaState.STARTING]) == 0
         ):
-            replicas_to_reconfigure = (
-                self._rank_manager.check_rank_consistency_and_reassign_minimally(
-                    active_replicas,
-                )
+            return
+        fingerprint = reduce(
+            xor,
+            (hash(r.replica_id.unique_id) for r in active_replicas),
+            len(active_replicas),
+        )
+        if fingerprint == self._last_rank_membership_fingerprint:
+            return
+        replicas_to_reconfigure = (
+            self._rank_manager.check_rank_consistency_and_reassign_minimally(
+                active_replicas,
             )
+        )
 
-            # Reconfigure replicas that had their ranks reassigned
-            self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
+        # Reconfigure replicas that had their ranks reassigned
+        self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
+        self._last_rank_membership_fingerprint = fingerprint
 
     def _handle_deployment_actor_failed_health_check(
         self,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -708,6 +708,97 @@ def print_verbose_scaling_log():
     logger.error(f"Scaling information\n{json.dumps(debug_info, indent=2)}")
 
 
+def _push_freshness_window_s(health_check_period_s: float) -> float:
+    """How long a pushed health result stays fresh enough to stand in for a probe."""
+    return max(health_check_period_s * 1.5, 1.0)
+
+
+# Most of a deployment's pushed health going stale at once (by its own
+# configured period) is the signature of controller-side ingest lag, not mass
+# replica failure. Deferring the pull fallback then avoids a probe storm that
+# would deepen the lag and can cascade into false kills; the cap bounds it so
+# a real mass outage still surfaces.
+HEALTH_PUSH_STALL_MIN_TRACKED = 64
+HEALTH_PUSH_STALL_STALE_FRACTION = 0.5
+HEALTH_PUSH_STALL_MAX_DEFER_S = 120.0
+
+
+class ReplicaHealthPushRegistry:
+    """Latest self-health pushed by each replica, keyed by replica unique id.
+
+    Written by the controller ingest path; consumed by the reconcile sweep. A
+    fresh healthy push lets the sweep skip firing a pull probe.
+    """
+
+    _PRUNE_THRESHOLD = 65536
+    _PRUNE_MAX_AGE_S = 600.0
+    _GAP_BUCKET_S = 0.25
+    _GAP_NBUCKETS = 240  # 60s range
+
+    def __init__(self):
+        # replica_unique_id -> (checked_at, received_at, healthy, consecutive_failures)
+        self._state: Dict[str, Tuple[float, float, bool, Optional[int]]] = {}
+        # Gap between a replica's consecutive accepted checked_at values = its
+        # actual self-check interval (same clock per replica, skew-free).
+        self._gap_hist = [0] * self._GAP_NBUCKETS
+        self._gap_count = 0
+        self._gap_max_s = 0.0
+
+    def record(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ):
+        prev = self._state.get(replica_unique_id)
+        if prev is not None and checked_at <= prev[0]:
+            return  # A delayed report must not clobber a newer observation.
+        if prev is not None:
+            gap = checked_at - prev[0]
+            b = int(gap / self._GAP_BUCKET_S)
+            self._gap_hist[b if b < self._GAP_NBUCKETS else self._GAP_NBUCKETS - 1] += 1
+            self._gap_count += 1
+            if gap > self._gap_max_s:
+                self._gap_max_s = gap
+        if len(self._state) > self._PRUNE_THRESHOLD:
+            # Age by controller-clock arrival time (v[1]), immune to replica skew.
+            cutoff = time.time() - self._PRUNE_MAX_AGE_S
+            self._state = {k: v for k, v in self._state.items() if v[1] >= cutoff}
+        self._state[replica_unique_id] = (
+            checked_at,
+            time.time(),
+            healthy,
+            consecutive_failures,
+        )
+
+    def get(
+        self, replica_unique_id: str
+    ) -> Optional[Tuple[float, float, bool, Optional[int]]]:
+        return self._state.get(replica_unique_id)
+
+    def gap_stats(self) -> Dict[str, float]:
+        """Percentiles of the replicas' actual self-check intervals."""
+
+        def pct(p):
+            if self._gap_count <= 0:
+                return 0.0
+            target = p * self._gap_count
+            cum = 0
+            for i, c in enumerate(self._gap_hist):
+                cum += c
+                if cum >= target:
+                    return (i + 1) * self._GAP_BUCKET_S
+            return self._GAP_NBUCKETS * self._GAP_BUCKET_S
+
+        return {
+            "count": self._gap_count,
+            "p50_s": pct(0.50),
+            "p99_s": pct(0.99),
+            "max_s": self._gap_max_s,
+        }
+
+
 class ActorReplicaWrapper:
     """Wraps a Ray actor for a deployment replica.
 
@@ -795,6 +886,11 @@ class ActorReplicaWrapper:
 
         # Outbound deployments polling state
         self._outbound_deployments: Optional[List[DeploymentID]] = None
+
+        # Latest replica-pushed self-health, consumed by check_health().
+        self._pushed_health: Optional[Tuple[float, float, bool, Optional[int]]] = None
+        self._last_consumed_push_ts: float = 0.0
+        self._last_push_consume_time: float = 0.0
 
         # Histogram to track routing stats delay from replica to controller
         self._routing_stats_delay_histogram = metrics.Histogram(
@@ -1644,6 +1740,12 @@ class ActorReplicaWrapper:
             # There's already an active health check.
             return False
 
+        # Pushed health is flowing -- probe only once it goes stale.
+        if time.time() - self._last_push_consume_time < _push_freshness_window_s(
+            self.health_check_period_s
+        ):
+            return False
+
         # If there's no active health check, kick off another and reset
         # the timer if it's been long enough since the last health
         # check. Add some randomness to avoid synchronizing across all
@@ -1686,6 +1788,56 @@ class ActorReplicaWrapper:
         )
         return time_since_last > randomized_period
 
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ) -> None:
+        """Stash the replica's latest pushed self-health observation.
+
+        checked_at is replica-clock (used only for ordering/dedupe);
+        received_at is controller-clock (used for freshness, immune to skew).
+        """
+        if checked_at > self._last_consumed_push_ts:
+            self._pushed_health = (
+                checked_at,
+                received_at,
+                healthy,
+                consecutive_failures,
+            )
+
+    def _take_fresh_pushed_health(self) -> Optional[bool]:
+        """Consume the pushed self-health observation, if fresh.
+
+        A fresh healthy observation defers the next pull probe; stale ones are
+        dropped so the pull path remains the fallback.
+        """
+        if self._pushed_health is None:
+            return None
+        checked_at, received_at, healthy, consecutive_failures = self._pushed_health
+        self._pushed_health = None
+        self._last_consumed_push_ts = checked_at
+        # Freshness window: 1.5x the period with a 1s floor -- push->ingest->
+        # consume latency must not flip sub-second periods onto the pull path
+        # (two interleaved observers would double-count flaky checks). Measured
+        # against the controller-clock arrival time, immune to replica clock skew.
+        if time.time() - received_at > _push_freshness_window_s(
+            self.health_check_period_s
+        ):
+            return None
+        self._last_push_consume_time = time.time()
+        return healthy, consecutive_failures
+
+    def defer_push_fallback_probe(self) -> None:
+        """Hold the push-staleness probe gate closed for another window.
+
+        Used when staleness is systemic (controller ingest lag): probing every
+        replica at once would amplify the lag and can cascade into false kills.
+        """
+        self._last_push_consume_time = time.time()
+
     def check_health(self) -> bool:
         """Check if the actor is healthy.
 
@@ -1697,6 +1849,25 @@ class ActorReplicaWrapper:
             3) Kicking off a new health check if needed.
         """
         response: ReplicaHealthCheckResponse = self._check_active_health_check()
+        # Consume the pushed observation only when no pull probe resolved this
+        # tick -- otherwise leave it stashed so a fresh push is never discarded
+        # in favor of an older in-flight probe result.
+        pushed = (
+            self._take_fresh_pushed_health()
+            if response is ReplicaHealthCheckResponse.NONE
+            else None
+        )
+        if response is ReplicaHealthCheckResponse.NONE and pushed is not None:
+            # No pull probe resolved this tick; use the pushed observation. The
+            # replica reports its own consecutive-failure count, so mirror it
+            # (robust to dropped/coalesced pushes) before the standard handling.
+            pushed_healthy, pushed_failures = pushed
+            if pushed_healthy:
+                response = ReplicaHealthCheckResponse.SUCCEEDED
+            else:
+                if pushed_failures is not None:
+                    self._consecutive_health_check_failures = pushed_failures - 1
+                response = ReplicaHealthCheckResponse.APP_FAILURE
         if response is ReplicaHealthCheckResponse.NONE:
             # No info; don't update replica health.
             pass
@@ -2088,6 +2259,21 @@ class DeploymentReplica:
     def has_outstanding_check(self) -> bool:
         """True if a health-check or routing-stats ref is in flight (dirty-set poll set)."""
         return self._actor.has_in_flight_health_or_routing_probe
+
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ) -> None:
+        """Stash the replica's pushed self-health for the next health check."""
+        self._actor.record_pushed_health(
+            checked_at, received_at, healthy, consecutive_failures
+        )
+
+    def defer_push_fallback_probe(self) -> None:
+        self._actor.defer_push_fallback_probe()
 
     def check_health(self) -> bool:
         """Check if the replica is healthy.
@@ -2905,12 +3091,19 @@ class DeploymentState:
         deployment_scheduler: DeploymentScheduler,
         cluster_node_info_cache: ClusterNodeInfoCache,
         autoscaling_state_manager: AutoscalingStateManager,
+        health_push_registry: Optional[ReplicaHealthPushRegistry] = None,
     ):
         self._id = id
         self._long_poll_host: LongPollHost = long_poll_host
         self._deployment_scheduler = deployment_scheduler
         self._cluster_node_info_cache = cluster_node_info_cache
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._health_push_registry = health_push_registry
+        self._push_probes_deferred: bool = False
+        self._push_stall_since: Optional[float] = None
+        self._push_stall_stale: int = 0
+        self._push_stall_total: int = 0
+        self._push_stall_window_s: float = 0.0
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
@@ -4810,12 +5003,67 @@ class DeploymentState:
                 DEFAULT_HEALTH_CHECK_PERIOD_S, DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S
             )
 
+    def _finalize_push_stall_verdict(self) -> None:
+        """Set next sweep's probe-deferral from this sweep's staleness tally.
+
+        Most of this deployment's pushed health going stale at once (by its own
+        window) reads as controller-side ingest lag, so fallback probes are
+        deferred -- bounded by HEALTH_PUSH_STALL_MAX_DEFER_S per episode so a
+        genuine mass outage still falls through to probes.
+        """
+        stale, total = self._push_stall_stale, self._push_stall_total
+        if (
+            total < HEALTH_PUSH_STALL_MIN_TRACKED
+            or stale < total * HEALTH_PUSH_STALL_STALE_FRACTION
+        ):
+            self._push_stall_since = None
+            self._push_probes_deferred = False
+            return
+        now = time.time()
+        if self._push_stall_since is None:
+            self._push_stall_since = now
+            logger.warning(
+                f"Pushed health went stale for {stale}/{total} replicas of "
+                f"{self._id} at once; treating as controller-side ingest lag "
+                "and deferring fallback probes for up to "
+                f"{HEALTH_PUSH_STALL_MAX_DEFER_S}s."
+            )
+        self._push_probes_deferred = (
+            now - self._push_stall_since < HEALTH_PUSH_STALL_MAX_DEFER_S
+        )
+
+    def _apply_pushed_health(self, replica: "DeploymentReplica") -> None:
+        """Hand the replica's latest pushed self-health to its wrapper.
+
+        Tallies push staleness for this deployment's stall verdict and, while
+        the previous sweep's verdict says staleness is systemic, keeps the
+        replica's probe gate closed.
+        """
+        if self._health_push_registry is None:
+            return
+        if self._push_probes_deferred:
+            replica.defer_push_fallback_probe()
+        pushed = self._health_push_registry.get(replica.replica_id.unique_id)
+        if pushed is None:
+            return
+        self._push_stall_total += 1
+        if time.time() - pushed[1] > self._push_stall_window_s:
+            self._push_stall_stale += 1
+        replica.record_pushed_health(*pushed)
+
     def check_and_update_replicas(self):
         """
         Check current state of all DeploymentReplica being tracked, and compare
         with state container from previous update() cycle to see if any state
         transition happened.
         """
+        self._finalize_push_stall_verdict()
+        self._push_stall_stale = 0
+        self._push_stall_total = 0
+        if self._target_state.info is not None:
+            self._push_stall_window_s = _push_freshness_window_s(
+                self._target_state.info.deployment_config.health_check_period_s
+            )
 
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
@@ -4827,6 +5075,8 @@ class DeploymentState:
         if not self._is_gang_deployment:
             origin: List[ReplicaState] = []
             pairs = self._dirty_set_active_pairs()
+            for replica, _ in pairs:
+                self._apply_pushed_health(replica)
             healths = [replica.check_health() for replica, _ in pairs]
             for (replica, st), is_healthy in zip(pairs, healths):
                 self._record_health_check_metrics(replica)
@@ -4856,6 +5106,7 @@ class DeploymentState:
             for replica in self._replicas.pop(
                 states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
             ):
+                self._apply_pushed_health(replica)
                 is_healthy = replica.check_health()
                 self._record_health_check_metrics(replica)
                 if is_healthy:
@@ -5717,6 +5968,7 @@ class DeploymentStateManager:
         autoscaling_state_manager: AutoscalingStateManager,
         head_node_id_override: Optional[str] = None,
         create_placement_group_fn_override: Optional[Callable] = None,
+        health_push_registry: Optional[ReplicaHealthPushRegistry] = None,
     ):
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
@@ -5727,6 +5979,7 @@ class DeploymentStateManager:
             create_placement_group_fn_override,
         )
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._health_push_registry = health_push_registry
 
         self._shutting_down = False
 
@@ -5782,6 +6035,7 @@ class DeploymentStateManager:
             self._deployment_scheduler,
             self._cluster_node_info_cache,
             self._autoscaling_state_manager,
+            health_push_registry=self._health_push_registry,
         )
 
     def _map_actor_names_to_deployment(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2157,6 +2157,20 @@ class DeploymentReplica:
         return self._actor.get_outbound_deployments()
 
 
+def _memoized_walk(obj, memo_attr: str, token, compute):
+    """Return compute() memoized on *token* in obj.<memo_attr>.
+
+    token=None means "uncacheable right now": recompute and drop the memo.
+    Callers must treat returned collections as immutable (they are shared).
+    """
+    memo = getattr(obj, memo_attr)
+    if token is not None and memo is not None and memo[0] == token:
+        return memo[1]
+    result = compute()
+    setattr(obj, memo_attr, None if token is None else (token, result))
+    return result
+
+
 class ReplicaStateContainer:
     """Container for mapping ReplicaStates to lists of DeploymentReplicas."""
 
@@ -2167,6 +2181,12 @@ class ReplicaStateContainer:
         # Incremental (state, version) counts for O(1) version-filtered count()
         # (maintained on add/pop/remove) -> replaces the per-tick O(N) version scan.
         self._sv_counts: Dict[tuple, int] = defaultdict(int)
+        # Bumped on every mutation; derived id collections memoize on it.
+        self._mutation_version: int = 0
+
+    @property
+    def mutation_version(self) -> int:
+        return self._mutation_version
 
     def __getstate__(self):
         # Exclude the callback to keep the container picklable (the callback
@@ -2190,6 +2210,7 @@ class ReplicaStateContainer:
         self._replicas[state].append(replica)
         self._replica_id_index[replica.replica_id] = replica
         self._sv_counts[(state, replica.version)] += 1
+        self._mutation_version += 1
         if self._on_replica_state_change and state != old_state:
             self._on_replica_state_change(old_state, state)
 
@@ -2287,6 +2308,8 @@ class ReplicaStateContainer:
         for replica in replicas:
             self._replica_id_index.pop(replica.replica_id, None)
 
+        if replicas:
+            self._mutation_version += 1
         return replicas
 
     def count(
@@ -2360,6 +2383,8 @@ class ReplicaStateContainer:
                     remaining.append(replica)
             if found_any:
                 self._replicas[state] = remaining
+        if removed:
+            self._mutation_version += 1
         return removed
 
     def __str__(self):
@@ -2927,7 +2952,11 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_ids: Optional[Set[str]] = None
+        self._last_rank_membership_version: Optional[int] = None
+        # (token, result) memos for per-tick id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._running_replica_ids_memo = None
+        self._active_node_ids_memo = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -3304,16 +3333,42 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
+    def _membership_cache_token(self) -> Optional[int]:
+        """Cache key for derived id collections, or None while uncacheable.
+
+        The container version tracks add/pop/remove, but STARTING/RECOVERING
+        replicas can have actor_id/actor_node_id materialize in place without
+        a container mutation -- disable caching while any exist.
+        """
+        if (
+            self._replicas.count(
+                states=[ReplicaState.STARTING, ReplicaState.RECOVERING]
+            )
+            > 0
+        ):
+            return None
+        return self._replicas.mutation_version
+
     def get_alive_replica_actor_ids(self) -> Set[str]:
-        return {replica.actor_id for replica in self._replicas.get()}
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_token(),
+            lambda: {replica.actor_id for replica in self._replicas.get()},
+        )
 
     def get_running_replica_ids(self) -> List[ReplicaID]:
-        return [
-            replica.replica_id
-            for replica in self._replicas.get(
-                [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
-            )
-        ]
+        return _memoized_walk(
+            self,
+            "_running_replica_ids_memo",
+            self._membership_cache_token(),
+            lambda: [
+                replica.replica_id
+                for replica in self._replicas.get(
+                    [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                )
+            ],
+        )
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -3365,11 +3420,16 @@ class DeploymentState:
             # node before all the replicas are migrated.
             ReplicaState.PENDING_MIGRATION,
         ]
-        return {
-            replica.actor_node_id
-            for replica in self._replicas.get(active_states)
-            if replica.actor_node_id is not None
-        }
+        return _memoized_walk(
+            self,
+            "_active_node_ids_memo",
+            self._membership_cache_token(),
+            lambda: {
+                replica.actor_node_id
+                for replica in self._replicas.get(active_states)
+                if replica.actor_node_id is not None
+            },
+        )
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
@@ -4875,12 +4935,10 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so the active replica-id set gates it.
+        membership changes, so the container mutation version gates it.
         """
-        active_replicas = self._replicas.get()
         if not (
-            active_replicas
-            and self._curr_status_info.status == DeploymentStatus.HEALTHY
+            self._curr_status_info.status == DeploymentStatus.HEALTHY
             # Skip consistency check if there are STARTING replicas. During node
             # migration, new replicas are created in STARTING state (without ranks)
             # after the status is set to HEALTHY. Running the consistency check
@@ -4888,8 +4946,11 @@ class DeploymentState:
             and self._replicas.count(states=[ReplicaState.STARTING]) == 0
         ):
             return
-        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
-        if active_replica_ids == self._last_rank_membership_ids:
+        version = self._replicas.mutation_version
+        if version == self._last_rank_membership_version:
+            return
+        active_replicas = self._replicas.get()
+        if not active_replicas:
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -4902,7 +4963,7 @@ class DeploymentState:
         if not self._rank_manager._last_rank_op_errored:
             # Only mark this membership as checked if the pass did not swallow an
             # error (fail_on_rank_error off); otherwise retry it next tick.
-            self._last_rank_membership_ids = active_replica_ids
+            self._last_rank_membership_version = version
 
     def _handle_deployment_actor_failed_health_check(
         self,
@@ -5670,6 +5731,9 @@ class DeploymentStateManager:
         self._shutting_down = False
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # (key, result) memos for cross-deployment id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._active_node_ids_memo = None
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
         # reconcile on it, skipping the O(replicas) pass on ticks with no change.
@@ -5996,12 +6060,30 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids = set()
-        for ds in self._deployment_states.values():
-            alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+    def _membership_cache_key(self) -> Optional[tuple]:
+        """Combined per-deployment token, or None if any deployment is
+        uncacheable. Deployment add/remove changes the key shape."""
+        parts = []
+        for deployment_id, ds in self._deployment_states.items():
+            token = ds._membership_cache_token()
+            if token is None:
+                return None
+            parts.append((deployment_id, token))
+        return tuple(parts)
 
-        return alive_replica_actor_ids
+    def get_alive_replica_actor_ids(self) -> Set[str]:
+        def compute():
+            alive_replica_actor_ids = set()
+            for ds in self._deployment_states.values():
+                alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+            return alive_replica_actor_ids
+
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_key(),
+            compute,
+        )
 
     def get_deployment_ids(self) -> List[DeploymentID]:
         return list(self._deployment_states.keys())
@@ -6429,10 +6511,16 @@ class DeploymentStateManager:
         This is used to determine which node has replicas. Only nodes with replicas and
         head node should have active proxies.
         """
-        node_ids = set()
-        for deployment_state in self._deployment_states.values():
-            node_ids.update(deployment_state.get_active_node_ids())
-        return node_ids
+
+        def compute():
+            node_ids = set()
+            for deployment_state in self._deployment_states.values():
+                node_ids.update(deployment_state.get_active_node_ids())
+            return node_ids
+
+        return _memoized_walk(
+            self, "_active_node_ids_memo", self._membership_cache_key(), compute
+        )
 
     def get_ingress_membership_version(self) -> int:
         """Monotonic counter of ingress running-replica-set changes (node/ports

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -732,6 +732,7 @@ class ReplicaHealthPushRegistry:
 
     _PRUNE_THRESHOLD = 65536
     _PRUNE_MAX_AGE_S = 600.0
+    _PRUNE_MIN_INTERVAL_S = 30.0
     _GAP_BUCKET_S = 0.25
     _GAP_NBUCKETS = 240  # 60s range
 
@@ -743,6 +744,7 @@ class ReplicaHealthPushRegistry:
         self._gap_hist = [0] * self._GAP_NBUCKETS
         self._gap_count = 0
         self._gap_max_s = 0.0
+        self._last_prune_time = 0.0
 
     def record(
         self,
@@ -761,9 +763,17 @@ class ReplicaHealthPushRegistry:
             self._gap_count += 1
             if gap > self._gap_max_s:
                 self._gap_max_s = gap
-        if len(self._state) > self._PRUNE_THRESHOLD:
+        now = time.time()
+        if (
+            len(self._state) > self._PRUNE_THRESHOLD
+            and now - self._last_prune_time > self._PRUNE_MIN_INTERVAL_S
+        ):
+            # Rate-limited: when everything is fresher than the age cutoff the
+            # prune is a no-op, and re-running the O(N) rebuild on every record
+            # would thrash the ingest path right at the scale it serves.
+            self._last_prune_time = now
             # Age by controller-clock arrival time (v[1]), immune to replica skew.
-            cutoff = time.time() - self._PRUNE_MAX_AGE_S
+            cutoff = now - self._PRUNE_MAX_AGE_S
             self._state = {k: v for k, v in self._state.items() if v[1] >= cutoff}
         self._state[replica_unique_id] = (
             checked_at,
@@ -3103,7 +3113,11 @@ class DeploymentState:
         self._push_stall_since: Optional[float] = None
         self._push_stall_stale: int = 0
         self._push_stall_total: int = 0
-        self._push_stall_window_s: float = 0.0
+        # Default to the stock period so pushes are not misread as stale on
+        # deployments that have no target info yet (recovery, deletion).
+        self._push_stall_window_s: float = _push_freshness_window_s(
+            DEFAULT_HEALTH_CHECK_PERIOD_S
+        )
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -721,7 +721,10 @@ class ReplicaMetricsManager:
     def self_health_snapshot(self):
         """(healthy, checked_at, consecutive_failures) from the local self-check;
         stamps that health is being carried on a response."""
-        self._last_health_carried_ts = time.time()
+        if self._self_health_checked_at is not None:
+            # Only a snapshot that actually carries health counts as carried;
+            # before the first self-check _health_kwargs sends nothing.
+            self._last_health_carried_ts = time.time()
         return (
             self._self_healthy,
             self._self_health_checked_at,
@@ -775,7 +778,8 @@ class ReplicaMetricsManager:
             # lapses.
             return
         if (
-            self._autoscaling_config is not None
+            healthy
+            and self._autoscaling_config is not None
             and RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
             and self._last_health_carried_ts is not None
             and time.time() - self._last_health_carried_ts < self._self_health_period_s
@@ -784,7 +788,8 @@ class ReplicaMetricsManager:
             # their metric reports; no separate heartbeat needed.
             return
         if (
-            self._last_health_reported_via_handle_ts is not None
+            healthy
+            and self._last_health_reported_via_handle_ts is not None
             and time.time() - self._last_health_reported_via_handle_ts
             < self._self_health_period_s
         ):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -85,6 +85,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
     RECONFIGURE_METHOD,
     RECORD_REPLICA_METADATA_METHOD,
+    REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     REQUEST_LATENCY_BUCKETS_MS,
     REQUEST_ROUTING_STATS_METHOD,
     SERVE_CONTROLLER_NAME,
@@ -358,6 +359,7 @@ class ReplicaMetricsManager:
 
     PUSH_METRICS_TO_CONTROLLER_TASK_NAME = "push_metrics_to_controller"
     RECORD_METRICS_TASK_NAME = "record_metrics"
+    PUSH_SELF_HEALTH_TASK_NAME = "push_self_health"
     SET_REPLICA_REQUEST_METRIC_GAUGE_TASK_NAME = "set_replica_request_metric_gauge"
 
     def __init__(
@@ -390,6 +392,18 @@ class ReplicaMetricsManager:
         # Tracks in-flight metrics push to controller. Skip if new one is sent.
         self._pending_metrics_push_ref: Optional[ObjectRef] = None
         self._metrics_push_lock = threading.Lock()
+
+        # Self-health push state: the latest local health-check result rides on
+        # metric report pushes, or on a lightweight heartbeat when this replica
+        # does not push metric reports.
+        self._self_healthy: Optional[bool] = None
+        self._self_health_checked_at: Optional[float] = None
+        self._eval_self_health_fn: Optional[Callable] = None
+        self._self_health_timeout_s: float = 0.0
+        self._self_health_period_s: float = 0.0
+        self._pushing_metric_reports = False
+        self._self_consecutive_failures = 0
+        self._pending_health_push_ref: Optional[ObjectRef] = None
 
         # If the interval is set to 0, eagerly sets all metrics.
         self._cached_metrics_enabled = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS != 0
@@ -648,6 +662,7 @@ class ReplicaMetricsManager:
 
     def start_metrics_pusher(self):
         self._metrics_pusher.start()
+        self._pushing_metric_reports = True
 
         # Push autoscaling metrics to the controller periodically.
         self._metrics_pusher.register_or_update_task(
@@ -665,6 +680,76 @@ class ReplicaMetricsManager:
             self._add_autoscaling_metrics_point_async,
             min(record_interval_s, self._autoscaling_config.metrics_interval_s),
         )
+
+    def reports_carry_health(self) -> bool:
+        """Metric-report pushes already carry health at least as often as it
+        is evaluated; frames/heartbeats would be redundant."""
+        return (
+            self._pushing_metric_reports
+            and self._autoscaling_config is not None
+            and self._autoscaling_config.metrics_interval_s
+            <= self._self_health_period_s
+        )
+
+    @property
+    def self_health_period_s(self) -> float:
+        return self._self_health_period_s
+
+    def start_self_health_pusher(
+        self, eval_fn: Callable, period_s: float, timeout_s: float
+    ):
+        """Periodically run the local health check and push the result.
+
+        eval_fn is an async callable that raises when unhealthy (the replica's
+        own check_health).
+        """
+        self._eval_self_health_fn = eval_fn
+        self._self_health_timeout_s = timeout_s
+        self._self_health_period_s = period_s
+        self._metrics_pusher.start()
+        self._metrics_pusher.register_or_update_task(
+            self.PUSH_SELF_HEALTH_TASK_NAME,
+            self._eval_and_push_self_health,
+            period_s,
+        )
+
+    async def _eval_and_push_self_health(self):
+        if self._self_consecutive_failures >= REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD:
+            # Latched: the controller will replace this replica; stop re-running
+            # the user check (parity with pull probes, which cease at the
+            # threshold) but keep reporting unhealthy.
+            healthy = False
+        else:
+            healthy = True
+            try:
+                await asyncio.wait_for(
+                    self._eval_self_health_fn(), timeout=self._self_health_timeout_s
+                )
+            except Exception:
+                healthy = False
+            self._self_consecutive_failures = (
+                0 if healthy else self._self_consecutive_failures + 1
+            )
+        self._self_healthy = healthy
+        self._self_health_checked_at = time.time()
+
+        if self.reports_carry_health():
+            # When the metric cadence is slower than the health period, fall
+            # through and heartbeat so freshness at the controller never
+            # lapses.
+            return
+        with self._metrics_push_lock:
+            if self._pending_health_push_ref is not None:
+                if not check_obj_ref_ready_nowait(self._pending_health_push_ref):
+                    return  # Previous heartbeat still in flight.
+            self._pending_health_push_ref = (
+                self._controller_handle.record_replica_health.remote(
+                    self._replica_id.unique_id,
+                    self._self_health_checked_at,
+                    healthy,
+                    self._self_consecutive_failures,
+                )
+            )
 
     def should_collect_ongoing_requests(self) -> bool:
         """Determine if replicas should collect ongoing request metrics.
@@ -948,6 +1033,9 @@ class ReplicaMetricsManager:
             timestamp=time.time(),
             aggregated_metrics=new_aggregated_metrics,
             metrics=new_metrics,
+            healthy=self._self_healthy,
+            health_checked_at=self._self_health_checked_at,
+            health_consecutive_failures=self._self_consecutive_failures,
         )
         with self._metrics_push_lock:
             if self._pending_metrics_push_ref is not None:
@@ -1076,6 +1164,11 @@ class Replica:
 
         # Guards against calling the user's callable constructor multiple times.
         self._user_callable_initialized = False
+        # Self-health task state: once active, check_health() serves the cached
+        # result instead of re-running the user check.
+        self._self_health_active = False
+        self._self_health_evaluated = False
+        self._last_self_health_error: Optional[str] = None
         self._user_callable_initialized_lock = asyncio.Lock()
         self._initialization_latency: Optional[float] = None
 
@@ -1876,6 +1969,9 @@ class Replica:
             # an initial health check. If an initial health check fails,
             # consider it an initialization failure.
             await self.check_health()
+            # From here on the periodic self-health task is the sole caller of
+            # the user health check; remote probes read its cached result.
+            self._start_self_health_pusher()
         except Exception:
             raise RuntimeError(traceback.format_exc()) from None
 
@@ -1903,6 +1999,8 @@ class Replica:
             self._metrics_manager.set_autoscaling_config(
                 deployment_config.autoscaling_config
             )
+            if self._user_callable_initialized:
+                self._start_self_health_pusher()
             self._metrics_manager.set_max_ongoing_requests(
                 deployment_config.max_ongoing_requests
             )
@@ -2138,7 +2236,17 @@ class Replica:
             extra={"log_to_stderr": False},
         )
 
-    async def check_health(self):
+    def _start_self_health_pusher(self):
+        """Evaluate at half the health-check period so every replica is checked
+        well within the configured period despite scheduling jitter."""
+        self._self_health_active = True
+        self._metrics_manager.start_self_health_pusher(
+            self._run_user_health_check,
+            self._deployment_config.health_check_period_s * 0.5,
+            self._deployment_config.health_check_timeout_s,
+        )
+
+    async def _run_user_health_check(self):
         try:
             # Runs the user-defined check_health on the user code loop if defined.
             # Otherwise, if the background watchdog has detected the user loop is
@@ -2152,7 +2260,21 @@ class Replica:
         except Exception as e:
             logger.warning("Replica health check failed.")
             self._healthy = False
+            self._last_self_health_error = repr(e)
             raise e from None
+        finally:
+            self._self_health_evaluated = True
+
+    async def check_health(self):
+        # While the self-health task is the active observer, serve its cached
+        # result -- concurrent callers must not re-run the user health check.
+        if self._self_health_active and self._self_health_evaluated:
+            if not self._healthy:
+                raise RuntimeError(
+                    self._last_self_health_error or "Replica self health check failed."
+                )
+            return
+        await self._run_user_health_check()
 
     async def record_routing_stats(self) -> Dict[str, Any]:
         try:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -403,6 +403,8 @@ class ReplicaMetricsManager:
         self._self_health_period_s: float = 0.0
         self._pushing_metric_reports = False
         self._self_consecutive_failures = 0
+        self._last_health_carried_ts: Optional[float] = None
+        self._last_health_reported_via_handle_ts: Optional[float] = None
         self._pending_health_push_ref: Optional[ObjectRef] = None
 
         # If the interval is set to 0, eagerly sets all metrics.
@@ -691,9 +693,40 @@ class ReplicaMetricsManager:
             <= self._self_health_period_s
         )
 
+    def self_health_report_entry(
+        self,
+    ) -> Optional[Tuple[str, Tuple[float, bool, Optional[int]]]]:
+        """Registry-shaped entry for this replica's own handle metric reports.
+
+        None while metric reports already carry health (no double delivery) or
+        before the first self-check. Consumption counts as handle-carried for
+        heartbeat suppression.
+        """
+        if self._self_health_checked_at is None or self.reports_carry_health():
+            return None
+        self._last_health_reported_via_handle_ts = time.time()
+        return (
+            self._replica_id.unique_id,
+            (
+                self._self_health_checked_at,
+                self._self_healthy,
+                self._self_consecutive_failures,
+            ),
+        )
+
     @property
     def self_health_period_s(self) -> float:
         return self._self_health_period_s
+
+    def self_health_snapshot(self):
+        """(healthy, checked_at, consecutive_failures) from the local self-check;
+        stamps that health is being carried on a response."""
+        self._last_health_carried_ts = time.time()
+        return (
+            self._self_healthy,
+            self._self_health_checked_at,
+            self._self_consecutive_failures,
+        )
 
     def start_self_health_pusher(
         self, eval_fn: Callable, period_s: float, timeout_s: float
@@ -740,6 +773,22 @@ class ReplicaMetricsManager:
             # When the metric cadence is slower than the health period, fall
             # through and heartbeat so freshness at the controller never
             # lapses.
+            return
+        if (
+            self._autoscaling_config is not None
+            and RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
+            and self._last_health_carried_ts is not None
+            and time.time() - self._last_health_carried_ts < self._self_health_period_s
+        ):
+            # Health rode recent responses and the handles forward it on
+            # their metric reports; no separate heartbeat needed.
+            return
+        if (
+            self._last_health_reported_via_handle_ts is not None
+            and time.time() - self._last_health_reported_via_handle_ts
+            < self._self_health_period_s
+        ):
+            # This replica's own handle metric reports carried its health.
             return
         with self._metrics_push_lock:
             if self._pending_health_push_ref is not None:
@@ -1789,6 +1838,17 @@ class Replica:
             raise e
         raise wrapped_exception from e
 
+    def _health_kwargs(self) -> Dict[str, Any]:
+        """Self-health fields piggybacked on the response queue-length info."""
+        healthy, checked_at, failures = self._metrics_manager.self_health_snapshot()
+        if checked_at is None:
+            return {}
+        return {
+            "healthy": healthy,
+            "health_checked_at": checked_at,
+            "health_consecutive_failures": failures,
+        }
+
     async def handle_request_with_rejection(
         self, request_metadata: RequestMetadata, *request_args, **request_kwargs
     ):
@@ -1800,7 +1860,9 @@ class Replica:
                 f"{request_metadata.request_id}.",
                 extra={"log_to_stderr": False},
             )
-            yield ReplicaQueueLengthInfo(False, self.get_num_ongoing_requests())
+            yield ReplicaQueueLengthInfo(
+                False, self.get_num_ongoing_requests(), **self._health_kwargs()
+            )
             return
 
         # Check if the replica has capacity for the request.
@@ -1811,7 +1873,9 @@ class Replica:
                 f"rejecting request {request_metadata.request_id}.",
                 extra={"log_to_stderr": False},
             )
-            yield ReplicaQueueLengthInfo(False, self.get_num_ongoing_requests())
+            yield ReplicaQueueLengthInfo(
+                False, self.get_num_ongoing_requests(), **self._health_kwargs()
+            )
             return
 
         request_args, request_kwargs, ray_trace_ctx = self._unpack_proxy_args(
@@ -1826,6 +1890,7 @@ class Replica:
                     # NOTE(edoakes): `_wrap_request` will increment the number
                     # of ongoing requests to include this one, so re-fetch the value.
                     num_ongoing_requests=self.get_num_ongoing_requests(),
+                    **self._health_kwargs(),
                 )
 
                 try:
@@ -2247,6 +2312,10 @@ class Replica:
             self._run_user_health_check,
             self._deployment_config.health_check_period_s * 0.5,
             self._deployment_config.health_check_timeout_s,
+        )
+        # Routers in this process fold our health into their handle reports.
+        ray.serve.context._set_self_health_report_provider(
+            self._metrics_manager.self_health_report_entry
         )
 
     async def _run_user_health_check(self):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -733,7 +733,10 @@ class ReplicaMetricsManager:
         self._self_healthy = healthy
         self._self_health_checked_at = time.time()
 
-        if self.reports_carry_health():
+        # An unhealthy result must reach the controller promptly to trigger
+        # replacement, so it is never suppressed -- suppression only applies
+        # while healthy.
+        if healthy and self.reports_carry_health():
             # When the metric cadence is slower than the health period, fall
             # through and heartbeat so freshness at the controller never
             # lapses.

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -101,6 +101,11 @@ from ray.util import metrics
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
+# Stop re-sending a replica's health on handle reports once it has gone this
+# long without a refresh; the controller already has it.
+_REPORT_HEALTH_MAX_AGE_S = 30.0
+
+
 class RouterMetricsManager:
     """Manages metrics for the router."""
 
@@ -124,6 +129,9 @@ class RouterMetricsManager:
         self._self_actor_id = self_actor_id
         self._handle_source = handle_source
         self._controller_handle = controller_handle
+        # Latest response-carried replica self-health, keyed by replica
+        # unique id: (checked_at, healthy, consecutive_failures).
+        self._replica_health: Dict[str, Tuple[float, bool, Optional[int]]] = {}
 
         # Exported metrics
         self.num_router_requests = router_requests_counter
@@ -276,6 +284,55 @@ class RouterMetricsManager:
             # is correctly decremented in this case.
             self.dec_num_queued_requests()
 
+    def _replica_health_for_report(
+        self,
+    ) -> Optional[Dict[str, Tuple[float, bool, Optional[int]]]]:
+        """Downstream replicas' carried health, plus the host replica's own
+        (when this router lives inside a replica) -- so a handle-owning
+        replica's health rides reports that already flow."""
+        # Entries not refreshed recently are already at the controller
+        # (deduped on arrival) -- re-sending them just bloats every report.
+        horizon = time.time() - _REPORT_HEALTH_MAX_AGE_S
+        health = {
+            uid: rec[:3]
+            for uid, rec in self._replica_health.items()
+            if rec[3] >= horizon
+        }
+        provider = ray.serve.context._get_self_health_report_provider()
+        if provider is not None:
+            try:
+                self_entry = provider()
+                if self_entry is not None:
+                    health[self_entry[0]] = self_entry[1]
+            except Exception:
+                # Never let health merging break the metrics report path.
+                logger.warning(
+                    "Failed to attach self-health to handle report.",
+                    exc_info=True,
+                )
+        return health or None
+
+    def record_replica_health(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int],
+    ):
+        """Keep the newest response-carried self-health per replica.
+
+        The router-clock recording time rides along so reports can age-prune
+        without cross-clock comparisons against replica-local checked_at.
+        """
+        prev = self._replica_health.get(replica_unique_id)
+        if prev is None or checked_at > prev[0]:
+            self._replica_health[replica_unique_id] = (
+                checked_at,
+                healthy,
+                consecutive_failures,
+                time.time(),
+            )
+
     def _update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
         """Prune list of replica ids in self.num_queries_sent_to_replicas.
 
@@ -284,6 +341,10 @@ class RouterMetricsManager:
         """
 
         running_replica_set = {replica.replica_id for replica in running_replicas}
+        unique_ids = {r.replica_id.unique_id for r in running_replicas}
+        self._replica_health = {
+            k: v for k, v in self._replica_health.items() if k in unique_ids
+        }
         with self._queries_lock:
             self.num_requests_sent_to_replicas = defaultdict(
                 int,
@@ -533,6 +594,7 @@ class RouterMetricsManager:
                 RUNNING_REQUESTS_KEY: running_requests,
             },
             timestamp=timestamp,
+            replica_health=self._replica_health_for_report(),
         )
 
         return handle_metric_report
@@ -1055,6 +1117,13 @@ class AsyncioRouter:
                 return result
 
             queue_info = await result.get_rejection_response()
+            if queue_info.health_checked_at is not None:
+                self._metrics_manager.record_replica_health(
+                    replica.replica_id.unique_id,
+                    queue_info.health_checked_at,
+                    queue_info.healthy,
+                    queue_info.health_consecutive_failures,
+                )
             self.request_router.on_new_queue_len_info(
                 replica.replica_id, queue_info.num_ongoing_requests
             )

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -785,6 +785,15 @@ class MockReplicaActorWrapper:
         self.health_check_called = True
         return self.healthy
 
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures=None,
+    ):
+        self.pushed_health = (checked_at, received_at, healthy, consecutive_failures)
+
     def get_routing_stats(self) -> Dict[str, Any]:
         return {}
 

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -42,6 +42,22 @@ _global_client: ServeControllerClient = None
 # handle is unusable and must not be reused. See #64647.
 _global_client_job_id: Optional[str] = None
 
+# Set inside replica processes once the self-health task runs: returns
+# (replica_unique_id, (checked_at, healthy, consecutive_failures)) or None.
+# Routers living in the same process fold it into their handle metric
+# reports, so a handle-owning replica's health rides messages that already
+# flow -- no standalone RPC.
+_self_health_report_provider: Optional[Callable] = None
+
+
+def _set_self_health_report_provider(provider: Optional[Callable]) -> None:
+    global _self_health_report_provider
+    _self_health_report_provider = provider
+
+
+def _get_self_health_report_provider() -> Optional[Callable]:
+    return _self_health_report_provider
+
 
 @DeveloperAPI
 @dataclass

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1641,6 +1641,20 @@ class ControllerHealthMetrics(BaseModel):
         default=0.0, description="When the controller started (epoch seconds)."
     )
     uptime_s: float = Field(default=0.0, description="Controller uptime in seconds.")
+
+    # Replica self-check intervals observed via health pushes.
+    push_checks_recorded: int = Field(
+        default=0, description="Replica self-check intervals observed via pushes."
+    )
+    push_check_gap_p50_s: float = Field(
+        default=0.0, description="Median replica self-check interval."
+    )
+    push_check_gap_p99_s: float = Field(
+        default=0.0, description="p99 replica self-check interval."
+    )
+    push_check_gap_max_s: float = Field(
+        default=0.0, description="Max replica self-check interval."
+    )
     last_control_loop_time: float = Field(
         default=0.0,
         description="Time of the last control loop execution (epoch seconds).",

--- a/python/ray/serve/tests/test_healthcheck.py
+++ b/python/ray/serve/tests/test_healthcheck.py
@@ -5,7 +5,10 @@ import pytest
 
 import ray
 from ray import serve
-from ray._common.test_utils import async_wait_for_condition, wait_for_condition
+from ray._common.test_utils import (
+    async_wait_for_condition,
+    wait_for_condition,
+)
 from ray.exceptions import RayError
 from ray.serve._private.common import DeploymentStatus
 from ray.serve._private.constants import (

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9977,9 +9977,10 @@ class TestRankConsistencyMembershipGate:
         ds._replicas.count.return_value = 0
         ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
         ds._rank_manager = Mock()
+        ds._rank_manager._last_rank_op_errored = False
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
         ds._reconfigure_replicas_with_new_ranks = Mock()
-        ds._last_rank_membership_fingerprint = None
+        ds._last_rank_membership_ids = None
         return ds
 
     def test_runs_once_then_skips_for_same_membership(self):
@@ -10007,12 +10008,33 @@ class TestRankConsistencyMembershipGate:
             == 2
         )
 
+    def test_swallowed_rank_error_reruns_next_tick(self):
+        # fail_on_rank_error off: the pass can swallow an error and return [].
+        # The membership must NOT be cached, so the next tick retries.
+        ds = self._ds(["a", "b", "c"])
+        ds._rank_manager._last_rank_op_errored = True
+        ds._maybe_check_rank_consistency()
+        assert ds._last_rank_membership_ids is None
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 2
+        )
+        # Once it succeeds, the membership is cached and the pass stops re-running.
+        ds._rank_manager._last_rank_op_errored = False
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 3
+        )
+
     def test_starting_replicas_skip_entirely(self):
         ds = self._ds(["a", "b"])
         ds._replicas.count.return_value = 1
         ds._maybe_check_rank_consistency()
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
-        assert ds._last_rank_membership_fingerprint is None
+        assert ds._last_rank_membership_ids is None
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9960,5 +9960,60 @@ def test_dirty_set_gauge_prunes_ids_no_longer_running(
     assert ds._last_health_check_healthy_replica_ids == running_ids
 
 
+class TestRankConsistencyMembershipGate:
+    """The rank-consistency pass runs only when replica membership changes."""
+
+    def _ds(self, uids):
+        from ray.serve._private.common import DeploymentStatus
+
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        replicas = []
+        for uid in uids:
+            r = Mock()
+            r.replica_id.unique_id = uid
+            replicas.append(r)
+        ds._replicas = Mock()
+        ds._replicas.get.return_value = replicas
+        ds._replicas.count.return_value = 0
+        ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
+        ds._rank_manager = Mock()
+        ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
+        ds._reconfigure_replicas_with_new_ranks = Mock()
+        ds._last_rank_membership_fingerprint = None
+        return ds
+
+    def test_runs_once_then_skips_for_same_membership(self):
+        ds = self._ds(["a", "b", "c"])
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 1
+        )
+
+    def test_membership_change_reruns(self):
+        ds = self._ds(["a", "b", "c"])
+        ds._maybe_check_rank_consistency()
+        new = []
+        for uid in ["a", "b", "d"]:
+            r = Mock()
+            r.replica_id.unique_id = uid
+            new.append(r)
+        ds._replicas.get.return_value = new
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 2
+        )
+
+    def test_starting_replicas_skip_entirely(self):
+        ds = self._ds(["a", "b"])
+        ds._replicas.count.return_value = 1
+        ds._maybe_check_rank_consistency()
+        ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
+        assert ds._last_rank_membership_fingerprint is None
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9975,12 +9975,13 @@ class TestRankConsistencyMembershipGate:
         ds._replicas = Mock()
         ds._replicas.get.return_value = replicas
         ds._replicas.count.return_value = 0
+        ds._replicas.mutation_version = 7
         ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
         ds._rank_manager = Mock()
         ds._rank_manager._last_rank_op_errored = False
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
         ds._reconfigure_replicas_with_new_ranks = Mock()
-        ds._last_rank_membership_ids = None
+        ds._last_rank_membership_version = None
         return ds
 
     def test_runs_once_then_skips_for_same_membership(self):
@@ -10002,6 +10003,8 @@ class TestRankConsistencyMembershipGate:
             r.replica_id.unique_id = uid
             new.append(r)
         ds._replicas.get.return_value = new
+        # Membership changes always bump the container mutation version.
+        ds._replicas.mutation_version = 8
         ds._maybe_check_rank_consistency()
         assert (
             ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
@@ -10014,7 +10017,7 @@ class TestRankConsistencyMembershipGate:
         ds = self._ds(["a", "b", "c"])
         ds._rank_manager._last_rank_op_errored = True
         ds._maybe_check_rank_consistency()
-        assert ds._last_rank_membership_ids is None
+        assert ds._last_rank_membership_version is None
         ds._maybe_check_rank_consistency()
         assert (
             ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
@@ -10034,7 +10037,83 @@ class TestRankConsistencyMembershipGate:
         ds._replicas.count.return_value = 1
         ds._maybe_check_rank_consistency()
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
-        assert ds._last_rank_membership_ids is None
+        assert ds._last_rank_membership_version is None
+
+
+class TestMutationVersionMemo:
+    """Container mutation version + memoized per-tick id-collection walks."""
+
+    def _replica(self, uid, actor_id=None, node_id=None):
+        r = Mock()
+        r.replica_id = uid
+        r.version = "v1"
+        r.actor_id = actor_id or f"actor-{uid}"
+        r.actor_node_id = node_id or f"node-{uid}"
+        return r
+
+    def test_version_bumps_only_on_real_mutation(self):
+        c = ds_mod.ReplicaStateContainer()
+        v0 = c.mutation_version
+        r = self._replica("a")
+        c.add(ReplicaState.STARTING, r)
+        assert c.mutation_version == v0 + 1
+        # Empty pops/removes (the steady-state case) do not bump.
+        assert c.pop(states=[ReplicaState.STOPPING]) == []
+        assert c.remove({"missing"}) == []
+        assert c.mutation_version == v0 + 1
+        assert c.pop(states=[ReplicaState.STARTING]) == [r]
+        assert c.mutation_version == v0 + 2
+
+    def _ds(self):
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        ds._replicas = ds_mod.ReplicaStateContainer()
+        ds._alive_replica_actor_ids_memo = None
+        ds._running_replica_ids_memo = None
+        ds._active_node_ids_memo = None
+        return ds
+
+    def test_getters_memoize_and_invalidate_on_mutation(self):
+        ds = self._ds()
+        ds._replicas.add(ReplicaState.RUNNING, self._replica("r1"))
+        ids1 = ds.get_running_replica_ids()
+        assert ids1 == ["r1"]
+        assert ds.get_running_replica_ids() is ids1  # cache hit
+        assert ds.get_alive_replica_actor_ids() == {"actor-r1"}
+        assert ds.get_active_node_ids() == {"node-r1"}
+
+        ds._replicas.add(ReplicaState.RUNNING, self._replica("r2"))
+        ids2 = ds.get_running_replica_ids()
+        assert set(ids2) == {"r1", "r2"} and ids2 is not ids1
+        assert ds.get_alive_replica_actor_ids() == {"actor-r1", "actor-r2"}
+        assert ds.get_active_node_ids() == {"node-r1", "node-r2"}
+
+    def test_starting_or_recovering_disables_caching(self):
+        ds = self._ds()
+        ds._replicas.add(ReplicaState.RUNNING, self._replica("r1"))
+        ds._replicas.add(ReplicaState.STARTING, self._replica("r2"))
+        a = ds.get_alive_replica_actor_ids()
+        b = ds.get_alive_replica_actor_ids()
+        # Recomputed each call (attrs may materialize in place), never cached.
+        assert a == b and a is not b
+        assert ds._alive_replica_actor_ids_memo is None
+
+    def test_autoscaling_update_skips_same_list_object(self):
+        from ray.serve._private import autoscaling_state as as_mod
+
+        das = as_mod.DeploymentAutoscalingState.__new__(
+            as_mod.DeploymentAutoscalingState
+        )
+        das._running_replicas = []
+        rid = Mock()
+        rid.to_full_id_str.return_value = "d#r1"
+        ids = [rid]
+        das.update_running_replica_ids(ids)
+        assert das._cached_running_replica_strs == {"d#r1"}
+        das._cached_running_replica_strs = {"sentinel"}
+        das.update_running_replica_ids(ids)  # same object -> skipped
+        assert das._cached_running_replica_strs == {"sentinel"}
+        das.update_running_replica_ids(list(ids))  # new object -> rebuilt
+        assert das._cached_running_replica_strs == {"d#r1"}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10293,6 +10293,18 @@ class TestPushSystemicStallGuard:
 class TestPushedHealthReviewRegressions:
     """Regressions for the agent-review findings on the push-health PR."""
 
+    def test_registry_prune_is_rate_limited(self):
+        r = ReplicaHealthPushRegistry()
+        r._PRUNE_THRESHOLD = 2
+        now = time.time()
+        r._state = {f"old{i}": (1.0, now - 1e4, True, None) for i in range(3)}
+        r.record("fresh1", now, True)
+        assert "old0" not in r._state  # over threshold -> pruned
+        r._state.update({f"old{i}": (1.0, now - 1e4, True, None) for i in range(3)})
+        r.record("fresh2", now + 1.0, True)
+        # Within _PRUNE_MIN_INTERVAL_S the O(N) prune must not re-run.
+        assert "old0" in r._state
+
     def test_registry_rejects_out_of_order_reports(self):
         r = ReplicaHealthPushRegistry()
         r.record("r1", checked_at=200.0, healthy=True)

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
@@ -52,6 +53,7 @@ from ray.serve._private.deployment_state import (
     DeploymentState,
     DeploymentStateManager,
     DeploymentVersion,
+    ReplicaHealthPushRegistry,
     ReplicaStartupStatus,
     ReplicaStateContainer,
 )
@@ -10118,3 +10120,222 @@ class TestMutationVersionMemo:
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestPushedHealth:
+    """Replica-pushed self-health short-circuits the pull probe; stale or absent
+    pushes fall back to the pull path unchanged."""
+
+    def _wrapper(self):
+        w = ActorReplicaWrapper.__new__(ActorReplicaWrapper)
+        w._actor_handle = Mock()
+        w._actor_handle.check_health.remote.return_value = "probe_ref"
+        w._health_check_ref = None
+        w._last_health_check_time = time.time()
+        w._consecutive_health_check_failures = 0
+        w._healthy = True
+        w._replica_id = "test_replica"
+        w._pushed_health = None
+        w._last_consumed_push_ts = 0.0
+        w._last_push_consume_time = 0.0
+        w._version = SimpleNamespace(
+            deployment_config=SimpleNamespace(health_check_period_s=10.0)
+        )
+        return w
+
+    def test_fresh_healthy_push_defers_pull_probe(self):
+        w = self._wrapper()
+        w._last_health_check_time = 0.0  # probe would fire without the push
+        now = time.time()
+        w.record_pushed_health(now, now, True)
+        assert w.check_health() is True
+        w._actor_handle.check_health.remote.assert_not_called()
+        assert w._health_check_ref is None
+        assert w._last_push_consume_time > 0.0  # probe gated while pushes flow
+
+    def test_stale_push_falls_back_to_pull_probe(self):
+        w = self._wrapper()
+        w._last_health_check_time = 0.0
+        w.record_pushed_health(time.time() - 60.0, time.time() - 60.0, True)
+        assert w.check_health() is True
+        w._actor_handle.check_health.remote.assert_called_once()
+
+    def test_unhealthy_pushes_count_toward_threshold(self):
+        w = self._wrapper()
+        threshold = ds_mod.REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+        for i in range(threshold):
+            w.record_pushed_health(time.time() + i * 1e-3, time.time(), False)
+            w.check_health()
+        assert w._healthy is False
+        assert w._consecutive_health_check_failures == threshold
+
+    def test_push_deduped_by_timestamp(self):
+        w = self._wrapper()
+        ts = time.time()
+        w.record_pushed_health(ts, ts, False)
+        w.check_health()
+        w.record_pushed_health(ts, ts, False)  # same observation again
+        w.check_health()
+        assert w._consecutive_health_check_failures == 1
+
+    def test_pushed_count_is_mirrored(self):
+        w = self._wrapper()
+        w.record_pushed_health(time.time(), time.time(), False, 7)
+        w.check_health()
+        assert w._consecutive_health_check_failures == 7
+        assert w._healthy is False
+
+    def test_healthy_push_resets_failure_count(self):
+        w = self._wrapper()
+        w.record_pushed_health(time.time(), time.time(), False)
+        w.check_health()
+        assert w._consecutive_health_check_failures == 1
+        w.record_pushed_health(time.time() + 1e-3, time.time(), True)
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 0
+
+
+class TestPushSystemicStallGuard:
+    """Most of a deployment's pushed health going stale at once (by its own
+    window) reads as controller-side lag: defer fallback probes, bounded so a
+    genuine mass outage still surfaces."""
+
+    def _ds(self, window_s=15.0):
+        from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
+
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        ds._health_push_registry = ReplicaHealthPushRegistry()
+        ds._push_probes_deferred = False
+        ds._push_stall_since = None
+        ds._push_stall_stale = 0
+        ds._push_stall_total = 0
+        ds._push_stall_window_s = window_s
+        ds._id = "test-deployment"
+        return ds
+
+    def _seed(self, ds, n, stale_n, age_s=60.0):
+        now = time.time()
+        for i in range(n):
+            received_at = now - age_s if i < stale_n else now
+            ds._health_push_registry._state[f"r{i}"] = (
+                now - age_s,
+                received_at,
+                True,
+                0,
+            )
+
+    def _sweep(self, ds, n):
+        for i in range(n):
+            replica = Mock()
+            replica.replica_id.unique_id = f"r{i}"
+            ds._apply_pushed_health(replica)
+
+    def _tally_and_verdict(self, ds, n, stale_n):
+        self._seed(ds, n, stale_n)
+        self._sweep(ds, n)
+        ds._finalize_push_stall_verdict()
+
+    def test_majority_stale_defers_next_sweep(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=80)
+        assert (ds._push_stall_stale, ds._push_stall_total) == (80, 100)
+        assert ds._push_probes_deferred
+        # Next sweep: every replica's probe gate is held closed.
+        replica = Mock()
+        replica.replica_id.unique_id = "r0"
+        ds._apply_pushed_health(replica)
+        replica.defer_push_fallback_probe.assert_called_once()
+
+    def test_below_min_tracked_never_defers(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=63, stale_n=63)
+        assert not ds._push_probes_deferred
+
+    def test_minority_stale_does_not_defer(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=49)
+        assert not ds._push_probes_deferred
+
+    def test_long_period_deployment_not_stale_by_its_own_window(self):
+        # Entries 60s old are fresh for a deployment whose configured window
+        # exceeds that (cursor review: the verdict must use the deployment's
+        # own period, not the default).
+        ds = self._ds(window_s=90.0)
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_stall_stale == 0
+        assert not ds._push_probes_deferred
+
+    def test_defer_is_bounded_per_episode(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_probes_deferred
+        ds._push_stall_since = time.time() - ds_mod.HEALTH_PUSH_STALL_MAX_DEFER_S - 1
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+
+    def test_recovery_clears_the_episode(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_probes_deferred
+        ds._push_stall_stale = 0
+        ds._push_stall_total = 100
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+        assert ds._push_stall_since is None
+
+    def test_defer_holds_wrapper_probe_gate(self):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._last_push_consume_time = 0.0
+        wrapper.defer_push_fallback_probe()
+        assert not wrapper._should_start_new_health_check()
+
+
+class TestPushedHealthReviewRegressions:
+    """Regressions for the agent-review findings on the push-health PR."""
+
+    def test_registry_rejects_out_of_order_reports(self):
+        r = ReplicaHealthPushRegistry()
+        r.record("r1", checked_at=200.0, healthy=True)
+        r.record("r1", checked_at=100.0, healthy=False)  # delayed older report
+        checked_at, _received_at, healthy, _cnt = r.get("r1")
+        assert checked_at == 200.0 and healthy is True
+
+    def test_resolved_probe_does_not_discard_fresh_push(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        # An in-flight probe resolves SUCCEEDED this tick...
+        w._health_check_ref = "probe_ref"
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        monkeypatch.setattr(ds_mod.ray, "get", lambda r: None)
+        now = time.time()
+        w.record_pushed_health(now, now, False, 1)
+        assert w.check_health() is True  # probe result wins this tick
+        assert w._pushed_health is not None  # ...but the push stays stashed
+        # Next tick (no probe): the push is consumed.
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 1
+
+
+def test_apply_pushed_health_hands_off_to_wrapper():
+    """DeploymentState routes registry entries to the replica wrapper; absent
+    entries or registry leave the pull path untouched."""
+    ds = DeploymentState.__new__(DeploymentState)
+    ds._health_push_registry = ReplicaHealthPushRegistry()
+    ds._push_probes_deferred = False
+    ds._push_stall_stale = 0
+    ds._push_stall_total = 0
+    ds._push_stall_window_s = 15.0
+    rep = Mock()
+    rep.replica_id.unique_id = "r1"
+    ds._health_push_registry.record("r1", 123.0, True)
+    DeploymentState._apply_pushed_health(ds, rep)
+    args = rep.record_pushed_health.call_args.args
+    assert args[0] == 123.0 and args[2] is True and args[3] is None
+
+    rep2 = Mock()
+    rep2.replica_id.unique_id = "r2"
+    DeploymentState._apply_pushed_health(ds, rep2)
+    rep2.record_pushed_health.assert_not_called()
+
+    ds._health_push_registry = None
+    DeploymentState._apply_pushed_health(ds, rep2)
+    rep2.record_pushed_health.assert_not_called()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9791,10 +9791,11 @@ class TestDirtySet:
         s._outstanding_dirty_set = set()
         s._dirty_set_rr_cursor = 0
         s._target_state = object()  # .info access raises -> default reconcile period
-        # Bind the real period helper so _dirty_set_active_pairs can call it on the shim.
+        # Bind the real period/ticks helpers so _dirty_set_active_pairs can call them.
         s._reconcile_sweep_period_s = DeploymentState._reconcile_sweep_period_s.__get__(
             s
         )
+        s._reconcile_sweep_ticks = DeploymentState._reconcile_sweep_ticks.__get__(s)
         return s
 
     def test_covers_all_running_within_one_sweep(self):
@@ -10245,6 +10246,40 @@ class TestPushSystemicStallGuard:
         replica.replica_id.unique_id = "r0"
         ds._apply_pushed_health(replica)
         replica.defer_push_fallback_probe.assert_called_once()
+
+    def test_accumulates_across_ticks_below_slice_threshold(self):
+        # Each tick samples only a small slice (< min tracked), but accumulation
+        # across ticks reaches the sample size, so systemic lag still engages.
+        ds = self._ds()
+        ds._push_stall_ticks = 0
+        ds._reconcile_sweep_ticks = lambda: 1000  # long sweep -> threshold path
+        for _ in range(8):  # 8 * 10 = 80 >= HEALTH_PUSH_STALL_MIN_TRACKED
+            self._seed(ds, 10, 10)
+            self._sweep(ds, 10)
+            ds._advance_push_stall_window()
+        assert ds._push_probes_deferred
+
+    def test_tiny_deployment_never_engages_even_accumulated(self):
+        # A full sweep accumulates < min tracked -> finalize bails, never defers.
+        ds = self._ds()
+        ds._push_stall_ticks = 0
+        ds._reconcile_sweep_ticks = lambda: 3
+        for _ in range(3):
+            self._seed(ds, 10, 10)
+            self._sweep(ds, 10)
+            ds._advance_push_stall_window()
+        assert not ds._push_probes_deferred
+
+    def test_large_slice_engages_in_one_tick(self):
+        # A single tick whose slice already exceeds the floor finalizes next
+        # tick -- prompt engagement preserved for large deployments.
+        ds = self._ds()
+        ds._push_stall_ticks = 0
+        ds._reconcile_sweep_ticks = lambda: 50
+        self._seed(ds, 100, 80)
+        self._sweep(ds, 100)
+        ds._advance_push_stall_window()  # total 100 >= floor -> finalized
+        assert ds._push_probes_deferred
 
     def test_below_min_tracked_never_defers(self):
         ds = self._ds()

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1384,6 +1384,18 @@ class TestSelfHealthReportEntry:
         assert m.reports_carry_health()
         assert m.self_health_report_entry() is None
 
+    def test_snapshot_does_not_stamp_before_first_check(self):
+        # Before the first self-check, _health_kwargs sends nothing, so the
+        # snapshot must not stamp handle-carried recency (which would suppress
+        # the first heartbeat of a fresh replica).
+        m = self._manager()
+        m._self_health_checked_at = None
+        m.self_health_snapshot()
+        assert m._last_health_carried_ts is None
+        m._self_health_checked_at = 123.0
+        m.self_health_snapshot()
+        assert m._last_health_carried_ts is not None
+
     def test_consumption_counts_as_carried(self):
         m = self._manager()
         m._self_health_checked_at = 123.0

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1360,3 +1360,161 @@ class TestCythonImplementationEdgeCases:
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestSelfHealthPush:
+    """The replica-side self-health task stores the local result and heartbeats
+    it to the controller only when metric report pushes are not carrying it."""
+
+    def _manager(self, pushing_reports=False):
+        import threading
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import ReplicaMetricsManager
+
+        m = ReplicaMetricsManager.__new__(ReplicaMetricsManager)
+        m._self_healthy = None
+        m._self_health_checked_at = None
+        m._self_health_timeout_s = 1.0
+        m._pushing_metric_reports = pushing_reports
+        m._autoscaling_config = (
+            SimpleNamespace(metrics_interval_s=10.0) if pushing_reports else None
+        )
+        m._self_health_period_s = 10.0
+        m._pending_health_push_ref = None
+        m._self_consecutive_failures = 0
+        m._metrics_push_lock = threading.Lock()
+        m._controller_handle = Mock()
+        m._replica_id = SimpleNamespace(unique_id="r1")
+        return m
+
+    @pytest.mark.asyncio
+    async def test_healthy_eval_heartbeats(self):
+        m = self._manager()
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is True
+        args = m._controller_handle.record_replica_health.remote.call_args.args
+        assert args[0] == "r1" and args[2] is True
+
+    @pytest.mark.asyncio
+    async def test_failing_eval_heartbeats_unhealthy(self):
+        m = self._manager()
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        assert (
+            m._controller_handle.record_replica_health.remote.call_args.args[2] is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_hanging_eval_times_out_unhealthy(self):
+        m = self._manager()
+        m._self_health_timeout_s = 0.05
+
+        async def hang():
+            await asyncio.sleep(10)
+
+        m._eval_self_health_fn = hang
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_metric_reports_carry_health(self):
+        m = self._manager(pushing_reports=True)
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is True
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_latches_unhealthy_at_threshold(self):
+        from ray.serve._private.constants import (
+            REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
+        )
+
+        m = self._manager(pushing_reports=True)
+        evals = []
+
+        async def bad():
+            evals.append(1)
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        for _ in range(REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD + 2):
+            await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        # The user check stops running at the threshold; pushes continue.
+        assert len(evals) == REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_heartbeats_when_metric_pushes_too_infrequent(self):
+        from types import SimpleNamespace
+
+        m = self._manager(pushing_reports=True)
+        m._autoscaling_config = SimpleNamespace(metrics_interval_s=30.0)
+        m._self_health_period_s = 10.0  # health evaluated 3x per metric push
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_called_once()
+
+    def test_self_check_runs_at_half_the_period(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica
+
+        r = Replica.__new__(Replica)
+        r._metrics_manager = Mock()
+        r._deployment_config = SimpleNamespace(
+            health_check_period_s=10.0, health_check_timeout_s=30.0
+        )
+        r._self_health_active = False
+        Replica._start_self_health_pusher(r)
+        args = r._metrics_manager.start_self_health_pusher.call_args.args
+        assert args[1] == 5.0  # half the period
+        assert args[2] == 30.0
+
+    def test_registry_tracks_self_check_intervals(self):
+        from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
+
+        r = ReplicaHealthPushRegistry()
+        t0 = 1000.0
+        for i in range(10):
+            r.record("r1", t0 + i * 5.0, True)
+        stats = r.gap_stats()
+        assert stats["count"] == 9
+        assert 4.75 <= stats["p99_s"] <= 5.25
+        assert stats["max_s"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_in_flight_heartbeat_skips_next(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        m = self._manager()
+        m._pending_health_push_ref = "in_flight"
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: False)
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1441,11 +1441,13 @@ class TestSelfHealthPush:
         m._controller_handle.record_replica_health.remote.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_latches_unhealthy_at_threshold(self):
+    async def test_latches_unhealthy_at_threshold(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
         from ray.serve._private.constants import (
             REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
         )
 
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: True)
         m = self._manager(pushing_reports=True)
         evals = []
 
@@ -1459,6 +1461,29 @@ class TestSelfHealthPush:
         assert m._self_healthy is False
         # The user check stops running at the threshold; pushes continue.
         assert len(evals) == REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_heartbeats_even_when_reports_carry_health(
+        self, monkeypatch
+    ):
+        # reports_carry_health() is true, but an unhealthy result must not be
+        # suppressed -- the controller needs it promptly to replace the replica.
+        import ray.serve._private.replica as replica_mod
+        from ray.serve._private.constants import (
+            REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
+        )
+
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        m = self._manager(pushing_reports=True)
+
+        async def bad():
+            raise RuntimeError("down")
+
+        m._eval_self_health_fn = bad
+        for _ in range(REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD):
+            await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        m._controller_handle.record_replica_health.remote.assert_called()
 
     @pytest.mark.asyncio
     async def test_heartbeats_when_metric_pushes_too_infrequent(self):

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1358,6 +1358,111 @@ class TestCythonImplementationEdgeCases:
         assert result[0].value == pytest.approx(1e-10, rel=1e-6)
 
 
+class TestSelfHealthReportEntry:
+    """A handle-owning replica's health rides its own handle metric reports;
+    frames and heartbeats stay quiet while that carries."""
+
+    def _manager(self, pushing_reports=False):
+        return TestSelfHealthPush()._manager(pushing_reports=pushing_reports)
+
+    def test_none_before_first_check(self):
+        m = self._manager()
+        assert m.self_health_report_entry() is None
+
+    def test_entry_after_check(self):
+        m = self._manager()
+        m._self_healthy = True
+        m._self_health_checked_at = 123.0
+        m._self_consecutive_failures = 0
+        uid, (checked_at, healthy, failures) = m.self_health_report_entry()
+        assert uid == "r1" and checked_at == 123.0 and healthy and failures == 0
+        assert m._last_health_reported_via_handle_ts is not None
+
+    def test_none_while_reports_carry_health(self):
+        m = self._manager(pushing_reports=True)
+        m._self_health_checked_at = 123.0
+        assert m.reports_carry_health()
+        assert m.self_health_report_entry() is None
+
+    def test_consumption_counts_as_carried(self):
+        m = self._manager()
+        m._self_health_checked_at = 123.0
+        assert m._last_health_reported_via_handle_ts is None
+        assert m.self_health_report_entry() is not None
+        # Consumption stamps handle-carried recency (heartbeat suppression).
+        assert m._last_health_reported_via_handle_ts is not None
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_suppressed_after_report_consumption(self):
+        m = self._manager()
+        m._self_health_checked_at = 123.0
+        assert m.self_health_report_entry() is not None
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+
+class TestRouterSelfHealthMerge:
+    """The router folds the host replica's own health into its handle report."""
+
+    def _metrics_manager(self):
+        from ray.serve._private.router import RouterMetricsManager
+
+        mm = RouterMetricsManager.__new__(RouterMetricsManager)
+        import time as _time
+
+        mm._replica_health = {"downstream": (1.0, True, 0, _time.time())}
+        return mm
+
+    def test_no_provider_passthrough(self):
+        import ray.serve.context as ctx
+
+        ctx._set_self_health_report_provider(None)
+        mm = self._metrics_manager()
+        assert mm._replica_health_for_report() == {"downstream": (1.0, True, 0)}
+
+    def test_provider_entry_merged(self):
+        import ray.serve.context as ctx
+
+        try:
+            ctx._set_self_health_report_provider(
+                lambda: ("self_replica", (2.0, False, 3))
+            )
+            mm = self._metrics_manager()
+            report = mm._replica_health_for_report()
+            assert report["downstream"] == (1.0, True, 0)
+            assert report["self_replica"] == (2.0, False, 3)
+        finally:
+            ctx._set_self_health_report_provider(None)
+
+    def test_provider_none_result_passthrough(self):
+        import ray.serve.context as ctx
+
+        try:
+            ctx._set_self_health_report_provider(lambda: None)
+            mm = self._metrics_manager()
+            assert mm._replica_health_for_report() == {"downstream": (1.0, True, 0)}
+        finally:
+            ctx._set_self_health_report_provider(None)
+
+    def test_empty_map_with_self_entry_still_reports(self):
+        import ray.serve.context as ctx
+
+        try:
+            ctx._set_self_health_report_provider(
+                lambda: ("self_replica", (2.0, True, 0))
+            )
+            mm = self._metrics_manager()
+            mm._replica_health = {}
+            assert mm._replica_health_for_report() == {"self_replica": (2.0, True, 0)}
+        finally:
+            ctx._set_self_health_report_provider(None)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
 
@@ -1384,6 +1489,8 @@ class TestSelfHealthPush:
         m._self_health_period_s = 10.0
         m._pending_health_push_ref = None
         m._self_consecutive_failures = 0
+        m._last_health_carried_ts = None
+        m._last_health_reported_via_handle_ts = None
         m._metrics_push_lock = threading.Lock()
         m._controller_handle = Mock()
         m._replica_id = SimpleNamespace(unique_id="r1")
@@ -1512,10 +1619,17 @@ class TestSelfHealthPush:
             health_check_period_s=10.0, health_check_timeout_s=30.0
         )
         r._self_health_active = False
-        Replica._start_self_health_pusher(r)
-        args = r._metrics_manager.start_self_health_pusher.call_args.args
-        assert args[1] == 5.0  # half the period
-        assert args[2] == 30.0
+        try:
+            Replica._start_self_health_pusher(r)
+            args = r._metrics_manager.start_self_health_pusher.call_args.args
+            assert args[1] == 5.0  # half the period
+            assert args[2] == 30.0
+        finally:
+            # _start_self_health_pusher publishes the process-global provider;
+            # leaving the Mock there pollutes later tests.
+            import ray.serve.context as ctx
+
+            ctx._set_self_health_report_provider(None)
 
     def test_registry_tracks_self_check_intervals(self):
         from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
@@ -1528,6 +1642,43 @@ class TestSelfHealthPush:
         assert stats["count"] == 9
         assert 4.75 <= stats["p99_s"] <= 5.25
         assert stats["max_s"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_health_rides_responses(self, monkeypatch):
+        import time as time_mod
+        from types import SimpleNamespace
+
+        import ray.serve._private.replica as replica_mod
+
+        monkeypatch.setattr(
+            replica_mod, "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE", True
+        )
+        m = self._manager()
+        m._autoscaling_config = SimpleNamespace(metrics_interval_s=10.0)
+        m._last_health_carried_ts = time_mod.time()  # responses carried it
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+        # Traffic stopped long ago -> heartbeat resumes.
+        m._last_health_carried_ts = time_mod.time() - 60.0
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_called_once()
+
+    def test_router_keeps_newest_response_carried_health(self):
+        from ray.serve._private.router import RouterMetricsManager
+
+        rm = RouterMetricsManager.__new__(RouterMetricsManager)
+        rm._replica_health = {}
+        rm.record_replica_health("r1", 200.0, True, 0)
+        rm.record_replica_health("r1", 100.0, False, 2)  # delayed older
+        assert rm._replica_health["r1"][:3] == (200.0, True, 0)
+        rm.record_replica_health("r1", 300.0, False, 1)
+        assert rm._replica_health["r1"][:3] == (300.0, False, 1)
 
     @pytest.mark.asyncio
     async def test_in_flight_heartbeat_skips_next(self, monkeypatch):


### PR DESCRIPTION
## [serve] Carry replica self-health on handle metric reports

Second PR of the push-health stack (stacked on #64913).

### Why
With P1, replicas that push autoscaling metric reports get health delivery for
free, and everyone else heartbeats. But the most common serving topology —
replicas called through deployment handles — already has *another* message flowing
to the controller on a fixed cadence: the **handle metric report** each router
sends for autoscaling. This PR folds replica health into those reports, removing
the P1 heartbeat for two classes of replica:

- **replicas behind active handles**: their health rides the responses they
  already return;
- **handle-owning replicas** (e.g. ingress/pipeline deployments): their own
  health rides the handle reports their in-process router already sends.

No new messages, no new RPCs — strictly more payload on existing ones.

### What
- **Response admission piggyback**: `ReplicaQueueLengthInfo` (the
  rejection-protocol admission message) carries the replica's latest self-check
  (healthy, checked_at, consecutive_failures) on both accept and reject.
- **Router carried-health map**: the router records the newest entry per replica
  (out-of-order responses resolved by `checked_at`; the recording wall-clock is
  kept alongside so age decisions never compare across machine clocks), prunes
  entries for departed replicas on membership updates, and drops entries not
  refreshed within 30 s — the controller already has those, and re-sending them
  bloats every report at high fan-in.
- **Self-health provider**: the replica publishes a process-local provider;
  routers living inside that replica merge the host's own health into their
  handle reports. The merge is exception-isolated — health can never break the
  metrics path.
- **Controller**: entries arriving on handle reports feed the same push registry
  P1 introduced; from there the existing freshness/fallback logic applies
  unchanged.

### Suppression (no double delivery, no lost heartbeats)
- A replica whose metric reports already carry health returns no self-entry
  (`reports_carry_health` gate) — one channel per fact.
- Consuming the self-entry stamps handle-carried recency, which suppresses the
  P1 heartbeat; if handle reports stop (traffic ceases, handle closed), the
  stamp ages out and the heartbeat resumes on its own. Fail-open in both
  directions.

### Testing
- New unit suites: self-entry gating and consumption stamping; router merge
  (newest-wins, age-prune, membership prune, provider exception isolation);
  controller forwarding into the registry.
- `test_deployment_state.py` + `test_metrics_utils.py` + `test_autoscaling_policy.py`
  green on this tier (375 tests).

### Benchmarks
Full-stack numbers are in #64909's table (8K/16K, HAProxy off: 52.1/42.9 ms
loops, ≤0.55% health-deadline misses). This PR's isolated contribution
(P1-only vs P1+P2 arms on the same harness) is being measured and lands here
before review.