### PR TITLE
[Data] Better estimate decoded Iceberg read size

### DIFF
--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -12,6 +12,9 @@ import pyarrow as pa
 from packaging import version
 
 from ray.data._internal.arrow_block import _BATCH_SIZE_PRESERVING_STUB_COL_NAME
+from ray.data._internal.datasource.parquet_datasource import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
 from ray.data._internal.planner.plan_expression.expression_visitors import _ExprVisitor
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockAccessor, BlockMetadata
@@ -124,6 +127,36 @@ def _get_empty_projection_schema() -> "Schema":
             required=False,
         )
     )
+
+
+def _estimate_inmemory_file_size(
+    data_file: "DataFile", projected_field_ids: Optional[Set[int]]
+) -> int:
+    """Estimate a data file's decoded size for the projected columns.
+
+    Iceberg's column sizes are compressed on-disk bytes. For Parquet, use them
+    only when they cover every projected top-level field, then apply Ray's
+    established Parquet decoding-ratio default. For other formats, retain the
+    existing whole-file estimate until Ray has a format-specific decode ratio.
+    """
+    if projected_field_ids == set():
+        return 0
+
+    file_format = getattr(data_file.file_format, "name", data_file.file_format)
+    if file_format != "PARQUET":
+        return data_file.file_size_in_bytes
+
+    column_sizes = data_file.column_sizes
+    if (
+        projected_field_ids is not None
+        and column_sizes is not None
+        and projected_field_ids.issubset(column_sizes)
+    ):
+        on_disk_size = sum(column_sizes[field_id] for field_id in projected_field_ids)
+    else:
+        on_disk_size = data_file.file_size_in_bytes
+
+    return int(on_disk_size * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT)
 
 
 class _IcebergExpressionVisitor(
@@ -496,10 +529,20 @@ class IcebergDatasource(Datasource):
         return data_scan
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
-        # Approximate the size by using the plan files - this will not
-        # incorporate the deletes, but that's a reasonable approximation
-        # task
-        return sum(task.file.file_size_in_bytes for task in self.plan_files)
+        projected_field_ids = self._get_projected_field_ids(self._get_data_scan())
+        # This does not account for delete files, but is a reasonable approximation.
+        return sum(
+            _estimate_inmemory_file_size(task.file, projected_field_ids)
+            for task in self.plan_files
+        )
+
+    def _get_projected_field_ids(self, data_scan: "DataScan") -> Optional[Set[int]]:
+        """Return projected top-level field IDs, or ``None`` for all fields."""
+        if self._is_empty_projection():
+            return set()
+        if self._projection_map is None:
+            return None
+        return {field.field_id for field in data_scan.projection().columns}
 
     def supports_predicate_pushdown(self) -> bool:
         """Returns True to indicate this datasource supports predicate pushdown."""
@@ -563,6 +606,7 @@ class IcebergDatasource(Datasource):
         projected_schema = data_scan.projection()
         # Get the arrow schema, to set in the metadata
         pya_schema = pyi_pa_io.schema_to_pyarrow(projected_schema)
+        projected_field_ids = self._get_projected_field_ids(data_scan)
 
         # An empty projection reads a fabricated stub column instead of none at
         # all, see ``_get_empty_projection_schema``. Declare the placeholder so
@@ -657,7 +701,10 @@ class IcebergDatasource(Datasource):
                 )
             metadata = BlockMetadata(
                 num_rows=num_rows,
-                size_bytes=sum(task.file.file_size_in_bytes for task in chunk_tasks),
+                size_bytes=sum(
+                    _estimate_inmemory_file_size(task.file, projected_field_ids)
+                    for task in chunk_tasks
+                ),
                 input_files=[task.file.file_path for task in chunk_tasks],
                 exec_stats=None,
             )

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -11,6 +11,9 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tupl
 import pyarrow as pa
 from packaging import version
 
+from ray.data._internal.datasource.parquet_datasource import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
 from ray.data._internal.planner.plan_expression.expression_visitors import _ExprVisitor
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockMetadata
@@ -83,6 +86,36 @@ if TYPE_CHECKING:
     from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
+
+
+def _estimate_inmemory_file_size(
+    data_file: "DataFile", projected_field_ids: Optional[Set[int]]
+) -> int:
+    """Estimate a data file's decoded size for the projected columns.
+
+    Iceberg's column sizes are compressed on-disk bytes. For Parquet, use them
+    only when they cover every projected top-level field, then apply Ray's
+    established Parquet decoding-ratio default. For other formats, retain the
+    existing whole-file estimate until Ray has a format-specific decode ratio.
+    """
+    if projected_field_ids == set():
+        return 0
+
+    file_format = getattr(data_file.file_format, "name", data_file.file_format)
+    if file_format != "PARQUET":
+        return data_file.file_size_in_bytes
+
+    column_sizes = data_file.column_sizes
+    if (
+        projected_field_ids is not None
+        and column_sizes is not None
+        and projected_field_ids.issubset(column_sizes)
+    ):
+        on_disk_size = sum(column_sizes[field_id] for field_id in projected_field_ids)
+    else:
+        on_disk_size = data_file.file_size_in_bytes
+
+    return int(on_disk_size * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT)
 
 
 class _IcebergExpressionVisitor(
@@ -384,10 +417,18 @@ class IcebergDatasource(Datasource):
         return data_scan
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
-        # Approximate the size by using the plan files - this will not
-        # incorporate the deletes, but that's a reasonable approximation
-        # task
-        return sum(task.file.file_size_in_bytes for task in self.plan_files)
+        projected_field_ids = self._get_projected_field_ids(self._get_data_scan())
+        # This does not account for delete files, but is a reasonable approximation.
+        return sum(
+            _estimate_inmemory_file_size(task.file, projected_field_ids)
+            for task in self.plan_files
+        )
+
+    def _get_projected_field_ids(self, data_scan: "DataScan") -> Optional[Set[int]]:
+        """Return projected top-level field IDs, or ``None`` for all fields."""
+        if self._projection_map is None:
+            return None
+        return {field.field_id for field in data_scan.projection().columns}
 
     def supports_predicate_pushdown(self) -> bool:
         """Returns True to indicate this datasource supports predicate pushdown."""
@@ -446,6 +487,7 @@ class IcebergDatasource(Datasource):
         projected_schema = data_scan.projection()
         # Get the arrow schema, to set in the metadata
         pya_schema = pyi_pa_io.schema_to_pyarrow(projected_schema)
+        projected_field_ids = self._get_projected_field_ids(data_scan)
 
         # Set the n_chunks to the min of the number of plan files and the actual
         # requested n_chunks, so that there are no empty tasks
@@ -498,7 +540,10 @@ class IcebergDatasource(Datasource):
             metadata = BlockMetadata(
                 num_rows=sum(task.file.record_count for task in chunk_tasks)
                 - position_delete_count,
-                size_bytes=sum(task.file.file_size_in_bytes for task in chunk_tasks),
+                size_bytes=sum(
+                    _estimate_inmemory_file_size(task.file, projected_field_ids)
+                    for task in chunk_tasks
+                ),
                 input_files=[task.file.file_path for task in chunk_tasks],
                 exec_stats=None,
             )

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -1,5 +1,6 @@
 import os
 import random
+from types import SimpleNamespace
 from typing import Any, Dict, Generator, List, Tuple, Type
 
 import numpy as np
@@ -15,14 +16,21 @@ from pyiceberg import (
 )
 from pyiceberg.catalog import Catalog
 from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.manifest import FileFormat
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.table import Table
 from pyiceberg.transforms import IdentityTransform
 
 import ray
 from ray.data import read_iceberg
-from ray.data._internal.datasource.iceberg_datasource import IcebergDatasource
-from ray.data._internal.logical.operators import Filter, Project
+from ray.data._internal.datasource.iceberg_datasource import (
+    IcebergDatasource,
+    _estimate_inmemory_file_size,
+)
+from ray.data._internal.datasource.parquet_datasource import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
+from ray.data._internal.logical.operators import Filter, Project, Read
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
@@ -203,6 +211,115 @@ def test_get_read_tasks():
     read_tasks = iceberg_ds.get_read_tasks(5)
     assert len(read_tasks) == 5
     assert all(len(rt.metadata.input_files) == 2 for rt in read_tasks)
+
+
+@pytest.mark.parametrize(
+    "file_format,column_sizes,projected_field_ids,expected_size",
+    [
+        (
+            FileFormat.PARQUET,
+            {1: 10, 2: 20},
+            {1, 2},
+            30 * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+        ),
+        (
+            FileFormat.PARQUET,
+            {1: 10},
+            {1, 2},
+            100 * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+        ),
+        (FileFormat.PARQUET, {1: 10}, set(), 0),
+        (FileFormat.AVRO, {1: 10, 2: 20}, {1, 2}, 100),
+    ],
+)
+def test_estimate_inmemory_file_size(
+    file_format, column_sizes, projected_field_ids, expected_size
+):
+    data_file = SimpleNamespace(
+        file_format=file_format,
+        file_size_in_bytes=100,
+        column_sizes=column_sizes,
+    )
+
+    assert _estimate_inmemory_file_size(data_file, projected_field_ids) == expected_size
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_size_estimate_matches_read_task_metadata():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        selected_fields=("col_a",),
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    read_tasks = iceberg_ds.get_read_tasks(3)
+    expected_size = sum(
+        task.file.column_sizes[1] * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+        for task in iceberg_ds.plan_files
+    )
+
+    assert iceberg_ds.estimate_inmemory_data_size() == expected_size
+    assert sum(task.metadata.size_bytes for task in read_tasks) == expected_size
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_default_size_estimate_uses_full_parquet_file_size():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    assert iceberg_ds.estimate_inmemory_data_size() == sum(
+        task.file.file_size_in_bytes * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+        for task in iceberg_ds.plan_files
+    )
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_projection_pushdown_updates_planner_size_estimate(monkeypatch):
+    from ray._private import auto_init_hook
+
+    monkeypatch.setattr(auto_init_hook, "enable_auto_connect", False)
+    monkeypatch.setattr(ray.util, "get_current_placement_group", lambda: None)
+    projected_ds = read_iceberg(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+        override_num_blocks=1,
+    ).select_columns(["col_a"])
+
+    optimized_plan = LogicalOptimizer().optimize(projected_ds._logical_plan)
+    read_op = optimized_plan.dag
+    assert isinstance(read_op, Read)
+
+    expected_size = sum(
+        task.file.column_sizes[1] * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+        for task in read_op.datasource.plan_files
+    )
+    assert read_op.infer_metadata().size_bytes == expected_size
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_empty_projection_has_zero_size_estimate():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        selected_fields=(),
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    assert iceberg_ds.estimate_inmemory_data_size() == 0
+    assert all(task.metadata.size_bytes == 0 for task in iceberg_ds.get_read_tasks(3))
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/datasource/test_iceberg.py
+++ b/python/ray/data/tests/datasource/test_iceberg.py
@@ -1,5 +1,6 @@
 import os
 import random
+from types import SimpleNamespace
 from typing import Any, Dict, Generator, List, Tuple, Type
 
 import numpy as np
@@ -15,6 +16,7 @@ from pyiceberg import (
 )
 from pyiceberg.catalog import Catalog
 from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.manifest import FileFormat
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.table import Table
 from pyiceberg.transforms import IdentityTransform
@@ -24,9 +26,13 @@ from ray.data import read_iceberg
 from ray.data._internal.arrow_block import _BATCH_SIZE_PRESERVING_STUB_COL_NAME
 from ray.data._internal.datasource.iceberg_datasource import (
     IcebergDatasource,
+    _estimate_inmemory_file_size,
     _get_read_task,
 )
-from ray.data._internal.logical.operators import Filter, Project
+from ray.data._internal.datasource.parquet_datasource import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
+from ray.data._internal.logical.operators import Filter, Project, Read
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
@@ -362,6 +368,115 @@ def test_get_read_task_normalizes_batch_schemas(monkeypatch):
         {"string": ["a"], "list": [["b"]]},
         {"string": ["c"], "list": [["d"]]},
     ]
+
+
+@pytest.mark.parametrize(
+    "file_format,column_sizes,projected_field_ids,expected_size",
+    [
+        (
+            FileFormat.PARQUET,
+            {1: 10, 2: 20},
+            {1, 2},
+            30 * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+        ),
+        (
+            FileFormat.PARQUET,
+            {1: 10},
+            {1, 2},
+            100 * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+        ),
+        (FileFormat.PARQUET, {1: 10}, set(), 0),
+        (FileFormat.AVRO, {1: 10, 2: 20}, {1, 2}, 100),
+    ],
+)
+def test_estimate_inmemory_file_size(
+    file_format, column_sizes, projected_field_ids, expected_size
+):
+    data_file = SimpleNamespace(
+        file_format=file_format,
+        file_size_in_bytes=100,
+        column_sizes=column_sizes,
+    )
+
+    assert _estimate_inmemory_file_size(data_file, projected_field_ids) == expected_size
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_size_estimate_matches_read_task_metadata():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        selected_fields=("col_a",),
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    read_tasks = iceberg_ds.get_read_tasks(3)
+    expected_size = sum(
+        task.file.column_sizes[1] * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+        for task in iceberg_ds.plan_files
+    )
+
+    assert iceberg_ds.estimate_inmemory_data_size() == expected_size
+    assert sum(task.metadata.size_bytes for task in read_tasks) == expected_size
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_default_size_estimate_uses_full_parquet_file_size():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    assert iceberg_ds.estimate_inmemory_data_size() == sum(
+        task.file.file_size_in_bytes * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+        for task in iceberg_ds.plan_files
+    )
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_projection_pushdown_updates_planner_size_estimate(monkeypatch):
+    from ray._private import auto_init_hook
+
+    monkeypatch.setattr(auto_init_hook, "enable_auto_connect", False)
+    monkeypatch.setattr(ray.util, "get_current_placement_group", lambda: None)
+    projected_ds = read_iceberg(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+        override_num_blocks=1,
+    ).select_columns(["col_a"])
+
+    optimized_plan = LogicalOptimizer().optimize(projected_ds._logical_plan)
+    read_op = optimized_plan.dag
+    assert isinstance(read_op, Read)
+
+    expected_size = sum(
+        task.file.column_sizes[1] * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+        for task in read_op.datasource.plan_files
+    )
+    assert read_op.infer_metadata().size_bytes == expected_size
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_empty_projection_has_zero_size_estimate():
+    iceberg_ds = IcebergDatasource(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        selected_fields=(),
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    assert iceberg_ds.estimate_inmemory_data_size() == 0
+    assert all(task.metadata.size_bytes == 0 for task in iceberg_ds.get_read_tasks(3))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
_I used CODEX to create this PR, and I stand by it. This summary is mine._

Previously, Iceberg read planning used the raw total file size as its in-memory size estimate. For Parquet data, this change estimates decoded in-memory size using Ray's standard 5× encoding ratio. When complete projected-column metrics are available in the Iceberg manifest, it applies that ratio only to the projected columns; otherwise it uses a 5× whole-file estimate. Consequently, unprojected Parquet reads now estimate 5× the encoded file size rather than 1×.

Since this data is present in the Iceberg manifests there are no additional file operations required for this, such as opening file footers.  So planning accuracy improves with no material cost.  


Codex summary follows:
-----
### Summary

- Use complete Iceberg `column_sizes` metrics for projected top-level Parquet fields.
- Apply Ray's existing Parquet decode-ratio estimate to the selected encoded bytes.
- Fall back to a 5× whole-file estimate when projected metrics are incomplete or unavailable.
- Preserve non-Parquet behavior and report an empty projection as zero bytes.
- Use the same estimate for datasource sizing and `ReadTask` metadata.

### Testing

- `bazel test //python/ray/data:test_iceberg` — passed.
- Focused estimator tests in `test_iceberg.py` — 8 passed, 54 deselected.
- File-scoped pre-commit hooks — passed.
- `git diff --check origin/master...HEAD` — passed.

AI assistance was used for investigation, implementation, testing, and drafting this description. This upstream PR is a draft for human line-by-line review before requesting review.

### Duplicate-work check

No open `ray-project/ray` issue or PR was found for projection-aware Iceberg decoded-size estimation. Searches for Iceberg decoded-size estimation, `column_sizes`, and Iceberg memory estimation returned no overlapping work.
