### PR TITLE
[release 2.57.0] [deps] Bump anyscale CLI to 0.26.105 in base images

### DIFF
--- a/docker/base-extra/requirements.in
+++ b/docker/base-extra/requirements.in
@@ -8,4 +8,4 @@ grpcio-tools
 jupyter_server_terminals
 
 # [backend] is for installing anyscale CLI for use in the anyscale cloud.
-anyscale[backend]>=0.26.74
+anyscale[backend]>=0.26.105

--- a/docker/base-slim/requirements.in
+++ b/docker/base-slim/requirements.in
@@ -1,4 +1,4 @@
-    anyscale
+    anyscale>=0.26.105
     packaging
     azure-identity
     adlfs[abfs]

--- a/python/deplocks/base_extra/ray_base_extra_py3.10.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.10.lock
@@ -150,8 +150,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   -r docker/base-extra/requirements.in
@@ -312,6 +313,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -531,7 +533,6 @@ colorama==0.4.6 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   anyscale
-    #   log-symbols
 comm==0.2.3 \
     --hash=sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971 \
     --hash=sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417
@@ -887,18 +888,6 @@ fsspec==2023.12.1 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   adlfs
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -939,6 +928,7 @@ google-auth==2.39.0 \
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -1406,9 +1396,9 @@ jupyterlab-widgets==3.0.16 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   ipywidgets
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   anyscale
@@ -1794,6 +1784,12 @@ oauth2client==4.1.3 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
+    #   requests-oauthlib
 overrides==7.7.0 ; python_full_version < '3.12' \
     --hash=sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a \
     --hash=sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49
@@ -2123,6 +2119,7 @@ python-dateutil==2.9.0.post0 \
     #   arrow
     #   botocore
     #   jupyter-client
+    #   kubernetes
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
     --hash=sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
@@ -2207,6 +2204,7 @@ pyyaml==6.0.3 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   anyscale
     #   jupyter-events
+    #   kubernetes
 pyzmq==27.1.0 \
     --hash=sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d \
     --hash=sha256:01f9437501886d3a1dd4b02ef59fb8cc384fa718ce066d52f175ee49dd5b7ed8 \
@@ -2325,8 +2323,16 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   msal
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -2494,6 +2500,7 @@ six==1.17.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   google-oauth
+    #   kubernetes
     #   oauth2client
     #   python-dateutil
     #   rfc3339-validator
@@ -2504,24 +2511,12 @@ smart-open==6.2.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   -r docker/base-deps/requirements.in
     #   anyscale
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -2652,6 +2647,7 @@ urllib3==1.26.20 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 wcwidth==0.6.0 \
     --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
@@ -2678,6 +2674,7 @@ websocket-client==1.9.0 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra/ray_base_extra_py3.11.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.11.lock
@@ -150,8 +150,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   -r docker/base-extra/requirements.in
@@ -306,6 +307,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -525,7 +527,6 @@ colorama==0.4.6 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   anyscale
-    #   log-symbols
 comm==0.2.3 \
     --hash=sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971 \
     --hash=sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417
@@ -875,18 +876,6 @@ fsspec==2023.12.1 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   adlfs
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -927,6 +916,7 @@ google-auth==2.39.0 \
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -1394,9 +1384,9 @@ jupyterlab-widgets==3.0.16 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   ipywidgets
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   anyscale
@@ -1782,6 +1772,12 @@ oauth2client==4.1.3 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
+    #   requests-oauthlib
 overrides==7.7.0 ; python_full_version < '3.12' \
     --hash=sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a \
     --hash=sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49
@@ -2111,6 +2107,7 @@ python-dateutil==2.9.0.post0 \
     #   arrow
     #   botocore
     #   jupyter-client
+    #   kubernetes
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
     --hash=sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
@@ -2195,6 +2192,7 @@ pyyaml==6.0.3 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   anyscale
     #   jupyter-events
+    #   kubernetes
 pyzmq==27.1.0 \
     --hash=sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d \
     --hash=sha256:01f9437501886d3a1dd4b02ef59fb8cc384fa718ce066d52f175ee49dd5b7ed8 \
@@ -2313,8 +2311,16 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   msal
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -2482,6 +2488,7 @@ six==1.17.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   google-oauth
+    #   kubernetes
     #   oauth2client
     #   python-dateutil
     #   rfc3339-validator
@@ -2492,24 +2499,12 @@ smart-open==6.2.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   -r docker/base-deps/requirements.in
     #   anyscale
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -2629,6 +2624,7 @@ urllib3==1.26.20 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 wcwidth==0.6.0 \
     --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
@@ -2655,6 +2651,7 @@ websocket-client==1.9.0 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra/ray_base_extra_py3.12.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.12.lock
@@ -150,8 +150,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   -r docker/base-extra/requirements.in
@@ -306,6 +307,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -525,7 +527,6 @@ colorama==0.4.6 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   anyscale
-    #   log-symbols
 comm==0.2.3 \
     --hash=sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971 \
     --hash=sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417
@@ -875,18 +876,6 @@ fsspec==2023.12.1 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   adlfs
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -927,6 +916,7 @@ google-auth==2.39.0 \
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -1394,9 +1384,9 @@ jupyterlab-widgets==3.0.16 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   ipywidgets
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   anyscale
@@ -1782,6 +1772,12 @@ oauth2client==4.1.3 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
+    #   requests-oauthlib
 packaging==26.1 \
     --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
     --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
@@ -2105,6 +2101,7 @@ python-dateutil==2.9.0.post0 \
     #   arrow
     #   botocore
     #   jupyter-client
+    #   kubernetes
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
     --hash=sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
@@ -2189,6 +2186,7 @@ pyyaml==6.0.3 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   anyscale
     #   jupyter-events
+    #   kubernetes
 pyzmq==27.1.0 \
     --hash=sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d \
     --hash=sha256:01f9437501886d3a1dd4b02ef59fb8cc384fa718ce066d52f175ee49dd5b7ed8 \
@@ -2307,8 +2305,16 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   msal
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -2476,6 +2482,7 @@ six==1.17.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   google-oauth
+    #   kubernetes
     #   oauth2client
     #   python-dateutil
     #   rfc3339-validator
@@ -2486,24 +2493,12 @@ smart-open==6.2.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   -r docker/base-deps/requirements.in
     #   anyscale
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -2623,6 +2618,7 @@ urllib3==1.26.20 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 wcwidth==0.6.0 \
     --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
@@ -2649,6 +2645,7 @@ websocket-client==1.9.0 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra/ray_base_extra_py3.13.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.13.lock
@@ -150,9 +150,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.80 \
-    --hash=sha256:3857ac9a1b9219e6980938c1e76b48d50e592c9e7782e167ead2e6b1153a907d \
-    --hash=sha256:8d2cc6faa9dd3f3e2bd23dc6405d81d367aea0db2bd8258aa049edd25c79592b
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
     #   -r docker/base-extra/requirements.in
@@ -876,18 +876,6 @@ fsspec==2023.12.1 \
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
     #   adlfs
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -2512,12 +2500,6 @@ smart-open==6.2.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
     #   -r docker/base-deps/requirements.in
     #   anyscale
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95

--- a/python/deplocks/base_extra/ray_base_extra_py3.14.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.14.lock
@@ -150,9 +150,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.103 \
-    --hash=sha256:37cd073d45c79fc62605fccf33bea9ac6a0c8ebc35781aa6ff9ffb0c4d6f89f3 \
-    --hash=sha256:76ac0765936e376cbfc13b89a2fb4f543c5aa48111a6d9f377bcafd84c4b06b4
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
     #   -r docker/base-extra/requirements.in

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
@@ -236,8 +236,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -539,6 +540,7 @@ certifi==2026.4.22 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -810,7 +812,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1630,18 +1631,6 @@ geventhttpclient==2.3.4 \
     --hash=sha256:fecf1b735591fb21ea124a374c207104a491ad0d772709845a10d5faa07fa833 \
     --hash=sha256:ffe87eb7f1956357c2144a56814b5ffc927cbb8932f143a0351c78b93129ebbc
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1693,6 +1682,7 @@ google-auth==2.39.0 \
     #   google-cloud-secret-manager
     #   google-cloud-storage
     #   gsutil
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -2361,6 +2351,12 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
+    #   anyscale
 libclang==18.1.1 \
     --hash=sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a \
     --hash=sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8 \
@@ -2395,12 +2391,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -4286,6 +4276,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -4395,6 +4386,7 @@ pyyaml==6.0.3 \
     #   -r release/ray_release/byod/requirements_byod_3.10.in
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -4526,6 +4518,7 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -4538,6 +4531,7 @@ requests-oauthlib==2.0.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4828,6 +4822,7 @@ six==1.17.0 \
     #   google-oauth
     #   google-pasta
     #   gsutil
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4844,24 +4839,12 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -5118,6 +5101,7 @@ urllib3==1.26.20 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -5244,6 +5228,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
@@ -186,8 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -353,6 +354,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -601,7 +603,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1107,18 +1108,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1160,6 +1149,7 @@ google-auth==2.39.0 \
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -1677,18 +1667,18 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
+    #   anyscale
 linkify-it-py==2.1.0 ; sys_platform != 'win32' \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   markdown-it-py
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -2377,6 +2367,12 @@ oauth2client==4.1.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
+    #   requests-oauthlib
 opencensus==0.11.4 \
     --hash=sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864 \
     --hash=sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2
@@ -3079,6 +3075,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -3182,6 +3179,7 @@ pyyaml==6.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -3308,9 +3306,17 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   msal
     #   ray
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -3545,6 +3551,7 @@ six==1.17.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   google-oauth
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   python-dateutil
@@ -3557,24 +3564,12 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -3751,6 +3746,7 @@ urllib3==1.26.20 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -3877,6 +3873,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
@@ -186,8 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -353,6 +354,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -601,7 +603,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1107,18 +1108,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1160,6 +1149,7 @@ google-auth==2.39.0 \
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -1677,18 +1667,18 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
+    #   anyscale
 linkify-it-py==2.1.0 ; sys_platform != 'win32' \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   markdown-it-py
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -2377,6 +2367,12 @@ oauth2client==4.1.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
+    #   requests-oauthlib
 opencensus==0.11.4 \
     --hash=sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864 \
     --hash=sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2
@@ -3071,6 +3067,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -3174,6 +3171,7 @@ pyyaml==6.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -3300,9 +3298,17 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   msal
     #   ray
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -3537,6 +3543,7 @@ six==1.17.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   google-oauth
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   python-dateutil
@@ -3549,24 +3556,12 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -3743,6 +3738,7 @@ urllib3==1.26.20 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -3869,6 +3865,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
@@ -186,9 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.80 \
-    --hash=sha256:3857ac9a1b9219e6980938c1e76b48d50e592c9e7782e167ead2e6b1153a907d \
-    --hash=sha256:8d2cc6faa9dd3f3e2bd23dc6405d81d367aea0db2bd8258aa049edd25c79592b
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -1109,18 +1109,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -3576,12 +3564,6 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
@@ -186,9 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.103 \
-    --hash=sha256:37cd073d45c79fc62605fccf33bea9ac6a0c8ebc35781aa6ff9ffb0c4d6f89f3 \
-    --hash=sha256:76ac0765936e376cbfc13b89a2fb4f543c5aa48111a6d9f377bcafd84c4b06b4
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
@@ -237,8 +237,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -540,6 +541,7 @@ certifi==2026.4.22 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -811,7 +813,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1591,18 +1592,6 @@ geventhttpclient==2.3.5 \
     --hash=sha256:ee48b9cdde46f4c1e4609f9ba7e4a4096f0447bb5e07ddd531b3bb67461cc4e2 \
     --hash=sha256:ef0b2b1577b9f46314849bc46695bb16c2420e5c8654b37a0d5a58fe62c43a04
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1654,6 +1643,7 @@ google-auth==2.39.0 \
     #   google-cloud-secret-manager
     #   google-cloud-storage
     #   gsutil
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -2328,6 +2318,12 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
+    #   anyscale
 libclang==18.1.1 \
     --hash=sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a \
     --hash=sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8 \
@@ -2362,12 +2358,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -4164,6 +4154,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -4273,6 +4264,7 @@ pyyaml==6.0.3 \
     #   -r release/ray_release/byod/requirements_byod_gpu_3.10.in
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -4404,6 +4396,7 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -4416,6 +4409,7 @@ requests-oauthlib==2.0.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4706,6 +4700,7 @@ six==1.17.0 \
     #   google-oauth
     #   google-pasta
     #   gsutil
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4722,24 +4717,12 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -4995,6 +4978,7 @@ urllib3==1.26.20 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -5121,6 +5105,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
@@ -194,9 +194,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
@@ -194,9 +194,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
@@ -194,9 +194,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
@@ -194,9 +194,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
@@ -169,9 +169,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.97 \
-    --hash=sha256:5b66b011b4703a6e61b93a0579fba12219a196e0a71b3336bc377b8ac806848f \
-    --hash=sha256:9d12e369256ac8b88ec81f605253cffa5e40f0d9b99ef2a725863b79968a8f9e
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
@@ -169,9 +169,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.97 \
-    --hash=sha256:5b66b011b4703a6e61b93a0579fba12219a196e0a71b3336bc377b8ac806848f \
-    --hash=sha256:9d12e369256ac8b88ec81f605253cffa5e40f0d9b99ef2a725863b79968a8f9e
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
@@ -226,8 +226,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -548,6 +549,7 @@ certifi==2026.4.22 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
     #   sentry-sdk
 cffi==1.17.1 \
@@ -835,7 +837,6 @@ colorama==0.4.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   anyscale
-    #   log-symbols
     #   sacrebleu
     #   tqdm-multiprocess
 colorful==0.5.8 \
@@ -1888,7 +1889,6 @@ gitpython==3.1.47 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
-    #   anyscale
     #   wandb
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
@@ -1945,6 +1945,7 @@ google-auth==2.39.0 \
     #   google-cloud-secret-manager
     #   google-cloud-storage
     #   gsutil
+    #   kubernetes
 google-auth-httplib2==0.3.1 \
     --hash=sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55 \
     --hash=sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c
@@ -2801,6 +2802,13 @@ kombu==5.6.2 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
+    #   -c release/ray_release/byod/requirements_compiled.txt
+    #   anyscale
 lightning-utilities==0.15.3 \
     --hash=sha256:6c55f1bee70084a1cbeaa41ada96e4b3a0fea5909e844dd335bd80f5a73c5f91 \
     --hash=sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033
@@ -2848,13 +2856,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_ml_byod_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   -c release/ray_release/byod/requirements_compiled.txt
-    #   anyscale
 lxml==6.1.0 \
     --hash=sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2 \
     --hash=sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773 \
@@ -5088,6 +5089,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   matplotlib
     #   pandas
     #   typepy
@@ -5217,6 +5219,7 @@ pyyaml==6.0.3 \
     #   huggingface-hub
     #   jupyter-events
     #   jupytext
+    #   kubernetes
     #   peft
     #   pytorch-lightning
     #   ray
@@ -5482,6 +5485,7 @@ requests==2.33.1 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -5497,6 +5501,7 @@ requests-oauthlib==2.0.0 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -5999,6 +6004,7 @@ six==1.17.0 \
     #   google-apitools
     #   google-oauth
     #   gsutil
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -6031,13 +6037,6 @@ soupsieve==2.8.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   -c release/ray_release/byod/requirements_compiled.txt
-    #   anyscale
 sqlitedict==2.1.0 \
     --hash=sha256:03d9cfb96d602996f1d4c2db2856f1224b96a9c431bdd16e78032a72940f9e8c
     # via lm-eval
@@ -6689,6 +6688,7 @@ urllib3==1.26.20 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
     #   sentry-sdk
 utilsforecast==0.2.15 \
@@ -6852,6 +6852,7 @@ websocket-client==1.9.0 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_slim/ray_base_slim_py3.10.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.10.lock
@@ -186,8 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-slim/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -359,6 +360,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -608,7 +610,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1028,18 +1029,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1057,6 +1046,7 @@ google-auth==2.39.0 \
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
+    #   kubernetes
 google-cloud-core==2.5.1 \
     --hash=sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811 \
     --hash=sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7
@@ -1449,18 +1439,18 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
+    #   anyscale
 linkify-it-py==2.1.0 ; sys_platform != 'win32' \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   markdown-it-py
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -2147,6 +2137,12 @@ oauth2client==4.1.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
+    #   requests-oauthlib
 opencensus==0.11.4 \
     --hash=sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864 \
     --hash=sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2
@@ -2829,6 +2825,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -2932,6 +2929,7 @@ pyyaml==6.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -3057,9 +3055,17 @@ requests==2.33.1 \
     #   google-api-core
     #   google-cloud-storage
     #   jupyterlab-server
+    #   kubernetes
     #   msal
     #   ray
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -3275,6 +3281,7 @@ six==1.17.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   python-dateutil
@@ -3287,24 +3294,12 @@ smart-open==6.2.0 \
     #   -r docker/base-slim/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -3490,6 +3485,7 @@ urllib3==1.26.20 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -3616,6 +3612,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_slim/ray_base_slim_py3.11.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.11.lock
@@ -186,8 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-slim/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -353,6 +354,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -602,7 +604,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1016,18 +1017,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1045,6 +1034,7 @@ google-auth==2.39.0 \
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
+    #   kubernetes
 google-cloud-core==2.5.1 \
     --hash=sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811 \
     --hash=sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7
@@ -1437,18 +1427,18 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
+    #   anyscale
 linkify-it-py==2.1.0 ; sys_platform != 'win32' \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   markdown-it-py
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -2135,6 +2125,12 @@ oauth2client==4.1.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
+    #   requests-oauthlib
 opencensus==0.11.4 \
     --hash=sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864 \
     --hash=sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2
@@ -2818,6 +2814,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -2921,6 +2918,7 @@ pyyaml==6.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -3046,9 +3044,17 @@ requests==2.33.1 \
     #   google-api-core
     #   google-cloud-storage
     #   jupyterlab-server
+    #   kubernetes
     #   msal
     #   ray
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -3281,6 +3287,7 @@ six==1.17.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   python-dateutil
@@ -3293,24 +3300,12 @@ smart-open==6.2.0 \
     #   -r docker/base-slim/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -3483,6 +3478,7 @@ urllib3==1.26.20 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -3609,6 +3605,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_slim/ray_base_slim_py3.12.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.12.lock
@@ -186,8 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-slim/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -353,6 +354,7 @@ certifi==2026.4.22 \
     #   anyscale
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -602,7 +604,6 @@ colorama==0.4.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
-    #   log-symbols
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1016,18 +1017,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -1045,6 +1034,7 @@ google-auth==2.39.0 \
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
+    #   kubernetes
 google-cloud-core==2.5.1 \
     --hash=sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811 \
     --hash=sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7
@@ -1437,18 +1427,18 @@ kombu==5.6.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   celery
+kubernetes==24.2.0 \
+    --hash=sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd \
+    --hash=sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
+    #   anyscale
 linkify-it-py==2.1.0 ; sys_platform != 'win32' \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   markdown-it-py
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   anyscale
 lz4==4.4.5 \
     --hash=sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc \
     --hash=sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f \
@@ -2135,6 +2125,12 @@ oauth2client==4.1.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
+    #   requests-oauthlib
 opencensus==0.11.4 \
     --hash=sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864 \
     --hash=sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2
@@ -2810,6 +2806,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-discovery==1.2.2 \
     --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
@@ -2913,6 +2910,7 @@ pyyaml==6.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==27.1.0 \
@@ -3038,9 +3036,17 @@ requests==2.33.1 \
     #   google-api-core
     #   google-cloud-storage
     #   jupyterlab-server
+    #   kubernetes
     #   msal
     #   ray
+    #   requests-oauthlib
     #   smart-open
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
+    #   kubernetes
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -3273,6 +3279,7 @@ six==1.17.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   python-dateutil
@@ -3285,24 +3292,12 @@ smart-open==6.2.0 \
     #   -r docker/base-slim/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
-    #   anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -3475,6 +3470,7 @@ urllib3==1.26.20 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   anyscale
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.22.0 \
     --hash=sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8 \
@@ -3601,6 +3597,7 @@ websocket-client==1.9.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   jupyter-server
+    #   kubernetes
 websockets==15.0.1 \
     --hash=sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2 \
     --hash=sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9 \

--- a/python/deplocks/base_slim/ray_base_slim_py3.13.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.13.lock
@@ -186,9 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.80 \
-    --hash=sha256:3857ac9a1b9219e6980938c1e76b48d50e592c9e7782e167ead2e6b1153a907d \
-    --hash=sha256:8d2cc6faa9dd3f3e2bd23dc6405d81d367aea0db2bd8258aa049edd25c79592b
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-slim/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \
@@ -1017,18 +1017,6 @@ fsspec==2023.12.1 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   adlfs
     #   ray
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   gitpython
-gitpython==3.1.47 \
-    --hash=sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905 \
-    --hash=sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   anyscale
 google-api-core==2.30.3 \
     --hash=sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8 \
     --hash=sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b
@@ -3304,12 +3292,6 @@ smart-open==6.2.0 \
     #   -r docker/base-slim/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.3 \
-    --hash=sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c \
-    --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   gitdb
 soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95

--- a/python/deplocks/base_slim/ray_base_slim_py3.14.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.14.lock
@@ -186,9 +186,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.103 \
-    --hash=sha256:37cd073d45c79fc62605fccf33bea9ac6a0c8ebc35781aa6ff9ffb0c4d6f89f3 \
-    --hash=sha256:76ac0765936e376cbfc13b89a2fb4f543c5aa48111a6d9f377bcafd84c4b06b4
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-slim/requirements.in
 argon2-cffi==25.1.0 \
     --hash=sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1 \

--- a/release/ray_release/byod/audio_transcription_py3.10.lock
+++ b/release/ray_release/byod/audio_transcription_py3.10.lock
@@ -157,6 +157,7 @@ aiohttp==3.13.3 \
     #   anyscale
     #   gcsfs
     #   google-auth
+    #   kubernetes
     #   ray
     #   s3fs
     #   taskiq
@@ -227,8 +228,9 @@ anyio==4.12.1 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.6.3 \
     --hash=sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c \
@@ -506,6 +508,7 @@ certifi==2025.1.31 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
@@ -709,9 +712,7 @@ cmake==4.1.2 \
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
 colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via
-    #   anyscale
-    #   log-symbols
+    # via anyscale
 colorful==0.5.7 \
     --hash=sha256:495dd3a23151a9568cee8a90fc1174c902ad7ef06655f50b6bddf9e80008da69 \
     --hash=sha256:c5452179b56601c178b03d468a5326cc1fe37d9be81d24d0d6bdab36c4b93ad8
@@ -1026,6 +1027,10 @@ dm-tree==0.1.9 \
     --hash=sha256:e97c34fcb44941c36b7ee81dcdbceba0fbe728bddcc77e5837ab2eb665bcbff8 \
     --hash=sha256:f68b0efad76703dd4648586c75618a48cdd671b68c3266fe980e323c15423607
     # via ray
+durationpy==0.10 \
+    --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
+    --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+    # via kubernetes
 entrypoints==0.4 \
     --hash=sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4 \
     --hash=sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f
@@ -1401,14 +1406,6 @@ geventhttpclient==2.3.5 \
     --hash=sha256:ee48b9cdde46f4c1e4609f9ba7e4a4096f0447bb5e07ddd531b3bb67461cc4e2 \
     --hash=sha256:ef0b2b1577b9f46314849bc46695bb16c2420e5c8654b37a0d5a58fe62c43a04
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via gitpython
-gitpython==3.1.44 \
-    --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
-    --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269
-    # via anyscale
 google-api-core==2.24.2 \
     --hash=sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9 \
     --hash=sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
@@ -2120,6 +2117,10 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
+kubernetes==36.0.0 \
+    --hash=sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9 \
+    --hash=sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425
+    # via anyscale
 libclang==18.1.1 \
     --hash=sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a \
     --hash=sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8 \
@@ -2148,10 +2149,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via anyscale
 lxml==4.9.4 \
     --hash=sha256:00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91 \
     --hash=sha256:01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229 \
@@ -3889,6 +3886,7 @@ python-dateutil==2.8.2 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-dotenv==1.1.1 \
     --hash=sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc \
@@ -3963,6 +3961,7 @@ pyyaml==6.0.1 \
     #   anyscale
     #   huggingface-hub
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   transformers
     #   uvicorn
@@ -4206,6 +4205,7 @@ requests==2.32.5 \
     #   google-oauth
     #   huggingface-hub
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -4216,7 +4216,9 @@ requests==2.32.5 \
 requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
     --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
-    # via google-auth-oauthlib
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4483,6 +4485,7 @@ six==1.17.0 \
     #   google-pasta
     #   gsutil
     #   isodate
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4498,10 +4501,6 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.1 \
-    --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
-    --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
-    # via gitdb
 soundfile==0.13.1 \
     --hash=sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618 \
     --hash=sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9 \
@@ -4516,10 +4515,6 @@ soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
     # via beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -4823,6 +4818,7 @@ urllib3==1.26.19 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.37.0 \
     --hash=sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13 \
@@ -5008,7 +5004,9 @@ webencodings==0.5.1 \
 websocket-client==1.8.0 \
     --hash=sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526 \
     --hash=sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da
-    # via jupyter-server
+    # via
+    #   jupyter-server
+    #   kubernetes
 websockets==11.0.3 \
     --hash=sha256:01f5567d9cf6f502d655151645d4e8b72b453413d3819d2b6f1185abc23e82dd \
     --hash=sha256:03aae4edc0b1c68498f41a6772d80ac7c1e33c06c6ffa2ac1c27a07653e79d6f \

--- a/release/ray_release/byod/document_embedding_py3.10.lock
+++ b/release/ray_release/byod/document_embedding_py3.10.lock
@@ -156,6 +156,7 @@ aiohttp==3.13.3 \
     #   anyscale
     #   gcsfs
     #   google-auth
+    #   kubernetes
     #   langchain
     #   ray
     #   s3fs
@@ -226,8 +227,9 @@ anyio==4.12.1 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -503,6 +505,7 @@ certifi==2025.1.31 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
@@ -705,9 +708,7 @@ cmake==4.1.0 \
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
 colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via
-    #   anyscale
-    #   log-symbols
+    # via anyscale
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1016,6 +1017,10 @@ dm-tree==0.1.9 \
     --hash=sha256:e97c34fcb44941c36b7ee81dcdbceba0fbe728bddcc77e5837ab2eb665bcbff8 \
     --hash=sha256:f68b0efad76703dd4648586c75618a48cdd671b68c3266fe980e323c15423607
     # via ray
+durationpy==0.10 \
+    --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
+    --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+    # via kubernetes
 entrypoints==0.4 \
     --hash=sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4 \
     --hash=sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f
@@ -1429,14 +1434,6 @@ geventhttpclient==2.3.4 \
     --hash=sha256:fecf1b735591fb21ea124a374c207104a491ad0d772709845a10d5faa07fa833 \
     --hash=sha256:ffe87eb7f1956357c2144a56814b5ffc927cbb8932f143a0351c78b93129ebbc
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via gitpython
-gitpython==3.1.44 \
-    --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
-    --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269
-    # via anyscale
 google-api-core==2.24.2 \
     --hash=sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9 \
     --hash=sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
@@ -2132,6 +2129,10 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
+kubernetes==36.0.0 \
+    --hash=sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9 \
+    --hash=sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425
+    # via anyscale
 langchain==0.0.277 \
     --hash=sha256:248444a78010d7b7d2f5293873d2a267deed42c396c88c27e68669c8342237b3 \
     --hash=sha256:c8b4046cd0b2f134bfb4d3826bcf3d3caf807f7c59a1f8c127bb13f6483d921d
@@ -2168,10 +2169,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via anyscale
 lxml==4.9.4 \
     --hash=sha256:00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91 \
     --hash=sha256:01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229 \
@@ -3843,6 +3840,7 @@ python-dateutil==2.8.2 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-dotenv==1.2.1 \
     --hash=sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6 \
@@ -3917,6 +3915,7 @@ pyyaml==6.0.1 \
     #   anyscale
     #   huggingface-hub
     #   jupyter-events
+    #   kubernetes
     #   langchain
     #   ray
     #   transformers
@@ -4161,6 +4160,7 @@ requests==2.32.5 \
     #   google-oauth
     #   huggingface-hub
     #   jupyterlab-server
+    #   kubernetes
     #   langchain
     #   langsmith
     #   locust
@@ -4173,7 +4173,9 @@ requests==2.32.5 \
 requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
     --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
-    # via google-auth-oauthlib
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4441,6 +4443,7 @@ six==1.16.0 \
     #   google-pasta
     #   gsutil
     #   isodate
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4457,10 +4460,6 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.1 \
-    --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
-    --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
-    # via gitdb
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
@@ -4469,10 +4468,6 @@ soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
     # via beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via anyscale
 sqlalchemy==2.0.43 \
     --hash=sha256:022e436a1cb39b13756cf93b48ecce7aa95382b9cfacceb80a7d263129dfd019 \
     --hash=sha256:03d73ab2a37d9e40dec4984d1813d7878e01dbdc742448d44a7341b7a9f408c7 \
@@ -4839,6 +4834,7 @@ urllib3==1.26.19 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.38.0 \
     --hash=sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02 \
@@ -5036,7 +5032,9 @@ webencodings==0.5.1 \
 websocket-client==1.8.0 \
     --hash=sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526 \
     --hash=sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da
-    # via jupyter-server
+    # via
+    #   jupyter-server
+    #   kubernetes
 websockets==11.0.3 \
     --hash=sha256:01f5567d9cf6f502d655151645d4e8b72b453413d3819d2b6f1185abc23e82dd \
     --hash=sha256:03aae4edc0b1c68498f41a6772d80ac7c1e33c06c6ffa2ac1c27a07653e79d6f \

--- a/release/ray_release/byod/gpu_cu130_py3.10.lock
+++ b/release/ray_release/byod/gpu_cu130_py3.10.lock
@@ -151,9 +151,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
     #   -r docker/base-extra/requirements.in

--- a/release/ray_release/byod/gpu_cu130_py3.11.lock
+++ b/release/ray_release/byod/gpu_cu130_py3.11.lock
@@ -151,9 +151,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
     #   -r docker/base-extra/requirements.in

--- a/release/ray_release/byod/gpu_cu130_py3.12.lock
+++ b/release/ray_release/byod/gpu_cu130_py3.12.lock
@@ -151,9 +151,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
     #   -r docker/base-extra/requirements.in

--- a/release/ray_release/byod/gpu_cu130_py3.13.lock
+++ b/release/ray_release/byod/gpu_cu130_py3.13.lock
@@ -151,9 +151,9 @@ anyio==4.13.0 \
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
     #   httpx
     #   jupyter-server
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via
     #   -c python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
     #   -r docker/base-extra/requirements.in

--- a/release/ray_release/byod/image_classification_py3.10.lock
+++ b/release/ray_release/byod/image_classification_py3.10.lock
@@ -152,6 +152,7 @@ aiohttp==3.13.3 \
     #   anyscale
     #   gcsfs
     #   google-auth
+    #   kubernetes
     #   ray
     #   s3fs
     #   taskiq
@@ -221,8 +222,9 @@ anyio==4.12.1 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -496,6 +498,7 @@ certifi==2025.1.31 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
@@ -698,9 +701,7 @@ cmake==4.1.0 \
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
 colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via
-    #   anyscale
-    #   log-symbols
+    # via anyscale
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1005,6 +1006,10 @@ dm-tree==0.1.9 \
     --hash=sha256:e97c34fcb44941c36b7ee81dcdbceba0fbe728bddcc77e5837ab2eb665bcbff8 \
     --hash=sha256:f68b0efad76703dd4648586c75618a48cdd671b68c3266fe980e323c15423607
     # via ray
+durationpy==0.10 \
+    --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
+    --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+    # via kubernetes
 entrypoints==0.4 \
     --hash=sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4 \
     --hash=sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f
@@ -1415,14 +1420,6 @@ geventhttpclient==2.3.4 \
     --hash=sha256:fecf1b735591fb21ea124a374c207104a491ad0d772709845a10d5faa07fa833 \
     --hash=sha256:ffe87eb7f1956357c2144a56814b5ffc927cbb8932f143a0351c78b93129ebbc
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via gitpython
-gitpython==3.1.44 \
-    --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
-    --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269
-    # via anyscale
 google-api-core==2.24.2 \
     --hash=sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9 \
     --hash=sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
@@ -2098,6 +2095,10 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
+kubernetes==36.0.0 \
+    --hash=sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9 \
+    --hash=sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425
+    # via anyscale
 libclang==18.1.1 \
     --hash=sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a \
     --hash=sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8 \
@@ -2126,10 +2127,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via anyscale
 lxml==4.9.4 \
     --hash=sha256:00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91 \
     --hash=sha256:01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229 \
@@ -3703,6 +3700,7 @@ python-dateutil==2.8.2 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-dotenv==1.2.1 \
     --hash=sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6 \
@@ -3775,6 +3773,7 @@ pyyaml==6.0.1 \
     #   -r release/ray_release/byod/requirements_byod_gpu_3.10.in
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   uvicorn
 pyzmq==26.0.3 \
@@ -3899,6 +3898,7 @@ requests==2.32.5 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -3908,7 +3908,9 @@ requests==2.32.5 \
 requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
     --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
-    # via google-auth-oauthlib
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4150,6 +4152,7 @@ six==1.16.0 \
     #   google-pasta
     #   gsutil
     #   isodate
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4166,10 +4169,6 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.1 \
-    --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
-    --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
-    # via gitdb
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
@@ -4178,10 +4177,6 @@ soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
     # via beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -4463,6 +4458,7 @@ urllib3==1.26.19 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.38.0 \
     --hash=sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02 \
@@ -4660,7 +4656,9 @@ webencodings==0.5.1 \
 websocket-client==1.8.0 \
     --hash=sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526 \
     --hash=sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da
-    # via jupyter-server
+    # via
+    #   jupyter-server
+    #   kubernetes
 websockets==11.0.3 \
     --hash=sha256:01f5567d9cf6f502d655151645d4e8b72b453413d3819d2b6f1185abc23e82dd \
     --hash=sha256:03aae4edc0b1c68498f41a6772d80ac7c1e33c06c6ffa2ac1c27a07653e79d6f \

--- a/release/ray_release/byod/large_image_embedding_py3.10.lock
+++ b/release/ray_release/byod/large_image_embedding_py3.10.lock
@@ -152,6 +152,7 @@ aiohttp==3.13.3 \
     #   anyscale
     #   gcsfs
     #   google-auth
+    #   kubernetes
     #   ray
     #   s3fs
     #   taskiq
@@ -221,8 +222,9 @@ anyio==4.12.1 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -496,6 +498,7 @@ certifi==2025.1.31 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
@@ -698,9 +701,7 @@ cmake==4.1.0 \
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
 colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via
-    #   anyscale
-    #   log-symbols
+    # via anyscale
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1005,6 +1006,10 @@ dm-tree==0.1.9 \
     --hash=sha256:e97c34fcb44941c36b7ee81dcdbceba0fbe728bddcc77e5837ab2eb665bcbff8 \
     --hash=sha256:f68b0efad76703dd4648586c75618a48cdd671b68c3266fe980e323c15423607
     # via ray
+durationpy==0.10 \
+    --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
+    --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+    # via kubernetes
 entrypoints==0.4 \
     --hash=sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4 \
     --hash=sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f
@@ -1419,14 +1424,6 @@ geventhttpclient==2.3.4 \
     --hash=sha256:fecf1b735591fb21ea124a374c207104a491ad0d772709845a10d5faa07fa833 \
     --hash=sha256:ffe87eb7f1956357c2144a56814b5ffc927cbb8932f143a0351c78b93129ebbc
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via gitpython
-gitpython==3.1.44 \
-    --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
-    --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269
-    # via anyscale
 google-api-core==2.24.2 \
     --hash=sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9 \
     --hash=sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
@@ -2118,6 +2115,10 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
+kubernetes==36.0.0 \
+    --hash=sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9 \
+    --hash=sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425
+    # via anyscale
 libclang==18.1.1 \
     --hash=sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a \
     --hash=sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8 \
@@ -2146,10 +2147,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via anyscale
 lxml==4.9.4 \
     --hash=sha256:00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91 \
     --hash=sha256:01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229 \
@@ -3943,6 +3940,7 @@ python-dateutil==2.8.2 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   pandas
 python-dotenv==1.2.1 \
     --hash=sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6 \
@@ -4016,6 +4014,7 @@ pyyaml==6.0.1 \
     #   anyscale
     #   huggingface-hub
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   transformers
     #   uvicorn
@@ -4259,6 +4258,7 @@ requests==2.32.5 \
     #   google-oauth
     #   huggingface-hub
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -4269,7 +4269,9 @@ requests==2.32.5 \
 requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
     --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
-    # via google-auth-oauthlib
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4528,6 +4530,7 @@ six==1.16.0 \
     #   google-pasta
     #   gsutil
     #   isodate
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4544,10 +4547,6 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.1 \
-    --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
-    --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
-    # via gitdb
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
@@ -4556,10 +4555,6 @@ soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
     # via beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -4851,6 +4846,7 @@ urllib3==1.26.19 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.38.0 \
     --hash=sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02 \
@@ -5048,7 +5044,9 @@ webencodings==0.5.1 \
 websocket-client==1.8.0 \
     --hash=sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526 \
     --hash=sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da
-    # via jupyter-server
+    # via
+    #   jupyter-server
+    #   kubernetes
 websockets==11.0.3 \
     --hash=sha256:01f5567d9cf6f502d655151645d4e8b72b453413d3819d2b6f1185abc23e82dd \
     --hash=sha256:03aae4edc0b1c68498f41a6772d80ac7c1e33c06c6ffa2ac1c27a07653e79d6f \

--- a/release/ray_release/byod/ml_torchft_py3.13.lock
+++ b/release/ray_release/byod/ml_torchft_py3.13.lock
@@ -214,9 +214,9 @@ anyio==4.13.0 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.102 \
-    --hash=sha256:12cbe08c37a0f15ef88d432bb60c9cd9d32a4fbf5742ec3303e1cbc0da571f25 \
-    --hash=sha256:3b7c3e342c183cb9a26f2fd9722aba59f903c0e097119c4af2ece8ececa8d333
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \

--- a/release/ray_release/byod/video_object_detection_py3.10.lock
+++ b/release/ray_release/byod/video_object_detection_py3.10.lock
@@ -152,6 +152,7 @@ aiohttp==3.13.3 \
     #   anyscale
     #   gcsfs
     #   google-auth
+    #   kubernetes
     #   ray
     #   s3fs
     #   taskiq
@@ -221,8 +222,9 @@ anyio==4.12.1 \
     #   starlette
     #   taskiq
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.105 \
+    --hash=sha256:4dd4d348312e5cbc6ccde8e484ffa1e09c866eacde5fae45cd2dd242994f46cb \
+    --hash=sha256:5e6258599be70051deb8156e5d3f748f090e2b830bc2e6cf49dfbec5b4ee04e9
     # via -r docker/base-extra/requirements.in
 argcomplete==3.3.0 \
     --hash=sha256:c168c3723482c031df3c207d4ba8fa702717ccb9fc0bfe4117166c1f537b4a54 \
@@ -548,6 +550,7 @@ certifi==2025.1.31 \
     #   geventhttpclient
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
@@ -750,9 +753,7 @@ cmake==4.1.0 \
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
 colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via
-    #   anyscale
-    #   log-symbols
+    # via anyscale
 colorful==0.5.8 \
     --hash=sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992 \
     --hash=sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445
@@ -1127,6 +1128,10 @@ dm-tree==0.1.9 \
     --hash=sha256:e97c34fcb44941c36b7ee81dcdbceba0fbe728bddcc77e5837ab2eb665bcbff8 \
     --hash=sha256:f68b0efad76703dd4648586c75618a48cdd671b68c3266fe980e323c15423607
     # via ray
+durationpy==0.10 \
+    --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
+    --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+    # via kubernetes
 entrypoints==0.4 \
     --hash=sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4 \
     --hash=sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f
@@ -1597,14 +1602,6 @@ geventhttpclient==2.3.4 \
     --hash=sha256:fecf1b735591fb21ea124a374c207104a491ad0d772709845a10d5faa07fa833 \
     --hash=sha256:ffe87eb7f1956357c2144a56814b5ffc927cbb8932f143a0351c78b93129ebbc
     # via locust
-gitdb==4.0.11 \
-    --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
-    --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
-    # via gitpython
-gitpython==3.1.44 \
-    --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
-    --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269
-    # via anyscale
 google-api-core==2.24.2 \
     --hash=sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9 \
     --hash=sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
@@ -2383,6 +2380,10 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
+kubernetes==36.0.0 \
+    --hash=sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9 \
+    --hash=sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425
+    # via anyscale
 libclang==18.1.1 \
     --hash=sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a \
     --hash=sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8 \
@@ -2411,10 +2412,6 @@ locust==2.18.0 \
     --hash=sha256:55036b2601ad7a2725885ceafb28f90390128a9a5dc631809da462f53b37cd56 \
     --hash=sha256:f8d668c2c33518c705664bc869791d58fc98ba8f1aadbf2335be36e4e681feae
     # via -r release/ray_release/byod/requirements_byod_gpu_3.10.in
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
-    # via anyscale
 lxml==4.9.4 \
     --hash=sha256:00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91 \
     --hash=sha256:01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229 \
@@ -4092,6 +4089,7 @@ python-dateutil==2.8.2 \
     #   botocore
     #   celery
     #   jupyter-client
+    #   kubernetes
     #   matplotlib
     #   pandas
 python-dotenv==1.2.1 \
@@ -4165,6 +4163,7 @@ pyyaml==6.0.1 \
     #   -r release/ray_release/byod/requirements_byod_gpu_3.10.in
     #   anyscale
     #   jupyter-events
+    #   kubernetes
     #   ray
     #   ultralytics
     #   uvicorn
@@ -4290,6 +4289,7 @@ requests==2.32.5 \
     #   google-cloud-storage
     #   google-oauth
     #   jupyterlab-server
+    #   kubernetes
     #   locust
     #   msal
     #   ray
@@ -4300,7 +4300,9 @@ requests==2.32.5 \
 requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
     --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
-    # via google-auth-oauthlib
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 retry-decorator==1.1.1 \
     --hash=sha256:e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe
     # via
@@ -4543,6 +4545,7 @@ six==1.16.0 \
     #   google-pasta
     #   gsutil
     #   isodate
+    #   kubernetes
     #   oauth2client
     #   opencensus
     #   petastorm
@@ -4559,10 +4562,6 @@ smart-open==6.2.0 \
     #   -r docker/base-deps/requirements.in
     #   anyscale
     #   ray
-smmap==5.0.1 \
-    --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
-    --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
-    # via gitdb
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
@@ -4571,10 +4570,6 @@ soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
     # via beautifulsoup4
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via anyscale
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -4870,6 +4865,7 @@ urllib3==1.26.19 \
     #   anyscale
     #   botocore
     #   geventhttpclient
+    #   kubernetes
     #   requests
 uvicorn==0.38.0 \
     --hash=sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02 \
@@ -5067,7 +5063,9 @@ webencodings==0.5.1 \
 websocket-client==1.8.0 \
     --hash=sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526 \
     --hash=sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da
-    # via jupyter-server
+    # via
+    #   jupyter-server
+    #   kubernetes
 websockets==11.0.3 \
     --hash=sha256:01f5567d9cf6f502d655151645d4e8b72b453413d3819d2b6f1185abc23e82dd \
     --hash=sha256:03aae4edc0b1c68498f41a6772d80ac7c1e33c06c6ffa2ac1c27a07653e79d6f \


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick of #64980 to `releases/2.57.0`.

Bumps the anyscale CLI version floor to `0.26.105` in `docker/base-slim/requirements.in` and `docker/base-extra/requirements.in`, and regenerates all affected lockfiles via `raydepsets build --all-configs`.

Lockfile changes are the anyscale pin (`0.26.74`–`0.26.103` → `0.26.105`) plus its transitive dependency changes (newer anyscale drops `gitpython`/`gitdb`/`smmap`/`spinners`/`log-symbols`, adds `kubernetes`/`oauthlib`/`requests-oauthlib`).

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)