### PR TITLE
[dashboard] Fix dashboard startup crash from unguarded kubernetes import

### DIFF
--- a/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py
+++ b/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py
@@ -8,13 +8,13 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from kubernetes.client.rest import ApiException
 
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.core.generated.platform_event_pb2 import Source
 from ray.dashboard.modules.platform_events.providers.k8s_provider import (
     KUBERAY_LABEL_KEY_CLUSTER,
     MAX_NON_CLUSTER_POD_CACHE,
+    ApiException,
     KubernetesEventProvider,
 )
 

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -324,6 +324,10 @@ def get_all_modules(module_type):
     for module_loader, name, ispkg in pkgutil.walk_packages(
         ray.dashboard.modules.__path__, ray.dashboard.modules.__name__ + "."
     ):
+        # Skip test packages and test modules.
+        leaf = name.rpartition(".")[2]
+        if leaf == "tests" or leaf.startswith("test_"):
+            continue
         try:
             importlib.import_module(name)
         except ModuleNotFoundError as e:

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -324,10 +324,6 @@ def get_all_modules(module_type):
     for module_loader, name, ispkg in pkgutil.walk_packages(
         ray.dashboard.modules.__path__, ray.dashboard.modules.__name__ + "."
     ):
-        # Skip test packages and test modules.
-        leaf = name.rpartition(".")[2]
-        if leaf == "tests" or leaf.startswith("test_"):
-            continue
         try:
             importlib.import_module(name)
         except ModuleNotFoundError as e:


### PR DESCRIPTION
## Description
https://github.com/ray-project/ray/pull/63937/ added `from kubernetes.client.rest import ApiException` on dashboard startup, however, this has bricked a significant number of tests that don't install kubernetes. 
```
==================== Test output for //python/ray/train:accelerate_torch_trainer_no_raydata:
2026-07-23 06:08:37,925	ERROR services.py:1431 -- Failed to start the dashboard , return code 1
2026-07-23 06:08:37,925	ERROR services.py:1456 -- Error should be written to 'dashboard.log' or 'dashboard.err'. We are printing the last 20 lines for you. See 'https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#logging-directory-structure' to find where the log file is.
2026-07-23 06:08:37,925	ERROR services.py:1500 --
The last 20 lines of /tmp/ray/session_2026-07-23_06-08-36_399861_6915/logs/dashboard.log (it contains the error message from the dashboard):
  File "/rayci/python/ray/dashboard/head.py", line 194, in _load_modules
    ) = self._load_dashboard_head_modules(modules_to_load)
  File "/rayci/python/ray/dashboard/head.py", line 232, in _load_dashboard_head_modules
    head_cls_list = dashboard_utils.get_all_modules(DashboardHeadModule)
  File "/rayci/python/ray/dashboard/utils.py", line 341, in get_all_modules
    raise e
  File "/rayci/python/ray/dashboard/utils.py", line 328, in get_all_modules
    importlib.import_module(name)
  File "/opt/miniforge/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/rayci/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py", line 11, in <module>
    from kubernetes.client.rest import ApiException
ModuleNotFoundError: No module named 'kubernetes'
2026-07-23 06:08:50,997	WARNING services.py:2248 -- WARNING: The object store is using /tmp/ray instead of /dev/shm because /dev/shm has only 2684354560 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=10.24gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.
2026-07-23 06:09:21,176	INFO node.py:425 -- Failed to get node info b'GCS cannot find the node with node ID 37b14b2da67f40127f7b09338d6917f43b32f89f712f5a1ea333e10b. The node registration may not be complete yet before the timeout. Try increase the RAY_raylet_start_wait_time_s config.'
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/train/accelerate_torch_trainer_no_raydata.runfiles/io_ray/python/ray/train/examples/accelerate/accelerate_torch_trainer_no_raydata.py", line 167, in <module>
    result = trainer.fit()
  File "/rayci/python/ray/train/v2/api/data_parallel_trainer.py", line 176, in fit
    train_fn_ref = ObjectRefWrapper(train_fn)
  File "/rayci/python/ray/train/v2/_internal/util.py", line 135, in __init__
    self._ref = ray.put(obj)
  File "/rayci/python/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    auto_init_ray()
  File "/rayci/python/ray/_private/auto_init_hook.py", line 15, in auto_init_ray
    ray.init()
  File "/rayci/python/ray/_private/client_mode_hook.py", line 134, in wrapper
    return func(*args, **kwargs)
  File "/rayci/python/ray/_private/worker.py", line 1917, in init
    _global_node = ray._private.node.Node(
  File "/rayci/python/ray/_private/node.py", line 427, in __init__
    raise Exception(
Exception: The current node timed out during startup. This could happen because some of the raylet failed to startup or the GCS has become overloaded.
================================================================================
```

We already provide a solution in `ray.dashboard.modules.platform_events.providers.k8s_provider` to not raise an import error
