### PR TITLE
[ci] Remove leftover TEMP(do-not-merge) comment in doc.rayci.yml

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -1,5 +1,3 @@
-# TEMP(do-not-merge): touch to tag this checker-only PR into the `doc` pipeline so
-# doc_api_policy_check runs against the docbuild image. Revert before un-drafting.
 group: doc
 steps:
   - name: docbuild


### PR DESCRIPTION
## Why are these changes needed?

`.buildkite/doc.rayci.yml` on master starts with a `TEMP(do-not-merge)` comment that was added in #65040 to tag that checker-only PR into the `doc` pipeline, with a note to revert it before un-drafting. It slipped into master. This removes the stale comment; no functional change.

## Related issue number

Leftover from #65040.

Not a duplicate: no open PR removes this comment (searched open PRs for `doc.rayci`).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(  (comment-only change; pre-commit hooks passed)

AI assistance was used for this change (Claude Code); the diff was reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)