### PR TITLE
[tune] Stop ASHA crashing when a trial reports None for the metric

### DIFF
--- a/python/ray/tune/schedulers/async_hyperband.py
+++ b/python/ray/tune/schedulers/async_hyperband.py
@@ -145,6 +145,13 @@ class AsyncHyperBandScheduler(FIFOScheduler):
         idx = np.random.choice(len(self._brackets), p=normalized)
         self._trial_info[trial.trial_id] = self._brackets[idx]
 
+    def _reward(self, result: Dict) -> Optional[float]:
+        # A trial can report the metric as None. _Bracket.on_result already handles that by
+        # warning and leaving the trial running, so keep None intact instead of failing here
+        # on the metric_op multiplication.
+        value = result[self._metric]
+        return None if value is None else self._metric_op * value
+
     def on_trial_result(
         self, tune_controller: "TuneController", trial: Trial, result: Dict
     ) -> str:
@@ -156,7 +163,7 @@ class AsyncHyperBandScheduler(FIFOScheduler):
         else:
             bracket = self._trial_info[trial.trial_id]
             action = bracket.on_result(
-                trial, result[self._time_attr], self._metric_op * result[self._metric]
+                trial, result[self._time_attr], self._reward(result)
             )
         if action == TrialScheduler.STOP:
             self._num_stopped += 1
@@ -168,9 +175,7 @@ class AsyncHyperBandScheduler(FIFOScheduler):
         if self._time_attr not in result or self._metric not in result:
             return
         bracket = self._trial_info[trial.trial_id]
-        bracket.on_result(
-            trial, result[self._time_attr], self._metric_op * result[self._metric]
-        )
+        bracket.on_result(trial, result[self._time_attr], self._reward(result))
         del self._trial_info[trial.trial_id]
 
     def on_trial_remove(self, tune_controller: "TuneController", trial: Trial):
@@ -258,15 +263,15 @@ class _Bracket:
             if cur_iter < milestone or trial.trial_id in recorded:
                 continue
             else:
-                cutoff = self.cutoff(recorded)
-                if cutoff is not None and cur_rew < cutoff:
-                    action = TrialScheduler.STOP
                 if cur_rew is None:
                     logger.warning(
                         "Reward attribute is None! Consider"
                         " reporting using a different field."
                     )
                 else:
+                    cutoff = self.cutoff(recorded)
+                    if cutoff is not None and cur_rew < cutoff:
+                        action = TrialScheduler.STOP
                     recorded[trial.trial_id] = cur_rew
                 break
         return action

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -2356,6 +2356,42 @@ class AsyncHyperBandSuite(unittest.TestCase):
             scheduler.on_trial_result(None, t3, result(2, 260)), TrialScheduler.STOP
         )
 
+    def testAsyncHBNoneMetric(self):
+        # A trial reporting None for the metric must not crash the scheduler: _Bracket.on_result
+        # warns and leaves the trial running, and the None is not recorded as a rung result.
+        scheduler = AsyncHyperBandScheduler(
+            metric="episode_reward_mean",
+            mode="max",
+            grace_period=1,
+            max_t=10,
+            reduction_factor=2,
+            brackets=1,
+        )
+        t1 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t1)
+        scheduler.on_trial_result(None, t1, result(1, 450))
+
+        t2 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t2)
+        self.assertEqual(
+            scheduler.on_trial_result(None, t2, result(1, None)),
+            TrialScheduler.CONTINUE,
+        )
+        for _, recorded in scheduler._brackets[0]._rungs:
+            self.assertNotIn(t2.trial_id, recorded)
+
+        # on_trial_complete goes through the same path
+        t3 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t3)
+        scheduler.on_trial_complete(None, t3, result(1, None))
+
+        # and a genuinely underperforming trial is still stopped
+        t4 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t4)
+        self.assertEqual(
+            scheduler.on_trial_result(None, t4, result(1, 0)), TrialScheduler.STOP
+        )
+
     def testAsyncHBSaveRestore(self):
         _, tmpfile = tempfile.mkstemp()
 


### PR DESCRIPTION
## Why are these changes needed?

`AsyncHyperBandScheduler` (ASHA) raises `TypeError` when a trial reports `None` for the metric, even though the scheduler already contains handling for exactly that case.

`_Bracket.on_result` has an explicit branch for it, which warns and leaves the trial running without recording a rung result:

```python
cutoff = self.cutoff(recorded)
if cutoff is not None and cur_rew < cutoff:
    action = TrialScheduler.STOP
if cur_rew is None:
    logger.warning(
        "Reward attribute is None! Consider"
        " reporting using a different field."
    )
else:
    recorded[trial.trial_id] = cur_rew
```

That branch cannot be reached. Both callers apply the metric op before the bracket sees the value:

```python
action = bracket.on_result(
    trial, result[self._time_attr], self._metric_op * result[self._metric]
)
```

`self._metric_op` is `1.0` or `-1.0`, so a `None` metric fails on the multiplication first:

```
TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'
```

And if the bracket is reached directly, `cur_rew < cutoff` is evaluated before the `cur_rew is None` check below it, so it raises for any rung that already holds a recorded result:

```
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```

`cutoff` is only `None` while a rung is empty, so the first trial to report `None` at a rung that has seen any other trial hits this.

### Reproduction

```python
scheduler = AsyncHyperBandScheduler(
    metric="episode_reward_mean", mode="max", grace_period=1, max_t=10,
    reduction_factor=2, brackets=1,
)
scheduler.on_trial_add(None, t1)
scheduler.on_trial_result(None, t1, result(1, 450))   # fine

scheduler.on_trial_add(None, t2)
scheduler.on_trial_result(None, t2, result(1, None))  # TypeError
```

```
File "python/ray/tune/schedulers/async_hyperband.py", line 159, in on_trial_result
    trial, result[self._time_attr], self._metric_op * result[self._metric]
                                    ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'
```

The crash surfaces inside the scheduler rather than at the trial that reported the bad value, so it is not obvious from the traceback which trial or metric caused it, and it takes down the tuning run rather than the single trial.

## Changes

- `_reward()` applies `self._metric_op` only to a non-`None` value, and both `on_trial_result` and `on_trial_complete` use it, so `None` reaches `_Bracket.on_result` the way that method already expects.
- `_Bracket.on_result` checks `cur_rew is None` before comparing it against the cutoff, so the existing warning runs instead of raising.

Behaviour for real metric values is unchanged. `None` is not recorded as a rung result, so it cannot influence a later cutoff, the trial continues, and an underperforming trial reporting a real value is still stopped. NaN handling is untouched: NaN still multiplies, still records, and `cutoff` still filters it via `np.nanpercentile`, which the existing `testAsyncHBNanPercentile` covers.

## Related issue number

None, self-found.

## Checks

- [x] I've signed off every commit (`git commit -s`)
- [x] I've run `scripts/format.sh` to lint the changes in this PR (`black` and `ruff` clean on both files)
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/
- [x] I've added any new APIs to the API Reference. (no new public API)
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the (Ray CI) section for more information.
- Testing Strategy
   - [x] Unit tests: `testAsyncHBNoneMetric` in `python/ray/tune/tests/test_trial_scheduler.py`, added next to the existing NaN/Inf coverage in `AsyncHyperBandSuite`. It reports `None` through both `on_trial_result` and `on_trial_complete`, asserts the trial continues and is not written into any rung, and asserts a genuinely underperforming trial is still stopped. It fails on master with the `TypeError` above and passes with this change.

## Not a duplicate

Re-checked per `AGENTS.md`:

```
gh pr list --repo ray-project/ray --state open --search "async_hyperband"
gh pr list --repo ray-project/ray --state open --search "AsyncHyperBand"
gh pr list --repo ray-project/ray --state open --search "ASHA in:title"
```

This PR is the only match; no other open PR or issue covers the `None`-metric crash in `AsyncHyperBandScheduler`.

## Tests run and results

```
python -m pytest python/ray/tune/tests/test_trial_scheduler.py -k AsyncHyperBandSuite
```

`testAsyncHBNoneMetric` fails on master with `TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'` and passes with this change; the rest of `AsyncHyperBandSuite`, including the existing `testAsyncHBNanPercentile`, passes both before and after. `black` and `ruff` are clean on both changed files.

## AI assistance

AI assistance was used in preparing this change, disclosed per `AGENTS.md`. This disclosure is being added retroactively: the PR was opened on 2026-07-25, after `AGENTS.md` merged on 2026-07-14, and the omission was mine.
