### PR TITLE
[ci/doc] Apply the direct-annotation rule to the doc-side resolve check

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -18,6 +18,26 @@ _SPHINX_AUTODOC_SHORTNAME = "~"
 _OVERRIDE_HOOK_MARKER = "__is_overridden__"
 
 
+def _is_directly_annotated(obj: object) -> bool:
+    """Whether an object owns an API annotation rather than inheriting one.
+
+    The @PublicAPI / @DeveloperAPI / @Deprecated decorators stamp ``_annotated``
+    with the decorated object's own ``__name__``, so a plain ``hasattr`` reads
+    true for every undecorated subclass of an annotated base as well. Comparing
+    the stored name against the object's own name is what distinguishes the two.
+
+    Deliberately identical to ``ray.util.annotations._is_annotated``, which is
+    the definition Ray itself uses. Keep it that way: a checker that disagrees
+    with the runtime about what counts as annotated is worse than one that
+    shares the runtime's edge cases (a subclass that reuses its base's name
+    reads as annotated in both).
+    """
+    annotation_owner = getattr(obj, "_annotated", None)
+    return annotation_owner is not None and annotation_owner == getattr(
+        obj, "__name__", None
+    )
+
+
 class AnnotationType(Enum):
     PUBLIC_API = "PublicAPI"
     DEVELOPER_API = "DeveloperAPI"
@@ -185,7 +205,16 @@ class API:
         ``_annotated_type`` attribute the @PublicAPI/@Deprecated decorators set.
         Objects that carry no annotation (for example methods of an annotated
         class) resolve to UNKNOWN.
+
+        Only an annotation the object *owns* counts. ``_annotated_type`` is a
+        plain class attribute, so an undecorated subclass reads its base's value
+        -- which would classify a subclass of a @Deprecated class as deprecated
+        and fail the resolve check on a documented name nobody deprecated.
+        Inheriting the marker resolves to UNKNOWN, the same accepted case as a
+        documented method of an annotated class.
         """
+        if not _is_directly_annotated(obj):
+            return AnnotationType.UNKNOWN
         annotated_type = getattr(obj, "_annotated_type", None)
         if annotated_type is None:
             return AnnotationType.UNKNOWN

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -7,9 +7,9 @@ from typing import Dict, List, Set, Tuple
 
 import click
 
-from ci.ray_ci.doc.api import API
+from ci.ray_ci.doc.api import API, _is_directly_annotated
 from ci.ray_ci.doc.autodoc import Autodoc
-from ci.ray_ci.doc.module import Module, _is_directly_annotated
+from ci.ray_ci.doc.module import Module
 
 # Each team config carries two exemption lists. Both feed the "every
 # @PublicAPI symbol must be documented" check identically (they're unioned at
@@ -340,8 +340,9 @@ def _import_status(module: str) -> Tuple[bool, bool]:
     """Return (importable, defines_public_api) for a module name.
 
     defines_public_api mirrors the walk's rule: an attribute is a public API of this
-    module only if it is @PublicAPI-annotated (has `_annotated`) AND is defined within
-    this module's namespace (so re-exports owned by other modules do not count).
+    module only if it is directly @PublicAPI-annotated (owns `_annotated` rather than
+    inheriting it from a base class) AND is defined within this module's namespace
+    (so re-exports owned by other modules do not count).
     """
     try:
         mod = importlib.import_module(module)

--- a/ci/ray_ci/doc/mock/mock_module.py
+++ b/ci/ray_ci/doc/mock/mock_module.py
@@ -73,6 +73,26 @@ class InheritedAnnotation(MockClass):
 
 
 @Deprecated
+class MockDeprecatedClass:
+    """
+    A directly-deprecated class. Documenting it is an error the check must catch.
+    """
+
+    pass
+
+
+class MockDeprecatedSubclass(MockDeprecatedClass):
+    """
+    An undecorated subclass of a deprecated class. It inherits ``_annotated_type``
+    as a plain class attribute, so reading that attribute without an ownership
+    check would classify it as deprecated and flag a documented name that nobody
+    deprecated.
+    """
+
+    pass
+
+
+@Deprecated
 def mock_function():
     """
     This function is used for testing purpose only. It should not be used in production.

--- a/ci/ray_ci/doc/module.py
+++ b/ci/ray_ci/doc/module.py
@@ -3,16 +3,7 @@ import inspect
 from types import ModuleType
 from typing import List
 
-from ci.ray_ci.doc.api import API, AnnotationType, CodeType
-
-
-def _is_directly_annotated(obj: object) -> bool:
-    """Return whether an object owns an API annotation, rather than
-    inheriting one from a base class."""
-    annotation_owner = getattr(obj, "_annotated", None)
-    return annotation_owner is not None and annotation_owner == getattr(
-        obj, "__name__", None
-    )
+from ci.ray_ci.doc.api import API, AnnotationType, CodeType, _is_directly_annotated
 
 
 class Module:

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -9,7 +9,14 @@ from ci.ray_ci.doc.api import (
     AnnotationType,
     CodeType,
 )
-from ci.ray_ci.doc.mock.mock_module import MockClass, mock_function, mock_w00t
+from ci.ray_ci.doc.mock.mock_module import (
+    InheritedAnnotation,
+    MockClass,
+    MockDeprecatedClass,
+    MockDeprecatedSubclass,
+    mock_function,
+    mock_w00t,
+)
 
 _MOCK = "ci.ray_ci.doc.mock.mock_module"
 
@@ -249,6 +256,20 @@ def test_introspect_annotation_type():
     assert API.introspect_annotation_type(object()) == AnnotationType.UNKNOWN
 
 
+def test_introspect_annotation_type_ignores_inherited_annotations():
+    # `_annotated_type` is a plain class attribute, so an undecorated subclass
+    # reads its base's value. Only an annotation the object owns counts, in
+    # either direction: an inherited @Deprecated must not make a subclass read
+    # as deprecated, and an inherited @PublicAPI must not make one read public.
+    assert (
+        API.introspect_annotation_type(MockDeprecatedClass) == AnnotationType.DEPRECATED
+    )
+    assert (
+        API.introspect_annotation_type(MockDeprecatedSubclass) == AnnotationType.UNKNOWN
+    )
+    assert API.introspect_annotation_type(InheritedAnnotation) == AnnotationType.UNKNOWN
+
+
 def test_canonical_name_of():
     # Classes and functions canonicalize to module.qualname; the object comes
     # from the same resolve() walk used to read the annotation.
@@ -289,6 +310,24 @@ def test_split_resolvable_and_broken_doc_apis():
 
     assert unresolved == [f"{_MOCK}.renamed_away"]
     assert non_public == [f"{mock_function.__module__}.{mock_function.__qualname__}"]
+
+
+def test_split_resolvable_accepts_subclass_of_deprecated_class():
+    # Regression: documenting an undecorated subclass of a @Deprecated class is
+    # legitimate -- the subclass was never deprecated. Reading the inherited
+    # `_annotated_type` would flag it as "documented API resolves to a
+    # deprecated object" and fail the check on a correct doc entry. The
+    # directly-deprecated base is still flagged, so the rule keeps its teeth.
+    unresolved, non_public = API.split_resolvable_and_broken_doc_apis(
+        [
+            _doc_api(f"{_MOCK}.MockDeprecatedSubclass", CodeType.CLASS),
+            _doc_api(f"{_MOCK}.MockDeprecatedClass", CodeType.CLASS),
+        ],
+        set(),
+    )
+
+    assert unresolved == []
+    assert non_public == [f"{_MOCK}.MockDeprecatedClass"]
 
 
 def test_split_resolvable_flags_private_documented_name():

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -5,26 +5,39 @@ import pytest
 from ci.ray_ci.doc.api import AnnotationType, CodeType
 from ci.ray_ci.doc.module import Module
 
+_MOCK = "ci.ray_ci.doc.mock.mock_module"
+
 
 def test_walk():
-    module = Module("ci.ray_ci.doc.mock.mock_module")
-    apis = module.get_apis()
-    assert apis[0].name == "ci.ray_ci.doc.mock.mock_module.MockClass"
-    assert apis[0].annotation_type.value == AnnotationType.PUBLIC_API.value
-    assert apis[0].code_type.value == CodeType.CLASS.value
-    assert apis[1].name == "ci.ray_ci.doc.mock.mock_module.mock_function"
-    assert apis[1].annotation_type.value == AnnotationType.DEPRECATED.value
-    assert apis[1].code_type.value == CodeType.FUNCTION.value
+    module = Module(_MOCK)
+    # Keyed by name rather than indexed: the walk's order follows dir(), so any
+    # annotated symbol added to the fixture would renumber positional asserts.
+    apis = {api.name: api for api in module.get_apis()}
+
+    mock_class = apis[f"{_MOCK}.MockClass"]
+    assert mock_class.annotation_type.value == AnnotationType.PUBLIC_API.value
+    assert mock_class.code_type.value == CodeType.CLASS.value
+
+    mock_func = apis[f"{_MOCK}.mock_function"]
+    assert mock_func.annotation_type.value == AnnotationType.DEPRECATED.value
+    assert mock_func.code_type.value == CodeType.FUNCTION.value
+
     assert module._module.__hash__ in module._visited
     assert module._module not in module._visited
 
 
 def test_walk_ignores_inherited_api_annotations():
-    module = Module("ci.ray_ci.doc.mock.mock_module")
+    module = Module(_MOCK)
+    names = {api.name for api in module.get_apis()}
 
-    assert "ci.ray_ci.doc.mock.mock_module.InheritedAnnotation" not in {
-        api.name for api in module.get_apis()
-    }
+    # Undecorated subclasses inherit `_annotated` as a plain attribute; neither
+    # the public nor the deprecated one is an API the walk owns.
+    assert f"{_MOCK}.InheritedAnnotation" not in names
+    assert f"{_MOCK}.MockDeprecatedSubclass" not in names
+    # Positive control: their directly-annotated bases are still found, so the
+    # assertions above cannot pass by the walk finding nothing at all.
+    assert f"{_MOCK}.MockClass" in names
+    assert f"{_MOCK}.MockDeprecatedClass" in names
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Follow-up to #65196, which stopped the API walk (`Module._is_api`) and the subpackage guard (`_import_status`) from treating an inherited annotation as an owned one. A third reader of that marker family was left on a plain `getattr`:

```python
annotated_type = getattr(obj, "_annotated_type", None)   # ci/ray_ci/doc/api.py
```

`_annotated_type` is a plain class attribute, so an undecorated subclass reads its base's value. That value is the only input to the "documented APIs resolve to public code" check (`split_resolvable_and_broken_doc_apis`), which means a documented, undecorated subclass of a `@Deprecated` class fails as "documented API resolves to a deprecated object" — on a doc entry that's correct, for a class nobody deprecated.

Same inheritance bug as #65196, opposite direction. It's latent today and stays latent until someone documents such a subclass, at which point it presents as an unexplained premerge failure on a correct doc change. Leaving it also means the checker carries two different definitions of "annotated" on the two sides of the same discrepancy check.

## What

Route `introspect_annotation_type` through `_is_directly_annotated`. This is safe in both directions:

- an inherited `@Deprecated` resolves to `UNKNOWN` and is accepted, removing the false failure
- an inherited `@PublicAPI` resolves to `UNKNOWN` and is still accepted, since `UNKNOWN` is already the accepted case for a documented method of an annotated class

Methods are unaffected either way — functions don't inherit class attributes, so `Dataset.map_batches` already resolved to `UNKNOWN`.

`_is_directly_annotated` moves from `module.py` to `api.py` so both sides share one definition. `module.py` already imports from `api.py`, so leaving it in place would have made the dependency circular. Its docstring now names `ray.util.annotations._is_annotated` as the definition it deliberately mirrors, so the name-equality edge case doesn't later get "fixed" into disagreeing with what Ray's runtime considers annotated.

Also refreshes the `_import_status` docstring, which still described the `hasattr` rule #65196 replaced.

## Tests

- A `@Deprecated` class and an undecorated subclass added to the mock fixture.
- `test_introspect_annotation_type_ignores_inherited_annotations` — covers both directions, and asserts the directly-annotated base still reads `DEPRECATED` so the rule keeps its teeth.
- `test_split_resolvable_accepts_subclass_of_deprecated_class` — end-to-end regression through the check that would actually have failed.

Both new tests fail without the `api.py` change (verified locally by reverting it).

Two hardening changes to the existing tests while the fixture grew:

- `test_walk` is rekeyed by name instead of list index. It silently depended on `dir()` ordering of the mock module, so any annotated symbol added to the fixture renumbered its assertions.
- `test_walk_ignores_inherited_api_annotations` gains a positive control. As written it asserts only absence, so it would pass if the walk found nothing at all.

Full suite: 44 passed (`ci/ray_ci/doc/`, excluding `test_update_cache_env.py`, which needs Sphinx installed).

## Related

Follow-up to #65196. Consistent with the AST-based `@PublicAPI` detection in #64788, which reads decorator nodes directly and so never had this bug — after this the runtime walk and the static check agree on what "annotated" means.
