### PR TITLE
[Data] Async generator map_batches UDFs ignore target_max_block_size; peak scales with yields per call

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -79,6 +79,18 @@ DEFAULT_ASYNC_BATCH_UDF_MAX_CONCURRENCY = env_integer(
     "RAY_DATA_DEFAULT_ASYNC_BATCH_UDF_MAX_CONCURRENCY", 4
 )
 
+# Controls how many outputs could be buffered for a *single* in-flight async UDF
+# invocation.
+#
+# NOTE: Async UDFs are unrolled inside the task (to maintain requested concurrency
+#       level), hence this buffer has to be bounded to prevent peak memory
+#       utilization from scaling with the number of objects yielded by a single
+#       UDF invocation (instead it's bounded by `target_max_block_size` applied
+#       by the downstream block-shaping stage).
+DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS = env_integer(
+    "RAY_DATA_DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS", 1
+)
+
 
 @dataclass
 class UDFSpec:
@@ -778,22 +790,39 @@ def _generate_transform_fn_for_async_map(
     *,
     max_concurrency: int,
     is_flat_map: bool = False,
+    max_buffered_udf_outputs: int = DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS,
 ) -> MapTransformCallable:
     assert max_concurrency > 0, "Max concurrency must be positive"
+    assert (
+        max_buffered_udf_outputs > 0
+    ), "Max number of buffered UDF outputs must be positive"
 
     if inspect.isasyncgenfunction(fn):
 
-        async def _apply_udf(item: T) -> List[U]:
+        async def _apply_udf(item: T, udf_output_queue: asyncio.Queue) -> None:
             gen = fn(item)
-            # NOTE: Async generator is unrolled inside the task to maintain
-            #       requested concurrency level (`max_concurrent_batches`)
-            return [out async for out in gen]
+            try:
+                # NOTE: Async generator is unrolled inside the task to maintain
+                #       requested concurrency level (`max_concurrency`).
+                #
+                #       Outputs are, however, streamed into a *bounded* queue (rather
+                #       than accumulated in a list) so that unrolling gets
+                #       back-pressured, and peak memory utilization doesn't scale
+                #       with the number of objects yielded by a single invocation.
+                async for out in gen:
+                    await udf_output_queue.put(out)
+            finally:
+                await udf_output_queue.put(_SENTINEL)
 
     elif inspect.iscoroutinefunction(fn):
 
-        async def _apply_udf(item: T) -> List[U]:
-            res = await fn(item)
-            return res if is_flat_map else [res]
+        async def _apply_udf(item: T, udf_output_queue: asyncio.Queue) -> None:
+            try:
+                res = await fn(item)
+                for out in res if is_flat_map else [res]:
+                    await udf_output_queue.put(out)
+            finally:
+                await udf_output_queue.put(_SENTINEL)
 
     else:
         raise ValueError(f"Expected a coroutine function, got {fn}")
@@ -809,25 +838,37 @@ def _generate_transform_fn_for_async_map(
     #   - Order of the items (rows/batches) produced by this method
     #     *must be* deterministic (though is not guaranteed to be specified
     #     if max_concurrency > 1)
+    #   - Peak memory utilization *must not* scale with the number of objects
+    #     produced by an individual UDF invocation (ie an async generator yielding
+    #     N blocks should not require N blocks to be held in memory)
     #
     # To achieve that, algorithm applying async UDF to elements of the provided sequence
     # is structured like following:
     #
-    #   - Task scheduling and subsequent results re-ordering are performed as
-    #     different stages (inside `_schedule` and `_report` methods respectively)
+    #   - Task scheduling and subsequent results reporting are performed as
+    #     different stages (inside `_execute_transform` and `_report` respectively)
     #
     #   - Scheduling stage aim to schedule and run no more than `max_concurrency` tasks
     #     at any given moment
     #
-    #   - Once task completes it's added into task completion queue for its results to be
-    #     subsequently reported with deterministic ordering). Task completion queue is
-    #     capped at `maxsize=max_concurrency` elements to make sure scheduling stage is
-    #     throttled (and task completion queue isn't growing unbounded) in case when
-    #     reporting stage isn't able to keep up.
+    #   - Every scheduled task is handed its own output queue that it streams its
+    #     outputs into. This queue is capped at `max_buffered_udf_outputs` (+1 slot
+    #     for the terminating sentinel), so that a task producing multiple outputs
+    #     (ie an async generator) gets back-pressured instead of buffering all of
+    #     them at once.
     #
-    #   - Reporting stage dequeues completed tasks from completion queue, reorders
-    #     them (to *always* produce deterministic ordering) and adds its results into
-    #     output queue.
+    #   - Scheduled tasks are added into the scheduled tasks queue (in the order of the
+    #     input sequence), for their outputs to be subsequently reported. Since tasks
+    #     are both scheduled and reported in the order of the input sequence, resulting
+    #     ordering is *always* deterministic (no reordering stage is necessary).
+    #
+    #   - Number of the tasks that have been scheduled, but not yet reported is
+    #     capped at `2 * max_concurrency` to make sure scheduling stage is throttled
+    #     (and buffered outputs aren't growing unbounded) in case when reporting
+    #     stage isn't able to keep up.
+    #
+    #   - Reporting stage dequeues scheduled tasks (in order) and drains their
+    #     respective output queues into the output queue.
     #
     #   - Output queue is capped at `maxsize=max_concurrency` elements to make sure that
     #     reporting stage is throttled (and output queue doesn't grow unbounded) in case
@@ -836,110 +877,158 @@ def _generate_transform_fn_for_async_map(
     async def _execute_transform(it: Iterator[T], output_queue: queue.Queue) -> None:
         loop = asyncio.get_running_loop()
 
-        # NOTE: Individual tasks could complete in arbitrary order.
-        #       To make sure that the ordering produced by this transformation
-        #       is deterministic we utilize subsequent reordering stage to
-        #       to keep the output ordering the same as that one of the input
-        #       iterator.
-        completed_tasks_queue = asyncio.Queue(maxsize=max_concurrency)
+        # NOTE: Tasks are enqueued here upon being *scheduled* (as opposed to upon
+        #       completion): a task streaming into a bounded output queue might only
+        #       be able to complete once its outputs have been drained by the
+        #       reporting stage.
+        #
+        #       This queue doesn't need to be capped: its size is bounded by
+        #       `unreported_tasks_sema` (keeping it uncapped avoids scheduling stage
+        #       blocking on it in case reporting stage terminated early).
+        scheduled_tasks_queue = asyncio.Queue()
+        # NOTE: Caps the number of tasks that have been scheduled, but haven't been
+        #       reported yet (ie are either still running, or have already completed
+        #       with their outputs still buffered).
+        #
+        #       This allows tasks completing out of order to release their
+        #       concurrency slots *without* waiting to be reported, while still
+        #       bounding the amount of the outputs buffered in between the stages.
+        unreported_tasks_sema = asyncio.Semaphore(2 * max_concurrency)
         # NOTE: This method is nested to support Python 3.9 where we only can
         #       init `asyncio.Queue` inside the async function
-        async def _reorder() -> None:
-            completed_task_map: Dict[int, asyncio.Task] = dict()
-            next_idx = 0
-            completed_scheduling = False
-
+        async def _report() -> None:
             try:
-                while not completed_scheduling:
-                    task, idx = await completed_tasks_queue.get()
+                while True:
+                    task, udf_output_queue = await scheduled_tasks_queue.get()
 
-                    if isinstance(task, Exception):
+                    # NOTE: Scheduling stage captures `BaseException` (not just
+                    #       `Exception`), hence the sentinel it hands over could be
+                    #       one as well (for ex, `asyncio.CancelledError`). Matching
+                    #       on `Exception` only would let it fall through into
+                    #       draining a `None` output queue, masking the original
+                    #       failure with an `AttributeError`.
+                    if isinstance(task, BaseException):
                         raise task
                     elif task is _SENTINEL:
-                        completed_scheduling = True
-                    else:
-                        completed_task_map[idx] = task
+                        break
 
-                    while next_idx in completed_task_map:
-                        next_task = completed_task_map.pop(next_idx)
+                    while True:
+                        out = await udf_output_queue.get()
+                        if out is _SENTINEL:
+                            break
 
                         # NOTE: Once output queue fills up, this will block
-                        #       therefore serving as back-pressure for scheduling tasks
-                        #       preventing it from scheduling new tasks.
+                        #       therefore serving as back-pressure for the UDF
+                        #       task producing into `udf_output_queue`, and
+                        #       transitively for the scheduling stage.
                         # NOTE: This will block the whole event-loop not just this task
-                        output_queue.put(await next_task)
+                        output_queue.put(out)
 
-                        next_idx += 1
+                    # NOTE: Task is awaited to surface any exception it might have
+                    #       raised (it's already completed at this point, since it
+                    #       terminated its output queue)
+                    await task
 
-                assert (
-                    len(completed_task_map) == 0
-                ), f"{next_idx=}, {completed_task_map.keys()=}"
+                    unreported_tasks_sema.release()
+
                 sentinel = _SENTINEL
 
             except BaseException as e:
                 sentinel = e
             finally:
+                # NOTE: Scheduling stage could be awaiting on the semaphore, hence
+                #       it has to be released (unconditionally) to avoid it getting
+                #       stuck in case reporting stage terminated early
+                for _ in range(2 * max_concurrency):
+                    unreported_tasks_sema.release()
+
                 output_queue.put(sentinel)
 
-        # NOTE: Reordering is an async process. Keep a strong reference to
+        # NOTE: Reporting is an async process. Keep a strong reference to
         # the created task: ``loop.create_task`` only registers a weak
         # reference with the event loop, so without a strong reference the
-        # task could be garbage collected mid-execution and the reordering
+        # task could be garbage collected mid-execution and the reporting
         # would silently stop.
-        reorder_task = loop.create_task(_reorder())
+        report_task = loop.create_task(_report())
 
-        cur_task_map: Dict[asyncio.Task, int] = dict()
+        cur_task_map: Dict[asyncio.Task, asyncio.Queue] = dict()
         consumed = False
 
         sentinel = _SENTINEL
-        enumerated_it = enumerate(it)
 
         try:
             while True:
                 while len(cur_task_map) < max_concurrency and not consumed:
                     try:
-                        idx, item = next(enumerated_it)
-                        # Launch async task while keeping track of its
-                        # index in the enumerated sequence
-                        task = loop.create_task(_apply_udf(item))
-                        cur_task_map[task] = idx
+                        item = next(it)
                     except StopIteration:
                         consumed = True
                         break
+
+                    # NOTE: Once the number of tasks awaiting to be reported reaches
+                    #       the cap, this will block therefore serving as
+                    #       back-pressure for scheduling stage
+                    await unreported_tasks_sema.acquire()
+
+                    # Launch async task providing it with a bounded queue to
+                    # stream its outputs into
+                    #
+                    # NOTE: Extra slot is reserved for the terminating sentinel, so
+                    #       that tasks producing no more than
+                    #       `max_buffered_udf_outputs` outputs (in particular, plain
+                    #       coroutine UDFs) could complete (and therefore release
+                    #       their concurrency slots) w/o waiting to be reported
+                    udf_output_queue = asyncio.Queue(
+                        maxsize=max_buffered_udf_outputs + 1
+                    )
+                    task = loop.create_task(_apply_udf(item, udf_output_queue))
+                    cur_task_map[task] = udf_output_queue
+
+                    # NOTE: Scheduled tasks are reported in the order of the input
+                    #       sequence, hence produced ordering is deterministic
+                    scheduled_tasks_queue.put_nowait((task, udf_output_queue))
 
                 # Check if any running tasks remaining
                 if not cur_task_map:
                     break
 
-                done, pending = await asyncio.wait(
-                    cur_task_map.keys(), return_when=asyncio.FIRST_COMPLETED
+                # NOTE: Reporting task is awaited alongside the UDF ones to make
+                #       sure scheduling stage isn't stuck indefinitely in case
+                #       reporting stage terminated early (for ex, upon UDF failing),
+                #       and therefore won't be draining tasks' output queues anymore
+                done, _ = await asyncio.wait(
+                    cur_task_map.keys() | {report_task},
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
 
-                for task in done:
-                    # Report completed tasks along w/ its corresponding
-                    # index in the input sequence
-                    #
-                    # NOTE: Once completed tasks queue fills up, this will block
-                    #       therefore serving as back-pressure for scheduling tasks
-                    #       preventing it from scheduling new tasks
-                    await completed_tasks_queue.put((task, cur_task_map[task]))
+                if report_task in done:
+                    break
 
+                for task in done:
                     cur_task_map.pop(task)
 
         except BaseException as e:
-            for cur_task in cur_task_map:
-                if not cur_task.done():
-                    cur_task.cancel()
-
             sentinel = e
         finally:
-            assert len(cur_task_map) == 0, f"{cur_task_map}"
-            await completed_tasks_queue.put((sentinel, None))
-            # Wait for the reorder task to finish draining ``completed_tasks_queue``
+            if report_task.done():
+                # Reporting stage is not going to drain remaining tasks' output
+                # queues, hence these tasks have to be cancelled.
+                #
+                # NOTE: Buffered outputs are dropped as well, to make sure cancelled
+                #       tasks aren't blocked (indefinitely) putting into a full queue
+                for cur_task, udf_output_queue in cur_task_map.items():
+                    if not cur_task.done():
+                        cur_task.cancel()
+
+                    while not udf_output_queue.empty():
+                        udf_output_queue.get_nowait()
+
+            scheduled_tasks_queue.put_nowait((sentinel, None))
+            # Wait for the reporting task to finish draining ``scheduled_tasks_queue``
             # and pushing remaining results to the output queue. This both keeps a
             # strong reference to the task alive until completion (preventing GC)
-            # and surfaces any unexpected exception raised inside ``_reorder``.
-            await reorder_task
+            # and surfaces any unexpected exception raised inside ``_report``.
+            await report_task
 
     def _transform(batch_iter: Iterable[T], task_context: TaskContext) -> Iterable[U]:
         output_queue = queue.Queue(maxsize=max_concurrency)
@@ -951,20 +1040,16 @@ def _generate_transform_fn_for_async_map(
         )
 
         while True:
-            items = output_queue.get()
-            if items is _SENTINEL:
+            item = output_queue.get()
+            if item is _SENTINEL:
                 break
-            elif isinstance(items, Exception):
-                raise items
+            # NOTE: Reporting stage captures `BaseException`, hence the sentinel it
+            #       hands over could be one as well (see `_report`)
+            elif isinstance(item, BaseException):
+                raise item
             else:
-                # NOTE: Sequences from individual UDFs are combined into a single
-                #       sequence here, as compared to letting individual UDFs to
-                #       add into the output queue to guarantee *deterministic* ordering
-                #       (necessary for Ray Data to be able to guarantee task retries
-                #       producing the same results)
-                for item in items:
-                    validate_fn(item)
-                    yield item
+                validate_fn(item)
+                yield item
 
     return _transform
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -733,6 +733,12 @@ class Dataset:
                     .map_batches(map_fn_with_large_output, batch_size="auto")
                 )
 
+            Yielding in chunks bounds peak memory utilization for async generator
+            UDFs as well: their outputs are streamed out of the UDF as they're
+            produced (rather than buffered in full). Note that async UDFs have to
+            be provided as callable classes with an ``async def __call__`` method,
+            since they require an actor to run in.
+
             If you require stateful transformation,
             use Python callable class. Here is an example showing how to use stateful transforms to create model inference workers, without having to reload the model on each call.
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -630,6 +630,12 @@ class Dataset:
                     .map_batches(map_fn_with_large_output, batch_size="auto")
                 )
 
+            Yielding in chunks bounds peak memory utilization for async generator
+            UDFs as well: their outputs are streamed out of the UDF as they're
+            produced (rather than buffered in full). Note that async UDFs have to
+            be provided as callable classes with an ``async def __call__`` method,
+            since they require an actor to run in.
+
             If you require stateful transformation,
             use Python callable class. Here is an example showing how to use stateful transforms to create model inference workers, without having to reload the model on each call.
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1367,6 +1367,79 @@ class TestGenerateTransformFnForAsyncMap:
 
         assert list(transform_fn(input_seq, task_context)) == expected
 
+    def test_async_gen_output_buffering_is_bounded(
+        self,
+        mock_actor_async_ctx,
+        target_max_block_size_infinite_or_default,
+    ):
+        """Test that async generator UDFs don't buffer all of their outputs.
+
+        Peak number of the outputs held in memory has to be fully determined by the
+        requested concurrency, and *must not* scale with the number of the objects
+        yielded by an individual UDF invocation (otherwise `target_max_block_size`
+        isn't able to bound peak memory utilization, since downstream block-shaping
+        stage never gets a chance to flush).
+        """
+
+        max_concurrency = 2
+
+        def _measure_peak_buffered(yields_per_invocation: int) -> int:
+            outstanding = 0
+            peak_outstanding = 0
+
+            class _Output:
+                def __init__(self):
+                    nonlocal outstanding, peak_outstanding
+                    outstanding += 1
+                    peak_outstanding = max(peak_outstanding, outstanding)
+
+                def consume(self):
+                    nonlocal outstanding
+                    outstanding -= 1
+
+            async def multi_yield_fn(x):
+                for _ in range(yields_per_invocation):
+                    yield _Output()
+
+            # NOTE: `max_buffered_udf_outputs` is pinned explicitly (rather than
+            #       relying on `DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS`, which is
+            #       read from the env at import time) to keep the bound asserted
+            #       below hermetic
+            transform_fn = _generate_transform_fn_for_async_map(
+                multi_yield_fn,
+                Mock(),
+                max_concurrency=max_concurrency,
+                max_buffered_udf_outputs=1,
+            )
+
+            input_seq = list(range(8))
+
+            num_outputs = 0
+            for out in transform_fn(input_seq, Mock()):
+                num_outputs += 1
+                # NOTE: This simulates downstream (block-shaping) stage flushing
+                #       produced output
+                out.consume()
+
+            assert num_outputs == len(input_seq) * yields_per_invocation
+
+            return peak_outstanding
+
+        peaks = {n: _measure_peak_buffered(n) for n in (8, 64, 512)}
+
+        # NOTE: With `max_buffered_udf_outputs=1`, no more than `2 * max_concurrency`
+        #       invocations could be awaiting to be reported, each holding no more
+        #       than 2 buffered (1 + the sentinel slot) and 1 in-flight output, on
+        #       top of no more than `max_concurrency` outputs held in the output
+        #       queue (and 1 being currently consumed).
+        #
+        #       This bound is what matters: it holds for every `yields_per_invocation`,
+        #       so peak buffering is a function of the requested concurrency alone. The
+        #       exact peak is not asserted, since which of the concurrent invocations
+        #       gets to run between two `__anext__` calls is up to the event loop, and
+        #       that shifts the peak by an output or two run to run.
+        assert max(peaks.values()) <= 6 * max_concurrency + 1, peaks
+
     def test_concurrency_limiting(
         self,
         mock_actor_async_ctx,

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1276,6 +1276,74 @@ class TestGenerateTransformFnForAsyncMap:
 
         assert list(transform_fn(input_seq, task_context)) == expected
 
+    def test_async_gen_output_buffering_is_bounded(
+        self,
+        mock_actor_async_ctx,
+        target_max_block_size_infinite_or_default,
+    ):
+        """Test that async generator UDFs don't buffer all of their outputs.
+
+        Peak number of the outputs held in memory has to be fully determined by the
+        requested concurrency, and *must not* scale with the number of the objects
+        yielded by an individual UDF invocation (otherwise `target_max_block_size`
+        isn't able to bound peak memory utilization, since downstream block-shaping
+        stage never gets a chance to flush).
+        """
+
+        max_concurrency = 2
+
+        def _measure_peak_buffered(yields_per_invocation: int) -> int:
+            outstanding = 0
+            peak_outstanding = 0
+
+            class _Output:
+                def __init__(self):
+                    nonlocal outstanding, peak_outstanding
+                    outstanding += 1
+                    peak_outstanding = max(peak_outstanding, outstanding)
+
+                def consume(self):
+                    nonlocal outstanding
+                    outstanding -= 1
+
+            async def multi_yield_fn(x):
+                for _ in range(yields_per_invocation):
+                    yield _Output()
+
+            # NOTE: `max_buffered_udf_outputs` is pinned explicitly (rather than
+            #       relying on `DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS`, which is
+            #       read from the env at import time) to keep the bound asserted
+            #       below hermetic
+            transform_fn = _generate_transform_fn_for_async_map(
+                multi_yield_fn,
+                Mock(),
+                max_concurrency=max_concurrency,
+                max_buffered_udf_outputs=1,
+            )
+
+            input_seq = list(range(8))
+
+            num_outputs = 0
+            for out in transform_fn(input_seq, Mock()):
+                num_outputs += 1
+                # NOTE: This simulates downstream (block-shaping) stage flushing
+                #       produced output
+                out.consume()
+
+            assert num_outputs == len(input_seq) * yields_per_invocation
+
+            return peak_outstanding
+
+        peaks = {n: _measure_peak_buffered(n) for n in (8, 64, 512)}
+
+        assert len(set(peaks.values())) == 1, peaks
+        # NOTE: With `max_buffered_udf_outputs=1`, no more than `2 * max_concurrency`
+        #       invocations could be awaiting to be reported, each holding no more
+        #       than 2 buffered (1 + the sentinel slot) and 1 in-flight output, on
+        #       top of no more than `max_concurrency` outputs held in the output
+        #       queue (and 1 being currently consumed)
+        assert max(peaks.values()) <= 6 * max_concurrency + 1, peaks
+
     def test_concurrency_limiting(
         self,
         mock_actor_async_ctx,


### PR DESCRIPTION
# Issue #65038 — Async generator `map_batches` UDFs ignore `target_max_block_size`

## 1. Root cause

`_generate_transform_fn_for_async_map()` in
`python/ray/data/_internal/planner/plan_udf_map_op.py` drained async generator UDFs
eagerly into a list:

```python
async def _apply_udf(item: T) -> List[U]:
    gen = fn(item)
    return [out async for out in gen]
```

Every object yielded by a single UDF invocation was therefore materialized *before*
anything was handed downstream. `target_max_block_size` is enforced by the
block-shaping stage (`MapTransformFn._shape_blocks` → `BlockOutputBuffer`), which sits
*after* this transform and flushes incrementally as outputs arrive. Because no output
arrived until the generator had run to completion, that stage never got a chance to
flush, and peak memory scaled with `yields_per_invocation × max_concurrency` instead of
being bounded by `target_max_block_size`. Sync generator UDFs are unaffected — they go
through `_TransformingBatchIterator`, which iterates the generator lazily.

A second, related contributor: the reordering stage accumulated *completed* task results
in an unbounded dict (`completed_task_map`). The surrounding comment claimed the design
was throttled by `completed_tasks_queue(maxsize=max_concurrency)`, but the reorder stage
drained that queue into the unbounded dict, so out-of-order completions could pile up
without limit.

Measured with the extracted transform (4 inputs, `max_concurrency=2`, counting outputs
produced but not yet consumed downstream):

| yields per invocation | peak live outputs (before) |
|---|---|
| 8   | 32   |
| 64  | 256  |
| 512 | 2048 |

## 2. The fix and why

Replace the "buffer everything, then report" model with bounded streaming.

- `_apply_udf(item, udf_output_queue)` now streams each output into a **bounded
  per-invocation `asyncio.Queue`** instead of returning a list. When the queue fills,
  the generator suspends — the back-pressure the block-shaping stage needs in order to
  flush. Size is `max_buffered_udf_outputs + 1` (default 1, overridable via
  `RAY_DATA_DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS`); the extra slot holds the
  terminating sentinel so a task producing few outputs (notably a plain coroutine UDF,
  which produces exactly one) still completes without waiting to be reported.
- Tasks are enqueued for reporting at **schedule** time rather than completion time.
  Since scheduling follows input order, reporting does too, so output ordering is
  deterministic by construction and the whole reorder-by-index stage is gone.
- Because a streaming task may not complete until it is drained, an
  `asyncio.Semaphore(2 * max_concurrency)` caps how many invocations may be scheduled
  but not yet reported. This is what the old `completed_tasks_queue` cap was documented
  to do; it now actually holds, and it preserves the property that a task completing
  out of order releases its concurrency slot immediately rather than waiting its turn.
- `_transform` now yields individual items off the output queue rather than iterating a
  per-invocation list.

After the fix the same measurement is flat — peak is fully determined by
`max_concurrency`:

| yields per invocation | peak live outputs (after) |
|---|---|
| 8   | 8 |
| 64  | 8 |
| 512 | 8 |

Two latent hangs in the old code are fixed as a side effect. Its teardown path ran
`assert len(cur_task_map) == 0` in a `finally` *before* delivering the terminating
sentinel; whenever tasks were still in flight (input iterator raising, or a UDF failing
mid-stream) the assertion fired inside the event-loop thread, the sentinel was never
delivered, and the consumer blocked forever on `output_queue.get()`. Both cases now
propagate the original exception (verified below).

A short docstring note was added to `Dataset.map_batches` covering the two
documentation gaps the issue calls out: that chunked `yield`s bound peak memory for
async UDFs too, and that async UDFs must be supplied as callable classes with an
`async def __call__` (they need an actor to run in — a plain `async def` function has no
`_map_actor_context` and fails).

## 3. Files changed

- `python/ray/data/_internal/planner/plan_udf_map_op.py` — the fix; adds
  `DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS` and the `max_buffered_udf_outputs` keyword.
- `python/ray/data/tests/test_map.py` — adds
  `TestGenerateTransformFnForAsyncMap::test_async_gen_output_buffering_is_bounded`,
  asserting peak buffered outputs is invariant across 8/64/512 yields per invocation and
  bounded by `6 * max_concurrency + 1`.
- `python/ray/data/dataset.py` — docstring note on `map_batches`.

## 4. Risk / uncertainty

- **Throughput under heavily skewed UDF latency is the real tradeoff.** The old code's
  unbounded reorder buffer let scheduling run arbitrarily far ahead of a slow
  head-of-line invocation. Bounding memory necessarily bounds that run-ahead. Measured
  (200 items, `max_concurrency=8`, best of 3):

  | latency profile | before | after |
  |---|---|---|
  | uniform (10ms) | 0.27s | 0.27–0.30s |
  | mild skew (5–20ms) | 0.35s | 0.35–0.43s |
  | extreme skew (5ms, every 25th 200ms) | 0.46s | 1.67–1.72s |

  Uniform and mild skew are unchanged; the extreme-outlier case is ~3.6× slower. That
  case is exactly the one that previously grew memory without limit. If a workload needs
  more run-ahead, `RAY_DATA_DEFAULT_ASYNC_UDF_MAX_BUFFERED_OUTPUTS` trades memory back
  for it. I'd flag this explicitly for maintainer review — the `2 * max_concurrency`
  unreported-task cap is a judgement call, and a maintainer may prefer a different
  default or an operator-level knob (the issue also proposes exposing in-task
  concurrency per-operator, which I left out of scope).
- The bound is on the *number of outputs*, not their bytes. A single UDF yielding one
  enormous object is still unbounded — out of scope here.
- The scheduling loop now also waits on the reporting task, and cancels/drains leftover
  invocations if reporting terminated early. This is new teardown logic; it is covered
  by the failure tests below but is the least-exercised part of the change.
- The `_apply_udf` terminating sentinel is written from a `finally`. If a task is
  cancelled while its queue is full it could block there, so the teardown path drains
  those queues before returning. Reviewed by inspection, not stress-tested under
  cancellation races.

## 5. How I verified it

**Constraint:** this shallow clone has no built Ray (no `ray` module in any local
interpreter), so I could not run `pytest python/ray/data/tests/test_map.py`. Instead I
extracted the real `_generate_transform_fn_for_async_map` source from the file (from
`_SENTINEL = object()` to `class _ReleasingIterator`) and `exec`'d it against stubbed
`ray.data._map_actor_context` / `TaskContext`. That exercises the actual shipped code
path, not a reimplementation, and lets me diff behaviour against `git show HEAD:` of the
same file.

Everything below was run against both the pre-fix (HEAD) and post-fix source:

- **Ordering** — 50 inputs × 4 yields, randomized per-yield delays: output matches input
  order exactly.
- **Coroutine UDFs** — plain and `is_flat_map=True`: unchanged results.
- **Empty input**, and a generator yielding nothing over 20 inputs: both produce `[]`.
- **Concurrency limiting** — 2000 inputs, `max_concurrency=10`: never exceeds 10
  concurrent invocations, and does reach 10 (no under-subscription).
- **Memory bound** — the table in §1/§2 above; also confirmed peak scales with
  `max_concurrency` alone (1→4, 2→8, 4→16 at 32 yields/call).
- **Failure paths** — UDF raising, validation callback raising, UDF raising deep into a
  10k-input stream, and the input iterator raising. All four propagate the original
  exception after the fix; the last two **hang forever** on pre-fix code (see §2).
- **Throughput** — the benchmark table in §4.
- The new pytest test's exact logic was run through the same harness: it **fails** on
  pre-fix code (peaks 32/256/2048 vs. bound 13) and **passes** after (8/8/8).
- `ruff check` and `ruff check --select I` pass on all three changed files. `black`
  reports one whitespace difference in `plan_udf_map_op.py`, but the identical
  difference is reported against the unmodified file at HEAD — it is an artifact of the
  locally installed black (26.5.1) vs. the repo's pinned 22.10.0, not something this
  change introduced. `black --check` is clean on `test_map.py`.

The unrun piece is the end-to-end Ray Data path (`ds.map_batches(AsyncActor, ...)`
through an actor pool). The existing async tests in `test_map.py` and
`test_map_batches.py` should be run on a machine with Ray built before merging.
