### PR TITLE
Warn on truncated job task progress data

### DIFF
--- a/python/ray/dashboard/client/src/pages/job/JobProgressBar.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobProgressBar.component.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { JobStatus } from "../../type/job";
+import { TEST_APP_WRAPPER } from "../../util/test-utils";
+import { useJobProgress, useJobProgressByLineage } from "./hook/useJobProgress";
+import { JobProgressBar } from "./JobProgressBar";
+
+jest.mock("./hook/useJobProgress");
+
+describe("JobProgressBar", () => {
+  beforeEach(() => {
+    (useJobProgressByLineage as jest.Mock).mockReturnValue({
+      progressGroups: [],
+      isLoading: false,
+      total: undefined,
+      totalTasks: undefined,
+      totalTaskAttempts: undefined,
+      numAfterTruncation: undefined,
+      latestFetchTimestamp: 0,
+    });
+  });
+
+  it("renders a warning when task progress data is truncated", async () => {
+    (useJobProgress as jest.Mock).mockReturnValue({
+      progress: { numFinished: 10000 },
+      isLoading: false,
+      driverExists: true,
+      totalTasks: 10000,
+      totalTaskAttempts: 12000,
+      numAfterTruncation: 10000,
+      latestFetchTimestamp: 1,
+    });
+
+    render(
+      <JobProgressBar
+        jobId="01000000"
+        job={{ status: JobStatus.RUNNING }}
+        onClickLink={() => {
+          // purposefully empty
+        }}
+      />,
+      { wrapper: TEST_APP_WRAPPER },
+    );
+
+    await screen.findByText(/Task progress may be incomplete/);
+    expect(
+      screen.getByText(/2,000 task entries were truncated/),
+    ).toBeInTheDocument();
+  });
+});

--- a/python/ray/dashboard/client/src/pages/job/JobProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobProgressBar.tsx
@@ -99,8 +99,8 @@ export const JobProgressBar = ({
   } = progressSource;
 
   const hasTruncatedTaskData =
-    finalTotalTaskAttempts !== undefined &&
-    finalNumAfterTruncation !== undefined &&
+    typeof finalTotalTaskAttempts === "number" &&
+    typeof finalNumAfterTruncation === "number" &&
     finalTotalTaskAttempts > finalNumAfterTruncation;
 
   return (

--- a/python/ray/dashboard/client/src/pages/job/JobProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobProgressBar.tsx
@@ -1,4 +1,9 @@
-import { Checkbox, FormControlLabel, LinearProgress } from "@mui/material";
+import {
+  Alert,
+  Checkbox,
+  FormControlLabel,
+  LinearProgress,
+} from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { UnifiedJob } from "../../type/job";
 import {
@@ -38,6 +43,8 @@ export const JobProgressBar = ({
     isLoading: progressLoading,
     driverExists,
     totalTasks,
+    totalTaskAttempts,
+    numAfterTruncation,
     latestFetchTimestamp: progressTimestamp,
   } = useJobProgress(jobId, advancedProgressBarExpanded);
   const {
@@ -45,6 +52,8 @@ export const JobProgressBar = ({
     isLoading: progressGroupsLoading,
     total,
     totalTasks: advancedTotalTasks,
+    totalTaskAttempts: advancedTotalTaskAttempts,
+    numAfterTruncation: advancedNumAfterTruncation,
     latestFetchTimestamp: totalTimestamp,
   } = useJobProgressByLineage(
     advancedProgressBarRendered ? jobId : undefined,
@@ -66,12 +75,33 @@ export const JobProgressBar = ({
   const { status } = job;
   // Use whichever data was received the most recently
   // Note these values may disagree in some way. It might better to consistently use one endpoint.
-  const [totalProgress, finalTotalTasks] =
+  const progressSource =
     total === undefined ||
     advancedTotalTasks === undefined ||
     progressTimestamp > totalTimestamp
-      ? [progress, totalTasks]
-      : [total, advancedTotalTasks];
+      ? {
+          totalProgress: progress,
+          finalTotalTasks: totalTasks,
+          finalTotalTaskAttempts: totalTaskAttempts,
+          finalNumAfterTruncation: numAfterTruncation,
+        }
+      : {
+          totalProgress: total,
+          finalTotalTasks: advancedTotalTasks,
+          finalTotalTaskAttempts: advancedTotalTaskAttempts,
+          finalNumAfterTruncation: advancedNumAfterTruncation,
+        };
+  const {
+    totalProgress,
+    finalTotalTasks,
+    finalTotalTaskAttempts,
+    finalNumAfterTruncation,
+  } = progressSource;
+
+  const hasTruncatedTaskData =
+    finalTotalTaskAttempts !== undefined &&
+    finalNumAfterTruncation !== undefined &&
+    finalTotalTaskAttempts > finalNumAfterTruncation;
 
   return (
     <div>
@@ -100,6 +130,16 @@ export const JobProgressBar = ({
           />
         }
       />
+      {hasTruncatedTaskData && (
+        <Alert severity="warning" sx={{ marginTop: 1 }}>
+          Task progress may be incomplete because Ray retrieved{" "}
+          {finalNumAfterTruncation.toLocaleString()} of{" "}
+          {finalTotalTaskAttempts.toLocaleString()} task entries from the state
+          backend. The remaining{" "}
+          {(finalTotalTaskAttempts - finalNumAfterTruncation).toLocaleString()}{" "}
+          task entries were truncated to avoid oversized payloads.
+        </Alert>
+      )}
       {advancedProgressBarExpanded && (
         <AdvancedProgressBar
           sx={{ marginTop: 0.5 }}

--- a/python/ray/dashboard/client/src/pages/job/hook/useJobProgress.ts
+++ b/python/ray/dashboard/client/src/pages/job/hook/useJobProgress.ts
@@ -78,7 +78,12 @@ const useFetchStateApiProgressByTaskName = (
         const summary = formatSummaryToTaskProgress(
           rsp.data.data.result.result,
         );
-        return { summary, totalTasks: rsp.data.data.result.num_filtered };
+        return {
+          summary,
+          totalTasks: rsp.data.data.result.num_filtered,
+          totalTaskAttempts: rsp.data.data.result.total,
+          numAfterTruncation: rsp.data.data.result.num_after_truncation,
+        };
       } else {
         setError(true);
         setRefresh(false);
@@ -130,6 +135,8 @@ export const useJobProgress = (
   return {
     progress: summed,
     totalTasks: data?.totalTasks,
+    totalTaskAttempts: data?.totalTaskAttempts,
+    numAfterTruncation: data?.numAfterTruncation,
     isLoading,
     msg,
     error,
@@ -194,6 +201,8 @@ export const useJobProgressByTaskName = (jobId: string) => {
     page: { pageNo: page, pageSize: 10 },
     total: formattedTasks.length,
     totalTasks: data?.totalTasks,
+    totalTaskAttempts: data?.totalTaskAttempts,
+    numAfterTruncation: data?.numAfterTruncation,
     isLoading,
     setPage,
     msg,
@@ -314,7 +323,12 @@ export const useJobProgressByLineage = (
           rsp.data.data.result.result,
           showFinishedTasks,
         );
-        return { summary, totalTasks: rsp.data.data.result.num_filtered };
+        return {
+          summary,
+          totalTasks: rsp.data.data.result.num_filtered,
+          totalTaskAttempts: rsp.data.data.result.total,
+          numAfterTruncation: rsp.data.data.result.num_after_truncation,
+        };
       } else {
         setError(true);
         setRefresh(false);
@@ -331,6 +345,8 @@ export const useJobProgressByLineage = (
     progressGroups: data?.summary?.progressGroups,
     total: data?.summary?.total,
     totalTasks: data?.totalTasks,
+    totalTaskAttempts: data?.totalTaskAttempts,
+    numAfterTruncation: data?.numAfterTruncation,
     isLoading,
     msg,
     error,

--- a/python/ray/dashboard/client/src/type/job.ts
+++ b/python/ray/dashboard/client/src/type/job.ts
@@ -140,6 +140,7 @@ export type StateApiJobProgressByTaskNameRsp = {
   data: {
     result: {
       result: StateApiJobProgressByTaskName;
+      num_after_truncation: number;
       num_filtered: number;
       total: number;
     };
@@ -185,6 +186,7 @@ export type StateApiNestedJobProgressRsp = {
   data: {
     result: {
       result: StateApiNestedJobProgress;
+      num_after_truncation: number;
       num_filtered: number;
       total: number;
     };


### PR DESCRIPTION
## Description

Fixes #49896.

The Ray dashboard job progress bar can show incomplete task progress when task entries are truncated by the state backend. This adds a warning when the state API reports `total > num_after_truncation`, matching the truncation warning behavior already used by Ray's state API client.

## Related issues

Fixes #49896.

## Additional information

Validation run:

```bash
npm test -- --watchAll=false --runInBand JobProgressBar.component.test.tsx
```