### PR TITLE
[release] Move cu130 jobs tests off g4dn.4xlarge to g6.4xlarge

### DIFF
--- a/release/jobs_tests/compute_tpl_gpu_node_cu130.yaml
+++ b/release/jobs_tests/compute_tpl_gpu_node_cu130.yaml
@@ -1,0 +1,20 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+head_node:
+  instance_type: g6.4xlarge
+  resources:
+    CPU: 16
+    GPU: 1
+
+worker_nodes:
+  - instance_type: m5.4xlarge
+    min_nodes: 1
+    max_nodes: 1
+    market_type: ON_DEMAND
+
+advanced_instance_config:
+  TagSpecifications:
+    - ResourceType: "instance"
+      Tags:
+        - Key: ttl-hours
+          Value: '24'

--- a/release/ray_release/buildkite/aws_instance_types.csv
+++ b/release/ray_release/buildkite/aws_instance_types.csv
@@ -155,6 +155,14 @@ g5g.4xlarge,16,1
 g5g.8xlarge,32,1
 g5g.metal,64,2
 g5g.xlarge,4,1
+g6.12xlarge,48,4
+g6.16xlarge,64,1
+g6.24xlarge,96,4
+g6.2xlarge,8,1
+g6.48xlarge,192,8
+g6.4xlarge,16,1
+g6.8xlarge,32,1
+g6.xlarge,4,1
 h1.16xlarge,64,0
 h1.2xlarge,8,0
 h1.4xlarge,16,0

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1392,28 +1392,28 @@
         byod:
           type: gpu-cu130
           python_depset: gpu_cu130_py3.10.lock
-        cluster_compute: compute_tpl_gpu_node.yaml
+        cluster_compute: compute_tpl_gpu_node_cu130.yaml
     - __suffix__: py311_cu130
       python: "3.11"
       cluster:
         byod:
           type: gpu-cu130
           python_depset: gpu_cu130_py3.11.lock
-        cluster_compute: compute_tpl_gpu_node.yaml
+        cluster_compute: compute_tpl_gpu_node_cu130.yaml
     - __suffix__: py312_cu130
       python: "3.12"
       cluster:
         byod:
           type: gpu-cu130
           python_depset: gpu_cu130_py3.12.lock
-        cluster_compute: compute_tpl_gpu_node.yaml
+        cluster_compute: compute_tpl_gpu_node_cu130.yaml
     - __suffix__: py313_cu130
       python: "3.13"
       cluster:
         byod:
           type: gpu-cu130
           python_depset: gpu_cu130_py3.13.lock
-        cluster_compute: compute_tpl_gpu_node.yaml
+        cluster_compute: compute_tpl_gpu_node_cu130.yaml
 
 - name: "jobs_check_cuda_version_cu130_py{{python}}"
   python: "{{python}}"
@@ -1429,7 +1429,7 @@
     byod:
       type: gpu-cu130
       python_depset: gpu_cu130_py{{python}}.lock
-    cluster_compute: compute_tpl_gpu_node.yaml
+    cluster_compute: compute_tpl_gpu_node_cu130.yaml
   run:
     timeout: 600
     script: python workloads/jobs_check_cuda_version.py --expected-cuda-version 13.0


### PR DESCRIPTION
## Why are these changes needed?

The cu130 jobs release tests (`jobs_check_cuda_available.py31x_cu130`, `jobs_check_cuda_version_cu130_py3.1x`) intermittently fail to launch on Anyscale:

```
[autoscaler] Launching instances failed: NewInstances[g4dn.4xlarge;num:1;all:false;market:on-demand]: could not launch any instances: api error Unsupported: Instance type g4dn.4xlarge is not supported in zone us-west-2d
```

All eight cu130 variants shared `release/jobs_tests/compute_tpl_gpu_node.yaml`, whose head node is `g4dn.4xlarge` (T4) — not available in every us-west-2 zone.

This PR:
- Adds a cu130-specific compute template `compute_tpl_gpu_node_cu130.yaml` with a `g6.4xlarge` (L4) head node — same 16 CPU / 1 GPU shape, supported across us-west-2 zones, and a better fit for CUDA 13 than T4 (which has known driver issues on CUDA 13).
- Points the eight cu130 test variants at the new template. The non-cu130 `jobs_check_cuda_available.aws` and serve tests keep the original g4dn template.
- Adds the g6 family to `aws_instance_types.csv`, so the release concurrency grouper classifies these as GPU tests instead of throwing in the fallback parser and dumping them into the default group (this also fixes the existing g6-based compiled-graphs computes).

Not a duplicate: no open PR or issue addresses the g4dn/us-west-2d launch failure or the cu130 jobs-test compute config (searched open PRs for `g4dn`, `cu130 instance type`, `us-west-2d`).

## Related issue number

N/A — observed in the `release` pipeline nightly runs on `releases/2.57.0` (e.g. build 103010, triggered by release-automation #3235).

## Checks

Verification run locally:
- Parsed `release_tests.yaml` and confirmed all 261 `cluster_compute` references resolve to existing files (only pre-existing `//`-rooted doc paths are handled elsewhere).
- Confirmed the new CSV rows parse and `g6.4xlarge -> (16, 1)` via the same `csv.DictReader` path `concurrency.py` uses.
- Pre-commit hooks ran at commit time.

These are release-test infra configs; the real test is the next nightly release run.

AI assistance (Claude Code) was used for this change; every line was reviewed by the submitter.

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR. (pre-commit hooks)
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)