### PR TITLE
[Data] fix `iter_torch_batches` device resolution

### DIFF
--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -524,7 +524,7 @@ class DataIterator(abc.ABC):
         Returns:
             An iterable over Torch Tensor batches.
         """
-        from torch import device as torch_device
+        import torch
 
         from ray.train.torch import get_device
         from ray.train.utils import _in_ray_train_worker
@@ -540,7 +540,14 @@ class DataIterator(abc.ABC):
             # Use the appropriate device for Ray Train, or falls back to CPU if
             # Ray Train is not being used.
             device = get_device() if _in_ray_train_worker() else "cpu"
-        device = torch_device(device)
+        device = torch.device(device)
+        if device.type == "cuda" and device.index is None:
+            # "cuda" without an index is thread-relative: it resolves to the
+            # calling thread's *current* CUDA device. finalize_fn runs on a
+            # background fetch thread, so the device on the finalize thread
+            # and consumer thread might be different. Pin the device to a
+            # concrete index here.
+            device = torch.device("cuda", torch.cuda.current_device())
 
         if collate_fn is None:
             # The default collate_fn handles formatting and Tensor creation.

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -541,7 +541,7 @@ class DataIterator(abc.ABC):
             # Ray Train is not being used.
             device = get_device() if _in_ray_train_worker() else "cpu"
         device = torch.device(device)
-        if device.type == "cuda" and device.index is None:
+        if torch.cuda.is_available() and device.type == "cuda" and device.index is None:
             # "cuda" without an index is thread-relative: it resolves to the
             # calling thread's *current* CUDA device. finalize_fn runs on a
             # background fetch thread, so the device on the finalize thread


### PR DESCRIPTION
## Description
When using `iter_torch_batches` with a custom device, users will frequently input `"cuda"` or `torch.device("cuda")` for the device information. When a cuda device is specified WITHOUT a device index, torch will select the current device based on the specific thread's current device index.

In `iter_torch_batches`, our finalize function runs on a different thread compared to the consumer thread, so there is the possibility that current device will change, which will make our data transfer incorrect. Therefore, we should pin the device to a specific index.

Specifically, we pin to the current device of the _consumer_ thread, as this is the device that the user would have intended to use.