### PR TITLE
[Data] Fix stale `use_datasource_v2` docstring default

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -579,8 +579,10 @@ class DataContext:
         use_datasource_v2: When True, ``ray.data.read_parquet()`` routes through
             the DataSourceV2 pipeline (``ListFiles → ReadFiles`` logical chain,
             driver-side first-file sampling for schema inference,
-            ``ParquetScanner`` / ``ParquetFileReader``). Defaults to False — V1
-            remains the production path while V2 bakes.
+            ``ParquetScanner`` / ``ParquetFileReader``). Defaults to True; set
+            ``RAY_DATA_USE_DATASOURCE_V2=0`` to fall back to the V1 read path.
+            Only ``read_parquet()`` consults this flag — every other read API
+            reads through V1 regardless of its value.
         parquet_chunker_target_chunk_size: Target chunk size in bytes used by
             ``ParquetFileChunker`` when splitting large Parquet files into
             multiple read tasks. When ``None``, the chunker's built-in default

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -579,11 +579,10 @@ class DataContext:
         use_datasource_v2: When True, ``ray.data.read_parquet()`` routes through
             the DataSourceV2 pipeline (``ListFiles → ReadFiles`` logical chain,
             driver-side first-file sampling for schema inference,
-            ``ParquetScanner`` / ``ParquetFileReader``). Temporarily set to True;
+            ``ParquetScanner`` / ``ParquetFileReader``). Defaults to True;
             override with ``RAY_DATA_USE_DATASOURCE_V2`` (``0`` for V1, ``1`` for
-            V2).
-            Only ``read_parquet()`` consults this flag — every other read API
-            reads through V1 regardless of its value.
+            V2). Parquet is the only reader migrated to V2 so far; the others
+            read through V1 for now regardless of this flag.
         parquet_chunker_target_chunk_size: Target chunk size in bytes used by
             ``ParquetFileChunker`` when splitting large Parquet files into
             multiple read tasks. When ``None``, the chunker's built-in default

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -579,8 +579,9 @@ class DataContext:
         use_datasource_v2: When True, ``ray.data.read_parquet()`` routes through
             the DataSourceV2 pipeline (``ListFiles → ReadFiles`` logical chain,
             driver-side first-file sampling for schema inference,
-            ``ParquetScanner`` / ``ParquetFileReader``). Defaults to True; set
-            ``RAY_DATA_USE_DATASOURCE_V2=0`` to fall back to the V1 read path.
+            ``ParquetScanner`` / ``ParquetFileReader``). Temporarily set to True;
+            override with ``RAY_DATA_USE_DATASOURCE_V2`` (``0`` for V1, ``1`` for
+            V2).
             Only ``read_parquet()`` consults this flag — every other read API
             reads through V1 regardless of its value.
         parquet_chunker_target_chunk_size: Target chunk size in bytes used by


### PR DESCRIPTION
The docstring said `use_datasource_v2` defaults to False and that "V1 remains the production path while V2 bakes". The default is True:

    DEFAULT_USE_DATASOURCE_V2 = env_bool("RAY_DATA_USE_DATASOURCE_V2", True)

so `read_parquet()` has been going through DataSourceV2 by default, and the docstring sends readers looking for an env var to enable something that is already on.

Also note the flag's scope, which was easy to over-read: `use_datasource_v2` is consulted in exactly one place (`read_parquet()` in read_api.py); every other read API reads through V1 no matter how it is set.

Docstring only, no behavior change.

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.