### PR TITLE
[codex] Add docs security contact file

### DIFF
--- a/doc/source/.well-known/security.txt
+++ b/doc/source/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:security@anyscale.com
+Expires: 2027-07-31T00:00:00Z
+Policy: https://github.com/ray-project/ray/security/policy
+Preferred-Languages: en

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -250,7 +250,7 @@ nb_mime_priority_overrides = [
     ("html", "text/plain", 90),
 ]
 
-html_extra_path = ["robots.txt"]
+html_extra_path = ["robots.txt", ".well-known"]
 
 html_baseurl = "https://docs.ray.io/en/latest/"
 


### PR DESCRIPTION
## Summary

- add a Sphinx-copied `.well-known/security.txt` for the docs site
- advertise Ray's vulnerability reporting address and security policy

Fixes ray-project/ray#64741.

## Testing

- Documentation/static asset change; not run locally.
