### PR TITLE
[cherry-pick][llm] Add Ray Serve LLM SGLang metrics dashboard (#64797)

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_sglang_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_sglang_dashboard_panels.py
@@ -1,0 +1,402 @@
+# ruff: noqa: E501
+
+from ray.dashboard.modules.metrics.dashboards.common import (
+    DashboardConfig,
+    GridPos,
+    Panel,
+    Row,
+    Target,
+)
+
+# ---------------------------------------------------------------------------
+# Reusable PromQL fragments
+# ---------------------------------------------------------------------------
+# SGLang emits two metric workers per replica: the tokenizer_manager (in the Serve
+# replica actor) emits token/latency metrics, and the rank-0 scheduler actor emits
+# scheduler-state/cache/KV metrics. SGLangServer tags both with
+# application/deployment/replica via extra_metric_labels, and there is exactly one
+# emitting worker per replica per metric family, so every panel groups by
+# (deployment, replica) directly.
+
+# Filter for SGLang metrics (carry model_name + deployment/replica).
+_SGLANG_FILTER = (
+    'model_name=~"$sglang_model_name", deployment=~"$deployment", {global_filters}'
+)
+
+# Filter for ray_serve_* metrics (they have no model_name label).
+_SERVE_FILTER = 'deployment=~"$deployment", {global_filters}'
+
+# Per-replica legend.
+_DEP_REPLICA = "{{deployment}}: {{replica}}"
+
+
+def _gauge(metric: str) -> str:
+    """Gauge grouped by deployment/replica."""
+    return f"sum by(deployment, replica) ({metric}{{{{{_SGLANG_FILTER}}}}})"
+
+
+def _rate(metric: str, agg_fn: str = "rate") -> str:
+    """rate()/increase() of a metric grouped by deployment/replica."""
+    return f"sum by(deployment, replica) ({agg_fn}({metric}{{{{{_SGLANG_FILTER}}}}}[$interval]))"
+
+
+def _mean(metric_base: str) -> str:
+    """Mean = sum(_sum) / sum(_count) per deployment/replica, with NaN guard."""
+    return (
+        "(\n"
+        "  (\n"
+        f"    sum by(deployment, replica) (rate({metric_base}_sum{{{{{_SGLANG_FILTER}}}}}[$interval]))\n"
+        "    /\n"
+        f"    sum by(deployment, replica) (rate({metric_base}_count{{{{{_SGLANG_FILTER}}}}}[$interval]))\n"
+        "  )\n"
+        "  and on(deployment, replica)\n"
+        "  (\n"
+        f"    sum by(deployment, replica) (rate({metric_base}_count{{{{{_SGLANG_FILTER}}}}}[$interval])) > 0\n"
+        "  )\n"
+        ")"
+    )
+
+
+def _percentile(metric_base: str, quantile: float) -> str:
+    """histogram_quantile per deployment/replica, with NaN guard."""
+    return (
+        "(\n"
+        "  histogram_quantile(\n"
+        f"    {quantile},\n"
+        f"    sum by (le, deployment, replica) (rate({metric_base}_bucket{{{{{_SGLANG_FILTER}}}}}[$interval]))\n"
+        "  )\n"
+        "  and on(deployment, replica)\n"
+        "  (\n"
+        f"    sum by(deployment, replica) (rate({metric_base}_count{{{{{_SGLANG_FILTER}}}}}[$interval])) > 0\n"
+        "  )\n"
+        ")"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Histogram helper: Mean / P50 / P90 panels for a given metric
+# ---------------------------------------------------------------------------
+def _histogram_panels(
+    metric_base: str,
+    label: str,
+    ids: tuple,
+    y: int,
+    unit: str = "s",
+    linewidth: int = 2,
+    description: str = "",
+) -> list:
+    """[Mean, P50, P90] panels for a histogram metric, grouped by deployment/replica."""
+    return [
+        Panel(
+            id=ids[0],
+            title=f"{label} -- Mean",
+            description=description,
+            unit=unit,
+            targets=[Target(expr=_mean(metric_base), legend=_DEP_REPLICA)],
+            fill=1,
+            linewidth=linewidth,
+            stack=False,
+            grid_pos=GridPos(0, y, 8, 8),
+        ),
+        Panel(
+            id=ids[1],
+            title=f"{label} -- P50",
+            description=description,
+            unit=unit,
+            targets=[Target(expr=_percentile(metric_base, 0.5), legend=_DEP_REPLICA)],
+            fill=1,
+            linewidth=linewidth,
+            stack=False,
+            grid_pos=GridPos(8, y, 8, 8),
+        ),
+        Panel(
+            id=ids[2],
+            title=f"{label} -- P90",
+            description=description,
+            unit=unit,
+            targets=[Target(expr=_percentile(metric_base, 0.9), legend=_DEP_REPLICA)],
+            fill=1,
+            linewidth=linewidth,
+            stack=False,
+            grid_pos=GridPos(16, y, 8, 8),
+        ),
+    ]
+
+
+# ===================================================================
+# Row 1: Throughput (3-per-row at y=1)
+# ===================================================================
+_throughput_panels = [
+    Panel(
+        id=2,
+        title="Requests / s",
+        description="",
+        unit="short",
+        targets=[
+            Target(
+                expr=f"sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))",
+                legend=_DEP_REPLICA,
+            ),
+            Target(
+                expr=f"sum(rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))",
+                legend="Total QPS",
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(0, 1, 8, 8),
+    ),
+    Panel(
+        id=3,
+        title="Prompt Tokens/s",
+        description="Number of prefill tokens processed per second.",
+        unit="tokens/s",
+        targets=[
+            Target(
+                expr=_rate("ray_sglang_prompt_tokens_total"),
+                legend=_DEP_REPLICA,
+            ),
+            Target(
+                expr=f"sum(rate(ray_sglang_prompt_tokens_total{{{{{_SGLANG_FILTER}}}}}[$interval]))",
+                legend="Total",
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(8, 1, 8, 8),
+    ),
+    Panel(
+        id=4,
+        title="Generation Tokens/s",
+        description="Number of generation tokens emitted per second.",
+        unit="tokens/s",
+        targets=[
+            Target(
+                expr=_rate("ray_sglang_generation_tokens_total"),
+                legend=_DEP_REPLICA,
+            ),
+            Target(
+                expr=f"sum(rate(ray_sglang_generation_tokens_total{{{{{_SGLANG_FILTER}}}}}[$interval]))",
+                legend="Total",
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(16, 1, 8, 8),
+    ),
+]
+
+# ===================================================================
+# Row 2: Latency (3x3 grid at y=18/26/34)
+# ===================================================================
+_latency_panels_list = [
+    *_histogram_panels(
+        "ray_sglang_inter_token_latency_seconds",
+        "TPOT",
+        (6, 7, 8),
+        18,
+    ),
+    *_histogram_panels(
+        "ray_sglang_time_to_first_token_seconds",
+        "TTFT",
+        (9, 10, 11),
+        26,
+    ),
+    *_histogram_panels(
+        "ray_sglang_e2e_request_latency_seconds",
+        "Request Latency",
+        (12, 13, 14),
+        34,
+        description="End-to-end request latency (in seconds).",
+    ),
+]
+
+# ===================================================================
+# Row 3: Cache (2-per-row at y=59)
+# ===================================================================
+_cache_panels = [
+    Panel(
+        id=16,
+        title="KV Cache Utilization",
+        description="Fraction of KV cache tokens currently in use.",
+        unit="percentunit",
+        targets=[
+            Target(
+                expr=_gauge("ray_sglang_token_usage"),
+                legend=_DEP_REPLICA,
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(0, 59, 12, 8),
+    ),
+    Panel(
+        id=17,
+        title="Cache Hit Rate",
+        description="Prefix cache hit rate over the selected interval.",
+        unit="percentunit",
+        targets=[
+            Target(
+                expr=_gauge("ray_sglang_cache_hit_rate"),
+                legend=_DEP_REPLICA,
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(12, 59, 12, 8),
+    ),
+]
+
+# ===================================================================
+# Row 4: Request Length (3-per-row at y=68/76)
+# ===================================================================
+_request_length_panels = [
+    *_histogram_panels(
+        "ray_sglang_prompt_tokens_histogram",
+        "Prompt Length",
+        (19, 20, 21),
+        68,
+        unit="short",
+        linewidth=1,
+    ),
+    *_histogram_panels(
+        "ray_sglang_generation_tokens_histogram",
+        "Generation Length",
+        (22, 23, 24),
+        76,
+        unit="short",
+        linewidth=1,
+    ),
+]
+
+# ===================================================================
+# Row 5: Scheduler / Request State (3-per-row at y=93/101)
+# ===================================================================
+_scheduler_panels = [
+    Panel(
+        id=26,
+        title="Scheduler: Running",
+        description="Requests currently being processed by the scheduler.",
+        unit="short",
+        targets=[
+            Target(
+                expr=_gauge("ray_sglang_num_running_reqs"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
+        grid_pos=GridPos(0, 93, 8, 8),
+    ),
+    Panel(
+        id=27,
+        title="Scheduler: Queued",
+        description="Requests waiting in the scheduler queue.",
+        unit="short",
+        targets=[
+            Target(
+                expr=_gauge("ray_sglang_num_queue_reqs"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
+        grid_pos=GridPos(8, 93, 8, 8),
+    ),
+    Panel(
+        id=28,
+        title="Scheduler: Paused",
+        description="Requests paused (e.g. for async weight reload).",
+        unit="short",
+        targets=[
+            Target(
+                expr=_gauge("ray_sglang_num_paused_reqs"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
+        grid_pos=GridPos(16, 93, 8, 8),
+    ),
+    Panel(
+        id=29,
+        title="Queue Time -- P50",
+        description="Time requests spend waiting before scheduling.",
+        unit="s",
+        targets=[
+            Target(
+                expr=_percentile("ray_sglang_queue_time_seconds", 0.5),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
+        grid_pos=GridPos(0, 101, 8, 8),
+    ),
+    Panel(
+        id=30,
+        title="Queue Time -- P90",
+        description="Time requests spend waiting before scheduling.",
+        unit="s",
+        targets=[
+            Target(
+                expr=_percentile("ray_sglang_queue_time_seconds", 0.9),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
+        grid_pos=GridPos(8, 101, 8, 8),
+    ),
+    Panel(
+        id=31,
+        title="Aborted Requests / s",
+        description="Aborted requests over the selected interval.",
+        unit="short",
+        targets=[
+            Target(
+                expr=_rate("ray_sglang_num_aborted_requests_total"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
+        grid_pos=GridPos(16, 101, 8, 8),
+    ),
+]
+
+# ===================================================================
+# Assemble rows and config
+# ===================================================================
+_ALL_ROWS = [
+    Row(title="Throughput", id=601, panels=_throughput_panels),
+    Row(title="Latency", id=602, panels=_latency_panels_list),
+    Row(title="Cache", id=603, panels=_cache_panels),
+    Row(title="Request Length", id=604, panels=_request_length_panels),
+    Row(title="Scheduler", id=605, panels=_scheduler_panels),
+]
+
+# Validate uniqueness of panel IDs across all rows
+_all_ids = sorted(panel.id for row in _ALL_ROWS for panel in row.panels)
+assert len(_all_ids) == len(
+    set(_all_ids)
+), f"Duplicated id found. Use unique id for each panel. {_all_ids}"
+
+serve_llm_sglang_dashboard_config = DashboardConfig(
+    name="SERVE_LLM_SGLANG",
+    default_uid="rayServeLlmSglangDashboard",
+    standard_global_filters=['ray_io_cluster=~"$Cluster"'],
+    base_json_file_name="serve_llm_sglang_grafana_dashboard_base.json",
+    rows=_ALL_ROWS,
+)

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_sglang_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_sglang_grafana_dashboard_base.json
@@ -1,0 +1,167 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "iteration": 1667344411089,
+  "links": [],
+  "panels": [],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false
+        },
+        "description": "Filter queries of a specific Prometheus type.",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "name": "sglang_model_name",
+        "label": "SGLang Model Name",
+        "type": "query",
+        "hide": 0,
+        "datasource": "${datasource}",
+        "definition": "label_values(ray_sglang_prompt_tokens_total{{{global_filters}}}, model_name)",
+        "query": {
+          "query": "label_values(ray_sglang_prompt_tokens_total{{{global_filters}}}, model_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": false,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "deployment",
+        "label": "Deployment",
+        "type": "query",
+        "hide": 0,
+        "datasource": "${datasource}",
+        "definition": "label_values(ray_serve_deployment_request_counter_total{{{global_filters}}}, deployment)",
+        "query": {
+          "query": "label_values(ray_serve_deployment_request_counter_total{{{global_filters}}}, deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "Cluster",
+        "label": "Cluster",
+        "description": "Filter queries to specific Ray clusters. The ray_io_cluster label is set per cluster (automatic for KubeRay via Prometheus PodMonitor).",
+        "type": "query",
+        "hide": 0,
+        "datasource": "${datasource}",
+        "definition": "label_values(ray_node_network_receive_speed{{{global_filters}}}, ray_io_cluster)",
+        "query": {
+          "query": "label_values(ray_node_network_receive_speed{{{global_filters}}}, ray_io_cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": false,
+        "allValue": ".*",
+        "current": {
+          "selected": false
+        }
+      },
+      {
+        "name": "interval",
+        "label": "Interval",
+        "type": "custom",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [
+          {
+            "selected": true,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          }
+        ],
+        "current": {
+          "selected": true,
+          "text": "5m",
+          "value": "5m"
+        }
+      }
+    ]
+  },
+  "rayMeta": [
+    "excludesSystemRoutes"
+  ],
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Serve LLM SGLang Dashboard",
+  "uid": "rayServeLlmSglangDashboard",
+  "version": 1
+}

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -27,6 +27,9 @@ from ray.dashboard.modules.metrics.dashboards.serve_deployment_dashboard_panels 
 from ray.dashboard.modules.metrics.dashboards.serve_llm_dashboard_panels import (
     serve_llm_dashboard_config,
 )
+from ray.dashboard.modules.metrics.dashboards.serve_llm_sglang_dashboard_panels import (
+    serve_llm_sglang_dashboard_config,
+)
 from ray.dashboard.modules.metrics.dashboards.train_dashboard_panels import (
     train_dashboard_config,
 )
@@ -135,6 +138,17 @@ def generate_serve_llm_grafana_dashboard() -> Tuple[str, str]:
       Tuple with format content, uid
     """
     return _generate_grafana_dashboard(serve_llm_dashboard_config)
+
+
+def generate_serve_llm_sglang_grafana_dashboard() -> Tuple[str, str]:
+    """
+    Generates the SGLang Serve LLM dashboard and returns both the content
+    and the uid.
+
+    Returns:
+      Tuple with format content, uid
+    """
+    return _generate_grafana_dashboard(serve_llm_sglang_dashboard_config)
 
 
 def generate_data_grafana_dashboard() -> Tuple[str, str]:

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -19,6 +19,7 @@ from ray.dashboard.modules.metrics.grafana_dashboard_factory import (
     generate_serve_deployment_grafana_dashboard,
     generate_serve_grafana_dashboard,
     generate_serve_llm_grafana_dashboard,
+    generate_serve_llm_sglang_grafana_dashboard,
     generate_train_grafana_dashboard,
 )
 from ray.dashboard.modules.metrics.templates import (
@@ -351,6 +352,18 @@ class MetricsHead(SubprocessModule):
                 content,
                 self._dashboard_uids["serve_llm"],
             ) = generate_serve_llm_grafana_dashboard()
+            f.write(content)
+        with open(
+            os.path.join(
+                self._grafana_dashboard_output_dir,
+                "serve_llm_sglang_grafana_dashboard.json",
+            ),
+            "w",
+        ) as f:
+            (
+                content,
+                self._dashboard_uids["serve_llm_sglang"],
+            ) = generate_serve_llm_sglang_grafana_dashboard()
             f.write(content)
         with open(
             os.path.join(

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -10,6 +10,7 @@ provide feedback at https://github.com/ray-project/ray/issues/61114.
 
 import copy
 import json
+import logging
 import signal
 import time
 import uuid
@@ -44,6 +45,8 @@ from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import (
     _add_openai_models_retrieve_route,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SGLangPauseConfig(BaseModel):
@@ -101,6 +104,34 @@ class SGLangServer:
                 "Please run `pip install sglang[all, ray]` to install required "
                 "dependencies."
             ) from e
+
+        # Route SGLang engine metrics through Ray's metric agent (Ray's
+        # Prometheus endpoint / dashboard). RayEngine runs schedulers as Ray
+        # actors and auto-wires the Ray-backed stat_loggers when enable_metrics
+        # is set.
+        if self._llm_config.log_engine_metrics:
+            self.engine_kwargs["enable_metrics"] = True
+            # Tag engine metrics with the Serve deployment/replica so the
+            # out-of-process scheduler series can be grouped per deployment
+            # (they can't be joined to the Serve counter on WorkerId).
+            from ray import serve
+            from ray.serve.exceptions import RayServeException
+
+            try:
+                rid = serve.get_replica_context().replica_id
+                self.engine_kwargs.setdefault(
+                    "extra_metric_labels",
+                    {
+                        "application": rid.deployment_id.app_name,
+                        "deployment": rid.deployment_id.name,
+                        "replica": rid.unique_id,
+                    },
+                )
+            except RayServeException:
+                logger.warning(
+                    "No Serve replica context; SGLang metrics will not carry "
+                    "deployment/replica labels."
+                )
 
         # TODO(issue-61108): remove this once sglang#18752 is merged and included
         # in the minimum supported SGLang version for this example.

--- a/python/requirements/llm/patches/sglang-ray-metrics-backend-patch
+++ b/python/requirements/llm/patches/sglang-ray-metrics-backend-patch
@@ -1,24 +1,9 @@
-#!/bin/bash
-# This script is used to build an extra layer on top of the base llm image
-# to run the llm sglang release tests
-
-set -exo pipefail
-pip3 uninstall -y vllm
-# 0.5.15 is the first release carrying the Ray metric backend wrappers
-# (sglang#26252) that SGLangServer's log_engine_metrics path relies on.
-pip3 install "sglang[all,ray]==0.5.15.post1"
-
-# Patch sglang's RayEngine to auto-wire the Ray metric backend for
-# log_engine_metrics. Canonical: python/requirements/llm/patches/sglang-ray-metrics-backend-patch
-# (inlined; the BYOD build context lacks the Ray source tree). Drop once upstreamed.
-SGLANG_SITE_PACKAGES="$(python3 -c 'import os, sglang; print(os.path.dirname(os.path.dirname(os.path.abspath(sglang.__file__))))')"
-cat > /tmp/sglang-ray-metrics-backend.patch <<'SGLANG_RAY_METRICS_PATCH'
 diff --git a/sglang/srt/observability/metrics_collector.py b/sglang/srt/observability/metrics_collector.py
 --- a/sglang/srt/observability/metrics_collector.py
 +++ b/sglang/srt/observability/metrics_collector.py
 @@ -1689,6 +1689,10 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
          self.histogram_time_to_first_token.labels(**labels).observe(value)
-
+ 
      def check_time_to_first_token_straggler(self, value: float) -> bool:
 +        # Injected backends (e.g. Ray) route metrics out of process and can't
 +        # introspect prometheus_client buckets here.
@@ -39,12 +24,12 @@ diff --git a/sglang/srt/observability/metrics_collector.py b/sglang/srt/observab
 +            for _ in range(num_new_tokens):
 +                his.observe(adjusted_interval)
 +            return
-
+ 
          # A faster version of the Histogram::observe which observes multiple values at the same time.
          # reference: https://github.com/prometheus/client_python/blob/v0.21.1/prometheus_client/metrics.py#L639
 -        his = self.histogram_inter_token_latency.labels(**labels)
          his._sum.inc(internval)
-
+ 
          for i, bound in enumerate(his._upper_bounds):
 diff --git a/sglang/srt/observability/ray_wrappers.py b/sglang/srt/observability/ray_wrappers.py
 --- a/sglang/srt/observability/ray_wrappers.py
@@ -52,7 +37,7 @@ diff --git a/sglang/srt/observability/ray_wrappers.py b/sglang/srt/observability
 @@ -142,6 +142,18 @@ class RayPrometheusMetric:
          """
          return re.sub(r"[^a-zA-Z0-9_]", "_", name)
-
+ 
 +    @staticmethod
 +    def _get_ascii_documentation(documentation: Optional[str]) -> str:
 +        """ASCII-coerce a description; Ray's metric backend rejects non-ASCII."""
@@ -65,7 +50,7 @@ diff --git a/sglang/srt/observability/ray_wrappers.py b/sglang/srt/observability
 +            .decode("ascii")
 +        )
 +
-
+ 
  class RayCounterWrapper(RayPrometheusMetric):
      """``prometheus_client.Counter`` compatible wrapper."""
 @@ -157,7 +169,7 @@ class RayCounterWrapper(RayPrometheusMetric):
@@ -76,7 +61,7 @@ diff --git a/sglang/srt/observability/ray_wrappers.py b/sglang/srt/observability
 +            description=self._get_ascii_documentation(documentation),
              tag_keys=tag_keys,
          )
-
+ 
 @@ -186,7 +198,7 @@ class RayGaugeWrapper(RayPrometheusMetric):
          name = self._get_sanitized_opentelemetry_name(name)
          self.metric = ray_metrics.Gauge(
@@ -85,7 +70,7 @@ diff --git a/sglang/srt/observability/ray_wrappers.py b/sglang/srt/observability
 +            description=self._get_ascii_documentation(documentation),
              tag_keys=tag_keys,
          )
-
+ 
 @@ -212,7 +224,7 @@ class RayHistogramWrapper(RayPrometheusMetric):
          name = self._get_sanitized_opentelemetry_name(name)
          self.metric = ray_metrics.Histogram(
@@ -106,7 +91,7 @@ diff --git a/sglang/srt/observability/ray_wrappers.py b/sglang/srt/observability
          )
 @@ -305,3 +317,22 @@ class RayExpertDispatchCollector(ExpertDispatchCollector):
      """``ExpertDispatchCollector`` that emits via Ray's metric system."""
-
+ 
      _histogram_cls = RayHistogramWrapper
 +
 +
@@ -143,9 +128,3 @@ diff --git a/sglang/srt/ray/engine.py b/sglang/srt/ray/engine.py
          server_args = ServerArgs(**kwargs)
          server_args.placement_group = placement_group
          super().__init__(server_args=server_args)
-SGLANG_RAY_METRICS_PATCH
-( cd "${SGLANG_SITE_PACKAGES}" && git apply /tmp/sglang-ray-metrics-backend.patch )
-# Reinstall opentelemetry-proto to regenerate _pb2.py files compatible with
-# the protobuf version that sglang pulls in (protobuf 4.x+ removed old-style
-# descriptor creation, causing Ray dashboard to crash on startup).
-pip3 install --upgrade opentelemetry-proto opentelemetry-sdk opentelemetry-exporter-prometheus


### PR DESCRIPTION
Cherry pick from #64797.

## Description
A Grafana dashboard for SGLang engine metrics under Ray Serve LLM, filterable by cluster, deployment, and replica.

- Routes SGLang engine metrics through Ray's Prometheus backend when `log_engine_metrics` is set.
- `SGLangServer` tags engine metrics with `application`/`deployment`/`replica` via
`ServerArgs.extra_metric_labels`, so the out-of-process scheduler metrics can be grouped per deployment/replica.
- BYOD release-test image installs `sglang[all,ray]==0.5.15.post1` plus the Ray-metric-backend patch
https://github.com/sgl-project/sglang/pull/31415.

### What metrics are emitted?
Per replica, there are 2 `WorkerIds`:
1. The serve replica actor's worker: the `tokenizer_manager` runs in process here, so this `WorkerId` also carries `ReplicaId`. Emits token / TTFT / ITL / latency metrics.
2. The rank-0 `SchedulerActor`'s worker (spawned by sglang's `RayEngine`). Emits schduler-state / cache / KV metrics. For TP > 1, with the default `enable_metrics_for_all_schedulers=False`, only rank 0 emits sglang metrics. The scheduler / KV / cache gauges are identical on every rank.


## Validation
- Generate traffic
- Create Grafana JSON
- Open Serve LLM SGLang dashboard

<details>
<summary><strong>SGLang prefix-cache load generator</strong></summary>

```python
"""
Usage:
    python load_sglang_prefix.py --duration 900 --concurrency 8
"""

import argparse
import random
import string
import threading
import time
from concurrent.futures import ThreadPoolExecutor, as_completed

from openai import OpenAI

BASE_URL = "http://localhost:8000/v1"
MODEL = "Qwen2.5-1.5B-Instruct"

# A long, fixed prefix shared by the "cache-hit" traffic. Reusing it across
# requests is exactly what fills SGLang's radix cache and drives cache-hit rate.
SHARED_PREFIX = (
    "You are a meticulous financial analyst. Use ONLY the reference dossier "
    "below to answer. Reference dossier:\n"
    + "\n".join(
        f"- Fact {i}: Company Acme division {i} reported revenue of "
        f"{1000 + i * 7} units, margin {i % 30}% in fiscal quarter {i % 4 + 1}."
        for i in range(220)
    )
    + "\nEnd of dossier. Answer questions strictly from the dossier.\n"
)

SHARED_SUFFIXES = [
    "Summarize the three highest-revenue divisions.",
    "Which divisions had margin above 20%? List them.",
    "What was the revenue of division 42?",
    "Compare divisions 10 and 100 by revenue and margin.",
    "Give the average revenue across all divisions.",
    "Which quarter appears most frequently for high-margin divisions?",
]

client = OpenAI(base_url=BASE_URL, api_key="not-needed")

_counts = {"ok": 0, "err": 0, "hit_traffic": 0, "miss_traffic": 0}
_lock = threading.Lock()


def _rand_words(n):
    return " ".join(
        "".join(random.choices(string.ascii_lowercase, k=random.randint(3, 9)))
        for _ in range(n)
    )


def one_request(kind):
    """kind: 'hit' (shared prefix) or 'miss' (unique prefix)."""
    stream = random.random() < 0.5
    if kind == "hit":
        content = SHARED_PREFIX + random.choice(SHARED_SUFFIXES)
    else:
        # Unique long-ish prefix so nothing is cached across requests.
        content = (
            f"[session {random.randint(0, 1_000_000)}] "
            f"{_rand_words(random.randint(30, 400))}. "
            "Answer in one sentence."
        )

    max_tokens = random.choice([16, 32, 64, 128, 256])

    try:
        resp = client.chat.completions.create(
            model=MODEL,
            messages=[{"role": "user", "content": content}],
            max_tokens=max_tokens,
            temperature=0.7,
            stream=stream,
        )

        if stream:
            for _ in resp:
                pass

        with _lock:
            _counts["ok"] += 1
            _counts["hit_traffic" if kind == "hit" else "miss_traffic"] += 1

        return True

    except Exception as e:  # noqa: BLE001
        with _lock:
            _counts["err"] += 1

        if _counts["err"] <= 5:
            print(f"  request error: {type(e).__name__}: {e}")

        return False


def main():
    ap = argparse.ArgumentParser()
    ap.add_argument("--duration", type=float, default=900, help="seconds")
    ap.add_argument("--concurrency", type=int, default=8)
    ap.add_argument(
        "--hit-ratio",
        type=float,
        default=0.7,
        help="fraction of requests using the shared prefix",
    )
    args = ap.parse_args()

    print(
        f"Load: duration={args.duration}s concurrency={args.concurrency} "
        f"hit_ratio={args.hit_ratio} -> {BASE_URL} model={MODEL}"
    )

    deadline = time.time() + args.duration
    last_report = time.time()

    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
        futures = set()

        while time.time() < deadline:
            while len(futures) < args.concurrency:
                kind = "hit" if random.random() < args.hit_ratio else "miss"
                futures.add(pool.submit(one_request, kind))

            done = {f for f in as_completed(futures, timeout=None) if f.done()}
            futures -= done

            if time.time() - last_report > 10:
                with _lock:
                    print(
                        f"  t={int(time.time() - (deadline - args.duration))}s "
                        f"ok={_counts['ok']} err={_counts['err']} "
                        f"hit={_counts['hit_traffic']} "
                        f"miss={_counts['miss_traffic']}"
                    )
                last_report = time.time()

        for f in as_completed(futures):
            pass

    print(f"DONE: {_counts}")


if __name__ == "__main__":
    main()
```

</details>

<details>
<summary><strong>Generate Grafana dashboard JSON</strong></summary>

```bash
cd /home/ray/default/ray

python3 - <<'PY'
from ray.dashboard.modules.metrics.grafana_dashboard_factory import (
    generate_serve_llm_sglang_grafana_dashboard,
)

content, uid = generate_serve_llm_sglang_grafana_dashboard()
open(
    "sglang_dashboard_artifacts/serve_llm_sglang_grafana_dashboard.json",
    "w",
).write(content)

print("uid:", uid, "bytes:", len(content))
PY
```

**Notes:**
- On a real Ray build from this branch, the dashboard head generates this automatically at startup and writes it under
`/tmp/ray/session_latest/metrics/grafana/dashboards/`. Manual generation is only needed here because we're using a nightly Ray build with the files overlaid.
- The generated JSON can be imported directly into Grafana.

</details>

**Note: Metrics can be filtered by deployments with replica granularity.**
<img width="1725" height="931" alt="Screenshot 2026-07-16 at 8 21 13 PM" src="https://github.com/user-attachments/assets/e2103bbf-9029-46fa-aa49-b5db9b95cee8" />
<img width="1720" height="663" alt="Screenshot 2026-07-16 at 8 21 34 PM" src="https://github.com/user-attachments/assets/e6a76bad-f621-48b8-aec2-263f91acebcd" />
<img width="1722" height="439" alt="Screenshot 2026-07-16 at 8 21 43 PM" src="https://github.com/user-attachments/assets/e1835778-4e15-47a4-bafc-75e290073a98" />




## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to
#1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples,
screenshots, etc.

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
