### PR TITLE
[Train] Fix Torch env setup for V1 worker groups

### DIFF
--- a/python/ray/train/tests/test_torch_device_manager.py
+++ b/python/ray/train/tests/test_torch_device_manager.py
@@ -162,10 +162,6 @@ def test_npu_device_manager(ray_2_node_2_npus):
             trainer.fit()
 
 
-@pytest.mark.skipif(
-    not is_v2_enabled(),
-    reason="Requires Train V2 to be enabled with a V1 worker group.",
-)
 def test_torch_backend_with_v1_worker_group():
     worker_group = MagicMock(spec=WorkerGroup)
     worker_group.get_resources_per_worker.return_value = {}

--- a/python/ray/train/tests/test_torch_device_manager.py
+++ b/python/ray/train/tests/test_torch_device_manager.py
@@ -20,8 +20,14 @@ from ray.air._internal.device_manager import (
 from ray.air._internal.device_manager.npu import NPU_TORCH_PACKAGE_AVAILABLE
 from ray.cluster_utils import Cluster
 from ray.train import ScalingConfig, TrainingFailedError
+from ray.train._internal.worker_group import WorkerGroup
 from ray.train.torch import TorchTrainer
-from ray.train.torch.config import _validate_tpu_resources
+from ray.train.torch.config import (
+    TorchConfig,
+    _set_torch_distributed_env_vars,
+    _TorchBackend,
+    _validate_tpu_resources,
+)
 from ray.train.v2._internal.constants import is_v2_enabled
 
 if NPU_TORCH_PACKAGE_AVAILABLE:
@@ -154,6 +160,32 @@ def test_npu_device_manager(ray_2_node_2_npus):
         # but the torch npu is actually not available
         with pytest.raises(TrainingFailedError):
             trainer.fit()
+
+
+@pytest.mark.skipif(
+    not is_v2_enabled(),
+    reason="Requires Train V2 to be enabled with a V1 worker group.",
+)
+def test_torch_backend_with_v1_worker_group():
+    worker_group = MagicMock(spec=WorkerGroup)
+    worker_group.get_resources_per_worker.return_value = {}
+    worker_group.execute_single.return_value = ("127.0.0.1", 1234)
+    worker_group.__len__.return_value = 1
+
+    backend = _TorchBackend()
+    config = TorchConfig()
+    with (
+        patch.object(dist, "is_available", return_value=True),
+        patch.object(ray, "get"),
+    ):
+        backend.on_start(worker_group, config)
+
+    executed_functions = [call.args[0] for call in worker_group.execute.call_args_list]
+    assert _set_torch_distributed_env_vars not in executed_functions
+
+    worker_group.execute.reset_mock()
+    backend.on_training_start(worker_group, config)
+    worker_group.execute.assert_called_once_with(_set_torch_distributed_env_vars)
 
 
 @pytest.mark.skipif(

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -15,12 +15,12 @@ from ray.air._internal.device_manager import register_custom_torch_dist_backend
 from ray.exceptions import GetTimeoutError
 from ray.train._internal.base_worker_group import BaseWorkerGroup
 from ray.train._internal.utils import get_address_and_port
+from ray.train._internal.worker_group import WorkerGroup as V1WorkerGroup
 from ray.train.backend import Backend, BackendConfig
 from ray.train.constants import (
     DEFAULT_TORCH_PROCESS_GROUP_SHUTDOWN_TIMEOUT_S,
     TORCH_PROCESS_GROUP_SHUTDOWN_TIMEOUT_S,
 )
-from ray.train.v2._internal.constants import is_v2_enabled
 from ray.train.v2._internal.util import TrainingFramework
 from ray.util import PublicAPI
 
@@ -247,7 +247,7 @@ class _TorchBackend(Backend):
 
             # PyTorch distributed backends require LOCAL_RANK and other env vars
             # before init_process_group. See https://pytorch.org/docs/stable/distributed.html
-            if is_v2_enabled():
+            if not isinstance(worker_group, V1WorkerGroup):
                 worker_group.execute(_set_torch_distributed_env_vars)
 
             setup_futures = []
@@ -286,5 +286,5 @@ class _TorchBackend(Backend):
     def on_training_start(
         self, worker_group: BaseWorkerGroup, backend_config: BackendConfig
     ):
-        if not is_v2_enabled():
+        if isinstance(worker_group, V1WorkerGroup):
             worker_group.execute(_set_torch_distributed_env_vars)


### PR DESCRIPTION
## Description

`_TorchBackend.on_start()` used the global Train V2 flag to decide whether a Train context was available. RLlib uses the V1 `BackendExecutor` even when Train V2 is enabled, so backend setup called `ray.train.get_context()` before a V1 session existed.

Use the concrete V1 `WorkerGroup` type to keep V1 environment setup in `on_training_start()` while preserving pre-process-group setup for V2 worker and replica groups.

This is not a duplicate: no open PR currently changes `_set_torch_distributed_env_vars` or this V1/V2 lifecycle split.

## Related issues

Related to #64796 and #64987.

## Additional information

Tests:

- Black, Ruff, pydoclint, AST, import-order, and Train circular-import checks passed.
- Added `test_torch_backend_with_v1_worker_group`.
- Full Bazel tests were not run locally because PyTorch, Bazel, and Linux are unavailable in the local environment.

AI assistance was used to trace the failure and draft the change. I reviewed every changed line and ran the checks listed above.
