### PR TITLE
[ci/doc] Guard annotation introspection against attribute lookup exceptions

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -215,7 +215,10 @@ class API:
         """
         if not _is_directly_annotated(obj):
             return AnnotationType.UNKNOWN
-        annotated_type = getattr(obj, "_annotated_type", None)
+        try:
+            annotated_type = getattr(obj, "_annotated_type", None)
+        except Exception:
+            return AnnotationType.UNKNOWN
         if annotated_type is None:
             return AnnotationType.UNKNOWN
         try:

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -258,6 +258,8 @@ def test_introspect_annotation_type():
     # A hostile object whose attribute lookup raises (e.g. ValueError from metaclass __getattr__)
     class HostileMetaclass(type):
         def __getattr__(cls, name):
+            if name == "_annotated":
+                return "HostileClass"
             if name == "_annotated_type":
                 raise ValueError("Simulated metaclass getattr failure")
             raise AttributeError(name)

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -255,6 +255,18 @@ def test_introspect_annotation_type():
     )
     assert API.introspect_annotation_type(object()) == AnnotationType.UNKNOWN
 
+    # A hostile object whose attribute lookup raises (e.g. ValueError from metaclass __getattr__)
+    class HostileMetaclass(type):
+        def __getattr__(cls, name):
+            if name == "_annotated_type":
+                raise ValueError("Simulated metaclass getattr failure")
+            raise AttributeError(name)
+
+    class HostileClass(metaclass=HostileMetaclass):
+        pass
+
+    assert API.introspect_annotation_type(HostileClass) == AnnotationType.UNKNOWN
+
 
 def test_introspect_annotation_type_ignores_inherited_annotations():
     # `_annotated_type` is a plain class attribute, so an undecorated subclass


### PR DESCRIPTION
## Description

This PR fixes the API documentation consistency check crashing when `API.introspect_annotation_type()` encounters objects whose attribute lookup raises exceptions other than `AttributeError` (e.g., lazy-loaded objects using module or metaclass `__getattr__`).

### Changes
- Wrap the `_annotated_type` lookup in `API.introspect_annotation_type()` with a localized `try/except Exception`.
- Return `AnnotationType.UNKNOWN` if attribute lookup raises, preserving the existing downstream fallback behavior.
- Add a focused regression test covering a hostile metaclass whose `__getattr__` raises `ValueError`, verifying that `API.introspect_annotation_type()` returns `AnnotationType.UNKNOWN` instead of propagating the exception.

The change is intentionally minimal and localized to the docs-to-code annotation introspection path. The module walking and API discovery logic remain unchanged, as intended by the issue discussion.

## Related issues

Fixes #65209

## Additional information

### Verification

The following tests were run:

```bash
pytest ci/ray_ci/doc/test_api.py
pytest ci/ray_ci/doc/test_autodoc.py
pytest ci/ray_ci/doc/test_module.py
```

No unrelated files or behaviors were modified.