### PR TITLE
[serve] Enable gRPC streaming tests under HAProxy

### DIFF
--- a/python/ray/serve/tests/test_cli_4.py
+++ b/python/ray/serve/tests/test_cli_4.py
@@ -118,10 +118,8 @@ def test_serving_request_through_grpc_proxy(ray_start_stop):
     # Ensures another custom defined method is responding correctly.
     ping_grpc_another_method(channel, app1)
 
-    # TODO: gRPC streaming is not supported in direct ingress / haproxy
-    if not RAY_SERVE_ENABLE_DIRECT_INGRESS:
-        # Ensure Streaming method is responding correctly.
-        ping_grpc_streaming(channel, app1)
+    # Ensure Streaming method is responding correctly.
+    ping_grpc_streaming(channel, app1)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -770,9 +770,6 @@ def test_grpc_client_sending_large_payload(ray_instance, ray_shutdown):
     )
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_client_streaming(ray_instance, ray_shutdown):
     """Test gRPC client streaming (stream-unary) requests.
 
@@ -909,9 +906,6 @@ def test_grpc_client_streaming_not_found(ray_instance, ray_shutdown):
     assert exc_info.value.code() == grpc.StatusCode.NOT_FOUND
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_bidirectional_streaming(ray_instance, ray_shutdown):
     """Test gRPC bidirectional streaming (stream-stream) requests.
 
@@ -962,9 +956,6 @@ def test_grpc_bidirectional_streaming(ray_instance, ray_shutdown):
     assert responses[2].num_x2 == 40
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_client_streaming_with_grpc_context(ray_instance, ray_shutdown):
     """Test gRPC client streaming with gRPC context.
 
@@ -1025,9 +1016,6 @@ def test_grpc_client_streaming_with_grpc_context(ray_instance, ray_shutdown):
     assert ("custom-key", "custom-value") in rpc_error.trailing_metadata()
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_bidirectional_streaming_with_grpc_context(ray_instance, ray_shutdown):
     """Test gRPC bidirectional streaming with gRPC context.
 
@@ -1086,9 +1074,6 @@ def test_grpc_bidirectional_streaming_with_grpc_context(ray_instance, ray_shutdo
     assert ("bidi-key", "bidi-value") in rpc_error.trailing_metadata()
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
 def test_grpc_streaming_internal_error(ray_instance, ray_shutdown, streaming_type: str):
     """Test gRPC streaming request with internal error.
@@ -1142,9 +1127,6 @@ def test_grpc_streaming_internal_error(ray_instance, ray_shutdown, streaming_typ
     assert error_message in rpc_error.details()
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
 def test_grpc_streaming_timeout(ray_instance, ray_shutdown, streaming_type: str):
     """Test gRPC streaming request timeout.
@@ -1209,9 +1191,6 @@ def test_grpc_streaming_timeout(ray_instance, ray_shutdown, streaming_type: str)
     ray.get(signal_actor.send.remote(clear=True))
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_client_streaming_empty_stream(ray_instance, ray_shutdown):
     """Test gRPC client streaming with empty stream.
 
@@ -1256,9 +1235,6 @@ def test_grpc_client_streaming_empty_stream(ray_instance, ray_shutdown):
     assert response.num_x2 == 0
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_bidi_streaming_empty_stream(ray_instance, ray_shutdown):
     """Test gRPC bidirectional streaming with empty stream.
 
@@ -1301,9 +1277,6 @@ def test_grpc_bidi_streaming_empty_stream(ray_instance, ray_shutdown):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
 async def test_grpc_streaming_cancellation(
     ray_instance, ray_shutdown, streaming_type: str
@@ -1374,9 +1347,6 @@ async def test_grpc_streaming_cancellation(
     ray.get(cancelled_signal_actor.send.remote(clear=True))
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
 def test_grpc_streaming_context_with_exception(
     ray_instance, ray_shutdown, streaming_type: str
@@ -1444,9 +1414,6 @@ def test_grpc_streaming_context_with_exception(
     assert real_error_message in rpc_error.details()
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
 def test_grpc_streaming_backpressure(ray_instance, ray_shutdown, streaming_type: str):
     """Test gRPC streaming with slow consumer (backpressure).
@@ -1517,9 +1484,6 @@ def test_grpc_streaming_backpressure(ray_instance, ray_shutdown, streaming_type:
             assert response.num_x2 == i + 1
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
 def test_grpc_streaming_client_error_mid_stream(
     ray_instance, ray_shutdown, streaming_type: str
@@ -1588,9 +1552,6 @@ def test_grpc_streaming_client_error_mid_stream(
             list(stub.BidiStreaming(error_request_generator()))
 
 
-@pytest.mark.skipif(
-    RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming."
-)
 def test_grpc_streaming_client_closes_channel_mid_stream(ray_instance, ray_shutdown):
     """Test gRPC streaming when client closes channel mid-stream.
 

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -12,7 +12,6 @@ from ray import serve
 from ray._common.test_utils import SignalActor
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
-    RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_NAMESPACE,
 )
 from ray.serve._private.test_utils import (
@@ -81,9 +80,8 @@ def test_serving_grpc_requests(ray_cluster):
     # Ensures another custom defined method is responding correctly.
     ping_grpc_another_method(channel, app_name)
 
-    if not RAY_SERVE_ENABLE_HA_PROXY:
-        # Ensure Streaming method is responding correctly.
-        ping_grpc_streaming(channel, app_name)
+    # Ensure Streaming method is responding correctly.
+    ping_grpc_streaming(channel, app_name)
 
     serve.run(g2)
 


### PR DESCRIPTION
## Why

HAProxy proxies gRPC end to end over HTTP/2. The gRPC frontend `bind` and the backend `server` lines both carry `proto h2`, so HAProxy decodes and forwards HTTP/2 streams, including client-streaming and bidirectional streaming, without any extra handling. gRPC-over-HAProxy support landed in #63735, and the streaming cases were skipped at that time as a scope cut rather than because of a real limitation.

## What changed

1. Remove the `skipif(RAY_SERVE_ENABLE_HA_PROXY, reason="HAProxy does not support streaming.")` markers from the 13 gRPC streaming tests in `test_grpc.py`.
2. Run the `Streaming` method assertion unconditionally in `test_serving_grpc_requests` (`test_grpc.py`) and `test_serving_request_through_grpc_proxy` (`test_cli_4.py`). Each previously gated that assertion behind an inline conditional (`if not RAY_SERVE_ENABLE_HA_PROXY` and `if not RAY_SERVE_ENABLE_DIRECT_INGRESS`). HAProxy forces `RAY_SERVE_ENABLE_DIRECT_INGRESS` on (`constants.py`), so both conditions were false under HAProxy and the assertion never ran there. Also drops the now-unused `RAY_SERVE_ENABLE_HA_PROXY` import in `test_grpc.py`.

The `serve: HAProxy tests` CI step runs the full serve suite under `RAY_SERVE_ENABLE_HA_PROXY=1`, so these all execute there now instead of being skipped.

## Testing

Ran under the bundled HAProxy 2.8.25 with `RAY_SERVE_ENABLE_HA_PROXY=1 RAY_SERVE_ENABLE_DIRECT_INGRESS=0`:

```
python -m pytest python/ray/serve/tests/test_grpc.py -k streaming
# 20 passed, 23 deselected

python -m pytest \
  python/ray/serve/tests/test_grpc.py::test_serving_grpc_requests \
  python/ray/serve/tests/test_cli_4.py::test_serving_request_through_grpc_proxy
# 2 passed
```

Streaming coverage now exercised under HAProxy: client and bidirectional streaming, the grpc-context variants, timeout, cancellation, backpressure, mid-stream client errors, and the server-streaming `Streaming` method in the gRPC and CLI end-to-end tests.

## Not a duplicate

No open PR or issue targets gRPC streaming under HAProxy (checked `gh pr list` and `gh issue list` on ray-project/ray).
