### PR TITLE
[serve] Hold references to long-lived background tasks

### DIFF
--- a/python/ray/llm/_internal/serve/benchmark/runners.py
+++ b/python/ray/llm/_internal/serve/benchmark/runners.py
@@ -562,6 +562,12 @@ async def run_rate_based_benchmark(
     stop_dispatching = asyncio.Event()
     all_done = asyncio.Event()
 
+    # The event loop only keeps a weak reference to a task, so a dispatched
+    # turn whose sole reference was the create_task() call below could be
+    # collected before it ever runs -- silently dropping that turn instead of
+    # raising, since `inflight` isn't incremented until the task starts.
+    _execute_turn_tasks: set[asyncio.Task] = set()
+
     total_slots = int(spec.request_rate * duration_s) if duration_s > 0 else 0
 
     # Two stacked progress bars: sent (top) chased by done (bottom).
@@ -751,7 +757,9 @@ async def run_rate_based_benchmark(
                 conv = _next_conv()
                 turn_idx = 0
 
-            asyncio.create_task(execute_turn(conv, turn_idx, http_session))
+            turn_task = asyncio.create_task(execute_turn(conv, turn_idx, http_session))
+            _execute_turn_tasks.add(turn_task)
+            turn_task.add_done_callback(_execute_turn_tasks.discard)
             pbar_sent.update(1)
             next_dispatch += interval_s
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -678,6 +678,20 @@ class ReplicaMetricsManager:
     async def shutdown(self):
         """Stop periodic background tasks."""
 
+        reporters = [
+            task
+            for task in (
+                self._cached_metrics_task,
+                self._max_processing_latency_task,
+                self._utilization_task,
+            )
+            if task is not None
+        ]
+        for task in reporters:
+            task.cancel()
+        if reporters:
+            await asyncio.gather(*reporters, return_exceptions=True)
+
         await self._metrics_pusher.graceful_shutdown()
 
     def start_metrics_pusher(self):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -656,6 +656,20 @@ class ReplicaMetricsManager:
     async def shutdown(self):
         """Stop periodic background tasks."""
 
+        reporters = [
+            task
+            for task in (
+                self._cached_metrics_task,
+                self._max_processing_latency_task,
+                self._utilization_task,
+            )
+            if task is not None
+        ]
+        for task in reporters:
+            task.cancel()
+        if reporters:
+            await asyncio.gather(*reporters, return_exceptions=True)
+
         await self._metrics_pusher.graceful_shutdown()
 
     def start_metrics_pusher(self):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -393,6 +393,12 @@ class ReplicaMetricsManager:
         self._max_ongoing_requests = max_ongoing_requests
         # Store event loop for scheduling async tasks from sync context
         self._event_loop = event_loop or asyncio.get_event_loop()
+        # The event loop only keeps weak references to tasks, so these
+        # long-lived reporters need a strong reference to survive. Same as
+        # Router._cached_metrics_task in router.py.
+        self._cached_metrics_task: Optional[asyncio.Task] = None
+        self._max_processing_latency_task: Optional[asyncio.Task] = None
+        self._utilization_task: Optional[asyncio.Task] = None
 
         # Cache user_callable_wrapper initialization state to avoid repeated runtime checks
         self._custom_metrics_enabled = False
@@ -454,7 +460,9 @@ class ReplicaMetricsManager:
         )
         if self._cached_metrics_enabled:
             self._cached_latencies: DefaultDict[str, Deque[float]] = defaultdict(deque)
-            self._event_loop.create_task(self._report_cached_metrics_forever())
+            self._cached_metrics_task = self._event_loop.create_task(
+                self._report_cached_metrics_forever()
+            )
 
         # Track maximum processing latency over a rolling window.
         self._max_processing_latency_trackers: DefaultDict[
@@ -473,7 +481,9 @@ class ReplicaMetricsManager:
         self._max_processing_latency_report_interval_s = (
             RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_REPORT_INTERVAL_S
         )
-        self._event_loop.create_task(self._report_max_processing_latency_forever())
+        self._max_processing_latency_task = self._event_loop.create_task(
+            self._report_max_processing_latency_forever()
+        )
 
         self._num_ongoing_requests_gauge = metrics.Gauge(
             "serve_replica_processing_queries",
@@ -513,7 +523,9 @@ class ReplicaMetricsManager:
         self._utilization_report_interval_s = (
             RAY_SERVE_REPLICA_UTILIZATION_REPORT_INTERVAL_S
         )
-        self._event_loop.create_task(self._report_utilization_forever())
+        self._utilization_task = self._event_loop.create_task(
+            self._report_utilization_forever()
+        )
 
         self.set_autoscaling_config(autoscaling_config)
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -380,6 +380,12 @@ class ReplicaMetricsManager:
         self._max_ongoing_requests = max_ongoing_requests
         # Store event loop for scheduling async tasks from sync context
         self._event_loop = event_loop or asyncio.get_event_loop()
+        # The event loop only keeps weak references to tasks, so these
+        # long-lived reporters need a strong reference to survive. Same as
+        # Router._cached_metrics_task in router.py.
+        self._cached_metrics_task: Optional[asyncio.Task] = None
+        self._max_processing_latency_task: Optional[asyncio.Task] = None
+        self._utilization_task: Optional[asyncio.Task] = None
 
         # Cache user_callable_wrapper initialization state to avoid repeated runtime checks
         self._custom_metrics_enabled = False
@@ -435,7 +441,9 @@ class ReplicaMetricsManager:
         )
         if self._cached_metrics_enabled:
             self._cached_latencies = defaultdict(deque)
-            self._event_loop.create_task(self._report_cached_metrics_forever())
+            self._cached_metrics_task = self._event_loop.create_task(
+                self._report_cached_metrics_forever()
+            )
 
         # Track maximum processing latency over a rolling window.
         self._max_processing_latency_trackers = defaultdict(
@@ -452,7 +460,9 @@ class ReplicaMetricsManager:
         self._max_processing_latency_report_interval_s = (
             RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_REPORT_INTERVAL_S
         )
-        self._event_loop.create_task(self._report_max_processing_latency_forever())
+        self._max_processing_latency_task = self._event_loop.create_task(
+            self._report_max_processing_latency_forever()
+        )
 
         self._num_ongoing_requests_gauge = metrics.Gauge(
             "serve_replica_processing_queries",
@@ -492,7 +502,9 @@ class ReplicaMetricsManager:
         self._utilization_report_interval_s = (
             RAY_SERVE_REPLICA_UTILIZATION_REPORT_INTERVAL_S
         )
-        self._event_loop.create_task(self._report_utilization_forever())
+        self._utilization_task = self._event_loop.create_task(
+            self._report_utilization_forever()
+        )
 
         self.set_autoscaling_config(autoscaling_config)
 

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -504,6 +504,9 @@ class RequestRouter(ABC):
         # Throttle state for router queue length gauge updates.
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
         self._queue_len_gauge_last_update: Dict[ReplicaID, float] = {}
+        # The event loop only keeps weak references to tasks, so the background
+        # cache-population probes below need a strong reference until they finish.
+        self._probe_tasks: Set[asyncio.Task] = set()
 
         # NOTE(edoakes): Python 3.10 removed the `loop` parameter to `asyncio.Event`.
         # Now, the `asyncio.Event` will call `get_running_loop` in its constructor to
@@ -917,7 +920,11 @@ class RequestRouter(ABC):
             if replica_id not in new_replica_id_set:
                 del self._queue_len_gauge_last_update[replica_id]
         # Populate cache for new replicas
-        self._event_loop.create_task(self._probe_queue_lens(replicas_to_ping, 0))
+        probe_task = self._event_loop.create_task(
+            self._probe_queue_lens(replicas_to_ping, 0)
+        )
+        self._probe_tasks.add(probe_task)
+        probe_task.add_done_callback(self._probe_tasks.discard)
         self._replicas_updated_event.set()
         self._maybe_start_routing_tasks()
 
@@ -1075,9 +1082,11 @@ class RequestRouter(ABC):
         elif len(not_in_cache) > 0:
             # If there are replicas without a valid cache entry, probe them in the
             # background to populate the cache.
-            self._event_loop.create_task(
+            probe_task = self._event_loop.create_task(
                 self._probe_queue_lens(not_in_cache, backoff_index)
             )
+            self._probe_tasks.add(probe_task)
+            probe_task.add_done_callback(self._probe_tasks.discard)
 
         # `self._replicas` may have been updated since the candidates were chosen.
         # In that case, return `None` so a new one is selected.


### PR DESCRIPTION
## Description

Five `create_task()` calls in `serve/_private` throw the returned task away. The event loop only keeps a **weak** reference to a running task, so one whose sole reference was the `create_task()` expression can be garbage collected before it finishes — [the asyncio docs say so explicitly](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task):

> Important: Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn't referenced elsewhere may get garbage collected at any time, even before it's done.

The clearest way to see this is a bug and not a style question: **Ray already does it correctly for the very same coroutine.**

`router.py:206` declares the attribute and `212` assigns the task:

```python
self._cached_metrics_task: Optional[asyncio.Task] = None
...
self._cached_metrics_task = event_loop.create_task(
    self._report_cached_metrics_forever()
)
```

`replica.py:438` calls the identical `_report_cached_metrics_forever()` and drops it on the floor:

```python
self._event_loop.create_task(self._report_cached_metrics_forever())
```

| site | task | what a collection costs |
|---|---|---|
| `replica.py:438` | `_report_cached_metrics_forever` | cached replica metrics stop being exported |
| `replica.py:455` | `_report_max_processing_latency_forever` | the max-processing-latency gauge goes stale |
| `replica.py:495` | `_report_utilization_forever` | utilization stops being reported, which autoscaling reads |
| `request_router.py:920` | `_probe_queue_lens(replicas_to_ping, 0)` | new replicas never get a queue-len cache entry |
| `request_router.py:1078` | `_probe_queue_lens(not_in_cache, backoff_index)` | the cache is never populated for uncached replicas |

The first three are process-lifetime reporters, which is the worst case — nothing else ever holds them.

## Changes

- `ReplicaMetricsManager`: declare `_cached_metrics_task`, `_max_processing_latency_task` and `_utilization_task` next to `_event_loop` and assign each reporter to its attribute — the same shape as `Router._cached_metrics_task`.
- `RequestRouter`: the two `_probe_queue_lens` probes are per-call rather than singletons, so they go into `self._probe_tasks` with `add_done_callback(self._probe_tasks.discard)`. That mirrors how `_probe_queue_lens` itself already keeps its per-replica tasks alive in `get_queue_len_tasks` (`request_router.py:963-968`).

Nothing else changes: no control flow, no scheduling order, no awaited behaviour. The tasks were fire-and-forget before and remain so — they simply can no longer be collected while still running.

## Related issues

None that I could find.

## Additional information

I did not add a unit test, and would rather say why than leave that unsaid: the failure is a garbage-collection race, so a test has to force a GC at a chosen moment and assert a task did *not* vanish — flaky by construction. Happy to add one if you have a shape in mind.

What I did run, with the versions pinned in `.pre-commit-config.yaml`:

```console
$ ruff check <changed files>              # ruff 0.8.4
All checks passed!
$ ruff check --select I <changed files>
All checks passed!
$ black --check <changed files>           # black 22.10.0
All done! ✨ 🍰 ✨
2 files would be left unchanged.
```

Found with an AST scan for `create_task` / `ensure_future` results discarded as bare expression statements — excluding `TaskGroup.create_task`, which does keep strong references. After this change that scan reports zero remaining sites under `python/ray/serve`.
