### PR TITLE
[Data][DNR] Bump shuffle release tests to SF1000; default hash_shuffle_v2 tests to 8KB inlining; TPC-H joins to 200 partitions

### DIFF
--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -35,6 +35,16 @@ def parse_args() -> argparse.Namespace:
         help="Strategy to use when shuffling data (see ShuffleStrategy for accepted values)",
     )
 
+    parser.add_argument(
+        "--num-partitions",
+        type=int,
+        default=None,
+        help=(
+            "Number of shuffle partitions. Sets "
+            "DataContext.default_hash_shuffle_parallelism (hash strategies only)."
+        ),
+    )
+
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--aggregate", action="store_true")
     consume_group.add_argument("--map-groups", action="store_true")
@@ -53,15 +63,23 @@ def main(args):
         DataContext.get_current().shuffle_strategy = ShuffleStrategy(
             args.shuffle_strategy
         )
+        if args.num_partitions is not None:
+            DataContext.get_current().default_hash_shuffle_parallelism = (
+                args.num_partitions
+            )
         # TODO: Don't override once we fix range-based shuffle
         override_num_blocks = (
             100
             if args.shuffle_strategy == ShuffleStrategy.SORT_SHUFFLE_PULL_BASED.value
             else None
         )
-        grouped_ds = ray.data.read_parquet(
-            path, override_num_blocks=override_num_blocks
-        ).groupby(args.group_by)
+        ds = ray.data.read_parquet(path, override_num_blocks=override_num_blocks)
+        # Cast string columns to large_string: on low-cardinality keys a single
+        # group's string data can exceed 2GB per column, overflowing Arrow's
+        # int32 string offsets when the shuffle reduce sorts the partition
+        # into one contiguous table.
+        ds = ds.map_batches(_cast_strings_to_large, batch_format="pyarrow")
+        grouped_ds = ds.groupby(args.group_by)
         consume_fn(grouped_ds)
 
         # Report arguments for the benchmark.
@@ -89,6 +107,21 @@ def get_consume_fn(args: argparse.Namespace):
         assert False, f"Invalid consume argument: {args}"
 
     return consume_fn
+
+
+def _cast_strings_to_large(table: pa.Table) -> pa.Table:
+    schema = pa.schema(
+        [
+            pa.field(
+                f.name,
+                pa.large_string() if types.is_string(f.type) else f.type,
+                f.nullable,
+            )
+            for f in table.schema
+        ],
+        metadata=table.schema.metadata,
+    )
+    return table.cast(schema)
 
 
 def normalize_table(table: pa.Table) -> pa.Table:

--- a/release/nightly_tests/dataset/tpch/tpch_q10.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q10.py
@@ -69,7 +69,7 @@ def main(args):
         orders_customer = orders_filtered.join(
             customer,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("o_custkey",),
             right_on=("c_custkey",),
         )
@@ -78,7 +78,7 @@ def main(args):
         orders_customer_nation = orders_customer.join(
             nation,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("c_nationkey",),
             right_on=("n_nationkey",),
         )
@@ -99,7 +99,7 @@ def main(args):
         ds = orders_customer_nation.join(
             lineitem_filtered,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("o_orderkey",),
             right_on=("l_orderkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q11.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q11.py
@@ -51,7 +51,7 @@ def main(args):
         nation_supplier = nation_filtered.join(
             supplier,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("n_nationkey",),
             right_on=("s_nationkey",),
         ).select_columns(["s_suppkey"])
@@ -63,7 +63,7 @@ def main(args):
             partsupp.join(
                 nation_supplier,
                 join_type="inner",
-                num_partitions=16,
+                num_partitions=200,
                 on=("ps_suppkey",),
                 right_on=("s_suppkey",),
             )

--- a/release/nightly_tests/dataset/tpch/tpch_q12.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q12.py
@@ -68,7 +68,7 @@ def main(args):
         joined = lineitem.join(
             orders,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("l_orderkey",),
             right_on=("o_orderkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q13.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q13.py
@@ -6,6 +6,9 @@ from common import parse_tpch_args, load_table, run_tpch_benchmark
 
 def main(args):
     def benchmark_fn():
+        # The original hardcoded counts (16, tuned at sf100) yield ~15GB join
+        # partitions at sf1000 -- reduce tasks too large for a single node.
+        join_num_partitions = 200
         # Q13: Customer Distribution Query
         # Find the distribution of customers by number of orders,
         # excluding orders with comments matching '%[WORD1]%[WORD2]%'
@@ -43,7 +46,7 @@ def main(args):
         joined = customers.join(
             orders,
             join_type="left_outer",
-            num_partitions=128,
+            num_partitions=join_num_partitions,
             on=("c_custkey",),
             right_on=("o_custkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q14.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q14.py
@@ -45,7 +45,7 @@ def main(args):
         joined = lineitem.join(
             part,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("l_partkey",),
             right_on=("p_partkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q15.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q15.py
@@ -6,6 +6,9 @@ from common import parse_tpch_args, load_table, to_f64, run_tpch_benchmark
 
 def main(args):
     def benchmark_fn():
+        # The original hardcoded counts (16, tuned at sf100) yield ~15GB join
+        # partitions at sf1000 -- reduce tasks too large for a single node.
+        join_num_partitions = 200
         from datetime import datetime
 
         # Q15: Top Supplier Query
@@ -66,7 +69,7 @@ def main(args):
             supplier.join(
                 top,
                 join_type="inner",
-                num_partitions=16,
+                num_partitions=join_num_partitions,
                 on=("s_suppkey",),
                 right_on=("l_suppkey",),
             )

--- a/release/nightly_tests/dataset/tpch/tpch_q17.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q17.py
@@ -54,7 +54,7 @@ def main(args):
             part_filtered.join(
                 lineitem,
                 join_type="inner",
-                num_partitions=16,
+                num_partitions=200,
                 on=("p_partkey",),
                 right_on=("l_partkey",),
             )
@@ -73,7 +73,7 @@ def main(args):
         ds = joined.join(
             avg_qty,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("p_partkey",),
         ).select_columns(["l_quantity", "l_extendedprice", "avg_quantity"])
 

--- a/release/nightly_tests/dataset/tpch/tpch_q18.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q18.py
@@ -54,7 +54,7 @@ def main(args):
         orders_customer = orders.join(
             customer.select_columns(["c_custkey", "c_name"]),
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("o_custkey",),
             right_on=("c_custkey",),
         )
@@ -66,7 +66,7 @@ def main(args):
         lineitem_large = lineitem.join(
             large_orders,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("l_orderkey",),
         )
         lineitem_large = lineitem_large.select_columns(
@@ -77,7 +77,7 @@ def main(args):
         ds = lineitem_large.join(
             orders_customer,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("l_orderkey",),
             right_on=("o_orderkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q2.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q2.py
@@ -74,7 +74,7 @@ def main(args):
 
         nation_region = region_filtered.join(
             nation,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("r_regionkey",),
             right_on=("n_regionkey",),
@@ -84,7 +84,7 @@ def main(args):
         # in both Branch B and the main pipeline (Ray Data has no CSE).
         regional_suppliers = nation_region.join(
             supplier,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("n_nationkey",),
             right_on=("s_nationkey",),
@@ -93,7 +93,7 @@ def main(args):
         # ── Branch B: min supply cost per part from regional suppliers ──
         regional_partsupp = partsupp.join(
             regional_suppliers.select_columns(["s_suppkey"]),
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("ps_suppkey",),
             right_on=("s_suppkey",),
@@ -118,7 +118,7 @@ def main(args):
         # Join part with partsupp
         part_partsupp = part_filtered.join(
             partsupp,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("p_partkey",),
             right_on=("ps_partkey",),
@@ -141,7 +141,7 @@ def main(args):
                     "n_name",
                 ]
             ),
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("ps_suppkey",),
             right_on=("s_suppkey",),
@@ -164,7 +164,7 @@ def main(args):
         # source via to_f64, and Min preserves the exact float64 value.
         ds = part_regional.join(
             min_cost,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("p_partkey",),
             right_on=("ps_partkey",),

--- a/release/nightly_tests/dataset/tpch/tpch_q20.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q20.py
@@ -72,7 +72,7 @@ def main(args):
         ps_forest = partsupp.join(
             forest_parts,
             join_type="left_semi",
-            num_partitions=16,
+            num_partitions=200,
             on=("ps_partkey",),
             right_on=("p_partkey",),
         )
@@ -95,7 +95,7 @@ def main(args):
         ps_li = ps_forest.join(
             li_agg,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("ps_partkey", "ps_suppkey"),
             right_on=("l_partkey", "l_suppkey"),
         )
@@ -108,7 +108,7 @@ def main(args):
         canadian_suppliers = supplier.join(
             nation_filtered,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("s_nationkey",),
             right_on=("n_nationkey",),
         ).select_columns(["s_suppkey", "s_name", "s_address"])
@@ -116,7 +116,7 @@ def main(args):
         result = canadian_suppliers.join(
             qualified_ps,
             join_type="left_semi",
-            num_partitions=16,
+            num_partitions=200,
             on=("s_suppkey",),
             right_on=("ps_suppkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q21.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q21.py
@@ -6,6 +6,9 @@ from common import parse_tpch_args, load_table, run_tpch_benchmark
 
 def main(args):
     def benchmark_fn():
+        # The original hardcoded counts (16, tuned at sf100) yield ~15GB join
+        # partitions at sf1000 -- reduce tasks too large for a single node.
+        join_num_partitions = 200
         # Q21: Suppliers Who Kept Orders Waiting Query
         # Identify suppliers in a given nation whose shipments were received
         # late, where at least one other supplier also filled the same order
@@ -94,7 +97,7 @@ def main(args):
         saudi_suppliers = supplier.join(
             saudi_nation,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             on=("s_nationkey",),
             right_on=("n_nationkey",),
         ).select_columns(["s_suppkey", "s_name"])
@@ -108,7 +111,7 @@ def main(args):
         ds = late_lineitem.join(
             failed_orders,
             join_type="left_semi",
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             on=("l_orderkey",),
             right_on=("o_orderkey",),
         )
@@ -117,7 +120,7 @@ def main(args):
         ds = ds.join(
             saudi_suppliers,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             on=("l_suppkey",),
             right_on=("s_suppkey",),
         )
@@ -127,7 +130,7 @@ def main(args):
         ds = ds.join(
             suppliers_per_order,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             on=("l_orderkey",),
         )
 
@@ -136,7 +139,7 @@ def main(args):
         ds = ds.join(
             late_suppliers_per_order,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             on=("l_orderkey",),
         )
 

--- a/release/nightly_tests/dataset/tpch/tpch_q22.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q22.py
@@ -6,6 +6,9 @@ from common import parse_tpch_args, load_table, to_f64, run_tpch_benchmark
 
 def main(args):
     def benchmark_fn():
+        # The original hardcoded counts (16, tuned at sf100) yield ~15GB join
+        # partitions at sf1000 -- reduce tasks too large for a single node.
+        join_num_partitions = 200
         # Q22: Global Sales Opportunity Query
         # Identify geographic areas where there are customers who may be
         # likely to make a purchase (above-average balance, no existing orders).
@@ -68,7 +71,7 @@ def main(args):
         custsale = custsale.join(
             orders,
             join_type="left_anti",
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             on=("c_custkey",),
             right_on=("o_custkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q3.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q3.py
@@ -55,7 +55,7 @@ def main(args):
         orders_customer = customer_filtered.join(
             orders_filtered,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("c_custkey",),
             right_on=("o_custkey",),
         ).select_columns(["o_orderkey", "o_orderdate", "o_shippriority"])
@@ -65,7 +65,7 @@ def main(args):
         ds = orders_customer.join(
             lineitem_filtered,
             join_type="inner",
-            num_partitions=16,
+            num_partitions=200,
             on=("o_orderkey",),
             right_on=("l_orderkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q4.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q4.py
@@ -57,7 +57,7 @@ def main(args):
         ds = orders_filtered.join(
             lineitem_late,
             join_type="left_semi",
-            num_partitions=16,
+            num_partitions=200,
             on=("o_orderkey",),
             right_on=("l_orderkey",),
         )

--- a/release/nightly_tests/dataset/tpch/tpch_q5.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q5.py
@@ -59,7 +59,7 @@ def main(args):
 
         nation_region = region_filtered.join(
             nation,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("r_regionkey",),
             right_on=("n_regionkey",),
@@ -69,7 +69,7 @@ def main(args):
         customer_nation = (
             nation_region.join(
                 customer,
-                num_partitions=16,
+                num_partitions=200,
                 join_type="inner",
                 on=("n_nationkey",),
                 right_on=("c_nationkey",),
@@ -83,7 +83,7 @@ def main(args):
         )
         orders_customer = orders_filtered.join(
             customer_nation,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("o_custkey",),
             right_on=("c_custkey",),
@@ -91,7 +91,7 @@ def main(args):
 
         lineitem_orders = lineitem.join(
             orders_customer,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_orderkey",),
             right_on=("o_orderkey",),
@@ -101,7 +101,7 @@ def main(args):
 
         ds = lineitem_orders.join(
             supplier,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_suppkey",),
             right_on=("s_suppkey",),

--- a/release/nightly_tests/dataset/tpch/tpch_q7.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q7.py
@@ -63,7 +63,7 @@ def main(args):
 
         customer_nation = nations_of_interest.join(
             customer,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("n_nationkey",),
             right_on=("c_nationkey",),
@@ -73,7 +73,7 @@ def main(args):
 
         orders_customer = orders.join(
             customer_nation,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("o_custkey",),
             right_on=("c_custkey",),
@@ -86,7 +86,7 @@ def main(args):
         )
         lineitem_orders = lineitem_filtered.join(
             orders_customer,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_orderkey",),
             right_on=("o_orderkey",),
@@ -97,7 +97,7 @@ def main(args):
         # Keep supplier join and supplier-nation join in the same linear pipeline.
         lineitem_supplier = lineitem_orders.join(
             supplier,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_suppkey",),
             right_on=("s_suppkey",),
@@ -114,7 +114,7 @@ def main(args):
 
         ds = lineitem_supplier.join(
             nations_of_interest,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("s_nationkey",),
             right_on=("n_nationkey",),

--- a/release/nightly_tests/dataset/tpch/tpch_q8.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q8.py
@@ -6,6 +6,9 @@ from common import parse_tpch_args, load_table, to_f64, run_tpch_benchmark
 
 def main(args):
     def benchmark_fn():
+        # The original hardcoded counts (16, tuned at sf100) yield ~15GB join
+        # partitions at sf1000 -- reduce tasks too large for a single node.
+        join_num_partitions = 200
         from datetime import datetime
 
         # Q8: National Market Share Query
@@ -73,7 +76,7 @@ def main(args):
         # Join region with nation
         nation_region = region_filtered.join(
             nation,
-            num_partitions=16,  # Empirical value to balance parallelism and shuffle overhead
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("r_regionkey",),
             right_on=("n_regionkey",),
@@ -82,7 +85,7 @@ def main(args):
         # Join customer with nation in the region.
         customer_nation = nation_region.join(
             customer,
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("n_nationkey",),
             right_on=("c_nationkey",),
@@ -98,7 +101,7 @@ def main(args):
         )
         orders_customer = orders_filtered.join(
             customer_nation,
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("o_custkey",),
             right_on=("c_custkey",),
@@ -107,7 +110,7 @@ def main(args):
         # Join lineitem with orders
         lineitem_orders = lineitem.join(
             orders_customer,
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("l_orderkey",),
             right_on=("o_orderkey",),
@@ -125,7 +128,7 @@ def main(args):
         # Join with part
         lineitem_part = lineitem_orders.join(
             part_filtered,
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("l_partkey",),
             right_on=("p_partkey",),
@@ -134,7 +137,7 @@ def main(args):
         # Keep supplier->nation on the main path.
         lineitem_supplier = lineitem_part.join(
             supplier,
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("l_suppkey",),
             right_on=("s_suppkey",),
@@ -144,7 +147,7 @@ def main(args):
 
         ds = lineitem_supplier.join(
             nation,
-            num_partitions=16,
+            num_partitions=join_num_partitions,
             join_type="inner",
             on=("s_nationkey",),
             right_on=("n_nationkey",),

--- a/release/nightly_tests/dataset/tpch/tpch_q9.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q9.py
@@ -62,7 +62,7 @@ def main(args):
 
         lineitem_part = lineitem.join(
             part,
-            num_partitions=16,
+            num_partitions=200,
             # Empirical value to balance parallelism and shuffle overhead
             join_type="inner",
             on=("l_partkey",),
@@ -86,7 +86,7 @@ def main(args):
         # Join lineitem with partsupp on part key and supplier key
         lineitem_partsupp = lineitem_part.join(
             partsupp,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_partkey", "l_suppkey"),
             right_on=("ps_partkey", "ps_suppkey"),
@@ -103,7 +103,7 @@ def main(args):
 
         lineitem_supplier = lineitem_partsupp.join(
             supplier,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_suppkey",),
             right_on=("s_suppkey",),
@@ -120,7 +120,7 @@ def main(args):
 
         lineitem_nation = lineitem_supplier.join(
             nation,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("s_nationkey",),
             right_on=("n_nationkey",),
@@ -137,7 +137,7 @@ def main(args):
 
         ds = lineitem_nation.join(
             orders,
-            num_partitions=16,
+            num_partitions=200,
             join_type="inner",
             on=("l_orderkey",),
             right_on=("o_orderkey",),

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -233,14 +233,23 @@
 #
 # The SF (scale factor) 1000 lineitem table contains ~6B rows.
 
-# TODO: Bump the scale from SF10 to SF1000 once we handle the scale.
+# Fixed-size hash-shuffle runs execute at SF1000 with 500 shuffle partitions.
+# hash_shuffle_v2 tests default to an 8KB object-inlining threshold
+# (RAY_max_direct_call_object_size): v2 returns shuffle shards from streaming
+# generator tasks, and shards below the inlining threshold accumulate in the
+# driver's in-process store instead of the object store, OOMing the head node.
+# sort_shuffle and autoscaling runs keep the original SF100 coverage.
+#
+# map_groups on "column08 column13 column14" (84 groups) stays at SF100: the
+# largest group is ~1.8% of the table (~16GB at SF1000) and hash partitioning
+# can't split a group, so its reduce task doesn't fit on a single node.
 
 - name: "aggregate_groups_{{scaling}}_{{shuffle_strategy}}_{{columns}}"
   python: "3.10"
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [sort_shuffle_pull_based, hash_shuffle, hash_shuffle_v2]
+      shuffle_strategy: [sort_shuffle_pull_based]
       columns:
         - "column08 column13 column14"   # 84 groups
         - "column02 column14"  # 7M groups
@@ -261,12 +270,114 @@
       --shuffle-strategy {{shuffle_strategy}}
 
 
+- name: "aggregate_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+    cluster_compute: "fixed_size_all_to_all_compute.yaml"
+
+  run:
+    timeout: 7200
+    script: >
+      python groupby_benchmark.py --sf 1000 --aggregate --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
+
+
+- name: "aggregate_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle_v2]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: "fixed_size_all_to_all_compute.yaml"
+
+  run:
+    timeout: 7200
+    script: >
+      python groupby_benchmark.py --sf 1000 --aggregate --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
+
+
+- name: "aggregate_groups_autoscaling_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+    cluster_compute: "autoscaling_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --aggregate --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+
+- name: "aggregate_groups_autoscaling_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle_v2]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: "autoscaling_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --aggregate --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+
 - name: "map_groups_{{scaling}}_{{shuffle_strategy}}_{{columns}}"
   python: "3.10"
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [sort_shuffle_pull_based, hash_shuffle, hash_shuffle_v2]
+      shuffle_strategy: [sort_shuffle_pull_based]
       columns:
         - "column08 column13 column14"   # 84 groups
         - "column02 column14"  # 7M groups
@@ -280,6 +391,161 @@
         - RAYTEST_FAIL_ON_DEAD_NODES=1
         - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+
+- name: "map_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle]
+      columns:
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+    cluster_compute: "fixed_size_all_to_all_compute.yaml"
+
+  run:
+    timeout: 7200
+    script: >
+      python groupby_benchmark.py --sf 1000 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
+
+
+- name: "map_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle_v2]
+      columns:
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: "fixed_size_all_to_all_compute.yaml"
+
+  run:
+    timeout: 7200
+    script: >
+      python groupby_benchmark.py --sf 1000 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
+
+
+- name: "map_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+    cluster_compute: "fixed_size_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+
+- name: "map_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle_v2]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: "fixed_size_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+
+- name: "map_groups_autoscaling_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+    cluster_compute: "autoscaling_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+
+- name: "map_groups_autoscaling_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [hash_shuffle_v2]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: "autoscaling_all_to_all_compute.yaml"
 
   run:
     timeout: 3600
@@ -324,11 +590,11 @@
 
   matrix:
     setup:
-      dataset: [sf100]
+      dataset: [sf1000]
       join_type: [inner, left_outer, right_outer, full_outer]
 
   run:
-    timeout: 3600
+    timeout: 10800
     script: >
       python join_benchmark.py
       --left_dataset s3://ray-benchmark-data/tpch/parquet/{{dataset}}/lineitem
@@ -336,7 +602,42 @@
       --left_join_keys column00
       --right_join_keys column0
       --join_type {{join_type}}
-      --num_partitions 50
+      --num_partitions 500
+
+# Same joins on hash shuffle v2. The strategy is selected via
+# RAY_DATA_DEFAULT_SHUFFLE_STRATEGY because join_benchmark.py has no
+# shuffle-strategy flag. The 8KB inlining threshold is required at this
+# scale: with the default 100KB threshold, v2's generator-returned shuffle
+# shards inline into the driver's in-process store and OOM the head node.
+- name: joins_{{dataset}}_{{join_type}}_hash_shuffle_v2
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAY_DATA_DEFAULT_SHUFFLE_STRATEGY=hash_shuffle_v2
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: fixed_size_all_to_all_compute.yaml
+
+  matrix:
+    setup:
+      dataset: [sf1000]
+      join_type: [inner, left_outer, right_outer, full_outer]
+
+  run:
+    timeout: 10800
+    script: >
+      python join_benchmark.py
+      --left_dataset s3://ray-benchmark-data/tpch/parquet/{{dataset}}/lineitem
+      --right_dataset s3://ray-benchmark-data/tpch/parquet/{{dataset}}/orders
+      --left_join_keys column00
+      --right_join_keys column0
+      --join_type {{join_type}}
+      --num_partitions 500
 
 ###############
 # Wide Schema tests


### PR DESCRIPTION
## Description

Release-test config changes to run the shuffle benchmarks at production scale, building on the findings from #65145:

- **SF1000 for fixed-size hash-shuffle groupby/join tests** (500 shuffle partitions, larger timeouts). `sort_shuffle` and autoscaling rows keep SF100 coverage. **Exception:** `map_groups` on `column08/13/14` (84 groups) stays at SF100 — the largest group is ~1.8% of the table (~16GB at SF1000), and hash partitioning cannot split a group, so its reduce task cannot be scheduled on any single node.
- **`hash_shuffle_v2` tests default to an 8KB object-inlining threshold** (`RAY_max_direct_call_object_size=8192`). v2 returns shuffle shards from streaming generator tasks; shards below the inlining threshold bypass the object store and accumulate in the driver's in-process store, OOMing the head node at SF1000 (validated in release runs: with the default 100KB threshold the driver reached 21.6GB and was OOM-killed; with inlining reduced the same joins pass).
- **New `joins_sf1000_*_hash_shuffle_v2` variants**, selected via `RAY_DATA_DEFAULT_SHUFFLE_STRATEGY` (join_benchmark.py has no strategy flag).
- **TPC-H queries use 200 join partitions** instead of hardcoded 16 (q13: 128). Those values were tuned at SF100 and produce ~15GB join partitions at SF1000; they also cap reduce parallelism at 16 tasks on 512-CPU clusters.
- `groupby_benchmark.py`: add `--num-partitions` (sets `DataContext.default_hash_shuffle_parallelism`); cast string columns to `large_string` so a single group's >2GB-per-column string data does not overflow Arrow int32 string offsets in the shuffle reduce.

Test names for existing groupby tests are unchanged; `joins_sf100_*` become `joins_sf1000_*` (baseline history restarts, as scale changed).

## Related issues
Related to #65103, #65145.

## Additional information
- Not duplicating existing work: #65145 is the exploratory comparison matrix (v1/v2 × batch size × inline threshold, DNR); this PR is the distilled, minimal config from those results. No other open PR touches these release test definitions.
- Validation run: `release_data_tests.yaml` expands to 191 unique test names (matrix-expansion check); `py_compile` on all modified scripts; `pre-commit run --files` on all changed files passed.
- AI assistance (Claude Code) was used for this change; a human reviews and runs the release tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)