### PR TITLE
[Serve] Add dependency ordered shutdown for deployments

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1027,12 +1027,15 @@ class ApplicationState:
                 or target_state_changed
             )
 
-        # Delete outdated deployments
-        for deployment_name in self._get_live_deployments():
-            if deployment_name not in self.target_deployments:
-                target_state_changed = (
-                    self._delete_deployment(deployment_name) or target_state_changed
-                )
+        # Delete outdated deployments. Skipped during a full instance
+        # shutdown, as it would bypass DeploymentStateManager's own tiered
+        # shutdown order.
+        if not self._deployment_state_manager.is_shutting_down():
+            for deployment_name in self._get_live_deployments():
+                if deployment_name not in self.target_deployments:
+                    target_state_changed = (
+                        self._delete_deployment(deployment_name) or target_state_changed
+                    )
 
         return target_state_changed
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -264,6 +264,12 @@ DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S = 20
 DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S = 2
 DEFAULT_HEALTH_CHECK_PERIOD_S = 10
 
+# Dependency ordered shutdown deletes deployments in tiers, callers before
+# callees. This is the max time to wait on a tier before advancing past it.
+RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S = get_env_float_positive(
+    "RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S", 30.0
+)
+
 # Dirty-set health-check reconcile: each control tick polls only replicas with an
 # in-flight check plus a round-robin slice, so a tick costs O(slice) instead of O(N).
 # CONTROLLER_HEALTH_CHECK_RECONCILIATION_FRACTION is how long one full sweep takes as a fraction of the

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -6074,6 +6074,10 @@ class DeploymentStateManager:
         """
         return self._shutting_down and len(self._deployment_states) == 0
 
+    def is_shutting_down(self) -> bool:
+        """Whether a full instance shutdown is in progress."""
+        return self._shutting_down
+
     def delete_checkpoint(self) -> None:
         """Delete the deployment state checkpoint from KV store."""
         self._kv_store.delete(CHECKPOINT_KEY)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -65,6 +65,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
     RAY_SERVE_RETAINED_DEAD_REPLICAS,
+    RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
     REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
@@ -5755,6 +5756,11 @@ class DeploymentStateManager:
 
         self._shutting_down = False
 
+        # Dependency ordered shutdown state.
+        self._shutdown_tiers: Optional[List[List[DeploymentID]]] = None
+        self._shutdown_tier_idx: int = 0
+        self._shutdown_tier_started_at: Optional[float] = None
+
         self._deployment_states: Dict[DeploymentID, DeploymentState] = {}
         # Monotonic counter bumped whenever an ingress deployment's running-replica
         # set (node/ports included) changes; the controller gates the direct-ingress port
@@ -5952,16 +5958,114 @@ class DeploymentStateManager:
         Shutdown all running replicas by notifying the controller, and leave
         it to the controller event loop to take actions afterwards.
 
-        Once shutdown signal is received, it will also prevent any new
-        deployments or replicas from being created.
+        Deployments are torn down in best effort dependency order. Callers are
+        deleted before the callees they depend on to reduce the chances of dead
+        handle errors.
 
-        One can send multiple shutdown signals but won't effectively make any
-        difference compare to calling it once.
+        This method is re-entrant. Deletion tiers are computed once on the
+        first call. Every later call advances through the tiers as earlier
+        tiers drain. Once the shutdown signal is received it also prevents any
+        new deployments or replicas from being created.
         """
         self._shutting_down = True
 
-        for deployment_state in self._deployment_states.values():
-            deployment_state.delete()
+        if self._shutdown_tiers is None:
+            self._shutdown_tiers = self._shutdown_deletion_tiers()
+            self._shutdown_tier_idx = 0
+            self._shutdown_tier_started_at = time.time()
+
+        self._advance_shutdown()
+
+    def _advance_shutdown(self):
+        """
+        Delete the current shutdown tier, advancing as tiers drain.
+
+        Deletes every deployment in the current tier and waits for the tier to
+        be fully gone from _deployment_states before moving to the next one.
+        If a tier does not drain within RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S it is
+        force advanced past.
+        """
+        while self._shutdown_tier_idx < len(self._shutdown_tiers):
+            tier = [
+                deployment_id
+                for deployment_id in self._shutdown_tiers[self._shutdown_tier_idx]
+                if deployment_id in self._deployment_states
+            ]
+            if tier:
+                for deployment_id in tier:
+                    self._deployment_states[deployment_id].delete()
+
+                waited = time.time() - self._shutdown_tier_started_at
+                if waited <= RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S:
+                    # Wait for this tier to drain before deleting the next tier
+                    # of deployments.
+                    return
+
+                logger.warning(
+                    f"Shutdown tier {self._shutdown_tier_idx} did not drain "
+                    f"within {RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S}s, force "
+                    f"advancing past {[str(d) for d in tier]} to avoid hanging "
+                    "shutdown.",
+                    extra={"log_to_stderr": False},
+                )
+
+            # Tier fully drained or force advanced, move to the next one.
+            self._shutdown_tier_idx += 1
+            self._shutdown_tier_started_at = time.time()
+
+    def _shutdown_deletion_tiers(self) -> List[List[DeploymentID]]:
+        """
+        Compute best effort reverse topological deletion tiers.
+
+        Builds a directed graph over currently tracked deployments derived from
+        each deployment's outbound handle usage (best effort). Runs Kahn's
+        algorithm keyed on the number of callers. Nodes with in degree 0 are
+        ingress and roots called by nothing, so they are emitted first and
+        leaf or downstream deployments last. Each Kahn wave becomes one
+        deletion tier.
+
+        Returns:
+            A list of tiers, each a list of DeploymentIDs, in deletion order.
+        """
+        ids = list(self._deployment_states.keys())
+        id_set = set(ids)
+
+        callees: Dict[DeploymentID, Set[DeploymentID]] = {i: set() for i in ids}
+        in_degree: Dict[DeploymentID, int] = {i: 0 for i in ids}
+
+        for caller in ids:
+            outbound = self._deployment_states[caller].get_outbound_deployments()
+            if not outbound:
+                continue
+            for callee in outbound:
+                if callee == caller or callee not in id_set:
+                    continue
+                if callee not in callees[caller]:
+                    callees[caller].add(callee)
+                    in_degree[callee] += 1
+
+        remaining = dict(in_degree)
+        queue = [i for i in ids if remaining[i] == 0]
+        tiers: List[List[DeploymentID]] = []
+        emitted = 0
+
+        while queue:
+            tiers.append(queue)
+            emitted += len(queue)
+            next_queue: List[DeploymentID] = []
+            for caller in queue:
+                for callee in callees[caller]:
+                    remaining[callee] -= 1
+                    if remaining[callee] == 0:
+                        next_queue.append(callee)
+            queue = next_queue
+
+        # Whatever Kahn's algorithm did not emit is part of a dependency cycle,
+        # so tear them down together as a final tier.
+        if emitted < len(ids):
+            tiers.append([i for i in ids if remaining[i] > 0])
+
+        return tiers
 
     def is_ready_for_shutdown(self) -> bool:
         """Return whether all deployments are shutdown.

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -160,6 +160,7 @@ py_test_module_list(
 py_test_module_list(
     size = "large",
     files = [
+        "test_dependency_ordered_shutdown.py",
         "test_deployment_scheduler.py",
     ],
     tags = [

--- a/python/ray/serve/tests/test_dependency_ordered_shutdown.py
+++ b/python/ray/serve/tests/test_dependency_ordered_shutdown.py
@@ -1,6 +1,6 @@
 import asyncio
 import sys
-from typing import List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 import pytest
 
@@ -15,8 +15,8 @@ from ray.serve.handle import DeploymentHandle
 
 
 @pytest.fixture
-def serve_shutdown_instance(request, monkeypatch):
-    """A Serve instance the test itself is allowed to shut down."""
+def shutdown_test_cluster(request, monkeypatch):
+    """A Ray cluster whose Serve instance the test itself shuts down."""
     for name, value in getattr(request, "param", {}).items():
         monkeypatch.setenv(name, value)
 
@@ -95,14 +95,12 @@ class LazyNode(_RecordsShutdown):
 
 @serve.deployment
 class PlainNode:
-    """Same shape as Node but does not record its teardown."""
+    """A placeholder for a deployment a LinkedNode needs to already exist."""
 
     def __init__(self, *downstream: DeploymentHandle):
         self._downstream = downstream
 
-    async def __call__(self) -> str:
-        for handle in self._downstream:
-            await handle.remote()
+    def __call__(self) -> str:
         return "plain"
 
 
@@ -113,9 +111,7 @@ class WedgedNode:
     def __init__(self, *downstream: DeploymentHandle):
         self._downstream = downstream
 
-    async def __call__(self) -> str:
-        for handle in self._downstream:
-            await handle.remote()
+    def __call__(self) -> str:
         return "wedged"
 
     async def __del__(self):
@@ -152,6 +148,20 @@ def _outbound(app_name: str, deployment_name: str) -> Set[Tuple[str, str]]:
     }
 
 
+def _wait_for_topology(expected: Dict[Tuple[str, str], Set[Tuple[str, str]]]):
+    """Wait until the controller sees exactly these caller to callee edges."""
+    seen = {}
+
+    def _matches() -> bool:
+        seen.update({node: _outbound(*node) for node in expected})
+        return seen == expected
+
+    try:
+        wait_for_condition(_matches, timeout=20)
+    except RuntimeError:
+        raise AssertionError(f"Expected topology {expected}, controller sees {seen}.")
+
+
 def _shutdown_order(recorder: ray.actor.ActorHandle) -> List[str]:
     return ray.get(recorder.get.remote())
 
@@ -166,10 +176,10 @@ def _replica_actor(deployment_name: str, app_name: str) -> ray.actor.ActorHandle
     raise RuntimeError(f"No live replica for {deployment_name} in app {app_name}.")
 
 
-class TestDependencyOrderedShutdown:
+class TestKnownTopologyShutdown:
     """Teardown order for topologies the controller fully knows."""
 
-    def test_linear_chain(self, serve_shutdown_instance):
+    def test_linear_chain(self, shutdown_test_cluster):
         recorder = Accumulator.remote()
 
         handle = serve.run(
@@ -180,73 +190,19 @@ class TestDependencyOrderedShutdown:
         )
         assert handle.remote().result() == "Ingress/Middle/Leaf"
 
-        wait_for_condition(
-            lambda: _outbound("chain", "Ingress") == {("chain", "Middle")}
-            and _outbound("chain", "Middle") == {("chain", "Leaf")}
-            and _outbound("chain", "Leaf") == set()
+        _wait_for_topology(
+            {
+                ("chain", "Ingress"): {("chain", "Middle")},
+                ("chain", "Middle"): {("chain", "Leaf")},
+                ("chain", "Leaf"): set(),
+            }
         )
 
         serve.shutdown()
 
         assert _shutdown_order(recorder) == ["Ingress", "Middle", "Leaf"]
 
-    def test_diamond_shared_leaf_last(self, serve_shutdown_instance):
-        recorder = Accumulator.remote()
-
-        leaf = _node("Leaf", recorder)
-        handle = serve.run(
-            _node(
-                "Ingress",
-                recorder,
-                _node("M1", recorder, leaf),
-                _node("M2", recorder, leaf),
-            ),
-            name="diamond",
-        )
-        assert handle.remote().result() == "Ingress/M1/Leaf/M2/Leaf"
-
-        wait_for_condition(
-            lambda: _outbound("diamond", "Ingress")
-            == {("diamond", "M1"), ("diamond", "M2")}
-            and _outbound("diamond", "M1") == {("diamond", "Leaf")}
-            and _outbound("diamond", "M2") == {("diamond", "Leaf")}
-        )
-
-        serve.shutdown()
-
-        order = _shutdown_order(recorder)
-        assert order[0] == "Ingress"
-        assert order[-1] == "Leaf"
-        assert set(order[1:3]) == {"M1", "M2"}
-
-    def test_independent_apps(self, serve_shutdown_instance):
-        recorder = Accumulator.remote()
-
-        serve.run(
-            _node("Ingress1", recorder, _node("Backend1", recorder)),
-            name="app1",
-            route_prefix="/app1",
-        )
-        serve.run(
-            _node("Ingress2", recorder, _node("Backend2", recorder)),
-            name="app2",
-            route_prefix="/app2",
-        )
-
-        wait_for_condition(
-            lambda: _outbound("app1", "Ingress1") == {("app1", "Backend1")}
-            and _outbound("app2", "Ingress2") == {("app2", "Backend2")}
-        )
-
-        serve.shutdown()
-
-        order = _shutdown_order(recorder)
-        assert set(order) == {"Ingress1", "Backend1", "Ingress2", "Backend2"}
-        assert max(order.index("Ingress1"), order.index("Ingress2")) < min(
-            order.index("Backend1"), order.index("Backend2")
-        )
-
-    def test_cross_app_chain(self, serve_shutdown_instance):
+    def test_cross_app_chain(self, shutdown_test_cluster):
         """A caller in one app is torn down before its callee in another."""
         recorder = Accumulator.remote()
 
@@ -262,9 +218,11 @@ class TestDependencyOrderedShutdown:
         )
         assert handle.remote().result() == "Caller/Middle/Leaf"
 
-        wait_for_condition(
-            lambda: _outbound("frontend", "Caller") == {("backend", "Middle")}
-            and _outbound("backend", "Middle") == {("backend", "Leaf")}
+        _wait_for_topology(
+            {
+                ("frontend", "Caller"): {("backend", "Middle")},
+                ("backend", "Middle"): {("backend", "Leaf")},
+            }
         )
 
         serve.shutdown()
@@ -275,7 +233,7 @@ class TestDependencyOrderedShutdown:
 class TestBestEffortTopologyShutdown:
     """Shutdown when the topology is incomplete, cyclic, or cannot drain."""
 
-    def test_incomplete_topology(self, serve_shutdown_instance):
+    def test_incomplete_topology(self, shutdown_test_cluster):
         """Handles created at request time are missing from the topology."""
         recorder = Accumulator.remote()
 
@@ -288,8 +246,12 @@ class TestBestEffortTopologyShutdown:
 
         assert handle.remote().result() == "Ingress/Middle/Leaf"
 
-        wait_for_condition(lambda: _outbound("main", "Ingress") == {("main", "Middle")})
-        assert _outbound("main", "Middle") == set()
+        _wait_for_topology(
+            {
+                ("main", "Ingress"): {("main", "Middle")},
+                ("main", "Middle"): set(),
+            }
+        )
 
         serve.shutdown()
 
@@ -299,26 +261,7 @@ class TestBestEffortTopologyShutdown:
         # The known edge is still respected.
         assert order.index("Ingress") < order.index("Middle")
 
-    def test_cycle(self, serve_shutdown_instance):
-        """A cycle has no caller first order, so it is torn down as a group."""
-        recorder = Accumulator.remote()
-
-        # Redeploy A after B is up to build the cycle.
-        serve.run(_plain("A"), name="app_a", route_prefix="/a")
-        serve.run(_linked("B", recorder, "A", "app_a"), name="app_b", route_prefix="/b")
-        serve.run(_linked("A", recorder, "B", "app_b"), name="app_a", route_prefix="/a")
-
-        wait_for_condition(
-            lambda: _outbound("app_a", "A") == {("app_b", "B")}
-            and _outbound("app_b", "B") == {("app_a", "A")},
-            timeout=20,
-        )
-
-        serve.shutdown()
-
-        assert sorted(_shutdown_order(recorder)) == ["A", "B"]
-
-    def test_ingress_into_cycle(self, serve_shutdown_instance):
+    def test_ingress_into_cycle(self, shutdown_test_cluster):
         """An ingress feeding a cycle drains before the cyclic remainder."""
         recorder = Accumulator.remote()
 
@@ -330,11 +273,12 @@ class TestBestEffortTopologyShutdown:
             route_prefix="/a",
         )
 
-        wait_for_condition(
-            lambda: _outbound("app_a", "Ingress") == {("app_a", "A")}
-            and _outbound("app_a", "A") == {("app_b", "B")}
-            and _outbound("app_b", "B") == {("app_a", "A")},
-            timeout=20,
+        _wait_for_topology(
+            {
+                ("app_a", "Ingress"): {("app_a", "A")},
+                ("app_a", "A"): {("app_b", "B")},
+                ("app_b", "B"): {("app_a", "A")},
+            }
         )
 
         serve.shutdown()
@@ -344,11 +288,11 @@ class TestBestEffortTopologyShutdown:
         assert sorted(order[1:]) == ["A", "B"]
 
     @pytest.mark.parametrize(
-        "serve_shutdown_instance",
+        "shutdown_test_cluster",
         [{"RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S": "2"}],
         indirect=True,
     )
-    def test_tier_that_never_drains(self, serve_shutdown_instance):
+    def test_tier_that_never_drains(self, shutdown_test_cluster):
         """A replica that refuses to stop does not block the tiers behind it."""
         recorder = Accumulator.remote()
 
@@ -362,29 +306,25 @@ class TestBestEffortTopologyShutdown:
         )
         assert handle.remote().result() == "Ingress/wedged"
 
+        _wait_for_topology(
+            {
+                ("chain", "Ingress"): {("chain", "Middle")},
+                ("chain", "Middle"): {("chain", "Leaf")},
+            }
+        )
+
         # Start the shutdown without blocking the driver on the stuck replica.
         client = _get_global_client()
         ray.get(client._controller.graceful_shutdown.remote(False))
 
-        wait_for_condition(lambda: "Leaf" in _shutdown_order(recorder), timeout=60)
+        # Leaf can only be torn down while Middle is still stopping, so its
+        # teardown proves shutdown advanced past the tier that never drained.
+        wait_for_condition(lambda: "Leaf" in _shutdown_order(recorder), timeout=20)
         assert _shutdown_order(recorder) == ["Ingress", "Leaf"]
-
-        # Leaf was torn down while Middle was still stopping, which is only
-        # possible if shutdown advanced past the tier that never drained.
         middle_replica = _replica_actor("Middle", "chain")
+
+        # Cleanup Middle so it doesn't sit in __del__ for its full 1000s grace period
         ray.kill(middle_replica)
-
-    def test_no_applications(self, serve_shutdown_instance):
-        """Shutting down an instance with nothing deployed completes."""
-        serve.start()
-
-        serve.shutdown()
-
-        assert not [
-            actor
-            for actor in ray.util.list_named_actors(all_namespaces=True)
-            if actor["name"].startswith("SERVE")
-        ]
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_dependency_ordered_shutdown.py
+++ b/python/ray/serve/tests/test_dependency_ordered_shutdown.py
@@ -1,0 +1,391 @@
+import asyncio
+import sys
+from typing import List, Set, Tuple
+
+import pytest
+
+import ray
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.serve._private.constants import SERVE_NAMESPACE
+from ray.serve._private.test_utils import Accumulator
+from ray.serve.api import get_deployment_handle
+from ray.serve.context import _get_global_client
+from ray.serve.handle import DeploymentHandle
+
+
+@pytest.fixture
+def serve_shutdown_instance(request, monkeypatch):
+    """A Serve instance the test itself is allowed to shut down."""
+    for name, value in getattr(request, "param", {}).items():
+        monkeypatch.setenv(name, value)
+
+    ray.init(num_cpus=16, namespace="test_dependency_ordered_shutdown")
+    yield
+    serve.shutdown()
+    ray.shutdown()
+
+
+class _RecordsShutdown:
+    """Record a deployment name when its replica is torn down."""
+
+    def _record_shutdown_as(self, name: str, recorder: ray.actor.ActorHandle):
+        self._shutdown_name = name
+        self._shutdown_recorder = recorder
+
+    async def __del__(self):
+        await self._shutdown_recorder.add.remote(self._shutdown_name)
+
+
+@serve.deployment
+class Node(_RecordsShutdown):
+    """A deployment that calls its downstream handles and records its teardown."""
+
+    def __init__(
+        self, name: str, recorder: ray.actor.ActorHandle, *downstream: DeploymentHandle
+    ):
+        self._record_shutdown_as(name, recorder)
+        self._downstream = downstream
+
+    async def __call__(self) -> str:
+        results = [await handle.remote() for handle in self._downstream]
+        return "/".join([self._shutdown_name, *results])
+
+
+@serve.deployment
+class LinkedNode(_RecordsShutdown):
+    """Builds its downstream handle in the constructor.
+
+    Used for edges a bind graph cannot express, such as an edge into another
+    app or an edge that closes a cycle.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        recorder: ray.actor.ActorHandle,
+        target_name: str,
+        target_app: str,
+    ):
+        self._record_shutdown_as(name, recorder)
+        self._downstream = get_deployment_handle(target_name, target_app)
+
+    async def __call__(self) -> str:
+        return f"{self._shutdown_name}/{await self._downstream.remote()}"
+
+
+@serve.deployment
+class LazyNode(_RecordsShutdown):
+    """Builds its downstream handle per request, after it reported as ready."""
+
+    def __init__(
+        self,
+        name: str,
+        recorder: ray.actor.ActorHandle,
+        target_name: str,
+        target_app: str,
+    ):
+        self._record_shutdown_as(name, recorder)
+        self._target = (target_name, target_app)
+
+    async def __call__(self) -> str:
+        handle = get_deployment_handle(*self._target)
+        return f"{self._shutdown_name}/{await handle.remote()}"
+
+
+@serve.deployment
+class PlainNode:
+    """Same shape as Node but does not record its teardown."""
+
+    def __init__(self, *downstream: DeploymentHandle):
+        self._downstream = downstream
+
+    async def __call__(self) -> str:
+        for handle in self._downstream:
+            await handle.remote()
+        return "plain"
+
+
+@serve.deployment(graceful_shutdown_timeout_s=1000)
+class WedgedNode:
+    """A deployment whose replica never finishes shutting down."""
+
+    def __init__(self, *downstream: DeploymentHandle):
+        self._downstream = downstream
+
+    async def __call__(self) -> str:
+        for handle in self._downstream:
+            await handle.remote()
+        return "wedged"
+
+    async def __del__(self):
+        await asyncio.sleep(1000)
+
+
+def _node(name: str, recorder: ray.actor.ActorHandle, *downstream):
+    return Node.options(name=name).bind(name, recorder, *downstream)
+
+
+def _linked(
+    name: str, recorder: ray.actor.ActorHandle, target_name: str, target_app: str
+):
+    return LinkedNode.options(name=name).bind(name, recorder, target_name, target_app)
+
+
+def _lazy(
+    name: str, recorder: ray.actor.ActorHandle, target_name: str, target_app: str
+):
+    return LazyNode.options(name=name).bind(name, recorder, target_name, target_app)
+
+
+def _plain(name: str, *downstream):
+    return PlainNode.options(name=name).bind(*downstream)
+
+
+def _outbound(app_name: str, deployment_name: str) -> Set[Tuple[str, str]]:
+    """The controller's view of what a deployment calls, as (app, name) pairs."""
+    details = _get_global_client().get_serve_details()
+    topology = details["applications"][app_name]["deployment_topology"]
+    return {
+        (dep["app_name"], dep["name"])
+        for dep in topology["nodes"][deployment_name]["outbound_deployments"]
+    }
+
+
+def _shutdown_order(recorder: ray.actor.ActorHandle) -> List[str]:
+    return ray.get(recorder.get.remote())
+
+
+def _replica_actor(deployment_name: str, app_name: str) -> ray.actor.ActorHandle:
+    """Handle to a live replica actor, raising if the replica is gone."""
+    prefix = f"SERVE_REPLICA::{app_name}#{deployment_name}#"
+    for actor in ray.util.list_named_actors(all_namespaces=True):
+        if actor["name"].startswith(prefix):
+            return ray.get_actor(actor["name"], namespace=SERVE_NAMESPACE)
+
+    raise RuntimeError(f"No live replica for {deployment_name} in app {app_name}.")
+
+
+class TestDependencyOrderedShutdown:
+    """Teardown order for topologies the controller fully knows."""
+
+    def test_linear_chain(self, serve_shutdown_instance):
+        recorder = Accumulator.remote()
+
+        handle = serve.run(
+            _node(
+                "Ingress", recorder, _node("Middle", recorder, _node("Leaf", recorder))
+            ),
+            name="chain",
+        )
+        assert handle.remote().result() == "Ingress/Middle/Leaf"
+
+        wait_for_condition(
+            lambda: _outbound("chain", "Ingress") == {("chain", "Middle")}
+            and _outbound("chain", "Middle") == {("chain", "Leaf")}
+            and _outbound("chain", "Leaf") == set()
+        )
+
+        serve.shutdown()
+
+        assert _shutdown_order(recorder) == ["Ingress", "Middle", "Leaf"]
+
+    def test_diamond_shared_leaf_last(self, serve_shutdown_instance):
+        recorder = Accumulator.remote()
+
+        leaf = _node("Leaf", recorder)
+        handle = serve.run(
+            _node(
+                "Ingress",
+                recorder,
+                _node("M1", recorder, leaf),
+                _node("M2", recorder, leaf),
+            ),
+            name="diamond",
+        )
+        assert handle.remote().result() == "Ingress/M1/Leaf/M2/Leaf"
+
+        wait_for_condition(
+            lambda: _outbound("diamond", "Ingress")
+            == {("diamond", "M1"), ("diamond", "M2")}
+            and _outbound("diamond", "M1") == {("diamond", "Leaf")}
+            and _outbound("diamond", "M2") == {("diamond", "Leaf")}
+        )
+
+        serve.shutdown()
+
+        order = _shutdown_order(recorder)
+        assert order[0] == "Ingress"
+        assert order[-1] == "Leaf"
+        assert set(order[1:3]) == {"M1", "M2"}
+
+    def test_independent_apps(self, serve_shutdown_instance):
+        recorder = Accumulator.remote()
+
+        serve.run(
+            _node("Ingress1", recorder, _node("Backend1", recorder)),
+            name="app1",
+            route_prefix="/app1",
+        )
+        serve.run(
+            _node("Ingress2", recorder, _node("Backend2", recorder)),
+            name="app2",
+            route_prefix="/app2",
+        )
+
+        wait_for_condition(
+            lambda: _outbound("app1", "Ingress1") == {("app1", "Backend1")}
+            and _outbound("app2", "Ingress2") == {("app2", "Backend2")}
+        )
+
+        serve.shutdown()
+
+        order = _shutdown_order(recorder)
+        assert set(order) == {"Ingress1", "Backend1", "Ingress2", "Backend2"}
+        assert max(order.index("Ingress1"), order.index("Ingress2")) < min(
+            order.index("Backend1"), order.index("Backend2")
+        )
+
+    def test_cross_app_chain(self, serve_shutdown_instance):
+        """A caller in one app is torn down before its callee in another."""
+        recorder = Accumulator.remote()
+
+        serve.run(
+            _node("Middle", recorder, _node("Leaf", recorder)),
+            name="backend",
+            route_prefix="/backend",
+        )
+        handle = serve.run(
+            _linked("Caller", recorder, "Middle", "backend"),
+            name="frontend",
+            route_prefix="/frontend",
+        )
+        assert handle.remote().result() == "Caller/Middle/Leaf"
+
+        wait_for_condition(
+            lambda: _outbound("frontend", "Caller") == {("backend", "Middle")}
+            and _outbound("backend", "Middle") == {("backend", "Leaf")}
+        )
+
+        serve.shutdown()
+
+        assert _shutdown_order(recorder) == ["Caller", "Middle", "Leaf"]
+
+
+class TestBestEffortTopologyShutdown:
+    """Shutdown when the topology is incomplete, cyclic, or cannot drain."""
+
+    def test_incomplete_topology(self, serve_shutdown_instance):
+        """Handles created at request time are missing from the topology."""
+        recorder = Accumulator.remote()
+
+        serve.run(_node("Leaf", recorder), name="leaf_app", route_prefix="/leaf")
+        handle = serve.run(
+            _node("Ingress", recorder, _lazy("Middle", recorder, "Leaf", "leaf_app")),
+            name="main",
+            route_prefix="/main",
+        )
+
+        assert handle.remote().result() == "Ingress/Middle/Leaf"
+
+        wait_for_condition(lambda: _outbound("main", "Ingress") == {("main", "Middle")})
+        assert _outbound("main", "Middle") == set()
+
+        serve.shutdown()
+
+        order = _shutdown_order(recorder)
+        assert set(order) == {"Ingress", "Middle", "Leaf"}
+
+        # The known edge is still respected.
+        assert order.index("Ingress") < order.index("Middle")
+
+    def test_cycle(self, serve_shutdown_instance):
+        """A cycle has no caller first order, so it is torn down as a group."""
+        recorder = Accumulator.remote()
+
+        # Redeploy A after B is up to build the cycle.
+        serve.run(_plain("A"), name="app_a", route_prefix="/a")
+        serve.run(_linked("B", recorder, "A", "app_a"), name="app_b", route_prefix="/b")
+        serve.run(_linked("A", recorder, "B", "app_b"), name="app_a", route_prefix="/a")
+
+        wait_for_condition(
+            lambda: _outbound("app_a", "A") == {("app_b", "B")}
+            and _outbound("app_b", "B") == {("app_a", "A")},
+            timeout=20,
+        )
+
+        serve.shutdown()
+
+        assert sorted(_shutdown_order(recorder)) == ["A", "B"]
+
+    def test_ingress_into_cycle(self, serve_shutdown_instance):
+        """An ingress feeding a cycle drains before the cyclic remainder."""
+        recorder = Accumulator.remote()
+
+        serve.run(_plain("Ingress", _plain("A")), name="app_a", route_prefix="/a")
+        serve.run(_linked("B", recorder, "A", "app_a"), name="app_b", route_prefix="/b")
+        serve.run(
+            _node("Ingress", recorder, _linked("A", recorder, "B", "app_b")),
+            name="app_a",
+            route_prefix="/a",
+        )
+
+        wait_for_condition(
+            lambda: _outbound("app_a", "Ingress") == {("app_a", "A")}
+            and _outbound("app_a", "A") == {("app_b", "B")}
+            and _outbound("app_b", "B") == {("app_a", "A")},
+            timeout=20,
+        )
+
+        serve.shutdown()
+
+        order = _shutdown_order(recorder)
+        assert order[0] == "Ingress"
+        assert sorted(order[1:]) == ["A", "B"]
+
+    @pytest.mark.parametrize(
+        "serve_shutdown_instance",
+        [{"RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S": "2"}],
+        indirect=True,
+    )
+    def test_tier_that_never_drains(self, serve_shutdown_instance):
+        """A replica that refuses to stop does not block the tiers behind it."""
+        recorder = Accumulator.remote()
+
+        handle = serve.run(
+            _node(
+                "Ingress",
+                recorder,
+                WedgedNode.options(name="Middle").bind(_node("Leaf", recorder)),
+            ),
+            name="chain",
+        )
+        assert handle.remote().result() == "Ingress/wedged"
+
+        # Start the shutdown without blocking the driver on the stuck replica.
+        client = _get_global_client()
+        ray.get(client._controller.graceful_shutdown.remote(False))
+
+        wait_for_condition(lambda: "Leaf" in _shutdown_order(recorder), timeout=60)
+        assert _shutdown_order(recorder) == ["Ingress", "Leaf"]
+
+        # Leaf was torn down while Middle was still stopping, which is only
+        # possible if shutdown advanced past the tier that never drained.
+        middle_replica = _replica_actor("Middle", "chain")
+        ray.kill(middle_replica)
+
+    def test_no_applications(self, serve_shutdown_instance):
+        """Shutting down an instance with nothing deployed completes."""
+        serve.start()
+
+        serve.shutdown()
+
+        assert not [
+            actor
+            for actor in ray.util.list_named_actors(all_namespaces=True)
+            if actor["name"].startswith("SERVE")
+        ]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -85,6 +85,7 @@ class MockDeploymentStateManager:
         self.deployment_infos: Dict[DeploymentID, DeploymentInfo] = dict()
         self.deployment_statuses: Dict[DeploymentID, DeploymentStatusInfo] = dict()
         self.deleting: Dict[DeploymentID, bool] = dict()
+        self._shutting_down = False
 
         # Recover
         recovered_deployments = self.kv_store.get("fake_deployment_state_checkpoint")
@@ -208,6 +209,9 @@ class MockDeploymentStateManager:
         """Mock method to return outbound deployments for a deployment."""
         # Return None by default, tests can override this
         return getattr(self, f"_outbound_deps_{id.name}_{id.app_name}", None)
+
+    def is_shutting_down(self) -> bool:
+        return self._shutting_down
 
 
 @pytest.fixture
@@ -836,6 +840,31 @@ def test_deploy_and_delete_app(mocked_application_state):
     deployment_state_manager.set_deployment_deleted(d2_id)
     ready_to_be_deleted = app_state.update()
     assert ready_to_be_deleted
+
+
+def test_delete_app_does_not_bypass_full_shutdown(mocked_application_state):
+    """Deleting an app must not delete its deployments
+    directly while a full instance shutdown is in progress.
+    """
+
+    app_state, deployment_state_manager = mocked_application_state
+
+    d1_id = DeploymentID(name="d1", app_name="test_app")
+    d2_id = DeploymentID(name="d2", app_name="test_app")
+    app_state.deploy_app(
+        {"d1": deployment_info("d1"), "d2": deployment_info("d2")},
+        external_scaler_enabled=False,
+    )
+    app_state.update()
+    assert not deployment_state_manager.deleting.get(d1_id)
+    assert not deployment_state_manager.deleting.get(d2_id)
+
+    deployment_state_manager._shutting_down = True
+    app_state.delete()
+    app_state.update()
+
+    assert not deployment_state_manager.deleting.get(d1_id)
+    assert not deployment_state_manager.deleting.get(d2_id)
 
 
 def test_app_deploy_failed_and_redeploy(mocked_application_state):

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10309,6 +10309,20 @@ class TestShutdownDeletionTiers:
         assert set(tiers[0]) == {a1, a2}
         assert set(tiers[1]) == {b1, b2}
 
+    def test_cross_app_chain(self, mock_deployment_state_manager):
+        """A caller in app1 orders before its callee in app2."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        ingress1 = _dep("ingress", app="app1")
+        ingress2 = _dep("ingress", app="app2")
+        leaf2 = _dep("leaf", app="app2")
+        _deploy_running(dsm, ingress1, outbound=[ingress2])
+        _deploy_running(dsm, ingress2, outbound=[leaf2])
+        _deploy_running(dsm, leaf2, outbound=[])
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert tiers == [[ingress1], [ingress2], [leaf2]]
+
     def test_no_deployments(self, mock_deployment_state_manager):
         """No deployments produces no tiers."""
         create_dsm, _, _, _ = mock_deployment_state_manager
@@ -10395,6 +10409,21 @@ class TestDependencyOrderedShutdown:
         assert dsm.is_ready_for_shutdown()
         assert order.index(b1) > order.index(a1)
         assert order.index(b2) > order.index(a2)
+
+    def test_cross_app_chain_delete_order(self, mock_deployment_state_manager):
+        """App 1 calling App 2 tears the app1 caller down before the app2 callee."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        ingress1 = _dep("ingress", app="app1")
+        ingress2 = _dep("ingress", app="app2")
+        leaf2 = _dep("leaf", app="app2")
+        _deploy_running(dsm, ingress1, outbound=[ingress2])
+        _deploy_running(dsm, ingress2, outbound=[leaf2])
+        _deploy_running(dsm, leaf2, outbound=[])
+
+        order = _run_shutdown_to_completion(dsm)
+        assert dsm.is_ready_for_shutdown()
+        assert order == [ingress1, ingress2, leaf2]
 
     def test_wedged_tier_still_completes(self, mock_deployment_state_manager):
         """A tier that never drains is force-advanced past after the timeout."""
@@ -10483,6 +10512,74 @@ def test_shutdown_tiers_survive_application_reconcile(mock_deployment_state_mana
 
     dsm.update()
     for r in ds_b._replicas.get([ReplicaState.STOPPING]):
+        r._actor.set_done_stopping()
+    dsm.update()
+    assert dsm.is_ready_for_shutdown()
+
+
+def test_cross_app_shutdown_survives_application_reconcile(
+    mock_deployment_state_manager,
+):
+    """Cross app tier order holds when each app delete wipes its target list."""
+    create_dsm, _, _, autoscaling_state_manager = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    def _make_app(name):
+        return ApplicationState(
+            name=name,
+            deployment_state_manager=dsm,
+            autoscaling_state_manager=autoscaling_state_manager,
+            endpoint_state=EndpointState(MockKVStore(), Mock()),
+            logging_config=LoggingConfig(),
+            external_scaler_enabled=False,
+        )
+
+    app1 = _make_app("app1")
+    app2 = _make_app("app2")
+    info1, _ = deployment_info(num_replicas=1)
+    info2, _ = deployment_info(num_replicas=1)
+    app1.deploy_app({"ingress": info1}, external_scaler_enabled=False)
+    app2.deploy_app({"backend": info2}, external_scaler_enabled=False)
+    app1.update()
+    app2.update()
+
+    ingress = _dep("ingress", app="app1")
+    backend = _dep("backend", app="app2")
+    ds_ingress = dsm._get_deployment_state_for_testing(ingress)
+    ds_backend = dsm._get_deployment_state_for_testing(backend)
+
+    dsm.update()
+    for r in ds_ingress._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_ready()
+    for r in ds_backend._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_ready()
+    dsm.update()
+    for r in ds_ingress._replicas.get([ReplicaState.RUNNING]):
+        r._actor._outbound_deployments = [backend]
+    for r in ds_backend._replicas.get([ReplicaState.RUNNING]):
+        r._actor._outbound_deployments = []
+
+    dsm.shutdown()
+    assert ds_ingress._target_state.deleting
+    assert not ds_backend._target_state.deleting
+
+    app1.delete()
+    app2.delete()
+    app1.update()
+    app2.update()
+    assert not ds_backend._target_state.deleting
+
+    dsm.update()
+    for r in ds_ingress._replicas.get([ReplicaState.STOPPING]):
+        r._actor.set_done_stopping()
+    dsm.update()
+    dsm.shutdown()
+    app1.update()
+    app2.update()
+    assert ds_backend._target_state.deleting
+
+    dsm.update()
+    for r in ds_backend._replicas.get([ReplicaState.STOPPING]):
         r._actor.set_done_stopping()
     dsm.update()
     assert dsm.is_ready_for_shutdown()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10146,5 +10146,284 @@ def test_dirty_set_gauge_prunes_ids_no_longer_running(
     assert ds._last_health_check_healthy_replica_ids == running_ids
 
 
+def _dep(name: str, app: str = "app") -> DeploymentID:
+    return DeploymentID(name=name, app_name=app)
+
+
+def _deploy_running(dsm, deployment_id, outbound=None):
+    """Deploy a single replica deployment and drive it to RUNNING.
+
+    outbound is the list of DeploymentIDs the replica reports calling. Pass []
+    for a known leaf and None to model a replica that has not reported an
+    outbound set yet.
+    """
+    info, _ = deployment_info(num_replicas=1)
+    assert dsm.deploy(deployment_id, info)
+    ds = dsm._get_deployment_state_for_testing(deployment_id)
+    dsm.update()
+    for r in ds._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_ready()
+    dsm.update()
+    assert ds._replicas.get([ReplicaState.RUNNING])
+    if outbound is not None:
+        for r in ds._replicas.get([ReplicaState.RUNNING]):
+            r._actor._outbound_deployments = list(outbound)
+    return ds
+
+
+def _finish_stopping(dsm):
+    """Simulate every currently stopping replica finishing its teardown."""
+    for ds in list(dsm._deployment_states.values()):
+        for r in ds._replicas.get([ReplicaState.STOPPING]):
+            r._actor.set_done_stopping()
+
+
+def _run_shutdown_to_completion(dsm, max_steps=50, wedged=None):
+    """Drive the controller's shutdown loop to completion.
+
+    Each step mirrors one control loop iteration: shutdown() advances the
+    deletion tiers and update() reconciles the teardown. Returns the order in
+    which deployments were first marked deleting, so callers can assert callers
+    drained before callees. Deployments in the wedged set never finish
+    stopping, modeling a stuck replica.
+    """
+    wedged = wedged or set()
+    delete_order = []
+    for _ in range(max_steps):
+        dsm.shutdown()
+        for deployment_id, deployment_state in dsm._deployment_states.items():
+            if deployment_state._target_state.deleting and (
+                deployment_id not in delete_order
+            ):
+                delete_order.append(deployment_id)
+        dsm.update()
+        for deployment_state in list(dsm._deployment_states.values()):
+            if deployment_state._id in wedged:
+                continue
+            for r in deployment_state._replicas.get([ReplicaState.STOPPING]):
+                r._actor.set_done_stopping()
+        dsm.update()
+        if dsm.is_ready_for_shutdown():
+            break
+    return delete_order
+
+
+class TestShutdownDeletionTiers:
+    """Unit tests for DeploymentStateManager._shutdown_deletion_tiers()."""
+
+    def test_linear_chain(self, mock_deployment_state_manager):
+        """A -> B -> C tiers out as [[A], [B], [C]]."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b, c = _dep("a"), _dep("b"), _dep("c")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[c])
+        _deploy_running(dsm, c, outbound=[])
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert tiers == [[a], [b], [c]]
+
+    def test_diamond(self, mock_deployment_state_manager):
+        """Ingress -> {m1, m2} -> leaf keeps the leaf in the last tier."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        ingress, m1, m2, leaf = _dep("ingress"), _dep("m1"), _dep("m2"), _dep("leaf")
+        _deploy_running(dsm, ingress, outbound=[m1, m2])
+        _deploy_running(dsm, m1, outbound=[leaf])
+        _deploy_running(dsm, m2, outbound=[leaf])
+        _deploy_running(dsm, leaf, outbound=[])
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert tiers[0] == [ingress]
+        assert set(tiers[1]) == {m1, m2}
+        assert tiers[2] == [leaf]
+
+    def test_cycle_appended_as_final_tier(self, mock_deployment_state_manager):
+        """A -> B -> C -> A has no safe order, so all three land in one tier."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b, c = _dep("a"), _dep("b"), _dep("c")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[c])
+        _deploy_running(dsm, c, outbound=[a])
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert len(tiers) == 1
+        assert set(tiers[0]) == {a, b, c}
+
+    def test_ingress_into_cycle(self, mock_deployment_state_manager):
+        """An ingress feeding a cycle drains before the cyclic remainder."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        ingress, a, b = _dep("ingress"), _dep("a"), _dep("b")
+        _deploy_running(dsm, ingress, outbound=[a])
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[a])
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert tiers[0] == [ingress]
+        assert set(tiers[1]) == {a, b}
+
+    def test_unknown_outbound_positioned_by_callers(
+        self, mock_deployment_state_manager
+    ):
+        """A node with unknown outbound is still ordered after its caller."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b = _dep("a"), _dep("b")
+        _deploy_running(dsm, a, outbound=[b])
+        # b's replica never reported an outbound set.
+        _deploy_running(dsm, b, outbound=None)
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert tiers == [[a], [b]]
+
+    def test_isolated_unknown_node_in_first_tier(self, mock_deployment_state_manager):
+        """An isolated node with unknown outbound is safe to delete first."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b, lone = _dep("a"), _dep("b"), _dep("lone")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[])
+        _deploy_running(dsm, lone, outbound=None)
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert set(tiers[0]) == {a, lone}
+        assert tiers[1] == [b]
+
+    def test_multi_app_independent(self, mock_deployment_state_manager):
+        """Two apps with no cross edges tier out independently."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a1, b1 = _dep("a", app="app1"), _dep("b", app="app1")
+        a2, b2 = _dep("a", app="app2"), _dep("b", app="app2")
+        _deploy_running(dsm, a1, outbound=[b1])
+        _deploy_running(dsm, b1, outbound=[])
+        _deploy_running(dsm, a2, outbound=[b2])
+        _deploy_running(dsm, b2, outbound=[])
+
+        tiers = dsm._shutdown_deletion_tiers()
+        assert set(tiers[0]) == {a1, a2}
+        assert set(tiers[1]) == {b1, b2}
+
+    def test_no_deployments(self, mock_deployment_state_manager):
+        """No deployments produces no tiers."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        assert dsm._shutdown_deletion_tiers() == []
+
+
+class TestDependencyOrderedShutdown:
+    """Tests for the re-entrant, dependency-ordered shutdown state machine."""
+
+    def test_linear_chain_delete_order(self, mock_deployment_state_manager):
+        """A -> B -> C: each callee is deleted only after its caller is gone."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b, c = _dep("a"), _dep("b"), _dep("c")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[c])
+        _deploy_running(dsm, c, outbound=[])
+
+        # First tier only deletes the ingress. Downstream stays untouched.
+        dsm.shutdown()
+        assert dsm._get_deployment_state_for_testing(a)._target_state.deleting
+        assert not dsm._get_deployment_state_for_testing(b)._target_state.deleting
+        assert not dsm._get_deployment_state_for_testing(c)._target_state.deleting
+
+        order = _run_shutdown_to_completion(dsm)
+        assert dsm.is_ready_for_shutdown()
+        assert order == [a, b, c]
+
+    def test_diamond_leaf_last(self, mock_deployment_state_manager):
+        """The shared leaf is deleted only after both middle nodes are gone."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        ingress, m1, m2, leaf = _dep("ingress"), _dep("m1"), _dep("m2"), _dep("leaf")
+        _deploy_running(dsm, ingress, outbound=[m1, m2])
+        _deploy_running(dsm, m1, outbound=[leaf])
+        _deploy_running(dsm, m2, outbound=[leaf])
+        _deploy_running(dsm, leaf, outbound=[])
+
+        order = _run_shutdown_to_completion(dsm)
+        assert dsm.is_ready_for_shutdown()
+        assert order[0] == ingress
+        assert order[-1] == leaf
+        assert order.index(leaf) > order.index(m1)
+        assert order.index(leaf) > order.index(m2)
+
+    def test_cycle_completes(self, mock_deployment_state_manager):
+        """A dependency cycle still shuts down cleanly without hanging."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b, c = _dep("a"), _dep("b"), _dep("c")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[c])
+        _deploy_running(dsm, c, outbound=[a])
+
+        order = _run_shutdown_to_completion(dsm)
+        assert dsm.is_ready_for_shutdown()
+        assert set(order) == {a, b, c}
+
+    def test_unknown_outbound_completes(self, mock_deployment_state_manager):
+        """Unknown outbound sets do not stall shutdown."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b = _dep("a"), _dep("b")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=None)
+
+        order = _run_shutdown_to_completion(dsm)
+        assert dsm.is_ready_for_shutdown()
+        assert order == [a, b]
+
+    def test_multi_app_independent(self, mock_deployment_state_manager):
+        """Independent apps tear down without interfering with each other."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a1, b1 = _dep("a", app="app1"), _dep("b", app="app1")
+        a2, b2 = _dep("a", app="app2"), _dep("b", app="app2")
+        _deploy_running(dsm, a1, outbound=[b1])
+        _deploy_running(dsm, b1, outbound=[])
+        _deploy_running(dsm, a2, outbound=[b2])
+        _deploy_running(dsm, b2, outbound=[])
+
+        order = _run_shutdown_to_completion(dsm)
+        assert dsm.is_ready_for_shutdown()
+        assert order.index(b1) > order.index(a1)
+        assert order.index(b2) > order.index(a2)
+
+    def test_wedged_tier_still_completes(self, mock_deployment_state_manager):
+        """A tier that never drains is force-advanced past after the timeout."""
+        create_dsm, timer, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        a, b, c = _dep("a"), _dep("b"), _dep("c")
+        _deploy_running(dsm, a, outbound=[b])
+        _deploy_running(dsm, b, outbound=[c])
+        _deploy_running(dsm, c, outbound=[])
+
+        with patch.object(ds_mod, "RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S", 5):
+            # First tier deletes A, but A's replica is wedged and never stops.
+            dsm.shutdown()
+            dsm.update()
+            assert dsm._get_deployment_state_for_testing(a)._target_state.deleting
+            assert not dsm._get_deployment_state_for_testing(b)._target_state.deleting
+
+            # Before the timeout elapses we stay gated on the wedged tier.
+            dsm.shutdown()
+            assert not dsm._get_deployment_state_for_testing(b)._target_state.deleting
+
+            # After the timeout we force-advance and delete the next tier even
+            # though A is still draining.
+            timer.advance(6)
+            dsm.shutdown()
+            assert dsm._get_deployment_state_for_testing(b)._target_state.deleting
+
+            # Once the wedged replica finally stops, shutdown completes.
+            order = _run_shutdown_to_completion(dsm)
+            assert dsm.is_ready_for_shutdown()
+            assert set(order) == {a, b, c}
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9,6 +9,7 @@ import pytest
 import ray.serve._private.deployment_state as ds_mod
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray._raylet import NodeID
+from ray.serve._private.application_state import ApplicationState
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
@@ -55,10 +56,12 @@ from ray.serve._private.deployment_state import (
     ReplicaStartupStatus,
     ReplicaStateContainer,
 )
+from ray.serve._private.endpoint_state import EndpointState
 from ray.serve._private.exceptions import DeploymentIsBeingDeletedError
 from ray.serve._private.long_poll import LongPollNamespace
 from ray.serve._private.test_utils import (
     MockDeploymentActorWrapper,
+    MockKVStore,
     MockPlacementGroup,
     dead_replicas_context,
     replica_rank_context,
@@ -69,7 +72,7 @@ from ray.serve._private.utils import (
     get_random_string,
 )
 from ray.serve.config import DeploymentActorConfig, GangSchedulingConfig
-from ray.serve.schema import ReplicaRank
+from ray.serve.schema import LoggingConfig, ReplicaRank
 from ray.util.placement_group import validate_placement_group
 
 TEST_DEPLOYMENT_ID = DeploymentID(name="test_deployment", app_name="test_app")
@@ -10423,6 +10426,66 @@ class TestDependencyOrderedShutdown:
             order = _run_shutdown_to_completion(dsm)
             assert dsm.is_ready_for_shutdown()
             assert set(order) == {a, b, c}
+
+
+def test_shutdown_tiers_survive_application_reconcile(mock_deployment_state_manager):
+    """Test ApplicationState does not bypass shutdown tiers."""
+    create_dsm, _, _, autoscaling_state_manager = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    app_state = ApplicationState(
+        name="app",
+        deployment_state_manager=dsm,
+        autoscaling_state_manager=autoscaling_state_manager,
+        endpoint_state=EndpointState(MockKVStore(), Mock()),
+        logging_config=LoggingConfig(),
+        external_scaler_enabled=False,
+    )
+    info_a, _ = deployment_info(num_replicas=1)
+    info_b, _ = deployment_info(num_replicas=1)
+    app_state.deploy_app({"a": info_a, "b": info_b}, external_scaler_enabled=False)
+    app_state.update()
+
+    a, b = _dep("a", app="app"), _dep("b", app="app")
+    ds_a = dsm._get_deployment_state_for_testing(a)
+    ds_b = dsm._get_deployment_state_for_testing(b)
+
+    dsm.update()
+    for r in ds_a._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_ready()
+    for r in ds_b._replicas.get([ReplicaState.STARTING]):
+        r._actor.set_ready()
+    dsm.update()
+    for r in ds_a._replicas.get([ReplicaState.RUNNING]):
+        r._actor._outbound_deployments = [b]
+    for r in ds_b._replicas.get([ReplicaState.RUNNING]):
+        r._actor._outbound_deployments = []
+
+    # Start a full instance shutdown. Tier 0 (a) starts deleting, b does not.
+    dsm.shutdown()
+    assert ds_a._target_state.deleting
+    assert not ds_b._target_state.deleting
+
+    # Deleting the app wipes its target deployment list. The reconcile pass
+    # this triggers must not use that to delete b out of tier order.
+    app_state.delete()
+    app_state.update()
+    assert not ds_b._target_state.deleting
+
+    # Drain a and advance to tier 1. Only now should b start deleting.
+    dsm.update()
+    for r in ds_a._replicas.get([ReplicaState.STOPPING]):
+        r._actor.set_done_stopping()
+    dsm.update()
+    dsm.shutdown()
+    app_state.update()
+    assert ds_b._target_state.deleting
+
+    dsm.update()
+    for r in ds_b._replicas.get([ReplicaState.STOPPING]):
+        r._actor.set_done_stopping()
+    dsm.update()
+    assert dsm.is_ready_for_shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Make Serve controller shutdown dependency ordered. Deployments delete in tiers, callers before callees, instead of all at once. This PR builds a graph and runs Kahn's algorithm into deletion tiers, with a per tier timeout so a stuck replica cannot hang shutdown. Best effort, since the edge data is not guaranteed to be loaded.

## Why
Concurrent teardown lets a still running deployment call into one already deleted, causing dead handle errors.

## Changes
- deployment_state.py: shutdown() is now re entrant. Added _shutdown_deletion_tiers() and _advance_shutdown().
- constants.py: Added RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S, default 30s.

## Tests
Added TestShutdownDeletionTiers and TestDependencyOrderedShutdown covering linear chain, diamond, cycle, unknown outbound, multi app, and timeout cases.

pytest test_deployment_state.py: 245 passed, 14 new. pre-commit: all passed.