### PR TITLE
[ci/doc] Ignore inherited API annotations in documentation checks

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -9,7 +9,7 @@ import click
 
 from ci.ray_ci.doc.api import API
 from ci.ray_ci.doc.autodoc import Autodoc
-from ci.ray_ci.doc.module import Module
+from ci.ray_ci.doc.module import Module, _is_directly_annotated
 
 # Each team config carries two exemption lists. Both feed the "every
 # @PublicAPI symbol must be documented" check identically (they're unioned at
@@ -357,7 +357,7 @@ def _import_status(module: str) -> Tuple[bool, bool]:
             origin = getattr(obj, "__module__", None)
             if not origin or (origin != module and not origin.startswith(f"{module}.")):
                 continue
-            if hasattr(obj, "_annotated"):
+            if _is_directly_annotated(obj):
                 return (True, True)
         except Exception:  # noqa: BLE001 - lazy attribute access blew up
             continue

--- a/ci/ray_ci/doc/mock/mock_module.py
+++ b/ci/ray_ci/doc/mock/mock_module.py
@@ -6,7 +6,7 @@ def PublicAPI(*args, **kwargs):
         return PublicAPI()(args[0])
 
     def wrap(obj):
-        obj._annotated = None
+        obj._annotated = obj.__name__
         obj._annotated_type = AnnotationType.PUBLIC_API
         return obj
 
@@ -18,7 +18,7 @@ def Deprecated(*args, **kwargs):
         return Deprecated()(args[0])
 
     def wrap(obj):
-        obj._annotated = None
+        obj._annotated = obj.__name__
         obj._annotated_type = AnnotationType.DEPRECATED
         return obj
 
@@ -64,6 +64,12 @@ class MockClass:
         detection of genuinely private symbols.
         """
         pass
+
+
+class InheritedAnnotation(MockClass):
+    """An undecorated subclass must not inherit MockClass's API annotation."""
+
+    pass
 
 
 @Deprecated

--- a/ci/ray_ci/doc/module.py
+++ b/ci/ray_ci/doc/module.py
@@ -6,6 +6,15 @@ from typing import List
 from ci.ray_ci.doc.api import API, AnnotationType, CodeType
 
 
+def _is_directly_annotated(obj: object) -> bool:
+    """Return whether an object owns an API annotation, rather than
+    inheriting one from a base class."""
+    annotation_owner = getattr(obj, "_annotated", None)
+    return annotation_owner is not None and annotation_owner == getattr(
+        obj, "__name__", None
+    )
+
+
 class Module:
     """
     Module class represents the top level module to walk through and find annotated
@@ -90,7 +99,7 @@ class Module:
         return module.__name__.startswith(self._module.__name__)
 
     def _is_api(self, module: ModuleType) -> bool:
-        return self._is_valid_child(module) and hasattr(module, "_annotated")
+        return self._is_valid_child(module) and _is_directly_annotated(module)
 
     def _get_annotation_type(self, module: ModuleType) -> AnnotationType:
         return AnnotationType(module._annotated_type.value)

--- a/ci/ray_ci/doc/test_cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/test_cmd_check_api_discrepancy.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+from types import ModuleType
 
 import pytest
 
@@ -224,6 +225,17 @@ def test_immediate_child_modules_of_plain_module_is_empty():
 def test_import_status_detects_public_api():
     # mock_module defines @PublicAPI classes/functions in its own namespace.
     assert cmd._import_status(f"{_PKG}.mock_module") == (True, True)
+
+
+def test_import_status_ignores_inherited_api_annotations(monkeypatch):
+    module_name = "fake_inherited_annotation_module"
+    module = ModuleType(module_name)
+    inherited_annotation = type("InheritedAnnotation", (MockClass,), {})
+    inherited_annotation.__module__ = module_name
+    module.InheritedAnnotation = inherited_annotation
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    assert cmd._import_status(module_name) == (True, False)
 
 
 def test_import_status_unimportable_module():

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -19,5 +19,13 @@ def test_walk():
     assert module._module not in module._visited
 
 
+def test_walk_ignores_inherited_api_annotations():
+    module = Module("ci.ray_ci.doc.mock.mock_module")
+
+    assert "ci.ray_ci.doc.mock.mock_module.InheritedAnnotation" not in {
+        api.name for api in module.get_apis()
+    }
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why
The API-doc checker used `hasattr`, so it treated subclasses as independently annotated. `RoundRobinRouter` inherits markers from public router base classes, causing the expanded Serve walk to report it as undocumented and fail premerge.

## What
Require annotations to be owned by the inspected object, matching `ray.util.annotations`, in both the API walk and subpackage guard. Add regression tests. Alternative: add `RoundRobinRouter` to the API index, but that incorrectly promotes an experimental implementation.

## Related issues
https://buildkite.com/ray-project/premerge/builds/71313#019fcae0-04dc-4fe2-a9dc-d7ba2ecd39e1

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
