### PR TITLE
[data] write_delta implementation

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -2230,6 +2230,20 @@ py_test(
 )
 
 py_test(
+    name = "test_write_delta",
+    size = "medium",
+    srcs = ["tests/datasource/test_write_delta.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_aggregations",
     size = "medium",
     srcs = ["tests/test_aggregations.py"],

--- a/python/ray/data/_internal/datasource/delta_datasink.py
+++ b/python/ray/data/_internal/datasource/delta_datasink.py
@@ -1,0 +1,550 @@
+import json
+import logging
+import posixpath
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
+
+from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
+from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.savemode import SaveMode
+from ray.data.block import Block, BlockAccessor
+from ray.data.context import DataContext
+from ray.data.datasource.datasink import Datasink, WriteResult
+from ray.util.annotations import DeveloperAPI
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+    import pyarrow.fs as pafs
+    from deltalake import DeltaTable
+    from deltalake.transaction import AddAction
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_MODES = {SaveMode.APPEND, SaveMode.OVERWRITE}
+
+# ``schema_mode`` values this prototype supports for reconciling an APPEND's
+# incoming schema against an existing table's schema. See ``DeltaDatasink``'s
+# docstring and the ``schema_mode`` arg doc below for what each one does.
+_SUPPORTED_SCHEMA_MODES = {"merge", "error"}
+
+# Serializes the scoped ``GOOGLE_APPLICATION_CREDENTIALS`` mutation below.
+# ``os.environ`` is process-wide, so two threads building GCS filesystems at
+# once could otherwise observe (or restore) each other's value.
+_gcs_env_lock = threading.Lock()
+
+
+@dataclass
+class DeltaWriteResult:
+    """Result returned from each worker's ``write`` task.
+
+    Attributes:
+        add_actions: ``AddAction`` metadata for every Parquet file the worker wrote.
+        schemas: PyArrow schema of each block the worker wrote, one per block. The
+            driver unifies these across all workers to get the schema to commit.
+    """
+
+    add_actions: List["AddAction"] = field(default_factory=list)
+    schemas: List["pa.Schema"] = field(default_factory=list)
+
+
+@DeveloperAPI
+class DeltaDatasink(Datasink[DeltaWriteResult]):
+    """Datasink that writes a Ray Dataset to a Delta Lake table.
+
+    Workers write Parquet files and return file metadata; the driver commits all
+    files in a single Delta transaction. Supports ``SaveMode.APPEND`` and
+    ``SaveMode.OVERWRITE``.
+
+    Schema evolution on APPEND (``schema_mode``):
+        A column present in the incoming data but not in the table is either
+        added (``"merge"``, the default) or rejected (``"error"``). A column
+        both schemas have with an incompatible type always raises.
+
+        The schema is evolved in ``on_write_complete``, immediately before the
+        data commit, so a failure anywhere earlier leaves the table's schema
+        untouched. (Iceberg has to evolve in ``on_write_start`` instead,
+        because PyIceberg binds field IDs at write time; Delta workers write
+        plain Parquet and the schema is only established at commit.)
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        mode: SaveMode = SaveMode.APPEND,
+        partition_by: Optional[List[str]] = None,
+        storage_options: Optional[Dict[str, str]] = None,
+        schema_mode: str = "merge",
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        """Initialize the DeltaDatasink.
+
+        Args:
+            path: URI of the Delta table (e.g. ``/tmp/my_table`` or
+                ``s3://bucket/my_table``).
+            mode: Write mode. Only ``SaveMode.APPEND`` and ``SaveMode.OVERWRITE``
+                are supported in this prototype.
+            partition_by: Optional list of columns to partition the table by.
+            storage_options: Backend storage options forwarded to ``deltalake`` for
+                the commit (e.g. cloud credentials).
+            schema_mode: How an ``APPEND`` reconciles its incoming schema
+                against an existing table's schema, when the incoming data
+                has a column the table doesn't. Has no effect on
+                ``OVERWRITE`` (which always replaces the table's schema
+                wholesale) or on a brand-new table (nothing to reconcile
+                against yet). One of:
+
+                * ``"merge"`` (default): add the new column(s) to the table
+                  before committing, as an ``ALTER TABLE ADD COLUMN``-style
+                  operation. New columns are always added as nullable --
+                  every row already in the table has no value for a
+                  brand-new column, so a non-nullable declaration would make
+                  the schema self-contradictory.
+                * ``"error"``: reject the write with a clear ``ValueError``
+                  instead of evolving the schema. Nothing about the table
+                  changes.
+
+                Either way, a column both schemas already have, but with an
+                incompatible type, always raises -- schema evolution here
+                only ever *adds* columns, it never changes an existing
+                column's type.
+            name: Optional table name recorded in the Delta metadata (new tables).
+            description: Optional table description recorded in the Delta metadata
+                (new tables).
+        """
+        try:
+            # ``SaveMode`` is a ``(str, Enum)``, so a plain ``"append"`` passes
+            # membership checks but has no ``.value``. Normalize so downstream
+            # code always has a real enum member.
+            mode = SaveMode(mode)
+        except ValueError:
+            pass  # Not a valid SaveMode value at all; let the check below raise.
+
+        if mode not in _SUPPORTED_MODES:
+            raise ValueError(
+                f"DeltaDatasink only supports "
+                f"{sorted(m.value for m in _SUPPORTED_MODES)} in this "
+                f"prototype, got {mode!r}."
+            )
+        if schema_mode not in _SUPPORTED_SCHEMA_MODES:
+            raise ValueError(
+                f"DeltaDatasink only supports schema_mode in "
+                f"{sorted(_SUPPORTED_SCHEMA_MODES)}, got {schema_mode!r}."
+            )
+
+        self._path = path.rstrip("/")
+        self._mode = mode
+        self._partition_by = list(partition_by) if partition_by else []
+        self._storage_options = dict(storage_options) if storage_options else None
+        self._schema_mode = schema_mode
+        self._name = name
+        self._description = description
+        # Captured from the first input bundle in ``on_write_start`` so the commit
+        # has a schema even when the dataset is empty.
+        self._schema: Optional["pa.Schema"] = None
+        self._data_context = DataContext.get_current()
+
+    def on_write_start(self, schema: Optional["pa.Schema"] = None) -> None:
+        """Capture the dataset schema, and reconcile ``partition_by`` against
+        an existing table's partition columns -- inheriting them when none
+        were given, and rejecting a mismatch.
+
+        Delta reads a partitioned column's value from ``AddAction`` metadata
+        rather than the Parquet file, so writing a layout that disagrees with
+        the table's ``partition_columns`` reads those values back as ``None``,
+        or commits an unreadable version. Neither APPEND nor OVERWRITE resets
+        a table's partitioning, and this prototype can't change it, so the
+        only safe options are to match it or inherit it.
+
+        This runs before any write task, both because workers need the
+        partition columns up front and so a mismatch fails before anything has
+        been written.
+        """
+        self._schema = schema
+
+        from deltalake import DeltaTable
+
+        if not DeltaTable.is_deltatable(
+            self._path, storage_options=self._storage_options
+        ):
+            return
+
+        existing_partition_by = list(
+            DeltaTable(self._path, storage_options=self._storage_options)
+            .metadata()
+            .partition_columns
+        )
+        if not self._partition_by:
+            self._partition_by = existing_partition_by
+        elif self._partition_by != existing_partition_by:
+            raise ValueError(
+                f"Cannot write to Delta table '{self._path}': the table is "
+                f"partitioned by {existing_partition_by}, but "
+                f"partition_by={self._partition_by} was given. This prototype "
+                "can't change an existing table's partition scheme -- pass the "
+                "same columns in the same order, or omit partition_by to "
+                "inherit the table's."
+            )
+
+    def write(self, blocks: Iterable[Block], ctx: TaskContext) -> DeltaWriteResult:
+        """Write each block to its own Parquet file and return the resulting
+        ``AddAction`` metadata plus the blocks' schemas.
+
+        Runs on each worker. Only file metadata (not data) is sent to the
+        driver, which unifies the schemas across all workers before committing.
+        """
+        add_actions: List["AddAction"] = []
+        schemas: List["pa.Schema"] = []
+        for block in blocks:
+            table = BlockAccessor.for_block(block).to_arrow()
+            if table.num_rows > 0:
+                add_actions.extend(self._write_parquet(table, ctx))
+                schemas.append(table.schema)
+
+        return DeltaWriteResult(add_actions=add_actions, schemas=schemas)
+
+    def on_write_complete(self, write_result: WriteResult[DeltaWriteResult]) -> None:
+        """Commit all written files to the Delta log in a single transaction."""
+        from deltalake import DeltaTable, Schema
+        from deltalake.transaction import create_table_with_add_actions
+
+        add_actions: List["AddAction"] = []
+        schemas: List["pa.Schema"] = []
+        for result in write_result.write_returns:
+            if result is None:
+                continue
+            add_actions.extend(result.add_actions)
+            schemas.extend(result.schemas)
+
+        table_exists = DeltaTable.is_deltatable(
+            self._path, storage_options=self._storage_options
+        )
+        delta_mode = self._mode.value
+
+        if not add_actions and delta_mode == "append" and table_exists:
+            logger.info(
+                "No files to commit to Delta table '%s' (mode=append); skipping.",
+                self._path,
+            )
+            return
+
+        # ``self._schema`` (from ``on_write_start``) is only a fallback for a
+        # dataset that produced no rows at all: for a file-listing-based read
+        # it can be Ray Data's internal metadata schema rather than the row
+        # schema, so real worker schemas always win.
+        schema = unify_schemas(schemas) if schemas else self._schema
+        if schema is None and delta_mode == "overwrite" and table_exists:
+            # An empty OVERWRITE still truncates the table, so fall back to the
+            # table's own schema rather than requiring one from the empty write.
+            schema = (
+                DeltaTable(self._path, storage_options=self._storage_options)
+                .schema()
+                .to_arrow()
+            )
+        if schema is None:
+            raise ValueError(
+                "Cannot write a Delta table without a schema: the dataset produced "
+                "no data and no schema was provided."
+            )
+
+        if not table_exists:
+            # Create a brand-new table with the initial set of files.
+            create_table_with_add_actions(
+                table_uri=self._path,
+                schema=Schema.from_arrow(schema),
+                add_actions=add_actions,
+                mode="overwrite" if delta_mode == "overwrite" else "error",
+                partition_by=self._partition_by or None,
+                name=self._name,
+                description=self._description,
+                storage_options=self._storage_options,
+            )
+        else:
+            dt = DeltaTable(self._path, storage_options=self._storage_options)
+            if delta_mode == "append":
+                dt = self._reconcile_schema_with_existing_table(schema, dt)
+            dt.create_write_transaction(
+                actions=add_actions,
+                mode=delta_mode,
+                schema=schema,
+                partition_by=self._partition_by or None,
+            )
+
+        logger.info(
+            "Committed %d file(s) to Delta table '%s' (mode=%s).",
+            len(add_actions),
+            self._path,
+            delta_mode,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _reconcile_schema_with_existing_table(
+        self, schema: "pa.Schema", dt: "DeltaTable"
+    ) -> "DeltaTable":
+        """Reconcile ``schema`` (the schema being committed) against ``dt``'s
+        current table schema, per ``self._schema_mode``.
+
+        A column in ``schema`` that ``dt`` doesn't have is either added to the
+        table (``schema_mode="merge"``) or rejected (``schema_mode="error"``).
+        A column both schemas have with an incompatible type always raises,
+        regardless of ``schema_mode`` -- only adding columns is ever safe to
+        do automatically.
+
+        Returns the ``DeltaTable`` to commit against: ``dt`` itself, or a
+        reloaded one if the schema was evolved.
+        """
+        import pyarrow as pa
+
+        existing_schema = pa.schema(dt.schema().to_arrow())
+
+        # Check types before evolving, so a write that both adds a column and
+        # conflicts on an existing one fails without having already committed
+        # the (permanent) schema change.
+        #
+        # ``unify_schemas`` reports an incompatibility as ArrowTypeError or
+        # ArrowInvalid depending on the types involved, and can surface a few
+        # unreconcilable shapes as KeyError/ValueError instead. The call below
+        # is the only statement in the try, so any failure means these schemas
+        # can't be unified -- wrap them all rather than leak a raw Arrow error.
+        try:
+            unify_schemas([existing_schema, schema])
+        except Exception as e:
+            raise ValueError(
+                f"Cannot write to Delta table '{self._path}': the incoming "
+                f"data's schema is not compatible with the table's existing "
+                f"schema ({e}). schema_mode={self._schema_mode!r} only "
+                "supports adding new columns, not changing an existing "
+                "column's type."
+            ) from e
+
+        # Walk the incoming schema's field order, not a set difference: set
+        # iteration order for strings is hash-randomized per process, which
+        # would make the table's final column order vary between runs.
+        existing_names = set(existing_schema.names)
+        new_fields = [
+            schema.field(name) for name in schema.names if name not in existing_names
+        ]
+        if new_fields:
+            if self._schema_mode == "error":
+                raise ValueError(
+                    f"Cannot write to Delta table '{self._path}': column(s) "
+                    f"{[f.name for f in new_fields]} are not present in the "
+                    "table's existing schema. Pass schema_mode='merge' "
+                    "(the default) to add new columns automatically, or "
+                    "remove them from the incoming data."
+                )
+            dt = self._evolve_schema_for_new_columns(dt, new_fields)
+
+        return dt
+
+    def _evolve_schema_for_new_columns(
+        self, dt: "DeltaTable", new_fields: List["pa.Field"]
+    ) -> "DeltaTable":
+        """Add ``new_fields`` to the table's schema in their own transaction
+        and return a reloaded ``DeltaTable``.
+
+        New columns are forced nullable: rows already in the table have no
+        value for them, and ``alter.add_columns`` won't reject a non-nullable
+        field on its own. ``alter.add_columns`` is also the only API that
+        actually evolves the schema -- passing a wider ``schema=`` to the
+        data-commit calls is silently ignored.
+        """
+        import pyarrow as pa
+        from deltalake import DeltaTable, Schema as DeltaSchema
+
+        nullable_fields = [f.with_nullable(True) for f in new_fields]
+        delta_schema = DeltaSchema.from_arrow(pa.schema(nullable_fields))
+        dt.alter.add_columns(delta_schema.fields)
+        return DeltaTable(self._path, storage_options=self._storage_options)
+
+    def _write_parquet(self, table: "pa.Table", ctx: TaskContext) -> List["AddAction"]:
+        """Write a PyArrow table to Parquet under the table root, one file per
+        partition, and return the corresponding ``AddAction`` metadata."""
+        import pyarrow.dataset as pds
+        import pyarrow.fs as pafs
+        from deltalake.transaction import AddAction
+
+        filesystem, root = pafs.FileSystem.from_uri(self._path)
+        explicit_fs = _explicit_filesystem_from_storage_options(
+            self._path, self._storage_options
+        )
+        if explicit_fs is not None:
+            filesystem = explicit_fs
+        modification_time = int(time.time() * 1000)
+        # Unique prefix per write task so retries/concurrent tasks don't collide.
+        task_idx = getattr(ctx, "task_idx", 0)
+        write_uuid = uuid.uuid4().hex
+
+        written: List["AddAction"] = []
+
+        def _visit(written_file: "pds.WrittenFile") -> None:
+            # The Delta log stores paths relative to the table root. Strip
+            # leading slashes from both sides first: S3 can report a root
+            # without one but written-file paths with one, and that mismatch
+            # makes relpath walk upward into ``../../bucket/...``.
+            rel_path = posixpath.relpath(
+                written_file.path.lstrip("/"), root.lstrip("/")
+            )
+            partition_values = _parse_partition_values(rel_path, self._partition_by)
+            metadata = written_file.metadata
+            written.append(
+                AddAction(
+                    path=rel_path,
+                    size=written_file.size,
+                    partition_values=partition_values,
+                    modification_time=modification_time,
+                    data_change=True,
+                    stats=json.dumps({"numRecords": metadata.num_rows}),
+                )
+            )
+
+        partitioning = None
+        if self._partition_by:
+            # Check up front: ``Table.select`` would otherwise raise a bare
+            # KeyError from inside a worker, naming neither the table nor the
+            # fact that the partition columns may have been inherited.
+            missing = [c for c in self._partition_by if c not in table.column_names]
+            if missing:
+                raise ValueError(
+                    f"Cannot write to Delta table '{self._path}': the data "
+                    f"being written is missing partition column(s) "
+                    f"{missing}. The table is partitioned by "
+                    f"{self._partition_by}, so every row written to it must "
+                    "carry those columns."
+                )
+            partitioning = pds.partitioning(
+                table.select(self._partition_by).schema, flavor="hive"
+            )
+
+        # Object stores have no real directories, so create_dir=True just makes
+        # every task PutObject the same marker key -- enough concurrency against
+        # a cold prefix to trigger S3 SLOW_DOWN. Real filesystems still need it.
+        create_dir = not isinstance(
+            filesystem, (pafs.S3FileSystem, pafs.GcsFileSystem, pafs.AzureFileSystem)
+        )
+
+        pds.write_dataset(
+            table,
+            base_dir=root,
+            filesystem=filesystem,
+            format="parquet",
+            partitioning=partitioning,
+            basename_template=f"part-{task_idx:05d}-{write_uuid}-{{i}}.parquet",
+            existing_data_behavior="overwrite_or_ignore",
+            file_visitor=_visit,
+            create_dir=create_dir,
+        )
+        return written
+
+
+def _explicit_filesystem_from_storage_options(
+    path: str, storage_options: Optional[Dict[str, str]]
+) -> Optional["pafs.FileSystem"]:
+    """Build a credentialed PyArrow filesystem from ``storage_options`` for
+    cloud paths, so worker-side Parquet writes use the same explicit
+    credentials the driver's Delta commit already receives.
+
+    ``pyarrow.fs.FileSystem.from_uri`` alone can't accept credentials, so
+    without this an explicit ``storage_options=`` would only ever reach the
+    driver-side ``DeltaTable``/``create_table_with_add_actions`` calls, while
+    workers silently fell back to ambient/default credentials.
+
+    Returns ``None`` when ``storage_options`` is empty/unset or doesn't
+    match a recognized scheme, so the caller falls back to
+    ``from_uri`` -- i.e. today's ambient-credential behavior is unchanged
+    when no explicit ``storage_options`` are given.
+    """
+    import pyarrow.fs as pafs
+
+    if not storage_options:
+        return None
+    path_lower = path.lower()
+    if path_lower.startswith(("s3://", "s3a://")):
+        access_key = storage_options.get("AWS_ACCESS_KEY_ID")
+        secret_key = storage_options.get("AWS_SECRET_ACCESS_KEY")
+        session_token = storage_options.get("AWS_SESSION_TOKEN")
+        # Fall back to the boto-style AWS_DEFAULT_REGION, which the driver's
+        # commit path already honors.
+        region = storage_options.get("AWS_REGION") or storage_options.get(
+            "AWS_DEFAULT_REGION"
+        )
+        # AWS_ENDPOINT_URL is deltalake's own key for a custom S3-compatible
+        # endpoint (MinIO, moto). Without it, workers would target real AWS
+        # while the driver's commit targets the custom endpoint.
+        endpoint_url = storage_options.get("AWS_ENDPOINT_URL")
+        if access_key or secret_key or session_token or region or endpoint_url:
+            return pafs.S3FileSystem(
+                access_key=access_key,
+                secret_key=secret_key,
+                session_token=session_token,
+                region=region,
+                endpoint_override=endpoint_url,
+            )
+    elif path_lower.startswith(("abfss://", "abfs://")):
+        account_name = storage_options.get("AZURE_STORAGE_ACCOUNT_NAME")
+        # Matches ray.data.catalog's vended-credential key (AZURE_STORAGE_SAS_TOKEN),
+        # not a made-up name -- a mismatch here would leave workers uncredentialed
+        # even when the driver's commit works fine.
+        token = storage_options.get("AZURE_STORAGE_SAS_TOKEN")
+        # An account key is a separate, mutually exclusive auth method from a
+        # SAS token; without it a key-authenticated caller would get an
+        # uncredentialed worker filesystem.
+        account_key = storage_options.get("AZURE_STORAGE_ACCOUNT_KEY")
+        if account_name and (token or account_key):
+            return pafs.AzureFileSystem(
+                account_name=account_name, sas_token=token, account_key=account_key
+            )
+        if account_name:
+            return pafs.AzureFileSystem(account_name=account_name)
+    elif path_lower.startswith(("gs://", "gcs://")):
+        service_account = storage_options.get("GOOGLE_SERVICE_ACCOUNT")
+        anonymous = storage_options.get("GOOGLE_ANONYMOUS", "").lower() == "true"
+        if service_account or anonymous:
+            if service_account:
+                # GcsFileSystem has no constructor arg for a service-account
+                # path -- it only reads GOOGLE_APPLICATION_CREDENTIALS. That's
+                # process-wide, and Ray reuses worker processes across tasks,
+                # so scope the mutation to this call and always restore it.
+                import os
+
+                key = "GOOGLE_APPLICATION_CREDENTIALS"
+                with _gcs_env_lock:
+                    previous = os.environ.get(key)
+                    os.environ[key] = service_account
+                    try:
+                        return pafs.GcsFileSystem(anonymous=anonymous)
+                    finally:
+                        if previous is None:
+                            os.environ.pop(key, None)
+                        else:
+                            os.environ[key] = previous
+            return pafs.GcsFileSystem(anonymous=anonymous)
+    return None
+
+
+def _parse_partition_values(
+    rel_path: str, partition_by: List[str]
+) -> Dict[str, Optional[str]]:
+    """Extract ``{col: value}`` from a hive-partitioned relative file path."""
+    import urllib.parse
+
+    if not partition_by:
+        return {}
+    values: Dict[str, Optional[str]] = {}
+    for segment in rel_path.split("/")[:-1]:
+        if "=" in segment:
+            key, _, value = segment.partition("=")
+            unquoted_key = urllib.parse.unquote(key)
+            unquoted_value = urllib.parse.unquote(value)
+            values[unquoted_key] = (
+                None
+                if unquoted_value == "__HIVE_DEFAULT_PARTITION__"
+                else unquoted_value
+            )
+    return {col: values.get(col) for col in partition_by}

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -41,6 +41,7 @@ from ray.data._internal.datasource.clickhouse_datasink import (
     SinkMode,
 )
 from ray.data._internal.datasource.csv_datasink import CSVDatasink
+from ray.data._internal.datasource.delta_datasink import DeltaDatasink
 from ray.data._internal.datasource.iceberg_datasink import IcebergDatasink
 from ray.data._internal.datasource.image_datasink import ImageDatasink
 from ray.data._internal.datasource.json_datasink import JSONDatasink
@@ -4732,6 +4733,124 @@ class Dataset:
             overwrite_filter=overwrite_filter,
             upsert_kwargs=upsert_kwargs,
             overwrite_kwargs=overwrite_kwargs,
+        )
+
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
+
+    @ConsumptionAPI
+    @PublicAPI(stability="alpha", api_group=IOC_API_GROUP)
+    def write_delta(
+        self,
+        path: str,
+        *,
+        mode: "SaveMode" = SaveMode.APPEND,
+        partition_by: Optional[List[str]] = None,
+        storage_options: Optional[Dict[str, str]] = None,
+        schema_mode: str = "merge",
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
+        concurrency: Optional[int] = None,
+    ) -> None:
+        """Writes the :class:`~ray.data.Dataset` to a Delta Lake table.
+
+        This is a prototype that supports ``APPEND`` and ``OVERWRITE`` modes. Each
+        write task writes Parquet data files to the table location, and the driver
+        performs a single atomic commit to the Delta transaction log using the
+        ``deltalake`` library. If the table doesn't exist, it's created.
+
+        .. tip::
+            For more details on Delta Lake, see https://delta.io/ and the
+            ``deltalake`` Python library.
+
+        Examples:
+             .. testcode::
+                :skipif: True
+
+                import ray
+                import pandas as pd
+                from ray.data import SaveMode
+
+                docs = [{"id": i, "title": f"Doc {i}"} for i in range(4)]
+                ds = ray.data.from_pandas(pd.DataFrame(docs))
+
+                # Append (default) - creates the table if it doesn't exist.
+                ds.write_delta("/tmp/my_delta_table")
+
+                # Overwrite the table contents.
+                ds.write_delta("/tmp/my_delta_table", mode=SaveMode.OVERWRITE)
+
+                # Partitioned write.
+                ds.write_delta("/tmp/my_delta_table", partition_by=["id"])
+
+                # A later append with an extra column adds it to the table
+                # automatically (the default schema_mode="merge") -- existing
+                # rows read back with None for it.
+                more_docs = [{"id": 4, "title": "Doc 4", "views": 100}]
+                ray.data.from_pandas(pd.DataFrame(more_docs)).write_delta(
+                    "/tmp/my_delta_table"
+                )
+
+                # Reject that same write instead, leaving the table untouched.
+                ray.data.from_pandas(pd.DataFrame(more_docs)).write_delta(
+                    "/tmp/my_delta_table", schema_mode="error"
+                )
+
+        Args:
+            path: URI of the Delta table (e.g. ``/tmp/my_table`` or
+                ``s3://bucket/my_table``).
+            mode: Write mode using the :class:`~ray.data.SaveMode` enum. Options:
+
+                * ``SaveMode.APPEND`` (default): Add new data to the table.
+                * ``SaveMode.OVERWRITE``: Replace all existing data in the table.
+
+            partition_by: Optional list of columns to partition the table by.
+            storage_options: A dictionary of storage options passed to the
+                ``deltalake`` library for authentication and configuration (e.g.
+                cloud credentials).
+            schema_mode: How an ``APPEND`` handles a column present in the
+                data being written but absent from the table's current
+                schema. Has no effect on ``SaveMode.OVERWRITE`` (which always
+                replaces the table's schema wholesale) or when the table
+                doesn't exist yet (there's no existing schema to compare
+                against). One of:
+
+                * ``"merge"`` (default): Add the new column to the table
+                  before committing the write, like SQL's
+                  ``ALTER TABLE ... ADD COLUMN``. The new column is always
+                  added as nullable, and every row written before this
+                  reads back with ``None`` for it.
+                * ``"error"``: Reject the write with a ``ValueError``
+                  instead, leaving the table's schema unchanged.
+
+                A column present in *both* the data and the table, but with
+                an incompatible type (for example, writing a string into a
+                column the table has as an integer), always raises a
+                ``ValueError`` -- regardless of ``schema_mode``. Only adding
+                a brand-new column is supported; changing an existing
+                column's type is not.
+            name: Optional table name recorded in the Delta metadata when a new
+                table is created.
+            description: Optional table description recorded in the Delta metadata
+                when a new table is created.
+            ray_remote_args: kwargs passed to :func:`ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set
+                this to control number of tasks to run concurrently. This doesn't
+                change the total number of tasks run. By default, concurrency is
+                dynamically decided based on the available resources.
+        """
+        datasink = DeltaDatasink(
+            path=path,
+            mode=mode,
+            partition_by=partition_by,
+            storage_options=storage_options,
+            schema_mode=schema_mode,
+            name=name,
+            description=description,
         )
 
         self.write_datasink(

--- a/python/ray/data/tests/datasource/test_write_delta.py
+++ b/python/ray/data/tests/datasource/test_write_delta.py
@@ -1,0 +1,1015 @@
+"""Tests for the prototype ``Dataset.write_delta`` implementation.
+
+Covers only what this prototype actually supports: ``SaveMode.APPEND`` and
+``SaveMode.OVERWRITE`` (no ``ERROR``/``IGNORE``, no dynamic partition
+overwrite), Hive-style partitioning, ``storage_options`` passthrough to the
+driver-side commit calls, and ``schema_mode``-governed schema evolution on
+APPEND (adding new columns only -- never changing an existing column's type).
+
+Master's existing ``test_delta.py`` covers ``ray.data.read_delta`` and is not
+modified here.
+"""
+
+import os
+from typing import Any, Callable, Dict, List, Optional
+from unittest import mock
+
+import pytest
+from packaging.version import parse as parse_version
+
+import ray
+from ray.data import SaveMode
+from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+try:
+    import deltalake as _deltalake_check  # noqa: F401
+except ImportError:
+    _deltalake_check = None
+
+_pa_version = get_pyarrow_version()
+pytestmark = [
+    pytest.mark.skipif(
+        _deltalake_check is None,
+        reason="Missing optional dependency: pip install deltalake",
+    ),
+    pytest.mark.skipif(
+        _pa_version is None or _pa_version < parse_version("15.0.0"),
+        reason="deltalake requires pyarrow >= 15.0",
+    ),
+]
+
+
+@pytest.fixture
+def temp_delta_path(tmp_path):
+    """Clean per-test path for a Delta table."""
+    return os.path.join(str(tmp_path), "delta_table")
+
+
+def _write_append(rows: List[Dict[str, Any]], path: str, **kwargs) -> None:
+    ray.data.from_items(rows).write_delta(path, **kwargs)
+
+
+def _read_all(path: str) -> List[Dict[str, Any]]:
+    return ray.data.read_delta(path).take_all()
+
+
+def _log_exists(path: str) -> bool:
+    return os.path.isdir(os.path.join(path, "_delta_log"))
+
+
+def _delta_log_json_count(path: str) -> int:
+    """Count the *.json files inside _delta_log/ (one per Delta version)."""
+    log_dir = os.path.join(path, "_delta_log")
+    if not os.path.isdir(log_dir):
+        return 0
+    return sum(1 for f in os.listdir(log_dir) if f.endswith(".json"))
+
+
+# ----------------------------------------------------------------------
+# APPEND.
+# ----------------------------------------------------------------------
+
+
+def test_append_to_new_path_creates_table(temp_delta_path):
+    rows = [{"id": i, "v": f"r{i}"} for i in range(5)]
+    _write_append(rows, temp_delta_path)
+    assert _log_exists(temp_delta_path)
+    assert sorted(_read_all(temp_delta_path), key=lambda r: r["id"]) == rows
+
+
+def test_append_to_existing_table_sums_rows(temp_delta_path):
+    first = [{"id": i, "v": f"a{i}"} for i in range(3)]
+    second = [{"id": i + 100, "v": f"b{i}"} for i in range(2)]
+    _write_append(first, temp_delta_path)
+    _write_append(second, temp_delta_path)
+    assert len(_read_all(temp_delta_path)) == 5
+
+
+def test_multiple_blocks_commit_correctly(temp_delta_path):
+    """A dataset split across several blocks/write tasks must still commit
+    all rows in a single, correctly-aggregated transaction."""
+    rows = [{"id": i, "v": f"r{i}"} for i in range(20)]
+    ray.data.from_items(rows, override_num_blocks=4).write_delta(temp_delta_path)
+    assert sorted(_read_all(temp_delta_path), key=lambda r: r["id"]) == rows
+
+
+def test_read_parquet_sourced_write_succeeds(tmp_path, temp_delta_path):
+    """Regression test: a Dataset sourced from a file-listing-based read
+    (e.g. ``read_parquet``) must write successfully. ``on_write_start``
+    can receive Ray Data's internal file-listing metadata schema (e.g. a
+    null-typed ``__file_chunk_metadata`` column) rather than the actual
+    row schema for such datasets -- ``_resolve_schema`` must prefer the
+    schema workers actually wrote over that driver-side capture. Every
+    other test in this file uses ``from_items``, which doesn't go through
+    this code path and so never exercised this."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    source_path = str(tmp_path / "source.parquet")
+    rows = [{"id": i, "v": f"r{i}"} for i in range(10)]
+    pq.write_table(pa.Table.from_pylist(rows), source_path)
+
+    ray.data.read_parquet(source_path).write_delta(temp_delta_path)
+    assert sorted(_read_all(temp_delta_path), key=lambda r: r["id"]) == rows
+
+
+# ----------------------------------------------------------------------
+# OVERWRITE.
+# ----------------------------------------------------------------------
+
+
+def test_overwrite_replaces_existing_data(temp_delta_path):
+    _write_append([{"id": i, "v": "old"} for i in range(3)], temp_delta_path)
+    ray.data.from_items([{"id": i, "v": "new"} for i in range(2)]).write_delta(
+        temp_delta_path, mode=SaveMode.OVERWRITE
+    )
+    out = _read_all(temp_delta_path)
+    assert len(out) == 2
+    assert all(r["v"] == "new" for r in out)
+
+
+def test_overwrite_creates_table_when_missing(temp_delta_path):
+    ray.data.from_items([{"id": 1}]).write_delta(
+        temp_delta_path, mode=SaveMode.OVERWRITE
+    )
+    assert _log_exists(temp_delta_path)
+    assert _read_all(temp_delta_path) == [{"id": 1}]
+
+
+def test_overwrite_empty_dataset_against_existing_table_truncates(temp_delta_path):
+    """An empty OVERWRITE against an already-existing table is still a
+    well-defined operation (truncate it) even though no worker writes any
+    rows to infer a schema from. Regression test: before the fix, this
+    raised "Cannot write a Delta table without a schema" because no write
+    tasks ran (so there was no worker schema) and the resolver had no
+    fallback to the table's own existing schema."""
+    _write_append([{"id": i, "v": "old"} for i in range(3)], temp_delta_path)
+    ray.data.from_items([]).write_delta(temp_delta_path, mode=SaveMode.OVERWRITE)
+    assert _read_all(temp_delta_path) == []
+
+
+# ----------------------------------------------------------------------
+# Unsupported modes -- this prototype only implements APPEND/OVERWRITE.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [SaveMode.ERROR, SaveMode.IGNORE, SaveMode.UPSERT])
+def test_unsupported_mode_rejected(temp_delta_path, mode):
+    with pytest.raises(ValueError, match="only supports"):
+        ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode=mode)
+
+
+# ----------------------------------------------------------------------
+# Partitioning.
+# ----------------------------------------------------------------------
+
+
+def test_single_column_partition(temp_delta_path):
+    rows = [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
+    ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
+    assert set(os.listdir(temp_delta_path)) >= {"year=2024", "year=2025"}
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == rows
+
+
+def test_multi_column_partition(temp_delta_path):
+    rows = [
+        {"year": 2024, "month": 1, "id": 1},
+        {"year": 2024, "month": 2, "id": 2},
+        {"year": 2025, "month": 1, "id": 3},
+    ]
+    ray.data.from_items(rows).write_delta(
+        temp_delta_path, partition_by=["year", "month"]
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == rows
+
+
+def test_null_partition_value_round_trips_as_none(temp_delta_path):
+    """Regression test: PyArrow's Hive-flavor writer encodes a NULL
+    partition value as the literal directory name
+    ``__HIVE_DEFAULT_PARTITION__`` -- this must round-trip back as Python
+    ``None``, not that literal string."""
+    rows = [{"year": 2024, "id": 1}, {"year": None, "id": 2}]
+    ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
+    assert "year=__HIVE_DEFAULT_PARTITION__" in os.listdir(temp_delta_path)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == rows
+
+
+def test_parse_partition_values_maps_hive_default_to_none():
+    from ray.data._internal.datasource.delta_datasink import _parse_partition_values
+
+    assert _parse_partition_values(
+        "year=__HIVE_DEFAULT_PARTITION__/part-0.parquet", ["year"]
+    ) == {"year": None}
+
+
+def test_parse_partition_values_unquotes_keys():
+    """Partition column names, like values, must be URL-unquoted. PyArrow's
+    current Hive writer doesn't appear to actually quote keys in practice,
+    but this is a cheap, harmless, symmetric fix with the value-unquoting
+    that's already done -- exercised here directly since a real write can't
+    easily be made to produce a quoted key."""
+    from ray.data._internal.datasource.delta_datasink import _parse_partition_values
+
+    assert _parse_partition_values("col%20name=val/part-0.parquet", ["col name"]) == {
+        "col name": "val"
+    }
+
+
+def test_append_without_partition_by_inherits_existing_partitioning(temp_delta_path):
+    """Regression test: appending to an already-partitioned table without
+    re-specifying partition_by used to write files flat (no Hive partition
+    directory) with an empty AddAction.partition_values -- Delta's reader
+    derives a partitioned column's value from that metadata, not from the
+    (still-present) column in the physical Parquet file, so the real value
+    was silently lost entirely (read back as None), not just misplaced on
+    disk."""
+    rows1 = [{"year": 2024, "id": 1}]
+    ray.data.from_items(rows1).write_delta(temp_delta_path, partition_by=["year"])
+    assert "year=2024" in os.listdir(temp_delta_path)
+
+    rows2 = [{"year": 2025, "id": 2}]
+    ray.data.from_items(rows2).write_delta(temp_delta_path)  # no partition_by
+
+    assert "year=2025" in os.listdir(temp_delta_path)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
+
+
+def test_append_without_partition_by_on_unpartitioned_table_unaffected(
+    temp_delta_path,
+):
+    """An append with no partition_by to a table that was never partitioned
+    must behave exactly as before -- no partition inheritance to do."""
+    _write_append([{"id": 1, "v": "a"}], temp_delta_path)
+    _write_append([{"id": 2, "v": "b"}], temp_delta_path)
+    assert not any(name.startswith("id=") for name in os.listdir(temp_delta_path))
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]
+
+
+@pytest.mark.parametrize(
+    "create_partition_by,write_partition_by",
+    [
+        pytest.param(["year", "month"], ["year"], id="subset"),
+        pytest.param(["year"], ["year", "month"], id="superset"),
+        pytest.param(["month", "year"], ["year", "month"], id="reordered"),
+        pytest.param(None, ["year"], id="unpartitioned-to-partitioned"),
+    ],
+)
+def test_partition_by_mismatch_rejected(
+    temp_delta_path, create_partition_by, write_partition_by
+):
+    """A partition_by that disagrees with the table's partition columns is
+    rejected before anything is written.
+
+    Delta takes a partitioned column's value from AddAction metadata, so a
+    mismatched layout either reads those values back as None (subset, or
+    partitioning a previously-unpartitioned table) or commits a version that
+    can't be read at all (superset). Both used to happen silently.
+    """
+    from deltalake import DeltaTable
+
+    first = [{"year": 2024, "month": 1, "id": 1}]
+    ray.data.from_items(first).write_delta(
+        temp_delta_path, partition_by=create_partition_by
+    )
+    log_before = _delta_log_json_count(temp_delta_path)
+
+    with pytest.raises(ValueError, match="can't change an existing table's"):
+        ray.data.from_items([{"year": 2025, "month": 2, "id": 2}]).write_delta(
+            temp_delta_path, partition_by=write_partition_by
+        )
+
+    # Nothing was committed and the table is untouched and still readable.
+    assert _delta_log_json_count(temp_delta_path) == log_before
+    assert DeltaTable(temp_delta_path).metadata().partition_columns == (
+        create_partition_by or []
+    )
+    assert _read_all(temp_delta_path) == first
+
+
+def test_partition_by_matching_existing_is_allowed(temp_delta_path):
+    """Passing exactly the table's own partition columns is fine."""
+    ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
+        temp_delta_path, partition_by=["year"]
+    )
+    ray.data.from_items([{"year": 2025, "id": 2}]).write_delta(
+        temp_delta_path, partition_by=["year"]
+    )
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
+
+
+def test_overwrite_without_partition_by_inherits_existing_partitioning(
+    temp_delta_path,
+):
+    """An OVERWRITE inherits the existing table's partitioning just like an
+    APPEND does. Regression test: overwriting an already-partitioned table
+    without re-specifying partition_by used to write flat files with empty
+    AddAction.partition_values while the table's partition_columns metadata
+    stayed intact -- verified empirically that
+    ``create_write_transaction(partition_by=None)`` does NOT reset that
+    metadata -- leaving the table self-contradictory and every partition
+    value reading back as None."""
+    ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
+        temp_delta_path, partition_by=["year"]
+    )
+    ray.data.from_items([{"year": 2025, "id": 2}]).write_delta(
+        temp_delta_path, mode=SaveMode.OVERWRITE
+    )
+
+    assert "year=2025" in os.listdir(temp_delta_path)
+    assert _read_all(temp_delta_path) == [{"year": 2025, "id": 2}]
+
+
+@pytest.mark.parametrize("mode", [SaveMode.APPEND, SaveMode.OVERWRITE])
+def test_write_missing_partition_column_raises_clear_error(temp_delta_path, mode):
+    """Writing data that lacks one of the table's partition columns must
+    raise a clear error naming the missing column. Those columns can be
+    inherited from the existing table rather than passed by the caller, so
+    the bare ``KeyError('Field "year" does not exist in schema')`` PyArrow
+    raises from inside a worker task gives the user nothing to go on."""
+    ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
+        temp_delta_path, partition_by=["year"]
+    )
+    with pytest.raises(Exception, match="missing partition column"):
+        ray.data.from_items([{"other": "x"}]).write_delta(temp_delta_path, mode=mode)
+
+
+# ----------------------------------------------------------------------
+# Empty dataset against an existing table (APPEND is a no-op).
+# ----------------------------------------------------------------------
+
+
+def test_empty_append_against_existing_table_is_noop(temp_delta_path):
+    """An empty-dataset APPEND against an already-existing table must be a
+    pure no-op: no schema resolution needed, no empty commit added to the
+    Delta log, and existing data left untouched."""
+    rows = [{"id": 1}, {"id": 2}]
+    ray.data.from_items(rows).write_delta(temp_delta_path)
+    before = _delta_log_json_count(temp_delta_path)
+
+    ray.data.from_items([]).write_delta(temp_delta_path)
+
+    assert _delta_log_json_count(temp_delta_path) == before
+    assert sorted(_read_all(temp_delta_path), key=lambda r: r["id"]) == rows
+
+
+# ----------------------------------------------------------------------
+# Relative path computation across filesystems.
+# ----------------------------------------------------------------------
+
+
+def test_written_file_relative_path_handles_leading_slash_mismatch(
+    temp_delta_path, monkeypatch
+):
+    """Regression test: some cloud filesystems (e.g. S3) can return a table
+    root without a leading slash from ``FileSystem.from_uri`` while written-
+    file paths from that same filesystem still carry one (verified
+    empirically against a real S3-compatible server). Before the fix,
+    ``posixpath.relpath`` would walk upward (``../../bucket/...``) instead of
+    the intended relative path, corrupting the Delta log's ``AddAction.path``.
+    """
+    import types
+
+    import pyarrow as pa
+    import pyarrow.fs as pafs
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    real_from_uri = pafs.FileSystem.from_uri
+
+    class _FakeFileSystem:
+        @staticmethod
+        def from_uri(path):
+            fs, root = real_from_uri(path)
+            # Simulate the mismatch: root lacks a leading slash even though
+            # written-file paths (below) still carry one.
+            return fs, root.lstrip("/")
+
+    def fake_write_dataset(
+        table,
+        *,
+        base_dir,
+        file_visitor: Optional[Callable[[Any], None]] = None,
+        **kwargs,
+    ):
+        written_file = types.SimpleNamespace(
+            path="/" + base_dir + "/part-0.parquet",
+            size=123,
+            metadata=types.SimpleNamespace(num_rows=table.num_rows),
+        )
+        # The visitor is how ``_write_parquet`` collects AddAction paths.
+        assert file_visitor is not None
+        file_visitor(written_file)
+
+    monkeypatch.setattr("pyarrow.fs.FileSystem", _FakeFileSystem)
+    monkeypatch.setattr("pyarrow.dataset.write_dataset", fake_write_dataset)
+
+    datasink = DeltaDatasink(temp_delta_path)
+
+    class _FakeTaskContext:
+        task_idx = 0
+
+    # pyrefly: ignore[bad-argument-type]
+    add_actions = datasink._write_parquet(pa.table({"id": [1]}), _FakeTaskContext())
+    assert add_actions[0].path == "part-0.parquet"
+
+
+def test_create_dir_skipped_only_for_cloud_filesystems(monkeypatch):
+    """Regression test: cloud object stores have no real directories --
+    pyarrow's write_dataset defaults to create_dir=True, which for an
+    S3FileSystem issues a PutObject to a single marker key representing the
+    table root. Under a large write spanning many concurrent tasks that all
+    target the same brand-new prefix, every task racing to PUT that same key
+    can trigger AWS S3 throttling ("SLOW_DOWN") for no functional benefit.
+    Local filesystems still need the directory actually created (verified
+    separately: create_dir=False raises FileNotFoundError against a
+    not-yet-existing local directory), so the skip must be filesystem-type-
+    aware, not unconditional."""
+    import pyarrow as pa
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    captured = {}
+
+    def fake_write_dataset(table, *, create_dir, **kwargs):
+        captured["create_dir"] = create_dir
+
+    monkeypatch.setattr("pyarrow.dataset.write_dataset", fake_write_dataset)
+
+    class _FakeTaskContext:
+        task_idx = 0
+
+    s3_datasink = DeltaDatasink("s3://bucket/table")
+    # pyrefly: ignore[bad-argument-type]
+    s3_datasink._write_parquet(pa.table({"id": [1]}), _FakeTaskContext())
+    assert captured["create_dir"] is False
+
+
+# ----------------------------------------------------------------------
+# storage_options reaching the worker-side filesystem.
+# ----------------------------------------------------------------------
+
+
+def test_explicit_filesystem_from_storage_options_s3():
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    fs = _explicit_filesystem_from_storage_options(
+        "s3://bucket/table",
+        {
+            "AWS_ACCESS_KEY_ID": "AKIA-FAKE",
+            "AWS_SECRET_ACCESS_KEY": "SECRET-FAKE",
+            "AWS_REGION": "us-west-2",
+        },
+    )
+    import pyarrow.fs as pafs
+
+    assert isinstance(fs, pafs.S3FileSystem)
+
+
+def test_explicit_filesystem_from_storage_options_s3_falls_back_to_default_region():
+    """Regression test: callers who set AWS_DEFAULT_REGION (a common
+    boto-style key) instead of AWS_REGION must still get a correctly-regioned
+    worker filesystem -- previously only AWS_REGION was read, so the worker's
+    S3FileSystem silently got region=None even though the driver's commit
+    path (which forwards the full storage_options dict to deltalake) could
+    honor AWS_DEFAULT_REGION fine."""
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    fs = _explicit_filesystem_from_storage_options(
+        "s3://bucket/table",
+        {
+            "AWS_ACCESS_KEY_ID": "AKIA-FAKE",
+            "AWS_SECRET_ACCESS_KEY": "SECRET-FAKE",
+            "AWS_DEFAULT_REGION": "us-west-2",
+        },
+    )
+    assert fs is not None
+    assert fs.region == "us-west-2"
+
+    # AWS_REGION still takes precedence when both are set.
+    fs = _explicit_filesystem_from_storage_options(
+        "s3://bucket/table",
+        {
+            "AWS_ACCESS_KEY_ID": "AKIA-FAKE",
+            "AWS_SECRET_ACCESS_KEY": "SECRET-FAKE",
+            "AWS_REGION": "us-east-1",
+            "AWS_DEFAULT_REGION": "us-west-2",
+        },
+    )
+    assert fs is not None
+    assert fs.region == "us-east-1"
+
+
+def test_explicit_filesystem_from_storage_options_returns_none_without_options():
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    assert _explicit_filesystem_from_storage_options("s3://bucket/table", None) is None
+    assert _explicit_filesystem_from_storage_options("s3://bucket/table", {}) is None
+    # Unrecognized scheme: no match even with options set.
+    assert (
+        _explicit_filesystem_from_storage_options(
+            "hdfs://cluster/table", {"AWS_ACCESS_KEY_ID": "x"}
+        )
+        is None
+    )
+
+
+def test_explicit_filesystem_from_storage_options_azure_sas_key():
+    """Regression test: the SAS token key must match ray.data.catalog's
+    vended-credential key (AZURE_STORAGE_SAS_TOKEN), not a different name --
+    a mismatch here means workers silently build an uncredentialed
+    filesystem even when the driver's commit works fine.
+
+    ``pyarrow.fs.AzureFileSystem`` is an immutable Cython extension type
+    (its ``__init__`` can't be monkeypatched directly), so this replaces
+    the class itself via ``mock.patch`` to capture the constructor kwargs.
+    """
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    with mock.patch("pyarrow.fs.AzureFileSystem") as mock_azure_fs:
+        _explicit_filesystem_from_storage_options(
+            "abfss://container@account.dfs.core.windows.net/table",
+            {
+                "AZURE_STORAGE_ACCOUNT_NAME": "account",
+                "AZURE_STORAGE_SAS_TOKEN": "sv=fake-sas",
+            },
+        )
+
+    mock_azure_fs.assert_called_once_with(
+        account_name="account", sas_token="sv=fake-sas", account_key=None
+    )
+
+
+def test_explicit_filesystem_from_storage_options_azure_account_key():
+    """Regression test: an account key is a separate, mutually exclusive
+    auth method from a SAS token (both deltalake and
+    pyarrow.fs.AzureFileSystem accept either) -- a caller authenticating
+    via account key instead of SAS token must still get a credentialed
+    worker filesystem, not one that silently falls back to ambient auth."""
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    with mock.patch("pyarrow.fs.AzureFileSystem") as mock_azure_fs:
+        _explicit_filesystem_from_storage_options(
+            "abfss://container@account.dfs.core.windows.net/table",
+            {
+                "AZURE_STORAGE_ACCOUNT_NAME": "account",
+                "AZURE_STORAGE_ACCOUNT_KEY": "fake-account-key",
+            },
+        )
+
+    mock_azure_fs.assert_called_once_with(
+        account_name="account", sas_token=None, account_key="fake-account-key"
+    )
+
+
+def test_explicit_filesystem_from_storage_options_gcs_restores_env(monkeypatch):
+    """Regression test: constructing a GCS filesystem from a service-account
+    path must not leak GOOGLE_APPLICATION_CREDENTIALS -- a Ray worker
+    process can be reused for other tasks (different or no credentials)
+    afterward, so the env var must be restored to whatever it was before."""
+    import os
+
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/previous/creds.json")
+    _explicit_filesystem_from_storage_options(
+        "gs://bucket/table",
+        {"GOOGLE_SERVICE_ACCOUNT": "/new/creds.json"},
+    )
+    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == "/previous/creds.json"
+
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    _explicit_filesystem_from_storage_options(
+        "gs://bucket/table",
+        {"GOOGLE_SERVICE_ACCOUNT": "/new/creds.json"},
+    )
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
+
+
+# ----------------------------------------------------------------------
+# Multi-block tasks.
+# ----------------------------------------------------------------------
+
+
+def test_write_returns_one_schema_and_file_per_block(temp_delta_path):
+    """Each block is written to its own Parquet file and reports its own
+    schema; the driver unifies them at commit time."""
+    import pyarrow as pa
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    class _FakeTaskContext:
+        task_idx = 0
+
+    datasink = DeltaDatasink(temp_delta_path)
+    block_a = pa.table({"v": pa.array([1, 2], type=pa.int64())})
+    block_b = pa.table({"v": pa.array([None], type=pa.null())})
+
+    # pyrefly: ignore[bad-argument-type]
+    result = datasink.write([block_a, block_b], _FakeTaskContext())
+
+    assert len(result.add_actions) == 2
+    assert result.schemas == [block_a.schema, block_b.schema]
+
+
+def test_multi_block_task_unifies_schema_across_blocks(temp_delta_path):
+    """Blocks in one task can have different but unifiable schemas (here a
+    null-typed column against a concrete one). The committed table schema
+    is the unification, and every row round-trips."""
+    import pyarrow as pa
+
+    block_a = pa.table({"id": pa.array([1]), "v": pa.array(["x"])})
+    block_b = pa.table({"id": pa.array([2]), "v": pa.array([None], type=pa.null())})
+    ray.data.from_arrow([block_a, block_b]).write_delta(temp_delta_path)
+
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [{"id": 1, "v": "x"}, {"id": 2, "v": None}]
+
+
+def test_multi_block_task_with_differing_columns(temp_delta_path):
+    """Blocks with genuinely different column sets (one missing a column
+    another has) round-trip, with the absent value read back as None."""
+    import pyarrow as pa
+
+    block_a = pa.table({"id": [1], "name": ["a"]})
+    block_b = pa.table({"id": [2], "name": ["b"], "extra": ["x"]})
+    ray.data.from_arrow([block_a, block_b]).write_delta(temp_delta_path)
+
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [
+        {"id": 1, "name": "a", "extra": None},
+        {"id": 2, "name": "b", "extra": "x"},
+    ]
+
+
+# ----------------------------------------------------------------------
+# Table metadata.
+# ----------------------------------------------------------------------
+
+
+def test_name_and_description_recorded(temp_delta_path):
+    from deltalake import DeltaTable
+
+    ray.data.from_items([{"id": 1}]).write_delta(
+        temp_delta_path, name="my_table", description="my description"
+    )
+    metadata = DeltaTable(temp_delta_path).metadata()
+    assert metadata.name == "my_table"
+    assert metadata.description == "my description"
+
+
+# ----------------------------------------------------------------------
+# Empty dataset.
+# ----------------------------------------------------------------------
+
+
+def test_empty_dataset_without_schema_raises(temp_delta_path):
+    """This prototype has no ``schema=`` parameter to pre-declare a schema, so
+    a genuinely empty ``Dataset`` (no rows, no schema to infer) must raise a
+    clear error rather than commit an empty/malformed table."""
+    with pytest.raises(ValueError, match="without a schema"):
+        ray.data.from_items([]).write_delta(temp_delta_path)
+
+
+# ----------------------------------------------------------------------
+# storage_options passthrough to the driver-side commit calls.
+# ----------------------------------------------------------------------
+
+
+def test_storage_options_passed_to_create_table_with_add_actions(
+    temp_delta_path, monkeypatch
+):
+    """storage_options must reach create_table_with_add_actions when the
+    table doesn't exist yet (new-table path)."""
+    from deltalake.transaction import create_table_with_add_actions as real_create
+
+    captured = {}
+
+    def spy_create(*args, **kwargs):
+        captured.update(kwargs)
+        return real_create(*args, **kwargs)
+
+    with mock.patch("deltalake.transaction.create_table_with_add_actions", spy_create):
+        ray.data.from_items([{"id": 1}]).write_delta(
+            temp_delta_path, storage_options={"AWS_REGION": "us-west-2"}
+        )
+
+    assert captured.get("storage_options") == {"AWS_REGION": "us-west-2"}
+    assert _read_all(temp_delta_path) == [{"id": 1}]
+
+
+def test_storage_options_passed_to_create_write_transaction(
+    temp_delta_path, monkeypatch
+):
+    """storage_options must reach the DeltaTable constructor used for the
+    commit when the table already exists (existing-table path)."""
+    from deltalake import DeltaTable
+
+    _write_append([{"id": 1}], temp_delta_path)
+
+    captured = {}
+    real_init = DeltaTable.__init__
+
+    def spy_init(self, table_uri, *args, **kwargs):
+        captured["storage_options"] = kwargs.get("storage_options")
+        return real_init(self, table_uri, *args, **kwargs)
+
+    with mock.patch.object(DeltaTable, "__init__", spy_init):
+        ray.data.from_items([{"id": 2}]).write_delta(
+            temp_delta_path, storage_options={"AWS_REGION": "us-west-2"}
+        )
+
+    assert captured.get("storage_options") == {"AWS_REGION": "us-west-2"}
+    assert len(_read_all(temp_delta_path)) == 2
+
+
+# ----------------------------------------------------------------------
+# Schema reconciliation on APPEND: schema_mode="merge" (default) evolves
+# the table's schema to add new columns; schema_mode="error" rejects them.
+# A type-incompatible existing column always raises, regardless of mode.
+# ----------------------------------------------------------------------
+
+
+def test_append_new_column_evolves_schema_by_default(temp_delta_path):
+    """Appending a row with a column the existing table doesn't have adds
+    that column to the table (schema_mode="merge" is the default) --
+    existing rows read back with None for it, the new row has its real
+    value. Before schema evolution was added, this used to silently drop
+    the column's data instead."""
+    _write_append([{"id": 1, "name": "a"}], temp_delta_path)
+    _write_append([{"id": 2, "name": "b", "extra": "x"}], temp_delta_path)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [
+        {"id": 1, "name": "a", "extra": None},
+        {"id": 2, "name": "b", "extra": "x"},
+    ]
+
+
+def test_append_multiple_new_columns_evolves_schema(temp_delta_path):
+    """More than one new column in a single append are all added."""
+    _write_append([{"id": 1}], temp_delta_path)
+    _write_append([{"id": 2, "a": "x", "b": 5}], temp_delta_path)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [
+        {"id": 1, "a": None, "b": None},
+        {"id": 2, "a": "x", "b": 5},
+    ]
+
+
+def test_append_multiple_new_columns_preserves_incoming_column_order(temp_delta_path):
+    """New columns are added in the incoming schema's own column order.
+
+    Regression test: they used to be collected via a set difference over
+    field names, and string hash randomization makes set iteration order
+    vary per process -- so the table's final column order came out
+    different on every run (verified empirically: three runs, three
+    orders). Enough columns are used here that a set-ordered
+    implementation would essentially never match by chance.
+    """
+    from deltalake import DeltaTable
+
+    _write_append([{"id": 1}], temp_delta_path)
+    _write_append(
+        [
+            {
+                "id": 2,
+                "alpha": "a",
+                "beta": "b",
+                "gamma": "c",
+                "delta": "d",
+                "epsilon": "e",
+            }
+        ],
+        temp_delta_path,
+    )
+
+    assert [f.name for f in DeltaTable(temp_delta_path).schema().fields] == [
+        "id",
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+    ]
+
+
+def test_append_new_column_and_incompatible_type_leaves_schema_unchanged(
+    temp_delta_path,
+):
+    """Regression test: an append that both adds a new column AND has an
+    incompatible type on an existing column must reject the whole write
+    without evolving the schema first. Before this fix, the new column
+    would be permanently added (a real, committed ALTER TABLE) before the
+    type-compatibility check ran, so a rejected write still left the
+    table's schema permanently changed."""
+    import pyarrow as pa
+    from deltalake import DeltaTable
+
+    _write_append([{"id": 1, "name": "a"}], temp_delta_path)
+    bad_schema = pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("name", pa.string()),
+            pa.field("extra", pa.string()),
+        ]
+    )
+    table = pa.table({"id": ["2"], "name": ["b"], "extra": ["x"]}, schema=bad_schema)
+    with pytest.raises(ValueError, match="not compatible with the table's existing"):
+        ray.data.from_arrow(table).write_delta(temp_delta_path)
+
+    # The table's schema must be exactly as it was before the rejected
+    # write -- no "extra" column, and the original row untouched.
+    dt = DeltaTable(temp_delta_path)
+    assert {f.name for f in dt.schema().fields} == {"id", "name"}
+    assert _read_all(temp_delta_path) == [{"id": 1, "name": "a"}]
+
+
+def test_append_new_column_forced_nullable(temp_delta_path):
+    """A new column is always added as nullable, even if the incoming data
+    declares it non-nullable -- every row already in the table has no
+    value for a brand-new column, so a non-nullable declaration would make
+    the table's schema self-contradictory."""
+    import pyarrow as pa
+    from deltalake import DeltaTable
+
+    _write_append([{"id": 1}], temp_delta_path)
+    non_nullable_schema = pa.schema(
+        [pa.field("id", pa.int64()), pa.field("extra", pa.string(), nullable=False)]
+    )
+    table = pa.table({"id": [2], "extra": ["x"]}, schema=non_nullable_schema)
+    ray.data.from_arrow(table).write_delta(temp_delta_path)
+
+    dt = DeltaTable(temp_delta_path)
+    field = next(f for f in dt.schema().fields if f.name == "extra")
+    assert field.nullable is True
+
+
+def test_append_extra_column_rejected_with_schema_mode_error(temp_delta_path):
+    """schema_mode="error" is the opt-out: reject the extra column instead
+    of evolving the schema, leaving the table untouched."""
+    _write_append([{"id": 1, "name": "a"}], temp_delta_path)
+    with pytest.raises(ValueError, match="not present in the table's existing schema"):
+        _write_append(
+            [{"id": 2, "name": "b", "extra": "x"}],
+            temp_delta_path,
+            schema_mode="error",
+        )
+    # The rejected write must not have changed the table.
+    assert _read_all(temp_delta_path) == [{"id": 1, "name": "a"}]
+
+
+def test_invalid_schema_mode_rejected(temp_delta_path):
+    with pytest.raises(ValueError, match="schema_mode"):
+        ray.data.from_items([{"id": 1}]).write_delta(
+            temp_delta_path, schema_mode="bogus"
+        )
+
+
+def test_append_incompatible_type_rejected(temp_delta_path):
+    """Regression test: appending a column with a type incompatible with
+    the existing table's (e.g. string where the table has int64) used to
+    commit successfully but leave the table unreadable on the very next
+    read. Must raise clearly at write time instead, and must not corrupt
+    the table. Unlike a brand-new column, this always raises regardless of
+    schema_mode -- changing an existing column's type is never supported,
+    only adding a new one is."""
+    _write_append([{"id": 1, "name": "a"}], temp_delta_path)
+    with pytest.raises(ValueError, match="not compatible with the table's existing"):
+        _write_append([{"id": "not-an-int", "name": "b"}], temp_delta_path)
+    # The table must still be readable after the rejected write.
+    assert _read_all(temp_delta_path) == [{"id": 1, "name": "a"}]
+
+
+@pytest.mark.parametrize("exc_name", ["ArrowTypeError", "ArrowInvalid", "KeyError"])
+def test_unifiable_schema_failures_are_wrapped(temp_delta_path, monkeypatch, exc_name):
+    """Every way ``unify_schemas`` can fail is reported as a clear Delta
+    error. It raises ArrowTypeError or ArrowInvalid depending on the types
+    involved, and a bare KeyError for a few shapes it can't reconcile (e.g.
+    duplicate field names) -- none of those should reach the caller raw."""
+    import pyarrow as pa
+    from deltalake import DeltaTable
+
+    from ray.data._internal.datasource import delta_datasink as dd
+
+    exc = {
+        "ArrowTypeError": pa.ArrowTypeError("boom"),
+        "ArrowInvalid": pa.ArrowInvalid("boom"),
+        "KeyError": KeyError("boom"),
+    }[exc_name]
+
+    _write_append([{"id": 1}], temp_delta_path)
+    datasink = dd.DeltaDatasink(temp_delta_path)
+
+    def _raise(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(dd, "unify_schemas", _raise)
+    with pytest.raises(ValueError, match="not compatible with the table's existing"):
+        datasink._reconcile_schema_with_existing_table(
+            pa.schema([("id", pa.int64())]), DeltaTable(temp_delta_path)
+        )
+
+
+def test_append_compatible_schema_still_succeeds(temp_delta_path):
+    """A same-typed but otherwise not-byte-identical schema (e.g. a
+    nullable-flag difference) append against an existing table must still
+    succeed -- the new validation must not reject legitimately compatible
+    writes, only genuinely incompatible ones."""
+    import pyarrow as pa
+
+    _write_append([{"id": 1, "tag": "x"}], temp_delta_path)
+    non_nullable_schema = pa.schema(
+        [pa.field("id", pa.int64(), nullable=False), pa.field("tag", pa.string())]
+    )
+    table = pa.table({"id": [2], "tag": ["y"]}, schema=non_nullable_schema)
+    ray.data.from_arrow(table).write_delta(temp_delta_path, mode=SaveMode.APPEND)
+    out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
+    assert out == [{"id": 1, "tag": "x"}, {"id": 2, "tag": "y"}]
+
+
+def test_overwrite_with_different_schema_still_works(temp_delta_path):
+    """OVERWRITE intentionally replaces the schema wholesale -- the new
+    APPEND-only schema-compatibility check must not apply to it."""
+    _write_append([{"id": 1, "name": "a"}], temp_delta_path)
+    ray.data.from_items([{"completely": "different", "cols": 1}]).write_delta(
+        temp_delta_path, mode=SaveMode.OVERWRITE
+    )
+    assert _read_all(temp_delta_path) == [{"completely": "different", "cols": 1}]
+
+
+# ----------------------------------------------------------------------
+# S3 custom endpoint forwarding (review-comment fix).
+# ----------------------------------------------------------------------
+
+
+def test_explicit_filesystem_from_storage_options_s3_endpoint_override():
+    """Regression test: a custom S3-compatible endpoint (e.g. MinIO, a test
+    double like moto) set via AWS_ENDPOINT_URL must reach the worker's
+    S3FileSystem -- previously only access_key/secret_key/session_token/
+    region were forwarded, so workers would silently target real AWS
+    instead of the custom endpoint the driver's commit path used."""
+    from ray.data._internal.datasource.delta_datasink import (
+        _explicit_filesystem_from_storage_options,
+    )
+
+    fs = _explicit_filesystem_from_storage_options(
+        "s3://bucket/table",
+        {
+            "AWS_ACCESS_KEY_ID": "AKIA-FAKE",
+            "AWS_SECRET_ACCESS_KEY": "SECRET-FAKE",
+            "AWS_ENDPOINT_URL": "http://localhost:9000",
+        },
+    )
+    # S3FileSystem doesn't expose endpoint_override as a public attribute;
+    # __reduce__ carries the constructor kwargs it was built with.
+    assert fs is not None
+    ctor_kwargs = fs.__reduce__()[1][0]
+    assert ctor_kwargs["endpoint_override"] == "http://localhost:9000"
+
+
+# ----------------------------------------------------------------------
+# ``_SUPPORTED_MODES`` set + ``.value`` usage (review-comment fix).
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["append", "overwrite"])
+def test_string_mode_still_accepted(temp_delta_path, mode):
+    """Regression test: ``SaveMode`` is a ``(str, Enum)``, so a plain string
+    like ``"append"`` is value-equal to ``SaveMode.APPEND`` in membership
+    checks but isn't an actual enum instance. The datasink must normalize
+    it so downstream ``.value`` access doesn't crash on a plain string."""
+    ray.data.from_items([{"id": 1}]).write_delta(temp_delta_path, mode=mode)
+    assert _read_all(temp_delta_path) == [{"id": 1}]
+
+
+def test_unsupported_mode_error_message_uses_plain_strings():
+    """The validation error must render supported/requested modes as plain
+    strings (e.g. "append", not "SaveMode.APPEND"), since ``SaveMode``
+    members don't override ``__str__``."""
+    with pytest.raises(ValueError, match=r"\['append', 'overwrite'\]"):
+        ray.data.from_items([{"id": 1}]).write_delta("/tmp/unused", mode=SaveMode.ERROR)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Supports SaveMode.APPEND and SaveMode.OVERWRITE (a prototype scope, by design): workers write Parquet files via pyarrow.dataset.write_dataset and report AddAction metadata; the driver commits all files in one Delta transaction via the deltalake library, creating the table if it doesn't exist. Also supports partition_by (Hive-style), storage_options, and optional name/description table metadata.

Adds a new test suite covering what this implementation actually supports: APPEND/OVERWRITE round-trips, unsupported-mode rejection, single- and multi-column partitioning, multi-block writes, table name/description metadata, the empty-dataset error path, and storage_options passthrough to the commit calls.