### PR TITLE
[core] Fix a teardown race in gcs_resource_load_puller_test

### DIFF
--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/ray/asio:instrumented_io_context",
-        "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_resource_load_puller",
         "//src/ray/raylet_rpc_client:fake_raylet_client",
         "//src/ray/raylet_rpc_client:raylet_client_pool",

--- a/src/ray/gcs/tests/gcs_resource_load_puller_test.cc
+++ b/src/ray/gcs/tests/gcs_resource_load_puller_test.cc
@@ -15,6 +15,7 @@
 #include "ray/gcs/gcs_resource_load_puller.h"
 
 #include <atomic>
+#include <future>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -23,7 +24,6 @@
 #include "absl/synchronization/mutex.h"
 #include "gtest/gtest.h"
 #include "ray/asio/asio_util.h"
-#include "ray/common/test_utils.h"
 #include "ray/raylet_rpc_client/fake_raylet_client.h"
 
 namespace ray {
@@ -98,6 +98,13 @@ class GcsResourceLoadPullerTest : public ::testing::Test {
         "GcsResourceLoadPullerTest.pull");
   }
 
+  void FlushPullThread() {
+    std::promise<void> done;
+    pull_io_thread_.GetIoService().post([&done]() { done.set_value(); },
+                                        "GcsResourceLoadPullerTest.flush");
+    done.get_future().get();
+  }
+
   InstrumentedIOContextWithThread pull_io_thread_;
   absl::Mutex mutex_;
   absl::flat_hash_map<NodeID, std::shared_ptr<MockRayletClient>> clients_;
@@ -113,19 +120,14 @@ TEST_F(GcsResourceLoadPullerTest, DisconnectsRayletsThatLeftTheSnapshot) {
   auto puller = MakePuller();
 
   PullOnPullThread(*puller, {AddressOf(node1), AddressOf(node2)});
-  ASSERT_TRUE(WaitForCondition(
-      [&]() {
-        return ClientFor(node1)->NumCalls() == 1 && ClientFor(node2)->NumCalls() == 1;
-      },
-      10000));
+  FlushPullThread();
+  EXPECT_EQ(ClientFor(node1)->NumCalls(), 1);
+  EXPECT_EQ(ClientFor(node2)->NumCalls(), 1);
 
   PullOnPullThread(*puller, {AddressOf(node2)});
-  ASSERT_TRUE(
-      WaitForCondition([&]() { return ClientFor(node2)->NumCalls() == 2; }, 10000));
-
   PullOnPullThread(*puller, {AddressOf(node1), AddressOf(node2)});
-  ASSERT_TRUE(
-      WaitForCondition([&]() { return ClientFor(node1)->NumCalls() == 2; }, 10000));
+  FlushPullThread();
+  EXPECT_EQ(ClientFor(node1)->NumCalls(), 2);
   EXPECT_EQ(FactoryCalls(node1), 2);
   EXPECT_EQ(FactoryCalls(node2), 1);
 }


### PR DESCRIPTION

## Description
 
`DisconnectsRayletsThatLeftTheSnapshot` covers the eviction path of the resource load puller added in #65024. Pull keeps the node IDs it saw in the previous round, and when the latest alive node snapshot no longer contains one of them, that node's pooled raylet client must be disconnected.

The test does check what it intends to check and then tears down. But it only waited for the specific condition it wanted to confirm, not for the whole pull to finish, so at teardown time Pull() is still in the middle of its loop on the pull thread and TSAN reports a race with the free.

This PR fixes it by replacing the polling waits with a sentinel posted to the pull io_context.



TSAN passes
<img width="590" height="128" alt="image" src="https://github.com/user-attachments/assets/24a20de0-2405-432a-9afc-6453405477a7" />
