### PR TITLE
[dashboard] Fix profiling status check to work behind a reverse proxy

### DIFF
--- a/python/ray/dashboard/client/src/common/ProfilingLink.component.test.tsx
+++ b/python/ray/dashboard/client/src/common/ProfilingLink.component.test.tsx
@@ -2,8 +2,38 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import "@testing-library/jest-dom";
+import { get } from "../service/requestHandlers";
 import { TEST_APP_WRAPPER } from "../util/test-utils";
-import { ProfilerButton } from "./ProfilingLink";
+import {
+  _resetProfilingEnabledCache,
+  CpuProfilingLink,
+  ProfilerButton,
+} from "./ProfilingLink";
+
+jest.mock("../service/requestHandlers");
+
+const mockedGet = jest.mocked(get);
+
+describe("fetchProfilingEnabled", () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+    _resetProfilingEnabledCache();
+  });
+
+  it("calls get() with /api/profiling_enabled instead of raw fetch", async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { data: { profilingEnabled: false } },
+    });
+
+    render(<CpuProfilingLink pid={12345} nodeId="node-abc" type="" />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    await waitFor(() => {
+      expect(mockedGet).toHaveBeenCalledWith("/api/profiling_enabled");
+    });
+  });
+});
 
 describe("ProfilerButton", () => {
   const mockProps = {

--- a/python/ray/dashboard/client/src/common/ProfilingLink.tsx
+++ b/python/ray/dashboard/client/src/common/ProfilingLink.tsx
@@ -16,20 +16,26 @@ import {
 } from "@mui/material";
 import React, { PropsWithChildren, useEffect, useState } from "react";
 import { HelpInfo } from "../components/Tooltip";
+import { get } from "../service/requestHandlers";
 import { ClassNameProps } from "./props";
 
 let cachedProfilingEnabled: boolean | null = null;
 let fetchPromise: Promise<void> | null = null;
+
+// Exported for tests: reset the module-level cache so each test starts fresh.
+export const _resetProfilingEnabledCache = () => {
+  cachedProfilingEnabled = null;
+  fetchPromise = null;
+};
 
 const fetchProfilingEnabled = (): Promise<void> => {
   if (cachedProfilingEnabled !== null) {
     return Promise.resolve();
   }
   if (!fetchPromise) {
-    fetchPromise = fetch("/api/profiling_enabled")
-      .then((res) => res.json())
-      .then((data) => {
-        cachedProfilingEnabled = data.data.profilingEnabled;
+    fetchPromise = get("/api/profiling_enabled")
+      .then((res) => {
+        cachedProfilingEnabled = res.data?.data?.profilingEnabled ?? false;
       })
       .catch(() => {
         cachedProfilingEnabled = false;


### PR DESCRIPTION
## Summary

`fetchProfilingEnabled()` in `ProfilingLink.tsx` used the native `fetch("/api/profiling_enabled")` with an **absolute** path. Under a reverse proxy (e.g. KubeRay's `/api/v1/namespaces/<ns>/services/<svc>/proxy/` prefix), the browser resolves that absolute path against the host root, bypassing the proxy prefix entirely — the request lands where no Ray dashboard is listening and the gateway returns 404. 

Every other dashboard request goes through `get()` / `axiosInstance` in `service/requestHandlers.ts`, whose `formatUrl()` helper strips the leading `/` so the request is sent **relative** to the path the dashboard is served from. This is the reverse-proxy-compatible pattern the codebase already standardizes on; `fetchProfilingEnabled()` was the lone exception.

## Changes

- `ProfilingLink.tsx`: replace raw `fetch("/api/profiling_enabled")` with `get("/api/profiling_enabled")` from `service/requestHandlers`. Response body now read from `res.data.data.profilingEnabled` (axios wraps the body in `.data`).
- `ProfilingLink.component.test.tsx`: add a unit test that mocks `requestHandlers` and asserts `get()` is called with `/api/profiling_enabled` (guards against a regression back to raw `fetch`).

