### PR TITLE
[core] only let worker subscribe to owner death when actor level back pressure is enabled

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -780,15 +780,15 @@ void CoreWorker::SubscribeToOwnerWorkerFailures() {
   std::call_once(subscribe_to_owner_worker_failures_flag_, [this]() {
     // Watch for owner-worker death so finished streaming-generator tasks with
     // unconsumed objects don't leak their actor-wide BP slot.
-    // Capture a weak_ptr: a raw `this` would UAF if the callback outlives
-    // CoreWorker, and a shared_ptr would cycle with gcs_client_ (which owns
-    // the subscription).
-    std::weak_ptr<CoreWorker> weak_self = shared_from_this();
+    // Prefer weak_from_this over shared_from_this: we only need a weak
+    // capture (a strong one would cycle with gcs_client_), and
+    // shared_from_this can throw bad_weak_ptr.
+    std::weak_ptr<CoreWorker> weak_self = weak_from_this();
     gcs_client_->Workers().AsyncSubscribeToWorkerFailures(
         [weak_self](const rpc::WorkerDeltaData &worker_failure_data) {
-          if (auto self = weak_self.lock()) {
-            self->HandleOwnerDied(
-                WorkerID::FromBinary(worker_failure_data.worker_id()));
+          std::shared_ptr<CoreWorker> self = weak_self.lock();
+          if (self != nullptr) {
+            self->HandleOwnerDied(WorkerID::FromBinary(worker_failure_data.worker_id()));
           }
         },
         nullptr);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -780,9 +780,16 @@ void CoreWorker::SubscribeToOwnerWorkerFailures() {
   std::call_once(subscribe_to_owner_worker_failures_flag_, [this]() {
     // Watch for owner-worker death so finished streaming-generator tasks with
     // unconsumed objects don't leak their actor-wide BP slot.
+    // Capture a weak_ptr: a raw `this` would UAF if the callback outlives
+    // CoreWorker, and a shared_ptr would cycle with gcs_client_ (which owns
+    // the subscription).
+    std::weak_ptr<CoreWorker> weak_self = shared_from_this();
     gcs_client_->Workers().AsyncSubscribeToWorkerFailures(
-        [this](const rpc::WorkerDeltaData &worker_failure_data) {
-          HandleOwnerDied(WorkerID::FromBinary(worker_failure_data.worker_id()));
+        [weak_self](const rpc::WorkerDeltaData &worker_failure_data) {
+          if (auto self = weak_self.lock()) {
+            self->HandleOwnerDied(
+                WorkerID::FromBinary(worker_failure_data.worker_id()));
+          }
         },
         nullptr);
   });
@@ -2992,10 +2999,6 @@ Status CoreWorker::ExecuteTask(
       // SystemExit propagate through ReserveSlot's wait loop.
       actor_generator_waiter_ = std::make_shared<ActorWideGeneratorBackpressureWaiter>(
           actor_generator_bp, options_.check_signals);
-      // Only actors with actor-wide BP need owner-death sweeps: finished
-      // generator tasks keep their shared budget until the owner drains or
-      // dies. Per-task BP alone does not retain state after the task finishes.
-      SubscribeToOwnerWorkerFailures();
     }
     RAY_LOG(INFO).WithField(task_spec.ActorCreationId()) << "Creating actor";
   } else if (task_spec.IsActorTask()) {
@@ -3384,17 +3387,23 @@ void CoreWorker::RegisterGeneratorBackpressureState(
     std::shared_ptr<TaskGeneratorBackpressureWaiter> waiter,
     std::shared_ptr<ActorTaskBackpressureMetadata> actor_metadata,
     const rpc::Address &owner_address) {
-  absl::MutexLock lock(&mutex_);
-  // Only insert if not present. The report path also writes this entry (with
-  // the same values); leaving an existing entry untouched avoids racing with
-  // any in-progress mutation there.
-  auto [it, inserted] = generator_backpressure_states_.try_emplace(generator_id);
-  if (!inserted) {
-    return;
+  {
+    absl::MutexLock lock(&mutex_);
+    // Only insert if not present. The report path also writes this entry (with
+    // the same values); leaving an existing entry untouched avoids racing with
+    // any in-progress mutation there.
+    auto [it, inserted] = generator_backpressure_states_.try_emplace(generator_id);
+    if (inserted) {
+      it->second.waiter = std::move(waiter);
+      it->second.actor_metadata = std::move(actor_metadata);
+      it->second.owner_worker_id = WorkerID::FromBinary(owner_address.worker_id());
+    }
   }
-  it->second.waiter = std::move(waiter);
-  it->second.actor_metadata = std::move(actor_metadata);
-  it->second.owner_worker_id = WorkerID::FromBinary(owner_address.worker_id());
+  // Any BP registration (per-task or actor-wide) needs owner-death sweeps:
+  // running tasks parked in WaitUntilObjectConsumed / ReserveActorWideSlot
+  // would otherwise hang, and finished actor-wide tasks would leak shared
+  // budget. call_once inside makes this cheap after the first registration.
+  SubscribeToOwnerWorkerFailures();
 }
 
 void CoreWorker::MarkGeneratorBackpressureTaskFinished(const ObjectID &generator_id) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -774,16 +774,18 @@ void CoreWorker::RegisterToGcs(int64_t worker_launch_time_ms,
   worker_data->set_worker_launched_time_ms(worker_launched_time_ms);
 
   gcs_client_->Workers().AsyncAdd(worker_data, nullptr);
+}
 
-  if (options_.worker_type == WorkerType::WORKER) {
+void CoreWorker::SubscribeToOwnerWorkerFailures() {
+  std::call_once(subscribe_to_owner_worker_failures_flag_, [this]() {
     // Watch for owner-worker death so finished streaming-generator tasks with
-    // unconsumed objects don't leak their actor-wide BP slot
+    // unconsumed objects don't leak their actor-wide BP slot.
     gcs_client_->Workers().AsyncSubscribeToWorkerFailures(
         [this](const rpc::WorkerDeltaData &worker_failure_data) {
           HandleOwnerDied(WorkerID::FromBinary(worker_failure_data.worker_id()));
         },
         nullptr);
-  }
+  });
 }
 
 void CoreWorker::HandleOwnerDied(const WorkerID &dead_owner) {
@@ -2990,6 +2992,10 @@ Status CoreWorker::ExecuteTask(
       // SystemExit propagate through ReserveSlot's wait loop.
       actor_generator_waiter_ = std::make_shared<ActorWideGeneratorBackpressureWaiter>(
           actor_generator_bp, options_.check_signals);
+      // Only actors with actor-wide BP need owner-death sweeps: finished
+      // generator tasks keep their shared budget until the owner drains or
+      // dies. Per-task BP alone does not retain state after the task finishes.
+      SubscribeToOwnerWorkerFailures();
     }
     RAY_LOG(INFO).WithField(task_spec.ActorCreationId()) << "Creating actor";
   } else if (task_spec.IsActorTask()) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1578,6 +1578,14 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// Used to lazily subscribe to node_changes only if the worker takes any owner actions.
   void SubscribeToNodeChanges();
 
+  /**
+   * Subscribe to GCS worker failures so ``HandleOwnerDied`` can reclaim
+   * actor-wide streaming-generator backpressure budget when an owner dies.
+   * Only called when this actor enables
+   * ``_actor_generator_backpressure_num_objects``.
+   */
+  void SubscribeToOwnerWorkerFailures();
+
   std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfo(
       const std::string &serialized_runtime_env_info) const;
 
@@ -2166,6 +2174,9 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Used to ensure we only subscribe to node changes once.
   std::once_flag subscribe_to_node_changes_flag_;
+
+  /** Used to ensure we only subscribe to owner-worker failures once. */
+  std::once_flag subscribe_to_owner_worker_failures_flag_;
 
   // Grant CoreWorkerShutdownExecutor access to CoreWorker internals for orchestrating
   // the shutdown procedure without exposing additional public APIs.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1579,10 +1579,11 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   void SubscribeToNodeChanges();
 
   /**
-   * Subscribe to GCS worker failures so ``HandleOwnerDied`` can reclaim
-   * actor-wide streaming-generator backpressure budget when an owner dies.
-   * Only called when this actor enables
-   * ``_actor_generator_backpressure_num_objects``.
+   * Subscribe to GCS worker failures so ``HandleOwnerDied`` can clean up
+   * generator backpressure state when an owner dies. Covers both per-task BP
+   * (unblock ``WaitUntilObjectConsumed``) and actor-wide BP (reclaim shared
+   * budget held by finished tasks). Called from
+   * ``RegisterGeneratorBackpressureState``; idempotent via ``std::call_once``.
    */
   void SubscribeToOwnerWorkerFailures();
 


### PR DESCRIPTION
## Description

Previously, workers were always subscribing to GCS for owner death notification, but that was only needed for actor-level backpressure. This PR makes the subscription only when actor-level backpressure is enabled.
