### PR TITLE
[data] avoid epoch end for failued attempts

### DIFF
--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -302,6 +302,7 @@ class BatchIterator:
         self, batch: Batch, blocked_start_s: float, blocked_end_s: float
     ) -> None:
         """Attribute per-stage blocked time via overlap with the training window.
+
         Each stage's spans on ``batch.metadata.stage_timings`` are intersected
         with the training thread's blocked window ``[blocked_start_s,
         blocked_end_s]``. Overlapping spans are merged first, so the result

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -284,26 +284,24 @@ class BatchIterator:
 
         self.before_epoch_start()
 
-        try:
-            while True:
-                with self.get_next_batch_context():
-                    blocked_start_s = time.perf_counter()
-                    try:
-                        batch = next(batch_iter)
-                    except StopIteration:
-                        break
-                    blocked_end_s = time.perf_counter()
-                self._attribute_blocked_time(batch, blocked_start_s, blocked_end_s)
-                with self.yield_batch_context(batch):
-                    yield batch.data
-        finally:
-            self.after_epoch_end()
+        while True:
+            with self.get_next_batch_context():
+                blocked_start_s = time.perf_counter()
+                try:
+                    batch = next(batch_iter)
+                except StopIteration:
+                    break
+                blocked_end_s = time.perf_counter()
+            self._attribute_blocked_time(batch, blocked_start_s, blocked_end_s)
+            with self.yield_batch_context(batch):
+                yield batch.data
+
+        self.after_epoch_end()
 
     def _attribute_blocked_time(
         self, batch: Batch, blocked_start_s: float, blocked_end_s: float
     ) -> None:
         """Attribute per-stage blocked time via overlap with the training window.
-
         Each stage's spans on ``batch.metadata.stage_timings`` are intersected
         with the training thread's blocked window ``[blocked_start_s,
         blocked_end_s]``. Overlapping spans are merged first, so the result


### PR DESCRIPTION
## Description
We don't want to call aftter_epoch_end for failed epochs because the function right now assumes successful epoch

## Related issues

https://github.com/ray-project/ray/pull/64994 originally made this change, but the PR evolved and we didn't actually need it anymore. Also caused a semantic change because previously this was interpreted as "after epoch success." But with the try/finally, it also triggers on breaks and errors.