### PR TITLE
[Observability] Add GPU uuid to the labels of GPU metrics

### DIFF
--- a/doc/source/ray-observability/reference/system-metrics.rst
+++ b/doc/source/ray-observability/reference/system-metrics.rst
@@ -49,8 +49,17 @@ Ray exports a number of system metrics, which provide introspection into the sta
      - `instance`
      - The number of CPU cores per node.
    * - `ray_node_gpus_utilization`
-     - `instance`, `GpuDeviceName`, `GpuIndex`
-     - The GPU utilization per GPU as a percentage quantity (0..NGPU*100). `GpuDeviceName` is a name of a GPU device (e.g., NVIDIA A10G) and `GpuIndex` is the index of the GPU.
+     - `instance`, `GpuDeviceName`, `GpuIndex`, `GpuUuid`
+     - The GPU utilization per GPU as a percentage quantity (0..NGPU*100). `GpuDeviceName` is a name of a GPU device (e.g., NVIDIA A10G), `GpuIndex` is the index of the GPU, and `GpuUuid` is the unique device identifier.
+   * - `ray_node_gpus_available`
+     - `instance`, `GpuDeviceName`, `GpuIndex`, `GpuUuid`
+     - The number of GPUs available.
+   * - `ray_node_gpu_power_milliwatts`
+     - `instance`, `GpuDeviceName`, `GpuIndex`, `GpuUuid`
+     - The current GPU power per GPU, in milliwatts.
+   * - `ray_node_gpu_temperature_celsius`
+     - `instance`, `GpuDeviceName`, `GpuIndex`, `GpuUuid`
+     - The current GPU temperature per GPU, in Celsius.
    * - `ray_node_disk_usage`
      - `instance`
      - The amount of disk space used per node, in bytes.
@@ -113,10 +122,10 @@ Ray exports a number of system metrics, which provide introspection into the sta
      - `Component`, `instance`
      - The measured CPU percentage, broken down by logical Ray component. Ray components consist of system components (e.g., raylet, gcs, dashboard, or agent) and the method names of running tasks/actors.
    * - `ray_node_gram_available`
-     - `instance`, `node_type`, `GpuIndex`, `GpuDeviceName`
+     - `instance`, `node_type`, `GpuIndex`, `GpuDeviceName`, `GpuUuid`
      - The amount of GPU memory available per GPU, in megabytes.
    * - `ray_node_gram_used`
-     - `instance`, `GpuDeviceName`, `GpuIndex`
+     - `instance`, `GpuDeviceName`, `GpuIndex`, `GpuUuid`
      - The amount of GPU memory used per GPU, in bytes.
    * - `ray_node_network_received`
      - `instance`, `node_type`

--- a/python/ray/dashboard/consts.py
+++ b/python/ray/dashboard/consts.py
@@ -68,7 +68,7 @@ DASHBOARD_METRIC_PORT = env_integer("DASHBOARD_METRIC_PORT", 44227)
 # We use RayNodeType to mark head/worker nodes. IsHeadNode is retained
 # for backward compatibility for user-customized dashboards that might rely on it
 NODE_TAG_KEYS = ["ip", "Version", "SessionName", "IsHeadNode", "RayNodeType"]
-GPU_TAG_KEYS = NODE_TAG_KEYS + ["GpuDeviceName", "GpuIndex"]
+GPU_TAG_KEYS = NODE_TAG_KEYS + ["GpuDeviceName", "GpuIndex", "GpuUuid"]
 
 # TpuDeviceName and TpuIndex are expected to be equal to the number of TPU
 # chips in the cluster. TpuType and TpuTopology are proportional to the number

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1672,6 +1672,7 @@ class ReporterAgent(
                 gram_total += gpu["memory_total"]
                 gpu_index = gpu.get("index")
                 gpu_name = gpu.get("name")
+                gpu_uuid = gpu.get("uuid")
                 gpu_power_mw = gpu.get("power_mw")
                 gpu_temperature_c = gpu.get("temperature_c")
 
@@ -1681,6 +1682,8 @@ class ReporterAgent(
                     gpu_tags = {**node_tags, "GpuIndex": str(gpu_index)}
                     if gpu_name:
                         gpu_tags["GpuDeviceName"] = gpu_name
+                    if gpu_uuid:
+                        gpu_tags["GpuUuid"] = gpu_uuid
 
                     # There's only 1 GPU per each index, so we record 1 here.
                     gpus_available_record = Record(

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -548,7 +548,7 @@ def test_report_stats_gpu(tmp_path):
         {
             "index": 3,
             "name": "NVIDIA A10G",
-            "uuid": "GPU-36e1567d-37ed-051e-f8ff-df807517b398",
+            "uuid": "GPU-36e1567d-37ed-051e-f8ff-df807517b399",
             "utilization_gpu": 3,
             "memory_used": 3,
             "memory_total": GPU_MEMORY,
@@ -584,6 +584,7 @@ def test_report_stats_gpu(tmp_path):
                 # The tag value must be string for prometheus.
                 "GpuIndex": str(index),
                 "GpuDeviceName": "NVIDIA A10G",
+                "GpuUuid": f"GPU-36e1567d-37ed-051e-f8ff-df807517b39{6 + index}",
                 "RayNodeType": "head",
                 "IsHeadNode": "true",
             }
@@ -662,10 +663,12 @@ def test_report_stats_gpu_power_and_temperature(tmp_path):
     assert temp_by_index["0"] == 65
     assert temp_by_index["1"] == 72
 
-    # Tags should include GpuIndex and GpuDeviceName
+    # Tags should include GpuIndex, GpuDeviceName and GpuUuid
+    expected_uuids = {"0": "GPU-aaa", "1": "GPU-bbb"}
     for r in power_records + temp_records:
         assert "GpuIndex" in r.tags
         assert r.tags.get("GpuDeviceName") == "NVIDIA A10G"
+        assert r.tags.get("GpuUuid") == expected_uuids[r.tags["GpuIndex"]]
 
 
 def test_report_stats_gpu_without_power_temperature(tmp_path):


### PR DESCRIPTION
We have `GpuDeviceName` and `GpuIndex` at the GPU metrics, but are missing the `uuid`. In this PR, we add it to the existing `GPU_TAG_KEYS` for the GPU metrics.

Verified that `GpuUuid` is available in the GPU metrics:

<img width="1412" height="712" alt="Screenshot 2026-07-29 at 3 52 49 PM" src="https://github.com/user-attachments/assets/1a266801-d1fd-4730-8f3d-3384cff9fb82" />
