### PR TITLE
[Data][release] Add fake-GPU image_embedding_from_jsonl release test

### DIFF
--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/fake_gpu_autoscaling_cluster_compute.yaml
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/fake_gpu_autoscaling_cluster_compute.yaml
@@ -1,0 +1,27 @@
+# Fake-GPU autoscaling config: GPU nodes are replaced with CPU nodes carrying a
+# logical GPU:1 resource, and Infer sleeps for the measured ViT-base batch time
+# (see main.py --fake-gpu, GPU_SECONDS_PER_IMAGE). Sidesteps real GPU capacity limits.
+# Autoscales from 0 up to 100 real CPU nodes + 40 fake-GPU nodes.
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    instance_type: r6a.8xlarge
+
+worker_nodes:
+    - instance_type: r6a.8xlarge
+      min_nodes: 0
+      max_nodes: 100
+      market_type: ON_DEMAND
+
+    # Fake-GPU nodes: no real GPU, just a logical GPU:1 resource so the Infer
+    # actors schedule here and emulate the forward pass with a sleep.
+    - instance_type: m5n.4xlarge
+      min_nodes: 0
+      max_nodes: 40
+      market_type: ON_DEMAND
+      resources:
+        CPU: 16
+        GPU: 1

--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/fake_gpu_fixed_size_cluster_compute.yaml
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/fake_gpu_fixed_size_cluster_compute.yaml
@@ -1,0 +1,27 @@
+# Fake-GPU fixed-size config: GPU nodes are replaced with CPU nodes carrying a
+# logical GPU:1 resource, and Infer sleeps for the measured ViT-base batch time
+# (see main.py --fake-gpu, GPU_SECONDS_PER_IMAGE). Sidesteps real GPU capacity limits.
+# 100 real CPU nodes + 40 fake-GPU nodes.
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    instance_type: r6a.8xlarge
+
+worker_nodes:
+    - instance_type: r6a.8xlarge
+      min_nodes: 100
+      max_nodes: 100
+      market_type: ON_DEMAND
+
+    # Fake-GPU nodes: no real GPU, just a logical GPU:1 resource so the Infer
+    # actors schedule here and emulate the forward pass with a sleep.
+    - instance_type: m5n.4xlarge
+      min_nodes: 40
+      max_nodes: 40
+      market_type: ON_DEMAND
+      resources:
+        CPU: 16
+        GPU: 1

--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
@@ -40,6 +40,12 @@ BATCH_SIZE = 1024
 # test runs.
 READ_MEMORY = 3 * 1024**3
 
+# Fake-GPU emulation: sleep instead of running the real ViT forward pass so the
+# benchmark can run on CPU nodes carrying a custom GPU:1 resource (sidesteps real
+# GPU capacity limits). 2.5 s/batch of 1024 is the measured ViT-base inference
+# time on an A10G (g5.4xlarge) from original GPU based test
+GPU_SECONDS_PER_IMAGE = 2.5 / 1024
+
 PROCESSOR = ViTImageProcessor(
     do_convert_rgb=None,
     do_normalize=True,
@@ -71,6 +77,14 @@ def parse_args():
         help=(
             "Whether to enable chaos. If set, this script terminates one worker node "
             "every minute with a grace period."
+        ),
+    )
+    parser.add_argument(
+        "--fake-gpu",
+        action="store_true",
+        help=(
+            "Use fake gpu mode if set. In this mode, Infer uses CPU nodes and sleeps "
+            "for the time GPU based Infer takes to process one batch"
         ),
     )
     return parser.parse_args()
@@ -186,6 +200,24 @@ class Infer:
         return result
 
 
+class FakeInfer:
+    """Fake-GPU Infer: sleeps for the measured per-batch inference time instead
+    of running the real ViT forward pass, so the benchmark can run on CPU nodes
+    carrying a custom GPU:1 resource (see GPU_SECONDS_PER_IMAGE)."""
+
+    def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        n = len(batch["original_url"])
+        # Emulate the GPU forward pass: sleep for the batch's inference time.
+        time.sleep(GPU_SECONDS_PER_IMAGE * n)
+        return {
+            "original_url": batch["original_url"],
+            "original_width": batch["original_width"],
+            "original_height": batch["original_height"],
+            # Real Infer returns model(...).logits, shape (n, 1000) float32.
+            "output": np.zeros((n, 1000), dtype=np.float32),
+        }
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -197,11 +229,16 @@ def main(args: argparse.Namespace, profiling: Profiling):
     if args.chaos:
         start_chaos()
 
+    infer_cls = FakeInfer if args.fake_gpu else Infer
     infer_kwargs = {
         "batch_size": BATCH_SIZE,
         "num_gpus": 1,
         "concurrency": tuple(args.inference_concurrency),
     }
+    if args.fake_gpu:
+        # Fake-GPU nodes are CPU nodes whose GPU:1 is a custom resource, so the
+        # actor must also claim a real CPU for its sleep "compute".
+        infer_kwargs["num_cpus"] = 1
 
     nsys_env = profiling.nsys_runtime_env()
     if nsys_env:
@@ -220,7 +257,7 @@ def main(args: argparse.Namespace, profiling: Profiling):
             .flat_map(decode)
             .map(preprocess)
             .map_batches(
-                Infer,
+                infer_cls,
                 **infer_kwargs,
             )
         )

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -1096,6 +1096,29 @@
           frequency: manual
           fail_on_dead_nodes: 0
           fail_on_spilling: 0  # We expected bounded spills with chaos.
+      - with:
+          case: fake_gpu_fixed_size
+          cluster_type: fake_gpu_fixed_size
+          args: --inference-concurrency 40 40 --fake-gpu
+          frequency: weekly
+          fail_on_dead_nodes: 0 # Allow node death during test
+          fail_on_spilling: 1
+      - with:
+          case: fake_gpu_autoscaling
+          cluster_type: fake_gpu_autoscaling
+          args: --inference-concurrency 1 40 --fake-gpu
+          frequency: weekly
+          fail_on_dead_nodes: 1
+          fail_on_spilling: 0  # We expected bounded spills with autoscaling.
+      - with:
+          case: fake_gpu_fixed_size_chaos
+          cluster_type: fake_gpu_fixed_size
+          args: --inference-concurrency 40 40 --chaos --fake-gpu
+          # This release test is run on a 'manual' frequency because it's expected to
+          # fail.
+          frequency: manual
+          fail_on_dead_nodes: 0
+          fail_on_spilling: 0  # We expected bounded spills with chaos.
 
   cluster:
     anyscale_sdk_2026: true


### PR DESCRIPTION
## Why this change

`image_embedding_from_jsonl` is a weekly Ray Data batch-inference benchmark that needs 40
GPU nodes (`g5.4xlarge`). Real GPU capacity is often unavailable, so the test is blocked on
fleet availability rather than on anything it is meant to measure.

This adds fake-GPU variants that exercise the same Ray Data code paths — read → decode →
preprocess → actor `map_batches` → write, plus autoscaling and chaos behaviour — on CPU
nodes carrying a *logical* `GPU:1` custom resource. The `Infer` actor is swapped for
`FakeInfer`, which sleeps for the measured per-batch inference time instead of running the
ViT forward pass, and returns stub logits of the same shape and dtype.

  Both new weekly cases were run on this commit via the release pipeline:
  [build 103231](https://buildkite.com/ray-project/release/builds/103231). Both passed.

