### PR TITLE
Clarify API deprecation policy

### DIFF
--- a/doc/source/ray-contribute/api-policy.md
+++ b/doc/source/ray-contribute/api-policy.md
@@ -76,7 +76,7 @@ Users have high expectations for certain exposure levels, so we need to be cauti
   - No annotations mean it is a developer API by default
 * - Can you remove or change this API's parameters?
   - Yes. The API should emit warning messages and you must set a deadline for the end-of-life of the original version that is **six months or +25 Ray minor versions, whichever comes first**. During the transition period, you must support both the new and old parameters.
-  - Yes. The API should emit warning messages and you must set a deadline for the change in **three months or +12 Ray minor versions**. During the transition period, you must support both the new and old parameters.
+  - Yes. The API should emit warning messages and you must set a deadline for the change in **three months or +12 Ray minor versions, whichever comes first**. During the transition period, you must support both the new and old parameters.
   - Users must allow for and expect breaking changes in alpha components, and must have no expectations of stability.
   - No
   - Yes

--- a/doc/source/ray-contribute/api-policy.md
+++ b/doc/source/ray-contribute/api-policy.md
@@ -69,13 +69,13 @@ Users have high expectations for certain exposure levels, so we need to be cauti
   - No
   - Yes
 * - Can this API be demoted to a lower level? If so then how?
-  - Can be demoted to Deprecated only. The API should emit warning messages and a deadline for deprecations in **six months (or +25 Ray minor versions)**.
-  - Can be demoted to Deprecated only. The API should emit warning messages and a deadline for deprecations in **three months (or +12 Ray minor versions)**.
+  - Can be demoted to Deprecated only. The API should emit warning messages and a deadline for deprecations in **six months or +25 Ray minor versions, whichever comes first**.
+  - Can be demoted to Deprecated only. The API should emit warning messages and a deadline for deprecations in **three months or +12 Ray minor versions, whichever comes first**.
   - Users must allow for and expect breaking changes in alpha components, and must have no expectations of stability.
   - Yes
   - No annotations mean it is a developer API by default
 * - Can you remove or change this API's parameters?
-  - Yes. The API should emit warning messages and you must set a deadline for the end-of-life of the original version that is **six months or +25 Ray minor versions**. During the transition period, you must support both the new and old parameters.
+  - Yes. The API should emit warning messages and you must set a deadline for the end-of-life of the original version that is **six months or +25 Ray minor versions, whichever comes first**. During the transition period, you must support both the new and old parameters.
   - Yes. The API should emit warning messages and you must set a deadline for the change in **three months or +12 Ray minor versions**. During the transition period, you must support both the new and old parameters.
   - Users must allow for and expect breaking changes in alpha components, and must have no expectations of stability.
   - No


### PR DESCRIPTION
Our current API deprecation policy states that we can deprecate APIs after six months or 25 Ray minor releases. The problem is that it's unclear whether the six months or 25 minor releases takes precedence if we don't release weekly. For example, if we release every month, 25 minor releases is 2+ years.

To resolve this ambiguity, I'm clarifying that the policy is "Six months or 25 Ray minor releases, **whichever comes first**"