### PR TITLE
[Data] Bump the `sort_reduce` memory multipler to 3x

### DIFF
--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
@@ -83,6 +83,8 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
         map_runtime_env: Optional runtime_env for map tasks; useful to
             isolate map workers from other ops.
         map_cpus: CPU request per map task.
+        peak_memory_multiplier: Multiplier applied to a task's input bytes to
+            derive its memory request.
         name: Display name shown in progress bars and logs.
     """
 
@@ -100,6 +102,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
         pre_map_merge_threshold: int = _DEFAULT_PRE_MAP_MERGE_THRESHOLD,
         map_runtime_env: Optional[Dict[str, Any]] = None,
         map_cpus: float = _DEFAULT_SHUFFLE_MAP_TASK_NUM_CPUS,
+        peak_memory_multiplier: float = SHUFFLE_PEAK_MEMORY_MULTIPLIER,
         name: str = "ShuffleMap",
     ):
         super().__init__(
@@ -115,6 +118,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
         # -- Map task config -------------------------------------------------
         self._shuffle_map_task_num_cpus: float = map_cpus
         self._map_runtime_env: Optional[Dict[str, Any]] = map_runtime_env
+        self._peak_memory_multiplier: float = peak_memory_multiplier
 
         # -- Pre-map merge ---------------------------------------------------
         self._pre_map_merge_threshold: int = pre_map_merge_threshold
@@ -222,7 +226,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
 
         resources: Dict[str, Any] = {"num_cpus": self._shuffle_map_task_num_cpus}
         if estimated_bytes > 0:
-            resources["memory"] = estimated_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER
+            resources["memory"] = estimated_bytes * self._peak_memory_multiplier
 
         ray_options: Dict[str, Any] = {
             **resources,
@@ -435,7 +439,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
 
     def incremental_resource_usage(self) -> ExecutionResources:
         avg_input = self._metrics.average_bytes_inputs_per_task
-        memory = int(avg_input * SHUFFLE_PEAK_MEMORY_MULTIPLIER) if avg_input else 0
+        memory = int(avg_input * self._peak_memory_multiplier) if avg_input else 0
         return ExecutionResources(
             cpu=self._shuffle_map_task_num_cpus,
             memory=memory,

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
@@ -226,7 +226,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
 
         resources: Dict[str, Any] = {"num_cpus": self._shuffle_map_task_num_cpus}
         if estimated_bytes > 0:
-            resources["memory"] = estimated_bytes * self._peak_memory_multiplier
+            resources["memory"] = int(estimated_bytes * self._peak_memory_multiplier)
 
         ray_options: Dict[str, Any] = {
             **resources,

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -69,6 +69,11 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         disallow_block_splitting: If True, output blocks are emitted as-is
             without being reshaped to `target_max_block_size`.
         reduce_ray_remote_args: Remote args for the reducer tasks.
+        peak_memory_multiplier: Multiplier applied to a partition's shard
+            bytes to derive each reduce task's memory request.  Raise for
+            reduce fns whose peak memory exceeds 2x their input (e.g. a
+            sorting reduce that materializes a sorted copy on top of the
+            concatenated input).
         name: Display name shown in progress bars and logs.
         should_emit_empty_partitions: If True (default), an empty partition emits one
             schema-only placeholder block.
@@ -93,6 +98,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         reduce_fn: ReduceFn,
         disallow_block_splitting: bool = False,
         reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
+        peak_memory_multiplier: float = SHUFFLE_PEAK_MEMORY_MULTIPLIER,
         name: str = "ShuffleReduce",
         should_emit_empty_partitions: bool = True,
         fused_output_map_transformer: Optional["MapTransformer"] = None,
@@ -114,6 +120,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         self._reduce_fn: ReduceFn = reduce_fn
         self._disallow_block_splitting: bool = disallow_block_splitting
         self._emit_empty_partitions: bool = should_emit_empty_partitions
+        self._peak_memory_multiplier: float = peak_memory_multiplier
 
         # -- Reduce task config & tracking -----------------------------------
         self._reduce_ray_remote_args: Dict[str, Any] = dict(
@@ -234,7 +241,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             estimated_bytes += sum((m.size_bytes or 0) for m in bundle.metadata)
 
         reduce_options = self._reduce_task_remote_args(
-            int(estimated_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
+            int(estimated_bytes * self._peak_memory_multiplier)
             if estimated_bytes > 0
             else 0
         )
@@ -445,7 +452,7 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             sizes = [b for b in upstream.get_partition_bytes().values() if b > 0]
             if sizes:
                 avg_bytes = sum(sizes) / len(sizes)
-                memory += int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
+                memory += int(avg_bytes * self._peak_memory_multiplier)
         return ExecutionResources.from_resource_dict(
             self._reduce_task_remote_args(memory)
         )

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -390,6 +390,8 @@ class FuseOperators(Rule):
             reduce_fn=up_op._reduce_fn,
             disallow_block_splitting=up_op._disallow_block_splitting,
             reduce_ray_remote_args=up_op._reduce_ray_remote_args,
+            peak_memory_multiplier=up_op._peak_memory_multiplier,
+            should_emit_empty_partitions=up_op._emit_empty_partitions,
             name=name,
             fused_output_map_transformer=down_op.get_map_transformer(),
             fused_output_map_task_kwargs=down_op.get_map_task_kwargs(),

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -21,6 +21,9 @@ from ray.data._internal.execution.operators.shuffle_operators.shuffle_map_operat
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_reduce_operator import (  # noqa: E501
     ShuffleReduceOp,
 )
+from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks import (
+    SHUFFLE_PEAK_MEMORY_MULTIPLIER,
+)
 from ray.data._internal.logical.operators import (
     AbstractAllToAll,
     Aggregate,
@@ -37,6 +40,14 @@ from ray.data._internal.planner.sort import generate_sort_fn
 from ray.data.context import DataContext, ShuffleStrategy
 
 logger = logging.getLogger(__name__)
+
+
+# A sorting reduce (`_sort_reduce`, used by repartition(sort=True) and thus
+# map_groups) peaks at ~3x its input: on top of holding the decoded input
+# shards and the concatenated table, sort_by materializes a sorted copy.
+# The generic 2x shuffle estimate under-requests it, overpacking reducers
+# per node and risking OOM kills.
+_SORT_REDUCE_PEAK_MEMORY_MULTIPLIER = 3
 
 
 def _plan_gpu_shuffle_repartition(
@@ -87,6 +98,11 @@ def _plan_hash_shuffle_repartition_v2(
 
     partition_fn = _make_hash_partition_fn(key_list, target_num_partitions)
     reduce_fn = _sort_reduce(key_list) if logical_op.sort else _concat_reduce
+    peak_memory_multiplier = (
+        _SORT_REDUCE_PEAK_MEMORY_MULTIPLIER
+        if logical_op.sort
+        else SHUFFLE_PEAK_MEMORY_MULTIPLIER
+    )
 
     map_op = ShuffleMapOp(
         input_physical_op,
@@ -105,6 +121,7 @@ def _plan_hash_shuffle_repartition_v2(
         num_partitions=target_num_partitions,
         reduce_fn=reduce_fn,
         disallow_block_splitting=True,
+        peak_memory_multiplier=peak_memory_multiplier,
         name=(
             f"HashShuffleReduce(keys={tuple(key_list)}, "
             f"partitions={target_num_partitions})"

--- a/python/ray/data/tests/test_hash_shuffle_v2.py
+++ b/python/ray/data/tests/test_hash_shuffle_v2.py
@@ -14,6 +14,7 @@ from ray.data._internal.execution.operators.shuffle_operators.shuffle_reduce_ope
     ShuffleReduceOp,
 )
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks import (
+    SHUFFLE_PEAK_MEMORY_MULTIPLIER,
     _encode_partition_ipc,
     _get_shard_batch,
     _ipc_write_options,
@@ -175,6 +176,26 @@ def test_repartition_with_sort_produces_sorted_partitions(
         for block_ref in ref_bundle.block_refs:
             ids = ray.get(block_ref)["id"].to_pylist()
             assert ids == sorted(ids)
+
+
+def test_sort_reduce_uses_higher_multiplier(ray_start_regular_shared_2_cpus):
+    """Sorted reduces request 3x their input (sort_by materializes a sorted
+    copy on top of the concatenated shards); plain concat reduces keep the
+    2x default."""
+    from ray.data._internal.logical.optimizers import get_execution_plan
+
+    sorted_dag = get_execution_plan(
+        ray.data.range(10).repartition(2, keys=["id"], sort=True)._logical_plan
+    )[0].dag
+    assert sorted_dag._peak_memory_multiplier == 3
+    # The multiplier drives the reduce task's memory request.
+    sorted_dag.input_dependencies[0]._partition_bytes[0] = 100
+    assert sorted_dag.incremental_resource_usage().memory == 300
+
+    plain_dag = get_execution_plan(
+        ray.data.range(10).repartition(2, keys=["id"])._logical_plan
+    )[0].dag
+    assert plain_dag._peak_memory_multiplier == SHUFFLE_PEAK_MEMORY_MULTIPLIER
 
 
 def test_get_shard_batch_no_timeout(ray_start_regular_shared_2_cpus):

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -574,6 +574,32 @@ def test_fuse_map_into_shuffle_reduce(
     assert sorted(extract_values("id", ds.take_all())) == list(range(100))
 
 
+def test_fused_shuffle_reduce_preserves_operator_config(
+    ray_start_regular_shared_2_cpus, restore_data_context
+):
+    """Fusing a map into ShuffleReduceOp must carry over operator-level config.
+
+    Regression test: the fusion rule rebuilds the reduce op, and used to drop
+    peak_memory_multiplier (resetting the sorted reduce's 3x memory request
+    back to the 2x default) and should_emit_empty_partitions.
+    """
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+
+    ds = (
+        ray.data.range(100)
+        .repartition(4, keys=["id"], sort=True)
+        .map_batches(lambda b: b)
+    )
+    dag = get_execution_plan(ds._logical_plan)[0].dag
+
+    assert dag.name == (
+        "HashShuffleReduce(keys=('id',), partitions=4)->MapBatches(<lambda>)"
+    )
+    assert dag._fused_output_map_transformer is not None
+    assert dag._peak_memory_multiplier == 3
+
+
 def test_map_not_fused_into_shuffle_reduce_with_downstream_limit(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):


### PR DESCRIPTION
## Description
There is an extra sort for the `sort_reduce`part so we should make its memory resource 3x not 2x, we overlooked that before and this could leadsto `map_groups` OOM because `map_groups` convert to `repartition(sort=True)` internally.
https://github.com/ray-project/ray/blob/6711f9f3f4ed24af5c0ddfa6dc4f533bd35fc328/python/ray/data/grouped_data.py#L234-L239

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
