### PR TITLE
[Train] Give test_e2e_wandb_integration a medium timeout

### DIFF
--- a/python/ray/train/BUILD.bazel
+++ b/python/ray/train/BUILD.bazel
@@ -919,7 +919,9 @@ py_test(
 
 py_test(
     name = "test_e2e_wandb_integration",
-    size = "small",
+    # Two full ``TorchTrainer.fit()`` runs (2 workers, 3 epochs) plus a
+    # ``ray.init`` per parameterization do not fit in small's 60s budget.
+    size = "medium",
     srcs = ["tests/test_e2e_wandb_integration.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "0"},
     tags = [


### PR DESCRIPTION
## Why

`test_e2e_wandb_integration` is marked `size = "small"`, which gives it a 60s budget. The test runs two full `TorchTrainer.fit()` calls (2 workers, 3 epochs each) plus a `ray.init` per parameterization, which does not fit.

## What changed

- `python/ray/train/BUILD.bazel`: `test_e2e_wandb_integration` `small` → `medium`, with a comment recording why.

## Testing

```
$ bazel query '//python/ray/train:test_e2e_wandb_integration' --output=build | grep size
  size = "medium",
```

