### PR TITLE
[Core] Fix TSAN data race in gcs_resource_load_puller_test

### DIFF
--- a/src/ray/gcs/tests/gcs_resource_load_puller_test.cc
+++ b/src/ray/gcs/tests/gcs_resource_load_puller_test.cc
@@ -91,14 +91,15 @@ class GcsResourceLoadPullerTest : public ::testing::Test {
 
   void PullOnPullThread(GcsResourceLoadPuller &puller,
                         std::vector<rpc::Address> raylet_addresses) {
-    std::promise<void> done;
+    auto done = std::make_shared<std::promise<void>>();
+    auto future = done->get_future();
     pull_io_thread_.GetIoService().post(
-        [&puller, &done, raylet_addresses = std::move(raylet_addresses)]() mutable {
+        [&puller, done, raylet_addresses = std::move(raylet_addresses)]() mutable {
           puller.Pull(std::move(raylet_addresses));
-          done.set_value();
+          done->set_value();
         },
         "GcsResourceLoadPullerTest.pull");
-    done.get_future().wait();
+    future.wait();
   }
 
   InstrumentedIOContextWithThread pull_io_thread_;

--- a/src/ray/gcs/tests/gcs_resource_load_puller_test.cc
+++ b/src/ray/gcs/tests/gcs_resource_load_puller_test.cc
@@ -15,6 +15,7 @@
 #include "ray/gcs/gcs_resource_load_puller.h"
 
 #include <atomic>
+#include <future>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -23,7 +24,6 @@
 #include "absl/synchronization/mutex.h"
 #include "gtest/gtest.h"
 #include "ray/asio/asio_util.h"
-#include "ray/common/test_utils.h"
 #include "ray/raylet_rpc_client/fake_raylet_client.h"
 
 namespace ray {
@@ -91,11 +91,14 @@ class GcsResourceLoadPullerTest : public ::testing::Test {
 
   void PullOnPullThread(GcsResourceLoadPuller &puller,
                         std::vector<rpc::Address> raylet_addresses) {
+    std::promise<void> done;
     pull_io_thread_.GetIoService().post(
-        [&puller, raylet_addresses = std::move(raylet_addresses)]() mutable {
+        [&puller, &done, raylet_addresses = std::move(raylet_addresses)]() mutable {
           puller.Pull(std::move(raylet_addresses));
+          done.set_value();
         },
         "GcsResourceLoadPullerTest.pull");
+    done.get_future().wait();
   }
 
   InstrumentedIOContextWithThread pull_io_thread_;
@@ -113,19 +116,14 @@ TEST_F(GcsResourceLoadPullerTest, DisconnectsRayletsThatLeftTheSnapshot) {
   auto puller = MakePuller();
 
   PullOnPullThread(*puller, {AddressOf(node1), AddressOf(node2)});
-  ASSERT_TRUE(WaitForCondition(
-      [&]() {
-        return ClientFor(node1)->NumCalls() == 1 && ClientFor(node2)->NumCalls() == 1;
-      },
-      10000));
+  EXPECT_EQ(ClientFor(node1)->NumCalls(), 1);
+  EXPECT_EQ(ClientFor(node2)->NumCalls(), 1);
 
   PullOnPullThread(*puller, {AddressOf(node2)});
-  ASSERT_TRUE(
-      WaitForCondition([&]() { return ClientFor(node2)->NumCalls() == 2; }, 10000));
+  EXPECT_EQ(ClientFor(node2)->NumCalls(), 2);
 
   PullOnPullThread(*puller, {AddressOf(node1), AddressOf(node2)});
-  ASSERT_TRUE(
-      WaitForCondition([&]() { return ClientFor(node1)->NumCalls() == 2; }, 10000));
+  EXPECT_EQ(ClientFor(node1)->NumCalls(), 2);
   EXPECT_EQ(FactoryCalls(node1), 2);
   EXPECT_EQ(FactoryCalls(node2), 1);
 }


### PR DESCRIPTION
The test `gcs_resource_load_puller_test` has a race condition
- The test body can succeed / exit as soon as the last `WaitForCondition` happens, which happens inside `puller.Pull` when the `num_calls_++` increment happens.
- That causes the test body to finish and destroy `puller` (it's a unique pointer)
- But actually `puller.Pull` hasn't necessarily returned yet and can still be accessing fields of the `puller` which are no longer valid.

I reproduced the error (pretty reliably) by sleeping after `num_calls_++` to keep `puller.Pull` running after the test body has exited.

The fix is to make `PullOnPullThread` synchronous and wait for the thread to finish.