### PR TITLE
[serve] Push-based replica health: replicas self-check and report over existing channels

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -210,6 +210,9 @@ class DeploymentAutoscalingState:
 
     def update_running_replica_ids(self, running_replicas: List[ReplicaID]):
         """Update cached set of running replica IDs for this deployment."""
+        if running_replicas is self._running_replicas:
+            # Same (cached) list object -- membership unchanged, skip rebuild.
+            return
         self._running_replicas = running_replicas
         self._cached_running_replica_strs = {
             r.to_full_id_str() for r in running_replicas
@@ -395,7 +398,9 @@ class DeploymentAutoscalingState:
             app_name=self._deployment_id.app_name,
             current_num_replicas=len(self._running_replicas),
             target_num_replicas=curr_target_num_replicas,
-            running_replicas=self._running_replicas,
+            # list(): AutoscalingContext.running_replicas is List[ReplicaID] on a
+            # stable PublicAPI; the tuple stays internal so the identity skip works.
+            running_replicas=list(self._running_replicas),
             total_num_requests=self.get_total_num_requests,
             capacity_adjusted_min_replicas=self.get_num_replicas_lower_bound(),
             capacity_adjusted_max_replicas=self.get_num_replicas_upper_bound(),

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1061,6 +1061,11 @@ class ReplicaMetricReport:
     aggregated_metrics: Dict[str, float]
     metrics: Dict[str, TimeSeries]
     timestamp: float
+    # Replica-pushed self-health (None = sender does not push health; the
+    # controller then falls back to pull probes).
+    healthy: Optional[bool] = None
+    health_checked_at: Optional[float] = None
+    health_consecutive_failures: Optional[int] = None
 
 
 @dataclass

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -61,6 +61,7 @@ from ray.serve._private.default_impl import (
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_state import (
     DeploymentStateManager,
+    ReplicaHealthPushRegistry,
 )
 from ray.serve._private.endpoint_state import EndpointState
 from ray.serve._private.exceptions import ExternalScalerDisabledError
@@ -254,6 +255,7 @@ class ServeController:
         ]
 
         self.autoscaling_state_manager = AutoscalingStateManager()
+        self._replica_health_push_registry = ReplicaHealthPushRegistry()
         self.deployment_state_manager = DeploymentStateManager(
             self.kv_store,
             self.long_poll_host,
@@ -261,6 +263,7 @@ class ServeController:
             get_all_live_placement_group_names(),
             self.cluster_node_info_cache,
             self.autoscaling_state_manager,
+            health_push_registry=self._replica_health_push_registry,
         )
 
         # Manage all applications' state
@@ -391,8 +394,28 @@ class ServeController:
         )
         # Track in health metrics
         self._health_metrics_tracker.record_replica_metrics_delay(latency_ms)
+        if replica_metric_report.healthy is not None:
+            self._replica_health_push_registry.record(
+                replica_metric_report.replica_id.unique_id,
+                replica_metric_report.health_checked_at
+                or replica_metric_report.timestamp,
+                replica_metric_report.healthy,
+                replica_metric_report.health_consecutive_failures,
+            )
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_metric_report
+        )
+
+    def record_replica_health(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ):
+        """Self-health heartbeat from replicas that do not push metric reports."""
+        self._replica_health_push_registry.record(
+            replica_unique_id, checked_at, healthy, consecutive_failures
         )
 
     def record_autoscaling_metrics_from_handle(
@@ -619,6 +642,14 @@ class ServeController:
             dsm_duration = time.time() - dsm_update_start_time
             self.dsm_update_duration_gauge_s.set(dsm_duration)
             self._health_metrics_tracker.record_dsm_update_duration(dsm_duration)
+            try:
+                _gs = self._replica_health_push_registry.gap_stats()
+                self._health_metrics_tracker.push_checks_recorded = _gs["count"]
+                self._health_metrics_tracker.push_check_gap_p50_s = _gs["p50_s"]
+                self._health_metrics_tracker.push_check_gap_p99_s = _gs["p99_s"]
+                self._health_metrics_tracker.push_check_gap_max_s = _gs["max_s"]
+            except Exception:
+                pass
             if not self.done_recovering_event.is_set() and not any_recovering:
                 self.done_recovering_event.set()
                 if num_loops > 0:

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -533,7 +533,8 @@ class ServeController:
         Controller decides where proxy actors should run
         (head node and nodes with deployment replicas).
         """
-        new_proxy_nodes = self.deployment_state_manager.get_active_node_ids()
+        # set(): the getter returns a frozenset memo, and this is mutated below.
+        new_proxy_nodes = set(self.deployment_state_manager.get_active_node_ids())
         new_proxy_nodes = new_proxy_nodes - set(
             self.cluster_node_info_cache.get_draining_nodes()
         )

--- a/python/ray/serve/_private/controller_health_metrics_tracker.py
+++ b/python/ray/serve/_private/controller_health_metrics_tracker.py
@@ -50,6 +50,13 @@ class ControllerHealthMetricsTracker:
     num_control_loops: int = 0
     last_control_loop_time: float = 0.0
 
+    # Replica self-check intervals observed via health pushes (set by the
+    # controller loop from the push registry).
+    push_checks_recorded: int = 0
+    push_check_gap_p50_s: float = 0.0
+    push_check_gap_p99_s: float = 0.0
+    push_check_gap_max_s: float = 0.0
+
     def record_loop_duration(self, duration: float):
         self.loop_durations.append(duration)
 
@@ -145,4 +152,8 @@ class ControllerHealthMetricsTracker:
             handle_metrics_delay_ms=handle_delay_stats,
             replica_metrics_delay_ms=replica_delay_stats,
             process_memory_mb=process_memory_mb,
+            push_checks_recorded=self.push_checks_recorded,
+            push_check_gap_p50_s=self.push_check_gap_p50_s,
+            push_check_gap_p99_s=self.push_check_gap_p99_s,
+            push_check_gap_max_s=self.push_check_gap_max_s,
         )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,8 +10,6 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from functools import reduce
-from operator import xor
 from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 import ray
@@ -2588,6 +2586,9 @@ class DeploymentRankManager:
         # Global rank manager (existing replica-level rank)
         self._replica_rank_manager = RankManager()
         self._fail_on_rank_error = fail_on_rank_error
+        # Whether the most recent rank op swallowed an error (fail_on_rank_error
+        # off). Read right after a call to decide whether its result is trustworthy.
+        self._last_rank_op_errored = False
 
         # Node rank manager (assigns rank IDs to nodes)
         self._node_rank_manager = RankManager()
@@ -2601,13 +2602,18 @@ class DeploymentRankManager:
     def _execute_with_error_handling(self, func, safe_default, *args, **kwargs):
         if self._fail_on_rank_error:
             # Let exceptions propagate
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+            self._last_rank_op_errored = False
+            return result
         else:
             # Catch exceptions and return safe default
             try:
-                return func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                self._last_rank_op_errored = False
+                return result
             except Exception as e:
                 logger.error(f"Error executing function {func.__name__}: {e}")
+                self._last_rank_op_errored = True
                 return safe_default
 
     def assign_rank(self, replica_id: str, node_id: str) -> ReplicaRank:
@@ -2935,7 +2941,7 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_fingerprint: Optional[int] = None
+        self._last_rank_membership_ids: Optional[Set[str]] = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -4982,7 +4988,7 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so a cheap fingerprint gates it.
+        membership changes, so the active replica-id set gates it.
         """
         active_replicas = self._replicas.get()
         if not (
@@ -4995,12 +5001,8 @@ class DeploymentState:
             and self._replicas.count(states=[ReplicaState.STARTING]) == 0
         ):
             return
-        fingerprint = reduce(
-            xor,
-            (hash(r.replica_id.unique_id) for r in active_replicas),
-            len(active_replicas),
-        )
-        if fingerprint == self._last_rank_membership_fingerprint:
+        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
+        if active_replica_ids == self._last_rank_membership_ids:
             return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
@@ -5010,7 +5012,10 @@ class DeploymentState:
 
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        self._last_rank_membership_fingerprint = fingerprint
+        if not self._rank_manager._last_rank_op_errored:
+            # Only mark this membership as checked if the pass did not swallow an
+            # error (fail_on_rank_error off); otherwise retry it next tick.
+            self._last_rank_membership_ids = active_replica_ids
 
     def _handle_deployment_actor_failed_health_check(
         self,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,7 +10,17 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 import ray
 from ray import ObjectRef, cloudpickle
@@ -2171,6 +2181,25 @@ class DeploymentReplica:
         return self._actor.get_outbound_deployments()
 
 
+def _memoized_walk(obj, memo_attr: str, token, compute):
+    """Return compute() memoized on *token* in obj.<memo_attr>.
+
+    token=None means "uncacheable right now": recompute and drop the memo.
+    Callers must treat returned collections as immutable (they are shared).
+    """
+    memo = getattr(obj, memo_attr, None)
+    if token is not None and memo is not None and memo[0] == token:
+        return memo[1]
+    result = compute()
+    setattr(obj, memo_attr, None if token is None else (token, result))
+    return result
+
+
+def _membership_term(replica_id: ReplicaID, state: ReplicaState) -> int:
+    """One replica's term in ReplicaStateContainer.membership_fingerprint."""
+    return hash((replica_id, state))
+
+
 class ReplicaStateContainer:
     """Container for mapping ReplicaStates to lists of DeploymentReplicas."""
 
@@ -2181,6 +2210,18 @@ class ReplicaStateContainer:
         # Incremental (state, version) counts for O(1) version-filtered count()
         # (maintained on add/pop/remove) -> replaces the per-tick O(N) version scan.
         self._sv_counts: Dict[tuple, int] = defaultdict(int)
+        # Derived id collections memoize on this (see membership_fingerprint).
+        self._membership_fingerprint: int = 0
+
+    @property
+    def membership_fingerprint(self) -> int:
+        """Fingerprint of the {replica id -> state} content, for memo keys.
+
+        Summed per-replica terms, so the pop-and-re-add churn of the health and
+        migration passes cancels exactly while real arrivals, departures and
+        state transitions change it.
+        """
+        return self._membership_fingerprint
 
     def __getstate__(self):
         # Exclude the callback to keep the container picklable (the callback
@@ -2204,6 +2245,7 @@ class ReplicaStateContainer:
         self._replicas[state].append(replica)
         self._replica_id_index[replica.replica_id] = replica
         self._sv_counts[(state, replica.version)] += 1
+        self._membership_fingerprint += _membership_term(replica.replica_id, state)
         if self._on_replica_state_change and state != old_state:
             self._on_replica_state_change(old_state, state)
 
@@ -2297,6 +2339,7 @@ class ReplicaStateContainer:
             replicas.extend(popped)
             for _r in popped:
                 self._sv_counts[(state, _r.version)] -= 1
+                self._membership_fingerprint -= _membership_term(_r.replica_id, state)
 
         for replica in replicas:
             self._replica_id_index.pop(replica.replica_id, None)
@@ -2367,6 +2410,9 @@ class ReplicaStateContainer:
                 if remaining_to_find > 0 and replica.replica_id in replica_ids:
                     removed.append(replica)
                     self._sv_counts[(state, replica.version)] -= 1
+                    self._membership_fingerprint -= _membership_term(
+                        replica.replica_id, state
+                    )
                     self._replica_id_index.pop(replica.replica_id, None)
                     remaining_to_find -= 1
                     found_any = True
@@ -2955,10 +3001,14 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
-        self._last_rank_membership_ids: Optional[Set[str]] = None
-        # Membership whose pass swallowed an error, and when, for retry backoff.
-        self._last_rank_error_ids: Optional[Set[str]] = None
+        self._last_rank_membership_fp: Optional[int] = None
+        # Fingerprint whose pass swallowed an error, and when, for retry backoff.
+        self._last_rank_error_fp: Optional[int] = None
         self._last_rank_error_ts: float = 0.0
+        # (token, result) memos for per-tick id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._running_replica_ids_memo = None
+        self._active_node_ids_memo = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -3335,16 +3385,42 @@ class DeploymentState:
         )
         return replica_failed or self.deployment_actor_terminally_failed()
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        return {replica.actor_id for replica in self._replicas.get()}
+    def _membership_cache_token(self) -> Optional[int]:
+        """Cache key for derived id collections, or None while uncacheable.
 
-    def get_running_replica_ids(self) -> List[ReplicaID]:
-        return [
-            replica.replica_id
-            for replica in self._replicas.get(
-                [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+        The container fingerprint tracks membership, but STARTING/RECOVERING
+        replicas can have actor_id/actor_node_id materialize in place without
+        a membership change -- disable caching while any exist.
+        """
+        if (
+            self._replicas.count(
+                states=[ReplicaState.STARTING, ReplicaState.RECOVERING]
             )
-        ]
+            > 0
+        ):
+            return None
+        return self._replicas.membership_fingerprint
+
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(replica.actor_id for replica in self._replicas.get()),
+        )
+
+    def get_running_replica_ids(self) -> Tuple[ReplicaID, ...]:
+        return _memoized_walk(
+            self,
+            "_running_replica_ids_memo",
+            self._membership_cache_token(),
+            lambda: tuple(
+                replica.replica_id
+                for replica in self._replicas.get(
+                    [ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
+                )
+            ),
+        )
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -3396,11 +3472,16 @@ class DeploymentState:
             # node before all the replicas are migrated.
             ReplicaState.PENDING_MIGRATION,
         ]
-        return {
-            replica.actor_node_id
-            for replica in self._replicas.get(active_states)
-            if replica.actor_node_id is not None
-        }
+        return _memoized_walk(
+            self,
+            "_active_node_ids_memo",
+            self._membership_cache_token(),
+            lambda: frozenset(
+                replica.actor_node_id
+                for replica in self._replicas.get(active_states)
+                if replica.actor_node_id is not None
+            ),
+        )
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
@@ -5005,7 +5086,7 @@ class DeploymentState:
         The pass is O(N) with heavy constants and used to run on every
         control-loop tick in steady state -- at 10K+ replicas it monopolizes
         the controller loop. Rank consistency can only be violated by
-        membership changes, so the active replica-id set gates it.
+        membership changes, so the container membership fingerprint gates it.
         """
         # O(1) guards first -- `get()` below copies the whole replica list, and these
         # two rule out the busiest ticks (rollouts, migrations) without paying for it.
@@ -5018,17 +5099,18 @@ class DeploymentState:
             or self._replicas.count(states=[ReplicaState.STARTING]) != 0
         ):
             return
+        fp = self._replicas.membership_fingerprint
+        if fp == self._last_rank_membership_fp:
+            return
         active_replicas = self._replicas.get()
         if not active_replicas:
-            return
-        active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
-        if active_replica_ids == self._last_rank_membership_ids:
+            self._last_rank_membership_fp = fp
             return
         # An errored pass leaves the membership uncached so it is retried; rate-limit that
         # retry while the membership still matches the one that failed. A real membership
         # change bypasses this and runs immediately.
         if (
-            self._last_rank_error_ids == active_replica_ids
+            self._last_rank_error_fp == fp
             and time.time() - self._last_rank_error_ts < _RANK_ERROR_RETRY_S
         ):
             return
@@ -5044,11 +5126,11 @@ class DeploymentState:
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
         if checked_cleanly:
-            self._last_rank_membership_ids = active_replica_ids
-            self._last_rank_error_ids = None
+            self._last_rank_membership_fp = fp
+            self._last_rank_error_fp = None
         else:
             # Not cached: an unvalidated membership must be rechecked, just not every tick.
-            self._last_rank_error_ids = active_replica_ids
+            self._last_rank_error_fp = fp
             self._last_rank_error_ts = time.time()
 
     def _handle_deployment_actor_failed_health_check(
@@ -5817,6 +5899,9 @@ class DeploymentStateManager:
         self._shutting_down = False
 
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
+        # (key, result) memos for cross-deployment id-collection walks.
+        self._alive_replica_actor_ids_memo = None
+        self._active_node_ids_memo = None
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
         # reconcile on it, skipping the O(replicas) pass on ticks with no change.
@@ -6143,12 +6228,31 @@ class DeploymentStateManager:
                     statuses.append(state.curr_status_info)
             return statuses
 
-    def get_alive_replica_actor_ids(self) -> Set[str]:
-        alive_replica_actor_ids = set()
-        for ds in self._deployment_states.values():
-            alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+    def _membership_cache_key(self) -> Optional[tuple]:
+        """Combined per-deployment token, or None if any deployment is
+        uncacheable. Deployment add/remove changes the key shape."""
+        parts = []
+        for deployment_id, ds in self._deployment_states.items():
+            token = ds._membership_cache_token()
+            if token is None:
+                return None
+            parts.append((deployment_id, token))
+        return tuple(parts)
 
-        return alive_replica_actor_ids
+    def get_alive_replica_actor_ids(self) -> FrozenSet[str]:
+        def compute():
+            alive_replica_actor_ids = set()
+            for ds in self._deployment_states.values():
+                alive_replica_actor_ids |= ds.get_alive_replica_actor_ids()
+            # Frozen: the memo is handed to callers and must not be mutable.
+            return frozenset(alive_replica_actor_ids)
+
+        return _memoized_walk(
+            self,
+            "_alive_replica_actor_ids_memo",
+            self._membership_cache_key(),
+            compute,
+        )
 
     def get_deployment_ids(self) -> List[DeploymentID]:
         return list(self._deployment_states.keys())
@@ -6575,16 +6679,23 @@ class DeploymentStateManager:
             return
         self._deployment_states[deployment_id].record_request_routing_info(info)
 
-    def get_active_node_ids(self) -> Set[str]:
+    def get_active_node_ids(self) -> FrozenSet[str]:
         """Return set of node ids with running replicas of any deployment.
 
         This is used to determine which node has replicas. Only nodes with replicas and
         head node should have active proxies.
         """
-        node_ids = set()
-        for deployment_state in self._deployment_states.values():
-            node_ids.update(deployment_state.get_active_node_ids())
-        return node_ids
+
+        def compute():
+            node_ids = set()
+            for deployment_state in self._deployment_states.values():
+                node_ids.update(deployment_state.get_active_node_ids())
+            # Frozen: the memo is handed to callers and must not be mutable.
+            return frozenset(node_ids)
+
+        return _memoized_walk(
+            self, "_active_node_ids_memo", self._membership_cache_key(), compute
+        )
 
     def get_ingress_membership_version(self) -> int:
         """Monotonic counter of ingress running-replica-set changes (node/ports

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2571,6 +2571,11 @@ class RankManager:
         return keys_needing_ranks
 
 
+# Minimum gap between retries of a rank-consistency pass that swallowed an error, so a
+# deterministic failure cannot re-run an O(N) pass and log every tick.
+_RANK_ERROR_RETRY_S = 30.0
+
+
 class DeploymentRankManager:
     """Manages replica ranks for a deployment.
     This class handles rank assignment, release, consistency checking, and reassignment.
@@ -2951,6 +2956,9 @@ class DeploymentState:
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
         self._last_rank_membership_ids: Optional[Set[str]] = None
+        # Membership whose pass swallowed an error, and when, for retry backoff.
+        self._last_rank_error_ids: Optional[Set[str]] = None
+        self._last_rank_error_ts: float = 0.0
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -5016,6 +5024,14 @@ class DeploymentState:
         active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
         if active_replica_ids == self._last_rank_membership_ids:
             return
+        # An errored pass leaves the membership uncached so it is retried; rate-limit that
+        # retry while the membership still matches the one that failed. A real membership
+        # change bypasses this and runs immediately.
+        if (
+            self._last_rank_error_ids == active_replica_ids
+            and time.time() - self._last_rank_error_ts < _RANK_ERROR_RETRY_S
+        ):
+            return
         replicas_to_reconfigure = (
             self._rank_manager.check_rank_consistency_and_reassign_minimally(
                 active_replicas,
@@ -5028,9 +5044,12 @@ class DeploymentState:
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
         if checked_cleanly:
-            # Deliberate: a deployment that keeps erroring never caches and is
-            # rechecked every tick, rather than latching an unvalidated membership.
             self._last_rank_membership_ids = active_replica_ids
+            self._last_rank_error_ids = None
+        else:
+            # Not cached: an unvalidated membership must be rechecked, just not every tick.
+            self._last_rank_error_ids = active_replica_ids
+            self._last_rank_error_ts = time.time()
 
     def _handle_deployment_actor_failed_health_check(
         self,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -10,6 +10,8 @@ from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
+from functools import reduce
+from operator import xor
 from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 import ray
@@ -2933,6 +2935,7 @@ class DeploymentState:
         self._rank_manager = DeploymentRankManager(
             fail_on_rank_error=RAY_SERVE_FAIL_ON_RANK_ERROR
         )
+        self._last_rank_membership_fingerprint: Optional[int] = None
 
         self.replica_average_ongoing_requests: Dict[str, float] = {}
 
@@ -4971,8 +4974,18 @@ class DeploymentState:
         # if we delay the rank reassignment, the rank system will be in an invalid state
         # for a longer period of time. Abrar made this decision because he is not confident
         # about how rollouts work in the deployment state machine.
+        self._maybe_check_rank_consistency()
+
+    def _maybe_check_rank_consistency(self) -> None:
+        """Run the rank-consistency pass only when replica membership changed.
+
+        The pass is O(N) with heavy constants and used to run on every
+        control-loop tick in steady state -- at 10K+ replicas it monopolizes
+        the controller loop. Rank consistency can only be violated by
+        membership changes, so a cheap fingerprint gates it.
+        """
         active_replicas = self._replicas.get()
-        if (
+        if not (
             active_replicas
             and self._curr_status_info.status == DeploymentStatus.HEALTHY
             # Skip consistency check if there are STARTING replicas. During node
@@ -4981,14 +4994,23 @@ class DeploymentState:
             # with STARTING replicas causes "active keys without ranks" error.
             and self._replicas.count(states=[ReplicaState.STARTING]) == 0
         ):
-            replicas_to_reconfigure = (
-                self._rank_manager.check_rank_consistency_and_reassign_minimally(
-                    active_replicas,
-                )
+            return
+        fingerprint = reduce(
+            xor,
+            (hash(r.replica_id.unique_id) for r in active_replicas),
+            len(active_replicas),
+        )
+        if fingerprint == self._last_rank_membership_fingerprint:
+            return
+        replicas_to_reconfigure = (
+            self._rank_manager.check_rank_consistency_and_reassign_minimally(
+                active_replicas,
             )
+        )
 
-            # Reconfigure replicas that had their ranks reassigned
-            self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
+        # Reconfigure replicas that had their ranks reassigned
+        self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
+        self._last_rank_membership_fingerprint = fingerprint
 
     def _handle_deployment_actor_failed_health_check(
         self,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -719,6 +719,138 @@ def print_verbose_scaling_log():
     logger.error(f"Scaling information\n{json.dumps(debug_info, indent=2)}")
 
 
+def _push_freshness_window_s(health_check_period_s: float) -> float:
+    """How long a pushed health result stays fresh enough to stand in for a probe."""
+    return max(health_check_period_s * 1.5, 1.0)
+
+
+# Most of a deployment's pushed health going stale at once (by its own
+# configured period) is the signature of controller-side ingest lag, not mass
+# replica failure. Deferring the pull fallback then avoids a probe storm that
+# would deepen the lag and can cascade into false kills; the cap bounds it so
+# a real mass outage still surfaces.
+HEALTH_PUSH_STALL_MIN_TRACKED = 64
+HEALTH_PUSH_STALL_STALE_FRACTION = 0.5
+HEALTH_PUSH_STALL_MAX_DEFER_S = 120.0
+# Expiry is staggered across at most this fraction of the cap. Taken from the cap
+# rather than from the period, which is unbounded relative to it: a long period
+# would otherwise stagger a replica past the start of the episode and cancel it.
+HEALTH_PUSH_STALL_STAGGER_FRACTION = 0.1
+
+
+class ReplicaHealthPushRegistry:
+    """Latest self-health pushed by each replica, keyed by replica unique id.
+
+    Written by the controller ingest path; consumed by the reconcile sweep. A
+    fresh healthy push lets the sweep skip firing a pull probe.
+    """
+
+    _PRUNE_THRESHOLD = 65536
+    _PRUNE_MAX_AGE_S = 600.0
+    _PRUNE_MIN_INTERVAL_S = 30.0
+    _GAP_BUCKET_S = 0.25
+    _GAP_NBUCKETS = 240  # 60s range
+    _GAP_WINDOW_S = 60.0
+
+    def __init__(self):
+        # replica_unique_id -> (checked_at, received_at, healthy, consecutive_failures)
+        self._state: Dict[str, Tuple[float, float, bool, Optional[int]]] = {}
+        # Gap between a replica's consecutive accepted checked_at values = its
+        # actual self-check interval (same clock per replica, skew-free). Held in
+        # two windows so the reported stats track current lag instead of averaging
+        # it away over the controller's lifetime.
+        self._gap_hist = [0] * self._GAP_NBUCKETS
+        self._gap_prev_hist = [0] * self._GAP_NBUCKETS
+        self._gap_max_s = 0.0
+        self._gap_prev_max_s = 0.0
+        self._gap_window_start = 0.0
+        self._gap_count = 0
+        self._last_prune_time = 0.0
+
+    def record(
+        self,
+        replica_unique_id: str,
+        checked_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ):
+        prev = self._state.get(replica_unique_id)
+        if prev is not None and checked_at <= prev[0]:
+            return  # A delayed report must not clobber a newer observation.
+        if prev is not None:
+            gap = checked_at - prev[0]
+            b = int(gap / self._GAP_BUCKET_S)
+            self._gap_hist[b if b < self._GAP_NBUCKETS else self._GAP_NBUCKETS - 1] += 1
+            self._gap_count += 1
+            if gap > self._gap_max_s:
+                self._gap_max_s = gap
+        now = time.time()
+        if (
+            len(self._state) > self._PRUNE_THRESHOLD
+            and now - self._last_prune_time > self._PRUNE_MIN_INTERVAL_S
+        ):
+            # Rate-limited: when everything is fresher than the age cutoff the
+            # prune is a no-op, and re-running the O(N) rebuild on every record
+            # would thrash the ingest path right at the scale it serves.
+            self._last_prune_time = now
+            # Age by controller-clock arrival time (v[1]), immune to replica skew.
+            cutoff = now - self._PRUNE_MAX_AGE_S
+            self._state = {k: v for k, v in self._state.items() if v[1] >= cutoff}
+        self._state[replica_unique_id] = (
+            checked_at,
+            now,
+            healthy,
+            consecutive_failures,
+        )
+
+    def get(
+        self, replica_unique_id: str
+    ) -> Optional[Tuple[float, float, bool, Optional[int]]]:
+        return self._state.get(replica_unique_id)
+
+    def _roll_gap_window(self, now: float) -> None:
+        """Retire the older of the two gap windows.
+
+        Lifetime percentiles go insensitive to a current lag spike once enough
+        samples accumulate, which is exactly when the stats are worth reading.
+        """
+        if now - self._gap_window_start < self._GAP_WINDOW_S:
+            return
+        self._gap_window_start = now
+        self._gap_prev_hist = self._gap_hist
+        self._gap_prev_max_s = self._gap_max_s
+        self._gap_hist = [0] * self._GAP_NBUCKETS
+        self._gap_max_s = 0.0
+
+    def gap_stats(self) -> Dict[str, float]:
+        """Percentiles of the replicas' actual self-check intervals.
+
+        Percentiles and max cover the last window or two; `count` stays
+        cumulative so it reads as a counter.
+        """
+        self._roll_gap_window(time.time())
+        merged = [c + p for c, p in zip(self._gap_hist, self._gap_prev_hist)]
+        total = sum(merged)
+
+        def pct(p):
+            if total <= 0:
+                return 0.0
+            target = p * total
+            cum = 0
+            for i, c in enumerate(merged):
+                cum += c
+                if cum >= target:
+                    return (i + 1) * self._GAP_BUCKET_S
+            return self._GAP_NBUCKETS * self._GAP_BUCKET_S
+
+        return {
+            "count": self._gap_count,
+            "p50_s": pct(0.50),
+            "p99_s": pct(0.99),
+            "max_s": max(self._gap_max_s, self._gap_prev_max_s),
+        }
+
+
 class ActorReplicaWrapper:
     """Wraps a Ray actor for a deployment replica.
 
@@ -806,6 +938,16 @@ class ActorReplicaWrapper:
 
         # Outbound deployments polling state
         self._outbound_deployments: Optional[List[DeploymentID]] = None
+
+        # Latest replica-pushed self-health, consumed by check_health().
+        self._pushed_health: Optional[Tuple[float, float, bool, Optional[int]]] = None
+        self._last_consumed_push_ts: float = 0.0
+        self._last_applied_push_received_at: float = 0.0
+        self._probe_deferred_until: float = 0.0
+        self._last_probe_applied_time: float = 0.0
+        # Stable per-replica fraction; staggers stall-deferral expiry (see
+        # defer_push_fallback_probe).
+        self._probe_defer_jitter: float = random.random()
 
         # Histogram to track routing stats delay from replica to controller
         self._routing_stats_delay_histogram = metrics.Histogram(
@@ -1658,6 +1800,18 @@ class ActorReplicaWrapper:
             # There's already an active health check.
             return False
 
+        # Pushed health is flowing -- probe only once the newest observation we
+        # hold goes stale. Anchored to when it arrived, not to when this loop got
+        # round to it, so a slow reconcile cannot stretch the window.
+        if time.time() - self._last_applied_push_received_at < _push_freshness_window_s(
+            self.health_check_period_s
+        ):
+            return False
+
+        # Staleness is systemic: hold off until the deployment's stall episode caps.
+        if time.time() < self._probe_deferred_until:
+            return False
+
         # If there's no active health check, kick off another and reset
         # the timer if it's been long enough since the last health
         # check. Add some randomness to avoid synchronizing across all
@@ -1700,6 +1854,71 @@ class ActorReplicaWrapper:
         )
         return time_since_last > randomized_period
 
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ) -> None:
+        """Stash the replica's latest pushed self-health observation.
+
+        checked_at is replica-clock (used only for ordering/dedupe);
+        received_at is controller-clock (used for freshness, immune to skew).
+        """
+        if checked_at > self._last_consumed_push_ts:
+            self._pushed_health = (
+                checked_at,
+                received_at,
+                healthy,
+                consecutive_failures,
+            )
+
+    def _take_fresh_pushed_health(self) -> Optional[Tuple[bool, Optional[int]]]:
+        """Consume the pushed self-health observation, if fresh.
+
+        A fresh healthy observation defers the next pull probe; stale ones are
+        dropped so the pull path remains the fallback.
+        """
+        if self._pushed_health is None:
+            return None
+        checked_at, received_at, healthy, consecutive_failures = self._pushed_health
+        self._pushed_health = None
+        self._last_consumed_push_ts = checked_at
+        # Freshness window: 1.5x the period with a 1s floor -- push->ingest->
+        # consume latency must not flip sub-second periods onto the pull path
+        # (two interleaved observers would double-count flaky checks). Measured
+        # against the controller-clock arrival time, immune to replica clock skew.
+        if time.time() - received_at > _push_freshness_window_s(
+            self.health_check_period_s
+        ):
+            return None
+        if received_at < self._last_probe_applied_time:
+            return None  # A probe already reported something newer than this.
+        self._last_applied_push_received_at = received_at
+        return healthy, consecutive_failures
+
+    def defer_push_fallback_probe(self, until: float) -> None:
+        """Hold the push-staleness probe gate closed until `until`; 0 retracts.
+
+        Used when staleness is systemic (controller ingest lag): probing every
+        replica at once would amplify the lag and can cascade into false kills.
+        The caller passes the stall episode's own deadline, so deferral cannot
+        outlive the episode; and because this is not a push, it must not touch
+        _last_applied_push_received_at, which gates whether a probe result is stale.
+
+        One deadline is shared by the whole deployment, so it is staggered per
+        replica -- otherwise every gate opens on the same tick and produces the
+        storm this defers. The offset is a fraction of the cap and only ever
+        shortens the hold, so it can neither outlive the episode nor cancel it.
+        """
+        if not until:
+            self._probe_deferred_until = 0.0
+            return
+        self._probe_deferred_until = until - self._probe_defer_jitter * (
+            HEALTH_PUSH_STALL_MAX_DEFER_S * HEALTH_PUSH_STALL_STAGGER_FRACTION
+        )
+
     def check_health(self) -> bool:
         """Check if the actor is healthy.
 
@@ -1711,6 +1930,52 @@ class ActorReplicaWrapper:
             3) Kicking off a new health check if needed.
         """
         response: ReplicaHealthCheckResponse = self._check_active_health_check()
+        if (
+            response
+            in (
+                ReplicaHealthCheckResponse.SUCCEEDED,
+                ReplicaHealthCheckResponse.APP_FAILURE,
+            )
+            and self._last_health_check_time < self._last_applied_push_received_at
+        ):
+            # This probe was already in flight when a newer push was applied, so it
+            # carries the older observation. ACTOR_CRASHED is exempt: a crash is
+            # authoritative and a dead replica pushes nothing.
+            response = ReplicaHealthCheckResponse.NONE
+            # Keep the latency sample (the probe really did take that long) but not
+            # the failure: the counter tracks what the controller acted on.
+            self._last_health_check_failed = None
+        if response is not ReplicaHealthCheckResponse.NONE:
+            # Watermark by when this probe was started: a push that arrived before
+            # that is strictly older information and must not be consumed next tick
+            # and overwrite the result. One that arrived mid-flight is not.
+            self._last_probe_applied_time = self._last_health_check_time
+        # Consume the pushed observation only when no pull probe resolved this
+        # tick -- otherwise leave it stashed so a fresh push is never discarded
+        # in favor of an older in-flight probe result.
+        pushed = (
+            self._take_fresh_pushed_health()
+            if response is ReplicaHealthCheckResponse.NONE
+            else None
+        )
+        if response is ReplicaHealthCheckResponse.NONE and pushed is not None:
+            # No pull probe resolved this tick; use the pushed observation. The
+            # replica reports its own consecutive-failure count, so mirror it
+            # (robust to dropped/coalesced pushes) before the standard handling.
+            pushed_healthy, pushed_failures = pushed
+            if pushed_healthy:
+                response = ReplicaHealthCheckResponse.SUCCEEDED
+            else:
+                if pushed_failures is not None:
+                    # Mirroring is what paces this: the replica advances its count
+                    # once per period. A push without one falls back to counting per
+                    # push, so no producer may omit it at sub-period cadence.
+                    self._consecutive_health_check_failures = pushed_failures - 1
+                response = ReplicaHealthCheckResponse.APP_FAILURE
+            # Only the probe paths set this, so the failures counter would go silent
+            # for the path the controller now acts on most. No latency: the
+            # controller measured no round trip.
+            self._last_health_check_failed = not pushed_healthy
         if response is ReplicaHealthCheckResponse.NONE:
             # No info; don't update replica health.
             pass
@@ -2112,6 +2377,21 @@ class DeploymentReplica:
     def has_outstanding_check(self) -> bool:
         """True if a health-check or routing-stats ref is in flight (dirty-set poll set)."""
         return self._actor.has_in_flight_health_or_routing_probe
+
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures: Optional[int] = None,
+    ) -> None:
+        """Stash the replica's pushed self-health for the next health check."""
+        self._actor.record_pushed_health(
+            checked_at, received_at, healthy, consecutive_failures
+        )
+
+    def defer_push_fallback_probe(self, until: float) -> None:
+        self._actor.defer_push_fallback_probe(until)
 
     def check_health(self) -> bool:
         """Check if the replica is healthy.
@@ -2954,12 +3234,26 @@ class DeploymentState:
         deployment_scheduler: DeploymentScheduler,
         cluster_node_info_cache: ClusterNodeInfoCache,
         autoscaling_state_manager: AutoscalingStateManager,
+        health_push_registry: Optional[ReplicaHealthPushRegistry] = None,
     ):
         self._id = id
         self._long_poll_host: LongPollHost = long_poll_host
         self._deployment_scheduler = deployment_scheduler
         self._cluster_node_info_cache = cluster_node_info_cache
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._health_push_registry = health_push_registry
+        self._push_probes_deferred: bool = False
+        self._push_stall_since: Optional[float] = None
+        self._push_stall_stale: int = 0
+        self._push_stall_total: int = 0
+        self._push_stall_ticks: int = 0
+        self._push_stall_seen: Set[str] = set()
+        self._rr_sampled_ids: Set[str] = set()
+        # Default to the stock period so pushes are not misread as stale on
+        # deployments that have no target info yet (recovery, deletion).
+        self._push_stall_window_s: float = _push_freshness_window_s(
+            DEFAULT_HEALTH_CHECK_PERIOD_S
+        )
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
@@ -4919,15 +5213,7 @@ class DeploymentState:
         self._outstanding_dirty_set = still
         n = container.count_state(ReplicaState.RUNNING)
         if n:
-            period = self._reconcile_sweep_period_s()
-            ticks = max(
-                1,
-                int(
-                    CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION
-                    * period
-                    / max(CONTROL_LOOP_INTERVAL_S, 1e-3)
-                ),
-            )
+            ticks = self._reconcile_sweep_ticks()
             slice_n = max(1, (n + ticks - 1) // ticks)
             start = self._dirty_set_rr_cursor % n
             sl = container.slice_state(ReplicaState.RUNNING, start, slice_n)
@@ -4939,6 +5225,10 @@ class DeploymentState:
                 if replica.replica_id not in seen:
                     pairs.append((replica, ReplicaState.RUNNING))
                     seen.add(replica.replica_id)
+        # Only the round-robin slice is a representative sample of the bucket; the
+        # in-flight and PENDING_MIGRATION entries above are front-loaded every tick
+        # and are stale-push by construction. The stall tally reads this.
+        self._rr_sampled_ids = {r.replica_id.unique_id for r in sl} if n else set()
         return pairs
 
     def _reconcile_sweep_period_s(self) -> float:
@@ -4961,12 +5251,119 @@ class DeploymentState:
                 DEFAULT_HEALTH_CHECK_PERIOD_S, DEFAULT_REQUEST_ROUTING_STATS_PERIOD_S
             )
 
+    def _reconcile_sweep_ticks(self) -> int:
+        """Control-loop ticks the dirty-set takes to sweep the RUNNING bucket
+        once (see _dirty_set_active_pairs)."""
+        return max(
+            1,
+            int(
+                CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION
+                * self._reconcile_sweep_period_s()
+                / max(CONTROL_LOOP_INTERVAL_S, 1e-3)
+            ),
+        )
+
+    def _advance_push_stall_window(self) -> None:
+        """Finalize the systemic-stall verdict once enough replicas have been
+        sampled across ticks (or a full sweep elapsed), then reset the tally.
+
+        Each tick only health-checks a dirty-set slice (~N/sweep_ticks), well
+        below the guard's min-tracked floor for all but the largest deployments;
+        accumulating across ticks lets the guard reach a deployment-representative
+        sample. A large deployment whose one-tick slice already exceeds the floor
+        still finalizes next tick, so engagement stays prompt where it matters.
+        """
+        self._push_stall_ticks += 1
+        if (
+            self._push_stall_total >= HEALTH_PUSH_STALL_MIN_TRACKED
+            or self._push_stall_ticks >= self._reconcile_sweep_ticks()
+        ):
+            self._finalize_push_stall_verdict()
+            self._push_stall_stale = 0
+            self._push_stall_total = 0
+            self._push_stall_ticks = 0
+            self._push_stall_seen.clear()
+
+    def _finalize_push_stall_verdict(self) -> None:
+        """Set probe-deferral from the accumulated staleness tally.
+
+        Most of this deployment's sampled pushes going stale at once (by its own
+        window) reads as controller-side ingest lag, so fallback probes are
+        deferred -- bounded by HEALTH_PUSH_STALL_MAX_DEFER_S per episode so a
+        genuine mass outage still falls through to probes.
+        """
+        stale, total = self._push_stall_stale, self._push_stall_total
+        if (
+            total < HEALTH_PUSH_STALL_MIN_TRACKED
+            or stale < total * HEALTH_PUSH_STALL_STALE_FRACTION
+        ):
+            self._push_stall_since = None
+            self._push_probes_deferred = False
+            return
+        now = time.time()
+        if self._push_stall_since is None:
+            self._push_stall_since = now
+            logger.warning(
+                f"Pushed health went stale for {stale}/{total} replicas of "
+                f"{self._id} at once; treating as controller-side ingest lag "
+                "and deferring fallback probes for up to "
+                f"{HEALTH_PUSH_STALL_MAX_DEFER_S}s."
+            )
+        self._push_probes_deferred = (
+            now - self._push_stall_since < HEALTH_PUSH_STALL_MAX_DEFER_S
+        )
+
+    def _apply_pushed_health(self, replica: "DeploymentReplica") -> None:
+        """Hand the replica's latest pushed self-health to its wrapper.
+
+        Tallies push staleness for this deployment's stall verdict and, while
+        the previous sweep's verdict says staleness is systemic, keeps the
+        replica's probe gate closed until that episode caps.
+        """
+        if self._health_push_registry is None:
+            return
+        replica_id = replica.replica_id.unique_id
+        pushed = self._health_push_registry.get(replica_id)
+        # Re-stamped every visit, including with 0, so an episode that ends early
+        # cannot leave a deadline behind that outlives it. A replica with no entry
+        # is never deferred: probes are its only health signal, and it cannot sway
+        # the verdict either. Both cases must retract, so this precedes the return.
+        if (
+            pushed is not None
+            and self._push_probes_deferred
+            and self._push_stall_since is not None
+        ):
+            replica.defer_push_fallback_probe(
+                self._push_stall_since + HEALTH_PUSH_STALL_MAX_DEFER_S
+            )
+        else:
+            replica.defer_push_fallback_probe(0.0)
+        if pushed is None:
+            return
+        if replica_id in self._rr_sampled_ids and replica_id not in (
+            self._push_stall_seen
+        ):
+            # One sample per replica per window, and only from the round-robin
+            # slice. The dirty set also re-visits every replica with an in-flight
+            # probe each tick, and those are stale-push by construction, so counting
+            # them reads a small failed cohort as fleet-wide ingest lag.
+            self._push_stall_seen.add(replica_id)
+            self._push_stall_total += 1
+            if time.time() - pushed[1] > self._push_stall_window_s:
+                self._push_stall_stale += 1
+        replica.record_pushed_health(*pushed)
+
     def check_and_update_replicas(self):
         """
         Check current state of all DeploymentReplica being tracked, and compare
         with state container from previous update() cycle to see if any state
         transition happened.
         """
+        self._advance_push_stall_window()
+        if self._target_state.info is not None:
+            self._push_stall_window_s = _push_freshness_window_s(
+                self._target_state.info.deployment_config.health_check_period_s
+            )
 
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
@@ -4978,6 +5375,8 @@ class DeploymentState:
         if not self._is_gang_deployment:
             origin: List[ReplicaState] = []
             pairs = self._dirty_set_active_pairs()
+            for replica, _ in pairs:
+                self._apply_pushed_health(replica)
             healths = [replica.check_health() for replica, _ in pairs]
             for (replica, st), is_healthy in zip(pairs, healths):
                 self._record_health_check_metrics(replica)
@@ -5004,9 +5403,14 @@ class DeploymentState:
                 {replica.replica_id for replica in unhealthy_replicas}
             )
         else:
-            for replica in self._replicas.pop(
+            gang_replicas = self._replicas.pop(
                 states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
-            ):
+            )
+            # The gang path visits every replica every tick, so the whole pass is
+            # already a representative sample.
+            self._rr_sampled_ids = {r.replica_id.unique_id for r in gang_replicas}
+            for replica in gang_replicas:
+                self._apply_pushed_health(replica)
                 is_healthy = replica.check_health()
                 self._record_health_check_metrics(replica)
                 if is_healthy:
@@ -5885,6 +6289,7 @@ class DeploymentStateManager:
         autoscaling_state_manager: AutoscalingStateManager,
         head_node_id_override: Optional[str] = None,
         create_placement_group_fn_override: Optional[Callable] = None,
+        health_push_registry: Optional[ReplicaHealthPushRegistry] = None,
     ):
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
@@ -5895,6 +6300,7 @@ class DeploymentStateManager:
             create_placement_group_fn_override,
         )
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._health_push_registry = health_push_registry
 
         self._shutting_down = False
 
@@ -5950,6 +6356,7 @@ class DeploymentStateManager:
             self._deployment_scheduler,
             self._cluster_node_info_cache,
             self._autoscaling_state_manager,
+            health_push_registry=self._health_push_registry,
         )
 
     def _map_actor_names_to_deployment(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2599,6 +2599,15 @@ class DeploymentRankManager:
         # Track which node each replica is on
         self._replica_to_node: Dict[str, str] = {}
 
+    @property
+    def last_rank_op_errored(self) -> bool:
+        """Whether the most recent rank op swallowed an error (fail_on_rank_error off).
+
+        Read it immediately after the call whose result you are judging: any further
+        rank op resets it.
+        """
+        return self._last_rank_op_errored
+
     def _execute_with_error_handling(self, func, safe_default, *args, **kwargs):
         if self._fail_on_rank_error:
             # Let exceptions propagate
@@ -4990,16 +4999,19 @@ class DeploymentState:
         the controller loop. Rank consistency can only be violated by
         membership changes, so the active replica-id set gates it.
         """
-        active_replicas = self._replicas.get()
-        if not (
-            active_replicas
-            and self._curr_status_info.status == DeploymentStatus.HEALTHY
+        # O(1) guards first -- `get()` below copies the whole replica list, and these
+        # two rule out the busiest ticks (rollouts, migrations) without paying for it.
+        if (
+            self._curr_status_info.status != DeploymentStatus.HEALTHY
             # Skip consistency check if there are STARTING replicas. During node
             # migration, new replicas are created in STARTING state (without ranks)
             # after the status is set to HEALTHY. Running the consistency check
             # with STARTING replicas causes "active keys without ranks" error.
-            and self._replicas.count(states=[ReplicaState.STARTING]) == 0
+            or self._replicas.count(states=[ReplicaState.STARTING]) != 0
         ):
+            return
+        active_replicas = self._replicas.get()
+        if not active_replicas:
             return
         active_replica_ids = {r.replica_id.unique_id for r in active_replicas}
         if active_replica_ids == self._last_rank_membership_ids:
@@ -5009,12 +5021,15 @@ class DeploymentState:
                 active_replicas,
             )
         )
+        # Snapshot now: the reconfigure below calls back into the rank manager, which
+        # resets this flag.
+        checked_cleanly = not self._rank_manager.last_rank_op_errored
 
         # Reconfigure replicas that had their ranks reassigned
         self._reconfigure_replicas_with_new_ranks(replicas_to_reconfigure)
-        if not self._rank_manager._last_rank_op_errored:
-            # Only mark this membership as checked if the pass did not swallow an
-            # error (fail_on_rank_error off); otherwise retry it next tick.
+        if checked_cleanly:
+            # Deliberate: a deployment that keeps erroring never caches and is
+            # rechecked every tick, rather than latching an unvalidated membership.
             self._last_rank_membership_ids = active_replica_ids
 
     def _handle_deployment_actor_failed_health_check(

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -85,6 +85,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
     RECONFIGURE_METHOD,
     RECORD_REPLICA_METADATA_METHOD,
+    REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     REQUEST_LATENCY_BUCKETS_MS,
     REQUEST_ROUTING_STATS_METHOD,
     SERVE_CONTROLLER_NAME,
@@ -358,6 +359,7 @@ class ReplicaMetricsManager:
 
     PUSH_METRICS_TO_CONTROLLER_TASK_NAME = "push_metrics_to_controller"
     RECORD_METRICS_TASK_NAME = "record_metrics"
+    PUSH_SELF_HEALTH_TASK_NAME = "push_self_health"
     SET_REPLICA_REQUEST_METRIC_GAUGE_TASK_NAME = "set_replica_request_metric_gauge"
 
     def __init__(
@@ -390,6 +392,21 @@ class ReplicaMetricsManager:
         # Tracks in-flight metrics push to controller. Skip if new one is sent.
         self._pending_metrics_push_ref: Optional[ObjectRef] = None
         self._metrics_push_lock = threading.Lock()
+
+        # Self-health push state: the latest local health-check result rides on
+        # metric report pushes, or on a lightweight heartbeat when this replica
+        # does not push metric reports.
+        self._self_healthy: Optional[bool] = None
+        self._self_health_checked_at: Optional[float] = None
+        self._eval_self_health_fn: Optional[Callable] = None
+        self._self_health_period_s: float = 0.0
+        # What the outstanding heartbeat carries; only meaningful while one is.
+        self._pending_push_healthy: bool = True
+        self._last_counted_failure_s: float = 0.0
+        self._last_health_carrying_report_s: float = 0.0
+        self._pushing_metric_reports = False
+        self._self_consecutive_failures = 0
+        self._pending_health_push_ref: Optional[ObjectRef] = None
 
         # If the interval is set to 0, eagerly sets all metrics.
         self._cached_metrics_enabled = RAY_SERVE_METRICS_EXPORT_INTERVAL_MS != 0
@@ -648,6 +665,7 @@ class ReplicaMetricsManager:
 
     def start_metrics_pusher(self):
         self._metrics_pusher.start()
+        self._pushing_metric_reports = True
 
         # Push autoscaling metrics to the controller periodically.
         self._metrics_pusher.register_or_update_task(
@@ -665,6 +683,98 @@ class ReplicaMetricsManager:
             self._add_autoscaling_metrics_point_async,
             min(record_interval_s, self._autoscaling_config.metrics_interval_s),
         )
+
+    def reports_carry_health(self) -> bool:
+        """A metric report carried health within the last period, so a heartbeat
+        would be redundant.
+
+        Observed rather than inferred from the configured interval: a report is
+        dropped whenever the previous one is still in flight, which happens exactly
+        when the controller is behind and the heartbeat is the remaining channel.
+        """
+        return (
+            time.time() - self._last_health_carrying_report_s
+            < self._self_health_period_s
+        )
+
+    def start_self_health_pusher(self, eval_fn: Callable, period_s: float):
+        """Periodically run the local health check and push the result.
+
+        eval_fn is an async callable that raises when unhealthy (the replica's
+        own check_health). period_s is the configured health-check period; the
+        check runs at half of it so every replica is checked well within the
+        period despite scheduling jitter.
+        """
+        self._eval_self_health_fn = eval_fn
+        self._self_health_period_s = period_s
+        self._metrics_pusher.start()
+        self._metrics_pusher.register_or_update_task(
+            self.PUSH_SELF_HEALTH_TASK_NAME,
+            self._eval_and_push_self_health,
+            period_s * 0.5,
+        )
+
+    async def _eval_and_push_self_health(self):
+        if self._self_consecutive_failures >= REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD:
+            # Latched: the controller will replace this replica; stop re-running
+            # the user check (parity with pull probes, which cease at the
+            # threshold) but keep reporting unhealthy.
+            healthy = False
+        else:
+            healthy = True
+            try:
+                # No deadline here: health_check_timeout_s is only delivered to the
+                # actor at startup, so enforcing it locally would pin a replica to
+                # whatever the value was then. The controller holds the live one and
+                # times the probe out itself; a check that hangs here stops
+                # refreshing the cache, which check_health() treats as stale.
+                await self._eval_self_health_fn()
+            except Exception:
+                healthy = False
+            counted_at = time.time()
+            if healthy:
+                self._self_consecutive_failures = 0
+            elif (
+                self._self_consecutive_failures == 0
+                or counted_at - self._last_counted_failure_s
+                >= self._self_health_period_s
+            ):
+                # Evals run twice per period for freshness, but the controller
+                # weighs this count against a threshold calibrated to the period.
+                # Counting every eval would replace a replica in half the wall
+                # clock the configuration asks for.
+                self._self_consecutive_failures += 1
+                self._last_counted_failure_s = counted_at
+        self._self_healthy = healthy
+        self._self_health_checked_at = time.time()
+
+        # An unhealthy result must reach the controller promptly to trigger
+        # replacement, so it is never suppressed -- suppression only applies
+        # while healthy.
+        if healthy and self.reports_carry_health():
+            # When the metric cadence is slower than the health period, fall
+            # through and heartbeat so freshness at the controller never
+            # lapses.
+            return
+        with self._metrics_push_lock:
+            in_flight = self._pending_health_push_ref is not None and (
+                not check_obj_ref_ready_nowait(self._pending_health_push_ref)
+            )
+            if in_flight and (healthy or not self._pending_push_healthy):
+                # Turning unhealthy is worth jumping the queue rather than waiting
+                # out a lag episode, but only until an unhealthy heartbeat is
+                # actually in flight: the payload is absolute, so a second one adds
+                # nothing and a flapping replica could otherwise queue many.
+                return
+            self._pending_health_push_ref = (
+                self._controller_handle.record_replica_health.remote(
+                    self._replica_id.unique_id,
+                    self._self_health_checked_at,
+                    healthy,
+                    self._self_consecutive_failures,
+                )
+            )
+            self._pending_push_healthy = healthy
 
     def should_collect_ongoing_requests(self) -> bool:
         """Determine if replicas should collect ongoing request metrics.
@@ -948,11 +1058,18 @@ class ReplicaMetricsManager:
             timestamp=time.time(),
             aggregated_metrics=new_aggregated_metrics,
             metrics=new_metrics,
+            healthy=self._self_healthy,
+            health_checked_at=self._self_health_checked_at,
+            health_consecutive_failures=self._self_consecutive_failures,
         )
         with self._metrics_push_lock:
             if self._pending_metrics_push_ref is not None:
                 if not check_obj_ref_ready_nowait(self._pending_metrics_push_ref):
                     return  # Previous push still in flight, skip and try again later
+            if replica_metric_report.healthy is not None:
+                # Only now is it true that a report carried health; the controller
+                # drops the field until the first self-check has run.
+                self._last_health_carrying_report_s = time.time()
             self._pending_metrics_push_ref = (
                 self._controller_handle.record_autoscaling_metrics_from_replica.remote(
                     compress_metric_report(replica_metric_report)
@@ -1076,6 +1193,13 @@ class Replica:
 
         # Guards against calling the user's callable constructor multiple times.
         self._user_callable_initialized = False
+        # Self-health task state: once active, check_health() serves the cached
+        # result instead of re-running the user check.
+        self._self_health_active = False
+        self._self_health_evaluated = False
+        self._self_health_evaluated_at: float = 0.0
+        self._health_check_lock = asyncio.Lock()
+        self._last_self_health_error: Optional[str] = None
         self._user_callable_initialized_lock = asyncio.Lock()
         self._initialization_latency: Optional[float] = None
 
@@ -1874,8 +1998,14 @@ class Replica:
 
             # A new replica should not be considered healthy until it passes
             # an initial health check. If an initial health check fails,
-            # consider it an initialization failure.
-            await self.check_health()
+            # consider it an initialization failure. Evaluated directly rather
+            # than through check_health: controller recovery re-enters this on a
+            # replica whose self-health task is already running, and a cached
+            # failure would fail a live replica that a fresh check passes.
+            await self._run_user_health_check()
+            # From here on the periodic self-health task is the sole caller of
+            # the user health check; remote probes read its cached result.
+            self._start_self_health_pusher()
         except Exception:
             raise RuntimeError(traceback.format_exc()) from None
 
@@ -1903,6 +2033,8 @@ class Replica:
             self._metrics_manager.set_autoscaling_config(
                 deployment_config.autoscaling_config
             )
+            if self._user_callable_initialized:
+                self._start_self_health_pusher()
             self._metrics_manager.set_max_ongoing_requests(
                 deployment_config.max_ongoing_requests
             )
@@ -2138,7 +2270,30 @@ class Replica:
             extra={"log_to_stderr": False},
         )
 
-    async def check_health(self):
+    def _start_self_health_pusher(self):
+        self._self_health_active = True
+        self._metrics_manager.start_self_health_pusher(
+            self._run_user_health_check,
+            self._deployment_config.health_check_period_s,
+        )
+
+    async def _run_user_health_check(self):
+        # Recovery re-enters this while the periodic self-health task may be part
+        # way through it; both write _healthy, and the user check is not promised
+        # to be reentrant. Whoever arrives second takes the result of the check
+        # that was already running rather than starting a second one.
+        entered_at = time.time()
+        async with self._health_check_lock:
+            if self._self_health_evaluated_at > entered_at:
+                if not self._healthy:
+                    raise RuntimeError(
+                        self._last_self_health_error
+                        or "Replica self health check failed."
+                    )
+                return
+            await self._run_user_health_check_locked()
+
+    async def _run_user_health_check_locked(self):
         try:
             # Runs the user-defined check_health on the user code loop if defined.
             # Otherwise, if the background watchdog has detected the user loop is
@@ -2149,10 +2304,46 @@ class Replica:
             if f is not None:
                 await f
             self._healthy = True
+        except asyncio.CancelledError:
+            # A caller giving up on us (its own deadline, or shutdown) must not
+            # leave a healthy verdict behind: CancelledError is not an Exception,
+            # so without this the cached result stays healthy even though nothing
+            # ever confirmed it.
+            self._healthy = False
+            self._last_self_health_error = "Replica health check timed out."
+            raise
         except Exception as e:
             logger.warning("Replica health check failed.")
             self._healthy = False
+            self._last_self_health_error = repr(e)
             raise e from None
+        finally:
+            self._self_health_evaluated = True
+            self._self_health_evaluated_at = time.time()
+
+    async def check_health(self):
+        # While the self-health task is the active observer, serve its cached
+        # result -- concurrent callers must not re-run the user health check.
+        # A healthy one expires: a self-check that hangs stops refreshing it, and
+        # this probe is then the only thing that can notice. An unhealthy one does
+        # not, because the task latches at the threshold and stops evaluating, so
+        # expiring it would re-run the check and flap against the pushes that are
+        # still reporting the replica unhealthy.
+        if (
+            self._self_health_active
+            and self._self_health_evaluated
+            and (
+                not self._healthy
+                or time.time() - self._self_health_evaluated_at
+                < self._deployment_config.health_check_period_s
+            )
+        ):
+            if not self._healthy:
+                raise RuntimeError(
+                    self._last_self_health_error or "Replica self health check failed."
+                )
+            return
+        await self._run_user_health_check()
 
     async def record_routing_stats(self) -> Dict[str, Any]:
         try:

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -787,6 +787,15 @@ class MockReplicaActorWrapper:
         self.health_check_called = True
         return self.healthy
 
+    def record_pushed_health(
+        self,
+        checked_at: float,
+        received_at: float,
+        healthy: bool,
+        consecutive_failures=None,
+    ):
+        self.pushed_health = (checked_at, received_at, healthy, consecutive_failures)
+
     def get_routing_stats(self) -> Dict[str, Any]:
         return {}
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1641,6 +1641,20 @@ class ControllerHealthMetrics(BaseModel):
         default=0.0, description="When the controller started (epoch seconds)."
     )
     uptime_s: float = Field(default=0.0, description="Controller uptime in seconds.")
+
+    # Replica self-check intervals observed via health pushes.
+    push_checks_recorded: int = Field(
+        default=0, description="Replica self-check intervals observed via pushes."
+    )
+    push_check_gap_p50_s: float = Field(
+        default=0.0, description="Median replica self-check interval."
+    )
+    push_check_gap_p99_s: float = Field(
+        default=0.0, description="p99 replica self-check interval."
+    )
+    push_check_gap_max_s: float = Field(
+        default=0.0, description="Max replica self-check interval."
+    )
     last_control_loop_time: float = Field(
         default=0.0,
         description="Time of the last control loop execution (epoch seconds).",

--- a/python/ray/serve/tests/test_healthcheck.py
+++ b/python/ray/serve/tests/test_healthcheck.py
@@ -5,7 +5,10 @@ import pytest
 
 import ray
 from ray import serve
-from ray._common.test_utils import async_wait_for_condition, wait_for_condition
+from ray._common.test_utils import (
+    async_wait_for_condition,
+    wait_for_condition,
+)
 from ray.exceptions import RayError
 from ray.serve._private.common import DeploymentStatus
 from ray.serve._private.constants import (

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10163,9 +10163,10 @@ class TestRankConsistencyMembershipGate:
         ds._replicas.count.return_value = 0
         ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
         ds._rank_manager = Mock()
+        ds._rank_manager._last_rank_op_errored = False
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
         ds._reconfigure_replicas_with_new_ranks = Mock()
-        ds._last_rank_membership_fingerprint = None
+        ds._last_rank_membership_ids = None
         return ds
 
     def test_runs_once_then_skips_for_same_membership(self):
@@ -10193,12 +10194,33 @@ class TestRankConsistencyMembershipGate:
             == 2
         )
 
+    def test_swallowed_rank_error_reruns_next_tick(self):
+        # fail_on_rank_error off: the pass can swallow an error and return [].
+        # The membership must NOT be cached, so the next tick retries.
+        ds = self._ds(["a", "b", "c"])
+        ds._rank_manager._last_rank_op_errored = True
+        ds._maybe_check_rank_consistency()
+        assert ds._last_rank_membership_ids is None
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 2
+        )
+        # Once it succeeds, the membership is cached and the pass stops re-running.
+        ds._rank_manager._last_rank_op_errored = False
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 3
+        )
+
     def test_starting_replicas_skip_entirely(self):
         ds = self._ds(["a", "b"])
         ds._replicas.count.return_value = 1
         ds._maybe_check_rank_consistency()
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
-        assert ds._last_rank_membership_fingerprint is None
+        assert ds._last_rank_membership_ids is None
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
@@ -52,6 +53,7 @@ from ray.serve._private.deployment_state import (
     DeploymentState,
     DeploymentStateManager,
     DeploymentVersion,
+    ReplicaHealthPushRegistry,
     ReplicaStartupStatus,
     ReplicaStateContainer,
 )
@@ -10008,10 +10010,11 @@ class TestDirtySet:
         s._outstanding_dirty_set = set()
         s._dirty_set_rr_cursor = 0
         s._target_state = object()  # .info access raises -> default reconcile period
-        # Bind the real period helper so _dirty_set_active_pairs can call it on the shim.
+        # Bind the real period/ticks helpers so _dirty_set_active_pairs can call them.
         s._reconcile_sweep_period_s = DeploymentState._reconcile_sweep_period_s.__get__(
             s
         )
+        s._reconcile_sweep_ticks = DeploymentState._reconcile_sweep_ticks.__get__(s)
         return s
 
     def test_covers_all_running_within_one_sweep(self):
@@ -10468,3 +10471,500 @@ def test_gang_health_churn_does_not_invalidate_the_memo(mock_deployment_state_ma
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestPushedHealth:
+    """Replica-pushed self-health short-circuits the pull probe; stale or absent
+    pushes fall back to the pull path unchanged."""
+
+    def _wrapper(self):
+        w = ActorReplicaWrapper.__new__(ActorReplicaWrapper)
+        w._actor_handle = Mock()
+        w._actor_handle.check_health.remote.return_value = "probe_ref"
+        w._health_check_ref = None
+        w._last_health_check_time = time.time()
+        w._consecutive_health_check_failures = 0
+        w._healthy = True
+        w._replica_id = "test_replica"
+        w._pushed_health = None
+        w._last_consumed_push_ts = 0.0
+        w._last_applied_push_received_at = 0.0
+        w._probe_deferred_until = 0.0
+        w._last_probe_applied_time = 0.0
+        w._probe_defer_jitter = 0.0
+        w._version = SimpleNamespace(
+            deployment_config=SimpleNamespace(
+                health_check_period_s=10.0, health_check_timeout_s=30.0
+            )
+        )
+        return w
+
+    def test_fresh_healthy_push_defers_pull_probe(self):
+        w = self._wrapper()
+        w._last_health_check_time = 0.0  # probe would fire without the push
+        now = time.time()
+        w.record_pushed_health(now, now, True)
+        assert w.check_health() is True
+        w._actor_handle.check_health.remote.assert_not_called()
+        assert w._health_check_ref is None
+        assert w._last_applied_push_received_at > 0.0  # probe gated while pushes flow
+
+    def test_stale_push_falls_back_to_pull_probe(self):
+        w = self._wrapper()
+        w._last_health_check_time = 0.0
+        w.record_pushed_health(time.time() - 60.0, time.time() - 60.0, True)
+        assert w.check_health() is True
+        w._actor_handle.check_health.remote.assert_called_once()
+
+    def test_unhealthy_pushes_count_toward_threshold(self):
+        w = self._wrapper()
+        threshold = ds_mod.REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+        for i in range(threshold):
+            w.record_pushed_health(time.time() + i * 1e-3, time.time(), False)
+            w.check_health()
+        assert w._healthy is False
+        assert w._consecutive_health_check_failures == threshold
+
+    def test_push_deduped_by_timestamp(self):
+        w = self._wrapper()
+        ts = time.time()
+        w.record_pushed_health(ts, ts, False)
+        w.check_health()
+        w.record_pushed_health(ts, ts, False)  # same observation again
+        w.check_health()
+        assert w._consecutive_health_check_failures == 1
+
+    def test_pushed_count_is_mirrored(self):
+        w = self._wrapper()
+        w.record_pushed_health(time.time(), time.time(), False, 7)
+        w.check_health()
+        assert w._consecutive_health_check_failures == 7
+        assert w._healthy is False
+
+    def test_healthy_push_resets_failure_count(self):
+        w = self._wrapper()
+        w.record_pushed_health(time.time(), time.time(), False)
+        w.check_health()
+        assert w._consecutive_health_check_failures == 1
+        w.record_pushed_health(time.time() + 1e-3, time.time(), True)
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 0
+
+
+class TestPushSystemicStallGuard:
+    """Most of a deployment's pushed health going stale at once (by its own
+    window) reads as controller-side lag: defer fallback probes, bounded so a
+    genuine mass outage still surfaces."""
+
+    def _ds(self, window_s=15.0):
+        from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
+
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        ds._health_push_registry = ReplicaHealthPushRegistry()
+        ds._push_probes_deferred = False
+        ds._push_stall_since = None
+        ds._push_stall_stale = 0
+        ds._push_stall_total = 0
+        ds._push_stall_seen = set()
+        ds._rr_sampled_ids = set()
+        ds._push_stall_window_s = window_s
+        ds._id = "test-deployment"
+        return ds
+
+    def _seed(self, ds, n, stale_n, age_s=60.0):
+        now = time.time()
+        for i in range(n):
+            received_at = now - age_s if i < stale_n else now
+            ds._health_push_registry._state[f"r{i}"] = (
+                now - age_s,
+                received_at,
+                True,
+                0,
+            )
+
+    def _sweep(self, ds, n, start=0):
+        ds._rr_sampled_ids = {f"r{i}" for i in range(start, start + n)}
+        for i in range(start, start + n):
+            replica = Mock()
+            replica.replica_id.unique_id = f"r{i}"
+            ds._apply_pushed_health(replica)
+
+    def _tally_and_verdict(self, ds, n, stale_n):
+        self._seed(ds, n, stale_n)
+        self._sweep(ds, n)
+        ds._finalize_push_stall_verdict()
+
+    def test_ending_the_episode_retracts_the_deadline(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=80)
+        assert ds._push_probes_deferred
+        # Staleness clears, so the episode ends well before its 120s cap.
+        ds._push_stall_stale = ds._push_stall_total = 0
+        ds._push_stall_seen.clear()
+        self._tally_and_verdict(ds, n=100, stale_n=0)
+        assert not ds._push_probes_deferred
+        replica = Mock()
+        replica.replica_id.unique_id = "r0"
+        ds._apply_pushed_health(replica)
+        # 0 retracts: a replica that stayed dead must not sit out the rest of a
+        # cap that no longer applies.
+        assert replica.defer_push_fallback_probe.call_args.args[0] == 0.0
+
+    def test_deferral_expiry_is_staggered_across_replicas(self):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._probe_defer_jitter = 1.0  # the far end of the stagger
+        until = time.time() + 120.0
+        wrapper.defer_push_fallback_probe(until)
+        # Staggered earlier, never later, so the episode cap still bounds it.
+        assert wrapper._probe_deferred_until < until
+        assert (
+            until - wrapper._probe_deferred_until
+            <= ds_mod.HEALTH_PUSH_STALL_MAX_DEFER_S
+            * ds_mod.HEALTH_PUSH_STALL_STAGGER_FRACTION
+        )
+
+    def test_stagger_cannot_cancel_the_deferral(self):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._version = SimpleNamespace(
+            deployment_config=SimpleNamespace(
+                health_check_period_s=300.0, health_check_timeout_s=30.0
+            )
+        )
+        wrapper._last_health_check_time = 0.0  # a probe would fire but for the defer
+        wrapper._probe_defer_jitter = 1.0  # the far end of the stagger
+        started = time.time()
+        wrapper.defer_push_fallback_probe(
+            started + ds_mod.HEALTH_PUSH_STALL_MAX_DEFER_S
+        )
+        # A long health period must not let the stagger eat the whole episode.
+        assert wrapper._probe_deferred_until > started
+        assert not wrapper._should_start_new_health_check()
+
+    def test_deferral_deadline_is_the_episode_cap(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=80)
+        assert ds._push_probes_deferred
+        replica = Mock()
+        replica.replica_id.unique_id = "r0"
+        ds._apply_pushed_health(replica)
+        until = replica.defer_push_fallback_probe.call_args.args[0]
+        assert until == ds._push_stall_since + ds_mod.HEALTH_PUSH_STALL_MAX_DEFER_S
+
+    def test_replica_that_never_pushed_is_not_deferred(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=80)
+        assert ds._push_probes_deferred
+        replica = Mock()
+        replica.replica_id.unique_id = "never-pushed"
+        ds._apply_pushed_health(replica)
+        # Retracted, not skipped: an entry pruned mid-episode would otherwise keep
+        # the last deadline it was given.
+        assert replica.defer_push_fallback_probe.call_args.args[0] == 0.0
+
+    def test_tally_ignores_the_in_flight_probe_cohort(self):
+        ds = self._ds()
+        self._seed(ds, n=100, stale_n=20)
+        # The dirty set front-loads the 20 stale-push replicas (they are the ones
+        # holding in-flight probes) ahead of a representative slice. Only the slice
+        # may be tallied, or 20% of the fleet reads as fleet-wide lag.
+        ds._rr_sampled_ids = {f"r{i}" for i in range(20, 100)}
+        for i in range(100):
+            replica = Mock()
+            replica.replica_id.unique_id = f"r{i}"
+            ds._apply_pushed_health(replica)
+        assert (ds._push_stall_stale, ds._push_stall_total) == (0, 80)
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+
+    def test_tally_counts_each_replica_once_per_window(self):
+        ds = self._ds()
+        self._seed(ds, n=10, stale_n=1)
+        # The dirty set re-polls a probing (stale) replica every tick; without
+        # dedupe those repeats alone would carry the window.
+        for _ in range(50):
+            replica = Mock()
+            replica.replica_id.unique_id = "r0"
+            ds._apply_pushed_health(replica)
+        self._sweep(ds, 10)
+        assert (ds._push_stall_stale, ds._push_stall_total) == (1, 10)
+
+    def test_majority_stale_defers_next_sweep(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=80)
+        assert (ds._push_stall_stale, ds._push_stall_total) == (80, 100)
+        assert ds._push_probes_deferred
+        # Next sweep: every replica's probe gate is held closed.
+        replica = Mock()
+        replica.replica_id.unique_id = "r0"
+        ds._apply_pushed_health(replica)
+        replica.defer_push_fallback_probe.assert_called_once()
+
+    def test_accumulates_across_ticks_below_slice_threshold(self):
+        # Each tick samples only a small slice (< min tracked), but accumulation
+        # across ticks reaches the sample size, so systemic lag still engages.
+        ds = self._ds()
+        ds._push_stall_ticks = 0
+        ds._reconcile_sweep_ticks = lambda: 1000  # long sweep -> threshold path
+        self._seed(ds, 80, 80)
+        for i in range(8):  # 8 slices of 10 distinct replicas >= MIN_TRACKED
+            self._sweep(ds, 10, start=i * 10)
+            ds._advance_push_stall_window()
+        assert ds._push_probes_deferred
+
+    def test_tiny_deployment_never_engages_even_accumulated(self):
+        # A full sweep accumulates < min tracked -> finalize bails, never defers.
+        ds = self._ds()
+        ds._push_stall_ticks = 0
+        ds._reconcile_sweep_ticks = lambda: 3
+        for _ in range(3):
+            self._seed(ds, 10, 10)
+            self._sweep(ds, 10)
+            ds._advance_push_stall_window()
+        assert not ds._push_probes_deferred
+
+    def test_large_slice_engages_in_one_tick(self):
+        # A single tick whose slice already exceeds the floor finalizes next
+        # tick -- prompt engagement preserved for large deployments.
+        ds = self._ds()
+        ds._push_stall_ticks = 0
+        ds._reconcile_sweep_ticks = lambda: 50
+        self._seed(ds, 100, 80)
+        self._sweep(ds, 100)
+        ds._advance_push_stall_window()  # total 100 >= floor -> finalized
+        assert ds._push_probes_deferred
+
+    def test_below_min_tracked_never_defers(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=63, stale_n=63)
+        assert not ds._push_probes_deferred
+
+    def test_minority_stale_does_not_defer(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=49)
+        assert not ds._push_probes_deferred
+
+    def test_long_period_deployment_not_stale_by_its_own_window(self):
+        # Entries 60s old are fresh for a deployment whose configured window
+        # exceeds that (cursor review: the verdict must use the deployment's
+        # own period, not the default).
+        ds = self._ds(window_s=90.0)
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_stall_stale == 0
+        assert not ds._push_probes_deferred
+
+    def test_defer_is_bounded_per_episode(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_probes_deferred
+        ds._push_stall_since = time.time() - ds_mod.HEALTH_PUSH_STALL_MAX_DEFER_S - 1
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+
+    def test_recovery_clears_the_episode(self):
+        ds = self._ds()
+        self._tally_and_verdict(ds, n=100, stale_n=100)
+        assert ds._push_probes_deferred
+        ds._push_stall_stale = 0
+        ds._push_stall_total = 100
+        ds._finalize_push_stall_verdict()
+        assert not ds._push_probes_deferred
+        assert ds._push_stall_since is None
+
+    def test_defer_holds_wrapper_probe_gate(self):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._last_applied_push_received_at = 0.0
+        wrapper._last_health_check_time = 0.0  # a probe would fire without the defer
+        assert wrapper._should_start_new_health_check()
+        wrapper.defer_push_fallback_probe(time.time() + 60.0)
+        assert not wrapper._should_start_new_health_check()
+
+    def test_defer_expires_with_the_episode_not_a_window_later(self):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._last_applied_push_received_at = 0.0
+        wrapper._last_health_check_time = 0.0
+        # Deadline already past: the gate opens on the spot, with no freshness
+        # window bolted on after the stall episode's cap.
+        wrapper.defer_push_fallback_probe(time.time() - 0.01)
+        assert wrapper._should_start_new_health_check()
+
+    def test_defer_does_not_discard_a_resolving_probe(self, monkeypatch):
+        wrapper = TestPushedHealth()._wrapper()
+        wrapper._health_check_ref = "probe_ref"
+        wrapper._last_health_check_time = time.time()
+        wrapper.defer_push_fallback_probe(time.time() + 60.0)
+        # Deferral is not an observation, so the drop guard must not treat the
+        # probe as superseded -- during a stall its result is all we have.
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+
+        def _failed(ref):
+            raise ds_mod.RayError()
+
+        monkeypatch.setattr(ds_mod.ray, "get", _failed)
+        assert wrapper.check_health() is True  # first failure, under the threshold
+        assert wrapper._consecutive_health_check_failures == 1
+
+
+class TestPushedHealthReviewRegressions:
+    """Regressions for the agent-review findings on the push-health PR."""
+
+    def test_registry_prune_is_rate_limited(self):
+        r = ReplicaHealthPushRegistry()
+        r._PRUNE_THRESHOLD = 2
+        now = time.time()
+        r._state = {f"old{i}": (1.0, now - 1e4, True, None) for i in range(3)}
+        r.record("fresh1", now, True)
+        assert "old0" not in r._state  # over threshold -> pruned
+        r._state.update({f"old{i}": (1.0, now - 1e4, True, None) for i in range(3)})
+        r.record("fresh2", now + 1.0, True)
+        # Within _PRUNE_MIN_INTERVAL_S the O(N) prune must not re-run.
+        assert "old0" in r._state
+
+    def test_gap_stats_track_a_sliding_window(self, monkeypatch):
+        clock = [1000.0]
+        monkeypatch.setattr(time, "time", lambda: clock[0])
+        r = ReplicaHealthPushRegistry()
+        r.record("r1", 100.0, True)
+        r.record("r1", 130.0, True)  # a 30s self-check gap
+        assert r.gap_stats()["max_s"] == 30.0
+        clock[0] += 2 * r._GAP_WINDOW_S  # the window holding it retires
+        stats = r.gap_stats()
+        assert stats["max_s"] == 0.0 and stats["p99_s"] == 0.0
+        assert stats["count"] == 1  # the cumulative counter is unaffected
+
+    def test_in_flight_probe_does_not_overwrite_a_newer_push(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        # A probe is in flight when an unhealthy push lands...
+        w._health_check_ref = "probe_ref"
+        w._last_health_check_time = time.time()
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: False)
+        now = time.time()
+        w.record_pushed_health(now, now, False, 2)
+        assert w.check_health() is True  # applied, still under the threshold
+        assert w._consecutive_health_check_failures == 2
+        # ...and resolves SUCCEEDED afterwards, carrying the older observation.
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        monkeypatch.setattr(ds_mod.ray, "get", lambda r: None)
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 2  # not reset by the stale probe
+
+    def test_in_flight_probe_still_reports_an_actor_crash(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        w._health_check_ref = "probe_ref"
+        w._last_health_check_time = time.time()
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: False)
+        now = time.time()
+        w.record_pushed_health(now, now, True)
+        assert w.check_health() is True
+        # A crash is authoritative even though a healthy push was just applied.
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+
+        def _crashed(ref):
+            raise ds_mod.RayActorError()
+
+        monkeypatch.setattr(ds_mod.ray, "get", _crashed)
+        assert w.check_health() is False
+
+    def test_push_failure_feeds_the_health_check_metrics(self):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        now = time.time()
+        w.record_pushed_health(now, now, False, 1)
+        assert w.check_health() is True  # under the threshold, still counted
+        assert w.last_health_check_failed is True
+        assert w.last_health_check_latency_ms is None  # no controller round trip
+        w.record_pushed_health(now + 1, now + 1, True)
+        assert w.check_health() is True
+        assert w.last_health_check_failed is False
+
+    def test_dropped_probe_is_not_counted_as_a_failure(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        w._health_check_ref = "probe_ref"
+        w._last_health_check_time = time.time()
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: False)
+        now = time.time()
+        w.record_pushed_health(now, now, True)
+        assert w.check_health() is True
+        # The in-flight probe resolves failed, but its result is dropped as stale --
+        # the counter must not see a failure the controller ignored.
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+
+        def _failed(ref):
+            raise ds_mod.RayError()
+
+        monkeypatch.setattr(ds_mod.ray, "get", _failed)
+        assert w.check_health() is True
+        assert not w.last_health_check_failed
+
+    def test_probe_applied_beats_a_push_stashed_before_it(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        now = time.time()
+        w.record_pushed_health(now - 5, now - 5, False, 2)  # stashed first...
+        w._health_check_ref = "probe_ref"
+        w._last_health_check_time = now - 1  # ...before this probe even started
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        monkeypatch.setattr(ds_mod.ray, "get", lambda r: None)
+        assert w.check_health() is True  # ...probe resolves this tick and wins
+        assert w._consecutive_health_check_failures == 0
+        # Next tick the stash must not resurrect the older observation.
+        w._health_check_ref = None
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 0
+
+    def test_probe_gate_follows_arrival_not_consumption(self):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        w._last_health_check_time = 0.0  # a probe would fire but for the push
+        window = ds_mod._push_freshness_window_s(w.health_check_period_s)
+        arrived = time.time() - window + 1.0  # nearly a window old on arrival
+        w.record_pushed_health(arrived, arrived, True)
+        assert w.check_health() is True
+        # Anchored to arrival, so the gate has ~1s left, not a fresh window.
+        assert w._last_applied_push_received_at == arrived
+        assert not w._should_start_new_health_check()
+
+    def test_registry_rejects_out_of_order_reports(self):
+        r = ReplicaHealthPushRegistry()
+        r.record("r1", checked_at=200.0, healthy=True)
+        r.record("r1", checked_at=100.0, healthy=False)  # delayed older report
+        checked_at, _received_at, healthy, _cnt = r.get("r1")
+        assert checked_at == 200.0 and healthy is True
+
+    def test_resolved_probe_does_not_discard_fresh_push(self, monkeypatch):
+        w = TestPushedHealth._wrapper(TestPushedHealth())
+        # An in-flight probe resolves SUCCEEDED this tick...
+        w._health_check_ref = "probe_ref"
+        monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        monkeypatch.setattr(ds_mod.ray, "get", lambda r: None)
+        now = time.time()
+        w.record_pushed_health(now, now, False, 1)
+        assert w.check_health() is True  # probe result wins this tick
+        assert w._pushed_health is not None  # ...but the push stays stashed
+        # Next tick (no probe): the push is consumed.
+        assert w.check_health() is True
+        assert w._consecutive_health_check_failures == 1
+
+
+def test_apply_pushed_health_hands_off_to_wrapper():
+    """DeploymentState routes registry entries to the replica wrapper; absent
+    entries or registry leave the pull path untouched."""
+    ds = DeploymentState.__new__(DeploymentState)
+    ds._health_push_registry = ReplicaHealthPushRegistry()
+    ds._push_probes_deferred = False
+    ds._push_stall_stale = 0
+    ds._push_stall_total = 0
+    ds._push_stall_seen = set()
+    ds._rr_sampled_ids = set()
+    ds._push_stall_window_s = 15.0
+    rep = Mock()
+    rep.replica_id.unique_id = "r1"
+    ds._health_push_registry.record("r1", 123.0, True)
+    DeploymentState._apply_pushed_health(ds, rep)
+    args = rep.record_pushed_health.call_args.args
+    assert args[0] == 123.0 and args[2] is True and args[3] is None
+
+    rep2 = Mock()
+    rep2.replica_id.unique_id = "r2"
+    DeploymentState._apply_pushed_health(ds, rep2)
+    rep2.record_pushed_health.assert_not_called()
+
+    ds._health_push_registry = None
+    DeploymentState._apply_pushed_health(ds, rep2)
+    rep2.record_pushed_health.assert_not_called()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10150,8 +10150,6 @@ class TestRankConsistencyMembershipGate:
     """The rank-consistency pass runs only when replica membership changes."""
 
     def _ds(self, uids):
-        from ray.serve._private.common import DeploymentStatus
-
         ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
         replicas = []
         for uid in uids:
@@ -10163,7 +10161,7 @@ class TestRankConsistencyMembershipGate:
         ds._replicas.count.return_value = 0
         ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
         ds._rank_manager = Mock()
-        ds._rank_manager._last_rank_op_errored = False
+        ds._rank_manager.last_rank_op_errored = False
         ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
         ds._reconfigure_replicas_with_new_ranks = Mock()
         ds._last_rank_membership_ids = None
@@ -10198,7 +10196,7 @@ class TestRankConsistencyMembershipGate:
         # fail_on_rank_error off: the pass can swallow an error and return [].
         # The membership must NOT be cached, so the next tick retries.
         ds = self._ds(["a", "b", "c"])
-        ds._rank_manager._last_rank_op_errored = True
+        ds._rank_manager.last_rank_op_errored = True
         ds._maybe_check_rank_consistency()
         assert ds._last_rank_membership_ids is None
         ds._maybe_check_rank_consistency()
@@ -10207,13 +10205,48 @@ class TestRankConsistencyMembershipGate:
             == 2
         )
         # Once it succeeds, the membership is cached and the pass stops re-running.
-        ds._rank_manager._last_rank_op_errored = False
+        ds._rank_manager.last_rank_op_errored = False
         ds._maybe_check_rank_consistency()
         ds._maybe_check_rank_consistency()
         assert (
             ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
             == 3
         )
+
+    def _real_manager_ds(self, uids, node_id="node-1"):
+        """Gate wired to a real DeploymentRankManager with error-swallowing on (the
+        production default), primed so one active replica has no node mapping -- which
+        trips the consistency impl's `assert node_id is not None`."""
+        ds = self._ds(uids)
+        mgr = ds_mod.DeploymentRankManager(fail_on_rank_error=False)
+        for uid in uids:
+            mgr.assign_rank(uid, node_id)
+        del mgr._replica_to_node[uids[-1]]
+        ds._rank_manager = mgr
+        return ds, mgr
+
+    def test_real_manager_swallowed_error_is_not_cached(self):
+        # RAY_SERVE_FAIL_ON_RANK_ERROR defaults off, so this is the production path:
+        # the pass logs, returns [], and the membership must NOT be cached.
+        ds, mgr = self._real_manager_ds(["a", "b"])
+
+        ds._maybe_check_rank_consistency()
+
+        assert mgr.last_rank_op_errored is True
+        assert ds._last_rank_membership_ids is None
+
+    def test_error_flag_read_before_reconfigure(self):
+        # Guards a latent hazard, not a live bug: today safe_default is [] and the
+        # reconfigure early-returns on an empty list. Stub it to call back into the
+        # manager -- get_replica_rank() clears the flag, so reading it after the
+        # reconfigure would see False and wrongly cache an unvalidated membership.
+        ds, mgr = self._real_manager_ds(["a", "b"])
+        ds._reconfigure_replicas_with_new_ranks = lambda _: mgr.get_replica_rank("a")
+
+        ds._maybe_check_rank_consistency()
+
+        assert mgr.last_rank_op_errored is False  # cleared by the reconfigure call
+        assert ds._last_rank_membership_ids is None  # ...yet still not cached
 
     def test_starting_replicas_skip_entirely(self):
         ds = self._ds(["a", "b"])

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -391,6 +391,39 @@ class TestReplicaStateContainer:
             states=[ReplicaState.STOPPING],
         ) == [r1]
 
+    def test_membership_fingerprint_ignores_rebucketing_churn(self):
+        """The health and migration passes pop a whole bucket and re-add it every
+        tick. Only a real change of the {replica id -> state} content may show up."""
+        c = ReplicaStateContainer()
+        r1, r2 = replica(deployment_version("1")), replica(deployment_version("1"))
+        c.add(ReplicaState.RUNNING, r1)
+        c.add(ReplicaState.RUNNING, r2)
+        settled = c.membership_fingerprint
+
+        # The migration pass: pop the bucket, re-add each replica to the state it
+        # came from. Order within a bucket is not membership.
+        for r in reversed(c.pop(states=[ReplicaState.RUNNING])):
+            c.add(ReplicaState.RUNNING, r)
+        assert c.membership_fingerprint == settled
+
+        # The in-place health path re-buckets a single replica: remove + re-add.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.RUNNING, r1)
+        assert c.membership_fingerprint == settled
+
+        # A real state transition, an arrival and a departure each change it.
+        c.remove({r1.replica_id})
+        c.add(ReplicaState.STOPPING, r1)
+        transitioned = c.membership_fingerprint
+        assert transitioned != settled
+
+        c.add(ReplicaState.RUNNING, replica(deployment_version("1")))
+        arrived = c.membership_fingerprint
+        assert arrived not in (settled, transitioned)
+
+        c.remove({r2.replica_id})
+        assert c.membership_fingerprint not in (settled, transitioned, arrived)
+
 
 def _mock_deployment_actor_wrapper(deployment_id, code_version: str, name: str):
     """Create a MockDeploymentActorWrapper for container tests."""
@@ -10180,6 +10213,9 @@ class CountingRankManager(ds_mod.DeploymentRankManager):
     instances = []
 
     def __init__(self, *args, **kwargs):
+        # The swallow-and-retry path under test only exists when errors are swallowed
+        # (the production default); four CI variants of this file set the env flag to 1.
+        kwargs["fail_on_rank_error"] = False
         super().__init__(*args, **kwargs)
         self.consistency_calls = 0
         self.raise_next = False
@@ -10283,6 +10319,151 @@ class TestRankConsistencyMembershipGate:
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
         assert ds._rank_manager.consistency_calls == 0
+
+    def test_draining_elsewhere_does_not_rerun_the_pass(
+        self, rank_gate_dsm, mock_deployment_state_manager
+    ):
+        """A node draining elsewhere in the cluster churns the buckets every tick
+        without changing membership; the O(N) pass must still be gated off."""
+        dsm, ds, rank_manager, _ = rank_gate_dsm
+        _, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+        node = NodeID.from_random().hex()
+        cluster_node_info_cache.add_node(node)
+        before = rank_manager.consistency_calls
+
+        cluster_node_info_cache.draining_nodes = {node: 60 * 1000}
+        for _ in range(5):
+            dsm.update()
+            # The gate's first guard is HEALTHY: a status flip would make this
+            # pass for the wrong reason.
+            assert ds._curr_status_info.status == DeploymentStatus.HEALTHY
+        assert rank_manager.consistency_calls == before
+
+
+def test_steady_state_ticks_do_not_change_the_fingerprint(
+    mock_deployment_state_manager,
+):
+    """The memo's whole value: an idle tick must not mutate the container."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=8, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    dsm.save_checkpoint()
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=8, by_state=[(ReplicaState.RUNNING, 8, v)])
+    for _ in range(3):
+        dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(20):
+        dsm.update()
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+
+
+def test_draining_elsewhere_does_not_invalidate_the_memo(
+    mock_deployment_state_manager,
+):
+    """A node draining elsewhere in the cluster makes the migration pass pop the
+    whole RUNNING bucket and re-add it every tick, membership unchanged."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    node, draining_node = NodeID.from_random().hex(), NodeID.from_random().hex()
+    cluster_node_info_cache.add_node(node)
+    cluster_node_info_cache.add_node(draining_node)
+    dsm = create_dsm()
+    info, v = deployment_info(num_replicas=4, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._get_deployment_state_for_testing(TEST_DEPLOYMENT_ID)
+    dsm.update()
+    for r in ds._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_node_id(node)
+        r._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+    # None of these replicas is on the draining node, so none of them moves.
+    cluster_node_info_cache.draining_nodes = {draining_node: 60 * 1000}
+    dsm.update()
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    # The controller and proxy read the manager-level getters, which key on the
+    # per-deployment tokens.
+    dsm_alive, dsm_nodes = dsm.get_alive_replica_actor_ids(), dsm.get_active_node_ids()
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list, so this witnesses the churn the test
+        # is about -- without it the assertions below could pass vacuously.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+        assert dsm.get_alive_replica_actor_ids() is dsm_alive
+        assert dsm.get_active_node_ids() is dsm_nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+
+
+def test_gang_health_churn_does_not_invalidate_the_memo(mock_deployment_state_manager):
+    """Gang deployments health-check through the pop-and-re-add path, so their
+    buckets churn on every tick with membership unchanged."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    deployment_id = DeploymentID(name="gang_memo", app_name="app")
+    info, v = deployment_info(
+        num_replicas=4,
+        version="v1",
+        gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+    )
+    dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+        return_value={
+            deployment_id: GangReservationResult(
+                success=True,
+                gang_pgs=[Mock(name="pg-0"), Mock(name="pg-1")],
+                gang_ids=["g0", "g1"],
+                gang_pg_names=["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"],
+            )
+        }
+    )
+    dsm.deploy(deployment_id, info)
+    ds = dsm._get_deployment_state_for_testing(deployment_id)
+    dsm.update()
+    for replica in ds._replicas.get([ReplicaState.STARTING]):
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
+    assert ds._is_gang_deployment, "the churn path under test is the gang one"
+
+    fp0 = ds._replicas.membership_fingerprint
+    alive, running, nodes = (
+        ds.get_alive_replica_actor_ids(),
+        ds.get_running_replica_ids(),
+        ds.get_active_node_ids(),
+    )
+    for _ in range(10):
+        bucket = ds._replicas._replicas[ReplicaState.RUNNING]
+        dsm.update()
+        # pop() installs a fresh bucket list: the churn is real, not assumed.
+        assert ds._replicas._replicas[ReplicaState.RUNNING] is not bucket
+        assert ds._replicas.membership_fingerprint == fp0
+        assert ds.get_alive_replica_actor_ids() is alive
+        assert ds.get_running_replica_ids() is running
+        assert ds.get_active_node_ids() is nodes
+    check_counts(ds, total=4, by_state=[(ReplicaState.RUNNING, 4, v)])
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10146,5 +10146,60 @@ def test_dirty_set_gauge_prunes_ids_no_longer_running(
     assert ds._last_health_check_healthy_replica_ids == running_ids
 
 
+class TestRankConsistencyMembershipGate:
+    """The rank-consistency pass runs only when replica membership changes."""
+
+    def _ds(self, uids):
+        from ray.serve._private.common import DeploymentStatus
+
+        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
+        replicas = []
+        for uid in uids:
+            r = Mock()
+            r.replica_id.unique_id = uid
+            replicas.append(r)
+        ds._replicas = Mock()
+        ds._replicas.get.return_value = replicas
+        ds._replicas.count.return_value = 0
+        ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
+        ds._rank_manager = Mock()
+        ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
+        ds._reconfigure_replicas_with_new_ranks = Mock()
+        ds._last_rank_membership_fingerprint = None
+        return ds
+
+    def test_runs_once_then_skips_for_same_membership(self):
+        ds = self._ds(["a", "b", "c"])
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 1
+        )
+
+    def test_membership_change_reruns(self):
+        ds = self._ds(["a", "b", "c"])
+        ds._maybe_check_rank_consistency()
+        new = []
+        for uid in ["a", "b", "d"]:
+            r = Mock()
+            r.replica_id.unique_id = uid
+            new.append(r)
+        ds._replicas.get.return_value = new
+        ds._maybe_check_rank_consistency()
+        assert (
+            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
+            == 2
+        )
+
+    def test_starting_replicas_skip_entirely(self):
+        ds = self._ds(["a", "b"])
+        ds._replicas.count.return_value = 1
+        ds._maybe_check_rank_consistency()
+        ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
+        assert ds._last_rank_membership_fingerprint is None
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10203,7 +10203,7 @@ def rank_gate_dsm(mock_deployment_state_manager, monkeypatch):
     CountingRankManager.instances = []
     monkeypatch.setattr(ds_mod, "DeploymentRankManager", CountingRankManager)
 
-    create_dsm, _, _, _ = mock_deployment_state_manager
+    create_dsm, timer, _, _ = mock_deployment_state_manager
     dsm: DeploymentStateManager = create_dsm()
     info, v1 = deployment_info(num_replicas=3, version="1")
     assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
@@ -10223,21 +10223,21 @@ def rank_gate_dsm(mock_deployment_state_manager, monkeypatch):
     assert (
         ds._rank_manager.consistency_calls >= 1
     ), "gate never ran for a new membership"
-    return dsm, ds, ds._rank_manager
+    return dsm, ds, ds._rank_manager, timer
 
 
 class TestRankConsistencyMembershipGate:
     """The rank-consistency pass runs only when replica membership changes."""
 
     def test_skips_while_membership_unchanged(self, rank_gate_dsm):
-        dsm, _, rank_manager = rank_gate_dsm
+        dsm, _, rank_manager, _ = rank_gate_dsm
         after_startup = rank_manager.consistency_calls
         for _ in range(5):
             dsm.update()
         assert rank_manager.consistency_calls == after_startup
 
     def test_reruns_when_a_replica_leaves(self, rank_gate_dsm):
-        dsm, ds, rank_manager = rank_gate_dsm
+        dsm, ds, rank_manager, timer = rank_gate_dsm
         before = rank_manager.consistency_calls
 
         # Membership change through the public path: scale up adds a new replica id.
@@ -10248,7 +10248,7 @@ class TestRankConsistencyMembershipGate:
     def test_swallowed_error_is_rechecked_next_tick(self, rank_gate_dsm):
         """fail_on_rank_error is off by default in production, so the pass can log and
         return a safe default. That membership must not be cached as validated."""
-        dsm, ds, rank_manager = rank_gate_dsm
+        dsm, ds, rank_manager, timer = rank_gate_dsm
 
         # Membership change makes the gate run; that run errors and is swallowed.
         rank_manager.raise_next = True
@@ -10256,10 +10256,14 @@ class TestRankConsistencyMembershipGate:
         errored_at = rank_manager.consistency_calls
         assert errored_at > 0, "the errored pass never ran"
 
-        # An errored pass must not be cached as validated, so it is retried even though
-        # membership is now stable.
+        # Rate-limited: the same membership is not re-run immediately...
         for _ in range(4):
             dsm.update()
+        assert rank_manager.consistency_calls == errored_at
+
+        # ...but it is not cached either, so it is retried once the backoff elapses.
+        timer.advance(ds_mod._RANK_ERROR_RETRY_S + 1)
+        dsm.update()
         assert rank_manager.consistency_calls > errored_at
 
     def test_starting_replicas_skip_the_pass(

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10146,114 +10146,139 @@ def test_dirty_set_gauge_prunes_ids_no_longer_running(
     assert ds._last_health_check_healthy_replica_ids == running_ids
 
 
+def _scale_to(dsm, ds, num_replicas, version="1", ticks=14):
+    """Change membership via the public deploy path and settle back to HEALTHY."""
+    info, _ = deployment_info(num_replicas=num_replicas, version=version)
+    dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    for _ in range(ticks):
+        dsm.update()
+        for replica in ds._replicas.get([ReplicaState.STARTING]):
+            replica._actor.set_ready()
+        if (
+            ds._curr_status_info.status == DeploymentStatus.HEALTHY
+            and ds._replicas.count(states=[ReplicaState.STARTING]) == 0
+        ):
+            dsm.update()
+            return
+    raise AssertionError(
+        "deployment never settled: status=%s running=%d starting=%d"
+        % (
+            ds._curr_status_info.status,
+            ds._replicas.count(states=[ReplicaState.RUNNING]),
+            ds._replicas.count(states=[ReplicaState.STARTING]),
+        )
+    )
+
+
+class CountingRankManager(ds_mod.DeploymentRankManager):
+    """Real rank manager that records how often the consistency pass runs.
+
+    Injected at the same seam the fixture uses for actor wrappers, so the rank logic under
+    test stays real; only the call count is added.
+    """
+
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.consistency_calls = 0
+        self.raise_next = False
+        CountingRankManager.instances.append(self)
+
+    def check_rank_consistency_and_reassign_minimally(self, active_replicas):
+        self.consistency_calls += 1
+        if self.raise_next:
+            self.raise_next = False
+            # Same shape as a real invariant violation: swallowed when
+            # fail_on_rank_error is off (the production default).
+            return self._execute_with_error_handling(
+                lambda: (_ for _ in ()).throw(RuntimeError("injected rank failure")), []
+            )
+        return super().check_rank_consistency_and_reassign_minimally(active_replicas)
+
+
+@pytest.fixture
+def rank_gate_dsm(mock_deployment_state_manager, monkeypatch):
+    """A running deployment whose rank manager counts consistency passes."""
+    CountingRankManager.instances = []
+    monkeypatch.setattr(ds_mod, "DeploymentRankManager", CountingRankManager)
+
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+    info, v1 = deployment_info(num_replicas=3, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_ready()
+    dsm.update()  # STARTING -> RUNNING
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v1)])
+
+    # Settle: the deployment reaches HEALTHY a tick or two after the replicas do, and the
+    # gate legitimately runs once for this membership. Tests measure from after that.
+    for _ in range(8):
+        dsm.update()
+    assert ds._curr_status_info.status == DeploymentStatus.HEALTHY
+    assert (
+        ds._rank_manager.consistency_calls >= 1
+    ), "gate never ran for a new membership"
+    return dsm, ds, ds._rank_manager
+
+
 class TestRankConsistencyMembershipGate:
     """The rank-consistency pass runs only when replica membership changes."""
 
-    def _ds(self, uids):
-        ds = ds_mod.DeploymentState.__new__(ds_mod.DeploymentState)
-        replicas = []
-        for uid in uids:
-            r = Mock()
-            r.replica_id.unique_id = uid
-            replicas.append(r)
-        ds._replicas = Mock()
-        ds._replicas.get.return_value = replicas
-        ds._replicas.count.return_value = 0
-        ds._curr_status_info = Mock(status=DeploymentStatus.HEALTHY)
-        ds._rank_manager = Mock()
-        ds._rank_manager.last_rank_op_errored = False
-        ds._rank_manager.check_rank_consistency_and_reassign_minimally.return_value = []
-        ds._reconfigure_replicas_with_new_ranks = Mock()
-        ds._last_rank_membership_ids = None
-        return ds
+    def test_skips_while_membership_unchanged(self, rank_gate_dsm):
+        dsm, _, rank_manager = rank_gate_dsm
+        after_startup = rank_manager.consistency_calls
+        for _ in range(5):
+            dsm.update()
+        assert rank_manager.consistency_calls == after_startup
 
-    def test_runs_once_then_skips_for_same_membership(self):
-        ds = self._ds(["a", "b", "c"])
-        ds._maybe_check_rank_consistency()
-        ds._maybe_check_rank_consistency()
-        ds._maybe_check_rank_consistency()
-        assert (
-            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
-            == 1
-        )
+    def test_reruns_when_a_replica_leaves(self, rank_gate_dsm):
+        dsm, ds, rank_manager = rank_gate_dsm
+        before = rank_manager.consistency_calls
 
-    def test_membership_change_reruns(self):
-        ds = self._ds(["a", "b", "c"])
-        ds._maybe_check_rank_consistency()
-        new = []
-        for uid in ["a", "b", "d"]:
-            r = Mock()
-            r.replica_id.unique_id = uid
-            new.append(r)
-        ds._replicas.get.return_value = new
-        ds._maybe_check_rank_consistency()
-        assert (
-            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
-            == 2
-        )
+        # Membership change through the public path: scale up adds a new replica id.
+        _scale_to(dsm, ds, 4)
 
-    def test_swallowed_rank_error_reruns_next_tick(self):
-        # fail_on_rank_error off: the pass can swallow an error and return [].
-        # The membership must NOT be cached, so the next tick retries.
-        ds = self._ds(["a", "b", "c"])
-        ds._rank_manager.last_rank_op_errored = True
-        ds._maybe_check_rank_consistency()
-        assert ds._last_rank_membership_ids is None
-        ds._maybe_check_rank_consistency()
-        assert (
-            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
-            == 2
-        )
-        # Once it succeeds, the membership is cached and the pass stops re-running.
-        ds._rank_manager.last_rank_op_errored = False
-        ds._maybe_check_rank_consistency()
-        ds._maybe_check_rank_consistency()
-        assert (
-            ds._rank_manager.check_rank_consistency_and_reassign_minimally.call_count
-            == 3
-        )
+        assert rank_manager.consistency_calls > before
 
-    def _real_manager_ds(self, uids, node_id="node-1"):
-        """Gate wired to a real DeploymentRankManager with error-swallowing on (the
-        production default), primed so one active replica has no node mapping -- which
-        trips the consistency impl's `assert node_id is not None`."""
-        ds = self._ds(uids)
-        mgr = ds_mod.DeploymentRankManager(fail_on_rank_error=False)
-        for uid in uids:
-            mgr.assign_rank(uid, node_id)
-        del mgr._replica_to_node[uids[-1]]
-        ds._rank_manager = mgr
-        return ds, mgr
+    def test_swallowed_error_is_rechecked_next_tick(self, rank_gate_dsm):
+        """fail_on_rank_error is off by default in production, so the pass can log and
+        return a safe default. That membership must not be cached as validated."""
+        dsm, ds, rank_manager = rank_gate_dsm
 
-    def test_real_manager_swallowed_error_is_not_cached(self):
-        # RAY_SERVE_FAIL_ON_RANK_ERROR defaults off, so this is the production path:
-        # the pass logs, returns [], and the membership must NOT be cached.
-        ds, mgr = self._real_manager_ds(["a", "b"])
+        # Membership change makes the gate run; that run errors and is swallowed.
+        rank_manager.raise_next = True
+        _scale_to(dsm, ds, 4)
+        errored_at = rank_manager.consistency_calls
+        assert errored_at > 0, "the errored pass never ran"
 
-        ds._maybe_check_rank_consistency()
+        # An errored pass must not be cached as validated, so it is retried even though
+        # membership is now stable.
+        for _ in range(4):
+            dsm.update()
+        assert rank_manager.consistency_calls > errored_at
 
-        assert mgr.last_rank_op_errored is True
-        assert ds._last_rank_membership_ids is None
+    def test_starting_replicas_skip_the_pass(
+        self, mock_deployment_state_manager, monkeypatch
+    ):
+        """A STARTING replica has no rank yet, so running the pass would raise
+        "active keys without ranks"; the guard must skip before that."""
+        CountingRankManager.instances = []
+        monkeypatch.setattr(ds_mod, "DeploymentRankManager", CountingRankManager)
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        info, _ = deployment_info(num_replicas=2, version="1")
+        assert dsm.deploy(TEST_DEPLOYMENT_ID, info)
+        ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    def test_error_flag_read_before_reconfigure(self):
-        # Guards a latent hazard, not a live bug: today safe_default is [] and the
-        # reconfigure early-returns on an empty list. Stub it to call back into the
-        # manager -- get_replica_rank() clears the flag, so reading it after the
-        # reconfigure would see False and wrongly cache an unvalidated membership.
-        ds, mgr = self._real_manager_ds(["a", "b"])
-        ds._reconfigure_replicas_with_new_ranks = lambda _: mgr.get_replica_rank("a")
-
-        ds._maybe_check_rank_consistency()
-
-        assert mgr.last_rank_op_errored is False  # cleared by the reconfigure call
-        assert ds._last_rank_membership_ids is None  # ...yet still not cached
-
-    def test_starting_replicas_skip_entirely(self):
-        ds = self._ds(["a", "b"])
-        ds._replicas.count.return_value = 1
-        ds._maybe_check_rank_consistency()
-        ds._rank_manager.check_rank_consistency_and_reassign_minimally.assert_not_called()
-        assert ds._last_rank_membership_ids is None
+        dsm.update()  # replicas are STARTING, never marked ready
+        dsm.update()
+        check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
+        assert ds._rank_manager.consistency_calls == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import time
 
 import pytest
 
@@ -1360,3 +1361,379 @@ class TestCythonImplementationEdgeCases:
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))
+
+
+class TestSelfHealthPush:
+    """The replica-side self-health task stores the local result and heartbeats
+    it to the controller only when metric report pushes are not carrying it."""
+
+    def _manager(self, pushing_reports=False):
+        import threading
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import ReplicaMetricsManager
+
+        m = ReplicaMetricsManager.__new__(ReplicaMetricsManager)
+        m._self_healthy = None
+        m._self_health_checked_at = None
+        m._pushing_metric_reports = pushing_reports
+        m._autoscaling_config = (
+            SimpleNamespace(metrics_interval_s=10.0) if pushing_reports else None
+        )
+        m._self_health_period_s = 10.0
+        m._last_health_carrying_report_s = time.time() if pushing_reports else 0.0
+        m._pending_health_push_ref = None
+        m._pending_push_healthy = True
+        m._last_counted_failure_s = 0.0
+        m._self_consecutive_failures = 0
+        m._metrics_push_lock = threading.Lock()
+        m._controller_handle = Mock()
+        m._replica_id = SimpleNamespace(unique_id="r1")
+        return m
+
+    @pytest.mark.asyncio
+    async def test_healthy_eval_heartbeats(self):
+        m = self._manager()
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is True
+        args = m._controller_handle.record_replica_health.remote.call_args.args
+        assert args[0] == "r1" and args[2] is True
+
+    @pytest.mark.asyncio
+    async def test_failing_eval_heartbeats_unhealthy(self):
+        m = self._manager()
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        assert (
+            m._controller_handle.record_replica_health.remote.call_args.args[2] is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_metric_reports_carry_health(self):
+        m = self._manager(pushing_reports=True)
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        assert m._self_healthy is True
+        m._controller_handle.record_replica_health.remote.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_latches_unhealthy_at_threshold(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+        from ray.serve._private.constants import (
+            REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
+        )
+
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        m = self._manager(pushing_reports=True)
+        evals = []
+
+        async def bad():
+            evals.append(1)
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        for _ in range(REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD + 2):
+            m._last_counted_failure_s -= m._self_health_period_s  # a period on
+            await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        # The user check stops running at the threshold; pushes continue.
+        assert len(evals) == REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_heartbeats_even_when_reports_carry_health(
+        self, monkeypatch
+    ):
+        # reports_carry_health() is true, but an unhealthy result must not be
+        # suppressed -- the controller needs it promptly to replace the replica.
+        import ray.serve._private.replica as replica_mod
+        from ray.serve._private.constants import (
+            REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
+        )
+
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        m = self._manager(pushing_reports=True)
+
+        async def bad():
+            raise RuntimeError("down")
+
+        m._eval_self_health_fn = bad
+        for _ in range(REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD):
+            await m._eval_and_push_self_health()
+        assert m._self_healthy is False
+        m._controller_handle.record_replica_health.remote.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_heartbeats_when_metric_pushes_too_infrequent(self):
+
+        m = self._manager(pushing_reports=True)
+        m._self_health_period_s = 10.0
+        m._last_health_carrying_report_s = time.time() - 30.0  # last report is old
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_called_once()
+
+    def test_self_check_runs_at_half_the_period(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica, ReplicaMetricsManager
+
+        r = Replica.__new__(Replica)
+        r._metrics_manager = Mock()
+        r._deployment_config = SimpleNamespace(
+            health_check_period_s=10.0, health_check_timeout_s=30.0
+        )
+        r._self_health_active = False
+        Replica._start_self_health_pusher(r)
+        args = r._metrics_manager.start_self_health_pusher.call_args.args
+        assert args[1] == 10.0  # the configured period, not the eval cadence
+
+        m = ReplicaMetricsManager.__new__(ReplicaMetricsManager)
+        m._metrics_pusher = Mock()
+        ReplicaMetricsManager.start_self_health_pusher(m, *args)
+        assert m._self_health_period_s == 10.0
+        # The check itself still runs twice per period.
+        assert m._metrics_pusher.register_or_update_task.call_args.args[2] == 5.0
+
+    def test_a_skipped_report_stops_suppressing_the_heartbeat(self):
+        """Regression: suppression used to be inferred from the configured interval,
+        so a report the replica never sent still silenced the heartbeat."""
+        m = self._manager(pushing_reports=True)
+        assert m.reports_carry_health()  # a report carried health just now
+        # The next report is dropped because the previous one is still in flight,
+        # so nothing carries health and the heartbeat has to take over.
+        m._last_health_carrying_report_s = time.time() - m._self_health_period_s
+        assert not m.reports_carry_health()
+
+    def test_registry_tracks_self_check_intervals(self):
+        from ray.serve._private.deployment_state import ReplicaHealthPushRegistry
+
+        r = ReplicaHealthPushRegistry()
+        t0 = 1000.0
+        for i in range(10):
+            r.record("r1", t0 + i * 5.0, True)
+        stats = r.gap_stats()
+        assert stats["count"] == 9
+        assert 4.75 <= stats["p99_s"] <= 5.25
+        assert stats["max_s"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_bypasses_an_in_flight_heartbeat(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        m = self._manager()
+        # A healthy heartbeat the lagging controller has not accepted yet.
+        m._pending_health_push_ref = "in_flight"
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: False)
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        await m._eval_and_push_self_health()
+        args = m._controller_handle.record_replica_health.remote.call_args.args
+        assert args[2] is False  # the change went out anyway
+
+    @pytest.mark.asyncio
+    async def test_repeat_unhealthy_does_not_pile_up_heartbeats(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        m = self._manager()
+        m._pending_health_push_ref = "in_flight"
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: False)
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        # The edge is worth one heartbeat; everything after it waits, so a wedged
+        # controller sees at most one extra in-flight push per replica.
+        await m._eval_and_push_self_health()
+        await m._eval_and_push_self_health()
+        await m._eval_and_push_self_health()
+        assert m._controller_handle.record_replica_health.remote.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_count_advances_once_per_period(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: True)
+        m = self._manager()
+        m._self_health_period_s = 10.0
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        await m._eval_and_push_self_health()
+        assert m._self_consecutive_failures == 1
+        # The next eval is half a period later: too soon to count again, or the
+        # replica reaches the threshold in half the wall clock asked for.
+        await m._eval_and_push_self_health()
+        assert m._self_consecutive_failures == 1
+        m._last_counted_failure_s -= 10.0  # a full period on
+        await m._eval_and_push_self_health()
+        assert m._self_consecutive_failures == 2
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_with_nothing_in_flight_sends_once(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        m = self._manager()  # nothing outstanding: this send is not a bypass
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: False)
+
+        async def bad():
+            raise RuntimeError("intended to fail")
+
+        m._eval_self_health_fn = bad
+        await m._eval_and_push_self_health()
+        await m._eval_and_push_self_health()
+        # The second must not fire: the heartbeat already in flight says unhealthy.
+        assert m._controller_handle.record_replica_health.remote.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_initial_check_is_fresh_not_the_self_health_cache(self):
+        """Controller recovery re-enters initialize() while the self-health task
+        runs; reading its cache there would fail a live replica."""
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica
+
+        r = Replica.__new__(Replica)
+        r._health_check_lock = asyncio.Lock()
+        r._self_health_active = True  # recovery: the task is already running...
+        r._self_health_evaluated = True
+        r._self_health_evaluated_at = time.time()
+        r._deployment_config = SimpleNamespace(health_check_period_s=10.0)
+        r._healthy = False  # ...and its most recent result was a failure
+        r._last_self_health_error = "transient"
+        calls = []
+
+        async def passes():
+            calls.append(1)
+
+        r._user_callable_wrapper = Mock()
+        r._user_callable_wrapper.call_user_health_check.return_value = passes()
+        # The cached read is what initialize() must not do.
+        with pytest.raises(RuntimeError):
+            await Replica.check_health(r)
+        assert not calls
+        # A fresh evaluation is what it does instead, and this replica is fine.
+        await Replica._run_user_health_check(r)
+        assert calls and r._healthy is True
+
+    @pytest.mark.asyncio
+    async def test_stale_cached_health_falls_through_to_a_real_check(self):
+        """A hung self-check stops refreshing the cache; the probe is then the only
+        thing that can notice, so it must not keep serving the old answer."""
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica
+
+        r = Replica.__new__(Replica)
+        r._health_check_lock = asyncio.Lock()
+        r._self_health_active = True
+        r._self_health_evaluated = True
+        r._healthy = True  # the last evaluation passed...
+        r._deployment_config = SimpleNamespace(health_check_period_s=10.0)
+        r._self_health_evaluated_at = time.time()
+        calls = []
+
+        async def passes():
+            calls.append(1)
+
+        r._user_callable_wrapper = Mock()
+        r._user_callable_wrapper.call_user_health_check.side_effect = lambda: passes()
+        await Replica.check_health(r)
+        assert not calls  # ...and while it is current it is served as-is
+        r._self_health_evaluated_at = time.time() - 11.0  # a period on, no refresh
+        await Replica.check_health(r)
+        assert calls  # the probe re-runs the check itself
+
+    @pytest.mark.asyncio
+    async def test_latched_unhealthy_cache_does_not_expire(self):
+        """The task stops evaluating at the threshold, so expiring its verdict would
+        re-run the check and flap against the pushes still reporting unhealthy."""
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica
+
+        r = Replica.__new__(Replica)
+        r._health_check_lock = asyncio.Lock()
+        r._self_health_active = True
+        r._self_health_evaluated = True
+        r._healthy = False  # latched: the task no longer refreshes this
+        r._last_self_health_error = "latched"
+        r._deployment_config = SimpleNamespace(health_check_period_s=10.0)
+        r._self_health_evaluated_at = time.time() - 60.0  # long past the period
+        calls = []
+        r._user_callable_wrapper = Mock()
+        r._user_callable_wrapper.call_user_health_check.side_effect = (
+            lambda: calls.append(1)
+        )
+        with pytest.raises(RuntimeError):
+            await Replica.check_health(r)
+        assert not calls  # the latch holds; the user check is not re-run
+
+    @pytest.mark.asyncio
+    async def test_timed_out_check_marks_cached_health_unhealthy(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from ray.serve._private.replica import Replica
+
+        r = Replica.__new__(Replica)
+        r._health_check_lock = asyncio.Lock()
+        r._healthy = True
+        r._last_self_health_error = None
+        r._self_health_evaluated = False
+        r._self_health_evaluated_at = 0.0
+        r._deployment_config = SimpleNamespace(health_check_period_s=10.0)
+        r._self_health_active = True
+        r._user_callable_wrapper = Mock()
+        r._user_callable_wrapper.call_user_health_check.return_value = (
+            asyncio.get_running_loop().create_future()
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(Replica._run_user_health_check(r), timeout=0.05)
+        assert r._healthy is False
+        # The pull fallback must not answer healthy for a wedged check.
+        with pytest.raises(RuntimeError):
+            await Replica.check_health(r)
+
+    @pytest.mark.asyncio
+    async def test_in_flight_heartbeat_skips_next(self, monkeypatch):
+        import ray.serve._private.replica as replica_mod
+
+        m = self._manager()
+        m._pending_health_push_ref = "in_flight"
+        monkeypatch.setattr(replica_mod, "check_obj_ref_ready_nowait", lambda r: False)
+
+        async def ok():
+            return None
+
+        m._eval_self_health_fn = ok
+        await m._eval_and_push_self_health()
+        m._controller_handle.record_replica_health.remote.assert_not_called()


### PR DESCRIPTION
## [serve] Push-based replica health: replicas self-check and report over existing channels

### Why
Pull health checking makes the controller the initiator: every health-check
period it schedules an actor call per replica, awaits the results, and tracks
the in-flight refs. Actor-call submission alone is ~0.5 ms of GIL-bound work, so
at 10K+ replicas the controller spends whole ticks just *asking* — and under
load the checks arrive late, which reads as replica failure when it is really
controller lag.

This PR inverts the direction. Replicas already know their own health — they run
the user's `check_health` locally — and most of them already send the controller
a periodic message (the autoscaling metric report). So: replicas self-check on
their own clock and the result rides messages that already flow. For a
metric-reporting replica the incremental cost of health is **three fields on an
existing report**; only non-reporting replicas fall back to a lightweight
heartbeat RPC (deduplicated, at most one in flight).

### What
**Replica side**
- A periodic self-health task evaluates the user health check at **half the
  configured period** (so results are always fresh within one period despite
  scheduling jitter) and latches at the unhealthy threshold — the user check
  stops re-running, unhealthy keeps being reported; parity with pull probes.
- Remote `check_health` calls serve the cached result while the task is active:
  concurrent probes can no longer re-run a user health check.
- `ReplicaMetricReport` carries (healthy, checked_at, consecutive_failures);
  when the metric cadence is slower than the health period, the heartbeat fills
  the gap so freshness never lapses.

**Controller side**
- A push registry keeps the newest entry per replica (out-of-order arrivals
  resolved by `checked_at`) and exposes self-check interval stats
  (p50/p99/max) on the controller health metrics.
- During the reconcile sweep, pushed entries are handed to the replica wrapper:
  a fresh push substitutes for scheduling a pull probe; the pull path remains,
  untouched, as the fallback for replicas whose push has gone stale (1.5× the
  health-check period).

**The stall guard**
When *most* of a deployment's pushes go stale simultaneously, the cause is
controller-side ingest lag, not mass replica failure — and probing thousands of
"stale" replicas at once drowns the already-lagging controller (we reproduced
this spiral at 16K). If ≥50% of ≥64 tracked replicas are stale in one sweep, the
sweep defers fallback probes, bounded at 120 s per episode so a genuine mass
outage still falls through to probes. Actor death detection (GCS) is unaffected
by the guard and remains immediate.

### Behavior changes
- Health-check freshness becomes replica-driven; detection latency for a hung
  replica is bounded by the freshness window + probe time (and by the 120 s
  episode cap while a stall verdict is active).
- No API or config changes; existing knobs (`health_check_period_s`,
  `health_check_timeout_s`, unhealthy threshold) keep their meanings.

### Testing
- Registry: newest-wins on out-of-order reports, gap statistics.
- Pusher: half-period scheduling, unhealthy latch, heartbeat suppression when
  reports carry health, in-flight heartbeat dedup.
- Controller: pushed-health handoff to wrappers, probe-result precedence when a
  probe resolves in the same tick (push stashed, consumed next tick), stall
  verdict engage/disengage and probe deferral.
- `test_deployment_state.py` + `test_metrics_utils.py` + `test_autoscaling_policy.py`
  green on this tier (364 tests).

### Benchmarks
Full-stack results (this PR + #<P2-number> + #<P3-number>): 8K replicas — health
freshness misses its deadline 23 times in 1.09M updates (pull baseline: 93.5%
missed); 16K — first clean completion on this harness, 0.55% misses. This PR's
isolated contribution (base vs P1-only arms, same harness) is being measured and
lands here before review.
<img width="1248" height="728" alt="perf_P1_loop_haproxy_on" src="https://github.com/user-attachments/assets/14dac367-b07a-4d79-acad-36350a95cc28" />
