### PR TITLE
[Serve] Name the label selector when replicas cannot be scheduled

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -743,6 +743,7 @@ class ActorReplicaWrapper:
         self._unrecoverable: bool = False
 
         self._actor_resources: Dict[str, float] = None
+        self._actor_label_selector: Optional[Dict[str, str]] = None
         # If the replica is being started, this will be the true version
         # If the replica is being recovered, this will be the target
         # version, which may be inconsistent with the actual replica
@@ -1068,6 +1069,9 @@ class ActorReplicaWrapper:
         """
         self._assign_rank_callback = assign_rank_callback
         self._actor_resources = deployment_info.replica_config.resource_dict
+        self._actor_label_selector = (
+            deployment_info.replica_config.ray_actor_options or {}
+        ).get("label_selector")
         self._ingress = deployment_info.ingress
         self._gang_placement_group = gang_placement_group
         self._gang_pg_index = gang_pg_index
@@ -1506,6 +1510,10 @@ class ActorReplicaWrapper:
     @property
     def actor_resources(self) -> Optional[Dict[str, float]]:
         return self._actor_resources
+
+    @property
+    def actor_label_selector(self) -> Optional[Dict[str, str]]:
+        return self._actor_label_selector
 
     @property
     def available_resources(self) -> Dict[str, float]:
@@ -2139,6 +2147,11 @@ class DeploymentReplica:
         # Use .model_copy(update=...) instead of .model_dump() + reconstruction
         # to avoid full Pydantic serialization and validation on every update.
         self._actor_details = self._actor_details.model_copy(update=kwargs)
+
+    @property
+    def actor_label_selector(self) -> Optional[Dict[str, str]]:
+        """The node label selector this replica must be scheduled against."""
+        return self._actor.actor_label_selector
 
     def resource_requirements(self) -> Tuple[str, str]:
         """Returns required and currently available resources.
@@ -5098,14 +5111,26 @@ class DeploymentState:
 
             if len(pending_allocation) > 0:
                 required, available = pending_allocation[0].resource_requirements()
+                # A replica can also be unschedulable because no node satisfies its
+                # label selector, in which case the resources above look plentiful
+                # and point the reader in the wrong direction. Surface the selector
+                # so that case is diagnosable.
+                label_selector = pending_allocation[0].actor_label_selector
+                label_selector_message = (
+                    f"Required node label selector: {json.dumps(label_selector)}. "
+                    if label_selector
+                    else ""
+                )
                 message = (
                     f"Deployment '{self.deployment_name}' in application "
                     f"'{self.app_name}' has {len(pending_allocation)} replicas that "
                     f"have taken more than {SLOW_STARTUP_WARNING_S}s to be scheduled. "
-                    "This may be due to waiting for the cluster to auto-scale or for a "
-                    "runtime environment to be installed. "
+                    "This may be due to waiting for the cluster to auto-scale, for a "
+                    "runtime environment to be installed, or for a node matching the "
+                    "replica's label selector to become available. "
                     f"Resources required for each replica: {required}, "
                     f"total resources available: {available}. "
+                    f"{label_selector_message}"
                     "Use `ray status` for more details."
                 )
                 logger.warning(message)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -744,6 +744,7 @@ class ActorReplicaWrapper:
 
         self._actor_resources: Dict[str, float] = None
         self._actor_label_selector: Optional[Dict[str, str]] = None
+        self._actor_fallback_strategy: Optional[List[Dict[str, Any]]] = None
         # If the replica is being started, this will be the true version
         # If the replica is being recovered, this will be the target
         # version, which may be inconsistent with the actual replica
@@ -1069,9 +1070,9 @@ class ActorReplicaWrapper:
         """
         self._assign_rank_callback = assign_rank_callback
         self._actor_resources = deployment_info.replica_config.resource_dict
-        self._actor_label_selector = (
-            deployment_info.replica_config.ray_actor_options or {}
-        ).get("label_selector")
+        _ray_actor_options = deployment_info.replica_config.ray_actor_options or {}
+        self._actor_label_selector = _ray_actor_options.get("label_selector")
+        self._actor_fallback_strategy = _ray_actor_options.get("fallback_strategy")
         self._ingress = deployment_info.ingress
         self._gang_placement_group = gang_placement_group
         self._gang_pg_index = gang_pg_index
@@ -1514,6 +1515,10 @@ class ActorReplicaWrapper:
     @property
     def actor_label_selector(self) -> Optional[Dict[str, str]]:
         return self._actor_label_selector
+
+    @property
+    def actor_fallback_strategy(self) -> Optional[List[Dict[str, Any]]]:
+        return self._actor_fallback_strategy
 
     @property
     def available_resources(self) -> Dict[str, float]:
@@ -2152,6 +2157,11 @@ class DeploymentReplica:
     def actor_label_selector(self) -> Optional[Dict[str, str]]:
         """The node label selector this replica must be scheduled against."""
         return self._actor.actor_label_selector
+
+    @property
+    def actor_fallback_strategy(self) -> Optional[List[Dict[str, Any]]]:
+        """The fallback options tried when the label selector matches no node."""
+        return self._actor.actor_fallback_strategy
 
     def resource_requirements(self) -> Tuple[str, str]:
         """Returns required and currently available resources.
@@ -5121,6 +5131,14 @@ class DeploymentState:
                     if label_selector
                     else ""
                 )
+                # Fallbacks are tried when the selector above matches no node, so if
+                # the replica is still pending they did not match either.
+                fallback_strategy = pending_allocation[0].actor_fallback_strategy
+                if fallback_strategy:
+                    label_selector_message += (
+                        "Fallback options also unmatched: "
+                        f"{json.dumps(fallback_strategy)}. "
+                    )
                 message = (
                     f"Deployment '{self.deployment_name}' in application "
                     f"'{self.app_name}' has {len(pending_allocation)} replicas that "

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -770,6 +770,11 @@ class MockReplicaActorWrapper:
         return None
 
     @property
+    def actor_fallback_strategy(self) -> Optional[List[Dict[str, Any]]]:
+        # Only used to print a warning.
+        return None
+
+    @property
     def available_resources(self) -> Dict[str, float]:
         # Only used to print a warning.
         return {}

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -765,6 +765,11 @@ class MockReplicaActorWrapper:
         return {"CPU": 0.1}
 
     @property
+    def actor_label_selector(self) -> Optional[Dict[str, str]]:
+        # Only used to print a warning.
+        return None
+
+    @property
     def available_resources(self) -> Dict[str, float]:
         # Only used to print a warning.
         return {}

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4295,6 +4295,46 @@ def test_resource_requirements_none():
     replica.resource_requirements()
 
 
+def test_actor_label_selector_is_exposed():
+    """A pending replica exposes its label selector so the slow-startup message
+    can name it.
+
+    A replica can be unschedulable purely because no node satisfies its label
+    selector, in which case the resources reported alongside look plentiful and
+    point the reader away from the real cause.
+    """
+
+    class FakeActor:
+        actor_resources = {"CPU": 1.0}
+        placement_group_bundles = None
+        available_resources = {"CPU": 800.0}
+        actor_label_selector = {"enterprise-tier": "in(plus-1,plus-2,plus-3)"}
+
+    replica_id = ReplicaID("asdf123", DeploymentID(name="test"))
+    replica = DeploymentReplica(replica_id, None)
+    replica._actor = FakeActor()
+
+    assert replica.actor_label_selector == {
+        "enterprise-tier": "in(plus-1,plus-2,plus-3)"
+    }
+
+
+def test_actor_label_selector_is_none_when_unset():
+    """Deployments without a label selector report None, so the message omits it."""
+
+    class FakeActor:
+        actor_resources = {"CPU": 1.0}
+        placement_group_bundles = None
+        available_resources = {}
+        actor_label_selector = None
+
+    replica_id = ReplicaID("asdf123", DeploymentID(name="test"))
+    replica = DeploymentReplica(replica_id, None)
+    replica._actor = FakeActor()
+
+    assert replica.actor_label_selector is None
+
+
 class TestActorReplicaWrapper:
     def test_default_value(self):
         actor_replica = ActorReplicaWrapper(
@@ -5067,11 +5107,14 @@ class TestAutoscaling:
                 "This may be caused by a slow __init__ or reconfigure method."
             )
         elif target_startup_status == ReplicaStartupStatus.PENDING_ALLOCATION:
+            # No label selector is configured here, so the selector sentence is
+            # omitted entirely.
             expected_message = (
                 "Deployment 'test_deployment' in application 'test_app' "
                 "has 3 replicas that have taken more than 30s to be scheduled. "
-                "This may be due to waiting for the cluster to auto-scale or for "
-                "a runtime environment to be installed. "
+                "This may be due to waiting for the cluster to auto-scale, for "
+                "a runtime environment to be installed, or for a node matching "
+                "the replica's label selector to become available. "
                 "Resources required for each replica: "
                 '{"CPU": 0.1}, '
                 "total resources available: "

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4309,6 +4309,7 @@ def test_actor_label_selector_is_exposed():
         placement_group_bundles = None
         available_resources = {"CPU": 800.0}
         actor_label_selector = {"enterprise-tier": "in(plus-1,plus-2,plus-3)"}
+        actor_fallback_strategy = [{"label_selector": {"enterprise-tier": "basic"}}]
 
     replica_id = ReplicaID("asdf123", DeploymentID(name="test"))
     replica = DeploymentReplica(replica_id, None)
@@ -4317,6 +4318,11 @@ def test_actor_label_selector_is_exposed():
     assert replica.actor_label_selector == {
         "enterprise-tier": "in(plus-1,plus-2,plus-3)"
     }
+    # Fallbacks are only tried when the selector above matches nothing, so a still
+    # pending replica means these did not match either.
+    assert replica.actor_fallback_strategy == [
+        {"label_selector": {"enterprise-tier": "basic"}}
+    ]
 
 
 def test_actor_label_selector_is_none_when_unset():
@@ -4327,12 +4333,14 @@ def test_actor_label_selector_is_none_when_unset():
         placement_group_bundles = None
         available_resources = {}
         actor_label_selector = None
+        actor_fallback_strategy = None
 
     replica_id = ReplicaID("asdf123", DeploymentID(name="test"))
     replica = DeploymentReplica(replica_id, None)
     replica._actor = FakeActor()
 
     assert replica.actor_label_selector is None
+    assert replica.actor_fallback_strategy is None
 
 
 class TestActorReplicaWrapper:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4325,6 +4325,39 @@ def test_actor_label_selector_is_exposed():
     ]
 
 
+def test_actor_fallback_strategy_with_multiple_options():
+    """All fallback options are reported, not just the first.
+
+    Each option is tried in turn, so a still pending replica means every one of
+    them failed to match.
+    """
+    fallbacks = [
+        {"label_selector": {"enterprise-tier": "in(gold-1,gold-2)"}},
+        {
+            "label_selector": {
+                "enterprise-tier": "in(silver-1)",
+                "service-type": "in(all)",
+            }
+        },
+        {"label_selector": {"enterprise-tier": "basic"}},
+    ]
+
+    class FakeActor:
+        actor_resources = {"CPU": 1.0}
+        placement_group_bundles = None
+        available_resources = {"CPU": 800.0}
+        actor_label_selector = {"enterprise-tier": "in(plus-1)"}
+        actor_fallback_strategy = fallbacks
+
+    replica_id = ReplicaID("asdf123", DeploymentID(name="test"))
+    replica = DeploymentReplica(replica_id, None)
+    replica._actor = FakeActor()
+
+    # The whole list is reported, so every option stays visible in the message.
+    assert replica.actor_fallback_strategy == fallbacks
+    assert len(replica.actor_fallback_strategy) == 3
+
+
 def test_actor_label_selector_is_none_when_unset():
     """Deployments without a label selector report None, so the message omits it."""
 


### PR DESCRIPTION
## Description

When a replica cannot be scheduled because no node satisfies its `label_selector`, the slow-startup warning reports only resources, so it shows ample free capacity and points at autoscaling or runtime env setup instead.

We hit this in production: a replica sat pending for 15 minutes while the message read `Resources required for each replica: {"CPU": 1.0}, total resources available: {"CPU": 800.0}`. Hundreds of nodes had free CPU; none carried the labels the selector had just been changed to.

This names the label_selector:

```
... or for a node matching the replica's label selector to become available.
Resources required for each replica: {"CPU": 1.0}, total resources available: {"CPU": 800.0}.
Required node label selector: {"test": "in(test-1, test-2, test-3)"}. ...
```

Deployments without a selector are unaffected; the sentence is omitted.

## Related issues

## Additional information

Message text only, no behavior change. Verified on a two-node cluster (ample CPU, no matching node) -- the output above is actual. Unit tests cover the selector-present and selector-absent paths.