### PR TITLE
[core][state] preserve StateSchema column order in filter_fields

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -327,7 +327,7 @@ def test_ray_address_to_api_server_url(shutdown_only):
 
 def test_filter_fields_preserves_schema_column_order():
     """filter_fields must emit columns in StateSchema order, not set order."""
-    data = {col: None for col in TaskState.list_columns(detail=True)}
+    data = {col: None for col in reversed(TaskState.list_columns(detail=True))}
 
     for detail in (True, False):
         expected = TaskState.list_columns(detail=detail)

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -82,6 +82,8 @@ from ray.util.state.common import (
     RuntimeEnvState,
     StateResource,
     StateSchema,
+    TaskState,
+    filter_fields,
     state_column,
 )
 from ray.util.state.exception import DataSourceUnavailable, RayStateApiException
@@ -321,6 +323,15 @@ def test_ray_address_to_api_server_url(shutdown_only):
     # localhost string
     _, gcs_port = parse_address(gcs_address)
     assert api_server_url == ray_address_to_api_server_url(f"localhost:{gcs_port}")
+
+
+def test_filter_fields_preserves_schema_column_order():
+    """filter_fields must emit columns in StateSchema order, not set order."""
+    data = {col: None for col in TaskState.list_columns(detail=True)}
+
+    for detail in (True, False):
+        expected = TaskState.list_columns(detail=detail)
+        assert list(filter_fields(data, TaskState, detail=detail).keys()) == expected
 
 
 def test_state_schema():

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -386,7 +386,7 @@ def filter_fields(data: dict, state_dataclass: StateSchema, detail: bool) -> dic
         A new dictionary containing only the columns allowed by the schema.
     """
     filtered_data = {}
-    columns = state_dataclass.columns() if detail else state_dataclass.base_columns()
+    columns = state_dataclass.list_columns(detail=detail)
     for col in columns:
         if col in data:
             filtered_data[col] = data[col]


### PR DESCRIPTION
## Description

Item 2 of #30805 asks that `task_id` appear first in `ray list tasks --detail`, so that tasks are easier to track.

Checking against current master, that symptom no longer reproduces: `task_id` is already the first field of the `TaskState` dataclass, and all CLI output paths (table, YAML, `--format json`) follow the dataclass field order. The CLI is correct today.

A related inconsistency, however, is still live one layer down. `filter_fields()` in `python/ray/util/state/common.py` builds the payload that the State API server returns, and it iterated over `columns()` / `base_columns()` — both of which return a `set`. Iterating a `set[str]` yields an order that depends on the per-process string hash seed, so the key order of `/api/v0/*` responses is non-deterministic and changes on every restart.

This is invisible from the CLI because `StateApiClient.list()` rebuilds each dict into a `TaskState` dataclass, which restores the schema order. Anything consuming the HTTP API directly sees the raw, shuffled order.

`StateSchema.list_columns()` already defines the canonical order, so this PR simply uses it in `filter_fields()`. It selects the same set of columns as before, only ordered — bringing the last remaining consumer in line with the order the schema already declares.

## Reproduction (before this change)

`base_columns()` returns a different order in every process:

```bash
for i in 1 2 3; do
  python -c "from ray.util.state.common import TaskState as T; print(list(T.base_columns())[:6])"
done
```

```
['attempt_number', 'actor_id', 'task_id', 'state', 'name', 'job_id']
['job_id', 'error_type', 'attempt_number', 'task_id', 'type', 'name']
['task_id', 'job_id', 'node_id', 'worker_id', 'parent_task_id', 'worker_pid']
```

`task_id` lands at position 3, 4, and 1 across three consecutive runs. That intermittency is likely why this went unnoticed for so long.

## After

The same three commands, with this change applied.

```bash
for i in 1 2 3; do
  python -c "from ray.util.state.common import TaskState as T; print(T.list_columns(detail=False)[:6])"
done
```

```
['task_id', 'attempt_number', 'name', 'state', 'job_id', 'actor_id']
['task_id', 'attempt_number', 'name', 'state', 'job_id', 'actor_id']
['task_id', 'attempt_number', 'name', 'state', 'job_id', 'actor_id']
```

Identical every run, and matching the `TaskState` field declaration order.

## Testing / Verification

- `test_filter_fields_preserves_schema_column_order` asserts the full key sequence for `detail=True` and `detail=False`, feeding `filter_fields()` a dict whose keys are in *reversed* schema order. Fails on master (`At index 0 diff: 'job_id' != 'task_id'`), passes with this change.

- `curl /api/v0/tasks` key order was different on every cluster restart; it is now stable and matches `ray list tasks --format json`.

- `columns()` / `base_columns()` / `detail_columns()` still return `Set[str]`; CLI output unchanged.

## Related issues

I picked up #30805 intending to fix item 2, and found it had already been fixed by #32353 — the issue is still open, though, and its item 2 checkbox was never ticked. While checking that, I noticed one consumer still isn't consistent with the schema order: `filter_fields()` never made the transition the CLI did, so the State API is still ordered by `set` iteration rather than by `list_columns()`. That's what this PR fixes — it isn't a re-fix of item 2.