### PR TITLE
[Data] Improve BatchIterator and iter_torch_batches

### DIFF
--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -1,6 +1,6 @@
 import abc
 from dataclasses import dataclass, field
-from typing import Any, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Tuple
 
 from ray.data._internal.stats import IterationStage, TimeSpan
 from ray.data.block import Block, DataBatch
@@ -110,6 +110,7 @@ class Batch:
     data: DataBatch
 
 
+@dataclass
 class CollatedBatch(Batch):
     """A batch of collated data.
 
@@ -119,6 +120,27 @@ class CollatedBatch(Batch):
     """
 
     data: Any
+
+
+@dataclass
+class FinalizedData:
+    """A wrapper for finalized data.
+
+    Returned by finalize functions with an optional callback.
+
+    Note: ``on_consume`` will be called right before the batch is
+        returned to the user.
+    """
+
+    data: Any
+    on_consume: Optional[Callable[[], None]] = None
+
+
+@dataclass
+class FinalizedBatch(CollatedBatch):
+    """A finalized batch."""
+
+    on_consume: Optional[Callable[[], None]] = None
 
 
 class BlockPrefetcher(metaclass=abc.ABCMeta):

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -8,6 +8,8 @@ from ray._common.utils import env_integer
 from ray.data._internal.block_batching.interfaces import (
     Batch,
     BlockPrefetcher,
+    FinalizedBatch,
+    FinalizedData,
 )
 from ray.data._internal.block_batching.util import (
     ActorBlockPrefetcher,
@@ -148,7 +150,7 @@ class BatchIterator:
         batch_format: Optional[str] = "default",
         drop_last: bool = False,
         collate_fn: Optional[Callable[[DataBatch], Any]] = None,
-        finalize_fn: Optional[Callable[[Any], Any]] = None,
+        finalize_fn: Optional[Callable[[Any], FinalizedData]] = None,
         shuffle_buffer_min_size: Optional[int] = None,
         shuffle_seed: Optional[int] = None,
         ensure_copy: bool = False,
@@ -235,10 +237,7 @@ class BatchIterator:
     def _finalize_batches(
         self,
         batch_iter: Iterator[Batch],
-    ) -> Iterator[Batch]:
-        if self._finalize_fn is None:
-            return batch_iter
-
+    ) -> Iterator[FinalizedBatch]:
         return finalize_batches(
             batch_iter, finalize_fn=self._finalize_fn, stats=self._stats
         )
@@ -248,7 +247,7 @@ class BatchIterator:
     ) -> Iterator[Batch]:
         return restore_original_order(batches)
 
-    def _pipeline(self, ref_bundles: Iterator[RefBundle]) -> Iterator[Batch]:
+    def _pipeline(self, ref_bundles: Iterator[RefBundle]) -> Iterator[FinalizedBatch]:
         # Step 1: Prefetch logical batches locally.
         block_iter = self._prefetch_blocks(ref_bundles)
 
@@ -285,19 +284,20 @@ class BatchIterator:
 
         self.before_epoch_start()
 
-        while True:
-            with self.get_next_batch_context():
-                blocked_start_s = time.perf_counter()
-                try:
-                    batch = next(batch_iter)
-                except StopIteration:
-                    break
-                blocked_end_s = time.perf_counter()
-            self._attribute_blocked_time(batch, blocked_start_s, blocked_end_s)
-            with self.yield_batch_context(batch):
-                yield batch.data
-
-        self.after_epoch_end()
+        try:
+            while True:
+                with self.get_next_batch_context():
+                    blocked_start_s = time.perf_counter()
+                    try:
+                        batch = next(batch_iter)
+                    except StopIteration:
+                        break
+                    blocked_end_s = time.perf_counter()
+                self._attribute_blocked_time(batch, blocked_start_s, blocked_end_s)
+                with self.yield_batch_context(batch):
+                    yield batch.data
+        finally:
+            self.after_epoch_end()
 
     def _attribute_blocked_time(
         self, batch: Batch, blocked_start_s: float, blocked_end_s: float
@@ -378,9 +378,12 @@ class BatchIterator:
             self._yielded_first_batch = True
 
     @contextmanager
-    def yield_batch_context(self, batch: Batch):
+    def yield_batch_context(self, batch: FinalizedBatch):
         """Context around yielding a batch to the user: tracks user time
         and periodically flushes metrics."""
+        assert isinstance(batch, FinalizedBatch)
+        if batch.on_consume is not None:
+            batch.on_consume()
         with self._stats.iter_user_s.timer() if self._stats else nullcontext():
             yield
 

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -26,6 +26,8 @@ from ray.data._internal.block_batching.interfaces import (
     BlockPrefetcher,
     BlockStageTimings,
     CollatedBatch,
+    FinalizedBatch,
+    FinalizedData,
     ResolvedBlock,
 )
 from ray.data._internal.stats import DatasetStats, TimeSpan, _maybe_time
@@ -448,20 +450,27 @@ def collate(
 
 def _finalize_batch(
     batch: CollatedBatch,
-    finalize_fn: Callable[[Any], Any],
+    finalize_fn: Optional[Callable[[Any], FinalizedData]],
     stats: Optional[DatasetStats],
-) -> CollatedBatch:
+) -> FinalizedBatch:
+    if finalize_fn is None:
+        return FinalizedBatch(data=batch.data, metadata=batch.metadata)
     with _maybe_time(stats.iter_finalize_batch_s if stats else None) as span:
         finalized_data = finalize_fn(batch.data)
+    assert isinstance(finalized_data, FinalizedData)
     batch.metadata.stage_timings.finalize = span
-    return dataclasses.replace(batch, data=finalized_data)
+    return FinalizedBatch(
+        data=finalized_data.data,
+        metadata=batch.metadata,
+        on_consume=finalized_data.on_consume,
+    )
 
 
 def finalize_batches(
     batch_iter: Iterator[CollatedBatch],
-    finalize_fn: Callable[[Any], Any],
+    finalize_fn: Optional[Callable[[Any], FinalizedData]],
     stats: Optional[DatasetStats] = None,
-) -> Iterator[CollatedBatch]:
+) -> Iterator[FinalizedBatch]:
     """Returns an iterator with finalize_fn applied to batches."""
     if not isinstance(batch_iter, Iterator):
         batch_iter = iter(batch_iter)

--- a/python/ray/data/_internal/utils/torch_utils.py
+++ b/python/ray/data/_internal/utils/torch_utils.py
@@ -27,7 +27,7 @@ class FinalizeFn(ABC):
 class DefaultFinalizeFn(FinalizeFn):
     """Default finalize_fn for ``iter_torch_batches``.
 
-    Synchronously move tensor batches to the target device on the current stream.
+    Move tensor batches to the target device on the current stream (can be non-blocking).
     """
 
     def __init__(self, device: torch.device):

--- a/python/ray/data/_internal/utils/torch_utils.py
+++ b/python/ray/data/_internal/utils/torch_utils.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import Any, Union
+
+import torch
+
+from ray.data._internal.block_batching.interfaces import FinalizedData
+from ray.data.collate_fn import (
+    TensorBatchType,
+    is_tensor_batch_type,
+)
+from ray.data.util.torch_utils import (
+    DEFAULT_TENSOR_NON_BLOCKING_TRANSFER,
+    move_tensors_to_device,
+)
+
+CustomBatchType = Any
+
+
+class FinalizeFn(ABC):
+    """Base finalize_fn interface for ``iter_torch_batches``."""
+
+    @abstractmethod
+    def __call__(self, batch: Union[TensorBatchType, CustomBatchType]) -> FinalizedData:
+        ...
+
+
+class DefaultFinalizeFn(FinalizeFn):
+    """Default finalize_fn for ``iter_torch_batches``.
+
+    Synchronously move tensor batches to the target device on the current stream.
+    """
+
+    def __init__(self, device: torch.device):
+        """Construct the DefaultFinalizeFn.
+
+        Args:
+            device: The device to transfer tensor batches to.
+        """
+        self._device = device
+
+    @torch.no_grad()
+    def __call__(self, batch: Union[TensorBatchType, CustomBatchType]) -> FinalizedData:
+        if is_tensor_batch_type(batch):
+            batch = move_tensors_to_device(
+                batch,
+                device=self._device,
+                non_blocking=DEFAULT_TENSOR_NON_BLOCKING_TRANSFER,
+            )
+        return FinalizedData(data=batch)

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -30,10 +30,7 @@ from ray.data.collate_fn import (
     DefaultCollateFn,
     NumpyBatchCollateFn,
     PandasBatchCollateFn,
-    TensorBatchReturnType,
-    TensorBatchType,
     _PinMemoryCollateFnWrapper,
-    is_tensor_batch_type,
 )
 from ray.data.context import DataContext
 from ray.util.annotations import Deprecated, PublicAPI, RayDeprecationWarning
@@ -44,6 +41,7 @@ if TYPE_CHECKING:
     import torch
 
     from ray.data._internal.execution.streaming_executor import StreamingExecutor
+    from ray.data._internal.utils.torch_utils import FinalizeFn
     from ray.data.dataset import (
         CollatedData,
         MaterializedDataset,
@@ -544,35 +542,6 @@ class DataIterator(abc.ABC):
             device = get_device() if _in_ray_train_worker() else "cpu"
         device = torch_device(device)
 
-        from ray.data.util.torch_utils import (
-            move_tensors_to_device,
-        )
-
-        # The default finalize_fn handles the host to device data transfer.
-        # This is executed in a 1-thread pool separately from collate_fn
-        # to allow independent parallelism of these steps.
-        def default_finalize_fn(
-            batch: TensorBatchType,
-        ) -> Union[TensorBatchReturnType, Any]:
-            """Default finalize function for moving PyTorch tensors to device. If
-            batch is of type `TensorBatchType`, it will be automatically moved to the
-            target device. For other types, you must handle device transfer
-            manually in your training loop.
-
-            Args:
-                batch: Input batch to move to device.
-
-            Returns:
-                Batch with tensors moved to the target device.
-                - If input is TensorBatchType, returns tensors moved to device
-                - Otherwise returns the same type as input without moving tensors
-                to device.
-            """
-            if is_tensor_batch_type(batch):
-                return move_tensors_to_device(batch, device=device)
-            else:
-                return batch
-
         if collate_fn is None:
             # The default collate_fn handles formatting and Tensor creation.
             # Here, we defer host to device data transfer to the subsequent
@@ -622,8 +591,13 @@ class DataIterator(abc.ABC):
             local_shuffle_buffer_size=local_shuffle_buffer_size,
             local_shuffle_seed=local_shuffle_seed,
             _collate_fn=collate_fn,
-            _finalize_fn=default_finalize_fn,
+            _finalize_fn=self._get_finalize_fn(device=device),
         )
+
+    def _get_finalize_fn(self, *, device: "torch.device") -> "FinalizeFn":
+        from ray.data._internal.utils.torch_utils import DefaultFinalizeFn
+
+        return DefaultFinalizeFn(device)
 
     def iter_tf_batches(
         self,

--- a/python/ray/data/tests/block_batching/test_iter_batches.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches.py
@@ -14,6 +14,7 @@ from ray.data._internal.block_batching.interfaces import (
     BatchMetadata,
     BatchStageTimings,
     BlockPrefetcher,
+    FinalizedData,
 )
 from ray.data._internal.block_batching.iter_batches import (
     BatchIterator,
@@ -423,7 +424,7 @@ def test_finalize_fn_uses_single_thread(ray_start_regular_shared):
             e = AssertionError("finalize_fn is being run concurrently.")
             q.put(e, block=True)
         semaphore.release()
-        return batch
+        return FinalizedData(data=batch)
 
     # Test that finalize_fn is called in a single thread,
     # even if prefetch_batches is set.
@@ -599,7 +600,7 @@ def test_finalize_fn_runs_after_restore_original_order(ray_start_regular_shared)
         idx = int(batch["foo"].iloc[0])
         with seen_lock:
             seen_by_finalize.append(idx)
-        return batch
+        return FinalizedData(data=batch)
 
     num_blocks = 16
     ref_bundles = ref_bundle_generator(num_blocks=num_blocks, num_rows=1)
@@ -818,7 +819,7 @@ def test_e2e_blocked_attribution_by_scenario(
         # Pass _finalize_fn via _iter_batches (private signature accepts it).
         def slow_finalize(data):
             time.sleep(SLEEP_S)
-            return data
+            return FinalizedData(data=data)
 
         iter_kwargs["_finalize_fn"] = slow_finalize
         ds = ray.data.range(50, override_num_blocks=5)

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -16,6 +16,7 @@ import ray
 from ray.data._internal.block_batching.interfaces import (
     Batch,
     BatchMetadata,
+    FinalizedData,
     ResolvedBlock,
 )
 from ray.data._internal.block_batching.util import (
@@ -157,7 +158,7 @@ def test_collate():
 
 def test_finalize():
     def finalize_fn(batch):
-        return pa.table({"bar": [1] * 2})
+        return FinalizedData(data=pa.table({"bar": [1] * 2}))
 
     batches = [
         Batch(BatchMetadata(batch_idx=i), data)


### PR DESCRIPTION
## Description
This PR introduces a series of incremental improvements to `BatchIterator` and `iter_torch_batches` api:
1. Introduce `FinalizeBatch` and `FinalizeData` abstractions that will call a `on_consume` callback right before batches are returned to the user. Potential use-cases are where you need final post-processing on the same _thread_ as the user's thread.
2. make `after_epoch_end` always trigger even if iterator is preempted or iterator errors.
3. Improve typing across finalize stages to use `FinalizeData` and `FinalizeBatch`.
4. Create a generic abstraction for finalize functions for `iter_torch_batches` and create a `DefautlFinalizeFn`. This prevents us from declaring the finalize function inline in `iter_torch_batches`, cleaning up code.

## Related issues
N/A

## Additional information
N/A