### PR TITLE
[Cherry-pick][2.57.0][core][build] Drop -Wl,-pie from vendored RocksDB WITH_TSAN link flags (#64917)

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -186,6 +186,14 @@ def ray_deps_setup():
         build_file = "@io_ray//bazel:rocksdb.BUILD",
         url = "https://github.com/facebook/rocksdb/archive/refs/tags/v10.6.2.tar.gz",
         sha256 = "14c619b8a10f994aa6061bd12182b20270c4c27c2f3d9cb4376d57f3cd1c5d7f",
+        patches = [
+            # WITH_TSAN=ON injects `-Wl,-pie`, which breaks every CMake
+            # try_compile under the rules_foreign_cc crosstool (clang +
+            # static libc++), aborting configure at find_package(Threads).
+            # `-fsanitize=thread` alone is sufficient for TSan.
+            "@io_ray//thirdparty/patches:rocksdb-tsan-no-pie.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     auto_http_archive(

--- a/thirdparty/patches/rocksdb-tsan-no-pie.patch
+++ b/thirdparty/patches/rocksdb-tsan-no-pie.patch
@@ -1,0 +1,18 @@
+RocksDB's WITH_TSAN block appends `-Wl,-pie` to CMAKE_EXE_LINKER_FLAGS,
+passing `-pie` directly to the linker behind the compiler driver's back.
+With Ray's rules_foreign_cc crosstool (clang + static libc++ via
+BAZEL_LINKLIBS), the driver still emits non-PIE startup objects, so every
+CMake try_compile probe fails to link and configure aborts at the first
+REQUIRED check (`find_package(Threads)`). TSan does not require PIE with
+clang on x86_64/aarch64 Linux; `-fsanitize=thread` alone is sufficient.
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -372,7 +372,7 @@
+ 
+ option(WITH_TSAN "build with TSAN" OFF)
+ if(WITH_TSAN)
+-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread -Wl,-pie")
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fPIC")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=thread -fPIC")
+   if(WITH_JEMALLOC)


### PR DESCRIPTION
Cherry-pick of #64917 (9ec37571b876176eb2063cfd01487ee14f2531fe) onto `releases/2.57.0`. Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)