### PR TITLE
[data] Fix write_lance compatibility with PyLance 6

### DIFF
--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -20,7 +20,7 @@ from ray.data._internal.arrow_ops.transform_pyarrow import (
     reorder_columns_by_schema,
 )
 from ray.data._internal.datasource.lance_utils import (
-    create_storage_options_provider,
+    get_lance_namespace_kwargs,
     get_or_create_namespace,
 )
 from ray.data._internal.savemode import SaveMode
@@ -134,7 +134,8 @@ def _write_fragment(
         DEFAULT_MAX_BYTES_PER_FILE if max_bytes_per_file is None else max_bytes_per_file
     )
 
-    storage_options_provider = create_storage_options_provider(
+    namespace_kwargs = get_lance_namespace_kwargs(
+        write_fragments,
         namespace_impl,
         namespace_properties,
         table_id,
@@ -153,7 +154,7 @@ def _write_fragment(
             max_bytes_per_file=max_bytes_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
-            storage_options_provider=storage_options_provider,
+            **namespace_kwargs,
         )
 
     fragments = call_with_retry(_write_once, **retry_params)
@@ -231,17 +232,6 @@ class _BaseLanceDatasink(Datasink):
         self.storage_options = merged_storage_options
 
     @property
-    def storage_options_provider(self):
-        """Lazily create storage options provider using namespace_impl/properties."""
-        if not self._has_namespace_storage_options:
-            return None
-        return create_storage_options_provider(
-            self._namespace_impl,
-            self._namespace_properties,
-            self.table_id,
-        )
-
-    @property
     def supports_distributed_writes(self) -> bool:
         return True
 
@@ -250,14 +240,19 @@ class _BaseLanceDatasink(Datasink):
 
         Raises whatever Lance raises if the dataset can't be opened (missing,
         bad ``storage_options``, etc.). Opening natively honors
-        ``storage_options``/``storage_options_provider``.
+        ``storage_options`` and namespace credentials.
         """
         import lance
 
         return lance.LanceDataset(
             self.uri,
             storage_options=self.storage_options,
-            storage_options_provider=self.storage_options_provider,
+            **get_lance_namespace_kwargs(
+                lance.LanceDataset,
+                self._namespace_impl,
+                self._namespace_properties,
+                self.table_id,
+            ),
         )
 
     def _dataset_exists(self) -> bool:
@@ -348,7 +343,12 @@ class _BaseLanceDatasink(Datasink):
             op,
             read_version=self.read_version,
             storage_options=self.storage_options,
-            storage_options_provider=self.storage_options_provider,
+            **get_lance_namespace_kwargs(
+                lance.LanceDataset.commit,
+                self._namespace_impl,
+                self._namespace_properties,
+                self.table_id,
+            ),
         )
 
 

--- a/python/ray/data/_internal/datasource/lance_utils.py
+++ b/python/ray/data/_internal/datasource/lance_utils.py
@@ -1,6 +1,7 @@
 import os
 from functools import lru_cache
-from typing import Dict, List, Optional, Tuple
+from inspect import signature
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 _NAMESPACE_CACHE_SIZE = int(os.environ.get("LANCE_RAY_NAMESPACE_CACHE_SIZE", "16"))
 
@@ -56,3 +57,28 @@ def create_storage_options_provider(
     from lance import LanceNamespaceStorageOptionsProvider
 
     return LanceNamespaceStorageOptionsProvider(namespace=namespace, table_id=table_id)
+
+
+def get_lance_namespace_kwargs(
+    target: Callable[..., Any],
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[Dict[str, str]],
+    table_id: Optional[List[str]],
+) -> Dict[str, Any]:
+    """Build namespace arguments for the installed PyLance API."""
+    if not _has_namespace_params(namespace_impl, table_id):
+        return {}
+
+    if "namespace_client" in signature(target).parameters:
+        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+        if namespace is None:
+            return {}
+        return {"namespace_client": namespace, "table_id": table_id}
+
+    return {
+        "storage_options_provider": create_storage_options_provider(
+            namespace_impl,
+            namespace_properties,
+            table_id,
+        )
+    }

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -15,6 +15,7 @@ from ray.data._internal.datasource.lance_datasink import (
     LanceDatasink,
     _write_fragment,
 )
+from ray.data._internal.datasource.lance_utils import get_lance_namespace_kwargs
 from ray.data._internal.object_extensions.arrow import ArrowPythonObjectType
 from ray.data.datasource import SaveMode
 from ray.data.datasource.path_util import _unwrap_protocol
@@ -367,6 +368,54 @@ def test_lance_namespace_write_rejects_non_create_mode(monkeypatch, mode):
             namespace_impl="dir",
             namespace_properties={"path": "/tmp/ns"},
         )
+
+
+def test_lance_namespace_kwargs_omits_namespace_for_plain_uri():
+    def current_lance_api(*, namespace_client=None, table_id=None):
+        pass
+
+    assert get_lance_namespace_kwargs(current_lance_api, None, None, None) == {}
+
+
+def test_lance_namespace_kwargs_uses_current_api(monkeypatch):
+    namespace = object()
+
+    def current_lance_api(*, namespace_client=None, table_id=None):
+        pass
+
+    monkeypatch.setattr(
+        "ray.data._internal.datasource.lance_utils.get_or_create_namespace",
+        lambda namespace_impl, namespace_properties: namespace,
+    )
+
+    assert get_lance_namespace_kwargs(
+        current_lance_api,
+        "dir",
+        {"path": "/tmp/ns"},
+        ["db", "table"],
+    ) == {
+        "namespace_client": namespace,
+        "table_id": ["db", "table"],
+    }
+
+
+def test_lance_namespace_kwargs_uses_legacy_api(monkeypatch):
+    provider = object()
+
+    def legacy_lance_api(*, storage_options_provider=None):
+        pass
+
+    monkeypatch.setattr(
+        "ray.data._internal.datasource.lance_utils.create_storage_options_provider",
+        lambda namespace_impl, namespace_properties, table_id: provider,
+    )
+
+    assert get_lance_namespace_kwargs(
+        legacy_lance_api,
+        "dir",
+        {"path": "/tmp/ns"},
+        ["db", "table"],
+    ) == {"storage_options_provider": provider}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

PyLance 6 removed the `storage_options_provider` keyword from
`write_fragments`, `LanceDataset`, and `LanceDataset.commit`, replacing it with
`namespace_client` and `table_id`. Ray currently passes the legacy keyword
unconditionally, including as `None` for plain URI writes, which causes
`Dataset.write_lance()` to fail with `TypeError`.

This change centralizes namespace argument selection based on the installed
callable's signature:

- plain URI writes omit namespace arguments;
- current PyLance APIs receive `namespace_client` and `table_id`;
- legacy PyLance APIs retain `storage_options_provider`.

The helper is applied consistently to fragment creation, dataset opening, and
commit. Focused regression tests cover plain, current, and legacy argument
selection.

## Related issues

Fixes #65129.

## Additional information

Duplicate checks found no open PR referencing #65129 or matching the affected
PyLance namespace API transition.

Validation:

- Standalone compiled-Ray production-path harness with PyLance 4.0.0:
  `4 passed` (fragment write, dataset open, commit/readback, namespace selection).
- The same harness with PyLance 6.0.1: `4 passed`.
- `pre-commit run ruff --files <changed Python files>`: passed, including import order.
- `pre-commit run black --files <changed Python files>`: passed.
- `pre-commit run pydoclint --files <changed Python files>`: passed.
- `python -m py_compile <changed Python files>`: passed.
- `git diff --check`: passed.

