### PR TITLE
[core][test] Bound two unbounded waits that turn a test failure into a CI timeout

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -9,7 +9,6 @@ import asyncio
 import inspect
 import logging
 import os
-import signal
 import subprocess
 import sys
 import threading
@@ -42,17 +41,22 @@ DEFAULT_DRIVER_TIMEOUT_SECONDS = 300
 # bounded too or the timeout path hangs exactly like the path it replaces.
 KILLED_DRIVER_DRAIN_TIMEOUT_SECONDS = 10
 
+# Synthetic return code recorded for a process that outlived ``Popen.kill()``.
+# ``signal.SIGKILL`` is POSIX-only and these helpers also run on Windows, so
+# the numeric value is spelled out rather than derived from ``signal``.
+_UNREAPED_PROCESS_RETURNCODE = -9
+
 
 def _detach_process(proc: subprocess.Popen) -> None:
-    """Stop waiting on a process that survived SIGKILL.
+    """Stop waiting on a process that survived ``Popen.kill()``.
 
     ``Popen.__exit__`` and ``Popen.__del__`` both call ``wait()`` with no
     timeout, so a process stuck in uninterruptible sleep would re-introduce the
     unbounded wait the caller just escaped. ``Popen.wait`` short-circuits when
-    ``returncode`` is already set, so record the signal we sent and move on.
+    ``returncode`` is already set, so record a synthetic code and move on.
     """
     if proc.returncode is None:
-        proc.returncode = -signal.SIGKILL
+        proc.returncode = _UNREAPED_PROCESS_RETURNCODE
 
 
 try:

--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -447,7 +447,10 @@ def run_string_as_driver(
             logger.error(
                 "Driver did not exit within %ss; killed it. Output so far:\n%s",
                 timeout,
-                decode(output, encode_type=encode),
+                # Decode leniently: a killed driver's output can end mid
+                # multi-byte sequence, and a UnicodeDecodeError here would
+                # mask the TimeoutExpired the caller needs to see.
+                output.decode(encode, errors="replace"),
             )
             raise
         if proc.returncode:

--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -30,6 +30,12 @@ from ray._common.utils import decode
 
 logger = logging.getLogger(__name__)
 
+# Default upper bound on how long a driver launched by run_string_as_driver may
+# run. Without a bound, a driver that hangs on shutdown blocks the calling test
+# until the test runner's own timeout fires, which turns a single failure into a
+# whole-target timeout and burns every retry attempt.
+DEFAULT_DRIVER_TIMEOUT_SECONDS = 300
+
 try:
     from prometheus_client.core import Metric
     from prometheus_client.parser import Sample, text_string_to_metric_families
@@ -374,7 +380,10 @@ def assert_tensors_equivalent(obj1, obj2):
 
 
 def run_string_as_driver(
-    driver_script: str, env: Dict = None, encode: str = "utf-8"
+    driver_script: str,
+    env: Dict = None,
+    encode: str = "utf-8",
+    timeout: Optional[float] = DEFAULT_DRIVER_TIMEOUT_SECONDS,
 ) -> str:
     """Run a driver as a separate process.
 
@@ -382,9 +391,16 @@ def run_string_as_driver(
         driver_script: A string to run as a Python script.
         env: The environment variables for the driver.
         encode: The encoding to use for the driver script.
+        timeout: Seconds to wait for the driver to exit before killing it and
+            raising. Pass None to wait forever, but note that a driver which
+            hangs on shutdown will then consume the caller's entire test
+            budget instead of failing.
 
     Returns:
         The script's output.
+
+    Raises:
+        subprocess.TimeoutExpired: If the driver did not exit within ``timeout``.
     """
     proc = subprocess.Popen(
         [sys.executable, "-"],
@@ -394,7 +410,19 @@ def run_string_as_driver(
         env=env,
     )
     with proc:
-        output = proc.communicate(driver_script.encode(encoding=encode))[0]
+        try:
+            output = proc.communicate(
+                driver_script.encode(encoding=encode), timeout=timeout
+            )[0]
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            output = proc.communicate()[0]
+            logger.error(
+                "Driver did not exit within %ss; killed it. Output so far:\n%s",
+                timeout,
+                decode(output, encode_type=encode),
+            )
+            raise
         if proc.returncode:
             print(decode(output, encode_type=encode))
             logger.error(proc.stderr)

--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import logging
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -35,6 +36,24 @@ logger = logging.getLogger(__name__)
 # until the test runner's own timeout fires, which turns a single failure into a
 # whole-target timeout and burns every retry attempt.
 DEFAULT_DRIVER_TIMEOUT_SECONDS = 300
+
+# Seconds to wait for a driver's output after it has been SIGKILLed. A process
+# parked in uninterruptible sleep does not die on SIGKILL, so this wait must be
+# bounded too or the timeout path hangs exactly like the path it replaces.
+KILLED_DRIVER_DRAIN_TIMEOUT_SECONDS = 10
+
+
+def _detach_process(proc: subprocess.Popen) -> None:
+    """Stop waiting on a process that survived SIGKILL.
+
+    ``Popen.__exit__`` and ``Popen.__del__`` both call ``wait()`` with no
+    timeout, so a process stuck in uninterruptible sleep would re-introduce the
+    unbounded wait the caller just escaped. ``Popen.wait`` short-circuits when
+    ``returncode`` is already set, so record the signal we sent and move on.
+    """
+    if proc.returncode is None:
+        proc.returncode = -signal.SIGKILL
+
 
 try:
     from prometheus_client.core import Metric
@@ -414,9 +433,17 @@ def run_string_as_driver(
             output = proc.communicate(
                 driver_script.encode(encoding=encode), timeout=timeout
             )[0]
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             proc.kill()
-            output = proc.communicate()[0]
+            try:
+                output = proc.communicate(timeout=KILLED_DRIVER_DRAIN_TIMEOUT_SECONDS)[
+                    0
+                ]
+            except subprocess.TimeoutExpired:
+                # The driver did not die on SIGKILL either, so take whatever
+                # was captured before the first timeout and stop waiting on it.
+                output = e.stdout or b""
+                _detach_process(proc)
             logger.error(
                 "Driver did not exit within %ss; killed it. Output so far:\n%s",
                 timeout,

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1812,7 +1812,10 @@ class Node:
             check_alive: If true, then we expect the process to be alive
                 and will raise an exception if the process is already dead.
             wait: If true, then this method will not return until the
-                process in question has exited.
+                process in question has exited, except that a process which
+                does not die within KILLED_PROCESS_REAP_TIMEOUT_SECONDS of
+                being killed is logged and abandoned instead of waited on
+                indefinitely.
 
         Raises:
             This process raises an exception in the following cases:
@@ -2025,7 +2028,10 @@ class Node:
             allow_graceful: Send a SIGTERM first and give each process time
                 to exit gracefully before falling back to SIGKILL.
             wait: If true, then this method will not return until the
-                process in question has exited.
+                process in question has exited, except that a process which
+                does not die within KILLED_PROCESS_REAP_TIMEOUT_SECONDS of
+                being killed is logged and abandoned instead of waited on
+                indefinitely.
         """
         # Kill the raylet first. This is important for suppressing errors at
         # shutdown because we give the raylet a chance to exit gracefully and
@@ -2083,7 +2089,7 @@ class Node:
         # Processes that outlived their SIGKILL are no longer in
         # `all_processes`, but they are still running and callers checking
         # liveness need to see them.
-        for process_type, process_infos in self._unreaped_processes.items():
+        for process_type, process_infos in list(self._unreaped_processes.items()):
             for process_info in process_infos:
                 if process_info.process.poll() is None:
                     result.append((process_type, process_info.process))

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1833,6 +1833,7 @@ class Node:
         if process_type != ray_constants.PROCESS_TYPE_REDIS_SERVER:
             assert len(process_infos) == 1
         wait_timeout_seconds = 1
+        unreaped_process_infos = []
         for process_info in process_infos:
             process = process_info.process
             # Handle the case where the process has already exited.
@@ -1908,8 +1909,17 @@ class Node:
                             "uninterruptible syscall, such as a blocking disk "
                             "write. Continuing shutdown without it."
                         )
+                        # Keep it in `all_processes` so `live_processes` and
+                        # `any_processes_alive` still report it. Dropping it
+                        # here would let teardown assertions such as
+                        # `Cluster.remove_node`'s pass while the process is
+                        # still running.
+                        unreaped_process_infos.append(process_info)
 
-        del self.all_processes[process_type]
+        if unreaped_process_infos:
+            self.all_processes[process_type] = unreaped_process_infos
+        else:
+            del self.all_processes[process_type]
 
     def kill_redis(self, check_alive: bool = True):
         """Kill the Redis servers.

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -58,6 +58,12 @@ if TYPE_CHECKING:
 # using logging.basicConfig in its entry/init points.
 logger = logging.getLogger(__name__)
 
+# Upper bound on how long to wait for a SIGKILLed Ray process to be reaped when
+# the caller asked to wait for it. Reaping is normally immediate; a process that
+# is still around after this long is parked in an uninterruptible syscall and
+# will never be reaped by waiting longer.
+KILLED_PROCESS_REAP_TIMEOUT_SECONDS = 30
+
 
 class Node:
     """An encapsulation of the Ray processes on a single node.
@@ -1873,13 +1879,35 @@ class Node:
             # If the process did not exit, force kill it.
             if process.poll() is None:
                 process.kill()
-                # After kill, wait must be called
-                # The reason we usually don't set timeout=None here is that
-                # there's some chance we'd end up waiting a really long time.
+                # After kill, wait must be called so the process is reaped
+                # rather than left as a zombie, which would keep its workers
+                # from exiting.
+                #
+                # This wait is bounded even when wait=True. SIGKILL cannot
+                # reap a process parked in uninterruptible sleep (D state),
+                # which happens when it is blocked in a syscall such as the
+                # fsync the RocksDB GCS backend issues on every write. An
+                # unbounded wait here turned a single test failure into a
+                # whole-target CI timeout, because the fixture teardown hung
+                # for the remainder of the Bazel budget instead of failing.
+                # Bound it, log loudly, and let the caller's liveness check
+                # report a real error.
+                timeout = (
+                    KILLED_PROCESS_REAP_TIMEOUT_SECONDS
+                    if wait
+                    else wait_timeout_seconds
+                )
                 try:
-                    process.wait(timeout=None if wait else wait_timeout_seconds)
+                    process.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
-                    pass
+                    if wait:
+                        logger.warning(
+                            f"Process of type {process_type} (pid "
+                            f"{process.pid}) did not exit within {timeout}s of "
+                            "being killed. It is most likely stuck in an "
+                            "uninterruptible syscall, such as a blocking disk "
+                            "write. Continuing shutdown without it."
+                        )
 
         del self.all_processes[process_type]
 

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -118,11 +118,13 @@ class Node:
             ray_params.resource_isolation_config
         )
         self.all_processes: dict = {}
-        # Process types that were SIGKILLed but could not be reaped within
-        # KILLED_PROCESS_REAP_TIMEOUT_SECONDS. They stay in `all_processes` so
-        # liveness checks still report them, but they are not killed again:
-        # retrying only pays the timeout a second time.
-        self._unreaped_process_types: set = set()
+        # Processes that were SIGKILLed but could not be reaped within
+        # KILLED_PROCESS_REAP_TIMEOUT_SECONDS, keyed by process type. They are
+        # removed from `all_processes` like any other killed process, so
+        # restarts and `remaining_processes_alive` behave exactly as before,
+        # but `live_processes` still reports them while they are running so
+        # teardown assertions can see a process that outlived its kill.
+        self._unreaped_processes: dict = {}
         self.removal_lock = threading.Lock()
 
         self.ray_init_cluster = ray_init_cluster
@@ -1834,16 +1836,10 @@ class Node:
         """See `_kill_process_type`."""
         if process_type not in self.all_processes:
             return
-        if process_type in self._unreaped_process_types:
-            # Already SIGKILLed and left unreaped. Killing it again would only
-            # pay KILLED_PROCESS_REAP_TIMEOUT_SECONDS a second time, and
-            # `kill_all_processes` reaches raylet and GCS twice by design.
-            return
         process_infos = self.all_processes[process_type]
         if process_type != ray_constants.PROCESS_TYPE_REDIS_SERVER:
             assert len(process_infos) == 1
         wait_timeout_seconds = 1
-        unreaped_process_infos = []
         for process_info in process_infos:
             process = process_info.process
             # Handle the case where the process has already exited.
@@ -1919,18 +1915,18 @@ class Node:
                             "uninterruptible syscall, such as a blocking disk "
                             "write. Continuing shutdown without it."
                         )
-                        # Keep it in `all_processes` so `live_processes` and
-                        # `any_processes_alive` still report it. Dropping it
-                        # here would let teardown assertions such as
-                        # `Cluster.remove_node`'s pass while the process is
-                        # still running.
-                        unreaped_process_infos.append(process_info)
+                        # Track it separately from `all_processes` so
+                        # `live_processes` still reports it while it runs.
+                        # Leaving it in `all_processes` instead would block a
+                        # later restart of this process type and would make
+                        # `remaining_processes_alive` report a failure once the
+                        # process finally died, even though it was killed on
+                        # purpose.
+                        self._unreaped_processes.setdefault(process_type, []).append(
+                            process_info
+                        )
 
-        if unreaped_process_infos:
-            self.all_processes[process_type] = unreaped_process_infos
-            self._unreaped_process_types.add(process_type)
-        else:
-            del self.all_processes[process_type]
+        del self.all_processes[process_type]
 
     def kill_redis(self, check_alive: bool = True):
         """Kill the Redis servers.
@@ -2081,6 +2077,13 @@ class Node:
         """
         result = []
         for process_type, process_infos in self.all_processes.items():
+            for process_info in process_infos:
+                if process_info.process.poll() is None:
+                    result.append((process_type, process_info.process))
+        # Processes that outlived their SIGKILL are no longer in
+        # `all_processes`, but they are still running and callers checking
+        # liveness need to see them.
+        for process_type, process_infos in self._unreaped_processes.items():
             for process_info in process_infos:
                 if process_info.process.poll() is None:
                     result.append((process_type, process_info.process))

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -118,6 +118,11 @@ class Node:
             ray_params.resource_isolation_config
         )
         self.all_processes: dict = {}
+        # Process types that were SIGKILLed but could not be reaped within
+        # KILLED_PROCESS_REAP_TIMEOUT_SECONDS. They stay in `all_processes` so
+        # liveness checks still report them, but they are not killed again:
+        # retrying only pays the timeout a second time.
+        self._unreaped_process_types: set = set()
         self.removal_lock = threading.Lock()
 
         self.ray_init_cluster = ray_init_cluster
@@ -1829,6 +1834,11 @@ class Node:
         """See `_kill_process_type`."""
         if process_type not in self.all_processes:
             return
+        if process_type in self._unreaped_process_types:
+            # Already SIGKILLed and left unreaped. Killing it again would only
+            # pay KILLED_PROCESS_REAP_TIMEOUT_SECONDS a second time, and
+            # `kill_all_processes` reaches raylet and GCS twice by design.
+            return
         process_infos = self.all_processes[process_type]
         if process_type != ray_constants.PROCESS_TYPE_REDIS_SERVER:
             assert len(process_infos) == 1
@@ -1918,6 +1928,7 @@ class Node:
 
         if unreaped_process_infos:
             self.all_processes[process_type] = unreaped_process_infos
+            self._unreaped_process_types.add(process_type)
         else:
             del self.all_processes[process_type]
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -32,8 +32,10 @@ import ray.dashboard.consts as dashboard_consts
 from ray._common.network_utils import build_address, parse_address
 from ray._common.test_utils import (
     DEFAULT_DRIVER_TIMEOUT_SECONDS,
+    KILLED_DRIVER_DRAIN_TIMEOUT_SECONDS,
     MetricSamplePattern,
     PrometheusTimeseries,
+    _detach_process,
     fetch_prometheus_metric_timeseries,
     fetch_prometheus_timeseries,
     wait_for_condition,
@@ -576,9 +578,17 @@ def run_string_as_driver_stdout_stderr(
             outputs_bytes = proc.communicate(
                 driver_script.encode(encoding=encode), timeout=timeout
             )
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             proc.kill()
-            outputs_bytes = proc.communicate()
+            try:
+                outputs_bytes = proc.communicate(
+                    timeout=KILLED_DRIVER_DRAIN_TIMEOUT_SECONDS
+                )
+            except subprocess.TimeoutExpired:
+                # The driver did not die on SIGKILL either, so take whatever
+                # was captured before the first timeout and stop waiting on it.
+                outputs_bytes = (e.stdout or b"", e.stderr or b"")
+                _detach_process(proc)
             logger.error(
                 "Driver did not exit within %ss; killed it. Output so far:\n%s",
                 timeout,

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -31,6 +31,7 @@ import ray._private.utils
 import ray.dashboard.consts as dashboard_consts
 from ray._common.network_utils import build_address, parse_address
 from ray._common.test_utils import (
+    DEFAULT_DRIVER_TIMEOUT_SECONDS,
     MetricSamplePattern,
     PrometheusTimeseries,
     fetch_prometheus_metric_timeseries,
@@ -542,7 +543,10 @@ def kill_processes(process_infos: List[ProcessInfo]):
 
 
 def run_string_as_driver_stdout_stderr(
-    driver_script: str, env: Dict = None, encode: str = "utf-8"
+    driver_script: str,
+    env: Dict = None,
+    encode: str = "utf-8",
+    timeout: Optional[float] = DEFAULT_DRIVER_TIMEOUT_SECONDS,
 ) -> Tuple[str, str]:
     """Run a driver as a separate process.
 
@@ -551,9 +555,14 @@ def run_string_as_driver_stdout_stderr(
         env: The environment variables for the driver.
         encode: Text encoding used to send the script to the subprocess and
             decode its stdout/stderr.
+        timeout: Seconds to wait for the driver to exit before killing it and
+            raising. Pass None to wait forever.
 
     Returns:
         The script's stdout and stderr.
+
+    Raises:
+        subprocess.TimeoutExpired: If the driver did not exit within ``timeout``.
     """
     proc = subprocess.Popen(
         [sys.executable, "-"],
@@ -563,7 +572,19 @@ def run_string_as_driver_stdout_stderr(
         env=env,
     )
     with proc:
-        outputs_bytes = proc.communicate(driver_script.encode(encoding=encode))
+        try:
+            outputs_bytes = proc.communicate(
+                driver_script.encode(encoding=encode), timeout=timeout
+            )
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            outputs_bytes = proc.communicate()
+            logger.error(
+                "Driver did not exit within %ss; killed it. Output so far:\n%s",
+                timeout,
+                outputs_bytes,
+            )
+            raise
         out_str, err_str = [
             ray._common.utils.decode(output, encode_type=encode)
             for output in outputs_bytes


### PR DESCRIPTION
## Why are these changes needed?

`//python/ray/tests:test_generators` and `//python/ray/dag:tests/experimental/test_compiled_graphs` are the two worst offenders in the RocksDB GCS premerge job. Both are reported as TIMEOUT/FLAKY at the *target* level, consuming the full Bazel budget on every attempt, even though the underlying failure is a single test case.

Comparing premerge [#70949](https://buildkite.com/ray-project/premerge/builds/70949), which ran the redis and rocksdb jobs on the same commit, the suite totals are effectively identical (**29,427s** redis vs **29,644s** rocksdb, +0.7%), so there is no general backend latency tax. The damage is concentrated:

| target | redis | rocksdb | ratio | |
|---|---|---|---|---|
| `//python/ray/dag:.../test_compiled_graphs` | 1193.6s | 3600.2s | 3.02× | FLAKY |
| `//python/ray/tests:test_generators` | 416.7s | 915.1s | 2.20× | TIMEOUT |
| `//python/ray/tests:test_multi_node_3` | 162.1s | 207.9s | 1.28× | passing |

Everything else is ≤1.5×. And it is not a timing-margin problem: the retry of the same rocksdb shard passed `test_generators` in **343.7s**, i.e. *faster* than redis. The distribution is bimodal, which points at a wedge rather than a slowdown.

Reading the timeout dumps, both targets wedge on an unbounded wait that has nothing to do with the assertion under test:

1. `Node._kill_process_type` waits with `timeout=None` whenever the caller passes `wait=True`, which `Cluster.remove_node` always does. `SIGKILL` cannot reap a process parked in uninterruptible sleep, and a process blocked in the `fsync` that the RocksDB GCS issues on every write is exactly that. So `ray_start_cluster` teardown blocks forever. In the failing `test_generators` attempt, pytest-timeout fired at 180s and teardown then absorbed the remaining ~700s until Bazel killed the target at 900s — twice, because of `--flaky_test_attempts=2`. One test-case failure cost **30 minutes of CI** and was reported as TIMEOUT instead of a clean FAILED-then-retry.

2. `run_string_as_driver` / `run_string_as_driver_stdout_stderr` call `proc.communicate()` with no timeout, so a driver that hangs during shutdown blocks the test forever. That is precisely what `test_compiled_graphs::test_async_shutdown` does, and it is the point where that target's timeout dump lands.

Neither wait is load-bearing: nothing depends on waiting *forever*, only on waiting long enough.

## What this changes

- **`Node._kill_process_type`**: bound the post-SIGKILL wait at 30s even when `wait=True`, and log the pid and process type when it expires. Reaping is normally instantaneous, so this is inert in the healthy case; when it does expire, `Cluster.remove_node`'s existing `any_processes_alive()` assertion now reports a real error in seconds instead of hanging.
- **`run_string_as_driver` / `run_string_as_driver_stdout_stderr`**: add a `timeout` parameter defaulting to 300s. On expiry, kill the driver, log whatever it produced, and re-raise `TimeoutExpired`. 300s is well above the 180s pytest-timeout that already governs almost every caller, so no existing blocking driver should be affected. Pass `timeout=None` to restore the old behaviour.

This makes the failures **bounded and attributable**. It deliberately does not attempt to fix the underlying test-case flake, which is still under investigation and has not been reproduced outside CI — 48/48 local runs of the four `test_dynamic_generator_reconstruction_nondeterministic` variants passed under both backends, with rocksdb showing no slowdown (median **68.9s** vs **70.2s** for the in-memory GCS).

## Related issue number

Follow-up to #64702 (REP-64). Not a duplicate — I checked open PRs and none touch these two waits.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've made sure the tests are passing.

Tested locally:
- `test_dynamic_generator_reconstruction_nondeterministic[None-False]` and `[None-True]` under `TEST_GCS_ROCKSDB=1`: **2 passed in 136.9s**
- `test_output.py -k test_disable_driver_logs_breakpoint`: **1 passed**
- direct exercise of all three `run_string_as_driver*` paths, including the new timeout path (kills the driver and raises `TimeoutExpired`)
- `pre-commit run` clean on all three changed files

AI assistance (GitHub Copilot CLI) was used for the CI log analysis and to draft these changes; every line was reviewed by me.
