### PR TITLE
[core][taskEvents out of GCS][3/n] Export task events from aggregator agent to dashboard head

### DIFF
--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -18,7 +18,7 @@ from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
     MultiConsumerEventBuffer,
 )
 from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
-    AsyncGCSTaskEventsPublisherClient,
+    AsyncDashboardHeadPublisherClient,
     AsyncHttpPublisherClient,
 )
 from ray.dashboard.modules.aggregator.publisher.ray_event_publisher import (
@@ -143,8 +143,10 @@ class AggregatorAgent(
             self._event_processing_enabled = True
             self._gcs_publisher = RayEventPublisher(
                 name="ray_gcs",
-                publish_client=AsyncGCSTaskEventsPublisherClient(
-                    gcs_client=self._dashboard_agent.gcs_client,
+                publish_client=AsyncDashboardHeadPublisherClient(
+                    # TODO(karticam): wire the dedicated flag (sub-goal b) and resolve the
+                    # dashboard head URL (sub-goal c); this path is inactive until then.
+                    endpoint=None,
                     executor=self._executor,
                 ),
                 event_buffer=self._event_buffer,

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -61,9 +61,9 @@ EVENTS_EXPORT_ADDR = os.environ.get(
 PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE = ray_constants.env_bool(
     "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE", True
 )
-# flag to enable publishing events to GCS
-PUBLISH_EVENTS_TO_GCS = ray_constants.env_bool(
-    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", False
+# flag to enable publishing events to the dashboard head
+PUBLISH_EVENTS_TO_DASHBOARD_HEAD = ray_constants.env_bool(
+    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD", False
 )
 # flag to control whether preserve the proto field name when converting the events to
 # JSON. If True, the proto field name will be preserved. If False, the proto field name
@@ -138,15 +138,13 @@ class AggregatorAgent(
             )
             self._http_endpoint_publisher = NoopPublisher()
 
-        if PUBLISH_EVENTS_TO_GCS:
-            logger.info("Publishing events to GCS is enabled")
+        if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
+            logger.info("Publishing events to the dashboard head is enabled")
             self._event_processing_enabled = True
-            self._gcs_publisher = RayEventPublisher(
-                name="ray_gcs",
+            self._dashboard_head_publisher = RayEventPublisher(
+                name="dashboard_head",
                 publish_client=AsyncDashboardHeadPublisherClient(
-                    # TODO(karticam): wire the dedicated flag (sub-goal b) and resolve the
-                    # dashboard head URL (sub-goal c); this path is inactive until then.
-                    endpoint=None,
+                    gcs_client=self._dashboard_agent.gcs_client,
                     executor=self._executor,
                 ),
                 event_buffer=self._event_buffer,
@@ -154,8 +152,8 @@ class AggregatorAgent(
                 task_metadata_buffer=self._task_metadata_buffer,
             )
         else:
-            logger.info("Publishing events to GCS is disabled")
-            self._gcs_publisher = NoopPublisher()
+            logger.info("Publishing events to the dashboard head is disabled")
+            self._dashboard_head_publisher = NoopPublisher()
 
         # Metrics
         self._open_telemetry_metric_recorder = OpenTelemetryMetricRecorder()
@@ -189,7 +187,7 @@ class AggregatorAgent(
         failed_count = 0
         events_data = request.events_data
 
-        if PUBLISH_EVENTS_TO_GCS:
+        if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
             self._task_metadata_buffer.merge(events_data.task_events_metadata)
 
         for event in events_data.events:
@@ -222,7 +220,7 @@ class AggregatorAgent(
         try:
             await asyncio.gather(
                 self._http_endpoint_publisher.run_forever(),
-                self._gcs_publisher.run_forever(),
+                self._dashboard_head_publisher.run_forever(),
             )
         finally:
             self._executor.shutdown()

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -67,9 +67,12 @@ PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE = ray_constants.env_bool(
 PUBLISH_EVENTS_TO_GCS = ray_constants.env_bool(
     "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", False
 )
-# flag to enable publishing task events to the dashboard head
-PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD = ray_constants.env_bool(
-    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD", False
+# flag to enable publishing task events to the dashboard head.
+# This happens only when this flag is true since it control spinning up
+# of TaskEventsHead, if task events are published there and if read
+# happens from there.
+PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD = (
+    ray._config.enable_task_events_to_dashboard_head()
 )
 # flag to control whether preserve the proto field name when converting the events to
 # JSON. If True, the proto field name will be preserved. If False, the proto field name

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -19,6 +19,7 @@ from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
 )
 from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
     AsyncDashboardHeadPublisherClient,
+    AsyncGCSTaskEventsPublisherClient,
     AsyncHttpPublisherClient,
 )
 from ray.dashboard.modules.aggregator.publisher.ray_event_publisher import (
@@ -60,6 +61,10 @@ EVENTS_EXPORT_ADDR = os.environ.get(
 # flag to enable publishing events to the external HTTP service
 PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE = ray_constants.env_bool(
     "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE", True
+)
+# flag to enable publishing events to GCS
+PUBLISH_EVENTS_TO_GCS = ray_constants.env_bool(
+    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", False
 )
 # flag to enable publishing events to the dashboard head
 PUBLISH_EVENTS_TO_DASHBOARD_HEAD = ray_constants.env_bool(
@@ -107,8 +112,14 @@ class AggregatorAgent(
             thread_name_prefix="aggregator_agent_executor",
         )
 
-        # Task metadata buffer accumulates dropped task attempts for GCS publishing
+        # Task metadata buffers accumulate dropped task attempts to publish. Each
+        # publisher needs its own buffer because reads are destructive
+        # (TaskEventsMetadataBuffer.get() pops), so a shared buffer would split the
+        # dropped attempts across publishers instead of delivering them to both.
         self._task_metadata_buffer = TaskEventsMetadataBuffer(
+            common_metric_tags=self._common_tags
+        )
+        self._dashboard_head_task_metadata_buffer = TaskEventsMetadataBuffer(
             common_metric_tags=self._common_tags
         )
 
@@ -138,6 +149,23 @@ class AggregatorAgent(
             )
             self._http_endpoint_publisher = NoopPublisher()
 
+        if PUBLISH_EVENTS_TO_GCS:
+            logger.info("Publishing events to GCS is enabled")
+            self._event_processing_enabled = True
+            self._gcs_publisher = RayEventPublisher(
+                name="ray_gcs",
+                publish_client=AsyncGCSTaskEventsPublisherClient(
+                    gcs_client=self._dashboard_agent.gcs_client,
+                    executor=self._executor,
+                ),
+                event_buffer=self._event_buffer,
+                common_metric_tags=self._common_tags,
+                task_metadata_buffer=self._task_metadata_buffer,
+            )
+        else:
+            logger.info("Publishing events to GCS is disabled")
+            self._gcs_publisher = NoopPublisher()
+
         if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
             logger.info("Publishing events to the dashboard head is enabled")
             self._event_processing_enabled = True
@@ -149,7 +177,7 @@ class AggregatorAgent(
                 ),
                 event_buffer=self._event_buffer,
                 common_metric_tags=self._common_tags,
-                task_metadata_buffer=self._task_metadata_buffer,
+                task_metadata_buffer=self._dashboard_head_task_metadata_buffer,
             )
         else:
             logger.info("Publishing events to the dashboard head is disabled")
@@ -187,8 +215,12 @@ class AggregatorAgent(
         failed_count = 0
         events_data = request.events_data
 
-        if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
+        if PUBLISH_EVENTS_TO_GCS:
             self._task_metadata_buffer.merge(events_data.task_events_metadata)
+        if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
+            self._dashboard_head_task_metadata_buffer.merge(
+                events_data.task_events_metadata
+            )
 
         for event in events_data.events:
             try:
@@ -220,6 +252,7 @@ class AggregatorAgent(
         try:
             await asyncio.gather(
                 self._http_endpoint_publisher.run_forever(),
+                self._gcs_publisher.run_forever(),
                 self._dashboard_head_publisher.run_forever(),
             )
         finally:

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -22,6 +22,7 @@ from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
     AsyncGCSTaskEventsPublisherClient,
     AsyncHttpPublisherClient,
 )
+from ray.dashboard.modules.aggregator.publisher.configs import TASK_EVENT_TYPES
 from ray.dashboard.modules.aggregator.publisher.ray_event_publisher import (
     NoopPublisher,
     RayEventPublisher,
@@ -66,9 +67,9 @@ PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE = ray_constants.env_bool(
 PUBLISH_EVENTS_TO_GCS = ray_constants.env_bool(
     "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", False
 )
-# flag to enable publishing events to the dashboard head
-PUBLISH_EVENTS_TO_DASHBOARD_HEAD = ray_constants.env_bool(
-    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD", False
+# flag to enable publishing task events to the dashboard head
+PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD = ray_constants.env_bool(
+    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD", False
 )
 # flag to control whether preserve the proto field name when converting the events to
 # JSON. If True, the proto field name will be preserved. If False, the proto field name
@@ -166,7 +167,7 @@ class AggregatorAgent(
             logger.info("Publishing events to GCS is disabled")
             self._gcs_publisher = NoopPublisher()
 
-        if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
+        if PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD:
             logger.info("Publishing events to the dashboard head is enabled")
             self._event_processing_enabled = True
             self._dashboard_head_publisher = RayEventPublisher(
@@ -174,6 +175,8 @@ class AggregatorAgent(
                 publish_client=AsyncDashboardHeadPublisherClient(
                     gcs_client=self._dashboard_agent.gcs_client,
                     executor=self._executor,
+                    endpoint_path="/api/task_events",
+                    exposable_event_types=TASK_EVENT_TYPES,
                 ),
                 event_buffer=self._event_buffer,
                 common_metric_tags=self._common_tags,
@@ -217,7 +220,7 @@ class AggregatorAgent(
 
         if PUBLISH_EVENTS_TO_GCS:
             self._task_metadata_buffer.merge(events_data.task_events_metadata)
-        if PUBLISH_EVENTS_TO_DASHBOARD_HEAD:
+        if PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD:
             self._dashboard_head_task_metadata_buffer.merge(
                 events_data.task_events_metadata
             )

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import aiohttp
 
+import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private import ray_constants
 from ray._private.authentication.http_token_authentication import (
@@ -191,6 +192,108 @@ class AsyncHttpPublisherClient(PublisherClientInterface):
         If a session is set explicitly, it will be used and managed by close().
         """
         self._session = session
+
+
+class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
+    """Client for publishing ray event batches to GCS."""
+
+    def __init__(
+        self,
+        gcs_client: GcsClient,
+        executor: ThreadPoolExecutor,
+        timeout_s: float = PUBLISHER_TIMEOUT_SECONDS,
+    ) -> None:
+        super().__init__()
+        self._gcs_client = gcs_client
+        self._executor = executor
+        self._timeout_s = timeout_s
+
+        self._exposable_event_types_list = GCS_EXPOSABLE_EVENT_TYPES
+
+    async def publish(
+        self,
+        batch: PublishBatch,
+    ) -> PublishStats:
+        events = batch.events
+        task_events_metadata = batch.task_events_metadata
+        has_dropped_task_attempts = (
+            task_events_metadata and task_events_metadata.dropped_task_attempts
+        )
+        if not events and not has_dropped_task_attempts:
+            # Nothing to publish -> success but nothing published
+            return PublishStats(
+                is_publish_successful=True,
+                num_events_published=0,
+                num_events_filtered_out=0,
+            )
+
+        # Filter events based on exposable event types
+        filtered_events = [e for e in events if self._can_expose_event(e)]
+        num_filtered_out = len(events) - len(filtered_events)
+
+        if not filtered_events and not has_dropped_task_attempts:
+            # all events filtered out and no task events metadata -> success but nothing published
+            return PublishStats(
+                is_publish_successful=True,
+                num_events_published=0,
+                num_events_filtered_out=num_filtered_out,
+            )
+
+        try:
+            events_data = self._create_ray_events_data(
+                filtered_events, task_events_metadata
+            )
+            request = events_event_aggregator_service_pb2.AddEventsRequest(
+                events_data=events_data
+            )
+            serialized_request = await get_or_create_event_loop().run_in_executor(
+                self._executor,
+                lambda: request.SerializeToString(),
+            )
+            status_code = await self._gcs_client.async_add_events(
+                serialized_request, self._timeout_s, self._executor
+            )
+
+            if status_code != dashboard_utils.HTTPStatusCode.OK:
+                logger.error(f"GCS AddEvents failed: {status_code}")
+                return PublishStats(
+                    is_publish_successful=False,
+                    num_events_published=0,
+                    num_events_filtered_out=0,
+                )
+            return PublishStats(
+                is_publish_successful=True,
+                num_events_published=len(filtered_events),
+                num_events_filtered_out=num_filtered_out,
+            )
+        except Exception as e:
+            logger.error(f"Failed to send events to GCS: {e}")
+            return PublishStats(
+                is_publish_successful=False,
+                num_events_published=0,
+                num_events_filtered_out=0,
+            )
+
+    def _create_ray_events_data(
+        self,
+        event_batch: List[events_base_event_pb2.RayEvent],
+        task_events_metadata: Optional[
+            events_event_aggregator_service_pb2.TaskEventsMetadata
+        ] = None,
+    ) -> events_event_aggregator_service_pb2.RayEventsData:
+        """
+        Helper method to create RayEventsData from event batch and metadata.
+        """
+        events_data = events_event_aggregator_service_pb2.RayEventsData()
+        events_data.events.extend(event_batch)
+
+        if task_events_metadata:
+            events_data.task_events_metadata.CopyFrom(task_events_metadata)
+
+        return events_data
+
+    async def close(self) -> None:
+        pass
 
 
 class AsyncDashboardHeadPublisherClient(PublisherClientInterface):

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -21,9 +21,9 @@ from ray.core.generated import (
 )
 from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
 from ray.dashboard.modules.aggregator.publisher.configs import (
-    GCS_EXPOSABLE_EVENT_TYPES,
     HTTP_EXPOSABLE_EVENT_TYPES,
     PUBLISHER_TIMEOUT_SECONDS,
+    TASK_EVENT_TYPES,
 )
 
 logger = logging.getLogger(__name__)
@@ -208,7 +208,7 @@ class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
         self._executor = executor
         self._timeout_s = timeout_s
 
-        self._exposable_event_types_list = GCS_EXPOSABLE_EVENT_TYPES
+        self._exposable_event_types_list = TASK_EVENT_TYPES
 
     async def publish(
         self,
@@ -297,28 +297,35 @@ class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
 
 
 class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
-    """Client for publishing ray task event batches to the dashboard head over HTTP."""
+    """Client for publishing ray event batches to the dashboard head over HTTP.
+
+    The destination endpoint path and the set of event types this client may publish are
+    supplied by the caller, so the same client can serve any dashboard-head ingestion
+    endpoint."""
 
     def __init__(
         self,
         gcs_client: GcsClient,
         executor: ThreadPoolExecutor,
+        endpoint_path: str,
+        exposable_event_types: List[str],
         timeout_s: float = PUBLISHER_TIMEOUT_SECONDS,
     ) -> None:
         super().__init__()
         self._gcs_client = gcs_client
         self._executor = executor
+        self._endpoint_path = endpoint_path
         self._timeout = aiohttp.ClientTimeout(total=timeout_s)
         self._session = None
         # Resolved lazily from InternalKV on first publish and cached.
         self._endpoint = None
 
-        self._exposable_event_types_list = GCS_EXPOSABLE_EVENT_TYPES
+        self._exposable_event_types_list = exposable_event_types
 
     async def _get_endpoint(self) -> Optional[str]:
-        """Lazily resolve and cache the dashboard head's task-events endpoint from
-        InternalKV. Returns None if the head has not registered its address yet, so the
-        caller can retry later."""
+        """Lazily resolve and cache the dashboard head's endpoint from InternalKV.
+        Returns None if the head has not registered its address yet, so the caller can
+        retry later."""
         if self._endpoint:
             return self._endpoint
         address = await self._gcs_client.async_internal_kv_get(
@@ -331,7 +338,7 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
         address = address.decode()
         if not address.startswith(("http://", "https://")):
             address = f"http://{address}"
-        self._endpoint = f"{address}/api/task_events"
+        self._endpoint = f"{address}{self._endpoint_path}"
         return self._endpoint
 
     async def publish(

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -397,12 +398,19 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
                 self._session = aiohttp.ClientSession(timeout=self._timeout)
             # Propagate the auth token so the POST passes the dashboard's auth middleware.
             headers = get_auth_headers_if_auth_enabled({})
-            async with self._session.post(
-                endpoint,
-                data=serialized_request,
-                headers=headers,
-            ) as resp:
-                resp.raise_for_status()
+            try:
+                async with self._session.post(
+                    endpoint,
+                    data=serialized_request,
+                    headers=headers,
+                ) as resp:
+                    resp.raise_for_status()
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
+                # Couldn't reach the endpoint; the dashboard head may have restarted at a
+                # new address. Drop the cached endpoint so the next publish re-resolves it
+                # from InternalKV.
+                self._endpoint = None
+                raise
             return PublishStats(
                 is_publish_successful=True,
                 num_events_published=len(filtered_events),

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -8,14 +8,17 @@ from typing import List, Optional
 import aiohttp
 
 from ray._common.utils import get_or_create_event_loop
+from ray._private import ray_constants
 from ray._private.authentication.http_token_authentication import (
     get_auth_headers_if_auth_enabled,
 )
 from ray._private.protobuf_compat import message_to_json
+from ray._raylet import GcsClient
 from ray.core.generated import (
     events_base_event_pb2,
     events_event_aggregator_service_pb2,
 )
+from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
 from ray.dashboard.modules.aggregator.publisher.configs import (
     GCS_EXPOSABLE_EVENT_TYPES,
     HTTP_EXPOSABLE_EVENT_TYPES,
@@ -195,17 +198,38 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
 
     def __init__(
         self,
-        endpoint: str,
+        gcs_client: GcsClient,
         executor: ThreadPoolExecutor,
         timeout_s: float = PUBLISHER_TIMEOUT_SECONDS,
     ) -> None:
         super().__init__()
-        self._endpoint = endpoint
+        self._gcs_client = gcs_client
         self._executor = executor
         self._timeout = aiohttp.ClientTimeout(total=timeout_s)
         self._session = None
+        # Resolved lazily from InternalKV on first publish and cached.
+        self._endpoint = None
 
         self._exposable_event_types_list = GCS_EXPOSABLE_EVENT_TYPES
+
+    async def _get_endpoint(self) -> Optional[str]:
+        """Lazily resolve and cache the dashboard head's task-events endpoint from
+        InternalKV. Returns None if the head has not registered its address yet, so the
+        caller can retry later."""
+        if self._endpoint:
+            return self._endpoint
+        address = await self._gcs_client.async_internal_kv_get(
+            ray_constants.DASHBOARD_ADDRESS.encode(),
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+            timeout=GCS_RPC_TIMEOUT_SECONDS,
+        )
+        if not address:
+            return None
+        address = address.decode()
+        if not address.startswith(("http://", "https://")):
+            address = f"http://{address}"
+        self._endpoint = f"{address}/api/task_events"
+        return self._endpoint
 
     async def publish(
         self,
@@ -237,6 +261,16 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
             )
 
         try:
+            endpoint = await self._get_endpoint()
+            if endpoint is None:
+                logger.warning(
+                    "Dashboard head address not yet in InternalKV; will retry."
+                )
+                return PublishStats(
+                    is_publish_successful=False,
+                    num_events_published=0,
+                    num_events_filtered_out=0,
+                )
             events_data = self._create_ray_events_data(
                 filtered_events, task_events_metadata
             )
@@ -254,7 +288,7 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
             # Propagate the auth token so the POST passes the dashboard's auth middleware.
             headers = get_auth_headers_if_auth_enabled({})
             async with self._session.post(
-                self._endpoint,
+                endpoint,
                 data=serialized_request,
                 headers=headers,
             ) as resp:

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -7,10 +7,11 @@ from typing import List, Optional
 
 import aiohttp
 
-import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
+from ray._private.authentication.http_token_authentication import (
+    get_auth_headers_if_auth_enabled,
+)
 from ray._private.protobuf_compat import message_to_json
-from ray._raylet import GcsClient
 from ray.core.generated import (
     events_base_event_pb2,
     events_event_aggregator_service_pb2,
@@ -189,19 +190,20 @@ class AsyncHttpPublisherClient(PublisherClientInterface):
         self._session = session
 
 
-class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
-    """Client for publishing ray event batches to GCS."""
+class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
+    """Client for publishing ray task event batches to the dashboard head over HTTP."""
 
     def __init__(
         self,
-        gcs_client: GcsClient,
+        endpoint: str,
         executor: ThreadPoolExecutor,
         timeout_s: float = PUBLISHER_TIMEOUT_SECONDS,
     ) -> None:
         super().__init__()
-        self._gcs_client = gcs_client
+        self._endpoint = endpoint
         self._executor = executor
-        self._timeout_s = timeout_s
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._session = None
 
         self._exposable_event_types_list = GCS_EXPOSABLE_EVENT_TYPES
 
@@ -245,24 +247,25 @@ class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
                 self._executor,
                 lambda: request.SerializeToString(),
             )
-            status_code = await self._gcs_client.async_add_events(
-                serialized_request, self._timeout_s, self._executor
-            )
 
-            if status_code != dashboard_utils.HTTPStatusCode.OK:
-                logger.error(f"GCS AddEvents failed: {status_code}")
-                return PublishStats(
-                    is_publish_successful=False,
-                    num_events_published=0,
-                    num_events_filtered_out=0,
-                )
+            # Create session on first use (lazy initialization)
+            if not self._session:
+                self._session = aiohttp.ClientSession(timeout=self._timeout)
+            # Propagate the auth token so the POST passes the dashboard's auth middleware.
+            headers = get_auth_headers_if_auth_enabled({})
+            async with self._session.post(
+                self._endpoint,
+                data=serialized_request,
+                headers=headers,
+            ) as resp:
+                resp.raise_for_status()
             return PublishStats(
                 is_publish_successful=True,
                 num_events_published=len(filtered_events),
                 num_events_filtered_out=num_filtered_out,
             )
         except Exception as e:
-            logger.error(f"Failed to send events to GCS: {e}")
+            logger.error(f"Failed to send events to the dashboard head: {e}")
             return PublishStats(
                 is_publish_successful=False,
                 num_events_published=0,
@@ -288,4 +291,6 @@ class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
         return events_data
 
     async def close(self) -> None:
-        pass
+        if self._session:
+            await self._session.close()
+            self._session = None

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -44,10 +44,10 @@ HTTP_EXPOSABLE_EVENT_TYPES = os.environ.get(
     DEFAULT_HTTP_EXPOSABLE_EVENT_TYPES,
 )
 
-# GCS Publisher specific configurations
-# List of event types that are allowed to be exposed to GCS, not overridden by environment variable
-# as GCS only supports Task event types
-GCS_EXPOSABLE_EVENT_TYPES = [
+# The task event types. Both the GCS publisher and the dashboard-head publisher expose
+# only these, since GCS and the dashboard-head task-events store only handle task events.
+# Not overridden by an environment variable.
+TASK_EVENT_TYPES = [
     "TASK_DEFINITION_EVENT",
     "TASK_LIFECYCLE_EVENT",
     "TASK_PROFILE_EVENT",

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -43,10 +43,10 @@ HTTP_EXPOSABLE_EVENT_TYPES = os.environ.get(
     DEFAULT_HTTP_EXPOSABLE_EVENT_TYPES,
 )
 
-# GCS Publisher specific configurations
-# List of event types that are allowed to be exposed to GCS, not overridden by environment variable
-# as GCS only supports Task event types
-GCS_EXPOSABLE_EVENT_TYPES = [
+# The task event types. Both the GCS publisher and the dashboard-head publisher expose
+# only these, since GCS and the dashboard-head task-events store only handle task events.
+# Not overridden by an environment variable.
+TASK_EVENT_TYPES = [
     "TASK_DEFINITION_EVENT",
     "TASK_LIFECYCLE_EVENT",
     "TASK_PROFILE_EVENT",

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -1314,7 +1314,7 @@ def _get_dashboard_head_events_from_httpserver(httpserver):
         {
             "env_vars": {
                 # Enable both publishers
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
                 # TODO(karticam): assumes the aggregator receives only the injected event;
@@ -1380,7 +1380,7 @@ def test_aggregator_agent_publish_to_both_dashboard_head_and_http(
                 # Disable the external HTTP publisher to test filtering in isolation
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
                 # Enable the dashboard-head publisher
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD": "True",
             },
         },
     ],
@@ -1405,7 +1405,7 @@ def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
         fake_timestamp[0], unique_task_name
     )
 
-    # DRIVER_JOB_LIFECYCLE_EVENT is not in GCS_EXPOSABLE_EVENT_TYPES, so the dashboard-head
+    # DRIVER_JOB_LIFECYCLE_EVENT is not in TASK_EVENT_TYPES, so the dashboard-head
     # publisher must filter it out.
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
@@ -1537,7 +1537,7 @@ def test_aggregator_agent_gcs_filtering_driver_job_events(
         fake_timestamp[0], unique_task_name
     )
 
-    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in TASK_EVENT_TYPES)
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
         source_type=RayEvent.SourceType.CORE_WORKER,

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -51,6 +51,7 @@ from ray.dashboard.modules.aggregator.publisher.configs import (
     PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
 )
 from ray.dashboard.tests.conftest import *  # noqa
+from ray.util.state import list_tasks
 
 _EVENT_AGGREGATOR_AGENT_TARGET_PORT = find_free_port()
 _EVENT_AGGREGATOR_AGENT_TARGET_IP = "127.0.0.1"
@@ -1245,6 +1246,35 @@ def _create_task_definition_event_with_ids(timestamp, unique_task_name: str):
     return event
 
 
+def _get_task_from_gcs(
+    unique_task_name: str,
+):
+    """Fetch and return the first matching task by task name from GCS, or None."""
+    try:
+        task = list_tasks(filters=[("name", "=", unique_task_name)])
+        if len(task) > 0:
+            return task[0]
+        return None
+    except Exception:
+        return None
+
+
+def _wait_for_and_verify_task_definition_event_in_gcs(
+    unique_task_name: str, sent_event
+):
+    """Wait for the task event to be stored in GCS and verify the fields match the sent event"""
+    wait_for_condition(lambda: _get_task_from_gcs(unique_task_name) is not None)
+    matched_task = _get_task_from_gcs(unique_task_name)
+
+    # Verify fields match
+    expected = sent_event.task_definition_event
+    assert matched_task.name == expected.task_name
+    assert matched_task.attempt_number == expected.task_attempt
+    assert matched_task.task_id == expected.task_id.hex()
+    assert matched_task.job_id == expected.job_id.hex()
+    assert matched_task.parent_task_id == expected.parent_task_id.hex()
+
+
 def override_dashboard_address_to_httpserver(gcs_address):
     """Point the dashboard-head publisher at the test httpserver by overwriting
     DASHBOARD_ADDRESS in InternalKV. The publisher resolves this address lazily on its
@@ -1425,6 +1455,136 @@ def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
         event.event_type != RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
         for event in _get_dashboard_head_events_from_httpserver(httpserver)
     )
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                # Enable both publishers
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_publish_to_both_gcs_and_http(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    cluster = ray_start_cluster_head_with_env_vars
+    agg_stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+
+    # Create an event with a unique task name to filter on
+    unique_task_name = f"gcs_only_task_{uuid.uuid4()}"
+    event = _create_task_definition_event_with_ids(fake_timestamp[0], unique_task_name)
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[event],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    agg_stub.AddEvents(request)
+
+    # Verify HTTP received the event
+    wait_for_condition(lambda: len(httpserver.log) == 1)
+    req, _ = httpserver.log[0]
+    req_json = json.loads(req.data)
+    assert len(req_json) == 1
+    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
+    assert req_json[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+
+    # Verify GCS stored the event and fields match
+    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, event)
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                # Disable HTTP publisher to test GCS filtering in isolation
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
+                # Enable GCS publisher
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_gcs_filtering_driver_job_events(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    """Test that driver job execution events are filtered out and not sent to GCS."""
+    cluster = ray_start_cluster_head_with_env_vars
+    agg_stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    unique_task_name = f"gcs_filter_task_{uuid.uuid4()}"
+
+    task_event = _create_task_definition_event_with_ids(
+        fake_timestamp[0], unique_task_name
+    )
+
+    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    driver_job_event = RayEvent(
+        event_id=b"driver_job_1",
+        source_type=RayEvent.SourceType.CORE_WORKER,
+        event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        timestamp=fake_timestamp[0],
+        severity=RayEvent.Severity.INFO,
+        message="driver job execution event - should be filtered",
+        driver_job_lifecycle_event=DriverJobLifecycleEvent(
+            job_id=b"test_job_1",
+            state_transitions=[
+                DriverJobLifecycleEvent.StateTransition(
+                    state=DriverJobLifecycleEvent.State.CREATED,
+                    timestamp=Timestamp(seconds=1234567890),
+                ),
+                DriverJobLifecycleEvent.StateTransition(
+                    state=DriverJobLifecycleEvent.State.FINISHED,
+                    timestamp=Timestamp(seconds=1234567890),
+                ),
+            ],
+        ),
+    )
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[task_event, driver_job_event],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    agg_stub.AddEvents(request)
+
+    # Wait for the task definition event to be stored in GCS (this should succeed)
+    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, task_event)
+
+    # Verify that only the task event was processed by GCS, not the driver job event
+    # We can verify this by checking that no other task events are stored beyond our expected one
+    # and ensuring that there were no errors during publishing.
+    # The filtering logic in the GCS publisher should have filtered out the driver job event
+
+    # Ensure HTTP publisher did not send anything (since it's disabled)
+    with pytest.raises(
+        RuntimeError, match="The condition wasn't met before the timeout expired."
+    ):
+        wait_for_condition(lambda: len(httpserver.log) > 0, 1)
+    assert len(httpserver.log) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -1314,7 +1314,7 @@ def _get_dashboard_head_events_from_httpserver(httpserver):
         {
             "env_vars": {
                 # Enable both publishers
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_enable_task_events_to_dashboard_head": "1",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
                 # TODO(karticam): assumes the aggregator receives only the injected event;
@@ -1380,7 +1380,7 @@ def test_aggregator_agent_publish_to_both_dashboard_head_and_http(
                 # Disable the external HTTP publisher to test filtering in isolation
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
                 # Enable the dashboard-head publisher
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_enable_task_events_to_dashboard_head": "1",
             },
         },
     ],

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -51,7 +51,6 @@ from ray.dashboard.modules.aggregator.publisher.configs import (
     PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
 )
 from ray.dashboard.tests.conftest import *  # noqa
-from ray.util.state import list_tasks
 
 _EVENT_AGGREGATOR_AGENT_TARGET_PORT = find_free_port()
 _EVENT_AGGREGATOR_AGENT_TARGET_IP = "127.0.0.1"
@@ -1233,21 +1232,8 @@ def test_aggregator_agent_http_svc_publish_disabled(
     assert len(httpserver.log) == 0
 
 
-def _get_task_from_gcs(
-    unique_task_name: str,
-):
-    """Fetch and return the first matching task by task name from GCS, or None."""
-    try:
-        task = list_tasks(filters=[("name", "=", unique_task_name)])
-        if len(task) > 0:
-            return task[0]
-        return None
-    except Exception:
-        return None
-
-
-def _create_task_definition_event_for_gcs(timestamp, unique_task_name: str):
-    """Create and return a task definition event for GCS with valid task id and job id and a unique task name"""
+def _create_task_definition_event_with_ids(timestamp, unique_task_name: str):
+    """Create a task definition event with valid task/job ids and a unique task name."""
     job_id = JobID.from_int(1)
     task_id = TaskID.for_fake_task(job_id)
 
@@ -1259,20 +1245,37 @@ def _create_task_definition_event_for_gcs(timestamp, unique_task_name: str):
     return event
 
 
-def _wait_for_and_verify_task_definition_event_in_gcs(
-    unique_task_name: str, sent_event
-):
-    """Wait for the task event to be stored in GCS and verify the fields match the sent event"""
-    wait_for_condition(lambda: _get_task_from_gcs(unique_task_name) is not None)
-    matched_task = _get_task_from_gcs(unique_task_name)
+def override_dashboard_address_to_httpserver(gcs_address):
+    """Point the dashboard-head publisher at the test httpserver by overwriting
+    DASHBOARD_ADDRESS in InternalKV. The publisher resolves this address lazily on its
+    first publish and caches it, so this must run before any exposable event is sent."""
+    gcs_client = GcsClient(address=gcs_address)
+    gcs_client.internal_kv_put(
+        ray_constants.DASHBOARD_ADDRESS.encode(),
+        _EVENT_AGGREGATOR_AGENT_TARGET_ADDR.encode(),
+        True,
+        namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+    )
 
-    # Verify fields match
-    expected = sent_event.task_definition_event
-    assert matched_task.name == expected.task_name
-    assert matched_task.attempt_number == expected.task_attempt
-    assert matched_task.task_id == expected.task_id.hex()
-    assert matched_task.job_id == expected.job_id.hex()
-    assert matched_task.parent_task_id == expected.parent_task_id.hex()
+
+def _get_json_events_from_httpserver(httpserver):
+    """Return every event POSTed as JSON by the external HTTP publisher to "/"."""
+    events = []
+    for req, _ in httpserver.log:
+        if req.path == "/":
+            events.extend(json.loads(req.get_data()))
+    return events
+
+
+def _get_dashboard_head_events_from_httpserver(httpserver):
+    """Return every RayEvent POSTed as a serialized AddEventsRequest proto by the
+    dashboard-head publisher to "/api/task_events"."""
+    events = []
+    for req, _ in httpserver.log:
+        if req.path == "/api/task_events":
+            add_events_request = AddEventsRequest.FromString(req.get_data())
+            events.extend(add_events_request.events_data.events)
+    return events
 
 
 @pytest.mark.parametrize(
@@ -1281,7 +1284,7 @@ def _wait_for_and_verify_task_definition_event_in_gcs(
         {
             "env_vars": {
                 # Enable both publishers
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
                 # TODO(karticam): assumes the aggregator receives only the injected event;
@@ -1292,7 +1295,7 @@ def _wait_for_and_verify_task_definition_event_in_gcs(
     ],
     indirect=True,
 )
-def test_aggregator_agent_publish_to_both_gcs_and_http(
+def test_aggregator_agent_publish_to_both_dashboard_head_and_http(
     ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
 ):
     cluster = ray_start_cluster_head_with_env_vars
@@ -1300,11 +1303,17 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
         cluster.gcs_address, cluster.head_node.node_id
     )
 
+    # The external HTTP publisher POSTs JSON to "/"; the dashboard-head publisher POSTs a
+    # serialized AddEventsRequest proto to "/api/task_events". Redirect the dashboard-head
+    # publisher to the same test httpserver by overriding its InternalKV address.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
-    # Create an event with a unique task name to filter on
-    unique_task_name = f"gcs_only_task_{uuid.uuid4()}"
-    event = _create_task_definition_event_for_gcs(fake_timestamp[0], unique_task_name)
+    unique_task_name = f"task_{uuid.uuid4()}"
+    event = _create_task_definition_event_with_ids(fake_timestamp[0], unique_task_name)
 
     request = AddEventsRequest(
         events_data=RayEventsData(
@@ -1317,16 +1326,20 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
 
     agg_stub.AddEvents(request)
 
-    # Verify HTTP received the event
-    wait_for_condition(lambda: len(httpserver.log) == 1)
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
-    assert len(req_json) == 1
-    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
-    assert req_json[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+    # The external HTTP publisher received the event as JSON at "/".
+    wait_for_condition(lambda: len(_get_json_events_from_httpserver(httpserver)) == 1)
+    json_events = _get_json_events_from_httpserver(httpserver)
+    assert json_events[0]["eventType"] == "TASK_DEFINITION_EVENT"
+    assert json_events[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
 
-    # Verify GCS stored the event and fields match
-    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, event)
+    # The dashboard-head publisher received the same event as a serialized proto at
+    # "/api/task_events".
+    wait_for_condition(
+        lambda: len(_get_dashboard_head_events_from_httpserver(httpserver)) == 1
+    )
+    dashboard_events = _get_dashboard_head_events_from_httpserver(httpserver)
+    assert dashboard_events[0].event_type == RayEvent.EventType.TASK_DEFINITION_EVENT
+    assert dashboard_events[0].task_definition_event.task_name == unique_task_name
 
 
 @pytest.mark.parametrize(
@@ -1334,31 +1347,36 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
     [
         {
             "env_vars": {
-                # Disable HTTP publisher to test GCS filtering in isolation
+                # Disable the external HTTP publisher to test filtering in isolation
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
-                # Enable GCS publisher
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                # Enable the dashboard-head publisher
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
             },
         },
     ],
     indirect=True,
 )
-def test_aggregator_agent_gcs_filtering_driver_job_events(
+def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
     ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
 ):
-    """Test that driver job execution events are filtered out and not sent to GCS."""
+    """Driver job events are filtered out and never sent to the dashboard head."""
     cluster = ray_start_cluster_head_with_env_vars
     agg_stub = get_event_aggregator_grpc_stub(
         cluster.gcs_address, cluster.head_node.node_id
     )
 
-    unique_task_name = f"gcs_filter_task_{uuid.uuid4()}"
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
-    task_event = _create_task_definition_event_for_gcs(
+    unique_task_name = f"task_{uuid.uuid4()}"
+    task_event = _create_task_definition_event_with_ids(
         fake_timestamp[0], unique_task_name
     )
 
-    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    # DRIVER_JOB_LIFECYCLE_EVENT is not in GCS_EXPOSABLE_EVENT_TYPES, so the dashboard-head
+    # publisher must filter it out.
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
         source_type=RayEvent.SourceType.CORE_WORKER,
@@ -1392,20 +1410,21 @@ def test_aggregator_agent_gcs_filtering_driver_job_events(
 
     agg_stub.AddEvents(request)
 
-    # Wait for the task definition event to be stored in GCS (this should succeed)
-    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, task_event)
+    # The task definition event reaches the dashboard head.
+    def _task_event_received():
+        return any(
+            event.event_type == RayEvent.EventType.TASK_DEFINITION_EVENT
+            and event.task_definition_event.task_name == unique_task_name
+            for event in _get_dashboard_head_events_from_httpserver(httpserver)
+        )
 
-    # Verify that only the task event was processed by GCS, not the driver job event
-    # We can verify this by checking that no other task events are stored beyond our expected one
-    # and ensuring that there were no errors during publishing.
-    # The filtering logic in the GCS publisher should have filtered out the driver job event
+    wait_for_condition(_task_event_received)
 
-    # Ensure HTTP publisher did not send anything (since it's disabled)
-    with pytest.raises(
-        RuntimeError, match="The condition wasn't met before the timeout expired."
-    ):
-        wait_for_condition(lambda: len(httpserver.log) > 0, 1)
-    assert len(httpserver.log) == 0
+    # The driver job lifecycle event was filtered out and never sent.
+    assert all(
+        event.event_type != RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
+        for event in _get_dashboard_head_events_from_httpserver(httpserver)
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -1294,7 +1294,7 @@ def _get_dashboard_head_events_from_httpserver(httpserver):
         {
             "env_vars": {
                 # Enable both publishers
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
             },
@@ -1357,7 +1357,7 @@ def test_aggregator_agent_publish_to_both_dashboard_head_and_http(
                 # Disable the external HTTP publisher to test filtering in isolation
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
                 # Enable the dashboard-head publisher
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD": "True",
             },
         },
     ],
@@ -1382,7 +1382,7 @@ def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
         fake_timestamp[0], unique_task_name
     )
 
-    # DRIVER_JOB_LIFECYCLE_EVENT is not in GCS_EXPOSABLE_EVENT_TYPES, so the dashboard-head
+    # DRIVER_JOB_LIFECYCLE_EVENT is not in TASK_EVENT_TYPES, so the dashboard-head
     # publisher must filter it out.
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
@@ -1514,7 +1514,7 @@ def test_aggregator_agent_gcs_filtering_driver_job_events(
         fake_timestamp[0], unique_task_name
     )
 
-    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in TASK_EVENT_TYPES)
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
         source_type=RayEvent.SourceType.CORE_WORKER,

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -51,6 +51,7 @@ from ray.dashboard.modules.aggregator.publisher.configs import (
     PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
 )
 from ray.dashboard.tests.conftest import *  # noqa
+from ray.util.state import list_tasks
 
 _EVENT_AGGREGATOR_AGENT_TARGET_PORT = find_free_port()
 _EVENT_AGGREGATOR_AGENT_TARGET_IP = "127.0.0.1"
@@ -1225,6 +1226,35 @@ def _create_task_definition_event_with_ids(timestamp, unique_task_name: str):
     return event
 
 
+def _get_task_from_gcs(
+    unique_task_name: str,
+):
+    """Fetch and return the first matching task by task name from GCS, or None."""
+    try:
+        task = list_tasks(filters=[("name", "=", unique_task_name)])
+        if len(task) > 0:
+            return task[0]
+        return None
+    except Exception:
+        return None
+
+
+def _wait_for_and_verify_task_definition_event_in_gcs(
+    unique_task_name: str, sent_event
+):
+    """Wait for the task event to be stored in GCS and verify the fields match the sent event"""
+    wait_for_condition(lambda: _get_task_from_gcs(unique_task_name) is not None)
+    matched_task = _get_task_from_gcs(unique_task_name)
+
+    # Verify fields match
+    expected = sent_event.task_definition_event
+    assert matched_task.name == expected.task_name
+    assert matched_task.attempt_number == expected.task_attempt
+    assert matched_task.task_id == expected.task_id.hex()
+    assert matched_task.job_id == expected.job_id.hex()
+    assert matched_task.parent_task_id == expected.parent_task_id.hex()
+
+
 def override_dashboard_address_to_httpserver(gcs_address):
     """Point the dashboard-head publisher at the test httpserver by overwriting
     DASHBOARD_ADDRESS in InternalKV. The publisher resolves this address lazily on its
@@ -1402,6 +1432,136 @@ def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
         event.event_type != RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
         for event in _get_dashboard_head_events_from_httpserver(httpserver)
     )
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                # Enable both publishers
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_publish_to_both_gcs_and_http(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    cluster = ray_start_cluster_head_with_env_vars
+    agg_stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+
+    # Create an event with a unique task name to filter on
+    unique_task_name = f"gcs_only_task_{uuid.uuid4()}"
+    event = _create_task_definition_event_with_ids(fake_timestamp[0], unique_task_name)
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[event],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    agg_stub.AddEvents(request)
+
+    # Verify HTTP received the event
+    wait_for_condition(lambda: len(httpserver.log) == 1)
+    req, _ = httpserver.log[0]
+    req_json = json.loads(req.data)
+    assert len(req_json) == 1
+    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
+    assert req_json[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+
+    # Verify GCS stored the event and fields match
+    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, event)
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                # Disable HTTP publisher to test GCS filtering in isolation
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
+                # Enable GCS publisher
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_gcs_filtering_driver_job_events(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    """Test that driver job execution events are filtered out and not sent to GCS."""
+    cluster = ray_start_cluster_head_with_env_vars
+    agg_stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    unique_task_name = f"gcs_filter_task_{uuid.uuid4()}"
+
+    task_event = _create_task_definition_event_with_ids(
+        fake_timestamp[0], unique_task_name
+    )
+
+    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    driver_job_event = RayEvent(
+        event_id=b"driver_job_1",
+        source_type=RayEvent.SourceType.CORE_WORKER,
+        event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        timestamp=fake_timestamp[0],
+        severity=RayEvent.Severity.INFO,
+        message="driver job execution event - should be filtered",
+        driver_job_lifecycle_event=DriverJobLifecycleEvent(
+            job_id=b"test_job_1",
+            state_transitions=[
+                DriverJobLifecycleEvent.StateTransition(
+                    state=DriverJobLifecycleEvent.State.CREATED,
+                    timestamp=Timestamp(seconds=1234567890),
+                ),
+                DriverJobLifecycleEvent.StateTransition(
+                    state=DriverJobLifecycleEvent.State.FINISHED,
+                    timestamp=Timestamp(seconds=1234567890),
+                ),
+            ],
+        ),
+    )
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[task_event, driver_job_event],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    agg_stub.AddEvents(request)
+
+    # Wait for the task definition event to be stored in GCS (this should succeed)
+    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, task_event)
+
+    # Verify that only the task event was processed by GCS, not the driver job event
+    # We can verify this by checking that no other task events are stored beyond our expected one
+    # and ensuring that there were no errors during publishing.
+    # The filtering logic in the GCS publisher should have filtered out the driver job event
+
+    # Ensure HTTP publisher did not send anything (since it's disabled)
+    with pytest.raises(
+        RuntimeError, match="The condition wasn't met before the timeout expired."
+    ):
+        wait_for_condition(lambda: len(httpserver.log) > 0, 1)
+    assert len(httpserver.log) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -51,7 +51,6 @@ from ray.dashboard.modules.aggregator.publisher.configs import (
     PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
 )
 from ray.dashboard.tests.conftest import *  # noqa
-from ray.util.state import list_tasks
 
 _EVENT_AGGREGATOR_AGENT_TARGET_PORT = find_free_port()
 _EVENT_AGGREGATOR_AGENT_TARGET_IP = "127.0.0.1"
@@ -1213,21 +1212,8 @@ def test_aggregator_agent_http_svc_publish_disabled(
     assert len(httpserver.log) == 0
 
 
-def _get_task_from_gcs(
-    unique_task_name: str,
-):
-    """Fetch and return the first matching task by task name from GCS, or None."""
-    try:
-        task = list_tasks(filters=[("name", "=", unique_task_name)])
-        if len(task) > 0:
-            return task[0]
-        return None
-    except Exception:
-        return None
-
-
-def _create_task_definition_event_for_gcs(timestamp, unique_task_name: str):
-    """Create and return a task definition event for GCS with valid task id and job id and a unique task name"""
+def _create_task_definition_event_with_ids(timestamp, unique_task_name: str):
+    """Create a task definition event with valid task/job ids and a unique task name."""
     job_id = JobID.from_int(1)
     task_id = TaskID.for_fake_task(job_id)
 
@@ -1239,20 +1225,37 @@ def _create_task_definition_event_for_gcs(timestamp, unique_task_name: str):
     return event
 
 
-def _wait_for_and_verify_task_definition_event_in_gcs(
-    unique_task_name: str, sent_event
-):
-    """Wait for the task event to be stored in GCS and verify the fields match the sent event"""
-    wait_for_condition(lambda: _get_task_from_gcs(unique_task_name) is not None)
-    matched_task = _get_task_from_gcs(unique_task_name)
+def override_dashboard_address_to_httpserver(gcs_address):
+    """Point the dashboard-head publisher at the test httpserver by overwriting
+    DASHBOARD_ADDRESS in InternalKV. The publisher resolves this address lazily on its
+    first publish and caches it, so this must run before any exposable event is sent."""
+    gcs_client = GcsClient(address=gcs_address)
+    gcs_client.internal_kv_put(
+        ray_constants.DASHBOARD_ADDRESS.encode(),
+        _EVENT_AGGREGATOR_AGENT_TARGET_ADDR.encode(),
+        True,
+        namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+    )
 
-    # Verify fields match
-    expected = sent_event.task_definition_event
-    assert matched_task.name == expected.task_name
-    assert matched_task.attempt_number == expected.task_attempt
-    assert matched_task.task_id == expected.task_id.hex()
-    assert matched_task.job_id == expected.job_id.hex()
-    assert matched_task.parent_task_id == expected.parent_task_id.hex()
+
+def _get_json_events_from_httpserver(httpserver):
+    """Return every event POSTed as JSON by the external HTTP publisher to "/"."""
+    events = []
+    for req, _ in httpserver.log:
+        if req.path == "/":
+            events.extend(json.loads(req.get_data()))
+    return events
+
+
+def _get_dashboard_head_events_from_httpserver(httpserver):
+    """Return every RayEvent POSTed as a serialized AddEventsRequest proto by the
+    dashboard-head publisher to "/api/task_events"."""
+    events = []
+    for req, _ in httpserver.log:
+        if req.path == "/api/task_events":
+            add_events_request = AddEventsRequest.FromString(req.get_data())
+            events.extend(add_events_request.events_data.events)
+    return events
 
 
 @pytest.mark.parametrize(
@@ -1261,7 +1264,7 @@ def _wait_for_and_verify_task_definition_event_in_gcs(
         {
             "env_vars": {
                 # Enable both publishers
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
             },
@@ -1269,7 +1272,7 @@ def _wait_for_and_verify_task_definition_event_in_gcs(
     ],
     indirect=True,
 )
-def test_aggregator_agent_publish_to_both_gcs_and_http(
+def test_aggregator_agent_publish_to_both_dashboard_head_and_http(
     ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
 ):
     cluster = ray_start_cluster_head_with_env_vars
@@ -1277,11 +1280,17 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
         cluster.gcs_address, cluster.head_node.node_id
     )
 
+    # The external HTTP publisher POSTs JSON to "/"; the dashboard-head publisher POSTs a
+    # serialized AddEventsRequest proto to "/api/task_events". Redirect the dashboard-head
+    # publisher to the same test httpserver by overriding its InternalKV address.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
-    # Create an event with a unique task name to filter on
-    unique_task_name = f"gcs_only_task_{uuid.uuid4()}"
-    event = _create_task_definition_event_for_gcs(fake_timestamp[0], unique_task_name)
+    unique_task_name = f"task_{uuid.uuid4()}"
+    event = _create_task_definition_event_with_ids(fake_timestamp[0], unique_task_name)
 
     request = AddEventsRequest(
         events_data=RayEventsData(
@@ -1294,16 +1303,20 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
 
     agg_stub.AddEvents(request)
 
-    # Verify HTTP received the event
-    wait_for_condition(lambda: len(httpserver.log) == 1)
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
-    assert len(req_json) == 1
-    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
-    assert req_json[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+    # The external HTTP publisher received the event as JSON at "/".
+    wait_for_condition(lambda: len(_get_json_events_from_httpserver(httpserver)) == 1)
+    json_events = _get_json_events_from_httpserver(httpserver)
+    assert json_events[0]["eventType"] == "TASK_DEFINITION_EVENT"
+    assert json_events[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
 
-    # Verify GCS stored the event and fields match
-    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, event)
+    # The dashboard-head publisher received the same event as a serialized proto at
+    # "/api/task_events".
+    wait_for_condition(
+        lambda: len(_get_dashboard_head_events_from_httpserver(httpserver)) == 1
+    )
+    dashboard_events = _get_dashboard_head_events_from_httpserver(httpserver)
+    assert dashboard_events[0].event_type == RayEvent.EventType.TASK_DEFINITION_EVENT
+    assert dashboard_events[0].task_definition_event.task_name == unique_task_name
 
 
 @pytest.mark.parametrize(
@@ -1311,31 +1324,36 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
     [
         {
             "env_vars": {
-                # Disable HTTP publisher to test GCS filtering in isolation
+                # Disable the external HTTP publisher to test filtering in isolation
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
-                # Enable GCS publisher
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                # Enable the dashboard-head publisher
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
             },
         },
     ],
     indirect=True,
 )
-def test_aggregator_agent_gcs_filtering_driver_job_events(
+def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
     ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
 ):
-    """Test that driver job execution events are filtered out and not sent to GCS."""
+    """Driver job events are filtered out and never sent to the dashboard head."""
     cluster = ray_start_cluster_head_with_env_vars
     agg_stub = get_event_aggregator_grpc_stub(
         cluster.gcs_address, cluster.head_node.node_id
     )
 
-    unique_task_name = f"gcs_filter_task_{uuid.uuid4()}"
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
-    task_event = _create_task_definition_event_for_gcs(
+    unique_task_name = f"task_{uuid.uuid4()}"
+    task_event = _create_task_definition_event_with_ids(
         fake_timestamp[0], unique_task_name
     )
 
-    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    # DRIVER_JOB_LIFECYCLE_EVENT is not in GCS_EXPOSABLE_EVENT_TYPES, so the dashboard-head
+    # publisher must filter it out.
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
         source_type=RayEvent.SourceType.CORE_WORKER,
@@ -1369,20 +1387,21 @@ def test_aggregator_agent_gcs_filtering_driver_job_events(
 
     agg_stub.AddEvents(request)
 
-    # Wait for the task definition event to be stored in GCS (this should succeed)
-    _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, task_event)
+    # The task definition event reaches the dashboard head.
+    def _task_event_received():
+        return any(
+            event.event_type == RayEvent.EventType.TASK_DEFINITION_EVENT
+            and event.task_definition_event.task_name == unique_task_name
+            for event in _get_dashboard_head_events_from_httpserver(httpserver)
+        )
 
-    # Verify that only the task event was processed by GCS, not the driver job event
-    # We can verify this by checking that no other task events are stored beyond our expected one
-    # and ensuring that there were no errors during publishing.
-    # The filtering logic in the GCS publisher should have filtered out the driver job event
+    wait_for_condition(_task_event_received)
 
-    # Ensure HTTP publisher did not send anything (since it's disabled)
-    with pytest.raises(
-        RuntimeError, match="The condition wasn't met before the timeout expired."
-    ):
-        wait_for_condition(lambda: len(httpserver.log) > 0, 1)
-    assert len(httpserver.log) == 0
+    # The driver job lifecycle event was filtered out and never sent.
+    assert all(
+        event.event_type != RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
+        for event in _get_dashboard_head_events_from_httpserver(httpserver)
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -15,16 +15,15 @@ logger = logging.getLogger(__name__)
 class TaskEventsHead(SubprocessModule):
     """Dashboard-head endpoint that receives task events from per-node aggregators.
 
-    The per-node aggregator agent POSTs an ``AddEventsRequest`` payload (the same
-    proto the aggregator sends to GCS) to this module, which holds the received
-    ``RayEvent``s in memory.
+    The per-node aggregator agent POSTs an ``AddEventsRequest`` payload
+     to this module, which holds the received``RayEvent``s in memory.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO(Task 3): replace this unbounded in-memory buffer with real storage +
-        # GC/eviction. It exists only so the ingestion endpoint has somewhere to put
-        # events for now; nothing reads it yet (State-API serving is a later task).
+        # TODO(karticam): Replace this with an in-memory store of task events.
+        #   This will mimic current GcsTaskManager and will power state API.
+        #   Will be done in future PRs.
         self._events = collections.deque()
 
     @property
@@ -35,12 +34,7 @@ class TaskEventsHead(SubprocessModule):
     def _deserialize_request(
         self, body: bytes
     ) -> events_event_aggregator_service_pb2.AddEventsRequest:
-        """Deserialize the POST body into an ``AddEventsRequest``.
-
-        Kept as a single seam because the on-the-wire encoding between the aggregator
-        and this endpoint is not finalized (binary proto vs JSON). Swap this method to
-        change the wire format without touching the handler.
-        """
+        """Deserialize the binary-proto POST body into an ``AddEventsRequest``."""
         return events_event_aggregator_service_pb2.AddEventsRequest.FromString(body)
 
     @routes.post("/api/task_events")

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -1,0 +1,73 @@
+import collections
+import logging
+
+import aiohttp.web
+
+import ray.dashboard.optional_utils as dashboard_optional_utils
+import ray.dashboard.utils as dashboard_utils
+from ray.core.generated import events_event_aggregator_service_pb2
+from ray.dashboard.subprocesses.module import SubprocessModule
+from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
+
+logger = logging.getLogger(__name__)
+
+
+class TaskEventsHead(SubprocessModule):
+    """Dashboard-head endpoint that receives task events from per-node aggregators.
+
+    The per-node aggregator agent POSTs an ``AddEventsRequest`` payload (the same
+    proto the aggregator sends to GCS) to this module, which holds the received
+    ``RayEvent``s in memory.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # TODO(Task 3): replace this unbounded in-memory buffer with real storage +
+        # GC/eviction. It exists only so the ingestion endpoint has somewhere to put
+        # events for now; nothing reads it yet (State-API serving is a later task).
+        self._events = collections.deque()
+
+    @property
+    def num_events_received(self) -> int:
+        """Number of task events currently held in the in-memory buffer (for tests)."""
+        return len(self._events)
+
+    def _deserialize_request(
+        self, body: bytes
+    ) -> events_event_aggregator_service_pb2.AddEventsRequest:
+        """Deserialize the POST body into an ``AddEventsRequest``.
+
+        Kept as a single seam because the on-the-wire encoding between the aggregator
+        and this endpoint is not finalized (binary proto vs JSON). Swap this method to
+        change the wire format without touching the handler.
+        """
+        return events_event_aggregator_service_pb2.AddEventsRequest.FromString(body)
+
+    @routes.post("/api/task_events")
+    async def add_task_events(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        body = await request.read()
+        try:
+            add_events_request = self._deserialize_request(body)
+        except Exception as e:
+            logger.warning(f"Failed to deserialize task events request: {e}")
+            return dashboard_optional_utils.rest_response(
+                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                message=f"Failed to deserialize task events request: {e}",
+            )
+
+        events_data = add_events_request.events_data
+        self._events.extend(events_data.events)
+        logger.debug(
+            "Received %d task events (%d total buffered)",
+            len(events_data.events),
+            len(self._events),
+        )
+        return dashboard_optional_utils.rest_response(
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="",
+        )
+
+    async def run(self):
+        await super().run()

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -1,0 +1,112 @@
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+import ray._private.ray_constants as ray_constants
+import ray.dashboard.consts as dashboard_consts
+from ray._common.ray_constants import (
+    LOGGING_ROTATE_BACKUP_COUNT,
+    LOGGING_ROTATE_BYTES,
+)
+from ray.core.generated import events_event_aggregator_service_pb2
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
+from ray.dashboard.subprocesses.module import SubprocessModuleConfig
+
+
+def _make_config() -> SubprocessModuleConfig:
+    return SubprocessModuleConfig(
+        cluster_id_hex="deadbeef",
+        gcs_address="127.0.0.1:6379",
+        session_name="test_session",
+        temp_dir="/tmp",
+        session_dir="/tmp",
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        log_dir="/tmp",
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
+        socket_dir="/tmp",
+    )
+
+
+def _make_head() -> TaskEventsHead:
+    return TaskEventsHead(_make_config())
+
+
+def _make_add_events_request(num_events: int) -> bytes:
+    events_data = events_event_aggregator_service_pb2.RayEventsData()
+    for i in range(num_events):
+        events_data.events.append(RayEvent(event_id=f"event_{i}".encode()))
+    request = events_event_aggregator_service_pb2.AddEventsRequest(
+        events_data=events_data
+    )
+    return request.SerializeToString()
+
+
+def _fake_request(body: bytes):
+    request = AsyncMock()
+    request.read.return_value = body
+    return request
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_buffers_events():
+    head = _make_head()
+    assert head.num_events_received == 0
+
+    body = _make_add_events_request(num_events=2)
+    response = await head.add_task_events(_fake_request(body))
+
+    assert response.status == 200
+    assert head.num_events_received == 2
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_accumulates_across_requests():
+    head = _make_head()
+
+    await head.add_task_events(_fake_request(_make_add_events_request(num_events=2)))
+    await head.add_task_events(_fake_request(_make_add_events_request(num_events=3)))
+
+    assert head.num_events_received == 5
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_empty_payload():
+    head = _make_head()
+
+    response = await head.add_task_events(_fake_request(_make_add_events_request(0)))
+
+    assert response.status == 200
+    assert head.num_events_received == 0
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_bad_payload_returns_error():
+    head = _make_head()
+
+    # A lone continuation byte is a truncated protobuf tag varint and reliably
+    # fails to parse, unlike arbitrary ASCII which protobuf may accept as
+    # unknown fields.
+    response = await head.add_task_events(_fake_request(b"\xff"))
+
+    # Malformed body must not raise; the handler returns an error response and
+    # nothing is buffered.
+    assert response.status != 200
+    assert head.num_events_received == 0
+
+
+def test_deserialize_request_roundtrip():
+    head = _make_head()
+
+    body = _make_add_events_request(num_events=1)
+    request = head._deserialize_request(body)
+
+    assert len(request.events_data.events) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -86,3 +86,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool record_task_actor_creation_sites() const
 
         c_bool start_python_gc_manager_thread() const
+
+        c_bool enable_task_events_to_dashboard_head() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -139,3 +139,7 @@ cdef class Config:
     @staticmethod
     def start_python_gc_manager_thread():
         return RayConfig.instance().start_python_gc_manager_thread()
+
+    @staticmethod
+    def enable_task_events_to_dashboard_head():
+        return RayConfig.instance().enable_task_events_to_dashboard_head()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1566,7 +1566,7 @@ def event_routing_config(request, monkeypatch):
     mode = getattr(request, "param", "default")
     # clear envs to ensure default behavior
     monkeypatch.delenv(
-        "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD", raising=False
+        "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", raising=False
     )
     monkeypatch.delenv("RAY_enable_core_worker_ray_event_to_aggregator", raising=False)
 
@@ -1578,7 +1578,7 @@ def event_routing_config(request, monkeypatch):
         monkeypatch.setenv("RAY_enable_core_worker_task_event_to_gcs", "0")
         # Ensure aggregator agent publishes to GCS
         monkeypatch.setenv(
-            "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD", "True"
+            "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", "True"
         )
     yield
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1566,7 +1566,7 @@ def event_routing_config(request, monkeypatch):
     mode = getattr(request, "param", "default")
     # clear envs to ensure default behavior
     monkeypatch.delenv(
-        "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", raising=False
+        "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD", raising=False
     )
     monkeypatch.delenv("RAY_enable_core_worker_ray_event_to_aggregator", raising=False)
 
@@ -1578,7 +1578,7 @@ def event_routing_config(request, monkeypatch):
         monkeypatch.setenv("RAY_enable_core_worker_task_event_to_gcs", "0")
         # Ensure aggregator agent publishes to GCS
         monkeypatch.setenv(
-            "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", "True"
+            "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD", "True"
         )
     yield
 

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -84,6 +84,7 @@ _EXPECTED_DASHBOARD_MODULES = [
     "ray.dashboard.modules.reporter.reporter_head.ReportHead",
     "ray.dashboard.modules.serve.serve_head.ServeHead",
     "ray.dashboard.modules.state.state_head.StateHead",
+    "ray.dashboard.modules.task_events.task_events_head.TaskEventsHead",
     "ray.dashboard.modules.train.train_head.TrainHead",
 ]
 

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -49,7 +49,6 @@ from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.dashboard.modules.aggregator.constants import CONSUMER_TAG_KEY
 from ray.dashboard.modules.aggregator.tests.test_aggregator_agent import (
     get_event_aggregator_grpc_stub,
-    override_dashboard_address_to_httpserver,
 )
 from ray.util.metrics import Counter, Gauge, Histogram, Metric
 from ray.util.state import list_nodes
@@ -515,7 +514,7 @@ def httpserver_listen_address():
             "env_vars": {
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_MAX_EVENT_BUFFER_SIZE": 2,
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
                 # Turn off task events generation to avoid the task events from the
                 # cluster impacting the test result
                 "RAY_task_events_report_interval_ms": 0,
@@ -536,14 +535,7 @@ def test_metrics_export_event_aggregator_agent(
     stub = get_event_aggregator_grpc_stub(
         cluster.gcs_address, cluster.head_node.node_id
     )
-    # The external HTTP publisher POSTs to "/"; the dashboard-head publisher POSTs to
-    # "/api/task_events". Redirect the dashboard-head publisher to the same test
-    # httpserver by overriding its InternalKV address so both publish deterministically.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
-    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
-        "", status=200
-    )
-    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
     metrics_export_port = cluster.head_node.metrics_export_port
     addr = cluster.head_node.node_ip_address
@@ -643,12 +635,7 @@ def test_metrics_export_event_aggregator_agent(
     )
 
     stub.AddEvents(request)
-    # Both publishers deliver to the test httpserver: the external HTTP publisher to "/"
-    # and the dashboard-head publisher to "/api/task_events".
-    wait_for_condition(
-        lambda: any(req.path == "/" for req, _ in httpserver.log)
-        and any(req.path == "/api/task_events" for req, _ in httpserver.log)
-    )
+    wait_for_condition(lambda: len(httpserver.log) == 1)
 
     wait_for_condition(test_case_stats_exist, timeout=30, retry_interval_ms=1000)
 
@@ -667,13 +654,13 @@ def test_metrics_export_event_aggregator_agent(
         retry_interval_ms=1000,
     )
 
-    expected_dashboard_head_publisher_metrics_values = {
+    expected_gcs_publisher_metrics_values = {
         "ray_aggregator_agent_published_events_total": 2.0,
         "ray_aggregator_agent_queue_dropped_events_total": 1.0,
     }
     wait_for_condition(
         lambda: test_case_publisher_specific_metrics_value_correct(
-            "dashboard_head", expected_dashboard_head_publisher_metrics_values
+            "ray_gcs", expected_gcs_publisher_metrics_values
         ),
         timeout=30,
         retry_interval_ms=1000,

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -49,6 +49,7 @@ from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.dashboard.modules.aggregator.constants import CONSUMER_TAG_KEY
 from ray.dashboard.modules.aggregator.tests.test_aggregator_agent import (
     get_event_aggregator_grpc_stub,
+    override_dashboard_address_to_httpserver,
 )
 from ray.util.metrics import Counter, Gauge, Histogram, Metric
 from ray.util.state import list_nodes
@@ -514,7 +515,7 @@ def httpserver_listen_address():
             "env_vars": {
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_MAX_EVENT_BUFFER_SIZE": 2,
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
                 # Turn off task events generation to avoid the task events from the
                 # cluster impacting the test result
                 "RAY_task_events_report_interval_ms": 0,
@@ -535,7 +536,14 @@ def test_metrics_export_event_aggregator_agent(
     stub = get_event_aggregator_grpc_stub(
         cluster.gcs_address, cluster.head_node.node_id
     )
+    # The external HTTP publisher POSTs to "/"; the dashboard-head publisher POSTs to
+    # "/api/task_events". Redirect the dashboard-head publisher to the same test
+    # httpserver by overriding its InternalKV address so both publish deterministically.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
     metrics_export_port = cluster.head_node.metrics_export_port
     addr = cluster.head_node.node_ip_address
@@ -635,7 +643,12 @@ def test_metrics_export_event_aggregator_agent(
     )
 
     stub.AddEvents(request)
-    wait_for_condition(lambda: len(httpserver.log) == 1)
+    # Both publishers deliver to the test httpserver: the external HTTP publisher to "/"
+    # and the dashboard-head publisher to "/api/task_events".
+    wait_for_condition(
+        lambda: any(req.path == "/" for req, _ in httpserver.log)
+        and any(req.path == "/api/task_events" for req, _ in httpserver.log)
+    )
 
     wait_for_condition(test_case_stats_exist, timeout=30, retry_interval_ms=1000)
 
@@ -654,13 +667,13 @@ def test_metrics_export_event_aggregator_agent(
         retry_interval_ms=1000,
     )
 
-    expected_gcs_publisher_metrics_values = {
+    expected_dashboard_head_publisher_metrics_values = {
         "ray_aggregator_agent_published_events_total": 2.0,
         "ray_aggregator_agent_queue_dropped_events_total": 1.0,
     }
     wait_for_condition(
         lambda: test_case_publisher_specific_metrics_value_correct(
-            "ray_gcs", expected_gcs_publisher_metrics_values
+            "dashboard_head", expected_dashboard_head_publisher_metrics_values
         ),
         timeout=30,
         retry_interval_ms=1000,

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -49,7 +49,6 @@ from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.dashboard.modules.aggregator.constants import CONSUMER_TAG_KEY
 from ray.dashboard.modules.aggregator.tests.test_aggregator_agent import (
     get_event_aggregator_grpc_stub,
-    override_dashboard_address_to_httpserver,
 )
 from ray.util.metrics import Counter, Gauge, Histogram, Metric
 from ray.util.state import list_nodes
@@ -515,7 +514,7 @@ def httpserver_listen_address():
             "env_vars": {
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_MAX_EVENT_BUFFER_SIZE": 2,
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
                 # Turn off task events generation to avoid the task events from the
                 # cluster impacting the test result
                 "RAY_task_events_report_interval_ms": 0,
@@ -532,14 +531,7 @@ def test_metrics_export_event_aggregator_agent(
     stub = get_event_aggregator_grpc_stub(
         cluster.gcs_address, cluster.head_node.node_id
     )
-    # The external HTTP publisher POSTs to "/"; the dashboard-head publisher POSTs to
-    # "/api/task_events". Redirect the dashboard-head publisher to the same test
-    # httpserver by overriding its InternalKV address so both publish deterministically.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
-    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
-        "", status=200
-    )
-    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
     metrics_export_port = cluster.head_node.metrics_export_port
     addr = cluster.head_node.node_ip_address
@@ -639,12 +631,7 @@ def test_metrics_export_event_aggregator_agent(
     )
 
     stub.AddEvents(request)
-    # Both publishers deliver to the test httpserver: the external HTTP publisher to "/"
-    # and the dashboard-head publisher to "/api/task_events".
-    wait_for_condition(
-        lambda: any(req.path == "/" for req, _ in httpserver.log)
-        and any(req.path == "/api/task_events" for req, _ in httpserver.log)
-    )
+    wait_for_condition(lambda: len(httpserver.log) == 1)
 
     wait_for_condition(test_case_stats_exist, timeout=30, retry_interval_ms=1000)
 
@@ -663,13 +650,13 @@ def test_metrics_export_event_aggregator_agent(
         retry_interval_ms=1000,
     )
 
-    expected_dashboard_head_publisher_metrics_values = {
+    expected_gcs_publisher_metrics_values = {
         "ray_aggregator_agent_published_events_total": 2.0,
         "ray_aggregator_agent_queue_dropped_events_total": 1.0,
     }
     wait_for_condition(
         lambda: test_case_publisher_specific_metrics_value_correct(
-            "dashboard_head", expected_dashboard_head_publisher_metrics_values
+            "ray_gcs", expected_gcs_publisher_metrics_values
         ),
         timeout=30,
         retry_interval_ms=1000,

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -49,6 +49,7 @@ from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.dashboard.modules.aggregator.constants import CONSUMER_TAG_KEY
 from ray.dashboard.modules.aggregator.tests.test_aggregator_agent import (
     get_event_aggregator_grpc_stub,
+    override_dashboard_address_to_httpserver,
 )
 from ray.util.metrics import Counter, Gauge, Histogram, Metric
 from ray.util.state import list_nodes
@@ -514,7 +515,7 @@ def httpserver_listen_address():
             "env_vars": {
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_MAX_EVENT_BUFFER_SIZE": 2,
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_DASHBOARD_HEAD": "True",
                 # Turn off task events generation to avoid the task events from the
                 # cluster impacting the test result
                 "RAY_task_events_report_interval_ms": 0,
@@ -531,7 +532,14 @@ def test_metrics_export_event_aggregator_agent(
     stub = get_event_aggregator_grpc_stub(
         cluster.gcs_address, cluster.head_node.node_id
     )
+    # The external HTTP publisher POSTs to "/"; the dashboard-head publisher POSTs to
+    # "/api/task_events". Redirect the dashboard-head publisher to the same test
+    # httpserver by overriding its InternalKV address so both publish deterministically.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
 
     metrics_export_port = cluster.head_node.metrics_export_port
     addr = cluster.head_node.node_ip_address
@@ -631,7 +639,12 @@ def test_metrics_export_event_aggregator_agent(
     )
 
     stub.AddEvents(request)
-    wait_for_condition(lambda: len(httpserver.log) == 1)
+    # Both publishers deliver to the test httpserver: the external HTTP publisher to "/"
+    # and the dashboard-head publisher to "/api/task_events".
+    wait_for_condition(
+        lambda: any(req.path == "/" for req, _ in httpserver.log)
+        and any(req.path == "/api/task_events" for req, _ in httpserver.log)
+    )
 
     wait_for_condition(test_case_stats_exist, timeout=30, retry_interval_ms=1000)
 
@@ -650,13 +663,13 @@ def test_metrics_export_event_aggregator_agent(
         retry_interval_ms=1000,
     )
 
-    expected_gcs_publisher_metrics_values = {
+    expected_dashboard_head_publisher_metrics_values = {
         "ray_aggregator_agent_published_events_total": 2.0,
         "ray_aggregator_agent_queue_dropped_events_total": 1.0,
     }
     wait_for_condition(
         lambda: test_case_publisher_specific_metrics_value_correct(
-            "ray_gcs", expected_gcs_publisher_metrics_values
+            "dashboard_head", expected_dashboard_head_publisher_metrics_values
         ),
         timeout=30,
         retry_interval_ms=1000,

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1125,6 +1125,12 @@ RAY_CONFIG(bool, enable_core_worker_ray_event_to_aggregator, false)
 // the recorder is used.
 RAY_CONFIG(bool, enable_ray_task_event_recorder, false)
 
+// Flag for the migration of task events from GCS to dashboard head. When true: the
+// aggregator publishes task events to the dashboard head, the TaskEventsHead module is
+// loaded, and the state API (list tasks / ray.timeline) reads task events from the
+// dashboard head instead of GCS.
+RAY_CONFIG(bool, enable_task_events_to_dashboard_head, false)
+
 // Configuration for pipe logger buffer size.
 RAY_CONFIG(uint64_t, pipe_logger_read_buf_size, 1024)
 


### PR DESCRIPTION
Part of the effort to move task-event observability data out of GCS and onto the
dashboard head. This PR adds support for moving task events from aggregator agent to dashboard head. Changes are as follows: 

1. Adds a new module `task_events_head` that hosts a POST `/api/task_events` endpoint to receive task events from the aggregator agent. For now it just buffers received events in memory. More stuff to be done in upcoming PRs.
  2. Adds a new publisher client `AsyncDashboardHeadPublisherClient` and a corresponding flag to `PUBLISH_EVENTS_TO_DASHBOARD_HEAD`. 
  3. The existing publisher `AsyncGCSTaskEventsPublisherClient` is still kept since some tests depend on it. This will be removed later after the entire migration completes.
  4. The new publisher client is similar to `AsyncGCSTaskEventsPublisherClient` in that it has the same event selection to export and has the same proto building, but sends the request over HTTP POST instead of a gRPC call.
  5. Each of the two publishers gets its own dropped-task-attempts metadata buffer, since`TaskEventsMetadataBuffer.get()` is destructive and a shared buffer would split the metadata across publishers.
  6. The publisher resolves the dashboard head's address lazily from InternalKV (DASHBOARD_ADDRESS) via `gcs_client`, then makes the POST request. If the address isn't registered yet the publish is marked unsuccessful and the publisher retries on its next cycle; once resolved, the endpoint is cached.
  
TESTING:
To test correct working of ray task event recorder (and other functionality related to the whole effort of migrating task events out of GCS), I turned changed the apt flags and triggered the CI suite in this PR: https://github.com/ray-project/ray/pull/65253