### PR TITLE
[serve] ResponseChannel: stream a deployment's response straight to HAProxy (POC)

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -273,9 +273,15 @@ def build_openai_app(builder_config: dict) -> Application:
     logger.info("============== Ingress Options ==============")
     logger.info(pprint.pformat(ingress_options))
 
-    return serve.deployment(ingress_cls, **ingress_options).bind(
+    app = serve.deployment(ingress_cls, **ingress_options).bind(
         llm_deployments=llm_deployments,
         model_cards=model_cards,
         lora_paths=lora_paths,
         **ingress_cls_config.ingress_extra_kwargs,
     )
+    # Opt the app into the ResponseChannel (leaf streams its response straight to
+    # HAProxy, off the ingress's response path). A general Serve marker; the LLM
+    # builder just sets it from the config.
+    if any(c.experimental_configs.get("response_channel") for c in llm_configs):
+        app = app._with_response_channel()
+    return app

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -64,6 +64,10 @@ from ray.llm._internal.serve.core.ingress.utils import (
     _sanitize_chat_completion_request,
 )
 from ray.llm._internal.serve.core.protocol import DeploymentProtocol, RawRequestInfo
+from ray.llm._internal.serve.core.server.response_channel import (
+    RESPONSE_ID_HEADER,
+    haproxy_base_for_leaf,
+)
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.observability.metrics.fast_api_metrics import (
     add_http_metrics_middleware,
@@ -275,6 +279,8 @@ class OpenAiIngress(DeploymentProtocol):
         self._get_lora_model_metadata_func = (
             _get_lora_model_metadata_func or self._default_get_lora_model_metadata_func
         )
+        # In-flight ResponseChannel drives, kept referenced so they are not GC'd.
+        self._response_channel_tasks: set = set()
 
     async def _default_get_lora_model_metadata_func(
         self, model_id: str, base_path: str
@@ -403,6 +409,29 @@ class OpenAiIngress(DeploymentProtocol):
         ):
             yield response
 
+    async def _kickoff_response_channel(
+        self, body, response_id: str, raw_request: Request
+    ) -> Response:
+        """ResponseChannel drive: do the request-side work, kick off the leaf to
+        stream its response straight to HAProxy (keyed by ``response_id``), and
+        return an empty 202. The ingress is off the response path; the response
+        bytes never traverse it. See ``core.server.response_channel``.
+        """
+        model_id = await self._get_model_id(body.model)
+        model_handle = self._get_configured_serve_handle(model_id)
+        if raw_request is not None:
+            session_id = session_id_from_headers(raw_request.headers)
+            if session_id:
+                model_handle = model_handle.options(session_id=session_id)
+        task = asyncio.ensure_future(
+            model_handle.produce_to_channel.remote(
+                body, response_id, haproxy_base_for_leaf()
+            )
+        )
+        self._response_channel_tasks.add(task)
+        task.add_done_callback(self._response_channel_tasks.discard)
+        return Response(status_code=202)
+
     async def model(self, model_id: str) -> Optional[ModelCard]:
         if model_id in self._model_cards:
             return self._model_cards[model_id]
@@ -475,6 +504,16 @@ class OpenAiIngress(DeploymentProtocol):
         call_method: str,
         raw_request: Optional[Request] = None,
     ) -> Response:
+
+        # HAProxy mints x-response-id only for apps that opted into the
+        # ResponseChannel (and strips any client-forged value), so its presence is
+        # the signal to stream the response back through the channel.
+        if raw_request is not None:
+            response_id = raw_request.headers.get(RESPONSE_ID_HEADER)
+            if response_id:
+                return await self._kickoff_response_channel(
+                    body, response_id, raw_request
+                )
 
         async with router_request_timeout(DEFAULT_LLM_ROUTER_HTTP_TIMEOUT):
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Type,
     Union,
 )
@@ -376,28 +377,22 @@ class OpenAiIngress(DeploymentProtocol):
         None,
     ]:
         """Calls the model deployment and returns the stream."""
-        model_handle = await self._resolve_model_handle(body.model, raw_request)
-
-        # TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix
-        # for tool calling ValidatorIterator serialization issue.
-        if isinstance(body, ChatCompletionRequest):
-            body = _sanitize_chat_completion_request(body)
-
-        # Convert Starlette request to serializable RawRequestInfo
-        raw_request_info: Optional[RawRequestInfo] = None
-        if raw_request is not None:
-            raw_request_info = RawRequestInfo.from_starlette_request(raw_request)
-
+        model_handle, body, raw_request_info = await self._prepare_request(
+            body, raw_request
+        )
         async for response in getattr(model_handle, call_method).remote(
             body, raw_request_info
         ):
             yield response
 
-    async def _resolve_model_handle(
-        self, model: str, raw_request: Optional[Request]
-    ) -> DeploymentHandle:
-        """Resolve the configured LLMServer handle for ``model``, carrying session
-        affinity from the client request.
+    async def _prepare_request(
+        self, body, raw_request: Optional[Request]
+    ) -> Tuple[DeploymentHandle, Any, Optional[RawRequestInfo]]:
+        """Resolve the model handle and serializable request info for ``body``.
+
+        Shared by the normal drive (``_get_response``) and the response-channel
+        drive so both apply the same session affinity, chat sanitization, and
+        request-info conversion.
 
         Propagate the session id from the client request to the downstream
         LLMServer handle. The Serve HTTP proxy attaches session_id to the
@@ -410,27 +405,43 @@ class OpenAiIngress(DeploymentProtocol):
         rewrite by an intermediate proxy doesn't silently drop session affinity on
         this second hop.
         """
-        model_id = await self._get_model_id(model)
+        model_id = await self._get_model_id(body.model)
         model_handle = self._get_configured_serve_handle(model_id)
         if raw_request is not None:
             session_id = session_id_from_headers(raw_request.headers)
             if session_id:
                 model_handle = model_handle.options(session_id=session_id)
-        return model_handle
+
+        # TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix
+        # for tool calling ValidatorIterator serialization issue.
+        if isinstance(body, ChatCompletionRequest):
+            body = _sanitize_chat_completion_request(body)
+
+        raw_request_info: Optional[RawRequestInfo] = None
+        if raw_request is not None:
+            raw_request_info = RawRequestInfo.from_starlette_request(raw_request)
+        return model_handle, body, raw_request_info
 
     async def _kickoff_response_channel(
-        self, body, response_id: str, raw_request: Request
+        self, body, response_id: str, call_method: str, raw_request: Request
     ) -> Response:
         """ResponseChannel drive: do the request-side work, kick off the leaf to
         stream its response straight to HAProxy (keyed by ``response_id``), and
         return an empty 202. The ingress is off the response path; the response
-        bytes never traverse it. See ``core.server.response_channel``.
+        bytes never traverse it. ``call_method`` selects the streaming engine
+        method (chat/completions/transcriptions). See
+        ``core.server.response_channel``.
         """
-        model_handle = await self._resolve_model_handle(body.model, raw_request)
-        raw_request_info = RawRequestInfo.from_starlette_request(raw_request)
+        model_handle, body, raw_request_info = await self._prepare_request(
+            body, raw_request
+        )
         task = asyncio.ensure_future(
             model_handle.produce_to_channel.remote(
-                body, response_id, haproxy_base_for_leaf(), raw_request_info
+                body,
+                response_id,
+                haproxy_base_for_leaf(),
+                call_method,
+                raw_request_info,
             )
         )
         self._response_channel_tasks.add(task)
@@ -517,7 +528,7 @@ class OpenAiIngress(DeploymentProtocol):
             response_id = raw_request.headers.get(RESPONSE_ID_HEADER)
             if response_id:
                 return await self._kickoff_response_channel(
-                    body, response_id, raw_request
+                    body, response_id, call_method, raw_request
                 )
 
         async with router_request_timeout(DEFAULT_LLM_ROUTER_HTTP_TIMEOUT):

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -281,8 +281,6 @@ class OpenAiIngress(DeploymentProtocol):
         self._get_lora_model_metadata_func = (
             _get_lora_model_metadata_func or self._default_get_lora_model_metadata_func
         )
-        # In-flight ResponseChannel drives, kept referenced so they are not GC'd.
-        self._response_channel_tasks: set = set()
 
     async def _default_get_lora_model_metadata_func(
         self, model_id: str, base_path: str
@@ -426,11 +424,14 @@ class OpenAiIngress(DeploymentProtocol):
     async def _kickoff_response_channel(
         self, body, response_id: str, call_method: str, raw_request: Request
     ) -> Response:
-        """ResponseChannel drive: do the request-side work, kick off the leaf to
-        stream its response straight to HAProxy (keyed by ``response_id``), and
-        return an empty 202. The ingress is off the response path; the response
-        bytes never traverse it. ``call_method`` selects the streaming engine
-        method (chat/completions/transcriptions). See
+        """ResponseChannel drive: do the request-side work, then drive the leaf to
+        stream its response straight to HAProxy (keyed by ``response_id``). The
+        response bytes never traverse the ingress, but this call is awaited so the
+        request stays "ongoing" here for its whole lifetime: that keeps admission
+        I/O-bound rather than a burst of fast-returning kickoffs, and lets the
+        ingress autoscale on real load. HAProxy issues this kickoff as a background
+        task, so the client stream is served off this path. ``call_method`` selects
+        the streaming engine method (chat/completions/transcriptions). See
         ``core.server.response_channel``.
         """
         model_handle, body, raw_request_info = await self._prepare_request(
@@ -442,17 +443,9 @@ class OpenAiIngress(DeploymentProtocol):
             raw_request.headers.get(RESPONSE_CHANNEL_BASE_HEADER)
             or haproxy_base_for_leaf()
         )
-        task = asyncio.ensure_future(
-            model_handle.produce_to_channel.remote(
-                body,
-                response_id,
-                haproxy_base,
-                call_method,
-                raw_request_info,
-            )
+        await model_handle.produce_to_channel.remote(
+            body, response_id, haproxy_base, call_method, raw_request_info
         )
-        self._response_channel_tasks.add(task)
-        task.add_done_callback(self._response_channel_tasks.discard)
         return Response(status_code=202)
 
     async def model(self, model_id: str) -> Optional[ModelCard]:

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -376,23 +376,7 @@ class OpenAiIngress(DeploymentProtocol):
         None,
     ]:
         """Calls the model deployment and returns the stream."""
-        model_id = await self._get_model_id(body.model)
-        model_handle = self._get_configured_serve_handle(model_id)
-
-        # Propagate the session id from the client request to the downstream
-        # LLMServer handle. The Serve HTTP proxy attaches session_id to the
-        # *ingress* deployment handle (proxy.py:_setup_request_context), but
-        # that does NOT carry over to a second handle hop (here -> LLMServer).
-        # Re-read the configured session header from the raw request and apply
-        # it via .options(session_id=...) so session-aware request routers
-        # (e.g. ConsistentHashRouter) on the LLMServer deployment see it.
-        # Uses the same case-insensitive, separator-tolerant matcher as
-        # proxy.py so a `-`/`_` rewrite by an intermediate proxy doesn't
-        # silently drop session affinity on this second hop.
-        if raw_request is not None:
-            session_id = session_id_from_headers(raw_request.headers)
-            if session_id:
-                model_handle = model_handle.options(session_id=session_id)
+        model_handle = await self._resolve_model_handle(body.model, raw_request)
 
         # TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix
         # for tool calling ValidatorIterator serialization issue.
@@ -409,6 +393,31 @@ class OpenAiIngress(DeploymentProtocol):
         ):
             yield response
 
+    async def _resolve_model_handle(
+        self, model: str, raw_request: Optional[Request]
+    ) -> DeploymentHandle:
+        """Resolve the configured LLMServer handle for ``model``, carrying session
+        affinity from the client request.
+
+        Propagate the session id from the client request to the downstream
+        LLMServer handle. The Serve HTTP proxy attaches session_id to the
+        *ingress* deployment handle (proxy.py:_setup_request_context), but that
+        does NOT carry over to a second handle hop (here -> LLMServer). Re-read the
+        configured session header from the raw request and apply it via
+        .options(session_id=...) so session-aware request routers (e.g.
+        ConsistentHashRouter) on the LLMServer deployment see it. Uses the same
+        case-insensitive, separator-tolerant matcher as proxy.py so a ``-``/``_``
+        rewrite by an intermediate proxy doesn't silently drop session affinity on
+        this second hop.
+        """
+        model_id = await self._get_model_id(model)
+        model_handle = self._get_configured_serve_handle(model_id)
+        if raw_request is not None:
+            session_id = session_id_from_headers(raw_request.headers)
+            if session_id:
+                model_handle = model_handle.options(session_id=session_id)
+        return model_handle
+
     async def _kickoff_response_channel(
         self, body, response_id: str, raw_request: Request
     ) -> Response:
@@ -417,15 +426,11 @@ class OpenAiIngress(DeploymentProtocol):
         return an empty 202. The ingress is off the response path; the response
         bytes never traverse it. See ``core.server.response_channel``.
         """
-        model_id = await self._get_model_id(body.model)
-        model_handle = self._get_configured_serve_handle(model_id)
-        if raw_request is not None:
-            session_id = session_id_from_headers(raw_request.headers)
-            if session_id:
-                model_handle = model_handle.options(session_id=session_id)
+        model_handle = await self._resolve_model_handle(body.model, raw_request)
+        raw_request_info = RawRequestInfo.from_starlette_request(raw_request)
         task = asyncio.ensure_future(
             model_handle.produce_to_channel.remote(
-                body, response_id, haproxy_base_for_leaf()
+                body, response_id, haproxy_base_for_leaf(), raw_request_info
             )
         )
         self._response_channel_tasks.add(task)

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -66,6 +66,7 @@ from ray.llm._internal.serve.core.ingress.utils import (
 )
 from ray.llm._internal.serve.core.protocol import DeploymentProtocol, RawRequestInfo
 from ray.llm._internal.serve.core.server.response_channel import (
+    RESPONSE_CHANNEL_BASE_HEADER,
     RESPONSE_ID_HEADER,
     haproxy_base_for_leaf,
 )
@@ -435,11 +436,17 @@ class OpenAiIngress(DeploymentProtocol):
         model_handle, body, raw_request_info = await self._prepare_request(
             body, raw_request
         )
+        # HAProxy advertises the ingest base to post the response to: this node's
+        # HAProxy for single-node, the client-holding node's for multi-node.
+        haproxy_base = (
+            raw_request.headers.get(RESPONSE_CHANNEL_BASE_HEADER)
+            or haproxy_base_for_leaf()
+        )
         task = asyncio.ensure_future(
             model_handle.produce_to_channel.remote(
                 body,
                 response_id,
-                haproxy_base_for_leaf(),
+                haproxy_base,
                 call_method,
                 raw_request_info,
             )

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -13,6 +13,7 @@ from typing import (
     Union,
 )
 
+import httpx
 from fastapi import HTTPException
 
 import ray
@@ -47,6 +48,7 @@ from ray.llm._internal.serve.utils.lora_serve_utils import (
 from ray.llm._internal.serve.utils.server_utils import (
     get_serve_request_id,
 )
+from ray.serve._private.response_channel import ResponseChannel
 
 if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.openai_api_models import (
@@ -184,6 +186,8 @@ class LLMServer(LLMServerProtocol):
         self._llm_config = llm_config
         self._engine_cls = engine_cls or self._get_default_engine_class()
         self.engine: Optional[LLMEngine] = None
+        # Lazily built on first ResponseChannel drive; reused across requests.
+        self._response_channel_client: Optional[httpx.AsyncClient] = None
         self._init_multiplex_loader(model_downloader)
 
     @classmethod
@@ -426,6 +430,36 @@ class LLMServer(LLMServerProtocol):
             batch_output_stream=True,
             raw_request_info=raw_request_info,
         )
+
+    async def produce_to_channel(
+        self, body: "CompletionRequest", response_id: str, haproxy_base: str
+    ) -> None:
+        """Stream this completion straight to HAProxy's ResponseChannel.
+
+        Called by a request-side ingress (via a handle) instead of relaying the
+        stream back up the DAG: the leaf drives the engine and streams each chunk
+        to HAProxy keyed by ``response_id``, so the ingress is off the response
+        path. See ``core.server.response_channel``.
+        """
+        body.stream = True
+        if self._response_channel_client is None:
+            self._response_channel_client = httpx.AsyncClient(timeout=None)
+        # The queue + background sender decouples generation from the network POST:
+        # the engine generates into a bounded buffer while the sender drains it, so
+        # slow reads never back-pressure and stall the engine under load.
+        channel = ResponseChannel(
+            response_id, haproxy_base, self._response_channel_client
+        )
+        gen = await self._run_request(body, engine_method="completions")
+        try:
+            async for chunk in gen:
+                await channel.write(chunk)
+        finally:
+            try:
+                await gen.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+            await channel.close()
 
     async def embeddings(
         self,

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -37,6 +37,7 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
 )
 from ray.llm._internal.serve.core.engine.protocol import LLMEngine
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
+from ray.llm._internal.serve.core.server.response_channel import ResponseChannel
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     push_telemetry_report_for_all_models,
@@ -48,7 +49,6 @@ from ray.llm._internal.serve.utils.lora_serve_utils import (
 from ray.llm._internal.serve.utils.server_utils import (
     get_serve_request_id,
 )
-from ray.serve._private.response_channel import ResponseChannel
 
 if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.openai_api_models import (
@@ -432,7 +432,11 @@ class LLMServer(LLMServerProtocol):
         )
 
     async def produce_to_channel(
-        self, body: "CompletionRequest", response_id: str, haproxy_base: str
+        self,
+        body: "CompletionRequest",
+        response_id: str,
+        haproxy_base: str,
+        raw_request_info: Optional[RawRequestInfo] = None,
     ) -> None:
         """Stream this completion straight to HAProxy's ResponseChannel.
 
@@ -450,7 +454,9 @@ class LLMServer(LLMServerProtocol):
         channel = ResponseChannel(
             response_id, haproxy_base, self._response_channel_client
         )
-        gen = await self._run_request(body, engine_method="completions")
+        gen = await self._run_request(
+            body, engine_method="completions", raw_request_info=raw_request_info
+        )
         try:
             async for chunk in gen:
                 await channel.write(chunk)

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -433,17 +433,21 @@ class LLMServer(LLMServerProtocol):
 
     async def produce_to_channel(
         self,
-        body: "CompletionRequest",
+        body: Union[
+            "CompletionRequest", "ChatCompletionRequest", "TranscriptionRequest"
+        ],
         response_id: str,
         haproxy_base: str,
+        call_method: str = "completions",
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> None:
-        """Stream this completion straight to HAProxy's ResponseChannel.
+        """Stream this response straight to HAProxy's ResponseChannel.
 
         Called by a request-side ingress (via a handle) instead of relaying the
         stream back up the DAG: the leaf drives the engine and streams each chunk
         to HAProxy keyed by ``response_id``, so the ingress is off the response
-        path. See ``core.server.response_channel``.
+        path. ``call_method`` names the streaming engine method to drive
+        (chat/completions/transcriptions). See ``core.server.response_channel``.
         """
         body.stream = True
         if self._response_channel_client is None:
@@ -455,7 +459,7 @@ class LLMServer(LLMServerProtocol):
             response_id, haproxy_base, self._response_channel_client
         )
         gen = await self._run_request(
-            body, engine_method="completions", raw_request_info=raw_request_info
+            body, engine_method=call_method, raw_request_info=raw_request_info
         )
         try:
             async for chunk in gen:

--- a/python/ray/llm/_internal/serve/core/server/response_channel.py
+++ b/python/ray/llm/_internal/serve/core/server/response_channel.py
@@ -1,0 +1,14 @@
+"""Re-export of the Serve-core ResponseChannel.
+
+The ResponseChannel is a general Serve primitive (any deployment can stream its
+response back to HAProxy, off the parents' response path). It lives in Serve
+core; this module re-exports it for the LLM serving code.
+"""
+
+from ray.serve._private.response_channel import (  # noqa: F401
+    RESPONSE_ID_HEADER,
+    ResponseChannel,
+    _to_json_line,
+    haproxy_base_for_leaf,
+    response_channel,
+)

--- a/python/ray/llm/_internal/serve/core/server/response_channel.py
+++ b/python/ray/llm/_internal/serve/core/server/response_channel.py
@@ -10,5 +10,4 @@ from ray.serve._private.response_channel import (  # noqa: F401
     ResponseChannel,
     _to_json_line,
     haproxy_base_for_leaf,
-    response_channel,
 )

--- a/python/ray/llm/_internal/serve/core/server/response_channel.py
+++ b/python/ray/llm/_internal/serve/core/server/response_channel.py
@@ -6,6 +6,7 @@ core; this module re-exports it for the LLM serving code.
 """
 
 from ray.serve._private.response_channel import (  # noqa: F401
+    RESPONSE_CHANNEL_BASE_HEADER,
     RESPONSE_ID_HEADER,
     ResponseChannel,
     _to_json_line,

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_response_channel.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_response_channel.py
@@ -1,0 +1,73 @@
+import json
+import sys
+
+import pytest
+
+from ray.llm._internal.serve.core.server.response_channel import (
+    ResponseChannel,
+    _to_json_line,
+)
+
+
+class _Model:
+    def model_dump_json(self):
+        return '{"choices":[{"text":"m"}]}'
+
+
+class _CapturingClient:
+    """Consumes the streamed request body so we can assert what was sent."""
+
+    def __init__(self):
+        self.url = None
+        self.body = b""
+
+    async def post(self, url, content=None):
+        self.url = url
+        if hasattr(content, "__aiter__"):
+            async for chunk in content:
+                self.body += chunk
+
+
+def test_to_json_line_normalizes_inputs():
+    assert _to_json_line(_Model()) == '{"choices":[{"text":"m"}]}'
+    assert _to_json_line({"a": 1}) == '{"a": 1}'
+    # SSE framing on a raw string is stripped (HAProxy re-adds it).
+    assert _to_json_line('data: {"a": 1}\n\n') == '{"a": 1}'
+
+
+@pytest.mark.asyncio
+async def test_channel_streams_newline_delimited_json_in_one_post():
+    client = _CapturingClient()
+    channel = ResponseChannel("rid-1", "http://haproxy:9000", client)
+
+    await channel.write({"choices": [{"text": "a"}]})
+    await channel.write('data: {"choices":[{"text":"b"}]}\n\n')
+    await channel.write(_Model())
+    await channel.close()
+
+    assert client.url == "http://haproxy:9000/internal/response/rid-1"
+    lines = [ln for ln in client.body.decode().split("\n") if ln]
+    assert [json.loads(ln) for ln in lines] == [
+        {"choices": [{"text": "a"}]},
+        {"choices": [{"text": "b"}]},
+        {"choices": [{"text": "m"}]},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_channel_posts_to_the_threads_internal_port():
+    # HAProxy tags the id with the client's thread; the leaf posts back to that
+    # thread's internal ingest port (frontend + offset(200) + thread - 1) so the
+    # push and the client stream share one per-thread queue. Thread 3, port 8000
+    # -> 8202.
+    client = _CapturingClient()
+    channel = ResponseChannel("t3-1-2-3", "http://127.0.0.1:8000", client)
+
+    await channel.write({"a": 1})
+    await channel.close()
+
+    assert client.url == "http://127.0.0.1:8202/internal/response/t3-1-2-3"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -273,6 +273,7 @@ class ApplicationState:
         self._route_prefix: Optional[str] = None
         self._ingress_deployment_name: Optional[str] = None
         self._ingress_request_router_deployment_name: Optional[str] = None
+        self._response_channel: bool = False
 
         self._status: ApplicationStatus = ApplicationStatus.DEPLOYING
         self._deployment_timestamp = time.time()
@@ -346,6 +347,10 @@ class ApplicationState:
         return self._ingress_request_router_deployment_name
 
     @property
+    def response_channel(self) -> bool:
+        return self._response_channel
+
+    @property
     def api_type(self) -> APIType:
         return self._target_state.api_type
 
@@ -413,6 +418,7 @@ class ApplicationState:
 
         ingress_deployment_name = None
         ingress_request_router_deployment_name = None
+        response_channel = False
 
         if deployment_infos is not None:
             for name, info in deployment_infos.items():
@@ -420,6 +426,8 @@ class ApplicationState:
                     ingress_deployment_name = name
                 if info.ingress_request_router:
                     ingress_request_router_deployment_name = name
+                if info.response_channel:
+                    response_channel = True
 
         target_state = ApplicationTargetState(
             deployment_infos,
@@ -447,6 +455,7 @@ class ApplicationState:
         self._ingress_request_router_deployment_name = (
             ingress_request_router_deployment_name
         )
+        self._response_channel = response_channel
         self._target_state = target_state
 
     def _set_target_state_deleting(self):
@@ -1424,6 +1433,12 @@ class ApplicationStateManager:
             return None
 
         return self._application_states[name].ingress_request_router_deployment
+
+    def get_response_channel(self, name: str) -> bool:
+        if name not in self._application_states:
+            return False
+
+        return self._application_states[name].response_channel
 
     def get_app_source(self, name: str) -> APIType:
         return self._application_states[name].api_type

--- a/python/ray/serve/_private/build_app.py
+++ b/python/ray/serve/_private/build_app.py
@@ -78,6 +78,9 @@ class BuiltApplication:
     # Optional ingress request router deployment for ingress bypass mode.
     # When set, this deployment serves /internal/route for HAProxy Lua routing.
     ingress_request_router_deployment: Optional[Deployment] = None
+    # Whether the app opted into the ResponseChannel: the leaf streams its
+    # response straight to HAProxy, off the ingress response path.
+    response_channel: bool = False
 
     def validate_single_fastapi_ingress(self) -> None:
         """Validate that the application has at most one FastAPI ingress."""
@@ -211,6 +214,7 @@ def build_app(
         },
         external_scaler_enabled=external_scaler_enabled,
         ingress_request_router_deployment=ingress_request_router_deployment,
+        response_channel=app._response_channel,
     )
 
 

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -359,6 +359,7 @@ class ServeControllerClient:
                     deployment.name,
                     ingress=is_ingress,
                     ingress_request_router=is_ingress_request_router,
+                    response_channel=app.response_channel and is_ingress,
                     replica_config=deployment._replica_config,
                     deployment_config=deployment._deployment_config,
                     version=deployment._version or get_random_string(),
@@ -386,6 +387,9 @@ class ServeControllerClient:
                 deployment_args_proto.ingress = deployment_args["ingress"]
                 deployment_args_proto.ingress_request_router = deployment_args[
                     "ingress_request_router"
+                ]
+                deployment_args_proto.response_channel = deployment_args[
+                    "response_channel"
                 ]
                 deployment_args_proto.uses_multiplexing = deployment_args[
                     "uses_multiplexing"

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -714,6 +714,13 @@ RAY_SERVE_ENABLE_DIRECT_INGRESS = (
 # Feature flag to use HAProxy.
 RAY_SERVE_ENABLE_HA_PROXY = os.environ.get("RAY_SERVE_ENABLE_HA_PROXY", "0") == "1"
 
+# The ResponseChannel binds one internal ingest port per HAProxy thread, at this
+# offset above the frontend port, each pinned to its thread. A leaf posts its
+# response to the port for its request's thread so the push and the client stream
+# stay on one thread (per-thread queue, no shared Lua lock). Both HAProxy config
+# generation and the leaf derive the port from ``response_channel.internal_port``.
+RAY_SERVE_RESPONSE_CHANNEL_INTERNAL_PORT_OFFSET = 200
+
 # Ingress request router replicas pinned to each proxy node.
 RAY_SERVE_INGRESS_ROUTER_REPLICAS_PER_NODE = get_env_int_positive(
     "RAY_SERVE_INGRESS_ROUTER_REPLICAS_PER_NODE", 1

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -721,6 +721,17 @@ RAY_SERVE_ENABLE_HA_PROXY = os.environ.get("RAY_SERVE_ENABLE_HA_PROXY", "0") == 
 # generation and the leaf derive the port from ``response_channel.internal_port``.
 RAY_SERVE_RESPONSE_CHANNEL_INTERNAL_PORT_OFFSET = 200
 
+# Multi-node ResponseChannel delivery. When off (default), HAProxy advertises a
+# loopback ingest base and binds the internal ingest ports on loopback, so a leaf
+# reaches HAProxy only when co-located (single node). When on, HAProxy advertises
+# this node's routable IP and binds the internal ingest ports on it, so a leaf on
+# another node can post responses to the HAProxy holding the client connection.
+# The routable ingest port is reachable cluster-wide, so it needs a network policy
+# restricting it to cluster nodes.
+RAY_SERVE_RESPONSE_CHANNEL_MULTINODE = (
+    os.environ.get("RAY_SERVE_RESPONSE_CHANNEL_MULTINODE", "0") == "1"
+)
+
 # Ingress request router replicas pinned to each proxy node.
 RAY_SERVE_INGRESS_ROUTER_REPLICAS_PER_NODE = get_env_int_positive(
     "RAY_SERVE_INGRESS_ROUTER_REPLICAS_PER_NODE", 1

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -1142,6 +1142,7 @@ class ServeController:
                         "deployer_job_id": args.deployer_job_id,
                         "ingress": args.ingress,
                         "ingress_request_router": args.ingress_request_router,
+                        "response_channel": args.response_channel,
                         "uses_multiplexing": args.uses_multiplexing,
                         "route_prefix": (
                             args.route_prefix if args.HasField("route_prefix") else None
@@ -1596,6 +1597,7 @@ class ServeController:
         ingress_deployment_name = (
             self.application_state_manager.get_ingress_deployment_name(app_name) or ""
         )
+        response_channel = self.application_state_manager.get_response_channel(app_name)
 
         # Get running replicas for the ingress deployment
         replica_details = self._get_running_replica_details_for_ingress_deployment(
@@ -1630,6 +1632,7 @@ class ServeController:
                     app_name=app_name,
                     ingress_request_router_targets=ingress_request_router_targets,
                     ingress_deployment_name=ingress_deployment_name,
+                    response_channel=response_channel,
                 )
             )
 

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -26,6 +26,7 @@ def get_deploy_args(
     replica_config: ReplicaConfig,
     ingress: bool = False,
     ingress_request_router: bool = False,
+    response_channel: bool = False,
     deployment_config: Optional[Union[DeploymentConfig, Dict[str, Any]]] = None,
     version: Optional[str] = None,
     route_prefix: Optional[str] = None,
@@ -56,6 +57,7 @@ def get_deploy_args(
         "deployer_job_id": ray.get_runtime_context().get_job_id(),
         "ingress": ingress,
         "ingress_request_router": ingress_request_router,
+        "response_channel": response_channel,
         "serialized_autoscaling_policy_def": serialized_autoscaling_policy_def,
         "serialized_request_router_cls": serialized_request_router_cls,
         "serialized_deployment_actors": serialized_deployment_actors,
@@ -73,6 +75,7 @@ def deploy_args_to_deployment_info(
     app_name: Optional[str] = None,
     ingress: bool = False,
     ingress_request_router: bool = False,
+    response_channel: bool = False,
     route_prefix: Optional[str] = None,
     uses_multiplexing: bool = False,
     **kwargs,
@@ -163,6 +166,7 @@ def deploy_args_to_deployment_info(
         route_prefix=route_prefix,
         ingress=ingress,
         ingress_request_router=ingress_request_router,
+        response_channel=response_channel,
     )
 
 

--- a/python/ray/serve/_private/deployment_info.py
+++ b/python/ray/serve/_private/deployment_info.py
@@ -22,6 +22,7 @@ class DeploymentInfo:
         route_prefix: Optional[str] = None,
         ingress: bool = False,
         ingress_request_router: bool = False,
+        response_channel: bool = False,
         target_capacity: Optional[float] = None,
         target_capacity_direction: Optional[TargetCapacityDirection] = None,
     ):
@@ -41,6 +42,7 @@ class DeploymentInfo:
         self.route_prefix = route_prefix
         self.ingress = ingress
         self.ingress_request_router = ingress_request_router
+        self.response_channel = response_channel
 
         self.target_capacity = target_capacity
         self.target_capacity_direction = target_capacity_direction
@@ -72,6 +74,7 @@ class DeploymentInfo:
             route_prefix=route_prefix or self.route_prefix,
             ingress=self.ingress,
             ingress_request_router=self.ingress_request_router,
+            response_channel=self.response_channel,
             target_capacity=self.target_capacity,
             target_capacity_direction=self.target_capacity_direction,
         )
@@ -147,6 +150,7 @@ class DeploymentInfo:
             "target_capacity": target_capacity,
             "target_capacity_direction": target_capacity_direction,
             "ingress_request_router": proto.ingress_request_router,
+            "response_channel": proto.response_channel,
         }
 
         return cls(**data)
@@ -171,6 +175,7 @@ class DeploymentInfo:
         else:
             data["target_capacity_direction"] = self.target_capacity_direction.name
         data["ingress_request_router"] = self.ingress_request_router
+        data["response_channel"] = self.response_channel
         return DeploymentInfoProto(**data)
 
     def to_dict(self):

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1410,10 +1410,14 @@ class HAProxyApi(ProxyApi):
                     # one for its request's thread. Derived from the same formula
                     # the leaf uses (internal_port in _private.response_channel),
                     # so the two cannot drift.
-                    "response_channel_internal_ports": [
-                        internal_port(self.cfg.frontend_port, t)
-                        for t in range(1, self.cfg.nbthread + 1)
-                    ],
+                    "response_channel_internal_ports": (
+                        [
+                            internal_port(self.cfg.frontend_port, t)
+                            for t in range(1, self.cfg.nbthread + 1)
+                        ]
+                        if has_response_channel
+                        else []
+                    ),
                     "ingress_request_router_timeout_s": (
                         RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S
                     ),

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -77,6 +77,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_HAPROXY_UPDATE_LATENCY_BUCKETS_S,
     RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY,
     RAY_SERVE_INGRESS_REQUEST_ROUTER_METRICS_ENABLED,
+    RAY_SERVE_RESPONSE_CHANNEL_MULTINODE,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
@@ -1282,14 +1283,30 @@ class HAProxyApi(ProxyApi):
             logger.debug(f"Wrote Lua routing script to {lua_path}")
         return lua_path
 
+    @property
+    def _response_channel_host(self) -> str:
+        """Host a leaf posts response chunks to (and the internal frontend binds).
+
+        Loopback keeps single-node delivery (leaf co-located with the HAProxy
+        holding the client). Multi-node advertises this node's routable IP so a
+        leaf on another node can reach this HAProxy.
+        """
+        if RAY_SERVE_RESPONSE_CHANNEL_MULTINODE:
+            return ray.util.get_node_ip_address()
+        return "127.0.0.1"
+
     def _write_response_channel_lua(self) -> str:
         """Write the ResponseChannel Lua and return its path.
 
-        The Lua re-injects the client request as a loopback kickoff, so it needs
-        the frontend port to reach HAProxy itself.
+        The Lua re-injects the client request as a loopback kickoff (needing the
+        frontend port to reach HAProxy) and advertises the ingest base a leaf
+        posts its response to.
         """
         content = _load_lua_template("response_channel.lua.tmpl").substitute(
-            FRONTEND_PORT=self.cfg.frontend_port
+            FRONTEND_PORT=self.cfg.frontend_port,
+            CHANNEL_ADVERTISE_BASE=(
+                f"http://{self._response_channel_host}:{self.cfg.frontend_port}"
+            ),
         )
         lua_path = os.path.join(
             os.path.dirname(self.config_file_path), "response_channel.lua"
@@ -1418,6 +1435,7 @@ class HAProxyApi(ProxyApi):
                         if has_response_channel
                         else []
                     ),
+                    "response_channel_bind_host": self._response_channel_host,
                     "ingress_request_router_timeout_s": (
                         RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S
                     ),

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -93,6 +93,7 @@ from ray.serve._private.proxy import (
     ProxyActorInterface,
     apply_per_node_port_overrides,
 )
+from ray.serve._private.response_channel import internal_port
 from ray.serve._private.utils import get_head_node_id, is_grpc_enabled
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.schema import (
@@ -126,8 +127,8 @@ def _haproxy_fmt_literal(value: Any) -> str:
     return '"' + s + '"'
 
 
-def _load_lua_template() -> string.Template:
-    path = Path(__file__).parent / "ingress_request_router.lua.tmpl"
+def _load_lua_template(name: str) -> string.Template:
+    path = Path(__file__).parent / name
     try:
         return string.Template(path.read_text())
     except FileNotFoundError as e:
@@ -517,6 +518,10 @@ class BackendConfig:
     # Ingress request router servers. When populated, HAProxy Lua calls
     # /internal/route on one of these to pick a data-plane replica.
     ingress_request_router_servers: List[ServerConfig] = field(default_factory=list)
+
+    # Whether this app opted into the ResponseChannel. When True, the frontend
+    # serves this backend's requests through the channel stream service.
+    response_channel: bool = False
 
     # The fallback server for this backend.
     fallback_server: Optional[ServerConfig] = None
@@ -1256,7 +1261,7 @@ class HAProxyApi(ProxyApi):
             metrics_post = ""
             metrics_set_truncated = ""
 
-        content = _load_lua_template().substitute(
+        content = _load_lua_template("ingress_request_router.lua.tmpl").substitute(
             TIMEOUT_S=RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S,
             FORWARD_BODY=str(RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY).lower(),
             # HAProxy's req_get_headers() returns lowercase header keys,
@@ -1275,6 +1280,22 @@ class HAProxyApi(ProxyApi):
         )
         if _write_if_changed(lua_path, content):
             logger.debug(f"Wrote Lua routing script to {lua_path}")
+        return lua_path
+
+    def _write_response_channel_lua(self) -> str:
+        """Write the ResponseChannel Lua and return its path.
+
+        The Lua re-injects the client request as a loopback kickoff, so it needs
+        the frontend port to reach HAProxy itself.
+        """
+        content = _load_lua_template("response_channel.lua.tmpl").substitute(
+            FRONTEND_PORT=self.cfg.frontend_port
+        )
+        lua_path = os.path.join(
+            os.path.dirname(self.config_file_path), "response_channel.lua"
+        )
+        if _write_if_changed(lua_path, content):
+            logger.debug(f"Wrote ResponseChannel Lua script to {lua_path}")
         return lua_path
 
     def _generate_config_file_internal(self) -> bool:
@@ -1306,6 +1327,11 @@ class HAProxyApi(ProxyApi):
                 http_backends
             )
             has_ingress_request_router = ingress_request_router_lua_path is not None
+
+            has_response_channel = any(b.response_channel for b in http_backends)
+            response_channel_lua_path = (
+                self._write_response_channel_lua() if has_response_channel else None
+            )
 
             # Enrich HTTP backends with precomputed health check configuration strings
             http_backends_with_health_config = [
@@ -1378,6 +1404,16 @@ class HAProxyApi(ProxyApi):
                     "route_info": health_route_info,
                     "has_ingress_request_router": has_ingress_request_router,
                     "ingress_request_router_lua_path": ingress_request_router_lua_path,
+                    "has_response_channel": has_response_channel,
+                    "response_channel_lua_path": response_channel_lua_path,
+                    # One internal ingest port per thread; the leaf posts to the
+                    # one for its request's thread. Derived from the same formula
+                    # the leaf uses (internal_port in _private.response_channel),
+                    # so the two cannot drift.
+                    "response_channel_internal_ports": [
+                        internal_port(self.cfg.frontend_port, t)
+                        for t in range(1, self.cfg.nbthread + 1)
+                    ],
                     "ingress_request_router_timeout_s": (
                         RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S
                     ),
@@ -2072,6 +2108,7 @@ class HAProxyManager(ProxyActorInterface):
             path_prefix=target_group.route_prefix,
             servers=servers,
             ingress_request_router_servers=ingress_request_router_servers,
+            response_channel=target_group.response_channel,
             app_name=target_group.app_name,
             ingress_deployment_name=target_group.ingress_deployment_name,
             fallback_server=fallback_server,

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -219,14 +219,16 @@ frontend http_frontend
     acl is_{{ backend.name or 'unknown' }} path {{ backend.path_prefix or '/' }}
 {%- endfor %}
     {%- if has_response_channel %}
-    # A client request to an opted-in app is served by response_channel_stream:
+    # A streaming request to an opted-in app is served by response_channel_stream:
     # it mints a response id, re-injects the request as a loopback kickoff (with
     # x-serve-response-channel, so it routes to the ingress instead of re-entering
-    # here), and drains the per-id queue to the client. Scoped per-backend, so
-    # plain apps behind the same HAProxy are untouched.
+    # here), and drains the per-id queue to the client. Scoped per-backend (plain
+    # apps behind the same HAProxy are untouched) and to the streaming POST
+    # endpoints (completions, chat completions, transcriptions), so non-streaming
+    # endpoints (models, embeddings, score, tokenize) flow the normal path.
 {%- for backend in backends %}
     {%- if backend.response_channel %}
-    http-request use-service lua.response_channel_stream if is_{{ backend.name or 'unknown' }} !{ hdr(x-serve-response-channel) -m found }
+    http-request use-service lua.response_channel_stream if is_{{ backend.name or 'unknown' }} METH_POST { path_end /completions /transcriptions } !{ hdr(x-serve-response-channel) -m found }
     {%- endif %}
 {%- endfor %}
     {%- endif %}

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -146,13 +146,14 @@ frontend prometheus
     http-request use-service prometheus-exporter if { path {{ config.metrics_uri }} }
     no log
 {%- if has_response_channel %}
-# ResponseChannel internal ingest. One loopback bind per thread, each pinned to
-# its thread, so a leaf posting to the port for thread N is handled on thread N.
-# The client's stream applet ran on that same thread and created the per-thread
-# queue there, so the push finds it with no cross-thread shared state.
+# ResponseChannel internal ingest. One bind per thread, each pinned to its
+# thread, so a leaf posting to the port for thread N is handled on thread N. The
+# client's stream applet ran on that same thread and created the per-thread queue
+# there, so the push finds it with no cross-thread shared state. The bind host is
+# loopback for single-node and this node's routable IP under multi-node.
 frontend response_channel_internal
 {%- for port in response_channel_internal_ports %}
-    bind 127.0.0.1:{{ port }} thread {{ loop.index }}
+    bind {{ response_channel_bind_host }}:{{ port }} thread {{ loop.index }}
 {%- endfor %}
     mode http
     option http-no-delay
@@ -211,6 +212,7 @@ frontend http_frontend
     # thread-pinned response_channel_internal frontend.
     http-request del-header x-serve-response-channel if !{ src 127.0.0.0/8 }
     http-request del-header x-response-id if !{ src 127.0.0.0/8 }
+    http-request del-header x-response-channel-base if !{ src 127.0.0.0/8 }
     {%- endif %}
     # Per-backend path ACLs (used for both ingress-request-router dispatch
     # and static use_backend selection below).

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -69,6 +69,13 @@ HAPROXY_CONFIG_TEMPLATE = """global
     {%- if has_ingress_request_router %}
     lua-load-per-thread {{ ingress_request_router_lua_path }}
     {%- endif %}
+    {%- if has_response_channel %}
+    # Per-thread: the push and stream for one request are pinned to the same thread
+    # (the response id carries the client's thread, and the leaf posts to that
+    # thread's internal port), so each thread owns an independent queue table with
+    # no shared lock. See the response_channel_internal frontend below.
+    lua-load-per-thread {{ response_channel_lua_path }}
+    {%- endif %}
     {%- if has_ingress_request_router and ingress_request_router_forward_body %}
     tune.bufsize {{ ingress_request_router_bufsize }}
     {%- else %}
@@ -138,6 +145,21 @@ frontend prometheus
     mode http
     http-request use-service prometheus-exporter if { path {{ config.metrics_uri }} }
     no log
+{%- if has_response_channel %}
+# ResponseChannel internal ingest. One loopback bind per thread, each pinned to
+# its thread, so a leaf posting to the port for thread N is handled on thread N.
+# The client's stream applet ran on that same thread and created the per-thread
+# queue there, so the push finds it with no cross-thread shared state.
+frontend response_channel_internal
+{%- for port in response_channel_internal_ports %}
+    bind 127.0.0.1:{{ port }} thread {{ loop.index }}
+{%- endfor %}
+    mode http
+    option http-no-delay
+    no log
+    http-request use-service lua.response_channel_push if { path_beg /internal/response/ }
+    http-request return status 404
+{%- endif %}
 frontend http_frontend
     bind {{ config.frontend_host }}:{{ config.frontend_port }}
     {%- if config.metrics_enabled %}
@@ -181,12 +203,33 @@ frontend http_frontend
     # Inject unique reload ID as header to track which HAProxy instance handled the request (testing only)
     http-request set-header x-haproxy-reload-id {{ config.reload_id }}
     {%- endif %}
+    {%- if has_response_channel %}
+    # ResponseChannel (response-path only, orthogonal to routing). Strip the
+    # channel headers from client requests; only the loopback kickoff HAProxy
+    # itself issues may carry them. The per-backend stream service below serves
+    # client requests to opted-in apps; the leaf's chunk stream lands on the
+    # thread-pinned response_channel_internal frontend.
+    http-request del-header x-serve-response-channel if !{ src 127.0.0.0/8 }
+    http-request del-header x-response-id if !{ src 127.0.0.0/8 }
+    {%- endif %}
     # Per-backend path ACLs (used for both ingress-request-router dispatch
     # and static use_backend selection below).
 {%- for backend in backends %}
     acl is_{{ backend.name or 'unknown' }} path_beg {{ '/' if not backend.path_prefix or backend.path_prefix == '/' else backend.path_prefix ~ '/' }}
     acl is_{{ backend.name or 'unknown' }} path {{ backend.path_prefix or '/' }}
 {%- endfor %}
+    {%- if has_response_channel %}
+    # A client request to an opted-in app is served by response_channel_stream:
+    # it mints a response id, re-injects the request as a loopback kickoff (with
+    # x-serve-response-channel, so it routes to the ingress instead of re-entering
+    # here), and drains the per-id queue to the client. Scoped per-backend, so
+    # plain apps behind the same HAProxy are untouched.
+{%- for backend in backends %}
+    {%- if backend.response_channel %}
+    http-request use-service lua.response_channel_stream if is_{{ backend.name or 'unknown' }} !{ hdr(x-serve-response-channel) -m found }
+    {%- endif %}
+{%- endfor %}
+    {%- endif %}
     {%- if config.metrics_enabled %}
     # Per-request HTTP metric vars (app / route / ingress deployment), set on the
     # first matching backend. Backends are sorted longest-prefix-first and the

--- a/python/ray/serve/_private/response_channel.lua.tmpl
+++ b/python/ray/serve/_private/response_channel.lua.tmpl
@@ -1,0 +1,106 @@
+-- ResponseChannel: leaf-to-HAProxy streaming that bypasses parent deployments
+-- on the response path. Orthogonal to request routing.
+--
+-- Two services correlated by a per-request response id via a shared queue:
+--   stream_completion : owns the client connection. Mints a response id, re-injects
+--                       the request as a loopback "kickoff" (same path, so normal
+--                       routing delivers it to the ingress) carrying the id, then
+--                       parks on the queue and streams chunks to the client.
+--   push_chunk        : /internal/response/{id}. The leaf POSTs its token stream
+--                       here; each line is enqueued, waking the client handler.
+--
+-- The kickoff request carries x-serve-response-channel:kickoff so it does NOT
+-- re-enter stream_completion (the frontend guards on the header's absence); it
+-- routes to the ingress backend by the ordinary use_backend rules. The ingress
+-- runs request-side work and kicks off the leaf; the leaf streams here. The
+-- ingress never sees the response bytes.
+
+local queues = {}
+local EOF = "\1EOF\1"
+local SEQ = 0
+local LOOPBACK = "http://127.0.0.1:${FRONTEND_PORT}"
+
+local function get_queue(id)
+  local q = queues[id]
+  if q == nil then
+    q = core.queue()
+    queues[id] = q
+  end
+  return q
+end
+
+-- Leaf -> HAProxy: read one streamed POST body line-by-line (newline-delimited,
+-- one chunk per line) and enqueue each as it arrives. getline yields while
+-- waiting, so chunks stream incrementally. End of body -> EOF.
+core.register_service("response_channel_push", "http", function(applet)
+  local id = string.match(applet.path, "/internal/response/([^/%?]+)")
+  if id == nil then
+    applet:set_status(400)
+    applet:add_header("content-length", "0")
+    applet:start_response()
+    return
+  end
+  local q = get_queue(id)
+  while true do
+    local line = applet:getline()
+    if line == nil or line == "" then
+      break
+    end
+    line = string.gsub(line, "[\r\n]+$$", "")
+    if #line > 0 then
+      q:push(line)
+    end
+  end
+  q:push(EOF)
+  applet:set_status(200)
+  applet:add_header("content-length", "0")
+  applet:start_response()
+end)
+
+-- Client <-> HAProxy: mint a response id, kick off generation via loopback, then
+-- stream chunks from the queue as Server-Sent Events.
+core.register_service("response_channel_stream", "http", function(applet)
+  local reqbody = applet:receive() or ""
+  SEQ = SEQ + 1
+  local now = core.now()
+  -- Encode this client's thread in the id. The leaf posts back to the internal
+  -- port pinned to this thread, so the push runs on the same thread and finds
+  -- this per-thread queue -- no shared state, no global lock.
+  local id = string.format("t%d-%d-%d-%d", core.thread, now.sec, now.usec, SEQ)
+  local q = get_queue(id)  -- create BEFORE kickoff so early leaf POSTs land here
+
+  local ctype = applet.headers["content-type"]
+  ctype = (ctype and ctype[0]) or "application/json"
+
+  -- Send the client its SSE headers now: nothing about them depends on the
+  -- kickoff's response, and the queue already exists, so flushing here overlaps
+  -- with the kickoff hop instead of waiting a round-trip behind it.
+  applet:set_status(200)
+  applet:add_header("content-type", "text/event-stream")
+  applet:add_header("cache-control", "no-cache")
+  applet:start_response()
+
+  -- Re-inject the request to the ingress via the ordinary routing path. The
+  -- kickoff header makes the frontend route it to the backend (not back here).
+  local hc = core.httpclient()
+  hc:post{
+    url = LOOPBACK .. applet.path,
+    headers = {
+      ["content-type"] = { ctype },
+      ["x-response-id"] = { id },
+      ["x-serve-response-channel"] = { "kickoff" },
+    },
+    body = reqbody,
+  }
+
+  while true do
+    local item = q:pop_wait()
+    if item == EOF then
+      applet:send("data: [DONE]\n\n")
+      break
+    else
+      applet:send("data: " .. item .. "\n\n")
+    end
+  end
+  queues[id] = nil
+end)

--- a/python/ray/serve/_private/response_channel.lua.tmpl
+++ b/python/ray/serve/_private/response_channel.lua.tmpl
@@ -83,19 +83,25 @@ core.register_service("response_channel_stream", "http", function(applet)
   applet:add_header("cache-control", "no-cache")
   applet:start_response()
 
-  -- Re-inject the request to the ingress via the ordinary routing path. The
+  -- Re-inject the request to the ingress via the ordinary routing path, in a
+  -- background task: the ingress holds this kickoff open for the whole response
+  -- (so its ongoing-request count reflects real load and autoscales), while this
+  -- applet drains the queue to the client below without waiting on it. The
   -- kickoff header makes the frontend route it to the backend (not back here).
-  local hc = core.httpclient()
-  hc:post{
-    url = LOOPBACK .. applet.path,
-    headers = {
-      ["content-type"] = { ctype },
-      ["x-response-id"] = { id },
-      ["x-response-channel-base"] = { ADVERTISE_BASE },
-      ["x-serve-response-channel"] = { "kickoff" },
-    },
-    body = reqbody,
-  }
+  local path = applet.path
+  core.register_task(function()
+    local hc = core.httpclient()
+    hc:post{
+      url = LOOPBACK .. path,
+      headers = {
+        ["content-type"] = { ctype },
+        ["x-response-id"] = { id },
+        ["x-response-channel-base"] = { ADVERTISE_BASE },
+        ["x-serve-response-channel"] = { "kickoff" },
+      },
+      body = reqbody,
+    }
+  end)
 
   while true do
     local item = q:pop_wait()

--- a/python/ray/serve/_private/response_channel.lua.tmpl
+++ b/python/ray/serve/_private/response_channel.lua.tmpl
@@ -19,6 +19,9 @@ local queues = {}
 local EOF = "\1EOF\1"
 local SEQ = 0
 local LOOPBACK = "http://127.0.0.1:${FRONTEND_PORT}"
+-- Ingest base a leaf posts its response to. Loopback for single-node; this
+-- node's routable IP under multi-node so a leaf elsewhere reaches this HAProxy.
+local ADVERTISE_BASE = "${CHANNEL_ADVERTISE_BASE}"
 
 local function get_queue(id)
   local q = queues[id]
@@ -88,6 +91,7 @@ core.register_service("response_channel_stream", "http", function(applet)
     headers = {
       ["content-type"] = { ctype },
       ["x-response-id"] = { id },
+      ["x-response-channel-base"] = { ADVERTISE_BASE },
       ["x-serve-response-channel"] = { "kickoff" },
     },
     body = reqbody,

--- a/python/ray/serve/_private/response_channel.py
+++ b/python/ray/serve/_private/response_channel.py
@@ -23,6 +23,10 @@ from ray.serve._private.constants import (
 )
 
 RESPONSE_ID_HEADER = "x-response-id"
+# The ingest base a leaf posts its response to, advertised by the HAProxy that
+# holds the client connection (loopback for single-node, its routable IP for
+# multi-node).
+RESPONSE_CHANNEL_BASE_HEADER = "x-response-channel-base"
 
 # HAProxy fronts the Serve HTTP port on the local node, so a co-located leaf
 # reaches it on loopback.

--- a/python/ray/serve/_private/response_channel.py
+++ b/python/ray/serve/_private/response_channel.py
@@ -7,22 +7,26 @@ per-request id HAProxy minted and forwarded as the ``x-response-id`` header.
 HAProxy drains the per-id queue to the waiting client, so parent deployments stay
 on the request path only; the response bytes never traverse them.
 
-General to any Serve deployment: ``response_channel(request)`` returns a channel
-when the incoming request carries the header, else ``None``.
+General to any Serve deployment: construct a ``ResponseChannel`` with the
+``x-response-id`` HAProxy forwards and stream chunks to it with ``write``.
 """
 
 import asyncio
 import json
 import re
-from typing import Optional
 
 import httpx
 
 from ray.serve._private.constants import (
+    DEFAULT_HTTP_PORT,
     RAY_SERVE_RESPONSE_CHANNEL_INTERNAL_PORT_OFFSET,
 )
 
 RESPONSE_ID_HEADER = "x-response-id"
+
+# HAProxy fronts the Serve HTTP port on the local node, so a co-located leaf
+# reaches it on loopback.
+_LEAF_HAPROXY_BASE = f"http://127.0.0.1:{DEFAULT_HTTP_PORT}"
 
 # The response id HAProxy mints is "t<thread>-<sec>-<usec>-<seq>". The leaf posts
 # back to the internal ingest port pinned to that thread so the push and the
@@ -107,30 +111,11 @@ def _to_json_line(chunk) -> str:
     return json.dumps(chunk)
 
 
-def haproxy_base_for_leaf(port: Optional[int] = None) -> str:
+def haproxy_base_for_leaf() -> str:
     """The HAProxy frontend the leaf posts its response channel to.
 
     HAProxy fronts the Serve HTTP port on the local node, so a co-located leaf
     reaches it on loopback. Multi-node delivery (leaf and client-holding HAProxy
     on different nodes) is not yet handled.
     """
-    from ray.serve._private.constants import DEFAULT_HTTP_PORT
-
-    return f"http://127.0.0.1:{port or DEFAULT_HTTP_PORT}"
-
-
-def response_channel(
-    request, client: httpx.AsyncClient, port: Optional[int] = None
-) -> Optional[ResponseChannel]:
-    """Return a ResponseChannel for ``request`` if it carries the channel header.
-
-    A deployment reached over HAProxy for an opted-in app receives the
-    ``x-response-id`` header; it writes its response to the returned channel
-    instead of returning it up the DAG. Returns ``None`` for requests without the
-    header (the app did not opt in), so the caller falls back to a normal
-    response.
-    """
-    response_id = request.headers.get(RESPONSE_ID_HEADER)
-    if not response_id:
-        return None
-    return ResponseChannel(response_id, haproxy_base_for_leaf(port), client)
+    return _LEAF_HAPROXY_BASE

--- a/python/ray/serve/_private/response_channel.py
+++ b/python/ray/serve/_private/response_channel.py
@@ -1,0 +1,136 @@
+"""Leaf-side ResponseChannel: stream a response straight back to HAProxy.
+
+A deployment whose app opted into the ResponseChannel (see
+``Application._with_response_channel``) streams its response chunks to HAProxy's
+``/internal/response/{response_id}`` over a single streamed POST, keyed by the
+per-request id HAProxy minted and forwarded as the ``x-response-id`` header.
+HAProxy drains the per-id queue to the waiting client, so parent deployments stay
+on the request path only; the response bytes never traverse them.
+
+General to any Serve deployment: ``response_channel(request)`` returns a channel
+when the incoming request carries the header, else ``None``.
+"""
+
+import asyncio
+import json
+import re
+from typing import Optional
+
+import httpx
+
+from ray.serve._private.constants import (
+    RAY_SERVE_RESPONSE_CHANNEL_INTERNAL_PORT_OFFSET,
+)
+
+RESPONSE_ID_HEADER = "x-response-id"
+
+# The response id HAProxy mints is "t<thread>-<sec>-<usec>-<seq>". The leaf posts
+# back to the internal ingest port pinned to that thread so the push and the
+# client's stream stay on one HAProxy thread (per-thread queue, no shared lock).
+_THREAD_RE = re.compile(r"^t(\d+)-")
+
+
+def internal_port(frontend_port: int, thread: int) -> int:
+    """The internal ingest port pinned to ``thread`` (1-based).
+
+    HAProxy binds one port per thread at a fixed offset above the frontend port;
+    the leaf posts to the port for its request's thread so push and stream share
+    a per-thread queue. HAProxy config generation and the leaf derive the port
+    from this one formula, so they cannot drift.
+    """
+    return frontend_port + RAY_SERVE_RESPONSE_CHANNEL_INTERNAL_PORT_OFFSET + thread - 1
+
+
+def _internal_url(response_id: str, haproxy_base: str) -> str:
+    """Rewrite ``haproxy_base`` to the per-thread internal ingest port for this id.
+
+    Falls back to ``haproxy_base`` if the id carries no thread (a caller that
+    minted its own id rather than HAProxy's thread-tagged one).
+    """
+    m = _THREAD_RE.match(response_id)
+    if not m:
+        return f"{haproxy_base}/internal/response/{response_id}"
+    scheme_host, _, port = haproxy_base.rpartition(":")
+    dst = internal_port(int(port), int(m.group(1)))
+    return f"{scheme_host}:{dst}/internal/response/{response_id}"
+
+
+class ResponseChannel:
+    """A pipe back to HAProxy for one request.
+
+    ``write`` enqueues a chunk; a single background sender streams the queued
+    chunks as the body of one POST, so generation is never blocked on a per-chunk
+    round-trip and the bounded queue applies backpressure. Each chunk is one
+    newline-delimited JSON line; HAProxy wraps it as a Server-Sent Event.
+    """
+
+    def __init__(self, response_id: str, haproxy_base: str, client: httpx.AsyncClient):
+        self._url = _internal_url(response_id, haproxy_base)
+        self._client = client
+        self._q: asyncio.Queue = asyncio.Queue(maxsize=2048)
+        self._task = asyncio.create_task(self._run())
+
+    async def _body(self):
+        while True:
+            item = await self._q.get()
+            if item is None:
+                return
+            yield (item + "\n").encode()
+
+    async def _run(self) -> None:
+        try:
+            await self._client.post(self._url, content=self._body())
+        except Exception:  # noqa: BLE001
+            # A drain-side failure (client gone, HAProxy reload) must not crash
+            # the producer; the caller aborts its own work on close().
+            pass
+
+    async def write(self, chunk) -> None:
+        """Enqueue one chunk. Accepts a pydantic model, a dict, or a raw JSON
+        string (any SSE ``data:`` framing is stripped; HAProxy re-adds it)."""
+        await self._q.put(_to_json_line(chunk))
+
+    async def close(self) -> None:
+        await self._q.put(None)
+        await self._task
+
+
+def _to_json_line(chunk) -> str:
+    """Normalize a chunk to a single JSON line with no SSE framing."""
+    if hasattr(chunk, "model_dump_json"):
+        return chunk.model_dump_json()
+    if isinstance(chunk, str):
+        s = chunk.strip()
+        if s.startswith("data:"):
+            s = s[len("data:") :].strip()
+        return s
+    return json.dumps(chunk)
+
+
+def haproxy_base_for_leaf(port: Optional[int] = None) -> str:
+    """The HAProxy frontend the leaf posts its response channel to.
+
+    HAProxy fronts the Serve HTTP port on the local node, so a co-located leaf
+    reaches it on loopback. Multi-node delivery (leaf and client-holding HAProxy
+    on different nodes) is not yet handled.
+    """
+    from ray.serve._private.constants import DEFAULT_HTTP_PORT
+
+    return f"http://127.0.0.1:{port or DEFAULT_HTTP_PORT}"
+
+
+def response_channel(
+    request, client: httpx.AsyncClient, port: Optional[int] = None
+) -> Optional[ResponseChannel]:
+    """Return a ResponseChannel for ``request`` if it carries the channel header.
+
+    A deployment reached over HAProxy for an opted-in app receives the
+    ``x-response-id`` header; it writes its response to the returned channel
+    instead of returning it up the DAG. Returns ``None`` for requests without the
+    header (the app did not opt in), so the caller falls back to a normal
+    response.
+    """
+    response_id = request.headers.get(RESPONSE_ID_HEADER)
+    if not response_id:
+        return None
+    return ResponseChannel(response_id, haproxy_base_for_leaf(port), client)

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -61,6 +61,8 @@ class Application:
         self._bound_deployment = bound_deployment
         # Optional peer ingress request router for ingress bypass mode.
         self._ingress_request_router: Optional["Application"] = None
+        # Opt every response from this app into the ResponseChannel.
+        self._response_channel: bool = False
 
     def _with_ingress_request_router(
         self, ingress_request_router: "Application"
@@ -68,6 +70,13 @@ class Application:
         # Internal-only, unstable hook for the Serve LLM direct-ingress stack.
         # This is not a stable public Serve API.
         self._ingress_request_router = ingress_request_router
+        return self
+
+    def _with_response_channel(self) -> "Application":
+        # Internal-only, unstable hook: opt every response from this app into the
+        # ResponseChannel, so a leaf streams its response straight to HAProxy and
+        # the ingress stays off the response path. Not a stable public Serve API.
+        self._response_channel = True
         return self
 
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1587,6 +1587,12 @@ class TargetGroup(BaseModel):
         "",
         description="Name of the application's ingress deployment.",
     )
+    # Whether the app opted into the ResponseChannel, so HAProxy serves this
+    # backend's responses off the ingress path. Only set on HTTP target groups.
+    response_channel: bool = Field(
+        False,
+        description="Whether the app's responses use the HAProxy ResponseChannel.",
+    )
 
 
 @PublicAPI(stability="alpha")

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -354,6 +354,7 @@ message DeploymentInfo {
   double target_capacity = 8;
   TargetCapacityDirection target_capacity_direction = 9;
   bool ingress_request_router = 10;
+  bool response_channel = 11;
 }
 
 // Wrap DeploymentInfo and route. The "" route value need to be convert to None/null.
@@ -515,6 +516,7 @@ message DeploymentArgs {
   optional string docs_path = 7;
   bool ingress_request_router = 8;
   bool uses_multiplexing = 9;
+  bool response_channel = 10;
 }
 
 message ApplicationArgs {


### PR DESCRIPTION
## What

ResponseChannel is a Serve-core primitive that lets a backend deployment stream its response straight to the HAProxy proxy instead of returning it up through the deployments that handled the request. For a Serve LLM app it takes the SSE token stream off the `OpenAiIngress` on the response path, while the request path (routing, request-side work) is unchanged.

This is a draft POC opened for design feedback.

## Usage

Opt in per app with one experimental config, then use the normal OpenAI streaming API:

```python
from ray import serve
from ray.serve.llm import LLMConfig, build_openai_app

llm_config = LLMConfig(
    model_loading_config={"model_id": "Qwen/Qwen2.5-0.5B-Instruct"},
    experimental_configs={"response_channel": True},  # opt in
)
serve.run(build_openai_app({"llm_configs": [llm_config]}))
```

```python
# Client: nothing changes. The response bytes just no longer traverse the ingress.
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="na")
for chunk in client.chat.completions.create(
    model="Qwen/Qwen2.5-0.5B-Instruct",
    messages=[{"role": "user", "content": "hi"}],
    stream=True,
):
    print(chunk.choices[0].delta.content or "", end="")
```

- Requires HAProxy: run with `RAY_SERVE_ENABLE_HA_PROXY=1`.
- Covers the streaming POST endpoints: `/v1/completions`, `/v1/chat/completions`, `/v1/audio/transcriptions` (with `stream=True`). Non-streaming endpoints (`/v1/models`, `/v1/embeddings`, ...) flow the normal path untouched.
- Multi-node: `RAY_SERVE_RESPONSE_CHANNEL_MULTINODE=1` makes HAProxy advertise its routable node IP so a leaf on another node posts back to the HAProxy holding the client connection (default is loopback / single node).

### General Serve API

The LLM builder is just one consumer. The opt-in is a per-app marker threaded exactly like `ingress_request_router`, so any Serve app can use it:

```python
app = MyDeployment.bind()._with_response_channel()   # internal, unstable
serve.run(app)
```

A deployment reached over the channel writes chunks to a `ResponseChannel` instead of returning them up the call graph. Mixed channel and plain apps coexist behind one HAProxy (the gating is per-backend).

## Architecture

Only the response path changes. The request still flows client to HAProxy to ingress to leaf exactly as today.

```mermaid
flowchart LR
    CLIENT([Client])
    HAP["HAProxy<br/>(per node)"]
    ING["OpenAiIngress"]
    LEAF["LLMServer<br/>(engine leaf)"]

    CLIENT ==>|"1 request"| HAP
    HAP ==>|"2 kickoff (loopback)"| ING
    ING ==>|"3 produce_to_channel"| LEAF
    LEAF -.->|"4 token stream"| HAP
    HAP -.->|"5 SSE to client"| CLIENT
```

Solid = request path (unchanged). Dashed = response path (bypasses the ingress).

1. HAProxy serves an opted-in backend's request with a Lua applet that mints a per-request response id tagged with the HAProxy thread, sends the client its SSE headers, and holds the client connection.
2. It re-injects the request to the ingress over the ordinary routing path (the "kickoff"), as a background task so this applet is free to stream.
3. The ingress does its request-side work and drives the leaf's `produce_to_channel` over a handle. It `await`s that drive (so the request stays accounted for, giving back-pressure and autoscaling) but never sees a response byte.
4. The leaf streams each chunk to `/internal/response/{id}` on a thread-pinned internal port. The push and the client stream share one HAProxy thread, so the per-request queue needs no lock.
5. HAProxy drains that queue to the client as Server-Sent Events.

How the two existing paths differ on the response:

- **legacy** (today's default, no flag): the leaf returns its response up the call graph, so the ingress relays every token (LLMServer to ingress to HAProxy to client).
- **direct streaming** (`RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING`): HAProxy makes a request-phase routing decision and kernel-splices straight to the leaf, dropping the ingress from both paths. It is a pull (splice, needs the routing decision up front and only one model). ResponseChannel is orthogonal and complementary: it keeps the ingress and the request path and only redirects the response as a push (the leaf opens the connection), so it works for multi-model, LoRA, guardrails, and other cases that need the ingress.

### Leaf side: writing to the channel

`LLMServer.produce_to_channel` is what the ingress drives in step 3. It runs the same streaming loop as the normal path, but the sink is a `ResponseChannel` instead of a value returned up the call graph:

```python
async def produce_to_channel(self, body, response_id, haproxy_base,
                             call_method="completions", raw_request_info=None):
    body.stream = True
    channel = ResponseChannel(response_id, haproxy_base, self._response_channel_client)
    gen = await self._run_request(body, engine_method=call_method,
                                  raw_request_info=raw_request_info)
    try:
        async for chunk in gen:
            await channel.write(chunk)      # enqueue each token
    finally:
        await gen.aclose()                  # client gone -> abort the engine gen
        await channel.close()               # EOF; wait for the POST to drain
```

`ResponseChannel` (Serve core, model-agnostic) is a bounded queue plus one background POST, not a round-trip per token:

- constructing it opens a single streamed POST to `/internal/response/{id}` on the thread-pinned internal port and starts a background sender task;
- `write(chunk)` only enqueues the chunk (normalized to one newline-delimited JSON line), so generation is never gated on the network; the 2048-slot queue applies back-pressure;
- the sender streams the queue as that POST's body, and `close()` enqueues a sentinel that ends the body, so HAProxy sees EOF and emits `[DONE]`.

The queue decoupling is what keeps a slow client from stalling the shared engine, and on teardown `gen.aclose()` aborts the engine generator if the client disconnected. `LLMServer` is just the first consumer; any deployment can drive a `ResponseChannel` the same way.

## Perf

opt-125m, one replica, one A10G, closed-loop concurrency sweep (at most `conc` requests in flight, ISL ~512 / OSL 128 tokens). `req/s` is throughput; the rest are latency in ms. `legacy` is today's ingress relay; `channel` is this PR; `direct streaming` is `RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING`.

legacy:

| conc | req/s | TTFT p50 | TTFT p99 | TPOT p50 | ITL p99 |
|---|---|---|---|---|---|
| 1 | 1.1 | 56 | 58 | 6.7 | 51 |
| 8 | 8.2 | 60 | 76 | 7.1 | 51 |
| 32 | 25.8 | 77 | 167 | 9.0 | 53 |
| 64 | 43.9 | 155 | 407 | 9.8 | 67 |
| 128 | 53.2 | 510 | 1310 | 15.1 | 119 |
| 256 | 31.9 | 3815 | 10266 | 31.0 | 250 |

channel (this PR):

| conc | req/s | TTFT p50 | TTFT p99 | TPOT p50 | ITL p99 |
|---|---|---|---|---|---|
| 1 | 1.1 | 21 | 35 | 7.0 | 8.5 |
| 8 | 8.2 | 42 | 63 | 7.3 | 9.2 |
| 32 | 27.0 | 75 | 203 | 8.4 | 12.9 |
| 64 | 44.4 | 221 | 363 | 9.4 | 19.9 |
| 128 | 50.5 | 646 | 5071 | 23.5 | 59 |
| 256 | 41.2 | 3977 | 12770 | 54.1 | 273 |

direct streaming:

| conc | req/s | TTFT p50 | TTFT p99 | TPOT p50 | ITL p99 |
|---|---|---|---|---|---|
| 1 | 1.1 | 17 | 27 | 7.1 | 8.5 |
| 8 | 8.0 | 33 | 53 | 7.6 | 9.8 |
| 32 | 28.1 | 49 | 151 | 8.4 | 12.1 |
| 64 | 51.8 | 99 | 278 | 8.5 | 14.6 |
| 128 | 41.6 | 918 | 6557 | 10.0 | 61 |
| 256 | 33.5 | 4746 | 9293 | 20.3 | 148 |

All three saturate near 50 req/s on one opt-125m replica and degrade gracefully to ~30 to 40 req/s at conc 256. The channel matches direct streaming's token-by-token smoothness (ITL p99 ~8 to 20ms through the usable range) and beats legacy's, which batches (~50 to 120ms). Direct streaming keeps the lowest TTFT because it drops the ingress via a kernel splice; the channel keeps the ingress and lands between direct streaming and legacy.

An earlier revision collapsed at conc 256 (~7 req/s) because the ingress fired the leaf drive and returned immediately, accepting an unbounded pile of background drives with no back-pressure on the kickoff rate. Awaiting the drive (step 3 above), so the request stays ongoing on the ingress while its tokens still bypass it, paces the kickoff rate and restores graceful degradation.

## Changes

- **Serve core (`python/ray/serve/_private/`):** new `response_channel.py` (leaf-side `ResponseChannel` and the `internal_port` port contract) and `response_channel.lua.tmpl` (the HAProxy stream/push services); `haproxy.py` / `haproxy_templates.py` (per-thread internal frontend, per-backend gating); the per-app marker threaded through `application_state.py`, `build_app.py`, `client.py`, `controller.py`, `deploy_utils.py`, `deployment_info.py`, `schema.py`, `deployment.py`, and `src/ray/protobuf/serve.proto`.
- **Serve LLM (`python/ray/llm/_internal/serve/`):** `ingress.py` (`_kickoff_response_channel`, header-gated in `_process_llm_request`), `llm_server.py` (`produce_to_channel`), `builder.py` (opt-in from `experimental_configs`), a thin re-export shim, and `test_response_channel.py`.

## Known limitations (POC)

- **Cross-node validation.** Multi-node is implemented and validated single-node in both modes; the routable ingest port additionally needs a network policy restricting it to cluster nodes, and a real cluster to validate the literal cross-node hop. Default is loopback (single node).
- **Streaming endpoints only.** The channel serves the streaming POST endpoints (completions, chat completions, transcriptions). Non-streaming endpoints flow the normal path.
- **Default HTTP port assumed.** `haproxy_base_for_leaf` uses the default port; a non-default `http_options.port` is not threaded to the leaf yet.
- **Experimental opt-in.** `experimental_configs["response_channel"]` / `Application._with_response_channel()`; no stable public API yet.

## Why this is not a duplicate

No open PR adds a leaf-to-proxy response channel. This builds on the merged HAProxy ingress-request-router work (#64489, #64724) and is orthogonal to direct streaming, which changes routing rather than the response path.

## Testing

Local:
- `pytest python/ray/llm/tests/serve/cpu/deployments/llm/test_response_channel.py` → 3 passed (chunk normalization, single-POST newline-delimited streaming, thread-tagged internal-port rewrite).
- Proto and schema round-trips for `DeploymentInfo.response_channel`, `DeploymentArgs.response_channel`, and `TargetGroup.response_channel`.
- `ruff`, `black==22.10.0`, import-order, and the full pre-commit suite (including `mypy`/`pyrefly` on ray serve, pydoclint, docstyle) pass.

GPU (one A10G):
- Chat and completions stream token-by-token through the channel (Qwen2.5-0.5B-Instruct); `GET /v1/models` returns without hanging.
- Multi-node validated single-node in both modes (opt-125m): default binds the ingest frontend on loopback; `RAY_SERVE_RESPONSE_CHANNEL_MULTINODE=1` advertises and binds on the node's routable IP and streams end-to-end.
- The perf sweep above (legacy vs channel vs direct streaming).

CI runs the serve unit suite (`test_build_app`, `test_controller_haproxy`) and the auto-globbed `test_response_channel.py`.

AI assistance (Claude Code) was used to prepare this change.
