### PR TITLE
[Core] Add death-reason label to `node_failure_total metric`

### DIFF
--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -645,7 +645,8 @@ std::shared_ptr<const rpc::GcsNodeInfo> GcsNodeManager::RemoveNodeFromCache(
         << ", death reason = " << rpc::NodeDeathInfo_Reason_Name(node_death_info.reason())
         << ", death message = " << node_death_info.reason_message();
     // Record stats that there's a new removed node.
-    ray_metric_node_failures_total_.Record(1);
+    ray_metric_node_failures_total_.Record(
+        1, {{"Reason", rpc::NodeDeathInfo_Reason_Name(node_death_info.reason())}});
     // Remove from alive nodes.
     alive_nodes_.erase(iter);
     // Remove from draining nodes if present.

--- a/src/ray/gcs/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_node_manager.h
@@ -422,7 +422,8 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   ray::stats::Count ray_metric_node_failures_total_{
       /*name=*/"node_failure_total",
       /*description=*/"Number of node failures that have happened in the cluster.",
-      /*unit=*/""};
+      /*unit=*/"",
+      /*tag_keys=*/{"Reason"}};
 
   friend GcsAutoscalerStateManagerTest;
   friend GcsStateTest;

--- a/src/ray/gcs/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_node_manager.h
@@ -423,7 +423,7 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
       /*name=*/"node_failure_total",
       /*description=*/"Number of node failures that have happened in the cluster.",
       /*unit=*/"",
-      /*tag_keys=*/{"Reason"}};
+      /*tag_keys=*/{"reason"}};
 
   friend GcsAutoscalerStateManagerTest;
   friend GcsStateTest;


### PR DESCRIPTION
Ray Core exposes a `ray_node_failure_total` counter. The problem is that it doesn't disambiguate expected failures like spot preemptions from unexpected failures like death from missed heartbeats. As a result, I can't use it to assert there are no unexpected node deaths on Ray Data release tests that're run on spot.

This also seems like a useful tag generally.