### PR TITLE
[core] deflake test_task_metrics nested tests by flushing stale samples

### DIFF
--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -242,12 +242,16 @@ ray.get(w)
     }
 
     def check_task_state():
-        assert tasks_by_state(info, timeseries) == expected
+        # Flush each poll: PrometheusTimeseries only merges samples and never
+        # drops series that disappear from /metrics. After gauge TTL (#64633),
+        # a mid-transition PENDING=9 observation can outlive the agent's series
+        # (especially with a poll interval >= TTL) and pin the sum at 9 forever.
+        assert tasks_by_state(info, timeseries, flush=True) == expected
 
     wait_for_assertion(
         check_task_state,
         timeout=30,
-        retry_interval_ms=2000,
+        retry_interval_ms=500,
     )
     assert tasks_by_name_and_state(info, timeseries) == {
         ("wrapper", "RUNNING_IN_RAY_GET"): 1.0,
@@ -296,12 +300,14 @@ ray.get(w)
     }
 
     def check_task_state():
-        assert tasks_by_state(info, timeseries) == expected
+        # See test_task_nested: flush so TTL-evicted gauge series cannot stick
+        # in PrometheusTimeseries and keep PENDING_NODE_ASSIGNMENT at 9.
+        assert tasks_by_state(info, timeseries, flush=True) == expected
 
     wait_for_assertion(
         check_task_state,
         timeout=30,
-        retry_interval_ms=2000,
+        retry_interval_ms=500,
     )
     assert tasks_by_name_and_state(info, timeseries) == {
         ("wrapper", "RUNNING_IN_RAY_WAIT"): 1.0,

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -253,6 +253,7 @@ ray.get(w)
         timeout=30,
         retry_interval_ms=500,
     )
+    timeseries.flush()
     assert tasks_by_name_and_state(info, timeseries) == {
         ("wrapper", "RUNNING_IN_RAY_GET"): 1.0,
         ("a", "RUNNING"): 1.0,
@@ -309,6 +310,7 @@ ray.get(w)
         timeout=30,
         retry_interval_ms=500,
     )
+    timeseries.flush()
     assert tasks_by_name_and_state(info, timeseries) == {
         ("wrapper", "RUNNING_IN_RAY_WAIT"): 1.0,
         ("a", "RUNNING"): 1.0,


### PR DESCRIPTION
## Description
The `PrometheusTimeseries` test util only merges scrapes and never drops series that disappear from `/metrics`. A mid-transition pending sample can outlive the agent-side series after gauge TTL and keep the summed count too high and cause flaky.

This PR uses `flush=True` on each poll (same idea as `test_stale_view_cleanup_when_job_exits`) so we only assert on the current scrape.

windows://python/ray/tests:test_task_metrics passes
<img width="1662" height="678" alt="image" src="https://github.com/user-attachments/assets/e0e9a9a1-b712-4fbd-9ad6-b06018368039" />
