### PR TITLE
[core][TPU] Use POSIX paths for VFIO sysfs vendor checks on windows

### DIFF
--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -104,9 +104,15 @@ def test_autodetect_num_tpus_vfio_mixed_groups(mock_list, mock_glob):
         "/sys/kernel/iommu_groups/10/devices": ["0000:01:00.0"],
         "/sys/kernel/iommu_groups/96/devices": ["0016:03:00.2"],
     }
+    # Build keys with os.path.join so they match production path construction
+    # on both POSIX and Windows (where join inserts backslashes).
     vendor_results = {
-        "/sys/kernel/iommu_groups/10/devices/0000:01:00.0/vendor": "0x1ae0\n",
-        "/sys/kernel/iommu_groups/96/devices/0016:03:00.2/vendor": "0x15b3\n",
+        os.path.join(
+            "/sys/kernel/iommu_groups/10/devices", "0000:01:00.0", "vendor"
+        ): "0x1ae0\n",
+        os.path.join(
+            "/sys/kernel/iommu_groups/96/devices", "0016:03:00.2", "vendor"
+        ): "0x15b3\n",
     }
 
     def fake_listdir(path):


### PR DESCRIPTION

## Description
Fix the test_tpu.py on windows 

```

[2026-08-03T18:43:13Z] ================================== FAILURES ===================================
--
  | [2026-08-03T18:43:13Z] _________________ test_autodetect_num_tpus_vfio_mixed_groups __________________
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] path = '/sys/kernel/iommu_groups/10/devices\\0000:01:00.0\\vendor', args = ()
  | [2026-08-03T18:43:13Z] kwargs = {'encoding': 'ascii'}
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z]     def fake_open(path, *args, **kwargs):
  | [2026-08-03T18:43:13Z]         try:
  | [2026-08-03T18:43:13Z] >           return mock.mock_open(read_data=vendor_results[path])()
  | [2026-08-03T18:43:13Z] E           KeyError: '/sys/kernel/iommu_groups/10/devices\\0000:01:00.0\\vendor'
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] python\ray\tests\accelerators\test_tpu.py:120: KeyError
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] During handling of the above exception, another exception occurred:
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] mock_list = <MagicMock name='listdir' id='2259299081216'>
  | [2026-08-03T18:43:13Z] mock_glob = <MagicMock name='glob' id='2259298850976'>
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z]     @patch("glob.glob")
  | [2026-08-03T18:43:13Z]     @patch("os.listdir")
  | [2026-08-03T18:43:13Z]     def test_autodetect_num_tpus_vfio_mixed_groups(mock_list, mock_glob):
  | [2026-08-03T18:43:13Z]         # Two VFIO groups: one is a Google TPU (vendor 0x1ae0), the other is the
  | [2026-08-03T18:43:13Z]         # BlueField-3 SoC (vendor 0x15b3). Only the TPU-backed group is counted.
  | [2026-08-03T18:43:13Z]         mock_glob.return_value = []
  | [2026-08-03T18:43:13Z]         listdir_results = {
  | [2026-08-03T18:43:13Z]             "/dev/vfio": ["vfio", "10", "96"],
  | [2026-08-03T18:43:13Z]             "/sys/kernel/iommu_groups/10/devices": ["0000:01:00.0"],
  | [2026-08-03T18:43:13Z]             "/sys/kernel/iommu_groups/96/devices": ["0016:03:00.2"],
  | [2026-08-03T18:43:13Z]         }
  | [2026-08-03T18:43:13Z]         vendor_results = {
  | [2026-08-03T18:43:13Z]             "/sys/kernel/iommu_groups/10/devices/0000:01:00.0/vendor": "0x1ae0\n",
  | [2026-08-03T18:43:13Z]             "/sys/kernel/iommu_groups/96/devices/0016:03:00.2/vendor": "0x15b3\n",
  | [2026-08-03T18:43:13Z]         }
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z]         def fake_listdir(path):
  | [2026-08-03T18:43:13Z]             try:
  | [2026-08-03T18:43:13Z]                 return listdir_results[path]
  | [2026-08-03T18:43:13Z]             except KeyError:
  | [2026-08-03T18:43:13Z]                 raise AssertionError(f"unexpected listdir: {path}")
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z]         def fake_open(path, *args, **kwargs):
  | [2026-08-03T18:43:13Z]             try:
  | [2026-08-03T18:43:13Z]                 return mock.mock_open(read_data=vendor_results[path])()
  | [2026-08-03T18:43:13Z]             except KeyError:
  | [2026-08-03T18:43:13Z]                 raise AssertionError(f"unexpected open: {path}")
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z]         mock_list.side_effect = fake_listdir
  | [2026-08-03T18:43:13Z]         with patch("builtins.open", side_effect=fake_open):
  | [2026-08-03T18:43:13Z]             TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
  | [2026-08-03T18:43:13Z] >           assert TPUAcceleratorManager.get_current_node_num_accelerators() == 1
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] python\ray\tests\accelerators\test_tpu.py:127:
  | [2026-08-03T18:43:13Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2026-08-03T18:43:13Z] C:\rayci\python\ray\_private\accelerators\tpu.py:678: in get_current_node_num_accelerators
  | [2026-08-03T18:43:13Z]     if _is_vfio_group_a_tpu(group):
  | [2026-08-03T18:43:13Z] C:\rayci\python\ray\_private\accelerators\tpu.py:601: in _is_vfio_group_a_tpu
  | [2026-08-03T18:43:13Z]     with open(vendor_path, encoding="ascii") as f:
  | [2026-08-03T18:43:13Z] C:\Miniconda3\lib\unittest\mock.py:1114: in __call__
  | [2026-08-03T18:43:13Z]     return self._mock_call(*args, **kwargs)
  | [2026-08-03T18:43:13Z] C:\Miniconda3\lib\unittest\mock.py:1118: in _mock_call
  | [2026-08-03T18:43:13Z]     return self._execute_mock_call(*args, **kwargs)
  | [2026-08-03T18:43:13Z] C:\Miniconda3\lib\unittest\mock.py:1179: in _execute_mock_call
  | [2026-08-03T18:43:13Z]     result = effect(*args, **kwargs)
  | [2026-08-03T18:43:13Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] path = '/sys/kernel/iommu_groups/10/devices\\0000:01:00.0\\vendor', args = ()
  | [2026-08-03T18:43:13Z] kwargs = {'encoding': 'ascii'}
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z]     def fake_open(path, *args, **kwargs):
  | [2026-08-03T18:43:13Z]         try:
  | [2026-08-03T18:43:13Z]             return mock.mock_open(read_data=vendor_results[path])()
  | [2026-08-03T18:43:13Z]         except KeyError:
  | [2026-08-03T18:43:13Z] >           raise AssertionError(f"unexpected open: {path}")
  | [2026-08-03T18:43:13Z] E           AssertionError: unexpected open: /sys/kernel/iommu_groups/10/devices\0000:01:00.0\vendor
  | [2026-08-03T18:43:13Z]
  | [2026-08-03T18:43:13Z] python\ray\tests\accelerators\test_tpu.py:122: AssertionError


```