### PR TITLE
[doc] Bump docs template build-id pins

### DIFF
--- a/doc/source/template_pins.json
+++ b/doc/source/template_pins.json
@@ -2,7 +2,7 @@
   "_note": "Pinned templates.ci.ray.io build ids for the docs build. Managed by the auto-bump workflow in anyscale/docs; prefer bumping via that PR rather than hand-editing. Consumed by template_collections.py. 'pins' maps each template in _TEMPLATE_COLLECTIONS to a build id, fetched as /templates/<name>/<id>/build.zip.",
   "pins": {
     "asynchronous_inference": "20260709-002741",
-    "audio-dataset-curation-llm-judge": "20260608-222228",
+    "audio-dataset-curation-llm-judge": "20260709-175135",
     "deepspeed_finetune": "20260709-002714",
     "deployment-serve-llm": "20260709-065934",
     "distributing-pytorch": "20260709-055846",


### PR DESCRIPTION
Automated bump of `doc/source/template_pins.json` to the current
`latest` template builds on templates.ci.ray.io.

Bumped:
- `audio-dataset-curation-llm-judge`: `20260608-222228` -> `20260709-175135`

The Read the Docs preview on this PR is the gate: a green build means the newer template content still renders.
