### PR TITLE
[release/2.57.0][core] Import pytest lazily in test_utils to fix runtime_env_container tests (#64762)

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -13,7 +13,6 @@ from unittest.mock import Mock
 
 import grpc
 import httpx
-import pytest
 import requests
 from starlette.requests import Request
 
@@ -78,6 +77,8 @@ def skip_if_haproxy(reason: str):
     directly. Mark those with this decorator instead of maintaining a separate
     test allowlist. The test still runs in the non-HAProxy steps.
     """
+    import pytest
+
     return pytest.mark.skipif(
         RAY_SERVE_ENABLE_HA_PROXY, reason=f"HAProxy ingress: {reason}"
     )


### PR DESCRIPTION
Cherry-pick of #64762 (934eda2e56c81484583dc3bc0328e6dba76683eb) to `releases/2.57.0`.

## Description
Fixes the `runtime env container tests` failure on the release branch (postmerge build [18756](https://buildkite.com/ray-project/postmerge/builds/18756)): `test_serve_telemetry[True/False]` fail with `ModuleNotFoundError: No module named 'pytest'` because `ray/serve/_private/test_utils.py` imports pytest at module level, and the scripts in `test_runtime_env_container` run inside a Ray image which does not have pytest installed. This change moves the import inside the functions that need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)