### PR TITLE
[autoscaler] Add demand vector truncation for V2 scheduler

### DIFF
--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -9,7 +9,10 @@ from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 from ray._private.protobuf_compat import message_to_dict
-from ray.autoscaler._private.constants import AUTOSCALER_CONSERVE_GPU_NODES
+from ray.autoscaler._private.constants import (
+    AUTOSCALER_CONSERVE_GPU_NODES,
+    AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE,
+)
 from ray.autoscaler._private.resource_demand_scheduler import (
     UtilizationScore,
     _fits,
@@ -1222,9 +1225,26 @@ class ResourceDemandScheduler(IResourceScheduler):
         )
 
         # Schedule the tasks/actor resource requests
+        resource_requests = ResourceRequestUtil.ungroup_by_count(
+            request.resource_requests
+        )
+        if len(resource_requests) > AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE:
+            resource_requests = sorted(
+                resource_requests,
+                key=ResourceDemandScheduler._sort_resource_request_for_truncation,
+                reverse=True,
+            )
+            resource_requests = resource_requests[
+                :AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE
+            ]
+            logger.info(
+                f"Truncated resource requests from "
+                f"{sum(r.count for r in request.resource_requests)} to "
+                f"{AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE} for scheduling."
+            )
         infeasible_requests = ResourceDemandScheduler._sched_resource_requests(
             ctx,
-            ResourceRequestUtil.ungroup_by_count(request.resource_requests),
+            resource_requests,
         )
 
         # Shutdown any idle nodes that's not needed (e.g. no resource constraints.
@@ -1576,6 +1596,28 @@ class ResourceDemandScheduler(IResourceScheduler):
 
         ctx.update(scheduled_nodes)
         return []
+
+    @staticmethod
+    def _sort_resource_request_for_truncation(req: "ResourceRequest") -> Tuple:
+        """
+        Sort resource requests by complexity for truncation priority.
+
+        Requests with more constraints (placement, labels, more resource types,
+        higher resource values) are sorted first so that truncation only drops
+        homogeneous simple requests from the tail.
+        """
+        label_constraint_len = (
+            len(req.label_selectors[0].label_constraints)
+            if req.label_selectors
+            else 0
+        )
+        return (
+            len(req.placement_constraints),
+            label_constraint_len,
+            len(req.resources_bundle.values()),
+            sum(req.resources_bundle.values()),
+            sorted(req.resources_bundle.items()),
+        )
 
     @staticmethod
     def _sched_resource_requests(

--- a/python/ray/autoscaler/v2/tests/test_scheduler.py
+++ b/python/ray/autoscaler/v2/tests/test_scheduler.py
@@ -3639,6 +3639,89 @@ class TestSchedulerPerformanceOptimizations:
         assert to_launch == {}
 
 
+class TestDemandTruncation:
+    def test_demand_truncation_basic(self):
+        """Truncation should not affect the correctness of to_launch decisions."""
+        node_type_configs = {
+            "type_1": NodeTypeConfig(
+                name="type_1",
+                resources={"CPU": 1},
+                min_worker_nodes=0,
+                max_worker_nodes=3000,
+            ),
+        }
+        # 3000 requests × 0.2 CPU each → needs 600 nodes (5 tasks per 1-CPU node).
+        # With truncation to 1000, scheduler sees 1000 requests → needs 200 nodes.
+        # This is expected: under-provisioning is corrected in the next reconcile.
+        requests = [ResourceRequestUtil.make({"CPU": 0.2})] * 3000
+
+        request = sched_request(
+            node_type_configs=node_type_configs,
+            resource_requests=requests,
+        )
+        reply = ResourceDemandScheduler(event_logger).schedule(request)
+        to_launch, _ = _launch_and_terminate(reply)
+
+        # With truncation to 1000 requests: 1000 × 0.2 CPU = 200 CPU → 200 nodes.
+        assert to_launch == {"type_1": 200}
+
+    def test_demand_truncation_preserves_complex_requests(self):
+        """GPU and label-constrained requests should survive truncation."""
+        node_type_configs = {
+            "gpu_type": NodeTypeConfig(
+                name="gpu_type",
+                resources={"CPU": 4, "GPU": 1},
+                min_worker_nodes=0,
+                max_worker_nodes=100,
+            ),
+            "cpu_type": NodeTypeConfig(
+                name="cpu_type",
+                resources={"CPU": 1},
+                min_worker_nodes=0,
+                max_worker_nodes=3000,
+            ),
+        }
+        # 10 GPU requests (complex) + 2000 simple CPU requests.
+        # After truncation to 1000, GPU requests must still be present.
+        gpu_requests = [ResourceRequestUtil.make({"CPU": 1, "GPU": 1})] * 10
+        cpu_requests = [ResourceRequestUtil.make({"CPU": 0.2})] * 2000
+        requests = cpu_requests + gpu_requests  # GPU at the end
+
+        request = sched_request(
+            node_type_configs=node_type_configs,
+            resource_requests=requests,
+        )
+        reply = ResourceDemandScheduler(event_logger).schedule(request)
+        to_launch, _ = _launch_and_terminate(reply)
+
+        # GPU nodes must be launched (GPU requests were not truncated).
+        assert "gpu_type" in to_launch
+        assert to_launch["gpu_type"] == 10
+
+    def test_no_truncation_below_threshold(self):
+        """No truncation when requests are below the limit."""
+        node_type_configs = {
+            "type_1": NodeTypeConfig(
+                name="type_1",
+                resources={"CPU": 1},
+                min_worker_nodes=0,
+                max_worker_nodes=3000,
+            ),
+        }
+        # 500 requests, below the 1000 threshold → no truncation.
+        requests = [ResourceRequestUtil.make({"CPU": 0.2})] * 500
+
+        request = sched_request(
+            node_type_configs=node_type_configs,
+            resource_requests=requests,
+        )
+        reply = ResourceDemandScheduler(event_logger).schedule(request)
+        to_launch, _ = _launch_and_terminate(reply)
+
+        # 500 × 0.2 CPU = 100 CPU → 100 nodes (no truncation, exact result).
+        assert to_launch == {"type_1": 100}
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))


### PR DESCRIPTION
V2 scheduler lacks the demand vector truncation that V1 has (AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE=1000). In large clusters with 10k+ pending requests, the bin-packing loop in _try_schedule becomes extremely expensive (O(requests × nodes) calls to contains()/SerializeToString).

This adds truncation before _sched_resource_requests: requests are sorted by complexity (GPU/label constraints first) then capped at 1000. Under-provisioning from truncation is self-correcting in subsequent reconcile rounds.

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
