### PR TITLE
[Data] Don't convert Arrow null columns to null[pyarrow] in to_pandas

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -290,10 +290,19 @@ class ArrowBlockAccessor(TableBlockAccessor):
         #   their own to_pandas_dtype() hooks. Note: native FixedShapeTensorType
         #   subclasses BaseExtensionType but not ExtensionType, so we check the
         #   broader BaseExtensionType.
+        # - Arrow's null type carries no type information, and pandas cannot box a
+        #   non-null value into a null[pyarrow] column, so fillna and masked
+        #   assignment raise ArrowInvalid (and can abort the worker from Arrow
+        #   C++). Fall back to pandas' default conversion; PandasBlockAccessor
+        #   .to_arrow() coerces all-null columns back to pa.null(), so the
+        #   round-trip is unchanged. A column that is all-null in every block
+        #   therefore stays null-typed rather than being promoted.
         def _types_mapper(t):
             if isinstance(t, pyarrow.BaseExtensionType) or pyarrow.types.is_dictionary(
                 t
             ):
+                return None
+            if pyarrow.types.is_null(t):
                 return None
             return pd.ArrowDtype(t)
 

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -347,6 +347,51 @@ def test_arrow_block_to_pandas_preserves_arrow_types_through_roundtrip(
     assert roundtripped.to_pydict() == {"x": expected_values}
 
 
+def test_arrow_block_to_pandas_null_type_is_not_arrow_backed():
+    # A block whose column is entirely null is typed pa.null(). Keeping that as
+    # null[pyarrow] makes the column unusable in pandas: fillna and masked
+    # assignment cannot box a non-null value into Arrow's null type. Fall back to
+    # pandas' default conversion instead, which still round-trips to pa.null().
+    table = pa.table({"x": pa.array([None, None], type=pa.null())})
+
+    df = ArrowBlockAccessor(table).to_pandas()
+    assert not isinstance(df.dtypes["x"], pd.ArrowDtype)
+    assert df["x"].tolist() == [None, None]
+
+    # Untouched, the column round-trips back to Arrow's null type.
+    roundtripped = BlockAccessor.for_block(df).to_arrow()
+    assert roundtripped.schema.field("x").type == pa.null()
+    assert roundtripped.to_pydict() == {"x": [None, None]}
+
+    # Filling the nulls now works and yields the fill value's type.
+    filled = BlockAccessor.for_block(df.fillna({"x": 3.0})).to_arrow()
+    assert filled.to_pydict() == {"x": [3.0, 3.0]}
+
+
+def test_pandas_udf_can_fill_per_block_null_columns(ray_start_regular_shared):
+    # One-row blocks type a column with no values as pa.null(), so a pandas UDF
+    # calling fillna used to fail with ArrowInvalid on whichever block happened
+    # to hold only nulls for that column.
+    ds = ray.data.from_items(
+        [
+            {"a": 1.0, "b": 2.0},
+            {"a": 3.0, "b": None},
+            {"a": None, "b": 4.0},
+        ],
+        override_num_blocks=3,
+    )
+
+    filled = ds.map_batches(
+        lambda df: df.fillna({"a": 0.0, "b": 0.0}), batch_format="pandas"
+    )
+
+    assert sorted(filled.take_all(), key=lambda row: row["a"]) == [
+        {"a": 0.0, "b": 4.0},
+        {"a": 1.0, "b": 2.0},
+        {"a": 3.0, "b": 0.0},
+    ]
+
+
 def test_arrow_block_to_pandas_opt_out_numpy_dtypes(restore_data_context):
     # https://github.com/ray-project/ray/issues/64765: opting out restores the
     # pre-2.56 numpy conversion, so standard Arrow types no longer become


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to #64765 / #63017. `ArrowBlockAccessor.to_pandas()` maps Arrow types to `pd.ArrowDtype` via a `_types_mapper`, with carve-outs for extension and dictionary types. Arrow's `null` type needs the same carve-out.

`null[pyarrow]` is unusable from pandas: the type carries no type information, so pandas cannot box a non-null value into such a column. `fillna` and masked assignment raise `ArrowInvalid`, and in some pyarrow/pandas combinations the failure comes out of Arrow C++ and aborts the worker process rather than raising.

This is easy to hit in practice because the type is assigned per block, not per dataset. A column that has values overall can still be entirely null within one block — which is common with small blocks — so a pandas UDF like `map_batches(lambda df: df.fillna(...), batch_format="pandas")` fails on whichever block happens to hold only nulls:

```python
ds = ray.data.from_items(
    [{"a": 1.0, "b": 2.0}, {"a": 3.0, "b": None}, {"a": None, "b": 4.0}],
    override_num_blocks=3,
)
ds.map_batches(lambda df: df.fillna({"a": 0.0, "b": 0.0}), batch_format="pandas").take_all()
# ArrowInvalid on the block where "a" (or "b") is all-null
```

The fix returns `None` from `_types_mapper` for null-typed columns, falling back to pandas' default conversion. The Arrow round-trip is unchanged: `PandasBlockAccessor.to_arrow()` already coerces all-null columns back to `pa.null()`. The one behavioral consequence, noted in a comment: a column that is all-null in *every* block stays null-typed instead of being promoted — same as before this change.

## Related issue number

Follow-up to #64765.


Two tests added:
- `test_arrow_block_to_pandas_null_type_is_not_arrow_backed` — a `pa.null()` column is not `pd.ArrowDtype`, still round-trips back to `pa.null()` untouched, and `fillna` now works and adopts the fill value's type.
- `test_pandas_udf_can_fill_per_block_null_columns` — end-to-end regression test for the `map_batches` + `fillna` failure above.

