### PR TITLE
[Core] Guard Status::operator<< against an OK status

### DIFF
--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -514,15 +514,24 @@ class RAY_EXPORT Status {
 
   std::string message() const { return ok() ? "" : state_->msg; }
 
+  // Append context to an error status's message. An OK status has no state_
+  // (ok() is state_ == nullptr), so appending to it is a no-op rather than a
+  // null dereference. The rvalue overload keeps the temporary an rvalue through
+  // a chain (`Status::Invalid(...) << a << b`) so the final init can move.
   template <typename... T>
-  Status &operator<<(T &&...msg) {
-    // An OK status has no state_ and no message to append to; appending context
-    // only makes sense on an error status.
-    if (state_ == nullptr) {
-      return *this;
+  Status &operator<<(T &&...msg) & {
+    if (!ok()) {
+      absl::StrAppend(&state_->msg, std::forward<T>(msg)...);
     }
-    absl::StrAppend(&state_->msg, std::forward<T>(msg)...);
     return *this;
+  }
+
+  template <typename... T>
+  Status &&operator<<(T &&...msg) && {
+    if (!ok()) {
+      absl::StrAppend(&state_->msg, std::forward<T>(msg)...);
+    }
+    return std::move(*this);
   }
 
  private:

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -516,6 +516,11 @@ class RAY_EXPORT Status {
 
   template <typename... T>
   Status &operator<<(T &&...msg) {
+    // An OK status has no state_ and no message to append to; appending context
+    // only makes sense on an error status.
+    if (state_ == nullptr) {
+      return *this;
+    }
     absl::StrAppend(&state_->msg, std::forward<T>(msg)...);
     return *this;
   }

--- a/src/ray/common/tests/status_test.cc
+++ b/src/ray/common/tests/status_test.cc
@@ -81,6 +81,20 @@ TEST(StatusTest, CopyAndMoveErrorStatus) {
   }
 }
 
+TEST(StatusTest, StreamAppend) {
+  // Appending to an error status adds context to its message.
+  Status invalid = Status::Invalid("bad") << " because of " << 42;
+  EXPECT_TRUE(invalid.IsInvalid());
+  EXPECT_EQ(invalid.message(), "bad because of 42");
+
+  // Appending to an OK status is a no-op and must not dereference the null
+  // state; it stays OK.
+  Status ok = Status::OK();
+  ok << "ignored";
+  EXPECT_TRUE(ok.ok());
+  EXPECT_EQ(ok.message(), "");
+}
+
 TEST(StatusTest, StringToCode) {
   auto ok = Status::OK();
   StatusCode status = Status::StringToCode(ok.CodeAsString());

--- a/src/ray/common/tests/status_test.cc
+++ b/src/ray/common/tests/status_test.cc
@@ -82,17 +82,25 @@ TEST(StatusTest, CopyAndMoveErrorStatus) {
 }
 
 TEST(StatusTest, StreamAppend) {
-  // Appending to an error status adds context to its message.
+  // Appending to an error status adds context to its message. This exercises the
+  // rvalue overload (append to a temporary, then move into `invalid`).
   Status invalid = Status::Invalid("bad") << " because of " << 42;
   EXPECT_TRUE(invalid.IsInvalid());
   EXPECT_EQ(invalid.message(), "bad because of 42");
 
+  // The lvalue overload appends in place.
+  Status err = Status::Invalid("bad");
+  err << " more";
+  EXPECT_EQ(err.message(), "bad more");
+
   // Appending to an OK status is a no-op and must not dereference the null
-  // state; it stays OK.
+  // state; it stays OK. Covers both overloads.
   Status ok = Status::OK();
   ok << "ignored";
   EXPECT_TRUE(ok.ok());
   EXPECT_EQ(ok.message(), "");
+  Status ok_rvalue = Status::OK() << "ignored";
+  EXPECT_TRUE(ok_rvalue.ok());
 }
 
 TEST(StatusTest, StringToCode) {


### PR DESCRIPTION
## Description

`Status::operator<<` appended to `state_->msg` unconditionally, but an OK status has `state_ == nullptr` (that is exactly what `ok()` checks), so `okStatus << "x"` dereferenced a null pointer. Every other `state_` accessor (`code()`, `rpc_code()`, `message()`, `ToString()`) already guards on `ok()`; `operator<<` was the exception.

The fix guards the append behind `!ok()`, making an append to an OK status a no-op. Appending context only makes sense on an error status, and the in-tree callers all start from an error factory (`Status::IOError("") << ...`), so this only removes the latent crash without changing existing behavior.

`operator<<` is also split into lvalue-ref (`&`) and rvalue-ref (`&&`) overloads. The `&&` overload returns `Status&&` and moves `*this`, so a chained append starting from a temporary (`Status::Invalid(...) << a << b`) stays an rvalue and the final initialization moves the state instead of copying the heap-allocated `State`.

## Related issues

Fixes #64982

## Additional information

Added a test covering all paths: appending to an error status concatenates the message (rvalue chain), the lvalue overload appends in place, and appending to an OK status is a no-op that stays OK for both overloads (the OK case segfaults without the fix). `bazel test //src/ray/common/tests:status_test` passes, including under `--config=asan`; verified the OK-status case crashes when the guard is reverted.