### PR TITLE
[serve] Read the multiplex marker statically so probing cannot initialize handles

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -67,14 +67,8 @@ def _callable_uses_multiplexing(callable_obj: Any) -> bool:
     serve.multiplexed(...)(fn)``) is detected. This case can only be caught at
     runtime, since it is not visible on the class statically.
     """
-    # NOTE: probed with `inspect.getattr_static` because a plain `getattr` has SIDE
-    # EFFECTS on objects with a dynamic `__getattr__`: `DeploymentHandle.__getattr__`
-    # returns `options(method_name=...)`, which eagerly initializes the handle's
-    # Router (and with it a controller long-poll subscription and a metric-report
-    # stream). Probing must not construct anything. `getattr_static` never invokes
-    # `__getattr__`/`__getattribute__` and reads the marker the decorator sets
-    # directly on the wrapper. The `is True` check is kept so a stray truthy
-    # attribute of the same name cannot register as a positive.
+    # Static: a plain `getattr` on a `DeploymentHandle` runs `__getattr__`, which
+    # eagerly initializes its Router. `is True` guards against truthy impostors.
     def _has_marker(obj: Any) -> bool:
         try:
             return (
@@ -97,11 +91,8 @@ def _callable_uses_multiplexing(callable_obj: Any) -> bool:
 
     # An instance that stored a multiplexed wrapper as an instance attribute.
     if not isinstance(callable_obj, type):
-        # `object.__getattribute__` rather than `getattr`: the latter falls back to
-        # `__getattr__` when the attribute is missing (e.g. a `__slots__` class), which
-        # is exactly the side-effecting path this function must avoid.
-        # `inspect.getattr_static` is not usable for `__dict__` -- it returns the
-        # getset descriptor rather than the instance mapping.
+        # `getattr` falls back to `__getattr__` on a `__slots__` class;
+        # `getattr_static` returns the descriptor rather than the instance mapping.
         try:
             instance_vars = object.__getattribute__(callable_obj, "__dict__")
         except AttributeError:

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -67,13 +67,22 @@ def _callable_uses_multiplexing(callable_obj: Any) -> bool:
     serve.multiplexed(...)(fn)``) is detected. This case can only be caught at
     runtime, since it is not visible on the class statically.
     """
-    # NOTE: the marker is checked with `is True` rather than truthiness because some
-    # objects (e.g. `DeploymentHandle`, whose `__getattr__` returns a handle for any
-    # name) return a truthy value for an arbitrary attribute. The decorator always
-    # sets the marker to the literal `True`, so this stays exact without false
-    # positives.
+    # NOTE: probed with `inspect.getattr_static` because a plain `getattr` has SIDE
+    # EFFECTS on objects with a dynamic `__getattr__`: `DeploymentHandle.__getattr__`
+    # returns `options(method_name=...)`, which eagerly initializes the handle's
+    # Router (and with it a controller long-poll subscription and a metric-report
+    # stream). Probing must not construct anything. `getattr_static` never invokes
+    # `__getattr__`/`__getattribute__` and reads the marker the decorator sets
+    # directly on the wrapper. The `is True` check is kept so a stray truthy
+    # attribute of the same name cannot register as a positive.
     def _has_marker(obj: Any) -> bool:
-        return getattr(obj, MULTIPLEXED_FUNCTION_MARKER_ATTR, False) is True
+        try:
+            return (
+                inspect.getattr_static(obj, MULTIPLEXED_FUNCTION_MARKER_ATTR, False)
+                is True
+            )
+        except Exception:
+            return False
 
     # Standalone function deployment decorated with `@serve.multiplexed`.
     if _has_marker(callable_obj):
@@ -88,7 +97,16 @@ def _callable_uses_multiplexing(callable_obj: Any) -> bool:
 
     # An instance that stored a multiplexed wrapper as an instance attribute.
     if not isinstance(callable_obj, type):
-        for attr in getattr(callable_obj, "__dict__", {}).values():
+        # `object.__getattribute__` rather than `getattr`: the latter falls back to
+        # `__getattr__` when the attribute is missing (e.g. a `__slots__` class), which
+        # is exactly the side-effecting path this function must avoid.
+        # `inspect.getattr_static` is not usable for `__dict__` -- it returns the
+        # getset descriptor rather than the instance mapping.
+        try:
+            instance_vars = object.__getattribute__(callable_obj, "__dict__")
+        except AttributeError:
+            instance_vars = {}
+        for attr in instance_vars.values():
             if _has_marker(attr):
                 return True
 

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -746,20 +746,11 @@ def test_callable_uses_multiplexing_ignores_handle_attrs():
 
 
 def test_callable_uses_multiplexing_does_not_initialize_handles():
-    """The instance-attribute scan must not read attributes with `getattr`.
-
-    `DeploymentHandle.__getattr__` is not inert: it returns
-    `options(method_name=...)`, which eagerly initializes the handle's Router, and
-    with it a controller long-poll subscription and a metric-report stream. Probing
-    for the multiplex marker with a plain `getattr` therefore built a Router on every
-    ingress replica holding a handle, which at scale measurably degraded the
-    controller. The marker must be read statically instead.
-    """
+    """Probing must not invoke `__getattr__`, which initializes a handle's Router."""
     from ray.serve._private.utils import _callable_uses_multiplexing
 
     class FakeHandle:
-        # Mirrors DeploymentHandle: any attribute access returns a new, initialized
-        # handle. Counts accesses so the test fails if the scan probes it at all.
+        # Mirrors DeploymentHandle: any attribute access builds an initialized handle.
         getattr_calls = 0
 
         def __getattr__(self, name):
@@ -776,9 +767,7 @@ def test_callable_uses_multiplexing_does_not_initialize_handles():
         f"initializes real DeploymentHandles as a side effect"
     )
 
-    # A callable with no instance __dict__ (``__slots__``) must also be probed
-    # without falling back to ``__getattr__``, which plain
-    # ``getattr(obj, "__dict__", {})`` would do.
+    # No instance `__dict__`: `getattr(obj, "__dict__", {})` would hit `__getattr__`.
     class SlottedIngress:
         __slots__ = ("_backend",)
         getattr_calls = 0

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -744,6 +744,58 @@ def test_callable_uses_multiplexing_ignores_handle_attrs():
     assert not _callable_uses_multiplexing(Ingress())
 
 
+
+def test_callable_uses_multiplexing_does_not_initialize_handles():
+    """The instance-attribute scan must not read attributes with `getattr`.
+
+    `DeploymentHandle.__getattr__` is not inert: it returns
+    `options(method_name=...)`, which eagerly initializes the handle's Router, and
+    with it a controller long-poll subscription and a metric-report stream. Probing
+    for the multiplex marker with a plain `getattr` therefore built a Router on every
+    ingress replica holding a handle, which at scale measurably degraded the
+    controller. The marker must be read statically instead.
+    """
+    from ray.serve._private.utils import _callable_uses_multiplexing
+
+    class FakeHandle:
+        # Mirrors DeploymentHandle: any attribute access returns a new, initialized
+        # handle. Counts accesses so the test fails if the scan probes it at all.
+        getattr_calls = 0
+
+        def __getattr__(self, name):
+            FakeHandle.getattr_calls += 1
+            return FakeHandle()
+
+    class Ingress:
+        def __init__(self):
+            self._backend = FakeHandle()
+
+    assert not _callable_uses_multiplexing(Ingress())
+    assert FakeHandle.getattr_calls == 0, (
+        f"scan invoked __getattr__ {FakeHandle.getattr_calls} time(s), which "
+        f"initializes real DeploymentHandles as a side effect"
+    )
+
+    # A callable with no instance __dict__ (``__slots__``) must also be probed
+    # without falling back to ``__getattr__``, which plain
+    # ``getattr(obj, "__dict__", {})`` would do.
+    class SlottedIngress:
+        __slots__ = ("_backend",)
+        getattr_calls = 0
+
+        def __init__(self):
+            self._backend = None
+
+        def __getattr__(self, name):
+            SlottedIngress.getattr_calls += 1
+            return "side effect"
+
+    assert not _callable_uses_multiplexing(SlottedIngress())
+    assert SlottedIngress.getattr_calls == 0, (
+        f"scan invoked __getattr__ {SlottedIngress.getattr_calls} time(s) on a "
+        f"__slots__ callable"
+    )
+
 @pytest.mark.parametrize(
     "haproxy_enabled, request_router_class, rejected",
     [

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -744,7 +744,6 @@ def test_callable_uses_multiplexing_ignores_handle_attrs():
     assert not _callable_uses_multiplexing(Ingress())
 
 
-
 def test_callable_uses_multiplexing_does_not_initialize_handles():
     """Probing must not invoke `__getattr__`, which initializes a handle's Router."""
     from ray.serve._private.utils import _callable_uses_multiplexing
@@ -784,6 +783,7 @@ def test_callable_uses_multiplexing_does_not_initialize_handles():
         f"scan invoked __getattr__ {SlottedIngress.getattr_calls} time(s) on a "
         f"__slots__ callable"
     )
+
 
 @pytest.mark.parametrize(
     "haproxy_enabled, request_router_class, rejected",


### PR DESCRIPTION
Follow on to PR https://github.com/ray-project/ray/pull/64045

## Why
`_callable_uses_multiplexing()` probed instance attributes with `getattr()`, which on a
`DeploymentHandle` triggers `__getattr__` → `options()` → eager Router initialization.
Under direct ingress this scan runs at startup on every ingress replica, so each one
holding a handle built a Router that would otherwise stay lazy — each adding a
controller long-poll subscription and metric-report stream. Cost scales with replicas.

## What
Both probes in the scan are now side-effect free:

- The marker is read with `inspect.getattr_static()`, which never invokes `__getattr__`.
- The instance `__dict__` is read with `object.__getattribute__()` rather than
  `getattr(obj, "__dict__", {})`, which falls back to `__getattr__` on a `__slots__`
  class. `getattr_static` is not usable here — for `__dict__` it returns the type's
  `getset_descriptor` rather than the instance mapping.

Detection is unchanged. Adds a regression test asserting the scan never invokes
`__getattr__`, covering both a handle-holding callable and a `__slots__` callable; the
existing test only covers false positives, so it cannot catch either.

## Test
4096-replica controller benchmark, HAProxy on, vs the immediate parent commit (n=1 per
arm): handle metric report delay **7275ms → 827ms**, `deployment_state_update`
0.242s → 0.151s, controller asyncio tasks 12182 → 10004.