### PR TITLE
[Fix][Serve] Fix Serve replica ASGIService bypasses token authentication

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -39,7 +39,9 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 import ray
 from ray import cloudpickle
 from ray._common.filters import CoreContextFilter
+from ray._common.tls_utils import add_port_to_grpc_server
 from ray._common.utils import get_or_create_event_loop
+from ray._private.grpc_utils import create_grpc_server_with_interceptors
 from ray.actor import ActorClass, ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.remote_function import RemoteFunction
@@ -1129,14 +1131,17 @@ class Replica:
 
         self._rank: Optional[ReplicaRank] = None
 
-        # gRPC server for inter-deployment communication
-        self._server = grpc.aio.server(
+        # gRPC server for inter-deployment communication. Created via the shared
+        # helper so Ray's authentication interceptor is attached when token auth
+        # is enabled; without it this server would accept unauthenticated calls.
+        self._server = create_grpc_server_with_interceptors(
+            asynchronous=True,
             options=[
                 (
                     "grpc.max_receive_message_length",
                     RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH,
                 )
-            ]
+            ],
         )
         # Silence spammy false positive errors from gRPC Python
         self._event_loop.set_exception_handler(asyncio_grpc_exception_handler)
@@ -1767,7 +1772,9 @@ class Replica:
 
         # Start the gRPC server for inter-deployment communication
         add_ASGIServiceServicer_to_server(self, self._server)
-        self._internal_grpc_port = self._server.add_insecure_port("[::]:0")
+        # Use the shared helper so RAY_USE_TLS is honored; binding the port
+        # directly would leave this server plaintext in a TLS-enabled cluster.
+        self._internal_grpc_port = add_port_to_grpc_server(self._server, "[::]:0")
         await self._server.start()
         logger.debug(
             f"Started inter-deployment gRPC server on port {self._internal_grpc_port}"

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -6,9 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set, Tuple, Union
 
-import grpc
-
 import ray
+from ray._private.grpc_utils import init_grpc_channel
 from ray.actor import ActorHandle
 from ray.serve._private.common import (
     DeploymentID,
@@ -286,7 +285,10 @@ class RunningReplica:
     @property
     def stub(self):
         if self._stub is None:
-            self._channel = grpc.aio.insecure_channel(
+            # Created via the shared helper so that Ray's authentication client
+            # interceptors and TLS credentials are applied; a raw insecure
+            # channel would be rejected by the replica's authenticated server.
+            self._channel = init_grpc_channel(
                 f"{self._replica_info.node_ip}:{self._replica_info.port}",
                 options=[
                     (
@@ -294,6 +296,7 @@ class RunningReplica:
                         RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH,
                     )
                 ],
+                asynchronous=True,
             )
             self._stub = ASGIServiceStub(self._channel)
 

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -137,6 +137,7 @@ py_test_module_list(
         "test_record_replica_metadata.py",
         "test_record_routing_stats.py",
         "test_regression.py",
+        "test_replica_grpc_auth.py",
         "test_replica_placement_group.py",
         "test_request_timeout.py",
         "test_round_robin_router.py",

--- a/python/ray/serve/tests/test_replica_grpc_auth.py
+++ b/python/ray/serve/tests/test_replica_grpc_auth.py
@@ -65,17 +65,20 @@ def serve_instance_with_token_auth():
         set_env_auth_token(token)
         reset_auth_token_state()
 
-        ray.init(
-            address="local",
-            num_cpus=8,
-            namespace="test_replica_grpc_auth",
-        )
-        serve.start()
         try:
+            ray.init(
+                address="local",
+                num_cpus=8,
+                namespace="test_replica_grpc_auth",
+            )
+            serve.start()
             yield token
         finally:
-            serve.shutdown()
-            ray.shutdown()
+            # Gate on `is_initialized`: `serve.shutdown()` connects lazily and
+            # would start a fresh cluster if `ray.init` above was what failed.
+            if ray.is_initialized():
+                serve.shutdown()
+                ray.shutdown()
             reset_auth_token_state()
 
 

--- a/python/ray/serve/tests/test_replica_grpc_auth.py
+++ b/python/ray/serve/tests/test_replica_grpc_auth.py
@@ -1,0 +1,152 @@
+"""Authentication tests for the replica's inter-deployment gRPC server.
+
+Every Serve replica starts an internal ``ASGIService`` gRPC server that carries
+handle-path (inter-deployment) traffic. That server must be created through
+Ray's shared gRPC helpers so the authentication interceptor is attached when
+``RAY_AUTH_MODE=token`` is set. Without it the server accepts calls from any
+peer that can reach the port and unpickles the attacker-supplied
+``pickled_request_metadata`` field before any validation runs.
+
+The server and the client (the router's channel to the replica) must stay in
+sync: attaching the interceptor without also sending the token from the client
+would reject all legitimate inter-deployment traffic, so
+``test_inter_deployment_traffic_still_works`` covers the other half.
+"""
+
+import sys
+
+import grpc
+import pytest
+
+import ray
+from ray import serve
+from ray._private.authentication.authentication_token_generator import (
+    generate_new_authentication_token,
+)
+from ray._private.authentication_test_utils import (
+    authentication_env_guard,
+    reset_auth_token_state,
+    set_auth_mode,
+    set_env_auth_token,
+)
+from ray.serve._private.common import DeploymentID
+from ray.serve._private.constants import SERVE_CONTROLLER_NAME, SERVE_NAMESPACE
+from ray.serve.generated import serve_pb2, serve_pb2_grpc
+
+# A payload that is not a valid pickle. If the auth interceptor is missing, the
+# replica reaches `pickle.loads()` on this field and fails with some non-auth
+# status code, which is exactly what these tests distinguish against.
+_UNPICKLABLE_PAYLOAD = b"this-is-not-a-pickle"
+
+
+@serve.deployment
+class Downstream:
+    def __call__(self) -> str:
+        return "hello"
+
+
+@serve.deployment
+class Ingress:
+    def __init__(self, handle):
+        self._handle = handle
+
+    async def __call__(self) -> str:
+        # `_by_reference=False` sends the request over the downstream replica's
+        # inter-deployment gRPC server instead of the Ray actor call path.
+        return await self._handle.options(_by_reference=False).remote()
+
+
+@pytest.fixture(scope="module")
+def serve_instance_with_token_auth():
+    """Start a Ray cluster and Serve instance with token authentication on."""
+    token = generate_new_authentication_token()
+    with authentication_env_guard():
+        set_auth_mode("token")
+        set_env_auth_token(token)
+        reset_auth_token_state()
+
+        ray.init(
+            address="local",
+            num_cpus=8,
+            namespace="test_replica_grpc_auth",
+        )
+        serve.start()
+        try:
+            yield token
+        finally:
+            serve.shutdown()
+            ray.shutdown()
+            reset_auth_token_state()
+
+
+@pytest.fixture(scope="module")
+def downstream_replica_address(serve_instance_with_token_auth):
+    """Deploy the app and return the downstream replica's gRPC address."""
+    serve.run(Ingress.bind(Downstream.bind()), name="auth_test_app")
+
+    controller = ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
+    all_replicas = ray.get(controller._all_running_replicas.remote())
+    replicas = all_replicas[DeploymentID(name="Downstream", app_name="auth_test_app")]
+    assert len(replicas) == 1, replicas
+
+    info = replicas[0]
+    assert info.port is not None, "replica did not report an inter-deployment gRPC port"
+    return f"{info.node_ip}:{info.port}"
+
+
+def _call_handle_request(address: str, metadata=None):
+    """Call ASGIService.HandleRequest over a raw channel, bypassing Ray's client.
+
+    This is what an unauthorized peer with network access to the replica port
+    can do; the channel deliberately does not go through ``init_grpc_channel``
+    so no token is attached unless ``metadata`` supplies one.
+    """
+    with grpc.insecure_channel(address) as channel:
+        stub = serve_pb2_grpc.ASGIServiceStub(channel)
+        request = serve_pb2.ASGIRequest(
+            pickled_request_metadata=_UNPICKLABLE_PAYLOAD,
+        )
+        return stub.HandleRequest(request, metadata=metadata, timeout=10)
+
+
+@pytest.mark.parametrize("with_token", [False, True], ids=["no_token", "wrong_token"])
+def test_unauthenticated_call_is_rejected(downstream_replica_address, with_token):
+    """A call with a missing or wrong token must be rejected before unpickling."""
+    metadata = None
+    if with_token:
+        wrong_token = generate_new_authentication_token()
+        metadata = (("authorization", f"Bearer {wrong_token}"),)
+
+    with pytest.raises(grpc.RpcError) as exc_info:
+        _call_handle_request(downstream_replica_address, metadata=metadata)
+
+    assert exc_info.value.code() == grpc.StatusCode.UNAUTHENTICATED
+
+
+def test_valid_token_passes_authentication(
+    downstream_replica_address, serve_instance_with_token_auth
+):
+    """A correctly-tokenned call must get past the interceptor.
+
+    The payload is still garbage, so the call fails — but it must fail inside
+    the servicer rather than with UNAUTHENTICATED, which is what proves the
+    interceptor is not rejecting legitimate callers.
+    """
+    token = serve_instance_with_token_auth
+    with pytest.raises(grpc.RpcError) as exc_info:
+        _call_handle_request(
+            downstream_replica_address,
+            metadata=(("authorization", f"Bearer {token}"),),
+        )
+
+    assert exc_info.value.code() != grpc.StatusCode.UNAUTHENTICATED
+
+
+def test_inter_deployment_traffic_still_works(downstream_replica_address):
+    """Legitimate handle-path gRPC traffic must keep working under token auth."""
+    handle = serve.get_app_handle("auth_test_app")
+    assert handle.remote().result() == "hello"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description

Every Serve replica starts an internal `ASGIService` gRPC server for handle-path traffic. It was built with a raw `grpc.aio.server()` and bound with `add_insecure_port("[::]:0")`, making it the only Python-side gRPC server in Ray that skipped both of Ray's transport controls:

- **No authentication.** Under `RAY_AUTH_MODE=token` it still accepted calls with a missing or invalid token, and reached `pickle.loads(request.pickled_request_metadata)` (the first statement of the unary and streaming handlers) before any validation.
- **No TLS.** Every other Ray Python gRPC server binds via `add_port_to_grpc_server`, which uses mTLS under `RAY_USE_TLS=1`. This port stayed plaintext.

Both sides of the channel now use Ray's shared helpers:

- `replica.py`
  - `grpc.aio.server(...)` → `create_grpc_server_with_interceptors(asynchronous=True, ...)`
  - `add_insecure_port(...)` → `add_port_to_grpc_server(...)`.
- `request_router/replica_wrapper.py`
  - `grpc.aio.insecure_channel(...)` → `init_grpc_channel(..., asynchronous=True)`.

They must change together: attaching the interceptor while the client used a raw insecure channel would reject *all* legitimate inter-deployment traffic under token mode. The user-facing gRPC proxy ingress and direct-ingress servers are deliberately untouched because those are the application's public API.

## Related issues
N/A

## Additional information

Load test (release test `pytest_serve_throughput_optimized_microbenchmarks.aws`)

https://buildkite.com/ray-project/release/builds/103066#019fce1d-0259-4cab-9af4-5f87ebae3056

```
perf_metrics = [{'perf_metric_name': 'http_p50_latency', 'perf_metric_value': 0.7683139999983268, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_p90_latency', 'perf_metric_value': 0.8034180000024094, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_p95_latency', 'perf_metric_value': 0.8324734500092744, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_p99_latency', 'perf_metric_value': 0.9347973000001268, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_1mb_p50_latency', 'perf_metric_value': 0.8530985000021474, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_1mb_p90_latency', 'perf_metric_value': 0.8736330000118642, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_1mb_p95_latency', 'perf_metric_value': 0.8828049999948462, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_1mb_p99_latency', 'perf_metric_value': 0.9786026100061918, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_10mb_p50_latency', 'perf_metric_value': 2.7588555000050974, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_10mb_p90_latency', 'perf_metric_value': 2.865425099997765, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_10mb_p95_latency', 'perf_metric_value': 2.9161830000049345, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_10mb_p99_latency', 'perf_metric_value': 3.1438252999896577, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_avg_rps', 'perf_metric_value': 3331.96, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_throughput_std', 'perf_metric_value': 62.54, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_model_comp_avg_rps', 'perf_metric_value': 1590.54, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_model_comp_throughput_std', 'perf_metric_value': 19.03, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_100_max_ongoing_requests_avg_rps', 'perf_metric_value': 3304.34, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_100_max_ongoing_requests_throughput_std', 'perf_metric_value': 65.89, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_model_comp_100_max_ongoing_requests_avg_rps', 'perf_metric_value': 1909.65, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_model_comp_100_max_ongoing_requests_throughput_std', 'perf_metric_value': 28.1, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_800_max_ongoing_requests_avg_rps', 'perf_metric_value': 2619.31, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_800_max_ongoing_requests_throughput_std', 'perf_metric_value': 46.12, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_model_comp_800_max_ongoing_requests_avg_rps', 'perf_metric_value': 1707.95, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_model_comp_800_max_ongoing_requests_throughput_std', 'perf_metric_value': 23.55, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_streaming_avg_tps', 'perf_metric_value': 47908.57, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_streaming_throughput_std', 'perf_metric_value': 222.59, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_streaming_p50_latency', 'perf_metric_value': 10386.088265499893, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_streaming_p90_latency', 'perf_metric_value': 10477.022655900078, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_streaming_p95_latency', 'perf_metric_value': 10485.486987499928, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_streaming_p99_latency', 'perf_metric_value': 10492.928692899884, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_intermediate_streaming_avg_tps', 'perf_metric_value': 12923.64, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_intermediate_streaming_throughput_std', 'perf_metric_value': 85.71, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'http_intermediate_streaming_p50_latency', 'perf_metric_value': 11569.407661000128, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_intermediate_streaming_p90_latency', 'perf_metric_value': 11726.095652999948, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_intermediate_streaming_p95_latency', 'perf_metric_value': 11732.701681050094, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'http_intermediate_streaming_p99_latency', 'perf_metric_value': 11740.571149500045, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_p50_latency', 'perf_metric_value': 0.26407450013721245, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_p90_latency', 'perf_metric_value': 0.28829300006236735, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_p95_latency', 'perf_metric_value': 0.29622000009794647, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_p99_latency', 'perf_metric_value': 0.33845479007140966, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_1mb_p50_latency', 'perf_metric_value': 0.6447290001005967, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_1mb_p90_latency', 'perf_metric_value': 1.0565519999090611, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_1mb_p95_latency', 'perf_metric_value': 1.2647335001247422, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_1mb_p99_latency', 'perf_metric_value': 1.7010767098713582, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_10mb_p50_latency', 'perf_metric_value': 7.56068900000173, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_10mb_p90_latency', 'perf_metric_value': 7.930718999955388, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_10mb_p95_latency', 'perf_metric_value': 8.15767950002737, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_10mb_p99_latency', 'perf_metric_value': 11.42704389995515, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'grpc_avg_rps', 'perf_metric_value': 4644.29, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_throughput_std', 'perf_metric_value': 44.42, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_model_comp_avg_rps', 'perf_metric_value': 1795.79, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_model_comp_throughput_std', 'perf_metric_value': 16.34, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_100_max_ongoing_requests_avg_rps', 'perf_metric_value': 4633.21, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_100_max_ongoing_requests_throughput_std', 'perf_metric_value': 41.86, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_model_comp_100_max_ongoing_requests_avg_rps', 'perf_metric_value': 1893.33, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_model_comp_100_max_ongoing_requests_throughput_std', 'perf_metric_value': 14.56, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_800_max_ongoing_requests_avg_rps', 'perf_metric_value': 4709.1, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_800_max_ongoing_requests_throughput_std', 'perf_metric_value': 56.88, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_model_comp_800_max_ongoing_requests_avg_rps', 'perf_metric_value': 1855.88, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'grpc_model_comp_800_max_ongoing_requests_throughput_std', 'perf_metric_value': 17.99, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_p50_latency', 'perf_metric_value': 0.5134040000029927, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_p90_latency', 'perf_metric_value': 0.5564400003095216, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_p95_latency', 'perf_metric_value': 0.5999905000635408, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_p99_latency', 'perf_metric_value': 0.7407399001431251, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_1mb_p50_latency', 'perf_metric_value': 3.020120499741097, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_1mb_p90_latency', 'perf_metric_value': 3.506031000324583, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_1mb_p95_latency', 'perf_metric_value': 3.684139449978829, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_1mb_p99_latency', 'perf_metric_value': 4.465063690327041, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_10mb_p50_latency', 'perf_metric_value': 24.76095550014179, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_10mb_p90_latency', 'perf_metric_value': 28.776263100235155, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_10mb_p95_latency', 'perf_metric_value': 29.590482499997957, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_10mb_p99_latency', 'perf_metric_value': 33.5603927801685, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_choose_dispatch_p50_latency', 'perf_metric_value': 1.3667685000200436, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_choose_dispatch_p90_latency', 'perf_metric_value': 1.4708630002132852, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_choose_dispatch_p95_latency', 'perf_metric_value': 1.534181500278464, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_choose_dispatch_p99_latency', 'perf_metric_value': 1.7805925101902174, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_avg_rps', 'perf_metric_value': 3577.94, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_throughput_std', 'perf_metric_value': 46.32, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_model_comp_avg_rps', 'perf_metric_value': 1024.02, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_model_comp_throughput_std', 'perf_metric_value': 28.41, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_100_max_ongoing_requests_avg_rps', 'perf_metric_value': 3608.89, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_100_max_ongoing_requests_throughput_std', 'perf_metric_value': 50.27, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_model_comp_100_max_ongoing_requests_avg_rps', 'perf_metric_value': 1713.96, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_model_comp_100_max_ongoing_requests_throughput_std', 'perf_metric_value': 8.49, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_800_max_ongoing_requests_avg_rps', 'perf_metric_value': 3469.5, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_800_max_ongoing_requests_throughput_std', 'perf_metric_value': 48.74, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_model_comp_800_max_ongoing_requests_avg_rps', 'perf_metric_value': 1669.48, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_model_comp_800_max_ongoing_requests_throughput_std', 'perf_metric_value': 9.71, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_streaming_avg_tps', 'perf_metric_value': 13061.88, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_streaming_throughput_std', 'perf_metric_value': 126.02, 'perf_metric_type': 'THROUGHPUT'}, {'perf_metric_name': 'handle_streaming_p50_latency', 'perf_metric_value': 11471.149349500138, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_streaming_p90_latency', 'perf_metric_value': 11600.003801100147, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_streaming_p95_latency', 'perf_metric_value': 11673.039116000291, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'handle_streaming_p99_latency', 'perf_metric_value': 11682.604228900054, 'perf_metric_type': 'LATENCY'}]
```