### PR TITLE
[core][actor scalability] Fix leaked named actor and name conflict when registration times out

### DIFF
--- a/src/mock/ray/gcs_client/accessors/actor_info_accessor.h
+++ b/src/mock/ray/gcs_client/accessors/actor_info_accessor.h
@@ -67,7 +67,9 @@ class FakeActorInfoAccessor : public gcs::ActorInfoAccessorInterface {
                                                  uint64_t,
                                                  const rpc::StatusCallback &,
                                                  int64_t = -1) override {}
-  Status SyncRegisterActor(const TaskSpecification &) override { return Status::OK(); }
+  Status SyncRegisterActor(const TaskSpecification &) override {
+    return sync_register_actor_status_;
+  }
   void AsyncKillActor(
       const ActorID &, bool, bool, const rpc::StatusCallback &, int64_t = -1) override {}
   void AsyncCreateActor(
@@ -132,6 +134,7 @@ class FakeActorInfoAccessor : public gcs::ActorInfoAccessorInterface {
   // Callbacks for AsyncCreateActor and AsyncRegisterActor
   rpc::ClientCallback<rpc::CreateActorReply> async_create_actor_callback_;
   rpc::StatusCallback async_register_actor_callback_;
+  Status sync_register_actor_status_ = Status::OK();
 };
 
 }  // namespace gcs

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2272,6 +2272,12 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     // for local driver. But the current code all go through the gcs right now.
     auto status = actor_creator_->RegisterActor(task_spec);
     if (!status.ok()) {
+      task_manager_->FailPendingTask(
+          task_spec.TaskId(), rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
+      // Detached actor doesn't need ref counting.
+      if (!is_detached) {
+        RemoveActorHandleReference(actor_id);
+      }
       return status;
     }
     io_service_.post(

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -914,6 +914,60 @@ TEST(CoreWorkerPlasmaStoreProviderFastPath, SendsOnlyRemoteIdsToRayletOnMixed) {
   EXPECT_EQ(pulled, (absl::flat_hash_set<ObjectID>{ids[1], ids[3]}));
 }
 
+TEST_F(CoreWorkerTest, NamedActorRegisterFailureReleasesHandleReference) {
+  // Named actors register synchronously. If the registration times out, the
+  // handle reference must still drop to zero so the GCS later learns there
+  // are no references and deletes the actor.
+  auto function = RayFunction(
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("module", "class", "actor_fn", ""));
+  std::string ray_namespace = "test_ns";
+  rpc::SchedulingStrategy scheduling_strategy;
+  scheduling_strategy.mutable_default_scheduling_strategy();
+  auto named_options = [&](std::string name) {
+    return ActorCreationOptions(
+        /*max_restarts=*/0,
+        /*max_task_retries=*/0,
+        /*max_concurrency=*/1,
+        /*resources=*/{},
+        /*placement_resources=*/{},
+        /*dynamic_worker_options=*/{},
+        /*is_detached=*/false,
+        std::move(name),
+        ray_namespace,
+        /*is_asyncio=*/false,
+        scheduling_strategy,
+        // With an empty runtime env, CreateActor falls back to the current
+        // task's env. This test worker has no task, so give a fake one here.
+        R"({"serialized_runtime_env": "{\"env_vars\": {\"T\": \"1\"}}"})");
+  };
+
+  mock_gcs_client_->mock_actor_accessor->sync_register_actor_status_ =
+      Status::TimedOut("injected registration timeout");
+  ActorID actor_id;
+  auto status = core_worker_->CreateActor(function,
+                                          {},
+                                          named_options("register_timeout_squatter"),
+                                          /*extension_data=*/"",
+                                          /*call_site=*/"",
+                                          &actor_id);
+  ASSERT_TRUE(status.IsTimedOut()) << status;
+  EXPECT_FALSE(reference_counter_->HasReference(ObjectID::ForActorHandle(actor_id)));
+  EXPECT_EQ(task_manager_->NumPendingTasks(), 0);
+
+  mock_gcs_client_->mock_actor_accessor->sync_register_actor_status_ = Status::OK();
+  ActorID ok_actor_id;
+  status = core_worker_->CreateActor(function,
+                                     {},
+                                     named_options("register_ok"),
+                                     /*extension_data=*/"",
+                                     /*call_site=*/"",
+                                     &ok_actor_id);
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_TRUE(reference_counter_->HasReference(ObjectID::ForActorHandle(ok_actor_id)));
+  EXPECT_EQ(task_manager_->NumPendingTasks(), 1);
+}
+
 TEST_F(CoreWorkerTest, HandlePubsubCommandBatchInvalidChannelType) {
   // Test that HandlePubsubCommandBatch returns InvalidArgument for an invalid channel
   // type. The publisher was created with only:


### PR DESCRIPTION
## Description

Currently, when a user tries to create a named actor, it can time out during the registration step because GCS might under pressure and for named actors, registration is a synchronous RPC, so we do not return the actor handle unless the register RPC returns.

The issue is that when the timeout does happen, owner holds the reference and forgot to delete it. Later, when GCS finally registers that actor, GCS sets up a long poll to watch whether the ref count drops to zero so it knows when to delete the actor. But since the worker is still holding the ref(forever), GCS thinks someone is still using it and never deletes the name. As a result, the user hits a name conflict error when they try to restart the same named actor.

This PR fixes it by removing the reference when the register RPC fails(timeout).