### PR TITLE
[Core] Exclude runtime_env_container tests from the core flaky step

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -524,7 +524,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --install-mask all-ray-libraries
         --run-flaky-tests
-        --except-tags multi_gpu,cgroup
+        --except-tags multi_gpu,cgroup,runtime_env_container
     depends_on:
       - corebuild-multipy(python=3.10)
 


### PR DESCRIPTION
## Description

Exclude `runtime_env_container` tests from the core flaky step: it never builds the image they need, so they fail at setup on every postmerge build and keep the target permanently stuck in FLAKY, even though the actual failure was already fixed in #64762. See https://buildkite.com/ray-project/postmerge/builds/18717#019f864f-ca0e-4241-9d23-a59644e5618b