### PR TITLE
[ci] Fetch xz-5.2.7 from tukaani.org first to fix org_lzma_lzma download failures

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -227,10 +227,15 @@ def ray_deps_setup():
         sha256 = "06327c2ddc81e126a6d9a78b0be5014b976a2c0832f492dcfc4755d7facf6d33",
         strip_prefix = "xz-5.2.7",
         urls = [
-            # Use the SourceForge redirector, which picks a live mirror,
-            # instead of pinning specific mirrors that can go offline.
-            "https://downloads.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
+            # Fetch from tukaani.org (the xz project's canonical host) first.
+            # The SourceForge redirector (kept below as a fallback) 302s to
+            # per-mirror hosts (*.dl.sourceforge.net) that intermittently time
+            # out or stop resolving in DNS; bazel does not fall through to the
+            # next URL when the redirector's chosen mirror fails, so it must not
+            # be listed first (#64906 added the redirector but left cold-cache
+            # builds failing because tukaani.org was never actually tried).
             "https://tukaani.org/xz/xz-5.2.7.tar.gz",
+            "https://downloads.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz",
         ],
         build_file = "//thirdparty/patches:org_lzma_lzma.BUILD.bazel",
     )


### PR DESCRIPTION
## What

Fetch `xz-5.2.7.tar.gz` (`@org_lzma_lzma`) from **tukaani.org first**, keeping the
SourceForge redirector only as a fallback.

## Why

`@org_lzma_lzma` is pulled in by `@boost//:iostreams`, so failing to fetch it breaks
the whole Ray C++ core build (the `wanda: core binary parts` steps, py3.10–3.14).

#64906 replaced the (dead) hardcoded SourceForge mirrors with the
`downloads.sourceforge.net` redirector plus a `tukaani.org` fallback. In practice the
redirector still 302s to those same dead per-mirror hosts, and **bazel never falls
through to the `tukaani.org` fallback** — the two configured URLs produce four
SourceForge-mirror attempts and zero tukaani attempts:

```
WARNING: Download from https://cfhcable.dl.sourceforge.net/.../xz-5.2.7.tar.gz failed: Connect timed out
WARNING: Download from https://superb-sea2.dl.sourceforge.net/.../xz-5.2.7.tar.gz failed: Unknown host
WARNING: Download from https://ayera.dl.sourceforge.net/.../xz-5.2.7.tar.gz failed: Unknown host
WARNING: Download from https://astuteinternet.dl.sourceforge.net/.../xz-5.2.7.tar.gz failed: Unknown host
ERROR: no such package '@@org_lzma_lzma//': Error downloading [ ...four sourceforge mirrors... ]
ERROR: @@boost//:iostreams depends on @@org_lzma_lzma//:lzma which failed to fetch. Analysis failed
```

Cold-cache builds therefore fail deterministically while SourceForge's redirector is
unhealthy; warm-cache agents (which already have the tarball) pass, which makes it look
like an intermittent flake.

### Evidence — deterministic on cold-cache agents (retry/rebuild does not help)

https://buildkite.com/ray-project/microcheck/builds/51215

https://buildkite.com/ray-project/microcheck/builds/51282

## Fix

Put `tukaani.org` (the xz project's canonical host) first; keep the SourceForge
redirector as a fallback.

## Testing

- Downloaded `https://tukaani.org/xz/xz-5.2.7.tar.gz` and confirmed its
  `sha256 = 06327c2ddc81e126a6d9a78b0be5014b976a2c0832f492dcfc4755d7facf6d33`, i.e. it
  matches the existing pin. bazel hash-checks the tarball regardless of source, so this
  is an availability-only change (a tampered download fails the hash, it does not build).
- The `wanda: core binary parts` steps in this PR's own CI exercise the fetch.

## Not a duplicate

Direct follow-up to #64906 (same file / same dependency): that PR introduced the
SourceForge redirector but left the `tukaani.org` fallback unreachable, so cold-cache
builds still fail. No other open PR addresses this.

AI assistance was used; the submitter reviewed every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
