### PR TITLE
[doc] Scope API signature bold weight to the object name

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -378,6 +378,16 @@ table.autosummary tr > td:first-child > p > a > code > span {
   overflow-wrap: break-word;
 }
 
+/* The theme bolds the whole signature via `dt { font-weight: 700 }`, flattening
+   its hierarchy. Reset to normal weight and re-bold only the object name so it
+   stays the scannable anchor. */
+dt.sig {
+  font-weight: normal;
+}
+dt.sig .sig-name {
+  font-weight: 700;
+}
+
 /* RTD footer container makes the parent */
 /* #main-sidebar always scrollable if you don't remove negative margin. */
 /* Restrict width to 30% of the window */


### PR DESCRIPTION
## Description

Ray's API reference signatures render entirely bold. pydata-sphinx-theme (0.18.0)
applies `dt { font-weight: 700 }` to the signature `<dt>`, so the module prefix,
object name, parameter names, and every inline type annotation all render at the
same bold weight — only default values and the `*` separator are exempt. The
result is a dense wall of bold that's hard to scan (a long-standing readability
complaint; see #32824).

This scopes the bold to the one token that anchors the signature — the documented
object name. Two rules added to `doc/source/_static/css/custom.css`:

```css
dt.sig { font-weight: normal; }
dt.sig .sig-name { font-weight: 700; }
```

Both selectors out-specify the theme's bare `dt` rule, so they win regardless of
stylesheet load order. `.sig` is only ever applied to API-signature `<dt>`
elements, so there is no effect on the `Parameters:` field-list label
(`dt.field-odd`), the nav, sidebar, admonitions, or any non-docstring content.
Parameter names stay **bold** in the `Parameters:` list — they come through
`<strong>` and are unaffected. Default values and `*` are already normal via the
theme's own `.sig-param .default_value, .sig-param .o` rule.

## Related issues

Related to #32824.

## Additional information

**Before / after** — real `ray.data.read_parquet` DOM rendered against the shipped
pydata-sphinx-theme 0.18.0 stylesheet:

<img width="881" height="308" alt="image" src="https://github.com/user-attachments/assets/da7945dc-307f-4fae-87a3-78e11e3e6751" />

| Token role | Before | After |
|---|---|---|
| object name — `read_parquet` | bold | **bold** (kept — the anchor) |
| module prefix — `ray.data.` | bold | normal |
| parameter names — `paths`, `filesystem` | bold | normal |
| type annotations — `str`, `List[str]`, `FileSystem` | bold | normal |
| default values — `= None` | normal | normal |
| operator / separator — `*`, `=` | normal | normal |

**Testing.** No automated tests apply to a docstring-CSS change. Verified by
rendering the live `ray.data.read_parquet` signature and `Parameters:` block
against the theme stylesheet, before vs after, in headless Chrome at light, dark,
and mobile widths: the signature de-bolds to name-only, the field list keeps bold
parameter names with normal-weight descriptions, and no non-docstring element
changes. Reviewers can also confirm on the Read the Docs PR preview build. Note:
`doc/source/` is in the global `exclude` in `.pre-commit-config.yaml`, so no
pre-commit/lint hook runs on this file.

**AI assistance.** This change was developed with AI assistance (Claude Code); the
diff and rationale were reviewed line-by-line before submitting.