### PR TITLE
[Data] Throttle OutputBackpressureGuard releases with a per-op interval

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -245,7 +245,11 @@ class StreamingExecutor(Executor, threading.Thread):
         # Constructed once per executor (not per scheduling iteration) so the
         # guard's idle-detection state accumulates across scheduling iterations.
         self._output_backpressure_guard = OutputBackpressureGuard(
-            self._topology, self._resource_manager
+            self._topology,
+            self._resource_manager,
+            release_interval_s=(
+                self._data_context.output_backpressure_guard_release_interval_s
+            ),
         )
         # Setup progress manager
         self._progress_manager = get_progress_manager(

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -9,7 +9,7 @@ import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import ray
 from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import ActorPoolInfo
@@ -136,14 +136,61 @@ class OutputBackpressureGuard:
     scheduling-loop iterations.
     """
 
-    def __init__(self, topology: Topology, resource_manager: ResourceManager):
+    def __init__(
+        self,
+        topology: Topology,
+        resource_manager: ResourceManager,
+        release_interval_s: Optional[float] = None,
+    ):
         self._topology = topology
         self._resource_manager = resource_manager
         self._idle_detector = IdleDetector()
+        # Per-op minimum interval between releases. ``None`` or non-positive
+        # disables it and preserves the legacy behavior of releasing whenever
+        # the raw evaluation says so. Wall clock (``time.time()``) matches the
+        # idiom already used by ``IdleDetector``.
+        if release_interval_s is None or release_interval_s <= 0:
+            self._release_interval_s = 0.0
+        else:
+            self._release_interval_s = float(release_interval_s)
+        # Per-op timestamp of the last release that actually produced output.
+        # A missing entry reads as 0, which falls outside the interval so the
+        # first release for each op is not throttled.
+        self._last_release_time: Dict[PhysicalOperator, float] = {}
+
+    def _within_release_interval(self, op: PhysicalOperator) -> bool:
+        if self._release_interval_s <= 0:
+            return False
+        last = self._last_release_time.get(op, 0)
+        return time.time() - last < self._release_interval_s
+
+    def notify_release_emitted(self, op: PhysicalOperator) -> None:
+        """Record that a release granted to ``op`` actually yielded output.
+
+        Callers must invoke this only once task output was really read, so the
+        interval throttles the rate at which bytes enter the object store rather
+        than the rate at which releases are merely offered. A release that turns
+        out to be a no-op leaves the interval untouched and stays available for
+        the next iteration."""
+        self._last_release_time[op] = time.time()
 
     def should_unblock(self, op: PhysicalOperator) -> bool:
         """Return True if output backpressure should be relaxed for ``op``
-        to preserve pipeline liveness."""
+        to preserve pipeline liveness.
+
+        With a positive ``release_interval_s``, releases that produced output
+        are rate-limited to at most one per interval per op. This is a pure
+        query: the caller is responsible for calling ``notify_release_emitted``
+        once the granted release actually yields output."""
+        # Evaluate first, unconditionally, so the idle-detection state inside
+        # keeps advancing (and its idle warning keeps firing) even while ``op``
+        # is being throttled. Only the release decision is gated below.
+        if not self._evaluate_unblock_raw(op):
+            return False
+        return not self._within_release_interval(op)
+
+    def _evaluate_unblock_raw(self, op: PhysicalOperator) -> bool:
+        """Underlying liveness check without interval throttling."""
         downstream_eligible_ops = list(
             self._resource_manager.get_downstream_eligible_ops(op)
         )
@@ -622,6 +669,10 @@ def process_completed_tasks(
             active_tasks[task.get_waitable()] = (state, task)
 
     remaining_output_budget: Dict[OpState, int] = {}
+    # Ops the guard unblocked this iteration. The release only counts against
+    # the guard's interval once output is actually read below, so a release that
+    # finds nothing to read doesn't consume the op's window.
+    guard_released_ops: Set[PhysicalOperator] = set()
     for op, state in topology.items():
         # Check all backpressure policies for max_task_output_bytes_to_read
         # Use the minimum limit from all policies (most restrictive)
@@ -646,6 +697,8 @@ def process_completed_tasks(
         # fires regardless of which policy drove the limit to 0.
         if max_bytes_to_read == 0 and output_backpressure_guard.should_unblock(op):
             max_bytes_to_read = 1
+            # Confirmed further down, once this op's output is really read.
+            guard_released_ops.add(op)
 
         # When the guard bumped the limit above 0, clear the policy attribution too
         in_backpressure = max_bytes_to_read == 0
@@ -737,6 +790,13 @@ def process_completed_tasks(
                                 metadata_fetcher,
                             )
                             op_data_tasks.append(task)
+                            if bytes_read > 0 and state.op in guard_released_ops:
+                                # The guard's release produced real output, so
+                                # start this op's interval from here.
+                                guard_released_ops.discard(state.op)
+                                output_backpressure_guard.notify_release_emitted(
+                                    state.op
+                                )
                             if state in remaining_output_budget:
                                 # Clamp remaining output budget at 0
                                 remaining_output_budget[state] = max(

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -176,9 +176,10 @@ class OutputBackpressureGuard:
         are rate-limited to at most one per interval per op. This is a pure
         query: the caller is responsible for calling ``notify_release_emitted``
         once the granted release actually yields output."""
-        # Evaluate first, unconditionally, so the idle-detection state inside
-        # keeps advancing (and its idle warning keeps firing) even while ``op``
-        # is being throttled. Only the release decision is gated below.
+        # Evaluate first, unconditionally so the idle-detection state advances
+        # (and its idle warning keeps firing) regardless of the throttle. The
+        # unblock it may authorize is still gated by the interval below; only the
+        # idle bookkeeping itself is not.
         if not self._evaluate_unblock_raw(op):
             return False
         if self._release_interval_s <= 0:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -158,20 +158,14 @@ class OutputBackpressureGuard:
         # first release for each op is not throttled.
         self._last_release_time: Dict[PhysicalOperator, float] = {}
 
-    def _within_release_interval(self, op: PhysicalOperator) -> bool:
-        if self._release_interval_s <= 0:
-            return False
-        last = self._last_release_time.get(op, 0)
-        return time.time() - last < self._release_interval_s
-
     def notify_release_emitted(self, op: PhysicalOperator) -> None:
         """Record that a release granted to ``op`` actually yielded output.
 
         Callers must invoke this only once task output was really read, so the
-        interval throttles the rate at which bytes enter the object store rather
-        than the rate at which releases are merely offered. A release that turns
-        out to be a no-op leaves the interval untouched and stays available for
-        the next iteration."""
+        interval throttles the rate at which upstream tasks are unblocked to
+        produce more output rather than the rate at which releases are merely
+        offered. A release that turns out to be a no-op leaves the interval
+        untouched and stays available for the next iteration."""
         self._last_release_time[op] = time.time()
 
     def should_unblock(self, op: PhysicalOperator) -> bool:
@@ -187,7 +181,10 @@ class OutputBackpressureGuard:
         # is being throttled. Only the release decision is gated below.
         if not self._evaluate_unblock_raw(op):
             return False
-        return not self._within_release_interval(op)
+        if self._release_interval_s <= 0:
+            return True
+        last_release_time = self._last_release_time.get(op, 0)
+        return time.time() - last_release_time >= self._release_interval_s
 
     def _evaluate_unblock_raw(self, op: PhysicalOperator) -> bool:
         """Underlying liveness check without interval throttling."""

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -283,6 +283,13 @@ DEFAULT_OP_RESOURCE_RESERVATION_RATIO = float(
     os.environ.get("RAY_DATA_OP_RESERVATION_RATIO", "0.5")
 )
 
+# Per-operator minimum interval (seconds) between successive
+# `OutputBackpressureGuard` releases. See the `DataContext` attribute docstring
+# for details. Defaults to None (no throttling -- preserves legacy behavior).
+DEFAULT_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S = env_float(
+    "RAY_DATA_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S", None
+)
+
 DEFAULT_MAX_ERRORED_BLOCKS = 0
 
 # Use this to prefix important warning messages for the user.
@@ -682,6 +689,15 @@ class DataContext:
             all-to-all operation.
             Raise this if your workload can wait a long time for cluster capacity.
             Set to -1 to disable.
+        output_backpressure_guard_release_interval_s: Per-operator minimum interval
+            in seconds between successive ``OutputBackpressureGuard`` releases. The
+            guard exists as a liveness escape hatch: when the resource allocator
+            clamps an op's output budget to 0, it flips the budget to 1 byte so the
+            executor emits one more block. On workloads with very large blocks this
+            per-iteration release can outpace downstream drain, so object store usage
+            grows even under "backpressure". A positive interval throttles releases
+            per op; only releases that actually yield output start the interval.
+            Defaults to None (no throttling, legacy behavior).
         max_errored_blocks: Max number of blocks that are allowed to have errors,
             unlimited if negative. This option allows application-level exceptions in
             block processing tasks. These exceptions may be caused by UDFs (e.g., due to
@@ -949,6 +965,9 @@ class DataContext:
     max_map_retries: int = DEFAULT_MAX_MAP_RETRIES
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
+    output_backpressure_guard_release_interval_s: Optional[
+        float
+    ] = DEFAULT_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS
     execution_no_progress_timeout_s: float = DEFAULT_EXECUTION_NO_PROGRESS_TIMEOUT_S
     log_internal_stack_trace: bool = DEFAULT_LOG_INTERNAL_STACK_TRACE

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -283,9 +283,6 @@ DEFAULT_OP_RESOURCE_RESERVATION_RATIO = float(
     os.environ.get("RAY_DATA_OP_RESERVATION_RATIO", "0.5")
 )
 
-# Per-operator minimum interval (seconds) between successive
-# `OutputBackpressureGuard` releases. See the `DataContext` attribute docstring
-# for details. Defaults to None (no throttling -- preserves legacy behavior).
 DEFAULT_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S = env_float(
     "RAY_DATA_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S", None
 )

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -2,7 +2,7 @@ import math
 import time
 from collections import defaultdict
 from datetime import timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -884,6 +884,93 @@ class TestOutputBackpressureGuard:
 
         # "Downstream idle with empty input queue" case should fire and unblock.
         topo[o3].total_enqueued_input_blocks = MagicMock(return_value=0)
+        assert guard.should_unblock(o2) is True
+
+    def _build_terminal_guard(
+        self, release_interval_s: Optional[float] = None
+    ) -> Tuple[OutputBackpressureGuard, PhysicalOperator]:
+        """Build a guard over ``o1 -> o2 -> Limit`` with no external consumer.
+
+        ``o2`` is terminal (the Limit op is ineligible), so the raw liveness
+        evaluation always says unblock and only the release interval gates
+        ``should_unblock``."""
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1)
+        o3 = LimitOperator(1, o2, DataContext.get_current())
+
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
+
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(),
+            DataContext.get_current(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+        )
+        guard = OutputBackpressureGuard(
+            topo, resource_manager, release_interval_s=release_interval_s
+        )
+        return guard, o2
+
+    def test_release_interval_throttling(self, restore_data_context):
+        """A release that yields output starts the op's interval; releases that
+        yield nothing don't consume the window."""
+        guard, o2 = self._build_terminal_guard(release_interval_s=100)
+
+        with freeze_time() as frozen:
+            # Releases are not throttled until one actually yields output.
+            assert guard.should_unblock(o2) is True
+            assert guard.should_unblock(o2) is True
+            guard.notify_release_emitted(o2)
+
+            # Within the interval the release is withheld.
+            assert guard.should_unblock(o2) is False
+            frozen.tick(timedelta(seconds=99))
+            assert guard.should_unblock(o2) is False
+
+            # Once the interval elapses, the release is granted again.
+            frozen.tick(timedelta(seconds=2))
+            assert guard.should_unblock(o2) is True
+
+    @pytest.mark.parametrize("release_interval_s", [None, 0, -1])
+    def test_release_interval_disabled(self, restore_data_context, release_interval_s):
+        """``None`` and non-positive intervals preserve the legacy behavior of
+        releasing on every evaluation."""
+        guard, o2 = self._build_terminal_guard(release_interval_s=release_interval_s)
+
+        assert guard.should_unblock(o2) is True
+        guard.notify_release_emitted(o2)
+        assert guard.should_unblock(o2) is True
+
+    def test_release_interval_is_per_op(self, restore_data_context):
+        """Throttling one op must not delay releases for another."""
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1)
+        o3 = mock_map_op(o2)
+
+        topo = build_streaming_topology(o3, ExecutionOptions(), noop_counter())
+
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(),
+            DataContext.get_current(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+        )
+        guard = OutputBackpressureGuard(topo, resource_manager, release_interval_s=100)
+
+        # o3 is terminal with no external consumer; o2 unblocks because its
+        # downstream (o3) has no active tasks and is resource constrained.
+        o3.num_active_tasks = MagicMock(return_value=0)
+        resource_manager.op_resource_allocator.can_submit_new_task = MagicMock(
+            return_value=False
+        )
+
+        assert guard.should_unblock(o3) is True
+        guard.notify_release_emitted(o3)
+        assert guard.should_unblock(o3) is False
+
+        # o2's window is independent of o3's.
         assert guard.should_unblock(o2) is True
 
 


### PR DESCRIPTION
## Description

**Summary:** Add an opt-in, per-operator minimum interval between `OutputBackpressureGuard` releases so the liveness escape hatch can't defeat backpressure on large-block workloads. Disabled by default; no behavior change unless configured.

`OutputBackpressureGuard` is a liveness escape hatch: when backpressure policies clamp an operator's output budget to 0 bytes, the guard flips it to 1 byte so the executor emits one more block and the pipeline can't deadlock. This check runs on every scheduling iteration, so whenever the guard keeps voting to release, an operator effectively emits a block per iteration.

On workloads with very large blocks (e.g. rows carrying raw audio buffers), that per-iteration release rate can outpace how fast downstream drains. At that point the escape hatch effectively defeats the backpressure it's meant to be a narrow exception to: the policies say "0 bytes", but the operator keeps emitting a large block every iteration anyway. Object store usage then grows unbounded even though the pipeline is nominally under backpressure, pushing the store toward spilling / OOM.

This PR adds an opt-in, per-operator **minimum interval between successive guard releases**. With a positive interval, the guard releases an operator at most once per interval, giving downstream time to drain between unblocks. The first release for each operator is never throttled, and idle-detection remains the liveness fallback, so pipeline liveness is preserved.

The feature is disabled by default (`None`), so existing behavior is unchanged.

## Related issues

<!-- Link an issue if one is filed, e.g. "Related to #XXXXX". -->

## Additional information

**New configuration**

- `DataContext.output_backpressure_guard_release_interval_s: Optional[float]`
- Env var: `RAY_DATA_OUTPUT_BACKPRESSURE_GUARD_RELEASE_INTERVAL_S`
- Default: `None` (no throttling — legacy behavior). Non-positive values also disable it.

**Usage**

```python
import ray

ctx = ray.data.DataContext.get_current()
# Release a fully-throttled operator at most once every 300s.
ctx.output_backpressure_guard_release_interval_s = 300
```
