### PR TITLE
[DO NOT MERGE] Serve microbenchmark regression investigation

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -628,12 +628,6 @@ RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS = get_env_bool(
 # Used for gc.set_threshold() when proxy GC optimizations are enabled.
 RAY_SERVE_PROXY_GC_THRESHOLD = get_env_int("RAY_SERVE_PROXY_GC_THRESHOLD", 700)
 
-# Feature flag to run gc.collect() + gc.freeze() at the end of replica
-# initialization. Objects allocated during startup are long-lived, so freezing
-# them excludes them from future GC scans, reducing GC pauses / tail latency in
-# the request path. Set to 0 to disable (e.g. if memory usage is a concern).
-RAY_SERVE_FREEZE_GC_ON_STARTUP = get_env_bool("RAY_SERVE_FREEZE_GC_ON_STARTUP", "1")
-
 # Interval at which cached metrics will be exported using the Ray metric API.
 # Set to `0` to disable caching entirely.
 RAY_SERVE_METRICS_EXPORT_INTERVAL_MS = get_env_int(
@@ -1059,7 +1053,6 @@ if RAY_SERVE_THROUGHPUT_OPTIMIZED:
     RAY_SERVE_ENABLE_DIRECT_INGRESS = get_env_bool(
         "RAY_SERVE_ENABLE_DIRECT_INGRESS", "1"
     )
-    RAY_SERVE_FREEZE_GC_ON_STARTUP = get_env_bool("RAY_SERVE_FREEZE_GC_ON_STARTUP", "1")
 
 if RAY_SERVE_ENABLE_HA_PROXY:
     # Direct ingress must be enabled if HAProxy is enabled.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -39,7 +39,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH,
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
-    RAY_SERVE_FREEZE_GC_ON_STARTUP,
     RAY_SERVE_LOG_TO_STDERR,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
@@ -328,8 +327,6 @@ class ServeController:
             msg += "  • Router running in main thread (not separate)\n"
         if not RAY_SERVE_LOG_TO_STDERR:
             msg += "  • Log to stderr disabled\n"
-        if RAY_SERVE_FREEZE_GC_ON_STARTUP:
-            msg += "  • Garbage collector is frozen on startup\n"
         msg += f"  • Request path log buffer size: {RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE}\n"
         logger.info(msg)
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2,7 +2,6 @@ import asyncio
 import concurrent.futures
 import errno
 import functools
-import gc
 import inspect
 import logging
 import math
@@ -68,7 +67,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT,
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
-    RAY_SERVE_FREEZE_GC_ON_STARTUP,
     RAY_SERVE_HAPROXY_METRICS_ENABLED,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S,
@@ -1815,8 +1813,7 @@ class Replica:
             # When controller restarts, it will call this method again.
             async with self._user_callable_initialized_lock:
                 self._initialization_start_time = time.time()
-                is_first_init = not self._user_callable_initialized
-                if is_first_init:
+                if not self._user_callable_initialized:
                     self._user_callable_asgi_app = (
                         await self._user_callable_wrapper.initialize_callable()
                     )
@@ -1861,16 +1858,6 @@ class Replica:
                         deployment_config.user_config,
                         rank=rank,
                     )
-
-                if is_first_init and RAY_SERVE_FREEZE_GC_ON_STARTUP:
-                    # User code initialization is complete, including the first
-                    # reconfigure call (if a user_config was provided). Collect
-                    # garbage and freeze the GC: startup objects are long-lived,
-                    # so excluding them from future GC scans reduces GC pauses
-                    # in the request path. Any allocations after this point
-                    # will be from user requests.
-                    gc.collect()
-                    gc.freeze()
 
             # A new replica should not be considered healthy until it passes
             # an initial health check. If an initial health check fails,


### PR DESCRIPTION
## Confirmation (empirical A/B)

Because #64742's entire runtime effect is gated by `RAY_SERVE_FREEZE_GC_ON_STARTUP`, toggling that flag on the current build isolates exactly this commit

Ran locally -- single-replica, no-op, 1 node (`freeze=0` reproduces pre-#64742 behavior, `freeze=1` is current default):

| metric | freeze=0 | freeze=1 | Δ |
|---|---|---|---|
| handle throughput (rps) | 418.9 | 474.0 | **+13.1%** |
| handle_model_comp throughput (rps) | 210.7 | 229.8 | **+9.1%** |
| handle_100 throughput (rps) | 1024.6 | 1149.9 | **+12.2%** |
| handle_800 throughput (rps) | 922.4 | 1059.0 | **+14.8%** |
| handle_10mb p50 latency (ms) | 6.15 | 7.00 | **+13.8% (worse)** |
| handle_10mb mean latency (ms) | 6.99 | 7.51 | +7.4% (worse) |

Enabling the freeze reproduces both directions: the no-op throughput jump and the `handle_10mb` median-latency regression.

## What

Revert #64742. Restores the pre-freeze baseline on all serve request-path benchmarks and removes the `handle_10mb` latency regression.

## Notes

- **AI assistance was used** to investigate and prepare this revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
