### PR TITLE
[core][raylet] Fix spill_manager_objects_bytes reports restored object count instead of restored bytes

### DIFF
--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -628,7 +628,7 @@ void LocalObjectManager::RecordMetrics() const {
   spill_manager_metrics_.spill_manager_objects_bytes_gauge.Record(spilled_bytes_total_,
                                                                   {{"State", "Spilled"}});
   spill_manager_metrics_.spill_manager_objects_bytes_gauge.Record(
-      restored_objects_total_, {{"State", "Restored"}});
+      restored_bytes_total_, {{"State", "Restored"}});
 
   spill_manager_metrics_.spill_manager_request_total_gauge.Record(spilled_objects_total_,
                                                                   {{"Type", "Spilled"}});

--- a/src/ray/raylet/tests/local_object_manager_test.cc
+++ b/src/ray/raylet/tests/local_object_manager_test.cc
@@ -308,6 +308,17 @@ class LocalObjectManagerTestWithMinSpillingSize {
 
   int64_t GetCurrentSpilledBytes() { return manager.spilled_bytes_current_; }
 
+  void SetRestoredStats(int64_t restored_bytes, int64_t restored_objects) {
+    manager.restored_bytes_total_ = restored_bytes;
+    manager.restored_objects_total_ = restored_objects;
+  }
+
+  double GetSpillManagerObjectsBytesMetric(const std::string &state) {
+    auto tag_to_value = fake_spill_manager_objects_bytes_gauge_.GetTagToValue();
+    absl::flat_hash_map<std::string, std::string> tags{{"State", state}};
+    return tag_to_value.at(tags);
+  }
+
   size_t GetCurrentSpilledCount() { return manager.spilled_objects_url_.size(); }
 
   void AssertNoLeaks() {
@@ -490,6 +501,14 @@ TEST_F(LocalObjectManagerTest, TestRestoreSpilledObject) {
   worker_pool.io_worker_client->ReplyRestoreObjects(10);
   // The restore should've been invoked.
   ASSERT_EQ(num_times_fired, 1);
+}
+
+TEST_F(LocalObjectManagerTest, TestRecordMetricsRestoredObjectsBytes) {
+  SetRestoredStats(10, 1);
+
+  manager.RecordMetrics();
+
+  EXPECT_DOUBLE_EQ(GetSpillManagerObjectsBytesMetric("Restored"), 10);
 }
 
 TEST_F(LocalObjectManagerTest, TestExplicitSpill) {


### PR DESCRIPTION

## Description

- What problem does this solve?

  The `spill_manager_objects_bytes` metric appears to report the wrong value for                                                                                                                              
  `State="Restored"`.                                                                                                                                                                                         
                                                                                                                                                                                                              
  In `LocalObjectManager::RecordMetrics()`, the restored sample for                                                                                                                                           
  `spill_manager_objects_bytes` is recorded with `restored_objects_total_`:  
                                                                 
  ```cpp                                                                                                                                                                                                      
    spill_manager_metrics_.spill_manager_objects_bytes_gauge.Record(                                                                                                                                            
        restored_objects_total_, {{"State", "Restored"}});          
  ```
  However, this metric is documented as a byte-size metric:                                                                                                                                                                                                                                                                                                                                                        
  name = "spill_manager_objects_bytes"                                                                                                                                                                        
  description = "Byte size of local objects broken per state ..." 



                                                               
- How does this PR solve it?

  correct the new value of the target metrics .

- Any relevant context for reviewers such as:

  #65012 

- Why is the problem important to solve?

  IIUC, It's a but for metrics on the corresponding value.

- Why was this approach chosen over others?

  direct & simple.

## Related issues

  Fixes #65012 

## Additional information
  N.A