### PR TITLE
[Data] Make hash shuffle v2 a shuffle strategy

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -251,10 +251,7 @@ def _plan_gpu_shuffle_aggregate(
             logical_op.aggs,
             fallback_reason,
         )
-        if data_context.use_hash_shuffle_v2:
-            return _plan_hash_shuffle_aggregate_v2(
-                data_context, logical_op, input_physical_op
-            )
+
         return _plan_hash_shuffle_aggregate(data_context, logical_op, input_physical_op)
 
     return GPUHashAggregateOperator(
@@ -302,18 +299,19 @@ def plan_all_to_all_op(
                 return _plan_gpu_shuffle_repartition(
                     data_context, op, input_physical_dag
                 )
+            elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE_V2:
+                return _plan_hash_shuffle_repartition_v2(
+                    data_context, op, input_physical_dag
+                )
             elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE:
-                if data_context.use_hash_shuffle_v2:
-                    return _plan_hash_shuffle_repartition_v2(
-                        data_context, op, input_physical_dag
-                    )
                 return _plan_hash_shuffle_repartition(
                     data_context, op, input_physical_dag
                 )
             else:
                 raise ValueError(
                     "Key-based repartitioning only supported for "
-                    f"`DataContext.shuffle_strategy=HASH_SHUFFLE` or "
+                    f"`DataContext.shuffle_strategy=HASH_SHUFFLE`, "
+                    f"`DataContext.shuffle_strategy=HASH_SHUFFLE_V2` or "
                     f"`DataContext.shuffle_strategy=GPU_SHUFFLE` "
                     f"(got {data_context.shuffle_strategy})"
                 )
@@ -345,11 +343,9 @@ def plan_all_to_all_op(
     elif isinstance(op, Aggregate):
         if data_context.shuffle_strategy == ShuffleStrategy.GPU_SHUFFLE:
             return _plan_gpu_shuffle_aggregate(data_context, op, input_physical_dag)
+        elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE_V2:
+            return _plan_hash_shuffle_aggregate_v2(data_context, op, input_physical_dag)
         elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE:
-            if data_context.use_hash_shuffle_v2:
-                return _plan_hash_shuffle_aggregate_v2(
-                    data_context, op, input_physical_dag
-                )
             return _plan_hash_shuffle_aggregate(data_context, op, input_physical_dag)
 
         debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -78,7 +78,7 @@ from ray.data._internal.planner.plan_udf_map_op import (
 from ray.data._internal.planner.plan_write_op import plan_write_op
 from ray.data._internal.usage import create_usage_callback
 from ray.data.checkpoint.load_checkpoint_callback import LoadCheckpointCallback
-from ray.data.context import DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.datasource.file_datasink import _FileDatasink
 
 LogicalOperatorType = TypeVar("LogicalOperatorType", bound=LogicalOperator)
@@ -195,7 +195,7 @@ def plan_join_op(
     data_context: DataContext,
 ) -> PhysicalOperator:
     assert len(physical_children) == 2
-    if data_context.use_hash_shuffle_v2:
+    if data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE_V2:
         return _plan_join_shuffle_v2(logical_op, physical_children, data_context)
     return JoinOperator(
         data_context=data_context,

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -38,6 +38,7 @@ class ShuffleStrategy(str, enum.Enum):
     SORT_SHUFFLE_PULL_BASED = "sort_shuffle_pull_based"
     SORT_SHUFFLE_PUSH_BASED = "sort_shuffle_push_based"
     HASH_SHUFFLE = "hash_shuffle"
+    HASH_SHUFFLE_V2 = "hash_shuffle_v2"
     GPU_SHUFFLE = "gpu_shuffle"
 
 
@@ -112,8 +113,6 @@ DEFAULT_HASH_SHUFFLE_REDUCE_BATCH_SIZE = env_integer(
 DEFAULT_HASH_SHUFFLE_REDUCE_GET_TIMEOUT_S = env_float(
     "RAY_DATA_HASH_SHUFFLE_REDUCE_GET_TIMEOUT_S", 1800.0
 )
-
-DEFAULT_USE_HASH_SHUFFLE_V2 = env_bool("RAY_DATA_USE_HASH_SHUFFLE_V2", False)
 
 DEFAULT_SCHEDULING_STRATEGY = "SPREAD"
 
@@ -784,10 +783,6 @@ class DataContext:
     join_operator_actor_num_cpus_override: float = None
     hash_shuffle_operator_actor_num_cpus_override: float = None
     hash_aggregate_operator_actor_num_cpus_override: float = None
-
-    # Whether to use task-based hash-shuffle v2 operators. When False, fall back
-    # to the legacy actor-based operators for joins, repartition, and aggregation.
-    use_hash_shuffle_v2: bool = DEFAULT_USE_HASH_SHUFFLE_V2
 
     ################################################################
     # GPU Shuffle configuration

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -224,6 +224,7 @@ class GroupedData:
             shuffled_ds = self._dataset.repartition(1)
         elif self._dataset.context.shuffle_strategy in (
             ShuffleStrategy.HASH_SHUFFLE,
+            ShuffleStrategy.HASH_SHUFFLE_V2,
             ShuffleStrategy.GPU_SHUFFLE,
         ):
             num_partitions = (

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -340,7 +340,11 @@ def configure_shuffle_method(request):
     # NOTE: We override default parallelism for hash-based shuffling to
     #       avoid excessive partitioning of the data (to achieve desired
     #       parallelism
-    if shuffle_strategy in [ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.GPU_SHUFFLE]:
+    if shuffle_strategy in [
+        ShuffleStrategy.HASH_SHUFFLE,
+        ShuffleStrategy.HASH_SHUFFLE_V2,
+        ShuffleStrategy.GPU_SHUFFLE,
+    ]:
         ctx.default_hash_shuffle_parallelism = 8
 
     if shuffle_strategy == ShuffleStrategy.GPU_SHUFFLE:

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -634,8 +634,7 @@ class TestPlanAllToAllOpRouting:
         )
 
         ctx = DataContext()
-        ctx.use_hash_shuffle_v2 = True
-        ctx._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+        ctx._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
         logical_op = self._make_repartition_op(keys=["user_id"], num_outputs=8)
         input_physical_op = _make_input_op_mock()

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -52,6 +52,7 @@ def _sort_series_of_lists_elements(s: pd.Series):
 
 def test_grouped_dataset_repr(
     ray_start_regular_shared_2_cpus,
+    configure_shuffle_method,
     disable_fallback_to_object_extension,
     target_max_block_size_infinite_or_default,
 ):
@@ -83,6 +84,7 @@ def test_groupby_none(
 
 def test_groupby_errors(
     ray_start_regular_shared_2_cpus,
+    configure_shuffle_method,
     disable_fallback_to_object_extension,
     target_max_block_size_infinite_or_default,
 ):
@@ -153,7 +155,7 @@ def test_groupby_with_column_expression_udf(
     ]
 
 
-def test_arrow_nan_element(ray_start_regular_shared_2_cpus):
+def test_arrow_nan_element(ray_start_regular_shared_2_cpus, configure_shuffle_method):
     ds = ray.data.from_items(
         [
             1.0,
@@ -492,6 +494,7 @@ def test_groupby_tabular_sum(
 @pytest.mark.parametrize("batch_format", ["pandas", "pyarrow"])
 def test_as_list_e2e(
     ray_start_regular_shared_2_cpus,
+    configure_shuffle_method,
     batch_format,
     num_parts,
     disable_fallback_to_object_extension,
@@ -520,6 +523,7 @@ def test_as_list_e2e(
 @pytest.mark.parametrize("batch_format", ["pandas", "pyarrow"])
 def test_as_list_with_nulls(
     ray_start_regular_shared_2_cpus,
+    configure_shuffle_method,
     batch_format,
     num_parts,
     disable_fallback_to_object_extension,
@@ -1308,7 +1312,9 @@ def test_groupby_map_groups_multicolumn_with_nan(
     )
 
 
-def test_groupby_map_groups_with_partial(disable_fallback_to_object_extension, capsys):
+def test_groupby_map_groups_with_partial(
+    configure_shuffle_method, disable_fallback_to_object_extension, capsys
+):
     """
     The partial function name should show up as
     +- Sort
@@ -1337,7 +1343,9 @@ def test_groupby_map_groups_with_partial(disable_fallback_to_object_extension, c
     assert "MapBatches(func)" in captured.out
 
 
-def test_map_groups_generator_udf(ray_start_regular_shared_2_cpus):
+def test_map_groups_generator_udf(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     """
     Tests that map_groups supports UDFs that return generators (iterators).
     """

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -32,20 +32,13 @@ from ray.data.aggregate import (
     Unique,
 )
 from ray.data.block import BlockAccessor
-from ray.data.context import DataContext, ShuffleStrategy
+from ray.data.context import ShuffleStrategy
 from ray.data.expressions import col
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.util import named_values
 from ray.tests.conftest import *  # noqa
 
 RANDOM_SEED = 123
-
-
-@pytest.fixture(autouse=True, params=[False, True], ids=["shufflev1", "shufflev2"])
-def hash_shuffle_version(request, restore_data_context):
-    """Run every groupby test on both v1 (old actor-based) & v2 shuffle."""
-    DataContext.get_current().use_hash_shuffle_v2 = request.param
-    return request.param
 
 
 def _sort_series_of_lists_elements(s: pd.Series):
@@ -592,7 +585,8 @@ def test_groupby_arrow_multi_agg(
         # NOTE: Hash-shuffle internally converts to pyarrow
         (
             ds_format == "pandas"
-            and configure_shuffle_method == ShuffleStrategy.HASH_SHUFFLE
+            and configure_shuffle_method
+            in (ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.HASH_SHUFFLE_V2)
         )
     )
 

--- a/python/ray/data/tests/test_hash_shuffle_v2.py
+++ b/python/ray/data/tests/test_hash_shuffle_v2.py
@@ -52,10 +52,9 @@ def _assert_keys_colocated(per_block):
 
 
 @pytest.fixture(autouse=True)
-def data_context_use_hash_shuffle_v2(restore_data_context):
+def data_context_hash_shuffle_v2(restore_data_context):
     ctx = restore_data_context
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
-    ctx.use_hash_shuffle_v2 = True
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
 
 @pytest.mark.parametrize("num_partitions", [1, 4, 8])

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -9,16 +9,20 @@ import ray
 from ray.data._internal.logical.operators import JoinType
 from ray.data._internal.util import MiB, rows_same
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
-from ray.data.context import DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.dataset import Dataset
 from ray.exceptions import RayTaskError
 from ray.tests.conftest import *  # noqa
 
 
-@pytest.fixture(autouse=True, params=[False, True], ids=["shufflev1", "shufflev2"])
+@pytest.fixture(
+    autouse=True,
+    params=[ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.HASH_SHUFFLE_V2],
+    ids=["shufflev1", "shufflev2"],
+)
 def hash_shuffle_version(request, restore_data_context):
     """Run every join test on both v1 (old actor-based) & v2 shuffle."""
-    DataContext.get_current().use_hash_shuffle_v2 = request.param
+    DataContext.get_current().shuffle_strategy = request.param
     return request.param
 
 

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -561,8 +561,7 @@ def test_fuse_map_into_shuffle_reduce(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
-    ctx.use_hash_shuffle_v2 = True
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
     ds = ray.data.range(100).repartition(4, keys=["id"]).map_batches(lambda b: b)
     dag = get_execution_plan(ds._logical_plan)[0].dag
@@ -579,8 +578,7 @@ def test_map_not_fused_into_shuffle_reduce_with_downstream_limit(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
-    ctx.use_hash_shuffle_v2 = True
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
     ds = (
         ray.data.range(100)
@@ -604,8 +602,7 @@ def test_concurrency_capped_map_not_fused_into_shuffle_reduce(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
-    ctx.use_hash_shuffle_v2 = True
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
     ds = (
         ray.data.range(100)
@@ -626,8 +623,7 @@ def test_non_file_datasink_write_not_fused_into_shuffle_reduce(
     from ray.data.datasource.datasink import Datasink
 
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
-    ctx.use_hash_shuffle_v2 = True
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
     class _NoopDatasink(Datasink):
         def write(self, blocks, ctx):

--- a/python/ray/data/tests/test_shuffle_diagnostics.py
+++ b/python/ray/data/tests/test_shuffle_diagnostics.py
@@ -20,7 +20,10 @@ SHUFFLE_ALL_TO_ALL_OPS = [
 def test_debug_limit_shuffle_execution_to_num_blocks(
     ray_start_regular, restore_data_context, configure_shuffle_method, shuffle_op
 ):
-    if configure_shuffle_method == ShuffleStrategy.HASH_SHUFFLE:
+    if configure_shuffle_method in (
+        ShuffleStrategy.HASH_SHUFFLE,
+        ShuffleStrategy.HASH_SHUFFLE_V2,
+    ):
         pytest.skip("Not supported by hash-shuffle")
 
     shuffle_fn = shuffle_op


### PR DESCRIPTION
## Description
As title, also removed the original flag `use_hash_shuffle_v2`, so the config can be more unified & much more easier to  parametrize the tests

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
