### PR TITLE
[Data] Deprecate `Dataset.zip`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3826,7 +3826,7 @@ class Dataset:
 
     @Deprecated(
         message=(
-            "`zip` is deprecated and will be removed in Ray 2.56. Use `join` on a "
+            "`DAtaset.zip` is deprecated and will be removed in Ray 2.56. Use `join` on a "
             "shared key instead. `zip` relies on deterministic ordering for "
             "correctness, which Ray Data doesn't gaurantee by default."
         ),

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3826,9 +3826,9 @@ class Dataset:
 
     @Deprecated(
         message=(
-            "`DAtaset.zip` is deprecated and will be removed in Ray 2.56. Use `join` on a "
-            "shared key instead. `zip` relies on deterministic ordering for "
-            "correctness, which Ray Data doesn't gaurantee by default."
+            "`Dataset.zip` is deprecated and will be removed in Ray 2.56. Use `join` "
+            "on a shared key instead. `zip` relies on deterministic ordering for "
+            "correctness, which Ray Data doesn't guarantee by default."
         ),
         warning=True,
     )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3828,7 +3828,7 @@ class Dataset:
         message=(
             "`zip` is deprecated and will be removed in Ray 2.56. Use `join` on a "
             "shared key instead. `zip` relies on deterministic ordering for "
-            "correctness, which Ray Data doesn't gaurantee by default.",
+            "correctness, which Ray Data doesn't gaurantee by default."
         ),
         warning=True,
     )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3826,7 +3826,7 @@ class Dataset:
 
     @Deprecated(
         message=(
-            "`Dataset.zip` is deprecated and will be removed in Ray 2.56. Use `join` "
+            "`Dataset.zip` is deprecated and will be removed in Ray 2.66. Use `join` "
             "on a shared key instead. `zip` relies on deterministic ordering for "
             "correctness, which Ray Data doesn't guarantee by default."
         ),

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3824,7 +3824,14 @@ class Dataset:
         logical_plan = LogicalPlan(op, self.context)
         return Dataset._from_parent(self, logical_plan)
 
-    @PublicAPI(api_group=SMJ_API_GROUP)
+    @Deprecated(
+        message=(
+            "`zip` is deprecated and will be removed in Ray 2.56. Use `join` on a "
+            "shared key instead. `zip` relies on deterministic ordering for "
+            "correctness, which Ray Data doesn't gaurantee by default.",
+        ),
+        warning=True,
+    )
     def zip(self, *other: "Dataset") -> "Dataset":
         """Zip the columns of this dataset with the columns of another.
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3826,7 +3826,7 @@ class Dataset:
 
     @Deprecated(
         message=(
-            "`Dataset.zip` is deprecated and will be removed in Ray 2.66. Use `join` "
+            "`Dataset.zip` is deprecated and will be removed in Ray 2.64. Use `join` "
             "on a shared key instead. `zip` relies on deterministic ordering for "
             "correctness, which Ray Data doesn't guarantee by default."
         ),

--- a/python/ray/data/tests/test_zip.py
+++ b/python/ray/data/tests/test_zip.py
@@ -188,6 +188,14 @@ def test_zip_does_not_free_shared_materialized_blocks(ray_start_regular_shared):
     assert len(result2) == 20
 
 
+def test_zip_emits_deprecation_warning(ray_start_regular_shared):
+    ds1 = ray.data.range(1)
+    ds2 = ray.data.range(1)
+
+    with pytest.warns(DeprecationWarning, match="`Dataset.zip` is deprecated"):
+        ds1.zip(ds2)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
`Dataset.zip` horizontally concatenates two datasets. For example, if `images: Dataset` contains a row `{"path": "dog_1234.png"}` and `labels: Dataset` contains a row `{"label": "dog"}`, you might try to join the datasets together with `images.zip(labels)`.

The problem is that `zip` relies on deterministically output ordering for correctness. If tasks finish out of order, then `zip` can silently and incorrectly combine rows. In the example, you might end up with an output row like `{"path": "dog_1234.png", "label": "cow"}`.

To prevent users from shooting themselves in the foot with an API that isn't guaranteed to be behave the way you expect it to, I'm deprecating this API.