### PR TITLE
[RLlib] Deflake 3 more learning tests hitting the 900s test budget

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -308,6 +308,7 @@ py_test(
 py_test(
     name = "learning_tests_stateless_cartpole_appo",
     size = "large",
+    timeout = "eternal",
     srcs = ["examples/algorithms/appo/stateless_cartpole_appo.py"],
     args = [
         "--as-test",
@@ -945,6 +946,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_ppo_multi_cpu",
     size = "large",
+    timeout = "eternal",
     srcs = ["examples/algorithms/ppo/multi_agent_cartpole_ppo.py"],
     args = [
         "--as-test",
@@ -1125,6 +1127,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_stateless_cartpole_ppo_multi_gpu",
     size = "large",
+    timeout = "eternal",
     srcs = ["examples/algorithms/ppo/multi_agent_stateless_cartpole_ppo.py"],
     args = [
         "--as-test",


### PR DESCRIPTION
## Summary

Three RLlib learning tests still flaky-**timeout** at the `size=large` (900s) test budget, even after #64744 moved the `_multi_cpu`/`_multi_gpu` learning tests out of the shared co-tenancy bucket via `learning_tests_use_all_core`. They legitimately run ~830–900s+, so they still tip over the 900s cap. This applies the same fix #64744 used for its siblings — add `timeout = "eternal"` — to the three targets it didn't cover:

- `learning_tests_multi_agent_cartpole_ppo_multi_cpu`
- `learning_tests_multi_agent_stateless_cartpole_ppo_multi_gpu`
- `learning_tests_stateless_cartpole_appo`

## Evidence this is a timeout (not convergence), and that `eternal` is the right lever

- **Confirmed timeout in CI.** microcheck build [#50168](https://buildkite.com/ray-project/microcheck/builds/50168), `rllib: learning tests` job, bazel summary:
  `//rllib:learning_tests_multi_agent_cartpole_ppo_multi_cpu   TIMEOUT in 2 out of 2 in 903.3s` — SIGTERM-killed at the 900s cap, in **both** `--flaky_test_attempts=2` retries (not a reward-assertion failure).
- **Bazel itself recommends `eternal`.** Same run's timeout warnings: `learning_tests_stateless_cartpole_appo: Test execution time (870.5s excluding execution overhead) ... Consider setting timeout="eternal" or size="enormous".` (identical warning for `pendulum_sac_multi_cpu` at 831s, which #64744 already `eternal`-ized).
- **Flaky tracker** ([flakey-tests.ray.io?owner=rllib](https://flakey-tests.ray.io/?owner=rllib)): these three sit around ~29% / ~10% / ~0% pass. They already carry `learning_tests_use_all_core`, so co-tenancy contention (the #64744 fix) is no longer the cause — the 900s cap is.

## Not a duplicate

#64744 ("Deflake three RLlib tests that hit their test time budget", merged) applied `timeout="eternal"` only to `multi_agent_footsies_ppo_multi_cpu` and `multi_agent_pendulum_sac_multi_cpu`. These three targets were **not** in that PR; this completes the same, already-accepted pattern for them.

## Testing

- Diff is 3 lines (one `timeout = "eternal",` per target, placed exactly as in the #64744 siblings); `pre-commit` (buildifier) passes.
- These are long, GPU/heavy learning tests that can't be run in local CI; the change is a Bazel `timeout` attribute (honored in microcheck/premerge) with **no behavioral change to the test itself** — so it's validated by the CI-log evidence above plus the identical, already-merged #64744 precedent.
- Kept as **draft** pending a green CI run confirming the tests pass within the `eternal` budget.

## AI assistance

Prepared with AI assistance (Claude Code); evidence gathered from the CI logs and flaky tracker linked above. A human owns and will confirm the change before it leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
