### PR TITLE
[Data] Add ignore_missing_paths and skip_paths to read_parquet (V2)

### DIFF
--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -109,11 +109,16 @@ class NonSamplingFileIndexer(FileIndexer):
         self,
         *,
         ignore_missing_paths: bool,
+        skip_paths: Optional[Iterable[str]] = None,
         num_workers: Optional[int] = None,
         max_paths_per_output: Optional[int] = None,
         file_chunker: Optional[FileChunker] = None,
     ):
         self._ignore_missing_paths = ignore_missing_paths
+        # Resolved paths to exclude from the listing (see
+        # ``ParquetDatasourceV2``). ``frozenset()`` when unset so the membership
+        # check in ``_get_path_contents`` is a cheap no-op.
+        self._skip_paths = frozenset(skip_paths) if skip_paths else frozenset()
         self._max_paths_per_output = (
             max_paths_per_output
             if max_paths_per_output is not None
@@ -167,7 +172,10 @@ class NonSamplingFileIndexer(FileIndexer):
             assert len(resolved_paths) == 1
 
             for path, file_size in _get_file_infos(
-                resolved_paths[0], filesystem, self._ignore_missing_paths
+                resolved_paths[0],
+                filesystem,
+                self._ignore_missing_paths,
+                self._skip_paths,
             ):
                 yield FileInfo(path=path, size=file_size)
 
@@ -218,7 +226,11 @@ class NonSamplingFileIndexer(FileIndexer):
                 root_path = path
 
             contents = _get_path_contents(
-                path, filesystem, self._ignore_missing_paths, root_path=root_path
+                path,
+                filesystem,
+                self._ignore_missing_paths,
+                self._skip_paths,
+                root_path=root_path,
             )
             for file_path, file_size in contents.files:
                 file_info_result = FileInfo(path=file_path, size=file_size)

--- a/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Tuple
+from typing import FrozenSet, Iterable, List, Optional, Tuple
 
 import pyarrow as pa
 from pyarrow.fs import FileSelector, FileType
@@ -22,6 +22,7 @@ def _expand_directory(
     base_path: str,
     filesystem: pa.fs.FileSystem,
     ignore_missing_path: bool,
+    skip_paths: FrozenSet[str] = frozenset(),
     *,
     root_path: Optional[str] = None,
 ) -> PathContents:
@@ -60,6 +61,11 @@ def _expand_directory(
         if any(relative.startswith(prefix) for prefix in exclude_prefixes):
             continue
 
+        # Drop entries explicitly excluded via ``skip_paths`` (files or a whole
+        # subdirectory) before they are yielded or descended into.
+        if child.path in skip_paths:
+            continue
+
         if child.type == FileType.File:
             files.append((child.path, child.size))
         elif child.type == FileType.Directory:
@@ -78,6 +84,7 @@ def _get_path_contents(
     path: str,
     filesystem: pa.fs.FileSystem,
     ignore_missing_path: bool,
+    skip_paths: FrozenSet[str] = frozenset(),
     *,
     root_path: Optional[str] = None,
 ) -> PathContents:
@@ -86,6 +93,15 @@ def _get_path_contents(
     Only one level of a directory is expanded; discovered subdirectories are
     returned in :attr:`PathContents.subdirs` for the caller to expand.
     """
+    # Skip explicitly-excluded paths *before* the existence check so a
+    # ``skip_paths`` entry drops a named path whether or not it exists — this
+    # is what distinguishes ``skip_paths`` (deterministic exclusion) from
+    # ``ignore_missing_paths`` (tolerate anything missing). This covers both
+    # top-level seed paths and discovered subdirectories, since both are routed
+    # through here.
+    if path in skip_paths:
+        return PathContents(files=[], subdirs=[])
+
     try:
         file_info = filesystem.get_file_info(path)
     except OSError as e:
@@ -95,7 +111,7 @@ def _get_path_contents(
         return PathContents(files=[(path, file_info.size)], subdirs=[])
     elif file_info.type == FileType.Directory:
         return _expand_directory(
-            path, filesystem, ignore_missing_path, root_path=root_path
+            path, filesystem, ignore_missing_path, skip_paths, root_path=root_path
         )
     elif file_info.type == FileType.NotFound and ignore_missing_path:
         return PathContents(files=[], subdirs=[])
@@ -107,6 +123,7 @@ def _get_file_infos(
     path: str,
     filesystem: pa.fs.FileSystem,
     ignore_missing_path: bool,
+    skip_paths: FrozenSet[str] = frozenset(),
     *,
     _root_path: Optional[str] = None,
 ) -> Iterable[Tuple[str, Optional[int]]]:
@@ -114,10 +131,10 @@ def _get_file_infos(
     if _root_path is None:
         _root_path = path
     contents = _get_path_contents(
-        path, filesystem, ignore_missing_path, root_path=_root_path
+        path, filesystem, ignore_missing_path, skip_paths, root_path=_root_path
     )
     yield from contents.files
     for subdir in contents.subdirs:
         yield from _get_file_infos(
-            subdir, filesystem, ignore_missing_path, _root_path=_root_path
+            subdir, filesystem, ignore_missing_path, skip_paths, _root_path=_root_path
         )

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -9,6 +9,7 @@ Constructed from `read_api.read_parquet` when
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
 import pyarrow as pa
@@ -106,12 +107,15 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         # per-file listing hot path.
         if skip_paths:
             # Accept a single path or any iterable of paths, mirroring how
-            # ``paths`` is handled. Normalize to a list first so a bare string
-            # isn't treated as an iterable of characters and non-list iterables
-            # (set, tuple) don't reach ``_resolve_paths_and_filesystem``, which
-            # only accepts str/pathlib.Path/list.
+            # ``paths`` is handled. Wrap a bare str/Path so it isn't iterated
+            # (a str would split into characters and a Path isn't iterable at
+            # all); other iterables (set, tuple) are materialized into a list
+            # since ``_resolve_paths_and_filesystem`` only accepts
+            # str/pathlib.Path/list.
             skip_paths_list = (
-                [skip_paths] if isinstance(skip_paths, str) else list(skip_paths)
+                [skip_paths]
+                if isinstance(skip_paths, (str, Path))
+                else list(skip_paths)
             )
             resolved_skip_paths, _ = _resolve_paths_and_filesystem(
                 skip_paths_list, self._filesystem

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -74,7 +74,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         partitioning: Optional[Partitioning] = Partitioning(PartitionStyle.HIVE),
         file_extensions: Optional[List[str]] = None,
         ignore_missing_paths: bool = False,
-        skip_paths: Optional[List[str]] = None,
+        skip_paths: Optional[Union[str, List[str]]] = None,
         include_paths: bool = False,
         include_row_hash: bool = False,
         shuffle: Optional[Union[Literal["files"], "FileShuffleConfig"]] = None,
@@ -105,8 +105,16 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         # handling, etc.). Stored as a set for O(1) membership checks in the
         # per-file listing hot path.
         if skip_paths:
+            # Accept a single path or any iterable of paths, mirroring how
+            # ``paths`` is handled. Normalize to a list first so a bare string
+            # isn't treated as an iterable of characters and non-list iterables
+            # (set, tuple) don't reach ``_resolve_paths_and_filesystem``, which
+            # only accepts str/pathlib.Path/list.
+            skip_paths_list = (
+                [skip_paths] if isinstance(skip_paths, str) else list(skip_paths)
+            )
             resolved_skip_paths, _ = _resolve_paths_and_filesystem(
-                skip_paths, self._filesystem
+                skip_paths_list, self._filesystem
             )
             self._skip_paths = frozenset(resolved_skip_paths)
         else:

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -74,6 +74,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         partitioning: Optional[Partitioning] = Partitioning(PartitionStyle.HIVE),
         file_extensions: Optional[List[str]] = None,
         ignore_missing_paths: bool = False,
+        skip_paths: Optional[List[str]] = None,
         include_paths: bool = False,
         include_row_hash: bool = False,
         shuffle: Optional[Union[Literal["files"], "FileShuffleConfig"]] = None,
@@ -98,6 +99,18 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         self._partitioning = partitioning
         self._file_extensions = file_extensions or ParquetDatasource._FILE_EXTENSIONS
         self._ignore_missing_paths = ignore_missing_paths
+        # Resolve "skip_paths" through the same path normalization as the
+        # input paths so exact-match comparison against the resolved paths the
+        # indexer yields is apples-to-apples (scheme stripping, ``local://``
+        # handling, etc.). Stored as a set for O(1) membership checks in the
+        # per-file listing hot path.
+        if skip_paths:
+            resolved_skip_paths, _ = _resolve_paths_and_filesystem(
+                skip_paths, self._filesystem
+            )
+            self._skip_paths = frozenset(resolved_skip_paths)
+        else:
+            self._skip_paths = frozenset()
         self._include_paths = include_paths
         self._include_row_hash = include_row_hash
         self._shuffle = shuffle
@@ -141,6 +154,10 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         return self._ignore_missing_paths
 
     @property
+    def skip_paths(self) -> "frozenset[str]":
+        return self._skip_paths
+
+    @property
     def include_paths(self) -> bool:
         return self._include_paths
 
@@ -151,6 +168,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
     def _get_file_indexer(self) -> FileIndexer:
         return NonSamplingFileIndexer(
             ignore_missing_paths=self._ignore_missing_paths,
+            skip_paths=self._skip_paths,
             file_chunker=self._file_chunker,
         )
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1359,7 +1359,7 @@ def read_parquet(
     include_row_hash: bool = False,
     file_extensions: Optional[List[str]] = ParquetDatasource._FILE_EXTENSIONS,
     ignore_missing_paths: bool = False,
-    skip_paths: Optional[List[str]] = None,
+    skip_paths: Optional[Union[str, List[str]]] = None,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
     **arrow_parquet_args,
@@ -1499,10 +1499,11 @@ def read_parquet(
         ignore_missing_paths: If "True", ignores any file/directory paths in "paths"
             that are not found. This only tolerates paths that are already missing
             when the files are listed.
-        skip_paths: An explicit list of file paths to exclude from the read. Any
-            listed or expanded file whose path matches an entry is skipped.
-            Use this to deterministically drop known-bad paths
-            (e.g. from a manifest diff) without paying to read them.
+        skip_paths: A path, or list of paths, to exclude from the read. Any
+            listed or expanded file whose path matches an entry is skipped,
+            whether or not it exists. Use this to deterministically drop
+            known-bad paths (e.g. from a manifest diff) without paying to read
+            them. Composes with ``ignore_missing_paths``.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
             to control number of tasks to run concurrently. This doesn't change the
             total number of tasks run or the total number of output blocks. By default,
@@ -1673,7 +1674,9 @@ def read_parquet(
 
     # ``ignore_missing_paths`` / ``skip_paths`` are only implemented on the V2
     # datasource path. Fail loudly rather than silently ignoring them on V1.
-    if ignore_missing_paths or skip_paths is not None:
+    # An empty ``skip_paths`` (``[]``) is a no-op, so only raise when the caller
+    # actually requested one of these behaviors.
+    if ignore_missing_paths or skip_paths:
         raise NotImplementedError(
             "`ignore_missing_paths` and `skip_paths` on `read_parquet` require "
             "the V2 datasource. Enable it with "

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1358,6 +1358,8 @@ def read_parquet(
     include_paths: bool = False,
     include_row_hash: bool = False,
     file_extensions: Optional[List[str]] = ParquetDatasource._FILE_EXTENSIONS,
+    ignore_missing_paths: bool = False,
+    skip_paths: Optional[List[str]] = None,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
     **arrow_parquet_args,
@@ -1494,6 +1496,13 @@ def read_parquet(
             returned dataset and include ``'row_hash'`` explicitly in the list
             to retain it.
         file_extensions: A list of file extensions to filter files by.
+        ignore_missing_paths: If "True", ignores any file/directory paths in "paths"
+            that are not found. This only tolerates paths that are already missing
+            when the files are listed.
+        skip_paths: An explicit list of file paths to exclude from the read. Any
+            listed or expanded file whose path matches an entry is skipped.
+            Use this to deterministically drop known-bad paths
+            (e.g. from a manifest diff) without paying to read them.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
             to control number of tasks to run concurrently. This doesn't change the
             total number of tasks run or the total number of output blocks. By default,
@@ -1638,6 +1647,8 @@ def read_parquet(
             filesystem=filesystem,
             partitioning=partitioning,
             file_extensions=file_extensions,
+            ignore_missing_paths=ignore_missing_paths,
+            skip_paths=skip_paths,
             include_paths=include_paths,
             include_row_hash=include_row_hash,
             shuffle=shuffle,
@@ -1659,6 +1670,16 @@ def read_parquet(
         if select_columns_after_read is not None:
             ds = ds.select_columns(select_columns_after_read)
         return ds
+
+    # ``ignore_missing_paths`` / ``skip_paths`` are only implemented on the V2
+    # datasource path. Fail loudly rather than silently ignoring them on V1.
+    if ignore_missing_paths or skip_paths is not None:
+        raise NotImplementedError(
+            "`ignore_missing_paths` and `skip_paths` on `read_parquet` require "
+            "the V2 datasource. Enable it with "
+            "`ray.data.DataContext.get_current().use_datasource_v2 = True` "
+            "(or set RAY_DATA_USE_DATASOURCE_V2=1)."
+        )
 
     datasource = ParquetDatasource(
         paths,

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -255,6 +255,18 @@ def test_read_parquet_v2_skip_paths_accepts_single_string(tmp_path, restore_ctx)
     assert _rows(ds) == [1, 2]
 
 
+def test_read_parquet_v2_skip_paths_accepts_bare_pathlib_path(tmp_path, restore_ctx):
+    # A bare pathlib.Path must not be treated as an iterable (it isn't one).
+    restore_ctx.use_datasource_v2 = True
+    a = tmp_path / "a.parquet"
+    b = tmp_path / "b.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    _write(b, pa.table({"a": [3, 4]}))
+
+    ds = ray.data.read_parquet([str(a), str(b)], skip_paths=b)
+    assert _rows(ds) == [1, 2]
+
+
 def test_read_parquet_v2_skip_paths_drops_missing_without_ignore(tmp_path, restore_ctx):
     # ``skip_paths`` excludes a named path before the existence check, so a
     # missing entry is dropped even without ``ignore_missing_paths``.

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -208,6 +208,77 @@ def test_read_parquet_v2_empty_dir_raises(tmp_path, restore_ctx):
         ray.data.read_parquet(str(tmp_path))
 
 
+def _rows(ds):
+    return sorted(r["a"] for r in ds.take_all())
+
+
+def test_read_parquet_v2_missing_path_raises_without_flag(tmp_path, restore_ctx):
+    restore_ctx.use_datasource_v2 = True
+    real = tmp_path / "a.parquet"
+    _write(real, pa.table({"a": [1, 2]}))
+    missing = str(tmp_path / "gone.parquet")
+
+    with pytest.raises(FileNotFoundError):
+        ray.data.read_parquet([str(real), missing]).take_all()
+
+
+def test_read_parquet_v2_ignore_missing_paths(tmp_path, restore_ctx):
+    restore_ctx.use_datasource_v2 = True
+    real = tmp_path / "a.parquet"
+    _write(real, pa.table({"a": [1, 2]}))
+    missing = str(tmp_path / "gone.parquet")
+
+    ds = ray.data.read_parquet([str(real), missing], ignore_missing_paths=True)
+    assert _rows(ds) == [1, 2]
+
+
+def test_read_parquet_v2_skip_paths_drops_existing_file(tmp_path, restore_ctx):
+    restore_ctx.use_datasource_v2 = True
+    a = tmp_path / "a.parquet"
+    b = tmp_path / "b.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    _write(b, pa.table({"a": [3, 4]}))
+
+    ds = ray.data.read_parquet([str(a), str(b)], skip_paths=[str(b)])
+    assert _rows(ds) == [1, 2]
+
+
+def test_read_parquet_v2_skip_paths_drops_missing_without_ignore(tmp_path, restore_ctx):
+    # ``skip_paths`` excludes a named path before the existence check, so a
+    # missing entry is dropped even without ``ignore_missing_paths``.
+    restore_ctx.use_datasource_v2 = True
+    a = tmp_path / "a.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    missing = str(tmp_path / "gone.parquet")
+
+    ds = ray.data.read_parquet([str(a), missing], skip_paths=[missing])
+    assert _rows(ds) == [1, 2]
+
+
+def test_read_parquet_v2_skip_paths_excludes_file_under_directory(
+    tmp_path, restore_ctx
+):
+    restore_ctx.use_datasource_v2 = True
+    a = tmp_path / "a.parquet"
+    b = tmp_path / "b.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    _write(b, pa.table({"a": [3, 4]}))
+
+    ds = ray.data.read_parquet([str(tmp_path)], skip_paths=[str(a)])
+    assert _rows(ds) == [3, 4]
+
+
+def test_read_parquet_v1_rejects_new_params(tmp_path, restore_ctx):
+    restore_ctx.use_datasource_v2 = False
+    a = tmp_path / "a.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+
+    with pytest.raises(NotImplementedError, match="V2 datasource"):
+        ray.data.read_parquet([str(a)], ignore_missing_paths=True)
+    with pytest.raises(NotImplementedError, match="V2 datasource"):
+        ray.data.read_parquet([str(a)], skip_paths=[str(a)])
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -243,6 +243,18 @@ def test_read_parquet_v2_skip_paths_drops_existing_file(tmp_path, restore_ctx):
     assert _rows(ds) == [1, 2]
 
 
+def test_read_parquet_v2_skip_paths_accepts_single_string(tmp_path, restore_ctx):
+    # ``skip_paths`` accepts a bare string (like ``paths``), not just a list.
+    restore_ctx.use_datasource_v2 = True
+    a = tmp_path / "a.parquet"
+    b = tmp_path / "b.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    _write(b, pa.table({"a": [3, 4]}))
+
+    ds = ray.data.read_parquet([str(a), str(b)], skip_paths=str(b))
+    assert _rows(ds) == [1, 2]
+
+
 def test_read_parquet_v2_skip_paths_drops_missing_without_ignore(tmp_path, restore_ctx):
     # ``skip_paths`` excludes a named path before the existence check, so a
     # missing entry is dropped even without ``ignore_missing_paths``.
@@ -277,6 +289,17 @@ def test_read_parquet_v1_rejects_new_params(tmp_path, restore_ctx):
         ray.data.read_parquet([str(a)], ignore_missing_paths=True)
     with pytest.raises(NotImplementedError, match="V2 datasource"):
         ray.data.read_parquet([str(a)], skip_paths=[str(a)])
+
+
+def test_read_parquet_v1_empty_skip_paths_is_noop(tmp_path, restore_ctx):
+    # An empty ``skip_paths`` requests nothing, so it must not trip the V1
+    # guard even though V1 doesn't implement the parameter.
+    restore_ctx.use_datasource_v2 = False
+    a = tmp_path / "a.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+
+    ds = ray.data.read_parquet([str(a)], skip_paths=[])
+    assert _rows(ds) == [1, 2]
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -181,6 +181,53 @@ class TestMissingPaths:
         assert results == [(str(real), 10)]
 
 
+class TestSkipPaths:
+    def test_skips_named_existing_file(self, tmp_path):
+        a = tmp_path / "a.csv"
+        b = tmp_path / "b.csv"
+        a.write_bytes(b"x" * 10)
+        b.write_bytes(b"x" * 20)
+        indexer = NonSamplingFileIndexer(
+            ignore_missing_paths=False, skip_paths={str(b)}
+        )
+
+        results = _list_all(indexer, [str(a), str(b)])
+        assert results == [(str(a), 10)]
+
+    def test_skips_missing_named_path_without_ignore_missing(self, tmp_path):
+        # ``skip_paths`` drops a named path *before* the existence check, so a
+        # missing entry is skipped even with ``ignore_missing_paths=False``.
+        a = tmp_path / "a.csv"
+        a.write_bytes(b"x" * 10)
+        missing = str(tmp_path / "gone.csv")
+        indexer = NonSamplingFileIndexer(
+            ignore_missing_paths=False, skip_paths={missing}
+        )
+
+        results = _list_all(indexer, [str(a), missing])
+        assert results == [(str(a), 10)]
+
+    def test_skips_file_discovered_under_directory(self, tmp_path):
+        a = tmp_path / "a.csv"
+        b = tmp_path / "b.csv"
+        a.write_bytes(b"x" * 10)
+        b.write_bytes(b"x" * 20)
+        indexer = NonSamplingFileIndexer(
+            ignore_missing_paths=False, skip_paths={str(a)}
+        )
+
+        results = _list_all(indexer, [str(tmp_path)])
+        assert results == [(str(b), 20)]
+
+    def test_empty_skip_paths_is_noop(self, tmp_path):
+        a = tmp_path / "a.csv"
+        a.write_bytes(b"x" * 10)
+        indexer = NonSamplingFileIndexer(ignore_missing_paths=False, skip_paths=None)
+
+        results = _list_all(indexer, [str(a)])
+        assert results == [(str(a), 10)]
+
+
 class TestManifestBatching:
     def test_splits_into_multiple_manifests(self, tmp_path):
         indexer = NonSamplingFileIndexer(


### PR DESCRIPTION
## Why are these changes needed?

`read_parquet` previously raised and failed the whole read if any input path
was missing. This is inconsistent with the ~15 other file-based `read_*` APIs,
which already accept `ignore_missing_paths`. The gap was hit in practice by a
user pointing `read_parquet` at a set of paths where some had been removed
upstream.

This PR closes that gap for the **V2 datasource** and adds a companion
`skip_paths` parameter:

- **`ignore_missing_paths`** (default `False`): tolerate input paths that are
  absent at listing time. Mirrors Spark's `spark.sql.files.ignoreMissingFiles`.
- **`skip_paths`** (default `None`): an explicit list of paths to exclude,
  whether or not they exist. The skip check runs *before* the existence check,
  so it can drop a perfectly readable file (e.g. a known-bad file from a
  manifest diff) and composes with `ignore_missing_paths`.

Both are listing-time decisions, threaded through `NonSamplingFileIndexer`
into **both** the sequential and threaded work-stealing traversal paths, so
behavior is identical regardless of `num_workers`. Passing either parameter on
the V1 datasource path raises `NotImplementedError` rather than silently
ignoring it.

### Scope / non-goals

This handles paths that are missing **at listing time**. 