### PR TITLE
[Serve][LLM] Pass remote URI as model for streaming load formats

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -9,6 +9,7 @@ from vllm.entrypoints.openai.cli_args import FrontendArgs
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.placement import PlacementGroupConfig
 from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig, is_remote_path
+from ray.llm._internal.common.utils.download_utils import STREAMING_LOAD_FORMATS
 from ray.llm._internal.common.utils.import_utils import try_import
 from ray.llm._internal.serve.constants import (
     ALLOW_NEW_PLACEMENT_GROUPS_IN_DEPLOYMENT,
@@ -193,7 +194,11 @@ class VLLMEngineConfig(BaseModelExtended):
             hf_model_id = llm_config.model_id
         elif isinstance(llm_config.model_loading_config.model_source, str):
             model_source = llm_config.model_loading_config.model_source
-            if is_remote_path(model_source):
+            load_format = llm_config.engine_kwargs.get("load_format")
+            if (
+                is_remote_path(model_source)
+                and load_format not in STREAMING_LOAD_FORMATS
+            ):
                 # Remote URIs (s3://, gs://, …) are download addresses,
                 # not HuggingFace IDs.  Using the URI verbatim as
                 # hf_model_id propagates the scheme and slashes into the
@@ -203,6 +208,9 @@ class VLLMEngineConfig(BaseModelExtended):
                 hf_model_id = llm_config.model_id
                 mirror_config = CloudMirrorConfig(bucket_uri=model_source)
             else:
+                # Streaming load formats read the weights directly from the
+                # remote URI, so pass it through as the model instead of
+                # mirroring it to disk.
                 hf_model_id = model_source
         else:
             # If it's a CloudMirrorConfig (or subtype)

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -201,6 +201,25 @@ class TestModelConfig:
         assert engine_config.mirror_config is not None
         assert engine_config.mirror_config.bucket_uri == bucket_uri
 
+    def test_streaming_remote_model_source_passes_uri_as_model(self):
+        """Streaming load formats must pass the remote URI to vLLM as the model.
+
+        RunAI streamer reads the weights directly from the remote URI, so the
+        URI must reach vLLM as ``model`` rather than being mirrored to disk
+        (which would hand vLLM a local path with no safetensors). See #64978.
+        """
+        bucket_uri = "s3://my-bucket/my-model"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+                model_source=bucket_uri,
+            ),
+            engine_kwargs={"load_format": "runai_streamer"},
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == bucket_uri
+        assert engine_config.mirror_config is None
+
     def test_hf_model_source_used_as_hf_model_id(self):
         """A plain HuggingFace model_source is used directly as hf_model_id."""
         llm_config = LLMConfig(


### PR DESCRIPTION
## Description

For streaming load formats (like `runai_streamer`), the RunAI streamer reads model weights directly from the remote object store into GPU memory, so vLLM must receive the object-store URI as its `model`.
Currently `VLLMEngineConfig.from_llm_config` routes any remote string `model_source` into the download-mirror path:

```python
if is_remote_path(model_source):   # s3://, gs://, abfss://, azure://
    hf_model_id = llm_config.model_id
    mirror_config = CloudMirrorConfig(bucket_uri=model_source)
```

vLLM is then handed  model_id, but never the URI. Under a streaming load format the per-node download mode is  NONE , so nothing is downloaded either. The engine can neither stream (no URI) nor load locally, and startup fails:

`RuntimeError: Failed to create vLLM engine config: gpt-oss-120b is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'`

## Related PRs
Runai_streamer  from a remote object store is broken for every remote string  model_source  —  s3:// ,  gs:// ,  abfss:// ,  azure:// . 
The one exception,  az:// , only works by coincidence: it is missing from  is_remote_path , so it skips the broken mirror branch and falls through to the pass-through path. The correct fix would be to include this and https://github.com/ray-project/ray/pull/65120 to add az:// to the scheme so it follows the logic correctly and is supported. 

## Fix
Make the decision inclusive of the load_format: 
- streaming load formats: pass the remote URI through as  model  instead of mirroring it.
- Non-streaming formats: keep the existing mirror/download behavior, which preserves the clean HF cache-directory naming from #64110.

This is the same approach Ray Data already uses (it keeps the remote  model_source  as the vLLM  model  for streaming), so it also makes the Serve and batch paths consistent.

##Testing

• Added  test_streaming_remote_model_source_passes_uri_as_model  in  python/ray/llm/tests/serve/cpu/configs/test_models.py .
• Validated  from_llm_config  in a built  ray-llm  environment (Ray + vLLM) across  s3:// ,  gs:// ,  azure:// , and  az:// :
• With the fix: all four schemes pass the URI through as  model  with no mirror config when  load_format=runai_streamer .
• Without the fix:  s3://  /  gs://  /  azure://  fall back to  model_id  with a mirror config;  az://  is unaffected until the follow-up https://github.com/ray-project/ray/pull/65120 is included.
• Non-streaming remote sources still mirror/download as before.

pytest python/ray/llm/tests/serve/cpu/configs/test_models.py -k streaming_remote_model_source
