### PR TITLE
[Job] Retry transient RPC errors in job monitor during GCS failover

### DIFF
--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -8,6 +8,8 @@ import time
 import traceback
 from typing import Any, AsyncIterator, Dict, Optional, Union
 
+import grpc
+
 import ray
 import ray._private.ray_constants as ray_constants
 from ray._common.utils import Timer, run_background_task
@@ -33,11 +35,39 @@ from ray.dashboard.modules.job.common import (
 from ray.dashboard.modules.job.job_log_storage_client import JobLogStorageClient
 from ray.dashboard.modules.job.job_supervisor import JobSupervisor
 from ray.dashboard.utils import close_logger_file_descriptor, get_head_node_id
-from ray.exceptions import ActorDiedError, ActorUnschedulableError, RuntimeEnvSetupError
+from ray.exceptions import (
+    ActorDiedError,
+    ActorUnschedulableError,
+    RpcError,
+    RuntimeEnvSetupError,
+)
 from ray.job_submission import JobErrorType, JobStatus
 from ray.runtime_env import RuntimeEnvConfig
 
 logger = logging.getLogger(__name__)
+
+# gRPC status codes that only mean the RPC didn't reach its destination, so they
+# carry no information about whether the JobSupervisor is still alive. These are
+# what in-flight RPCs fail with while the GCS is restarting during a failover.
+_TRANSIENT_RPC_CODES = frozenset(
+    {
+        grpc.StatusCode.CANCELLED.value[0],
+        grpc.StatusCode.UNAVAILABLE.value[0],
+    }
+)
+
+# How long the JobSupervisor may keep failing to answer pings with a transient RPC
+# error before it is presumed gone. This reuses the GCS reconnect budget on purpose:
+# once the GCS has been unreachable for longer than this, the GCS client gives up and
+# tears down the process, so there is nothing to be gained by retrying for longer.
+_GCS_RECONNECT_TIMEOUT_S = ray_constants.env_integer(
+    "RAY_gcs_rpc_server_reconnect_timeout_s", 60
+)
+
+
+def _is_transient_rpc_error(exc: Exception) -> bool:
+    """Whether `exc` is an RPC failure that may succeed when retried."""
+    return isinstance(exc, RpcError) and exc.rpc_code in _TRANSIENT_RPC_CODES
 
 
 def generate_job_id() -> str:
@@ -164,6 +194,12 @@ class JobManager:
         job_status = None
         job_info = None
         ping_obj_ref = None
+        # Start of the current streak of `JobSupervisor` pings that failed with a
+        # transient RPC error, or None if there is no such streak. Only pings move
+        # this window: a transient error from any other RPC means this iteration never
+        # got as far as asking the supervisor anything, so it carries no evidence
+        # about the supervisor and the streak starts over.
+        first_failed_ping_time = None
 
         while True:
             try:
@@ -265,16 +301,87 @@ class JobManager:
                         max_task_retries=-1
                     ).remote()
                 ready, _ = ray.wait([ping_obj_ref], timeout=0)
-                if ready:
-                    ray.get(ping_obj_ref)
-                    ping_obj_ref = None
-                else:
+                if not ready:
                     continue
 
+                try:
+                    ray.get(ping_obj_ref)
+                except Exception as ping_exc:
+                    if _is_transient_rpc_error(ping_exc):
+                        # The ping never made it to the supervisor (e.g. the GCS is
+                        # failing over), which says nothing about whether the
+                        # supervisor is alive. Give it the reconnect budget to answer
+                        # before concluding anything.
+                        if first_failed_ping_time is None:
+                            first_failed_ping_time = time.monotonic()
+                        elapsed = time.monotonic() - first_failed_ping_time
+                        if elapsed < _GCS_RECONNECT_TIMEOUT_S:
+                            logger.warning(
+                                f"Job monitoring for job {job_id} could not reach the "
+                                f"JobSupervisor for {elapsed:.0f}s, retrying for up "
+                                f"to {_GCS_RECONNECT_TIMEOUT_S}s: {ping_exc}."
+                            )
+                            # Drop the failed ping so the next iteration issues a new
+                            # one instead of replaying the same error.
+                            ping_obj_ref = None
+                            continue
+                    # Either the supervisor is known to be gone, or it stayed
+                    # unreachable for the whole window and is presumed gone. Let the
+                    # handler below fail the job.
+                    raise
+
+                ping_obj_ref = None
+                # The supervisor answered, so it is alive and any earlier streak of
+                # failed pings is over -- including one long enough to have presumed
+                # it gone, since an answer is better evidence than a timed-out window.
+                first_failed_ping_time = None
+
             except Exception as e:
-                job_status = await self._job_info_client.get_status(
-                    job_id, timeout=None
+                is_transient = _is_transient_rpc_error(e)
+                # A streak of failed pings that outlasted the window means the
+                # supervisor is presumed gone. That conclusion has to survive the
+                # retries below, so it is not reset by transient errors on the way to
+                # recording it.
+                supervisor_presumed_gone = (
+                    first_failed_ping_time is not None
+                    and time.monotonic() - first_failed_ping_time
+                    >= _GCS_RECONNECT_TIMEOUT_S
                 )
+                if is_transient and not supervisor_presumed_gone:
+                    # This error did not come from a ping, so the supervisor was never
+                    # asked anything on this iteration: retry, and don't touch the GCS
+                    # while doing so -- reading the job status here would be one more
+                    # RPC to the component that is currently unreachable.
+                    logger.warning(
+                        f"Job monitoring for job {job_id} hit a transient RPC error, "
+                        f"retrying: {e}."
+                    )
+                    # Nothing was learned about the supervisor, so the ping streak
+                    # starts over, and any in-flight ping is dropped so that the next
+                    # iteration issues a new one.
+                    first_failed_ping_time = None
+                    ping_obj_ref = None
+                    continue
+
+                try:
+                    job_status = await self._job_info_client.get_status(
+                        job_id, timeout=None
+                    )
+                except Exception as status_exc:
+                    if not _is_transient_rpc_error(status_exc):
+                        raise
+                    # Keep the monitor alive and try again on the next iteration
+                    # instead of letting this escape: an exception here would drop
+                    # the job from `monitored_jobs` without a terminal status and
+                    # without killing the supervisor, leaving it running with nobody
+                    # left to converge it.
+                    logger.warning(
+                        f"Job monitoring for job {job_id} could not read the job "
+                        f"status, retrying: {status_exc}."
+                    )
+                    ping_obj_ref = None
+                    continue
+
                 target_job_error_message = ""
                 target_job_error_type: Optional[JobErrorType] = None
                 if job_status is not None and job_status.is_terminal():
@@ -307,26 +414,47 @@ class JobManager:
                         target_job_error_type = JobErrorType.JOB_SUPERVISOR_ACTOR_DIED
 
                     else:
-                        logger.error(
-                            f"Job monitoring for job {job_id} failed "
-                            f"unexpectedly: {e}.",
-                            exc_info=e,
-                        )
+                        if is_transient:
+                            logger.error(
+                                f"Job monitoring for job {job_id} gave up after the "
+                                f"JobSupervisor stayed unreachable for more than "
+                                f"{_GCS_RECONNECT_TIMEOUT_S}s: {e}.",
+                                exc_info=e,
+                            )
+                        else:
+                            logger.error(
+                                f"Job monitoring for job {job_id} failed "
+                                f"unexpectedly: {e}.",
+                                exc_info=e,
+                            )
 
                         target_job_error_message = f"Unexpected error occurred: {e}"
                         target_job_error_type = (
                             JobErrorType.JOB_SUPERVISOR_ACTOR_UNKNOWN_FAILURE
                         )
 
+                    try:
+                        await self._job_info_client.put_status(
+                            job_id,
+                            JobStatus.FAILED,
+                            message=target_job_error_message,
+                            error_type=target_job_error_type
+                            or JobErrorType.JOB_SUPERVISOR_ACTOR_UNKNOWN_FAILURE,
+                            timeout=None,
+                        )
+                    except Exception as put_exc:
+                        if not _is_transient_rpc_error(put_exc):
+                            raise
+                        # Same reasoning as the status read above: retry rather than
+                        # exit, so that the job is still converged once the GCS is
+                        # reachable again.
+                        logger.warning(
+                            f"Job monitoring for job {job_id} could not record the "
+                            f"terminal status, retrying: {put_exc}."
+                        )
+                        ping_obj_ref = None
+                        continue
                     job_status = JobStatus.FAILED
-                    await self._job_info_client.put_status(
-                        job_id,
-                        job_status,
-                        message=target_job_error_message,
-                        error_type=target_job_error_type
-                        or JobErrorType.JOB_SUPERVISOR_ACTOR_UNKNOWN_FAILURE,
-                        timeout=None,
-                    )
 
                 # Log error message to the job driver file for easy access.
                 if target_job_error_message:
@@ -349,10 +477,21 @@ class JobManager:
                 break
 
         # Kill the actor defensively to avoid leaking actors in unexpected error cases.
-        if job_supervisor is None:
-            job_supervisor = self._get_actor_for_job(job_id)
-        if job_supervisor is not None:
-            ray.kill(job_supervisor, no_restart=True)
+        try:
+            if job_supervisor is None:
+                job_supervisor = self._get_actor_for_job(job_id)
+            if job_supervisor is not None:
+                ray.kill(job_supervisor, no_restart=True)
+        except Exception as kill_exc:
+            if not _is_transient_rpc_error(kill_exc):
+                raise
+            # The job has reached a terminal status by now, so there is nothing left
+            # to converge; the supervisor exits on its own once its driver is done,
+            # and is reaped with the cluster otherwise.
+            logger.warning(
+                f"Job monitoring for job {job_id} could not kill the JobSupervisor: "
+                f"{kill_exc}."
+            )
 
     def _handle_supervisor_startup(self, job_id: str, result: Optional[Exception]):
         """Handle the result of starting a job supervisor actor.

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -33,11 +33,34 @@ from ray.dashboard.modules.job.common import (
 from ray.dashboard.modules.job.job_log_storage_client import JobLogStorageClient
 from ray.dashboard.modules.job.job_supervisor import JobSupervisor
 from ray.dashboard.utils import close_logger_file_descriptor, get_head_node_id
-from ray.exceptions import ActorDiedError, ActorUnschedulableError, RuntimeEnvSetupError
+from ray.exceptions import (
+    ActorDiedError,
+    ActorUnschedulableError,
+    RpcError,
+    RuntimeEnvSetupError,
+)
 from ray.job_submission import JobErrorType, JobStatus
 from ray.runtime_env import RuntimeEnvConfig
 
 logger = logging.getLogger(__name__)
+
+# gRPC status codes considered transient during GCS failover.
+_TRANSIENT_RPC_CODES = {1, 14}  # CANCELLED=1, UNAVAILABLE=14
+
+# Max consecutive transient failures before giving up.
+_MAX_TRANSIENT_ERROR_RETRIES = ray_constants.env_integer(
+    "RAY_JOB_MONITOR_MAX_TRANSIENT_ERROR_RETRIES", 40
+)
+
+
+def _is_transient_rpc_error(exc: Exception) -> bool:
+    """Return True if the exception is a transient gRPC error."""
+    if isinstance(exc, RpcError) and exc.rpc_code in _TRANSIENT_RPC_CODES:
+        return True
+    if isinstance(exc, RpcError):
+        error_msg = str(exc).lower()
+        return "cancelled" in error_msg or "unavailable" in error_msg
+    return False
 
 
 def generate_job_id() -> str:
@@ -164,6 +187,8 @@ class JobManager:
         job_status = None
         job_info = None
         ping_obj_ref = None
+        transient_error_count = 0
+        gcs_unreachable_exhausted = False
 
         while True:
             try:
@@ -268,13 +293,43 @@ class JobManager:
                 if ready:
                     ray.get(ping_obj_ref)
                     ping_obj_ref = None
+                    transient_error_count = 0
                 else:
                     continue
 
             except Exception as e:
-                job_status = await self._job_info_client.get_status(
-                    job_id, timeout=None
-                )
+                try:
+                    job_status = await self._job_info_client.get_status(
+                        job_id, timeout=None
+                    )
+                except Exception as get_status_exc:
+                    if _is_transient_rpc_error(e) or _is_transient_rpc_error(
+                        get_status_exc
+                    ):
+                        transient_error_count += 1
+                        if transient_error_count < _MAX_TRANSIENT_ERROR_RETRIES:
+                            logger.warning(
+                                f"Job {job_id} monitoring hit transient RPC "
+                                f"error (attempt {transient_error_count}/"
+                                f"{_MAX_TRANSIENT_ERROR_RETRIES}): {e}. "
+                                f"GCS also unreachable, retrying..."
+                            )
+                            await asyncio.sleep(
+                                min(2 ** min(transient_error_count, 5), 30)
+                            )
+                            ping_obj_ref = None
+                            continue
+                        logger.error(
+                            f"Job {job_id} monitoring exhausted "
+                            f"{_MAX_TRANSIENT_ERROR_RETRIES} transient "
+                            f"error retries while GCS unreachable. "
+                            f"Cannot determine job state, stopping "
+                            f"monitor without overwriting status: {e}.",
+                            exc_info=e,
+                        )
+                        gcs_unreachable_exhausted = True
+                        break
+                    job_status = None
                 target_job_error_message = ""
                 target_job_error_type: Optional[JobErrorType] = None
                 if job_status is not None and job_status.is_terminal():
@@ -307,11 +362,38 @@ class JobManager:
                         target_job_error_type = JobErrorType.JOB_SUPERVISOR_ACTOR_DIED
 
                     else:
-                        logger.error(
-                            f"Job monitoring for job {job_id} failed "
-                            f"unexpectedly: {e}.",
-                            exc_info=e,
-                        )
+                        if _is_transient_rpc_error(e):
+                            transient_error_count += 1
+                            if transient_error_count < _MAX_TRANSIENT_ERROR_RETRIES:
+                                logger.warning(
+                                    f"Job {job_id} monitoring hit transient "
+                                    f"RPC error (attempt "
+                                    f"{transient_error_count}/"
+                                    f"{_MAX_TRANSIENT_ERROR_RETRIES}): {e}. "
+                                    f"Retrying after backoff..."
+                                )
+                                await asyncio.sleep(
+                                    min(
+                                        2 ** min(transient_error_count, 5),
+                                        30,
+                                    )
+                                )
+                                ping_obj_ref = None
+                                continue
+
+                            logger.error(
+                                f"Job {job_id} monitoring exhausted "
+                                f"{_MAX_TRANSIENT_ERROR_RETRIES} transient "
+                                f"error retries, marking as failed: {e}.",
+                                exc_info=e,
+                            )
+
+                        else:
+                            logger.error(
+                                f"Job monitoring for job {job_id} failed "
+                                f"unexpectedly: {e}.",
+                                exc_info=e,
+                            )
 
                         target_job_error_message = f"Unexpected error occurred: {e}"
                         target_job_error_type = (
@@ -349,10 +431,13 @@ class JobManager:
                 break
 
         # Kill the actor defensively to avoid leaking actors in unexpected error cases.
-        if job_supervisor is None:
-            job_supervisor = self._get_actor_for_job(job_id)
-        if job_supervisor is not None:
-            ray.kill(job_supervisor, no_restart=True)
+        # Skip kill if we exited because GCS was unreachable — the job may still
+        # be running and will recover once GCS comes back.
+        if not gcs_unreachable_exhausted:
+            if job_supervisor is None:
+                job_supervisor = self._get_actor_for_job(job_id)
+            if job_supervisor is not None:
+                ray.kill(job_supervisor, no_restart=True)
 
     def _handle_supervisor_startup(self, job_id: str, result: Optional[Exception]):
         """Handle the result of starting a job supervisor actor.

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1656,5 +1656,52 @@ async def test_no_task_events_exported(shared_ray_instance, tmp_path):
         assert "JobSupervisor" not in t.name
 
 
+@pytest.mark.asyncio
+async def test_job_monitor_retries_transient_rpc_errors(job_manager, tmp_path):
+    """Test that transient RPC errors (CANCELLED/UNAVAILABLE) during GCS failover
+    are retried instead of immediately marking the job as FAILED."""
+    from unittest.mock import patch as mock_patch
+
+    from ray.dashboard.modules.job.job_manager import _is_transient_rpc_error
+    from ray.exceptions import RpcError
+
+    assert _is_transient_rpc_error(RpcError("RPC error: CANCELLED", rpc_code=1))
+    assert _is_transient_rpc_error(RpcError("RPC error: UNAVAILABLE", rpc_code=14))
+    assert not _is_transient_rpc_error(RuntimeError("some other error"))
+    assert not _is_transient_rpc_error(RpcError("RPC error: INTERNAL", rpc_code=13))
+    assert not _is_transient_rpc_error(
+        RuntimeError("task was cancelled before it started running")
+    )
+
+    job_id = await job_manager.submit_job(entrypoint="sleep 600")
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+
+    call_count = {"value": 0}
+    original_get_status = job_manager._job_info_client.get_status
+
+    async def mock_get_status(*args, **kwargs):
+        call_count["value"] += 1
+        if call_count["value"] <= 3:
+            raise RpcError("RPC error: CANCELLED", rpc_code=1)
+        return await original_get_status(*args, **kwargs)
+
+    with mock_patch.object(
+        job_manager._job_info_client, "get_status", side_effect=mock_get_status
+    ):
+        await asyncio.sleep(2)
+
+    status = await job_manager.get_job_status(job_id)
+    assert (
+        status == JobStatus.RUNNING
+    ), f"Job should remain RUNNING after transient RPC errors, got {status}"
+
+    job_manager.stop_job(job_id)
+    await async_wait_for_condition(
+        check_job_stopped, job_manager=job_manager, job_id=job_id
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -9,6 +9,7 @@ import urllib.request
 from unittest.mock import patch
 from uuid import uuid4
 
+import grpc
 import pytest
 
 import ray
@@ -42,6 +43,7 @@ from ray.dashboard.modules.job.tests.conftest import (
     create_job_manager,
     create_ray_cluster,
 )
+from ray.exceptions import RpcError
 from ray.job_submission import JobErrorType, JobStatus
 from ray.tests.conftest import call_ray_start  # noqa: F401
 from ray.util.state import get_actor, list_tasks
@@ -1654,6 +1656,298 @@ async def test_no_task_events_exported(shared_ray_instance, tmp_path):
     # Assert no task events for the JobSupervisor are exported.
     for t in list_tasks():
         assert "JobSupervisor" not in t.name
+
+
+def test_is_transient_rpc_error():
+    """Only gRPC codes meaning "the RPC never got through" are treated as transient."""
+    from ray.dashboard.modules.job.job_manager import _is_transient_rpc_error
+
+    assert _is_transient_rpc_error(
+        RpcError("RPC error: CANCELLED", rpc_code=grpc.StatusCode.CANCELLED.value[0])
+    )
+    assert _is_transient_rpc_error(
+        RpcError(
+            "RPC error: UNAVAILABLE", rpc_code=grpc.StatusCode.UNAVAILABLE.value[0]
+        )
+    )
+    # A permanent gRPC failure, a missing status code, and a non-RPC exception all
+    # carry information about the callee, so they must not be retried blindly.
+    assert not _is_transient_rpc_error(
+        RpcError("RPC error: INTERNAL", rpc_code=grpc.StatusCode.INTERNAL.value[0])
+    )
+    assert not _is_transient_rpc_error(RpcError("RPC error"))
+    assert not _is_transient_rpc_error(
+        RuntimeError("task was cancelled before it started running")
+    )
+
+
+def _cancelled_rpc_error() -> RpcError:
+    """The error an in-flight RPC fails with while the GCS restarts under it."""
+    return RpcError("RPC error: CANCELLED", rpc_code=grpc.StatusCode.CANCELLED.value[0])
+
+
+def _patch_failing_ping(should_fail):
+    """Make the monitor's ping of the `JobSupervisor` fail transiently.
+
+    `_monitor_job_internal` is the only code under test that passes a bare
+    `ObjectRef` to `ray.get`, so keying off that shape fails the ping and nothing
+    else.
+    """
+    original_get = ray.get
+
+    def maybe_failing_get(object_refs, *args, **kwargs):
+        if isinstance(object_refs, ray.ObjectRef) and should_fail():
+            raise _cancelled_rpc_error()
+        return original_get(object_refs, *args, **kwargs)
+
+    return patch.object(ray, "get", maybe_failing_get)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fail_every_read",
+    [False, True],
+    ids=["in_flight_rpc_dropped", "gcs_unreachable"],
+)
+async def test_job_monitor_survives_transient_rpc_errors(job_manager, fail_every_read):
+    """The monitor must keep monitoring a running job when its RPCs fail transiently.
+
+    This reproduces the GCS failover failure mode: while the GCS restarts, RPCs
+    issued from the monitoring loop fail with CANCELLED even though the driver and
+    the JobSupervisor are both still alive.
+
+    Both parametrizations must be tolerated:
+    - `in_flight_rpc_dropped`: only some reads fail, which is what a single dropped
+      in-flight RPC looks like and what was seen in production.
+    - `gcs_unreachable`: every read fails for as long as the outage lasts. The
+      monitor must not issue any further RPC of its own here, because an exception
+      escaping the loop would leave the job running with no monitor at all.
+    """
+    job_id = await job_manager.submit_job(entrypoint="sleep 600")
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+
+    original_get_status = job_manager._job_info_client.get_status
+    state = {"calls": 0, "raised": 0}
+
+    async def flaky_get_status(*args, **kwargs):
+        state["calls"] += 1
+        if not fail_every_read and state["calls"] % 2 == 0:
+            # Let every other read through, which is what a single dropped in-flight
+            # RPC looks like: the monitor's next read of the same value succeeds.
+            return await original_get_status(*args, **kwargs)
+        state["raised"] += 1
+        raise _cancelled_rpc_error()
+
+    with patch.object(job_manager._job_info_client, "get_status", flaky_get_status):
+        # The monitor has to survive repeated transient errors. If it instead treats
+        # them as "the supervisor is gone", it marks the job FAILED and exits on the
+        # very first one, so the count never gets here.
+        await async_wait_for_condition(lambda: state["raised"] >= 3)
+
+    # The monitor is still registered, i.e. its coroutine neither returned nor died.
+    assert job_id in job_manager.monitored_jobs
+    assert await job_manager.get_job_status(job_id) == JobStatus.RUNNING
+
+    job_manager.stop_job(job_id)
+    await async_wait_for_condition(
+        check_job_stopped, job_manager=job_manager, job_id=job_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_monitor_fails_job_when_pings_keep_failing(job_manager):
+    """Once the retry window is exhausted the job must converge, not linger.
+
+    A monitor that retried forever would leave a job that can never reach a terminal
+    state, so a `JobSupervisor` that stays unreachable for the whole window has to be
+    treated as gone: the job is failed and the supervisor killed, exactly as an
+    unrecognized exception did before.
+    """
+    from ray.dashboard.modules.job import job_manager as job_manager_module
+
+    job_id = await job_manager.submit_job(entrypoint="sleep 600")
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+
+    # A zero-length window means the first failed ping is already past the deadline,
+    # so the monitor has to draw its conclusion immediately.
+    no_window = patch.object(job_manager_module, "_GCS_RECONNECT_TIMEOUT_S", 0)
+    with no_window, _patch_failing_ping(lambda: True):
+        await async_wait_for_condition(
+            check_job_failed,
+            job_manager=job_manager,
+            job_id=job_id,
+            expected_error_type=JobErrorType.JOB_SUPERVISOR_ACTOR_UNKNOWN_FAILURE,
+        )
+
+    data = await job_manager.get_job_info(job_id)
+    assert "RPC error: CANCELLED" in data.message
+
+
+@pytest.mark.asyncio
+async def test_job_monitor_does_not_fail_job_after_gcs_comes_back(job_manager):
+    """A GCS outage must not spend the window that a failed ping is measured against.
+
+    While the GCS is unreachable the monitor never gets as far as asking the
+    `JobSupervisor` anything, so those iterations carry no evidence about it. If they
+    counted, an outage longer than the window would leave it already exhausted, and
+    the first dropped ping after the GCS came back would fail a perfectly healthy job
+    and kill its live supervisor.
+    """
+    from ray.dashboard.modules.job import job_manager as job_manager_module
+
+    window = 1
+    outage_s = 1.5 * window
+
+    job_id = await job_manager.submit_job(entrypoint="sleep 600")
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+
+    original_get_status = job_manager._job_info_client.get_status
+    outage_start = time.monotonic()
+    state = {"read_failures": 0, "pings": 0, "ping_failures": 0}
+
+    def gcs_unreachable():
+        return time.monotonic() - outage_start < outage_s
+
+    async def flaky_get_status(*args, **kwargs):
+        if gcs_unreachable():
+            state["read_failures"] += 1
+            raise _cancelled_rpc_error()
+        return await original_get_status(*args, **kwargs)
+
+    def should_fail_ping():
+        state["pings"] += 1
+        # Exactly one ping is dropped, and only once the GCS answers again -- by
+        # which point the outage has already lasted longer than the whole window.
+        if state["ping_failures"] or gcs_unreachable():
+            return False
+        state["ping_failures"] += 1
+        return True
+
+    short_window = patch.object(job_manager_module, "_GCS_RECONNECT_TIMEOUT_S", window)
+    fail_reads = patch.object(
+        job_manager._job_info_client, "get_status", flaky_get_status
+    )
+    with short_window, fail_reads, _patch_failing_ping(should_fail_ping):
+        await async_wait_for_condition(lambda: state["ping_failures"] == 1)
+        pings_before = state["pings"]
+        # The supervisor answers again right after the dropped ping, so the monitor
+        # has to still be there to hear it. One that had counted the outage against
+        # the window would have failed the job and stopped pinging instead.
+        await async_wait_for_condition(lambda: state["pings"] >= pings_before + 3)
+
+    assert state["read_failures"] > 0
+    assert job_id in job_manager.monitored_jobs
+    assert await job_manager.get_job_status(job_id) == JobStatus.RUNNING
+
+    job_manager.stop_job(job_id)
+    await async_wait_for_condition(
+        check_job_stopped, job_manager=job_manager, job_id=job_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_monitor_retries_failing_job_while_gcs_unreachable(job_manager):
+    """Failing a job needs the GCS, so an unreachable GCS can only delay it.
+
+    Both halves of the conclusion -- writing the terminal status and killing the
+    supervisor -- go through the GCS, so a monitor that has decided the supervisor is
+    gone can act only once the GCS answers. Until then it has to keep retrying: if
+    the failing read escaped instead, the job would be left running with no monitor,
+    no terminal status and a live supervisor, which is the outcome the window exists
+    to prevent.
+    """
+    from ray.dashboard.modules.job import job_manager as job_manager_module
+
+    job_id = await job_manager.submit_job(entrypoint="sleep 600")
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+
+    original_get_status = job_manager._job_info_client.get_status
+    state = {"converging": False, "reads_while_converging": 0}
+
+    async def flaky_get_status(*args, **kwargs):
+        if not state["converging"]:
+            # The read at the top of the loop keeps working, so the monitor gets as
+            # far as pinging the supervisor.
+            return await original_get_status(*args, **kwargs)
+        # This is the read the monitor makes on its way to failing the job.
+        state["converging"] = False
+        state["reads_while_converging"] += 1
+        raise _cancelled_rpc_error()
+
+    def should_fail_ping():
+        state["converging"] = True
+        return True
+
+    # A zero-length window makes every failed ping conclusive right away, so every
+    # iteration reaches the failure path and finds the GCS unreachable there.
+    no_window = patch.object(job_manager_module, "_GCS_RECONNECT_TIMEOUT_S", 0)
+    fail_reads = patch.object(
+        job_manager._job_info_client, "get_status", flaky_get_status
+    )
+    with no_window, fail_reads, _patch_failing_ping(should_fail_ping):
+        await async_wait_for_condition(lambda: state["reads_while_converging"] >= 3)
+        # The monitor is still registered, i.e. the failing read neither ended its
+        # coroutine nor killed it.
+        assert job_id in job_manager.monitored_jobs
+
+    # Nothing was recorded while the GCS was unreachable, and the supervisor answers
+    # as soon as pings get through again, so the job just carries on.
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+    job_manager.stop_job(job_id)
+    await async_wait_for_condition(
+        check_job_stopped, job_manager=job_manager, job_id=job_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_monitor_keeps_monitoring_while_gcs_stays_unreachable(job_manager):
+    """Transient errors that aren't from a ping must never fail the job on their own.
+
+    They mean the monitor couldn't reach the GCS, not that the supervisor is gone, so
+    even with a zero-length window they may only be retried -- and retried without
+    issuing more RPCs of the monitor's own, since an exception escaping the loop would
+    leave the job running with no monitor at all.
+    """
+    from ray.dashboard.modules.job import job_manager as job_manager_module
+
+    job_id = await job_manager.submit_job(entrypoint="sleep 600")
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+
+    state = {"raised": 0}
+
+    async def unreachable_get_status(*args, **kwargs):
+        state["raised"] += 1
+        raise _cancelled_rpc_error()
+
+    no_window = patch.object(job_manager_module, "_GCS_RECONNECT_TIMEOUT_S", 0)
+    fail_reads = patch.object(
+        job_manager._job_info_client, "get_status", unreachable_get_status
+    )
+    with no_window, fail_reads:
+        await async_wait_for_condition(lambda: state["raised"] >= 3)
+        # The monitor is still registered, i.e. its coroutine neither returned nor
+        # died on the unguarded status read.
+        assert job_id in job_manager.monitored_jobs
+
+    await async_wait_for_condition(
+        check_job_running, job_manager=job_manager, job_id=job_id
+    )
+    job_manager.stop_job(job_id)
+    await async_wait_for_condition(
+        check_job_stopped, job_manager=job_manager, job_id=job_id
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Description：

During GCS HA failover (kill head pod), the job monitoring loop in dashboard_agent receives gRPC CANCELLED/UNAVAILABLE errors. The current except Exception handler does not distinguish transient errors from permanent failures, immediately marking jobs as FAILED — even though the Driver process and Worker Actors remain alive on the worker node.

This is inconsistent with how other Ray components handle GCS disconnections:
- Raylet (C++): has NotifyGCSRestart reconnection mechanism
- CoreWorker (C++): has automatic reconnection
- job_manager.py (Python): no retry ← this PR fixes it

Changes:
- Add _is_transient_rpc_error() to identify CANCELLED (code 1) and UNAVAILABLE (code 14) gRPC errors
- Wrap get_status() in try/except — if GCS is also unreachable and error is transient, retry
- If get_status() succeeds but original error is transient, retry instead of marking FAILED
- Exponential backoff: min(2^n, 30)s, max 40 attempts (~20min)
- Reset retry counter on successful supervisor ping
- Add unit test for _is_transient_rpc_error() helper

Configurable via RAY_JOB_MONITOR_MAX_TRANSIENT_ERROR_RETRIES env var (default 40).

Related issues

Fixes #65025

Additional information

- Verified on a production GCS HA cluster with a high-frequency actor workload (256 actors batch create/kill)
- Kill head pod → job stays RUNNING → GCS recovers → monitoring resumes
- Non-transient errors still immediately mark FAILED (no behavior change)
- Test: pytest python/ray/dashboard/modules/job/tests/test_job_manager.py::test_job_monitor_retries_transient_rpc_errors -v