### PR TITLE
[core][actor scalability] Replace the per registration WaitForActorRefDeleted poll with an owner push

### DIFF
--- a/python/ray/tests/test_actor_lineage_reconstruction.py
+++ b/python/ray/tests/test_actor_lineage_reconstruction.py
@@ -34,6 +34,7 @@ def test_actor_reconstruction_triggered_by_lineage_reconstruction(
             {
                 "ray::rpc::ActorInfoGcsService.grpc_client.RestartActorForLineageReconstruction": failure,
                 "ray::rpc::ActorInfoGcsService.grpc_client.ReportActorOutOfScope": failure,
+                "ray::rpc::ActorInfoGcsService.grpc_client.ReportActorRefDeleted": failure,
             }
         ),
     )

--- a/python/ray/tests/test_core_worker_fault_tolerance.py
+++ b/python/ray/tests/test_core_worker_fault_tolerance.py
@@ -131,19 +131,22 @@ def test_get_object_status_rpc_retry_and_idempotency(
 
 
 @pytest.mark.parametrize("deterministic_failure", RPC_FAILURE_TYPES)
-def test_wait_for_actor_ref_deleted_rpc_retry_and_idempotency(
+def test_actor_ref_deleted_rpc_retry_and_idempotency(
     monkeypatch, shutdown_only, deterministic_failure
 ):
-    """Test that WaitForActorRefDeleted RPC retries work correctly.
-    Verify that the RPC is idempotent when network failures occur.
-    The GCS actor manager will trigger this RPC during actor initialization
-    to monitor when the actor handles have gone out of scope and the actor should be destroyed.
+    """Test that the actor ref deleted RPC retries correctly and is idempotent
+    when network failures occur. The owner pushes ReportActorRefDeleted to the
+    GCS when the actor's reference count hits zero, with one injected failure.
     """
     failure = RPC_FAILURE_MAP[deterministic_failure].copy()
     failure["num_failures"] = 1
     monkeypatch.setenv(
         "RAY_testing_rpc_failure",
-        json.dumps({"CoreWorkerService.grpc_client.WaitForActorRefDeleted": failure}),
+        json.dumps(
+            {
+                "ray::rpc::ActorInfoGcsService.grpc_client.ReportActorRefDeleted": failure,
+            }
+        ),
     )
 
     ray.init()

--- a/src/mock/ray/gcs/gcs_actor_manager.h
+++ b/src/mock/ray/gcs/gcs_actor_manager.h
@@ -48,7 +48,8 @@ class MockGcsActorManager : public GcsActorManager {
             /*actor_by_state_gauge=*/fake_actor_by_state_gauge_,
             /*gcs_actor_by_state_gauge=*/fake_gcs_actor_by_state_gauge_,
             /*observability_publisher=*/FakeObsPublisher(),
-            /*clock=*/clock_) {}
+            /*clock=*/clock_,
+            /*is_owner_dead=*/[](const NodeID &, const WorkerID &) { return false; }) {}
 
   static pubsub::ObservabilityPublisher *FakeObsPublisher() {
     static auto holder = std::make_unique<pubsub::ObservabilityPublisher>(

--- a/src/mock/ray/gcs_client/accessors/actor_info_accessor.h
+++ b/src/mock/ray/gcs_client/accessors/actor_info_accessor.h
@@ -58,6 +58,14 @@ class FakeActorInfoAccessor : public gcs::ActorInfoAccessorInterface {
                                   uint64_t,
                                   const rpc::StatusCallback &,
                                   int64_t = -1) override {}
+  void AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                  const rpc::StatusCallback &callback,
+                                  int64_t = -1) override {
+    reported_ref_deleted_actor_ids_.push_back(actor_id);
+    if (callback) {
+      callback(Status::OK());
+    }
+  }
   void AsyncRegisterActor(const TaskSpecification &task_spec,
                           const rpc::StatusCallback &callback,
                           int64_t = -1) override {
@@ -135,6 +143,7 @@ class FakeActorInfoAccessor : public gcs::ActorInfoAccessorInterface {
   rpc::ClientCallback<rpc::CreateActorReply> async_create_actor_callback_;
   rpc::StatusCallback async_register_actor_callback_;
   Status sync_register_actor_status_ = Status::OK();
+  std::vector<ActorID> reported_ref_deleted_actor_ids_;
 };
 
 }  // namespace gcs

--- a/src/ray/core_worker/actor_management/actor_creator.cc
+++ b/src/ray/core_worker/actor_management/actor_creator.cc
@@ -65,6 +65,11 @@ void ActorCreator::AsyncReportActorOutOfScope(
       actor_id, num_restarts_due_to_lineage_reconstruction, callback);
 }
 
+void ActorCreator::AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                              rpc::StatusCallback callback) {
+  actor_client_.AsyncReportActorRefDeleted(actor_id, callback);
+}
+
 bool ActorCreator::IsActorInRegistering(const ActorID &actor_id) const {
   return registering_actors_->find(actor_id) != registering_actors_->end();
 }

--- a/src/ray/core_worker/actor_management/actor_creator.h
+++ b/src/ray/core_worker/actor_management/actor_creator.h
@@ -50,6 +50,15 @@ class ActorCreatorInterface {
       uint64_t num_restarts_due_to_lineage_reconstructions,
       rpc::StatusCallback callback) = 0;
 
+  /// Asynchronously report to the GCS that all references to the actor
+  /// (including lineage refs) have been deleted, so the GCS can permanently
+  /// destroy the actor.
+  ///
+  /// \param actor_id The ID of the actor.
+  /// \param callback Callback that will be called after the report completes.
+  virtual void AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                          rpc::StatusCallback callback) = 0;
+
   /// Asynchronously request GCS to create the actor.
   ///
   /// \param task_spec The specification for the actor creation task.
@@ -89,6 +98,9 @@ class ActorCreator : public ActorCreatorInterface {
 
   void AsyncReportActorOutOfScope(const ActorID &actor_id,
                                   uint64_t num_restarts_due_to_lineage_reconstruction,
+                                  rpc::StatusCallback callback) override;
+
+  void AsyncReportActorRefDeleted(const ActorID &actor_id,
                                   rpc::StatusCallback callback) override;
 
   bool IsActorInRegistering(const ActorID &actor_id) const override;

--- a/src/ray/core_worker/actor_management/actor_manager.cc
+++ b/src/ray/core_worker/actor_management/actor_manager.cc
@@ -211,8 +211,8 @@ void ActorManager::OnActorKilled(const ActorID &actor_id) {
 void ActorManager::WaitForActorRefDeleted(
     const ActorID &actor_id,
     std::function<void(const ActorID &)> actor_ref_deleted_callback) {
-  // GCS actor manager will wait until the actor has been created before polling the
-  // owner. This should avoid any asynchronous problems.
+  // The GCS only polls after a restart, for actors it reloaded from the table.
+  // New registrations rely on this worker reporting the deletion instead.
   auto callback =
       [actor_id, actor_ref_deleted_callback = std::move(actor_ref_deleted_callback)](
           const ObjectID &object_id) { actor_ref_deleted_callback(actor_id); };

--- a/src/ray/core_worker/actor_management/fake_actor_creator.h
+++ b/src/ray/core_worker/actor_management/fake_actor_creator.h
@@ -42,6 +42,14 @@ class FakeActorCreator : public ActorCreatorInterface {
                                   uint64_t num_restarts_due_to_lineage_reconstruction,
                                   rpc::StatusCallback callback) override {}
 
+  void AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                  rpc::StatusCallback callback) override {
+    ref_deleted_reports.push_back(actor_id);
+    if (callback) {
+      callback(Status::OK());
+    }
+  }
+
   void AsyncCreateActor(
       const TaskSpecification &task_spec,
       const rpc::ClientCallback<rpc::CreateActorReply> &callback) override {}
@@ -57,6 +65,7 @@ class FakeActorCreator : public ActorCreatorInterface {
 
   std::list<rpc::StatusCallback> callbacks;
   bool actor_pending = false;
+  std::vector<ActorID> ref_deleted_reports;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2187,9 +2187,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       actor_creation_options.allow_out_of_order_execution,
       root_detached_actor_id,
       actor_creation_options.actor_generator_backpressure_num_objects);
-  // Add the actor handle before we submit the actor creation task, since the
-  // actor handle must be in scope by the time the GCS sends the
-  // WaitForActorRefDeletedRequest.
+  // Add the actor handle before we submit the actor creation task, so the owner
+  // holds a reference before it arms the ref-deleted notification.
   RAY_CHECK(actor_manager_->EmplaceNewActorHandle(
       std::move(actor_handle), CurrentCallSite(), rpc_address_, /*owned=*/!is_detached))
       << "Attempt to emplace new actor handle for the actor being created with actor id: "
@@ -2255,6 +2254,14 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     io_service_.post(
         [this, task_spec = std::move(task_spec)]() {
           actor_creator_->AsyncRegisterActor(task_spec, [this, task_spec](Status status) {
+            if (!task_spec.IsDetachedActor()) {
+              // Armed once the registration has resolved, so a report cannot reach
+              // the GCS ahead of it. Armed on failure too: the status can come from
+              // the client (a shut down GCS connection fails queued requests), in
+              // which case the GCS may have registered the actor anyway.
+              actor_task_submitter_->NotifyGCSWhenActorRefDeleted(
+                  task_spec.ActorCreationId());
+            }
             if (!status.ok()) {
               RAY_LOG(ERROR).WithField(task_spec.ActorCreationId())
                   << "Failed to register actor. Error message: " << status;
@@ -2271,10 +2278,16 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     // functions like list actors these actors need to be there, especially
     // for local driver. But the current code all go through the gcs right now.
     auto status = actor_creator_->RegisterActor(task_spec);
+    // Detached actors are not ref counted. Armed even when the registration
+    // failed, for the reason above plus the client side deadline on this call: a
+    // timed out registration may still land later. For a failure the GCS itself
+    // produced, such as AlreadyExists, this costs one ignored report.
+    if (!is_detached) {
+      actor_task_submitter_->NotifyGCSWhenActorRefDeleted(actor_id);
+    }
     if (!status.ok()) {
       task_manager_->FailPendingTask(
           task_spec.TaskId(), rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
-      // Detached actor doesn't need ref counting.
       if (!is_detached) {
         RemoveActorHandleReference(actor_id);
       }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2281,7 +2281,11 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     // Detached actors are not ref counted. Armed even when the registration
     // failed, for the reason above plus the client side deadline on this call: a
     // timed out registration may still land later. For a failure the GCS itself
-    // produced, such as AlreadyExists, this costs one ignored report.
+    // produced, such as AlreadyExists, this costs one ignored report. For a
+    // timeout, the report can also be processed before the still-queued
+    // registration and be dropped, and the late registration then leaks until
+    // this worker exits. Arming is still strictly better: unarmed, every
+    // late-landing registration leaks, not just the overtaken ones.
     if (!is_detached) {
       actor_task_submitter_->NotifyGCSWhenActorRefDeleted(actor_id);
     }

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -62,6 +62,27 @@ void ActorTaskSubmitter::NotifyGCSWhenActorOutOfScope(
   }
 }
 
+void ActorTaskSubmitter::NotifyGCSWhenActorRefDeleted(const ActorID &actor_id) {
+  const auto actor_creation_return_id = ObjectID::ForActorHandle(actor_id);
+  auto actor_ref_deleted_callback = [this, actor_id](const ObjectID &object_id) {
+    actor_creator_.AsyncReportActorRefDeleted(actor_id, [actor_id](Status status) {
+      if (!status.ok()) {
+        // The GCS client only retries UNAVAILABLE and UNKNOWN, so other errors
+        // surface here and the report is lost.
+        RAY_LOG(ERROR).WithField(actor_id)
+            << "Failed to report actor ref deleted: " << status
+            << ". The actor may not be destroyed until its owner exits.";
+      }
+    });
+  };
+
+  if (!reference_counter_->AddObjectRefDeletedCallback(actor_creation_return_id,
+                                                       actor_ref_deleted_callback)) {
+    RAY_LOG(DEBUG).WithField(actor_id) << "Actor ref already deleted";
+    actor_ref_deleted_callback(actor_creation_return_id);
+  }
+}
+
 void ActorTaskSubmitter::AddActorQueueIfNotExists(const ActorID &actor_id,
                                                   int32_t max_pending_calls,
                                                   bool allow_out_of_order_execution,

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -124,9 +124,13 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   void SubmitActorCreationTask(TaskSpecification task_spec);
 
   /// Arrange for the GCS to destroy the actor once all references to it
-  /// (including lineage refs) are deleted. Call this only after the actor's
-  /// registration has resolved: an earlier report reaches the GCS before the
-  /// registration and is dropped as a report for an unknown actor.
+  /// (including lineage refs) are deleted. Arm only once the actor's
+  /// registration has resolved: a report that reaches the GCS before its
+  /// registration is dropped as a report for an unknown actor. The sync
+  /// registration path arms this even after a client-side timeout, where the
+  /// registration did not resolve; a report that outruns it leaks the
+  /// late-registered actor until its owner exits (accepted, see
+  /// CoreWorker::CreateActor).
   void NotifyGCSWhenActorRefDeleted(const ActorID &actor_id);
 
   /// Create connection to actor and send all pending tasks.

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -123,6 +123,12 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   /// Submit an actor creation task to an actor via GCS.
   void SubmitActorCreationTask(TaskSpecification task_spec);
 
+  /// Arrange for the GCS to destroy the actor once all references to it
+  /// (including lineage refs) are deleted. Call this only after the actor's
+  /// registration has resolved: an earlier report reaches the GCS before the
+  /// registration and is dropped as a report for an unknown actor.
+  void NotifyGCSWhenActorRefDeleted(const ActorID &actor_id);
+
   /// Create connection to actor and send all pending tasks.
   ///
   /// \param[in] actor_id Actor ID.

--- a/src/ray/core_worker/task_submission/tests/actor_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/actor_task_submitter_test.cc
@@ -1011,6 +1011,51 @@ TEST_P(ActorTaskSubmitterTest, TestPerConcurrencyGroupSequencing) {
   ASSERT_EQ(worker_client_->received_seq_nos.size(), 4);
 }
 
+// When the ref count hits zero, the notification should fire so the GCS learns
+// there are no references and destroys the actor.
+TEST_P(ActorTaskSubmitterTest, TestNotifyGCSWhenActorRefDeletedReportsOnRefDeletion) {
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  const ObjectID actor_handle_id = ObjectID::ForActorHandle(actor_id);
+  rpc::Address addr;
+  reference_counter_->AddOwnedObject(actor_handle_id,
+                                     {},
+                                     addr,
+                                     "",
+                                     0,
+                                     LineageReconstructionEligibility::ELIGIBLE,
+                                     /*add_local_ref=*/true);
+
+  submitter_.NotifyGCSWhenActorRefDeleted(actor_id);
+  ASSERT_TRUE(actor_creator_.ref_deleted_reports.empty())
+      << "The report must not be sent while a reference is still held.";
+
+  reference_counter_->RemoveLocalReference(actor_handle_id, nullptr);
+  ASSERT_EQ(actor_creator_.ref_deleted_reports, std::vector<ActorID>{actor_id});
+}
+
+// An anonymous actor registers asynchronously, but the notification is only
+// installed after the registration resolves, or the notification could race
+// ahead of the inflight RegisterActor and be dropped as unknown. So it is
+// possible that the user deletes the actor handle first and the notification
+// is installed later; in this case, it should fire immediately.
+TEST_P(ActorTaskSubmitterTest,
+       TestNotifyGCSWhenActorRefDeletedReportsIfRefAlreadyDeleted) {
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  const ObjectID actor_handle_id = ObjectID::ForActorHandle(actor_id);
+  rpc::Address addr;
+  reference_counter_->AddOwnedObject(actor_handle_id,
+                                     {},
+                                     addr,
+                                     "",
+                                     0,
+                                     LineageReconstructionEligibility::ELIGIBLE,
+                                     /*add_local_ref=*/true);
+  reference_counter_->RemoveLocalReference(actor_handle_id, nullptr);
+
+  submitter_.NotifyGCSWhenActorRefDeleted(actor_id);
+  ASSERT_EQ(actor_creator_.ref_deleted_reports, std::vector<ActorID>{actor_id});
+}
+
 INSTANTIATE_TEST_SUITE_P(AllowOutOfOrderExecution,
                          ActorTaskSubmitterTest,
                          ::testing::Values(true, false));

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -769,6 +769,28 @@ ObjectID CreateInlineObjectInMemoryStoreAndRefCounter(
                    reference_counter.HasReference(inlined_dependency_id));
   return inlined_dependency_id;
 }
+
+// Options for a Python actor. CreateActor falls back to the current task's runtime
+// env when given an empty one, and a test worker has no task, so pass a fake env.
+ActorCreationOptions MakeActorCreationOptions(std::string name, bool is_detached) {
+  rpc::SchedulingStrategy scheduling_strategy;
+  scheduling_strategy.mutable_default_scheduling_strategy();
+  // ActorCreationOptions takes the namespace by non-const reference.
+  std::string ray_namespace = "test_ns";
+  return ActorCreationOptions(
+      /*max_restarts=*/0,
+      /*max_task_retries=*/0,
+      /*max_concurrency=*/1,
+      /*resources=*/{},
+      /*placement_resources=*/{},
+      /*dynamic_worker_options=*/{},
+      is_detached,
+      std::move(name),
+      ray_namespace,
+      /*is_asyncio=*/false,
+      scheduling_strategy,
+      R"({"serialized_runtime_env": "{\"env_vars\": {\"T\": \"1\"}}"})");
+}
 }  // namespace
 TEST_F(CoreWorkerTest, ActorTaskCancelDuringDepResolution) {
   /*
@@ -921,51 +943,77 @@ TEST_F(CoreWorkerTest, NamedActorRegisterFailureReleasesHandleReference) {
   auto function = RayFunction(
       Language::PYTHON,
       FunctionDescriptorBuilder::BuildPython("module", "class", "actor_fn", ""));
-  std::string ray_namespace = "test_ns";
-  rpc::SchedulingStrategy scheduling_strategy;
-  scheduling_strategy.mutable_default_scheduling_strategy();
-  auto named_options = [&](std::string name) {
-    return ActorCreationOptions(
-        /*max_restarts=*/0,
-        /*max_task_retries=*/0,
-        /*max_concurrency=*/1,
-        /*resources=*/{},
-        /*placement_resources=*/{},
-        /*dynamic_worker_options=*/{},
-        /*is_detached=*/false,
-        std::move(name),
-        ray_namespace,
-        /*is_asyncio=*/false,
-        scheduling_strategy,
-        // With an empty runtime env, CreateActor falls back to the current
-        // task's env. This test worker has no task, so give a fake one here.
-        R"({"serialized_runtime_env": "{\"env_vars\": {\"T\": \"1\"}}"})");
-  };
 
   mock_gcs_client_->mock_actor_accessor->sync_register_actor_status_ =
       Status::TimedOut("injected registration timeout");
   ActorID actor_id;
-  auto status = core_worker_->CreateActor(function,
-                                          {},
-                                          named_options("register_timeout_squatter"),
-                                          /*extension_data=*/"",
-                                          /*call_site=*/"",
-                                          &actor_id);
+  auto status =
+      core_worker_->CreateActor(function,
+                                {},
+                                MakeActorCreationOptions("register_timeout_squatter",
+                                                         /*is_detached=*/false),
+                                /*extension_data=*/"",
+                                /*call_site=*/"",
+                                &actor_id);
   ASSERT_TRUE(status.IsTimedOut()) << status;
   EXPECT_FALSE(reference_counter_->HasReference(ObjectID::ForActorHandle(actor_id)));
   EXPECT_EQ(task_manager_->NumPendingTasks(), 0);
+  ASSERT_EQ(mock_gcs_client_->mock_actor_accessor->reported_ref_deleted_actor_ids_,
+            std::vector<ActorID>{actor_id});
 
   mock_gcs_client_->mock_actor_accessor->sync_register_actor_status_ = Status::OK();
   ActorID ok_actor_id;
-  status = core_worker_->CreateActor(function,
-                                     {},
-                                     named_options("register_ok"),
-                                     /*extension_data=*/"",
-                                     /*call_site=*/"",
-                                     &ok_actor_id);
+  status = core_worker_->CreateActor(
+      function,
+      {},
+      MakeActorCreationOptions("register_ok", /*is_detached=*/false),
+      /*extension_data=*/"",
+      /*call_site=*/"",
+      &ok_actor_id);
   ASSERT_TRUE(status.ok()) << status;
+  while (io_service_.poll_one() > 0) {
+  }
   EXPECT_TRUE(reference_counter_->HasReference(ObjectID::ForActorHandle(ok_actor_id)));
   EXPECT_EQ(task_manager_->NumPendingTasks(), 1);
+  EXPECT_EQ(mock_gcs_client_->mock_actor_accessor->reported_ref_deleted_actor_ids_,
+            std::vector<ActorID>{actor_id});
+}
+
+TEST_F(CoreWorkerTest, DetachedActorNeverReportsRefDeleted) {
+  // A detached actor's handle is not ref counted, so arming the report would find
+  // no reference to wait on and fire at once, destroying the actor right after it
+  // was created. Both registration paths must skip it: a named actor registers
+  // synchronously, an unnamed one through the io_service.
+  auto function = RayFunction(
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("module", "class", "actor_fn", ""));
+
+  ActorID named_actor_id;
+  ASSERT_TRUE(core_worker_
+                  ->CreateActor(function,
+                                {},
+                                MakeActorCreationOptions("detached_named",
+                                                         /*is_detached=*/true),
+                                /*extension_data=*/"",
+                                /*call_site=*/"",
+                                &named_actor_id)
+                  .ok());
+
+  ActorID unnamed_actor_id;
+  ASSERT_TRUE(core_worker_
+                  ->CreateActor(function,
+                                {},
+                                MakeActorCreationOptions("", /*is_detached=*/true),
+                                /*extension_data=*/"",
+                                /*call_site=*/"",
+                                &unnamed_actor_id)
+                  .ok());
+  while (io_service_.poll_one() > 0) {
+  }
+  mock_gcs_client_->mock_actor_accessor->async_register_actor_callback_(Status::OK());
+
+  EXPECT_TRUE(
+      mock_gcs_client_->mock_actor_accessor->reported_ref_deleted_actor_ids_.empty());
 }
 
 TEST_F(CoreWorkerTest, HandlePubsubCommandBatchInvalidChannelType) {

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -189,6 +189,8 @@ ray_cc_library(
         ":grpc_service_interfaces",
         "//src/ray/pubsub:gcs_publisher",
         "//src/ray/stats:stats_metric",
+        "//src/ray/util:thread_checker",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -237,7 +237,8 @@ GcsActorManager::GcsActorManager(
     ray::observability::MetricInterface &actor_by_state_gauge,
     ray::observability::MetricInterface &gcs_actor_by_state_gauge,
     pubsub::ObservabilityPublisher *observability_publisher,
-    ClockInterface &clock)
+    ClockInterface &clock,
+    std::function<bool(const NodeID &, const WorkerID &)> is_owner_dead)
     : gcs_actor_scheduler_(std::move(scheduler)),
       gcs_table_storage_(gcs_table_storage),
       io_context_(io_context),
@@ -255,8 +256,10 @@ GcsActorManager::GcsActorManager(
       actor_gc_delay_(RayConfig::instance().gcs_actor_table_min_duration_ms()),
       actor_by_state_gauge_(actor_by_state_gauge),
       gcs_actor_by_state_gauge_(gcs_actor_by_state_gauge),
-      clock_(clock) {
+      clock_(clock),
+      is_owner_dead_(std::move(is_owner_dead)) {
   RAY_CHECK(destroy_owned_placement_group_if_needed_);
+  RAY_CHECK(is_owner_dead_);
   actor_state_counter_ = std::make_shared<
       CounterMap<std::pair<rpc::ActorTableData::ActorState, std::string>>>();
   // On change, only retract keys that dropped to zero (emit their final 0). Live
@@ -308,6 +311,34 @@ void GcsActorManager::HandleReportActorOutOfScope(
     RAY_LOG(INFO).WithField(actor_id) << "The out of scope actor is already dead";
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   }
+}
+
+void GcsActorManager::HandleReportActorRefDeleted(
+    rpc::ReportActorRefDeletedRequest request,
+    rpc::ReportActorRefDeletedReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
+  auto actor_id = ActorID::FromBinary(request.actor_id());
+  if (!registered_actors_.contains(actor_id)) {
+    RAY_LOG(INFO).WithField(actor_id)
+        << "Ignoring a ref-deleted report for an actor that was never registered "
+           "or is already destroyed";
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+    return;
+  }
+  // Unlike the out-of-scope report, this needs no staleness guard: REF_DELETED
+  // is terminal, so the actor is erased here and any duplicate report lands in
+  // the branch above.
+  RAY_LOG(INFO).WithField(actor_id)
+      << "Actor has no references (including lineage refs), destroying actor";
+  int64_t timeout_ms = RayConfig::instance().actor_graceful_shutdown_timeout_ms();
+  DestroyActor(
+      actor_id,
+      GenActorRefDeletedCause(GetActorTableData(actor_id)),
+      /*force_kill=*/false,
+      [reply, send_reply_callback]() {
+        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+      },
+      timeout_ms);
 }
 
 void GcsActorManager::HandleRegisterActor(rpc::RegisterActorRequest request,
@@ -682,6 +713,24 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
     return Status::OK();
   }
 
+  // Reject a registration whose owner is already known to be dead: the owner's
+  // death was processed before this (queued or retried) registration arrived, so
+  // the cleanup that destroys an owner's actors has already scanned past this one
+  // and nothing is guaranteed to look at it again. Detached actors are rejected
+  // too, since their creation task also comes from the dead caller. Rejecting
+  // instead of registering keeps the name free.
+  const auto &caller_address = request.task_spec().caller_address();
+  const auto owner_node_id = NodeID::FromBinary(caller_address.node_id());
+  const auto owner_worker_id = WorkerID::FromBinary(caller_address.worker_id());
+  if (is_owner_dead_(owner_node_id, owner_worker_id)) {
+    return Status::Invalid(absl::StrFormat(
+        "Actor %s was not registered: the GCS had already recorded the death of "
+        "its owner (worker %s on node %s).",
+        actor_id.Hex(),
+        owner_worker_id.Hex(),
+        owner_node_id.Hex()));
+  }
+
   const auto job_id = JobID::FromBinary(request.task_spec().job_id());
 
   // Use the namespace in task options by default. Otherwise use the
@@ -725,15 +774,12 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
   registered_actors_.emplace(actor->GetActorID(), actor);
   function_manager_.AddJobReference(actor_id.JobId());
 
-  const auto &owner_address = actor->GetOwnerAddress();
-  auto node_id = NodeID::FromBinary(owner_address.node_id());
-  auto worker_id = WorkerID::FromBinary(owner_address.worker_id());
-  RAY_CHECK(unresolved_actors_[node_id][worker_id].emplace(actor->GetActorID()).second);
+  RAY_CHECK(unresolved_actors_[owner_node_id][owner_worker_id]
+                .emplace(actor->GetActorID())
+                .second);
 
   if (!actor->IsDetached()) {
-    // This actor is owned. Send a long polling request to the actor's
-    // owner to determine when the actor should be removed.
-    PollOwnerForActorRefDeleted(actor);
+    AddActorToOwner(actor);
   } else {
     // If it's a detached actor, we need to register the runtime env it used to GC.
     runtime_env_manager_.AddURIReference(actor->GetActorID().Hex(),
@@ -931,24 +977,28 @@ std::vector<std::pair<std::string, std::string>> GcsActorManager::ListNamedActor
   return actors;
 }
 
+void GcsActorManager::AddActorToOwner(const std::shared_ptr<GcsActor> &actor) {
+  const auto &actor_id = actor->GetActorID();
+  const auto &owner_node_id = actor->GetOwnerNodeID();
+  const auto &owner_id = actor->GetOwnerID();
+  auto [it, inserted] = owners_[owner_node_id].try_emplace(owner_id);
+  if (inserted) {
+    RAY_LOG(DEBUG) << "Adding owner " << owner_id << " of actor " << actor_id
+                   << ", job id = " << actor_id.JobId();
+  }
+  it->second.insert(actor_id);
+}
+
 void GcsActorManager::PollOwnerForActorRefDeleted(
     const std::shared_ptr<GcsActor> &actor) {
   const auto &actor_id = actor->GetActorID();
   const auto &owner_node_id = actor->GetOwnerNodeID();
   const auto &owner_id = actor->GetOwnerID();
-  auto &workers = owners_[owner_node_id];
-  auto it = workers.find(owner_id);
-  if (it == workers.end()) {
-    RAY_LOG(DEBUG) << "Adding owner " << owner_id << " of actor " << actor_id
-                   << ", job id = " << actor_id.JobId();
-    it = workers.emplace(owner_id, Owner(actor->GetOwnerAddress())).first;
-  }
-  it->second.children_actor_ids_.insert(actor_id);
 
   rpc::WaitForActorRefDeletedRequest wait_request;
   wait_request.set_intended_worker_id(owner_id.Binary());
   wait_request.set_actor_id(actor_id.Binary());
-  auto client = worker_client_pool_.GetOrConnect(it->second.address_);
+  auto client = worker_client_pool_.GetOrConnect(actor->GetOwnerAddress());
   client->WaitForActorRefDeleted(
       std::move(wait_request),
       [this, owner_node_id, owner_id, actor_id](
@@ -1220,7 +1270,7 @@ void GcsActorManager::OnWorkerDead(const ray::NodeID &node_id,
     auto owner = it->second.find(worker_id);
     // Make a copy of the children actor IDs since we will delete from the
     // list.
-    const auto children_ids = owner->second.children_actor_ids_;
+    const auto children_ids = owner->second;
     for (const auto &child_id : children_ids) {
       DestroyActor(child_id,
                    GenOwnerDiedCause(GetActorTableData(child_id),
@@ -1294,7 +1344,7 @@ void GcsActorManager::OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
     std::vector<std::pair<WorkerID, ActorID>> children_ids;
     // Make a copy of all the actor IDs owned by workers on the dead node.
     for (const auto &owner : it->second) {
-      for (const auto &child_id : owner.second.children_actor_ids_) {
+      for (const auto &child_id : owner.second) {
         children_ids.emplace_back(owner.first, child_id);
       }
     }
@@ -1782,8 +1832,10 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       }
 
       if (!actor->IsDetached()) {
-        // This actor is owned. Send a long polling request to the actor's
-        // owner to determine when the actor should be removed.
+        AddActorToOwner(actor);
+        // The GCS may have missed events entirely while it was down, so
+        // re-establish the check by asking the owner rather than relying on a
+        // report it may already have delivered.
         PollOwnerForActorRefDeleted(actor);
       }
 
@@ -1869,9 +1921,8 @@ void GcsActorManager::RemoveActorFromOwner(const std::shared_ptr<GcsActor> &acto
   auto &node = owners_[owner_node_id];
   auto worker_it = node.find(owner_id);
   RAY_CHECK(worker_it != node.end());
-  auto &owner = worker_it->second;
-  RAY_CHECK(owner.children_actor_ids_.erase(actor_id));
-  if (owner.children_actor_ids_.empty()) {
+  RAY_CHECK(worker_it->second.erase(actor_id));
+  if (worker_it->second.empty()) {
     node.erase(worker_it);
     if (node.empty()) {
       owners_.erase(owner_node_id);

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -318,7 +318,13 @@ void GcsActorManager::HandleReportActorRefDeleted(
     rpc::ReportActorRefDeletedReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   auto actor_id = ActorID::FromBinary(request.actor_id());
-  if (!registered_actors_.contains(actor_id)) {
+  auto it = registered_actors_.find(actor_id);
+  if (it == registered_actors_.end()) {
+    // Never registered or already destroyed. This branch also consumes a report
+    // that outran its own still-queued registration (only reachable when a sync
+    // registration timed out client-side and released the handle); that
+    // registration then leaks until its owner exits (accepted, see the arming
+    // comment in CoreWorker::CreateActor).
     RAY_LOG(INFO).WithField(actor_id)
         << "Ignoring a ref-deleted report for an actor that was never registered "
            "or is already destroyed";
@@ -333,7 +339,7 @@ void GcsActorManager::HandleReportActorRefDeleted(
   int64_t timeout_ms = RayConfig::instance().actor_graceful_shutdown_timeout_ms();
   DestroyActor(
       actor_id,
-      GenActorRefDeletedCause(GetActorTableData(actor_id)),
+      GenActorRefDeletedCause(&it->second->GetActorTableData()),
       /*force_kill=*/false,
       [reply, send_reply_callback]() {
         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -718,7 +724,9 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
   // the cleanup that destroys an owner's actors has already scanned past this one
   // and nothing is guaranteed to look at it again. Detached actors are rejected
   // too, since their creation task also comes from the dead caller. Rejecting
-  // instead of registering keeps the name free.
+  // instead of registering keeps the name free. Both death indexes are bounded,
+  // so this check is best-effort: a registration admitted after its owner's
+  // death was evicted is only reclaimed when a GCS restart re-arms the poll.
   const auto &caller_address = request.task_spec().caller_address();
   const auto owner_node_id = NodeID::FromBinary(caller_address.node_id());
   const auto owner_worker_id = WorkerID::FromBinary(caller_address.worker_id());

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest_prod.h>
 
+#include <functional>
 #include <list>
 #include <memory>
 #include <optional>
@@ -115,7 +116,8 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
       ray::observability::MetricInterface &actor_by_state_gauge,
       ray::observability::MetricInterface &gcs_actor_by_state_gauge,
       pubsub::ObservabilityPublisher *observability_publisher,
-      ClockInterface &clock);
+      ClockInterface &clock,
+      std::function<bool(const NodeID &, const WorkerID &)> is_owner_dead);
 
   ~GcsActorManager() override;
 
@@ -154,6 +156,10 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
 
   void HandleReportActorOutOfScope(rpc::ReportActorOutOfScopeRequest request,
                                    rpc::ReportActorOutOfScopeReply *reply,
+                                   rpc::SendReplyCallback send_reply_callback) override;
+
+  void HandleReportActorRefDeleted(rpc::ReportActorRefDeletedRequest request,
+                                   rpc::ReportActorRefDeletedReply *reply,
                                    rpc::SendReplyCallback send_reply_callback) override;
 
   /// Set actors on the node as preempted and publish the actor information.
@@ -287,18 +293,15 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   const ray::rpc::ActorDeathCause GenNodeDiedCause(
       const ray::rpc::ActorTableData *actor_data,
       std::shared_ptr<const rpc::GcsNodeInfo> node);
-  /// A data structure representing an actor's owner.
-  struct Owner {
-    explicit Owner(rpc::Address address) : address_(std::move(address)) {}
-    /// The address of the owner.
-    rpc::Address address_;
-    /// The IDs of actors owned by this worker.
-    absl::flat_hash_set<ActorID> children_actor_ids_;
-  };
+  /// Record the actor in its owner's list of children, so that the actor is
+  /// destroyed when the GCS learns that the owner died. Idempotent. This should
+  /// not be called for detached actors, whose lifetime is not tied to an owner.
+  void AddActorToOwner(const std::shared_ptr<GcsActor> &actor);
 
   /// Poll an actor's owner so that we will receive a notification when the
-  /// actor has no references, or the owner has died. This should not be
-  /// called for detached actors.
+  /// actor has no references, or the owner has died. Only used for actors
+  /// reloaded after a GCS restart; a new registration relies on the owner's
+  /// report instead. This should not be called for detached actors.
   void PollOwnerForActorRefDeleted(const std::shared_ptr<GcsActor> &actor);
 
   /// Destroy an actor that has gone out of scope. This cleans up all local
@@ -493,10 +496,11 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// Map contains the relationship of node and created actors. Each node ID
   /// maps to a map from worker ID to the actor created on that worker.
   absl::flat_hash_map<NodeID, absl::flat_hash_map<WorkerID, ActorID>> created_actors_;
-  /// Map from worker ID to a client and the IDs of the actors owned by that
-  /// worker. An owned actor should be destroyed once it has gone out of scope,
+  /// Map from worker ID to the IDs of the actors owned by that worker. An owned
+  /// actor should be destroyed once it has gone out of scope,
   /// according to its owner, or the owner dies.
-  absl::flat_hash_map<NodeID, absl::flat_hash_map<WorkerID, Owner>> owners_;
+  absl::flat_hash_map<NodeID, absl::flat_hash_map<WorkerID, absl::flat_hash_set<ActorID>>>
+      owners_;
 
   /// The scheduler to schedule all registered actors.
   std::unique_ptr<GcsActorSchedulerInterface> gcs_actor_scheduler_;
@@ -534,6 +538,10 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   ray::observability::MetricInterface &actor_by_state_gauge_;
   ray::observability::MetricInterface &gcs_actor_by_state_gauge_;
   ClockInterface &clock_;
+  /// Whether the GCS has already processed the death of an actor's owner, either
+  /// the worker itself or its node. A hit is always a real death; a miss is no
+  /// evidence either way.
+  std::function<bool(const NodeID &, const WorkerID &)> is_owner_dead_;
 
   /// Total number of successfully created actors in the cluster lifetime.
   int64_t lifetime_num_created_actors_ = 0;

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -186,7 +186,10 @@ class GcsActorManagerTest : public ::testing::Test {
         fake_actor_by_state_gauge_,
         fake_gcs_actor_by_state_gauge_,
         observability_publisher_.get(),
-        clock_);
+        clock_,
+        [this](const NodeID &node_id, const WorkerID &worker_id) {
+          return dead_workers_.contains(worker_id) || dead_nodes_.contains(node_id);
+        });
 
     for (int i = 1; i <= 10; i++) {
       auto job_id = JobID::FromInt(i);
@@ -227,7 +230,34 @@ class GcsActorManagerTest : public ::testing::Test {
                : nullptr;
   }
 
+  void ReportActorRefDeleted(const ActorID &actor_id) {
+    rpc::ReportActorRefDeletedRequest request;
+    request.set_actor_id(actor_id.Binary());
+    auto reply = std::make_shared<rpc::ReportActorRefDeletedReply>();
+    gcs_actor_manager_->HandleReportActorRefDeleted(
+        request, reply.get(), [reply](auto status, auto success, auto failure) {});
+  }
+
+  Status CallRegisterActor(const rpc::RegisterActorRequest &request) {
+    return gcs_actor_manager_->RegisterActor(request, [](const Status &) {});
+  }
+
+  bool IsActorRegistered(const ActorID &actor_id) const {
+    return gcs_actor_manager_->registered_actors_.contains(actor_id);
+  }
+
+  void KillOwnerWorker(const NodeID &node_id,
+                       const WorkerID &worker_id,
+                       const std::string &worker_ip,
+                       rpc::WorkerExitType exit_type,
+                       const std::string &exit_detail) {
+    dead_workers_.insert(worker_id);
+    gcs_actor_manager_->OnWorkerDead(
+        node_id, worker_id, worker_ip, exit_type, exit_detail);
+  }
+
   void OnNodeDead(const NodeID &node_id) {
+    dead_nodes_.insert(node_id);
     auto node_info = std::make_shared<rpc::GcsNodeInfo>();
     node_info->set_node_id(node_id.Binary());
     gcs_actor_manager_->OnNodeDead(node_info, "127.0.0.1");
@@ -268,7 +298,10 @@ class GcsActorManagerTest : public ::testing::Test {
         fake_actor_by_state_gauge_,
         fake_gcs_actor_by_state_gauge_,
         observability_publisher_.get(),
-        clock_);
+        clock_,
+        [this](const NodeID &node_id, const WorkerID &worker_id) {
+          return dead_workers_.contains(worker_id) || dead_nodes_.contains(node_id);
+        });
   }
 
   size_t RegisteredActorCount(const gcs::GcsActorManager &actor_manager) const {
@@ -362,6 +395,11 @@ class GcsActorManagerTest : public ::testing::Test {
   std::unique_ptr<rpc::RayletClientPool> raylet_client_pool_;
   std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;
   absl::flat_hash_map<JobID, std::string> job_namespace_table_;
+  // Worker and node deaths are owned by the worker and node managers in
+  // production; the fixture injects predicates over these sets so tests can mark
+  // an owner dead.
+  absl::flat_hash_set<WorkerID> dead_workers_;
+  absl::flat_hash_set<NodeID> dead_nodes_;
   std::unique_ptr<gcs::GcsActorManager> gcs_actor_manager_;
   std::shared_ptr<pubsub::GcsPublisher> gcs_publisher_;
   std::unique_ptr<pubsub::ObservabilityPublisher> observability_publisher_;
@@ -407,7 +445,9 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   ASSERT_EQ(finished_actors.size(), 1);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 1);
 
-  ASSERT_TRUE(worker_client_->Reply());
+  // Registering an actor must not arm a poll on its owner; only Initialize does.
+  ASSERT_FALSE(worker_client_->Reply());
+  ReportActorRefDeleted(actor->GetActorID());
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 0);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::DEAD, ""), 1);
@@ -496,7 +536,7 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
     gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
     io_service_.run_one();
     // Actor is killed.
-    ASSERT_TRUE(worker_client_->Reply());
+    ReportActorRefDeleted(actor->GetActorID());
     ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
   }
 
@@ -568,7 +608,7 @@ TEST_F(GcsActorManagerTest, TestNonDeadEntryEvictionDecrementsCounter) {
     gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
     io_service_.run_one();
     // Actor is killed.
-    ASSERT_TRUE(worker_client_->Reply());
+    ReportActorRefDeleted(actor->GetActorID());
     ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
   }
   drain_io_context();
@@ -774,8 +814,6 @@ TEST_F(GcsActorManagerTest, TestWorkerFailure) {
       "worker process has died."));
   // No more actors to schedule.
   ASSERT_EQ(mock_actor_scheduler_->actors.size(), 0);
-
-  ASSERT_TRUE(worker_client_->Reply());
 }
 
 TEST_F(GcsActorManagerTest, TestNodeFailure) {
@@ -822,8 +860,6 @@ TEST_F(GcsActorManagerTest, TestNodeFailure) {
       "node has died."));
   // No more actors to schedule.
   ASSERT_EQ(mock_actor_scheduler_->actors.size(), 0);
-
-  ASSERT_TRUE(worker_client_->Reply());
 }
 
 TEST_F(GcsActorManagerTest, TestActorReconstruction) {
@@ -890,8 +926,6 @@ TEST_F(GcsActorManagerTest, TestActorReconstruction) {
       "node has died."));
   // No more actors to schedule.
   ASSERT_EQ(mock_actor_scheduler_->actors.size(), 0);
-
-  ASSERT_TRUE(worker_client_->Reply());
 }
 
 TEST_F(GcsActorManagerTest, TestActorRestartWhenOwnerDead) {
@@ -1109,8 +1143,6 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionWorkerFailure) {
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, "test"),
             actor->GetActorID());
 
-  // Detached actor has no reply of WaitForActorRefDeleted request.
-  ASSERT_FALSE(worker_client_->Reply());
   // Kill this detached actor
   rpc::KillActorViaGcsReply reply;
   rpc::KillActorViaGcsRequest request;
@@ -1271,8 +1303,8 @@ TEST_F(GcsActorManagerTest, TestDestroyActorBeforeActorCreationCompletes) {
   auto actor = mock_actor_scheduler_->actors.back();
   mock_actor_scheduler_->actors.clear();
 
-  // Simulate the reply of WaitForActorRefDeleted request to trigger actor destruction.
-  ASSERT_TRUE(worker_client_->Reply());
+  // The owner reports that all references to the actor are deleted.
+  ReportActorRefDeleted(actor->GetActorID());
 
   // Check that the actor is in state `DEAD`.
   actor->UpdateAddress(RandomAddress());
@@ -2421,9 +2453,8 @@ TEST_F(GcsActorManagerTest, TestGetNamedActorOnDeletedActorRefReturnsNotFound) {
   // Actor should now be DEAD
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
 
-  // Simulate the reply of WaitForActorRefDeleted request to trigger actor ref deletion
-  ASSERT_TRUE(worker_client_->Reply())
-      << "Failed to notify the actor manager that the actor has been deleted.";
+  // The owner reports that all references (including lineage refs) are deleted.
+  ReportActorRefDeleted(actor->GetActorID());
   // Actor ref should be deleted and is no longer reconstructable
   drain_io_context();
 
@@ -2462,9 +2493,8 @@ TEST_F(GcsActorManagerTest, TestRegisterNamedActorOnDeletedActorRefCreatesNewAct
   // Actor should now be DEAD
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
 
-  // Simulate the reply of WaitForActorRefDeleted request to trigger actor ref deletion
-  ASSERT_TRUE(worker_client_->Reply())
-      << "Failed to notify the actor manager that the actor has been deleted.";
+  // The owner reports that all references (including lineage refs) are deleted.
+  ReportActorRefDeleted(actor->GetActorID());
   drain_io_context();
 
   rpc::RegisterActorRequest register_request =
@@ -2620,6 +2650,56 @@ TEST_F(GcsActorManagerTest, TestInitializeRestoresLocalRayletAddressForAliveActo
   ASSERT_EQ(local_raylet_address->node_id(), node_id.Binary());
   ASSERT_EQ(local_raylet_address->ip_address(), "127.0.0.1");
   ASSERT_EQ(local_raylet_address->port(), 9999);
+
+  // Reloading an owned actor re-arms the owner poll, the only path that still
+  // uses it: the GCS may have missed events entirely while it was down, so it
+  // re-establishes the check by asking.
+  ASSERT_TRUE(worker_client_->Reply());
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
+}
+
+TEST_F(GcsActorManagerTest, TestRegisterAfterOwnerDeathIsRejected) {
+  // A registration can reach the GCS *after* its owner's death was processed
+  // (the owner dies right after sending it, and the RPC is queued or retried).
+  // Owner-death cleanup only scans bookkeeping populated at registration, so
+  // accepting it would leave an actor nothing ever destroys.
+  const JobID job_id = JobID::FromInt(1);
+  auto request = GenRegisterActorRequest(job_id,
+                                         /*max_restarts=*/0,
+                                         /*detached=*/false,
+                                         /*name=*/"rejected_after_owner_death",
+                                         /*ray_namespace=*/"test_namespace");
+  const auto &owner_address = request.task_spec().caller_address();
+  const auto owner_node_id = NodeID::FromBinary(owner_address.node_id());
+  const auto owner_worker_id = WorkerID::FromBinary(owner_address.worker_id());
+  const auto actor_id =
+      ActorID::FromBinary(request.task_spec().actor_creation_task_spec().actor_id());
+
+  KillOwnerWorker(owner_node_id,
+                  owner_worker_id,
+                  "127.0.0.1",
+                  rpc::WorkerExitType::SYSTEM_ERROR,
+                  "owner worker process has died.");
+  drain_io_context();
+
+  auto status = CallRegisterActor(request);
+  ASSERT_TRUE(status.IsInvalid()) << status;
+  ASSERT_FALSE(IsActorRegistered(actor_id))
+      << "An actor whose owner already died must not be registered.";
+
+  // The node half of the predicate rejects too.
+  auto node_request = GenRegisterActorRequest(job_id, /*max_restarts=*/0);
+  OnNodeDead(NodeID::FromBinary(node_request.task_spec().caller_address().node_id()));
+  ASSERT_TRUE(CallRegisterActor(node_request).IsInvalid());
+
+  // The name must still be usable: a rejected registration that reserved it
+  // would make this second attempt fail with AlreadyExists.
+  auto retry = GenRegisterActorRequest(job_id,
+                                       /*max_restarts=*/0,
+                                       /*detached=*/false,
+                                       /*name=*/"rejected_after_owner_death",
+                                       /*ray_namespace=*/"test_namespace");
+  ASSERT_TRUE(CallRegisterActor(retry).ok());
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -246,14 +246,9 @@ class GcsActorManagerTest : public ::testing::Test {
     return gcs_actor_manager_->registered_actors_.contains(actor_id);
   }
 
-  void KillOwnerWorker(const NodeID &node_id,
-                       const WorkerID &worker_id,
-                       const std::string &worker_ip,
-                       rpc::WorkerExitType exit_type,
-                       const std::string &exit_detail) {
+  void KillOwnerWorker(const NodeID &node_id, const WorkerID &worker_id) {
     dead_workers_.insert(worker_id);
-    gcs_actor_manager_->OnWorkerDead(
-        node_id, worker_id, worker_ip, exit_type, exit_detail);
+    gcs_actor_manager_->OnWorkerDead(node_id, worker_id);
   }
 
   void OnNodeDead(const NodeID &node_id) {
@@ -2675,11 +2670,7 @@ TEST_F(GcsActorManagerTest, TestRegisterAfterOwnerDeathIsRejected) {
   const auto actor_id =
       ActorID::FromBinary(request.task_spec().actor_creation_task_spec().actor_id());
 
-  KillOwnerWorker(owner_node_id,
-                  owner_worker_id,
-                  "127.0.0.1",
-                  rpc::WorkerExitType::SYSTEM_ERROR,
-                  "owner worker process has died.");
+  KillOwnerWorker(owner_node_id, owner_worker_id);
   drain_io_context();
 
   auto status = CallRegisterActor(request);
@@ -2691,6 +2682,19 @@ TEST_F(GcsActorManagerTest, TestRegisterAfterOwnerDeathIsRejected) {
   auto node_request = GenRegisterActorRequest(job_id, /*max_restarts=*/0);
   OnNodeDead(NodeID::FromBinary(node_request.task_spec().caller_address().node_id()));
   ASSERT_TRUE(CallRegisterActor(node_request).IsInvalid());
+
+  // Detached actors are rejected too: their creation task also comes from the
+  // dead caller, so exempting them would park an actor nothing ever creates.
+  auto detached_request = GenRegisterActorRequest(job_id,
+                                                  /*max_restarts=*/0,
+                                                  /*detached=*/true,
+                                                  /*name=*/"detached_rejected",
+                                                  /*ray_namespace=*/"test_namespace");
+  KillOwnerWorker(
+      NodeID::FromBinary(detached_request.task_spec().caller_address().node_id()),
+      WorkerID::FromBinary(detached_request.task_spec().caller_address().worker_id()));
+  drain_io_context();
+  ASSERT_TRUE(CallRegisterActor(detached_request).IsInvalid());
 
   // The name must still be usable: a rejected registration that reserved it
   // would make this second attempt fail with AlreadyExists.

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -347,9 +347,11 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
       metrics_.placement_group_creation_latency_in_ms_histogram,
       metrics_.placement_group_scheduling_latency_in_ms_histogram,
       metrics_.placement_group_count_gauge);
+  // Before the actor manager: it asks the worker manager whether an actor's owner
+  // is already known to be dead.
+  InitGcsWorkerManager(gcs_init_data);
   InitGcsActorManager(
       gcs_init_data, metrics_.actor_by_state_gauge, metrics_.gcs_actor_by_state_gauge);
-  InitGcsWorkerManager(gcs_init_data);
   InitGcsTaskManager(metrics_.task_events_reported_gauge,
                      metrics_.task_events_dropped_gauge,
                      metrics_.task_events_stored_gauge);
@@ -644,7 +646,13 @@ void GcsServer::InitGcsActorManager(
       actor_by_state_gauge,
       gcs_actor_by_state_gauge,
       observability_publisher_.get(),
-      clock_);
+      clock_,
+      // The RPC server is shut down before either manager is destroyed, so this
+      // cannot run after they are gone.
+      [this](const NodeID &node_id, const WorkerID &worker_id) {
+        return gcs_worker_manager_->IsWorkerDead(worker_id) ||
+               gcs_node_manager_->IsNodeDead(node_id);
+      });
 
   gcs_actor_manager_->Initialize(gcs_init_data);
   rpc_server_.RegisterService(std::make_unique<rpc::ActorInfoGrpcService>(

--- a/src/ray/gcs/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_worker_manager.cc
@@ -80,6 +80,15 @@ void GcsWorkerManager::HandleReportWorkerFailure(
          worker_failure_data->MergeFrom(request.worker_failure());
          worker_failure_data->set_is_alive(false);
 
+         // Index the death before the listeners below run: one of them calls
+         // GcsActorManager::OnWorkerDead, whose scan of this owner's actors is the
+         // last one guaranteed to happen. A registration arriving after that scan
+         // has to be able to see the death, which rules out waiting for the row to
+         // be persisted. Retention is still bookkept once the row is written.
+         if (!is_duplicate_death_report) {
+           dead_worker_ids_.insert(worker_id);
+         }
+
          for (auto &listener : worker_dead_listeners_) {
            listener(worker_failure_data);
          }
@@ -97,6 +106,11 @@ void GcsWorkerManager::HandleReportWorkerFailure(
              RAY_LOG(ERROR).WithField(worker_id).WithField(node_id).WithField(
                  "worker_address", worker_ip_address)
                  << "Failed to report worker failure";
+             // Nothing retains this worker, so drop the index entry that the
+             // retention list would otherwise never evict.
+             if (!is_duplicate_death_report) {
+               dead_worker_ids_.erase(worker_id);
+             }
            } else {
              if (!IsIntentionalWorkerFailure(worker_failure_data->exit_type())) {
                ray_metric_unintentional_worker_failures_.Record(1);
@@ -348,6 +362,7 @@ void GcsWorkerManager::GetWorkerInfo(
 }
 
 void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_data) {
+  RAY_CHECK(thread_checker_.IsOnSameThread());
   std::array<std::vector<std::pair<uint64_t, WorkerID>>, kNumDeadWorkerTiers>
       dead_workers_bucket;
   for (const auto &[worker_id, data] : gcs_init_data.Workers()) {
@@ -365,6 +380,7 @@ void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_dat
         [](const auto &left, const auto &right) { return left.first < right.first; });
     for (const auto &entry : dead_workers_bucket[tier]) {
       dead_workers_by_tier_[tier].push_back(entry.second);
+      dead_worker_ids_.insert(entry.second);
     }
   }
   const size_t cap = RayConfig::instance().maximum_gcs_dead_worker_cached_count();
@@ -387,6 +403,9 @@ void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_dat
     }
   }
   if (!to_evict.empty()) {
+    for (const auto &evict_id : to_evict) {
+      dead_worker_ids_.erase(evict_id);
+    }
     gcs_table_storage_.WorkerTable().BatchDelete(to_evict,
                                                  {[](const auto &) {}, io_context_});
   }
@@ -394,6 +413,7 @@ void GcsWorkerManager::RestoreDeadWorkerIdsQueue(const GcsInitData &gcs_init_dat
 
 void GcsWorkerManager::TrimDeadWorkers(const WorkerID &worker_id,
                                        rpc::WorkerExitType exit_type) {
+  RAY_CHECK(thread_checker_.IsOnSameThread());
   dead_workers_by_tier_[DeadWorkerTier(exit_type)].push_back(worker_id);
   if (TotalDeadWorkers() <=
       RayConfig::instance().maximum_gcs_dead_worker_cached_count()) {
@@ -403,6 +423,7 @@ void GcsWorkerManager::TrimDeadWorkers(const WorkerID &worker_id,
     if (!tier.empty()) {
       const WorkerID evict_id = tier.front();
       tier.pop_front();
+      dead_worker_ids_.erase(evict_id);
       gcs_table_storage_.WorkerTable().Delete(evict_id,
                                               {[](const auto &) {}, io_context_});
       break;

--- a/src/ray/gcs/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_worker_manager.cc
@@ -106,11 +106,12 @@ void GcsWorkerManager::HandleReportWorkerFailure(
              RAY_LOG(ERROR).WithField(worker_id).WithField(node_id).WithField(
                  "worker_address", worker_ip_address)
                  << "Failed to report worker failure";
-             // Nothing retains this worker, so drop the index entry that the
-             // retention list would otherwise never evict.
-             if (!is_duplicate_death_report) {
-               dead_worker_ids_.erase(worker_id);
-             }
+             // The death index entry is kept even though the retention list will
+             // never evict it: the listeners above already acted on this death,
+             // so forgetting it would re-admit registrations from this dead
+             // owner. Table writes are assumed reliable elsewhere (the actor
+             // table put is RAY_CHECK_OK'd), so this retains at most one
+             // WorkerID per failed write.
            } else {
              if (!IsIntentionalWorkerFailure(worker_failure_data->exit_type())) {
                ray_metric_unintentional_worker_failures_.Record(1);

--- a/src/ray/gcs/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_worker_manager.h
@@ -18,12 +18,14 @@
 #include <deque>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "ray/gcs/gcs_kv_manager.h"
 #include "ray/gcs/gcs_table_storage.h"
 #include "ray/gcs/grpc_service_interfaces.h"
 #include "ray/gcs/usage_stats_client.h"
 #include "ray/pubsub/gcs_publisher.h"
 #include "ray/stats/metric.h"
+#include "ray/util/thread_checker.h"
 
 namespace ray {
 namespace gcs {
@@ -65,6 +67,16 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
       rpc::UpdateWorkerNumPausedThreadsReply *reply,
       rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Returns true if the GCS has processed this worker's death. Bounded by
+  /// `maximum_gcs_dead_worker_cached_count`: an evicted (long dead) worker reads
+  /// as not dead, so callers must treat a hit as evidence of death and a miss as
+  /// no evidence either way. At capacity an intentional exit can be evicted right
+  /// away, so a miss does not mean the worker died long ago.
+  bool IsWorkerDead(const WorkerID &worker_id) const {
+    RAY_CHECK(thread_checker_.IsOnSameThread());
+    return dead_worker_ids_.contains(worker_id);
+  }
+
   void AddWorkerDeadListener(
       std::function<void(std::shared_ptr<rpc::WorkerTableData>)> listener);
 
@@ -97,7 +109,7 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
   gcs::GcsTableStorage &gcs_table_storage_;
   instrumented_io_context &io_context_;
   pubsub::GcsPublisher &gcs_publisher_;
-  UsageStatsClient *usage_stats_client_;
+  UsageStatsClient *usage_stats_client_ = nullptr;
 
   /// Only listens for unexpected worker deaths not expected like node death.
   std::vector<std::function<void(std::shared_ptr<rpc::WorkerTableData>)>>
@@ -135,6 +147,21 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
   /// Dead worker ids bucketed by retention priority tier; each tier is FIFO (oldest at
   /// front). Bounds retention in the worker table. Only accessed on io_context_.
   std::array<std::deque<WorkerID>, kNumDeadWorkerTiers> dead_workers_by_tier_;
+
+  /// Liveness index for the dead workers `dead_workers_by_tier_` retains. Inserted
+  /// as soon as the death is processed, which is earlier than the retention list is
+  /// updated, because the actor manager's admission check has to see the death on
+  /// the same io_context turn (see `HandleReportWorkerFailure`). Erased when the
+  /// retention list evicts the worker, or when the worker's row failed to be
+  /// written. It is a set over a multiset: a worker reported dead twice before its
+  /// row is written occupies two deque slots but one entry here, so evicting the
+  /// first slot drops the entry while the second still tracks the worker. That
+  /// direction is safe, since a miss is never taken as evidence of life.
+  absl::flat_hash_set<WorkerID> dead_worker_ids_;
+
+  // Makes sure the two unprotected dead-worker structures above are only
+  // accessed from io_context_'s thread.
+  ThreadChecker thread_checker_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/grpc_service_interfaces.h
+++ b/src/ray/gcs/grpc_service_interfaces.h
@@ -74,6 +74,10 @@ class ActorInfoGcsServiceHandler {
   virtual void HandleReportActorOutOfScope(ReportActorOutOfScopeRequest request,
                                            ReportActorOutOfScopeReply *reply,
                                            SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleReportActorRefDeleted(ReportActorRefDeletedRequest request,
+                                           ReportActorRefDeletedReply *reply,
+                                           SendReplyCallback send_reply_callback) = 0;
 };
 
 class NodeInfoGcsServiceHandler {

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -39,6 +39,8 @@ void ActorInfoGrpcService::InitServerCallFactories(
   RPC_SERVICE_HANDLER(ActorInfoGcsService, KillActorViaGcs, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(
       ActorInfoGcsService, ReportActorOutOfScope, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(
+      ActorInfoGcsService, ReportActorRefDeleted, max_active_rpcs_per_handler_)
 }
 
 void NodeInfoGrpcService::InitServerCallFactories(

--- a/src/ray/gcs/tests/export_api/gcs_actor_manager_export_event_test.cc
+++ b/src/ray/gcs/tests/export_api/gcs_actor_manager_export_event_test.cc
@@ -186,7 +186,8 @@ class GcsActorManagerTest : public ::testing::Test {
         actor_by_state_gauge_,
         gcs_actor_by_state_gauge_,
         observability_publisher_.get(),
-        clock_);
+        clock_,
+        [](const NodeID &, const WorkerID &) { return false; });
 
     for (int i = 1; i <= 10; i++) {
       auto job_id = JobID::FromInt(i);
@@ -199,6 +200,25 @@ class GcsActorManagerTest : public ::testing::Test {
     io_service_.stop();
     thread_io_service_->join();
     std::filesystem::remove_all(log_dir_.c_str());
+  }
+
+  void ReportActorRefDeleted(const ActorID &actor_id) {
+    // The actor manager's state is modified on the io_service thread, so run the
+    // handler there, like the real RPC would.
+    std::promise<bool> promise;
+    io_service_.post(
+        [this, actor_id, &promise]() {
+          rpc::ReportActorRefDeletedRequest request;
+          request.set_actor_id(actor_id.Binary());
+          // The reply is written from the ActorTable().Put completion after this
+          // task returns; keep it alive until the reply callback has run.
+          auto reply = std::make_shared<rpc::ReportActorRefDeletedReply>();
+          gcs_actor_manager_->HandleReportActorRefDeleted(
+              request, reply.get(), [reply](auto status, auto success, auto failure) {});
+          promise.set_value(true);
+        },
+        "test");
+    promise.get_future().get();
   }
 
   void WaitActorCreated(const ActorID &actor_id) {
@@ -327,7 +347,7 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   ASSERT_EQ(finished_actors.size(), 1);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 1);
 
-  ASSERT_TRUE(worker_client_->Reply());
+  ReportActorRefDeleted(actor->GetActorID());
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 0);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::DEAD, ""), 1);

--- a/src/ray/gcs/tests/gcs_worker_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_worker_manager_test.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <future>
 #include <memory>
 #include <vector>
 
@@ -72,6 +73,29 @@ class GcsWorkerManagerTest : public Test {
   }
 
   std::shared_ptr<gcs::GcsWorkerManager> GetWorkerManager() { return worker_manager_; }
+
+  // The manager's dead-worker state is only valid on io_service_, so reach it the
+  // way production does instead of from the test thread.
+  bool IsWorkerDead(const WorkerID &worker_id) {
+    std::promise<bool> promise;
+    io_service_.post(
+        [this, &promise, worker_id] {
+          promise.set_value(worker_manager_->IsWorkerDead(worker_id));
+        },
+        "test.IsWorkerDead");
+    return promise.get_future().get();
+  }
+
+  void RestoreDeadWorkerIdsQueue(const gcs::GcsInitData &gcs_init_data) {
+    std::promise<void> promise;
+    io_service_.post(
+        [this, &promise, &gcs_init_data] {
+          worker_manager_->RestoreDeadWorkerIdsQueue(gcs_init_data);
+          promise.set_value();
+        },
+        "test.RestoreDeadWorkerIdsQueue");
+    promise.get_future().get();
+  }
 
   gcs::GcsInitData LoadInitData() {
     gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
@@ -376,7 +400,7 @@ TEST_F(GcsWorkerManagerTest, TestRestoreDeadWorkerIdsQueue) {
   // Rebuild the queue from the startup snapshot (as GCS does before serving); it
   // bulk-trims the table to the cap, keeping the newest by death time
   gcs::GcsInitData gcs_init_data = LoadInitData();
-  worker_manager->RestoreDeadWorkerIdsQueue(gcs_init_data);
+  RestoreDeadWorkerIdsQueue(gcs_init_data);
 
   auto remaining = get_all_worker_ids();
   ASSERT_EQ(remaining.size(), 3);
@@ -385,6 +409,48 @@ TEST_F(GcsWorkerManagerTest, TestRestoreDeadWorkerIdsQueue) {
   EXPECT_TRUE(contains(remaining, worker_ids[2]));
   EXPECT_TRUE(contains(remaining, worker_ids[3]));
   EXPECT_TRUE(contains(remaining, worker_ids[4]));
+
+  // The liveness index is in memory only, so a restart must reseed it from the
+  // table that survived, and must not remember the rows it just evicted.
+  EXPECT_TRUE(IsWorkerDead(worker_ids[2]));
+  EXPECT_FALSE(IsWorkerDead(worker_ids[0]));
+}
+
+TEST_F(GcsWorkerManagerTest, TestIsWorkerDead) {
+  // The liveness index must answer as soon as a death is reported, since callers
+  // such as actor registration ask on the same io_context turn, and it must not
+  // claim a worker is dead on no evidence.
+  auto worker_manager = GetWorkerManager();
+  const auto dead_worker_id = WorkerID::FromRandom();
+  const auto unknown_worker_id = WorkerID::FromRandom();
+
+  ASSERT_FALSE(IsWorkerDead(dead_worker_id));
+  ASSERT_FALSE(IsWorkerDead(unknown_worker_id));
+
+  // A listener runs before the table write completes, so it is the cheapest
+  // proxy for "recorded before anything else can observe the death".
+  bool dead_when_listener_ran = false;
+  worker_manager->AddWorkerDeadListener(
+      [&](const std::shared_ptr<rpc::WorkerTableData> &data) {
+        dead_when_listener_ran = worker_manager->IsWorkerDead(dead_worker_id);
+      });
+
+  rpc::ReportWorkerFailureRequest request;
+  request.mutable_worker_failure()->mutable_worker_address()->set_worker_id(
+      dead_worker_id.Binary());
+  request.mutable_worker_failure()->set_exit_type(rpc::WorkerExitType::SYSTEM_ERROR);
+  rpc::ReportWorkerFailureReply reply;
+  std::promise<void> promise;
+  worker_manager->HandleReportWorkerFailure(
+      request,
+      &reply,
+      [&promise](Status status, std::function<void()>, std::function<void()>) {
+        promise.set_value();
+      });
+  promise.get_future().get();
+
+  ASSERT_TRUE(dead_when_listener_ran);
+  ASSERT_TRUE(IsWorkerDead(dead_worker_id));
 }
 
 TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
@@ -463,7 +529,7 @@ TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
     add_dead_worker(
         idle.back(), /*end_ms=*/(i + 1) * 10, rpc::WorkerExitType::INTENDED_SYSTEM_EXIT);
   }
-  worker_manager->RestoreDeadWorkerIdsQueue(LoadInitData());
+  RestoreDeadWorkerIdsQueue(LoadInitData());
 
   auto after_restore = get_all_worker_ids();
   ASSERT_EQ(after_restore.size(), 3);
@@ -485,4 +551,22 @@ TEST_F(GcsWorkerManagerTest, TestPriorityEviction) {
   EXPECT_TRUE(contains(after_deaths, idle3));
   EXPECT_FALSE(contains(after_deaths, idle[1]));
   EXPECT_FALSE(contains(after_deaths, idle[2]));
+  EXPECT_FALSE(IsWorkerDead(idle[1]));
+  EXPECT_FALSE(IsWorkerDead(idle[2]));
+
+  // Phase 3: a failure drains the intentional-exit tier, so the next intentional
+  // exit is the only entry in the lowest tier and evicts itself. Its row must
+  // still not survive: the eviction is issued after its own row is written.
+  WorkerID failure3 = WorkerID::FromRandom();
+  report_worker_dead(failure3, rpc::WorkerExitType::USER_ERROR);
+  WorkerID idle4 = WorkerID::FromRandom();
+  report_worker_dead(idle4, rpc::WorkerExitType::INTENDED_SYSTEM_EXIT);
+
+  auto after_self_eviction = get_all_worker_ids();
+  ASSERT_EQ(after_self_eviction.size(), 3);
+  EXPECT_TRUE(contains(after_self_eviction, failure1));
+  EXPECT_TRUE(contains(after_self_eviction, failure2));
+  EXPECT_TRUE(contains(after_self_eviction, failure3));
+  EXPECT_FALSE(contains(after_self_eviction, idle4));
+  EXPECT_FALSE(IsWorkerDead(idle4));
 }

--- a/src/ray/gcs_rpc_client/accessors/actor_info_accessor.cc
+++ b/src/ray/gcs_rpc_client/accessors/actor_info_accessor.cc
@@ -255,6 +255,21 @@ void ActorInfoAccessor::AsyncReportActorOutOfScope(
       timeout_ms);
 }
 
+void ActorInfoAccessor::AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                                   const rpc::StatusCallback &callback,
+                                                   int64_t timeout_ms) {
+  rpc::ReportActorRefDeletedRequest request;
+  request.set_actor_id(actor_id.Binary());
+  context_->GetGcsRpcClient().ReportActorRefDeleted(
+      std::move(request),
+      [callback](const Status &status, rpc::ReportActorRefDeletedReply &&reply) {
+        if (callback) {
+          callback(status);
+        }
+      },
+      timeout_ms);
+}
+
 void ActorInfoAccessor::AsyncSubscribe(
     const ActorID &actor_id,
     const rpc::SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,

--- a/src/ray/gcs_rpc_client/accessors/actor_info_accessor.h
+++ b/src/ray/gcs_rpc_client/accessors/actor_info_accessor.h
@@ -124,6 +124,18 @@ class ActorInfoAccessor : public ActorInfoAccessorInterface {
                                   int64_t timeout_ms = -1) override;
 
   /**
+    Report that all references to the actor (including lineage refs) have been
+    deleted, so the GCS can permanently destroy the actor.
+
+    @param actor_id The ID of the actor.
+    @param callback Callback that will be called after the operation completes.
+    @param timeout_ms RPC timeout in milliseconds. -1 means the default.
+   */
+  void AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                  const rpc::StatusCallback &callback,
+                                  int64_t timeout_ms = -1) override;
+
+  /**
     Register actor to GCS asynchronously.
 
     @param task_spec The specification for the actor creation task.

--- a/src/ray/gcs_rpc_client/accessors/actor_info_accessor_interface.h
+++ b/src/ray/gcs_rpc_client/accessors/actor_info_accessor_interface.h
@@ -119,6 +119,18 @@ class ActorInfoAccessorInterface {
       int64_t timeout_ms = -1) = 0;
 
   /**
+  Report that all references to the actor (including lineage refs) have been
+  deleted, so the GCS can permanently destroy the actor.
+
+  @param actor_id The ID of the actor.
+  @param callback Callback that will be called after the operation completes.
+  @param timeout_ms Timeout in milliseconds. -1 means the default.
+ */
+  virtual void AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                          const rpc::StatusCallback &callback,
+                                          int64_t timeout_ms = -1) = 0;
+
+  /**
     Register actor asynchronously.
 
     @param task_spec The specification for the actor creation task.

--- a/src/ray/gcs_rpc_client/rpc_client.h
+++ b/src/ray/gcs_rpc_client/rpc_client.h
@@ -286,6 +286,11 @@ class GcsRpcClient {
                              /*method_timeout_ms*/ -1, )
 
   VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService,
+                             ReportActorRefDeleted,
+                             actor_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
+  VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService,
                              RestartActorForLineageReconstruction,
                              actor_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )

--- a/src/ray/gcs_rpc_client/tests/gcs_client_injectable_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_injectable_test.cc
@@ -128,6 +128,9 @@ class TestActorInfoAccessor : public ActorInfoAccessorInterface {
                                   uint64_t num_restarts_due_to_lineage_reconstruction,
                                   const rpc::StatusCallback &callback,
                                   int64_t timeout_ms = -1) override {}
+  void AsyncReportActorRefDeleted(const ActorID &actor_id,
+                                  const rpc::StatusCallback &callback,
+                                  int64_t timeout_ms = -1) override {}
   void AsyncRegisterActor(const TaskSpecification &task_spec,
                           const rpc::StatusCallback &callback,
                           int64_t timeout_ms = -1) override {}

--- a/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
@@ -317,9 +317,9 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     message.mutable_actor_creation_task_spec()->set_actor_id(actor_id.Binary());
     message.mutable_actor_creation_task_spec()->set_is_detached(is_detached);
     message.mutable_actor_creation_task_spec()->set_ray_namespace("test");
-    // If the actor is non-detached, the `WaitForActorRefDeleted` function of the core
-    // worker client is called during the actor registration process. In order to simulate
-    // the scenario of registration failure, we set the address to an illegal value.
+    // A non-detached actor is recorded under its owner. Give it an owner address
+    // that cannot be reached, so that a poll the GCS makes after a restart fails
+    // and the actor is destroyed.
     if (!is_detached) {
       rpc::Address address;
       address.set_worker_id(WorkerID::FromRandom().Binary());
@@ -339,6 +339,13 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     gcs_client_->Actors().AsyncRegisterActor(
         task_spec, [promise](Status status) { promise->set_value(status.ok()); });
     return WaitReady(promise->get_future(), timeout_ms_);
+  }
+
+  bool ReportActorRefDeleted(const ActorID &actor_id) {
+    std::promise<bool> promise;
+    gcs_client_->Actors().AsyncReportActorRefDeleted(
+        actor_id, [&promise](Status status) { promise.set_value(status.ok()); });
+    return WaitReady(promise.get_future(), timeout_ms_);
   }
 
   rpc::ActorTableData GetActor(const ActorID &actor_id) {
@@ -787,13 +794,7 @@ TEST_P(GcsClientTest, TestActorTableResubscribe) {
   // expected number of actor subscription messages before registering actor.
   auto expected_num_subscribe_one_notifications = num_subscribe_one_notifications + 1;
 
-  // NOTE: In the process of actor registration, if the callback function of
-  // `WaitForActorRefDeleted` is executed first, and then the callback function of
-  // `ActorTable().Put` is executed, the actor registration fails, we will receive one
-  // notification message; otherwise, the actor registration succeeds, we will receive
-  // two notification messages. So we can't assert whether the actor is registered
-  // successfully.
-  RegisterActor(actor_table_data, false);
+  ASSERT_TRUE(RegisterActor(actor_table_data, false));
 
   auto condition_subscribe_one = [&num_subscribe_one_notifications,
                                   expected_num_subscribe_one_notifications]() {
@@ -965,39 +966,42 @@ TEST_P(GcsClientTest, TestEvictExpiredDestroyedActors) {
   if (RayConfig::instance().gcs_storage() == gcs::GcsServer::kInMemoryStorage) {
     return;
   }
-  // Register actors and the actors will be destroyed.
+  // Register twice the retained count of actors, half of them before a restart, and
+  // destroy each one the way its owner would.
   JobID job_id = JobID::FromInt(1);
   AddJob(job_id);
-  absl::flat_hash_set<ActorID> actor_ids;
   int actor_count = RayConfig::instance().maximum_gcs_destroyed_actor_cached_count();
-  for (int index = 0; index < actor_count; ++index) {
-    auto actor_table_data = GenActorTableData(job_id);
-    RegisterActor(actor_table_data, false);
-    actor_ids.insert(ActorID::FromBinary(actor_table_data->actor_id()));
-  }
+  auto register_and_destroy_actors =
+      [this, job_id, actor_count](absl::flat_hash_set<ActorID> &ids) {
+        for (int index = 0; index < actor_count; ++index) {
+          auto actor_table_data = GenActorTableData(job_id);
+          auto actor_id = ActorID::FromBinary(actor_table_data->actor_id());
+          ASSERT_TRUE(RegisterActor(actor_table_data, false));
+          ASSERT_TRUE(ReportActorRefDeleted(actor_id));
+          ids.insert(actor_id);
+        }
+      };
+  absl::flat_hash_set<ActorID> destroyed_before_restart;
+  register_and_destroy_actors(destroyed_before_restart);
 
   // Restart GCS.
   RestartGcsServer();
   ReconnectClient();
 
-  for (int index = 0; index < actor_count; ++index) {
-    auto actor_table_data = GenActorTableData(job_id);
-    RegisterActor(actor_table_data, false);
-    actor_ids.insert(ActorID::FromBinary(actor_table_data->actor_id()));
-  }
+  absl::flat_hash_set<ActorID> destroyed_after_restart;
+  register_and_destroy_actors(destroyed_after_restart);
 
-  // NOTE: GCS will not reply when actor registration fails, so when GCS restarts, gcs
-  // client will register the actor again and the status of the actor may be
-  // `DEPENDENCIES_UNREADY` or `DEAD`. We should get all dead actors.
+  // Only the retained count survives; the rest were evicted.
   auto condition = [this]() {
     return GetAllActors(true).size() ==
            RayConfig::instance().maximum_gcs_destroyed_actor_cached_count();
   };
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 
+  // Eviction is oldest first, so the ones that survived are the later batch.
   auto actors = GetAllActors(true);
   for (const auto &actor : actors) {
-    EXPECT_TRUE(actor_ids.contains(ActorID::FromBinary(actor.actor_id())));
+    EXPECT_TRUE(destroyed_after_restart.contains(ActorID::FromBinary(actor.actor_id())));
   }
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -488,6 +488,8 @@ service CoreWorkerService {
   // Waits for the actor's owner to decide that the actor has no references.
   // Replying to this message indicates that the client should force-kill the
   // actor process, if still alive and mark the actor as permanently dead.
+  // Only sent for actors reloaded after a GCS restart; a new registration relies
+  // on the owner's ReportActorRefDeleted instead.
   // Failure: Retries, it's idempotent.
   rpc WaitForActorRefDeleted(WaitForActorRefDeletedRequest)
       returns (WaitForActorRefDeletedReply);

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -175,6 +175,15 @@ message ReportActorOutOfScopeReply {
   GcsStatus status = 1;
 }
 
+message ReportActorRefDeletedRequest {
+  // ID of this actor.
+  bytes actor_id = 1;
+}
+
+message ReportActorRefDeletedReply {
+  GcsStatus status = 1;
+}
+
 // Service for actor info access.
 service ActorInfoGcsService {
   // Register actor to gcs service.
@@ -195,6 +204,9 @@ service ActorInfoGcsService {
   rpc KillActorViaGcs(KillActorViaGcsRequest) returns (KillActorViaGcsReply);
   rpc ReportActorOutOfScope(ReportActorOutOfScopeRequest)
       returns (ReportActorOutOfScopeReply);
+  // Report that all references to the actor (including lineage refs) are deleted.
+  rpc ReportActorRefDeleted(ReportActorRefDeletedRequest)
+      returns (ReportActorRefDeletedReply);
 }
 
 message GetClusterIdRequest {}


### PR DESCRIPTION
## Description
I'm working on improving actor scalability for RL / post-training / pre-training workloads. At large scale, like 2k+ or even 10k+ nodes, actor startup and restart time becomes really important.

One big bottleneck of the whole startup process is that every actor needs to register in GCS, and during registration, GCS needs to set up one long-poll RPC (`WaitForActorRefDeleted`) to the actor's owner, per actor, to know when the ref count goes to zero so GCS can delete the actor. This causes LARGE overhead just from setting up that poll during actor registration if your driver is the owner of 40k actors.


## Why `WaitForActorRefDeleted`
So, every one register step, GCS needs to set a long-poll RPC (`WaitForActorRefDeleted`) .

On surface, `WaitForActorRefDeleted` is used for GCS to know when to delete an actor. 

But living in an  async world, this `WaitForActorRefDeleted` has another duty, filter out the outdated register actor.

Consider the following cases that we needs to filter out the outdated register actor。
- case 1
    - driver sends RegisterActor, somehow failed due to network, our retryable client  will resend at rpc level.
    - At mean time, driver got killed
    - worker dies -> raylet -> GCS, since our RegisterActor is waiting to be resent
    - GCS try to delets all actors uner that worker, found nothing
    - RegisterActor finally comes,  Now, The key is GCS is using `WaitForActorRefDeleted`  to directly query the owner, and found no owner, so CGS eventually won't register.

- case 2
  - Actually, node dies can also applied to the above case.

- case 3
  - And even more, for normal actor, register actor is async, so user could del the actor handle already while the retryable client is still sending RegisterActor. So, when RegisterActor arrives, it is out of dated.

And living in a fault tolerance world, this `WaitForActorRefDeleted` also responds for rescanning all actors if needs to be deleted once GCS restarted(This not related to actor register though)


So, clearly, for all the above reasons, we pay this RPC cost per actor register.



##  Push instead of poll?

An easy to think solution to avoid paying the cost and speed up then actor start up is we use push: the owner itself push to the GCS when actor ref counting goes to 0. note that since we have a retryable client, as long as the owner is alive, the push will consistently retry.

but how we filter out the outdated register actor on GCS since we don't had the passive poll?

We still needs to check at the register time that if:
-  worker had died
- Node had died
- ref counting is already 0(case 3)


**For worker/Node death, we would needs to rely on the GCS table to directly look up at local.**
- For the node table, we already have a dead node index in GCS memory, so we can use it directly.
- For the worker table, we add a new dead worker index, respecting the max worker entry limit.


**For ref counting is already 0(case 3), We can ensure we will only push after the register RPC back even ref counting reach to 0 already. Because pushing “actor ref counting is 0” to GCS without a actor register success response arrives first is meaningless.**


_**The perf gain comes from replacing the poll setup with a super quick in memory lookup**_


## What does this PR do
- On the owner side, register the push callback to ref counting once the RegisterActor response comes back.
- On GCS, when the push is received, delete the actor, using the same destruction path that the poll reply previously took.
- On GCS, RegisterActor no longer sets up the poll. It just keeps the owner of the actor as the original behavior does, so that once the owner dies, we can delete the actor.
- On GCS, RegisterActor will no longer use the poll to detect whether this is an outdated RegisterActor. Instead, it will directly look up the dead node index and the dead worker index (both in memory) to see if the owner of this actor is already dead.

## Trade off
Clearly, we have a MAX LIMIT for the worker table and the node table, since we can't let memory grow infinitely just to record all dead workers and nodes. But considering the race condition window and the MAX LIMIT we have, it should be pretty safe.


## e2e Perf

You can see the benchmark code here: https://github.com/ray-project/ray/pull/64446. Note that the perf results below are based on the centralized scheduling(not in ray now), but the optimization itself should have the same effect for current ray.

before this PR


This PR:



## TODO
I didn't touch the path where, when GCS restarts, it still uses WaitForActorRefDeleted to detect whether any of the live actors in its table actually need to be deleted. We could refactor this in a future PR.