### PR TITLE
[Serve] Add optional tie break key to best fit node scheduling

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -592,15 +592,20 @@ class DeploymentScheduler(ABC):
         self,
         required_resources: RequestedResources,
         available_resources: Dict[str, AvailableNodeResources],
+        tie_break_key: Optional[Callable[[str], Any]] = None,
     ) -> Optional[str]:
         """Chooses a node using best fit strategy.
 
         This strategy picks the node where, if the required resources
         were to be scheduled on that node, it will leave the smallest
         remaining space. This minimizes fragmentation of resources.
+
+        If multiple nodes tie on remaining space and `tie_break_key` is
+        provided, the node with the smallest `tie_break_key` value wins.
         """
 
         min_remaining_space = None
+        min_tie_break = None
         chosen_node = None
 
         for node_id in available_resources:
@@ -610,8 +615,18 @@ class DeploymentScheduler(ABC):
             # TODO(zcin): We can make this better by only considering
             # custom resources that required_resources has.
             remaining_space = available_resources[node_id] - required_resources
+            tie_break = tie_break_key(node_id) if tie_break_key else None
+
             if min_remaining_space is None or remaining_space < min_remaining_space:
                 min_remaining_space = remaining_space
+                min_tie_break = tie_break
+                chosen_node = node_id
+            elif (
+                tie_break_key is not None
+                and remaining_space == min_remaining_space
+                and tie_break < min_tie_break
+            ):
+                min_tie_break = tie_break
                 chosen_node = node_id
 
         return chosen_node

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -604,8 +604,7 @@ class DeploymentScheduler(ABC):
         provided, the node with the smallest `tie_break_key` value wins.
         """
 
-        min_remaining_space = None
-        min_tie_break = None
+        min_key = None
         chosen_node = None
 
         for node_id in available_resources:
@@ -615,18 +614,15 @@ class DeploymentScheduler(ABC):
             # TODO(zcin): We can make this better by only considering
             # custom resources that required_resources has.
             remaining_space = available_resources[node_id] - required_resources
-            tie_break = tie_break_key(node_id) if tie_break_key else None
+            # Tuple compares remaining space first, then the tie break key only on a tie.
+            current_key = (
+                (remaining_space, tie_break_key(node_id))
+                if tie_break_key
+                else (remaining_space,)
+            )
 
-            if min_remaining_space is None or remaining_space < min_remaining_space:
-                min_remaining_space = remaining_space
-                min_tie_break = tie_break
-                chosen_node = node_id
-            elif (
-                tie_break_key is not None
-                and remaining_space == min_remaining_space
-                and tie_break < min_tie_break
-            ):
-                min_tie_break = tie_break
+            if min_key is None or current_key < min_key:
+                min_key = current_key
                 chosen_node = node_id
 
         return chosen_node

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -566,6 +566,51 @@ def test_best_fit_node():
         Resources.CUSTOM_PRIORITY = original
 
 
+def test_best_fit_node_tie_break_key():
+    """Test that _best_fit_node uses tie_break_key only to break ties."""
+
+    scheduler = default_impl.create_deployment_scheduler(
+        MockClusterNodeInfoCache(),
+        head_node_id_override="fake-head-node-id",
+        create_placement_group_fn_override=None,
+    )
+
+    required_resources = RequestedResources(CPU=1)
+    tie_break_key = {"node1": 5, "node2": 1, "node3": 3}.get
+
+    # All nodes leave identical remaining space, so the smallest key wins.
+    assert "node2" == scheduler._best_fit_node(
+        required_resources=required_resources,
+        available_resources={
+            "node1": AvailableNodeResources(CPU=3),
+            "node2": AvailableNodeResources(CPU=3),
+            "node3": AvailableNodeResources(CPU=3),
+        },
+        tie_break_key=tie_break_key,
+    )
+
+    # Best fit dominates: node1 leaves less space and wins despite the largest key.
+    assert "node1" == scheduler._best_fit_node(
+        required_resources=required_resources,
+        available_resources={
+            "node1": AvailableNodeResources(CPU=2),
+            "node2": AvailableNodeResources(CPU=3),
+            "node3": AvailableNodeResources(CPU=3),
+        },
+        tie_break_key=tie_break_key,
+    )
+
+    # An equal key keeps the first node seen; the tie break only wins if strictly smaller.
+    assert "node1" == scheduler._best_fit_node(
+        required_resources=required_resources,
+        available_resources={
+            "node1": AvailableNodeResources(CPU=3),
+            "node2": AvailableNodeResources(CPU=3),
+        },
+        tie_break_key=lambda node_id: 0,
+    )
+
+
 def test_schedule_replica():
     """Test DeploymentScheduler._schedule_replica()"""
 


### PR DESCRIPTION
## What

- Add an optional `tie_break_key: Optional[Callable[[str], Any]]` to `_best_fit_node` so the smallest key wins when nodes tie on remaining space.

## Why

- Best fit leaves ties unordered, so they currently resolve by dict iteration order.
- A tie break key lets callers add a secondary preference without changing fit quality.
- Best fit still dominates because the key is consulted only on an exact tie.

## Changes

- `python/ray/serve/_private/deployment_scheduler.py`: `_best_fit_node` gains `tie_break_key=None` and keeps its original behavior when the argument is omitted.

## Tests

- `test_best_fit_node_tie_break_key` checks that the smallest key wins on a tie, that best fit dominates the key, and that an equal key keeps the first node seen.
