### PR TITLE
[core][uv] Keep the command intact when it has "--option=value" arguments

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -240,17 +240,28 @@ def _parse_args(
     Replacement for parser.parse_args that handles unknown arguments
     by keeping them in the command list instead of erroring and
     discarding them.
+
+    The returned command is always a suffix of 'args', so the caller can
+    recover the 'uv run' arguments from its length.
     """
-    parser.rargs = args
+    rargs = list(args)
+    parser.rargs = rargs
     parser.largs = []
     options = parser.get_default_values()
     try:
-        parser._process_args(parser.largs, parser.rargs, options)
+        parser._process_args(parser.largs, rargs, options)
     except optparse.BadOptionError as err:
-        # If we hit an argument that is not recognized, we put it
-        # back into the unconsumed arguments
-        parser.rargs = [err.opt_str] + parser.rargs
-    return options, parser.rargs
+        # We hit an argument that is not recognized, so it belongs to the
+        # command rather than to 'uv run'. optparse has already removed it from
+        # rargs, and for the "--opt=value" form it put the bare "value" back, so
+        # we cannot just prepend err.opt_str to recover the original arguments.
+        # Instead, locate the offending argument in args and cut there.
+        boundary = len(args) - len(rargs)
+        if not (rargs and args[boundary] == f"{err.opt_str}={rargs[0]}"):
+            # The argument was removed entirely rather than split at the "=".
+            boundary -= 1
+        return options, list(args[boundary:])
+    return options, rargs
 
 
 def _check_working_dir_files(
@@ -352,19 +363,13 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         )
 
     # Extract the arguments uv_run_args of 'uv run' that are not part of the command.
-    args_to_parse = cmdline[2:]  # Remove 'uv run' prefix
-    original_length = len(
-        args_to_parse
-    )  # Save before parsing (parser modifies in-place)
-
     parser = _create_uv_run_parser()
-    (options, command) = _parse_args(parser, args_to_parse)
+    (options, command) = _parse_args(parser, cmdline[2:])  # Remove 'uv run' prefix
 
-    # Calculate how many arguments were consumed by the parser.
     # Since disable_interspersed_args() is set, parsing stops at the first
-    # unrecognized argument (the command), so all consumed args are uv options.
-    args_consumed = original_length - len(command)
-    uv_run_args = cmdline[: 2 + args_consumed]
+    # argument that is not a uv option, so the returned command is a suffix of
+    # cmdline and everything before it belongs to 'uv run'.
+    uv_run_args = cmdline[: len(cmdline) - len(command)]
 
     # Remove the "--directory" argument since it has already been taken into
     # account when setting the current working directory of the current process.

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -318,6 +318,36 @@ def test_uv_run_runtime_env_hook():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")
+def test_uv_run_runtime_env_hook_option_with_equals(monkeypatch):
+    # Arguments of the command written as "--option=value" must not cut the
+    # 'uv run' arguments short, see
+    # https://github.com/ray-project/ray/issues/62650. Ray Client passes all of
+    # the arguments of its server in this form.
+    from ray._private.runtime_env import uv_runtime_env_hook
+
+    monkeypatch.setattr(
+        uv_runtime_env_hook,
+        "_get_uv_run_cmdline",
+        lambda: [
+            "uv",
+            "run",
+            "--no-project",
+            "-m",
+            "ray.util.client.server",
+            "--address=127.0.0.1:6379",
+            "--mode=specific-server",
+        ],
+    )
+    monkeypatch.setenv("UV_PYTHON", sys.executable)
+
+    runtime_env = uv_runtime_env_hook.hook({})
+
+    assert runtime_env["py_executable"] == (
+        f"uv run --no-project --python {sys.executable} python"
+    )
+
+
 def test_uv_run_parser():
     from ray._private.runtime_env.uv_runtime_env_hook import (
         _create_uv_run_parser,
@@ -366,6 +396,40 @@ def test_uv_run_parser():
     assert options.extras == ["vllm"]
     assert options.module == "my_module.submodule"
     assert command == ["--model", "Qwen/Qwen3-32B"]
+
+    # The same arguments written as "--option=value". optparse consumes the
+    # "value" half of the argument before it reports the option as unknown, so
+    # the command used to come back with "--model" and "Qwen/Qwen3-32B" as two
+    # separate entries and the caller then cut the 'uv run' arguments one
+    # argument short (https://github.com/ray-project/ray/issues/62650).
+    options, command = _parse_args(
+        parser,
+        [
+            "--isolated",
+            "--extra=vllm",
+            "-m",
+            "my_module.submodule",
+            "--model=Qwen/Qwen3-32B",
+        ],
+    )
+    assert options.isolated
+    assert options.extras == ["vllm"]
+    assert options.module == "my_module.submodule"
+    assert command == ["--model=Qwen/Qwen3-32B"]
+
+    # An unknown option in "--option=value" form right after 'uv run'.
+    options, command = _parse_args(parser, ["--model=Qwen/Qwen3-32B", "script.py"])
+    assert command == ["--model=Qwen/Qwen3-32B", "script.py"]
+
+    # An unknown option in "--option=value" form with an empty value.
+    options, command = _parse_args(parser, ["--no-dev", "--model="])
+    assert options.no_dev
+    assert command == ["--model="]
+
+    # An unknown option whose value itself looks like "--option=value".
+    options, command = _parse_args(parser, ["--no-dev", "--model", "--model=x"])
+    assert options.no_dev
+    assert command == ["--model", "--model=x"]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")


### PR DESCRIPTION
## Description

`uv run` currently breaks whenever the first argument of the wrapped command is written as `--option=value`.

The runtime env hook has to split the driver's command line into the part that belongs to `uv run` and the part that is the actual command. It does that by parsing the command line with an `optparse` parser that knows the `uv run` options, treating the first argument the parser doesn't recognize as the start of the command, and then recovering the `uv run` arguments by subtracting the length of that command from the original command line.

That subtraction assumes the command handed back by `_parse_args` is a suffix of the arguments it was given. It isn't, when the first unrecognized argument uses the `--option=value` form: `optparse._process_long_opt` pops the argument, splits it at the `=`, pushes the bare `value` back onto the remaining arguments, and *only then* reports the option as unknown. The command therefore comes back one entry longer than the slice it is measured against, and the `uv run` arguments are cut one argument short:

| command line | `uv_run_args` before | `uv_run_args` after |
| --- | --- | --- |
| `uv run -m ray.util.client.server --address=h:p` | `uv run -m` | `uv run -m ray.util.client.server` |
| `uv run -m ray.util.client.server --address h p` | `uv run -m ray.util.client.server` | unchanged |
| `uv run --model=x script.py` | `uv` | `uv run` |

The truncated `uv run -m` then reaches the `argparse` call just below, which fails with the error from the issue:

```
usage: __main__.py [-h] [--directory DIRECTORY] [-m MODULE]
__main__.py: error: argument -m/--module: expected one argument
```

Ray Client passes every argument of its server in the `--option=value` form (`--address=...`, `--host=...`, `--port=...`, `--mode=...`), so `uv run` combined with Ray Client fails this way every time.

## Related issues

Fixes #62650

## Additional information

`_parse_args` now returns a command that is always a suffix of the arguments it was given, by locating the unrecognized argument in the original list instead of rebuilding it from `err.opt_str`. The caller then derives the boundary directly from the command's length, which removes the `original_length`/`args_consumed` bookkeeping.

Two details worth flagging for review:

- Prepending `err.opt_str` cannot recover the original argument, because after the exception the remaining arguments look identical for `--address=h:p` and `--address h:p`. So the boundary is decided by checking whether the original argument at that position is exactly `f"{err.opt_str}={rargs[0]}"`. Comparing the whole reconstructed argument rather than using `startswith` matters for a case like `--model --model=x`, where the *value* of a space-separated unknown option itself looks like `option=value`.
- `_parse_args` now copies the list it is given instead of parsing it in place, so the caller no longer has to snapshot its length before parsing.

### Testing

- `test_uv_run_parser` gains the `--option=value` forms, including an empty value, an unknown option in that form directly after `uv run`, and the `--model --model=x` case above.
- `test_uv_run_runtime_env_hook_option_with_equals` is a new test covering the reported failure at the `hook()` level, using a Ray Client style command line. It stubs `_get_uv_run_cmdline`, so it needs neither a cluster nor a real `uv` process.

Both tests fail on master (the new one with the exact `argument -m/--module: expected one argument` above) and pass with this change:

```
$ pytest python/ray/tests/test_runtime_env_uv_run.py -k "test_uv_run_parser or option_with_equals"
2 passed, 8 deselected
```

I also replayed every command line the existing tests in this file use through the old and the new boundary logic and confirmed they agree on all of them, so the change only affects the `--option=value` case that was broken.

`ruff check`, `ruff format` and `pydoclint` are clean on both files. The other tests in this file need a Ray cluster or a real `uv` subprocess, which my sandbox can't provide (`psutil.pids()` is blocked), so I'm relying on CI for those.
