### PR TITLE
Fix(rllib): Use target_qf_twin head in IQL target prediction

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1847,6 +1847,18 @@ py_test(
     deps = [":conftest"],
 )
 
+# IQL
+py_test(
+    name = "test_iql_rl_module",
+    size = "small",
+    srcs = ["algorithms/iql/tests/test_iql_rl_module.py"],
+    tags = [
+        "algorithms",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
 # MARWIL
 py_test(
     name = "test_marwil",

--- a/rllib/algorithms/iql/tests/test_iql_rl_module.py
+++ b/rllib/algorithms/iql/tests/test_iql_rl_module.py
@@ -1,60 +1,49 @@
 import unittest
+
 import numpy as np
 from gymnasium.spaces import Box
 
-import ray
-from ray.rllib.algorithms.iql.torch.default_iql_torch_rl_module import DefaultIQLTorchRLModule
 from ray.rllib.algorithms.iql.iql_learner import QF_TARGET_PREDS
+from ray.rllib.algorithms.iql.torch.default_iql_torch_rl_module import (
+    DefaultIQLTorchRLModule,
+)
 from ray.rllib.core.columns import Columns
 from ray.rllib.utils.framework import try_import_torch
-from ray.rllib.utils.torch_utils import convert_to_torch_tensor
 
 torch, nn = try_import_torch()
 
 
 class TestIQLRLModule(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        ray.init()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        ray.shutdown()
-
-    def test_iql_torch_rl_module_forward_train_twin_q(self):
-        """Verify DefaultIQLTorchRLModule forward_train behavior with twin_q=True and twin_q=False."""
-        obs_space = Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
-        action_space = Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+    def test_forward_train_target_preds_are_frozen(self):
+        """QF_TARGET_PREDS must derive only from frozen target nets (#64931)."""
+        obs_space = Box(-1.0, 1.0, (4,), np.float32)
+        action_space = Box(-1.0, 1.0, (2,), np.float32)
 
         for twin_q in [True, False]:
-            model_config = {"twin_q": twin_q}
             module = DefaultIQLTorchRLModule(
                 observation_space=obs_space,
                 action_space=action_space,
-                model_config=model_config,
+                model_config={"twin_q": twin_q},
             )
             module.make_target_networks()
 
-            # In twin_q mode, set distinct weights for target_qf_twin and qf_twin to ensure target_qf_twin is evaluated
-            if twin_q:
-                with torch.no_grad():
-                    for p in module.target_qf_twin.parameters():
-                        p.fill_(100.0)
-                    for p in module.qf_twin.parameters():
-                        p.fill_(-100.0)
-
-            batch = convert_to_torch_tensor({
+            batch = {
                 Columns.OBS: torch.randn(2, 4),
                 Columns.ACTIONS: torch.randn(2, 2),
                 Columns.NEXT_OBS: torch.randn(2, 4),
-            })
-
+            }
             outputs = module._forward_train(batch)
+
             self.assertIn(QF_TARGET_PREDS, outputs)
             self.assertEqual(outputs[QF_TARGET_PREDS].shape, (2,))
+            # Bug #64931 used the online `qf_twin` head here, which makes this
+            # tensor require grad and leaks gradients into the twin-Q update.
+            self.assertFalse(outputs[QF_TARGET_PREDS].requires_grad)
 
 
 if __name__ == "__main__":
     import sys
+
     import pytest
+
     sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/algorithms/iql/tests/test_iql_rl_module.py
+++ b/rllib/algorithms/iql/tests/test_iql_rl_module.py
@@ -1,0 +1,60 @@
+import unittest
+import numpy as np
+from gymnasium.spaces import Box
+
+import ray
+from ray.rllib.algorithms.iql.torch.default_iql_torch_rl_module import DefaultIQLTorchRLModule
+from ray.rllib.algorithms.iql.iql_learner import QF_TARGET_PREDS
+from ray.rllib.core.columns import Columns
+from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.torch_utils import convert_to_torch_tensor
+
+torch, nn = try_import_torch()
+
+
+class TestIQLRLModule(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_iql_torch_rl_module_forward_train_twin_q(self):
+        """Verify DefaultIQLTorchRLModule forward_train behavior with twin_q=True and twin_q=False."""
+        obs_space = Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+        action_space = Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+        for twin_q in [True, False]:
+            model_config = {"twin_q": twin_q}
+            module = DefaultIQLTorchRLModule(
+                observation_space=obs_space,
+                action_space=action_space,
+                model_config=model_config,
+            )
+            module.make_target_networks()
+
+            # In twin_q mode, set distinct weights for target_qf_twin and qf_twin to ensure target_qf_twin is evaluated
+            if twin_q:
+                with torch.no_grad():
+                    for p in module.target_qf_twin.parameters():
+                        p.fill_(100.0)
+                    for p in module.qf_twin.parameters():
+                        p.fill_(-100.0)
+
+            batch = convert_to_torch_tensor({
+                Columns.OBS: torch.randn(2, 4),
+                Columns.ACTIONS: torch.randn(2, 2),
+                Columns.NEXT_OBS: torch.randn(2, 4),
+            })
+
+            outputs = module._forward_train(batch)
+            self.assertIn(QF_TARGET_PREDS, outputs)
+            self.assertEqual(outputs[QF_TARGET_PREDS].shape, (2,))
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/algorithms/iql/torch/default_iql_torch_rl_module.py
+++ b/rllib/algorithms/iql/torch/default_iql_torch_rl_module.py
@@ -52,7 +52,7 @@ class DefaultIQLTorchRLModule(DefaultSACTorchRLModule, DefaultIQLRLModule):
             output[QF_TARGET_PREDS] = torch.min(
                 output[QF_TARGET_PREDS],
                 self._qf_forward_train_helper(
-                    batch_curr, encoder=self.target_qf_twin_encoder, head=self.qf_twin
+                    batch_curr, encoder=self.target_qf_twin_encoder, head=self.target_qf_twin
                 ),
             )
 

--- a/rllib/algorithms/iql/torch/default_iql_torch_rl_module.py
+++ b/rllib/algorithms/iql/torch/default_iql_torch_rl_module.py
@@ -52,7 +52,9 @@ class DefaultIQLTorchRLModule(DefaultSACTorchRLModule, DefaultIQLRLModule):
             output[QF_TARGET_PREDS] = torch.min(
                 output[QF_TARGET_PREDS],
                 self._qf_forward_train_helper(
-                    batch_curr, encoder=self.target_qf_twin_encoder, head=self.target_qf_twin
+                    batch_curr,
+                    encoder=self.target_qf_twin_encoder,
+                    head=self.target_qf_twin,
                 ),
             )
 


### PR DESCRIPTION
Fixes #64931.

In `DefaultIQLTorchRLModule._forward_train`, the twin-Q branch of `QF_TARGET_PREDS` was incorrectly passing the online `self.qf_twin` head instead of the frozen `self.target_qf_twin`. Because `QF_TARGET_PREDS` flows un-detached into the value loss, this caused spurious gradients to accumulate onto `qf_twin`'s parameters after the correct `critic_twin_loss` gradients were already stored, corrupting the twin-Q update and causing loss divergence.

This PR fixes the mathematical correctness by ensuring both Q-networks train symmetrically against the same frozen target predictions.