### PR TITLE
[ci][release test] Retry only on infra failures and report the real result status

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -851,6 +851,24 @@ py_test(
 )
 
 py_test(
+    name = "test_ray_test_db_reporter",
+    size = "small",
+    srcs = ["ray_release/tests/test_ray_test_db_reporter.py"],
+    data = [
+        "ray_release/configs/oss_config.yaml",
+    ],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("pytest"),
+    ],
+)
+
+py_test(
     name = "test_result",
     size = "small",
     srcs = ["ray_release/tests/test_result.py"],

--- a/release/hello_world_tests/hello_world.py
+++ b/release/hello_world_tests/hello_world.py
@@ -8,7 +8,6 @@ def hello_world():
 
 def main():
     print(ray.get(hello_world.remote()))
-    exit(1)
 
 
 if __name__ == "__main__":

--- a/release/hello_world_tests/hello_world.py
+++ b/release/hello_world_tests/hello_world.py
@@ -8,6 +8,7 @@ def hello_world():
 
 def main():
     print(ray.get(hello_world.remote()))
+    exit(1)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -146,10 +146,6 @@ def get_step(
     if smoke_test:
         cmd += ["--smoke-test"]
 
-    num_retries = test.get("run", {}).get("num_retries")
-    if num_retries:
-        step["retry"]["automatic"][0]["limit"] = num_retries
-
     step["commands"] = [" ".join(cmd)]
 
     env_to_use = test.get("env", DEFAULT_ENVIRONMENT)
@@ -164,6 +160,14 @@ def get_step(
     env_dict["ANYSCALE_PROJECT"] = get_test_project_id(test, default_project_id)
 
     step["env"].update(env_dict)
+
+    # Set after the env update above so a per-test environment cannot clobber it.
+    num_retries = test.get("run", {}).get("num_retries")
+    if num_retries:
+        step["retry"]["automatic"][0]["limit"] = num_retries
+        # Keep the in-job view of the retry budget aligned with Buildkite's, so
+        # ray_release.result.should_retry knows which attempt is the last one.
+        step["env"]["BUILDKITE_MAX_RETRIES"] = str(num_retries)
 
     commit = get_test_env_var("RAY_COMMIT")
     branch = get_test_env_var("RAY_BRANCH")

--- a/release/ray_release/exception.py
+++ b/release/ray_release/exception.py
@@ -8,7 +8,7 @@ class ExitCode(enum.Enum):
     UNSPECIFIED = 2
     UNKNOWN = 3
 
-    # Hard infra errors (non-retryable)
+    # Hard infra errors (see RETRYABLE_EXIT_CODES below)
     CLI_ERROR = 10
     CONFIG_ERROR = 11
     SETUP_ERROR = 12
@@ -20,7 +20,7 @@ class ExitCode(enum.Enum):
     FETCH_RESULT_ERROR = 18
     ANYSCALE_ERROR = 19
 
-    # Infra timeouts (retryable)
+    # Infra timeouts (see RETRYABLE_EXIT_CODES below)
     RAY_WHEELS_TIMEOUT = 30
     CLUSTER_ENV_BUILD_TIMEOUT = 31
     CLUSTER_STARTUP_TIMEOUT = 32
@@ -31,6 +31,33 @@ class ExitCode(enum.Enum):
     COMMAND_ALERT = 41
     COMMAND_TIMEOUT = 42
     PREPARE_ERROR = 43
+
+
+# Exit codes for failures where the test never got a fair chance to run, and where a
+# second attempt has a real chance of succeeding.
+#
+# This is the single source of truth for retry behavior: ray_release.result.should_retry
+# reads it, and run_release_test.sh acts on the retry marker that decision produces.
+# Adding a member here causes real, billable re-runs -- be deliberate.
+#
+# Deliberately excluded:
+#   CLI_ERROR, CONFIG_ERROR: deterministic; a second attempt fails identically.
+#   FETCH_RESULT_ERROR:      the test already ran, so a retry pays for a full re-run
+#                            just to recover a result file.
+#   Everything else:         the test ran and failed on its own merits.
+RETRYABLE_EXIT_CODES = frozenset(
+    {
+        ExitCode.SETUP_ERROR,
+        ExitCode.CLUSTER_RESOURCE_ERROR,
+        ExitCode.CLUSTER_ENV_BUILD_ERROR,
+        ExitCode.CLUSTER_STARTUP_ERROR,
+        ExitCode.ANYSCALE_ERROR,
+        ExitCode.RAY_WHEELS_TIMEOUT,
+        ExitCode.CLUSTER_ENV_BUILD_TIMEOUT,
+        ExitCode.CLUSTER_STARTUP_TIMEOUT,
+        ExitCode.CLUSTER_WAIT_TIMEOUT,
+    }
+)
 
 
 class ReleaseTestError(RuntimeError):

--- a/release/ray_release/reporter/ray_test_db.py
+++ b/release/ray_release/reporter/ray_test_db.py
@@ -4,7 +4,7 @@ import os
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
-from ray_release.result import Result, ResultStatus
+from ray_release.result import Result
 from ray_release.test import Test
 from ray_release.test_automation.release_state_machine import ReleaseTestStateMachine
 
@@ -28,10 +28,10 @@ class RayTestDBReporter(Reporter):
         ):
             logger.info("Skip upload test results. We only upload on branch pipeline.")
             return
-        if result.status == ResultStatus.TRANSIENT_INFRA_ERROR.value:
+        if result.will_retry:
             logger.info(
-                f"Skip recording result for test {test.get_name()} due to transient "
-                "infra error result"
+                f"Skip recording result for test {test.get_name()}; Buildkite will "
+                "retry this attempt and the final one is what counts"
             )
             return
         logger.info(

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -2,9 +2,14 @@ import enum
 import os
 import traceback
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, Optional
 
-from ray_release.exception import ExitCode, ReleaseTestError
+from ray_release.exception import RETRYABLE_EXIT_CODES, ExitCode, ReleaseTestError
+
+# run_release_test.sh owns this path and re-reads it after the test process exits to
+# decide whether to ask Buildkite for another attempt.
+RETRY_MARKER_ENV_VAR = "RELEASE_TEST_RETRY_MARKER"
 
 
 class ResultStatus(enum.Enum):
@@ -15,6 +20,7 @@ class ResultStatus(enum.Enum):
     SUCCESS = "success"
     UNKNOWN = "unknown"
     RUNTIME_ERROR = "runtime_error"
+    # Deprecated: no longer assigned. Retryability now lives on Result.will_retry.
     TRANSIENT_INFRA_ERROR = "transient_infra_error"
     INFRA_ERROR = "infra_error"
     INFRA_TIMEOUT = "infra_timeout"
@@ -45,18 +51,42 @@ class Result:
     prometheus_metrics: Optional[Dict] = None
     extra_tags: Optional[Dict] = None
 
+    # Whether Buildkite will run this test again. Consumed by RayTestDBReporter, so an
+    # attempt that is about to be superseded is not recorded, and -- via the retry
+    # marker -- by run_release_test.sh.
+    will_retry: bool = False
 
-def _is_transient_error(runtime: int) -> bool:
+
+def should_retry(result: Result) -> bool:
     """
-    Classify whether an infra-failure issue is a transient issue. This is based on
-    the status of its previous retries, and its runtime.
+    Whether this attempt is worth running again.
+
+    An attempt is retried only when the test never got a fair chance to run, the
+    Buildkite retry budget is not yet exhausted, and the attempt was cheap enough that
+    re-running it is worth the compute.
     """
+    try:
+        exit_code = ExitCode(result.return_code)
+    except ValueError:
+        # An exit code we do not recognize. Fail closed and surface the failure.
+        return False
+    if exit_code not in RETRYABLE_EXIT_CODES:
+        return False
     retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", 0))
     max_retry = int(os.environ.get("BUILDKITE_MAX_RETRIES", 1))
     if retry_count >= max_retry:
         # Already reach retry limit
         return False
-    return runtime <= int(os.environ.get("BUILDKITE_TIME_LIMIT_FOR_RETRY", 0))
+    return (result.runtime or 0) <= int(
+        os.environ.get("BUILDKITE_TIME_LIMIT_FOR_RETRY", 0)
+    )
+
+
+def write_retry_marker(result: Result) -> None:
+    """Tell run_release_test.sh that Buildkite should be asked for another attempt."""
+    marker = os.environ.get(RETRY_MARKER_ENV_VAR)
+    if marker and result.will_retry:
+        Path(marker).touch()
 
 
 def update_result_from_exception(
@@ -71,13 +101,9 @@ def update_result_from_exception(
         result.runtime = 0
         return
 
-    # Used for transient error detection.
-    # The logic does not really make sense.. but it is the same as the logic
-    # before refactoring.. and there are tests depends on the behavior..a
-    # TODO(aslonnie): clean up the logic...
-    original_runtime = result.runtime or 0
-
     exit_code = e.exit_code
+    result.return_code = exit_code.value
+
     if 1 <= exit_code.value < 10:
         result.status = ResultStatus.RUNTIME_ERROR.value
     elif 10 <= exit_code.value < 20:
@@ -91,9 +117,6 @@ def update_result_from_exception(
         result.status = ResultStatus.ERROR.value
         result.runtime = 0
 
-    # if this result is to be retried, mark its status as transient
-    # this logic should be in-sync with run_release_test.sh
-    if _is_transient_error(original_runtime):
-        result.status = ResultStatus.TRANSIENT_INFRA_ERROR.value
-
-    result.return_code = exit_code.value
+    # Retryability keys off the exit code, so the runtimes zeroed out above cannot
+    # affect the decision: neither TIMEOUT nor ERROR is retryable.
+    result.will_retry = should_retry(result)

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -21,7 +21,7 @@ from ray_release.reporter.artifacts import ArtifactsReporter
 from ray_release.reporter.db import DBReporter
 from ray_release.reporter.log import LogReporter
 from ray_release.reporter.ray_test_db import RayTestDBReporter
-from ray_release.result import Result
+from ray_release.result import Result, write_retry_marker
 
 
 @click.command()
@@ -144,6 +144,12 @@ def main(
     except ReleaseTestError as e:
         logger.exception(e)
         return_code = e.exit_code.value
+
+    # glue.run_release_test mutates `result` in place, so will_retry is set even when
+    # the pipeline raised. This runs after the reporters, so the marker always agrees
+    # with what was (or was not) recorded.
+    write_retry_marker(result)
+
     logger.info(
         f"Release test pipeline for test {test['name']} completed. "
         f"Returning with exit code = {return_code}"

--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -40,6 +40,14 @@ class ReleaseTestStateMachine(TestStateMachine):
             for result in self.test_results[:CONTINUOUS_FAILURE_TO_JAIL]
         )
 
+    # TODO(sai): release tests never enter the FLAKY state -- every flaky transition
+    # below is hardcoded to False. That was tolerable while a failure of any kind was
+    # retried and only the final attempt was recorded, which hid flakes from the state
+    # machine entirely. Retries are now limited to RETRYABLE_EXIT_CODES, so a test that
+    # fails for non-infra reasons has its first-attempt failure persisted and flakiness
+    # is visible in the result history for the first time. Implement real flaky
+    # detection here so those tests surface as FLAKY instead of oscillating between
+    # PASSING and FAILING and triggering a bisect on every flip.
     def _passing_to_flaky(self) -> bool:
         return False
 

--- a/release/ray_release/tests/_test_run_release_test_sh.py
+++ b/release/ray_release/tests/_test_run_release_test_sh.py
@@ -3,6 +3,8 @@ import sys
 
 import click
 
+from ray_release.result import Result, should_retry, write_retry_marker
+
 
 @click.command()
 @click.argument("state_file", type=str)
@@ -26,17 +28,19 @@ def main(
     with open(state_file, "wt") as fp:
         fp.write(str(state))
 
-    if state == 1:
-        print(f"Exiting with status: {exit_1}")
-        sys.exit(exit_1)
+    exit_codes = {1: exit_1, 2: exit_2, 3: exit_3}
+    if state not in exit_codes:
+        return
 
-    if state == 2:
-        print(f"Exiting with status: {exit_2}")
-        sys.exit(exit_2)
+    exit_code = exit_codes[state]
+    print(f"Exiting with status: {exit_code}")
 
-    if state == 3:
-        print(f"Exiting with status: {exit_3}")
-        sys.exit(exit_3)
+    # Same handshake as scripts/run_release_test.py, using the same logic.
+    result = Result(return_code=exit_code, runtime=0)
+    result.will_retry = should_retry(result)
+    write_retry_marker(result)
+
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_ray_test_db_reporter.py
+++ b/release/ray_release/tests/test_ray_test_db_reporter.py
@@ -1,0 +1,71 @@
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from ray_release.bazel import bazel_runfile
+from ray_release.configs.global_config import get_global_config, init_global_config
+from ray_release.reporter.ray_test_db import RayTestDBReporter
+from ray_release.result import Result, ResultStatus
+from ray_release.test import Test
+from ray_release.test_automation.release_state_machine import ReleaseTestStateMachine
+from ray_release.test_automation.state_machine import TestStateMachine
+
+init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+
+# Pre-populate these so the state machine constructor short-circuits instead of
+# reaching for real GitHub and Buildkite tokens out of AWS Secrets Manager.
+TestStateMachine.ray_repo = mock.MagicMock()
+TestStateMachine.ray_buildkite = mock.MagicMock()
+
+
+@pytest.fixture
+def postmerge_env():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "BUILDKITE_BRANCH": "master",
+            "BUILDKITE_PIPELINE_ID": get_global_config()["ci_pipeline_postmerge"][0],
+        },
+    ):
+        yield
+
+
+def test_skips_recording_an_attempt_that_will_be_retried(postmerge_env):
+    test = Test({"name": "test_x"})
+    result = Result(status=ResultStatus.INFRA_ERROR.value, will_retry=True)
+
+    with mock.patch.object(Test, "persist_result_to_s3") as persist:
+        RayTestDBReporter().report_result(test, result)
+
+    persist.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ResultStatus.ERROR.value,
+        ResultStatus.RUNTIME_ERROR.value,
+        ResultStatus.INFRA_ERROR.value,
+        ResultStatus.SUCCESS.value,
+    ],
+)
+def test_records_a_final_attempt_whatever_its_status(postmerge_env, status):
+    test = Test({"name": "test_x"})
+    result = Result(status=status, will_retry=False)
+
+    with mock.patch.object(Test, "persist_result_to_s3") as persist, mock.patch.object(
+        Test, "update_from_s3"
+    ), mock.patch.object(Test, "get_test_results", return_value=[]), mock.patch.object(
+        Test, "persist_to_s3"
+    ), mock.patch.object(
+        ReleaseTestStateMachine, "move"
+    ):
+        RayTestDBReporter().report_result(test, result)
+
+    persist.assert_called_once_with(result)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_result.py
+++ b/release/ray_release/tests/test_result.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from ray_release.exception import (
+    RETRYABLE_EXIT_CODES,
     ExitCode,
     ReleaseTestConfigError,
     ReleaseTestError,
@@ -65,6 +66,40 @@ def test_update_result_from_exception():
         assert result.return_code == ExitCode.SETUP_ERROR.value
         assert result.status == ResultStatus.INFRA_ERROR.value
         assert result.runtime == 3600
+
+
+def test_retryable_exit_codes_are_infra_only():
+    assert RETRYABLE_EXIT_CODES == {
+        ExitCode.SETUP_ERROR,
+        ExitCode.CLUSTER_RESOURCE_ERROR,
+        ExitCode.CLUSTER_ENV_BUILD_ERROR,
+        ExitCode.CLUSTER_STARTUP_ERROR,
+        ExitCode.ANYSCALE_ERROR,
+        ExitCode.RAY_WHEELS_TIMEOUT,
+        ExitCode.CLUSTER_ENV_BUILD_TIMEOUT,
+        ExitCode.CLUSTER_STARTUP_TIMEOUT,
+        ExitCode.CLUSTER_WAIT_TIMEOUT,
+    }
+
+
+@pytest.mark.parametrize(
+    "exit_code",
+    [
+        ExitCode.SUCCESS,
+        ExitCode.UNCAUGHT,
+        ExitCode.UNSPECIFIED,
+        ExitCode.UNKNOWN,
+        ExitCode.CLI_ERROR,
+        ExitCode.CONFIG_ERROR,
+        ExitCode.FETCH_RESULT_ERROR,
+        ExitCode.COMMAND_ERROR,
+        ExitCode.COMMAND_ALERT,
+        ExitCode.COMMAND_TIMEOUT,
+        ExitCode.PREPARE_ERROR,
+    ],
+)
+def test_non_infra_exit_codes_are_not_retryable(exit_code):
+    assert exit_code not in RETRYABLE_EXIT_CODES
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_result.py
+++ b/release/ray_release/tests/test_result.py
@@ -6,22 +6,48 @@ import pytest
 
 from ray_release.exception import (
     RETRYABLE_EXIT_CODES,
+    ClusterStartupTimeout,
     ExitCode,
     ReleaseTestConfigError,
     ReleaseTestError,
     ReleaseTestSetupError,
+    TestCommandError,
+    TestCommandTimeout,
 )
-from ray_release.result import Result, ResultStatus, update_result_from_exception
+from ray_release.result import (
+    RETRY_MARKER_ENV_VAR,
+    Result,
+    ResultStatus,
+    update_result_from_exception,
+    write_retry_marker,
+)
 
 
-def test_update_result_from_exception():
-    # config error
+@pytest.fixture(autouse=True)
+def clean_retry_env():
+    """Retry decisions read these env vars; none may leak in from the runner."""
+    with mock.patch.dict(os.environ, {}, clear=False):
+        for var in (
+            "BUILDKITE_RETRY_COUNT",
+            "BUILDKITE_MAX_RETRIES",
+            "BUILDKITE_TIME_LIMIT_FOR_RETRY",
+            RETRY_MARKER_ENV_VAR,
+        ):
+            os.environ.pop(var, None)
+        yield
+
+
+def test_update_result_from_exception_config_error():
     result = Result()
     update_result_from_exception(result, ReleaseTestConfigError())
     assert result.return_code == ExitCode.CONFIG_ERROR.value
+    assert result.status == ResultStatus.INFRA_ERROR.value
     assert result.last_logs is None
+    # Deterministic: a retry would fail in exactly the same way.
+    assert result.will_retry is False
 
-    # release test error
+
+def test_update_result_from_exception_release_test_error():
     result = Result()
     result.runtime = 10
     try:
@@ -31,41 +57,120 @@ def test_update_result_from_exception():
     assert result.return_code == ExitCode.UNSPECIFIED.value
     assert result.status == ResultStatus.RUNTIME_ERROR.value
     assert result.runtime == 10
+    assert result.will_retry is False
     assert "ReleaseTestError" in result.last_logs
     assert __file__ in result.last_logs
 
-    # unknown error
+
+def test_update_result_from_exception_unknown_error():
     result = Result()
     update_result_from_exception(result, Exception("generic"))
     assert result.return_code == ExitCode.UNKNOWN.value
     assert result.status == ResultStatus.UNKNOWN.value
     assert result.runtime == 0
+    assert result.will_retry is False
     assert result.last_logs is None
 
-    # retriable
+
+def test_update_result_from_exception_infra_error_is_retried():
     with mock.patch.dict(os.environ, {"BUILDKITE_TIME_LIMIT_FOR_RETRY": "100"}):
         result = Result()
         result.runtime = 10
         update_result_from_exception(result, ReleaseTestSetupError())
-        assert result.return_code == ExitCode.SETUP_ERROR.value
-        assert result.status == ResultStatus.TRANSIENT_INFRA_ERROR.value
-        assert result.runtime == 10
-    # retry limit reached, not retriable
-    with mock.patch.dict(os.environ, {"BUILDKITE_RETRY_COUNT": "1"}):
+    assert result.return_code == ExitCode.SETUP_ERROR.value
+    # The real classification survives; it is no longer overwritten.
+    assert result.status == ResultStatus.INFRA_ERROR.value
+    assert result.runtime == 10
+    assert result.will_retry is True
+
+
+def test_update_result_from_exception_infra_timeout_is_retried():
+    with mock.patch.dict(os.environ, {"BUILDKITE_TIME_LIMIT_FOR_RETRY": "100"}):
+        result = Result()
+        result.runtime = 10
+        update_result_from_exception(result, ClusterStartupTimeout())
+    assert result.return_code == ExitCode.CLUSTER_STARTUP_TIMEOUT.value
+    assert result.status == ResultStatus.INFRA_TIMEOUT.value
+    assert result.will_retry is True
+
+
+def test_update_result_from_exception_command_error_is_not_retried():
+    with mock.patch.dict(os.environ, {"BUILDKITE_TIME_LIMIT_FOR_RETRY": "100"}):
+        result = Result()
+        result.runtime = 10
+        update_result_from_exception(result, TestCommandError())
+    assert result.return_code == ExitCode.COMMAND_ERROR.value
+    assert result.status == ResultStatus.ERROR.value
+    assert result.runtime == 0
+    assert result.will_retry is False
+
+
+def test_update_result_from_exception_command_timeout_is_not_retried():
+    with mock.patch.dict(os.environ, {"BUILDKITE_TIME_LIMIT_FOR_RETRY": "100"}):
+        result = Result()
+        result.runtime = 10
+        update_result_from_exception(result, TestCommandTimeout())
+    assert result.return_code == ExitCode.COMMAND_TIMEOUT.value
+    assert result.status == ResultStatus.TIMEOUT.value
+    assert result.runtime == 0
+    assert result.will_retry is False
+
+
+def test_update_result_from_exception_retry_limit_reached():
+    with mock.patch.dict(
+        os.environ,
+        {"BUILDKITE_TIME_LIMIT_FOR_RETRY": "100", "BUILDKITE_RETRY_COUNT": "1"},
+    ):
         result = Result()
         result.runtime = 10
         update_result_from_exception(result, ReleaseTestSetupError())
-        assert result.return_code == ExitCode.SETUP_ERROR.value
-        assert result.status == ResultStatus.INFRA_ERROR.value
-        assert result.runtime == 10
-    # too long to run, not retriable
+    assert result.status == ResultStatus.INFRA_ERROR.value
+    assert result.will_retry is False
+
+
+def test_update_result_from_exception_too_expensive_to_retry():
     with mock.patch.dict(os.environ, {"BUILDKITE_TIME_LIMIT_FOR_RETRY": "1"}):
         result = Result()
         result.runtime = 3600
         update_result_from_exception(result, ReleaseTestSetupError())
-        assert result.return_code == ExitCode.SETUP_ERROR.value
-        assert result.status == ResultStatus.INFRA_ERROR.value
-        assert result.runtime == 3600
+    assert result.status == ResultStatus.INFRA_ERROR.value
+    assert result.runtime == 3600
+    assert result.will_retry is False
+
+
+def test_update_result_from_exception_honours_higher_retry_limit():
+    """A test configured with num_retries: 3 keeps retrying past attempt 1."""
+    with mock.patch.dict(
+        os.environ,
+        {
+            "BUILDKITE_TIME_LIMIT_FOR_RETRY": "100",
+            "BUILDKITE_RETRY_COUNT": "1",
+            "BUILDKITE_MAX_RETRIES": "3",
+        },
+    ):
+        result = Result()
+        result.runtime = 10
+        update_result_from_exception(result, ReleaseTestSetupError())
+    assert result.will_retry is True
+
+
+def test_write_retry_marker_creates_file_when_retrying(tmp_path):
+    marker = tmp_path / "retry"
+    with mock.patch.dict(os.environ, {RETRY_MARKER_ENV_VAR: str(marker)}):
+        write_retry_marker(Result(will_retry=True))
+    assert marker.exists()
+
+
+def test_write_retry_marker_noop_when_not_retrying(tmp_path):
+    marker = tmp_path / "retry"
+    with mock.patch.dict(os.environ, {RETRY_MARKER_ENV_VAR: str(marker)}):
+        write_retry_marker(Result(will_retry=False))
+    assert not marker.exists()
+
+
+def test_write_retry_marker_noop_without_env_var():
+    # Local runs outside run_release_test.sh must not blow up.
+    write_retry_marker(Result(will_retry=True))
 
 
 def test_retryable_exit_codes_are_infra_only():

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -24,6 +24,14 @@ def setup(tmpdir):
     ] = "python ray_release/tests/_test_run_release_test_sh.py"
     os.environ["OVERRIDE_SLEEP_TIME"] = "0"
     os.environ["MAX_RETRIES"] = "3"
+    os.environ["RELEASE_TEST_RETRY_MARKER"] = os.path.join(tmpdir, "retry_marker")
+    # The fake test script imports ray_release; make sure it resolves under bazel.
+    os.environ["PYTHONPATH"] = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    )
+    # should_retry() reads these; give the fake script a real retry budget.
+    os.environ["BUILDKITE_TIME_LIMIT_FOR_RETRY"] = "10800"
+    os.environ.pop("BUILDKITE_RETRY_COUNT", None)
 
     yield state_file, test_script
 
@@ -109,9 +117,49 @@ def test_repeat(setup):
             ExitCode.COMMAND_ALERT,
             ExitCode.SUCCESS,
         )
-        == 79  # BUILDKITE_RETRY_CODE
+        == ExitCode.COMMAND_ALERT.value
     )
     assert _read_state(state_file) == 2
+
+
+@pytest.mark.parametrize(
+    "exit_code",
+    [
+        ExitCode.COMMAND_ERROR,
+        ExitCode.COMMAND_ALERT,
+        ExitCode.PREPARE_ERROR,
+        ExitCode.CONFIG_ERROR,
+        ExitCode.CLI_ERROR,
+        ExitCode.FETCH_RESULT_ERROR,
+    ],
+)
+def test_non_infra_failures_are_not_retried(setup, exit_code):
+    """These must surface their own exit code, not the Buildkite retry code."""
+    state_file, test_script = setup
+
+    assert (
+        _run_script(test_script, state_file, exit_code, exit_code, exit_code)
+        == exit_code.value
+    )
+    assert _read_state(state_file) == 1
+
+
+@pytest.mark.parametrize(
+    "exit_code",
+    [
+        ExitCode.SETUP_ERROR,
+        ExitCode.CLUSTER_RESOURCE_ERROR,
+        ExitCode.ANYSCALE_ERROR,
+        ExitCode.CLUSTER_STARTUP_TIMEOUT,
+    ],
+)
+def test_infra_failures_ask_for_a_retry(setup, exit_code):
+    state_file, test_script = setup
+
+    assert (
+        _run_script(test_script, state_file, exit_code, exit_code, exit_code)
+        == 79  # BUILDKITE_RETRY_CODE
+    )
 
 
 def test_parameters(setup):

--- a/release/ray_release/tests/test_step.py
+++ b/release/ray_release/tests/test_step.py
@@ -39,6 +39,8 @@ def test_get_step(mock):
         step = get_step(_stub_test({}), run_id=2)
     assert step["label"] == "test with spaces (None) (2)"
     assert step["retry"]["automatic"][0]["limit"] == 3
+    # run_release_test.sh reads this to know whether the current attempt is the last.
+    assert step["env"]["BUILDKITE_MAX_RETRIES"] == "3"
     assert "commands" in step
     first_command = shlex.split(step["commands"][0])
     assert first_command[0] == "./release/run_release_test.sh"

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -25,11 +25,14 @@ reason() {
 
 RAY_TEST_SCRIPT=${RAY_TEST_SCRIPT-"python ray_release/scripts/run_release_test.py"}
 RELEASE_RESULTS_DIR=${RELEASE_RESULTS_DIR-/tmp/artifacts}
-BUILDKITE_MAX_RETRIES=1
+BUILDKITE_MAX_RETRIES=${BUILDKITE_MAX_RETRIES:-1}
 BUILDKITE_RETRY_CODE=79
-BUILDKITE_TIME_LIMIT_FOR_RETRY=10800 # 3 hours
+BUILDKITE_TIME_LIMIT_FOR_RETRY=${BUILDKITE_TIME_LIMIT_FOR_RETRY:-10800} # 3 hours
+# The test process touches this file when it decides Buildkite should try again.
+# It, not the exit code, is what drives the retry -- see ray_release/result.py.
+RELEASE_TEST_RETRY_MARKER=${RELEASE_TEST_RETRY_MARKER:-/tmp/release_test_retry}
 
-export RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR BUILDKITE_MAX_RETRIES BUILDKITE_RETRY_CODE BUILDKITE_TIME_LIMIT_FOR_RETRY
+export RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR BUILDKITE_MAX_RETRIES BUILDKITE_RETRY_CODE BUILDKITE_TIME_LIMIT_FOR_RETRY RELEASE_TEST_RETRY_MARKER
 
 if [[ -n "${RAY_COMMIT_OF_WHEEL-}" ]]; then
   git config --global --add safe.directory /workdir
@@ -82,6 +85,9 @@ while [[ "$RETRY_NUM" -lt "$MAX_RETRIES" ]]; do
   if [[ -z "${NO_ARTIFACTS}" ]]; then
     rm -rf "${RELEASE_RESULTS_DIR:?}"/* || true
   fi
+
+  # A marker from a previous attempt in this job must not leak into this one.
+  rm -f "${RELEASE_TEST_RETRY_MARKER}"
 
   _term() {
     echo "[SCRIPT $(date +'%Y-%m-%d %H:%M:%S'),...] Caught SIGTERM signal, sending SIGTERM to release test script"
@@ -156,7 +162,8 @@ else
   echo "RELEASE MANAGER: This could be an error in the test. Please REVIEW THE LOGS and ping the test owner."
 fi
 
-if [[ "$EXIT_CODE" -ne 0 && "$RUNTIME" -le "$BUILDKITE_TIME_LIMIT_FOR_RETRY" ]]; then
+if [[ -f "${RELEASE_TEST_RETRY_MARKER}" ]]; then
+  echo "The test asked for another attempt; exiting with the Buildkite retry code."
   exit "$BUILDKITE_RETRY_CODE"
 else
   exit "$EXIT_CODE"


### PR DESCRIPTION
## Description

Release tests are currently retried on Buildkite for **any** failure that ran under the 3-hour cost cap, and `update_result_from_exception` overwrites `result.status` with `TRANSIENT_INFRA_ERROR` for all of them. A genuine assertion failure, a `CommandError`, and an uncaught exception are each reported as a transient infra problem, re-run at full cost, and — because `RayTestDBReporter` skips persisting anything marked `TRANSIENT_INFRA_ERROR` — dropped from the test history on the first attempt.

That was not the original design:

- #34057 gated retries on `INFRA_ERROR` / `INFRA_TIMEOUT`.
- #34110 added the runtime bound the next day, purely as a **cost cap** on retries, not as a signal of transience.
- #37786 deleted the status gate and raised the cap from 30 min to 3 h, with an empty PR description.
- What survives carries a `TODO(aslonnie)` in `result.py` noting the logic "does not really make sense".

This PR restores an infra-only gate, narrows it further, and separates the two concerns that got conflated: *what failed* and *whether it is worth another attempt*.

### What changes

**`RETRYABLE_EXIT_CODES` becomes the single source of truth** (`ray_release/exception.py`) — infra timeouts (30–33) plus the transient Anyscale infra errors `SETUP_ERROR`, `CLUSTER_RESOURCE_ERROR`, `CLUSTER_ENV_BUILD_ERROR`, `CLUSTER_STARTUP_ERROR`, `ANYSCALE_ERROR`. Deliberately excluded, and commented as such:

- `CLI_ERROR` / `CONFIG_ERROR` — deterministic; a second attempt fails identically.
- `FETCH_RESULT_ERROR` — the test already ran, so a retry pays for a full re-run just to recover a result file.
- Everything else — the test ran and failed on its own merits.

**`result.status` is no longer overwritten.** Retryability moves to a new `Result.will_retry` flag, so a command error reports `error` and a runtime failure reports `runtime_error`. `TRANSIENT_INFRA_ERROR` stays in the enum, marked deprecated and never assigned, since historical rows and dashboards still reference the string. This also resolves the `TODO(aslonnie)`: the decision now keys off the exit code, so the runtimes that get zeroed out for `TIMEOUT`/`ERROR` can no longer affect it.

**`RayTestDBReporter` keys its skip off `will_retry`** instead of the status. Recording behavior is unchanged — still one row per build rather than per attempt — but the status that gets recorded is now truthful. Keeping the skip matters: without it, a build whose two attempts both fail would write two failing rows for the same commit and trip `_passing_to_consistently_failing`, jumping straight to `CONSISTENTLY_FAILING` instead of `FAILING`.

**`run_release_test.sh` no longer re-derives the retry decision.** It was exiting `79` based on its own exit-code and runtime check, duplicating a decision Python had already made against a differently-measured runtime — the reason for the `# this logic should be in-sync with run_release_test.sh` comment. The test process now publishes its decision through a marker file and the shell honors it, so the two cannot drift. Fail-closed: a hard crash writes no marker, so the real exit code surfaces. The 3-hour cost cap is unchanged, just applied in one place now.

**`num_retries` propagates into the job as `BUILDKITE_MAX_RETRIES`.** The shell hardcoded `1`, so for the four tests configured with `num_retries: 3`, attempts 2 and 3 were treated as final while Buildkite kept retrying.

### Expected effect on test state

Genuine failures will now be recorded on the first attempt, where a flake that passed on retry previously recorded only the pass. Expect more `PASSING → FAILING` transitions and correspondingly more bisect triggers. That is the intended outcome — real flakes become visible — but it is a visible change in issue and bisect volume, so it is worth watching after this lands.

Note that `_passing_to_flaky` is still hardcoded `False` for release tests, so nothing will actually be labeled `FLAKY` yet. A `TODO` is added recording that follow-up, since this PR is what makes the necessary input available.

## Related issues

None.

## Additional information

### ⚠️ Contains a temporary commit that must be removed before merge

`82cf0ceb1c "Force hello_world tests to fail to test non-infra failure"` adds `exit(1)` to `release/hello_world_tests/hello_world.py`. It exists only to prove in real CI that a non-infra failure now surfaces its own exit code instead of triggering a second attempt. **It must be dropped before this merges.**

### Not duplicating existing work

Checked before starting; neither search returned anything touching this logic:

```bash
gh pr list --repo ray-project/ray --state open --search "release test retry transient infra"
gh pr list --repo ray-project/ray --state open --search "_is_transient_error"
```

### Tests

Full release unit suite:

```bash
bazel test --test_tag_filters=release_unit //release/... --test_output=errors
# Executed 27 out of 29 tests: 29 tests pass.
```

Linting on all 13 touched files, shellcheck included:

```bash
pre-commit run --files release/ray_release/exception.py release/ray_release/result.py \
  release/ray_release/reporter/ray_test_db.py release/ray_release/buildkite/step.py \
  release/ray_release/scripts/run_release_test.py \
  release/ray_release/test_automation/release_state_machine.py \
  release/ray_release/tests/test_result.py release/ray_release/tests/test_run_script.py \
  release/ray_release/tests/test_ray_test_db_reporter.py release/ray_release/tests/test_step.py \
  release/ray_release/tests/_test_run_release_test_sh.py release/run_release_test.sh \
  release/BUILD.bazel
# All hooks passed.
```

Manual end-to-end check of the shell handshake:

```bash
# COMMAND_ERROR (40) surfaces its own exit code
./run_release_test.sh /tmp/smoke_state 40 40 40   # -> exit 40   (was 79)
# SETUP_ERROR (12) still asks Buildkite for another attempt
./run_release_test.sh /tmp/smoke_state 12 12 12   # -> exit 79
```

New and changed coverage:

| Behavior | Test |
| --- | --- |
| Only infra exit codes are retryable | `test_result.py::test_retryable_exit_codes_are_infra_only`, `::test_non_infra_exit_codes_are_not_retryable` |
| `status` survives; `will_retry` carries retryability | `test_result.py::test_update_result_from_exception_*` (9 cases) |
| Marker handshake | `test_result.py::test_write_retry_marker_*` |
| Shell honors the marker end to end | `test_run_script.py::test_non_infra_failures_are_not_retried`, `::test_infra_failures_ask_for_a_retry` (10 parametrized cases driving the real script) |
| Reporter skip keyed on `will_retry` | `test_ray_test_db_reporter.py` — first coverage for this reporter |
| `num_retries` reaches the job env | `test_step.py::test_get_step` |

Not verifiable locally: the Buildkite retry itself and the S3 / state-machine path, both of which are mocked. The `hello_world` commit above covers the first of those in real CI.

### AI assistance

This PR was written with AI assistance (Claude Code). Every line has been reviewed by the submitter, and the test commands above were run locally.
