### PR TITLE
[dashboard] Stream job log responses

### DIFF
--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -593,7 +593,6 @@ class JobDeleteResponse:
     deleted: bool
 
 
-# TODO(jiaodong): Support log streaming #19415
 @dataclass
 class JobLogsResponse:
     logs: str

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -163,18 +163,19 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
                 status=aiohttp.web.HTTPBadRequest.status_code,
             )
 
+        response = None
         log_chunks = self.get_job_manager().get_job_log_chunks(job.submission_id)
         try:
-            first_chunk = next(log_chunks)
-        except StopIteration:
-            first_chunk = None
+            try:
+                first_chunk = next(log_chunks)
+            except StopIteration:
+                first_chunk = None
 
-        response = StreamResponse()
-        response.content_type = "application/json"
-        response.charset = "utf-8"
-        await response.prepare(req)
+            response = StreamResponse()
+            response.content_type = "application/json"
+            response.charset = "utf-8"
+            await response.prepare(req)
 
-        try:
             await response.write(b'{"logs":"')
             if first_chunk is not None:
                 await response.write(_encode_log_chunk(first_chunk))
@@ -182,15 +183,18 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
                 await response.write(_encode_log_chunk(chunk))
             await response.write(b'"}')
             await response.write_eof()
+            return response
         except asyncio.CancelledError:
-            response.force_close()
+            if response is not None and response.prepared:
+                response.force_close()
             raise
         except Exception:
-            logger.exception("Error while streaming job logs")
-            response.force_close()
+            if response is not None and response.prepared:
+                logger.exception("Error while streaming job logs")
+                response.force_close()
             raise
-
-        return response
+        finally:
+            log_chunks.close()
 
     @routes.get("/api/job_agent/jobs/{job_or_submission_id}/logs/tail")
     @optional_utils.init_ray_and_catch_exceptions()

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -1,17 +1,17 @@
+import asyncio
 import dataclasses
 import json
 import logging
 import traceback
 
 import aiohttp
-from aiohttp.web import Request, Response
+from aiohttp.web import Request, Response, StreamResponse
 
 import ray
 import ray.dashboard.optional_utils as optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray.dashboard.modules.job.common import (
     JobDeleteResponse,
-    JobLogsResponse,
     JobStopResponse,
     JobSubmitRequest,
     JobSubmitResponse,
@@ -22,6 +22,10 @@ from ray.dashboard.modules.job.utils import find_job_by_ids, parse_and_validate_
 
 routes = optional_utils.DashboardAgentRouteTable
 logger = logging.getLogger(__name__)
+
+
+def _encode_log_chunk(chunk: str) -> bytes:
+    return json.dumps(chunk)[1:-1].encode()
 
 
 class JobAgent(dashboard_utils.DashboardAgentModule):
@@ -140,7 +144,7 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
 
     @routes.get("/api/job_agent/jobs/{job_or_submission_id}/logs")
     @optional_utils.init_ray_and_catch_exceptions()
-    async def get_job_logs(self, req: Request) -> Response:
+    async def get_job_logs(self, req: Request) -> StreamResponse:
         job_or_submission_id = req.match_info["job_or_submission_id"]
         job = await find_job_by_ids(
             self._dashboard_agent.gcs_client,
@@ -159,12 +163,34 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
                 status=aiohttp.web.HTTPBadRequest.status_code,
             )
 
-        resp = JobLogsResponse(
-            logs=self.get_job_manager().get_job_logs(job.submission_id)
-        )
-        return Response(
-            text=json.dumps(dataclasses.asdict(resp)), content_type="application/json"
-        )
+        log_chunks = self.get_job_manager().get_job_log_chunks(job.submission_id)
+        try:
+            first_chunk = next(log_chunks)
+        except StopIteration:
+            first_chunk = None
+
+        response = StreamResponse()
+        response.content_type = "application/json"
+        response.charset = "utf-8"
+        await response.prepare(req)
+
+        try:
+            await response.write(b'{"logs":"')
+            if first_chunk is not None:
+                await response.write(_encode_log_chunk(first_chunk))
+            for chunk in log_chunks:
+                await response.write(_encode_log_chunk(chunk))
+            await response.write(b'"}')
+        except asyncio.CancelledError:
+            response.force_close()
+            raise
+        except Exception:
+            logger.exception("Error while streaming job logs")
+            response.force_close()
+            return response
+
+        await response.write_eof()
+        return response
 
     @routes.get("/api/job_agent/jobs/{job_or_submission_id}/logs/tail")
     @optional_utils.init_ray_and_catch_exceptions()

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -181,15 +181,15 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
             for chunk in log_chunks:
                 await response.write(_encode_log_chunk(chunk))
             await response.write(b'"}')
+            await response.write_eof()
         except asyncio.CancelledError:
             response.force_close()
             raise
         except Exception:
             logger.exception("Error while streaming job logs")
             response.force_close()
-            return response
+            raise
 
-        await response.write_eof()
         return response
 
     @routes.get("/api/job_agent/jobs/{job_or_submission_id}/logs/tail")

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -580,6 +580,7 @@ class JobHead(SubprocessModule):
                 status=aiohttp.web.HTTPBadRequest.status_code,
             )
 
+        response = None
         try:
             job_agent_client = self.get_job_driver_agent_client(job)
             if not job_agent_client:
@@ -596,22 +597,22 @@ class JobHead(SubprocessModule):
                 response.charset = "utf-8"
                 await response.prepare(req)
 
-                try:
-                    async for chunk in agent_response.content.iter_chunked(
-                        JOB_LOG_CHUNK_SIZE
-                    ):
-                        await response.write(chunk)
-                except asyncio.CancelledError:
-                    response.force_close()
-                    raise
-                except Exception:
-                    logger.exception("Error while streaming job logs")
-                    response.force_close()
-                    return response
-
+                async for chunk in agent_response.content.iter_chunked(
+                    JOB_LOG_CHUNK_SIZE
+                ):
+                    await response.write(chunk)
                 await response.write_eof()
                 return response
+        except asyncio.CancelledError:
+            if response is not None:
+                response.force_close()
+            raise
         except Exception:
+            if req.writer.output_size > 0:
+                logger.exception("Error while streaming job logs")
+                if response is not None:
+                    response.force_close()
+                raise
             return Response(
                 text=traceback.format_exc(),
                 status=aiohttp.web.HTTPInternalServerError.status_code,

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -121,6 +121,7 @@ class JobAgentSubmissionClient:
     ):
         self._agent_address = dashboard_agent_address
         self._session = aiohttp.ClientSession()
+        self._stream_session = aiohttp.ClientSession()
 
     def _get_headers(self):
         """Get auth headers if token authentication is enabled."""
@@ -186,13 +187,14 @@ class JobAgentSubmissionClient:
     async def stream_job_logs_internal(
         self, job_id: str
     ) -> AsyncIterator[ClientResponse]:
-        async with self._session.get(
+        async with self._stream_session.get(
             f"{self._agent_address}/api/job_agent/jobs/{job_id}/logs",
             headers=self._get_headers(),
             timeout=aiohttp.ClientTimeout(
                 total=None,
                 connect=30,
                 sock_connect=30,
+                sock_read=60,
             ),
         ) as resp:
             if resp.status != 200:
@@ -226,7 +228,10 @@ class JobAgentSubmissionClient:
 
     async def close(self, ignore_error=True):
         try:
-            await self._session.close()
+            await asyncio.gather(
+                self._session.close(),
+                self._stream_session.close(),
+            )
         except Exception:
             if not ignore_error:
                 raise

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -189,7 +189,11 @@ class JobAgentSubmissionClient:
         async with self._session.get(
             f"{self._agent_address}/api/job_agent/jobs/{job_id}/logs",
             headers=self._get_headers(),
-            timeout=aiohttp.ClientTimeout(total=None, sock_connect=30),
+            timeout=aiohttp.ClientTimeout(
+                total=None,
+                connect=30,
+                sock_connect=30,
+            ),
         ) as resp:
             if resp.status != 200:
                 await self._raise_error(resp)

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -608,10 +608,9 @@ class JobHead(SubprocessModule):
                 response.force_close()
             raise
         except Exception:
-            if req.writer.output_size > 0:
+            if response is not None and response.prepared:
                 logger.exception("Error while streaming job logs")
-                if response is not None:
-                    response.force_close()
+                response.force_close()
                 raise
             return Response(
                 text=traceback.format_exc(),

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -6,6 +6,7 @@ import logging
 import os
 import time
 import traceback
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import AsyncIterator, Dict, Optional, Tuple
 
@@ -43,6 +44,7 @@ from ray.dashboard.modules.job.common import (
     JobSubmitResponse,
     http_uri_components_to_uri,
 )
+from ray.dashboard.modules.job.job_log_storage_client import JOB_LOG_CHUNK_SIZE
 from ray.dashboard.modules.job.pydantic_models import JobDetails, JobType
 from ray.dashboard.modules.job.utils import (
     find_job_by_ids,
@@ -179,6 +181,18 @@ class JobAgentSubmissionClient:
                 return JobLogsResponse(**result_json)
             else:
                 await self._raise_error(resp)
+
+    @asynccontextmanager
+    async def stream_job_logs_internal(
+        self, job_id: str
+    ) -> AsyncIterator[ClientResponse]:
+        async with self._session.get(
+            f"{self._agent_address}/api/job_agent/jobs/{job_id}/logs",
+            headers=self._get_headers(),
+        ) as resp:
+            if resp.status != 200:
+                await self._raise_error(resp)
+            yield resp
 
     async def tail_job_logs(self, job_id: str) -> AsyncIterator[str]:
         """Get an iterator that follows the logs of a job."""
@@ -546,8 +560,8 @@ class JobHead(SubprocessModule):
             content_type="application/json",
         )
 
-    @routes.get("/api/jobs/{job_or_submission_id}/logs")
-    async def get_job_logs(self, req: Request) -> Response:
+    @routes.get("/api/jobs/{job_or_submission_id}/logs", resp_type=ResponseType.STREAM)
+    async def get_job_logs(self, req: Request) -> StreamResponse:
         job_or_submission_id = req.match_info["job_or_submission_id"]
         job = await find_job_by_ids(
             self.gcs_client,
@@ -568,15 +582,35 @@ class JobHead(SubprocessModule):
 
         try:
             job_agent_client = self.get_job_driver_agent_client(job)
-            payload = (
-                await job_agent_client.get_job_logs_internal(job.submission_id)
-                if job_agent_client
-                else JobLogsResponse("")
-            )
-            return Response(
-                text=json.dumps(dataclasses.asdict(payload)),
-                content_type="application/json",
-            )
+            if not job_agent_client:
+                return Response(
+                    text=json.dumps(dataclasses.asdict(JobLogsResponse(""))),
+                    content_type="application/json",
+                )
+
+            async with job_agent_client.stream_job_logs_internal(
+                job.submission_id
+            ) as agent_response:
+                response = StreamResponse()
+                response.content_type = "application/json"
+                response.charset = "utf-8"
+                await response.prepare(req)
+
+                try:
+                    async for chunk in agent_response.content.iter_chunked(
+                        JOB_LOG_CHUNK_SIZE
+                    ):
+                        await response.write(chunk)
+                except asyncio.CancelledError:
+                    response.force_close()
+                    raise
+                except Exception:
+                    logger.exception("Error while streaming job logs")
+                    response.force_close()
+                    return response
+
+                await response.write_eof()
+                return response
         except Exception:
             return Response(
                 text=traceback.format_exc(),

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -189,6 +189,7 @@ class JobAgentSubmissionClient:
         async with self._session.get(
             f"{self._agent_address}/api/job_agent/jobs/{job_id}/logs",
             headers=self._get_headers(),
+            timeout=aiohttp.ClientTimeout(total=None, sock_connect=30),
         ) as resp:
             if resp.status != 200:
                 await self._raise_error(resp)

--- a/python/ray/dashboard/modules/job/job_log_storage_client.py
+++ b/python/ray/dashboard/modules/job/job_log_storage_client.py
@@ -21,14 +21,24 @@ class JobLogStorageClient:
 
     def get_logs(self, job_id: str) -> str:
         try:
-            with open(self.get_log_file_path(job_id), "r") as f:
+            with open(
+                self.get_log_file_path(job_id),
+                "r",
+                encoding="utf-8",
+                errors="replace",
+            ) as f:
                 return f.read()
         except FileNotFoundError:
             return ""
 
     def get_log_chunks(self, job_id: str) -> Iterator[str]:
         try:
-            with open(self.get_log_file_path(job_id), "r") as f:
+            with open(
+                self.get_log_file_path(job_id),
+                "r",
+                encoding="utf-8",
+                errors="replace",
+            ) as f:
                 while chunk := f.read(JOB_LOG_CHUNK_SIZE):
                     yield chunk
         except FileNotFoundError:

--- a/python/ray/dashboard/modules/job/job_log_storage_client.py
+++ b/python/ray/dashboard/modules/job/job_log_storage_client.py
@@ -1,5 +1,5 @@
 import os
-from typing import AsyncIterator, Iterator, List, Tuple
+from typing import AsyncIterator, Generator, List, Tuple
 
 import ray
 from ray.dashboard.modules.job.common import JOB_LOGS_PATH_TEMPLATE
@@ -31,7 +31,7 @@ class JobLogStorageClient:
         except FileNotFoundError:
             return ""
 
-    def get_log_chunks(self, job_id: str) -> Iterator[str]:
+    def get_log_chunks(self, job_id: str) -> Generator[str, None, None]:
         try:
             with open(
                 self.get_log_file_path(job_id),

--- a/python/ray/dashboard/modules/job/job_log_storage_client.py
+++ b/python/ray/dashboard/modules/job/job_log_storage_client.py
@@ -1,9 +1,11 @@
 import os
-from typing import AsyncIterator, List, Tuple
+from typing import AsyncIterator, Iterator, List, Tuple
 
 import ray
 from ray.dashboard.modules.job.common import JOB_LOGS_PATH_TEMPLATE
 from ray.dashboard.modules.job.utils import fast_tail_last_n_lines, file_tail_iterator
+
+JOB_LOG_CHUNK_SIZE = 64 * 1024
 
 
 class JobLogStorageClient:
@@ -23,6 +25,14 @@ class JobLogStorageClient:
                 return f.read()
         except FileNotFoundError:
             return ""
+
+    def get_log_chunks(self, job_id: str) -> Iterator[str]:
+        try:
+            with open(self.get_log_file_path(job_id), "r") as f:
+                while chunk := f.read(JOB_LOG_CHUNK_SIZE):
+                    yield chunk
+        except FileNotFoundError:
+            return
 
     def tail_logs(self, job_id: str) -> AsyncIterator[List[str]]:
         return file_tail_iterator(self.get_log_file_path(job_id))

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -6,7 +6,7 @@ import random
 import string
 import time
 import traceback
-from typing import Any, AsyncIterator, Dict, Iterator, Optional, Union
+from typing import Any, AsyncIterator, Dict, Generator, Optional, Union
 
 import ray
 import ray._private.ray_constants as ray_constants
@@ -683,7 +683,7 @@ class JobManager:
         """Get all logs produced by a job."""
         return self._log_client.get_logs(job_id)
 
-    def get_job_log_chunks(self, job_id: str) -> Iterator[str]:
+    def get_job_log_chunks(self, job_id: str) -> Generator[str, None, None]:
         """Get logs produced by a job in bounded chunks."""
         return self._log_client.get_log_chunks(job_id)
 

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -6,7 +6,7 @@ import random
 import string
 import time
 import traceback
-from typing import Any, AsyncIterator, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, Iterator, Optional, Union
 
 import ray
 import ray._private.ray_constants as ray_constants
@@ -682,6 +682,10 @@ class JobManager:
     def get_job_logs(self, job_id: str) -> str:
         """Get all logs produced by a job."""
         return self._log_client.get_logs(job_id)
+
+    def get_job_log_chunks(self, job_id: str) -> Iterator[str]:
+        """Get logs produced by a job in bounded chunks."""
+        return self._log_client.get_log_chunks(job_id)
 
     async def tail_job_logs(self, job_id: str) -> AsyncIterator[str]:
         """Return an iterator following the logs of a job."""

--- a/python/ray/dashboard/modules/job/tests/test_job_agent.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_agent.py
@@ -74,6 +74,15 @@ class JobAgentSubmissionBrowserClient(JobAgentSubmissionClient):
         ] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"  # noqa: E501
 
 
+@pytest.mark.asyncio
+async def test_job_agent_submission_client_separates_stream_session():
+    client = JobAgentSubmissionClient("http://localhost")
+    try:
+        assert client._session.connector is not client._stream_session.connector
+    finally:
+        await client.close()
+
+
 @pytest_asyncio.fixture
 async def job_sdk_client(make_sure_dashboard_http_port_unused):
     with _ray_start(include_dashboard=True, num_cpus=1) as ctx:

--- a/python/ray/dashboard/modules/job/tests/test_job_log_storage_client.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_log_storage_client.py
@@ -1,0 +1,26 @@
+import json
+from unittest.mock import patch
+
+from ray.dashboard.modules.job.job_agent import _encode_log_chunk
+from ray.dashboard.modules.job.job_log_storage_client import (
+    JOB_LOG_CHUNK_SIZE,
+    JobLogStorageClient,
+)
+
+
+def test_get_log_chunks_are_bounded_and_json_encodable(tmp_path):
+    pattern = 'line\nquote: " backslash: \\ unicode: \u2603\n'
+    content = pattern * (2 * JOB_LOG_CHUNK_SIZE // len(pattern) + 1)
+    log_path = tmp_path / "job.log"
+    log_path.write_text(content)
+    client = JobLogStorageClient()
+
+    with patch.object(client, "get_log_file_path", return_value=log_path):
+        chunks = list(client.get_log_chunks("job"))
+
+    assert "".join(chunks) == content
+    assert len(chunks) == 3
+    assert all(len(chunk) <= JOB_LOG_CHUNK_SIZE for chunk in chunks)
+
+    response = b'{"logs":"' + b"".join(map(_encode_log_chunk, chunks)) + b'"}'
+    assert json.loads(response)["logs"] == content

--- a/python/ray/dashboard/modules/job/tests/test_job_log_storage_client.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_log_storage_client.py
@@ -1,5 +1,8 @@
 import json
+import sys
 from unittest.mock import patch
+
+import pytest
 
 from ray.dashboard.modules.job.job_agent import _encode_log_chunk
 from ray.dashboard.modules.job.job_log_storage_client import (
@@ -12,7 +15,7 @@ def test_get_log_chunks_are_bounded_and_json_encodable(tmp_path):
     pattern = 'line\nquote: " backslash: \\ unicode: \u2603\n'
     content = pattern * (2 * JOB_LOG_CHUNK_SIZE // len(pattern) + 1)
     log_path = tmp_path / "job.log"
-    log_path.write_text(content)
+    log_path.write_text(content, encoding="utf-8")
     client = JobLogStorageClient()
 
     with patch.object(client, "get_log_file_path", return_value=log_path):
@@ -24,3 +27,19 @@ def test_get_log_chunks_are_bounded_and_json_encodable(tmp_path):
 
     response = b'{"logs":"' + b"".join(map(_encode_log_chunk, chunks)) + b'"}'
     assert json.loads(response)["logs"] == content
+
+
+def test_get_logs_replace_invalid_utf8(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_bytes(b"before\xffafter")
+    client = JobLogStorageClient()
+
+    with patch.object(client, "get_log_file_path", return_value=log_path):
+        logs = client.get_logs("job")
+        chunks = list(client.get_log_chunks("job"))
+
+    assert logs == "".join(chunks) == "before\ufffdafter"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -244,7 +244,7 @@ def init_ray_and_catch_exceptions() -> Callable:
                         raise e from None
                 return await f(self, *args, **kwargs)
             except Exception as e:
-                if is_response_started(args[-1]):
+                if is_response_started(args[-1] if args else None):
                     raise
                 logger.exception(f"Unexpected error in handler: {e}")
                 return Response(

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -27,7 +27,11 @@ from ray._raylet import RAY_INTERNAL_DASHBOARD_NAMESPACE
 # installation must be included in this file. This allows us to determine if
 # the agent has the necessary dependencies to be started.
 from ray.dashboard.optional_deps import aiohttp, hdrs
-from ray.dashboard.routes import method_route_table_factory, rest_response
+from ray.dashboard.routes import (
+    is_response_started,
+    method_route_table_factory,
+    rest_response,
+)
 from ray.dashboard.utils import (
     DashboardAgentModule,
     DashboardHeadModule,
@@ -240,8 +244,7 @@ def init_ray_and_catch_exceptions() -> Callable:
                         raise e from None
                 return await f(self, *args, **kwargs)
             except Exception as e:
-                request = args[-1]
-                if request.writer.output_size > 0:
+                if is_response_started(args[-1]):
                     raise
                 logger.exception(f"Unexpected error in handler: {e}")
                 return Response(

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -240,6 +240,9 @@ def init_ray_and_catch_exceptions() -> Callable:
                         raise e from None
                 return await f(self, *args, **kwargs)
             except Exception as e:
+                request = args[-1]
+                if request.writer.output_size > 0:
+                    raise
                 logger.exception(f"Unexpected error in handler: {e}")
                 return Response(
                     text=traceback.format_exc(),

--- a/python/ray/dashboard/routes.py
+++ b/python/ray/dashboard/routes.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import traceback
-from typing import Any
+from typing import Any, Optional
 
 from ray.dashboard.optional_deps import PathLike, RouteDef, aiohttp, hdrs
 from ray.dashboard.utils import CustomEncoder, HTTPStatusCode, to_google_style
@@ -14,9 +14,10 @@ from ray.dashboard.utils import CustomEncoder, HTTPStatusCode, to_google_style
 logger = logging.getLogger(__name__)
 
 
-def is_response_started(request: aiohttp.web.Request) -> bool:
+def is_response_started(request: Optional[aiohttp.web.Request]) -> bool:
     """Return whether response bytes have been sent when no response object is held."""
-    return request.writer.output_size > 0
+    writer = getattr(request, "writer", None)
+    return getattr(writer, "output_size", 0) > 0
 
 
 class BaseRouteTable(abc.ABC):
@@ -147,7 +148,7 @@ def method_route_table_factory():
                         req = args[-1]
                         return await handler(bind_info.instance, req)
                     except Exception:
-                        if is_response_started(args[-1]):
+                        if is_response_started(args[-1] if args else None):
                             raise
                         logger.exception("Handle %s %s failed.", method, path)
                         return rest_response(

--- a/python/ray/dashboard/routes.py
+++ b/python/ray/dashboard/routes.py
@@ -14,6 +14,11 @@ from ray.dashboard.utils import CustomEncoder, HTTPStatusCode, to_google_style
 logger = logging.getLogger(__name__)
 
 
+def is_response_started(request: aiohttp.web.Request) -> bool:
+    """Return whether response bytes have been sent when no response object is held."""
+    return request.writer.output_size > 0
+
+
 class BaseRouteTable(abc.ABC):
     """A base class to bind http route to a target instance. Subclass should implement
     the _register_route method. It should define how the handler interacts with
@@ -142,6 +147,8 @@ def method_route_table_factory():
                         req = args[-1]
                         return await handler(bind_info.instance, req)
                     except Exception:
+                        if is_response_started(args[-1]):
+                            raise
                         logger.exception("Handle %s %s failed.", method, path)
                         return rest_response(
                             status_code=HTTPStatusCode.INTERNAL_ERROR,

--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -331,7 +331,11 @@ class SubprocessModuleHandle:
             url,
             data=body,
             headers=filter_hop_by_hop_headers(request.headers),
-            timeout=aiohttp.ClientTimeout(total=None, sock_connect=30),
+            timeout=aiohttp.ClientTimeout(
+                total=None,
+                connect=30,
+                sock_connect=30,
+            ),
         ) as backend_resp:
             proxy_resp = aiohttp.web.StreamResponse(
                 status=backend_resp.status,

--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -331,6 +331,7 @@ class SubprocessModuleHandle:
             url,
             data=body,
             headers=filter_hop_by_hop_headers(request.headers),
+            timeout=aiohttp.ClientTimeout(total=None, sock_connect=30),
         ) as backend_resp:
             proxy_resp = aiohttp.web.StreamResponse(
                 status=backend_resp.status,

--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -103,6 +103,7 @@ class SubprocessModuleHandle:
         self.parent_conn = None
         self.process = None
         self.http_client_session: Optional[aiohttp.ClientSession] = None
+        self.stream_http_client_session: Optional[aiohttp.ClientSession] = None
         self.health_check_task = None
 
     def str_for_state(self, incarnation: int, pid: Optional[int]):
@@ -157,6 +158,9 @@ class SubprocessModuleHandle:
 
         module_name = self.module_cls.__name__
         self.http_client_session = get_http_session_to_module(
+            module_name, self.config.socket_dir, self.config.session_name
+        )
+        self.stream_http_client_session = get_http_session_to_module(
             module_name, self.config.socket_dir, self.config.session_name
         )
 
@@ -226,6 +230,9 @@ class SubprocessModuleHandle:
         if self.http_client_session:
             await self.http_client_session.close()
             self.http_client_session = None
+        if self.stream_http_client_session:
+            await self.stream_http_client_session.close()
+            self.stream_http_client_session = None
 
     async def _health_check(self) -> aiohttp.web.Response:
         """
@@ -326,7 +333,7 @@ class SubprocessModuleHandle:
         """
         url = f"http://localhost{request.path_qs}"
         body = await request.read()
-        async with self.http_client_session.request(
+        async with self.stream_http_client_session.request(
             request.method,
             url,
             data=body,

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -104,9 +104,16 @@ async def test_handle_can_health_check(default_module_config):
     subprocess_handle = SubprocessModuleHandle(loop, TestModule, default_module_config)
     subprocess_handle.start_module()
     subprocess_handle.wait_for_module_ready()
-    response = await subprocess_handle._health_check()
-    assert response.status == 200
-    assert response.body == b"success"
+    try:
+        assert (
+            subprocess_handle.http_client_session.connector
+            is not subprocess_handle.stream_http_client_session.connector
+        )
+        response = await subprocess_handle._health_check()
+        assert response.status == 200
+        assert response.body == b"success"
+    finally:
+        await subprocess_handle.destroy_module()
 
 
 @pytest.mark.asyncio
@@ -119,11 +126,13 @@ async def test_destroy_module_cleans_up_resources(default_module_config, monkeyp
     parent_conn = _DummyConn()
     process = _DummyProcess(alive=True)
     http_session = _DummySession()
+    stream_http_session = _DummySession()
     health_task = asyncio.create_task(asyncio.sleep(1000))
 
     handle.parent_conn = parent_conn
     handle.process = process
     handle.http_client_session = http_session
+    handle.stream_http_client_session = stream_http_session
     handle.health_check_task = health_task
 
     await handle.destroy_module()
@@ -138,9 +147,11 @@ async def test_destroy_module_cleans_up_resources(default_module_config, monkeyp
     assert not process.kill_called
     assert handle.process is None
 
-    # HTTP client session is closed and cleared.
+    # HTTP client sessions are closed and cleared.
     assert http_session.closed
     assert handle.http_client_session is None
+    assert stream_http_session.closed
+    assert handle.stream_http_client_session is None
 
     # Health check task is cancelled and cleared.
     # Note: destroy_module() may call cancel() without awaiting the task, so the

--- a/python/ray/dashboard/tests/test_utils.py
+++ b/python/ray/dashboard/tests/test_utils.py
@@ -8,6 +8,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from aiohttp.web import Application, StreamResponse
 
 from ray.dashboard.optional_utils import init_ray_and_catch_exceptions
+from ray.dashboard.routes import method_route_table_factory
 from ray.dashboard.utils import close_logger_file_descriptor
 
 
@@ -27,12 +28,16 @@ def test_close_logger_file_descriptor():
 
 
 @pytest.mark.asyncio
-async def test_init_ray_decorator_does_not_replace_started_response():
+async def test_route_wrappers_do_not_replace_started_response():
+    routes = method_route_table_factory()
+
     class Handler:
+        @routes.get("/before")
         @init_ray_and_catch_exceptions()
         async def fail_before_prepare(self, request):
             raise RuntimeError("test error")
 
+        @routes.get("/after")
         @init_ray_and_catch_exceptions()
         async def fail_after_prepare(self, request):
             response = StreamResponse()
@@ -43,8 +48,8 @@ async def test_init_ray_decorator_does_not_replace_started_response():
 
     app = Application()
     handler = Handler()
-    app.router.add_get("/before", handler.fail_before_prepare)
-    app.router.add_get("/after", handler.fail_after_prepare)
+    routes.bind(handler)
+    app.add_routes(routes.bound_routes())
 
     with patch("ray.dashboard.optional_utils.ray.is_initialized", return_value=True):
         async with TestClient(TestServer(app)) as client:

--- a/python/ray/dashboard/tests/test_utils.py
+++ b/python/ray/dashboard/tests/test_utils.py
@@ -1,8 +1,13 @@
 import logging
 import sys
+from unittest.mock import patch
 
+import aiohttp
 import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.web import Application, StreamResponse
 
+from ray.dashboard.optional_utils import init_ray_and_catch_exceptions
 from ray.dashboard.utils import close_logger_file_descriptor
 
 
@@ -19,6 +24,37 @@ def test_close_logger_file_descriptor():
     assert job_driver_handler.stream.closed is False
     close_logger_file_descriptor(logger)
     assert job_driver_handler.stream is None
+
+
+@pytest.mark.asyncio
+async def test_init_ray_decorator_does_not_replace_started_response():
+    class Handler:
+        @init_ray_and_catch_exceptions()
+        async def fail_before_prepare(self, request):
+            raise RuntimeError("test error")
+
+        @init_ray_and_catch_exceptions()
+        async def fail_after_prepare(self, request):
+            response = StreamResponse()
+            await response.prepare(request)
+            await response.write(b"partial")
+            response.force_close()
+            raise RuntimeError("test error")
+
+    app = Application()
+    handler = Handler()
+    app.router.add_get("/before", handler.fail_before_prepare)
+    app.router.add_get("/after", handler.fail_after_prepare)
+
+    with patch("ray.dashboard.optional_utils.ray.is_initialized", return_value=True):
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get("/before")
+            assert response.status == 500
+
+            response = await client.get("/after")
+            assert response.status == 200
+            with pytest.raises(aiohttp.ClientPayloadError):
+                await response.read()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`GET /api/jobs/{job_or_submission_id}/logs` currently materializes the full driver log at each dashboard hop. Large or concurrent requests can exhaust dashboard memory.

This change:

- reads driver logs in 64 KiB chunks
- JSON-escapes chunks incrementally
- streams the response through JobAgent, JobHead, and the parent dashboard proxy with backpressure
- isolates streaming traffic from regular request pools, keeps total stream duration unlimited, and bounds connection/read waits
- preserves the existing `{"logs": string}` response and `JobSubmissionClient.get_job_logs()` behavior

The SDK still returns one complete string, so client memory remains proportional to returned log size.

## Related issues

Fixes #28336.

No open PR implements request-time streaming. #61537 was closed and truncated large responses. #65006 rotates logs on disk, which is complementary.

## Additional information

Testing:

- `.venv/bin/pytest -q python/ray/dashboard/modules/job/tests/test_job_log_storage_client.py python/ray/dashboard/tests/test_utils.py`: 4 passed
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/pytest -q python/ray/dashboard/modules/job/tests/test_http_job_server.py::test_submit_job_with_exception_in_driver python/ray/dashboard/modules/job/tests/test_http_job_server.py::test_missing_resources`: 2 passed
- focused `JobAgentSubmissionClient` session isolation test: 1 passed
- focused subprocess session lifecycle, HTTP proxy, and stream proxy tests: 4 passed
- `pre-commit run --files <changed files>`: passed
- `npm run build` in `python/ray/dashboard/client`: passed
- Local Ray head and Jobs CLI/API smoke with an 8.39 MiB log: complete output, valid JSON, chunked transfer, healthy dashboard
- Three concurrent throttled full-log requests: complete valid JSON and bounded server RSS growth

AI assistance was used. I reviewed every changed line and ran the tests above locally.