### PR TITLE
[core][cgraph] Deprecate Ray Compiled Graphs

### DIFF
--- a/doc/source/ray-core/compiled-graph/compiled-graph-api.rst
+++ b/doc/source/ray-core/compiled-graph/compiled-graph-api.rst
@@ -1,6 +1,12 @@
 Compiled Graph API
 ==================
 
+.. warning::
+
+    Ray Compiled Graph is deprecated and will be removed in a future release.
+    For direct GPU-to-GPU tensor transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
+
 Input and Output Nodes
 ----------------------
 

--- a/doc/source/ray-core/compiled-graph/overlap.rst
+++ b/doc/source/ray-core/compiled-graph/overlap.rst
@@ -3,6 +3,12 @@
 Experimental: Overlapping communication and computation
 =======================================================
 
+.. warning::
+
+    Ray Compiled Graph is deprecated and will be removed in a future release.
+    For direct GPU-to-GPU tensor transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
+
 Compiled Graph currently provides experimental support for GPU communication and computation overlap. When you turn this feature on, it automatically overlaps the GPU communication with computation operations, thereby hiding the communication overhead and improving performance.
 
 To enable this feature, specify ``_overlap_gpu_communication=True`` when calling :func:`dag.experimental_compile() <ray.dag.DAGNode.experimental_compile>`.

--- a/doc/source/ray-core/compiled-graph/profiling.rst
+++ b/doc/source/ray-core/compiled-graph/profiling.rst
@@ -1,6 +1,12 @@
 Profiling
 =========
 
+.. warning::
+
+    Ray Compiled Graph is deprecated and will be removed in a future release.
+    For direct GPU-to-GPU tensor transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
+
 Ray Compiled Graph provides both PyTorch-based and Nsight-based profiling functionalities to better understand the performance
 of individual tasks, system overhead, and performance bottlenecks. You can pick your favorite profiler based on your preference.
 

--- a/doc/source/ray-core/compiled-graph/quickstart.rst
+++ b/doc/source/ray-core/compiled-graph/quickstart.rst
@@ -1,6 +1,12 @@
 Quickstart
 ==========
 
+.. warning::
+
+    Ray Compiled Graph is deprecated and will be removed in a future release.
+    For direct GPU-to-GPU tensor transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
+
 Hello World
 -----------
 This "hello world" example uses Ray Compiled Graph. First, install Ray.

--- a/doc/source/ray-core/compiled-graph/ray-compiled-graph.rst
+++ b/doc/source/ray-core/compiled-graph/ray-compiled-graph.rst
@@ -1,12 +1,13 @@
 .. _ray-compiled-graph:
 
-Ray Compiled Graph (beta)
-=========================
+Ray Compiled Graph (deprecated)
+===============================
 
 .. warning::
 
-    Ray Compiled Graph is currently in beta (since Ray 2.44). The APIs are subject to change and expected to evolve.
-    The API is available from Ray 2.32, but it's recommended to use a version after 2.44.
+    Ray Compiled Graph is deprecated and will be removed in a future release.
+    For direct GPU-to-GPU tensor transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
 
 As large language models (LLMs) become common, programming distributed systems with multiple GPUs is essential.
 :ref:`Ray Core APIs <core-key-concepts>` facilitate using multiple GPUs but have limitations such as:

--- a/doc/source/ray-core/compiled-graph/troubleshooting.rst
+++ b/doc/source/ray-core/compiled-graph/troubleshooting.rst
@@ -1,6 +1,12 @@
 Troubleshooting
 ===============
 
+.. warning::
+
+    Ray Compiled Graph is deprecated and will be removed in a future release.
+    For direct GPU-to-GPU tensor transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
+
 This page contains common issues and solutions for Compiled Graph execution.
 
 Limitations

--- a/doc/source/ray-core/ray-dag.rst
+++ b/doc/source/ray-core/ray-dag.rst
@@ -19,12 +19,12 @@ computation graph.
 
 
 .. note::
-    
-    Ray has introduced an experimental API for high-performance workloads that is
-    especially well suited for applications using multiple GPUs. This API is built on top of
-    the Ray DAG API.
 
-    See :ref:`Ray Compiled Graph <ray-compiled-graph>` for more details.
+    :ref:`Ray Compiled Graph <ray-compiled-graph>`, an experimental API for
+    high-performance workloads built on top of the Ray DAG API, is deprecated
+    and will be removed in a future release. For direct GPU-to-GPU tensor
+    transfer between actors, use
+    :ref:`Ray Direct Transport (RDT) <direct-transport>` instead.
 
 
 When ``.bind()`` is called on a ``ray.remote`` decorated class or function, it will

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -813,6 +813,12 @@ class _ExecutableTaskRecord:
 class CompiledDAG:
     """Experimental class for accelerated execution.
 
+    .. deprecated::
+        Ray Compiled Graph is deprecated and will be removed in a future
+        release. For direct GPU-to-GPU tensor transfer between actors, use
+        Ray Direct Transport (RDT) instead:
+        https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html
+
     This class should not be called directly. Instead, create
     a ray.dag and call experimental_compile().
 

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -39,6 +39,12 @@ DEFAULT_OVERLAP_GPU_COMMUNICATION = env_bool(
 class DAGContext:
     """Global settings for Ray DAG.
 
+    .. deprecated::
+        Ray Compiled Graph is deprecated and will be removed in a future
+        release. For direct GPU-to-GPU tensor transfer between actors, use
+        Ray Direct Transport (RDT) instead:
+        https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html
+
     You can configure parameters in the DAGContext by setting the environment
     variables, `RAY_CGRAPH_<param>` (e.g., `RAY_CGRAPH_buffer_size_bytes`) or Python.
 

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -292,6 +292,12 @@ class DAGNode(DAGNodeBase):
     ) -> "ray.dag.CompiledDAG":
         """Compile an accelerated execution path for this DAG.
 
+        .. deprecated::
+            Ray Compiled Graph is deprecated and will be removed in a future
+            release. For direct GPU-to-GPU tensor transfer between actors, use
+            Ray Direct Transport (RDT) instead:
+            https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html
+
         Args:
             _submit_timeout: The maximum time in seconds to wait for execute() calls.
                 None means using default timeout, 0 means immediate timeout
@@ -338,6 +344,14 @@ class DAGNode(DAGNodeBase):
         Returns:
             A compiled DAG.
         """
+        warnings.warn(
+            "Ray Compiled Graph is deprecated and will be removed in a future "
+            "release. For direct GPU-to-GPU tensor transfer between actors, use "
+            "Ray Direct Transport (RDT) instead: "
+            "https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html",
+            RayDeprecationWarning,
+            stacklevel=2,
+        )
         from ray.dag import DAGContext
 
         ctx = DAGContext.get_current()

--- a/python/ray/dag/tests/experimental/test_compiled_graphs.py
+++ b/python/ray/dag/tests/experimental/test_compiled_graphs.py
@@ -43,6 +43,18 @@ def temporary_change_timeout(request):
     ctx.submit_timeout = original
 
 
+def test_experimental_compile_deprecation_warning(ray_start_regular):
+    from ray.util.annotations import RayDeprecationWarning
+
+    a = Actor.remote(0)
+    with InputNode() as i:
+        dag = a.echo.bind(i)
+
+    with pytest.warns(RayDeprecationWarning, match="Ray Compiled Graph is deprecated"):
+        compiled_dag = dag.experimental_compile()
+    compiled_dag.teardown()
+
+
 def test_basic(ray_start_regular):
     a = Actor.remote(0)
     with InputNode() as i:

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -38,6 +38,12 @@ class CompiledDAGRef:
     """
     A reference to a compiled DAG execution result.
 
+    .. deprecated::
+        Ray Compiled Graph is deprecated and will be removed in a future
+        release. For direct GPU-to-GPU tensor transfer between actors, use
+        Ray Direct Transport (RDT) instead:
+        https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html
+
     This is a subclass of ObjectRef and resembles ObjectRef.  For example,
     similar to ObjectRef, ray.get() can be called on it to retrieve the result.
     However, there are several major differences:


### PR DESCRIPTION
## Why are these changes needed?

Marks Ray Compiled Graphs (cgraph / aDAG) as deprecated, pointing users to **Ray Direct Transport (RDT)** as the successor for direct GPU-to-GPU tensor transfer between actors. The wind-down has already informally started (the GPU cgraph test target is disabled with a "will be deprecated/removed soon" note, and all `compiled_graphs*` release benchmarks are `frequency: manual`); this makes it official and user-visible.

**What this does:**
- `DAGNode.experimental_compile()` emits a `RayDeprecationWarning` — the single funnel all cgraph usage flows through.
- Deprecation notes on the `CompiledDAG`, `DAGContext`, and `CompiledDAGRef` docstrings.
- Docs: the compiled-graph landing page becomes "Ray Compiled Graph (deprecated)" with a banner linking to :ref:`direct-transport`; the same banner is added to the quickstart/profiling/overlap/troubleshooting/API sub-pages; the recommendation note in `ray-dag.rst` is updated.
- Adds `test_experimental_compile_deprecation_warning` asserting the warning fires.

**What this deliberately does NOT do:**
- The feature is unchanged and fully functional. `compiled_graphs` CI targets and the manual-frequency `compiled_graphs*` release benchmarks keep working; the warning fires once at compile time, outside benchmark timing loops.
- Shared infra reused by RDT and Serve is untouched: `ray.experimental.channel`, `ray.experimental.collective`, the base `ray.dag` nodes (`InputNode`/`DAGNode`/`MultiOutputNode`, `py_obj_scanner` — used by Serve), and `with_tensor_transport`.

## Related issue number

N/A

## Checks

- Not a duplicate: searched open PRs for compiled-graph deprecation work; none exists.
- AI assistance was used for this PR (Claude Code); the change has been reviewed line-by-line.
- Tests: verified against a real Ray build (edited module overlaid onto ray 2.56.1): the `RayDeprecationWarning` fires with the expected message, `pytest.warns` in the new test passes, and a compiled DAG still executes end-to-end and tears down cleanly afterward. Ray's root `pytest.ini` ignores warnings globally, so existing cgraph tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
