### PR TITLE
[data] Gate write_delta partition round-trip assertions on pyarrow>=19

### DIFF
--- a/python/ray/data/tests/datasource/test_write_delta.py
+++ b/python/ray/data/tests/datasource/test_write_delta.py
@@ -40,6 +40,31 @@ pytestmark = [
     ),
 ]
 
+# Whether ``read_delta`` gives partition columns back with their declared types.
+#
+# A Delta reader takes a partitioned column's value from metadata rather than
+# from the Parquet file (the writer omits it there), so restoring the declared
+# type is the reader's job. ``read_delta`` delegates that to PyArrow -- see the
+# comment on ``partition_columns=[]`` in ``ParquetDatasource.from_pyarrow_dataset``
+# -- and on pyarrow<19 it doesn't happen: values come back as the raw Hive path
+# strings instead, so ``2024`` reads as ``"2024"`` and a null partition as the
+# literal ``"__HIVE_DEFAULT_PARTITION__"``.
+#
+# That's a gap in the *read* path, which this file doesn't own; the writes
+# themselves are fine on every version. Rather than weaken the assertions
+# everywhere, the round-trip *value* checks below skip on old pyarrow while the
+# on-disk layout checks keep running. 19 is the lowest version observed to
+# round-trip correctly (17 fails, 19 and 20 pass); 18 is simply untested.
+_PARTITION_VALUES_ROUND_TRIP = _pa_version is not None and _pa_version >= parse_version(
+    "19.0.0"
+)
+_NO_TYPED_PARTITION_VALUES = (
+    "read_delta returns partition values as untyped Hive path strings on pyarrow<19"
+)
+_skip_without_typed_partition_values = pytest.mark.skipif(
+    not _PARTITION_VALUES_ROUND_TRIP, reason=_NO_TYPED_PARTITION_VALUES
+)
+
 
 @pytest.fixture
 def temp_delta_path(tmp_path):
@@ -170,10 +195,14 @@ def test_single_column_partition(temp_delta_path):
     rows = [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
     ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
     assert set(os.listdir(temp_delta_path)) >= {"year=2024", "year=2025"}
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == rows
 
 
+@_skip_without_typed_partition_values
 def test_multi_column_partition(temp_delta_path):
     rows = [
         {"year": 2024, "month": 1, "id": 1},
@@ -195,6 +224,9 @@ def test_null_partition_value_round_trips_as_none(temp_delta_path):
     rows = [{"year": 2024, "id": 1}, {"year": None, "id": 2}]
     ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
     assert "year=__HIVE_DEFAULT_PARTITION__" in os.listdir(temp_delta_path)
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == rows
 
@@ -236,6 +268,9 @@ def test_append_without_partition_by_inherits_existing_partitioning(temp_delta_p
     ray.data.from_items(rows2).write_delta(temp_delta_path)  # no partition_by
 
     assert "year=2025" in os.listdir(temp_delta_path)
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
 
@@ -285,14 +320,21 @@ def test_partition_by_mismatch_rejected(
             temp_delta_path, partition_by=write_partition_by
         )
 
-    # Nothing was committed and the table is untouched and still readable.
+    # Nothing was committed and the table is untouched -- the assertions that
+    # actually guard against the corruption this test exists for.
     assert _delta_log_json_count(temp_delta_path) == log_before
     assert DeltaTable(temp_delta_path).metadata().partition_columns == (
         create_partition_by or []
     )
+
+    # Only the baseline tables that are themselves partitioned depend on
+    # partition values surviving the read; the unpartitioned case is unaffected.
+    if create_partition_by and not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     assert _read_all(temp_delta_path) == first
 
 
+@_skip_without_typed_partition_values
 def test_partition_by_matching_existing_is_allowed(temp_delta_path):
     """Passing exactly the table's own partition columns is fine."""
     ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
@@ -324,6 +366,9 @@ def test_overwrite_without_partition_by_inherits_existing_partitioning(
     )
 
     assert "year=2025" in os.listdir(temp_delta_path)
+
+    if not _PARTITION_VALUES_ROUND_TRIP:
+        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     assert _read_all(temp_delta_path) == [{"year": 2025, "id": 2}]
 
 


### PR DESCRIPTION
## Summary

The `arrow v17` CI job went red when `test_write_delta.py` landed in #64923. Nine tests fail, all asserting the same thing — that a partition value survives a write/read round trip:

```
assert [{'id': 1, 'year': '2024'}, {'id': 2, 'year': '__HIVE_DEFAULT_PARTITION__'}]
    == [{'id': 1, 'year': 2024},   {'id': 2, 'year': None}]
```

On pyarrow<19, `read_delta` hands partition columns back as the raw Hive path strings: `2024` reads as `"2024"`, and a null partition as the literal `"__HIVE_DEFAULT_PARTITION__"`.

**This is a read-path gap, not a write regression.** A Delta reader takes a partitioned column's value from metadata rather than from the Parquet file (the writer omits it there), so restoring the declared type is the reader's job. `read_delta` delegates that to PyArrow — see the comment on `partition_columns=[]` in `ParquetDatasource.from_pyarrow_dataset` — and the delegation doesn't hold on pyarrow 17. The same writes round-trip correctly on arrow 19 and 20, with the same `deltalake==1.5.0`; only `pyarrow` differs between the images.

It surfaced only now because the read-side suite has no partition coverage at all — `grep -c partition test_delta.py` returns 0 — so nothing had ever read a partitioned Delta table in CI.

## What this changes

Skips just the value comparisons below pyarrow 19, keeping the on-disk layout and Delta-log assertions running everywhere. Most notably, `test_partition_by_mismatch_rejected` keeps its "nothing was committed, `partition_columns` unchanged" assertions on all versions — those are the regression net for a table-corrupting bug and are version-independent, so a blanket skip would have quietly given them up.

19 is the lowest version observed to round-trip correctly (17 fails, 19 and 20 pass); 18 is untested, so the boundary is set at the lowest version with evidence rather than a guess.

## Follow-up (not in this PR)

Fix `read_delta` so partition values are typed on pyarrow 17 too, and add partition coverage to `test_delta.py` so the read path can't regress unnoticed again.

## Test plan

- `pytest python/ray/data/tests/datasource/test_write_delta.py` on pyarrow 20 — **58 passed, 0 skipped** (gate inactive, nothing weakened).
- With the gate forced off to simulate pyarrow<19 — **49 passed, exactly the 9 CI-failing IDs skipped, 0 failed**, confirming the gate is neither too broad nor too narrow. The `unpartitioned-to-partitioned` parametrization, which never failed, correctly keeps running.
- `ruff` 0.8.4, `black` 22.10.0, and the repo-pinned `pyrefly` — clean.
- I could not reproduce locally under pyarrow 17 (the venv hangs on `DeltaTable` reads, likely an arro3/pyarrow ABI issue on macOS arm64), so CI's `arrow v17` job is the real check. I did confirm on pyarrow 20 that the written Delta log carries `int64`/`None` correctly, which is what rules out a write-side cause.

## AI assistance disclosure

This PR was developed with AI assistance (Claude). All changes were reviewed and are defended by the submitting human.