### PR TITLE
[release/2.57.0][Data] Propagate `isolate_read_workers` to DatasourceV2 (#65191)

### DIFF
--- a/python/ray/data/_internal/planner/plan_read_files_op.py
+++ b/python/ray/data/_internal/planner/plan_read_files_op.py
@@ -92,4 +92,5 @@ def plan_read_files_op(
         name=op.name,
         compute_strategy=op.compute,
         ray_remote_args=op.ray_remote_args,
+        isolate_workers=data_context.isolate_read_workers,
     )

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
+import pyarrow.parquet as pq
 import pytest
 
 import ray
@@ -22,6 +23,10 @@ from ray._common.test_utils import (
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
 )
+from ray.data._internal.execution.operators.task_pool_map_operator import (
+    TaskPoolMapOperator,
+)
+from ray.data._internal.logical.optimizers import get_execution_plan
 from ray.data._internal.planner.plan_udf_map_op import (
     _generate_transform_fn_for_async_map,
     _MapActorContext,
@@ -1554,6 +1559,7 @@ def test_downstream_operators_scheduled_on_different_workers_than_read_workers(
     ray.data.read_datasource(SetMarkerDatasource()).map(
         check_marker_not_set
     ).materialize()
+    assert False
 
 
 @pytest.mark.parametrize(
@@ -1594,6 +1600,30 @@ def test_isolate_read_workers_preserves_runtime_env(
     ray.data.read_datasource(
         CheckEnvVarDatasource(), ray_remote_args={"runtime_env": runtime_env}
     ).materialize()
+
+
+@pytest.mark.parametrize("isolate_read_workers", [True, False])
+def test_isolate_read_workers_propagated_for_datasource_v2(
+    tmp_path, ray_start_regular_shared, restore_data_context, isolate_read_workers
+):
+    """DataContext.isolate_read_workers must land on the ReadFiles physical op (DSv2)."""
+    ctx = DataContext.get_current()
+    ctx.use_datasource_v2 = True
+    ctx.isolate_read_workers = isolate_read_workers
+
+    pq.write_table(pa.table({"a": [1]}), str(tmp_path / "data.parquet"))
+    ds = ray.data.read_parquet(str(tmp_path))
+
+    physical_plan, _ = get_execution_plan(ds._logical_plan)
+    op = physical_plan.dag
+    while op is not None:
+        if isinstance(op, TaskPoolMapOperator) and "ReadFiles" in op.name:
+            assert op.isolate_workers is isolate_read_workers
+            return
+        deps = op.input_dependencies
+        op = deps[0] if deps else None
+
+    pytest.fail("Expected a ReadFiles TaskPoolMapOperator in the physical plan")
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1559,7 +1559,6 @@ def test_downstream_operators_scheduled_on_different_workers_than_read_workers(
     ray.data.read_datasource(SetMarkerDatasource()).map(
         check_marker_not_set
     ).materialize()
-    assert False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cherry-pick of #65191 to `releases/2.57.0`.

> **Note:** #65191 is still open on master at the time of this cherry-pick (picked from its head commit e3413a2f9270). If it changes before merging to master, this PR should be updated to match.

## Original description

https://github.com/ray-project/ray/pull/63490 added a setting, `isolate_read_workers`, to run reads on dedicated worker processes. The intention was to mitigate memory bloat from PyArrow from affecting downstream stages.

The PR only added a test with `Datasource` (V1), but not with `DatasourceV2`. As a result, we've shipped a bug where the flag doesn't work correctly with `DatasourceV2`.

This PR fixes the bug and also adds a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)