### PR TITLE
[data] Add write_delta release benchmark

### DIFF
--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -6,9 +6,15 @@ from typing import Callable
 from benchmark import Benchmark
 
 import ray
+from ray.data import SaveMode
 
 # Add a random prefix to avoid conflicts between different runs.
 WRITE_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
+# Region of the ray-data-write-benchmark bucket. write_parquet resolves this
+# automatically, but deltalake's Rust S3 client doesn't follow a region
+# redirect -- it defaults to us-east-1 and fails outright ("Received redirect
+# without LOCATION") against a bucket hosted elsewhere unless told explicitly.
+WRITE_DELTA_STORAGE_OPTIONS = {"AWS_REGION": "us-west-2"}
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,8 +43,31 @@ def parse_args() -> argparse.Namespace:
         metavar=("feature", "label"),
     )
     consume_group.add_argument("--write", action="store_true")
+    consume_group.add_argument("--write-delta", action="store_true")
 
-    return parser.parse_args()
+    # Modifiers for --write-delta (not alternative consume actions, so they
+    # live outside the mutually-exclusive group above).
+    parser.add_argument(
+        "--write-delta-mode",
+        choices=["append", "overwrite"],
+        default="append",
+        help="SaveMode to use with --write-delta.",
+    )
+    parser.add_argument(
+        "--write-delta-partition-by",
+        type=str,
+        default=None,
+        help="Column to Hive-partition the Delta table by, when using --write-delta.",
+    )
+
+    args = parser.parse_args()
+    if not args.write_delta and (
+        args.write_delta_mode != "append" or args.write_delta_partition_by
+    ):
+        parser.error(
+            "--write-delta-mode/--write-delta-partition-by require --write-delta."
+        )
+    return args
 
 
 def main(args):
@@ -53,6 +82,13 @@ def main(args):
 
         # Report arguments for the benchmark.
         return vars(args)
+
+    if args.write_delta and args.write_delta_mode == "overwrite":
+        # Populate the table once first (same source/scale as the timed run
+        # below) so "main" genuinely overwrites existing data instead of
+        # creating an empty table -- an OVERWRITE against a not-yet-existing
+        # table is just a create, which isn't the interesting case to time.
+        benchmark.run_fn("setup_populate", benchmark_fn)
 
     benchmark.run_fn("main", benchmark_fn)
     benchmark.write_result()
@@ -109,6 +145,26 @@ def get_consume_fn(args: argparse.Namespace) -> Callable[[ray.data.Dataset], Non
 
         def consume_fn(ds):
             ds.write_parquet(WRITE_PATH)
+
+    elif args.write_delta:
+
+        def consume_fn(ds):
+            mode = (
+                SaveMode.OVERWRITE
+                if args.write_delta_mode == "overwrite"
+                else SaveMode.APPEND
+            )
+            partition_by = (
+                [args.write_delta_partition_by]
+                if args.write_delta_partition_by
+                else None
+            )
+            ds.write_delta(
+                WRITE_PATH,
+                mode=mode,
+                partition_by=partition_by,
+                storage_options=WRITE_DELTA_STORAGE_OPTIONS,
+            )
 
     else:
         assert False, f"Invalid consume arguments: {args}"

--- a/release/ray_release/byod/byod_install_deltalake.sh
+++ b/release/ray_release/byod/byod_install_deltalake.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -exo pipefail
+
+pip3 install --no-cache-dir "deltalake==1.5.0"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -119,6 +119,57 @@
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet --write
 
+- name: write_delta
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet --write-delta
+
+- name: write_delta_smoke
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+    cluster_compute: fixed_size_1_cpu_compute.yaml
+  run:
+    timeout: 600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf10/lineitem --format parquet --write-delta
+
+- name: write_delta_overwrite
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf100/lineitem --format parquet --write-delta
+      --write-delta-mode overwrite
+
+- name: write_delta_partitioned
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet --write-delta
+      --write-delta-partition-by column08
+
 ###############
 # Iceberg tests
 ###############


### PR DESCRIPTION
## Summary

Adds a `write_delta` counterpart to the existing `write_parquet` release benchmark,
reusing the same real dataset and harness rather than inventing new synthetic-data
infrastructure:

- `read_and_consume_benchmark.py`: adds a `--write-delta` consume option, mirroring
  the existing `--write` (`write_parquet`) option exactly — same read path, same
  `Benchmark`/`BenchmarkMetric` reporting, just a different write call.
- `release_data_tests.yaml`: registers a `write_delta` test entry alongside
  `write_parquet`, reading the same TPCH SF1000 `lineitem` source
  (`s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem`), so the two are a direct,
  apples-to-apples Parquet-vs-Delta write comparison on identical input data.
- `byod_install_deltalake.sh`: new post-build script installing `deltalake==1.5.0`
  (matching the version pinned in `python/requirements_compiled*.txt`), needed
  because — unlike parquet/image/tfrecords — `deltalake` isn't in the base
  release-test image. Mirrors `byod_install_pyiceberg.sh`'s exact shape.

## Test plan

- `python -m py_compile` on the modified script — passes.
- `ruff check` / `black --check` (repo-pinned versions) on the modified script —
  clean.
- `shellcheck` (via pre-commit) on the new byod script — clean.
- YAML: loaded `release_data_tests.yaml` with `yaml.safe_load` and confirmed the new
  `write_delta` entry parses correctly and appears exactly once.
- End-to-end local smoke test (no S3/cluster access): wrote a small local Parquet
  source, invoked the modified script's `main()` directly with a constructed
  `args.Namespace` (`--format parquet --write-delta` equivalent) against a local
  `write_delta` destination, confirmed the `Benchmark` harness times and reports the
  run, and confirmed the resulting Delta table reads back correctly via
  `ray.data.read_delta(...)`.

## AI assistance disclosure

This PR was developed with AI assistance (Claude). All changes were reviewed and are
defended by the submitting human.
