### PR TITLE
[core] Fix task log info fields in lifecycle events

### DIFF
--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1689,6 +1689,13 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
         for key in keys:
             task_state[key] = src.get(key)
 
+    task_log_info = task_state["task_log_info"]
+    if task_log_info:
+        # The offsets are int64, which MessageToDict renders as strings.
+        for field in ("stdout_start", "stdout_end", "stderr_start", "stderr_end"):
+            if field in task_log_info:
+                task_log_info[field] = int(task_log_info[field])
+
     task_state["creation_time_ms"] = None
     task_state["start_time_ms"] = None
     task_state["end_time_ms"] = None

--- a/src/ray/common/protobuf_utils.cc
+++ b/src/ray/common/protobuf_utils.cc
@@ -380,10 +380,12 @@ void TaskLogInfoToExport(const rpc::TaskLogInfo &src,
                          rpc::ExportTaskEventData::TaskLogInfo *dest) {
   dest->set_stdout_file(src.stdout_file());
   dest->set_stderr_file(src.stderr_file());
-  dest->set_stdout_start(src.stdout_start());
-  dest->set_stdout_end(src.stdout_end());
-  dest->set_stderr_start(src.stderr_start());
-  dest->set_stderr_end(src.stderr_end());
+  // The export schema is public and its offsets are int32, so the wider offsets are
+  // narrowed here rather than changing a field type that consumers already parse.
+  dest->set_stdout_start(static_cast<int32_t>(src.stdout_start()));
+  dest->set_stdout_end(static_cast<int32_t>(src.stdout_end()));
+  dest->set_stderr_start(static_cast<int32_t>(src.stderr_start()));
+  dest->set_stderr_end(static_cast<int32_t>(src.stderr_end()));
 }
 
 std::optional<rpc::autoscaler::PlacementConstraint>

--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -158,6 +158,30 @@ rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskLifecycleEvent &&event) {
   if (event.has_actor_repr_name()) {
     task_state_update->set_actor_repr_name(event.actor_repr_name());
   }
+  if (event.has_task_log_info()) {
+    const rpc::events::TaskLifecycleEvent::TaskLogInfo &src = event.task_log_info();
+    rpc::TaskLogInfo *dst = task_state_update->mutable_task_log_info();
+    if (src.has_stdout_file()) {
+      dst->set_stdout_file(src.stdout_file());
+    }
+    if (src.has_stderr_file()) {
+      dst->set_stderr_file(src.stderr_file());
+    }
+    // The offsets narrow to int32 because that is the width TaskLogInfo has always
+    // used on this side.
+    if (src.has_stdout_start()) {
+      dst->set_stdout_start(static_cast<int32_t>(src.stdout_start()));
+    }
+    if (src.has_stdout_end()) {
+      dst->set_stdout_end(static_cast<int32_t>(src.stdout_end()));
+    }
+    if (src.has_stderr_start()) {
+      dst->set_stderr_start(static_cast<int32_t>(src.stderr_start()));
+    }
+    if (src.has_stderr_end()) {
+      dst->set_stderr_end(static_cast<int32_t>(src.stderr_end()));
+    }
+  }
 
   for (const auto &state_transition : event.state_transitions()) {
     int64_t ns = ProtoTimestampToAbslTimeNanos(state_transition.timestamp());

--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -159,13 +159,13 @@ rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskLifecycleEvent &&event) {
     task_state_update->set_actor_repr_name(event.actor_repr_name());
   }
   if (event.has_task_log_info()) {
-    const rpc::events::TaskLifecycleEvent::TaskLogInfo &src = event.task_log_info();
+    rpc::events::TaskLifecycleEvent::TaskLogInfo &src = *event.mutable_task_log_info();
     rpc::TaskLogInfo *dst = task_state_update->mutable_task_log_info();
     if (src.has_stdout_file()) {
-      dst->set_stdout_file(src.stdout_file());
+      *dst->mutable_stdout_file() = std::move(*src.mutable_stdout_file());
     }
     if (src.has_stderr_file()) {
-      dst->set_stderr_file(src.stderr_file());
+      *dst->mutable_stderr_file() = std::move(*src.mutable_stderr_file());
     }
     if (src.has_stdout_start()) {
       dst->set_stdout_start(src.stdout_start());

--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -167,19 +167,17 @@ rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskLifecycleEvent &&event) {
     if (src.has_stderr_file()) {
       dst->set_stderr_file(src.stderr_file());
     }
-    // The offsets narrow to int32 because that is the width TaskLogInfo has always
-    // used on this side.
     if (src.has_stdout_start()) {
-      dst->set_stdout_start(static_cast<int32_t>(src.stdout_start()));
+      dst->set_stdout_start(src.stdout_start());
     }
     if (src.has_stdout_end()) {
-      dst->set_stdout_end(static_cast<int32_t>(src.stdout_end()));
+      dst->set_stdout_end(src.stdout_end());
     }
     if (src.has_stderr_start()) {
-      dst->set_stderr_start(static_cast<int32_t>(src.stderr_start()));
+      dst->set_stderr_start(src.stderr_start());
     }
     if (src.has_stderr_end()) {
-      dst->set_stderr_end(static_cast<int32_t>(src.stderr_end()));
+      dst->set_stderr_end(src.stderr_end());
     }
   }
 

--- a/src/ray/gcs/tests/gcs_ray_event_converter_test.cc
+++ b/src/ray/gcs/tests/gcs_ray_event_converter_test.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/gcs_ray_event_converter.h"
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "ray/common/id.h"
 #include "ray/util/logging.h"
@@ -775,6 +777,27 @@ TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventTaskLogInfoZeroStart
   const rpc::TaskLogInfo &converted = task_event.state_updates().task_log_info();
   EXPECT_TRUE(converted.has_stdout_start());
   EXPECT_EQ(converted.stdout_start(), 0);
+}
+
+// A worker log can exceed 2 GiB, so offsets past the int32 range must round-trip.
+TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventTaskLogInfoLargeOffsets) {
+  const int64_t past_int32_max =
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+
+  rpc::events::AddEventsRequest request = MakeLifecycleEventRequest(1);
+  rpc::events::TaskLifecycleEvent::TaskLogInfo *log_info =
+      request.mutable_events_data()
+          ->mutable_events(0)
+          ->mutable_task_lifecycle_event()
+          ->mutable_task_log_info();
+  log_info->set_stdout_start(past_int32_max);
+  log_info->set_stdout_end(past_int32_max + 100);
+
+  rpc::TaskEvents task_event = ConvertSingleEvent(std::move(request));
+
+  const rpc::TaskLogInfo &converted = task_event.state_updates().task_log_info();
+  EXPECT_EQ(converted.stdout_start(), past_int32_max);
+  EXPECT_EQ(converted.stdout_end(), past_int32_max + 100);
 }
 
 // The log paths arrive when the task starts and the end offsets when it finishes. GCS

--- a/src/ray/gcs/tests/gcs_ray_event_converter_test.cc
+++ b/src/ray/gcs/tests/gcs_ray_event_converter_test.cc
@@ -16,6 +16,7 @@
 
 #include "gtest/gtest.h"
 #include "ray/common/id.h"
+#include "ray/util/logging.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/events_event_aggregator_service.pb.h"
 #include "src/ray/protobuf/gcs_service.pb.h"
@@ -671,6 +672,146 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<OptionalFieldTestCase> &info) {
       return info.param.test_name;
     });
+
+namespace {
+
+// Builds a request holding a single TaskLifecycleEvent for the given attempt, so the
+// task_log_info tests can convert one event at a time and merge the results.
+rpc::events::AddEventsRequest MakeLifecycleEventRequest(int32_t attempt) {
+  rpc::events::AddEventsRequest request;
+  rpc::events::RayEvent &event = *request.mutable_events_data()->mutable_events()->Add();
+  event.set_event_type(rpc::events::RayEvent::TASK_LIFECYCLE_EVENT);
+  rpc::events::TaskLifecycleEvent &lifecycle_event =
+      *event.mutable_task_lifecycle_event();
+  lifecycle_event.set_task_id("test_task_id");
+  lifecycle_event.set_task_attempt(attempt);
+  lifecycle_event.set_job_id("test_job_id");
+  return request;
+}
+
+rpc::TaskEvents ConvertSingleEvent(rpc::events::AddEventsRequest &&request) {
+  std::vector<rpc::AddTaskEventDataRequest> requests =
+      ConvertToTaskEventDataRequests(std::move(request));
+  RAY_CHECK_EQ(requests.size(), static_cast<size_t>(1));
+  return requests[0].data().events_by_task()[0];
+}
+
+}  // namespace
+
+TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventTaskLogInfo) {
+  rpc::events::AddEventsRequest request = MakeLifecycleEventRequest(1);
+  rpc::events::TaskLifecycleEvent::TaskLogInfo *log_info =
+      request.mutable_events_data()
+          ->mutable_events(0)
+          ->mutable_task_lifecycle_event()
+          ->mutable_task_log_info();
+  log_info->set_stdout_file("/tmp/worker-out.log");
+  log_info->set_stderr_file("/tmp/worker-err.log");
+  log_info->set_stdout_start(10);
+  log_info->set_stdout_end(20);
+  log_info->set_stderr_start(30);
+  log_info->set_stderr_end(40);
+
+  rpc::TaskEvents task_event = ConvertSingleEvent(std::move(request));
+
+  ASSERT_TRUE(task_event.has_state_updates());
+  ASSERT_TRUE(task_event.state_updates().has_task_log_info());
+  const rpc::TaskLogInfo &converted = task_event.state_updates().task_log_info();
+  EXPECT_EQ(converted.stdout_file(), "/tmp/worker-out.log");
+  EXPECT_EQ(converted.stderr_file(), "/tmp/worker-err.log");
+  EXPECT_EQ(converted.stdout_start(), 10);
+  EXPECT_EQ(converted.stdout_end(), 20);
+  EXPECT_EQ(converted.stderr_start(), 30);
+  EXPECT_EQ(converted.stderr_end(), 40);
+}
+
+TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventWithoutTaskLogInfo) {
+  rpc::TaskEvents task_event = ConvertSingleEvent(MakeLifecycleEventRequest(1));
+
+  ASSERT_TRUE(task_event.has_state_updates());
+  EXPECT_FALSE(task_event.state_updates().has_task_log_info());
+}
+
+// The event a task emits when it finishes carries only the end offsets. The fields it
+// leaves unset must stay unset after conversion.
+TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventTaskLogInfoEndOffsetsOnly) {
+  rpc::events::AddEventsRequest request = MakeLifecycleEventRequest(1);
+  rpc::events::TaskLifecycleEvent::TaskLogInfo *log_info =
+      request.mutable_events_data()
+          ->mutable_events(0)
+          ->mutable_task_lifecycle_event()
+          ->mutable_task_log_info();
+  log_info->set_stdout_end(20);
+  log_info->set_stderr_end(40);
+
+  rpc::TaskEvents task_event = ConvertSingleEvent(std::move(request));
+
+  ASSERT_TRUE(task_event.state_updates().has_task_log_info());
+  const rpc::TaskLogInfo &converted = task_event.state_updates().task_log_info();
+  EXPECT_FALSE(converted.has_stdout_file());
+  EXPECT_FALSE(converted.has_stderr_file());
+  EXPECT_FALSE(converted.has_stdout_start());
+  EXPECT_FALSE(converted.has_stderr_start());
+  EXPECT_TRUE(converted.has_stdout_end());
+  EXPECT_EQ(converted.stdout_end(), 20);
+  EXPECT_TRUE(converted.has_stderr_end());
+  EXPECT_EQ(converted.stderr_end(), 40);
+}
+
+// A start offset of 0 is legitimate for the first task writing to a fresh log file, so it
+// must survive conversion rather than being treated as absent.
+TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventTaskLogInfoZeroStartOffset) {
+  rpc::events::AddEventsRequest request = MakeLifecycleEventRequest(1);
+  rpc::events::TaskLifecycleEvent::TaskLogInfo *log_info =
+      request.mutable_events_data()
+          ->mutable_events(0)
+          ->mutable_task_lifecycle_event()
+          ->mutable_task_log_info();
+  log_info->set_stdout_file("/tmp/worker-out.log");
+  log_info->set_stdout_start(0);
+
+  rpc::TaskEvents task_event = ConvertSingleEvent(std::move(request));
+
+  const rpc::TaskLogInfo &converted = task_event.state_updates().task_log_info();
+  EXPECT_TRUE(converted.has_stdout_start());
+  EXPECT_EQ(converted.stdout_start(), 0);
+}
+
+// The log paths arrive when the task starts and the end offsets when it finishes. GCS
+// merges the two events into one attempt, so the paths and start offsets reported first
+// must survive the merge.
+TEST(GcsRayEventConverterTest, TestConvertTaskLifecycleEventTaskLogInfoMerge) {
+  rpc::events::AddEventsRequest start_request = MakeLifecycleEventRequest(1);
+  rpc::events::TaskLifecycleEvent::TaskLogInfo *start_log_info =
+      start_request.mutable_events_data()
+          ->mutable_events(0)
+          ->mutable_task_lifecycle_event()
+          ->mutable_task_log_info();
+  start_log_info->set_stdout_file("/tmp/worker-out.log");
+  start_log_info->set_stderr_file("/tmp/worker-err.log");
+  start_log_info->set_stdout_start(10);
+  start_log_info->set_stderr_start(30);
+
+  rpc::events::AddEventsRequest end_request = MakeLifecycleEventRequest(1);
+  rpc::events::TaskLifecycleEvent::TaskLogInfo *end_log_info =
+      end_request.mutable_events_data()
+          ->mutable_events(0)
+          ->mutable_task_lifecycle_event()
+          ->mutable_task_log_info();
+  end_log_info->set_stdout_end(20);
+  end_log_info->set_stderr_end(40);
+
+  rpc::TaskEvents merged = ConvertSingleEvent(std::move(start_request));
+  merged.MergeFrom(ConvertSingleEvent(std::move(end_request)));
+
+  const rpc::TaskLogInfo &converted = merged.state_updates().task_log_info();
+  EXPECT_EQ(converted.stdout_file(), "/tmp/worker-out.log");
+  EXPECT_EQ(converted.stderr_file(), "/tmp/worker-err.log");
+  EXPECT_EQ(converted.stdout_start(), 10);
+  EXPECT_EQ(converted.stderr_start(), 30);
+  EXPECT_EQ(converted.stdout_end(), 20);
+  EXPECT_EQ(converted.stderr_end(), 40);
+}
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -187,13 +187,13 @@ message TaskLogInfo {
   // stderr log file absolute path.
   optional string stderr_file = 2;
   // Start offset of stdout when task starts.
-  optional int32 stdout_start = 3;
+  optional int64 stdout_start = 3;
   // End offset of stdout when task finishes.
-  optional int32 stdout_end = 4;
+  optional int64 stdout_end = 4;
   // Start offset of stderr when task starts.
-  optional int32 stderr_start = 5;
+  optional int64 stderr_start = 5;
   // End offset of stderr when task finishes.
-  optional int32 stderr_end = 6;
+  optional int64 stderr_end = 6;
 }
 
 // Represents task states which could be changed during task execution.

--- a/src/ray/protobuf/public/events_task_lifecycle_event.proto
+++ b/src/ray/protobuf/public/events_task_lifecycle_event.proto
@@ -33,19 +33,23 @@ message TaskLifecycleEvent {
     google.protobuf.Timestamp timestamp = 2;
   }
 
+  // Fields carry explicit presence because the log paths and the start offsets are
+  // reported when the task starts, while the end offsets arrive in a later event.
+  // Consumers merge the two, so an unset field must stay distinguishable from an
+  // empty one to avoid overwriting what the earlier event reported.
   message TaskLogInfo {
     // stdout log file absolute path.
-    string stdout_file = 1;
+    optional string stdout_file = 1;
     // stderr log file absolute path.
-    string stderr_file = 2;
+    optional string stderr_file = 2;
     // Start offset of stdout when task starts.
-    int64 stdout_start = 3;
+    optional int64 stdout_start = 3;
     // End offset of stdout when task finishes.
-    int64 stdout_end = 4;
+    optional int64 stdout_end = 4;
     // Start offset of stderr when task starts.
-    int64 stderr_start = 5;
+    optional int64 stderr_start = 5;
     // End offset of stderr when task finishes.
-    int64 stderr_end = 6;
+    optional int64 stderr_end = 6;
   }
 
   repeated StateTransition state_transitions = 3;


### PR DESCRIPTION
Found the bug when working on task event migration from GCS to dashboard head. I switched off the task event buffer to GCS direct flag and rather routed task events via the aggregator. This led to failing `test_log_get` and `test_log_task` in `test_state_api_log` due to this error: 

`ray.util.state.exception.RayStateApiException: Could not find log file for task attempt:`

`ray logs task <task_id>` resolves a task's log file using `task_log_info`. When task events reach GCS through the event aggregator (via the ray event framework), the field never arrives, and the lookup fails. This happens because the `gcs_ray_event_converter` never maps task log info to `TaskEvents` before storing them. Since we want to store them the right way, we want to check if fields were ever populated by source. Since we need `has_*` checks for them, we also add optional to the fields in the proto `TaskLifecycleEvent`. 
