### PR TITLE
[java] Upgrade com.google.code.gson from 2.9.1 to 2.11.0 (#64273)

### DIFF
--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -6,7 +6,7 @@ def gen_java_deps():
         artifacts = [
             "com.fasterxml.jackson.core:jackson-databind:2.18.8",
             "com.github.java-json-tools:json-schema-validator:2.2.14",
-            "com.google.code.gson:gson:2.9.1",
+            "com.google.code.gson:gson:2.11.0",
             "com.google.guava:guava:32.0.1-jre",
             "com.google.protobuf:protobuf-java:3.23.4",
             "com.google.protobuf:protobuf-java-util:3.23.4",


### PR DESCRIPTION
## Why are these changes needed?

Fixes #64273

The Java dependency `com.google.code.gson:gson` is currently pinned to
version `2.9.1`, which is outdated. This PR upgrades it to `2.11.0`,
which includes bug fixes, performance improvements, and security
enhancements over the previous version.

Key changes in gson 2.10.0–2.11.0:
- Improved `TypeToken` API safety
- Fixed edge cases in JSON parsing
- Performance improvements in serialization/deserialization

## Changes

- Updated `java/dependencies.bzl`: bumped `com.google.code.gson:gson`
  from `2.9.1` to `2.11.0`
- No lock file update required (Ray uses dynamic Maven resolution via
  `rules_jvm_external`, no `maven_install.json` pins gson)

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing.

## Testing

Dependency version bump only. No API-level changes to Ray source code.
Gson 2.11.0 is backward compatible with 2.9.1 for all usages present
in this codebase.