### PR TITLE
[Data] Generate sortable, collision-resistant Dataset IDs

### DIFF
--- a/python/ray/data/_internal/dataset_id.py
+++ b/python/ray/data/_internal/dataset_id.py
@@ -1,30 +1,44 @@
 import os
+import string
 import time
+from typing import Callable
 
-_BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+# ASCII order is required so fixed-width IDs preserve lexicographic sorting.
+_BASE62_ALPHABET = string.digits + string.ascii_uppercase + string.ascii_lowercase
 _ULID_LENGTH = 22
-_TIMESTAMP_BITS = 48
-_RANDOM_BITS = 80
+_NUM_TIMESTAMP_BITS = 48
+_NUM_RANDOM_BITS = 80
 
 
 def _encode_base62(value: int) -> str:
     """Encode a ULID integer as a fixed-width Base62 string."""
-    if value < 0:
-        raise ValueError("Cannot encode a negative value in Base62")
+    assert value >= 0, f"Received a negative value to encode: {value}"
 
     encoded = ""
     while value:
         value, remainder = divmod(value, len(_BASE62_ALPHABET))
         encoded = _BASE62_ALPHABET[remainder] + encoded
 
-    return encoded.rjust(_ULID_LENGTH, "0")
+    encoded = encoded.rjust(_ULID_LENGTH, "0")
+    assert len(encoded) == _ULID_LENGTH, encoded
+    return encoded
 
 
-def generate_dataset_ulid() -> str:
-    """Generate a time-sortable, practically unique Dataset ULID."""
-    timestamp_ms = time.time_ns() // 1_000_000
-    if not 0 <= timestamp_ms < 1 << _TIMESTAMP_BITS:
-        raise ValueError("Timestamp must fit in 48 bits")
+def generate_dataset_ulid(*, get_time_ns: Callable[[], int] = time.time_ns) -> str:
+    """Generate a time-sortable, practically unique Dataset ULID.
 
-    random_value = int.from_bytes(os.urandom(_RANDOM_BITS // 8), byteorder="big")
-    return _encode_base62((timestamp_ms << _RANDOM_BITS) | random_value)
+    Args:
+        get_time_ns: A callable that returns the current time in nanoseconds.
+
+    Returns:
+        A 22-character Base62-encoded Dataset ULID.
+    """
+    timestamp_ms = get_time_ns() // 1_000_000
+    assert 0 <= timestamp_ms < 1 << _NUM_TIMESTAMP_BITS, (
+        f"Timestamp {timestamp_ms} ms does not fit in " f"{_NUM_TIMESTAMP_BITS} bits"
+    )
+
+    # Byte order doesn't affect randomness. Big-endian is used to interpret the
+    # random bytes as an integer.
+    random_value = int.from_bytes(os.urandom(_NUM_RANDOM_BITS // 8), byteorder="big")
+    return _encode_base62((timestamp_ms << _NUM_RANDOM_BITS) | random_value)

--- a/python/ray/data/_internal/dataset_id.py
+++ b/python/ray/data/_internal/dataset_id.py
@@ -1,0 +1,30 @@
+import os
+import time
+
+_BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_ULID_LENGTH = 22
+_TIMESTAMP_BITS = 48
+_RANDOM_BITS = 80
+
+
+def _encode_base62(value: int) -> str:
+    """Encode a ULID integer as a fixed-width Base62 string."""
+    if value < 0:
+        raise ValueError("Cannot encode a negative value in Base62")
+
+    encoded = ""
+    while value:
+        value, remainder = divmod(value, len(_BASE62_ALPHABET))
+        encoded = _BASE62_ALPHABET[remainder] + encoded
+
+    return encoded.rjust(_ULID_LENGTH, "0")
+
+
+def generate_dataset_ulid() -> str:
+    """Generate a time-sortable, practically unique Dataset ULID."""
+    timestamp_ms = time.time_ns() // 1_000_000
+    if not 0 <= timestamp_ms < 1 << _TIMESTAMP_BITS:
+        raise ValueError("Timestamp must fit in 48 bits")
+
+    random_value = int.from_bytes(os.urandom(_RANDOM_BITS // 8), byteorder="big")
+    return _encode_base62((timestamp_ms << _RANDOM_BITS) | random_value)

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -301,6 +301,8 @@ DEFAULT_ENABLE_PER_NODE_METRICS = bool(
     int(os.environ.get("RAY_DATA_PER_NODE_METRICS", "0"))
 )
 
+DEFAULT_USE_LEGACY_DATASET_IDS = env_bool("RAY_DATA_USE_LEGACY_DATASET_IDS", False)
+
 DEFAULT_ISOLATE_READ_WORKERS = env_bool("RAY_DATA_ISOLATE_READ_WORKERS", False)
 
 DEFAULT_DEFAULT_MAP_LOGICAL_MEMORY_ENABLED = env_bool(
@@ -669,6 +671,7 @@ class DataContext:
         hash_aggregate_operator_actor_num_cpus_per_partition_override: Override CPU
             allocation per partition for hash aggregate operator actors.
         use_polars_sort: Whether to use Polars for tabular dataset sorting operations.
+        use_legacy_dataset_ids: Whether to use legacy counter-based Dataset IDs.
         enable_per_node_metrics: Enable per node metrics reporting for Ray Data,
             disabled by default.
         override_object_store_memory_limit_fraction: Override the fraction of object
@@ -810,6 +813,7 @@ class DataContext:
     large_args_threshold: int = DEFAULT_LARGE_ARGS_THRESHOLD
     use_polars: bool = DEFAULT_USE_POLARS
     use_polars_sort: bool = DEFAULT_USE_POLARS_SORT
+    use_legacy_dataset_ids: bool = DEFAULT_USE_LEGACY_DATASET_IDS
     eager_free: bool = DEFAULT_EAGER_FREE
     decoding_size_estimation: bool = DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED
     min_parallelism: int = DEFAULT_MIN_PARALLELISM

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -30,6 +30,7 @@ from ray._common.usage import usage_lib
 from ray._private.internal_api import get_memory_info_reply, get_state_from_address
 from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
+from ray.data._internal.dataset_id import generate_dataset_ulid
 from ray.data._internal.dataset_repr import (
     build_dataset_ascii_repr,
     build_dataset_summary_repr,
@@ -313,7 +314,10 @@ class Dataset:
         # Bind context to logical plan.
         self._logical_plan.context = context
 
-        self._set_uuid(_StatsManager.gen_dataset_id_from_stats_actor())
+        if self._context.use_legacy_dataset_ids:
+            self._set_uuid(_StatsManager.gen_dataset_id_from_stats_actor())
+        else:
+            self._set_uuid(generate_dataset_ulid())
 
     @classmethod
     def _from_parent(cls, parent: "Dataset", logical_plan: LogicalPlan) -> "Dataset":
@@ -7839,11 +7843,14 @@ class Dataset:
         }
 
     def __setstate__(self, state):
-        self._uuid = state["uuid"]
         self._logical_plan = state["logical_plan"]
         self._dataset_name = state.get("dataset_name")
         self._in_stats = state["in_stats"]
         self._context = state["context"]
+        if self._context.use_legacy_dataset_ids:
+            self._set_uuid(state["uuid"])
+        else:
+            self._set_uuid(generate_dataset_ulid())
         self._cache = _ExecutionCache()
         self._run_index = -1
         self._current_executor = None

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -206,19 +206,6 @@ def test_dataset_lineage_serialization(shutdown_only):
     assert sorted(extract_values("id", ds.take())) == list(range(2, 12))
 
 
-def test_dataset_lineage_serialization_legacy_dataset_id(
-    ray_start_regular, restore_data_context
-):
-    """Legacy mode preserves the Dataset UUID during lineage serialization."""
-    context = ray.data.DataContext.get_current()
-    context.use_legacy_dataset_ids = True
-
-    ds = ray.data.range(1)
-    original_uuid = ds._get_uuid()
-    restored_ds = Dataset.deserialize_lineage(ds.serialize_lineage())
-    assert restored_ds._get_uuid() == original_uuid
-
-
 def test_dataset_lineage_serialization_unsupported(shutdown_only):
     ray.init()
     # In-memory data sources not supported.

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -192,7 +192,6 @@ def test_dataset_lineage_serialization(shutdown_only):
     ds = ds.map(column_udf("id", lambda x: x + 1))
     ds = ds.random_shuffle()
     uuid = ds._get_uuid()
-    plan_uuid = ds._uuid
 
     serialized_ds = ds.serialize_lineage()
 
@@ -201,11 +200,23 @@ def test_dataset_lineage_serialization(shutdown_only):
 
     ds = Dataset.deserialize_lineage(serialized_ds)
     # Check Dataset state.
-    assert ds._get_uuid() == uuid
-    assert ds._uuid == plan_uuid
+    assert ds._get_uuid() != uuid
     # Check Dataset content.
     assert ds.count() == 10
     assert sorted(extract_values("id", ds.take())) == list(range(2, 12))
+
+
+def test_dataset_lineage_serialization_legacy_dataset_id(
+    ray_start_regular, restore_data_context
+):
+    """Legacy mode preserves the Dataset UUID during lineage serialization."""
+    context = ray.data.DataContext.get_current()
+    context.use_legacy_dataset_ids = True
+
+    ds = ray.data.range(1)
+    original_uuid = ds._get_uuid()
+    restored_ds = Dataset.deserialize_lineage(ds.serialize_lineage())
+    assert restored_ds._get_uuid() == original_uuid
 
 
 def test_dataset_lineage_serialization_unsupported(shutdown_only):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -594,7 +594,9 @@ def canonicalize(
     filter_global_stats: bool = True,
 ) -> str:
     # Dataset UUID expression.
-    canonicalized_stats = re.sub(r"([a-f\d]{32})", "U", stats)
+    canonicalized_stats = re.sub(r"(dataset_uuid=)[^,\n]+", r"\g<1>N", stats)
+    # Other UUID expressions.
+    canonicalized_stats = re.sub(r"([a-f\d]{32})", "U", canonicalized_stats)
     # Time expressions.
     canonicalized_stats = re.sub(r"[0-9\.]+(ms|us|s)", "T", canonicalized_stats)
     # Memory expressions.

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2225,7 +2225,6 @@ import ray
 
 ds = ray.data.range(100, override_num_blocks=20).map_batches(lambda x: x)
 ds.set_name("train")
-ds._set_uuid("1234")
 
 split = ds.streaming_split(1)[0]
 
@@ -2236,8 +2235,15 @@ for epoch in range({num_epochs}):
     # Need to run the code as s sub process, because the executor
     # runs on the SplitCoordinator actor.
     out = run_string_as_driver(driver_script)
+    match = re.search(
+        r"Starting execution of Dataset (train_[A-Za-z0-9]+)_0",
+        out,
+    )
+    assert match is not None
+    dataset_id_prefix = match.group(1)
+
     for i in range(num_epochs):
-        dataset_id = f"train_1234_{i}"
+        dataset_id = f"{dataset_id_prefix}_{i}"
         assert f"Starting execution of Dataset {dataset_id}" in out
 
 

--- a/python/ray/data/tests/test_telemetry.py
+++ b/python/ray/data/tests/test_telemetry.py
@@ -33,7 +33,9 @@ def test_used_on_data_range(reset_usage_lib, callsite: TelemetryCallsite):
     check_library_usage_telemetry(
         _call_data_range,
         callsite=callsite,
-        expected_library_usages=[{"core", "dataset"}],
+        expected_library_usages=[
+            {"dataset"} if callsite == TelemetryCallsite.DRIVER else {"core", "dataset"}
+        ],
     )
 
 

--- a/python/ray/data/tests/unit/test_dataset_id.py
+++ b/python/ray/data/tests/unit/test_dataset_id.py
@@ -1,40 +1,33 @@
-from unittest.mock import patch
+import string
 
 from ray.data._internal.dataset_id import generate_dataset_ulid
 
-BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+BASE62_ALPHABET = string.digits + string.ascii_uppercase + string.ascii_lowercase
 
 
-def test_generate_dataset_ulid():
-    """Dataset ULIDs are fixed-width, Base62, unique, and time-sortable."""
-    with (
-        patch(
-            "ray.data._internal.dataset_id.time.time_ns",
-            side_effect=[0, 1_000_000, 1_000_000, 2_000_000],
-        ),
-        patch(
-            "ray.data._internal.dataset_id.os.urandom",
-            side_effect=[
-                b"\x00" * 10,
-                b"\x00" * 10,
-                b"\xff" * 10,
-                b"\x00" * 10,
-            ],
-        ),
-    ):
-        zero_ulid = generate_dataset_ulid()
-        same_time_low = generate_dataset_ulid()
-        same_time_high = generate_dataset_ulid()
-        later_ulid = generate_dataset_ulid()
+def test_generate_dataset_ulid_returns_time_sortable_ids():
+    earlier_ulid = generate_dataset_ulid(get_time_ns=lambda: 0)
+    later_ulid = generate_dataset_ulid(get_time_ns=lambda: 1_000_000)
 
-    assert zero_ulid == "0" * 22
+    assert earlier_ulid < later_ulid
 
-    for ulid in (zero_ulid, same_time_low, same_time_high, later_ulid):
-        assert len(ulid) == 22
-        assert all(char in BASE62_ALPHABET for char in ulid)
 
-    assert same_time_low != same_time_high
-    assert same_time_high < later_ulid
+def test_generate_dataset_ulid_does_not_return_collisions():
+    ulids = {generate_dataset_ulid() for _ in range(100_000)}
+
+    assert len(ulids) == 100_000
+
+
+def test_generate_dataset_ulid_only_uses_base62_chars():
+    ulid = generate_dataset_ulid()
+
+    assert all(char in BASE62_ALPHABET for char in ulid)
+
+
+def test_generate_dataset_ulid_returns_short_id():
+    ulid = generate_dataset_ulid()
+
+    assert len(ulid) == 22
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/test_dataset_id.py
+++ b/python/ray/data/tests/unit/test_dataset_id.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+from ray.data._internal.dataset_id import generate_dataset_ulid
+
+BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+
+def test_generate_dataset_ulid():
+    """Dataset ULIDs are fixed-width, Base62, unique, and time-sortable."""
+    with (
+        patch(
+            "ray.data._internal.dataset_id.time.time_ns",
+            side_effect=[0, 1_000_000, 1_000_000, 2_000_000],
+        ),
+        patch(
+            "ray.data._internal.dataset_id.os.urandom",
+            side_effect=[
+                b"\x00" * 10,
+                b"\x00" * 10,
+                b"\xff" * 10,
+                b"\x00" * 10,
+            ],
+        ),
+    ):
+        zero_ulid = generate_dataset_ulid()
+        same_time_low = generate_dataset_ulid()
+        same_time_high = generate_dataset_ulid()
+        later_ulid = generate_dataset_ulid()
+
+    assert zero_ulid == "0" * 22
+
+    for ulid in (zero_ulid, same_time_low, same_time_high, later_ulid):
+        assert len(ulid) == 22
+        assert all(char in BASE62_ALPHABET for char in ulid)
+
+    assert same_time_low != same_time_high
+    assert same_time_high < later_ulid
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
### Description

This PR replaces counter-based Dataset IDs with 22-character, Base62-encoded ULIDs.

Each ULID contains a timestamp and random data, making it sortable by creation time and practically collision-free.

The full ID format remains:

`{dataset_name}_{dataset_ulid}_{run_index}`

This PR also:

- Generates a new Dataset ULID during deserialization.
- Keeps the run index for repeated executions and training epochs.
- Adds `RAY_DATA_USE_LEGACY_DATASET_IDS` as a temporary compatibility option.


### Tests
Focused Dataset ID tests: `5 passed`

Also updates `test_dataset_id_train_ingest` test in `python/ray/data/tests/test_stats.py` to verify that the same generated Dataset ID is used across epochs while the run index increases.

---

Closes https://github.com/ray-project/ray/issues/65073