### PR TITLE
[serve] Allow scale-to-zero when target_capacity is left at 100

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -189,8 +189,26 @@ class DeploymentAutoscalingState:
             del self._replica_metrics[replica_id]
 
     def get_num_replicas_lower_bound(self) -> int:
-        if self._config.initial_replicas is not None and (
+        # While scaling up under a `target_capacity` limit, hold the number of
+        # replicas at `initial_replicas` so that autoscaling doesn't immediately
+        # scale the deployment back down before it has any metrics.
+        #
+        # A `target_capacity` of 100 imposes no limit on the number of replicas,
+        # so it is equivalent to an unset `target_capacity` and the deployment is
+        # already at full capacity. Treat it as such here, matching
+        # `get_capacity_adjusted_num_replicas`. Otherwise a deployment left at
+        # `target_capacity=100` with `target_capacity_direction=UP`, which is
+        # where KubeRay's `NewClusterWithIncrementalUpgrade` leaves it once an
+        # upgrade completes, keeps `initial_replicas` as its lower bound forever
+        # and can never scale down to `min_replicas`.
+        scaling_up_under_capacity_limit = (
             self._target_capacity_direction == TargetCapacityDirection.UP
+            and self._target_capacity is not None
+            and self._target_capacity != 100
+        )
+        if (
+            self._config.initial_replicas is not None
+            and scaling_up_under_capacity_limit
         ):
             return get_capacity_adjusted_num_replicas(
                 self._config.initial_replicas,

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ray.serve._private.autoscaling_state import DeploymentAutoscalingState
-from ray.serve._private.common import DeploymentID, ReplicaID, TimeStampedValue
+from ray.serve._private.common import (
+    DeploymentID,
+    ReplicaID,
+    TargetCapacityDirection,
+    TimeStampedValue,
+)
 from ray.serve._private.constants import (
     CONTROL_LOOP_INTERVAL_S,
     SERVE_AUTOSCALING_DECISION_COUNTERS_KEY,
@@ -1569,6 +1574,93 @@ class TestAppLevelPolicyStateIsolation:
         assert final_state[d2][SERVE_AUTOSCALING_DECISION_TIMESTAMP_KEY] == fake_now
         # user state remains intact
         assert final_state[d2]["counter"] == 5
+
+
+class TestNumReplicasLowerBound:
+    """Tests for `DeploymentAutoscalingState.get_num_replicas_lower_bound`."""
+
+    def _create_state(
+        self,
+        *,
+        min_replicas: int,
+        initial_replicas: int,
+        max_replicas: int,
+        target_capacity,
+        target_capacity_direction,
+    ) -> DeploymentAutoscalingState:
+        state = DeploymentAutoscalingState(DeploymentID(name="test", app_name="app"))
+
+        info = MagicMock()
+        info.deployment_config.autoscaling_config = AutoscalingConfig(
+            min_replicas=min_replicas,
+            initial_replicas=initial_replicas,
+            max_replicas=max_replicas,
+        )
+        info.deployment_config.gang_scheduling_config = None
+        info.target_capacity = target_capacity
+        info.target_capacity_direction = target_capacity_direction
+        info.config_changed.return_value = False
+
+        state.register(info, curr_target_num_replicas=initial_replicas)
+        return state
+
+    @pytest.mark.parametrize("target_capacity", [100, 100.0, None])
+    def test_full_capacity_allows_scale_to_zero(self, target_capacity):
+        """A deployment at full capacity must be able to reach `min_replicas`.
+
+        `target_capacity=100` imposes no limit on the number of replicas, so it
+        is equivalent to an unset `target_capacity`. In both cases the
+        `initial_replicas` floor must not apply, otherwise a deployment left at
+        `target_capacity=100` with direction UP (where KubeRay's
+        `NewClusterWithIncrementalUpgrade` leaves it after an upgrade finishes)
+        can never scale down to `min_replicas=0`.
+        """
+        state = self._create_state(
+            min_replicas=0,
+            initial_replicas=1,
+            max_replicas=2,
+            target_capacity=target_capacity,
+            target_capacity_direction=TargetCapacityDirection.UP,
+        )
+
+        assert state.get_num_replicas_lower_bound() == 0
+
+    @pytest.mark.parametrize(
+        "target_capacity,expected_lower_bound",
+        [(0, 0), (50, 2), (100, 0)],
+    )
+    def test_partial_capacity_holds_initial_replicas(
+        self, target_capacity, expected_lower_bound
+    ):
+        """While ramping up under a real capacity limit, hold `initial_replicas`.
+
+        At `target_capacity=100` the limit is a no-op, so the bound falls back to
+        the capacity-adjusted `min_replicas` instead.
+        """
+        state = self._create_state(
+            min_replicas=0,
+            initial_replicas=4,
+            max_replicas=8,
+            target_capacity=target_capacity,
+            target_capacity_direction=TargetCapacityDirection.UP,
+        )
+
+        assert state.get_num_replicas_lower_bound() == expected_lower_bound
+
+    @pytest.mark.parametrize("target_capacity", [50, 100, None])
+    def test_not_scaling_up_uses_min_replicas(self, target_capacity):
+        """When not scaling up, the bound is always the adjusted `min_replicas`."""
+        for direction in [TargetCapacityDirection.DOWN, None]:
+            state = self._create_state(
+                min_replicas=2,
+                initial_replicas=6,
+                max_replicas=8,
+                target_capacity=target_capacity,
+                target_capacity_direction=direction,
+            )
+
+            expected = 1 if target_capacity == 50 else 2
+            assert state.get_num_replicas_lower_bound() == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why these changes are needed

Closes #62682.

`DeploymentAutoscalingState.get_num_replicas_lower_bound` holds a deployment's replica floor at `initial_replicas` whenever `target_capacity_direction` is `UP`. The intent is sound: while a deployment is still ramping up under a `target_capacity` limit and has no metrics yet, autoscaling should not immediately scale it back down.

The problem is the condition does not account for `target_capacity=100`. A `target_capacity` of 100 imposes no limit on the number of replicas, and Serve already treats it as equivalent to an unset `target_capacity` elsewhere: `get_capacity_adjusted_num_replicas` returns `num_replicas` unchanged for both `None` and `100`, and `test_target_capacity_100_no_effect` asserts that setting `target_capacity` to 100 has no effect. The lower bound did not make that distinction, so a deployment sitting at `target_capacity=100` with direction `UP` kept `initial_replicas` as its floor indefinitely.

That is exactly the state KubeRay's `NewClusterWithIncrementalUpgrade` leaves behind. It ramps `target_capacity` from 0 to 100 across the upgrade and the last value it sends is 100, never `None`, so the direction stays `UP` forever. An autoscaling deployment configured with `min_replicas=0` and `initial_replicas=1` could therefore never scale back to zero once an incremental upgrade finished.

The fix applies the `initial_replicas` floor only while scaling up under a real capacity limit, meaning a `target_capacity` that is set and is not 100. In every other case the bound falls back to the capacity-adjusted `min_replicas`, which is what the deployment already does when `target_capacity` is unset.

The change is deliberately scoped to the lower bound rather than to `calculate_target_capacity_direction`. Normalizing the direction itself at 100 would alter the meaning of the stored direction for every consumer, whereas the reported failure is entirely in the replica floor.

## Why this is not a duplicate

There is no open PR against `ray-project/ray` for this issue, and the issue has no cross-referenced pull requests at all. I checked both directions before starting:

```
gh api "search/issues?q=repo:ray-project/ray+is:pr+is:open+62682"
gh api "repos/ray-project/ray/issues/62682/timeline" --jq '.[] | select(.event=="cross-referenced")'
```

Both returned empty. I also confirmed the bug is still present at `master` by reading `get_num_replicas_lower_bound` at HEAD.

## Related changes

None.

## Checks

Tests run locally against this branch, using the Ray-pinned `protobuf==6.33.6` and a nightly wheel with `python/ray/serve` symlinked to the checkout via `python/ray/setup-dev.py`:

```
pytest python/ray/serve/tests/unit/test_autoscaling_policy.py \
       python/ray/serve/tests/unit/test_controller.py \
       python/ray/serve/tests/unit/test_deployment_state.py
```

Result: `377 passed`. The baseline on the same three files before this change was `368 passed`, so the 9 added cases are the entire difference and nothing regressed.

Fail-before and pass-after were verified against the base ref rather than by stashing. With `python/ray/serve/_private/autoscaling_state.py` checked out from `upstream/master` and the new tests in place, `TestNumReplicasLowerBound` fails 4 of 9 cases with `assert 1 == 0` and `assert 4 == 0`, which is the deployment being pinned at `initial_replicas`. Restoring the fix turns all 9 green.

The new `TestNumReplicasLowerBound` class covers three things: that a deployment at full capacity (`target_capacity` of `100`, `100.0`, or `None`) can reach `min_replicas=0`; that a genuine partial capacity limit still holds `initial_replicas` (`target_capacity=50` keeps a floor of 2, while 0 and 100 do not); and that directions other than `UP` continue to use the capacity-adjusted `min_replicas`.

`black==22.10.0` and `ruff==0.8.4` (the versions pinned in `.pre-commit-config.yaml`), including the isort pass, report no changes and no findings on both touched files. Commits are DCO signed off.

AI assistance was used to write this change.
