### PR TITLE
[serve] Add `replica_id` handle option to pin a request to a replica

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -798,6 +798,9 @@ class RequestMetadata:
     # Session ID.
     session_id: str = ""
 
+    # Pin routing to this replica (full id string) when set.
+    replica_id: str = ""
+
     # If this request expects a streaming response.
     is_streaming: bool = False
 

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -127,6 +127,7 @@ def get_request_metadata(init_options, handle_options):
         app_name=_request_context.app_name,
         multiplexed_model_id=handle_options.multiplexed_model_id,
         session_id=handle_options.session_id,
+        replica_id=handle_options.replica_id,
         is_streaming=handle_options.stream,
         _request_protocol=request_protocol,
         grpc_context=_request_context.grpc_context,

--- a/python/ray/serve/_private/handle_options.py
+++ b/python/ray/serve/_private/handle_options.py
@@ -57,6 +57,7 @@ class DynamicHandleOptionsBase(ABC):
     method_name: str = "__call__"
     multiplexed_model_id: str = ""
     session_id: str = ""
+    replica_id: str = ""
     stream: bool = False
 
     @abstractmethod

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1012,6 +1012,17 @@ class AsyncioRouter:
         wrapped.__cause__ = e
         return wrapped
 
+    def _resolve_pinned_replica(self, replica_id: str) -> Optional[RunningReplica]:
+        """Resolve a ``replica_id`` pin to its replica, bypassing the router."""
+        if not replica_id:
+            return None
+        replica = self.request_router.curr_replicas.get(
+            ReplicaID.from_full_id_str(replica_id)
+        )
+        if replica is None:
+            raise DeploymentUnavailableError(self.deployment_id)
+        return replica
+
     async def _route_and_send_request_once(
         self,
         pr: PendingRequest,
@@ -1030,8 +1041,13 @@ class AsyncioRouter:
 
             num_curr_replicas = len(self.request_router.curr_replicas)
             with self._metrics_manager.wrap_queued_request(is_retry, num_curr_replicas):
-                replica = await self.request_router._choose_replica_for_request(
-                    pr, is_retry=is_retry
+                pinned_replica = self._resolve_pinned_replica(pr.metadata.replica_id)
+                replica = (
+                    pinned_replica
+                    if pinned_replica is not None
+                    else await self.request_router._choose_replica_for_request(
+                        pr, is_retry=is_retry
+                    )
                 )
 
                 # If the queue len cache is disabled or we're sending a request to Java,
@@ -1040,6 +1056,7 @@ class AsyncioRouter:
                 with_rejection = (
                     self._enable_strict_max_ongoing_requests
                     and not replica.is_cross_language
+                    and pinned_replica is None
                 )
                 result = replica.try_send_request(pr, with_rejection=with_rejection)
                 # Proactively update the queue length cache.

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -295,6 +295,7 @@ class _DeploymentHandleBase(Generic[T]):
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         session_id: Union[str, DEFAULT] = DEFAULT.VALUE,
+        replica_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
@@ -1090,6 +1091,7 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         session_id: Union[str, DEFAULT] = DEFAULT.VALUE,
+        replica_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
@@ -1103,6 +1105,9 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
             method_name: The method name to call on the deployment.
             multiplexed_model_id: The model ID to use for multiplexed model requests.
             session_id: Session identifier used for honoring session stickiness.
+            replica_id: Pin the request to this replica (full id string),
+                bypassing the request router. Raises
+                ``DeploymentUnavailableError`` if the replica is not running.
             stream: Whether to use streaming for the request.
             use_new_handle_api: Whether to use the new handle API.
             _prefer_local_routing: Whether to prefer local routing.
@@ -1142,6 +1147,7 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
             method_name=method_name,
             multiplexed_model_id=multiplexed_model_id,
             session_id=session_id,
+            replica_id=replica_id,
             stream=stream,
             _prefer_local_routing=_prefer_local_routing,
             _by_reference=_by_reference,

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -871,6 +871,44 @@ class TestAssignRequest:
             assert not replica_result._is_generator_object
             assert replica_result._replica_id == r1_id
 
+    async def test_replica_id_pin_dispatches_to_target(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+    ):
+        router, fake_request_router = setup_router
+        d_id = DeploymentID(name="test")
+        chosen_id = ReplicaID(unique_id="chosen", deployment_id=d_id)
+        pinned_id = ReplicaID(unique_id="pinned", deployment_id=d_id)
+        # choose_replica would return `chosen`; both are in curr_replicas.
+        fake_request_router.set_replica_to_return(FakeReplica(chosen_id))
+        fake_request_router.set_replica_to_return_on_retry(FakeReplica(pinned_id))
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+            replica_id=pinned_id.to_full_id_str(),
+        )
+        replica_result = await router.assign_request(request_metadata)
+        assert replica_result._replica_id == pinned_id
+
+    async def test_replica_id_pin_missing_raises(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+    ):
+        router, fake_request_router = setup_router
+        d_id = DeploymentID(name="test")
+        fake_request_router.set_replica_to_return(
+            FakeReplica(ReplicaID(unique_id="present", deployment_id=d_id))
+        )
+        absent_id = ReplicaID(unique_id="absent", deployment_id=d_id)
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+            replica_id=absent_id.to_full_id_str(),
+        )
+        with pytest.raises(DeploymentUnavailableError):
+            await router.assign_request(request_metadata)
+
     @pytest.mark.parametrize(
         "setup_router",
         [


### PR DESCRIPTION
## Description
Some requests are not scheduling decisions -- the caller already knows the one replica that must serve them, because that replica owns per-request state.

In LLM token aware routing, the engine books a request's lifecycle events (added / prefill complete / decode progress / completed) back to the `LLMRouter` ingress replica that routed it, which owns the request's booked token load and fans it out to peers. That is, a request maps 1:1 to a `LLMRouter` replica. Load-balancing these events across ingress replicas corrupts per-replica load accounting.

Today a DeploymentHandle can only reach a policy-chosen replica; there is no way to address a specific one through Serve's request path.

## Related issues
Closes https://github.com/ray-project/ray/issues/64940.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
