### PR TITLE
[Serve][LLM] Support az:// as a downloadable Azure scheme

### DIFF
--- a/python/ray/llm/_internal/common/callbacks/cloud_downloader.py
+++ b/python/ray/llm/_internal/common/callbacks/cloud_downloader.py
@@ -18,7 +18,7 @@ class CloudDownloaderConfig(BaseModel):
     @classmethod
     def validate_paths(cls, v: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
         # Supported cloud storage URI schemes
-        valid_schemes = ("s3://", "gs://", "abfss://", "azure://")
+        valid_schemes = ("s3://", "gs://", "abfss://", "azure://", "az://")
 
         for i, (cloud_uri, _) in enumerate(v):
             if not any(cloud_uri.startswith(scheme) for scheme in valid_schemes):
@@ -35,7 +35,7 @@ class CloudDownloader(CallbackBase):
     This callback expects self.kwargs to contain a 'paths' field which should be
     a list of tuples, where each tuple contains (cloud_uri, local_path) strings.
 
-    Supported cloud storage URIs: s3://, gs://, abfss://, azure://
+    Supported cloud storage URIs: s3://, gs://, abfss://, azure://, az://
 
     Example:
         ```

--- a/python/ray/llm/_internal/common/utils/cloud_filesystem/pyarrow_filesystem.py
+++ b/python/ray/llm/_internal/common/utils/cloud_filesystem/pyarrow_filesystem.py
@@ -45,7 +45,9 @@ class PyArrowFileSystem(BaseCloudFileSystem):
         # Check for anonymous access pattern (only for S3/GCS)
         # e.g. s3://anonymous@bucket/path
         if "@" in object_uri and not (
-            object_uri.startswith("abfss://") or object_uri.startswith("azure://")
+            object_uri.startswith("abfss://")
+            or object_uri.startswith("azure://")
+            or object_uri.startswith("az://")
         ):
             parts = object_uri.split("@", 1)
             # Check if the first part ends with "anonymous"
@@ -71,6 +73,8 @@ class PyArrowFileSystem(BaseCloudFileSystem):
             fs, path = PyArrowFileSystem._create_abfss_filesystem(object_uri)
         elif object_uri.startswith("azure://"):
             fs, path = PyArrowFileSystem._create_azure_filesystem(object_uri)
+        elif object_uri.startswith("az://"):
+            fs, path = PyArrowFileSystem._create_az_filesystem(object_uri)
         else:
             raise ValueError(f"Unsupported URI scheme: {object_uri}")
 
@@ -169,6 +173,66 @@ class PyArrowFileSystem(BaseCloudFileSystem):
             Tuple of (PyArrow FileSystem, path without abfss:// prefix)
         """
         return PyArrowFileSystem._create_azure_filesystem(object_uri)
+
+    @staticmethod
+    def _create_az_filesystem(object_uri: str) -> Tuple[pa_fs.FileSystem, str]:
+        """Create a filesystem for an az:// Azure Blob Storage URI.
+
+        Unlike ``azure://``/``abfss://``, which embed the storage account in the
+        hostname, the ``az://`` scheme takes the form ``az://container/path`` and
+        reads the account from the ``AZURE_STORAGE_ACCOUNT_NAME`` environment
+        variable. This matches the convention the RunAI streamer uses, so the same
+        ``az://`` URI can be used for both streaming and downloading.
+
+        Args:
+            object_uri: az:// URI (az://container/path)
+
+        Returns:
+            Tuple of (PyArrow FileSystem, path without the az:// prefix)
+
+        Raises:
+            ImportError: If required dependencies are not installed.
+            ValueError: If the az:// URI format is invalid or the account name
+                environment variable is not set.
+        """
+        try:
+            import adlfs
+            from azure.identity import DefaultAzureCredential
+        except ImportError:
+            raise ImportError(
+                "You must `pip install adlfs azure-identity` "
+                "to use az:// URIs. "
+                "Note that these must be preinstalled on all nodes in the Ray cluster."
+            )
+
+        azure_storage_account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
+        if not azure_storage_account_name:
+            raise ValueError(
+                "az:// URIs require the AZURE_STORAGE_ACCOUNT_NAME environment "
+                f"variable to identify the storage account: {object_uri}"
+            )
+
+        # Strip the scheme and validate the container name
+        path_without_scheme = object_uri[len("az://") :]
+        container_part = path_without_scheme.split("/")[0]
+        if not container_part:
+            raise ValueError(
+                f"Invalid az:// URI format - missing container name: {object_uri}"
+            )
+
+        # Create the adlfs filesystem
+        adlfs_fs = adlfs.AzureBlobFileSystem(
+            account_name=azure_storage_account_name,
+            credential=DefaultAzureCredential(),
+        )
+
+        # Wrap with PyArrow's PyFileSystem for compatibility
+        fs = pa_fs.PyFileSystem(pa_fs.FSSpecHandler(adlfs_fs))
+
+        # Return the path without the scheme prefix
+        path = path_without_scheme
+
+        return fs, path
 
     @staticmethod
     def _filter_files(

--- a/python/ray/llm/_internal/common/utils/cloud_filesystem/pyarrow_filesystem.py
+++ b/python/ray/llm/_internal/common/utils/cloud_filesystem/pyarrow_filesystem.py
@@ -212,9 +212,9 @@ class PyArrowFileSystem(BaseCloudFileSystem):
                 f"variable to identify the storage account: {object_uri}"
             )
 
-        # Strip the scheme and validate the container name
-        path_without_scheme = object_uri[len("az://") :]
-        container_part = path_without_scheme.split("/")[0]
+        # Parse and validate the az:// URI
+        parsed = urlparse(object_uri)
+        container_part = parsed.netloc
         if not container_part:
             raise ValueError(
                 f"Invalid az:// URI format - missing container name: {object_uri}"
@@ -230,7 +230,7 @@ class PyArrowFileSystem(BaseCloudFileSystem):
         fs = pa_fs.PyFileSystem(pa_fs.FSSpecHandler(adlfs_fs))
 
         # Return the path without the scheme prefix
-        path = path_without_scheme
+        path = f"{container_part}{parsed.path}"
 
         return fs, path
 

--- a/python/ray/llm/_internal/common/utils/cloud_filesystem/pyarrow_filesystem.py
+++ b/python/ray/llm/_internal/common/utils/cloud_filesystem/pyarrow_filesystem.py
@@ -220,10 +220,25 @@ class PyArrowFileSystem(BaseCloudFileSystem):
                 f"Invalid az:// URI format - missing container name: {object_uri}"
             )
 
-        # Create the adlfs filesystem
+        # Create the adlfs filesystem. adlfs reads an account key, SAS token, or
+        # connection string from the environment (the same variables the RunAI
+        # streamer honors), so only fall back to DefaultAzureCredential when none
+        # of them are set; an explicit credential would otherwise take precedence
+        # over the account key and SAS token.
+        credential = None
+        if not any(
+            os.getenv(var)
+            for var in (
+                "AZURE_STORAGE_CONNECTION_STRING",
+                "AZURE_STORAGE_ACCOUNT_KEY",
+                "AZURE_STORAGE_SAS_TOKEN",
+            )
+        ):
+            credential = DefaultAzureCredential()
+
         adlfs_fs = adlfs.AzureBlobFileSystem(
             account_name=azure_storage_account_name,
-            credential=DefaultAzureCredential(),
+            credential=credential,
         )
 
         # Wrap with PyArrow's PyFileSystem for compatibility

--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -45,6 +45,7 @@ def is_remote_path(path: str) -> bool:
         or path.startswith("gs://")
         or path.startswith("abfss://")
         or path.startswith("azure://")
+        or path.startswith("az://")
         or path.startswith("pyarrow-")
     )
 
@@ -58,7 +59,7 @@ class CloudMirrorConfig(BaseModelExtended):
     """Unified mirror config for cloud storage (S3, GCS, or Azure).
 
     Args:
-        bucket_uri: URI of the bucket (s3://, gs://, abfss://, or azure://)
+        bucket_uri: URI of the bucket (s3://, gs://, abfss://, azure://, or az://)
         extra_files: Additional files to download
     """
 
@@ -74,7 +75,8 @@ class CloudMirrorConfig(BaseModelExtended):
         if not is_remote_path(value):
             raise ValueError(
                 f'Got invalid value "{value}" for bucket_uri. '
-                'Expected a URI that starts with "s3://", "gs://", "abfss://", or "azure://".'
+                'Expected a URI that starts with "s3://", "gs://", "abfss://", '
+                '"azure://", or "az://".'
             )
         return value
 
@@ -89,7 +91,7 @@ class CloudMirrorConfig(BaseModelExtended):
             return "gcs"
         elif self.bucket_uri.startswith("abfss://"):
             return "abfss"
-        elif self.bucket_uri.startswith("azure://"):
+        elif self.bucket_uri.startswith(("azure://", "az://")):
             return "azure"
         return None
 
@@ -109,13 +111,14 @@ class LoraMirrorConfig(BaseModelExtended):
         if not is_remote_path(value):
             raise ValueError(
                 f'Got invalid value "{value}" for bucket_uri. '
-                'Expected a URI that starts with "s3://", "gs://", "abfss://", or "azure://".'
+                'Expected a URI that starts with "s3://", "gs://", "abfss://", '
+                '"azure://", or "az://".'
             )
         return value
 
     @property
     def _bucket_name_and_path(self) -> str:
-        for prefix in ["s3://", "gs://", "abfss://", "azure://"]:
+        for prefix in ["s3://", "gs://", "abfss://", "azure://", "az://"]:
             if self.bucket_uri.startswith(prefix):
                 return self.bucket_uri[len(prefix) :]
         return self.bucket_uri
@@ -162,7 +165,7 @@ class CloudFileSystem:
             return S3FileSystem
         elif bucket_uri.startswith("gs://"):
             return GCSFileSystem
-        elif bucket_uri.startswith(("abfss://", "azure://")):
+        elif bucket_uri.startswith(("abfss://", "azure://", "az://")):
             return AzureFileSystem
         else:
             raise ValueError(f"Unsupported URI scheme: {bucket_uri}")

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -9,6 +9,7 @@ from vllm.entrypoints.openai.cli_args import FrontendArgs
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.placement import PlacementGroupConfig
 from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig, is_remote_path
+from ray.llm._internal.common.utils.download_utils import STREAMING_LOAD_FORMATS
 from ray.llm._internal.common.utils.import_utils import try_import
 from ray.llm._internal.serve.constants import (
     ALLOW_NEW_PLACEMENT_GROUPS_IN_DEPLOYMENT,
@@ -193,7 +194,11 @@ class VLLMEngineConfig(BaseModelExtended):
             hf_model_id = llm_config.model_id
         elif isinstance(llm_config.model_loading_config.model_source, str):
             model_source = llm_config.model_loading_config.model_source
-            if is_remote_path(model_source):
+            load_format = llm_config.engine_kwargs.get("load_format")
+            if (
+                is_remote_path(model_source)
+                and load_format not in STREAMING_LOAD_FORMATS
+            ):
                 # Remote URIs (s3://, gs://, …) are download addresses,
                 # not HuggingFace IDs.  Using the URI verbatim as
                 # hf_model_id propagates the scheme and slashes into the
@@ -203,6 +208,9 @@ class VLLMEngineConfig(BaseModelExtended):
                 hf_model_id = llm_config.model_id
                 mirror_config = CloudMirrorConfig(bucket_uri=model_source)
             else:
+                # Streaming load formats read the weights directly from the
+                # remote URI, so pass it through as the model instead of
+                # mirroring it to disk.
                 hf_model_id = model_source
         else:
             # If it's a CloudMirrorConfig (or subtype)

--- a/python/ray/llm/tests/common/cloud/test_mirror_config.py
+++ b/python/ray/llm/tests/common/cloud/test_mirror_config.py
@@ -45,6 +45,12 @@ class TestCloudMirrorConfig:
         )
         assert config.storage_type == "azure"
 
+    def test_valid_az_uri(self):
+        """Test valid az:// URI (account supplied out-of-band via env var)."""
+        config = CloudMirrorConfig(bucket_uri="az://container/path")
+        assert config.bucket_uri == "az://container/path"
+        assert config.storage_type == "azure"
+
     def test_none_uri(self):
         """Test None URI."""
         config = CloudMirrorConfig(bucket_uri=None)
@@ -117,6 +123,18 @@ class TestLoraMirrorConfig:
         assert config.bucket_name == "container"
         assert config.bucket_path == "lora/models"
 
+    def test_valid_az_config(self):
+        """Test valid az:// LoRA config."""
+        config = LoraMirrorConfig(
+            lora_model_id="test-model",
+            bucket_uri="az://container/lora/models",
+            max_total_tokens=1000,
+        )
+        assert config.lora_model_id == "test-model"
+        assert config.bucket_uri == "az://container/lora/models"
+        assert config.bucket_name == "container"
+        assert config.bucket_path == "lora/models"
+
     def test_bucket_path_parsing(self):
         """Test bucket path parsing for different URI formats."""
         # S3 with multiple path segments
@@ -132,6 +150,15 @@ class TestLoraMirrorConfig:
         config = LoraMirrorConfig(
             lora_model_id="test",
             bucket_uri="abfss://container@account.dfs.core.windows.net/deep/nested/path",
+            max_total_tokens=1000,
+        )
+        assert config.bucket_name == "container"
+        assert config.bucket_path == "deep/nested/path"
+
+        # az:// with multiple path segments
+        config = LoraMirrorConfig(
+            lora_model_id="test",
+            bucket_uri="az://container/deep/nested/path",
             max_total_tokens=1000,
         )
         assert config.bucket_name == "container"

--- a/python/ray/llm/tests/common/cloud/test_pyarrow_filesystem.py
+++ b/python/ray/llm/tests/common/cloud/test_pyarrow_filesystem.py
@@ -419,7 +419,7 @@ class TestPyArrowFileSystemAzureSupport:
             account_name="account", credential=mock_cred.return_value
         )
 
-    @patch.dict("os.environ", {"AZURE_STORAGE_ACCOUNT_NAME": "myaccount"})
+    @patch.dict("os.environ", {"AZURE_STORAGE_ACCOUNT_NAME": "myaccount"}, clear=True)
     @patch("adlfs.AzureBlobFileSystem")
     @patch("azure.identity.DefaultAzureCredential")
     @patch("pyarrow.fs.PyFileSystem")
@@ -436,12 +436,39 @@ class TestPyArrowFileSystemAzureSupport:
         assert fs == mock_pyfs_instance
         assert path == "container/path/to/file"
 
-        # The account name comes from AZURE_STORAGE_ACCOUNT_NAME, not the URI
+        # Account name comes from AZURE_STORAGE_ACCOUNT_NAME, not the URI
+        # No key/SAS/connection string set, so DefaultAzureCredential is used
         mock_adlfs.assert_called_once_with(
             account_name="myaccount", credential=mock_cred.return_value
         )
         mock_handler.assert_called_once_with(mock_adlfs_instance)
         mock_pyfs.assert_called_once_with(mock_handler.return_value)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "AZURE_STORAGE_ACCOUNT_NAME": "myaccount",
+            "AZURE_STORAGE_ACCOUNT_KEY": "secret-key",
+        },
+        clear=True,
+    )
+    @patch("adlfs.AzureBlobFileSystem")
+    @patch("azure.identity.DefaultAzureCredential")
+    @patch("pyarrow.fs.PyFileSystem")
+    @patch("pyarrow.fs.FSSpecHandler")
+    def test_az_defers_to_credential_env_vars(
+        self, mock_handler, mock_pyfs, mock_cred, mock_adlfs
+    ):
+        """Test az:// lets adlfs read an account key/SAS/connection string.
+
+        When one of those credential env vars is set (as the RunAI streamer
+        supports), DefaultAzureCredential must not be forced, otherwise it would
+        take precedence over the account key and SAS token in adlfs.
+        """
+        PyArrowFileSystem._create_az_filesystem("az://container/path")
+
+        mock_cred.assert_not_called()
+        mock_adlfs.assert_called_once_with(account_name="myaccount", credential=None)
 
     def test_az_missing_account_env(self):
         """Test az:// raises when AZURE_STORAGE_ACCOUNT_NAME is unset."""

--- a/python/ray/llm/tests/common/cloud/test_pyarrow_filesystem.py
+++ b/python/ray/llm/tests/common/cloud/test_pyarrow_filesystem.py
@@ -419,6 +419,118 @@ class TestPyArrowFileSystemAzureSupport:
             account_name="account", credential=mock_cred.return_value
         )
 
+    @patch.dict("os.environ", {"AZURE_STORAGE_ACCOUNT_NAME": "myaccount"})
+    @patch("adlfs.AzureBlobFileSystem")
+    @patch("azure.identity.DefaultAzureCredential")
+    @patch("pyarrow.fs.PyFileSystem")
+    @patch("pyarrow.fs.FSSpecHandler")
+    def test_get_fs_and_path_az(self, mock_handler, mock_pyfs, mock_cred, mock_adlfs):
+        """Test getting az:// filesystem and path (account from env var)."""
+        mock_adlfs_instance = MagicMock()
+        mock_adlfs.return_value = mock_adlfs_instance
+        mock_pyfs_instance = MagicMock()
+        mock_pyfs.return_value = mock_pyfs_instance
+
+        fs, path = PyArrowFileSystem.get_fs_and_path("az://container/path/to/file")
+
+        assert fs == mock_pyfs_instance
+        assert path == "container/path/to/file"
+
+        # The account name comes from AZURE_STORAGE_ACCOUNT_NAME, not the URI
+        mock_adlfs.assert_called_once_with(
+            account_name="myaccount", credential=mock_cred.return_value
+        )
+        mock_handler.assert_called_once_with(mock_adlfs_instance)
+        mock_pyfs.assert_called_once_with(mock_handler.return_value)
+
+    def test_az_missing_account_env(self):
+        """Test az:// raises when AZURE_STORAGE_ACCOUNT_NAME is unset."""
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "adlfs.AzureBlobFileSystem"
+        ), patch("azure.identity.DefaultAzureCredential"), patch(
+            "pyarrow.fs.PyFileSystem"
+        ), patch(
+            "pyarrow.fs.FSSpecHandler"
+        ):
+            with pytest.raises(ValueError, match="AZURE_STORAGE_ACCOUNT_NAME"):
+                PyArrowFileSystem._create_az_filesystem("az://container/path")
+
+    def test_az_import_error(self):
+        """Test ImportError when adlfs is not available for az://."""
+        with patch(
+            "builtins.__import__", side_effect=ImportError("No module named 'adlfs'")
+        ):
+            with pytest.raises(
+                ImportError, match="You must `pip install adlfs azure-identity`"
+            ):
+                PyArrowFileSystem._create_az_filesystem("az://container/path")
+
+    def test_az_uri_validation(self):
+        """Test az:// URI validation."""
+        # Test valid URIs
+        valid_uris = [
+            "az://container/path",
+            "az://my-container/deep/nested/path",
+        ]
+
+        for uri in valid_uris:
+            with patch.dict(
+                "os.environ", {"AZURE_STORAGE_ACCOUNT_NAME": "myaccount"}
+            ), patch("adlfs.AzureBlobFileSystem"), patch(
+                "azure.identity.DefaultAzureCredential"
+            ), patch(
+                "pyarrow.fs.PyFileSystem"
+            ), patch(
+                "pyarrow.fs.FSSpecHandler"
+            ):
+                # Should not raise an exception
+                PyArrowFileSystem._create_az_filesystem(uri)
+
+        # Test invalid URIs (account env set so the container check is reached)
+        invalid_uris = [
+            "az:///path",  # Empty container
+            "az://",  # Empty container
+        ]
+
+        for uri in invalid_uris:
+            with patch.dict(
+                "os.environ", {"AZURE_STORAGE_ACCOUNT_NAME": "myaccount"}
+            ), patch("adlfs.AzureBlobFileSystem"), patch(
+                "azure.identity.DefaultAzureCredential"
+            ), patch(
+                "pyarrow.fs.PyFileSystem"
+            ), patch(
+                "pyarrow.fs.FSSpecHandler"
+            ):
+                with pytest.raises(ValueError):
+                    PyArrowFileSystem._create_az_filesystem(uri)
+
+    @patch.dict("os.environ", {"AZURE_STORAGE_ACCOUNT_NAME": "myaccount"})
+    @patch("adlfs.AzureBlobFileSystem")
+    @patch("azure.identity.DefaultAzureCredential")
+    @patch("pyarrow.fs.PyFileSystem")
+    @patch("pyarrow.fs.FSSpecHandler")
+    def test_az_anonymous_access_ignored(
+        self, mock_handler, mock_pyfs, mock_cred, mock_adlfs
+    ):
+        """Test that anonymous access pattern is ignored for az:// URIs."""
+        mock_adlfs_instance = MagicMock()
+        mock_adlfs.return_value = mock_adlfs_instance
+        mock_pyfs_instance = MagicMock()
+        mock_pyfs.return_value = mock_pyfs_instance
+
+        # az:// URI with @ symbol should not trigger anonymous access logic
+        fs, path = PyArrowFileSystem.get_fs_and_path("az://anonymous@container/path")
+
+        assert fs == mock_pyfs_instance
+        assert path == "anonymous@container/path"
+
+        # Verify that DefaultAzureCredential was used, not anonymous access
+        mock_cred.assert_called_once()
+        mock_adlfs.assert_called_once_with(
+            account_name="myaccount", credential=mock_cred.return_value
+        )
+
     def test_abfss_uri_validation(self):
         """Test ABFSS URI validation."""
         # Test valid URIs

--- a/python/ray/llm/tests/common/cloud/test_utils.py
+++ b/python/ray/llm/tests/common/cloud/test_utils.py
@@ -308,6 +308,11 @@ class TestIsRemotePath:
             is True
         )
 
+    def test_az_paths(self):
+        """Test az:// path detection."""
+        assert is_remote_path("az://container/path") is True
+        assert is_remote_path("az://container") is True
+
     def test_local_paths(self):
         """Test local path detection."""
         assert is_remote_path("/local/path") is False

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -220,6 +220,44 @@ class TestModelConfig:
         assert engine_config.hf_model_id == bucket_uri
         assert engine_config.mirror_config is None
 
+    def test_az_streaming_model_source_passes_uri_as_model(self):
+        """An az:// streaming source is passed through to vLLM as the model.
+
+        ``az://`` is a remote scheme, so with a streaming load format the URI
+        must reach vLLM as ``model`` (streamed directly) rather than being
+        mirrored to disk.
+        """
+        bucket_uri = "az://container/my-model"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+                model_source=bucket_uri,
+            ),
+            engine_kwargs={"load_format": "runai_streamer"},
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == bucket_uri
+        assert engine_config.mirror_config is None
+
+    def test_az_non_streaming_model_source_is_mirrored(self):
+        """An az:// non-streaming source is mirrored like the other schemes.
+
+        Without a streaming load format the weights are downloaded, so the URI
+        must be carried by mirror_config while hf_model_id falls back to the
+        user-supplied model_id (keeping the HF cache directory name clean).
+        """
+        bucket_uri = "az://container/my-model"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+                model_source=bucket_uri,
+            ),
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == "llm_model_id"
+        assert engine_config.mirror_config is not None
+        assert engine_config.mirror_config.bucket_uri == bucket_uri
+
     def test_hf_model_source_used_as_hf_model_id(self):
         """A plain HuggingFace model_source is used directly as hf_model_id."""
         llm_config = LLMConfig(

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -201,6 +201,25 @@ class TestModelConfig:
         assert engine_config.mirror_config is not None
         assert engine_config.mirror_config.bucket_uri == bucket_uri
 
+    def test_streaming_remote_model_source_passes_uri_as_model(self):
+        """Streaming load formats must pass the remote URI to vLLM as the model.
+
+        RunAI streamer reads the weights directly from the remote URI, so the
+        URI must reach vLLM as ``model`` rather than being mirrored to disk
+        (which would hand vLLM a local path with no safetensors). See #64978.
+        """
+        bucket_uri = "s3://my-bucket/my-model"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="llm_model_id",
+                model_source=bucket_uri,
+            ),
+            engine_kwargs={"load_format": "runai_streamer"},
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == bucket_uri
+        assert engine_config.mirror_config is None
+
     def test_hf_model_source_used_as_hf_model_id(self):
         """A plain HuggingFace model_source is used directly as hf_model_id."""
         llm_config = LLMConfig(


### PR DESCRIPTION
**⚠️ Stacked on #64996 ** This PR is branched off #64996 and should come after it. The `load_format`-aware guard added in #64996 is what keeps `az://` *streaming* working once `az://` becomes a download-capable scheme here. 

## Description
Currently `az://`  in Ray Serve LLM works **only** for streaming load formats (`runai_streamer`), and only *by coincidence*.
Since `az://` is absent from `is_remote_path`, so it falls through to the passthrough branch in `VLLMEngineConfig.from_llm_config` and reaches the streamer verbatim.
With any **non-streaming** `load_format`, Ray's downloader rejects it outright:
`ValueError: Unsupported URI scheme: az://...`

The correct behavior should be that `load_format` decides stream-vs-download for all file systems `s3://`/`gs://`/`azure://`/`abfss://` including `az://`.

## What this PR does

Makes `az://` a **first-class Azure scheme** that supports both streaming and downloading, so `load_format` not the URI scheme  decides the transfer mode, just like `s3://` ie.

- Recognize `az://` across the cloud URI helpers: `is_remote_path`, `CloudMirrorConfig`, `LoraMirrorConfig`, `CloudFileSystem._get_provider_fs`, and `CloudDownloader`.
- Add `PyArrowFileSystem._create_az_filesystem`, mirroring the existing`azure://` handler. The only difference: `az://container/path` reads the  storage account from `AZURE_STORAGE_ACCOUNT_NAME` (the convention the RunAI   streamer already uses) instead of embedding it in the hostname — so the **same `az://` URI works for both streaming and downloading**.

### Authentication
`_create_az_filesystem` honors the same credentials the RunAI streamer does, so
any setup that streams `az://` today can also download it:
- `AZURE_STORAGE_CONNECTION_STRING`, `AZURE_STORAGE_ACCOUNT_KEY`, and
  `AZURE_STORAGE_SAS_TOKEN` are read by `adlfs` from the environment.
- `DefaultAzureCredential` (Entra ID / workload identity) is used **only** when
  none of the above are set — otherwise an explicit credential would take
  precedence over the account key and SAS token inside `adlfs`.

## Testing
**Unit tests** — added `az://` coverage matching the existing `s3://`/`azure://`
suites:
- `is_remote_path`, `CloudMirrorConfig`/`LoraMirrorConfig` (scheme + path parsing)
- `PyArrowFileSystem`: `get_fs_and_path`, URI validation, missing-account error,  import error, anonymous-access exclusion, and credential deferral to  key/SAS/connection-string
- `from_llm_config`: `az://` streaming → passthrough, non-streaming → mirror
pytest python/ray/llm/tests/common/cloud/
pytest python/ray/llm/tests/serve/cpu/configs/test_models.py


**Manual cluster validation** (on AKS, Azure Blob via workload identity):
- Downloaded a model (`Qwen2.5-0.5B-Instruct`) from an `az://` bucket e2e via the new path.
- Verified `download_model_files(mirror_config=az://...)` — the exact call  `node_init` makes — produces a clean HF cache dir (`models--<model_id>`, not a malformed `models--az:--...`).
- Confirmed `from_llm_config` routing for `az://` streaming and non-streaming