### PR TITLE
[ci] Stop long-running many-task tests after 22h instead of job timeout

### DIFF
--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -1,5 +1,6 @@
 # This workload tests repeatedly killing actors and submitting tasks to them.
 import numpy as np
+import os
 import sys
 import time
 
@@ -88,6 +89,9 @@ class Parent(object):
 
 parents = [Parent.remote(num_children, death_probability) for _ in range(num_parents)]
 
+# Stop before the 24h job timeout so the test exits cleanly as success.
+MAX_RUNTIME_S = int(os.environ.get("MAX_RUNTIME_S", 22 * 60 * 60))
+
 iteration = 0
 start_time = time.time()
 previous_time = start_time
@@ -120,3 +124,6 @@ while True:
     )
     previous_time = new_time
     iteration += 1
+    if new_time - start_time > MAX_RUNTIME_S:
+        print(f"Reached max runtime of {MAX_RUNTIME_S}s. Exiting successfully.")
+        break

--- a/release/long_running_tests/workloads/many_actor_tasks.py
+++ b/release/long_running_tests/workloads/many_actor_tasks.py
@@ -1,4 +1,5 @@
 # This workload tests submitting many actor methods.
+import os
 import time
 
 import numpy as np
@@ -56,6 +57,9 @@ actors = [
     for i in range(num_nodes * 5)
 ]
 
+# Stop before the 24h job timeout so the test exits cleanly as success.
+MAX_RUNTIME_S = int(os.environ.get("MAX_RUNTIME_S", 22 * 60 * 60))
+
 iteration = 0
 start_time = time.time()
 previous_time = start_time
@@ -84,3 +88,6 @@ while True:
     )
     previous_time = new_time
     iteration += 1
+    if new_time - start_time > MAX_RUNTIME_S:
+        print(f"Reached max runtime of {MAX_RUNTIME_S}s. Exiting successfully.")
+        break

--- a/release/long_running_tests/workloads/many_tasks.py
+++ b/release/long_running_tests/workloads/many_tasks.py
@@ -1,4 +1,5 @@
 # This workload tests submitting and getting many tasks over and over.
+import os
 import time
 
 import numpy as np
@@ -46,6 +47,9 @@ def f(*xs):
     return np.zeros(1024, dtype=np.uint8)
 
 
+# Stop before the 24h job timeout so the test exits cleanly as success.
+MAX_RUNTIME_S = int(os.environ.get("MAX_RUNTIME_S", 22 * 60 * 60))
+
 iteration = 0
 ids = []
 start_time = time.time()
@@ -79,3 +83,6 @@ while True:
     )
     previous_time = new_time
     iteration += 1
+    if new_time - start_time > MAX_RUNTIME_S:
+        print(f"Reached max runtime of {MAX_RUNTIME_S}s. Exiting successfully.")
+        break

--- a/release/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/release/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -1,5 +1,6 @@
 # This workload stresses distributed reference counting by passing and
 # returning serialized ObjectRefs.
+import os
 import time
 import random
 
@@ -62,6 +63,9 @@ def f(*xs):
         return child.remote(*xs)
 
 
+# Stop before the 24h job timeout so the test exits cleanly as success.
+MAX_RUNTIME_S = int(os.environ.get("MAX_RUNTIME_S", 22 * 60 * 60))
+
 iteration = 0
 ids = []
 start_time = time.time()
@@ -107,3 +111,6 @@ while True:
             "elapsed_time": new_time - start_time,
         }
     )
+    if new_time - start_time > MAX_RUNTIME_S:
+        print(f"Reached max runtime of {MAX_RUNTIME_S}s. Exiting successfully.")
+        break

--- a/release/long_running_tests/workloads/node_failures.py
+++ b/release/long_running_tests/workloads/node_failures.py
@@ -1,4 +1,5 @@
 # This workload tests repeatedly killing a node and adding a new node.
+import os
 import time
 
 import ray
@@ -44,6 +45,9 @@ def f(*xs):
     return 1
 
 
+# Stop before the 24h job timeout so the test exits cleanly as success.
+MAX_RUNTIME_S = int(os.environ.get("MAX_RUNTIME_S", 22 * 60 * 60))
+
 iteration = 0
 previous_ids = [1 for _ in range(100)]
 start_time = time.time()
@@ -81,3 +85,6 @@ while True:
     )
     previous_time = new_time
     iteration += 1
+    if new_time - start_time > MAX_RUNTIME_S:
+        print(f"Reached max runtime of {MAX_RUNTIME_S}s. Exiting successfully.")
+        break

--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -1,3 +1,4 @@
+import os
 import re
 import time
 import subprocess
@@ -76,6 +77,10 @@ print(f"num_connections: {NUM_CONNECTIONS}")
 print(f"num_threads: {NUM_THREADS}")
 print(f"time_per_cycle: {TIME_PER_CYCLE}")
 
+# Stop before the 24h job timeout so the test exits cleanly as success.
+MAX_RUNTIME_S = int(os.environ.get("MAX_RUNTIME_S", 22 * 60 * 60))
+start_time = time.time()
+
 while True:
     proc = subprocess.Popen(
         [
@@ -134,3 +139,6 @@ while True:
     print(err.decode())
 
     update_progress(metrics_dict)
+    if time.time() - start_time > MAX_RUNTIME_S:
+        print(f"Reached max runtime of {MAX_RUNTIME_S}s. Exiting successfully.")
+        break


### PR DESCRIPTION
## Description

Several long-running release tests (many_tasks, many_tasks_serialized_ids, many_actor_tasks, actor_deaths, node_failures, serve) loop indefinitely until the 24h job timeout kills them and marks them as failures. Their actual runtime can be cut shorter, like 23.5 hours.

So they can produce noisy false failure alerts. This PR makes these workloads exit successfully after 22h by default, with the limit overridable via MAX_RUNTIME_S.
