### PR TITLE
[Data] Remove intermediate materialization in tpch tests

### DIFF
--- a/release/nightly_tests/dataset/tpch/tpch_q11.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q11.py
@@ -28,8 +28,8 @@ def main(args):
         #
         # Note:
         # Outer query and subquery share the nation -> supplier -> partsupp
-        # chain. Materialize the intermediate (partsupp_germany) once and
-        # derive both the per-part aggregate and the scalar threshold from it.
+        # chain. Build partsupp_germany once and derive both the per-part
+        # aggregate and the scalar threshold from it.
 
         # Q11 parameters. Per the TPC-H spec, FRACTION is defined as
         # 0.0001 / SF so the threshold tracks per-part stock values
@@ -57,8 +57,6 @@ def main(args):
         ).select_columns(["s_suppkey"])
 
         # partsupp restricted to national suppliers, with stock value.
-        # Materialize so the scalar total and the per-part aggregate both
-        # read from the same intermediate (Ray Data has no CSE).
         partsupp_germany = (
             partsupp.join(
                 nation_supplier,
@@ -71,7 +69,6 @@ def main(args):
                 "value", to_f64(col("ps_supplycost")) * to_f64(col("ps_availqty"))
             )
             .select_columns(["ps_partkey", "value"])
-            .materialize()
         )
 
         # Scalar threshold = SUM(value) * fraction. aggregate() returns a dict.

--- a/release/nightly_tests/dataset/tpch/tpch_q15.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q15.py
@@ -28,7 +28,7 @@ def main(args):
         #   ORDER BY s_suppkey;
         #
         # Note:
-        # Materialize the revenue view and derive the scalar max from it,
+        # Build the revenue view once and derive the scalar max from it,
         # mirroring the Q2 min-cost decorrelation. Float equality is safe:
         # max_revenue comes from the same Sum output column, so comparing
         # the groupwise sums to it is bit-exact.
@@ -50,10 +50,8 @@ def main(args):
             "rev", to_f64(col("l_extendedprice")) * (1 - to_f64(col("l_discount")))
         )
 
-        revenue = (
-            lineitem.groupby("l_suppkey")
-            .aggregate(Sum(on="rev", alias_name="total_revenue"))
-            .materialize()
+        revenue = lineitem.groupby("l_suppkey").aggregate(
+            Sum(on="rev", alias_name="total_revenue")
         )
 
         max_revenue = revenue.aggregate(Max(on="total_revenue", alias_name="max_rev"))[

--- a/release/nightly_tests/dataset/tpch/tpch_q17.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q17.py
@@ -24,10 +24,9 @@ def main(args):
         #
         # Note:
         # The correlated subquery is decorrelated by joining lineitem with
-        # the filtered parts first, materializing the small result, then
-        # computing AVG(l_quantity) per partkey from that intermediate.
-        # This avoids a double S3 read of lineitem and scopes the groupby
-        # to only the matching rows.
+        # the filtered parts first, then computing AVG(l_quantity) per
+        # partkey from that intermediate. This scopes the groupby to only
+        # the matching rows.
 
         # Load tables with early projection.
         part = load_table("part", args.sf).select_columns(
@@ -46,21 +45,16 @@ def main(args):
             expr=(col("p_brand") == brand) & (col("p_container") == container)
         ).select_columns(["p_partkey"])
 
-        # Join lineitem with filtered parts first, then materialize the small
-        # result for dual consumption (avg_qty groupby + filter pipeline).
-        # This avoids a double S3 read of lineitem and reduces the groupby
-        # from the full lineitem table to only matching rows.
-        joined = (
-            part_filtered.join(
-                lineitem,
-                join_type="inner",
-                num_partitions=16,
-                on=("p_partkey",),
-                right_on=("l_partkey",),
-            )
-            .select_columns(["p_partkey", "l_quantity", "l_extendedprice"])
-            .materialize()
-        )
+        # Join lineitem with filtered parts first, then reuse the result for
+        # both the avg_qty groupby and the filter pipeline. This reduces the
+        # groupby from the full lineitem table to only matching rows.
+        joined = part_filtered.join(
+            lineitem,
+            join_type="inner",
+            num_partitions=16,
+            on=("p_partkey",),
+            right_on=("l_partkey",),
+        ).select_columns(["p_partkey", "l_quantity", "l_extendedprice"])
 
         # Decorrelate: compute average quantity per part (only matching parts).
         avg_qty = (

--- a/release/nightly_tests/dataset/tpch/tpch_q2.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q2.py
@@ -80,15 +80,13 @@ def main(args):
             right_on=("n_regionkey",),
         ).select_columns(["n_nationkey", "n_name"])
 
-        # Materialize to avoid recomputing the region->nation->supplier chain
-        # in both Branch B and the main pipeline (Ray Data has no CSE).
         regional_suppliers = nation_region.join(
             supplier,
             num_partitions=16,
             join_type="inner",
             on=("n_nationkey",),
             right_on=("s_nationkey",),
-        ).materialize()
+        )
 
         # ── Branch B: min supply cost per part from regional suppliers ──
         regional_partsupp = partsupp.join(

--- a/release/nightly_tests/dataset/tpch/tpch_q21.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q21.py
@@ -73,14 +73,9 @@ def main(args):
 
         # ── Pre-aggregate: distinct LATE suppliers per order (NOT EXISTS) ─
         # Late lineitem: l_receiptdate > l_commitdate.
-        # Materialize to avoid recomputing the filter in both the
-        # late_suppliers_per_order branch and the main pipeline
-        # (Ray Data has no CSE).
-        late_lineitem = (
-            lineitem.filter(expr=col("l_receiptdate") > col("l_commitdate"))
-            .select_columns(["l_orderkey", "l_suppkey"])
-            .materialize()
-        )
+        late_lineitem = lineitem.filter(
+            expr=col("l_receiptdate") > col("l_commitdate")
+        ).select_columns(["l_orderkey", "l_suppkey"])
 
         late_suppliers_per_order = (
             late_lineitem.groupby("l_orderkey")


### PR DESCRIPTION
## Description
To accurate get the performance from tpch, we shouldn't intermediate materialization as it is bad for pipeline & add plan time overhead (that's basically 2 sequential ray data pipeline)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
