### PR TITLE
[release-2.57.0][release] Fix huggingface_accelerate release test: floor peft>=0.18 for transformers 5.x (#65062)

### DIFF
--- a/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
@@ -4379,10 +4379,12 @@ patsy==1.0.2 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   statsmodels
-peft==0.17.1 \
-    --hash=sha256:3d129d64def3d74779c32a080d2567e5f7b674e77d546e3585138216d903f99e \
-    --hash=sha256:e6002b42517976c290b3b8bbb9829a33dd5d470676b2dec7cb4df8501b77eb9f
-    # via lm-eval
+peft==0.19.1 \
+    --hash=sha256:0d97542fe96dcdaa20d3b81c06f26f988618f416a73544ab23c3618ccb674a40 \
+    --hash=sha256:2113f72a81621b5913ef28f9022204c742df111890c5f49d812716a4a301e356
+    # via
+    #   -r release/ray_release/byod/requirements_ml_byod_3.10.in
+    #   lm-eval
 petastorm==0.12.1 \
     --hash=sha256:25f7737bbbd8ebcbe6aac9546c50ee7e739902facd434c1dd2d4c6fe7c0acfe9
     # via -r release/ray_release/byod/requirements_ml_byod_3.10.in

--- a/release/ray_release/byod/byod_huggingface_transformers_test.sh
+++ b/release/ray_release/byod/byod_huggingface_transformers_test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# This script is used to build an extra layer on top of the base anyscale/ray image
-# to run the Hugging Face Transformers release test.
-
-set -exo pipefail
-
-# Update accelerate version
-pip3 install accelerate==0.32.0
-pip3 install peft==0.10.0

--- a/release/ray_release/byod/ml_torchft_py3.13.lock
+++ b/release/ray_release/byod/ml_torchft_py3.13.lock
@@ -4268,7 +4268,9 @@ patsy==1.0.2 \
 peft==0.19.1 \
     --hash=sha256:0d97542fe96dcdaa20d3b81c06f26f988618f416a73544ab23c3618ccb674a40 \
     --hash=sha256:2113f72a81621b5913ef28f9022204c742df111890c5f49d812716a4a301e356
-    # via lm-eval
+    # via
+    #   -r release/ray_release/byod/requirements_ml_byod_3.13.in
+    #   lm-eval
 petastorm==0.12.1 \
     --hash=sha256:25f7737bbbd8ebcbe6aac9546c50ee7e739902facd434c1dd2d4c6fe7c0acfe9
     # via -r release/ray_release/byod/requirements_ml_byod_3.13.in

--- a/release/ray_release/byod/requirements_ml_byod_3.10.in
+++ b/release/ray_release/byod/requirements_ml_byod_3.10.in
@@ -28,6 +28,9 @@ numpy
 openai-whisper
 openskill
 orjson
+# peft is pulled in by lm_eval; 0.17.x imports HybridCache, removed in
+# transformers 5.x, breaking `import transformers` at runtime.
+peft>=0.18
 petastorm
 protobuf
 pyarrow

--- a/release/ray_release/byod/requirements_ml_byod_3.13.in
+++ b/release/ray_release/byod/requirements_ml_byod_3.13.in
@@ -27,6 +27,9 @@ numpy
 openai-whisper
 openskill
 orjson
+# peft is pulled in by lm_eval; 0.17.x imports HybridCache, removed in
+# transformers 5.x, breaking `import transformers` at runtime.
+peft>=0.18
 petastorm
 protobuf
 pyarrow

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2317,7 +2317,6 @@
     anyscale_sdk_2026: true
     byod:
       type: gpu
-      post_build_script: byod_huggingface_transformers_test.sh
     cluster_compute: compute_aws.yaml
 
   run:

--- a/release/train_tests/huggingface_accelerate/test_huggingface_accelerate.py
+++ b/release/train_tests/huggingface_accelerate/test_huggingface_accelerate.py
@@ -3,10 +3,10 @@ import tempfile
 import torch
 import evaluate
 from datasets import load_dataset
+from torch.optim import AdamW
 from transformers import (
     AutoTokenizer,
     AutoModelForSequenceClassification,
-    AdamW,
     get_linear_schedule_with_warmup,
 )
 from accelerate import Accelerator
@@ -22,7 +22,7 @@ def train_func():
     accelerator = Accelerator()
 
     # Datasets
-    dataset = load_dataset("yelp_review_full")
+    dataset = load_dataset("Yelp/yelp_review_full")
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
 
     def tokenize_function(examples):

--- a/release/train_tests/huggingface_transformers/test_huggingface_transformers.py
+++ b/release/train_tests/huggingface_transformers/test_huggingface_transformers.py
@@ -20,7 +20,7 @@ from ray.train.torch import TorchTrainer
 # ============================================================
 def train_func():
     # Datasets
-    dataset = load_dataset("yelp_review_full")
+    dataset = load_dataset("Yelp/yelp_review_full")
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
 
     def tokenize_function(examples):
@@ -49,7 +49,7 @@ def train_func():
     # Hugging Face Trainer
     training_args = TrainingArguments(
         output_dir="test_trainer",
-        evaluation_strategy="epoch",
+        eval_strategy="epoch",
         save_strategy="epoch",
         report_to="none",
     )


### PR DESCRIPTION
Cherry-pick of #65062 onto `releases/2.57.0`.

## Why are these changes needed?

The `huggingface_accelerate` nightly release test fails at startup with:

```
ImportError: cannot import name 'HybridCache' from 'transformers'
```

Root cause: after the HuggingFace stack upgrade (#64054), the ray-ml base-extra-testdeps lock pairs `transformers==5.11.0` with `peft==0.17.1`. `peft` has no source pin — it is pulled in transitively by `lm_eval` — so uv left it at a stale resolution. peft 0.17.x imports `HybridCache` from transformers at module scope, but transformers 5.x removed that class, and transformers' `trainer_utils` imports peft whenever it is installed, so any `import transformers` on the image crashes.

Fix: add a `peft>=0.18` floor (0.18 made the `HybridCache` import lazy and version-guarded) to the ml byod source requirements for both py3.10 and py3.13, and recompile the affected locks.

Clean cherry-pick of merge commit 6e160e6ed24b496edae5fca5cd87f5882a76d241 — no conflicts, diff identical to master.

Successful release test run on master: https://buildkite.com/ray-project/release/builds/102272/canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
