### PR TITLE
[Core] Fix recovery suppression race in ObjectRecoveryManager

### DIFF
--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -66,19 +66,23 @@ std::optional<rpc::ErrorType> ObjectRecoveryManager::RecoverObject(
             RAY_CHECK(objects_pending_recovery_.erase(object_id)) << object_id;
           }
           // Retry recovery if a concurrent node failure invalidated the location.
-          bool owned_by_us = false;
-          NodeID pinned_at;
-          bool spilled = false;
-          bool ref_exists = reference_counter_.IsPlasmaObjectPinnedOrSpilled(
-              object_id, &owned_by_us, &pinned_at, &spilled);
-          if (ref_exists && owned_by_us && pinned_at.IsNil() && !spilled) {
-            RAY_LOG(WARNING).WithField(object_id)
-                << "Object still has no valid location after recovery attempt, "
-                   "requeuing for recovery";
-            reference_counter_.MarkObjectForRecovery(object_id);
-          } else {
-            RAY_LOG(INFO).WithField(object_id) << "Recovery complete for object";
+          bool was_successful_recovery = obj != nullptr && obj->IsInPlasmaError();
+          if (was_successful_recovery) {
+            bool cb_owned_by_us = false;
+            NodeID cb_pinned_at;
+            bool cb_spilled = false;
+            bool cb_ref_exists = reference_counter_.IsPlasmaObjectPinnedOrSpilled(
+                object_id, &cb_owned_by_us, &cb_pinned_at, &cb_spilled);
+            if (cb_ref_exists && cb_owned_by_us && cb_pinned_at.IsNil() &&
+                !cb_spilled) {
+              RAY_LOG(WARNING).WithField(object_id)
+                  << "Object still has no valid location after recovery attempt, "
+                     "requeuing for recovery";
+              reference_counter_.MarkObjectForRecovery(object_id);
+              return;
+            }
           }
+          RAY_LOG(INFO).WithField(object_id) << "Recovery complete for object";
         });
     // Gets the node ids from reference_counter and then gets addresses from the local
     // gcs_client.

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -65,7 +65,20 @@ std::optional<rpc::ErrorType> ObjectRecoveryManager::RecoverObject(
             absl::MutexLock lock(&objects_pending_recovery_mu_);
             RAY_CHECK(objects_pending_recovery_.erase(object_id)) << object_id;
           }
-          RAY_LOG(INFO).WithField(object_id) << "Recovery complete for object";
+          // Retry recovery if a concurrent node failure invalidated the location.
+          bool owned_by_us = false;
+          NodeID pinned_at;
+          bool spilled = false;
+          bool ref_exists = reference_counter_.IsPlasmaObjectPinnedOrSpilled(
+              object_id, &owned_by_us, &pinned_at, &spilled);
+          if (ref_exists && owned_by_us && pinned_at.IsNil() && !spilled) {
+            RAY_LOG(WARNING).WithField(object_id)
+                << "Object still has no valid location after recovery attempt, "
+                   "requeuing for recovery";
+            reference_counter_.MarkObjectForRecovery(object_id);
+          } else {
+            RAY_LOG(INFO).WithField(object_id) << "Recovery complete for object";
+          }
         });
     // Gets the node ids from reference_counter and then gets addresses from the local
     // gcs_client.

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -1867,8 +1867,7 @@ std::optional<std::string> ReferenceCounter::GetTensorTransport(
 void ReferenceCounter::MarkObjectForRecovery(const ObjectID &object_id) {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
-  if (it != object_id_refs_.end() &&
-      !it->second.OutOfScope(lineage_pinning_enabled_)) {
+  if (it != object_id_refs_.end() && !it->second.OutOfScope(lineage_pinning_enabled_)) {
     objects_to_recover_.push_back(object_id);
   }
 }

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -1864,5 +1864,13 @@ std::optional<std::string> ReferenceCounter::GetTensorTransport(
   return it->second.tensor_transport_;
 }
 
+void ReferenceCounter::MarkObjectForRecovery(const ObjectID &object_id) {
+  absl::MutexLock lock(&mutex_);
+  auto it = object_id_refs_.find(object_id);
+  if (it != object_id_refs_.end() &&
+      !it->second.OutOfScope(lineage_pinning_enabled_)) {
+    objects_to_recover_.push_back(object_id);
+  }
+}
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -209,6 +209,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   std::vector<ObjectID> FlushObjectsToRecover() override;
 
+  void MarkObjectForRecovery(const ObjectID &object_id) override
+      ABSL_LOCKS_EXCLUDED(mutex_);
+
   bool HasReference(const ObjectID &object_id) const override ABSL_LOCKS_EXCLUDED(mutex_);
 
   void AddObjectRefStats(

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -468,6 +468,9 @@ class ReferenceCounterInterface {
 
   virtual std::vector<ObjectID> FlushObjectsToRecover() = 0;
 
+  /// Re-queue an object for recovery if it is still in scope.
+  virtual void MarkObjectForRecovery(const ObjectID &object_id) = 0;
+
   /// Whether we have a reference to a particular ObjectID.
   ///
   /// \param[in] object_id The object ID to check for.

--- a/src/ray/core_worker/tests/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/tests/object_recovery_manager_test.cc
@@ -144,7 +144,7 @@ class ObjectRecoveryManagerTestBase : public ::testing::Test {
             rpc::Address(),
             publisher_.get(),
             subscriber_.get(),
-            /*is_node_dead=*/[](const NodeID &) { return false; },
+            /*is_node_dead=*/[this](const NodeID &) { return node_died_; },
             /*free_object_on_nodes_async=*/
             [](const ObjectID &, const absl::flat_hash_set<NodeID> &) {},
             *std::make_shared<ray::observability::FakeGauge>(),
@@ -184,6 +184,7 @@ class ObjectRecoveryManagerTestBase : public ::testing::Test {
   }
 
   NodeID local_node_id_;
+  bool node_died_ = false;
   absl::flat_hash_map<ObjectID, rpc::ErrorType> failed_reconstructions_;
 
   // Used by memory_store_.
@@ -546,6 +547,149 @@ TEST_F(ObjectRecoveryManagerTest, TestTaskCancelledReconstructionFails) {
   ASSERT_EQ(failed_reconstructions_[object_id],
             rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE_TASK_CANCELLED);
   ASSERT_EQ(task_manager_->num_tasks_resubmitted, 0);
+}
+
+TEST_F(ObjectRecoveryManagerTest, TestRecoveryRequeuesWhenNodeDiesDuringPin) {
+  // Test that if a pin reply arrives but the node is already dead,
+  // the callback requeues the object for recovery.
+
+  // Stop the background io_context thread so we control callback execution.
+  io_context_.Stop();
+
+  ObjectID object_id = ObjectID::FromRandom();
+  NodeID remote_node_id = NodeID::FromRandom();
+  ref_counter_->AddOwnedObject(object_id,
+                               {},
+                               rpc::Address(),
+                               "",
+                               0,
+                               LineageReconstructionEligibility::ELIGIBLE,
+                               /*add_local_ref=*/true);
+
+  // Start recovery.
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+
+  rpc::Address address;
+  address.set_node_id(remote_node_id.Binary());
+  object_directory_->SetLocations(object_id, {address});
+  ASSERT_EQ(object_directory_->Flush(), 1);
+
+  // Mark node dead before pin reply.
+  node_died_ = true;
+
+  ASSERT_EQ(raylet_client_->Flush(), 1);
+
+  auto objects = ref_counter_->FlushObjectsToRecover();
+  ASSERT_EQ(objects.size(), 1);
+  ASSERT_EQ(objects[0], object_id);
+  memory_store_->Delete(objects);
+
+  // RecoverObject is suppressed
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+  ASSERT_EQ(object_directory_->Flush(), 0);
+
+  // Run GetAsync callback.
+  io_context_.GetIoService().restart();
+  io_context_.GetIoService().poll();
+
+  // Callback requeues
+  auto requeued = ref_counter_->FlushObjectsToRecover();
+  ASSERT_EQ(requeued.size(), 1);
+  ASSERT_EQ(requeued[0], object_id);
+
+  // Verify recovery is no longer suppressed.
+  memory_store_->Delete(requeued);
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+  ASSERT_EQ(object_directory_->Flush(), 1);
+}
+
+TEST_F(ObjectRecoveryManagerTest, TestRecoveryRequeuesWhenNodeDiesAfterPin) {
+  // Test that if a pin succeeds but the node dies before the GetAsync
+  // callback fires, the callback requeues the object for recovery.
+
+  // Stop the background io_context thread to control callback execution.
+  io_context_.Stop();
+
+  ObjectID object_id = ObjectID::FromRandom();
+  NodeID remote_node_id = NodeID::FromRandom();
+  ref_counter_->AddOwnedObject(object_id,
+                               {},
+                               rpc::Address(),
+                               "",
+                               0,
+                               LineageReconstructionEligibility::ELIGIBLE,
+                               /*add_local_ref=*/true);
+
+  // Start recovery.
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+
+  // Directory returns a location.
+  rpc::Address address;
+  address.set_node_id(remote_node_id.Binary());
+  object_directory_->SetLocations(object_id, {address});
+  ASSERT_EQ(object_directory_->Flush(), 1);
+
+  // Pin succeeds with node alive — sets pinned location.
+  ASSERT_EQ(raylet_client_->Flush(), 1);
+
+  // Node dies — clears pinned_at and pushes to objects_to_recover_.
+  ref_counter_->ResetObjectsOnRemovedNode(remote_node_id);
+  auto objects = ref_counter_->FlushObjectsToRecover();
+  ASSERT_EQ(objects.size(), 1);
+  ASSERT_EQ(objects[0], object_id);
+  memory_store_->Delete(objects);
+
+  // RecoverObject is suppressed, callback hasn't cleared pending yet.
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+  ASSERT_EQ(object_directory_->Flush(), 0);
+
+  // Run GetAsync callback.
+  io_context_.GetIoService().restart();
+  io_context_.GetIoService().poll();
+
+  // Callback requeues
+  auto requeued = ref_counter_->FlushObjectsToRecover();
+  ASSERT_EQ(requeued.size(), 1);
+  ASSERT_EQ(requeued[0], object_id);
+
+  // Verify recovery is no longer suppressed.
+  memory_store_->Delete(requeued);
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+  ASSERT_EQ(object_directory_->Flush(), 1);
+}
+
+TEST_F(ObjectRecoveryManagerTest, TestRecoveryCallbackNoRequeueWhenHealthy) {
+  // Test that the callback does not requeue the object when
+  // it has a valid pinned location.
+
+  // Stop the background io_context thread so we control callback execution.
+  io_context_.Stop();
+
+  ObjectID object_id = ObjectID::FromRandom();
+  NodeID remote_node_id = NodeID::FromRandom();
+  ref_counter_->AddOwnedObject(object_id,
+                               {},
+                               rpc::Address(),
+                               "",
+                               0,
+                               LineageReconstructionEligibility::ELIGIBLE,
+                               /*add_local_ref=*/true);
+
+  // Start recovery, pin succeeds on a healthy node.
+  ASSERT_FALSE(manager_.RecoverObject(object_id).has_value());
+  rpc::Address address;
+  address.set_node_id(remote_node_id.Binary());
+  object_directory_->SetLocations(object_id, {address});
+  ASSERT_EQ(object_directory_->Flush(), 1);
+  ASSERT_EQ(raylet_client_->Flush(), 1);
+
+  // Run the GetAsync callback.
+  io_context_.GetIoService().restart();
+  io_context_.GetIoService().poll();
+
+  // Callback should NOT requeue
+  auto requeued = ref_counter_->FlushObjectsToRecover();
+  ASSERT_TRUE(requeued.empty());
 }
 
 }  // namespace core


### PR DESCRIPTION
## Description

`ObjectRecoveryManager` keeps an object in `objects_pending_recovery_` until a `GetAsync` callback fires after recovery completes. Because `Put()` posts the callback to the `io_context` rather than running it inline, there is a window where a node failure can invalidate the recovered location before the callback executes. If the periodic recovery timer fires during this window, the new `RecoverObject` call is suppressed as already pending. When the stale callback finally runs, it unconditionally erases the pending marker without checking whether the object still has a valid location, leaving the object permanently unrecoverable.

This can occur in two scenarios:
1. The pinned node is already dead when the pin reply arrives
   (`UpdateObjectPinnedAtRaylet` detects it and requeues, but the suppressed
   `RecoverObject` means nothing acts on it).
2. The pin succeeds on a live node, but the node dies before the callback
   drains (`ResetObjectsOnRemovedNode` clears the location, same suppression).

In both cases the object is never recovered.

The fix adds a check inside  `GetAsync` callback which checks object's current state before declaring recovery complete. If the object still has no valid pinned or spilled location, it is requeued for recovery via a new `MarkObjectForRecovery` method on `ReferenceCounter`.

## Related issue number
Fixes #64694 

## Additional information
An alternative approach was to use a generator counter. But the current method is easier and follows `UpdateObjectPinnedAtRaylet` which uses the same pattern of checking  at commit time and requeuing if the location is invalid.
The generation counter adds new state to track across multiple callbacks and introduces redundant RPCs when generations don't match.

