### PR TITLE
[data] Add catalog support and credential refresh to write_delta

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -2246,6 +2246,20 @@ py_test(
 )
 
 py_test(
+    name = "test_write_delta_catalog_e2e",
+    size = "medium",
+    srcs = ["tests/datasource/test_write_delta_catalog_e2e.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_aggregations",
     size = "medium",
     srcs = ["tests/test_aggregations.py"],

--- a/python/ray/data/_internal/cloud_auth.py
+++ b/python/ray/data/_internal/cloud_auth.py
@@ -1,0 +1,66 @@
+"""Helpers for recognizing and recovering from cloud credential failures.
+
+Format-agnostic: an expired S3 session token or Azure SAS token looks the same
+to any datasource or datasink that talks to object storage, so these live here
+rather than next to one format's implementation.
+"""
+
+import os
+from typing import Dict
+
+# Substring patterns identifying an authentication/authorization failure from a
+# cloud filesystem (expired/invalid credentials), as opposed to a transient
+# network error or a genuine logical error. A plain backoff-and-retry fails
+# identically every time on one of these -- credentials need to be refreshed
+# first.
+AUTH_ERROR_PATTERNS = [
+    # AWS / S3 (botocore, PyArrow S3FileSystem).
+    "ExpiredToken",
+    "ExpiredTokenException",
+    "InvalidAccessKeyId",
+    "SignatureDoesNotMatch",
+    "RequestTimeTooSkewed",
+    "AccessDenied",
+    "UnrecognizedClientException",
+    # Azure.
+    "AuthenticationFailed",
+    "InvalidAuthenticationInfo",
+    "ExpiredAuthenticationToken",
+    # GCS.
+    "invalid_grant",
+    "Invalid Credentials",
+    # Generic HTTP status codes surfaced by cloud filesystem clients.
+    "401 ",
+    "403 ",
+]
+
+
+def is_auth_error(exc: BaseException) -> bool:
+    """Best-effort check for whether ``exc`` is an authentication/authorization
+    failure from a cloud filesystem (expired/invalid credentials), as opposed
+    to a transient network error or a genuine logical error.
+
+    Used to trigger a credential-refresh-and-retry rather than the plain
+    backoff-and-retry used for transient errors: retrying an auth failure
+    unchanged always fails identically, so it needs a different response.
+    """
+    message = str(exc)
+    return any(pattern in message for pattern in AUTH_ERROR_PATTERNS)
+
+
+def restore_environ(snapshot: Dict[str, str]) -> None:
+    """Restore ``os.environ`` to ``snapshot``, dropping any keys added since.
+
+    Used to undo credential env vars that a credential-vending call writes as a
+    side effect, so they don't outlive the task in a reused worker process.
+    Best-effort: it can't tell our own additions apart from an unrelated
+    concurrent mutation in the same process. Having the vending mechanism not
+    mutate the environment at all is the real fix; this contains the damage
+    until then.
+    """
+    for key in list(os.environ):
+        if key not in snapshot:
+            del os.environ[key]
+    for key, value in snapshot.items():
+        if os.environ.get(key) != value:
+            os.environ[key] = value

--- a/python/ray/data/_internal/datasource/delta_datasink.py
+++ b/python/ray/data/_internal/datasource/delta_datasink.py
@@ -1,18 +1,27 @@
 import json
 import logging
+import os
 import posixpath
 import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 
+from ray._common.retry import call_with_retry
 from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
+from ray.data._internal.cloud_auth import (
+    AUTH_ERROR_PATTERNS,
+    is_auth_error,
+    restore_environ,
+)
 from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.planner.plan_write_op import WRITE_UUID_KWARG_NAME
 from ray.data._internal.savemode import SaveMode
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink, WriteResult
+from ray.data.datasource.path_util import _filesystem_root_from_uri
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
@@ -20,6 +29,8 @@ if TYPE_CHECKING:
     import pyarrow.fs as pafs
     from deltalake import DeltaTable
     from deltalake.transaction import AddAction
+
+    from ray.data.catalog import Catalog
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +79,18 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
         untouched. (Iceberg has to evolve in ``on_write_start`` instead,
         because PyIceberg binds field IDs at write time; Delta workers write
         plain Parquet and the schema is only established at commit.)
+
+    Credential refresh on an authentication error is attempted on both the
+    driver's commit and each worker's Parquet write:
+
+    * With no ``catalog=`` and no explicit ``filesystem=``, a plain retry is
+      already a refresh -- PyArrow and deltalake both re-resolve the standard
+      cloud SDK credential chain on each new filesystem/``DeltaTable``.
+    * With ``catalog=``, an auth error re-calls ``catalog.resolve(...)`` for a
+      fresh vended credential. This works on the driver for any cloud the
+      catalog supports. On a worker it only works when the catalog returns an
+      explicit picklable filesystem (AWS today); for other credential shapes
+      the auth error propagates as it did before.
     """
 
     def __init__(
@@ -78,6 +101,10 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
         partition_by: Optional[List[str]] = None,
         storage_options: Optional[Dict[str, str]] = None,
         schema_mode: str = "merge",
+        user_storage_options: Optional[Dict[str, str]] = None,
+        filesystem: Optional["pafs.FileSystem"] = None,
+        catalog: Optional["Catalog"] = None,
+        table_identifier: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
     ):
@@ -85,12 +112,16 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
 
         Args:
             path: URI of the Delta table (e.g. ``/tmp/my_table`` or
-                ``s3://bucket/my_table``).
+                ``s3://bucket/my_table``). If ``catalog`` is set, this is
+                already the physical location the catalog resolved
+                ``table_identifier`` to.
             mode: Write mode. Only ``SaveMode.APPEND`` and ``SaveMode.OVERWRITE``
                 are supported in this prototype.
             partition_by: Optional list of columns to partition the table by.
             storage_options: Backend storage options forwarded to ``deltalake`` for
-                the commit (e.g. cloud credentials).
+                the commit (e.g. cloud credentials). When ``catalog`` is set, this
+                is already the catalog-resolved defaults merged with
+                ``user_storage_options`` (the latter winning).
             schema_mode: How an ``APPEND`` reconciles its incoming schema
                 against an existing table's schema, when the incoming data
                 has a column the table doesn't. Has no effect on
@@ -112,6 +143,30 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
                 incompatible type, always raises -- schema evolution here
                 only ever *adds* columns, it never changes an existing
                 column's type.
+            user_storage_options: The exact storage_options the caller passed to
+                :meth:`Dataset.write_delta` directly, before any catalog-resolved
+                defaults were merged in. Kept separately so a credential refresh
+                re-merges fresh catalog values with *these* (which always take
+                precedence) instead of with whatever the previous, now-stale
+                merge produced. Defaults to ``storage_options`` when not given
+                (i.e. no catalog was involved, so there's nothing to distinguish).
+            filesystem: Optional pre-built PyArrow filesystem used for both the
+                driver commit's worker-visible writes and each worker's own
+                Parquet write, instead of one built from ``storage_options`` or
+                ambient credentials.
+            catalog: Optional catalog used to resolve ``table_identifier`` to
+                ``path`` (and to ``storage_options``/``filesystem``, if the
+                catalog returns them). Kept as-is on this datasink -- including
+                when the datasink is pickled to run on a worker -- so that a
+                worker can call ``catalog.resolve(...)`` again on a
+                credential-expiry error, without needing a round-trip to the
+                driver. Requires ``table_identifier``.
+            table_identifier: The catalog's name for the table (e.g.
+                ``"main.schema.table"``), as opposed to ``path``, which is the
+                physical location the catalog resolved it *to*. Both are needed
+                because a credential refresh re-calls ``catalog.resolve()``,
+                which takes the identifier -- a physical URI can't be resolved.
+                Required with ``catalog``, and unused without one.
             name: Optional table name recorded in the Delta metadata (new tables).
             description: Optional table description recorded in the Delta metadata
                 (new tables).
@@ -135,12 +190,36 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
                 f"DeltaDatasink only supports schema_mode in "
                 f"{sorted(_SUPPORTED_SCHEMA_MODES)}, got {schema_mode!r}."
             )
+        if catalog is not None and not table_identifier:
+            raise ValueError(
+                "table_identifier is required with catalog: a credential "
+                "refresh re-calls catalog.resolve() with it, and the catalog "
+                "resolves identifiers (e.g. 'main.schema.table'), not the "
+                "physical location it already resolved one to."
+            )
 
         self._path = path.rstrip("/")
         self._mode = mode
         self._partition_by = list(partition_by) if partition_by else []
         self._storage_options = dict(storage_options) if storage_options else None
         self._schema_mode = schema_mode
+        # Only the caller's *own* keys belong here -- these are re-applied on
+        # top of every catalog refresh, so anything the catalog itself vended
+        # must be excluded or a stale value (e.g. the first session token)
+        # would keep winning and make each refresh a no-op for exactly the
+        # keys that needed to change. Empty when the caller supplied none,
+        # rather than falling back to ``storage_options``: by the time a
+        # catalog is involved that dict is already catalog-merged.
+        self._user_storage_options = (
+            dict(user_storage_options) if user_storage_options else {}
+        )
+        self._filesystem = filesystem
+        self._catalog = catalog
+        # No fallback to ``path``: the two are different kinds of string (a
+        # catalog identifier vs. a physical location) and only the identifier
+        # can be re-resolved, so defaulting one to the other would just defer
+        # the failure into the refresh path as ``resolve(<physical URI>)``.
+        self._table_identifier = table_identifier
         self._name = name
         self._description = description
         # Captured from the first input bundle in ``on_write_start`` so the commit
@@ -168,16 +247,32 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
 
         from deltalake import DeltaTable
 
-        if not DeltaTable.is_deltatable(
-            self._path, storage_options=self._storage_options
-        ):
+        def _read_existing_partition_by() -> Optional[List[str]]:
+            """The table's partition columns, or None if it doesn't exist yet."""
+            if not DeltaTable.is_deltatable(
+                self._path, storage_options=self._storage_options
+            ):
+                return None
+            return list(
+                DeltaTable(self._path, storage_options=self._storage_options)
+                .metadata()
+                .partition_columns
+            )
+
+        # Retried and credential-refreshed like the commit's own calls in
+        # ``on_write_complete``: these are the same kind of driver-side Delta
+        # log reads, so an expired token or a throttled request here would
+        # otherwise fail the whole job before any refresh could happen. The
+        # validation below stays outside the retry -- a partition mismatch is a
+        # logical error that must not be retried.
+        existing_partition_by = self._with_retry(
+            _read_existing_partition_by,
+            description=f"read partition columns of Delta table '{self._path}'",
+            refresh=self._refresh_driver_filesystem,
+        )
+        if existing_partition_by is None:
             return
 
-        existing_partition_by = list(
-            DeltaTable(self._path, storage_options=self._storage_options)
-            .metadata()
-            .partition_columns
-        )
         if not self._partition_by:
             self._partition_by = existing_partition_by
         elif self._partition_by != existing_partition_by:
@@ -199,10 +294,10 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
         """
         add_actions: List["AddAction"] = []
         schemas: List["pa.Schema"] = []
-        for block in blocks:
+        for block_idx, block in enumerate(blocks):
             table = BlockAccessor.for_block(block).to_arrow()
             if table.num_rows > 0:
-                add_actions.extend(self._write_parquet(table, ctx))
+                add_actions.extend(self._write_parquet(table, ctx, block_idx))
                 schemas.append(table.schema)
 
         return DeltaWriteResult(add_actions=add_actions, schemas=schemas)
@@ -220,8 +315,12 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
             add_actions.extend(result.add_actions)
             schemas.extend(result.schemas)
 
-        table_exists = DeltaTable.is_deltatable(
-            self._path, storage_options=self._storage_options
+        table_exists = self._with_retry(
+            lambda: DeltaTable.is_deltatable(
+                self._path, storage_options=self._storage_options
+            ),
+            description=f"check whether a Delta table exists at '{self._path}'",
+            refresh=self._refresh_driver_filesystem,
         )
         delta_mode = self._mode.value
 
@@ -240,10 +339,12 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
         if schema is None and delta_mode == "overwrite" and table_exists:
             # An empty OVERWRITE still truncates the table, so fall back to the
             # table's own schema rather than requiring one from the empty write.
-            schema = (
-                DeltaTable(self._path, storage_options=self._storage_options)
+            schema = self._with_retry(
+                lambda: DeltaTable(self._path, storage_options=self._storage_options)
                 .schema()
-                .to_arrow()
+                .to_arrow(),
+                description=f"read the existing schema of Delta table '{self._path}'",
+                refresh=self._refresh_driver_filesystem,
             )
         if schema is None:
             raise ValueError(
@@ -253,25 +354,41 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
 
         if not table_exists:
             # Create a brand-new table with the initial set of files.
-            create_table_with_add_actions(
-                table_uri=self._path,
-                schema=Schema.from_arrow(schema),
-                add_actions=add_actions,
-                mode="overwrite" if delta_mode == "overwrite" else "error",
-                partition_by=self._partition_by or None,
-                name=self._name,
-                description=self._description,
-                storage_options=self._storage_options,
+            self._with_retry(
+                lambda: create_table_with_add_actions(
+                    table_uri=self._path,
+                    schema=Schema.from_arrow(schema),
+                    add_actions=add_actions,
+                    mode="overwrite" if delta_mode == "overwrite" else "error",
+                    partition_by=self._partition_by or None,
+                    name=self._name,
+                    description=self._description,
+                    storage_options=self._storage_options,
+                ),
+                description=f"create Delta table at '{self._path}'",
+                refresh=self._refresh_driver_filesystem,
             )
         else:
-            dt = DeltaTable(self._path, storage_options=self._storage_options)
-            if delta_mode == "append":
-                dt = self._reconcile_schema_with_existing_table(schema, dt)
-            dt.create_write_transaction(
-                actions=add_actions,
-                mode=delta_mode,
-                schema=schema,
-                partition_by=self._partition_by or None,
+            # `schema` is bound as a default argument (evaluated once, here)
+            # rather than captured via closure, so its already-narrowed
+            # non-None type (checked above) carries into `_commit` instead of
+            # widening back to `Optional[pa.Schema]` across the closure
+            # boundary.
+            def _commit(schema: "pa.Schema" = schema) -> None:
+                dt = DeltaTable(self._path, storage_options=self._storage_options)
+                if delta_mode == "append":
+                    dt = self._reconcile_schema_with_existing_table(schema, dt)
+                dt.create_write_transaction(
+                    actions=add_actions,
+                    mode=delta_mode,
+                    schema=schema,
+                    partition_by=self._partition_by or None,
+                )
+
+            self._with_retry(
+                _commit,
+                description=f"commit to Delta table at '{self._path}'",
+                refresh=self._refresh_driver_filesystem,
             )
 
         logger.info(
@@ -280,6 +397,210 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
             self._path,
             delta_mode,
         )
+
+    # ------------------------------------------------------------------
+    # Driver-side retry / credential refresh.
+    # ------------------------------------------------------------------
+    def _refresh_driver_filesystem(self) -> bool:
+        """Re-resolve credentials via the catalog on a driver-side auth error.
+
+        Returns ``True`` if a refresh was attempted, ``False`` if there's
+        nothing this datasink knows how to do beyond a plain retry.
+        """
+        catalog = self._catalog
+        table_identifier = self._table_identifier
+        # ``__init__`` rejects a catalog without an identifier, so this is
+        # belt-and-braces -- but it keeps the precondition visible right where
+        # the identifier is used rather than only at construction.
+        if catalog is None or table_identifier is None:
+            return False
+
+        from ray.data.catalog import CatalogAccessMode, ReaderFormat
+
+        resolved = catalog.resolve(
+            table_identifier,
+            reader=ReaderFormat.DELTA,
+            mode=CatalogAccessMode.WRITE,
+        )
+        # `catalog.resolve()` also writes freshly-vended credentials into this
+        # process's own environment as a side effect (e.g.
+        # `DatabricksUnityCatalog._apply_env`) -- that's what the deltalake
+        # calls in `on_write_complete` actually pick up, for any cloud the
+        # catalog supports, since delta-rs resolves credentials from the
+        # environment on each call rather than caching them at import time.
+        # The explicit fields below are applied too, for completeness, but
+        # aren't required for the driver's own commit to succeed.
+        if resolved.storage_options:
+            # Merge with the caller's *original* storage_options
+            # (`_user_storage_options`), not the current (possibly now-stale)
+            # `_storage_options` -- otherwise a stale value for a key the
+            # fresh resolve() just updated (e.g. a session token) would keep
+            # winning the merge on every subsequent refresh, making the
+            # refresh a no-op for exactly the fields that needed to change.
+            self._storage_options = {
+                **resolved.storage_options,
+                **self._user_storage_options,
+            }
+        if resolved.filesystem is not None:
+            self._filesystem = resolved.filesystem
+        logger.info(
+            "Refreshed Delta write credentials for '%s' via catalog after an "
+            "auth error.",
+            self._path,
+        )
+        return True
+
+    def _with_retry(
+        self,
+        func: Callable[[], Any],
+        description: str,
+        *,
+        refresh: Optional[Callable[[], bool]] = None,
+        retry_auth_errors: bool = True,
+    ) -> Any:
+        """Retry ``func``, refreshing credentials first on an auth error.
+
+        Used from both sides of the write: the driver's Delta log reads and
+        commit, and each worker's Parquet write.
+
+        Args:
+            func: The operation to run and retry.
+            description: Passed to ``call_with_retry`` for its log messages.
+            refresh: Called on an auth error before the next attempt. Each
+                implementation decides for itself whether a refresh is possible
+                and no-ops if not, so there's no need to pre-check here.
+            retry_auth_errors: Whether an auth error is worth retrying at all.
+                ``False`` when nothing about the next attempt could differ --
+                otherwise it just fails identically ``commit_max_attempts``
+                times over.
+
+        Returns:
+            Whatever ``func`` returns on the attempt that succeeds.
+        """
+        cfg = self._data_context.delta_config
+        retried_errors = list(cfg.commit_retried_errors)
+        if cfg.credential_refresh_enabled and retry_auth_errors:
+            retried_errors = retried_errors + AUTH_ERROR_PATTERNS
+
+        def wrapped() -> Any:
+            try:
+                return func()
+            except Exception as e:
+                if (
+                    refresh is not None
+                    and cfg.credential_refresh_enabled
+                    and is_auth_error(e)
+                ):
+                    refresh()
+                raise
+
+        return call_with_retry(
+            wrapped,
+            description=description,
+            match=retried_errors,
+            max_attempts=cfg.commit_max_attempts,
+            max_backoff_s=cfg.commit_retry_max_backoff_s,
+        )
+
+    # ------------------------------------------------------------------
+    # Worker-side retry / credential refresh.
+    # ------------------------------------------------------------------
+    def _resolve_worker_filesystem(self) -> "pafs.FileSystem":
+        """Build the filesystem a worker should use for its Parquet write."""
+        import pyarrow.fs as pafs
+
+        if self._filesystem is not None:
+            return self._filesystem
+        explicit_fs = _explicit_filesystem_from_storage_options(
+            self._path, self._storage_options
+        )
+        if explicit_fs is not None:
+            return explicit_fs
+        fs, _ = pafs.FileSystem.from_uri(self._path)
+        return fs
+
+    def _can_refresh_worker_credentials(self) -> bool:
+        """Whether a worker can safely re-resolve catalog credentials.
+
+        Only when the catalog already handed this datasink an explicit,
+        picklable filesystem -- the AWS-backed Delta write shape. Since
+        ``write_delta`` rejects a user-supplied ``filesystem=`` alongside
+        ``catalog=``, a non-``None`` filesystem here can only have come from
+        the catalog.
+
+        This must be decided *without* calling ``resolve()``, because
+        ``resolve()`` itself has credential-delivery side effects: Unity
+        Catalog's ``_apply_env`` writes the vended credentials into this
+        process's environment and never restores them. For a shape a worker
+        can't use anyway (Azure, which has no explicit-filesystem path
+        today), calling ``resolve()`` just to discover that would leave live
+        credentials in a worker process that Ray then reuses for unrelated
+        tasks.
+        """
+        return self._catalog is not None and self._filesystem is not None
+
+    def _worker_retry_can_change_credentials(self) -> bool:
+        """Whether retrying a worker-side auth error could plausibly succeed.
+
+        An auth failure repeated against the same credentials fails
+        identically, so retrying one is only worth the backoff when the next
+        attempt can present different credentials.
+        """
+        if self._can_refresh_worker_credentials():
+            # The catalog vends a fresh credential on each resolve().
+            return True
+        if self._catalog is not None:
+            # A catalog whose credential shape a worker can't rebuild from --
+            # see ``_can_refresh_worker_credentials``.
+            return False
+        # No catalog: each attempt re-runs ``_resolve_worker_filesystem``,
+        # which rebuilds the filesystem and so re-resolves the ambient cloud
+        # SDK credential chain -- unless a filesystem object was handed in, in
+        # which case every attempt reuses that same object and nothing can
+        # change. (A ``storage_options`` dict carrying a full static credential
+        # set is a middle ground: the rebuild re-reads the same fixed keys.
+        # Left as retryable because partial options -- region or endpoint only
+        # -- still leave the credential chain to be resolved at construction.)
+        return self._filesystem is None
+
+    def _refresh_worker_filesystem(self) -> bool:
+        """Re-resolve credentials via the catalog on a worker-side auth error.
+
+        Scoped to the shape ``_can_refresh_worker_credentials`` describes; for
+        anything else this is a no-op returning ``False`` and the caller lets
+        the auth error propagate, same as before this feature existed.
+        """
+        catalog = self._catalog
+        table_identifier = self._table_identifier
+        if (
+            catalog is None
+            or table_identifier is None
+            or not self._can_refresh_worker_credentials()
+        ):
+            return False
+
+        from ray.data.catalog import CatalogAccessMode, ReaderFormat
+
+        # ``resolve()`` may also seed the vended credentials into this
+        # process's environment without restoring them (Unity Catalog's
+        # ``_apply_env``). A worker process outlives this task and gets reused
+        # for unrelated ones, so undo whatever it changed -- the refreshed
+        # filesystem below carries the credentials we actually write with, so
+        # nothing downstream needs them in the environment.
+        env_before = dict(os.environ)
+        try:
+            resolved = catalog.resolve(
+                table_identifier,
+                reader=ReaderFormat.DELTA,
+                mode=CatalogAccessMode.WRITE,
+            )
+        finally:
+            restore_environ(env_before)
+
+        if resolved.filesystem is None:
+            return False
+        self._filesystem = resolved.filesystem
+        return True
 
     # ------------------------------------------------------------------
     # Helpers
@@ -363,46 +684,40 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
         dt.alter.add_columns(delta_schema.fields)
         return DeltaTable(self._path, storage_options=self._storage_options)
 
-    def _write_parquet(self, table: "pa.Table", ctx: TaskContext) -> List["AddAction"]:
+    def _write_parquet(
+        self, table: "pa.Table", ctx: TaskContext, block_idx: int = 0
+    ) -> List["AddAction"]:
         """Write a PyArrow table to Parquet under the table root, one file per
-        partition, and return the corresponding ``AddAction`` metadata."""
+        partition, and return the corresponding ``AddAction`` metadata.
+
+        ``block_idx`` distinguishes the blocks of one write task from each
+        other in the output filenames -- see the ``write_uuid`` comment below.
+        It defaults to 0 for direct single-block calls.
+        """
         import pyarrow.dataset as pds
         import pyarrow.fs as pafs
         from deltalake.transaction import AddAction
 
-        filesystem, root = pafs.FileSystem.from_uri(self._path)
-        explicit_fs = _explicit_filesystem_from_storage_options(
-            self._path, self._storage_options
-        )
-        if explicit_fs is not None:
-            filesystem = explicit_fs
+        # Path only -- the filesystem comes from ``_resolve_worker_filesystem``
+        # below. See ``_filesystem_root_from_uri`` for why ``FileSystem.from_uri`` can't be
+        # used to derive it.
+        root = _filesystem_root_from_uri(self._path)
         modification_time = int(time.time() * 1000)
-        # Unique prefix per write task so retries/concurrent tasks don't collide.
         task_idx = getattr(ctx, "task_idx", 0)
-        write_uuid = uuid.uuid4().hex
-
-        written: List["AddAction"] = []
-
-        def _visit(written_file: "pds.WrittenFile") -> None:
-            # The Delta log stores paths relative to the table root. Strip
-            # leading slashes from both sides first: S3 can report a root
-            # without one but written-file paths with one, and that mismatch
-            # makes relpath walk upward into ``../../bucket/...``.
-            rel_path = posixpath.relpath(
-                written_file.path.lstrip("/"), root.lstrip("/")
-            )
-            partition_values = _parse_partition_values(rel_path, self._partition_by)
-            metadata = written_file.metadata
-            written.append(
-                AddAction(
-                    path=rel_path,
-                    size=written_file.size,
-                    partition_values=partition_values,
-                    modification_time=modification_time,
-                    data_change=True,
-                    stats=json.dumps({"numRecords": metadata.num_rows}),
-                )
-            )
+        # Fixed once per write job at plan time, so a retry reuses the same
+        # filenames instead of leaking orphans under a fresh random name. The
+        # fallback only applies to direct/test calls.
+        #
+        # Because it's job-level rather than per-call, it can't distinguish the
+        # blocks within one task on its own -- ``basename_template``'s ``{i}``
+        # restarts at 0 on every ``write_dataset`` call, so two blocks would
+        # both claim ``...-0.parquet`` and the second would overwrite the first
+        # (``existing_data_behavior="overwrite_or_ignore"``). ``block_idx``
+        # below is what keeps them apart; it's stable across retries because a
+        # retried task re-iterates the same blocks in the same order.
+        write_uuid = (
+            getattr(ctx, "kwargs", {}).get(WRITE_UUID_KWARG_NAME) or uuid.uuid4().hex
+        )
 
         partitioning = None
         if self._partition_by:
@@ -422,25 +737,63 @@ class DeltaDatasink(Datasink[DeltaWriteResult]):
                 table.select(self._partition_by).schema, flavor="hive"
             )
 
-        # Object stores have no real directories, so create_dir=True just makes
-        # every task PutObject the same marker key -- enough concurrency against
-        # a cold prefix to trigger S3 SLOW_DOWN. Real filesystems still need it.
-        create_dir = not isinstance(
-            filesystem, (pafs.S3FileSystem, pafs.GcsFileSystem, pafs.AzureFileSystem)
-        )
+        def _do_write() -> List["AddAction"]:
+            written: List["AddAction"] = []
 
-        pds.write_dataset(
-            table,
-            base_dir=root,
-            filesystem=filesystem,
-            format="parquet",
-            partitioning=partitioning,
-            basename_template=f"part-{task_idx:05d}-{write_uuid}-{{i}}.parquet",
-            existing_data_behavior="overwrite_or_ignore",
-            file_visitor=_visit,
-            create_dir=create_dir,
+            def _visit(written_file: "pds.WrittenFile") -> None:
+                # The Delta log stores paths relative to the table root. Strip
+                # leading slashes from both sides first: S3 can report a root
+                # without one but written-file paths with one, and that
+                # mismatch makes relpath walk upward into ``../../bucket/...``.
+                rel_path = posixpath.relpath(
+                    written_file.path.lstrip("/"), root.lstrip("/")
+                )
+                partition_values = _parse_partition_values(rel_path, self._partition_by)
+                metadata = written_file.metadata
+                written.append(
+                    AddAction(
+                        path=rel_path,
+                        size=written_file.size,
+                        partition_values=partition_values,
+                        modification_time=modification_time,
+                        data_change=True,
+                        stats=json.dumps({"numRecords": metadata.num_rows}),
+                    )
+                )
+
+            filesystem = self._resolve_worker_filesystem()
+            # Object stores have no real directories, so create_dir=True just
+            # makes every task PutObject the same marker key -- enough
+            # concurrency against a cold prefix to trigger S3 SLOW_DOWN. Real
+            # filesystems still need it.
+            create_dir = not isinstance(
+                filesystem,
+                (pafs.S3FileSystem, pafs.GcsFileSystem, pafs.AzureFileSystem),
+            )
+
+            pds.write_dataset(
+                table,
+                base_dir=root,
+                filesystem=filesystem,
+                format="parquet",
+                partitioning=partitioning,
+                basename_template=(
+                    f"part-{task_idx:05d}-{block_idx:05d}-{write_uuid}-{{i}}.parquet"
+                ),
+                existing_data_behavior="overwrite_or_ignore",
+                file_visitor=_visit,
+                create_dir=create_dir,
+            )
+            return written
+
+        return self._with_retry(
+            _do_write,
+            description=f"write Parquet files to '{root}'",
+            refresh=self._refresh_worker_filesystem,
+            # A worker that can't rebuild its filesystem with different
+            # credentials gains nothing from retrying an auth error.
+            retry_auth_errors=self._worker_retry_can_change_credentials(),
         )
-        return written
 
 
 def _explicit_filesystem_from_storage_options(

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -229,6 +229,15 @@ DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS = (
     "DEADLINE_EXCEEDED",
 )
 
+DEFAULT_DELTA_COMMIT_MAX_ATTEMPTS = env_integer("RAY_DATA_DELTA_COMMIT_MAX_ATTEMPTS", 5)
+DEFAULT_DELTA_COMMIT_RETRY_MAX_BACKOFF_S = env_integer(
+    "RAY_DATA_DELTA_COMMIT_RETRY_MAX_BACKOFF_S", 16
+)
+# Reuses the same transient-error substring set already proven for Iceberg's
+# catalog operations -- both are HTTP/RPC calls to a metadata service, so the
+# same class of transient failures (rate limiting, connection resets) applies.
+DEFAULT_DELTA_COMMIT_RETRIED_ERRORS = DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS
+
 DEFAULT_LANCE_READ_FRAGMENTS_ERRORS_TO_RETRY = ("LanceError(IO)",)
 DEFAULT_LANCE_READ_FRAGMENTS_MAX_ATTEMPTS = env_integer(
     "RAY_DATA_LANCE_READ_FRAGMENTS_MAX_ATTEMPTS", 10
@@ -374,6 +383,36 @@ class IcebergConfig:
     catalog_retried_errors: List[str] = field(
         default_factory=lambda: list(DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS)
     )
+
+
+@DeveloperAPI
+@dataclass
+class DeltaConfig:
+    """Configuration for the ``write_delta`` prototype's commit/retry behavior.
+
+    Args:
+        commit_max_attempts: Maximum number of retry attempts for the driver's
+            Delta commit operations (existence check, create table, write
+            transaction). Defaults to 5.
+        commit_retry_max_backoff_s: Maximum backoff time in seconds between
+            commit retry attempts. Uses exponential backoff with jitter.
+            Defaults to 16.
+        commit_retried_errors: A list of substrings of error messages that
+            should trigger a retry of a commit operation, in addition to
+            authentication errors (which are always retried when
+            ``credential_refresh_enabled`` is set).
+        credential_refresh_enabled: Whether an authentication error (expired
+            or invalid cloud/catalog credentials) triggers a credential
+            refresh before the next retry attempt, on both the driver and
+            workers. Defaults to ``True``.
+    """
+
+    commit_max_attempts: int = DEFAULT_DELTA_COMMIT_MAX_ATTEMPTS
+    commit_retry_max_backoff_s: int = DEFAULT_DELTA_COMMIT_RETRY_MAX_BACKOFF_S
+    commit_retried_errors: List[str] = field(
+        default_factory=lambda: list(DEFAULT_DELTA_COMMIT_RETRIED_ERRORS)
+    )
+    credential_refresh_enabled: bool = True
 
 
 @DeveloperAPI
@@ -643,6 +682,9 @@ class DataContext:
         iceberg_config: Configuration for Iceberg datasource operations including
             retry settings for file writes and catalog operations. See
             :class:`IcebergConfig` for details.
+        delta_config: Configuration for the ``write_delta`` prototype's
+            commit/retry behavior, including credential-refresh-on-auth-error.
+            See :class:`DeltaConfig` for details.
         default_hash_shuffle_parallelism: Default parallelism level for hash-based
             shuffle operations if the number of partitions is unspecifed.
         hash_shuffle_compression: Codec used to compress hash-shuffle
@@ -873,6 +915,7 @@ class DataContext:
     )
     lance_config: LanceConfig = field(default_factory=LanceConfig)
     iceberg_config: IcebergConfig = field(default_factory=IcebergConfig)
+    delta_config: DeltaConfig = field(default_factory=DeltaConfig)
     enable_per_node_metrics: bool = DEFAULT_ENABLE_PER_NODE_METRICS
     override_object_store_memory_limit_fraction: float = None
     memory_usage_poll_interval_s: Optional[float] = 1

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4754,10 +4754,12 @@ class Dataset:
         self,
         path: str,
         *,
+        catalog: Optional["Catalog"] = None,
         mode: "SaveMode" = SaveMode.APPEND,
         partition_by: Optional[List[str]] = None,
         storage_options: Optional[Dict[str, str]] = None,
         schema_mode: str = "merge",
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
@@ -4809,7 +4811,13 @@ class Dataset:
 
         Args:
             path: URI of the Delta table (e.g. ``/tmp/my_table`` or
-                ``s3://bucket/my_table``).
+                ``s3://bucket/my_table``). If ``catalog`` is set, this is instead
+                the table identifier the catalog resolves (e.g.
+                ``"main.schema.table"``).
+            catalog: Optional catalog (e.g. a Unity Catalog connector) that
+                resolves ``path`` to its physical location and vends
+                credentials for it. See :class:`~ray.data.catalog.Catalog`.
+                Cannot be combined with ``filesystem``.
             mode: Write mode using the :class:`~ray.data.SaveMode` enum. Options:
 
                 * ``SaveMode.APPEND`` (default): Add new data to the table.
@@ -4840,6 +4848,9 @@ class Dataset:
                 ``ValueError`` -- regardless of ``schema_mode``. Only adding
                 a brand-new column is supported; changing an existing
                 column's type is not.
+            filesystem: Optional PyArrow filesystem used for worker Parquet
+                writes, instead of one built from ``storage_options`` or ambient
+                credentials. Cannot be combined with ``catalog``.
             name: Optional table name recorded in the Delta metadata when a new
                 table is created.
             description: Optional table description recorded in the Delta metadata
@@ -4850,12 +4861,45 @@ class Dataset:
                 change the total number of tasks run. By default, concurrency is
                 dynamically decided based on the available resources.
         """
+        # Only meaningful with a catalog: it's the identifier the catalog
+        # resolves, captured before ``path`` is rewritten to the physical
+        # location below, so a later refresh can re-resolve the same table.
+        table_identifier = path if catalog is not None else None
+        # Preserved before any catalog merge below, so a later credential
+        # refresh can re-merge fresh catalog values with these (which should
+        # always win) instead of with a since-stale merged dict.
+        user_storage_options = storage_options
+        if catalog is not None:
+            from ray.data.catalog import CatalogAccessMode, ReaderFormat
+
+            if filesystem is not None:
+                raise ValueError(
+                    "`filesystem` cannot be specified with `catalog`. The "
+                    "`catalog` will resolve the `filesystem` with appropriate "
+                    "credentials automatically."
+                )
+            resolved = catalog.resolve(
+                path, reader=ReaderFormat.DELTA, mode=CatalogAccessMode.WRITE
+            )
+            path = resolved.path
+            if resolved.storage_options:
+                storage_options = {
+                    **resolved.storage_options,
+                    **(user_storage_options or {}),
+                }
+            if resolved.filesystem is not None:
+                filesystem = resolved.filesystem
+
         datasink = DeltaDatasink(
             path=path,
             mode=mode,
             partition_by=partition_by,
             storage_options=storage_options,
             schema_mode=schema_mode,
+            user_storage_options=user_storage_options,
+            filesystem=filesystem,
+            catalog=catalog,
+            table_identifier=table_identifier,
             name=name,
             description=description,
         )

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -479,6 +479,32 @@ def _unwrap_protocol(path):
     return netloc + parsed_path + params + query
 
 
+def _filesystem_root_from_uri(uri: str) -> str:
+    """The path form the filesystem backing ``uri`` expects to be given.
+
+    Returns what ``pyarrow.fs.FileSystem.from_uri`` would hand back as its
+    path, without also *building* a filesystem the way ``from_uri`` does. That
+    matters because for an ``s3://`` URI ``from_uri`` resolves the bucket's
+    region against real AWS: it fails outright against any S3-compatible
+    endpoint (MinIO, moto, Ceph) even with ``AWS_ENDPOINT_URL`` set, and costs a
+    network round-trip every time it's called.
+
+    Scheme conventions, matching ``from_uri``:
+
+    * ``s3``/``s3a``/``gs``/``gcs``: ``bucket/key``.
+    * ``abfs``/``abfss``: ``container/key``. The storage account belongs to the
+      ``AzureFileSystem`` object rather than the path, so the
+      ``@account.dfs.core.windows.net`` host is dropped -- leaving it in points
+      writes at a container literally named ``container@account...``.
+    * local paths: unchanged.
+    """
+    parsed = urlparse(uri, allow_fragments=False)
+    if parsed.scheme in ("abfs", "abfss") and "@" in parsed.netloc:
+        container = parsed.netloc.split("@")[0]
+        return f"{container}{parsed.path}"
+    return _unwrap_protocol(uri)
+
+
 def _is_http_url(path) -> bool:
     parsed = urlparse(path)
     return parsed.scheme in ("http", "https")

--- a/python/ray/data/tests/catalog_test_utils.py
+++ b/python/ray/data/tests/catalog_test_utils.py
@@ -1,0 +1,44 @@
+"""Shared catalog test doubles.
+
+These live in an importable module rather than inside a test file on purpose.
+``write_delta`` pickles the ``Catalog`` to its write tasks so a worker can
+re-resolve credentials itself, and a class defined in a pytest module can't be
+imported back by name in a Ray worker process (``ModuleNotFoundError: No module
+named 'test_catalog'``). Defining the double here makes it picklable, which is
+what lets the catalog-backed write paths be tested end-to-end at all.
+"""
+
+from typing import List, Union
+
+from ray.data.catalog import Catalog, CatalogAccessMode, ReaderFormat, ResolvedSource
+
+
+class FakeCatalog(Catalog):
+    """Returns pre-baked ``ResolvedSource``s; records ``(table, reader, mode)``.
+
+    Accepts either a single ``ResolvedSource`` or a list. With a list, each
+    ``resolve()`` returns the next entry and the last one repeats once
+    exhausted -- which is how a credential *refresh* is simulated: the first
+    call vends one set of values, the second a different set.
+
+    Note when used across processes: ``calls`` only records resolutions made in
+    the process holding that instance. A worker gets an unpickled copy, so
+    driver-side assertions on ``calls`` never see worker-side resolutions.
+    """
+
+    def __init__(self, resolved: Union[ResolvedSource, List[ResolvedSource]]):
+        self._resolved: List[ResolvedSource] = (
+            list(resolved) if isinstance(resolved, list) else [resolved]
+        )
+        self.calls: List[tuple] = []
+
+    def resolve(
+        self,
+        table: str,
+        *,
+        reader: ReaderFormat,
+        mode: CatalogAccessMode = CatalogAccessMode.READ,
+    ) -> ResolvedSource:
+        self.calls.append((table, reader, mode))
+        idx = min(len(self.calls) - 1, len(self._resolved) - 1)
+        return self._resolved[idx]

--- a/python/ray/data/tests/datasource/test_write_delta.py
+++ b/python/ray/data/tests/datasource/test_write_delta.py
@@ -20,6 +20,7 @@ from packaging.version import parse as parse_version
 import ray
 from ray.data import SaveMode
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.tests.catalog_test_utils import FakeCatalog
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
@@ -39,6 +40,31 @@ pytestmark = [
         reason="deltalake requires pyarrow >= 15.0",
     ),
 ]
+
+# Whether ``read_delta`` gives partition columns back with their declared types.
+#
+# A Delta reader takes a partitioned column's value from metadata rather than
+# from the Parquet file (the writer omits it there), so restoring the declared
+# type is the reader's job. ``read_delta`` delegates that to PyArrow -- see the
+# comment on ``partition_columns=[]`` in ``ParquetDatasource.from_pyarrow_dataset``
+# -- and on pyarrow<19 it doesn't happen: values come back as the raw Hive path
+# strings instead, so ``2024`` reads as ``"2024"`` and a null partition as the
+# literal ``"__HIVE_DEFAULT_PARTITION__"``.
+#
+# That's a gap in the *read* path, which this file doesn't own; the writes
+# themselves are fine on every version. Rather than weaken the assertions
+# everywhere, the round-trip *value* checks below skip on old pyarrow while the
+# on-disk layout checks keep running. 19 is the lowest version observed to
+# round-trip correctly (17 fails, 19 and 20 pass); 18 is simply untested.
+_PARTITION_VALUES_ROUND_TRIP = _pa_version is not None and _pa_version >= parse_version(
+    "19.0.0"
+)
+_NO_TYPED_PARTITION_VALUES = (
+    "read_delta returns partition values as untyped Hive path strings on pyarrow<19"
+)
+_skip_without_typed_partition_values = pytest.mark.skipif(
+    not _PARTITION_VALUES_ROUND_TRIP, reason=_NO_TYPED_PARTITION_VALUES
+)
 
 
 @pytest.fixture
@@ -170,10 +196,14 @@ def test_single_column_partition(temp_delta_path):
     rows = [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
     ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
     assert set(os.listdir(temp_delta_path)) >= {"year=2024", "year=2025"}
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == rows
 
 
+@_skip_without_typed_partition_values
 def test_multi_column_partition(temp_delta_path):
     rows = [
         {"year": 2024, "month": 1, "id": 1},
@@ -195,6 +225,9 @@ def test_null_partition_value_round_trips_as_none(temp_delta_path):
     rows = [{"year": 2024, "id": 1}, {"year": None, "id": 2}]
     ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
     assert "year=__HIVE_DEFAULT_PARTITION__" in os.listdir(temp_delta_path)
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == rows
 
@@ -236,6 +269,9 @@ def test_append_without_partition_by_inherits_existing_partitioning(temp_delta_p
     ray.data.from_items(rows2).write_delta(temp_delta_path)  # no partition_by
 
     assert "year=2025" in os.listdir(temp_delta_path)
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
 
@@ -285,14 +321,21 @@ def test_partition_by_mismatch_rejected(
             temp_delta_path, partition_by=write_partition_by
         )
 
-    # Nothing was committed and the table is untouched and still readable.
+    # Nothing was committed and the table is untouched -- the assertions that
+    # actually guard against the corruption this test exists for.
     assert _delta_log_json_count(temp_delta_path) == log_before
     assert DeltaTable(temp_delta_path).metadata().partition_columns == (
         create_partition_by or []
     )
+
+    # Only the baseline tables that are themselves partitioned depend on
+    # partition values surviving the read; the unpartitioned case is unaffected.
+    if create_partition_by and not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     assert _read_all(temp_delta_path) == first
 
 
+@_skip_without_typed_partition_values
 def test_partition_by_matching_existing_is_allowed(temp_delta_path):
     """Passing exactly the table's own partition columns is fine."""
     ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
@@ -324,6 +367,9 @@ def test_overwrite_without_partition_by_inherits_existing_partitioning(
     )
 
     assert "year=2025" in os.listdir(temp_delta_path)
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     assert _read_all(temp_delta_path) == [{"year": 2025, "id": 2}]
 
 
@@ -450,6 +496,60 @@ def test_create_dir_skipped_only_for_cloud_filesystems(monkeypatch):
     # pyrefly: ignore[bad-argument-type]
     s3_datasink._write_parquet(pa.table({"id": [1]}), _FakeTaskContext())
     assert captured["create_dir"] is False
+
+
+# ----------------------------------------------------------------------
+# Filesystem root derivation.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # Azure: the storage account lives on the AzureFileSystem object, not in
+        # the path, so the "@account.dfs.core.windows.net" host must be dropped.
+        # Regression: keeping it pointed writes at a container literally named
+        # "container@account..." and made every AddAction relative path wrong.
+        ("abfss://container@acct.dfs.core.windows.net/tbl", "container/tbl"),
+        ("abfs://container@acct.dfs.core.windows.net/a/b", "container/a/b"),
+        # Object stores: bucket/key.
+        ("s3://bucket/tbl", "bucket/tbl"),
+        ("s3a://bucket/tbl", "bucket/tbl"),
+        ("gs://bucket/a/b", "bucket/a/b"),
+        ("gcs://bucket/a/b", "bucket/a/b"),
+        # Local paths pass through.
+        ("/tmp/local/tbl", "/tmp/local/tbl"),
+        ("file:///tmp/x", "/tmp/x"),
+    ],
+)
+def test_filesystem_root_from_uri_matches_conventions(path, expected):
+    """``_filesystem_root_from_uri`` must return exactly what each filesystem expects as a
+    path -- i.e. what ``FileSystem.from_uri`` would return -- without building a
+    filesystem, since doing so resolves an S3 bucket against real AWS and so
+    fails against any S3-compatible endpoint."""
+    from ray.data.datasource.path_util import _filesystem_root_from_uri
+
+    assert _filesystem_root_from_uri(path) == expected
+
+
+def test_filesystem_root_from_uri_agrees_with_from_uri():
+    """Pins the parity claim above for every scheme ``from_uri`` can resolve
+    without network access (it can't for ``s3://``, which is the whole reason
+    ``_filesystem_root_from_uri`` exists)."""
+    import pyarrow.fs as pafs
+
+    from ray.data.datasource.path_util import _filesystem_root_from_uri
+
+    for path in [
+        "abfss://container@acct.dfs.core.windows.net/tbl",
+        "abfs://container@acct.dfs.core.windows.net/a/b",
+        "gs://bucket/tbl",
+        "gcs://bucket/a/b",
+        "/tmp/local/tbl",
+        "file:///tmp/x",
+    ]:
+        _, from_uri_path = pafs.FileSystem.from_uri(path)
+        assert _filesystem_root_from_uri(path) == from_uri_path, path
 
 
 # ----------------------------------------------------------------------
@@ -629,6 +729,48 @@ def test_write_returns_one_schema_and_file_per_block(temp_delta_path):
 
     assert len(result.add_actions) == 2
     assert result.schemas == [block_a.schema, block_b.schema]
+
+
+def test_multi_block_task_with_job_write_uuid_does_not_collide(temp_delta_path):
+    """Blocks in one task must not overwrite each other's output file.
+
+    The write UUID is fixed once per job (so a retry reuses the same
+    filenames), which means it is identical for every block in a task, and
+    ``basename_template``'s ``{i}`` restarts at 0 on each ``write_dataset``
+    call. Without a per-block component in the name, the second block would
+    write to the same path as the first and -- under
+    ``existing_data_behavior="overwrite_or_ignore"`` -- silently replace it,
+    while the commit reported the same path twice.
+
+    The other multi-block tests can't catch this: they leave ``ctx.kwargs``
+    empty, so they take the per-call ``uuid4()`` fallback rather than the
+    production path exercised here."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data._internal.planner.plan_write_op import WRITE_UUID_KWARG_NAME
+
+    class _FakeTaskContext:
+        task_idx = 0
+        kwargs = {WRITE_UUID_KWARG_NAME: "fixedjobuuid"}
+
+    datasink = DeltaDatasink(temp_delta_path)
+    block_a = pa.table({"id": [1, 2]})
+    block_b = pa.table({"id": [3, 4]})
+
+    # pyrefly: ignore[bad-argument-type]
+    result = datasink.write([block_a, block_b], _FakeTaskContext())
+
+    paths = [action.path for action in result.add_actions]
+    assert len(paths) == len(set(paths)), f"duplicate AddAction paths: {paths}"
+    written = sorted(f for f in os.listdir(temp_delta_path) if f.endswith(".parquet"))
+    assert len(written) == 2, written
+    # Every row survived -- nothing was overwritten.
+    total = 0
+    for name in written:
+        total += pq.read_table(os.path.join(temp_delta_path, name)).num_rows
+    assert total == 4
 
 
 def test_multi_block_task_unifies_schema_across_blocks(temp_delta_path):
@@ -1007,6 +1149,609 @@ def test_unsupported_mode_error_message_uses_plain_strings():
     members don't override ``__str__``."""
     with pytest.raises(ValueError, match=r"\['append', 'overwrite'\]"):
         ray.data.from_items([{"id": 1}]).write_delta("/tmp/unused", mode=SaveMode.ERROR)
+
+
+# ----------------------------------------------------------------------
+# Deterministic write filenames survive a retry.
+# ----------------------------------------------------------------------
+
+
+def test_write_parquet_retry_reuses_same_write_uuid(temp_delta_path, monkeypatch):
+    """Regression test: a worker's write_uuid must be fixed across retries of
+    the same task (baked into ctx.kwargs[WRITE_UUID_KWARG_NAME] once per write
+    job, not regenerated per attempt) -- otherwise a retried write leaks
+    orphan files under a fresh random name instead of overwriting the failed
+    attempt's files."""
+    import pyarrow as pa
+    import pyarrow.dataset as pds
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data._internal.planner.plan_write_op import WRITE_UUID_KWARG_NAME
+
+    real_write_dataset = pds.write_dataset
+    captured_templates = []
+    call_count = {"n": 0}
+
+    def fake_write_dataset(table, *, basename_template, **kwargs):
+        captured_templates.append(basename_template)
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise IOError("Connection reset")
+        real_write_dataset(table, basename_template=basename_template, **kwargs)
+
+    monkeypatch.setattr("pyarrow.dataset.write_dataset", fake_write_dataset)
+
+    class _FakeTaskContext:
+        task_idx = 0
+        kwargs = {WRITE_UUID_KWARG_NAME: "fixed-uuid-1234"}
+
+    datasink = DeltaDatasink(temp_delta_path)
+    table = pa.table({"id": [1, 2, 3]})
+    # pyrefly: ignore[bad-argument-type]
+    add_actions = datasink._write_parquet(table, _FakeTaskContext())
+
+    assert call_count["n"] == 2
+    assert captured_templates[0] == captured_templates[1]
+    assert "fixed-uuid-1234" in captured_templates[0]
+    assert len(add_actions) == 1
+    assert "fixed-uuid-1234" in add_actions[0].path
+
+
+# ----------------------------------------------------------------------
+# is_auth_error classification.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("An error occurred (ExpiredToken) when calling ListObjectsV2", True),
+        ("AWS Error AccessDenied during HeadObject operation", True),
+        ("AuthenticationFailed: Server failed to authenticate the request", True),
+        ("invalid_grant: Bad Request", True),
+        ("HTTP 403 Forbidden", True),
+        ("Some other unrelated transient network blip", False),
+        ("Connection reset by peer", False),
+    ],
+)
+def test_is_auth_error(message, expected):
+    from ray.data._internal.cloud_auth import is_auth_error
+
+    assert is_auth_error(Exception(message)) is expected
+
+
+# ----------------------------------------------------------------------
+# Driver-side retry + credential refresh.
+# ----------------------------------------------------------------------
+
+
+# Shared with test_catalog.py, and importable (not defined in a test module) so
+# it survives pickling to a Ray worker -- see catalog_test_utils.
+_FakeCatalog = FakeCatalog
+
+
+def test_with_retry_retries_transient_error_without_catalog(temp_delta_path):
+    """Without a catalog, an auth error is still retried -- a plain retry is
+    itself the refresh mechanism for ambient credentials (see the class
+    docstring), so no explicit refresh call is needed for it to succeed."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    datasink = DeltaDatasink(temp_delta_path)
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise Exception("AWS Error ExpiredToken during PutObject")
+        return "ok"
+
+    assert datasink._with_retry(flaky, description="test") == "ok"
+    assert attempts["n"] == 2
+
+
+def test_with_retry_refreshes_via_catalog_on_auth_error(temp_delta_path):
+    """With a catalog configured, an auth error triggers exactly one
+    catalog.resolve() re-call before the next retry attempt, and the
+    freshly-resolved storage_options are applied."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import CatalogAccessMode, ReaderFormat, ResolvedSource
+
+    catalog = _FakeCatalog(
+        ResolvedSource(storage_options={"AWS_SESSION_TOKEN": "fresh-token"})
+    )
+    datasink = DeltaDatasink(
+        temp_delta_path, catalog=catalog, table_identifier="main.db.tbl"
+    )
+
+    attempts = {"n": 0}
+
+    def flaky_commit():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise Exception("AWS Error ExpiredToken during PutObject")
+        return "committed"
+
+    assert (
+        datasink._with_retry(
+            flaky_commit,
+            description="test commit",
+            # Same call shape the driver commit uses.
+            refresh=datasink._refresh_driver_filesystem,
+        )
+        == "committed"
+    )
+    assert attempts["n"] == 2
+    assert catalog.calls == [
+        ("main.db.tbl", ReaderFormat.DELTA, CatalogAccessMode.WRITE)
+    ]
+    assert datasink._storage_options is not None
+    assert datasink._storage_options["AWS_SESSION_TOKEN"] == "fresh-token"
+
+
+def test_with_retry_refresh_preserves_user_storage_options_override(
+    temp_delta_path,
+):
+    """Regression test: a user-supplied static storage_options value must
+    survive a catalog-triggered refresh. The fresh catalog value applies for
+    keys the user didn't set (e.g. a rotated session token), but a key the
+    user explicitly overrode -- which the catalog also has a default for --
+    must keep the user's value, not the catalog's, on every refresh, not just
+    the first resolution."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import ResolvedSource
+
+    catalog = _FakeCatalog(
+        ResolvedSource(
+            storage_options={
+                "AWS_SESSION_TOKEN": "fresh-token",
+                "AWS_REGION": "catalog-default-region",
+            }
+        )
+    )
+    datasink = DeltaDatasink(
+        temp_delta_path,
+        catalog=catalog,
+        table_identifier="main.db.tbl",
+        storage_options={"AWS_REGION": "user-override-region"},
+        user_storage_options={"AWS_REGION": "user-override-region"},
+    )
+
+    attempts = {"n": 0}
+
+    def flaky_commit():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise Exception("AWS Error ExpiredToken during PutObject")
+        return "committed"
+
+    datasink._with_retry(
+        flaky_commit,
+        description="test",
+        refresh=datasink._refresh_driver_filesystem,
+    )
+
+    assert datasink._storage_options is not None
+    assert datasink._storage_options["AWS_SESSION_TOKEN"] == "fresh-token"
+    assert datasink._storage_options["AWS_REGION"] == "user-override-region"
+
+
+def test_catalog_refresh_advances_token_without_user_storage_options(temp_delta_path):
+    """Regression test: a refresh must pick up freshly vended credentials when
+    the caller passed no ``storage_options`` at all -- the common
+    ``write_delta(path, catalog=...)`` call.
+
+    ``Dataset.write_delta`` forwards ``user_storage_options=None`` in that
+    case, and the datasink used to fall back to its own (already
+    catalog-merged) ``storage_options``. That froze the *first* vended token as
+    if the caller had supplied it, so it won every later merge and the refresh
+    never actually changed the token that had expired. Goes through
+    ``write_delta`` rather than constructing the datasink directly so the
+    catalog merge under test is the real one.
+    """
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import ResolvedSource
+
+    catalog = _FakeCatalog(
+        [
+            ResolvedSource(
+                path=temp_delta_path, storage_options={"AWS_SESSION_TOKEN": "token-1"}
+            ),
+            ResolvedSource(
+                path=temp_delta_path, storage_options={"AWS_SESSION_TOKEN": "token-2"}
+            ),
+        ]
+    )
+
+    with mock.patch(
+        "ray.data.dataset.DeltaDatasink"
+    ) as datasink_cls, mock.patch.object(ray.data.Dataset, "write_datasink"):
+        ray.data.from_items([{"id": 1}]).write_delta("main.db.tbl", catalog=catalog)
+    _, kwargs = datasink_cls.call_args
+    assert kwargs["user_storage_options"] is None
+
+    datasink = DeltaDatasink(**kwargs)
+    assert datasink._storage_options == {"AWS_SESSION_TOKEN": "token-1"}
+
+    assert datasink._refresh_driver_filesystem() is True
+    assert datasink._storage_options == {"AWS_SESSION_TOKEN": "token-2"}
+
+
+def test_on_write_start_retries_transient_failure(temp_delta_path, monkeypatch):
+    """``on_write_start``'s Delta log reads are retried like the commit's own.
+
+    They are the same kind of driver-side call ``on_write_complete`` already
+    wraps, so an expired token or a throttled request here used to fail the
+    whole write job outright, before any retry or credential refresh could
+    happen.
+    """
+    from deltalake import DeltaTable
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
+        temp_delta_path, partition_by=["year"]
+    )
+
+    real_is_deltatable = DeltaTable.is_deltatable
+    attempts = {"n": 0}
+
+    def flaky_is_deltatable(table_uri, storage_options=None):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise Exception("AWS Error ExpiredToken during GetObject")
+        return real_is_deltatable(table_uri, storage_options=storage_options)
+
+    monkeypatch.setattr(DeltaTable, "is_deltatable", staticmethod(flaky_is_deltatable))
+
+    datasink = DeltaDatasink(temp_delta_path)
+    datasink.on_write_start()
+
+    assert attempts["n"] == 2
+    # Retried, so partitioning was still inherited rather than lost.
+    assert datasink._partition_by == ["year"]
+
+
+def test_on_write_start_does_not_retry_partition_mismatch(temp_delta_path, monkeypatch):
+    """A partition mismatch is a logical error, so it must be raised straight
+    out of ``on_write_start`` rather than retried -- only the Delta log reads
+    are inside the retry."""
+    from deltalake import DeltaTable
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
+        temp_delta_path, partition_by=["year"]
+    )
+
+    real_is_deltatable = DeltaTable.is_deltatable
+    calls = {"n": 0}
+
+    def counting_is_deltatable(table_uri, storage_options=None):
+        calls["n"] += 1
+        return real_is_deltatable(table_uri, storage_options=storage_options)
+
+    monkeypatch.setattr(
+        DeltaTable, "is_deltatable", staticmethod(counting_is_deltatable)
+    )
+
+    datasink = DeltaDatasink(temp_delta_path, partition_by=["month"])
+    with pytest.raises(ValueError, match="can't change an existing table's"):
+        datasink.on_write_start()
+
+    assert calls["n"] == 1
+
+
+def test_with_retry_opt_out_does_not_retry_auth_errors(temp_delta_path):
+    """DeltaConfig.credential_refresh_enabled=False disables the extra
+    auth-error retry/refresh entirely -- the first failure propagates."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.context import DataContext
+
+    ctx = DataContext.get_current()
+    original = ctx.delta_config.credential_refresh_enabled
+    ctx.delta_config.credential_refresh_enabled = False
+    try:
+        datasink = DeltaDatasink(temp_delta_path)
+        attempts = {"n": 0}
+
+        def always_fails():
+            attempts["n"] += 1
+            raise Exception("AWS Error ExpiredToken during PutObject")
+
+        with pytest.raises(Exception, match="ExpiredToken"):
+            datasink._with_retry(always_fails, description="test")
+        assert attempts["n"] == 1
+    finally:
+        ctx.delta_config.credential_refresh_enabled = original
+
+
+# ----------------------------------------------------------------------
+# Worker-side retry + credential refresh (AWS-only catalog scope).
+# ----------------------------------------------------------------------
+
+
+def test_worker_refresh_via_catalog_succeeds_for_aws_shaped_response(temp_delta_path):
+    """A catalog response carrying an explicit filesystem (confirmed true for
+    AWS-backed Delta writes) lets a worker refresh successfully."""
+    import pyarrow.fs as pafs
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import CatalogAccessMode, ReaderFormat, ResolvedSource
+
+    fresh_fs = pafs.S3FileSystem(access_key="a", secret_key="b", region="us-west-2")
+    stale_fs = pafs.S3FileSystem(access_key="c", secret_key="d", region="us-west-2")
+    catalog = _FakeCatalog(ResolvedSource(filesystem=fresh_fs))
+    # ``write_delta`` always hands the datasink the catalog's own filesystem for
+    # this shape, because the driver resolved before constructing it. That
+    # already-present filesystem is what tells a worker a refresh is safe --
+    # see ``_can_refresh_worker_credentials``.
+    datasink = DeltaDatasink(
+        temp_delta_path,
+        catalog=catalog,
+        table_identifier="main.db.tbl",
+        filesystem=stale_fs,
+    )
+
+    assert datasink._refresh_worker_filesystem() is True
+    assert datasink._filesystem is fresh_fs
+    assert catalog.calls == [
+        ("main.db.tbl", ReaderFormat.DELTA, CatalogAccessMode.WRITE)
+    ]
+
+
+def test_worker_refresh_restores_environment_mutated_by_resolve(temp_delta_path):
+    """A worker-side ``catalog.resolve()`` must not leave credentials behind in
+    the worker process's environment.
+
+    Unity Catalog delivers vended credentials by writing them into
+    ``os.environ`` (``_apply_env``) and never restores them. A Ray worker
+    process outlives the task and is reused for unrelated ones, so anything
+    left there leaks into whatever runs next. The refreshed filesystem carries
+    the credentials the write actually uses, so nothing needs them in the
+    environment afterwards.
+    """
+    import pyarrow.fs as pafs
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import Catalog, CatalogAccessMode, ResolvedSource
+
+    key = "RAY_TEST_VENDED_CREDENTIAL"
+
+    class _EnvMutatingCatalog(Catalog):
+        """Mimics ``DatabricksUnityCatalog._resolve_storage``: mutates the
+        environment as a side effect and returns an explicit filesystem."""
+
+        def __init__(self, filesystem):
+            self._filesystem = filesystem
+            self.calls = 0
+
+        def resolve(self, table, *, reader, mode=CatalogAccessMode.READ):
+            self.calls += 1
+            os.environ[key] = "vended-secret"
+            return ResolvedSource(filesystem=self._filesystem)
+
+    fresh_fs = pafs.S3FileSystem(access_key="a", secret_key="b", region="us-west-2")
+    stale_fs = pafs.S3FileSystem(access_key="c", secret_key="d", region="us-west-2")
+    catalog = _EnvMutatingCatalog(fresh_fs)
+    datasink = DeltaDatasink(
+        temp_delta_path,
+        catalog=catalog,
+        table_identifier="main.db.tbl",
+        filesystem=stale_fs,
+    )
+
+    os.environ.pop(key, None)
+    try:
+        assert datasink._refresh_worker_filesystem() is True
+        assert datasink._filesystem is fresh_fs
+        assert catalog.calls == 1
+        assert key not in os.environ
+    finally:
+        os.environ.pop(key, None)
+
+
+def test_worker_refresh_via_catalog_declines_for_azure_shaped_response(
+    temp_delta_path,
+):
+    """A catalog whose credentials a worker can't rebuild from (today's shape
+    for Azure Unity Catalog vending, which returns no explicit filesystem)
+    declines the refresh -- and must decline *without calling* ``resolve()``.
+
+    ``resolve()`` delivers Azure's SAS token by mutating this process's
+    environment and never restoring it, so calling it merely to discover the
+    shape is unusable would leak live credentials into a worker Ray then
+    reuses. That makes the check a precondition, not a post-hoc test of the
+    result. Locks in the documented AWS-only scope for this PR."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import ResolvedSource
+
+    catalog = _FakeCatalog(
+        ResolvedSource(storage_options={"AZURE_STORAGE_SAS_TOKEN": "x"})
+    )
+    datasink = DeltaDatasink(
+        temp_delta_path, catalog=catalog, table_identifier="main.db.tbl"
+    )
+
+    assert datasink._refresh_worker_filesystem() is False
+    assert datasink._filesystem is None
+    assert catalog.calls == []
+
+
+def test_worker_retry_retries_transient_error_without_catalog(temp_delta_path):
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    datasink = DeltaDatasink(temp_delta_path)
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise Exception("AWS Error ExpiredToken during PutObject")
+        return "ok"
+
+    assert (
+        datasink._with_retry(
+            flaky,
+            description="test",
+            refresh=datasink._refresh_worker_filesystem,
+            retry_auth_errors=datasink._worker_retry_can_change_credentials(),
+        )
+        == "ok"
+    )
+    assert attempts["n"] == 2
+
+
+def test_worker_retry_does_not_retry_unrefreshable_auth_error(temp_delta_path):
+    """End-to-end: an auth error a worker can't refresh from raises on the
+    *first* attempt rather than being retried.
+
+    With an Azure-shaped catalog response there is no fresh credential a worker
+    can apply, so retrying can only fail identically -- and each attempt would
+    otherwise re-call ``catalog.resolve()``, hitting the catalog's REST API
+    repeatedly and (before the precondition check) re-leaking credentials into
+    the worker's environment every time. The error propagating immediately is
+    also the behavior this feature promises for unsupported shapes: the same as
+    if credential refresh didn't exist."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import ResolvedSource
+
+    catalog = _FakeCatalog(
+        ResolvedSource(storage_options={"AZURE_STORAGE_SAS_TOKEN": "x"})
+    )
+    datasink = DeltaDatasink(
+        temp_delta_path, catalog=catalog, table_identifier="main.db.tbl"
+    )
+
+    attempts = {"n": 0}
+
+    def always_fails():
+        attempts["n"] += 1
+        raise Exception("AuthenticationFailed: token expired")
+
+    with pytest.raises(Exception, match="AuthenticationFailed"):
+        datasink._with_retry(
+            always_fails,
+            description="test",
+            refresh=datasink._refresh_worker_filesystem,
+            retry_auth_errors=datasink._worker_retry_can_change_credentials(),
+        )
+    assert attempts["n"] == 1
+    assert catalog.calls == []
+
+
+def test_worker_retry_does_not_retry_auth_error_with_fixed_filesystem(
+    temp_delta_path,
+):
+    """An auth error must not be retried when the caller pinned a filesystem.
+
+    Retrying a worker auth error is only useful because each attempt re-runs
+    ``_resolve_worker_filesystem``, rebuilding the filesystem and so
+    re-resolving the ambient cloud SDK credential chain. A caller-supplied
+    ``filesystem=`` is returned as-is on every attempt, so its credentials
+    can never change and retrying just burns the full backoff schedule before
+    failing with the same error."""
+    import pyarrow.fs as pafs
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    datasink = DeltaDatasink(
+        temp_delta_path,
+        filesystem=pafs.S3FileSystem(
+            access_key="a", secret_key="b", region="us-west-2"
+        ),
+    )
+    attempts = {"n": 0}
+
+    def always_fails():
+        attempts["n"] += 1
+        raise Exception("AWS Error ExpiredToken during PutObject")
+
+    with pytest.raises(Exception, match="ExpiredToken"):
+        datasink._with_retry(
+            always_fails,
+            description="test",
+            refresh=datasink._refresh_worker_filesystem,
+            retry_auth_errors=datasink._worker_retry_can_change_credentials(),
+        )
+    assert attempts["n"] == 1
+
+
+def test_worker_retry_still_retries_auth_error_without_fixed_filesystem(
+    temp_delta_path,
+):
+    """The complement of the test above: with nothing pinned, each attempt
+    rebuilds the filesystem, so an auth error stays retryable."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+
+    datasink = DeltaDatasink(temp_delta_path)
+    assert datasink._worker_retry_can_change_credentials() is True
+
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise Exception("AWS Error ExpiredToken during PutObject")
+        return "ok"
+
+    assert (
+        datasink._with_retry(
+            flaky,
+            description="test",
+            refresh=datasink._refresh_worker_filesystem,
+            retry_auth_errors=datasink._worker_retry_can_change_credentials(),
+        )
+        == "ok"
+    )
+    assert attempts["n"] == 2
+
+
+# ----------------------------------------------------------------------
+# catalog= interaction at the datasink level.
+#
+# The ``catalog=`` *wiring* on ``Dataset.write_delta`` (resolve, merge,
+# reject-conflicting-filesystem) is covered in ``test_catalog.py`` alongside
+# the equivalent write_parquet/write_iceberg tests. What's left here is
+# datasink-internal behavior that has no analogue in the other writers.
+# ----------------------------------------------------------------------
+
+
+def test_datasink_with_catalog_is_picklable(temp_delta_path):
+    """The datasink must survive being pickled to a worker with a live
+    catalog reference attached (the mechanism that lets workers re-resolve
+    catalog-vended credentials on their own)."""
+    import pickle
+
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import ResolvedSource
+
+    catalog = _FakeCatalog(ResolvedSource(path=temp_delta_path))
+    datasink = DeltaDatasink(
+        temp_delta_path, catalog=catalog, table_identifier="main.db.tbl"
+    )
+
+    restored = pickle.loads(pickle.dumps(datasink))
+
+    assert restored._catalog is not None
+    assert restored._table_identifier == "main.db.tbl"
+
+
+def test_catalog_without_table_identifier_rejected(temp_delta_path):
+    """``catalog`` needs the identifier the catalog resolves, which ``path``
+    isn't -- by then it's the physical location resolution produced.
+
+    There used to be a silent fallback (``table or path``), which just deferred
+    the failure into the refresh path as ``resolve('<physical URI>')``. Fail at
+    construction instead."""
+    from ray.data._internal.datasource.delta_datasink import DeltaDatasink
+    from ray.data.catalog import ResolvedSource
+
+    catalog = _FakeCatalog(ResolvedSource(path=temp_delta_path))
+    with pytest.raises(ValueError, match="table_identifier is required"):
+        DeltaDatasink(temp_delta_path, catalog=catalog)
+
+    # Without a catalog it's simply unused, so omitting it is fine.
+    assert DeltaDatasink(temp_delta_path)._table_identifier is None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_write_delta_catalog_e2e.py
+++ b/python/ray/data/tests/datasource/test_write_delta_catalog_e2e.py
@@ -1,0 +1,240 @@
+"""End-to-end ``write_delta(catalog=...)`` tests over a real S3-compatible endpoint.
+
+Everything else covering ``catalog=`` runs in-process against a test double.
+These tests instead drive the whole path for real: a catalog resolves the table
+to an ``s3://`` location and vends credentials, the datasink (with the catalog
+attached) is pickled out to real Ray worker processes, each worker writes
+Parquet over S3, and the driver commits one Delta transaction -- then the table
+is read back and compared.
+
+Storage is a local ``moto`` S3 server, via the ``s3_server`` fixture the rest of
+the Ray Data suite already uses. That makes these tests hermetic; it also means
+they only run where ``moto_server`` is installed, and skip cleanly otherwise.
+
+Deliberately *not* covered here: recovery from a worker-side authentication
+failure. moto does not enforce credentials -- writing with deliberately invalid
+keys succeeds against it -- so there is no way to provoke a genuine auth error.
+Loosening ``AUTH_ERROR_PATTERNS`` to match some other error would only make a
+test pass, so that behavior stays unit-tested in ``test_write_delta.py``
+(``test_worker_refresh_via_catalog_succeeds_for_aws_shaped_response`` and
+friends) where the failure can be injected honestly.
+"""
+
+import uuid
+
+import pytest
+
+import ray
+from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.tests.catalog_test_utils import FakeCatalog
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+pa = pytest.importorskip("pyarrow")
+pytest.importorskip("deltalake")
+
+from packaging.version import parse as parse_version  # noqa: E402
+
+_pa_version = get_pyarrow_version()
+pytestmark = pytest.mark.skipif(
+    _pa_version is None or _pa_version < parse_version("15.0.0"),
+    reason="deltalake requires pyarrow >= 15.0",
+)
+
+# On pyarrow<19 ``read_delta`` hands partition columns back as the raw Hive path
+# strings rather than their declared types, so a partitioned round trip can't be
+# value-compared there. See the longer note in ``test_write_delta.py``; it's a
+# read-path gap, unrelated to the catalog wiring this file covers.
+_skip_without_typed_partition_values = pytest.mark.skipif(
+    _pa_version is None or _pa_version < parse_version("19.0.0"),
+    reason="read_delta returns partition values as untyped Hive path strings on pyarrow<19",
+)
+
+
+@pytest.fixture
+def s3_delta_table(aws_credentials, s3_server):
+    """A fresh S3 bucket on the local moto server, plus the ``storage_options``
+    needed to reach it.
+
+    Yields ``(path, storage_options)``. ``AWS_ALLOW_HTTP`` is required because
+    ``deltalake``'s Rust object_store refuses a non-TLS endpoint otherwise, and
+    ``AWS_ENDPOINT_URL`` is what points both the driver's commit and the
+    workers' Parquet writes at moto rather than real AWS.
+    """
+    import pyarrow.fs as pafs
+
+    bucket = f"delta-e2e-{uuid.uuid4().hex[:12]}"
+    storage_options = {
+        "AWS_ACCESS_KEY_ID": aws_credentials["access_key"],
+        "AWS_SECRET_ACCESS_KEY": aws_credentials["secret_key"],
+        "AWS_SESSION_TOKEN": aws_credentials["session_token"],
+        "AWS_REGION": "us-west-2",
+        "AWS_ENDPOINT_URL": s3_server,
+        "AWS_ALLOW_HTTP": "true",
+    }
+
+    fs = pafs.S3FileSystem(
+        access_key=aws_credentials["access_key"],
+        secret_key=aws_credentials["secret_key"],
+        session_token=aws_credentials["session_token"],
+        region="us-west-2",
+        endpoint_override=s3_server,
+        allow_bucket_creation=True,
+        allow_bucket_deletion=True,
+    )
+    fs.create_dir(bucket)
+    yield f"s3://{bucket}/tbl", storage_options
+
+
+def _catalog_for(path, storage_options):
+    """A catalog that vends ``path`` plus an endpoint-aware S3 filesystem.
+
+    Mirrors what ``DatabricksUnityCatalog`` returns for an AWS-backed Delta
+    table -- an explicit, picklable filesystem carrying the credentials -- which
+    is the shape the datasink's worker-side handling depends on. The real class
+    can't be used verbatim here because ``_build_s3_filesystem`` has no endpoint
+    override, so it would always target real AWS; the UC translation itself is
+    covered in ``test_catalog.py`` instead.
+    """
+    import pyarrow.fs as pafs
+
+    from ray.data.catalog import ResolvedSource
+
+    fs = pafs.S3FileSystem(
+        access_key=storage_options["AWS_ACCESS_KEY_ID"],
+        secret_key=storage_options["AWS_SECRET_ACCESS_KEY"],
+        session_token=storage_options["AWS_SESSION_TOKEN"],
+        region=storage_options["AWS_REGION"],
+        endpoint_override=storage_options["AWS_ENDPOINT_URL"],
+    )
+    return FakeCatalog(
+        ResolvedSource(path=path, filesystem=fs, storage_options=storage_options)
+    )
+
+
+def _read_back(path, storage_options):
+    return sorted(
+        ray.data.read_delta(path, storage_options=storage_options).take_all(),
+        key=lambda r: r["id"],
+    )
+
+
+def test_multi_block_write_via_catalog_round_trips(
+    ray_start_regular_shared, s3_delta_table
+):
+    """The full distributed path: resolve on the driver, ship the datasink (and
+    catalog) to several real workers, write Parquet to S3 in parallel, commit
+    once, read back.
+
+    This is the test that would have caught ``_write_parquet`` deriving the
+    table root via ``FileSystem.from_uri``: that also *builds* a filesystem, so
+    for an ``s3://`` URI it resolved the bucket against real AWS and failed
+    outright against any S3-compatible endpoint.
+    """
+    path, storage_options = s3_delta_table
+    catalog = _catalog_for(path, storage_options)
+    rows = [{"id": i, "v": f"r{i}"} for i in range(12)]
+
+    ray.data.from_items(rows, override_num_blocks=4).write_delta(
+        "main.db.tbl", catalog=catalog
+    )
+
+    from ray.data.catalog import CatalogAccessMode, ReaderFormat
+
+    assert catalog.calls == [
+        ("main.db.tbl", ReaderFormat.DELTA, CatalogAccessMode.WRITE)
+    ]
+    assert _read_back(path, storage_options) == rows
+
+
+@_skip_without_typed_partition_values
+def test_partitioned_write_via_catalog_round_trips(
+    ray_start_regular_shared, s3_delta_table
+):
+    """Partitioned writes through a catalog round-trip too.
+
+    Worth covering separately: Delta takes a partition column's value from the
+    ``AddAction`` metadata the workers report, not from the Parquet file, so the
+    partition values only survive if that metadata makes it back to the driver
+    intact across the S3 write path.
+    """
+    path, storage_options = s3_delta_table
+    catalog = _catalog_for(path, storage_options)
+    rows = [{"id": i, "year": 2024 + (i % 2), "v": f"r{i}"} for i in range(8)]
+
+    ray.data.from_items(rows, override_num_blocks=2).write_delta(
+        "main.db.tbl", catalog=catalog, partition_by=["year"]
+    )
+
+    out = _read_back(path, storage_options)
+    assert out == rows
+    assert {r["year"] for r in out} == {2024, 2025}
+
+
+def test_append_via_catalog_accumulates(ray_start_regular_shared, s3_delta_table):
+    """A second catalog-backed APPEND adds to the table rather than replacing
+    it, and re-resolves the catalog for the new write."""
+    path, storage_options = s3_delta_table
+    catalog = _catalog_for(path, storage_options)
+
+    first = [{"id": i, "v": "a"} for i in range(4)]
+    second = [{"id": i + 100, "v": "b"} for i in range(4)]
+    ray.data.from_items(first).write_delta("main.db.tbl", catalog=catalog)
+    ray.data.from_items(second).write_delta("main.db.tbl", catalog=catalog)
+
+    assert len(catalog.calls) == 2
+    assert _read_back(path, storage_options) == first + second
+
+
+def test_overwrite_via_catalog_replaces(ray_start_regular_shared, s3_delta_table):
+    """OVERWRITE through a catalog replaces the table's data over S3."""
+    from ray.data import SaveMode
+
+    path, storage_options = s3_delta_table
+    catalog = _catalog_for(path, storage_options)
+
+    ray.data.from_items([{"id": i, "v": "old"} for i in range(6)]).write_delta(
+        "main.db.tbl", catalog=catalog
+    )
+    new_rows = [{"id": i, "v": "new"} for i in range(2)]
+    ray.data.from_items(new_rows).write_delta(
+        "main.db.tbl", catalog=catalog, mode=SaveMode.OVERWRITE
+    )
+
+    assert _read_back(path, storage_options) == new_rows
+
+
+def test_catalog_vended_credentials_reach_workers(
+    ray_start_regular_shared, s3_delta_table, monkeypatch
+):
+    """Workers must authenticate with the catalog-vended filesystem, not with
+    whatever credentials happen to be in their own environment.
+
+    Ambient credentials are cleared from the driver's environment before the
+    write, so nothing a worker inherits could substitute for the vended ones. A
+    passing write means the credentials genuinely travelled with the datasink.
+    """
+    path, storage_options = s3_delta_table
+    catalog = _catalog_for(path, storage_options)
+
+    for key in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_SECURITY_TOKEN",
+        "AWS_ENDPOINT_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    rows = [{"id": i, "v": f"r{i}"} for i in range(6)]
+    ray.data.from_items(rows, override_num_blocks=3).write_delta(
+        "main.db.tbl", catalog=catalog
+    )
+
+    assert _read_back(path, storage_options) == rows
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_catalog.py
+++ b/python/ray/data/tests/test_catalog.py
@@ -12,12 +12,12 @@ import pytest
 
 import ray
 from ray.data.catalog import (
-    Catalog,
     CatalogAccessMode,
     DatabricksUnityCatalog,
     ReaderFormat,
     ResolvedSource,
 )
+from ray.data.tests.catalog_test_utils import FakeCatalog
 
 # conftest provides ray_start_regular_shared
 from ray.data.tests.conftest import *  # noqa: F401,F403
@@ -260,16 +260,10 @@ def test_resolve_gcp_delta_raises(uc_catalog, isolated_env):
 # ---------------------------------------------------------------------------
 
 
-class _FakeCatalog(Catalog):
-    """Returns a pre-baked ResolvedSource; records (table, reader, mode) calls."""
-
-    def __init__(self, resolved):
-        self._resolved = resolved
-        self.calls = []
-
-    def resolve(self, table, *, reader, mode=CatalogAccessMode.READ):
-        self.calls.append((table, reader, mode))
-        return self._resolved
+# Defined in an importable module rather than here so it survives pickling to a
+# Ray worker -- ``write_delta`` ships the catalog to its write tasks, and a class
+# defined in a pytest module can't be imported back by name there.
+_FakeCatalog = FakeCatalog
 
 
 def test_read_parquet_with_catalog(ray_start_regular_shared, tmp_path):
@@ -487,6 +481,89 @@ def test_write_iceberg_rejects_catalog_kwargs_with_catalog(ray_start_regular_sha
             catalog_kwargs={"type": "sql", "uri": "explicit"},
         )
     assert catalog.calls == []  # rejected before the catalog is consulted
+
+
+def test_write_delta_with_catalog(ray_start_regular_shared, tmp_path):
+    # write_delta resolves the table identifier on the driver and writes to the
+    # catalog-resolved physical location, requesting WRITE access.
+    deltalake = pytest.importorskip("deltalake")  # noqa: F841
+    out = str(tmp_path / "delta-out")
+    catalog = _FakeCatalog(ResolvedSource(path=out))
+
+    ray.data.range(3).write_delta("main.db.tbl", catalog=catalog)
+
+    assert catalog.calls == [
+        ("main.db.tbl", ReaderFormat.DELTA, CatalogAccessMode.WRITE)
+    ]
+    ds = ray.data.read_delta(out)
+    assert sorted(r["id"] for r in ds.take_all()) == [0, 1, 2]
+
+
+def test_write_delta_catalog_rejects_filesystem(ray_start_regular_shared):
+    # Passing both `filesystem` and `catalog` is rejected, matching write_parquet:
+    # a silent credential swap is a bigger hazard on a write than on a read.
+    catalog = _FakeCatalog(ResolvedSource(path="s3://bucket/prefix"))
+    with pytest.raises(ValueError, match="filesystem"):
+        ray.data.range(1).write_delta(
+            "main.db.tbl", catalog=catalog, filesystem=pafs.LocalFileSystem()
+        )
+
+
+def test_write_delta_catalog_merges_storage_options_user_wins(
+    ray_start_regular_shared, tmp_path
+):
+    # The catalog supplies defaults; the caller's own storage_options override
+    # them. Asserted on the datasink rather than end-to-end, since the merged
+    # dict is what gets forwarded to deltalake.
+    out = str(tmp_path / "delta-out")
+    catalog = _FakeCatalog(
+        ResolvedSource(
+            path=out,
+            storage_options={
+                "AWS_SESSION_TOKEN": "catalog-token",
+                "AWS_REGION": "catalog-region",
+            },
+        )
+    )
+
+    with mock.patch(
+        "ray.data.dataset.DeltaDatasink"
+    ) as datasink_cls, mock.patch.object(ray.data.Dataset, "write_datasink"):
+        ray.data.range(1).write_delta(
+            "main.db.tbl",
+            catalog=catalog,
+            storage_options={"AWS_REGION": "user-region"},
+        )
+
+    _, kwargs = datasink_cls.call_args
+    assert kwargs["storage_options"] == {
+        "AWS_SESSION_TOKEN": "catalog-token",
+        "AWS_REGION": "user-region",
+    }
+    # The caller's original values are threaded through separately so a later
+    # credential refresh re-merges against them rather than the merged dict.
+    assert kwargs["user_storage_options"] == {"AWS_REGION": "user-region"}
+
+
+def test_write_delta_with_unity_catalog_builds_s3_filesystem(uc_catalog, isolated_env):
+    # The real DatabricksUnityCatalog (SDK mocked, no workspace hit) must hand
+    # write_delta an S3FileSystem carrying the vended session token. That
+    # explicit filesystem is the AWS-shaped signal a worker uses to decide a
+    # credential refresh is safe -- see DeltaDatasink._can_refresh_worker_credentials.
+    patcher = _mock_uc_sdk(storage_location="s3://bucket/tbl")
+    try:
+        with mock.patch(
+            "ray.data.dataset.DeltaDatasink"
+        ) as datasink_cls, mock.patch.object(ray.data.Dataset, "write_datasink"):
+            ray.data.range(1).write_delta("main.sales.txns", catalog=uc_catalog)
+    finally:
+        patcher.stop()
+
+    _, kwargs = datasink_cls.call_args
+    assert isinstance(kwargs["filesystem"], pafs.S3FileSystem)
+    assert kwargs["catalog"] is uc_catalog
+    # The identifier, not the resolved physical path -- a refresh re-resolves it.
+    assert kwargs["table_identifier"] == "main.sales.txns"
 
 
 # ---------------------------------------------------------------------------

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -6,9 +6,15 @@ from typing import Callable
 from benchmark import Benchmark
 
 import ray
+from ray.data import SaveMode
 
 # Add a random prefix to avoid conflicts between different runs.
 WRITE_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
+# Region of the ray-data-write-benchmark bucket. write_parquet resolves this
+# automatically, but deltalake's Rust S3 client doesn't follow a region
+# redirect -- it defaults to us-east-1 and fails outright ("Received redirect
+# without LOCATION") against a bucket hosted elsewhere unless told explicitly.
+WRITE_DELTA_STORAGE_OPTIONS = {"AWS_REGION": "us-west-2"}
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,8 +43,31 @@ def parse_args() -> argparse.Namespace:
         metavar=("feature", "label"),
     )
     consume_group.add_argument("--write", action="store_true")
+    consume_group.add_argument("--write-delta", action="store_true")
 
-    return parser.parse_args()
+    # Modifiers for --write-delta (not alternative consume actions, so they
+    # live outside the mutually-exclusive group above).
+    parser.add_argument(
+        "--write-delta-mode",
+        choices=["append", "overwrite"],
+        default="append",
+        help="SaveMode to use with --write-delta.",
+    )
+    parser.add_argument(
+        "--write-delta-partition-by",
+        type=str,
+        default=None,
+        help="Column to Hive-partition the Delta table by, when using --write-delta.",
+    )
+
+    args = parser.parse_args()
+    if not args.write_delta and (
+        args.write_delta_mode != "append" or args.write_delta_partition_by
+    ):
+        parser.error(
+            "--write-delta-mode/--write-delta-partition-by require --write-delta."
+        )
+    return args
 
 
 def main(args):
@@ -53,6 +82,13 @@ def main(args):
 
         # Report arguments for the benchmark.
         return vars(args)
+
+    if args.write_delta and args.write_delta_mode == "overwrite":
+        # Populate the table once first (same source/scale as the timed run
+        # below) so "main" genuinely overwrites existing data instead of
+        # creating an empty table -- an OVERWRITE against a not-yet-existing
+        # table is just a create, which isn't the interesting case to time.
+        benchmark.run_fn("setup_populate", benchmark_fn)
 
     benchmark.run_fn("main", benchmark_fn)
     benchmark.write_result()
@@ -109,6 +145,26 @@ def get_consume_fn(args: argparse.Namespace) -> Callable[[ray.data.Dataset], Non
 
         def consume_fn(ds):
             ds.write_parquet(WRITE_PATH)
+
+    elif args.write_delta:
+
+        def consume_fn(ds):
+            mode = (
+                SaveMode.OVERWRITE
+                if args.write_delta_mode == "overwrite"
+                else SaveMode.APPEND
+            )
+            partition_by = (
+                [args.write_delta_partition_by]
+                if args.write_delta_partition_by
+                else None
+            )
+            ds.write_delta(
+                WRITE_PATH,
+                mode=mode,
+                partition_by=partition_by,
+                storage_options=WRITE_DELTA_STORAGE_OPTIONS,
+            )
 
     else:
         assert False, f"Invalid consume arguments: {args}"

--- a/release/ray_release/byod/byod_install_deltalake.sh
+++ b/release/ray_release/byod/byod_install_deltalake.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -exo pipefail
+
+pip3 install --no-cache-dir "deltalake==1.5.0"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -119,6 +119,57 @@
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet --write
 
+- name: write_delta
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet --write-delta
+
+- name: write_delta_smoke
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+    cluster_compute: fixed_size_1_cpu_compute.yaml
+  run:
+    timeout: 600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf10/lineitem --format parquet --write-delta
+
+- name: write_delta_overwrite
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf100/lineitem --format parquet --write-delta
+      --write-delta-mode overwrite
+
+- name: write_delta_partitioned
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      post_build_script: byod_install_deltalake.sh
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet --write-delta
+      --write-delta-partition-by column08
+
 ###############
 # Iceberg tests
 ###############


### PR DESCRIPTION
## Summary

Third PR in the `write_delta` stack, on top of #64923 (core) and #64925 (benchmark) —
**only the top commit `a86f61c896` is new here.** It adds:

**1. Deterministic write filenames** (prerequisite fix). `_write_parquet` generated a fresh
`uuid4()` per call, so a retry wrote under a *different* name and leaked orphan Parquet
files instead of overwriting. Now reuses `ctx.kwargs[WRITE_UUID_KWARG_NAME]` — the same
per-job UUID `ParquetDatasink` relies on, fixed once at `MapOperator.create()` time, so it
survives full task retries. This had to land first; everything below adds retries.

**2. Credential refresh on an auth error,** driver and worker. There was previously no retry
logic in this file, so a write outliving its credential TTL (~1h for STS / Azure AD /
vended tokens) failed partway with no recovery. Adds `is_auth_error()` plus `_with_retry`
(driver) and `_with_worker_retry` (worker), both wrapping
`ray._common.retry.call_with_retry` rather than hand-rolling a loop. Without a catalog a
plain retry *is* the refresh: PyArrow and `deltalake`'s `object_store` re-resolve the
standard cloud SDK credential chain on every new filesystem/`DeltaTable`.

**3. `catalog=` on `Dataset.write_delta`,** reusing the already-shipped `ray.data.catalog`
module (`Catalog`, `ResolvedSource`, `ReaderFormat`, `CatalogAccessMode`) exactly as
`read_delta` / `write_parquet` / `write_iceberg` do — no new catalog classes or exports. The
new part: on an auth error the datasink re-calls `catalog.resolve()` for a fresh vended
credential **on workers as well as the driver**, which means shipping the (picklable)
`Catalog` in the datasink state. Also fixes a bug found while wiring that up — re-merging
resolved `storage_options` against the *current* dict let a stale token keep winning for
exactly the keys `resolve()` had just updated, making every later refresh a no-op; each
refresh now merges against the caller's original values.

## API changes

`write_delta` gains mutually-exclusive `catalog=` / `filesystem=` kwargs (with `catalog`,
`path` is the table identifier, e.g. `"main.schema.table"`). New `DataContext.delta_config`
(`DeltaConfig`, mirroring `IcebergConfig`) for retry attempts/backoff plus a
`credential_refresh_enabled` opt-out, with `RAY_DATA_DELTA_COMMIT_*` env defaults. No
existing signature or behavior changes; `ray/data/catalog.py` is untouched.

## Scope and disclosed limitations

Worker-side catalog refresh is **AWS-only, by design.** Unity Catalog returns an explicit
picklable PyArrow filesystem for AWS, but delivers Azure's SAS token by mutating the
calling process's environment without restoring it — on a reused Ray worker that would leak
live credentials into whatever unrelated task runs there next. Worker refresh therefore
proceeds only when `resolve()` returns an explicit filesystem; otherwise the auth error
propagates, identical to today. Fixing Azure means changing the shared `catalog.py`, which
affects every existing `catalog=` consumer (`read_delta`, `write_parquet`, `write_iceberg`,
`read_parquet`) — deferred to its own PR rather than bundled here.

Also disclosed: workers call `catalog.resolve()` independently with no cross-worker
coordination or caching, and the `Catalog`'s credential material travels through the object
store as part of the task's serialized args.

## Test plan

15 new tests (78 in the file): filename determinism across a retry, `is_auth_error`
classification, driver + worker retry/refresh for both the ambient and catalog-vended paths
including the AWS-succeeds / Azure-declines boundary, the
refresh-preserves-user-`storage_options` regression, the
`credential_refresh_enabled=False` opt-out, `catalog=` resolve/merge/conflict-rejection,
and datasink picklability with a live catalog.

- `pytest python/ray/data/tests/datasource/test_write_delta.py` — 78 passed.
- `pytest python/ray/data/tests/test_catalog.py` — 30 passed (existing suite unaffected).
- `pytest python/ray/data/tests/datasource/test_delta.py` — 15 passed (read side, untouched).
- pyrefly 0.51.0 via `ci/lint/pyrefly-check.sh`, ruff 0.8.4, black 22.10.0 — clean.

No live-cloud or live-Unity-Catalog run: the catalog paths use a `_FakeCatalog` double
(subclassing the real `Catalog`, like the one in `test_catalog.py`) plus monkeypatched auth
failures.

## Related

Stacked on #64923 and #64925. Since both are still open, the diff shown here is cumulative
— only the top commit is new. Not a duplicate: no other open PR adds `catalog=` or
credential refresh to `write_delta`.

## AI assistance disclosure

This PR was developed with AI assistance (Claude). All changes were reviewed and are
defended by the submitting human.