### PR TITLE
[RLlib] Fix squashed-Gaussian log-prob corruption for saturated policies

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -2328,6 +2328,17 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_torch_squashed_gaussian",
+    size = "small",
+    srcs = ["core/distribution/torch/tests/test_torch_squashed_gaussian.py"],
+    tags = [
+        "core",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
 # Default Models
 py_test(
     name = "test_base_models",

--- a/rllib/algorithms/cql/torch/default_cql_torch_rl_module.py
+++ b/rllib/algorithms/cql/torch/default_cql_torch_rl_module.py
@@ -165,13 +165,11 @@ class DefaultCQLTorchRLModule(DefaultSACTorchRLModule):
             action_logits = self.pi(pi_encoder_outs[ENCODER_OUT])
             # Generate the squashed Gaussian from the model's logits.
             action_dist = self.get_train_action_dist_cls().from_logits(action_logits)
-            # Sample the actions. Note, we want to make a backward pass through
-            # these actions.
-            output[Columns.ACTIONS] = action_dist.rsample()
-            # Compute the action log-probabilities.
-            output[Columns.ACTION_LOGP] = action_dist.logp(
-                output[Columns.ACTIONS]
-            ).view(batch_size, num_actions, 1)
+            # Sample the actions (reparameterized, for backprop) together with
+            # their log-probs, so logp is exact even if the policy saturates.
+            actions, action_logp = action_dist.rsample_and_logp()
+            output[Columns.ACTIONS] = actions
+            output[Columns.ACTION_LOGP] = action_logp.view(batch_size, num_actions, 1)
         else:
             output[Columns.ACTIONS] = actions
 

--- a/rllib/algorithms/sac/torch/default_sac_torch_rl_module.py
+++ b/rllib/algorithms/sac/torch/default_sac_torch_rl_module.py
@@ -153,16 +153,15 @@ class DefaultSACTorchRLModule(TorchRLModule, DefaultSACRLModule):
         # Sample actions for the current state. Note that we need to apply the
         # reparameterization trick (`rsample()` instead of `sample()`) to avoid the
         # expectation over actions.
-        actions_resampled = action_dist_curr.rsample()
-        # Compute the log probabilities for the current state (for the critic loss).
-        output["logp_resampled"] = action_dist_curr.logp(actions_resampled)
+        (
+            actions_resampled,
+            output["logp_resampled"],
+        ) = action_dist_curr.rsample_and_logp()
 
-        # Sample actions for the next state.
-        actions_next_resampled = action_dist_next.sample().detach()
-        # Compute the log probabilities for the next state.
-        output["logp_next_resampled"] = (
-            action_dist_next.logp(actions_next_resampled)
-        ).detach()
+        # Sample actions for the next state
+        actions_next_resampled, logp_next_resampled = action_dist_next.sample_and_logp()
+        actions_next_resampled = actions_next_resampled.detach()
+        output["logp_next_resampled"] = logp_next_resampled.detach()
 
         # Compute Q-values for the current policy in the current state with
         # the sampled actions.

--- a/rllib/algorithms/tqc/torch/default_tqc_torch_rl_module.py
+++ b/rllib/algorithms/tqc/torch/default_tqc_torch_rl_module.py
@@ -96,8 +96,7 @@ class DefaultTQCTorchRLModule(TorchRLModule, DefaultTQCRLModule):
         # Sample actions from current policy for current observations
         action_dist_class = self.catalog.get_action_dist_cls(framework=self.framework)
         action_dist_curr = action_dist_class.from_logits(pi_out)
-        actions_curr = action_dist_curr.rsample()
-        logp_curr = action_dist_curr.logp(actions_curr)
+        actions_curr, logp_curr = action_dist_curr.rsample_and_logp()
 
         output["actions_curr"] = actions_curr
         output["logp_curr"] = logp_curr
@@ -128,8 +127,7 @@ class DefaultTQCTorchRLModule(TorchRLModule, DefaultTQCRLModule):
 
             # Sample actions for next state
             action_dist_next = action_dist_class.from_logits(pi_out_next)
-            actions_next = action_dist_next.rsample()
-            logp_next = action_dist_next.logp(actions_next)
+            actions_next, logp_next = action_dist_next.rsample_and_logp()
 
             output["actions_next"] = actions_next
             output["logp_next"] = logp_next

--- a/rllib/core/distribution/torch/tests/test_torch_squashed_gaussian.py
+++ b/rllib/core/distribution/torch/tests/test_torch_squashed_gaussian.py
@@ -1,0 +1,63 @@
+import unittest
+
+import torch
+
+from ray.rllib.core.distribution.torch.torch_distribution import TorchSquashedGaussian
+
+
+class TestTorchSquashedGaussian(unittest.TestCase):
+    """Regression tests for the squashed-Gaussian log-prob fix.
+
+    The bug: ``logp(action)`` recovered the pre-squash sample with
+    ``atanh(clamp(action, -1 + 1e-6, 1 - 1e-6))``. That clamp caps the recovered
+    value at ``atanh(1 - 1e-6) ~= 7.25``, so once the policy mean saturates
+    ``tanh`` the Gaussian log-prob was evaluated far from the true mean and
+    collapsed to a large *negative* value -- a sign flip that then corrupted
+    alpha tuning and the SAC/TQC critic target.
+
+    The fix: ``rsample_and_logp()`` / ``sample_and_logp()`` compute the log-prob
+    from the pre-squash sample directly (no ``atanh`` round-trip), so they are
+    correct even when the policy saturates.
+    """
+
+    def test_logp_is_positive_for_a_saturated_policy(self):
+        # A confident policy (large mean, small std) puts almost all of its mass
+        # near the action boundary, so its own samples have a large *positive*
+        # log-density. This is exactly where the bug bit: it returned a large
+        # negative value instead. The fix must return a finite, positive logp.
+        loc = torch.full((1024, 6), 10.0)  # mean well past tanh's linear range
+        log_std = torch.full((1024, 6), -2.0)  # small std -> confident policy
+        dist = TorchSquashedGaussian.from_logits(torch.cat([loc, log_std], dim=-1))
+
+        _, logp = dist.rsample_and_logp()
+
+        self.assertTrue(torch.isfinite(logp).all())
+        self.assertGreater(logp.mean().item(), 0.0)  # the bug produced ~ -1000s here
+
+    def test_logp_matches_the_squashed_gaussian_formula(self):
+        # The squashed-Gaussian log-prob of a pre-squash sample x is:
+        #   log N(x | loc, scale)  -  sum_i log(1 - tanh(x_i)^2)
+        # Check rsample_and_logp() against this formula in the unsaturated
+        # regime, where recovering x via atanh is accurate and the naive tanh
+        # Jacobian above is numerically well-behaved.
+        torch.manual_seed(0)
+        loc = torch.zeros(256, 4)
+        log_std = torch.full((256, 4), -0.5)
+        scale = log_std.exp()
+        dist = TorchSquashedGaussian.from_logits(torch.cat([loc, log_std], dim=-1))
+
+        action, logp = dist.rsample_and_logp()
+
+        x = torch.atanh(action.clamp(-1 + 1e-6, 1 - 1e-6))  # pre-squash sample
+        expected = torch.distributions.Normal(loc, scale).log_prob(x).sum(
+            -1
+        ) - torch.log(1 - torch.tanh(x) ** 2).sum(-1)
+        self.assertTrue(torch.allclose(logp, expected, atol=1e-3))
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/core/distribution/torch/tests/test_torch_squashed_gaussian.py
+++ b/rllib/core/distribution/torch/tests/test_torch_squashed_gaussian.py
@@ -6,53 +6,22 @@ from ray.rllib.core.distribution.torch.torch_distribution import TorchSquashedGa
 
 
 class TestTorchSquashedGaussian(unittest.TestCase):
-    """Regression tests for the squashed-Gaussian log-prob fix.
-
-    The bug: ``logp(action)`` recovered the pre-squash sample with
-    ``atanh(clamp(action, -1 + 1e-6, 1 - 1e-6))``. That clamp caps the recovered
-    value at ``atanh(1 - 1e-6) ~= 7.25``, so once the policy mean saturates
-    ``tanh`` the Gaussian log-prob was evaluated far from the true mean and
-    collapsed to a large *negative* value -- a sign flip that then corrupted
-    alpha tuning and the SAC/TQC critic target.
-
-    The fix: ``rsample_and_logp()`` / ``sample_and_logp()`` compute the log-prob
-    from the pre-squash sample directly (no ``atanh`` round-trip), so they are
-    correct even when the policy saturates.
-    """
-
     def test_logp_is_positive_for_a_saturated_policy(self):
+        # Regression test for #65036
         # A confident policy (large mean, small std) puts almost all of its mass
         # near the action boundary, so its own samples have a large *positive*
-        # log-density. This is exactly where the bug bit: it returned a large
+        # log-density. If we regress, we return a large
         # negative value instead. The fix must return a finite, positive logp.
         loc = torch.full((1024, 6), 10.0)  # mean well past tanh's linear range
         log_std = torch.full((1024, 6), -2.0)  # small std -> confident policy
         dist = TorchSquashedGaussian.from_logits(torch.cat([loc, log_std], dim=-1))
 
         _, logp = dist.rsample_and_logp()
+        print(logp)
+        print(_)
 
         self.assertTrue(torch.isfinite(logp).all())
-        self.assertGreater(logp.mean().item(), 0.0)  # the bug produced ~ -1000s here
-
-    def test_logp_matches_the_squashed_gaussian_formula(self):
-        # The squashed-Gaussian log-prob of a pre-squash sample x is:
-        #   log N(x | loc, scale)  -  sum_i log(1 - tanh(x_i)^2)
-        # Check rsample_and_logp() against this formula in the unsaturated
-        # regime, where recovering x via atanh is accurate and the naive tanh
-        # Jacobian above is numerically well-behaved.
-        torch.manual_seed(0)
-        loc = torch.zeros(256, 4)
-        log_std = torch.full((256, 4), -0.5)
-        scale = log_std.exp()
-        dist = TorchSquashedGaussian.from_logits(torch.cat([loc, log_std], dim=-1))
-
-        action, logp = dist.rsample_and_logp()
-
-        x = torch.atanh(action.clamp(-1 + 1e-6, 1 - 1e-6))  # pre-squash sample
-        expected = torch.distributions.Normal(loc, scale).log_prob(x).sum(
-            -1
-        ) - torch.log(1 - torch.tanh(x) ** 2).sum(-1)
-        self.assertTrue(torch.allclose(logp, expected, atol=1e-3))
+        self.assertGreater(logp.mean().item(), 0.0)
 
 
 if __name__ == "__main__":

--- a/rllib/core/distribution/torch/tests/test_torch_squashed_gaussian.py
+++ b/rllib/core/distribution/torch/tests/test_torch_squashed_gaussian.py
@@ -17,8 +17,6 @@ class TestTorchSquashedGaussian(unittest.TestCase):
         dist = TorchSquashedGaussian.from_logits(torch.cat([loc, log_std], dim=-1))
 
         _, logp = dist.rsample_and_logp()
-        print(logp)
-        print(_)
 
         self.assertTrue(torch.isfinite(logp).all())
         self.assertGreater(logp.mean().item(), 0.0)

--- a/rllib/core/distribution/torch/torch_distribution.py
+++ b/rllib/core/distribution/torch/torch_distribution.py
@@ -4,6 +4,7 @@ the code. This matches the design pattern of torch distribution which developers
 already be familiar with.
 """
 import abc
+import math
 from typing import Dict, Iterable, List, Optional
 
 import gymnasium as gym
@@ -66,6 +67,14 @@ class TorchDistribution(Distribution, abc.ABC):
             sample_shape if sample_shape is not None else torch.Size()
         )
         return rsample
+
+    def sample_and_logp(self, *, sample_shape=None):
+        sample = self.sample(sample_shape=sample_shape)
+        return sample, self.logp(sample)
+
+    def rsample_and_logp(self, *, sample_shape=None):
+        rsample = self.rsample(sample_shape=sample_shape)
+        return rsample, self.logp(rsample)
 
     @classmethod
     @override(Distribution)
@@ -263,35 +272,56 @@ class TorchSquashedGaussian(TorchDistribution):
     def sample(
         self, *, sample_shape=None
     ) -> Union[TensorType, Tuple[TensorType, TensorType]]:
-        # Sample from the Normal distribution.
         sample = super().sample(
             sample_shape=sample_shape if sample_shape is not None else torch.Size()
         )
-        # Return the squashed sample.
         return self._squash(sample)
 
     @override(TorchDistribution)
     def rsample(
         self, *, sample_shape=None
     ) -> Union[TensorType, Tuple[TensorType, TensorType]]:
-        # Sample from the Normal distribution.
         sample = super().rsample(
             sample_shape=sample_shape if sample_shape is not None else torch.Size()
         )
-        # Return the squashed sample.
         return self._squash(sample)
 
     @override(TorchDistribution)
     def logp(self, value: TensorType, **kwargs) -> TensorType:
-        # Unsquash value.
-        value = self._unsquash(value)
-        # Get log-probabilities from Normal distribution.
-        logp = super().logp(value, **kwargs)
-        # Clip the log probabilities as a safeguard and sum.
-        logp = torch.clamp(logp, -100, 100).sum(-1)
-        # Return the log probabilities for squashed Normal.
-        value = torch.tanh(value)
-        return logp - torch.log(1 - value**2 + SMALL_NUMBER).sum(-1)
+        """Returns the log probability of `value` under the squashed Gaussian.
+
+        Exact for interior actions.
+        `rsample_and_logp()` / `sample_and_logp()` are always exact.
+        """
+        return self._squashed_logp(self._unsquash(value))
+
+    def _squashed_logp(self, unsquashed: TensorType) -> TensorType:
+        # Normal log-prob of the pre-squash sample minus the tanh Jacobian
+        # log(1 - tanh(x)^2), via the numerically stable identity
+        #   log(1 - tanh(x)^2) = 2 * (log(2) - x - softplus(-2x)).
+        # This is a known SAC implementation trick.
+        # See Haarnoja et al. 2018 (arXiv:1801.01290), Appendix C
+        # Eq. 21 for the tanh change of variables, and OpenAI Spinning Up's SAC
+        # (spinup/algos/pytorch/sac/core.py) for this numerically stable form.
+        logp = super().logp(unsquashed).sum(-1)
+        jacobian = 2.0 * (
+            math.log(2.0) - unsquashed - nn.functional.softplus(-2.0 * unsquashed)
+        )
+        return logp - jacobian.sum(-1)
+
+    @override(TorchDistribution)
+    def rsample_and_logp(self, *, sample_shape=None):
+        unsquashed = super().rsample(
+            sample_shape=sample_shape if sample_shape is not None else torch.Size()
+        )
+        return self._squash(unsquashed), self._squashed_logp(unsquashed)
+
+    @override(TorchDistribution)
+    def sample_and_logp(self, *, sample_shape=None):
+        unsquashed = super().sample(
+            sample_shape=sample_shape if sample_shape is not None else torch.Size()
+        )
+        return self._squash(unsquashed), self._squashed_logp(unsquashed)
 
     @override(TorchDistribution)
     def entropy(self) -> TensorType:


### PR DESCRIPTION
TorchSquashedGaussian.logp() recovered the pre-squash value via atanh(clamp(action)), which caps the recovered value at ~7.25 and corrupts logp (large negative) once the policy mean saturates tanh. This breaks SAC/TQC alpha tuning and the critic entropy target on envs where the policy saturates (e.g. Humanoid).

This is also part of the picture why TQC can't solve humanoid.
The solution involves some magic math ( see https://github.com/openai/spinningup/blob/master/spinup/algos/pytorch/sac/core.py#L59-L60 )

Adds a regression unit test.

