### PR TITLE
[2.57.0][core][observability] Fix deadlock between metric registration and collect() in OpenTelemetryMetricRecorder (#64946)

### DIFF
--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -47,7 +47,31 @@ class OpenTelemetryMetricRecorder:
     _metrics_initialized_lock = threading.Lock()
 
     def __init__(self, gauge_metric_ttl_seconds: Optional[float] = None):
+        # Lock-ordering contract:
+        #   _registration_lock -> SDK meter locks (via meter.create_*)
+        #   _registration_lock -> _lock
+        #   SDK measurement-consumer lock -> _lock (the SDK holds its own lock
+        #       while invoking our observable callbacks during collect(), and the
+        #       callbacks acquire _lock)
+        # _lock must therefore never be held across an SDK call that can acquire
+        # the measurement-consumer lock — i.e. observable-instrument creation
+        # (meter.create_observable_*, which registers the instrument with the
+        # consumer). Holding _lock there deadlocks with a concurrent scrape:
+        # registration holds _lock and waits on the consumer lock inside
+        # create_*, while collect() holds the consumer lock and waits on _lock
+        # inside a callback. _registration_lock exists so that instrument
+        # registration stays serialized (no duplicate instruments on a race)
+        # without _lock being held across those SDK entry points.
+        #
+        # Note: the synchronous histogram paths (set_metric_value,
+        # record_histogram_aggregated_batch) do call instrument.record() while
+        # holding _lock. That is safe from this deadlock: record() only takes
+        # per-reader-storage locks, never the measurement-consumer lock, and
+        # reader-storage code never calls back into this recorder, so no lock
+        # cycle can form. Keep any new SDK call out of _lock unless it has the
+        # same property.
         self._lock = threading.Lock()
+        self._registration_lock = threading.Lock()
         self._registered_instruments = {}
         # Gauge observations are stored as tag_key -> (value, last_update_monotonic).
         # Unlike counters/sums, gauges are evicted once they have not been refreshed
@@ -191,66 +215,79 @@ class OpenTelemetryMetricRecorder:
             OpenTelemetryMetricRecorder._metrics_initialized = True
 
     def register_gauge_metric(self, name: str, description: str) -> None:
-        with self._lock:
-            if name in self._registered_instruments:
-                # Gauge with the same name is already registered.
-                return
+        with self._registration_lock:
+            with self._lock:
+                if name in self._registered_instruments:
+                    # Gauge with the same name is already registered.
+                    return
 
             callback = self._create_observable_callback(name, MetricType.GAUGE)
+            # Created without holding self._lock: create_observable_gauge acquires
+            # SDK-internal locks that are also held around our callbacks during
+            # collect() (see the lock-ordering contract in __init__).
             instrument = self.meter.create_observable_gauge(
                 name=f"{NAMESPACE}_{name}",
                 description=description,
                 unit="1",
                 callbacks=[callback],
             )
-            self._registered_instruments[name] = instrument
-            self._gauge_observations_by_name[name] = {}
+            with self._lock:
+                self._registered_instruments[name] = instrument
+                self._gauge_observations_by_name[name] = {}
 
     def register_counter_metric(self, name: str, description: str) -> None:
         """
         Register an observable counter metric with the given name and description.
         """
-        with self._lock:
-            if name in self._registered_instruments:
-                # Counter with the same name is already registered. This is a common
-                # case when metrics are exported from multiple Ray components (e.g.,
-                # raylet, worker, etc.) running in the same node. Since each component
-                # may export metrics with the same name, the same metric might be
-                # registered multiple times.
-                return
+        with self._registration_lock:
+            with self._lock:
+                if name in self._registered_instruments:
+                    # Counter with the same name is already registered. This is a
+                    # common case when metrics are exported from multiple Ray
+                    # components (e.g., raylet, worker, etc.) running in the same
+                    # node. Since each component may export metrics with the same
+                    # name, the same metric might be registered multiple times.
+                    return
 
             callback = self._create_observable_callback(name, MetricType.COUNTER)
+            # Created without holding self._lock (see __init__ lock-ordering
+            # contract).
             instrument = self.meter.create_observable_counter(
                 name=f"{NAMESPACE}_{name}",
                 description=description,
                 unit="1",
                 callbacks=[callback],
             )
-            self._registered_instruments[name] = instrument
-            self._counter_observations_by_name[name] = {}
+            with self._lock:
+                self._registered_instruments[name] = instrument
+                self._counter_observations_by_name[name] = {}
 
     def register_sum_metric(self, name: str, description: str) -> None:
         """
         Register an observable sum metric with the given name and description.
         """
-        with self._lock:
-            if name in self._registered_instruments:
-                # Sum with the same name is already registered. This is a common
-                # case when metrics are exported from multiple Ray components (e.g.,
-                # raylet, worker, etc.) running in the same node. Since each component
-                # may export metrics with the same name, the same metric might be
-                # registered multiple times.
-                return
+        with self._registration_lock:
+            with self._lock:
+                if name in self._registered_instruments:
+                    # Sum with the same name is already registered. This is a common
+                    # case when metrics are exported from multiple Ray components
+                    # (e.g., raylet, worker, etc.) running in the same node. Since
+                    # each component may export metrics with the same name, the same
+                    # metric might be registered multiple times.
+                    return
 
             callback = self._create_observable_callback(name, MetricType.SUM)
+            # Created without holding self._lock (see __init__ lock-ordering
+            # contract).
             instrument = self.meter.create_observable_up_down_counter(
                 name=f"{NAMESPACE}_{name}",
                 description=description,
                 unit="1",
                 callbacks=[callback],
             )
-            self._registered_instruments[name] = instrument
-            self._sum_observations_by_name[name] = {}
+            with self._lock:
+                self._registered_instruments[name] = instrument
+                self._sum_observations_by_name[name] = {}
 
     def register_histogram_metric(
         self, name: str, description: str, buckets: List[float]
@@ -258,40 +295,41 @@ class OpenTelemetryMetricRecorder:
         """
         Register a histogram metric with the given name and description.
         """
-        with self._lock:
-            if name in self._registered_instruments:
-                # Histogram with the same name is already registered. This is a common
-                # case when metrics are exported from multiple Ray components (e.g.,
-                # raylet, worker, etc.) running in the same node. Since each component
-                # may export metrics with the same name, the same metric might be
-                # registered multiple times.
-                return
+        with self._registration_lock:
+            with self._lock:
+                if name in self._registered_instruments:
+                    # Histogram with the same name is already registered. This is a
+                    # common case when metrics are exported from multiple Ray
+                    # components (e.g., raylet, worker, etc.) running in the same
+                    # node. Since each component may export metrics with the same
+                    # name, the same metric might be registered multiple times.
+                    return
 
+            # Created without holding self._lock (see __init__ lock-ordering
+            # contract).
             instrument = self.meter.create_histogram(
                 name=f"{NAMESPACE}_{name}",
                 description=description,
                 unit="1",
                 explicit_bucket_boundaries_advisory=buckets,
             )
-            self._registered_instruments[name] = instrument
 
             # calculate the bucket midpoints; this is used for converting histogram
             # internal representation to approximated histogram data points.
+            midpoints = []
             for i in range(len(buckets)):
                 if i == 0:
                     lower_bound = 0.0 if buckets[0] > 0 else buckets[0] * 2.0
-                    self._histogram_bucket_midpoints[name].append(
-                        (lower_bound + buckets[0]) / 2.0
-                    )
+                    midpoints.append((lower_bound + buckets[0]) / 2.0)
                 else:
-                    self._histogram_bucket_midpoints[name].append(
-                        (buckets[i] + buckets[i - 1]) / 2.0
-                    )
+                    midpoints.append((buckets[i] + buckets[i - 1]) / 2.0)
             # Approximated mid point for Inf+ bucket. Inf+ bucket is an implicit bucket
             # that is not part of buckets.
-            self._histogram_bucket_midpoints[name].append(
-                1.0 if buckets[-1] <= 0 else buckets[-1] * 2.0
-            )
+            midpoints.append(1.0 if buckets[-1] <= 0 else buckets[-1] * 2.0)
+
+            with self._lock:
+                self._registered_instruments[name] = instrument
+                self._histogram_bucket_midpoints[name] = midpoints
 
     def get_histogram_bucket_midpoints(self, name: str) -> List[float]:
         """

--- a/python/ray/tests/test_open_telemetry_metric_recorder.py
+++ b/python/ray/tests/test_open_telemetry_metric_recorder.py
@@ -1,9 +1,13 @@
 import os
 import sys
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 from opentelemetry.metrics import NoOpHistogram
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 from ray._private.metrics_agent import Gauge, Record
 from ray._private.telemetry.metric_types import MetricType
@@ -508,6 +512,106 @@ def test_init_metrics_sets_service_name_resource(
         )
     finally:
         OpenTelemetryMetricRecorder._metrics_initialized = original_flag
+
+
+@pytest.mark.parametrize(
+    "register_method,register_args",
+    [
+        ("register_gauge_metric", ("test_deadlock_gauge", "description")),
+        ("register_counter_metric", ("test_deadlock_counter", "description")),
+        ("register_sum_metric", ("test_deadlock_sum", "description")),
+        # Histogram registration does not go through the measurement-consumer
+        # lock today (synchronous instruments are not registered with the
+        # consumer), so it could not deadlock pre-fix; included as a tripwire
+        # in case that ever changes.
+        (
+            "register_histogram_metric",
+            ("test_deadlock_histogram", "description", [1.0, 10.0]),
+        ),
+    ],
+)
+@patch("opentelemetry.metrics.set_meter_provider")
+@patch("opentelemetry.metrics.get_meter")
+def test_register_does_not_deadlock_with_concurrent_collect(
+    mock_get_meter, mock_set_meter_provider, register_method, register_args
+):
+    """Regression test for an AB/BA deadlock between instrument registration and
+    metric collection.
+
+    The OpenTelemetry SDK holds an SDK-internal lock while invoking
+    observable-instrument callbacks during collect(), and the recorder's
+    callbacks acquire ``recorder._lock``. If registration holds
+    ``recorder._lock`` across ``meter.create_*`` (which acquires that same
+    SDK-internal lock), a registration that races a collect() deadlocks the
+    process permanently:
+
+        registration: recorder._lock -> SDK lock
+        collect():    SDK lock       -> recorder._lock
+
+    This test parks a real SDK collect() inside an instrument callback that
+    contends on ``recorder._lock`` (exactly like the recorder's own callbacks
+    do) while another thread registers a new instrument, and asserts that both
+    complete.
+    """
+    mock_get_meter.return_value = MagicMock()
+    recorder = OpenTelemetryMetricRecorder()
+    # Use a local provider/reader so collect() exercises the real SDK locking,
+    # independent of the process-global meter provider.
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    recorder.meter = provider.get_meter(__name__)
+
+    in_callback = threading.Event()
+    registration_started = threading.Event()
+
+    def contending_callback(options):
+        # Runs inside collect() with the SDK lock held.
+        in_callback.set()
+        registration_started.wait(timeout=30)
+        # Contend on the recorder lock exactly like the recorder's own
+        # observable callbacks do on every scrape.
+        with recorder._lock:
+            return []
+
+    recorder.meter.create_observable_gauge(
+        name="test_contending_gauge", callbacks=[contending_callback]
+    )
+
+    collect_thread = threading.Thread(target=reader.collect, daemon=True)
+    collect_thread.start()
+    assert in_callback.wait(timeout=10), "collect() never invoked the callback"
+
+    register_thread = threading.Thread(
+        target=getattr(recorder, register_method),
+        args=register_args,
+        daemon=True,
+    )
+    register_thread.start()
+    # Let the registration reach its lock acquisitions before releasing the
+    # callback. Under the pre-fix locking (recorder._lock held across
+    # meter.create_*) recorder._lock is what becomes visibly held; under the
+    # fixed locking it is _registration_lock — break on either so the barrier
+    # is fast in both worlds instead of sleeping out the full budget.
+    for _ in range(100):
+        if (
+            recorder._registration_lock.locked()
+            or recorder._lock.locked()
+            or not register_thread.is_alive()
+        ):
+            break
+        time.sleep(0.01)
+    registration_started.set()
+
+    register_thread.join(timeout=10)
+    registration_deadlocked = register_thread.is_alive()
+    collect_thread.join(timeout=10)
+    assert not registration_deadlocked, (
+        f"{register_method}() deadlocked against a concurrent collect(); "
+        "instrument creation must not run while holding recorder._lock."
+    )
+    assert not collect_thread.is_alive(), "collect() did not complete"
+    with recorder._lock:
+        assert register_args[0] in recorder._registered_instruments
 
 
 def test_get_service_name_decodes_otel_resource_attributes():


### PR DESCRIPTION
Cherry-pick of #64946 (`0c26e4d4f2538b607b24f3f626f199f5024537b6`) onto `releases/2.57.0`.

Fixes a lock-order inversion in `OpenTelemetryMetricRecorder` that can permanently deadlock the dashboard agent when an instrument registration races a metrics scrape (observed live on Ray 2.56.1). See #64946 for the full analysis and py-spy capture.

Clean cherry-pick, no conflicts (`git cherry-pick -x`). Touches only `python/ray/_private/telemetry/open_telemetry_metric_recorder.py` and its test file.

🤖 Cherry-pick prepared with [Claude Code](https://claude.com/claude-code)
