### PR TITLE
[data][train] Rename allocated -> reserved in autoscaling coordinator

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
@@ -35,7 +35,7 @@ class AutoscalingCoordinator(abc.ABC):
                 The requester is responsible for periodically sending new requests
                 to avoid the request being purged.
             request_remaining: If true, after reserving requested resources to each
-                requester, remaining resources will also be allocated to this requester.
+                requester, remaining resources will also be reserved to this requester.
             priority: The priority of the request. Higher value means higher priority.
             label_selectors: Optional per-bundle label selectors, one per entry in
                 ``resources``. Forwarded to the autoscaler as
@@ -50,9 +50,9 @@ class AutoscalingCoordinator(abc.ABC):
 
     @abc.abstractmethod
     def get_reserved_resources(self) -> List[ResourceDict]:
-        """Get the allocated resources for the requester.
+        """Get the reserved resources for the requester.
 
         Returns:
-            A list of dictionaries representing the allocated resources bundles.
+            A list of dictionaries representing the reserved resources bundles.
         """
         ...

--- a/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
@@ -34,7 +34,7 @@ class AutoscalingCoordinator(abc.ABC):
             expire_after_s: Time in seconds after which this request will expire.
                 The requester is responsible for periodically sending new requests
                 to avoid the request being purged.
-            request_remaining: If true, after allocating requested resources to each
+            request_remaining: If true, after reserving requested resources to each
                 requester, remaining resources will also be allocated to this requester.
             priority: The priority of the request. Higher value means higher priority.
             label_selectors: Optional per-bundle label selectors, one per entry in
@@ -49,7 +49,7 @@ class AutoscalingCoordinator(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_allocated_resources(self) -> List[ResourceDict]:
+    def get_reserved_resources(self) -> List[ResourceDict]:
         """Get the allocated resources for the requester.
 
         Returns:

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -120,20 +120,20 @@ class OngoingRequest:
     requested_resources: List[ResourceDict]
     # The expiration time of the request.
     expiration_time: float
-    # If true, after allocating requested resources to each requester,
-    # remaining resources will also be allocated to this requester.
+    # If true, after reserving requested resources to each requester,
+    # remaining resources will also be reserved to this requester.
     request_remaining: bool
     # The priority of the request, higher value means higher priority.
     priority: int
-    # Resources that are already allocated to the requester.
-    allocated_resources: List[ResourceDict]
+    # Resources that are already reserved to the requester.
+    reserved_resources: List[ResourceDict]
     # Per-bundle label selectors, parallel to ``requested_resources``.
     # Empty dicts mean no label constraint on that bundle. Required to have
     # the same length as ``requested_resources``.
     requested_label_selectors: List[Dict[str, str]]
 
     def __lt__(self, other):
-        """Used to sort requests when allocating resources.
+        """Used to sort requests when reserving resources.
 
         Higher priority first, then earlier first_request_time first.
         """
@@ -149,7 +149,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
 
     Create one instance per requester. Multiple instances sharing the same
     ``requester_id`` will have diverging caches and break the FIFO ordering
-    guarantee that ``request_resources`` and ``get_allocated_resources`` rely on.
+    guarantee that ``request_resources`` and ``get_reserved_resources`` rely on.
     """
 
     def __init__(
@@ -162,9 +162,9 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         # Label selector keyed by ``SUBCLUSTER_LABEL_KEY`` pinning this
         # requester to a single subcluster.
         self._subcluster_selector = subcluster_selector
-        self._cached_allocated_resources: List[ResourceDict] = []
-        # In-flight get_allocated_resources ref, or None if no request is pending.
-        self._pending_allocated_resources: Optional[ray.ObjectRef] = None
+        self._cached_reserved_resources: List[ResourceDict] = []
+        # In-flight get_reserved_resources ref, or None if no request is pending.
+        self._pending_reserved_resources: Optional[ray.ObjectRef] = None
         if autoscaling_coordinator_actor is not None:
             # Bypass the cached_property by injecting the actor directly.
             # Used in tests to avoid the shared named actor.
@@ -200,16 +200,16 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
     def cancel_request(self) -> None:
         """Fire-and-forget: cancel a resource request on the coordinator actor.
 
-        Also clears client-side state (pending ref and cached allocation) so
-        a subsequent ``get_allocated_resources`` call returns a fresh result
+        Also clears client-side state (pending ref and cached reservation) so
+        a subsequent ``get_reserved_resources`` call returns a fresh result
         rather than stale data from a prior pipeline run.
         """
-        self._pending_allocated_resources = None
-        self._cached_allocated_resources = []
+        self._pending_reserved_resources = None
+        self._cached_reserved_resources = []
         self._autoscaling_coordinator.cancel_request.remote(self._requester_id)
 
-    def get_allocated_resources(self) -> List[ResourceDict]:
-        """Return allocated resources without blocking.
+    def get_reserved_resources(self) -> List[ResourceDict]:
+        """Return reserved resources without blocking.
 
         Submits an async RPC and immediately returns the last cached result.
         The cache is updated the next time the pending RPC completes.
@@ -220,16 +220,16 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
 
         On actor errors, returns the cached value and logs a warning; never raises.
         """
-        ref = self._pending_allocated_resources
+        ref = self._pending_reserved_resources
         if ref is not None:
             ready, _ = ray.wait([ref], timeout=0)
             if ready:
-                self._pending_allocated_resources = None
+                self._pending_reserved_resources = None
                 try:
-                    self._cached_allocated_resources = ray.get(ref, timeout=0)
+                    self._cached_reserved_resources = ray.get(ref, timeout=0)
                 except ray.exceptions.RayError:
                     logger.warning(
-                        f"Failed to get allocated resources for {self._requester_id};"
+                        f"Failed to get reserved resources for {self._requester_id};"
                         " falling back to the cached value."
                         " If this persists, file a GitHub issue.",
                         exc_info=RAY_DATA_AUTOSCALING_COORDINATOR_LOG_TRACEBACK,
@@ -237,14 +237,14 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
 
         # Submit a new request if none is currently in-flight
         # (first call, or the previous request completed or errored).
-        if self._pending_allocated_resources is None:
-            self._pending_allocated_resources = (
-                self._autoscaling_coordinator.get_allocated_resources.remote(
+        if self._pending_reserved_resources is None:
+            self._pending_reserved_resources = (
+                self._autoscaling_coordinator.get_reserved_resources.remote(
                     self._requester_id,
                 )
             )
 
-        return self._cached_allocated_resources
+        return self._cached_reserved_resources
 
 
 def _default_send_resources_request(
@@ -262,7 +262,7 @@ class _AutoscalingCoordinatorActor:
 
     This actor is responsible for:
     * Merging received requests and dispatching them to Ray Autoscaler.
-    * Allocating cluster resources to the requesters.
+    * Reserving cluster resources to the requesters.
     """
 
     TICK_INTERVAL_S = 20
@@ -307,7 +307,7 @@ class _AutoscalingCoordinatorActor:
         with self._lock:
             self._merge_and_send_requests()
             self._update_cluster_node_resources()
-            self._reallocate_resources()
+            self._rereserve_resources()
 
     def request_resources(
         self,
@@ -346,7 +346,7 @@ class _AutoscalingCoordinatorActor:
                         f"Bundle {i} label_selector targets subcluster "
                         f"{bundle_subcluster!r}, but requester is registered to "
                         f"{req_subcluster!r}. Per-bundle cross-subcluster "
-                        f"allocation is not supported."
+                        f"reservation is not supported."
                     )
         with self._lock:
             now = self._get_current_time()
@@ -385,16 +385,16 @@ class _AutoscalingCoordinatorActor:
                     request_remaining=request_remaining,
                     priority=priority.value,
                     expiration_time=now + expire_after_s,
-                    allocated_resources=[],
+                    reserved_resources=[],
                 )
             # Write subcluster after all validations so a rejected call
             # never leaves the registry on a new subcluster.
             self._subcluster_selectors[requester_id] = subcluster_selector
             if request_updated:
                 # If the request has updated, immediately send
-                # a new request and reallocate resources.
+                # a new request and rereserve resources.
                 self._merge_and_send_requests()
-                self._reallocate_resources()
+                self._rereserve_resources()
 
     def cancel_request(
         self,
@@ -407,7 +407,7 @@ class _AutoscalingCoordinatorActor:
             del self._ongoing_reqs[requester_id]
             self._subcluster_selectors.pop(requester_id, None)
             self._merge_and_send_requests()
-            self._reallocate_resources()
+            self._rereserve_resources()
 
     def _purge_expired_requests(self):
         now = self._get_current_time()
@@ -442,12 +442,12 @@ class _AutoscalingCoordinatorActor:
         else:
             self._send_resources_request(merged_req)
 
-    def get_allocated_resources(self, requester_id: str) -> List[ResourceDict]:
-        """Get the allocated resources for the requester."""
+    def get_reserved_resources(self, requester_id: str) -> List[ResourceDict]:
+        """Get the reserved resources for the requester."""
         with self._lock:
             if requester_id not in self._ongoing_reqs:
                 return []
-            return self._ongoing_reqs[requester_id].allocated_resources
+            return self._ongoing_reqs[requester_id].reserved_resources
 
     def _maybe_subtract_resources(self, res1: ResourceDict, res2: ResourceDict) -> bool:
         """If res2<=res1, subtract res2 from res1 in-place, and return True.
@@ -489,8 +489,8 @@ class _AutoscalingCoordinatorActor:
         self._cluster_node_resources = cluster_node_resources
         return True
 
-    def _reallocate_resources(self):
-        """Reallocate cluster resources.
+    def _rereserve_resources(self):
+        """Rereserve cluster resources.
 
         Each requester's subcluster comes from its ``subcluster_selector``.
         A requester without one is eligible only for the ``None`` bucket.
@@ -512,15 +512,15 @@ class _AutoscalingCoordinatorActor:
 
         # TODO(hchen): Optimize the following triple loop.
         for requester_id, ongoing_req in live_items:
-            ongoing_req.allocated_resources = []
+            ongoing_req.reserved_resources = []
             subcluster = _subcluster_of(requester_id)
             for bundle in ongoing_req.requested_resources:
                 for node_resource in cluster_node_resources.get(subcluster, []):
                     if self._maybe_subtract_resources(node_resource, bundle):
-                        ongoing_req.allocated_resources.append(bundle)
+                        ongoing_req.reserved_resources.append(bundle)
                         break
 
-        # Allocate remaining resources. Multiple concurrent requesters in
+        # Reserve remaining resources. Multiple concurrent requesters in
         # the same subcluster split that subcluster's leftovers equally.
         remaining_items = [
             (req_id, req) for req_id, req in live_items if req.request_remaining
@@ -534,20 +534,20 @@ class _AutoscalingCoordinatorActor:
             if not eligible:
                 continue
             for node_resource in node_resources:
-                # Integer division may leave some resources unallocated.
+                # Integer division may leave some resources unreserved.
                 divided = {k: v // len(eligible) for k, v in node_resource.items()}
                 if not any(v > 0 for v in divided.values()):
                     continue
                 for r in eligible:
-                    r.allocated_resources.append(divided)
+                    r.reserved_resources.append(divided)
 
         if logger.isEnabledFor(logging.DEBUG):
-            msg = "Allocated resources:\n"
+            msg = "Reserved resources:\n"
             for requester_id, ongoing_req in self._ongoing_reqs.items():
-                allocated_resources_log_str = _format_resources_for_log(
-                    ongoing_req.allocated_resources
+                reserved_resources_log_str = _format_resources_for_log(
+                    ongoing_req.reserved_resources
                 )
-                msg += f"Requester {requester_id}: {allocated_resources_log_str}\n"
+                msg += f"Requester {requester_id}: {reserved_resources_log_str}\n"
             logger.debug(msg)
 
 

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -249,7 +249,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         # Last time when a request was sent to Ray's autoscaler.
         self._last_request_time = 0
         # Track the last non-empty explicit request so low-utilization heartbeats
-        # can keep it alive briefly without turning allocated remaining-share
+        # can keep it alive briefly without turning reserved remaining-share
         # resources into explicit autoscaler demand.
         self._last_non_empty_resource_request: List[ResourceDict] = []
         self._last_non_empty_request_time: Optional[float] = None
@@ -277,9 +277,9 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._autoscaling_enabled = is_autoscaling_enabled()
 
         # Register with the coordinator immediately so the actor knows about this
-        # requester before the first ``get_reserved_resources call``. The cached value
+        # requester before the first ``get_reserved_resources`` call. The cached value
         # returned by ``get_reserved_resources`` (and thus ``get_total_resources``) will
-        # be empty until the actor responds with the first allocation (cold-start).
+        # be empty until the actor responds with the first reservation (cold-start).
         self._send_resource_request([])
 
     def try_trigger_scaling(self):

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -277,8 +277,8 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._autoscaling_enabled = is_autoscaling_enabled()
 
         # Register with the coordinator immediately so the actor knows about this
-        # requester before the first ``get_allocated_resources call``. The cached value
-        # returned by ``get_allocated_resources`` (and thus ``get_total_resources``) will
+        # requester before the first ``get_reserved_resources call``. The cached value
+        # returned by ``get_reserved_resources`` (and thus ``get_total_resources``) will
         # be empty until the actor responds with the first allocation (cold-start).
         self._send_resource_request([])
 
@@ -421,7 +421,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
     def get_total_resources(self) -> ExecutionResources:
         """Get total resources available from the autoscaling coordinator."""
-        resources = self._autoscaling_coordinator.get_allocated_resources()
+        resources = self._autoscaling_coordinator.get_reserved_resources()
         total = ExecutionResources.zero()
         for res in resources:
             total = total.add(ExecutionResources.from_resource_dict(res))

--- a/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
@@ -72,7 +72,7 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
         self._allocation = None
 
     def get_reserved_resources(self) -> List[ResourceDict]:
-        """Return the allocated resources if they haven't expired."""
+        """Return the reserved resources if they haven't expired."""
         if self._allocation is None:
             return []
 

--- a/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
@@ -71,7 +71,7 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
     def cancel_request(self) -> None:
         self._allocation = None
 
-    def get_allocated_resources(self) -> List[ResourceDict]:
+    def get_reserved_resources(self) -> List[ResourceDict]:
         """Return the allocated resources if they haven't expired."""
         if self._allocation is None:
             return []

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -79,7 +79,7 @@ def test_basic(cluster_nodes):
         expire_after_s=req1_timeout,
     )
     mock_request_resources.assert_called_once_with(req1)
-    res1 = as_coordinator.get_allocated_resources("requester1")
+    res1 = as_coordinator.get_reserved_resources("requester1")
 
     def _remove_head_node_resources(res):
         for r in res:
@@ -109,7 +109,7 @@ def test_basic(cluster_nodes):
         request_remaining=True,
     )
     mock_request_resources.assert_called_with(req1 + req2)
-    res2 = as_coordinator.get_allocated_resources("requester2")
+    res2 = as_coordinator.get_reserved_resources("requester2")
     _remove_head_node_resources(res2)
     assert res2 == req2 + [{"CPU": 5, "GPU": 3, "object_store_memory": 800}]
 
@@ -121,10 +121,10 @@ def test_basic(cluster_nodes):
         expire_after_s=req1_timeout,
     )
     mock_request_resources.assert_called_with(req1_updated + req2)
-    res1 = as_coordinator.get_allocated_resources("requester1")
+    res1 = as_coordinator.get_reserved_resources("requester1")
     _remove_head_node_resources(res1)
     assert res1 == req1_updated
-    res2 = as_coordinator.get_allocated_resources("requester2")
+    res2 = as_coordinator.get_reserved_resources("requester2")
     _remove_head_node_resources(res2)
     assert res2 == req2 + [{"CPU": 4, "GPU": 2, "object_store_memory": 600}]
 
@@ -132,8 +132,8 @@ def test_basic(cluster_nodes):
     mocked_time = req1_timeout + 0.1
     as_coordinator._tick()
     mock_request_resources.assert_called_with(req2)
-    res1 = as_coordinator.get_allocated_resources("requester1")
-    res2 = as_coordinator.get_allocated_resources("requester2")
+    res1 = as_coordinator.get_reserved_resources("requester1")
+    res2 = as_coordinator.get_reserved_resources("requester2")
     _remove_head_node_resources(res1)
     _remove_head_node_resources(res2)
     assert res1 == []
@@ -143,8 +143,8 @@ def test_basic(cluster_nodes):
     mocked_time = req2_timeout + 0.1
     as_coordinator._tick()
     mock_request_resources.assert_called_with([])
-    res1 = as_coordinator.get_allocated_resources("requester1")
-    res2 = as_coordinator.get_allocated_resources("requester2")
+    res1 = as_coordinator.get_reserved_resources("requester1")
+    res2 = as_coordinator.get_reserved_resources("requester2")
     _remove_head_node_resources(res1)
     _remove_head_node_resources(res2)
     assert res1 == []
@@ -152,7 +152,7 @@ def test_basic(cluster_nodes):
 
     # Test canceling a request
     as_coordinator.cancel_request("requester2")
-    res2 = as_coordinator.get_allocated_resources("requester2")
+    res2 = as_coordinator.get_reserved_resources("requester2")
     _remove_head_node_resources(res2)
     assert res2 == []
 
@@ -197,8 +197,8 @@ def test_double_allocation_with_multiple_request_remaining():
     )
 
     # Get allocated resources
-    res1 = coordinator.get_allocated_resources("requester1")
-    res2 = coordinator.get_allocated_resources("requester2")
+    res1 = coordinator.get_reserved_resources("requester1")
+    res2 = coordinator.get_reserved_resources("requester2")
 
     # After allocating specific requests (req1 and req2):
     # Remaining = CPU: 10-2-3=5, GPU: 5-1-1=3, memory: 1000-100-200=700
@@ -309,7 +309,7 @@ def test_autoscaling_coordinator_e2e(cluster, gpu_tasks_include_cpu):
 
         def check_allocated_resources():
             allocated = ray.get(
-                as_coordinator.get_allocated_resources.remote(requester_id)
+                as_coordinator.get_reserved_resources.remote(requester_id)
             )
             allocated = [
                 {
@@ -387,8 +387,8 @@ def autoscaling_coordinator_actor(ray_start_regular_shared):
     ray.kill(actor)
 
 
-def test_get_allocated_resources_eventually_consistent(autoscaling_coordinator_actor):
-    """get_allocated_resources eventually reflects a submitted request_resources call."""
+def test_get_reserved_resources_eventually_consistent(autoscaling_coordinator_actor):
+    """get_reserved_resources eventually reflects a submitted request_resources call."""
     coordinator = DefaultAutoscalingCoordinator(
         "test", autoscaling_coordinator_actor=autoscaling_coordinator_actor
     )
@@ -396,13 +396,13 @@ def test_get_allocated_resources_eventually_consistent(autoscaling_coordinator_a
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
 
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
         retry_interval_ms=100,
         timeout=5,
     )
 
 
-def test_get_allocated_resources_returns_cached_while_pending(
+def test_get_reserved_resources_returns_cached_while_pending(
     autoscaling_coordinator_actor, monkeypatch
 ):
     """Returns the last cached value without blocking when a ref is still in-flight."""
@@ -412,7 +412,7 @@ def test_get_allocated_resources_returns_cached_while_pending(
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
         retry_interval_ms=100,
         timeout=5,
     )
@@ -425,10 +425,10 @@ def test_get_allocated_resources_returns_cached_while_pending(
 
     coordinator.request_resources(resources=[{"CPU": 2}], expire_after_s=60)
     # Should return the stale cached value, not block.
-    assert coordinator.get_allocated_resources() == [{"CPU": 1}]
+    assert coordinator.get_reserved_resources() == [{"CPU": 1}]
 
 
-def test_get_allocated_resources_returns_cached_on_actor_error(
+def test_get_reserved_resources_returns_cached_on_actor_error(
     autoscaling_coordinator_actor, monkeypatch
 ):
     """Actor errors fall back to the cached value, log a warning, and never raise.
@@ -441,7 +441,7 @@ def test_get_allocated_resources_returns_cached_on_actor_error(
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
         retry_interval_ms=100,
         timeout=5,
     )
@@ -454,35 +454,35 @@ def test_get_allocated_resources_returns_cached_on_actor_error(
     monkeypatch.setattr(ray, "get", Mock(side_effect=ray.exceptions.RayActorError()))
 
     # Must return the last cached value, not raise.
-    assert coordinator.get_allocated_resources() == [{"CPU": 1}]
+    assert coordinator.get_reserved_resources() == [{"CPU": 1}]
 
     # Recovery: submit a new request after the error and verify it eventually
     # resolves, proving the coordinator can communicate with the actor again.
     monkeypatch.undo()
     coordinator.request_resources(resources=[{"CPU": 2}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 2}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 2}],
         retry_interval_ms=100,
         timeout=5,
     )
 
 
 def test_cancel_request_makes_get_return_empty(autoscaling_coordinator_actor):
-    """After cancel_request, get_allocated_resources eventually returns []."""
+    """After cancel_request, get_reserved_resources eventually returns []."""
     coordinator = DefaultAutoscalingCoordinator(
         "test", autoscaling_coordinator_actor=autoscaling_coordinator_actor
     )
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
         retry_interval_ms=100,
         timeout=5,
     )
 
     coordinator.cancel_request()
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [],
+        lambda: coordinator.get_reserved_resources() == [],
         retry_interval_ms=100,
         timeout=5,
     )
@@ -499,7 +499,7 @@ def test_non_ray_errors_propagate(autoscaling_coordinator_actor, monkeypatch):
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
         retry_interval_ms=100,
         timeout=5,
     )
@@ -510,7 +510,7 @@ def test_non_ray_errors_propagate(autoscaling_coordinator_actor, monkeypatch):
     )
 
     with pytest.raises(ValueError, match="unexpected local error"):
-        coordinator.get_allocated_resources()
+        coordinator.get_reserved_resources()
 
 
 def test_coordinator_accepts_zero_resource_for_missing_resource_type(
@@ -525,7 +525,7 @@ def test_coordinator_accepts_zero_resource_for_missing_resource_type(
     coordinator.request_resources(resources=[{"CPU": 1, "GPU": 0}], expire_after_s=1)
 
     wait_for_condition(
-        lambda: coordinator.get_allocated_resources() == [{"CPU": 1, "GPU": 0}],
+        lambda: coordinator.get_reserved_resources() == [{"CPU": 1, "GPU": 0}],
         retry_interval_ms=100,
         timeout=5,
     )
@@ -743,8 +743,8 @@ def test_label_selector_disjoint_requesters_dont_cross_talk():
         request_remaining=True,
     )
 
-    train = coord.get_allocated_resources("train")
-    val = coord.get_allocated_resources("val")
+    train = coord.get_reserved_resources("train")
+    val = coord.get_reserved_resources("val")
     assert {"CPU": 4} in train and {"CPU": 4} in val
     # Training bucket: 2 x 8 - 4 explicit = 12 leftover, all to train.
     assert sum(a["CPU"] for a in train if a != {"CPU": 4}) == 12
@@ -767,7 +767,7 @@ def test_unlabeled_requester_only_sees_none_bucket():
         request_remaining=True,
     )
 
-    alloc = coord.get_allocated_resources("anon")
+    alloc = coord.get_reserved_resources("anon")
     total_cpu = sum(a["CPU"] for a in alloc)
     assert total_cpu == 2, (
         f"unlabeled requester should only see the 2-CPU None bucket; got "
@@ -791,8 +791,8 @@ def test_labeled_and_unlabeled_requesters_are_isolated():
         request_remaining=True,
     )
 
-    train_total = sum(a["CPU"] for a in coord.get_allocated_resources("train"))
-    anon_total = sum(a["CPU"] for a in coord.get_allocated_resources("anon"))
+    train_total = sum(a["CPU"] for a in coord.get_reserved_resources("train"))
+    anon_total = sum(a["CPU"] for a in coord.get_reserved_resources("anon"))
     # Training bucket: 2 x 8 = 16 CPU; anon gets none of it.
     assert train_total == 16
     # Default bucket: 1 x 2 = 2 CPU; train gets none of it.
@@ -810,7 +810,7 @@ def test_label_selector_unmatched_yields_no_allocation():
         expire_after_s=10,
         request_remaining=True,
     )
-    assert coord.get_allocated_resources("ghost") == []
+    assert coord.get_reserved_resources("ghost") == []
 
 
 def test_label_selector_partial_fit_when_demand_exceeds_capacity():
@@ -824,7 +824,7 @@ def test_label_selector_partial_fit_when_demand_exceeds_capacity():
         expire_after_s=10,
     )
     # Validation has one 4-CPU node; only the first 3-CPU bundle fits.
-    assert coord.get_allocated_resources("val") == [{"CPU": 3}]
+    assert coord.get_reserved_resources("val") == [{"CPU": 3}]
 
 
 def test_full_tick_exercises_update_merge_reallocate():
@@ -853,7 +853,7 @@ def test_full_tick_exercises_update_merge_reallocate():
     )
     # Before the join: only 4 CPU in the training bucket; 1 used explicitly,
     # 3 leftover go to train.
-    train_total = sum(a["CPU"] for a in coord.get_allocated_resources("train"))
+    train_total = sum(a["CPU"] for a in coord.get_reserved_resources("train"))
     assert train_total == 4
 
     # A new training node joins the cluster.
@@ -867,7 +867,7 @@ def test_full_tick_exercises_update_merge_reallocate():
     )
     # Without a tick, the coordinator still sees the old snapshot.
     coord._tick()
-    train_total = sum(a["CPU"] for a in coord.get_allocated_resources("train"))
+    train_total = sum(a["CPU"] for a in coord.get_reserved_resources("train"))
     # Now: 4 + 8 = 12 total; 1 explicit + 11 leftover.
     assert train_total == 12
 
@@ -896,8 +896,8 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
         request_remaining=True,
     )
 
-    train_idle_alloc = coord.get_allocated_resources("train_idle")
-    val_active_alloc = coord.get_allocated_resources("val_active")
+    train_idle_alloc = coord.get_reserved_resources("train_idle")
+    val_active_alloc = coord.get_reserved_resources("val_active")
 
     # Training bucket: 2 x 8 = 16 CPU, all leftover, all to train_idle.
     train_idle_cpu = sum(a.get("CPU", 0) for a in train_idle_alloc)

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -204,9 +204,9 @@ class TestClusterAutoscaling:
             or gpu_util >= scale_up_threshold
             or mem_util >= scale_up_threshold
         )
-        resources_allocated = autoscaler.get_total_resources()
+        resources_reserved = autoscaler.get_total_resources()
         if not should_scale_up:
-            assert resources_allocated == ExecutionResources.zero()
+            assert resources_reserved == ExecutionResources.zero()
         else:
             expected_num_resource_spec1_requested = 2 + scale_up_delta
             expected_num_resource_spec2_requested = 1 + scale_up_delta
@@ -225,7 +225,7 @@ class TestClusterAutoscaling:
                 ),
             )
 
-            assert resources_allocated == expected_resources
+            assert resources_reserved == expected_resources
 
     def test_get_node_resource_spec_and_count_from_zero(self):
         """Test that get_node_resource_spec_and_count can discover node types
@@ -299,8 +299,8 @@ class TestClusterAutoscaling:
         autoscaler.try_trigger_scaling()
 
         # Should request scale_up_delta nodes of each type
-        # Verify via get_total_resources which returns what was allocated
-        resources_allocated = autoscaler.get_total_resources()
+        # Verify via get_total_resources which returns what was reserved
+        resources_reserved = autoscaler.get_total_resources()
         expected_resources = ExecutionResources(
             cpu=resource_spec1.cpu * scale_up_delta
             + resource_spec2.cpu * scale_up_delta,
@@ -309,15 +309,15 @@ class TestClusterAutoscaling:
             memory=resource_spec1.mem * scale_up_delta
             + resource_spec2.mem * scale_up_delta,
         )
-        assert resources_allocated == expected_resources
+        assert resources_reserved == expected_resources
 
-    def test_low_utilization_sends_current_allocation(self):
-        """Test that low utilization sends current allocation.
+    def test_low_utilization_sends_current_reservation(self):
+        """Test that low utilization sends current reservation.
 
         Test scenario:
-        1. Dataset has already been allocated resources (1 nodes)
+        1. Dataset has already been reserved resources (1 nodes)
         2. Utilization is low (0%, below default threshold)
-        3. Should send current allocation to preserve resource footprint
+        3. Should send current reservation to preserve resource footprint
         """
         utilization: ExecutionResources = ...
 
@@ -355,7 +355,7 @@ class TestClusterAutoscaling:
         """Below the scale-up threshold, the last explicit request is resent briefly.
 
         This avoids immediately dropping explicit autoscaler demand (and avoids
-        re-submitting ``get_allocated_resources()`` shapes as explicit demand).
+        re-submitting ``get_reserved_resources()`` shapes as explicit demand).
         """
         current_time = {"t": 0.0}
 
@@ -711,10 +711,10 @@ class TestClusterAutoscaling:
 
         autoscaler.try_trigger_scaling()
 
-        resources_allocated = autoscaler.get_total_resources()
-        assert resources_allocated.cpu == node_spec.cpu * expected_nodes
-        assert resources_allocated.gpu == node_spec.gpu * expected_nodes
-        assert resources_allocated.memory == node_spec.mem * expected_nodes
+        resources_reserved = autoscaler.get_total_resources()
+        assert resources_reserved.cpu == node_spec.cpu * expected_nodes
+        assert resources_reserved.gpu == node_spec.gpu * expected_nodes
+        assert resources_reserved.memory == node_spec.mem * expected_nodes
 
     def test_try_scale_up_respects_resource_limits_heterogeneous_nodes(self):
         """Test that smaller bundles are included even when larger bundles exceed limits.
@@ -757,7 +757,7 @@ class TestClusterAutoscaling:
 
         autoscaler.try_trigger_scaling()
 
-        resources_allocated = autoscaler.get_total_resources()
+        resources_reserved = autoscaler.get_total_resources()
         # With delta=1:
         #   - Active bundles: 1 small (4 CPUs) - existing nodes, always included
         #   - Pending bundles: 1 small (4 CPUs) + 1 large (8 CPUs) - scale-up delta
@@ -768,18 +768,18 @@ class TestClusterAutoscaling:
         #   - Add large: 8 + 8 = 16 CPUs ✗ (exceeds limit)
         # Result: 2 small bundles (8 CPUs)
         # Ray autoscaler would see: need 2 small nodes, have 1 → spin up 1 more
-        assert resources_allocated.cpu == 8, (
-            f"Expected 8 CPUs (2 small node bundles), got {resources_allocated.cpu}. "
+        assert resources_reserved.cpu == 8, (
+            f"Expected 8 CPUs (2 small node bundles), got {resources_reserved.cpu}. "
             "Smaller bundles should be included even when larger ones exceed limits."
         )
-        assert resources_allocated.gpu == 0
-        assert resources_allocated.memory == 4 * GiB
+        assert resources_reserved.gpu == 0
+        assert resources_reserved.memory == 4 * GiB
 
     def test_try_scale_up_existing_nodes_prioritized_over_delta(self):
         """Test that existing node bundles are prioritized over scale-up delta bundles.
 
         This tests a scenario where:
-        - Large existing node: 1 node at 6 CPUs (currently allocated)
+        - Large existing node: 1 node at 6 CPUs (currently reserved)
         - Small node type available: can add nodes at 2 CPUs each
         - User limit: 8 CPUs
         - Scale-up delta: 2 (want to add 2 small nodes)
@@ -820,7 +820,7 @@ class TestClusterAutoscaling:
 
         autoscaler.try_trigger_scaling()
 
-        resources_allocated = autoscaler.get_total_resources()
+        resources_reserved = autoscaler.get_total_resources()
         # Active bundles: 1 large (6 CPUs) - must be included
         # Pending bundles: 2 large (12 CPUs) + 2 small (4 CPUs) = delta requests
         # After capping to 8 CPUs:
@@ -830,14 +830,14 @@ class TestClusterAutoscaling:
         #   - Add small: 6 + 2 = 8 CPUs ✓
         #   - Add another small: 8 + 2 = 10 CPUs ✗
         # Result: 1 large (active) + 1 small (delta) = 8 CPUs
-        assert resources_allocated.cpu == 8, (
-            f"Expected 8 CPUs (1 existing large + 1 delta small), got {resources_allocated.cpu}. "
+        assert resources_reserved.cpu == 8, (
+            f"Expected 8 CPUs (1 existing large + 1 delta small), got {resources_reserved.cpu}. "
             "Existing node bundles should always be included before scale-up delta."
         )
         # Verify we have the large node's resources (it must be included)
-        assert resources_allocated.memory >= large_node_spec.mem, (
+        assert resources_reserved.memory >= large_node_spec.mem, (
             f"Existing large node (mem={large_node_spec.mem}) should be included. "
-            f"Got total memory={resources_allocated.memory}"
+            f"Got total memory={resources_reserved.memory}"
         )
 
     def test_try_scale_up_logs_info_message(self, propagate_logs, caplog):

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 class ElasticScalingPolicy(ScalingPolicy):
 
-    # Minimum interval in seconds between querying the AutoscalingCoordinator for allocated resources.
+    # Minimum interval in seconds between querying the AutoscalingCoordinator for reserved resources.
     GET_RESERVED_RESOURCES_INTERVAL_S = 1
     # Minimum interval in seconds between logging warnings about insufficient workers.
     INSUFFICIENT_WORKERS_WARNING_INTERVAL_S = 30
@@ -47,7 +47,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         the list of node resources. The returned number is capped at the maximum
         number of workers.
 
-        For GPUs, this divides raw allocated resources by per-worker requirements.
+        For GPUs, this divides raw reserved resources by per-worker requirements.
         For TPUs, an additional check ensures workers align with physically intact
         TPU slices (see ``_get_strict_tpu_worker_count``).
 
@@ -92,7 +92,7 @@ class ElasticScalingPolicy(ScalingPolicy):
     def _get_strict_tpu_worker_count(self, total_num_workers: int) -> int:
         """Calculate the number of workers that can run on intact TPU slices.
 
-        The Autoscaler's allocated resources might overestimate the number of
+        The Autoscaler's reserved resources might overestimate the number of
         schedulable TPU workers because it counts raw resources. TPUs require
         atomic, interconnected slices. This function checks the cluster for
         physically intact slices to prevent scaling onto fractional/broken
@@ -104,7 +104,7 @@ class ElasticScalingPolicy(ScalingPolicy):
 
         Args:
             total_num_workers: The initial estimate of workers based on raw
-                allocated resources.
+                reserved resources.
 
         Returns:
             The number of workers aligned to fully intact TPU slices.
@@ -236,7 +236,7 @@ class ElasticScalingPolicy(ScalingPolicy):
             )
             return NoopDecision()
         elif num_workers < self.scaling_config.min_workers:
-            # This covers an edge case where allocated resources decrease to less
+            # This covers an edge case where reserved resources decrease to less
             # than the minimum number of workers.
             # This situation is rare, since cluster downsizing typically involves
             # worker failures. However, this check is still useful to fully
@@ -255,7 +255,7 @@ class ElasticScalingPolicy(ScalingPolicy):
     # ---------------------------------------------------
 
     def _get_reserved_resources(self) -> Optional[List[ResourceDict]]:
-        """Get allocated resources from AutoscalingCoordinator.
+        """Get reserved resources from AutoscalingCoordinator.
         Return None if there is an error."""
         now = time_monotonic()
         time_since_last_call = now - self._latest_reserved_resources_query_time
@@ -273,7 +273,7 @@ class ElasticScalingPolicy(ScalingPolicy):
             )
         except Exception:
             msg = (
-                f"Failed to get allocated resources for {self._requester_id}."
+                f"Failed to get reserved resources for {self._requester_id}."
                 " Will not resize the worker group."
                 " If this only happens transiently during network partition or"
                 " CPU being overloaded, it's safe to ignore this error."

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class ElasticScalingPolicy(ScalingPolicy):
 
     # Minimum interval in seconds between querying the AutoscalingCoordinator for allocated resources.
-    GET_ALLOCATED_RESOURCES_INTERVAL_S = 1
+    GET_RESERVED_RESOURCES_INTERVAL_S = 1
     # Minimum interval in seconds between logging warnings about insufficient workers.
     INSUFFICIENT_WORKERS_WARNING_INTERVAL_S = 30
 
@@ -36,13 +36,13 @@ class ElasticScalingPolicy(ScalingPolicy):
 
         self._latest_monitor_time = float("-inf")
         self._latest_insufficient_workers_warning_time = float("-inf")
-        self._latest_allocated_resources_query_time = float("-inf")
-        self._latest_allocated_resources: Optional[List[ResourceDict]] = None
+        self._latest_reserved_resources_query_time = float("-inf")
+        self._latest_reserved_resources: Optional[List[ResourceDict]] = None
 
     def _get_num_workers_for_resource_request(self) -> int:
         return self.scaling_config.max_workers
 
-    def _count_possible_workers(self, allocated_resources: List[ResourceDict]) -> int:
+    def _count_possible_workers(self, reserved_resources: List[ResourceDict]) -> int:
         """Count the number of workers that can be started/restarted with the given
         the list of node resources. The returned number is capped at the maximum
         number of workers.
@@ -52,7 +52,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         TPU slices (see ``_get_strict_tpu_worker_count``).
 
         Args:
-            allocated_resources: Per-node reserved resources from the AutoscalingCoordinator.
+            reserved_resources: Per-node reserved resources from the AutoscalingCoordinator.
 
         Returns:
             The number of workers that can be started/restarted with the current resources.
@@ -65,7 +65,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         if sum(single_worker_resources.values()) == 0:
             return self.scaling_config.max_workers
 
-        for resources in allocated_resources:
+        for resources in reserved_resources:
             num_workers = min(
                 [
                     resources.get(resource, 0.0) // single_worker_resources[resource]
@@ -161,11 +161,11 @@ class ElasticScalingPolicy(ScalingPolicy):
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         self._maybe_send_resource_request()
 
-        allocated_resources = self._get_allocated_resources()
-        if allocated_resources is None:
+        reserved_resources = self._get_reserved_resources()
+        if reserved_resources is None:
             return NoopDecision()
 
-        num_workers = self._count_possible_workers(allocated_resources)
+        num_workers = self._count_possible_workers(reserved_resources)
 
         if num_workers < self.scaling_config.min_workers:
             now = time_monotonic()
@@ -222,11 +222,11 @@ class ElasticScalingPolicy(ScalingPolicy):
 
         self._latest_monitor_time = now
 
-        allocated_resources = self._get_allocated_resources()
-        if allocated_resources is None:
+        reserved_resources = self._get_reserved_resources()
+        if reserved_resources is None:
             return NoopDecision()
 
-        num_workers = self._count_possible_workers(allocated_resources)
+        num_workers = self._count_possible_workers(reserved_resources)
 
         if num_workers == worker_group_state.num_workers:
             logger.info(
@@ -254,19 +254,19 @@ class ElasticScalingPolicy(ScalingPolicy):
     # Methods for interacting with AutoscalingCoordinator
     # ---------------------------------------------------
 
-    def _get_allocated_resources(self) -> Optional[List[ResourceDict]]:
+    def _get_reserved_resources(self) -> Optional[List[ResourceDict]]:
         """Get allocated resources from AutoscalingCoordinator.
         Return None if there is an error."""
         now = time_monotonic()
-        time_since_last_call = now - self._latest_allocated_resources_query_time
+        time_since_last_call = now - self._latest_reserved_resources_query_time
 
-        if time_since_last_call < self.GET_ALLOCATED_RESOURCES_INTERVAL_S:
-            return self._latest_allocated_resources
+        if time_since_last_call < self.GET_RESERVED_RESOURCES_INTERVAL_S:
+            return self._latest_reserved_resources
 
-        allocated_resources = None
+        reserved_resources = None
         try:
-            allocated_resources = ray.get(
-                self._autoscaling_coordinator.get_allocated_resources.remote(
+            reserved_resources = ray.get(
+                self._autoscaling_coordinator.get_reserved_resources.remote(
                     self._requester_id
                 ),
                 timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
@@ -281,7 +281,7 @@ class ElasticScalingPolicy(ScalingPolicy):
             )
             logger.warning(msg, exc_info=True)
         finally:
-            self._latest_allocated_resources_query_time = time_monotonic()
-            self._latest_allocated_resources = allocated_resources
+            self._latest_reserved_resources_query_time = time_monotonic()
+            self._latest_reserved_resources = reserved_resources
 
-        return self._latest_allocated_resources
+        return self._latest_reserved_resources

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -30,9 +30,9 @@ from ray.train.v2.api.config import ScalingConfig
 @pytest.fixture(autouse=True)
 def mock_autoscaling_coordinator(monkeypatch):
     mock_coordinator = MagicMock()
-    mock_coordinator._allocated_resources = None
-    mock_coordinator.get_allocated_resources.remote = MagicMock(
-        side_effect=lambda _: mock_coordinator._allocated_resources
+    mock_coordinator._reserved_resources = None
+    mock_coordinator.get_reserved_resources.remote = MagicMock(
+        side_effect=lambda _: mock_coordinator._reserved_resources
     )
 
     monkeypatch.setattr(
@@ -58,7 +58,7 @@ def _make_reserved(resources_per_worker: dict, num_nodes: int) -> list:
     """Build a list of reserved resource bundles with ``num_nodes`` entries.
 
     Mirrors the ``List[ResourceDict]`` returned by
-    ``AutoscalingCoordinator.get_allocated_resources``.
+    ``AutoscalingCoordinator.get_reserved_resources``.
     """
     return [dict(resources_per_worker) for _ in range(num_nodes)]
 
@@ -82,7 +82,7 @@ def _get_mock_worker_group_state(
     )
 
 
-@patch.object(ElasticScalingPolicy, "GET_ALLOCATED_RESOURCES_INTERVAL_S", 0.0)
+@patch.object(ElasticScalingPolicy, "GET_RESERVED_RESOURCES_INTERVAL_S", 0.0)
 def test_non_running_worker_group_decision():
     """Test decisions being made when the worker group is initializing/restarting.
     Ensures that the policy will resize the worker group as soon as resources are available.
@@ -104,14 +104,14 @@ def test_non_running_worker_group_decision():
     assert isinstance(decision, NoopDecision)
 
     # Resources for < min workers are available
-    mock_coordinator._allocated_resources = _make_reserved(
+    mock_coordinator._reserved_resources = _make_reserved(
         resources_per_worker, min_workers - 1
     )
     decision = policy.make_decision_for_non_running_worker_group()
     assert isinstance(decision, NoopDecision)
 
     # Resources for >= min workers are available
-    mock_coordinator._allocated_resources = _make_reserved(
+    mock_coordinator._reserved_resources = _make_reserved(
         resources_per_worker, min_workers
     )
     decision = policy.make_decision_for_non_running_worker_group()
@@ -119,7 +119,7 @@ def test_non_running_worker_group_decision():
     assert decision.num_workers == min_workers
 
     # Resources for >= max workers are available
-    mock_coordinator._allocated_resources = _make_reserved(
+    mock_coordinator._reserved_resources = _make_reserved(
         resources_per_worker, max_workers
     )
     decision = policy.make_decision_for_non_running_worker_group()
@@ -146,12 +146,12 @@ def test_before_controller_abort():
     )
 
 
-def test_get_allocated_resources_interval():
+def test_get_reserved_resources_interval():
     """Tests that remote calls to the AutoscalingCoordinator are spaced out by a minimum time interval."""
     min_workers, max_workers = 4, 64
     resources_per_worker = {"CPU": 8, "GPU": 1}
-    get_allocated_resources_interval_s = (
-        ElasticScalingPolicy.GET_ALLOCATED_RESOURCES_INTERVAL_S
+    get_reserved_resources_interval_s = (
+        ElasticScalingPolicy.GET_RESERVED_RESOURCES_INTERVAL_S
     )
 
     scaling_config = ScalingConfig(
@@ -165,54 +165,54 @@ def test_get_allocated_resources_interval():
 
     with freeze_time() as frozen_time:
         # No resources are available at the start
-        allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources is None
+        reserved_resources = policy._get_reserved_resources()
+        assert reserved_resources is None
 
         # Resources for < min workers are available
-        frozen_time.tick(get_allocated_resources_interval_s)
-        mock_coordinator._allocated_resources = _make_reserved(
+        frozen_time.tick(get_reserved_resources_interval_s)
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, min_workers - 1
         )
-        allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == _make_reserved(
+        reserved_resources = policy._get_reserved_resources()
+        assert reserved_resources == _make_reserved(
             resources_per_worker, min_workers - 1
         )
 
-        # Resources for >= min workers are available, but get_allocated_resources interval
+        # Resources for >= min workers are available, but get_reserved_resources interval
         # has not yet passed.
-        mock_coordinator._allocated_resources = _make_reserved(
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, min_workers
         )
-        allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == _make_reserved(
+        reserved_resources = policy._get_reserved_resources()
+        assert reserved_resources == _make_reserved(
             resources_per_worker, min_workers - 1
         )
 
-        # Resources for >= min workers are available and the get_allocated_resources
+        # Resources for >= min workers are available and the get_reserved_resources
         # interval has passed.
-        frozen_time.tick(get_allocated_resources_interval_s)
-        mock_coordinator._allocated_resources = _make_reserved(
+        frozen_time.tick(get_reserved_resources_interval_s)
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, min_workers
         )
-        allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == _make_reserved(resources_per_worker, min_workers)
+        reserved_resources = policy._get_reserved_resources()
+        assert reserved_resources == _make_reserved(resources_per_worker, min_workers)
 
-        # Resources for >= max workers are available but the get_allocated_resources
+        # Resources for >= max workers are available but the get_reserved_resources
         # interval has not yet passed.
-        mock_coordinator._allocated_resources = _make_reserved(
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, max_workers
         )
-        allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == _make_reserved(resources_per_worker, min_workers)
+        reserved_resources = policy._get_reserved_resources()
+        assert reserved_resources == _make_reserved(resources_per_worker, min_workers)
 
-        # Resources for >= max workers are available and the get_allocated_resources
+        # Resources for >= max workers are available and the get_reserved_resources
         # interval has passed.
-        frozen_time.tick(get_allocated_resources_interval_s)
-        allocated_resources = policy._get_allocated_resources()
-        assert allocated_resources == _make_reserved(resources_per_worker, max_workers)
+        frozen_time.tick(get_reserved_resources_interval_s)
+        reserved_resources = policy._get_reserved_resources()
+        assert reserved_resources == _make_reserved(resources_per_worker, max_workers)
 
 
-@patch.object(ElasticScalingPolicy, "GET_ALLOCATED_RESOURCES_INTERVAL_S", 0.0)
+@patch.object(ElasticScalingPolicy, "GET_RESERVED_RESOURCES_INTERVAL_S", 0.0)
 def test_running_worker_group_decision():
     """Test decisions being made when the worker group is running.
     Ensures that the policy will resize the worker group when there is a change
@@ -237,7 +237,7 @@ def test_running_worker_group_decision():
     worker_group_status = _get_mock_worker_group_status(min_workers)
 
     # No change in resources
-    mock_coordinator._allocated_resources = _make_reserved(
+    mock_coordinator._reserved_resources = _make_reserved(
         resources_per_worker, min_workers
     )
     decision = policy.make_decision_for_running_worker_group(
@@ -247,7 +247,7 @@ def test_running_worker_group_decision():
     assert isinstance(decision, NoopDecision)
 
     # Resources for < min workers are available
-    mock_coordinator._allocated_resources = _make_reserved(
+    mock_coordinator._reserved_resources = _make_reserved(
         resources_per_worker, min_workers - 1
     )
     decision = policy.make_decision_for_running_worker_group(
@@ -257,7 +257,7 @@ def test_running_worker_group_decision():
     assert isinstance(decision, NoopDecision)
 
     # More resources are available.
-    mock_coordinator._allocated_resources = _make_reserved(
+    mock_coordinator._reserved_resources = _make_reserved(
         resources_per_worker, max_workers
     )
     decision = policy.make_decision_for_running_worker_group(
@@ -296,7 +296,7 @@ def test_monitor_recently_started_worker_group():
 
         # Even though there are new resources available, we should not resize yet
         # because the monitor interval has not passed since
-        mock_coordinator._allocated_resources = _make_reserved(
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, max_workers - 1
         )
 
@@ -340,7 +340,7 @@ def test_monitor_long_running_worker_group():
     with freeze_time() as frozen_time:
         worker_group_state = _get_mock_worker_group_state(min_workers, time_monotonic())
         worker_group_status = _get_mock_worker_group_status(min_workers)
-        mock_coordinator._allocated_resources = _make_reserved(
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, min_workers
         )
 
@@ -356,7 +356,7 @@ def test_monitor_long_running_worker_group():
 
         # We recently considered resizing, so we should wait until the next interval
         # to consider again --> no-op even if new resources are available
-        mock_coordinator._allocated_resources = _make_reserved(
+        mock_coordinator._reserved_resources = _make_reserved(
             resources_per_worker, max_workers
         )
         frozen_time.tick(monitor_interval_s / 2)
@@ -515,9 +515,9 @@ def test_count_possible_workers_tpu_slice_rounding(
     policy = ElasticScalingPolicy(scaling_config)
 
     tpu_node = {"TPU": 4, "CPU": 1, "accelerator_type:TPU-V6E": 1}
-    allocated_resources = _make_reserved(tpu_node, num_autoscaler_nodes)
+    reserved_resources = _make_reserved(tpu_node, num_autoscaler_nodes)
 
-    assert policy._count_possible_workers(allocated_resources) == expected_workers
+    assert policy._count_possible_workers(reserved_resources) == expected_workers
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
The motivation is that "allocation" can be ambiguous. It could refer to dividing resources into different shares (which is what `get_allocated_resources` actually does), it could be allocating memory on a node (which is what it doesn't), or it could mean returning the resources that are in use (which is not necessarily true, the resources may or may not be in use)

In practice, when there are multiple requesters, the return value of `get_allocated_resources` really means that a) the autoscaling coordinator is giving the requester a _partition_ of the _available (in use or not in use)_  resources and b) the requester has exclusive rights to those resources. We use it as a way to "reserve" resources for that requester, since we are competing w/ other requesters. So I think a better term would be `get_reserved_resources` to capture both a) and b)
## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
