### PR TITLE
[Cherry-pick][2.57.0][train] Make train v1 v2 use autoscaling coordinator (#64824)

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -236,6 +236,11 @@ class ScalingConfig:
             resources_per_worker.setdefault(accelerator, 0.001)
         return resources_per_worker
 
+    def _label_selector_per_worker(
+        self, num_workers: int
+    ) -> Optional[List[Dict[str, str]]]:
+        return None
+
     @property
     def _trainer_resources_not_none(self):
         if self.trainer_resources is None:

--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -9,11 +9,15 @@ from ray import train
 from ray.data import DataIterator
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
-    ExecutionResources,
 )
 from ray.tests.conftest import *  # noqa
 from ray.train import DataConfig, ScalingConfig
 from ray.train.data_parallel_trainer import DataParallelTrainer
+
+
+@pytest.fixture(autouse=True)
+def disable_train_v2_for_v1_trainer_tests(monkeypatch):
+    monkeypatch.setenv("RAY_TRAIN_V2_ENABLED", "0")
 
 
 @pytest.fixture
@@ -137,8 +141,8 @@ def test_split(ray_start_4_cpus):
     test.fit()
 
 
-def test_configure_execution_options_carryover_context(ray_start_4_cpus):
-    """Tests that execution options in DataContext are carried over to DatConfig
+def test_default_ingest_options_carried_over_from_context(ray_start_4_cpus):
+    """Tests that execution options in DataContext are carried over to DataConfig
     automatically."""
 
     ctx = ray.data.DataContext.get_current()
@@ -146,10 +150,10 @@ def test_configure_execution_options_carryover_context(ray_start_4_cpus):
     ctx.execution_options.verbose_progress = True
 
     data_config = DataConfig()
-
-    ingest_options = data_config.default_ingest_options()
-    assert ingest_options.preserve_order is True
-    assert ingest_options.verbose_progress is True
+    resolved = data_config._resolve_execution_options("train")
+    assert resolved == DataConfig.default_ingest_options()
+    assert resolved.preserve_order is True
+    assert resolved.verbose_progress is True
 
 
 @pytest.mark.parametrize("enable_locality", [True, False])
@@ -277,7 +281,8 @@ def _run_data_config_resource_test(data_config):
     # Resources used by training workers.
     cpus_per_worker, gpus_per_worker = 2, 1
 
-    original_execution_options = data_config._get_execution_options("train")
+    original_execution_options = data_config._resolve_execution_options("train")
+    assert original_execution_options is not None
 
     ray.init(num_cpus=cluster_cpus, num_gpus=cluster_gpus)
 
@@ -287,32 +292,24 @@ def _run_data_config_resource_test(data_config):
                 train_ds = train.get_dataset_shard("train")
                 new_execution_options = train_ds.get_context().execution_options
                 if original_execution_options.is_resource_limits_default():
-                    # If the original resource limits are default, the new resource
-                    # limits should be the default as well.
                     assert new_execution_options.is_resource_limits_default()
                     exclude_resources = new_execution_options.exclude_resources
                     assert (
                         exclude_resources.cpu
                         == original_execution_options.exclude_resources.cpu
-                        + cpus_per_worker * num_workers
-                        + 1  # trainer coordinator
                     )
                     assert (
                         exclude_resources.gpu
                         == original_execution_options.exclude_resources.gpu
-                        + gpus_per_worker * num_workers
                     )
                 else:
-                    # If the original resource limits are not default, the new resource
-                    # limits should be the same as the original ones.
-                    # And the new exclude_resources should be zero.
                     assert (
                         new_execution_options.resource_limits
                         == original_execution_options.resource_limits
                     )
                     assert (
                         new_execution_options.exclude_resources
-                        == ExecutionResources.zero()
+                        == original_execution_options.exclude_resources
                     )
 
             kwargs.pop("scaling_config", None)
@@ -358,32 +355,26 @@ def test_data_config_manual_resource_limits(shutdown_only):
     _run_data_config_resource_test(data_config)
 
 
-def test_v1_train_with_v2_data_autoscaler_sets_exclude_resources(
+def test_v1_train_without_execution_options_uses_default_ingest(
     shutdown_only, monkeypatch
 ):
-    """Regression test for the Train V1 + V2 cluster autoscaler combination."""
+    """Without user execution_options, datasets use default ingest options."""
     monkeypatch.setenv("RAY_DATA_CLUSTER_AUTOSCALER", "V2")
 
     ray.init(num_cpus=10, num_gpus=2)
 
-    num_train_cpus, num_train_gpus = 4.0, 2.0
     data_config = DataConfig()
-    data_config.set_train_total_resources(
-        num_train_cpus=num_train_cpus, num_train_gpus=num_train_gpus
-    )
-
-    iterators = data_config.configure(
+    data_config.configure(
         datasets={"train": ray.data.range(10)},
         world_size=2,
         worker_handles=None,
         worker_node_ids=None,
     )
 
-    exclude_resources = (
-        iterators[0]["train"].get_context().execution_options.exclude_resources
-    )
-    assert exclude_resources.cpu == num_train_cpus
-    assert exclude_resources.gpu == num_train_gpus
+    resolved = data_config._resolve_execution_options("train")
+    assert resolved == DataConfig.default_ingest_options()
+    assert resolved.is_resource_limits_default()
+    assert data_config._get_user_execution_options("train") is None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -447,6 +447,16 @@ class ExecutionOptions:
             f"label_selector={self.label_selector})"
         )
 
+    def __eq__(self, other: "ExecutionOptions") -> bool:
+        return (
+            self.resource_limits == other.resource_limits
+            and self.exclude_resources == other.exclude_resources
+            and self.preserve_order == other.preserve_order
+            and self.actor_locality_enabled == other.actor_locality_enabled
+            and self.verbose_progress == other.verbose_progress
+            and self.label_selector == other.label_selector
+        )
+
     @property
     def resource_limits(self) -> ExecutionResources:
         return self._resource_limits

--- a/python/ray/train/BUILD.bazel
+++ b/python/ray/train/BUILD.bazel
@@ -353,6 +353,17 @@ py_test(
 )
 
 py_test(
+    name = "test_autoscaling_coordinator_client",
+    size = "small",
+    srcs = ["tests/test_autoscaling_coordinator_client.py"],
+    tags = [
+        "exclusive",
+        "team:ml",
+    ],
+    deps = [":train_lib"],
+)
+
+py_test(
     name = "test_backend",
     size = "large",
     srcs = ["tests/test_backend.py"],

--- a/python/ray/train/_internal/autoscaling_coordinator_client.py
+++ b/python/ray/train/_internal/autoscaling_coordinator_client.py
@@ -1,0 +1,78 @@
+import threading
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
+    ResourceDict,
+)
+
+if TYPE_CHECKING:
+    from ray.air.config import ScalingConfig
+
+
+def build_train_resource_request(
+    scaling_config: "ScalingConfig",
+    num_workers: int,
+) -> Tuple[List[ResourceDict], Optional[List[Dict[str, str]]]]:
+    """Build coordinator bundles for worker resources and optional trainer resources.
+
+    Trainer bundles are included when ``scaling_config._trainer_resources_not_none``
+    is non-empty (Ray Train V1). Ray Train V2 overrides this to ``{}``.
+    """
+    resources_per_worker = scaling_config._resources_per_worker_not_none
+    worker_bundles = [resources_per_worker] * num_workers
+    trainer_resources = scaling_config._trainer_resources_not_none
+    if trainer_resources:
+        resources = [trainer_resources] + worker_bundles
+    else:
+        resources = worker_bundles
+
+    label_selectors = scaling_config._label_selector_per_worker(num_workers)
+    if trainer_resources and label_selectors is not None:
+        label_selectors = [{}] + label_selectors
+    return resources, label_selectors
+
+
+class TrainV1ResourceReservation:
+    """Context manager that registers train resources for the duration of a run.
+    NOTE: Only used by the train V1
+    """
+
+    def __init__(
+        self,
+        requester_id: str,
+        scaling_config: "ScalingConfig",
+        num_workers: int,
+    ):
+        from ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client import (  # noqa: E501
+            AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            AUTOSCALING_REQUESTS_INTERVAL_S,
+            TrainAutoscalingCoordinatorClient,
+        )
+
+        self._client = TrainAutoscalingCoordinatorClient(requester_id)
+        self._scaling_config = scaling_config
+        self._num_workers = num_workers
+        self._refresh_interval_s = AUTOSCALING_REQUESTS_INTERVAL_S
+        # 1 seconda more, since a send_resource_request could stall
+        # up to AUTOSCALING_REQUESTS_GET_TIMEOUT_S seconds
+        self._refresh_join_timeout_s = AUTOSCALING_REQUESTS_GET_TIMEOUT_S + 1
+        self._stop_event = threading.Event()
+        self._refresh_thread: Optional[threading.Thread] = None
+
+    def __enter__(self) -> "TrainV1ResourceReservation":
+        self._client.send_resource_request(self._scaling_config, self._num_workers)
+        self._refresh_thread = threading.Thread(
+            target=self._refresh_loop, daemon=True, name="train-resource-reservation"
+        )
+        self._refresh_thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._stop_event.set()
+        if self._refresh_thread is not None:
+            self._refresh_thread.join(timeout=self._refresh_join_timeout_s)
+        self._client.cancel_resource_request()
+
+    def _refresh_loop(self) -> None:
+        while not self._stop_event.wait(self._refresh_interval_s):
+            self._client.send_resource_request(self._scaling_config, self._num_workers)

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -767,20 +767,21 @@ class BackendExecutor:
                 before terminating the Ray actors.
 
         """
-        if graceful_termination:
-            try:
-                self._backend.on_shutdown(self.worker_group, self._backend_config)
-            except RayActorError:
-                logger.warning(
-                    "Graceful shutdown of backend failed. This is "
-                    "expected if one of the workers has crashed."
-                )
+        if self.is_started():
+            if graceful_termination:
+                try:
+                    self._backend.on_shutdown(self.worker_group, self._backend_config)
+                except RayActorError:
+                    logger.warning(
+                        "Graceful shutdown of backend failed. This is "
+                        "expected if one of the workers has crashed."
+                    )
 
-        if graceful_termination:
-            self.worker_group.shutdown()
-        else:
-            self.worker_group.shutdown(patience_s=0)
-        self.worker_group = InactiveWorkerGroup()
+            if graceful_termination:
+                self.worker_group.shutdown()
+            else:
+                self.worker_group.shutdown(patience_s=0)
+            self.worker_group = InactiveWorkerGroup()
 
         if self._placement_group:
             remove_placement_group(self._placement_group)

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -1,5 +1,4 @@
 import copy
-from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 from ray.actor import ActorHandle
@@ -31,17 +30,22 @@ class DataConfig:
             datasets_to_split: Specifies which datasets should be split among workers.
                 Can be set to "all" or a list of dataset names. Defaults to "all",
                 i.e. split all datasets.
-            execution_options: The execution options to pass to Ray Data. Can be either:
-                1. A single ExecutionOptions object that is applied to all datasets.
-                2. A dict mapping dataset names to ExecutionOptions. If a dataset name
-                is not in the dict, it defaults to ``DataConfig.default_ingest_options()``.
-                By default, the options are optimized for data ingest. When overriding,
-                base your options off ``DataConfig.default_ingest_options()``.
+            execution_options: Optional Ray Data execution options. When set, they are
+                applied to dataset shards. When ``None`` (the default), Train applies
+                :meth:`default_ingest_options` to each dataset shard. Can be either:
+
+                1. A single ExecutionOptions object applied to all datasets.
+                2. A dict mapping dataset names to ExecutionOptions for per-dataset
+                   overrides. Datasets not present in the dict use
+                   :meth:`default_ingest_options`.
+
+                NOTE: For exclude_resources and resource_limits, those options only affect
+                Ray Data *after* train performs its cluster resource reservation.
+                So if you specify exclude_resources, it will exclude the resources
+                from data's reservation, *not* train's reservation.
             enable_shard_locality: If true, dataset sharding across Train workers will
                 consider locality to minimize cross-node data transfer. Enabled by default.
         """
-        from ray.data import ExecutionOptions
-
         if isinstance(datasets_to_split, list) or datasets_to_split == "all":
             self._datasets_to_split = datasets_to_split
         else:
@@ -51,35 +55,32 @@ class DataConfig:
                 f"{type(datasets_to_split).__name__} with value {datasets_to_split}."
             )
 
-        default_execution_options = DataConfig.default_ingest_options()
-
-        if isinstance(execution_options, ExecutionOptions):
-            default_execution_options = execution_options
-        # If None, all datasets will use the default ingest options.
-        self._execution_options: Dict[str, "ExecutionOptions"] = defaultdict(
-            lambda: copy.deepcopy(default_execution_options)
-        )
-        if isinstance(execution_options, dict):
-            self._execution_options.update(execution_options)
-
+        self._user_execution_options = execution_options
         self._enable_shard_locality = enable_shard_locality
 
-        self._num_train_cpus = 0.0
-        self._num_train_gpus = 0.0
+    def _get_user_execution_options(
+        self, dataset_name: str
+    ) -> Optional["ExecutionOptions"]:
+        """Return user-provided execution options for a dataset, if any."""
+        if self._user_execution_options is None:
+            return None
+        if isinstance(self._user_execution_options, dict):
+            if dataset_name not in self._user_execution_options:
+                return None
+            return self._user_execution_options[dataset_name]
+        return self._user_execution_options
 
-    def set_train_total_resources(self, num_train_cpus: float, num_train_gpus: float):
-        """Set the total number of CPUs and GPUs used by training.
+    def _resolve_execution_options(self, dataset_name: str) -> "ExecutionOptions":
+        """Return a deep copy of the effective execution options for a dataset shard.
 
-        If CPU or GPU resource limits are not set, they will be set to the
-        total cluster resources minus the resources used by training.
+        Returns a deep copy so callers (including subclasses that override
+        ``configure``) can mutate the result without aliasing the driver
+        ``DataContext`` or the user-supplied ``ExecutionOptions`` object.
         """
-        # TODO: We may also include other resources besides CPU and GPU.
-        self._num_train_cpus = num_train_cpus
-        self._num_train_gpus = num_train_gpus
-
-    def _get_execution_options(self, dataset_name: str) -> "ExecutionOptions":
-        """Return a copy of the configured execution options for a given dataset name."""
-        return copy.deepcopy(self._execution_options[dataset_name])
+        return copy.deepcopy(
+            self._get_user_execution_options(dataset_name)
+            or self.default_ingest_options()
+        )
 
     @DeveloperAPI
     def configure(
@@ -104,10 +105,6 @@ class DataConfig:
             equal to `world_size`. Each element of the list contains the assigned
             `DataIterator` instances by name for the worker.
         """
-        from ray.data._internal.execution.interfaces.execution_options import (
-            ExecutionResources,
-        )
-
         output = [{} for _ in range(world_size)]
 
         for dataset_name, dataset in datasets.items():
@@ -121,20 +118,8 @@ class DataConfig:
 
         locality_hints = worker_node_ids if self._enable_shard_locality else None
         for name, ds in datasets.items():
-            execution_options = self._get_execution_options(name)
-
-            if execution_options.is_resource_limits_default():
-                if not self._scaling_policy_reserves_train_resources():
-                    execution_options._set_exclude_resources(
-                        execution_options.exclude_resources.add(
-                            ExecutionResources(
-                                cpu=self._num_train_cpus, gpu=self._num_train_gpus
-                            )
-                        )
-                    )
-
             ds = ds.copy(ds)
-            ds.context.execution_options = execution_options
+            ds.context.execution_options = self._resolve_execution_options(name)
 
             if name in datasets_to_split:
                 for i, split in enumerate(
@@ -148,16 +133,6 @@ class DataConfig:
                     output[i][name] = ds.iterator()
 
         return output
-
-    @classmethod
-    def _scaling_policy_reserves_train_resources(cls) -> bool:
-        """True iff Ray Train V2's ScalingPolicy will register training resources
-        with the AutoscalingCoordinator for this run.
-
-        """
-        from ray.train.v2._internal.constants import is_v2_enabled
-
-        return is_v2_enabled()
 
     @staticmethod
     def default_ingest_options() -> "ExecutionOptions":

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -8,6 +8,9 @@ from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray.air.config import RunConfig, ScalingConfig
 from ray.train import BackendConfig, Checkpoint
 from ray.train._internal import session
+from ray.train._internal.autoscaling_coordinator_client import (
+    TrainV1ResourceReservation,
+)
 from ray.train._internal.backend_executor import BackendExecutor, TrialInfo
 from ray.train._internal.data_config import DataConfig
 from ray.train._internal.session import _TrainingResult, get_session
@@ -259,12 +262,6 @@ class DataParallelTrainer(BaseTrainer):
             resume_from_checkpoint=resume_from_checkpoint,
         )
 
-        train_total_resources = self.scaling_config.total_resources
-        self._data_config.set_train_total_resources(
-            train_total_resources.get("CPU", 0),
-            train_total_resources.get("GPU", 0),
-        )
-
         if env_integer(RAY_TRAIN_ENABLE_STATE_TRACKING, 0):
             from ray.train._internal.state.state_actor import get_or_create_state_actor
 
@@ -454,23 +451,39 @@ class DataParallelTrainer(BaseTrainer):
             max_retries=0,
         )
 
-        # Start the remote actors.
-        backend_executor.start()
+        requester_id = f"train-{trial_info.run_id}"
 
-        training_iterator = self._training_iterator_cls(
-            backend_executor=backend_executor,
-            backend_config=self._backend_config,
-            train_func=train_loop_per_worker,
-            datasets=self.datasets,
-            metadata=self.metadata,
-            data_config=self._data_config,
-            checkpoint=self.starting_checkpoint,
-        )
+        # NOTE: This spawns a thread that will continously refresh
+        # its autoscaling request.
+        with TrainV1ResourceReservation(
+            requester_id=requester_id,
+            scaling_config=scaling_config,
+            num_workers=scaling_config.num_workers,
+        ):
+            try:
+                # Start the remote actors.
+                # TODO(jhsu): Later, we need to fix this to support passing in the
+                # locations of each reservation
+                backend_executor.start()
 
-        self._run_training(training_iterator)
+                training_iterator = self._training_iterator_cls(
+                    backend_executor=backend_executor,
+                    backend_config=self._backend_config,
+                    train_func=train_loop_per_worker,
+                    datasets=self.datasets,
+                    metadata=self.metadata,
+                    data_config=self._data_config,
+                    checkpoint=self.starting_checkpoint,
+                )
 
-        # Shutdown workers.
-        backend_executor.shutdown()
+                self._run_training(training_iterator)
+            finally:
+                # Shut down workers (and release their placement group) before the
+                # resource reservation is cancelled on context exit. Otherwise there
+                # is a window where workers still hold CPUs/GPUs without an active
+                # reservation, allowing Ray Data to potentially reclaim those resources
+                # during teardown.
+                backend_executor.shutdown()
 
     def get_dataset_config(self) -> DataConfig:
         """Returns a copy of this Trainer's final dataset configs.

--- a/python/ray/train/tests/test_autoscaling_coordinator_client.py
+++ b/python/ray/train/tests/test_autoscaling_coordinator_client.py
@@ -1,0 +1,54 @@
+import pytest
+
+import ray.air
+from ray.train._internal.autoscaling_coordinator_client import (
+    build_train_resource_request,
+)
+
+
+def test_build_train_resource_request_includes_default_trainer_bundle_v1():
+    scaling_config = ray.air.ScalingConfig(
+        num_workers=2,
+        use_gpu=True,
+        resources_per_worker={"CPU": 4, "GPU": 1},
+    )
+
+    resources, label_selectors = build_train_resource_request(scaling_config, 2)
+
+    assert resources == [
+        {"CPU": 1},  # Trainer bundle for v1
+        {"CPU": 4, "GPU": 1},
+        {"CPU": 4, "GPU": 1},
+    ]
+    assert label_selectors is None
+
+
+def test_build_train_resource_request_respects_zero_trainer_resources_v1():
+    scaling_config = ray.air.ScalingConfig(
+        num_workers=2,
+        trainer_resources={"CPU": 0},
+        resources_per_worker={"CPU": 1},
+    )
+
+    resources, label_selectors = build_train_resource_request(scaling_config, 2)
+
+    assert resources == [{"CPU": 1}, {"CPU": 1}]
+    assert label_selectors is None
+
+
+def test_build_train_resource_request_prepends_trainer_label_selector_v1():
+    scaling_config = ray.air.ScalingConfig(
+        num_workers=2,
+        resources_per_worker={"CPU": 1},
+    )
+
+    resources, label_selectors = build_train_resource_request(scaling_config, 2)
+
+    assert resources == [{"CPU": 1}, {"CPU": 1}, {"CPU": 1}]
+    assert label_selectors is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -42,6 +42,22 @@ py_test(
 )
 
 py_test(
+    name = "test_autoscaling_coordinator_client",
+    size = "small",
+    srcs = ["tests/test_autoscaling_coordinator_client.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_async_checkpointing_validation",
     size = "large",
     srcs = ["tests/test_async_checkpointing_validation.py"],

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import ray
 import ray.train
+from ray.data.context import DataContext
+from ray.train.v2._internal.data_integration.dataset_manager import DatasetManager
 from ray.train.v2._internal.data_integration.interfaces import (
     DatasetShardMetadata,
     DatasetShardProvider,
@@ -20,7 +22,6 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
     from ray.data import DataIterator, Dataset, NodeIdStr
-    from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
 
@@ -30,14 +31,10 @@ class RayDatasetShardProvider:
         self,
         datasets: Dict[str, GenDataset],
         data_config: ray.train.DataConfig,
-        data_context: "DataContext",
+        data_context: DataContext,
         world_size: int,
         worker_node_ids: List["NodeIdStr"],
     ):
-        from ray.train.v2._internal.data_integration.dataset_manager import (
-            DatasetManager,
-        )
-
         self._dataset_names = set(datasets)
         self._dataset_manager = (
             ray.remote(DatasetManager)
@@ -93,7 +90,6 @@ class DatasetsCallback(WorkerGroupCallback):
     ):
         self._datasets = datasets
         self._data_config = copy.deepcopy(train_run_context.dataset_config)
-        self._scaling_config = train_run_context.scaling_config
         self._dataset_shard_provider: Optional[RayDatasetShardProvider] = None
 
         # Capture the current DataContext to propagate it to
@@ -104,22 +100,7 @@ class DatasetsCallback(WorkerGroupCallback):
         # 3. Lastly, when the worker group is initialized, the Controller
         #    will call the `after_worker_group_start` callback to propagate
         #    the DataContext to Train workers.
-        from ray.data.context import DataContext
-
         self._data_context = copy.deepcopy(DataContext.get_current())
-
-    def get_train_total_resources(
-        self, scaling_config: ray.train.ScalingConfig
-    ) -> Dict[str, float]:
-        """Return the resources reserved for training, so that Data can exclude
-        these resources logically from its available pool."""
-        if scaling_config.elasticity_enabled:
-            # If Train is running with a variable number of workers,
-            # we can't provide a fixed number of resources to exclude.
-            # Instead, Train and Data should coordinate via the autoscaling
-            # coordinator to allocate resources dynamically.
-            return {}
-        return scaling_config.total_resources
 
     # --------------------------
     # WorkerGroupCallback
@@ -132,13 +113,6 @@ class DatasetsCallback(WorkerGroupCallback):
         worker_node_ids = [worker.metadata.node_id for worker in workers]
         datasets = {k: v() if callable(v) else v for k, v in self._datasets.items()}
 
-        # TODO: Move this to the constructor.
-        # Notify the DataConfig about the total resources reserved for training.
-        total_train_resources = self.get_train_total_resources(self._scaling_config)
-        self._data_config.set_train_total_resources(
-            total_train_resources.get("CPU", 0), total_train_resources.get("GPU", 0)
-        )
-
         self._dataset_shard_provider = RayDatasetShardProvider(
             datasets=datasets,
             data_config=self._data_config,
@@ -150,9 +124,7 @@ class DatasetsCallback(WorkerGroupCallback):
 
     def after_worker_group_start(self, worker_group: WorkerGroup):
         # Propagate DataContext
-        from ray.data.context import DataContext
-
-        def _propagate_data_context(ctx: "DataContext"):
+        def _propagate_data_context(ctx: DataContext):
             DataContext._set_current(ctx)
 
         worker_group.execute(

--- a/python/ray/train/v2/_internal/execution/scaling_policy/__init__.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/__init__.py
@@ -1,10 +1,10 @@
 # isort: off
-from .scaling_policy import ScalingDecision, ScalingPolicy, NoopDecision, ResizeDecision
-from .scaling_policy import (
+from ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client import (  # noqa: E501
     AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
     AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
     AUTOSCALING_REQUESTS_INTERVAL_S,
 )
+from .scaling_policy import ScalingDecision, ScalingPolicy, NoopDecision, ResizeDecision
 from .elastic import ElasticScalingPolicy
 from .fixed import FixedScalingPolicy
 from .factory import create_scaling_policy

--- a/python/ray/train/v2/_internal/execution/scaling_policy/autoscaling_coordinator_client.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/autoscaling_coordinator_client.py
@@ -1,0 +1,102 @@
+import logging
+import time
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+import ray
+from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+    ResourceRequestPriority,
+    get_or_create_autoscaling_coordinator,
+)
+from ray.train._internal.autoscaling_coordinator_client import (
+    build_train_resource_request,
+)
+
+if TYPE_CHECKING:
+    from ray.actor import ActorProxy
+    from ray.air.config import ScalingConfig
+    from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+        _AutoscalingCoordinatorActor,
+    )
+
+logger = logging.getLogger(__name__)
+
+# The time in seconds after which an autoscaling request will expire.
+AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
+# Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
+AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
+# Interval in seconds between resource requests to the AutoscalingCoordinator.
+AUTOSCALING_REQUESTS_INTERVAL_S = 20
+
+
+class TrainAutoscalingCoordinatorClient:
+    """Thin client for registering train worker resources with the coordinator.
+
+    This is the train version, the data version is called `DefaultAutoscalingCoordinator`"""
+
+    def __init__(self, requester_id: str):
+        self._requester_id = requester_id
+        self._latest_autoscaling_request_time = float("-inf")
+
+    @cached_property
+    def _autoscaling_coordinator(self) -> "ActorProxy[_AutoscalingCoordinatorActor]":
+        return get_or_create_autoscaling_coordinator()
+
+    def send_resource_request(
+        self,
+        scaling_config: "ScalingConfig",
+        num_workers: int,
+    ) -> None:
+        """Register training resources with the AutoscalingCoordinator."""
+        resources, label_selectors = build_train_resource_request(
+            scaling_config, num_workers
+        )
+        try:
+            ray.get(
+                self._autoscaling_coordinator.request_resources.remote(
+                    requester_id=self._requester_id,
+                    resources=resources,
+                    label_selectors=label_selectors,
+                    expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+                    priority=ResourceRequestPriority.HIGH,
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+            self._latest_autoscaling_request_time = time.monotonic()
+        except Exception:
+            msg = (
+                f"Failed to send resource request for {self._requester_id}."
+                " If this only happens transiently during network partition or"
+                " CPU being overloaded, it's safe to ignore this error."
+                " If this error persists, file a GitHub issue."
+            )
+            logger.warning(msg, exc_info=True)
+
+    def maybe_send_resource_request(
+        self,
+        scaling_config: "ScalingConfig",
+        num_workers: int,
+    ) -> None:
+        now = time.monotonic()
+        if (
+            now - self._latest_autoscaling_request_time
+            < AUTOSCALING_REQUESTS_INTERVAL_S
+        ):
+            return
+        self.send_resource_request(scaling_config, num_workers)
+
+    def cancel_resource_request(self) -> None:
+        try:
+            ray.get(
+                self._autoscaling_coordinator.cancel_request.remote(
+                    requester_id=self._requester_id,
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+        except Exception:
+            msg = (
+                f"Failed to cancel resource request for {self._requester_id}."
+                " The request will still expire after the timeout of"
+                f" {AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
+            )
+            logger.warning(msg, exc_info=True)

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -1,14 +1,17 @@
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import List, Optional
 
 import ray
+from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
+    ResourceDict,
+)
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
     ScalingDecision,
     ScalingPolicy,
 )
-from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
+from ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client import (  # noqa: E501
     AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
 )
 from ray.train.v2._internal.execution.worker_group import (
@@ -19,11 +22,6 @@ from ray.train.v2._internal.util import time_monotonic
 from ray.train.v2.api.config import ScalingConfig
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-        ResourceDict,
-    )
 
 
 class ElasticScalingPolicy(ScalingPolicy):
@@ -39,14 +37,12 @@ class ElasticScalingPolicy(ScalingPolicy):
         self._latest_monitor_time = float("-inf")
         self._latest_insufficient_workers_warning_time = float("-inf")
         self._latest_allocated_resources_query_time = float("-inf")
-        self._latest_allocated_resources: Optional[List["ResourceDict"]] = None
+        self._latest_allocated_resources: Optional[List[ResourceDict]] = None
 
     def _get_num_workers_for_resource_request(self) -> int:
         return self.scaling_config.max_workers
 
-    def _count_possible_workers(
-        self, allocated_resources: List[Dict[str, float]]
-    ) -> int:
+    def _count_possible_workers(self, allocated_resources: List[ResourceDict]) -> int:
         """Count the number of workers that can be started/restarted with the given
         the list of node resources. The returned number is capped at the maximum
         number of workers.
@@ -56,7 +52,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         TPU slices (see ``_get_strict_tpu_worker_count``).
 
         Args:
-            allocated_resources: The resources currently allocated by the AutoscalingCoordinator.
+            allocated_resources: Per-node reserved resources from the AutoscalingCoordinator.
 
         Returns:
             The number of workers that can be started/restarted with the current resources.
@@ -258,7 +254,7 @@ class ElasticScalingPolicy(ScalingPolicy):
     # Methods for interacting with AutoscalingCoordinator
     # ---------------------------------------------------
 
-    def _get_allocated_resources(self) -> Optional[List["ResourceDict"]]:
+    def _get_allocated_resources(self) -> Optional[List[ResourceDict]]:
         """Get allocated resources from AutoscalingCoordinator.
         Return None if there is an error."""
         now = time_monotonic()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -1,28 +1,20 @@
 import abc
 import logging
-import uuid
 from dataclasses import dataclass
-from functools import cached_property
-from typing import Dict
+from typing import Dict, Optional
 
-import ray
 from ray.train.v2._internal.execution.callback import ControllerCallback
 from ray.train.v2._internal.execution.context import TrainRunContext
+from ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client import (  # noqa: E501
+    TrainAutoscalingCoordinatorClient,
+)
 from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
     WorkerGroupState,
 )
-from ray.train.v2._internal.util import time_monotonic
 from ray.train.v2.api.config import ScalingConfig
 
 logger = logging.getLogger(__name__)
-
-# The time in seconds after which an autoscaling request will expire.
-AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
-# Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
-AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
-# Interval in seconds between resource requests to the AutoscalingCoordinator.
-AUTOSCALING_REQUESTS_INTERVAL_S = 20
 
 
 @dataclass
@@ -62,8 +54,10 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
 
     def __init__(self, scaling_config: ScalingConfig):
         self.scaling_config = scaling_config
-        self._requester_id = "train-" + uuid.uuid4().hex
-        self._latest_autoscaling_request_time = float("-inf")
+        # Due to multiple train dataset runs, the requester_id
+        # isn't set until the run is started.
+        self._requester_id: Optional[str] = None
+        self._coordinator_client: Optional[TrainAutoscalingCoordinatorClient] = None
 
     @abc.abstractmethod
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
@@ -89,71 +83,37 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
     # Methods for interacting with AutoscalingCoordinator
     # ---------------------------------------------------
 
-    @cached_property
-    def _autoscaling_coordinator(self):
-        from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-            get_or_create_autoscaling_coordinator,
-        )
-
-        return get_or_create_autoscaling_coordinator()
-
     def _maybe_send_resource_request(self):
         """Send a resource request to AutoscalingCoordinator,
         if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
-        now = time_monotonic()
-        if (
-            now - self._latest_autoscaling_request_time
-            < AUTOSCALING_REQUESTS_INTERVAL_S
-        ):
-            return
-        self._send_resource_request()
+        assert self._coordinator_client is not None
+        self._coordinator_client.maybe_send_resource_request(
+            self.scaling_config,
+            self._get_num_workers_for_resource_request(),
+        )
 
     def _send_resource_request(self):
         """Register training resources with the AutoscalingCoordinator."""
-        resources_per_worker = self.scaling_config._resources_per_worker_not_none
-        num_workers = self._get_num_workers_for_resource_request()
-        label_selectors = self.scaling_config._label_selector_per_worker(num_workers)
-        try:
-            from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-                ResourceRequestPriority,
-            )
-
-            ray.get(
-                self._autoscaling_coordinator.request_resources.remote(
-                    requester_id=self._requester_id,
-                    resources=[resources_per_worker] * num_workers,
-                    label_selectors=label_selectors,
-                    expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
-                    priority=ResourceRequestPriority.HIGH,
-                ),
-                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-            self._latest_autoscaling_request_time = time_monotonic()
-        except Exception:
-            msg = (
-                f"Failed to send resource request for {self._requester_id}."
-                " If this only happens transiently during network partition or"
-                " CPU being overloaded, it's safe to ignore this error."
-                " If this error persists, file a GitHub issue."
-            )
-            logger.warning(msg, exc_info=True)
+        assert self._coordinator_client is not None
+        self._coordinator_client.send_resource_request(
+            self.scaling_config,
+            self._get_num_workers_for_resource_request(),
+        )
 
     def _cancel_resource_request(self):
-        """Cancel the resource request to AutoscalingCoordinator."""
-        try:
-            ray.get(
-                self._autoscaling_coordinator.cancel_request.remote(
-                    requester_id=self._requester_id,
-                ),
-                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-        except Exception:
-            msg = (
-                f"Failed to cancel resource request for {self._requester_id}."
-                " The request will still expire after the timeout of"
-                f" {AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
-            )
-            logger.warning(msg, exc_info=True)
+        """Cancel the resource request to AutoscalingCoordinator.
+
+        No-ops if the coordinator client was never created (i.e. the controller
+        was aborted before ``after_controller_start`` ran).
+        """
+        if self._coordinator_client is None:
+            return
+        self._coordinator_client.cancel_resource_request()
+
+    @property
+    def _autoscaling_coordinator(self):
+        assert self._coordinator_client is not None
+        return self._coordinator_client._autoscaling_coordinator
 
     # --------------------------
     # ControllerCallback
@@ -162,6 +122,7 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
     def after_controller_start(self, train_run_context: TrainRunContext):
         """Register training resources with the AutoscalingCoordinator."""
         self._requester_id = f"train-{train_run_context.run_id}"
+        self._coordinator_client = TrainAutoscalingCoordinatorClient(self._requester_id)
         resources_per_worker = self.scaling_config._resources_per_worker_not_none
         num_workers = self._get_num_workers_for_resource_request()
         label_selectors = self.scaling_config._label_selector_per_worker(num_workers)

--- a/python/ray/train/v2/_internal/state/util.py
+++ b/python/ray/train/v2/_internal/state/util.py
@@ -57,27 +57,23 @@ def is_actor_alive(actor_id: str, timeout: int) -> bool:
 
 
 def construct_data_config(data_config: DataConfig) -> DataConfigSchema:
-    """Serialize a user-facing DataConfig into the exportable schema.
-
-    Note: This function assumes data_config._execution_options (a defaultdict)
-    hasn't been read between initialization of the field and this function call.
-    Any read materializes a dataset key and affects the data config shape,
-    wrongly capturing a per dataset execution options even if the user only
-    provided a default.
-    """
-    exec_options = data_config._execution_options
-
+    """Serialize a user-facing DataConfig into the exportable schema."""
+    user_execution_options = data_config._user_execution_options
     per_dataset_execution_options = {}
-    if exec_options:
+    default_options = DataConfig.default_ingest_options()
+
+    if isinstance(user_execution_options, dict):
         per_dataset_execution_options = {
             ds_name: execution_options_to_model(opts)
-            for ds_name, opts in exec_options.items()
+            for ds_name, opts in user_execution_options.items()
         }
+    elif user_execution_options is not None:
+        default_options = user_execution_options
 
     return DataConfigSchema(
         datasets_to_split=data_config._datasets_to_split,
         data_execution_options=DataExecutionOptions(
-            default=execution_options_to_model(exec_options.default_factory()),
+            default=execution_options_to_model(default_options),
             per_dataset_execution_options=per_dataset_execution_options,
         ),
         enable_shard_locality=data_config._enable_shard_locality,

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -287,6 +287,7 @@ class ScalingConfig(ScalingConfigV1):
 
     @property
     def _trainer_resources_not_none(self):
+        # V2 controller uses num_cpus=0; trainer_resources are V1-only.
         return {}
 
     @property

--- a/python/ray/train/v2/tests/test_autoscaling_coordinator_client.py
+++ b/python/ray/train/v2/tests/test_autoscaling_coordinator_client.py
@@ -1,0 +1,28 @@
+import pytest
+
+import ray.train
+from ray.train._internal.autoscaling_coordinator_client import (
+    build_train_resource_request,
+)
+
+
+def test_build_train_resource_request_excludes_trainer_bundle_v2():
+    scaling_config = ray.train.ScalingConfig(
+        num_workers=2,
+        use_gpu=True,
+        resources_per_worker={"CPU": 4, "GPU": 1},
+    )
+
+    resources, label_selectors = build_train_resource_request(scaling_config, 2)
+
+    assert resources == [
+        {"CPU": 4, "GPU": 1},
+        {"CPU": 4, "GPU": 1},
+    ]
+    assert label_selectors is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_data_config.py
+++ b/python/ray/train/v2/tests/test_data_config.py
@@ -1,35 +1,24 @@
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
 )
-from ray.train import DataConfig
+from ray.train._internal.data_config import DataConfig
 
 
 def test_per_dataset_execution_options_single(ray_start_4_cpus):
-    """Test that a single ExecutionOptions object applies to all datasets."""
-    # Create execution options with specific settings
+    """A single ExecutionOptions object applies to all datasets."""
     execution_options = ExecutionOptions()
     execution_options.preserve_order = True
     execution_options.verbose_progress = True
 
     data_config = DataConfig(execution_options=execution_options)
 
-    # Verify that all datasets get the same execution options
-    train_options = data_config._get_execution_options("train")
-    test_options = data_config._get_execution_options("test")
-    val_options = data_config._get_execution_options("val")
-
-    assert train_options.preserve_order is True
-    assert train_options.verbose_progress is True
-    assert test_options.preserve_order is True
-    assert test_options.verbose_progress is True
-    assert val_options.preserve_order is True
-    assert val_options.verbose_progress is True
+    # All datasets should get the same options.
+    for dataset_name in ("train", "test", "val"):
+        assert data_config._resolve_execution_options(dataset_name) == execution_options
 
 
 def test_per_dataset_execution_options_dict(ray_start_4_cpus):
-    """Test that a dict of ExecutionOptions maps to specific datasets, and datasets
-    not in the dict get default ingest options. Also tests resource limits."""
-    # Create different execution options for different datasets
+    """Per-dataset ExecutionOptions only apply to configured datasets."""
     train_options = ExecutionOptions()
     train_options.preserve_order = True
     train_options.verbose_progress = True
@@ -44,56 +33,29 @@ def test_per_dataset_execution_options_dict(ray_start_4_cpus):
         "train": train_options,
         "test": test_options,
     }
-
     data_config = DataConfig(execution_options=execution_options_dict)
 
-    # Verify that each dataset in the dict gets its specific options
-    retrieved_train_options = data_config._get_execution_options("train")
-    retrieved_test_options = data_config._get_execution_options("test")
+    assert data_config._resolve_execution_options("train") == train_options
+    assert data_config._resolve_execution_options("test") == test_options
 
-    assert retrieved_train_options.preserve_order is True
-    assert retrieved_train_options.verbose_progress is True
-    assert retrieved_test_options.preserve_order is False
-    assert retrieved_test_options.verbose_progress is False
-
-    # Verify resource limits
-    assert retrieved_train_options.resource_limits.cpu == 4
-    assert retrieved_train_options.resource_limits.gpu == 2
-    assert retrieved_test_options.resource_limits.cpu == 2
-    assert retrieved_test_options.resource_limits.gpu == 1
-
-    # Verify that a dataset not in the dict gets default options
-    default_options = DataConfig.default_ingest_options()
-    retrieved_val_options = data_config._get_execution_options("val")
-    assert retrieved_val_options.preserve_order == default_options.preserve_order
-    assert retrieved_val_options.verbose_progress == default_options.verbose_progress
-    assert (
-        retrieved_val_options.resource_limits.cpu == default_options.resource_limits.cpu
-    )
-    assert (
-        retrieved_val_options.resource_limits.gpu == default_options.resource_limits.gpu
+    # Datasets not in the dict fall back to default ingest options.
+    assert data_config._resolve_execution_options("val") == (
+        DataConfig.default_ingest_options()
     )
 
 
 def test_per_dataset_execution_options_default(ray_start_4_cpus):
-    """Test that None or empty dict execution_options results in all datasets
-    using default options."""
-    # Test with None
-    data_config_none = DataConfig(execution_options=None)
+    """When execution_options is None, datasets use default ingest options."""
     default_options = DataConfig.default_ingest_options()
-    retrieved_train_options = data_config_none._get_execution_options("train")
-    retrieved_test_options = data_config_none._get_execution_options("test")
 
-    assert retrieved_train_options.preserve_order == default_options.preserve_order
-    assert retrieved_test_options.preserve_order == default_options.preserve_order
+    data_config_none = DataConfig(execution_options=None)
+    assert data_config_none._get_user_execution_options("train") is None
+    assert data_config_none._resolve_execution_options("train") == default_options
 
-    # Test with empty dict
+    # empty dict is user-specified but contains no per-dataset overrides.
     data_config_empty = DataConfig(execution_options={})
-    retrieved_train_options = data_config_empty._get_execution_options("train")
-    retrieved_test_options = data_config_empty._get_execution_options("test")
-
-    assert retrieved_train_options.preserve_order == default_options.preserve_order
-    assert retrieved_test_options.preserve_order == default_options.preserve_order
+    assert data_config_empty._get_user_execution_options("train") is None
+    assert data_config_empty._resolve_execution_options("train") == default_options
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -170,19 +170,18 @@ def test_data_context_propagation(ray_start_4_cpus, restore_data_context):  # no
     trainer.fit()
 
 
-def test_configure_execution_options_carryover_context():
-    """Tests that execution options in DataContext
-    carry over to DataConfig automatically."""
+def test_default_ingest_options_inherited_from_context():
+    """Train uses default_ingest_options, not driver DataContext execution options."""
 
     ctx = ray.data.DataContext.get_current()
     ctx.execution_options.preserve_order = True
     ctx.execution_options.verbose_progress = True
 
     data_config = ray.train.DataConfig()
-
-    ingest_options = data_config.default_ingest_options()
-    assert ingest_options.preserve_order is True
-    assert ingest_options.verbose_progress is True
+    resolved = data_config._resolve_execution_options("train")
+    assert resolved == ray.train.DataConfig.default_ingest_options()
+    assert resolved.preserve_order is True
+    assert resolved.verbose_progress is True
 
 
 @pytest.mark.parametrize("enable_shard_locality", [True, False])
@@ -519,22 +518,23 @@ def test_per_dataset_execution_options_dict(ray_start_4_cpus):
         assert val_shard.get_context().execution_options.resource_limits.cpu == 2
         assert val_shard.get_context().execution_options.resource_limits.gpu == 1
 
-        # Verify dataset not in the dict gets default options
+        # Verify dataset not in the dict uses default ingest options.
+        default_options = ray.train.DataConfig.default_ingest_options()
         assert (
             test_shard.get_context().execution_options.preserve_order
-            == test_shard_2.get_context().execution_options.preserve_order
+            == default_options.preserve_order
         )
         assert (
             test_shard.get_context().execution_options.verbose_progress
-            == test_shard_2.get_context().execution_options.verbose_progress
+            == default_options.verbose_progress
         )
         assert (
-            test_shard.get_context().execution_options.resource_limits.cpu
-            == test_shard_2.get_context().execution_options.resource_limits.cpu
+            test_shard.get_context().execution_options.resource_limits
+            == default_options.resource_limits
         )
         assert (
-            test_shard.get_context().execution_options.resource_limits.gpu
-            == test_shard_2.get_context().execution_options.resource_limits.gpu
+            test_shard_2.get_context().execution_options.preserve_order
+            == test_shard.get_context().execution_options.preserve_order
         )
 
     trainer = DataParallelTrainer(
@@ -591,11 +591,10 @@ def test_exclude_train_resources_applies_to_each_dataset(ray_start_4_cpus):
         assert test_exec_options.exclude_resources.cpu == 1
         assert test_exec_options.exclude_resources.gpu == 0
 
-        # Check val dataset — no user-defined exclude_resources, so zero
+        # Check val dataset — no user execution_options, so Ray Data defaults apply.
         val_ds = ray.train.get_dataset_shard("val")
         val_exec_options = val_ds.get_context().execution_options
-        assert val_exec_options.is_resource_limits_default()
-        default_options = ray.train.DataConfig.default_ingest_options()
+        default_options = ExecutionOptions()
         assert (
             val_exec_options.exclude_resources.cpu
             == default_options.exclude_resources.cpu
@@ -742,13 +741,11 @@ def test_fixed_scaling_policy_coordinator_lifecycle(
         priority=ResourceRequestPriority.HIGH,
     )
 
-    with patch(
-        "ray.get",
-        side_effect=lambda x, **_: x,
+    with patch("ray.get", side_effect=lambda x, **_: x,), patch(
+        "ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client.get_or_create_autoscaling_coordinator",
+        return_value=mock_coordinator,
     ):
         policy = FixedScalingPolicy(scaling_config)
-        # Inject mock coordinator
-        policy.__dict__["_autoscaling_coordinator"] = mock_coordinator
 
         with freeze_time() as frozen_time:
             # Simulate controller start

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -36,7 +36,8 @@ def mock_autoscaling_coordinator(monkeypatch):
     )
 
     monkeypatch.setattr(
-        ElasticScalingPolicy, "_autoscaling_coordinator", mock_coordinator
+        "ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client.get_or_create_autoscaling_coordinator",
+        lambda: mock_coordinator,
     )
 
 
@@ -47,6 +48,19 @@ def patch_ray_get():
         side_effect=lambda x, **_: x,
     ):
         yield
+
+
+def _start_scaling_policy(policy, run_id: str = "test-run") -> None:
+    policy.after_controller_start(MagicMock(run_id=run_id))
+
+
+def _make_reserved(resources_per_worker: dict, num_nodes: int) -> list:
+    """Build a list of reserved resource bundles with ``num_nodes`` entries.
+
+    Mirrors the ``List[ResourceDict]`` returned by
+    ``AutoscalingCoordinator.get_allocated_resources``.
+    """
+    return [dict(resources_per_worker) for _ in range(num_nodes)]
 
 
 def _get_mock_worker_group_status(num_workers: int) -> WorkerGroupPollStatus:
@@ -82,6 +96,7 @@ def test_non_running_worker_group_decision():
         use_gpu=True,
     )
     policy = ElasticScalingPolicy(scaling_config)
+    _start_scaling_policy(policy)
     mock_coordinator = policy._autoscaling_coordinator
 
     # No resources are available at the start
@@ -89,18 +104,24 @@ def test_non_running_worker_group_decision():
     assert isinstance(decision, NoopDecision)
 
     # Resources for < min workers are available
-    mock_coordinator._allocated_resources = [resources_per_worker] * (min_workers - 1)
+    mock_coordinator._allocated_resources = _make_reserved(
+        resources_per_worker, min_workers - 1
+    )
     decision = policy.make_decision_for_non_running_worker_group()
     assert isinstance(decision, NoopDecision)
 
     # Resources for >= min workers are available
-    mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+    mock_coordinator._allocated_resources = _make_reserved(
+        resources_per_worker, min_workers
+    )
     decision = policy.make_decision_for_non_running_worker_group()
     assert isinstance(decision, ResizeDecision)
     assert decision.num_workers == min_workers
 
     # Resources for >= max workers are available
-    mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+    mock_coordinator._allocated_resources = _make_reserved(
+        resources_per_worker, max_workers
+    )
     decision = policy.make_decision_for_non_running_worker_group()
     assert isinstance(decision, ResizeDecision)
     assert decision.num_workers == max_workers
@@ -115,6 +136,7 @@ def test_before_controller_abort():
         use_gpu=True,
     )
     policy = ElasticScalingPolicy(scaling_config)
+    _start_scaling_policy(policy)
     mock_coordinator = policy._autoscaling_coordinator
 
     # Call before_controller_abort and check that cancel_request is called with the requester_id
@@ -138,6 +160,7 @@ def test_get_allocated_resources_interval():
         use_gpu=True,
     )
     policy = ElasticScalingPolicy(scaling_config)
+    _start_scaling_policy(policy)
     mock_coordinator = policy._autoscaling_coordinator
 
     with freeze_time() as frozen_time:
@@ -147,36 +170,46 @@ def test_get_allocated_resources_interval():
 
         # Resources for < min workers are available
         frozen_time.tick(get_allocated_resources_interval_s)
-        mock_coordinator._allocated_resources = [resources_per_worker] * (
-            min_workers - 1
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, min_workers - 1
         )
         allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == [resources_per_worker] * (min_workers - 1)
+        assert allocated_resources == _make_reserved(
+            resources_per_worker, min_workers - 1
+        )
 
         # Resources for >= min workers are available, but get_allocated_resources interval
         # has not yet passed.
-        mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, min_workers
+        )
         allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == [resources_per_worker] * (min_workers - 1)
+        assert allocated_resources == _make_reserved(
+            resources_per_worker, min_workers - 1
+        )
 
         # Resources for >= min workers are available and the get_allocated_resources
         # interval has passed.
         frozen_time.tick(get_allocated_resources_interval_s)
-        mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, min_workers
+        )
         allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == [resources_per_worker] * min_workers
+        assert allocated_resources == _make_reserved(resources_per_worker, min_workers)
 
         # Resources for >= max workers are available but the get_allocated_resources
         # interval has not yet passed.
-        mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, max_workers
+        )
         allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == [resources_per_worker] * min_workers
+        assert allocated_resources == _make_reserved(resources_per_worker, min_workers)
 
         # Resources for >= max workers are available and the get_allocated_resources
         # interval has passed.
         frozen_time.tick(get_allocated_resources_interval_s)
         allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == [resources_per_worker] * max_workers
+        assert allocated_resources == _make_reserved(resources_per_worker, max_workers)
 
 
 @patch.object(ElasticScalingPolicy, "GET_ALLOCATED_RESOURCES_INTERVAL_S", 0.0)
@@ -196,6 +229,7 @@ def test_running_worker_group_decision():
         elastic_resize_monitor_interval_s=0.0,
     )
     policy = ElasticScalingPolicy(scaling_config)
+    _start_scaling_policy(policy)
     mock_coordinator = policy._autoscaling_coordinator
 
     # The worker group just started
@@ -203,7 +237,9 @@ def test_running_worker_group_decision():
     worker_group_status = _get_mock_worker_group_status(min_workers)
 
     # No change in resources
-    mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+    mock_coordinator._allocated_resources = _make_reserved(
+        resources_per_worker, min_workers
+    )
     decision = policy.make_decision_for_running_worker_group(
         worker_group_state=worker_group_state,
         worker_group_status=worker_group_status,
@@ -211,7 +247,9 @@ def test_running_worker_group_decision():
     assert isinstance(decision, NoopDecision)
 
     # Resources for < min workers are available
-    mock_coordinator._allocated_resources = [resources_per_worker] * (min_workers - 1)
+    mock_coordinator._allocated_resources = _make_reserved(
+        resources_per_worker, min_workers - 1
+    )
     decision = policy.make_decision_for_running_worker_group(
         worker_group_state=worker_group_state,
         worker_group_status=worker_group_status,
@@ -219,7 +257,9 @@ def test_running_worker_group_decision():
     assert isinstance(decision, NoopDecision)
 
     # More resources are available.
-    mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+    mock_coordinator._allocated_resources = _make_reserved(
+        resources_per_worker, max_workers
+    )
     decision = policy.make_decision_for_running_worker_group(
         worker_group_state=worker_group_state,
         worker_group_status=worker_group_status,
@@ -243,6 +283,7 @@ def test_monitor_recently_started_worker_group():
         elastic_resize_monitor_interval_s=monitor_interval_s,
     )
     policy = ElasticScalingPolicy(scaling_config)
+    _start_scaling_policy(policy)
     mock_coordinator = policy._autoscaling_coordinator
 
     with freeze_time() as frozen_time:
@@ -255,8 +296,8 @@ def test_monitor_recently_started_worker_group():
 
         # Even though there are new resources available, we should not resize yet
         # because the monitor interval has not passed since
-        mock_coordinator._allocated_resources = [resources_per_worker] * (
-            max_workers - 1
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, max_workers - 1
         )
 
         assert isinstance(
@@ -293,12 +334,15 @@ def test_monitor_long_running_worker_group():
         elastic_resize_monitor_interval_s=monitor_interval_s,
     )
     policy = ElasticScalingPolicy(scaling_config)
+    _start_scaling_policy(policy)
     mock_coordinator = policy._autoscaling_coordinator
 
     with freeze_time() as frozen_time:
         worker_group_state = _get_mock_worker_group_state(min_workers, time_monotonic())
         worker_group_status = _get_mock_worker_group_status(min_workers)
-        mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, min_workers
+        )
 
         # The worker group has been running for a while at the same size
         frozen_time.tick(monitor_interval_s * 60)
@@ -312,7 +356,9 @@ def test_monitor_long_running_worker_group():
 
         # We recently considered resizing, so we should wait until the next interval
         # to consider again --> no-op even if new resources are available
-        mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+        mock_coordinator._allocated_resources = _make_reserved(
+            resources_per_worker, max_workers
+        )
         frozen_time.tick(monitor_interval_s / 2)
         decision = policy.make_decision_for_running_worker_group(
             worker_group_state=worker_group_state,
@@ -344,18 +390,20 @@ def test_count_possible_workers():
     assert policy._count_possible_workers([]) == 0
 
     # Single node
-    assert policy._count_possible_workers([{"CPU": 8, "GPU": 1}]) == 1
-    assert policy._count_possible_workers([{"CPU": 16, "GPU": 2}]) == 2
-    assert policy._count_possible_workers([{"CPU": 16, "GPU": 1}]) == 1
+    assert policy._count_possible_workers(_make_reserved({"CPU": 8, "GPU": 1}, 1)) == 1
+    assert policy._count_possible_workers(_make_reserved({"CPU": 16, "GPU": 2}, 1)) == 2
+    assert policy._count_possible_workers(_make_reserved({"CPU": 16, "GPU": 1}, 1)) == 1
 
     # Multinode
-    assert policy._count_possible_workers([{"CPU": 7, "GPU": 1}] * 2) == 0
-    assert policy._count_possible_workers([{"CPU": 9, "GPU": 2}] * 8) == 8
-    assert policy._count_possible_workers([{"CPU": 16, "GPU": 2}] * 2) == 4
-    assert policy._count_possible_workers([{"CPU": 8, "GPU": 1}] * 4) == 4
+    assert policy._count_possible_workers(_make_reserved({"CPU": 7, "GPU": 1}, 2)) == 0
+    assert policy._count_possible_workers(_make_reserved({"CPU": 9, "GPU": 2}, 8)) == 8
+    assert policy._count_possible_workers(_make_reserved({"CPU": 16, "GPU": 2}, 2)) == 4
+    assert policy._count_possible_workers(_make_reserved({"CPU": 8, "GPU": 1}, 4)) == 4
 
     # If there are excess resources, the number of workers is still capped at max_workers
-    assert policy._count_possible_workers([{"CPU": 16, "GPU": 2}] * 10) == 8
+    assert (
+        policy._count_possible_workers(_make_reserved({"CPU": 16, "GPU": 2}, 10)) == 8
+    )
 
 
 def test_count_possible_workers_with_zero_resources():
@@ -381,11 +429,8 @@ def test_request_and_clear():
         )
     )
     assert isinstance(policy, ControllerCallback)
-    mock_coordinator = policy._autoscaling_coordinator
 
-    def assert_resource_request_called_with():
-        nonlocal mock_coordinator
-
+    def assert_resource_request_called_with(mock_coordinator):
         mock_coordinator.request_resources.remote.assert_called_with(
             requester_id=policy._requester_id,
             resources=[resources_per_worker] * 4,
@@ -399,9 +444,10 @@ def test_request_and_clear():
         worker_group_status = _get_mock_worker_group_status(2)
 
         # Test request_resources is called when the controller starts.
-        policy.after_controller_start(train_run_context=MagicMock())
+        policy.after_controller_start(train_run_context=MagicMock(run_id="test-run"))
+        mock_coordinator = policy._autoscaling_coordinator
         assert mock_coordinator.request_resources.remote.call_count == 1
-        assert_resource_request_called_with()
+        assert_resource_request_called_with(mock_coordinator)
 
         # Test request_resources is only called in
         # `make_decision_for_running_worker_group`,
@@ -419,7 +465,7 @@ def test_request_and_clear():
             worker_group_status=worker_group_status,
         )
         assert mock_coordinator.request_resources.remote.call_count == 2
-        assert_resource_request_called_with()
+        assert_resource_request_called_with(mock_coordinator)
 
     # Test cancel_request is called when the controller is shutting down.
     asyncio.run(policy.before_controller_shutdown())
@@ -469,7 +515,7 @@ def test_count_possible_workers_tpu_slice_rounding(
     policy = ElasticScalingPolicy(scaling_config)
 
     tpu_node = {"TPU": 4, "CPU": 1, "accelerator_type:TPU-V6E": 1}
-    allocated_resources = [tpu_node] * num_autoscaler_nodes
+    allocated_resources = _make_reserved(tpu_node, num_autoscaler_nodes)
 
     assert policy._count_possible_workers(allocated_resources) == expected_workers
 

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -1065,8 +1065,8 @@ def test_execution_options_to_model_defaults_and_custom():
 
 def test_construct_data_config_defaults_and_split_variants():
     """Test construct_data_config with default config and different split options."""
-    # Default: data_execution_options.default mirrors the library default ingest
-    # options and per_dataset_execution_options is empty.
+    # Default: data_execution_options.default mirrors Ray Data defaults and
+    # per_dataset_execution_options is empty.
     default = construct_data_config(DataConfig())
     assert isinstance(default, DataConfigSchema)
     assert default.datasets_to_split == "all"
@@ -1138,7 +1138,7 @@ def test_construct_data_config_per_dataset_execution_options():
     assert result.datasets_to_split == ["ds1", "ds2", "ds3"]
     assert result.enable_shard_locality is False
 
-    # default reflects the library default ingest options.
+    # default reflects Ray Data execution options defaults.
     assert result.data_execution_options.default == execution_options_to_model(
         DataConfig.default_ingest_options()
     )


### PR DESCRIPTION
Cherry-pick of #64824 (f9de725e6092413b8acfd30d8b5b797348a1ddb5) onto `releases/2.57.0`. Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)