### PR TITLE
[Data] Raise a clear error when webdataset tar keys are not adjacent

### DIFF
--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -168,9 +168,15 @@ def _group_by_keys(
     Yields:
         Dict[str, Any]: Grouped samples, where files sharing the same key prefix are
         combined into a single dictionary.
+
+    Raises:
+        ValueError: If a key reappears after files with a different key. The
+            WebDataset format requires all files belonging to a sample to be
+            stored consecutively.
     """
     meta = meta or {}
     current_sample = None
+    completed_keys = set()
     for filesample in data:
         assert isinstance(filesample, dict)
         fname, value = filesample["fname"], filesample["data"]
@@ -178,9 +184,21 @@ def _group_by_keys(
         if prefix is None:
             continue
         if current_sample is None or prefix != current_sample["__key__"]:
-            if _valid_sample(current_sample):
-                current_sample.update(meta)
-                yield current_sample
+            if current_sample is not None:
+                completed_key = current_sample["__key__"]
+                if _valid_sample(current_sample):
+                    current_sample.update(meta)
+                    yield current_sample
+                completed_keys.add(completed_key)
+            if prefix in completed_keys:
+                raise ValueError(
+                    f"{fname}: key {prefix!r} reappears after files with a "
+                    "different key. The WebDataset format requires all files "
+                    "belonging to a sample to be stored consecutively, so this "
+                    "sample would be split into several incomplete rows. Sort "
+                    "the files by name when writing the tar file. Tar is "
+                    f"{meta.get('__url__')}"
+                )
             current_sample = dict(__key__=prefix)
             if "__url__" in filesample:
                 current_sample["__url__"] = filesample["__url__"]

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -11,6 +11,7 @@ import pytest
 import webdataset as wds
 
 import ray
+from ray.data._internal.datasource.webdataset_datasource import _group_by_keys
 from ray.tests.conftest import *  # noqa
 
 
@@ -327,6 +328,46 @@ def test_custom_decoder_bypasses_unsafe_guard(ray_start_2_cpus, tmp_path):
 
     assert len(rows) == 1
     assert rows[0]["pkl"] == {"key": "value"}
+
+
+def _file_samples(*names):
+    return [{"fname": name, "data": name.encode("utf-8")} for name in names]
+
+
+def test_group_by_keys_groups_consecutive_files():
+    samples = list(
+        _group_by_keys(
+            _file_samples("000000.a", "000000.b", "000001.a", "000001.b"),
+            meta={"__url__": "test.tar"},
+        )
+    )
+
+    assert [sample["__key__"] for sample in samples] == ["000000", "000001"]
+    assert all(sample.keys() >= {"a", "b"} for sample in samples)
+
+
+def test_group_by_keys_raises_on_non_adjacent_keys():
+    # "000000" reappears after "000001", so its files would otherwise be split
+    # across two incomplete rows.
+    with pytest.raises(ValueError, match="reappears"):
+        list(
+            _group_by_keys(
+                _file_samples("000000.a", "000001.a", "000000.b", "000001.b"),
+                meta={"__url__": "test.tar"},
+            )
+        )
+
+
+def test_webdataset_non_adjacent_keys_raises(ray_start_2_cpus, tmp_path):
+    path = os.path.join(tmp_path, "unsorted.tar")
+    with TarWriter(path) as tf:
+        tf.write("000000.a", b"0")
+        tf.write("000001.a", b"1")
+        tf.write("000000.b", b"0")
+
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)])
+    with pytest.raises(Exception, match="reappears"):
+        ds.take_all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`_group_by_keys` builds WebDataset samples by grouping *consecutive* files that share a key prefix. When a tar stores a sample's files non-consecutively, the grouper emits the same `__key__` more than once, and each of those rows holds only the fields that happened to appear before the key changed. The read appears to succeed while silently producing duplicate keys and rows with missing columns.

For files `000000.a, 000001.a, 000000.b, 000001.b` the reader previously returned four rows — keys `000000`, `000001`, `000000`, `000001` — each missing one of its two fields, with no error or warning.

The WebDataset format specification requires all files belonging to a sample to be stored consecutively, so buffering an entire shard to regroup it would both contradict the format and break the reader's streaming behaviour. This change instead tracks the keys whose samples have already been completed and raises a `ValueError` naming the offending file and tar when one of them reappears, so a malformed shard is reported rather than read as corrupt rows.

Memory stays proportional to the number of keys in a shard rather than to the data, and valid (sorted) shards are unaffected.

## Related issues

Closes #44068

## Additional information

**Behaviour change:** reads of malformed tars that previously "succeeded" now raise. That is the intent, since the previous result was silently incorrect. This mirrors the duplicate-suffix `ValueError` that `_group_by_keys` already raises a few lines below. If you would rather keep a lenient path, I'm happy to put the check behind an opt-out argument.

**Tests added:**

- `test_group_by_keys_raises_on_non_adjacent_keys` — regression test for the reported case; confirmed failing (`DID NOT RAISE ValueError`) with the fix reverted, and passing with it.
- `test_group_by_keys_groups_consecutive_files` — guards that valid, consecutive shards still group into complete samples.
- `test_webdataset_non_adjacent_keys_raises` — end-to-end through `ray.data.read_webdataset`.

The first two need no Ray cluster, so they are fast unit tests over the pure helper.

**Local verification:** `pytest python/ray/data/tests/datasource/test_webdataset.py` gives 15 passed, 3 failed. The three failures are `test_webdataset_expand_json`, `test_webdataset_coding` and `test_webdataset_decoding`, which fail at their `import torch` / `import PIL.Image` lines because those optional test dependencies aren't installed in my local environment; they are unrelated to this change.
