### PR TITLE
[Serve] Apply newest-replica-first downscaling across nodes

### DIFF
--- a/doc/source/serve/advanced-guides/replica-scheduling.md
+++ b/doc/source/serve/advanced-guides/replica-scheduling.md
@@ -77,11 +77,13 @@ When scheduling a replica, the scheduler evaluates strategies in the following p
 
 ### Downscaling behavior
 
-When Ray Serve scales down a deployment, it intelligently selects which replicas to stop:
+When Ray Serve scales down a deployment, it selects which replicas to stop in the following priority order:
 
 1. **Non-running replicas first**: Pending, launching, or recovering replicas are stopped before running replicas.
-2. **Minimize node count**: Running replicas are stopped from nodes with the fewest total replicas across all deployments, helping to free up nodes faster. Among replicas on the same node, newer replicas are stopped before older ones.
-3. **Head node protection**: Replicas on the head node have the lowest priority for removal since the head node can't be released. Among replicas on the head node, newer replicas are stopped before older ones.
+2. **Head node protection**: Because the head node can't be released, replicas on worker nodes are always stopped before replicas on the head node, regardless of the criteria below.
+3. **Non-matching nodes first**: If the deployment uses a `label_selector` or `placement_group_bundle_label_selector`, replicas on fallback nodes that don't match the selector are stopped before replicas on matching nodes.
+4. **Minimize node count**: Running replicas are stopped from nodes with the fewest total replicas across all deployments, helping to free up nodes faster.
+5. **Newest replicas first**: Among nodes that are otherwise tied, the node hosting the most recently started replica is drained first. Within each node, newer replicas are stopped before older ones. This preserves long-lived, warmed-up replicas and stops recently scaled-up replicas first.
 
 :::{note}
 Running replicas on the head node isn't recommended for production deployments. The head node runs critical cluster processes such as the GCS and Serve controller, and replica workloads can compete for resources.

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -1287,7 +1287,10 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
             ordered_running_replicas_of_target_deployment[replica_node_id].append(
                 replica_id
             )
-            node_newest_replica_rank.setdefault(replica_node_id, rank)
+            if replica_node_id not in node_newest_replica_rank:
+                node_newest_replica_rank[replica_node_id] = rank
+
+        num_ordered_replicas = len(ordered_running_replicas)
 
         # Prioritize based on following priority:
         # 1. Prioritize replicas not on the head node because we can't relinquish the head node.
@@ -1308,7 +1311,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
                 int(is_head_node),
                 int(match_labels),
                 len(all_replicas),
-                node_newest_replica_rank.get(node_id, len(ordered_running_replicas)),
+                node_newest_replica_rank.get(node_id, num_ordered_replicas),
             )
 
         for node_id, _ in sorted(

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -1278,18 +1278,25 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         ordered_running_replicas_of_target_deployment: Dict[
             str, List[ReplicaID]
         ] = defaultdict(list)
-        for replica_id, replica_node_id in ordered_running_replicas:
+        # Rank each node by the most recently started replica of the target
+        # deployment it hosts (rank 0 = hosts the newest replica), so that
+        # nodes tied on the priorities below drain their recently scaled-up
+        # replicas first instead of older, better-placed ones.
+        node_newest_replica_rank: Dict[str, int] = {}
+        for rank, (replica_id, replica_node_id) in enumerate(ordered_running_replicas):
             ordered_running_replicas_of_target_deployment[replica_node_id].append(
                 replica_id
             )
+            node_newest_replica_rank.setdefault(replica_node_id, rank)
 
         # Prioritize based on following priority:
         # 1. Prioritize replicas not on the head node because we can't relinquish the head node.
         # 2. Prioritize replicas on fallback nodes that don't match the label or bundle label selector.
         # 3. Prioritize replicas on nodes with fewer total replicas so we can relinquish them.
+        # 4. Break ties in favor of nodes hosting more recently started replicas.
         def scale_down_priority(
             node_and_replicas: Tuple[str, Set[ReplicaID]],
-        ) -> Tuple[int, int, int]:
+        ) -> Tuple[int, int, int, int]:
             node_id, all_replicas = node_and_replicas
             node_labels = self._cluster_node_info_cache.get_node_labels(node_id)
             match_labels = not labels_to_check or any(
@@ -1297,7 +1304,12 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
                 for labels in labels_to_check
             )
             is_head_node = node_id == self._head_node_id
-            return int(is_head_node), int(match_labels), len(all_replicas)
+            return (
+                int(is_head_node),
+                int(match_labels),
+                len(all_replicas),
+                node_newest_replica_rank.get(node_id, len(ordered_running_replicas)),
+            )
 
         for node_id, _ in sorted(
             node_to_running_replicas_of_all_deployments.items(), key=scale_down_priority

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -992,6 +992,62 @@ def test_downscale_single_deployment():
     scheduler.on_deployment_deleted(dep_id)
 
 
+def test_downscale_newest_replica_first_across_tied_nodes():
+    """Test that when nodes are tied on all other priorities, the most
+    recently started replicas are stopped first even across nodes.
+    """
+
+    dep_id = DeploymentID(name="deployment1")
+    cluster_node_info_cache = MockClusterNodeInfoCache()
+    cluster_node_info_cache.add_node("node1")
+    cluster_node_info_cache.add_node("node2")
+    scheduler = default_impl.create_deployment_scheduler(
+        cluster_node_info_cache,
+        head_node_id_override="fake-head-node-id",
+        create_placement_group_fn_override=None,
+    )
+
+    scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
+    scheduler.on_deployment_deployed(
+        dep_id, ReplicaConfig.create(lambda x: x, ray_actor_options={"num_cpus": 0})
+    )
+    r1_id = ReplicaID(unique_id="replica1", deployment_id=dep_id)
+    r2_id = ReplicaID(unique_id="replica2", deployment_id=dep_id)
+    scheduler.on_replica_running(r1_id, "node1")
+    scheduler.on_replica_running(r2_id, "node2")
+    deployment_to_replicas_to_stop = scheduler.schedule(
+        upscales={},
+        downscales={
+            dep_id: DeploymentDownscaleRequest(deployment_id=dep_id, num_to_stop=1)
+        },
+    )
+    # Both nodes have one replica; stop the newer replica (r2).
+    assert deployment_to_replicas_to_stop[dep_id] == {r2_id}
+    scheduler.on_replica_stopping(r2_id)
+
+    # Scale up to two replicas per node, with the newest replica on node2.
+    r3_id = ReplicaID(unique_id="replica3", deployment_id=dep_id)
+    r4_id = ReplicaID(unique_id="replica4", deployment_id=dep_id)
+    r5_id = ReplicaID(unique_id="replica5", deployment_id=dep_id)
+    scheduler.on_replica_running(r3_id, "node1")
+    scheduler.on_replica_running(r4_id, "node2")
+    scheduler.on_replica_running(r5_id, "node2")
+    deployment_to_replicas_to_stop = scheduler.schedule(
+        upscales={},
+        downscales={
+            dep_id: DeploymentDownscaleRequest(deployment_id=dep_id, num_to_stop=2)
+        },
+    )
+    # Both nodes have two replicas; drain node2 first since it hosts the
+    # most recently started replica, relinquishing the whole node.
+    assert deployment_to_replicas_to_stop[dep_id] == {r4_id, r5_id}
+    scheduler.on_replica_stopping(r4_id)
+    scheduler.on_replica_stopping(r5_id)
+    scheduler.on_replica_stopping(r1_id)
+    scheduler.on_replica_stopping(r3_id)
+    scheduler.on_deployment_deleted(dep_id)
+
+
 def test_schedule_passes_placement_group_options():
     """Test that bundle_label_selector is passed to CreatePlacementGroupRequest."""
     cluster_node_info_cache = MockClusterNodeInfoCache()


### PR DESCRIPTION
## Description

#52929 changed scale-down to stop the most recently started replicas first,
but only **within** a node. This PR extends the same preference **across**
nodes: when multiple nodes are tied on the existing scale-down priorities,
the iteration order is effectively arbitrary today, so a node hosting older,
warmed-up replicas can be selected before one hosting replicas that were just
scaled up.

This adds the recency of each node's newest replica as a fourth tie-breaking
key in `scale_down_priority`, reusing the ordering source from #52929. It is
strictly a tie-breaker — if nodes differ on any existing priority, behavior
remains unchanged.

## Related issues

Related to #52929