### PR TITLE
[release] Validate Windows wheels from TestPyPI in release automation

### DIFF
--- a/.buildkite/release-automation/verify-windows-wheels.sh
+++ b/.buildkite/release-automation/verify-windows-wheels.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+set -x
+
+# Sets RAY_COMMIT and RAY_VERSION
+source .buildkite/release-automation/set-ray-version.sh
+
+if [[ "${PYTHON_VERSION:-}" == "" ]]; then
+    echo "Python version not set" >/dev/stderr
+    exit 1
+fi
+
+# The Windows agents only carry a fixed system Python; use uv to provision
+# the Python version under test, same as python/build-wheel-windows.sh.
+pip install uv
+
+VENV_DIR="$(mktemp -d)/rayio_${PYTHON_VERSION}"
+
+_clean_up() {
+    rm -rf "$(dirname "${VENV_DIR}")"
+}
+trap _clean_up EXIT
+
+uv venv --seed --python "${PYTHON_VERSION}" "${VENV_DIR}"
+source "${VENV_DIR}/Scripts/activate"
+
+pip install \
+    --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple \
+    "ray[cpp]==${RAY_VERSION}"
+
+(
+    cd release/util
+    python sanity_check.py --ray_version="${RAY_VERSION}" --ray_commit="${RAY_COMMIT}"
+)
+
+# Unlike Linux and macOS, sanity_check_cpp.sh is skipped: building the C++
+# example requires a bazel + MSVC toolchain that is not available on the
+# Windows runner agents. Installing ray[cpp] above still verifies that the
+# ray_cpp win_amd64 wheel is published and installable.

--- a/.buildkite/release-automation/wheels.rayci.yml
+++ b/.buildkite/release-automation/wheels.rayci.yml
@@ -77,6 +77,28 @@ steps:
     commands:
       - bash .buildkite/release-automation/verify-macos-wheels.sh
 
+  - block: "Download & validate Ray wheels from TestPyPI Windows"
+    key: block-validate-windows-wheels
+    depends_on: []
+
+  - label: "Windows Python {{matrix}}"
+    key: validate-windows-wheels
+    depends_on:
+      - block-validate-windows-wheels
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - export PYTHON_VERSION={{matrix}}
+      - export RAY_VERSION="$RAY_VERSION"
+      - export RAY_COMMIT="$RAY_COMMIT"
+      - bash .buildkite/release-automation/verify-windows-wheels.sh
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+
   - block: "Upload wheels to PyPI"
     key: block-upload-wheels-pypi
     depends_on: []


### PR DESCRIPTION
## Why are these changes needed?

The release wheel-validation pipeline (`Upload & Validate wheels`) verifies Linux x86_64/arm64 wheels (py3.10–3.14) and macOS wheels from TestPyPI, but has **no Windows step at all** — shipped Windows wheels are never install-tested before the PyPI upload.

This adds a `Windows Python {{matrix}}` validation step mirroring `verify-linux-wheels.sh`:
- provisions the target Python with `uv` (Windows runner agents only carry a fixed system Python)
- `pip install ray[cpp]==$RAY_VERSION` from TestPyPI
- runs `release/util/sanity_check.py` (version/commit assertion + `ray.init()` + remote task)

`sanity_check_cpp.sh` is skipped on Windows since the runner agents lack a bazel + MSVC toolchain; installing `ray[cpp]` still verifies the `ray_cpp` win_amd64 wheel is published and installable.

The 3.13/3.14 matrix entries depend on #64970 (Windows wheel builds for those versions) landing before the next release; the 3.10–3.12 entries validate wheels we already ship today.

## Related issue number

Follow-up to #64970.

## Checks

- Not a duplicate: searched open PRs for windows wheel validation work; none exists.
- AI assistance was used for this PR (Claude Code); the change has been reviewed line-by-line.
- Tests: `bash -n` and `shellcheck` pass on the new script; YAML validated. The step itself only executes inside a release-automation run (gated behind its block step), so it cannot be exercised by premerge CI — it should be validated by triggering the release-automation wheels pipeline against an existing release version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
