### PR TITLE
[Data] Managed Torch Inference

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1215,6 +1215,20 @@ py_test(
 )
 
 py_test(
+    name = "test_torch_inference",
+    size = "small",
+    srcs = ["tests/test_torch_inference.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_dynamic_block_split",
     size = "large",
     srcs = ["tests/test_dynamic_block_split.py"],

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1216,10 +1216,11 @@ py_test(
 
 py_test(
     name = "test_torch_inference",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_torch_inference.py"],
     tags = [
         "exclusive",
+        "gpu",
         "team:data",
     ],
     deps = [

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -183,12 +183,15 @@ class ActorPoolStrategy(ComputeStrategy):
 
     @property
     def enable_true_multi_threading(self) -> bool:
-        # backwards compatibility from serialization.
-        if "_enable_true_multi_threading" not in self.__dict__:
-            self._enable_true_multi_threading = self.__dict__.get(
-                "enable_true_multi_threading", None
+        # backwards compatibility from serialization: instances pickled
+        # before this became a property carry the value under the public
+        # name instead.
+        return bool(
+            self.__dict__.get(
+                "_enable_true_multi_threading",
+                self.__dict__.get("enable_true_multi_threading"),
             )
-        return bool(self._enable_true_multi_threading)
+        )
 
     def __eq__(self, other: Any) -> bool:
         # intentionally compare resolved enable_true_multi_threading values

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -114,7 +114,7 @@ class ActorPoolStrategy(ComputeStrategy):
         max_size: Optional[int] = None,
         initial_size: Optional[int] = None,
         max_tasks_in_flight_per_actor: Optional[int] = None,
-        enable_true_multi_threading: bool = False,
+        enable_true_multi_threading: Optional[bool] = None,
     ):
         """Construct ActorPoolStrategy for a Dataset transform.
 
@@ -130,9 +130,10 @@ class ActorPoolStrategy(ComputeStrategy):
                 opportunities for pipelining task dependency prefetching with
                 computation and avoiding actor startup delays, but will also increase
                 queueing delay.
-            enable_true_multi_threading: If enable_true_multi_threading=False, no more than 1 UDF
-                runs per actor. Otherwise, respects the `max_concurrency` argument. For more details, see
-                the `ActorPoolStrategy` class docstring.
+            enable_true_multi_threading: If enable_true_multi_threading=False, no more
+                than 1 UDF runs per actor. Otherwise, respects the `max_concurrency` argument.
+                By default, this flag is `None`, which gets translated to `False`.
+                For more details, see the `ActorPoolStrategy` class docstring.
         """
         if size is not None:
             if size < 1:
@@ -178,9 +179,20 @@ class ActorPoolStrategy(ComputeStrategy):
         self.max_tasks_in_flight_per_actor = max_tasks_in_flight_per_actor
         self.num_workers = 0
         self.ready_to_total_workers_ratio = 0.8
-        self.enable_true_multi_threading = enable_true_multi_threading
+        self._enable_true_multi_threading = enable_true_multi_threading
+
+    @property
+    def enable_true_multi_threading(self) -> bool:
+        # backwards compatibility from serialization.
+        if "_enable_true_multi_threading" not in self.__dict__:
+            self._enable_true_multi_threading = self.__dict__.get(
+                "enable_true_multi_threading", None
+            )
+        return bool(self._enable_true_multi_threading)
 
     def __eq__(self, other: Any) -> bool:
+        # intentionally compare resolved enable_true_multi_threading values
+        # because the two strategy classes are effectively the same.
         return isinstance(other, ActorPoolStrategy) and (
             self.min_size == other.min_size
             and self.max_size == other.max_size

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -256,6 +256,42 @@ class MapBatches(AbstractUDFMap):
             "_name",
             self._get_operator_name(self.__class__.__name__, self.fn),
         )
+        self._wrap_torch_inference()
+
+    def _wrap_torch_inference(self) -> None:
+        """Detect a ``TorchInference`` UDF and wrap it in the managed
+        callable that drives collate/transfer/process/finalize.
+        """
+        from ray.data._internal.utils.torch_inference import (
+            is_torch_inference_class,
+            is_torch_inference_instance,
+            validate_torch_inference_op,
+        )
+
+        if is_torch_inference_instance(self.fn):
+            raise ValueError(
+                "Pass the `TorchInference` subclass to `map_batches`, "
+                "not an instance of it."
+            )
+        if not is_torch_inference_class(self.fn):
+            return
+
+        validate_torch_inference_op(
+            self.fn,
+            self.fn_args,
+            self.fn_kwargs,
+            self.compute,
+            self.ray_remote_args,
+        )
+        self._set_torch_inference_udf()
+
+    def _set_torch_inference_udf(self) -> None:
+        """Replace ``fn`` with the managed serial wrapper."""
+        from ray.data._internal.utils.torch_inference import (
+            make_torch_inference_callable,
+        )
+
+        object.__setattr__(self, "fn", make_torch_inference_callable(self.fn))
 
 
 @dataclass(frozen=True, repr=False, eq=False)

--- a/python/ray/data/_internal/utils/torch_inference.py
+++ b/python/ray/data/_internal/utils/torch_inference.py
@@ -222,7 +222,9 @@ def make_torch_inference_callable(user_cls: "CallableClass") -> "CallableClass":
             )
             validate_collated_batch(collated, user_cls)
 
-            moved = move_tensors_to_device(collated, self._ti_device)
+            moved = move_tensors_to_device(
+                collated, self._ti_device, non_blocking=False
+            )
 
             out, output_other = split_batch_and_other(
                 self._ti_user.process_on_device(input_batch, moved, collated_other)

--- a/python/ray/data/_internal/utils/torch_inference.py
+++ b/python/ray/data/_internal/utils/torch_inference.py
@@ -22,6 +22,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    Union,
 )
 
 from ray.data.util.torch_inference import TorchInference
@@ -34,6 +35,10 @@ if TYPE_CHECKING:
     from ray.data.collate_fn import TensorBatchType
 
 logger = logging.getLogger(__name__)
+
+# The host side of the managed transfers: `collate` outputs must live here,
+# and `process_on_device` outputs are moved back here before `finalize`.
+_CPU_DEVICE = "cpu"
 
 # Methods a `TorchInference` subclass may override; validated (e.g. must
 # not be async) before wrapping.
@@ -112,7 +117,9 @@ def validate_torch_inference_op(
         )
 
 
-def split_batch_and_other(ret: Any) -> "Tuple[Any, Any]":
+def split_batch_and_other(
+    ret: Union["TensorBatchType", Tuple["TensorBatchType", Any]],
+) -> Tuple["TensorBatchType", Any]:
     """Split a ``collate``/``process_on_device`` return into
     ``(tensors, other)``.
 
@@ -149,9 +156,9 @@ def _validate_no_tensors_off_device(
 ) -> None:
     """Raise if any tensor in ``batch`` is not on ``device``; ``requirement``
     is the caller's message prefix (what must hold, and why)."""
-    from ray.data._internal.utils.torch_utils import find_tensor_off_device
+    from ray.data._internal.utils.torch_utils import find_first_tensor_not_on_device
 
-    off_device = find_tensor_off_device(batch, device)
+    off_device = find_first_tensor_not_on_device(batch, device)
     if off_device is not None:
         raise ValueError(f"{requirement}; found a tensor on `{off_device.device}`.")
 
@@ -171,7 +178,7 @@ def validate_collated_batch(collated: Any, user_cls: Type[TorchInference]) -> No
         )
     _validate_no_tensors_off_device(
         collated,
-        torch.device("cpu"),
+        torch.device(_CPU_DEVICE),
         f"`{user_cls.__name__}.collate` must return CPU tensors (Ray "
         "manages the transfer to the device)",
     )
@@ -243,7 +250,7 @@ def make_torch_inference_callable(user_cls: Type[TorchInference]) -> "CallableCl
             )
             validate_processed_batch(out, self._ti_device, user_cls)
 
-            cpu_out = move_tensors_to_device(out, "cpu", non_blocking=False)
+            cpu_out = move_tensors_to_device(out, _CPU_DEVICE, non_blocking=False)
 
             return self._ti_user.finalize(input_batch, cpu_out, output_other)
 

--- a/python/ray/data/_internal/utils/torch_inference.py
+++ b/python/ray/data/_internal/utils/torch_inference.py
@@ -21,6 +21,7 @@ from typing import (
     Iterable,
     Optional,
     Tuple,
+    Type,
 )
 
 from ray.data.util.torch_inference import TorchInference
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 
     from ray.data._internal.compute import ComputeStrategy
     from ray.data.block import CallableClass, DataBatch
+    from ray.data.collate_fn import TensorBatchType
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ def is_torch_inference_instance(fn: Any) -> bool:
 
 
 def validate_torch_inference_op(
-    cls: type,
+    cls: Type[TorchInference],
     fn_args: Optional[Iterable[Any]],
     fn_kwargs: Optional[Dict[str, Any]],
     compute: "ComputeStrategy",
@@ -94,7 +96,7 @@ def validate_torch_inference_op(
                 "`TorchInference` methods are called synchronously."
             )
 
-    if "__call__" in vars(cls):
+    if "__call__" in cls.__dict__:
         logger.warning(
             f"`TorchInference` subclass `{cls.__name__}` defines "
             "`__call__`, but it will not be used directly: batches flow "
@@ -123,7 +125,7 @@ def split_batch_and_other(ret: Any) -> "Tuple[Any, Any]":
     return ret, None
 
 
-def _resolve_cuda_device(user: Any, user_cls: type) -> "torch.device":
+def _resolve_cuda_device(user: TorchInference) -> "torch.device":
     """Resolve and validate ``user.get_device()`` into a concrete CUDA device."""
     import torch
 
@@ -132,7 +134,7 @@ def _resolve_cuda_device(user: Any, user_cls: type) -> "torch.device":
     device = torch.device(user.get_device())
     if device.type != "cuda":
         raise ValueError(
-            f"`{user_cls.__name__}.get_device()` must return a CUDA device; "
+            f"`{type(user).__name__}.get_device()` must return a CUDA device; "
             f"got `{device}`. The `TorchInference` flow is GPU-only."
         )
     if torch.cuda.is_available() and device.index is None:
@@ -142,11 +144,22 @@ def _resolve_cuda_device(user: Any, user_cls: type) -> "torch.device":
     return device
 
 
-def validate_collated_batch(collated: Any, user_cls: type) -> None:
+def _validate_no_tensors_off_device(
+    batch: "TensorBatchType", device: "torch.device", requirement: str
+) -> None:
+    """Raise if any tensor in ``batch`` is not on ``device``; ``requirement``
+    is the caller's message prefix (what must hold, and why)."""
+    from ray.data._internal.utils.torch_utils import find_tensor_off_device
+
+    off_device = find_tensor_off_device(batch, device)
+    if off_device is not None:
+        raise ValueError(f"{requirement}; found a tensor on `{off_device.device}`.")
+
+
+def validate_collated_batch(collated: Any, user_cls: Type[TorchInference]) -> None:
     """Validate the ``collate`` output: a ``TensorBatchType`` of CPU tensors."""
     import torch
 
-    from ray.data._internal.utils.torch_utils import find_tensor_off_device
     from ray.data.collate_fn import is_tensor_batch_type
 
     if not is_tensor_batch_type(collated):
@@ -156,19 +169,19 @@ def validate_collated_batch(collated: Any, user_cls: type) -> None:
             f"tensors), or a `(TensorBatchType, other)` tuple; got "
             f"{type(collated)}."
         )
-    off_cpu = find_tensor_off_device(collated, torch.device("cpu"))
-    if off_cpu is not None:
-        raise ValueError(
-            f"`{user_cls.__name__}.collate` must return CPU tensors (Ray "
-            "manages the transfer to the device); found a tensor on "
-            f"`{off_cpu.device}`."
-        )
+    _validate_no_tensors_off_device(
+        collated,
+        torch.device("cpu"),
+        f"`{user_cls.__name__}.collate` must return CPU tensors (Ray "
+        "manages the transfer to the device)",
+    )
 
 
-def validate_processed_batch(out: Any, device: "torch.device", user_cls: type) -> None:
+def validate_processed_batch(
+    out: Any, device: "torch.device", user_cls: Type[TorchInference]
+) -> None:
     """Validate the ``process_on_device`` output: a ``TensorBatchType`` on
     ``device``."""
-    from ray.data._internal.utils.torch_utils import find_tensor_off_device
     from ray.data.collate_fn import is_tensor_batch_type
 
     if not is_tensor_batch_type(out):
@@ -177,16 +190,15 @@ def validate_processed_batch(out: Any, device: "torch.device", user_cls: type) -
             "`TensorBatchType`, or a `(TensorBatchType, other)` tuple; got "
             f"{type(out)}."
         )
-    off_device = find_tensor_off_device(out, device)
-    if off_device is not None:
-        raise ValueError(
-            f"`{user_cls.__name__}.process_on_device` must return tensors on "
-            f"`{device}` (Ray manages the transfer back to the host); found "
-            f"a tensor on `{off_device.device}`."
-        )
+    _validate_no_tensors_off_device(
+        out,
+        device,
+        f"`{user_cls.__name__}.process_on_device` must return tensors on "
+        f"`{device}` (Ray manages the transfer back to the host)",
+    )
 
 
-def make_torch_inference_callable(user_cls: "CallableClass") -> "CallableClass":
+def make_torch_inference_callable(user_cls: Type[TorchInference]) -> "CallableClass":
     """Wrap a ``TorchInference`` subclass in a managed callable class.
 
     Per batch, the wrapper's ``__call__`` runs the flow serially: ``collate``
@@ -205,7 +217,7 @@ def make_torch_inference_callable(user_cls: "CallableClass") -> "CallableClass":
             self._ti_user: TorchInference = user_cls(*args, **kwargs)
             assert isinstance(self._ti_user, TorchInference)
 
-            self._ti_device = _resolve_cuda_device(self._ti_user, user_cls)
+            self._ti_device = _resolve_cuda_device(self._ti_user)
 
         def __repr__(self) -> str:
             return repr(self._ti_user)

--- a/python/ray/data/_internal/utils/torch_inference.py
+++ b/python/ray/data/_internal/utils/torch_inference.py
@@ -1,0 +1,240 @@
+"""Ray-managed execution of
+:class:`~ray.data.util.torch_inference.TorchInference`.
+
+``Dataset.map_batches`` detects UDF classes that subclass
+``TorchInference`` and wraps them in a managed callable that drives the
+``collate`` -> host-to-device transfer -> ``process_on_device`` ->
+device-to-host transfer -> ``finalize`` flow, so users only implement the
+model-specific pieces.
+
+NOTE: This module must stay importable without ``torch``: detection runs for
+every ``map_batches`` call, so anything needing torch is imported lazily.
+"""
+
+import inspect
+import logging
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Optional,
+    Tuple,
+)
+
+from ray.data.util.torch_inference import TorchInference
+
+if TYPE_CHECKING:
+    import torch
+
+    from ray.data._internal.compute import ComputeStrategy
+    from ray.data.block import CallableClass, DataBatch
+
+logger = logging.getLogger(__name__)
+
+# Methods a `TorchInference` subclass may override; validated (e.g. must
+# not be async) before wrapping.
+_TORCH_INFERENCE_METHODS = (
+    "initialize",
+    "get_device",
+    "collate",
+    "process_on_device",
+    "finalize",
+)
+
+
+class _BaseTorchInferenceUDFWrapper:
+    """Marker base class for the Ray-managed ``TorchInference`` wrappers."""
+
+
+def is_torch_inference_class(fn: Any) -> bool:
+    """True iff ``fn`` is a ``TorchInference`` subclass (the class itself,
+    not an instance)."""
+    return isinstance(fn, type) and issubclass(fn, TorchInference)
+
+
+def is_torch_inference_instance(fn: Any) -> bool:
+    """True iff ``fn`` is an *instance* of a ``TorchInference`` subclass
+    (users must pass the class, not an instance)."""
+    return isinstance(fn, TorchInference)
+
+
+def validate_torch_inference_op(
+    cls: type,
+    fn_args: Optional[Iterable[Any]],
+    fn_kwargs: Optional[Dict[str, Any]],
+    compute: "ComputeStrategy",
+    ray_remote_args: Dict[str, Any],
+) -> None:
+    """Validate a ``map_batches`` call whose UDF is a ``TorchInference``.
+
+    Raises for arguments the managed flow can't honor; warns for likely
+    misconfigurations. Does not modify any of its inputs.
+    (``fn_constructor_args``/``fn_constructor_kwargs`` are supported — they
+    are forwarded to ``initialize``.)
+    """
+    from ray.data._internal.compute import ActorPoolStrategy
+
+    assert isinstance(compute, ActorPoolStrategy)
+
+    if fn_args or fn_kwargs:
+        raise ValueError(
+            "`fn_args` and `fn_kwargs` are not supported with a "
+            "`TorchInference`; its methods only take the batch."
+        )
+
+    for method_name in _TORCH_INFERENCE_METHODS:
+        method = getattr(cls, method_name, None)
+        if method is None:
+            continue
+        if inspect.iscoroutinefunction(method) or inspect.isasyncgenfunction(method):
+            raise TypeError(
+                f"`{cls.__name__}.{method_name}` must not be async; "
+                "`TorchInference` methods are called synchronously."
+            )
+
+    if "__call__" in vars(cls):
+        logger.warning(
+            f"`TorchInference` subclass `{cls.__name__}` defines "
+            "`__call__`, but it will not be used directly: batches flow "
+            "through the Ray-managed flow (`collate` -> `process_on_device` "
+            "-> `finalize`), driven by a Ray-provided `__call__`."
+        )
+
+    if not ray_remote_args.get("num_gpus"):
+        logger.warning(
+            f"`{cls.__name__}` is a `TorchInference` but `num_gpus` is "
+            "not set; the managed flow is GPU-only, so pass `num_gpus` to "
+            "`map_batches` so the actor is scheduled on a GPU."
+        )
+
+
+def split_batch_and_other(ret: Any) -> "Tuple[Any, Any]":
+    """Split a ``collate``/``process_on_device`` return into
+    ``(tensors, other)``.
+
+    A 2-tuple always means ``(tensors, other)``; any other return is
+    ``(ret, None)``. (To return a batch that IS a pair of tensors, use a
+    list or also do: ``((tensors, tensors), None)``.)
+    """
+    if isinstance(ret, tuple) and len(ret) == 2:
+        return ret[0], ret[1]
+    return ret, None
+
+
+def _resolve_cuda_device(user: Any, user_cls: type) -> "torch.device":
+    """Resolve and validate ``user.get_device()`` into a concrete CUDA device."""
+    import torch
+
+    # `torch.device(...)` is idempotent, so a `get_device` that returns a
+    # device string still works.
+    device = torch.device(user.get_device())
+    if device.type != "cuda":
+        raise ValueError(
+            f"`{user_cls.__name__}.get_device()` must return a CUDA device; "
+            f"got `{device}`. The `TorchInference` flow is GPU-only."
+        )
+    if torch.cuda.is_available() and device.index is None:
+        # Resolve "cuda" to a concrete index so different actor threads all
+        # deterministically resolve to the same device.
+        device = torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
+def validate_collated_batch(collated: Any, user_cls: type) -> None:
+    """Validate the ``collate`` output: a ``TensorBatchType`` of CPU tensors."""
+    import torch
+
+    from ray.data._internal.utils.torch_utils import find_tensor_off_device
+    from ray.data.collate_fn import is_tensor_batch_type
+
+    if not is_tensor_batch_type(collated):
+        raise ValueError(
+            f"`{user_cls.__name__}.collate` must return a `TensorBatchType` "
+            "(a `torch.Tensor`, sequence of tensors, or mapping of str to "
+            f"tensors), or a `(TensorBatchType, other)` tuple; got "
+            f"{type(collated)}."
+        )
+    off_cpu = find_tensor_off_device(collated, torch.device("cpu"))
+    if off_cpu is not None:
+        raise ValueError(
+            f"`{user_cls.__name__}.collate` must return CPU tensors (Ray "
+            "manages the transfer to the device); found a tensor on "
+            f"`{off_cpu.device}`."
+        )
+
+
+def validate_processed_batch(out: Any, device: "torch.device", user_cls: type) -> None:
+    """Validate the ``process_on_device`` output: a ``TensorBatchType`` on
+    ``device``."""
+    from ray.data._internal.utils.torch_utils import find_tensor_off_device
+    from ray.data.collate_fn import is_tensor_batch_type
+
+    if not is_tensor_batch_type(out):
+        raise ValueError(
+            f"`{user_cls.__name__}.process_on_device` must return a "
+            "`TensorBatchType`, or a `(TensorBatchType, other)` tuple; got "
+            f"{type(out)}."
+        )
+    off_device = find_tensor_off_device(out, device)
+    if off_device is not None:
+        raise ValueError(
+            f"`{user_cls.__name__}.process_on_device` must return tensors on "
+            f"`{device}` (Ray manages the transfer back to the host); found "
+            f"a tensor on `{off_device.device}`."
+        )
+
+
+def make_torch_inference_callable(user_cls: "CallableClass") -> "CallableClass":
+    """Wrap a ``TorchInference`` subclass in a managed callable class.
+
+    Per batch, the wrapper's ``__call__`` runs the flow serially: ``collate``
+    (validated CPU tensors) -> synchronous host-to-device transfer ->
+    ``process_on_device`` (validated on-device tensors) -> synchronous
+    device-to-host transfer -> ``finalize``. Everything runs on the current
+    stream; there is no overlap between the stages.
+    """
+    import torch
+
+    from ray.data.util.torch_inference import TorchInference
+    from ray.data.util.torch_utils import move_tensors_to_device
+
+    class _TorchInferenceUDFWrapper(_BaseTorchInferenceUDFWrapper):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._ti_user: TorchInference = user_cls(*args, **kwargs)
+            assert isinstance(self._ti_user, TorchInference)
+
+            self._ti_device = _resolve_cuda_device(self._ti_user, user_cls)
+
+        def __repr__(self) -> str:
+            return repr(self._ti_user)
+
+        @torch.no_grad()
+        def __call__(self, batch: "DataBatch") -> "DataBatch":
+            # Shallow copy: `collate` replacing keys in the batch mapping
+            # can't corrupt the `input_batch` handed to process_on_device/
+            # finalize (the underlying arrays are shared, not copied).
+            input_batch = dict(batch) if isinstance(batch, Mapping) else batch
+
+            collated, collated_other = split_batch_and_other(
+                self._ti_user.collate(batch)
+            )
+            validate_collated_batch(collated, user_cls)
+
+            moved = move_tensors_to_device(collated, self._ti_device)
+
+            out, output_other = split_batch_and_other(
+                self._ti_user.process_on_device(input_batch, moved, collated_other)
+            )
+            validate_processed_batch(out, self._ti_device, user_cls)
+
+            cpu_out = move_tensors_to_device(out, "cpu", non_blocking=False)
+
+            return self._ti_user.finalize(input_batch, cpu_out, output_other)
+
+    # Wrapping happens before the MapBatches logical op is built, so take the
+    # user's class name for operator naming (`_get_operator_name` uses
+    # `fn.__name__`).
+    _TorchInferenceUDFWrapper.__name__ = user_cls.__name__
+    return _TorchInferenceUDFWrapper

--- a/python/ray/data/_internal/utils/torch_utils.py
+++ b/python/ray/data/_internal/utils/torch_utils.py
@@ -62,7 +62,7 @@ def _iter_tensors(batch: TensorBatchType):
             yield from _iter_tensors(value)
 
 
-def find_tensor_off_device(
+def find_first_tensor_not_on_device(
     batch: TensorBatchType, device: torch.device
 ) -> Optional[torch.Tensor]:
     """Return the first tensor in ``batch`` not on ``device``, else None.

--- a/python/ray/data/_internal/utils/torch_utils.py
+++ b/python/ray/data/_internal/utils/torch_utils.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from collections.abc import Mapping
+from typing import Any, Optional, Union
 
 import torch
 
@@ -47,3 +48,31 @@ class DefaultFinalizeFn(FinalizeFn):
                 non_blocking=DEFAULT_TENSOR_NON_BLOCKING_TRANSFER,
             )
         return FinalizedData(data=batch)
+
+
+def _iter_tensors(batch: TensorBatchType):
+    """Yield every tensor in a TensorBatchType, recursively."""
+    if isinstance(batch, torch.Tensor):
+        yield batch
+    elif isinstance(batch, Mapping):
+        for value in batch.values():
+            yield from _iter_tensors(value)
+    elif isinstance(batch, (list, tuple)):
+        for value in batch:
+            yield from _iter_tensors(value)
+
+
+def find_tensor_off_device(
+    batch: TensorBatchType, device: torch.device
+) -> Optional[torch.Tensor]:
+    """Return the first tensor in ``batch`` not on ``device``, else None.
+
+    A ``device`` without an index (e.g. plain ``cuda``) matches any index of
+    that device type.
+    """
+    for tensor in _iter_tensors(batch):
+        if tensor.device.type != device.type or (
+            device.index is not None and tensor.device.index != device.index
+        ):
+            return tensor
+    return None

--- a/python/ray/data/tests/test_torch_inference.py
+++ b/python/ray/data/tests/test_torch_inference.py
@@ -1,0 +1,368 @@
+import logging
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+import ray
+from ray.data._internal.logical.operators.map_operator import MapBatches
+from ray.data._internal.utils.torch_inference import (
+    is_torch_inference_class,
+    is_torch_inference_instance,
+    make_torch_inference_callable,
+)
+from ray.data._internal.utils.torch_utils import find_tensor_off_device
+from ray.data.tests.conftest import *  # noqa
+from ray.data.util.torch_inference import TorchInference
+from ray.tests.conftest import *  # noqa
+
+
+class MyInferenceActor(TorchInference):
+    # pyrefly: ignore[bad-override]  # narrowing `*args/**kwargs` is the API.
+    def initialize(self):
+        self.scale = 2.0
+
+    def get_device(self):
+        return torch.device("cuda")
+
+    def process_on_device(self, input_batch, collated_tensors, collated_other):
+        return {"y": collated_tensors["x"] * self.scale}
+
+
+class PlainCallableActor:
+    def __call__(self, batch):
+        return batch
+
+
+def _make_input_ds(n=32):
+    return ray.data.range(n).map_batches(
+        lambda b: {"x": b["id"].astype(np.float32)}, batch_size=None
+    )
+
+
+# ===== Base class defaults =====
+
+
+def test_init_calls_initialize():
+    actor = MyInferenceActor()
+    assert actor.scale == 2.0
+
+
+def test_default_collate_converts_numpy_batch():
+    actor = MyInferenceActor()
+    batch = {
+        "x": np.arange(6, dtype=np.float32).reshape(3, 2),
+        "id": np.arange(3, dtype=np.int64),
+    }
+    tensors = actor.collate(batch)
+    assert isinstance(tensors, dict)
+    assert set(tensors) == {"x", "id"}
+    x, ids = tensors["x"], tensors["id"]
+    assert isinstance(x, torch.Tensor) and isinstance(ids, torch.Tensor)
+    assert torch.equal(x, torch.as_tensor(batch["x"]))
+    assert x.dtype == torch.float32
+    assert ids.dtype == torch.int64
+
+
+@pytest.mark.parametrize(
+    "bad_batch",
+    [
+        pd.DataFrame({"x": [1.0, 2.0]}),
+        [1, 2, 3],
+        {"x": [1.0, 2.0]},
+        {"x": torch.zeros(2)},
+    ],
+)
+def test_default_collate_rejects_non_numpy_batch(bad_batch):
+    actor = MyInferenceActor()
+    with pytest.raises(TypeError, match="override `collate`"):
+        actor.collate(bad_batch)
+
+
+def test_default_finalize_converts_tensor_mapping():
+    actor = MyInferenceActor()
+    out = actor.finalize({}, {"y": torch.arange(3, dtype=torch.float32)}, None)
+    assert isinstance(out["y"], np.ndarray)
+    assert np.array_equal(out["y"], np.arange(3, dtype=np.float32))
+
+
+def test_default_finalize_converts_recursively():
+    # The conversion preserves the dict/sequence structure and converts every
+    # tensor leaf. (Annotated Any: the nesting is deeper than the declared
+    # `TensorBatchType`, which the recursive default supports at runtime.)
+    actor = MyInferenceActor()
+    nested_output: Any = {
+        "flat": torch.zeros(2),
+        "chunks": [torch.zeros(2), torch.ones(2)],
+        "nested": {"inner": (torch.arange(3),)},
+    }
+    out = actor.finalize({}, nested_output, None)
+    assert isinstance(out["flat"], np.ndarray)
+    assert isinstance(out["chunks"], list)
+    assert all(isinstance(chunk, np.ndarray) for chunk in out["chunks"])
+    assert np.array_equal(out["chunks"][1], np.ones(2))
+    assert isinstance(out["nested"]["inner"], tuple)
+    assert np.array_equal(out["nested"]["inner"][0], np.arange(3))
+
+
+@pytest.mark.parametrize(
+    "bad_output",
+    [
+        "not tensors",
+        {"y": "not a tensor"},
+        {"y": np.zeros(2)},
+        {"y": [torch.zeros(2), None]},
+    ],
+)
+def test_default_finalize_rejects_non_tensor_leaves(bad_output):
+    actor = MyInferenceActor()
+    with pytest.raises(TypeError, match="Override `finalize`"):
+        actor.finalize({}, bad_output, None)
+
+
+def test_default_finalize_rejects_output_other():
+    # The default can't know how to fold side data into the batch.
+    actor = MyInferenceActor()
+    with pytest.raises(TypeError, match="output_other"):
+        actor.finalize({}, {"y": torch.zeros(2)}, {"lengths": [1, 2]})
+
+
+def test_split_batch_and_other():
+    from ray.data._internal.utils.torch_inference import split_batch_and_other
+
+    tensors = {"x": torch.zeros(2)}
+    # Bare TensorBatchType -> no side data.
+    assert split_batch_and_other(tensors) == (tensors, None)
+    # A 2-tuple always means (tensors, other) — even when `other` is a
+    # tensor. A batch that IS a pair of tensors must be a list instead.
+    assert split_batch_and_other((tensors, {"dims": (2, 3)})) == (
+        tensors,
+        {"dims": (2, 3)},
+    )
+    assert split_batch_and_other((tensors, None)) == (tensors, None)
+    t1, t2 = torch.zeros(2), torch.ones(2)
+    assert split_batch_and_other((t1, t2)) == (t1, t2)
+    # Non-2-tuples are never split.
+    triple = (t1, t2, torch.zeros(2))
+    assert split_batch_and_other(triple) == (triple, None)
+    assert split_batch_and_other([t1, t2]) == ([t1, t2], None)
+
+
+def test_default_get_device():
+    class DefaultDevice(TorchInference):
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            return collated_tensors
+
+    actor = DefaultDevice()
+    if torch.cuda.is_available():
+        assert actor.get_device() == torch.device("cuda")
+    else:
+        with pytest.raises(AssertionError):
+            actor.get_device()
+
+
+def test_process_on_device_not_implemented():
+    class NoProcess(TorchInference):
+        pass
+
+    with pytest.raises(NotImplementedError, match="process_on_device"):
+        NoProcess().process_on_device({}, {}, None)
+
+
+# ===== Detection =====
+
+
+def test_detection():
+    assert is_torch_inference_class(MyInferenceActor)
+    assert is_torch_inference_class(TorchInference)
+    assert not is_torch_inference_class(PlainCallableActor)
+    assert not is_torch_inference_class(lambda b: b)
+    assert not is_torch_inference_class("not a class")
+    # Instances don't match the class check, but match the instance check.
+    actor = MyInferenceActor()
+    assert not is_torch_inference_class(actor)
+    assert is_torch_inference_instance(actor)
+    assert not is_torch_inference_instance(MyInferenceActor)
+    assert not is_torch_inference_instance(PlainCallableActor())
+
+
+def test_wrapper_not_detected_and_keeps_name():
+    wrapper_cls = make_torch_inference_callable(MyInferenceActor)
+    # Composition: the wrapper is not a subclass, so plan rewrites re-running
+    # __post_init__ can't wrap it again.
+    assert not is_torch_inference_class(wrapper_cls)
+    assert wrapper_cls.__name__ == "MyInferenceActor"
+
+
+def test_wrapper_rejects_non_cuda_device():
+    # The device comes from the instance's `get_device()`, so the GPU-only
+    # check happens at actor init — before any CUDA state is touched, so it
+    # is testable without a GPU.
+    class CpuDevice(MyInferenceActor):
+        def get_device(self):
+            return torch.device("cpu")
+
+    wrapper_cls = make_torch_inference_callable(CpuDevice)
+    with pytest.raises(ValueError, match="must return a CUDA device"):
+        wrapper_cls()
+
+
+# ===== Tensor helpers =====
+
+
+def test_find_tensor_off_device():
+    t_cpu = torch.zeros(2)
+    assert find_tensor_off_device({"a": t_cpu}, torch.device("cpu")) is None
+    assert find_tensor_off_device({"a": t_cpu}, torch.device("cuda")) is t_cpu
+    # Nested containers are searched; index-less specs match any index.
+    assert find_tensor_off_device([(t_cpu,)], torch.device("cuda:1")) is t_cpu
+
+
+# ===== map_batches validation =====
+
+
+def test_instance_rejected(ray_start_regular_shared_2_cpus):
+    # `map_batches`'s generic UDF validation rejects the (non-callable)
+    # instance before the TorchInference-specific check; either way,
+    # passing an instance fails at map_batches time.
+    with pytest.raises(ValueError):
+        _make_input_ds().map_batches(
+            MyInferenceActor(),  # pyrefly: ignore[bad-argument-type]
+            batch_size=8,
+            compute=ray.data.ActorPoolStrategy(size=1),
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"fn_args": (1,)},
+        {"fn_kwargs": {"a": 1}},
+    ],
+)
+def test_fn_args_rejected(ray_start_regular_shared_2_cpus, kwargs):
+    with pytest.raises(ValueError, match="fn_args"):
+        _make_input_ds().map_batches(
+            MyInferenceActor,
+            batch_size=8,
+            compute=ray.data.ActorPoolStrategy(size=1),
+            **kwargs,
+        )
+
+
+def test_fn_constructor_args_forwarded_to_initialize(ray_start_regular_shared_2_cpus):
+    class Parameterized(TorchInference):
+        # pyrefly: ignore[bad-override]  # narrowing `*args/**kwargs` is the API.
+        def initialize(self, scale, offset=0.0):
+            self.scale = scale
+            self.offset = offset
+
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            return collated_tensors
+
+    # The base __init__ forwards constructor args to initialize.
+    actor = Parameterized(2.0, offset=1.0)
+    assert actor.scale == 2.0 and actor.offset == 1.0
+
+    # And map_batches accepts them for the wrapped actor.
+    ds = _make_input_ds().map_batches(
+        Parameterized,
+        batch_size=8,
+        compute=ray.data.ActorPoolStrategy(size=1),
+        fn_constructor_args=(2.0,),
+        fn_constructor_kwargs={"offset": 1.0},
+        num_gpus=0.001,
+    )
+    op = ds._logical_plan.dag
+    assert isinstance(op, MapBatches)
+    assert op.fn_constructor_args == (2.0,)
+    assert op.fn_constructor_kwargs == {"offset": 1.0}
+
+
+def test_async_method_rejected(ray_start_regular_shared_2_cpus):
+    class AsyncCollate(MyInferenceActor):
+        # pyrefly: ignore[bad-override]  # async is the defect under test.
+        async def collate(self, input_batch):
+            ...
+
+    with pytest.raises(TypeError, match="async"):
+        _make_input_ds().map_batches(
+            AsyncCollate,
+            batch_size=8,
+            compute=ray.data.ActorPoolStrategy(size=1),
+        )
+
+
+def test_call_warns(ray_start_regular_shared_2_cpus, caplog, propagate_logs):
+    class WithCall(MyInferenceActor):
+        def __call__(self, batch):
+            return batch
+
+    with caplog.at_level(logging.WARNING, logger="ray.data"):
+        _make_input_ds().map_batches(
+            WithCall,
+            batch_size=8,
+            compute=ray.data.ActorPoolStrategy(size=1),
+            num_gpus=0.001,
+        )
+    assert "will not be used directly" in caplog.text
+
+
+def test_missing_num_gpus_warns(
+    ray_start_regular_shared_2_cpus, caplog, propagate_logs
+):
+    with caplog.at_level(logging.WARNING, logger="ray.data"):
+        _make_input_ds().map_batches(
+            MyInferenceActor,
+            batch_size=8,
+            compute=ray.data.ActorPoolStrategy(size=1),
+        )
+    assert "num_gpus" in caplog.text
+
+
+# ===== Wrapping =====
+
+
+def test_serial_wrap_applied(ray_start_regular_shared_2_cpus):
+    strategy = ray.data.ActorPoolStrategy(size=1)
+    ds = _make_input_ds().map_batches(
+        MyInferenceActor,
+        batch_size=8,
+        compute=strategy,
+        num_gpus=0.001,
+    )
+    op = ds._logical_plan.dag
+    assert isinstance(op, MapBatches)
+    # The UDF is replaced by the managed wrapper, keeping the user's name.
+    assert op.fn is not MyInferenceActor
+    assert isinstance(op.fn, type)
+    assert op.fn.__name__ == "MyInferenceActor"
+    assert op.name == "MapBatches(MyInferenceActor)"
+    # The serial flow needs no concurrency normalization.
+    assert "max_concurrency" not in op.ray_remote_args
+    assert isinstance(op.compute, ray.data.ActorPoolStrategy)
+    assert op.compute.max_tasks_in_flight_per_actor is None
+
+
+def test_replace_does_not_rewrap(ray_start_regular_shared_2_cpus):
+    # Logical-plan rewrites reconstruct operators with dataclasses.replace,
+    # which re-runs __post_init__ with the already-wrapped fn.
+    ds = _make_input_ds().map_batches(
+        MyInferenceActor,
+        batch_size=8,
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_gpus=0.001,
+    )
+    op = ds._logical_plan.dag
+    assert isinstance(op, MapBatches)
+    op2 = replace(op, input_dependencies=op.input_dependencies)
+    assert op2.fn is op.fn
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_torch_inference.py
+++ b/python/ray/data/tests/test_torch_inference.py
@@ -160,7 +160,7 @@ def test_default_get_device():
     if torch.cuda.is_available():
         assert actor.get_device() == torch.device("cuda")
     else:
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError, match="CUDA is not available"):
             actor.get_device()
 
 

--- a/python/ray/data/tests/test_torch_inference.py
+++ b/python/ray/data/tests/test_torch_inference.py
@@ -362,6 +362,176 @@ def test_replace_does_not_rewrap(ray_start_regular_shared_2_cpus):
     assert op2.fn is op.fn
 
 
+# ===== GPU end-to-end (runs in the GPU CI job; skipped without CUDA) =====
+
+GPU_FEATURES = 64
+GPU_BATCH_SIZE = 256
+GPU_NUM_BATCHES = 8
+GPU_NUM_ROWS = GPU_NUM_BATCHES * GPU_BATCH_SIZE
+
+
+def _make_gpu_source():
+    """Rows where every element of row `id` is `1 + id`, so per-row sums are
+    unique, nonzero integers (exact in fp32) — a zeroed, torn, or cross-batch
+    read after the device transfer changes the checksum."""
+
+    def to_x(batch):
+        ids = np.asarray(batch["id"], dtype=np.int64)
+        vals = (1.0 + ids).astype(np.float32)
+        return {"id": ids, "data": np.repeat(vals[:, None], GPU_FEATURES, axis=1)}
+
+    return (
+        ray.data.range(GPU_NUM_ROWS, override_num_blocks=GPU_NUM_BATCHES)
+        .map_batches(to_x, batch_size=GPU_BATCH_SIZE)
+        .materialize()
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_e2e_cuda(shutdown_only):
+    ray.init(num_cpus=2, num_gpus=1)
+
+    # NOTE: Defined inside the test so cloudpickle serializes it by value
+    # (module-level test classes aren't importable from Ray workers).
+    class Predictor(TorchInference):
+        def collate(self, input_batch):
+            # Only the model input takes the tensor path; `id` stays in
+            # `input_batch`. The `(tensors, other)` form threads per-batch
+            # side data (here, the batch's min id) to process_on_device.
+            return (
+                {"data": torch.from_numpy(input_batch["data"])},
+                {"min_id": int(input_batch["id"].min())},
+            )
+
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            tensor = collated_tensors["data"]
+            # The managed flow must hand us device tensors, the untouched
+            # pre-collate batch, and collate's side data.
+            assert tensor.device.type == "cuda"
+            assert isinstance(input_batch["id"], np.ndarray)
+            assert collated_other == {"min_id": int(input_batch["id"].min())}
+            # Forward the side data on to finalize.
+            return (
+                {"rowsum": tensor.sum(dim=1), "double": tensor[:, 0] * 2.0},
+                collated_other,
+            )
+
+        def finalize(self, input_batch, output_tensors, output_other):
+            # process_on_device's side data arrives untouched.
+            assert output_other == {"min_id": int(input_batch["id"].min())}
+            return {
+                "id": input_batch["id"],
+                "rowsum": output_tensors["rowsum"].numpy(),
+                "double": output_tensors["double"].numpy(),
+            }
+
+    ds = _make_gpu_source().map_batches(
+        Predictor,
+        batch_size=GPU_BATCH_SIZE,
+        batch_format="numpy",
+        zero_copy_batch=True,
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_gpus=1,
+    )
+
+    rows = sorted(ds.take_all(), key=lambda row: row["id"])
+    ids = np.asarray([row["id"] for row in rows], dtype=np.int64)
+    rowsums = np.asarray([row["rowsum"] for row in rows])
+    doubles = np.asarray([row["double"] for row in rows])
+
+    # Exactly-once id coverage (passthrough via `input_batch` intact).
+    assert np.array_equal(ids, np.arange(GPU_NUM_ROWS, dtype=np.int64))
+    # Exact per-row checksums: the H2D delivered the right bytes.
+    assert np.array_equal(rowsums, (GPU_FEATURES * (1.0 + ids)).astype(np.float32))
+    # Compute results survive the D2H.
+    assert np.array_equal(doubles, (2.0 * (1.0 + ids)).astype(np.float32))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_e2e_cuda_default_collate_and_finalize(shutdown_only):
+    # Only `process_on_device` implemented: the default `get_device` (cuda),
+    # `collate` (numpy -> tensors), and `finalize` (tensors -> numpy) carry
+    # the batch through the managed flow. `fn_constructor_args` reach
+    # `initialize`.
+    ray.init(num_cpus=2, num_gpus=1)
+
+    class MinimalPredictor(TorchInference):
+        # pyrefly: ignore[bad-override]  # narrowing `*args/**kwargs` is the API.
+        def initialize(self, scale):
+            self.scale = scale
+
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            return {
+                "id": collated_tensors["id"],
+                "rowsum": collated_tensors["data"].sum(dim=1) * self.scale,
+            }
+
+    ds = _make_gpu_source().map_batches(
+        MinimalPredictor,
+        batch_size=GPU_BATCH_SIZE,
+        batch_format="numpy",
+        compute=ray.data.ActorPoolStrategy(size=1),
+        fn_constructor_args=(2.0,),
+        num_gpus=1,
+    )
+
+    rows = sorted(ds.take_all(), key=lambda row: row["id"])
+    ids = np.asarray([row["id"] for row in rows], dtype=np.int64)
+    rowsums = np.asarray([row["rowsum"] for row in rows])
+    assert np.array_equal(ids, np.arange(GPU_NUM_ROWS, dtype=np.int64))
+    assert np.array_equal(
+        rowsums, (2.0 * GPU_FEATURES * (1.0 + ids)).astype(np.float32)
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_collate_output_must_be_cpu(shutdown_only):
+    ray.init(num_cpus=2, num_gpus=1)
+
+    class GpuCollate(TorchInference):
+        def collate(self, input_batch):
+            return {"data": torch.from_numpy(input_batch["data"]).cuda()}
+
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            return collated_tensors
+
+        def finalize(self, input_batch, output_tensors, output_other):
+            return {"data": output_tensors["data"].numpy()}
+
+    ds = _make_gpu_source().map_batches(
+        GpuCollate,
+        batch_size=GPU_BATCH_SIZE,
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_gpus=1,
+    )
+    with pytest.raises(Exception, match="must return CPU tensors"):
+        ds.take_all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_process_output_must_be_on_device(shutdown_only):
+    ray.init(num_cpus=2, num_gpus=1)
+
+    class CpuProcess(TorchInference):
+        def collate(self, input_batch):
+            return {"data": torch.from_numpy(input_batch["data"])}
+
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            return {"data": collated_tensors["data"].cpu()}
+
+        def finalize(self, input_batch, output_tensors, output_other):
+            return {"data": output_tensors["data"].numpy()}
+
+    ds = _make_gpu_source().map_batches(
+        CpuProcess,
+        batch_size=GPU_BATCH_SIZE,
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_gpus=1,
+    )
+    with pytest.raises(Exception, match="must return tensors on"):
+        ds.take_all()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_torch_inference.py
+++ b/python/ray/data/tests/test_torch_inference.py
@@ -14,7 +14,7 @@ from ray.data._internal.utils.torch_inference import (
     is_torch_inference_instance,
     make_torch_inference_callable,
 )
-from ray.data._internal.utils.torch_utils import find_tensor_off_device
+from ray.data._internal.utils.torch_utils import find_first_tensor_not_on_device
 from ray.data.tests.conftest import *  # noqa
 from ray.data.util.torch_inference import TorchInference
 from ray.tests.conftest import *  # noqa
@@ -213,12 +213,12 @@ def test_wrapper_rejects_non_cuda_device():
 # ===== Tensor helpers =====
 
 
-def test_find_tensor_off_device():
+def test_find_first_tensor_not_on_device():
     t_cpu = torch.zeros(2)
-    assert find_tensor_off_device({"a": t_cpu}, torch.device("cpu")) is None
-    assert find_tensor_off_device({"a": t_cpu}, torch.device("cuda")) is t_cpu
+    assert find_first_tensor_not_on_device({"a": t_cpu}, torch.device("cpu")) is None
+    assert find_first_tensor_not_on_device({"a": t_cpu}, torch.device("cuda")) is t_cpu
     # Nested containers are searched; index-less specs match any index.
-    assert find_tensor_off_device([(t_cpu,)], torch.device("cuda:1")) is t_cpu
+    assert find_first_tensor_not_on_device([(t_cpu,)], torch.device("cuda:1")) is t_cpu
 
 
 # ===== map_batches validation =====

--- a/python/ray/data/util/torch_inference.py
+++ b/python/ray/data/util/torch_inference.py
@@ -12,16 +12,16 @@ if TYPE_CHECKING:
 
 @PublicAPI(stability="alpha")
 class TorchInference:
-    """Base class for Torch batch inference with
+    """Base class for PyTorch batch inference with
     :meth:`~ray.data.Dataset.map_batches`.
 
     Subclass this and implement :meth:`process_on_device`. For every batch,
     Ray Data runs:
 
-    1. :meth:`collate` — convert the batch into CPU tensors.
+    1. :meth:`collate` — convert the batch into CPU torch tensors.
     2. Ray Data moves the tensors to the :meth:`get_device` device.
-    3. :meth:`process_on_device` — compute on the device tensors.
-    4. Ray Data moves the resulting tensors back to the CPU.
+    3. :meth:`process_on_device` — compute on the device torch tensors.
+    4. Ray Data moves the resulting torch tensors back to the CPU.
     5. :meth:`finalize` — convert them into the output batch.
 
     Override :meth:`collate`, :meth:`finalize`, or :meth:`get_device` only if

--- a/python/ray/data/util/torch_inference.py
+++ b/python/ray/data/util/torch_inference.py
@@ -1,0 +1,237 @@
+"""The user-facing base class for Torch batch inference with ``map_batches``."""
+from typing import TYPE_CHECKING, Any, Tuple, Union
+
+from ray.util.annotations import PublicAPI
+
+if TYPE_CHECKING:
+    import torch
+
+    from ray.data.block import DataBatch
+    from ray.data.collate_fn import TensorBatchType
+
+
+@PublicAPI(stability="alpha")
+class TorchInference:
+    """Base class for Torch batch inference with
+    :meth:`~ray.data.Dataset.map_batches`.
+
+    Subclass this and implement :meth:`process_on_device`. For every batch,
+    Ray Data runs:
+
+    1. :meth:`collate` — convert the batch into CPU tensors.
+    2. Ray Data moves the tensors to the :meth:`get_device` device.
+    3. :meth:`process_on_device` — compute on the device tensors.
+    4. Ray Data moves the resulting tensors back to the CPU.
+    5. :meth:`finalize` — convert them into the output batch.
+
+    Override :meth:`collate`, :meth:`finalize`, or :meth:`get_device` only if
+    the defaults don't fit your data.
+
+    **Passing non-tensor data between steps.** Only tensors go through the
+    managed device transfers, but :meth:`collate` and
+    :meth:`process_on_device` can each return a ``(tensors, other)`` tuple to
+    hand small side values (original shapes, padding lengths, strings, etc)
+    directly to the next step: ``collate``'s ``other`` arrives as
+    ``collated_other`` in :meth:`process_on_device`, and
+    ``process_on_device``'s ``other`` arrives as ``output_other`` in
+    :meth:`finalize`. Return a bare ``TensorBatchType`` and the next step
+    receives ``None`` instead. Ray Data passes ``other`` values through
+    untouched.
+
+    Examples:
+
+        Minimal — only :meth:`process_on_device`, everything else default:
+
+        .. testcode::
+            :skipif: True
+
+            import numpy as np
+            import torch
+            import ray
+            from ray.data.util.torch_inference import TorchInference
+
+            class MyInferenceActor(TorchInference):
+
+                def initialize(self):
+                    self.model = torch.nn.Identity().cuda().eval()
+
+                def process_on_device(
+                    self, input_batch, collated_tensors, collated_other
+                ):
+                    out = self.model(collated_tensors["data"])
+                    return {"mean": out.float().mean(dim=1)}
+
+            ds = (
+                ray.data.from_numpy(np.ones((32, 100), dtype=np.float32))
+                .map_batches(
+                    MyInferenceActor,
+                    batch_size=4,
+                    compute=ray.data.ActorPoolStrategy(size=1),
+                    num_gpus=1,
+                )
+            )
+
+    .. note::
+        Don't define ``__init__`` in your subclass — put setup code in
+        :meth:`initialize`, which Ray Data calls once when the actor starts.
+
+    .. note::
+        With the default :meth:`collate`, the ``batch_format`` given to
+        ``map_batches`` must be ``"default"`` or ``"numpy"``.
+
+    The per-batch methods run under ``torch.no_grad()``; gradients are not
+    recorded.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        """Forward the constructor arguments to :meth:`initialize`.
+
+        Args:
+            *args: Forwarded to :meth:`initialize`.
+            **kwargs: Forwarded to :meth:`initialize`.
+        """
+        self.initialize(*args, **kwargs)
+
+    def initialize(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize actor state, such as the model.
+
+        Called once when the actor starts. Override this instead of defining
+        ``__init__``.
+
+        Args:
+            *args: The ``fn_constructor_args`` given to
+                :meth:`~ray.data.Dataset.map_batches`.
+            **kwargs: The ``fn_constructor_kwargs`` given to
+                :meth:`~ray.data.Dataset.map_batches`.
+        """
+        pass
+
+    def get_device(self) -> "torch.device":
+        """Return the device batches are processed on.
+
+        Called once when the actor starts. The default returns
+        ``torch.device("cuda")``.
+
+        Returns:
+            The device that :meth:`collate` outputs are moved to and that
+            :meth:`process_on_device` runs on. Must be a CUDA device.
+        """
+        import torch
+
+        assert torch.cuda.is_available()
+        return torch.device("cuda")
+
+    def collate(
+        self, input_batch: "DataBatch"
+    ) -> Union["TensorBatchType", Tuple["TensorBatchType", Any]]:
+        """Convert an input batch into CPU tensors.
+
+        Nested tensor sequences (e.g. ``Dict[str, List[Tensor]]``) are treated
+        as chunks of one logical tensor and concatenated along the batch
+        dimension during the device transfer. Use flat structures to preserve
+        tensor shapes as-is.
+
+        Args:
+            input_batch: The batch to convert, in the ``batch_format`` given
+                to :meth:`~ray.data.Dataset.map_batches`. The default
+                implementation only supports NumPy batches
+                (``Dict[str, np.ndarray]``) and raises ``TypeError`` for
+                other batch formats.
+
+        Returns:
+            The batch as Torch tensors, optionally with side data:
+
+            - ``tensors``: the tensors must be on the CPU; Ray Data moves
+              them to the :meth:`get_device` device before calling
+              :meth:`process_on_device`.
+            - ``(tensors, other)``: additionally hand ``other`` — any
+              non-tensor side value, passed through untouched — to
+              :meth:`process_on_device` as ``collated_other``. When only
+              ``tensors`` is returned, ``collated_other`` is ``None``.
+        """
+        import numpy as np
+
+        from ray.data.util.torch_utils import (
+            _get_type_str,
+            convert_ndarray_batch_to_torch_tensor_batch,
+        )
+
+        if not isinstance(input_batch, dict) or not all(
+            isinstance(column, np.ndarray) for column in input_batch.values()
+        ):
+            raise TypeError(
+                "The default `collate` only supports NumPy batches "
+                f"(`Dict[str, np.ndarray]`); got {_get_type_str(input_batch)}. "
+                'Use `batch_format="numpy"` in `map_batches`, or override '
+                "`collate` to convert the batch yourself."
+            )
+        return convert_ndarray_batch_to_torch_tensor_batch(input_batch)
+
+    def process_on_device(
+        self,
+        input_batch: "DataBatch",
+        collated_tensors: "TensorBatchType",
+        collated_other: Any,
+    ) -> Union["TensorBatchType", Tuple["TensorBatchType", Any]]:
+        """Process a batch of device tensors and return device tensors.
+
+        This is the only method a subclass must implement.
+
+        Args:
+            input_batch: The untouched input batch (pre-:meth:`collate`), for
+                reading fields that don't go through the tensor path.
+            collated_tensors: The tensors returned by :meth:`collate`, moved
+                to the :meth:`get_device` device.
+            collated_other: The side data returned by :meth:`collate`, or
+                ``None`` if :meth:`collate` returned only tensors.
+
+        Returns:
+            The resulting Torch tensors, optionally with side data:
+
+            - ``tensors``: the tensors must be on the device; Ray Data moves
+              them back to the CPU before calling :meth:`finalize`.
+            - ``(tensors, other)``: additionally hand ``other`` — any
+              non-tensor side value, passed through untouched — to
+              :meth:`finalize` as ``output_other``. When only ``tensors`` is
+              returned, ``output_other`` is ``None``.
+        """
+        raise NotImplementedError(
+            f"`{type(self).__name__}` must implement `process_on_device`."
+        )
+
+    def finalize(
+        self,
+        input_batch: "DataBatch",
+        output_tensors: "TensorBatchType",
+        output_other: Any,
+    ) -> "DataBatch":
+        """Convert the output tensors into the batch ``map_batches`` returns.
+
+        Args:
+            input_batch: The untouched input batch (pre-:meth:`collate`), for
+                passing fields through to the output.
+            output_tensors: The tensors returned by :meth:`process_on_device`,
+                already moved back to the CPU.
+            output_other: The side data returned by :meth:`process_on_device`,
+                or ``None`` if it returned only tensors.
+
+        Returns:
+            The output batch, in a format
+            :meth:`~ray.data.Dataset.map_batches` accepts. The default
+            implementation recursively converts every Torch tensor into a
+            NumPy array, preserving the surrounding dict/sequence structure
+            (e.g. ``Dict[str, torch.Tensor]`` becomes
+            ``Dict[str, np.ndarray]``), and raises ``TypeError`` for
+            non-tensor values — or for a non-``None`` ``output_other``, which
+            it doesn't know how to fold into the batch; override ``finalize``
+            to consume it.
+        """
+        from ray.data.util.torch_utils import convert_tensors_to_numpy
+
+        if output_other is not None:
+            raise TypeError(
+                "The default `finalize` doesn't know how to fold "
+                "`output_other` into the output batch. Override `finalize` "
+                "to consume the side data returned by `process_on_device`."
+            )
+        return convert_tensors_to_numpy(output_tensors)

--- a/python/ray/data/util/torch_inference.py
+++ b/python/ray/data/util/torch_inference.py
@@ -118,7 +118,11 @@ class TorchInference:
         """
         import torch
 
-        assert torch.cuda.is_available()
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "CUDA is not available on this system. The default TorchInference "
+                "flow is GPU-only and requires a CUDA-capable device."
+            )
         return torch.device("cuda")
 
     def collate(

--- a/python/ray/data/util/torch_utils.py
+++ b/python/ray/data/util/torch_utils.py
@@ -529,7 +529,7 @@ def convert_tensors_to_numpy(batch: TensorBatchType) -> Any:
     ``TorchInference.finalize`` error path).
     """
     if _is_tensor(batch):
-        return batch.detach().numpy()
+        return batch.detach().cpu().numpy()
     elif isinstance(batch, Mapping):
         return {k: convert_tensors_to_numpy(v) for k, v in batch.items()}
     elif isinstance(batch, (list, tuple)):

--- a/python/ray/data/util/torch_utils.py
+++ b/python/ray/data/util/torch_utils.py
@@ -519,3 +519,23 @@ def move_tensors_to_device(
             "Dict[str, torch.Tensor], "
             "Mapping[str, List/Tuple[torch.Tensor]]"
         )
+
+
+def convert_tensors_to_numpy(batch: TensorBatchType) -> Any:
+    """Recursively convert every Torch tensor in ``batch`` to a NumPy array,
+    preserving the surrounding dict/sequence structure.
+
+    Raises ``TypeError`` on non-tensor leaves (the default
+    ``TorchInference.finalize`` error path).
+    """
+    if _is_tensor(batch):
+        return batch.detach().numpy()
+    elif isinstance(batch, Mapping):
+        return {k: convert_tensors_to_numpy(v) for k, v in batch.items()}
+    elif isinstance(batch, (list, tuple)):
+        return type(batch)(convert_tensors_to_numpy(v) for v in batch)
+    raise TypeError(
+        "The default `finalize` only supports Torch tensors nested in "
+        f"dicts/sequences; got {_get_type_str(batch)}. Override `finalize` "
+        "to convert the output yourself."
+    )


### PR DESCRIPTION
## Motivation
Batch inference via `map_batches` with a GPU actor has a lot of the same boilerplate code: move data to and from the device, convert data into tensors that can be processed by the GPU, convert the resultant output tensors back to a format that Ray Data can process. A lot of this is duplicated code, and similar to how we have sensible defaults in other parts of our API (such as `DefaultCollateFn` for `iter_torch_batches`), we should provide a short-hand framework for batch inference on `map_batches`.

## API
The user has to subclass this class:
```
@PublicAPI(stability="alpha")
class TorchInference:

    def initialize(self, *args: Any, **kwargs: Any) -> None:
        pass

    def get_device(self) -> "torch.device":
        ...

    def collate(
        self, input_batch: "DataBatch"
    ) -> Union["TensorBatchType", Tuple["TensorBatchType", Any]]:
        ...

    def process_on_device(
        self,
        input_batch: "DataBatch",
        collated_tensors: "TensorBatchType",
        collated_other: Any,
    ) -> Union["TensorBatchType", Tuple["TensorBatchType", Any]]:
        raise NotImplementedError()

    def finalize(
        self,
        input_batch: "DataBatch",
        output_tensors: "TensorBatchType",
        output_other: Any,
    ) -> "DataBatch":
        ...
```
and mandatorily implement `process_on_device` but can also optionally implement the other 4 methods. On the Ray Data side, we manage moving data to and from device and also providing sensible defaults for `get_device`, `collate` and `finalize`.

### The Defaults
- `get_device`: `torch.device("cuda")`
- `collate`: take a numpy batch, convert and concatenate tensors as necessary.
- `fianlize`: recursively take every Tensor in the batch and convert them to numpy via `.numpy()`.

## What Happens Underneath?
After initialization, for each batch, the following occurs:
1. The `DataBatch` is fed into `collate`
2. The tensor output of `collate` is moved to device.
3. `process_on_device` is called on GPU device.
4. The tensor output of `process_on_device` is moved back to CPU.
5. `finalize` is called on CPU tensor.

Each stage may need to reference 1) additional information created in the steps that are not tensors and 2) some other columns in the original batch. Therefore, for each function invocation, we provide the original batch as `input_batch` and any other miscellaneous output as `output_other`.