### PR TITLE
[Data] Allow custom `collate_fn` to be used with custom device in iter_torch_batches

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6196,12 +6196,14 @@ class Dataset:
                 ``collate_fn``.
             device: The device on which the tensor should be placed. Defaults to
                 "auto" which moves the tensors to the appropriate device when the
-                Dataset is passed to Ray Train and ``collate_fn`` is not provided.
-                Otherwise, defaults to CPU. You can't use this parameter with
-                ``collate_fn``.
+                Dataset is passed to Ray Train, and to CPU otherwise. When used
+                together with ``collate_fn``, the device transfer only applies if
+                the ``collate_fn`` output is a `TensorBatchType`; for other output
+                types, you must handle the device transfer manually.
             collate_fn: A function to convert a Numpy batch to a PyTorch tensor batch.
-                When this parameter is specified, the user should manually handle the
-                host to device data transfer outside of collate_fn.
+                If the output of ``collate_fn`` is a `TensorBatchType`, it is
+                automatically moved to the target device (see ``device``);
+                otherwise, you must handle the device transfer manually.
                 This is useful for further processing the data after it has been
                 batched. Potential use cases include collating along a dimension other
                 than the first, padding sequences of various lengths, or generally
@@ -6209,7 +6211,7 @@ class Dataset:
                 default collate function is used which simply converts the batch of
                 numpy arrays to a batch of PyTorch tensors. This API is still
                 experimental and is subject to change. You can't use this parameter in
-                conjunction with ``dtypes`` or ``device``.
+                conjunction with ``dtypes``.
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If not ``None``, the data is randomly shuffled
                 using a local in-memory shuffle buffer, and this value serves as the

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -481,15 +481,16 @@ class DataIterator(abc.ABC):
                 with ``collate_fn``.
             device: The device on which the tensor should be placed. Defaults to
                 "auto" which moves the tensors to the appropriate device when the
-                Dataset is passed to Ray Train and ``collate_fn`` is not provided.
-                Otherwise, defaults to CPU. You can't use this parameter with
-                ``collate_fn``.
+                Dataset is passed to Ray Train, and to CPU otherwise. When used
+                together with ``collate_fn``, the device transfer only applies if
+                the ``collate_fn`` output is a `TensorBatchType`; for other output
+                types, you must handle the device transfer manually.
             collate_fn: [Alpha] A function to customize how data batches are collated
                 before being passed to the model. This is useful for last-mile data
                 formatting such as padding, masking, or packaging tensors into custom
                 data structures. If not provided, `iter_torch_batches` automatically
-                converts batches to `torch.Tensor`s and moves them to the device
-                assigned to the current worker. The input to `collate_fn` may be:
+                converts batches to `torch.Tensor`s and moves them to the target
+                device (see ``device``). The input to `collate_fn` may be:
 
                 1. pyarrow.Table, where you should provide a callable class that
                    subclasses `ArrowBatchCollateFn` (recommended for best performance).
@@ -503,7 +504,7 @@ class DataIterator(abc.ABC):
 
                 The output can be any type. Return a non-pinned `TensorBatchType` to
                 get managed memory pinning (see ``pin_memory``) and transfer to the
-                current worker's device. Any other output type means you must
+                target device (see ``device``). Any other output type means you must
                 handle device transfer manually in your training loop (consider using
                 :meth:`~ray.data.DataIterator.iter_batches` instead).
                 Note: This function is called in a multi-threaded context; avoid using
@@ -530,11 +531,11 @@ class DataIterator(abc.ABC):
         from ray.train.torch import get_device
         from ray.train.utils import _in_ray_train_worker
 
-        if collate_fn is not None and (dtypes is not None or device != "auto"):
+        if collate_fn is not None and dtypes is not None:
             raise ValueError(
-                "collate_fn cannot be used with dtypes and device."
-                "You should manually move the output Torch tensors to the"
-                "desired dtype and device outside of collate_fn."
+                "collate_fn cannot be used with dtypes. You should manually "
+                "convert the output Torch tensors to the desired dtype "
+                "inside collate_fn."
             )
 
         if device == "auto":
@@ -555,7 +556,7 @@ class DataIterator(abc.ABC):
         ) -> Union[TensorBatchReturnType, Any]:
             """Default finalize function for moving PyTorch tensors to device. If
             batch is of type `TensorBatchType`, it will be automatically moved to the
-            current worker's device. For other types, you must handle device transfer
+            target device. For other types, you must handle device transfer
             manually in your training loop.
 
             Args:

--- a/python/ray/data/tests/test_iter_torch_batches.py
+++ b/python/ray/data/tests/test_iter_torch_batches.py
@@ -128,5 +128,61 @@ def test_iter_torch_batches_pin_memory_with_custom_collate_fn(
     )
 
 
+def test_iter_torch_batches_device_with_custom_collate_fn(ray_start_regular_shared):
+    """Test that an explicit device composes with a custom collate fn."""
+    from ray.data.collate_fn import NumpyBatchCollateFn
+
+    class _TensorDictCollateFn(NumpyBatchCollateFn):
+        def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, torch.Tensor]:
+            return {k: torch.as_tensor(v) for k, v in batch.items()}
+
+    ds = ray.data.range(8)
+
+    # Explicit CPU device: tensors stay on CPU with the collated values.
+    batches = list(
+        ds.iterator().iter_torch_batches(
+            collate_fn=_TensorDictCollateFn(), batch_size=4, device="cpu"
+        )
+    )
+    assert len(batches) == 2
+    assert all(batch["id"].device.type == "cpu" for batch in batches)
+    assert sorted(t for batch in batches for t in batch["id"].tolist()) == list(
+        range(8)
+    )
+
+    # Non-CPU device: collated tensors are moved to the requested device. Use
+    # the "meta" device so the test doesn't require an accelerator.
+    batches = list(
+        ds.iterator().iter_torch_batches(
+            collate_fn=_TensorDictCollateFn(), batch_size=4, device="meta"
+        )
+    )
+    assert len(batches) == 2
+    assert all(batch["id"].device.type == "meta" for batch in batches)
+    assert all(batch["id"].shape == (4,) for batch in batches)
+
+
+def test_iter_torch_batches_device_with_non_tensor_collate_output(
+    ray_start_regular_shared,
+):
+    """Test that non-TensorBatchType collate outputs pass through unchanged when
+    an explicit device is specified."""
+    from ray.data.collate_fn import NumpyBatchCollateFn
+
+    class _ListCollateFn(NumpyBatchCollateFn):
+        def __call__(self, batch: Dict[str, np.ndarray]) -> list:
+            return batch["id"].tolist()
+
+    ds = ray.data.range(8)
+    batches = list(
+        ds.iterator().iter_torch_batches(
+            collate_fn=_ListCollateFn(), batch_size=4, device="meta"
+        )
+    )
+    assert len(batches) == 2
+    assert all(isinstance(batch, list) for batch in batches)
+    assert sorted(t for batch in batches for t in batch) == list(range(8))
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_iterator.py
+++ b/python/ray/data/tests/test_iterator.py
@@ -276,12 +276,14 @@ def test_torch_conversion_collate_fn(ray_start_regular_shared):
             assert isinstance(batch, torch.Tensor)
             assert batch.tolist() == list(range(5, 10))
 
-    with pytest.raises(ValueError):
-        for batch in it.iter_torch_batches(collate_fn=collate_fn, device="cpu"):
-            assert isinstance(batch, torch.Tensor)
-            assert batch.tolist() == list(range(5, 10))
+    # collate_fn can be used together with an explicit device.
+    for batch in it.iter_torch_batches(collate_fn=collate_fn, device="cpu"):
+        assert isinstance(batch, torch.Tensor)
+        assert batch.device.type == "cpu"
+        assert batch.tolist() == list(range(5, 10))
 
-    # Test that we don't automatically set device if collate_fn is specified.
+    # Test that outside a Ray Train worker, the "auto" device resolves to CPU
+    # even if collate_fn is specified.
     with patch("ray.train.torch.get_device", lambda: torch.device("cuda")):
         devices = ray.train.torch.get_device()
         assert devices.type == "cuda"

--- a/python/ray/train/tests/test_iter_torch_batches_gpu.py
+++ b/python/ray/train/tests/test_iter_torch_batches_gpu.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 import ray
-import ray.train.torch
 from ray.data.iterator import (
     ArrowBatchCollateFn,
     NumpyBatchCollateFn,
@@ -244,7 +243,6 @@ def collate_fn_map():
 @pytest.mark.parametrize("pin_memory", [True, False])
 def test_custom_batch_collate_fn(
     ray_start_4_cpus_1_gpu,
-    monkeypatch,
     collate_batch_type,
     return_type,
     device,
@@ -255,7 +253,8 @@ def test_custom_batch_collate_fn(
     the batch before it is converted to a PyTorch tensor.
 
     Note that the collate_fn doesn't move the tensors to the device --
-    that happens in the iterator (finalize_fn).
+    that happens in the iterator (finalize_fn), which moves the collated
+    batch to the device passed to `iter_torch_batches`.
     """
     # Skip GPU tests if CUDA is not available
     if device == "cuda:0" and not torch.cuda.is_available():
@@ -271,18 +270,16 @@ def test_custom_batch_collate_fn(
             f"Collate function not found for ({collate_batch_type}, {return_type})"
         )
 
-    # Set the device that's returned by device="auto" -> get_device()
-    # This is used in `finalize_fn` to move the tensors to the correct device.
     device = torch.device(device)
-    monkeypatch.setattr(ray.train.utils, "_in_ray_train_worker", lambda: True)
-    monkeypatch.setattr(ray.train.torch, "get_device", lambda: device)
 
     ds = ray.data.from_items(
         [{"id": i + 5, "value": i} for i in range(5)],
     )
     it = ds.iterator()
 
-    for batch in it.iter_torch_batches(collate_fn=collate_fn, pin_memory=pin_memory):
+    for batch in it.iter_torch_batches(
+        collate_fn=collate_fn, pin_memory=pin_memory, device=device
+    ):
         if return_type == "single":
             assert isinstance(batch, torch.Tensor)
             assert sorted(batch.tolist()) == list(range(5, 10))


### PR DESCRIPTION
## Description
Originally we didn't allow users to specify a custom collate function when they used a custom device in `iter_torch_batches`. However, specifying a custom device is important if we want users to provide custom collate functions with a supported return type (collection of tensors) and have ray data move to the device automatically.