### PR TITLE
feat(serve): add circuit-breaker middleware for deployment handles

### DIFF
--- a/python/ray/serve/_private/__init__.py
+++ b/python/ray/serve/_private/__init__.py
@@ -1,0 +1,1 @@
+from .circuit_breaker import CircuitBreakerMiddleware  # noqa: F401

--- a/python/ray/serve/_private/circuit_breaker.py
+++ b/python/ray/serve/_private/circuit_breaker.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class CircuitBreakerState:
+    failure_count: int = 0
+    state: str = "closed"  # closed, open, half_open
+    opened_at: float = 0.0
+
+
+class CircuitBreakerMiddleware:
+    """Simple circuit breaker to guard calls to deployment handles.
+
+    - closed: calls pass through; consecutive failures increment counter.
+    - open: calls fail fast until cooldown elapses.
+    - half_open: allow a probe call; success -> closed/reset, failure -> open.
+    """
+
+    def __init__(
+        self,
+        *,
+        error_threshold: int = 5,
+        cooldown_seconds: float = 10.0,
+    ) -> None:
+        self._threshold = max(1, error_threshold)
+        self._cooldown = max(0.0, cooldown_seconds)
+        self._state = CircuitBreakerState()
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def before_call(self) -> None:
+        if self._state.state == "open":
+            if self._now() - self._state.opened_at >= self._cooldown:
+                self._state.state = "half_open"
+                self._state.failure_count = 0
+            else:
+                raise RuntimeError("CircuitBreaker: open")
+
+    def record_success(self) -> None:
+        if self._state.state in ("half_open", "open"):
+            self._state = CircuitBreakerState()
+        else:
+            self._state.failure_count = 0
+
+    def record_failure(self) -> None:
+        if self._state.state == "half_open":
+            self._state.state = "open"
+            self._state.opened_at = self._now()
+            self._state.failure_count = 1
+            return
+        self._state.failure_count += 1
+        if self._state.failure_count >= self._threshold:
+            self._state.state = "open"
+            self._state.opened_at = self._now()
+
+    @property
+    def state(self) -> CircuitBreakerState:
+        return self._state

--- a/python/ray/serve/_private/circuit_breaker.py
+++ b/python/ray/serve/_private/circuit_breaker.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import threading
 import time
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, replace
 
 
 @dataclass
@@ -17,7 +17,14 @@ class CircuitBreakerMiddleware:
 
     - closed: calls pass through; consecutive failures increment counter.
     - open: calls fail fast until cooldown elapses.
-    - half_open: allow a probe call; success -> closed/reset, failure -> open.
+    - half_open: exactly one probe call is allowed through; success ->
+      closed/reset, failure -> open. Concurrent callers during half_open
+      fail fast until that probe resolves.
+
+    All state reads/transitions are guarded by a lock so that concurrent
+    callers (e.g. multiple in-flight requests on the same handle) cannot
+    race past the cooldown check and each believe they are the half-open
+    probe.
     """
 
     def __init__(
@@ -29,35 +36,47 @@ class CircuitBreakerMiddleware:
         self._threshold = max(1, error_threshold)
         self._cooldown = max(0.0, cooldown_seconds)
         self._state = CircuitBreakerState()
+        self._lock = threading.Lock()
 
     def _now(self) -> float:
         return time.monotonic()
 
     def before_call(self) -> None:
-        if self._state.state == "open":
-            if self._now() - self._state.opened_at >= self._cooldown:
-                self._state.state = "half_open"
-                self._state.failure_count = 0
-            else:
+        with self._lock:
+            if self._state.state == "open":
+                if self._now() - self._state.opened_at >= self._cooldown:
+                    # This caller wins the transition and becomes the sole
+                    # half-open probe. Any other caller observes "half_open"
+                    # below (never "open" again) until the probe resolves.
+                    self._state.state = "half_open"
+                    self._state.failure_count = 0
+                    return
                 raise RuntimeError("CircuitBreaker: open")
+            if self._state.state == "half_open":
+                # A probe is already in flight; reject until it resolves via
+                # record_success/record_failure.
+                raise RuntimeError("CircuitBreaker: half-open probe in flight")
 
     def record_success(self) -> None:
-        if self._state.state in ("half_open", "open"):
-            self._state = CircuitBreakerState()
-        else:
-            self._state.failure_count = 0
+        with self._lock:
+            if self._state.state in ("half_open", "open"):
+                self._state = CircuitBreakerState()
+            else:
+                self._state.failure_count = 0
 
     def record_failure(self) -> None:
-        if self._state.state == "half_open":
-            self._state.state = "open"
-            self._state.opened_at = self._now()
-            self._state.failure_count = 1
-            return
-        self._state.failure_count += 1
-        if self._state.failure_count >= self._threshold:
-            self._state.state = "open"
-            self._state.opened_at = self._now()
+        with self._lock:
+            if self._state.state == "half_open":
+                self._state.state = "open"
+                self._state.opened_at = self._now()
+                self._state.failure_count = 1
+                return
+            self._state.failure_count += 1
+            if self._state.failure_count >= self._threshold:
+                self._state.state = "open"
+                self._state.opened_at = self._now()
 
     @property
     def state(self) -> CircuitBreakerState:
-        return self._state
+        with self._lock:
+            return replace(self._state)

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -107,6 +107,7 @@ py_test_module_list(
         "test_batching.py",
         "test_broadcast.py",
         "test_callback.py",
+        "test_circuit_breaker.py",
         "test_cluster.py",
         "test_controller.py",
         "test_controller_benchmark.py",

--- a/python/ray/serve/tests/test_circuit_breaker.py
+++ b/python/ray/serve/tests/test_circuit_breaker.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from ray.serve._private.circuit_breaker import CircuitBreakerMiddleware
+
+
+@pytest.mark.asyncio
+async def test_closed_to_open_and_half_open_transition():
+    cb = CircuitBreakerMiddleware(error_threshold=2, cooldown_seconds=0.1)
+
+    # Two consecutive failures -> open
+    cb.before_call(); cb.record_failure()
+    cb.before_call(); cb.record_failure()
+    assert cb.state.state == "open"
+
+    # Calls should fail fast while open
+    with pytest.raises(RuntimeError):
+        cb.before_call()
+
+    # After cooldown -> half_open, one success closes
+    await asyncio.sleep(0.11)
+    cb.before_call()
+    assert cb.state.state == "half_open"
+    cb.record_success()
+    assert cb.state.state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_half_open_failure_reopens():
+    cb = CircuitBreakerMiddleware(error_threshold=1, cooldown_seconds=0.0)
+
+    # Open directly
+    cb.before_call(); cb.record_failure()
+    assert cb.state.state == "open"
+
+    # Next call triggers half_open then failure brings it back to open
+    cb.before_call()
+    assert cb.state.state == "half_open"
+    cb.record_failure()
+    assert cb.state.state == "open"

--- a/python/ray/serve/tests/test_circuit_breaker.py
+++ b/python/ray/serve/tests/test_circuit_breaker.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+
 import pytest
 
 from ray.serve._private.circuit_breaker import CircuitBreakerMiddleware
@@ -40,3 +42,41 @@ async def test_half_open_failure_reopens():
     assert cb.state.state == "half_open"
     cb.record_failure()
     assert cb.state.state == "open"
+
+
+def test_only_one_concurrent_half_open_probe_admitted():
+    cb = CircuitBreakerMiddleware(error_threshold=1, cooldown_seconds=0.0)
+
+    # Open directly, then let cooldown elapse immediately (cooldown=0).
+    cb.before_call()
+    cb.record_failure()
+    assert cb.state.state == "open"
+
+    admitted = 0
+    rejected = 0
+    lock = threading.Lock()
+    start = threading.Barrier(16)
+
+    def worker():
+        nonlocal admitted, rejected
+        start.wait()
+        try:
+            cb.before_call()
+        except RuntimeError:
+            with lock:
+                rejected += 1
+            return
+        with lock:
+            admitted += 1
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one caller may win the open->half_open transition and become
+    # the probe; every other concurrent caller must fail fast.
+    assert admitted == 1
+    assert rejected == 15
+    assert cb.state.state == "half_open"


### PR DESCRIPTION
Introduce CircuitBreakerMiddleware under python/ray/serve/_private that guards deployment handle calls with configurable consecutive-error threshold and cooldown. Includes tests covering Closed→Open→Half-Open transitions and fail-fast behavior. Exported via _private.__init__ for internal use.