### PR TITLE
[Fix][Core] Report shutdown from `check_signals` instead of exiting the process

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -158,7 +158,6 @@ from ray.includes.libcoreworker cimport (
     ActorHandleSharedPtr,
     CActorCreationOptions,
     CPlacementGroupCreationOptions,
-    CCoreWorker,
     CCoreWorkerOptions,
     CCoreWorkerProcess,
     CTaskOptions,
@@ -2807,7 +2806,6 @@ cdef c_bool kill_main_task(const CTaskID &task_id) nogil:
 
 
 cdef CRayStatus check_signals() nogil:
-    cdef shared_ptr[CCoreWorker] worker
     with gil:
         # The Python exceptions are not handled if it is raised from cdef,
         # so we have to handle it here.
@@ -2842,13 +2840,14 @@ cdef CRayStatus check_signals() nogil:
         # Unblock nogil backpressure waits. Uses job/task guards so periodic io threads
         # do not call GetCurrentTaskID() without a job (WorkerContext CHECK).
         #
-        # GetCoreWorker() exits the process once the core worker is gone, and background
-        # threads keep polling for signals while ray.shutdown() tears it down. A
-        # compiled-graph channel's worker.channel_io thread is one of those pollers; the
-        # CoreWorker destructor is what joins it, so it outlives the global pointer.
-        worker = CCoreWorkerProcess.TryGetWorker()
-        if (worker.get() != NULL
-                and worker.get().ShouldInterruptTaskForCancellation()):
+        # Deliberately not GetCoreWorker(), which exits the process once the core worker
+        # is gone: background threads keep polling here while ray.shutdown() tears it
+        # down. Falling through to OK leaves such a poller waiting instead of bailing
+        # out. That is what a compiled-graph channel writer wants, since
+        # ~MutableObjectProvider unblocks it with ChannelError moments later, and
+        # PollWriterClosure RAY_CHECKs any other non-OK status. Other check_signals
+        # callers lose a bail-out they only ever had by way of that process exit.
+        if CCoreWorkerProcess.ShouldInterruptTaskForCancellation():
             return CRayStatus.Interrupted(b"")
 
     return CRayStatus.OK()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -158,6 +158,7 @@ from ray.includes.libcoreworker cimport (
     ActorHandleSharedPtr,
     CActorCreationOptions,
     CPlacementGroupCreationOptions,
+    CCoreWorker,
     CCoreWorkerOptions,
     CCoreWorkerProcess,
     CTaskOptions,
@@ -2806,6 +2807,7 @@ cdef c_bool kill_main_task(const CTaskID &task_id) nogil:
 
 
 cdef CRayStatus check_signals() nogil:
+    cdef shared_ptr[CCoreWorker] worker
     with gil:
         # The Python exceptions are not handled if it is raised from cdef,
         # so we have to handle it here.
@@ -2839,7 +2841,14 @@ cdef CRayStatus check_signals() nogil:
         # signal to worker threads (CancelActorTaskOnExecutor for non-async actors).
         # Unblock nogil backpressure waits. Uses job/task guards so periodic io threads
         # do not call GetCurrentTaskID() without a job (WorkerContext CHECK).
-        if CCoreWorkerProcess.GetCoreWorker().ShouldInterruptTaskForCancellation():
+        #
+        # GetCoreWorker() exits the process once the core worker is gone, and background
+        # threads keep polling for signals while ray.shutdown() tears it down. A
+        # compiled-graph channel's worker.channel_io thread is one of those pollers; the
+        # CoreWorker destructor is what joins it, so it outlives the global pointer.
+        worker = CCoreWorkerProcess.TryGetWorker()
+        if (worker.get() != NULL
+                and worker.get().ShouldInterruptTaskForCancellation()):
             return CRayStatus.Interrupted(b"")
 
     return CRayStatus.OK()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2835,18 +2835,19 @@ cdef CRayStatus check_signals() nogil:
         # By default, if signals raise an exception, Python just prints them.
         # To keep the same behavior, we don't handle any other exceptions.
 
+        # Background threads keep polling here while ray.shutdown() clears the core
+        # worker, so report that the same way the sys.is_finalizing() branch above does
+        # and let the caller stop. Reaching the core worker through GetCoreWorker()
+        # instead would exit the process outright.
+        if not CCoreWorkerProcess.HasCoreWorker():
+            return CRayStatus.IntentionalSystemExit(
+                "The core worker is shut down.".encode("utf-8")
+            )
+
         # ray.cancel marks running sync actor tasks canceled without sending an OS
         # signal to worker threads (CancelActorTaskOnExecutor for non-async actors).
         # Unblock nogil backpressure waits. Uses job/task guards so periodic io threads
         # do not call GetCurrentTaskID() without a job (WorkerContext CHECK).
-        #
-        # Deliberately not GetCoreWorker(), which exits the process once the core worker
-        # is gone, while background threads keep polling here as ray.shutdown() tears it
-        # down. Falling through to OK keeps such a poller waiting; a non-OK status would
-        # make it stop and report an error. Waiting is what a compiled-graph channel
-        # writer needs, since ~MutableObjectProvider wakes it with ChannelError moments
-        # later, and PollWriterClosure RAY_CHECKs any other non-OK status. Other
-        # check_signals callers now keep waiting too, where the process used to exit.
         if CCoreWorkerProcess.ShouldInterruptTaskForCancellation():
             return CRayStatus.Interrupted(b"")
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2841,12 +2841,12 @@ cdef CRayStatus check_signals() nogil:
         # do not call GetCurrentTaskID() without a job (WorkerContext CHECK).
         #
         # Deliberately not GetCoreWorker(), which exits the process once the core worker
-        # is gone: background threads keep polling here while ray.shutdown() tears it
-        # down. Falling through to OK leaves such a poller waiting instead of bailing
-        # out. That is what a compiled-graph channel writer wants, since
-        # ~MutableObjectProvider unblocks it with ChannelError moments later, and
-        # PollWriterClosure RAY_CHECKs any other non-OK status. Other check_signals
-        # callers lose a bail-out they only ever had by way of that process exit.
+        # is gone, while background threads keep polling here as ray.shutdown() tears it
+        # down. Falling through to OK keeps such a poller waiting; a non-OK status would
+        # make it stop and report an error. Waiting is what a compiled-graph channel
+        # writer needs, since ~MutableObjectProvider wakes it with ChannelError moments
+        # later, and PollWriterClosure RAY_CHECKs any other non-OK status. Other
+        # check_signals callers now keep waiting too, where the process used to exit.
         if CCoreWorkerProcess.ShouldInterruptTaskForCancellation():
             return CRayStatus.Interrupted(b"")
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2806,6 +2806,7 @@ cdef c_bool kill_main_task(const CTaskID &task_id) nogil:
 
 
 cdef CRayStatus check_signals() nogil:
+    cdef optional[c_bool] should_interrupt
     with gil:
         # The Python exceptions are not handled if it is raised from cdef,
         # so we have to handle it here.
@@ -2835,20 +2836,21 @@ cdef CRayStatus check_signals() nogil:
         # By default, if signals raise an exception, Python just prints them.
         # To keep the same behavior, we don't handle any other exceptions.
 
-        # Background threads keep polling here while ray.shutdown() clears the core
-        # worker, so report that the same way the sys.is_finalizing() branch above does
-        # and let the caller stop. Reaching the core worker through GetCoreWorker()
-        # instead would exit the process outright.
-        if not CCoreWorkerProcess.HasCoreWorker():
-            return CRayStatus.IntentionalSystemExit(
-                "The core worker is shut down.".encode("utf-8")
-            )
-
         # ray.cancel marks running sync actor tasks canceled without sending an OS
         # signal to worker threads (CancelActorTaskOnExecutor for non-async actors).
         # Unblock nogil backpressure waits. Uses job/task guards so periodic io threads
         # do not call GetCurrentTaskID() without a job (WorkerContext CHECK).
-        if CCoreWorkerProcess.ShouldInterruptTaskForCancellation():
+        #
+        # Empty means the core worker is gone, which background threads polling here run
+        # into while ray.shutdown() clears it. Report that the same way the
+        # sys.is_finalizing() branch above does and let the caller stop; reaching the core
+        # worker through GetCoreWorker() instead would exit the process outright.
+        should_interrupt = CCoreWorkerProcess.ShouldInterruptTaskForCancellation()
+        if not should_interrupt.has_value():
+            return CRayStatus.IntentionalSystemExit(
+                "The core worker is shut down.".encode("utf-8")
+            )
+        if should_interrupt.value():
             return CRayStatus.Interrupted(b"")
 
     return CRayStatus.OK()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2847,9 +2847,7 @@ cdef CRayStatus check_signals() nogil:
         # worker through GetCoreWorker() instead would exit the process outright.
         should_interrupt = CCoreWorkerProcess.ShouldInterruptTaskForCancellation()
         if not should_interrupt.has_value():
-            return CRayStatus.IntentionalSystemExit(
-                "The core worker is shut down.".encode("utf-8")
-            )
+            return CRayStatus.IntentionalSystemExit(b"The core worker is shut down.")
         if should_interrupt.value():
             return CRayStatus.Interrupted(b"")
 

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -499,10 +499,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         @staticmethod
         CCoreWorker &GetCoreWorker()
 
-        # Null when the core worker is uninitialized or already shut down, where
-        # GetCoreWorker() exits the process instead.
         @staticmethod
-        shared_ptr[CCoreWorker] TryGetWorker()
+        c_bool ShouldInterruptTaskForCancellation()
 
         @staticmethod
         void Shutdown()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -499,6 +499,11 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         @staticmethod
         CCoreWorker &GetCoreWorker()
 
+        # Null when the core worker is uninitialized or already shut down, where
+        # GetCoreWorker() exits the process instead.
+        @staticmethod
+        shared_ptr[CCoreWorker] TryGetWorker()
+
         @staticmethod
         void Shutdown()
 

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -500,10 +500,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CCoreWorker &GetCoreWorker()
 
         @staticmethod
-        c_bool HasCoreWorker()
-
-        @staticmethod
-        c_bool ShouldInterruptTaskForCancellation()
+        optional[c_bool] ShouldInterruptTaskForCancellation()
 
         @staticmethod
         void Shutdown()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -500,6 +500,9 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CCoreWorker &GetCoreWorker()
 
         @staticmethod
+        c_bool HasCoreWorker()
+
+        @staticmethod
         c_bool ShouldInterruptTaskForCancellation()
 
         @staticmethod

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import logging
+import os
 import pickle
 import sys
 import time
@@ -13,6 +14,7 @@ import ray
 import ray.cluster_utils
 import ray.exceptions
 import ray.experimental.channel as ray_channel
+from ray._common.test_utils import run_string_as_driver
 from ray._private.test_utils import get_actor_node_id
 from ray.dag.compiled_dag_node import CompiledDAG
 from ray.exceptions import RayChannelError, RayChannelTimeoutError
@@ -1207,6 +1209,69 @@ def test_payload_resize_large(ray_start_cluster):
     val = b"x" * size
     ch.write(val)
     ray.get(a.read.remote(ch, val))
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" and sys.platform != "darwin",
+    reason="Requires Linux or Mac.",
+)
+def test_shutdown_with_remote_reader_does_not_kill_driver(ray_start_cluster):
+    """ray.shutdown() must not kill a driver that holds a cross-node channel.
+
+    A channel with a remote reader waits for the next value on a worker.channel_io thread,
+    checking for signals as it waits. Only the CoreWorker destructor joins that thread, so
+    it outlives the process-wide CoreWorker pointer, and a check landing in that window
+    reaches CoreWorkerProcess::GetCoreWorker(), which exits the process.
+
+    The interval has to be set on a subprocess because RayConfig reads it once per
+    process. At 1ms a check lands in that window on nearly every run, against roughly one
+    run in two at the 1000ms default.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1)
+    cluster.wait_for_nodes()
+
+    driver_script = """
+import ray
+import ray.experimental.channel as ray_channel
+
+ray.init(address="{address}")
+
+
+@ray.remote(num_cpus=1)
+class Reader:
+    def get_node_id(self):
+        return ray.get_runtime_context().get_node_id()
+
+
+driver_node = ray.get_runtime_context().get_node_id()
+reader_node = next(
+    node["NodeID"]
+    for node in ray.nodes()
+    if node["Alive"] and node["NodeID"] != driver_node
+)
+reader = Reader.options(
+    label_selector={{ray._raylet.RAY_NODE_ID_KEY: reader_node}}
+).remote()
+assert ray.get(reader.get_node_id.remote()) == reader_node
+
+channel = ray_channel.Channel(None, [(reader, reader_node)], 1000)
+channel.write(b"x")
+
+# The reader never reads, so the polling thread is still waiting at shutdown.
+ray.shutdown()
+print("DRIVER_EXITED_CLEANLY")
+""".format(
+        address=cluster.address
+    )
+
+    # run_string_as_driver hands env to Popen, which replaces rather than extends it.
+    output = run_string_as_driver(
+        driver_script,
+        env={**os.environ, "RAY_get_check_signal_interval_milliseconds": "1"},
+    )
+    assert "DRIVER_EXITED_CLEANLY" in output, output
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import logging
-import os
 import pickle
 import sys
 import time
@@ -14,7 +13,6 @@ import ray
 import ray.cluster_utils
 import ray.exceptions
 import ray.experimental.channel as ray_channel
-from ray._common.test_utils import run_string_as_driver
 from ray._private.test_utils import get_actor_node_id
 from ray.dag.compiled_dag_node import CompiledDAG
 from ray.exceptions import RayChannelError, RayChannelTimeoutError
@@ -1209,78 +1207,6 @@ def test_payload_resize_large(ray_start_cluster):
     val = b"x" * size
     ch.write(val)
     ray.get(a.read.remote(ch, val))
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux" and sys.platform != "darwin",
-    reason="Requires Linux or Mac.",
-)
-def test_shutdown_with_remote_reader_does_not_kill_driver(ray_start_cluster):
-    """ray.shutdown() must not kill a driver that holds a cross-node channel.
-
-    A channel with a remote reader waits for the next value on a worker.channel_io thread,
-    checking for signals as it waits. Only the CoreWorker destructor joins that thread, so
-    it outlives the process-wide CoreWorker pointer, and a check landing in that window
-    reaches CoreWorkerProcess::GetCoreWorker(), which exits the process.
-
-    The interval has to be set on a subprocess because RayConfig reads it once per
-    process. At 1ms a check lands in that window on nearly every run, against roughly one
-    run in two at the 1000ms default.
-    """
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1)
-    cluster.add_node(num_cpus=1)
-    cluster.wait_for_nodes()
-
-    driver_script = """
-import ray
-import ray.experimental.channel as ray_channel
-
-ray.init(address="{address}")
-
-
-@ray.remote(num_cpus=1)
-class Reader:
-    def get_node_id(self):
-        return ray.get_runtime_context().get_node_id()
-
-
-driver_node = ray.get_runtime_context().get_node_id()
-reader_node = next(
-    node["NodeID"]
-    for node in ray.nodes()
-    if node["Alive"] and node["NodeID"] != driver_node
-)
-reader = Reader.options(
-    label_selector={{ray._raylet.RAY_NODE_ID_KEY: reader_node}}
-).remote()
-assert ray.get(reader.get_node_id.remote()) == reader_node
-
-channel = ray_channel.Channel(None, [(reader, reader_node)], 1000)
-channel.write(b"x")
-
-# The reader never reads, so the polling thread is still waiting at shutdown.
-ray.shutdown()
-print("DRIVER_EXITED_CLEANLY")
-""".format(
-        address=cluster.address
-    )
-
-    # run_string_as_driver hands env to Popen, which replaces rather than extends it.
-    # RAY_LOG_TO_STDERR routes the core worker's own logs into the captured output, so the
-    # assertion below sees them; by default they only reach the session log directory.
-    output = run_string_as_driver(
-        driver_script,
-        env={
-            **os.environ,
-            "RAY_get_check_signal_interval_milliseconds": "1",
-            "RAY_LOG_TO_STDERR": "1",
-        },
-    )
-    assert "DRIVER_EXITED_CLEANLY" in output, output
-    # A non-zero exit already raises out of run_string_as_driver. This catches the weaker
-    # case where a poll hit the window but the process happened to survive it.
-    assert "The core worker has already been shutdown" not in output, output
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -1267,11 +1267,20 @@ print("DRIVER_EXITED_CLEANLY")
     )
 
     # run_string_as_driver hands env to Popen, which replaces rather than extends it.
+    # RAY_LOG_TO_STDERR routes the core worker's own logs into the captured output, so the
+    # assertion below sees them; by default they only reach the session log directory.
     output = run_string_as_driver(
         driver_script,
-        env={**os.environ, "RAY_get_check_signal_interval_milliseconds": "1"},
+        env={
+            **os.environ,
+            "RAY_get_check_signal_interval_milliseconds": "1",
+            "RAY_LOG_TO_STDERR": "1",
+        },
     )
     assert "DRIVER_EXITED_CLEANLY" in output, output
+    # A non-zero exit already raises out of run_string_as_driver. This catches the weaker
+    # case where a poll hit the window but the process happened to survive it.
+    assert "The core worker has already been shutdown" not in output, output
 
 
 @pytest.mark.skipif(

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -1042,8 +1042,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::TryGetCoreWorker() const {
 bool CoreWorkerProcessImpl::ShouldInterruptTaskForCancellation() const {
   const auto read_locked = core_worker_.LockForRead();
   // Bind by reference. Copying the shared_ptr would let a caller that outlives
-  // ShutdownDriver() become the last owner and run ~CoreWorker on its own thread, and
-  // ~MutableObjectProvider joins that very thread.
+  // ShutdownDriver() become the last owner and run ~CoreWorker on its own thread, which
+  // deadlocks when ~MutableObjectProvider joins that same thread.
   const auto &worker = read_locked.Get();
   return worker != nullptr && worker->ShouldInterruptTaskForCancellation();
 }

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -133,6 +133,10 @@ std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker() {
   return core_worker_process->TryGetCoreWorker();
 }
 
+bool CoreWorkerProcess::HasCoreWorker() {
+  return core_worker_process != nullptr && core_worker_process->HasCoreWorker();
+}
+
 bool CoreWorkerProcess::ShouldInterruptTaskForCancellation() {
   return core_worker_process != nullptr &&
          core_worker_process->ShouldInterruptTaskForCancellation();
@@ -1037,6 +1041,11 @@ void CoreWorkerProcessImpl::ShutdownDriver() {
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::TryGetCoreWorker() const {
   const auto read_locked = core_worker_.LockForRead();
   return read_locked.Get();
+}
+
+bool CoreWorkerProcessImpl::HasCoreWorker() const {
+  const auto read_locked = core_worker_.LockForRead();
+  return read_locked.Get() != nullptr;
 }
 
 bool CoreWorkerProcessImpl::ShouldInterruptTaskForCancellation() const {

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -133,13 +133,11 @@ std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker() {
   return core_worker_process->TryGetCoreWorker();
 }
 
-bool CoreWorkerProcess::HasCoreWorker() {
-  return core_worker_process != nullptr && core_worker_process->HasCoreWorker();
-}
-
-bool CoreWorkerProcess::ShouldInterruptTaskForCancellation() {
-  return core_worker_process != nullptr &&
-         core_worker_process->ShouldInterruptTaskForCancellation();
+std::optional<bool> CoreWorkerProcess::ShouldInterruptTaskForCancellation() {
+  if (core_worker_process == nullptr) {
+    return std::nullopt;
+  }
+  return core_worker_process->ShouldInterruptTaskForCancellation();
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
@@ -1043,18 +1041,16 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::TryGetCoreWorker() const {
   return read_locked.Get();
 }
 
-bool CoreWorkerProcessImpl::HasCoreWorker() const {
-  const auto read_locked = core_worker_.LockForRead();
-  return read_locked.Get() != nullptr;
-}
-
-bool CoreWorkerProcessImpl::ShouldInterruptTaskForCancellation() const {
+std::optional<bool> CoreWorkerProcessImpl::ShouldInterruptTaskForCancellation() const {
   const auto read_locked = core_worker_.LockForRead();
   // Bind by reference. Copying the shared_ptr would let a caller that outlives
   // ShutdownDriver() become the last owner and run ~CoreWorker on its own thread, which
   // deadlocks when ~MutableObjectProvider joins that same thread.
   const auto &worker = read_locked.Get();
-  return worker != nullptr && worker->ShouldInterruptTaskForCancellation();
+  if (worker == nullptr) {
+    return std::nullopt;
+  }
+  return worker->ShouldInterruptTaskForCancellation();
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::GetCoreWorker() const {

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -133,6 +133,11 @@ std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker() {
   return core_worker_process->TryGetCoreWorker();
 }
 
+bool CoreWorkerProcess::ShouldInterruptTaskForCancellation() {
+  return core_worker_process != nullptr &&
+         core_worker_process->ShouldInterruptTaskForCancellation();
+}
+
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
     CoreWorkerOptions options, const WorkerID &worker_id) {
   /// Event loop where the IO events are handled. e.g. async GCS operations.
@@ -1032,6 +1037,15 @@ void CoreWorkerProcessImpl::ShutdownDriver() {
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::TryGetCoreWorker() const {
   const auto read_locked = core_worker_.LockForRead();
   return read_locked.Get();
+}
+
+bool CoreWorkerProcessImpl::ShouldInterruptTaskForCancellation() const {
+  const auto read_locked = core_worker_.LockForRead();
+  // Bind by reference. Copying the shared_ptr would let a caller that outlives
+  // ShutdownDriver() become the last owner and run ~CoreWorker on its own thread, and
+  // ~MutableObjectProvider joins that very thread.
+  const auto &worker = read_locked.Get();
+  return worker != nullptr && worker->ShouldInterruptTaskForCancellation();
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::GetCoreWorker() const {

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -95,8 +95,9 @@ class CoreWorkerProcess {
   /// Whether a running task has been marked for cancellation and should be interrupted.
   ///
   /// Unlike GetCoreWorker(), returns false rather than exiting the process when the core
-  /// worker is already gone, so background threads can poll this during shutdown. Hands
-  /// out no reference to the CoreWorker, so a caller can never become its last owner.
+  /// worker is already gone, so background threads can poll this during shutdown. No
+  /// reference to the CoreWorker escapes, which keeps a caller from becoming its last
+  /// owner.
   static bool ShouldInterruptTaskForCancellation();
 
   /// Whether the current process has been initialized for core worker.

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -16,6 +16,7 @@
 
 #include <boost/thread.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "ray/common/metrics.h"
@@ -92,18 +93,12 @@ class CoreWorkerProcess {
   /// \return The `CoreWorker` instance.
   static std::shared_ptr<CoreWorker> TryGetWorker();
 
-  /// Whether the core worker for this process exists. False once ray.shutdown() has
-  /// cleared it, which background threads can use to stop instead of calling
-  /// GetCoreWorker() and exiting the process.
-  static bool HasCoreWorker();
-
   /// Whether a running task has been marked for cancellation and should be interrupted.
-  ///
-  /// Unlike GetCoreWorker(), returns false rather than exiting the process when the core
-  /// worker is already gone, so background threads can poll this during shutdown. No
-  /// reference to the CoreWorker escapes, which keeps a caller from becoming its last
-  /// owner.
-  static bool ShouldInterruptTaskForCancellation();
+  /// Empty once the core worker is gone, so that background threads polling during
+  /// shutdown can tell that case apart in one read instead of exiting the process the way
+  /// GetCoreWorker() does. No reference to the CoreWorker escapes, which keeps a caller
+  /// from becoming its last owner.
+  static std::optional<bool> ShouldInterruptTaskForCancellation();
 
   /// Whether the current process has been initialized for core worker.
   static bool IsInitialized();
@@ -147,9 +142,7 @@ class CoreWorkerProcessImpl {
   /// Try to get core worker. Returns nullptr if core worker doesn't exist.
   std::shared_ptr<CoreWorker> TryGetCoreWorker() const;
 
-  bool HasCoreWorker() const;
-
-  bool ShouldInterruptTaskForCancellation() const;
+  std::optional<bool> ShouldInterruptTaskForCancellation() const;
 
   std::shared_ptr<CoreWorker> CreateCoreWorker(CoreWorkerOptions options,
                                                const WorkerID &worker_id);

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -92,6 +92,11 @@ class CoreWorkerProcess {
   /// \return The `CoreWorker` instance.
   static std::shared_ptr<CoreWorker> TryGetWorker();
 
+  /// Whether the core worker for this process exists. False once ray.shutdown() has
+  /// cleared it, which background threads can use to stop instead of calling
+  /// GetCoreWorker() and exiting the process.
+  static bool HasCoreWorker();
+
   /// Whether a running task has been marked for cancellation and should be interrupted.
   ///
   /// Unlike GetCoreWorker(), returns false rather than exiting the process when the core
@@ -141,6 +146,8 @@ class CoreWorkerProcessImpl {
 
   /// Try to get core worker. Returns nullptr if core worker doesn't exist.
   std::shared_ptr<CoreWorker> TryGetCoreWorker() const;
+
+  bool HasCoreWorker() const;
 
   bool ShouldInterruptTaskForCancellation() const;
 

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -142,6 +142,7 @@ class CoreWorkerProcessImpl {
   /// Try to get core worker. Returns nullptr if core worker doesn't exist.
   std::shared_ptr<CoreWorker> TryGetCoreWorker() const;
 
+  /// Whether a running task should be interrupted. Empty if core worker doesn't exist.
   std::optional<bool> ShouldInterruptTaskForCancellation() const;
 
   std::shared_ptr<CoreWorker> CreateCoreWorker(CoreWorkerOptions options,

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -92,6 +92,13 @@ class CoreWorkerProcess {
   /// \return The `CoreWorker` instance.
   static std::shared_ptr<CoreWorker> TryGetWorker();
 
+  /// Whether a running task has been marked for cancellation and should be interrupted.
+  ///
+  /// Unlike GetCoreWorker(), returns false rather than exiting the process when the core
+  /// worker is already gone, so background threads can poll this during shutdown. Hands
+  /// out no reference to the CoreWorker, so a caller can never become its last owner.
+  static bool ShouldInterruptTaskForCancellation();
+
   /// Whether the current process has been initialized for core worker.
   static bool IsInitialized();
 
@@ -133,6 +140,8 @@ class CoreWorkerProcessImpl {
 
   /// Try to get core worker. Returns nullptr if core worker doesn't exist.
   std::shared_ptr<CoreWorker> TryGetCoreWorker() const;
+
+  bool ShouldInterruptTaskForCancellation() const;
 
   std::shared_ptr<CoreWorker> CreateCoreWorker(CoreWorkerOptions options,
                                                const WorkerID &worker_id);

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -225,13 +225,13 @@ void MutableObjectProvider::PollWriterClosure(
   // The corresponding ReadRelease() will be automatically called when
   // `object` goes out of scope.
   Status status = object_manager_->ReadAcquire(writer_object_id, object);
-  // Check if the thread returned from ReadAcquire() because the process is exiting, not
-  // because there is something to read.
-  if (status.code() == StatusCode::ChannelError) {
-    // The process is exiting.
+  if (!status.ok()) {
+    // ChannelError is how ~MutableObjectProvider ends this thread. Any other status comes
+    // from check_signals reporting that the process is going away, during either
+    // ray.shutdown() or interpreter finalization. Neither leaves a value to push.
+    RAY_LOG(DEBUG).WithField(writer_object_id) << "Writer poll stopped: " << status;
     return;
   }
-  RAY_CHECK_EQ(static_cast<int>(status.code()), static_cast<int>(StatusCode::OK));
 
   RAY_CHECK(object->GetData());
   RAY_CHECK(object->GetMetadata());

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -226,10 +226,22 @@ void MutableObjectProvider::PollWriterClosure(
   // `object` goes out of scope.
   Status status = object_manager_->ReadAcquire(writer_object_id, object);
   if (!status.ok()) {
-    // ChannelError is how ~MutableObjectProvider ends this thread. Any other status comes
-    // from check_signals reporting that the process is going away, during either
-    // ray.shutdown() or interpreter finalization. Neither leaves a value to push.
-    RAY_LOG(DEBUG).WithField(writer_object_id) << "Writer poll stopped: " << status;
+    // ChannelError is how ~MutableObjectProvider ends this thread. IntentionalSystemExit
+    // and Interrupted come from check_signals once the process is going away, during
+    // either ray.shutdown() or interpreter finalization. None of those leaves a value to
+    // push, so stop polling. Anything else is unexpected, and stopping is silent from a
+    // reader's point of view, so say so loudly enough to be found.
+    const bool expected = status.code() == StatusCode::ChannelError ||
+                          status.code() == StatusCode::IntentionalSystemExit ||
+                          status.code() == StatusCode::Interrupted;
+    if (expected) {
+      RAY_LOG(DEBUG).WithField(writer_object_id) << "Writer poll stopped: " << status;
+    } else {
+      RAY_LOG(WARNING).WithField(writer_object_id)
+          << "Writer poll stopped on an unexpected status, readers of this channel will "
+             "not receive further values: "
+          << status;
+    }
     return;
   }
 


### PR DESCRIPTION
## Description

`//python/ray/tests:test_channel` failed in about half of all CI runs while every test inside it passed. The target's output ends with a test printing `PASSED`, immediately followed by `The core worker has already been shutdown` from `core_worker_process.cc`, and then stops. Nothing hangs: those tests take about 11 seconds against a 180s timeout.

`check_signals()` in `python/ray/_raylet.pyx` reached the core worker through `CoreWorkerProcess::GetCoreWorker()`, which calls `QuickExit()` once the core worker is gone, even though shutdown is a normal state:

<img width="881" height="619" alt="check-signals-shutdown-race" src="https://github.com/user-attachments/assets/2b7e0a1f-42a6-467f-b5db-6921227b4ac6" />

A poll in that window kills the driver just after a test has passed, and `_Exit()` takes pytest's summary and the `failed_test_logs` artifact with it, which is why the target looked like it was hanging.

`check_signals` now reports the shutdown rather than exiting, returning `IntentionalSystemExit` the way its own `sys.is_finalizing()` branch already does for the same class of event. `CoreWorkerProcess::ShouldInterruptTaskForCancellation()` now returns `std::optional<bool>`, empty when the core worker is gone, so both facts come back from one read under the lock that already guards the pointer. It hands out no `shared_ptr` to the `CoreWorker`, which matters because a caller holding the last reference would run `~CoreWorker`, and that joins the very thread it was running on.

Returning a non-OK status needed one more change. `MutableObjectProvider::PollWriterClosure` accepted only `OK` or `ChannelError` and `RAY_CHECK`ed anything else, so it now stops polling on any non-OK status. That `RAY_CHECK` was also a live crash before this PR. `check_signals` returns `IntentionalSystemExit` while the interpreter is finalizing, and since that is neither `OK` nor `ChannelError`, a channel writer polling at that moment aborted the process.

Other `check_signals` callers see the change too: a blocking call that races `ray.shutdown()` now stops with `SystemExit` instead of having the process exit underneath it.

## Related issues

N/A

## Additional information

A/B tested on CI by running all core tests 25 times:

- Without the changes in this PR (9/25 `test_channel` failed):
  - Code: https://github.com/ray-project/ray/pull/65186
  - Run: https://buildkite.com/ray-project/premerge/builds/71411
- With the changes in this PR (0/25 `test_channel` failed):
  - Code: https://github.com/ray-project/ray/pull/65185
  - Run: https://buildkite.com/ray-project/premerge/builds/71412