### PR TITLE
[Serve] Fix proxy state crash on `ActorUnschedulableError` during RayService incremental upgrade

### DIFF
--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -314,14 +314,24 @@ class ActorProxyWrapper(ProxyWrapper):
 
     def kill(self):
         """Kills the proxy actor after graceful shutdown."""
-        try:
-            # Prevent multiple concurrent kill attempts
-            if self.is_shutdown():
+        # Prevent multiple concurrent kill attempts
+        if self.is_shutdown():
+            try:
                 ray.kill(self._actor_handle, no_restart=True)
-                return
+            except Exception as e:
+                logger.warning(f"Force kill of proxy actor failed: {e}")
+            return
 
+        try:
             shutdown_ref = self._actor_handle.shutdown.remote()
             ray.get(shutdown_ref, timeout=5)
+        except ray.exceptions.ActorUnschedulableError:
+            # The actor was never scheduled because its target node died while creation was pending.
+            # We can safely swallow this error and proceed to force kill the handle.
+            logger.info(
+                f"Proxy actor on {self._node_id} was unschedulable (node likely died). "
+                "Skipping graceful shutdown."
+            )
         except Exception as e:
             logger.warning(
                 f"Graceful shutdown of proxy actor on {self._node_id} failed: {e}"

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -11,7 +11,7 @@ from ray import ObjectRef
 from ray._common.network_utils import build_address
 from ray._common.utils import Timer, TimerBase
 from ray.actor import ActorHandle
-from ray.exceptions import GetTimeoutError, RayActorError
+from ray.exceptions import ActorUnschedulableError, GetTimeoutError, RayActorError
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.common import NodeId, RequestProtocol
 from ray.serve._private.constants import (
@@ -288,7 +288,7 @@ class ActorProxyWrapper(ProxyWrapper):
         """
         try:
             ray.get(self._actor_handle.check_health.remote(), timeout=0)
-        except RayActorError:
+        except (RayActorError, ActorUnschedulableError):
             # The actor is dead, so it's ready for shutdown.
             return True
         except GetTimeoutError:
@@ -314,15 +314,24 @@ class ActorProxyWrapper(ProxyWrapper):
 
     def kill(self):
         """Kills the proxy actor after graceful shutdown."""
-        # Prevent multiple concurrent kill attempts
-        if self.is_shutdown():
-            return
+        try:
+            # Prevent multiple concurrent kill attempts
+            if self.is_shutdown():
+                ray.kill(self._actor_handle, no_restart=True)
+                return
 
-        shutdown_ref = self._actor_handle.shutdown.remote()
-        ray.get(shutdown_ref, timeout=5)
+            shutdown_ref = self._actor_handle.shutdown.remote()
+            ray.get(shutdown_ref, timeout=5)
+        except Exception as e:
+            logger.warning(
+                f"Graceful shutdown of proxy actor on {self._node_id} failed: {e}"
+            )
 
         # Shutdown completed successfully, now kill the actor
-        ray.kill(self._actor_handle, no_restart=True)
+        try:
+            ray.kill(self._actor_handle, no_restart=True)
+        except Exception as e:
+            logger.warning(f"Force kill of proxy actor failed: {e}")
 
 
 class ProxyState:


### PR DESCRIPTION
## Description
Fixes an issue where the Ray Serve controller loop crashes with an uncaught `ActorUnschedulableError` when attempting to shut down a proxy pinned to a dead or non-existant node. This PR wraps the shutdown `ray.get()` call in a `try...except` block, allowing the controller to gracefully clean up the dead proxy handle.

#### When does this bug occur?
This race condition occurs when a proxy actor is created on a node that dies while the creation is still pending. It can be seen during RayService incremental upgrades when GCS Fault Tolerance with Redis is enabled:
1. During an incremental upgrade a new RayCluster spins up to serve traffic in parallel with the old cluster and connects to Redis, restoring old proxy actors pinned to pre-upgrade node IDs.
2. Since the old node is dead/doesn't exist on the new cluster, proxy creation gets stuck in `PENDING_CREATION`.
3. The Serve controller detects the node ID is not in `alive_node_ids` and calls `shutdown()` on the pending proxy handle. `ray.get()` throws an `ActorUnschedulableError`, crashing the controller.

## Related issues
This issue was brought up in discussion in the [KubeRay slack channel](https://ray.slack.com/archives/C02GFQ82JPM/p1785178982761919).

## Additional information
