### PR TITLE
[Fix][Core/Dashboard] component_cpu_percentage metric always zero for dashboard subprocess modules

### DIFF
--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -381,11 +381,17 @@ class DashboardHead:
             assert subprocess_module_handle.process is not None
             pid = subprocess_module_handle.process.pid
             live_pids.add(pid)
-            proc = self._get_subprocess_module_proc(pid)
-            if proc is not None:
+            try:
                 self._record_cpu_mem_metrics_for_proc(
-                    proc, subprocess_module_handle.module_cls.__name__
+                    self._get_subprocess_module_proc(pid),
+                    subprocess_module_handle.module_cls.__name__,
                 )
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                # The module may have exited between a health check and this
+                # cycle, either before its handle is built or before it is read.
+                # Skip it rather than abandoning the remaining modules, the
+                # stale-handle cleanup below, and the event loop metrics.
+                continue
         # Drop the handles of modules that exited or restarted under a new pid.
         for stale_pid in self._subprocess_module_procs.keys() - live_pids:
             del self._subprocess_module_procs[stale_pid]
@@ -403,26 +409,22 @@ class DashboardHead:
             )
             self._event_loop_lag_s_max = None
 
-    def _get_subprocess_module_proc(self, pid: int) -> Optional[psutil.Process]:
+    def _get_subprocess_module_proc(self, pid: int) -> psutil.Process:
         """Return the cached psutil.Process for pid, creating it if needed.
 
         Reusing the handle is what gives cpu_percent() a baseline to measure
         against. See the comment on self._subprocess_module_procs.
 
-        Returns None if the process is gone or inaccessible, so that one module
-        exiting mid-cycle does not cost the remaining modules their metrics.
+        Raises psutil.NoSuchProcess or psutil.AccessDenied if the module's
+        process is gone or inaccessible. Callers recording one module at a time
+        handle that per module.
         """
         proc = self._subprocess_module_procs.get(pid)
         # is_running() is False once the process is gone, and also once the pid
         # has been reused by an unrelated process, in which case the cached
         # handle's baseline no longer describes the process being measured.
         if proc is None or not proc.is_running():
-            try:
-                proc = psutil.Process(pid)
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                # A module can exit between a health check and this cycle.
-                self._subprocess_module_procs.pop(pid, None)
-                return None
+            proc = psutil.Process(pid)
             self._subprocess_module_procs[pid] = proc
         return proc
 

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -381,10 +381,11 @@ class DashboardHead:
             assert subprocess_module_handle.process is not None
             pid = subprocess_module_handle.process.pid
             live_pids.add(pid)
-            self._record_cpu_mem_metrics_for_proc(
-                self._get_subprocess_module_proc(pid),
-                subprocess_module_handle.module_cls.__name__,
-            )
+            proc = self._get_subprocess_module_proc(pid)
+            if proc is not None:
+                self._record_cpu_mem_metrics_for_proc(
+                    proc, subprocess_module_handle.module_cls.__name__
+                )
         # Drop the handles of modules that exited or restarted under a new pid.
         for stale_pid in self._subprocess_module_procs.keys() - live_pids:
             del self._subprocess_module_procs[stale_pid]
@@ -402,18 +403,26 @@ class DashboardHead:
             )
             self._event_loop_lag_s_max = None
 
-    def _get_subprocess_module_proc(self, pid: int) -> psutil.Process:
+    def _get_subprocess_module_proc(self, pid: int) -> Optional[psutil.Process]:
         """Return the cached psutil.Process for pid, creating it if needed.
 
         Reusing the handle is what gives cpu_percent() a baseline to measure
         against. See the comment on self._subprocess_module_procs.
+
+        Returns None if the process is gone or inaccessible, so that one module
+        exiting mid-cycle does not cost the remaining modules their metrics.
         """
         proc = self._subprocess_module_procs.get(pid)
         # is_running() is False once the process is gone, and also once the pid
         # has been reused by an unrelated process, in which case the cached
         # handle's baseline no longer describes the process being measured.
         if proc is None or not proc.is_running():
-            proc = psutil.Process(pid)
+            try:
+                proc = psutil.Process(pid)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                # A module can exit between a health check and this cycle.
+                self._subprocess_module_procs.pop(pid, None)
+                return None
             self._subprocess_module_procs[pid] = proc
         return proc
 

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -132,12 +132,10 @@ class DashboardHead:
         self.ip = node_ip_address
         self.pid = os.getpid()
         self.dashboard_proc = psutil.Process()
-        # pid -> psutil.Process of a subprocess module. The handles are kept
-        # across metric-record cycles because psutil.Process.cpu_percent() is
-        # measured relative to the previous call on the *same* object: the first
-        # call on a freshly created object always returns a meaningless 0.0.
-        # The reporter agent caches its handles for the same reason, see
-        # https://github.com/ray-project/ray/issues/29848
+        # pid -> psutil.Process, reused across record cycles: cpu_percent()
+        # measures against the previous call on the same object and reads 0.0
+        # on the first one. The reporter agent caches handles for the same
+        # reason, see https://github.com/ray-project/ray/issues/29848
         self._subprocess_module_procs: Dict[int, psutil.Process] = {}
         self.proxy_server_url = proxy_server_url
 
@@ -387,12 +385,11 @@ class DashboardHead:
                     subprocess_module_handle.module_cls.__name__,
                 )
             except (psutil.NoSuchProcess, psutil.AccessDenied):
-                # The module may have exited between a health check and this
-                # cycle, either before its handle is built or before it is read.
-                # Skip it rather than abandoning the remaining modules, the
-                # stale-handle cleanup below, and the event loop metrics.
+                # A module can exit between a health check and this cycle.
+                # Letting that escape would cost every later module in this
+                # loop its metrics too.
                 continue
-        # Drop the handles of modules that exited or restarted under a new pid.
+        # A restarted module comes back under a new pid, leaving its old handle here.
         for stale_pid in self._subprocess_module_procs.keys() - live_pids:
             del self._subprocess_module_procs[stale_pid]
 
@@ -416,13 +413,12 @@ class DashboardHead:
         against. See the comment on self._subprocess_module_procs.
 
         Raises psutil.NoSuchProcess or psutil.AccessDenied if the module's
-        process is gone or inaccessible. Callers recording one module at a time
-        handle that per module.
+        process is gone or inaccessible.
         """
         proc = self._subprocess_module_procs.get(pid)
-        # is_running() is False once the process is gone, and also once the pid
-        # has been reused by an unrelated process, in which case the cached
-        # handle's baseline no longer describes the process being measured.
+        # is_running() is False when the process is gone, and when its pid has
+        # been reused by something else, where the cached baseline would belong
+        # to a different process.
         if proc is None or not proc.is_running():
             proc = psutil.Process(pid)
             self._subprocess_module_procs[pid] = proc

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -3,7 +3,7 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import ray
 import ray.dashboard.consts as dashboard_consts
@@ -132,6 +132,13 @@ class DashboardHead:
         self.ip = node_ip_address
         self.pid = os.getpid()
         self.dashboard_proc = psutil.Process()
+        # pid -> psutil.Process of a subprocess module. The handles are kept
+        # across metric-record cycles because psutil.Process.cpu_percent() is
+        # measured relative to the previous call on the *same* object: the first
+        # call on a freshly created object always returns a meaningless 0.0.
+        # The reporter agent caches its handles for the same reason, see
+        # https://github.com/ray-project/ray/issues/29848
+        self._subprocess_module_procs: Dict[int, psutil.Process] = {}
         self.proxy_server_url = proxy_server_url
 
         # If the dashboard is started as non-minimal version, http server should
@@ -369,12 +376,18 @@ class DashboardHead:
         }
         assert "dashboard" in AVAILABLE_COMPONENT_NAMES_FOR_METRICS
         self._record_cpu_mem_metrics_for_proc(self.dashboard_proc)
+        live_pids = set()
         for subprocess_module_handle in subprocess_module_handles:
             assert subprocess_module_handle.process is not None
-            proc = psutil.Process(subprocess_module_handle.process.pid)
+            pid = subprocess_module_handle.process.pid
+            live_pids.add(pid)
             self._record_cpu_mem_metrics_for_proc(
-                proc, subprocess_module_handle.module_cls.__name__
+                self._get_subprocess_module_proc(pid),
+                subprocess_module_handle.module_cls.__name__,
             )
+        # Drop the handles of modules that exited or restarted under a new pid.
+        for stale_pid in self._subprocess_module_procs.keys() - live_pids:
+            del self._subprocess_module_procs[stale_pid]
 
         loop = ray._common.utils.get_or_create_event_loop()
 
@@ -388,6 +401,21 @@ class DashboardHead:
                 float(self._event_loop_lag_s_max)
             )
             self._event_loop_lag_s_max = None
+
+    def _get_subprocess_module_proc(self, pid: int) -> psutil.Process:
+        """Return the cached psutil.Process for pid, creating it if needed.
+
+        Reusing the handle is what gives cpu_percent() a baseline to measure
+        against. See the comment on self._subprocess_module_procs.
+        """
+        proc = self._subprocess_module_procs.get(pid)
+        # is_running() is False once the process is gone, and also once the pid
+        # has been reused by an unrelated process, in which case the cached
+        # handle's baseline no longer describes the process being measured.
+        if proc is None or not proc.is_running():
+            proc = psutil.Process(pid)
+            self._subprocess_module_procs[pid] = proc
+        return proc
 
     def _record_cpu_mem_metrics_for_proc(
         self, proc: psutil.Process, module_name: str = ""

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1720,6 +1720,13 @@ def _busy_process():
         process.wait()
 
 
+def _reaped_process():
+    """A process that has already exited and been reaped, so its pid is gone."""
+    process = subprocess.Popen([sys.executable, "-c", "pass"])
+    process.wait()
+    return process
+
+
 def _fake_subprocess_module_handle(process, module_name="DataHead"):
     """Build a stand-in for SubprocessModuleHandle.
 
@@ -1875,6 +1882,30 @@ async def test_dashboard_component_cpu_percentage_becomes_nonzero(tmpdir):
             if cpu_percentage > 0:
                 break
         assert cpu_percentage > 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.asyncio
+async def test_exited_subprocess_module_does_not_hide_other_modules(tmpdir):
+    """A module that has exited must not cost the other modules their metrics.
+
+    A module can exit between a health check and the next record cycle, which
+    makes `psutil.Process(pid)` raise `NoSuchProcess`. Recording has to carry on
+    with the remaining modules instead of abandoning the cycle.
+    """
+    head = _make_dashboard_head_for_metrics(tmpdir)
+    with _busy_process() as live_process:
+        # The exited module is recorded first, so an unhandled NoSuchProcess
+        # would abandon the cycle before reaching the live one.
+        handles = [
+            _fake_subprocess_module_handle(_reaped_process(), "ExitedHead"),
+            _fake_subprocess_module_handle(live_process, "DataHead"),
+        ]
+
+        assert await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1707,8 +1707,8 @@ _COMPONENT_CPU_METRIC = "ray_component_cpu_percentage"
 _record_metrics_once = DashboardHead._record_dashboard_metrics.__wrapped__
 
 
-# Any non-zero reading works; the tests only care that a reused handle reports
-# something other than the meaningless first-call 0.0.
+# Any non-zero value works; the tests only check that a reused handle stops
+# reading 0.0.
 _STUB_CPU_PERCENTAGE = 12.5
 
 
@@ -1728,19 +1728,18 @@ def _idle_process():
 def _stub_cpu_percent(monkeypatch):
     """Emulate psutil's cpu_percent() contract without spending any CPU.
 
-    psutil measures CPU relative to the previous call on the *same* Process
-    object and reports a meaningless 0.0 the first time a given object is asked.
-    Producing a real non-zero reading would mean pegging a core for long enough
-    to register, so the contract is emulated instead: a handle reads 0.0 until it
-    is reused. `as_dict(attrs=["cpu_percent", ...])` dispatches here, which is
-    how the code under test reads the value.
+    psutil measures CPU against the previous call on the same Process object and
+    reads 0.0 the first time an object is asked. Getting a real non-zero reading
+    means pegging a core long enough to register, so this emulates the contract
+    instead: a handle reads 0.0 until it is reused. The code under test reads the
+    value through `as_dict(attrs=["cpu_percent", ...])`, which dispatches here.
     """
 
     def cpu_percent(self, *args, **kwargs):
         if getattr(self, "_asked_before", False):
             return _STUB_CPU_PERCENTAGE
-        # Marking the instance rather than its pid or id() is what makes this
-        # emulate psutil: a rebuilt handle for the same pid starts over at 0.0.
+        # Mark the instance, not the pid: a rebuilt handle for the same pid has
+        # to start over at 0.0, the way psutil behaves.
         self._asked_before = True
         return 0.0
 
@@ -1855,8 +1854,8 @@ async def test_restarted_subprocess_module_cpu_percentage_becomes_nonzero(
         handle = _fake_subprocess_module_handle(first_process)
         await _record_twice(head, [handle])
 
-    # Leaving the block above reaped the first process. Simulate the health
-    # check restarting the module under a new pid.
+    # Leaving the block above reaped the first process, so this stands in for the
+    # health check restarting the module under a new pid.
     with _idle_process() as second_process:
         handle.process = second_process
         assert second_process.pid != first_process.pid

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1707,10 +1707,15 @@ _COMPONENT_CPU_METRIC = "ray_component_cpu_percentage"
 _record_metrics_once = DashboardHead._record_dashboard_metrics.__wrapped__
 
 
+# Any non-zero reading works; the tests only care that a reused handle reports
+# something other than the meaningless first-call 0.0.
+_STUB_CPU_PERCENTAGE = 12.5
+
+
 @contextlib.contextmanager
-def _busy_process():
-    """Spawn a CPU-bound child process, and reap it on exit."""
-    process = subprocess.Popen([sys.executable, "-c", "while True: pass"])
+def _idle_process():
+    """Spawn a child process that only sleeps, and reap it on exit."""
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(3600)"])
     try:
         yield process
     finally:
@@ -1718,6 +1723,28 @@ def _busy_process():
         # Wait so the pid is not left behind as a zombie, which psutil still
         # considers running.
         process.wait()
+
+
+def _stub_cpu_percent(monkeypatch):
+    """Emulate psutil's cpu_percent() contract without spending any CPU.
+
+    psutil measures CPU relative to the previous call on the *same* Process
+    object and reports a meaningless 0.0 the first time a given object is asked.
+    Producing a real non-zero reading would mean pegging a core for long enough
+    to register, so the contract is emulated instead: a handle reads 0.0 until it
+    is reused. `as_dict(attrs=["cpu_percent", ...])` dispatches here, which is
+    how the code under test reads the value.
+    """
+
+    def cpu_percent(self, *args, **kwargs):
+        if getattr(self, "_asked_before", False):
+            return _STUB_CPU_PERCENTAGE
+        # Marking the instance rather than its pid or id() is what makes this
+        # emulate psutil: a rebuilt handle for the same pid starts over at 0.0.
+        self._asked_before = True
+        return 0.0
+
+    monkeypatch.setattr(psutil.Process, "cpu_percent", cpu_percent)
 
 
 def _fake_subprocess_module_handle(process, module_name="DataHead"):
@@ -1777,23 +1804,10 @@ def _component_cpu_percentage(head, component, pid=None):
     return None
 
 
-async def _record_until_nonzero_cpu(head, handles, component, pid=None, cycles=20):
-    """Drive record cycles until `component` reports non-zero CPU.
-
-    Returns the last value read, which is 0.0 if the metric never moved. A
-    process spinning in a `while True` loop pegs a core, so one cycle past the
-    first is normally enough; the rest of the budget is for a heavily loaded
-    machine where the child gets little CPU time. The sleep matters:
-    cpu_percent() over a zero-length interval reads 0.0.
-    """
-    value = 0.0
-    for _ in range(cycles):
-        await asyncio.sleep(0.1)
-        await _record_metrics_once(head, handles)
-        value = _component_cpu_percentage(head, component, pid) or 0.0
-        if value > 0:
-            break
-    return value
+async def _record_twice(head, handles):
+    """Record two cycles, the minimum for a handle to report CPU usage."""
+    await _record_metrics_once(head, handles)
+    await _record_metrics_once(head, handles)
 
 
 @pytest.mark.skipif(
@@ -1801,7 +1815,7 @@ async def _record_until_nonzero_cpu(head, handles, component, pid=None, cycles=2
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.asyncio
-async def test_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir):
+async def test_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir, monkeypatch):
     """The `dashboard_<Module>` CPU metric must not be stuck at zero.
 
     `psutil.Process.cpu_percent()` is measured relative to the previous call on
@@ -1810,17 +1824,20 @@ async def test_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir):
     metric at ~0. See https://github.com/ray-project/ray/issues/29848
     """
     head = _make_dashboard_head_for_metrics(tmpdir)
-    with _busy_process() as process:
+    _stub_cpu_percent(monkeypatch)
+    with _idle_process() as process:
         handles = [_fake_subprocess_module_handle(process)]
 
         await _record_metrics_once(head, handles)
-        # The very first cycle has no baseline to compare against, so 0.0 is
+        # The very first reading has no baseline to compare against, so 0.0 is
         # expected.
         assert _component_cpu_percentage(head, "dashboard_DataHead") == 0.0
 
+        await _record_metrics_once(head, handles)
         assert (
-            await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
-        ), "ray_component_cpu_percentage stayed at 0 for a CPU-bound module"
+            _component_cpu_percentage(head, "dashboard_DataHead")
+            == _STUB_CPU_PERCENTAGE
+        ), "the module's handle was rebuilt, so its CPU reading stayed at 0"
 
 
 @pytest.mark.skipif(
@@ -1828,26 +1845,26 @@ async def test_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir):
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.asyncio
-async def test_restarted_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir):
+async def test_restarted_subprocess_module_cpu_percentage_becomes_nonzero(
+    tmpdir, monkeypatch
+):
     """A module that restarts under a new pid still reports its CPU usage."""
     head = _make_dashboard_head_for_metrics(tmpdir)
-    with _busy_process() as first_process:
+    _stub_cpu_percent(monkeypatch)
+    with _idle_process() as first_process:
         handle = _fake_subprocess_module_handle(first_process)
-        await _record_until_nonzero_cpu(
-            head, [handle], "dashboard_DataHead", first_process.pid
-        )
+        await _record_twice(head, [handle])
 
     # Leaving the block above reaped the first process. Simulate the health
     # check restarting the module under a new pid.
-    with _busy_process() as second_process:
+    with _idle_process() as second_process:
         handle.process = second_process
         assert second_process.pid != first_process.pid
 
+        await _record_twice(head, [handle])
         assert (
-            await _record_until_nonzero_cpu(
-                head, [handle], "dashboard_DataHead", second_process.pid
-            )
-            > 0
+            _component_cpu_percentage(head, "dashboard_DataHead", second_process.pid)
+            == _STUB_CPU_PERCENTAGE
         ), "the restarted module's CPU usage was not reported under its new pid"
 
 
@@ -1856,25 +1873,14 @@ async def test_restarted_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.asyncio
-async def test_dashboard_component_cpu_percentage_becomes_nonzero(tmpdir):
+async def test_dashboard_component_cpu_percentage_becomes_nonzero(tmpdir, monkeypatch):
     """Recording module metrics must not disturb the main `dashboard` component."""
     head = _make_dashboard_head_for_metrics(tmpdir)
-    with _busy_process() as process:
-        handles = [_fake_subprocess_module_handle(process)]
+    _stub_cpu_percent(monkeypatch)
+    with _idle_process() as process:
+        await _record_twice(head, [_fake_subprocess_module_handle(process)])
 
-        cpu_percentage = 0.0
-        for _ in range(20):
-            # The `dashboard` component measures the process running this test,
-            # so burn CPU here rather than sleeping, to give it something to
-            # report.
-            deadline = time.monotonic() + 0.1
-            while time.monotonic() < deadline:
-                pass
-            await _record_metrics_once(head, handles)
-            cpu_percentage = _component_cpu_percentage(head, "dashboard") or 0.0
-            if cpu_percentage > 0:
-                break
-        assert cpu_percentage > 0
+    assert _component_cpu_percentage(head, "dashboard") == _STUB_CPU_PERCENTAGE
 
 
 @pytest.mark.skipif(
@@ -1884,7 +1890,7 @@ async def test_dashboard_component_cpu_percentage_becomes_nonzero(tmpdir):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("recorded_while_alive", [False, True])
 async def test_exited_subprocess_module_does_not_hide_other_modules(
-    tmpdir, recorded_while_alive
+    tmpdir, monkeypatch, recorded_while_alive
 ):
     """A module that has exited must not cost the other modules their metrics.
 
@@ -1894,8 +1900,11 @@ async def test_exited_subprocess_module_does_not_hide_other_modules(
     a module that was never recorded and one whose handle is already cached.
     """
     head = _make_dashboard_head_for_metrics(tmpdir)
-    with _busy_process() as live_process:
-        exiting_process = subprocess.Popen([sys.executable, "-c", "while True: pass"])
+    _stub_cpu_percent(monkeypatch)
+    with _idle_process() as live_process:
+        exiting_process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(3600)"]
+        )
         # The exiting module is recorded first, so an unhandled psutil error
         # would abandon the cycle before reaching the live one.
         handles = [
@@ -1909,7 +1918,11 @@ async def test_exited_subprocess_module_does_not_hide_other_modules(
             exiting_process.kill()
             exiting_process.wait()
 
-        assert await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
+        await _record_twice(head, handles)
+        assert (
+            _component_cpu_percentage(head, "dashboard_DataHead")
+            == _STUB_CPU_PERCENTAGE
+        )
 
 
 @pytest.mark.skipif(
@@ -1927,7 +1940,8 @@ async def test_subprocess_module_dying_mid_read_does_not_hide_other_modules(
     too small to hit reliably, so `as_dict` is patched to raise for one module.
     """
     head = _make_dashboard_head_for_metrics(tmpdir)
-    with _busy_process() as dying_process, _busy_process() as live_process:
+    _stub_cpu_percent(monkeypatch)
+    with _idle_process() as dying_process, _idle_process() as live_process:
         handles = [
             _fake_subprocess_module_handle(dying_process, "DyingHead"),
             _fake_subprocess_module_handle(live_process, "DataHead"),
@@ -1941,7 +1955,11 @@ async def test_subprocess_module_dying_mid_read_does_not_hide_other_modules(
 
         monkeypatch.setattr(psutil.Process, "as_dict", as_dict)
 
-        assert await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
+        await _record_twice(head, handles)
+        assert (
+            _component_cpu_percentage(head, "dashboard_DataHead")
+            == _STUB_CPU_PERCENTAGE
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1720,13 +1720,6 @@ def _busy_process():
         process.wait()
 
 
-def _reaped_process():
-    """A process that has already exited and been reaped, so its pid is gone."""
-    process = subprocess.Popen([sys.executable, "-c", "pass"])
-    process.wait()
-    return process
-
-
 def _fake_subprocess_module_handle(process, module_name="DataHead"):
     """Build a stand-in for SubprocessModuleHandle.
 
@@ -1889,21 +1882,64 @@ async def test_dashboard_component_cpu_percentage_becomes_nonzero(tmpdir):
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.asyncio
-async def test_exited_subprocess_module_does_not_hide_other_modules(tmpdir):
+@pytest.mark.parametrize("recorded_while_alive", [False, True])
+async def test_exited_subprocess_module_does_not_hide_other_modules(
+    tmpdir, recorded_while_alive
+):
     """A module that has exited must not cost the other modules their metrics.
 
-    A module can exit between a health check and the next record cycle, which
-    makes `psutil.Process(pid)` raise `NoSuchProcess`. Recording has to carry on
-    with the remaining modules instead of abandoning the cycle.
+    A module can exit between a health check and the next record cycle, making
+    psutil raise `NoSuchProcess`. Recording has to carry on with the remaining
+    modules instead of abandoning the cycle. `recorded_while_alive` covers both
+    a module that was never recorded and one whose handle is already cached.
     """
     head = _make_dashboard_head_for_metrics(tmpdir)
     with _busy_process() as live_process:
-        # The exited module is recorded first, so an unhandled NoSuchProcess
+        exiting_process = subprocess.Popen([sys.executable, "-c", "while True: pass"])
+        # The exiting module is recorded first, so an unhandled psutil error
         # would abandon the cycle before reaching the live one.
         handles = [
-            _fake_subprocess_module_handle(_reaped_process(), "ExitedHead"),
+            _fake_subprocess_module_handle(exiting_process, "ExitedHead"),
             _fake_subprocess_module_handle(live_process, "DataHead"),
         ]
+        try:
+            if recorded_while_alive:
+                await _record_metrics_once(head, handles)
+        finally:
+            exiting_process.kill()
+            exiting_process.wait()
+
+        assert await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.asyncio
+async def test_subprocess_module_dying_mid_read_does_not_hide_other_modules(
+    tmpdir, monkeypatch
+):
+    """A module dying while its metrics are read must not hide the others.
+
+    A cached handle can pass the liveness check and then have its process exit
+    before the attributes are read, which makes `as_dict` raise. That window is
+    too small to hit reliably, so `as_dict` is patched to raise for one module.
+    """
+    head = _make_dashboard_head_for_metrics(tmpdir)
+    with _busy_process() as dying_process, _busy_process() as live_process:
+        handles = [
+            _fake_subprocess_module_handle(dying_process, "DyingHead"),
+            _fake_subprocess_module_handle(live_process, "DataHead"),
+        ]
+        real_as_dict = psutil.Process.as_dict
+
+        def as_dict(self, *args, **kwargs):
+            if self.pid == dying_process.pid:
+                raise psutil.NoSuchProcess(self.pid)
+            return real_as_dict(self, *args, **kwargs)
+
+        monkeypatch.setattr(psutil.Process, "as_dict", as_dict)
 
         assert await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
 

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import contextlib
 import copy
 import ipaddress
 import json
@@ -10,6 +11,7 @@ import subprocess
 import sys
 import time
 import warnings
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from urllib.parse import quote_plus
 
@@ -49,6 +51,7 @@ from ray._private.test_utils import (
 )
 from ray.core.generated import common_pb2
 from ray.dashboard import dashboard
+from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
 from ray.dashboard.head import DashboardHead
 from ray.dashboard.utils import DashboardHeadModule
 from ray.experimental.internal_kv import _initialize_internal_kv
@@ -1694,6 +1697,184 @@ async def test_dashboard_exports_metric_on_event_loop_lag(
         return True
 
     wait_for_condition(check_lag_metrics)
+
+
+_COMPONENT_CPU_METRIC = "ray_component_cpu_percentage"
+
+# `_record_dashboard_metrics` is wrapped in an infinite loop by
+# `async_loop_forever`. `__wrapped__` is the undecorated coroutine, so a test can
+# drive one record cycle at a time.
+_record_metrics_once = DashboardHead._record_dashboard_metrics.__wrapped__
+
+
+@contextlib.contextmanager
+def _busy_process():
+    """Spawn a CPU-bound child process, and reap it on exit."""
+    process = subprocess.Popen([sys.executable, "-c", "while True: pass"])
+    try:
+        yield process
+    finally:
+        process.kill()
+        # Wait so the pid is not left behind as a zombie, which psutil still
+        # considers running.
+        process.wait()
+
+
+def _fake_subprocess_module_handle(process, module_name="DataHead"):
+    """Build a stand-in for SubprocessModuleHandle.
+
+    `_record_dashboard_metrics` only reads `process.pid` and
+    `module_cls.__name__` off the handle, the latter becoming the
+    `dashboard_<module_name>` component label.
+    """
+    return SimpleNamespace(process=process, module_cls=type(module_name, (), {}))
+
+
+def _make_dashboard_head_for_metrics(tmpdir):
+    """A DashboardHead wired up only enough to record metrics.
+
+    `DashboardHead.__init__` does no I/O and makes no GCS connection, so it can
+    be constructed directly. `metrics` and `_event_loop_lag_s_max` are normally
+    initialized in `run()`, which these tests do not call.
+    """
+    head = DashboardHead(
+        http_host="127.0.0.1",
+        http_port=8265,
+        http_port_retries=1,
+        node_ip_address="127.0.0.1",
+        gcs_address="127.0.0.1:6379",
+        cluster_id_hex=ray.ClusterID.from_random().hex(),
+        log_dir=str(tmpdir),
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
+        temp_dir=str(tmpdir),
+        session_dir=str(tmpdir),
+        minimal=True,
+        serve_frontend=False,
+    )
+    head.metrics = DashboardPrometheusMetrics()
+    head._event_loop_lag_s_max = None
+    return head
+
+
+def _component_cpu_percentage(head, component, pid=None):
+    """Read the exported CPU percentage of `component`, or None if unexported.
+
+    A component that restarted has a sample per pid it has run under, so `pid`
+    selects which one to read.
+    """
+    for metric in head.metrics.registry.collect():
+        for sample in metric.samples:
+            if (
+                sample.name == _COMPONENT_CPU_METRIC
+                and sample.labels.get("Component") == component
+                and (pid is None or sample.labels.get("pid") == str(pid))
+            ):
+                return sample.value
+    return None
+
+
+async def _record_until_nonzero_cpu(head, handles, component, pid=None, cycles=20):
+    """Drive record cycles until `component` reports non-zero CPU.
+
+    Returns the last value read, which is 0.0 if the metric never moved. A
+    process spinning in a `while True` loop pegs a core, so one cycle past the
+    first is normally enough; the rest of the budget is for a heavily loaded
+    machine where the child gets little CPU time. The sleep matters:
+    cpu_percent() over a zero-length interval reads 0.0.
+    """
+    value = 0.0
+    for _ in range(cycles):
+        await asyncio.sleep(0.1)
+        await _record_metrics_once(head, handles)
+        value = _component_cpu_percentage(head, component, pid) or 0.0
+        if value > 0:
+            break
+    return value
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.asyncio
+async def test_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir):
+    """The `dashboard_<Module>` CPU metric must not be stuck at zero.
+
+    `psutil.Process.cpu_percent()` is measured relative to the previous call on
+    the *same* Process object, so it returns 0.0 the first time it is called on a
+    new object. Building a fresh Process every record cycle therefore pinned this
+    metric at ~0. See https://github.com/ray-project/ray/issues/29848
+    """
+    head = _make_dashboard_head_for_metrics(tmpdir)
+    with _busy_process() as process:
+        handles = [_fake_subprocess_module_handle(process)]
+
+        await _record_metrics_once(head, handles)
+        # The very first cycle has no baseline to compare against, so 0.0 is
+        # expected.
+        assert _component_cpu_percentage(head, "dashboard_DataHead") == 0.0
+
+        assert (
+            await _record_until_nonzero_cpu(head, handles, "dashboard_DataHead") > 0
+        ), "ray_component_cpu_percentage stayed at 0 for a CPU-bound module"
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.asyncio
+async def test_restarted_subprocess_module_cpu_percentage_becomes_nonzero(tmpdir):
+    """A module that restarts under a new pid still reports its CPU usage."""
+    head = _make_dashboard_head_for_metrics(tmpdir)
+    with _busy_process() as first_process:
+        handle = _fake_subprocess_module_handle(first_process)
+        await _record_until_nonzero_cpu(
+            head, [handle], "dashboard_DataHead", first_process.pid
+        )
+
+    # Leaving the block above reaped the first process. Simulate the health
+    # check restarting the module under a new pid.
+    with _busy_process() as second_process:
+        handle.process = second_process
+        assert second_process.pid != first_process.pid
+
+        assert (
+            await _record_until_nonzero_cpu(
+                head, [handle], "dashboard_DataHead", second_process.pid
+            )
+            > 0
+        ), "the restarted module's CPU usage was not reported under its new pid"
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.asyncio
+async def test_dashboard_component_cpu_percentage_becomes_nonzero(tmpdir):
+    """Recording module metrics must not disturb the main `dashboard` component."""
+    head = _make_dashboard_head_for_metrics(tmpdir)
+    with _busy_process() as process:
+        handles = [_fake_subprocess_module_handle(process)]
+
+        cpu_percentage = 0.0
+        for _ in range(20):
+            # The `dashboard` component measures the process running this test,
+            # so burn CPU here rather than sleeping, to give it something to
+            # report.
+            deadline = time.monotonic() + 0.1
+            while time.monotonic() < deadline:
+                pass
+            await _record_metrics_once(head, handles)
+            cpu_percentage = _component_cpu_percentage(head, "dashboard") or 0.0
+            if cpu_percentage > 0:
+                break
+        assert cpu_percentage > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The `component_cpu_percentage` metric is currently always zero for dashboard subprocess modules. This PR fixes this.

## Related issues
Similar symptom with #29848 

## Additional information

Before

<img width="1674" height="201" alt="image" src="https://github.com/user-attachments/assets/34808022-0855-4a37-a361-734f06a53bf5" />

After

<img width="1674" height="201" alt="image" src="https://github.com/user-attachments/assets/721d3898-00f0-4435-bdbe-5e481f3c6a74" />
