### PR TITLE
[release/2.57.0][Data] Add tf-keras to `text_embedding` pip install packages (#64889)

### DIFF
--- a/release/ray_release/byod/byod_install_text_embedding.sh
+++ b/release/ray_release/byod/byod_install_text_embedding.sh
@@ -6,4 +6,5 @@ set -exo pipefail
 pip3 install --no-cache-dir --upgrade-strategy only-if-needed \
   transformers==4.56.2 \
   sentence-transformers==5.1.0 \
-  torch==2.8.0
+  torch==2.8.0 \
+  tf-keras==2.20.1


### PR DESCRIPTION
Cherry-pick of #64889 (cf37ed6b0d6034e2008369a417da6985fffc0895) to `releases/2.57.0`.

## Description
The `text_embedding` release test fails at import time because the environment has TensorFlow with Keras 3, but `transformers==4.56.2` does not support Keras 3. It tries to import `tf_keras` first and falls back to `keras`, then raises a `ValueError` when it detects Keras 3.

Fix: Add `tf-keras` to the post-build script to make sure `transformers` finds it instead of falling back to Keras 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)