### PR TITLE
[train] Add preemption benchmark release test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2234,7 +2234,8 @@
     timeout: 10800
     script: RAY_TRAIN_V2_ENABLED=1 python test_preemption_benchmark.py
     wait_for_nodes:
-      num_nodes: 2
+      # Includes the head node: 1 head + 8 `min_nodes` training workers.
+      num_nodes: 9
   alert: default
 
 - name: train_colocate_trainer

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2234,7 +2234,6 @@
     timeout: 10800
     script: RAY_TRAIN_V2_ENABLED=1 python test_preemption_benchmark.py
     wait_for_nodes:
-      # Includes the head node: 1 head + 8 `min_nodes` training workers.
       num_nodes: 9
   alert: default
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2219,6 +2219,24 @@
       num_nodes: 2
   alert: default
 
+- name: train_preemption_benchmark
+  python: "3.10"
+  group: Train tests
+  working_dir: train_tests/preemption
+  frequency: nightly
+  team: ml
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      type: gpu
+    cluster_compute: compute_aws.yaml
+  run:
+    timeout: 10800
+    script: RAY_TRAIN_V2_ENABLED=1 python test_preemption_benchmark.py
+    wait_for_nodes:
+      num_nodes: 2
+  alert: default
+
 - name: train_colocate_trainer
   python: "3.10"
   group: Train tests

--- a/release/train_tests/preemption/compute_aws.yaml
+++ b/release/train_tests/preemption/compute_aws.yaml
@@ -1,0 +1,20 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+  TagSpecifications:
+    - ResourceType: "instance"
+      Tags:
+        - Key: ttl-hours
+          Value: '24'
+
+head_node:
+    instance_type: m5.4xlarge
+
+worker_nodes:
+    # The benchmark terminates worker instances to inject preemptions, so
+    # `max_nodes` leaves room for replacements while the run recovers.
+    - name: train-worker-node
+      instance_type: g4dn.xlarge
+      min_nodes: 2
+      max_nodes: 4
+      market_type: ON_DEMAND

--- a/release/train_tests/preemption/compute_aws.yaml
+++ b/release/train_tests/preemption/compute_aws.yaml
@@ -11,10 +11,12 @@ head_node:
     instance_type: m5.4xlarge
 
 worker_nodes:
-    # The benchmark terminates worker instances to inject preemptions, so
-    # `max_nodes` leaves room for replacements while the run recovers.
+    # 8 x g4dn.xlarge = 8 T4s, one per worker, so a single preempted instance
+    # takes out 1/8 of the group. The benchmark terminates instances to inject
+    # preemptions, so `max_nodes` leaves room for replacements to come up while
+    # the dead ones are still being reaped.
     - name: train-worker-node
       instance_type: g4dn.xlarge
-      min_nodes: 2
-      max_nodes: 4
+      min_nodes: 8
+      max_nodes: 10
       market_type: ON_DEMAND

--- a/release/train_tests/preemption/compute_aws.yaml
+++ b/release/train_tests/preemption/compute_aws.yaml
@@ -11,10 +11,6 @@ head_node:
     instance_type: m5.4xlarge
 
 worker_nodes:
-    # 8 x g4dn.xlarge = 8 T4s, one per worker, so a single preempted instance
-    # takes out 1/8 of the group. The benchmark terminates instances to inject
-    # preemptions, so `max_nodes` leaves room for replacements to come up while
-    # the dead ones are still being reaped.
     - name: train-worker-node
       instance_type: g4dn.xlarge
       min_nodes: 8

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -1,37 +1,3 @@
-"""Benchmark: how much work does preemption handling save?
-
-Runs the same training workload twice, under the same injected preemption
-schedule, and compares how much work each arm has to redo:
-
-* ``baseline``: periodic checkpoints only. The training function never looks at
-  ``ray.train.get_preemption_info()``, so on a preemption it resumes from the
-  last periodic checkpoint and replays everything since.
-* ``jit``: periodic checkpoints plus a just-in-time checkpoint taken when a
-  preemption is first observed (the checkpoint-and-continue pattern). On a
-  preemption it resumes from that just-in-time checkpoint, replaying ~nothing.
-
-The headline metrics are ``wasted_steps`` -- steps executed beyond the target,
-i.e. pure recompute -- and ``wasted_gpu_seconds``, which scales that by the
-worker count because a single preempted node forces the whole group to restart
-and redo the same work. Both are measured by counting every step executed
-across all attempts and subtracting the target, so they are immune to how long
-the autoscaler took to replace an instance. End-to-end wall-clock time is
-reported alongside them, but it is dominated by node replacement and is the
-noisier signal.
-
-A preemption lands at a random point in the checkpoint interval, so over
-several preemptions the baseline loses ``checkpoint_interval / 2`` steps each
-on average, while the ``jit`` arm only loses the steps taken during the drain
-grace window.
-
-Preemptions are injected with ``EC2InstanceTerminatorWithGracePeriod``, which
-drains a node through the GCS with ``DRAIN_NODE_REASON_PREEMPTION`` and a real
-deadline, waits out the grace period, then stops the instance. That drives the
-whole production path: the preemption watcher, the fan-out to every worker,
-``get_preemption_info()``, ``PreemptingState``, and a real
-``RayActorError.preempted`` death.
-"""
-
 import argparse
 import logging
 import os
@@ -41,6 +7,7 @@ from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
+import torchvision.models as tv_models
 
 import ray
 import ray.train
@@ -58,53 +25,24 @@ logger.setLevel(logging.INFO)
 
 STORAGE_PATH = os.environ.get("ANYSCALE_ARTIFACT_STORAGE", "/mnt/cluster_storage")
 
-# Mirrors the hardcoded `grace_period_s` default of
-# `EC2InstanceTerminatorWithGracePeriod`; we cannot currently override it (see
-# the TODO in `run_arm`). Recorded in the results so a run's numbers can be read
-# against the window they were measured with.
-#
-# This is the hard budget for the just-in-time checkpoint: the watcher poll
-# (~5s) plus the checkpoint save+upload must fit inside it, or the node is gone
-# before the checkpoint commits and the `jit` arm degrades to the baseline.
-# `vit_b_16` is ~86M params (~0.35GB), which uploads in a few seconds; going
-# much larger (e.g. `vit_l_16` at ~1.2GB) eats most of the window.
 GRACE_PERIOD_S = 30
 
-# Image size for the synthetic batches. Matches what the torchvision ImageNet
-# classifiers expect.
+# What the torchvision ImageNet classifiers expect.
 IMAGE_SIZE = 224
 
-# The `jit` arm should never redo more work than the baseline. Allow a small
-# slack for the step that was in flight when the node went away.
+# Slack for the step that was in flight when the node went away.
 WASTED_STEPS_SLACK = 5
 
 
-# ==== Workload ====
-
-
 def create_model(model_name: str) -> nn.Module:
-    """Build a torchvision classifier.
-
-    A real architecture (rather than a stack of Linear layers) makes each step
-    represent genuine training work, so `wasted_steps` translates into GPU-time
-    that a user would actually lose.
-    """
-    import torchvision.models as tv_models
-
     if not hasattr(tv_models, model_name):
         raise ValueError(f"Unknown torchvision model: {model_name}")
-    # `weights=None` -- we measure recompute, not accuracy, so random init is
-    # fine and avoids downloading weights onto every worker.
     return getattr(tv_models, model_name)(weights=None)
 
 
 @ray.remote(num_cpus=0)
 class StepTracker:
-    """Counts work across worker-group restarts.
-
-    Lives on the driver so it survives the restarts that a preemption causes.
-    Only rank 0 reports, so counts are per-run rather than per-worker.
-    """
+    """Counts work across worker-group restarts."""
 
     def __init__(self):
         self._executed_steps = 0
@@ -131,12 +69,7 @@ class StepTracker:
         logger.info("Just-in-time checkpoint saved at step %d", step)
 
     def _mean_step_time_s(self) -> float:
-        """Mean seconds per step, excluding time spent restarting.
-
-        Summing each attempt's own span (rather than dividing end-to-end time)
-        leaves out the minutes spent waiting for the autoscaler to replace a
-        preempted node, so this reflects training throughput only.
-        """
+        """Mean seconds per step, excluding time spent restarting."""
         if not self._executed_steps:
             return 0.0
         training_s = sum(a["last_step_at"] - a["started_at"] for a in self._attempts)
@@ -153,18 +86,6 @@ class StepTracker:
 
 
 def train_func(config: Dict):
-    """Train to `target_steps`, checkpointing periodically.
-
-    In the `jit` arm, also save a single checkpoint the first time a preemption
-    is observed, then keep training. `get_preemption_info()` stays set for the
-    whole grace window, so the `saved_on_preemption` guard keeps this to one
-    extra checkpoint instead of one per step.
-
-    The watcher fans the signal out to *every* worker, not just the ones on the
-    doomed node -- but as independent RPCs, so ranks can observe it on different
-    steps. Since `report` is an all-rank barrier, the decision is all-reduced
-    (see `any_rank_preempted`) so the ranks stay in lockstep.
-    """
     target_steps = config["target_steps"]
     checkpoint_interval = config["checkpoint_interval"]
     use_jit_checkpoint = config["use_jit_checkpoint"]
@@ -192,14 +113,6 @@ def train_func(config: Dict):
     logger.info("Attempt starting at step %d (target %d)", start_step, target_steps)
 
     def save_checkpoint(step: int, metrics: Dict):
-        """Report a checkpoint from rank 0 only.
-
-        `report` is an all-rank barrier, so every rank must call it the same
-        number of times -- but only rank 0 needs to upload. Under DDP all ranks
-        hold identical weights, so uploading from every rank would multiply the
-        checkpoint traffic by `num_workers` for no benefit, and the just-in-time
-        save has to fit inside the drain grace period.
-        """
         if not is_rank_0:
             ray.train.report(metrics, checkpoint=None)
             return
@@ -216,10 +129,6 @@ def train_func(config: Dict):
                 metrics, checkpoint=ray.train.Checkpoint.from_directory(tmpdir)
             )
 
-    # Synthetic batches: this benchmark measures recomputed work, not accuracy,
-    # so fixed random tensors keep step time deterministic and avoid a data
-    # dependency. The forward/backward is the real model's, which is what makes
-    # a "wasted step" cost real GPU time.
     device = ray.train.torch.get_device()
     batch = torch.randn(config["batch_size"], 3, IMAGE_SIZE, IMAGE_SIZE, device=device)
     target = torch.randint(0, 1000, (config["batch_size"],), device=device)
@@ -229,13 +138,16 @@ def train_func(config: Dict):
     def any_rank_preempted() -> bool:
         """Whether *any* rank has observed the preemption yet.
 
-        `get_preemption_info()` is per-worker state and the watcher fans the
-        signal out with independent RPCs, so ranks can observe it on different
-        steps. Since `report` is an all-rank barrier, the decision to take a
-        just-in-time checkpoint has to be collective -- otherwise one rank
-        reports and the others don't, and the barrier deadlocks. All-reduce the
-        flag so every rank agrees on the same step. (This mirrors what a real
-        coordinated emergency checkpoint has to do.)
+        The watcher fans the signal out with independent RPCs, so ranks might
+        observe it on different steps. Every rank has to take the branch below on
+        the same step: a rank that enters `report` while the others run another
+        `backward` deadlocks the group, because `report` and DDP's gradient
+        all-reduce are both collectives and neither side can yield to the other.
+
+        TODO(lehui): Ray Train should own this agreement instead of the UDF. JAX exposes
+        `reached_preemption_sync_point(step)`, which all-reduces the max step
+        across hosts and returns True at max+1, so Orbax users never write a
+        collective themselves.
         """
         local = ray.train.get_preemption_info() is not None
         if (
@@ -249,7 +161,6 @@ def train_func(config: Dict):
 
     saved_on_preemption = False
     for step in range(start_step, target_steps):
-        # One unit of work.
         optimizer.zero_grad()
         loss = loss_fn(model(batch), target)
         loss.backward()
@@ -258,9 +169,8 @@ def train_func(config: Dict):
         if is_rank_0:
             ray.get(tracker.record_step.remote())
 
-        # Just-in-time checkpoint on the first observed preemption, then keep
-        # training until the node is actually reclaimed. Every rank evaluates
-        # this identically, so they stay in lockstep on the `report` barrier.
+        # Checkpoint on the first observed preemption, then keep training until
+        # the node is actually reclaimed.
         if use_jit_checkpoint and not saved_on_preemption and any_rank_preempted():
             saved_on_preemption = True
             save_checkpoint(step, {"step": step, "jit": True})
@@ -268,24 +178,15 @@ def train_func(config: Dict):
                 ray.get(tracker.record_jit_checkpoint.remote(step))
             continue
 
-        # Only checkpoint steps report. Train V2 does not persist metrics that
-        # aren't attached to a checkpoint, so a metrics-only `report` would be a
-        # no-op that still pays for the all-rank barrier and the controller
-        # draining a size-1 result queue (~2s/step in an earlier run of this
-        # benchmark). Progress is visible from the checkpoint reports, and the
-        # benchmark's own counters live in `StepTracker`, not `Result.metrics`.
         if step % checkpoint_interval == 0 or step == target_steps - 1:
             save_checkpoint(step, {"step": step, "jit": False})
-
-
-# ==== Harness ====
 
 
 def wait_for_worker_nodes(num_nodes: int, timeout_s: int = 900) -> None:
     """Wait until `num_nodes` worker nodes are alive.
 
-    Terminated instances have to be replaced between arms so both arms train on
-    the same cluster size.
+    Terminated instances have to be replaced between experiments so both train
+    on the same cluster size.
     """
     head_node_id = ray.get_runtime_context().get_node_id()
     deadline = time.time() + timeout_s
@@ -307,36 +208,21 @@ def wait_for_worker_nodes(num_nodes: int, timeout_s: int = 900) -> None:
     )
 
 
-def run_arm(arm: str, use_jit_checkpoint: bool, args: argparse.Namespace) -> Dict:
-    """Run one arm end to end and return its metrics.
+def run_experiment(use_jit_checkpoint: bool, args: argparse.Namespace) -> Dict:
+    """Run one experiment end to end and return its metrics.
 
-    Both arms share this path deliberately: the preemption schedule, failure
-    budgets, model, and step target must be identical for the comparison to mean
-    anything, so `use_jit_checkpoint` is the only thing that differs between
-    them. It selects the checkpoint-and-continue branch inside `train_func`.
+    Both experiments share this path deliberately: the preemption schedule,
+    failure budgets, model, and step target have to be identical for the
+    comparison to mean anything, so `use_jit_checkpoint` is the only difference.
     """
-    logger.info(
-        "=== Running arm '%s' (use_jit_checkpoint=%s) ===", arm, use_jit_checkpoint
-    )
+    label = "jit" if use_jit_checkpoint else "baseline"
+    logger.info("=== Running %s experiment ===", label)
     wait_for_worker_nodes(args.num_workers)
 
-    tracker_name = f"step_tracker_{arm}"
+    tracker_name = f"step_tracker_{label}"
     tracker = StepTracker.options(name=tracker_name).remote()
 
-    # Inject the preemption schedule. `kill_delay_s` lets the run get far enough
-    # past a periodic checkpoint that the baseline has real work to lose.
-    #
-    # The killer drains the node with a reclaim deadline of
-    # `now + grace_period_s`, waits that long, then force-stops Ray on it. That
-    # deadline is what reaches the UDF as `get_preemption_info().deadline_ms`,
-    # so it bounds how long a rank has to write its just-in-time checkpoint.
-    #
-    # TODO: make the grace period sweepable. `grace_period_s` is a ctor kwarg of
-    # `EC2InstanceTerminatorWithGracePeriod` (default 30s), but
-    # `get_and_run_resource_killer` does not forward extra kwargs, so we are
-    # pinned to the default. Either add a **kwargs passthrough there, or
-    # construct the killer actor directly here, so the benchmark can measure how
-    # the savings degrade once the window is too short for the JIT save.
+    # TODO: make the grace period configurable.
     resource_killer = get_and_run_resource_killer(
         EC2InstanceTerminatorWithGracePeriod,
         kill_interval_s=args.kill_interval_s,
@@ -356,13 +242,11 @@ def run_arm(arm: str, use_jit_checkpoint: bool, args: argparse.Namespace) -> Dic
         },
         scaling_config=ScalingConfig(num_workers=args.num_workers, use_gpu=True),
         run_config=RunConfig(
-            name=f"preemption_benchmark_{arm}_{int(time.time())}",
+            name=f"preemption_benchmark_{label}_{int(time.time())}",
             storage_path=STORAGE_PATH,
-            # Preemptions consume `max_preemption_failures`, not `max_failures`,
-            # so a spot run isn't hard-failed by planned interruptions.
             failure_config=FailureConfig(
                 max_failures=0,
-                max_preemption_failures=args.num_preemptions + 2,
+                max_preemption_failures=args.num_preemptions + 1,
             ),
             checkpoint_config=CheckpointConfig(num_to_keep=2),
         ),
@@ -374,7 +258,7 @@ def run_arm(arm: str, use_jit_checkpoint: bool, args: argparse.Namespace) -> Dic
         result = trainer.fit()
         completed = result.error is None
     except Exception as e:  # noqa: BLE001 - report the failure as a metric
-        logger.exception("Arm '%s' failed", arm)
+        logger.exception("%s experiment failed", label)
         completed = False
         error = repr(e)
     e2e_time = time.time() - start_time
@@ -385,20 +269,16 @@ def run_arm(arm: str, use_jit_checkpoint: bool, args: argparse.Namespace) -> Dic
 
     wasted_steps = max(0, summary["executed_steps"] - args.target_steps)
     metrics = {
-        "arm": arm,
         "completed": completed,
         "error": error,
         "e2e_time": e2e_time,
-        # Steps executed beyond the target == work redone after a preemption.
         "wasted_steps": wasted_steps,
-        # A preempted node forces *every* worker to restart and redo the same
-        # steps, so the cost to the cluster scales with the worker count.
         "wasted_gpu_seconds": (
             wasted_steps * summary["mean_step_time_s"] * args.num_workers
         ),
         **summary,
     }
-    logger.info("Arm '%s' metrics: %s", arm, metrics)
+    logger.info("%s experiment metrics: %s", label, metrics)
     return metrics
 
 
@@ -421,8 +301,8 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=1600,
         help=(
-            "Sized for a ~1.8h two-arm run at the 1.13s/step measured for "
-            "vit_b_16 on 8xT4. The budget is linear in step time, so re-measure "
+            "Sized for a ~1.8h run of both experiments at the 1.13s/step measured "
+            "for vit_b_16 on 8xT4. The budget is linear in step time, so re-measure "
             "with `--num-preemptions 0` before changing the model or worker "
             "count, and keep `--checkpoint-interval` at about a quarter of this."
         ),
@@ -434,7 +314,7 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Periodic checkpoint interval in steps. A preemption lands at a "
             "random point in the interval, so the baseline loses this/2 on "
-            "average per preemption while the jit arm loses only the steps "
+            "average per preemption, while the jit experiment loses only the steps "
             "taken during the grace window. The gap grows with this value."
         ),
     )
@@ -459,10 +339,8 @@ def main():
     args = parse_args()
     ray.init()
 
-    # Run the baseline first so both arms see a cluster that has already been
-    # through node replacement.
-    baseline = run_arm("baseline", use_jit_checkpoint=False, args=args)
-    jit = run_arm("jit", use_jit_checkpoint=True, args=args)
+    baseline = run_experiment(use_jit_checkpoint=False, args=args)
+    jit = run_experiment(use_jit_checkpoint=True, args=args)
 
     steps_saved = baseline["wasted_steps"] - jit["wasted_steps"]
     time_saved = baseline["e2e_time"] - jit["e2e_time"]
@@ -479,9 +357,6 @@ def main():
         "time_saved_pct": (
             100.0 * time_saved / baseline["e2e_time"] if baseline["e2e_time"] else 0.0
         ),
-        # Recompute avoided, in GPU-seconds across the whole worker group. This
-        # is the headline cost number: unlike `time_saved_s` it isn't polluted
-        # by how long the autoscaler took to replace the preempted instances.
         "gpu_seconds_saved": (
             baseline["wasted_gpu_seconds"] - jit["wasted_gpu_seconds"]
         ),
@@ -491,12 +366,10 @@ def main():
     logger.info("Preemption benchmark results: %s", results)
     safe_write_to_results_json(results)
 
-    assert jit["completed"], f"jit arm did not finish: {jit['error']}"
-    assert baseline["completed"], f"baseline arm did not finish: {baseline['error']}"
+    for label, metrics in [("baseline", baseline), ("jit", jit)]:
+        assert metrics["completed"], f"{label} did not finish: {metrics['error']}"
 
     if not args.num_preemptions:
-        # Calibration run: nothing was preempted, so there is nothing to compare.
-        # `mean_step_time_s` above is the number to size `--target-steps` with.
         logger.info(
             "No preemptions were injected; skipping the comparison assertions. "
             "Measured %.2fs/step.",
@@ -504,16 +377,13 @@ def main():
         )
         return
 
-    # The just-in-time checkpoint has to actually have been taken, otherwise the
-    # arms are identical and the comparison is meaningless.
     assert jit["jit_checkpoints"] > 0, (
         "No just-in-time checkpoint was taken -- the preemption was probably "
         "never observed by the training function."
     )
 
-    # The core claim: checkpoint-and-continue redoes less work.
     assert jit["wasted_steps"] <= baseline["wasted_steps"] + WASTED_STEPS_SLACK, (
-        f"jit arm redid more work than the baseline: "
+        f"jit experiment redid more work than the baseline: "
         f"{jit['wasted_steps']=} vs {baseline['wasted_steps']=}"
     )
 

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -419,17 +419,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--target-steps",
         type=int,
-        default=1000,
+        default=1600,
         help=(
-            "Sized for a ~2h two-arm run at roughly 1.5s/step. Measure the real "
-            "step time first (a short run with --num-preemptions 0) before "
-            "changing this, since the budget is linear in it."
+            "Sized for a ~1.8h two-arm run at the 1.13s/step measured for "
+            "vit_b_16 on 8xT4. The budget is linear in step time, so re-measure "
+            "with `--num-preemptions 0` before changing the model or worker "
+            "count, and keep `--checkpoint-interval` at about a quarter of this."
         ),
     )
     parser.add_argument(
         "--checkpoint-interval",
         type=int,
-        default=250,
+        default=400,
         help=(
             "Periodic checkpoint interval in steps. A preemption lands at a "
             "random point in the interval, so the baseline loses this/2 on "
@@ -492,6 +493,16 @@ def main():
 
     assert jit["completed"], f"jit arm did not finish: {jit['error']}"
     assert baseline["completed"], f"baseline arm did not finish: {baseline['error']}"
+
+    if not args.num_preemptions:
+        # Calibration run: nothing was preempted, so there is nothing to compare.
+        # `mean_step_time_s` above is the number to size `--target-steps` with.
+        logger.info(
+            "No preemptions were injected; skipping the comparison assertions. "
+            "Measured %.2fs/step.",
+            baseline["mean_step_time_s"],
+        )
+        return
 
     # The just-in-time checkpoint has to actually have been taken, otherwise the
     # arms are identical and the comparison is meaningless.

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -253,9 +253,13 @@ def run_experiment(use_jit_checkpoint: bool, args: argparse.Namespace) -> Dict:
         error = repr(e)
     e2e_time = time.time() - start_time
 
-    summary = ray.get(tracker.summary.remote())
-    ray.kill(resource_killer)
-    ray.kill(tracker)
+    try:
+        summary = ray.get(tracker.summary.remote())
+    finally:
+        # Release these even if the tracker is unreachable, so a failed
+        # experiment does not leave a killer terminating nodes behind it.
+        ray.kill(resource_killer)
+        ray.kill(tracker)
 
     wasted_steps = max(0, summary["executed_steps"] - args.target_steps)
     metrics = {

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -1,0 +1,387 @@
+"""Benchmark: how much work does preemption handling save?
+
+Runs the same training workload twice, under the same injected preemption
+schedule, and compares how much work each arm has to redo:
+
+* ``baseline``: periodic checkpoints only. The training function never looks at
+  ``ray.train.get_preemption_info()``, so on a preemption it resumes from the
+  last periodic checkpoint and replays everything since.
+* ``jit``: periodic checkpoints plus a just-in-time checkpoint taken when a
+  preemption is first observed (the checkpoint-and-continue pattern). On a
+  preemption it resumes from that just-in-time checkpoint, replaying ~nothing.
+
+The headline metric is ``wasted_steps`` -- steps executed beyond the target,
+i.e. pure recompute. It is measured by counting every step executed across all
+attempts and subtracting the target, so it is immune to cluster/network noise.
+End-to-end wall-clock time is reported alongside it.
+
+Preemptions are injected with ``EC2InstanceTerminatorWithGracePeriod``, which
+drains a node through the GCS with ``DRAIN_NODE_REASON_PREEMPTION`` and a real
+deadline, waits out the grace period, then stops the instance. That drives the
+whole production path: the preemption watcher, the fan-out to every worker,
+``get_preemption_info()``, ``PreemptingState``, and a real
+``RayActorError.preempted`` death.
+"""
+
+import argparse
+import logging
+import os
+import tempfile
+import time
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+import ray
+import ray.train
+import ray.train.torch
+from ray._private.test_utils import (
+    EC2InstanceTerminatorWithGracePeriod,
+    get_and_run_resource_killer,
+    safe_write_to_results_json,
+)
+from ray.train import CheckpointConfig, FailureConfig, RunConfig, ScalingConfig
+from ray.train.torch import TorchTrainer
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+STORAGE_PATH = os.environ.get("ANYSCALE_ARTIFACT_STORAGE", "/mnt/cluster_storage")
+
+# Mirrors the hardcoded `grace_period_s` default of
+# `EC2InstanceTerminatorWithGracePeriod`; we cannot currently override it (see
+# the TODO in `run_arm`). Recorded in the results so a run's numbers can be read
+# against the window they were measured with. The just-in-time checkpoint has to
+# finish inside this window, so keep the model small enough that a save fits
+# comfortably alongside the watcher's poll interval.
+GRACE_PERIOD_S = 30
+
+# The `jit` arm should never redo more work than the baseline. Allow a small
+# slack for the step that was in flight when the node went away.
+WASTED_STEPS_SLACK = 5
+
+
+# ==== Workload ====
+
+
+def create_model(hidden_dim: int, num_layers: int) -> nn.Module:
+    layers: List[nn.Module] = [nn.Linear(hidden_dim, hidden_dim), nn.ReLU()]
+    for _ in range(num_layers - 1):
+        layers += [nn.Linear(hidden_dim, hidden_dim), nn.ReLU()]
+    layers.append(nn.Linear(hidden_dim, 10))
+    return nn.Sequential(*layers)
+
+
+@ray.remote(num_cpus=0)
+class StepTracker:
+    """Counts work across worker-group restarts.
+
+    Lives on the driver so it survives the restarts that a preemption causes.
+    Only rank 0 reports, so counts are per-run rather than per-worker.
+    """
+
+    def __init__(self):
+        self._executed_steps = 0
+        self._attempts: List[Dict] = []
+        self._jit_checkpoints = 0
+
+    def record_attempt(self, resumed_from_step: int) -> None:
+        self._attempts.append(
+            {"resumed_from_step": resumed_from_step, "started_at": time.time()}
+        )
+
+    def record_step(self) -> None:
+        self._executed_steps += 1
+
+    def record_jit_checkpoint(self, step: int) -> None:
+        self._jit_checkpoints += 1
+        logger.info("Just-in-time checkpoint saved at step %d", step)
+
+    def summary(self) -> Dict:
+        return {
+            "executed_steps": self._executed_steps,
+            "num_attempts": len(self._attempts),
+            "resumed_from_steps": [a["resumed_from_step"] for a in self._attempts],
+            "jit_checkpoints": self._jit_checkpoints,
+        }
+
+
+def train_func(config: Dict):
+    """Train to `target_steps`, checkpointing periodically.
+
+    In the `jit` arm, also save a single checkpoint the first time a preemption
+    is observed, then keep training. `get_preemption_info()` stays set for the
+    whole grace window, so the `saved_on_preemption` guard keeps this to one
+    extra checkpoint instead of one per step.
+
+    Note that `report` is a barrier across all ranks. The preemption watcher
+    fans the signal out to *every* worker, so all ranks reach this report and
+    the just-in-time checkpoint commits even though only some nodes are being
+    preempted.
+    """
+    target_steps = config["target_steps"]
+    checkpoint_interval = config["checkpoint_interval"]
+    step_duration_s = config["step_duration_s"]
+    use_jit_checkpoint = config["use_jit_checkpoint"]
+    tracker = ray.get_actor(config["tracker_name"])
+
+    model = create_model(config["hidden_dim"], config["num_layers"])
+    model = ray.train.torch.prepare_model(model)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    loss_fn = nn.MSELoss()
+
+    start_step = 0
+    checkpoint = ray.train.get_checkpoint()
+    if checkpoint:
+        with checkpoint.as_directory() as checkpoint_dir:
+            state = torch.load(
+                os.path.join(checkpoint_dir, "state.pt"), map_location="cpu"
+            )
+        model.load_state_dict(state["model"])
+        optimizer.load_state_dict(state["optimizer"])
+        start_step = state["step"] + 1
+
+    if ray.train.get_context().get_world_rank() == 0:
+        ray.get(tracker.record_attempt.remote(start_step))
+    logger.info("Attempt starting at step %d (target %d)", start_step, target_steps)
+
+    def save_checkpoint(step: int, metrics: Dict):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch.save(
+                {
+                    "model": model.state_dict(),
+                    "optimizer": optimizer.state_dict(),
+                    "step": step,
+                },
+                os.path.join(tmpdir, "state.pt"),
+            )
+            ray.train.report(
+                metrics, checkpoint=ray.train.Checkpoint.from_directory(tmpdir)
+            )
+
+    device = ray.train.torch.get_device()
+    batch = torch.randn(config["batch_size"], config["hidden_dim"], device=device)
+    target = torch.randn(config["batch_size"], 10, device=device)
+
+    saved_on_preemption = False
+    for step in range(start_step, target_steps):
+        # One unit of work.
+        optimizer.zero_grad()
+        loss = loss_fn(model(batch), target)
+        loss.backward()
+        optimizer.step()
+        time.sleep(step_duration_s)
+
+        if ray.train.get_context().get_world_rank() == 0:
+            ray.get(tracker.record_step.remote())
+
+        # Just-in-time checkpoint on the first observed preemption, then keep
+        # training until the node is actually reclaimed.
+        if (
+            use_jit_checkpoint
+            and not saved_on_preemption
+            and ray.train.get_preemption_info() is not None
+        ):
+            saved_on_preemption = True
+            save_checkpoint(step, {"step": step, "jit": True})
+            if ray.train.get_context().get_world_rank() == 0:
+                ray.get(tracker.record_jit_checkpoint.remote(step))
+            continue
+
+        if step % checkpoint_interval == 0 or step == target_steps - 1:
+            save_checkpoint(step, {"step": step, "jit": False})
+        else:
+            ray.train.report({"step": step, "jit": False})
+
+
+# ==== Harness ====
+
+
+def wait_for_worker_nodes(num_nodes: int, timeout_s: int = 900) -> None:
+    """Wait until `num_nodes` worker nodes are alive.
+
+    Terminated instances have to be replaced between arms so both arms train on
+    the same cluster size.
+    """
+    head_node_id = ray.get_runtime_context().get_node_id()
+    deadline = time.time() + timeout_s
+    num_alive = 0
+    while time.time() < deadline:
+        num_alive = len(
+            [
+                node
+                for node in ray.nodes()
+                if node["Alive"] and node["NodeID"] != head_node_id
+            ]
+        )
+        if num_alive >= num_nodes:
+            return
+        logger.info("Waiting for worker nodes: %d/%d alive", num_alive, num_nodes)
+        time.sleep(10)
+    raise TimeoutError(
+        f"Only {num_alive} of {num_nodes} worker nodes came back within {timeout_s}s."
+    )
+
+
+def run_arm(arm: str, args: argparse.Namespace) -> Dict:
+    """Run one arm end to end and return its metrics."""
+    logger.info("=== Running arm '%s' ===", arm)
+    wait_for_worker_nodes(args.num_workers)
+
+    tracker_name = f"step_tracker_{arm}"
+    tracker = StepTracker.options(name=tracker_name).remote()
+
+    # Inject the preemption schedule. `kill_delay_s` lets the run get far enough
+    # past a periodic checkpoint that the baseline has real work to lose.
+    #
+    # The killer drains the node with a reclaim deadline of
+    # `now + grace_period_s`, waits that long, then force-stops Ray on it. That
+    # deadline is what reaches the UDF as `get_preemption_info().deadline_ms`,
+    # so it bounds how long a rank has to write its just-in-time checkpoint.
+    #
+    # TODO: make the grace period sweepable. `grace_period_s` is a ctor kwarg of
+    # `EC2InstanceTerminatorWithGracePeriod` (default 30s), but
+    # `get_and_run_resource_killer` does not forward extra kwargs, so we are
+    # pinned to the default. Either add a **kwargs passthrough there, or
+    # construct the killer actor directly here, so the benchmark can measure how
+    # the savings degrade once the window is too short for the JIT save.
+    resource_killer = get_and_run_resource_killer(
+        EC2InstanceTerminatorWithGracePeriod,
+        kill_interval_s=args.kill_interval_s,
+        max_to_kill=args.num_preemptions,
+        kill_delay_s=args.kill_delay_s,
+    )
+
+    trainer = TorchTrainer(
+        train_func,
+        train_loop_config={
+            "target_steps": args.target_steps,
+            "checkpoint_interval": args.checkpoint_interval,
+            "step_duration_s": args.step_duration_s,
+            "hidden_dim": args.hidden_dim,
+            "num_layers": args.num_layers,
+            "batch_size": args.batch_size,
+            "use_jit_checkpoint": arm == "jit",
+            "tracker_name": tracker_name,
+        },
+        scaling_config=ScalingConfig(num_workers=args.num_workers, use_gpu=True),
+        run_config=RunConfig(
+            name=f"preemption_benchmark_{arm}_{int(time.time())}",
+            storage_path=STORAGE_PATH,
+            # Preemptions consume `max_preemption_failures`, not `max_failures`,
+            # so a spot run isn't hard-failed by planned interruptions.
+            failure_config=FailureConfig(
+                max_failures=0,
+                max_preemption_failures=args.num_preemptions + 2,
+            ),
+            checkpoint_config=CheckpointConfig(num_to_keep=2),
+        ),
+    )
+
+    start_time = time.time()
+    error: Optional[str] = None
+    try:
+        result = trainer.fit()
+        completed = result.error is None
+    except Exception as e:  # noqa: BLE001 - report the failure as a metric
+        logger.exception("Arm '%s' failed", arm)
+        completed = False
+        error = repr(e)
+    e2e_time = time.time() - start_time
+
+    summary = ray.get(tracker.summary.remote())
+    ray.kill(resource_killer)
+    ray.kill(tracker)
+
+    metrics = {
+        "arm": arm,
+        "completed": completed,
+        "error": error,
+        "e2e_time": e2e_time,
+        # Steps executed beyond the target == work redone after a preemption.
+        "wasted_steps": max(0, summary["executed_steps"] - args.target_steps),
+        **summary,
+    }
+    logger.info("Arm '%s' metrics: %s", arm, metrics)
+    return metrics
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--target-steps", type=int, default=600)
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=100,
+        help=(
+            "Periodic checkpoint interval in steps. The baseline loses up to "
+            "this much work per preemption; the jit arm loses ~none, so the "
+            "gap grows with this value."
+        ),
+    )
+    parser.add_argument("--step-duration-s", type=float, default=0.2)
+    parser.add_argument("--hidden-dim", type=int, default=1024)
+    parser.add_argument("--num-layers", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--num-preemptions", type=int, default=2)
+    parser.add_argument(
+        "--kill-delay-s",
+        type=int,
+        default=90,
+        help="Wait before the first preemption so the run builds up work to lose.",
+    )
+    parser.add_argument("--kill-interval-s", type=int, default=120)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    ray.init()
+
+    # Run the baseline first so both arms see a cluster that has already been
+    # through node replacement.
+    baseline = run_arm("baseline", args)
+    jit = run_arm("jit", args)
+
+    steps_saved = baseline["wasted_steps"] - jit["wasted_steps"]
+    time_saved = baseline["e2e_time"] - jit["e2e_time"]
+    results = {
+        "baseline": baseline,
+        "jit": jit,
+        "steps_saved": steps_saved,
+        "steps_saved_pct": (
+            100.0 * steps_saved / baseline["wasted_steps"]
+            if baseline["wasted_steps"]
+            else 0.0
+        ),
+        "time_saved_s": time_saved,
+        "time_saved_pct": (
+            100.0 * time_saved / baseline["e2e_time"] if baseline["e2e_time"] else 0.0
+        ),
+        "estimated_time_saved_s": steps_saved * args.step_duration_s,
+        "config": dict(vars(args), grace_period_s=GRACE_PERIOD_S),
+    }
+    logger.info("Preemption benchmark results: %s", results)
+    safe_write_to_results_json(results)
+
+    assert jit["completed"], f"jit arm did not finish: {jit['error']}"
+    assert baseline["completed"], f"baseline arm did not finish: {baseline['error']}"
+
+    # The just-in-time checkpoint has to actually have been taken, otherwise the
+    # arms are identical and the comparison is meaningless.
+    assert jit["jit_checkpoints"] > 0, (
+        "No just-in-time checkpoint was taken -- the preemption was probably "
+        "never observed by the training function."
+    )
+
+    # The core claim: checkpoint-and-continue redoes less work.
+    assert jit["wasted_steps"] <= baseline["wasted_steps"] + WASTED_STEPS_SLACK, (
+        f"jit arm redid more work than the baseline: "
+        f"{jit['wasted_steps']=} vs {baseline['wasted_steps']=}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -133,32 +133,6 @@ def train_func(config: Dict):
     batch = torch.randn(config["batch_size"], 3, IMAGE_SIZE, IMAGE_SIZE, device=device)
     target = torch.randint(0, 1000, (config["batch_size"],), device=device)
 
-    preempt_flag = torch.zeros(1, device=device)
-
-    def any_rank_preempted() -> bool:
-        """Whether *any* rank has observed the preemption yet.
-
-        The watcher fans the signal out with independent RPCs, so ranks might
-        observe it on different steps. Every rank has to take the branch below on
-        the same step: a rank that enters `report` while the others run another
-        `backward` deadlocks the group, because `report` and DDP's gradient
-        all-reduce are both collectives and neither side can yield to the other.
-
-        TODO(lehui): Ray Train should own this agreement instead of the UDF. JAX exposes
-        `reached_preemption_sync_point(step)`, which all-reduces the max step
-        across hosts and returns True at max+1, so Orbax users never write a
-        collective themselves.
-        """
-        local = ray.train.get_preemption_info() is not None
-        if (
-            not torch.distributed.is_available()
-            or not torch.distributed.is_initialized()
-        ):
-            return local
-        preempt_flag[0] = 1.0 if local else 0.0
-        torch.distributed.all_reduce(preempt_flag, op=torch.distributed.ReduceOp.MAX)
-        return preempt_flag.item() > 0
-
     saved_on_preemption = False
     for step in range(start_step, target_steps):
         optimizer.zero_grad()
@@ -170,8 +144,13 @@ def train_func(config: Dict):
             ray.get(tracker.record_step.remote())
 
         # Checkpoint on the first observed preemption, then keep training until
-        # the node is actually reclaimed.
-        if use_jit_checkpoint and not saved_on_preemption and any_rank_preempted():
+        # the node is actually reclaimed. `get_preemption_info` returns the same
+        # value on every rank, so all ranks take this branch on the same step.
+        if (
+            use_jit_checkpoint
+            and not saved_on_preemption
+            and ray.train.get_preemption_info() is not None
+        ):
             saved_on_preemption = True
             save_checkpoint(step, {"step": step, "jit": True})
             if is_rank_0:

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -17,6 +17,7 @@ from ray._private.test_utils import (
     get_and_run_resource_killer,
     safe_write_to_results_json,
 )
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray.train import CheckpointConfig, FailureConfig, RunConfig, ScalingConfig
 from ray.train.torch import TorchTrainer
 
@@ -42,7 +43,11 @@ def create_model(model_name: str) -> nn.Module:
 
 @ray.remote(num_cpus=0)
 class StepTracker:
-    """Counts work across worker-group restarts."""
+    """Counts work across worker-group restarts.
+
+    Must be pinned to the head node: it has to outlive the worker nodes, and a
+    preemption reclaims a worker node.
+    """
 
     def __init__(self):
         self._executed_steps = 0
@@ -199,7 +204,13 @@ def run_experiment(use_jit_checkpoint: bool, args: argparse.Namespace) -> Dict:
     wait_for_worker_nodes(args.num_workers)
 
     tracker_name = f"step_tracker_{label}"
-    tracker = StepTracker.options(name=tracker_name).remote()
+    # Without the head-node pin the tracker can land on a worker node and be
+    # reclaimed along with it, which fails every subsequent attempt.
+    tracker = StepTracker.options(
+        name=tracker_name,
+        resources={HEAD_NODE_RESOURCE_NAME: 0.001},
+        scheduling_strategy="DEFAULT",
+    ).remote()
 
     # TODO: make the grace period configurable.
     resource_killer = get_and_run_resource_killer(

--- a/release/train_tests/preemption/test_preemption_benchmark.py
+++ b/release/train_tests/preemption/test_preemption_benchmark.py
@@ -10,10 +10,19 @@ schedule, and compares how much work each arm has to redo:
   preemption is first observed (the checkpoint-and-continue pattern). On a
   preemption it resumes from that just-in-time checkpoint, replaying ~nothing.
 
-The headline metric is ``wasted_steps`` -- steps executed beyond the target,
-i.e. pure recompute. It is measured by counting every step executed across all
-attempts and subtracting the target, so it is immune to cluster/network noise.
-End-to-end wall-clock time is reported alongside it.
+The headline metrics are ``wasted_steps`` -- steps executed beyond the target,
+i.e. pure recompute -- and ``wasted_gpu_seconds``, which scales that by the
+worker count because a single preempted node forces the whole group to restart
+and redo the same work. Both are measured by counting every step executed
+across all attempts and subtracting the target, so they are immune to how long
+the autoscaler took to replace an instance. End-to-end wall-clock time is
+reported alongside them, but it is dominated by node replacement and is the
+noisier signal.
+
+A preemption lands at a random point in the checkpoint interval, so over
+several preemptions the baseline loses ``checkpoint_interval / 2`` steps each
+on average, while the ``jit`` arm only loses the steps taken during the drain
+grace window.
 
 Preemptions are injected with ``EC2InstanceTerminatorWithGracePeriod``, which
 drains a node through the GCS with ``DRAIN_NODE_REASON_PREEMPTION`` and a real
@@ -52,10 +61,18 @@ STORAGE_PATH = os.environ.get("ANYSCALE_ARTIFACT_STORAGE", "/mnt/cluster_storage
 # Mirrors the hardcoded `grace_period_s` default of
 # `EC2InstanceTerminatorWithGracePeriod`; we cannot currently override it (see
 # the TODO in `run_arm`). Recorded in the results so a run's numbers can be read
-# against the window they were measured with. The just-in-time checkpoint has to
-# finish inside this window, so keep the model small enough that a save fits
-# comfortably alongside the watcher's poll interval.
+# against the window they were measured with.
+#
+# This is the hard budget for the just-in-time checkpoint: the watcher poll
+# (~5s) plus the checkpoint save+upload must fit inside it, or the node is gone
+# before the checkpoint commits and the `jit` arm degrades to the baseline.
+# `vit_b_16` is ~86M params (~0.35GB), which uploads in a few seconds; going
+# much larger (e.g. `vit_l_16` at ~1.2GB) eats most of the window.
 GRACE_PERIOD_S = 30
+
+# Image size for the synthetic batches. Matches what the torchvision ImageNet
+# classifiers expect.
+IMAGE_SIZE = 224
 
 # The `jit` arm should never redo more work than the baseline. Allow a small
 # slack for the step that was in flight when the node went away.
@@ -65,12 +82,20 @@ WASTED_STEPS_SLACK = 5
 # ==== Workload ====
 
 
-def create_model(hidden_dim: int, num_layers: int) -> nn.Module:
-    layers: List[nn.Module] = [nn.Linear(hidden_dim, hidden_dim), nn.ReLU()]
-    for _ in range(num_layers - 1):
-        layers += [nn.Linear(hidden_dim, hidden_dim), nn.ReLU()]
-    layers.append(nn.Linear(hidden_dim, 10))
-    return nn.Sequential(*layers)
+def create_model(model_name: str) -> nn.Module:
+    """Build a torchvision classifier.
+
+    A real architecture (rather than a stack of Linear layers) makes each step
+    represent genuine training work, so `wasted_steps` translates into GPU-time
+    that a user would actually lose.
+    """
+    import torchvision.models as tv_models
+
+    if not hasattr(tv_models, model_name):
+        raise ValueError(f"Unknown torchvision model: {model_name}")
+    # `weights=None` -- we measure recompute, not accuracy, so random init is
+    # fine and avoids downloading weights onto every worker.
+    return getattr(tv_models, model_name)(weights=None)
 
 
 @ray.remote(num_cpus=0)
@@ -87,16 +112,35 @@ class StepTracker:
         self._jit_checkpoints = 0
 
     def record_attempt(self, resumed_from_step: int) -> None:
+        now = time.time()
         self._attempts.append(
-            {"resumed_from_step": resumed_from_step, "started_at": time.time()}
+            {
+                "resumed_from_step": resumed_from_step,
+                "started_at": now,
+                "last_step_at": now,
+            }
         )
 
     def record_step(self) -> None:
         self._executed_steps += 1
+        if self._attempts:
+            self._attempts[-1]["last_step_at"] = time.time()
 
     def record_jit_checkpoint(self, step: int) -> None:
         self._jit_checkpoints += 1
         logger.info("Just-in-time checkpoint saved at step %d", step)
+
+    def _mean_step_time_s(self) -> float:
+        """Mean seconds per step, excluding time spent restarting.
+
+        Summing each attempt's own span (rather than dividing end-to-end time)
+        leaves out the minutes spent waiting for the autoscaler to replace a
+        preempted node, so this reflects training throughput only.
+        """
+        if not self._executed_steps:
+            return 0.0
+        training_s = sum(a["last_step_at"] - a["started_at"] for a in self._attempts)
+        return training_s / self._executed_steps
 
     def summary(self) -> Dict:
         return {
@@ -104,6 +148,7 @@ class StepTracker:
             "num_attempts": len(self._attempts),
             "resumed_from_steps": [a["resumed_from_step"] for a in self._attempts],
             "jit_checkpoints": self._jit_checkpoints,
+            "mean_step_time_s": self._mean_step_time_s(),
         }
 
 
@@ -115,21 +160,21 @@ def train_func(config: Dict):
     whole grace window, so the `saved_on_preemption` guard keeps this to one
     extra checkpoint instead of one per step.
 
-    Note that `report` is a barrier across all ranks. The preemption watcher
-    fans the signal out to *every* worker, so all ranks reach this report and
-    the just-in-time checkpoint commits even though only some nodes are being
-    preempted.
+    The watcher fans the signal out to *every* worker, not just the ones on the
+    doomed node -- but as independent RPCs, so ranks can observe it on different
+    steps. Since `report` is an all-rank barrier, the decision is all-reduced
+    (see `any_rank_preempted`) so the ranks stay in lockstep.
     """
     target_steps = config["target_steps"]
     checkpoint_interval = config["checkpoint_interval"]
-    step_duration_s = config["step_duration_s"]
     use_jit_checkpoint = config["use_jit_checkpoint"]
     tracker = ray.get_actor(config["tracker_name"])
+    is_rank_0 = ray.train.get_context().get_world_rank() == 0
 
-    model = create_model(config["hidden_dim"], config["num_layers"])
+    model = create_model(config["model"])
     model = ray.train.torch.prepare_model(model)
-    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
-    loss_fn = nn.MSELoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+    loss_fn = nn.CrossEntropyLoss()
 
     start_step = 0
     checkpoint = ray.train.get_checkpoint()
@@ -142,11 +187,22 @@ def train_func(config: Dict):
         optimizer.load_state_dict(state["optimizer"])
         start_step = state["step"] + 1
 
-    if ray.train.get_context().get_world_rank() == 0:
+    if is_rank_0:
         ray.get(tracker.record_attempt.remote(start_step))
     logger.info("Attempt starting at step %d (target %d)", start_step, target_steps)
 
     def save_checkpoint(step: int, metrics: Dict):
+        """Report a checkpoint from rank 0 only.
+
+        `report` is an all-rank barrier, so every rank must call it the same
+        number of times -- but only rank 0 needs to upload. Under DDP all ranks
+        hold identical weights, so uploading from every rank would multiply the
+        checkpoint traffic by `num_workers` for no benefit, and the just-in-time
+        save has to fit inside the drain grace period.
+        """
+        if not is_rank_0:
+            ray.train.report(metrics, checkpoint=None)
+            return
         with tempfile.TemporaryDirectory() as tmpdir:
             torch.save(
                 {
@@ -160,9 +216,36 @@ def train_func(config: Dict):
                 metrics, checkpoint=ray.train.Checkpoint.from_directory(tmpdir)
             )
 
+    # Synthetic batches: this benchmark measures recomputed work, not accuracy,
+    # so fixed random tensors keep step time deterministic and avoid a data
+    # dependency. The forward/backward is the real model's, which is what makes
+    # a "wasted step" cost real GPU time.
     device = ray.train.torch.get_device()
-    batch = torch.randn(config["batch_size"], config["hidden_dim"], device=device)
-    target = torch.randn(config["batch_size"], 10, device=device)
+    batch = torch.randn(config["batch_size"], 3, IMAGE_SIZE, IMAGE_SIZE, device=device)
+    target = torch.randint(0, 1000, (config["batch_size"],), device=device)
+
+    preempt_flag = torch.zeros(1, device=device)
+
+    def any_rank_preempted() -> bool:
+        """Whether *any* rank has observed the preemption yet.
+
+        `get_preemption_info()` is per-worker state and the watcher fans the
+        signal out with independent RPCs, so ranks can observe it on different
+        steps. Since `report` is an all-rank barrier, the decision to take a
+        just-in-time checkpoint has to be collective -- otherwise one rank
+        reports and the others don't, and the barrier deadlocks. All-reduce the
+        flag so every rank agrees on the same step. (This mirrors what a real
+        coordinated emergency checkpoint has to do.)
+        """
+        local = ray.train.get_preemption_info() is not None
+        if (
+            not torch.distributed.is_available()
+            or not torch.distributed.is_initialized()
+        ):
+            return local
+        preempt_flag[0] = 1.0 if local else 0.0
+        torch.distributed.all_reduce(preempt_flag, op=torch.distributed.ReduceOp.MAX)
+        return preempt_flag.item() > 0
 
     saved_on_preemption = False
     for step in range(start_step, target_steps):
@@ -171,28 +254,28 @@ def train_func(config: Dict):
         loss = loss_fn(model(batch), target)
         loss.backward()
         optimizer.step()
-        time.sleep(step_duration_s)
 
-        if ray.train.get_context().get_world_rank() == 0:
+        if is_rank_0:
             ray.get(tracker.record_step.remote())
 
         # Just-in-time checkpoint on the first observed preemption, then keep
-        # training until the node is actually reclaimed.
-        if (
-            use_jit_checkpoint
-            and not saved_on_preemption
-            and ray.train.get_preemption_info() is not None
-        ):
+        # training until the node is actually reclaimed. Every rank evaluates
+        # this identically, so they stay in lockstep on the `report` barrier.
+        if use_jit_checkpoint and not saved_on_preemption and any_rank_preempted():
             saved_on_preemption = True
             save_checkpoint(step, {"step": step, "jit": True})
-            if ray.train.get_context().get_world_rank() == 0:
+            if is_rank_0:
                 ray.get(tracker.record_jit_checkpoint.remote(step))
             continue
 
+        # Only checkpoint steps report. Train V2 does not persist metrics that
+        # aren't attached to a checkpoint, so a metrics-only `report` would be a
+        # no-op that still pays for the all-rank barrier and the controller
+        # draining a size-1 result queue (~2s/step in an earlier run of this
+        # benchmark). Progress is visible from the checkpoint reports, and the
+        # benchmark's own counters live in `StepTracker`, not `Result.metrics`.
         if step % checkpoint_interval == 0 or step == target_steps - 1:
             save_checkpoint(step, {"step": step, "jit": False})
-        else:
-            ray.train.report({"step": step, "jit": False})
 
 
 # ==== Harness ====
@@ -224,9 +307,17 @@ def wait_for_worker_nodes(num_nodes: int, timeout_s: int = 900) -> None:
     )
 
 
-def run_arm(arm: str, args: argparse.Namespace) -> Dict:
-    """Run one arm end to end and return its metrics."""
-    logger.info("=== Running arm '%s' ===", arm)
+def run_arm(arm: str, use_jit_checkpoint: bool, args: argparse.Namespace) -> Dict:
+    """Run one arm end to end and return its metrics.
+
+    Both arms share this path deliberately: the preemption schedule, failure
+    budgets, model, and step target must be identical for the comparison to mean
+    anything, so `use_jit_checkpoint` is the only thing that differs between
+    them. It selects the checkpoint-and-continue branch inside `train_func`.
+    """
+    logger.info(
+        "=== Running arm '%s' (use_jit_checkpoint=%s) ===", arm, use_jit_checkpoint
+    )
     wait_for_worker_nodes(args.num_workers)
 
     tracker_name = f"step_tracker_{arm}"
@@ -258,11 +349,9 @@ def run_arm(arm: str, args: argparse.Namespace) -> Dict:
         train_loop_config={
             "target_steps": args.target_steps,
             "checkpoint_interval": args.checkpoint_interval,
-            "step_duration_s": args.step_duration_s,
-            "hidden_dim": args.hidden_dim,
-            "num_layers": args.num_layers,
+            "model": args.model,
             "batch_size": args.batch_size,
-            "use_jit_checkpoint": arm == "jit",
+            "use_jit_checkpoint": use_jit_checkpoint,
             "tracker_name": tracker_name,
         },
         scaling_config=ScalingConfig(num_workers=args.num_workers, use_gpu=True),
@@ -294,13 +383,19 @@ def run_arm(arm: str, args: argparse.Namespace) -> Dict:
     ray.kill(resource_killer)
     ray.kill(tracker)
 
+    wasted_steps = max(0, summary["executed_steps"] - args.target_steps)
     metrics = {
         "arm": arm,
         "completed": completed,
         "error": error,
         "e2e_time": e2e_time,
         # Steps executed beyond the target == work redone after a preemption.
-        "wasted_steps": max(0, summary["executed_steps"] - args.target_steps),
+        "wasted_steps": wasted_steps,
+        # A preempted node forces *every* worker to restart and redo the same
+        # steps, so the cost to the cluster scales with the worker count.
+        "wasted_gpu_seconds": (
+            wasted_steps * summary["mean_step_time_s"] * args.num_workers
+        ),
         **summary,
     }
     logger.info("Arm '%s' metrics: %s", arm, metrics)
@@ -309,30 +404,53 @@ def run_arm(arm: str, args: argparse.Namespace) -> Dict:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--num-workers", type=int, default=2)
-    parser.add_argument("--target-steps", type=int, default=600)
+    parser.add_argument("--num-workers", type=int, default=8)
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="vit_b_16",
+        help=(
+            "torchvision classifier to train. `vit_b_16` (~86M params, ~0.35GB "
+            "checkpoint) keeps the just-in-time save well inside the drain "
+            "grace period. `vit_l_16` (~304M) stresses that window and is much "
+            "slower on g4dn, where the gradient all-reduce dominates step time."
+        ),
+    )
+    parser.add_argument(
+        "--target-steps",
+        type=int,
+        default=1000,
+        help=(
+            "Sized for a ~2h two-arm run at roughly 1.5s/step. Measure the real "
+            "step time first (a short run with --num-preemptions 0) before "
+            "changing this, since the budget is linear in it."
+        ),
+    )
     parser.add_argument(
         "--checkpoint-interval",
         type=int,
-        default=100,
+        default=250,
         help=(
-            "Periodic checkpoint interval in steps. The baseline loses up to "
-            "this much work per preemption; the jit arm loses ~none, so the "
-            "gap grows with this value."
+            "Periodic checkpoint interval in steps. A preemption lands at a "
+            "random point in the interval, so the baseline loses this/2 on "
+            "average per preemption while the jit arm loses only the steps "
+            "taken during the grace window. The gap grows with this value."
         ),
     )
-    parser.add_argument("--step-duration-s", type=float, default=0.2)
-    parser.add_argument("--hidden-dim", type=int, default=1024)
-    parser.add_argument("--num-layers", type=int, default=8)
     parser.add_argument("--batch-size", type=int, default=32)
-    parser.add_argument("--num-preemptions", type=int, default=2)
+    parser.add_argument("--num-preemptions", type=int, default=4)
     parser.add_argument(
         "--kill-delay-s",
         type=int,
-        default=90,
+        default=300,
         help="Wait before the first preemption so the run builds up work to lose.",
     )
-    parser.add_argument("--kill-interval-s", type=int, default=120)
+    parser.add_argument(
+        "--kill-interval-s",
+        type=int,
+        default=600,
+        help="Spacing between preemptions; spreads them across the run.",
+    )
     return parser.parse_args()
 
 
@@ -342,8 +460,8 @@ def main():
 
     # Run the baseline first so both arms see a cluster that has already been
     # through node replacement.
-    baseline = run_arm("baseline", args)
-    jit = run_arm("jit", args)
+    baseline = run_arm("baseline", use_jit_checkpoint=False, args=args)
+    jit = run_arm("jit", use_jit_checkpoint=True, args=args)
 
     steps_saved = baseline["wasted_steps"] - jit["wasted_steps"]
     time_saved = baseline["e2e_time"] - jit["e2e_time"]
@@ -360,7 +478,13 @@ def main():
         "time_saved_pct": (
             100.0 * time_saved / baseline["e2e_time"] if baseline["e2e_time"] else 0.0
         ),
-        "estimated_time_saved_s": steps_saved * args.step_duration_s,
+        # Recompute avoided, in GPU-seconds across the whole worker group. This
+        # is the headline cost number: unlike `time_saved_s` it isn't polluted
+        # by how long the autoscaler took to replace the preempted instances.
+        "gpu_seconds_saved": (
+            baseline["wasted_gpu_seconds"] - jit["wasted_gpu_seconds"]
+        ),
+        "estimated_time_saved_s": steps_saved * baseline["mean_step_time_s"],
         "config": dict(vars(args), grace_period_s=GRACE_PERIOD_S),
     }
     logger.info("Preemption benchmark results: %s", results)


### PR DESCRIPTION
## Description
1. Adds a nightly release test that quantifies how much recomputation Ray Train's preemption handling actually saves. 

* baseline — periodic checkpoints only. On a preemption it resumes from the last periodic checkpoint and replays * everything since.  
* jit — periodic checkpoints plus a just-in-time checkpoint taken when get_preemption_info() first returns a signal, then keeps training On a preemption it resumes from that checkpoint and replays close to nothing.

results:
```
{"baseline":{"arm":"baseline","completed":true,"error":null,"e2e_time":3128.691361427307,"wasted_steps":517,"wasted_gpu_seconds":4655.648543788061,"executed_steps":2117,"num_attempts":5,"resumed_from_steps":[0,401,401,801,1201],"jit_checkpoints":0,"mean_step_time_s":1.125640363585121},"jit":{"arm":"jit","completed":true,"error":null,"e2e_time":2653.292846918106,"wasted_steps":91,"wasted_gpu_seconds":825.4366041439514,"executed_steps":1691,"num_attempts":5,"resumed_from_steps":[0,696,867,1396,1548],"jit_checkpoints":4,"mean_step_time_s":1.1338414892087245},"steps_saved":426,"steps_saved_pct":82.39845261121857,"time_saved_s":475.39851450920105,"time_saved_pct":15.194803820224841,"gpu_seconds_saved":3830.2119396441094,"estimated_time_saved_s":479.52279488726157,"config":{"num_workers":8,"model":"vit_b_16","target_steps":1600,"checkpoint_interval":400,"batch_size":32,"num_preemptions":4,"kill_delay_s":300,"kill_interval_s":600,"grace_period_s":30}}
```

## Related issues
[#63968](https://github.com/ray-project/ray/issues/63968)

## Additional information
successful release test run: https://buildkite.com/ray-project/release/builds/102057
