### PR TITLE
Add perf metrics for 2.57.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 105.664512,
+    "_dashboard_memory_usage_mb": 103.878656,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.06,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3753\t1.56GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n6481\t0.81GiB\tpython distributed/test_many_actors.py\n3079\t0.7GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3953\t0.29GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4410\t0.16GiB\tray::DashboardAgent\n1382\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3367\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4412\t0.09GiB\tray::RuntimeEnvAgent\n3881\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n6622\t0.08GiB\tray::DashboardTester.run",
-    "actors_per_second": 543.8785742285336,
+    "_peak_memory": 4.24,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4039\t1.65GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n6384\t0.81GiB\tpython distributed/test_many_actors.py\n3153\t0.69GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4247\t0.29GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4704\t0.16GiB\tray::DashboardAgent\n3359\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1398\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4168\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4706\t0.09GiB\tray::RuntimeEnvAgent\n6512\t0.08GiB\tray::DashboardTester.run",
+    "actors_per_second": 575.2367632651517,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 543.8785742285336
+            "perf_metric_value": 575.2367632651517
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.979
+            "perf_metric_value": 9.881
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1657.416
+            "perf_metric_value": 1495.388
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3448.611
+            "perf_metric_value": 5021.808
         }
     ],
-    "time": 18.386456966400146
+    "time": 17.384146213531494
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 104.574976,
+    "_dashboard_memory_usage_mb": 103.510016,
     "_dashboard_test_success": true,
-    "_peak_memory": 10.13,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3559\t0.58GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2968\t0.37GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n9406\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3759\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4246\t0.15GiB\tray::DashboardAgent\n3145\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1349\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3687\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5552\t0.09GiB\tray::StateAPIGeneratorActor.start\n4248\t0.09GiB\tray::RuntimeEnvAgent",
+    "_peak_memory": 10.66,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3989\t0.53GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3087\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n9017\t0.18GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4192\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4667\t0.15GiB\tray::DashboardAgent\n3228\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1350\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5093\t0.09GiB\tray::StateAPIGeneratorActor.start\n4669\t0.09GiB\tray::RuntimeEnvAgent\n4195\t0.09GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 404.91633590598434
+            "perf_metric_value": 372.4894970726082
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.93
+            "perf_metric_value": 5.563
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.679
+            "perf_metric_value": 21.245
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 40.594
+            "perf_metric_value": 73.808
         }
     ],
-    "tasks_per_second": 404.91633590598434,
-    "time": 302.46964597702026,
+    "tasks_per_second": 372.4894970726082,
+    "time": 302.68463945388794,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 74.715136,
+    "_dashboard_memory_usage_mb": 80.777216,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.6,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1383\t3.81GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3730\t0.8GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3059\t0.65GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5041\t0.34GiB\tpython distributed/test_many_pgs.py\n597\t0.26GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4392\t0.14GiB\tray::DashboardAgent\n3932\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3370\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4394\t0.09GiB\tray::RuntimeEnvAgent\n3860\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
+    "_peak_memory": 2.75,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4151\t0.85GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3187\t0.69GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5491\t0.39GiB\tpython distributed/test_many_pgs.py\n602\t0.26GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4355\t0.15GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4810\t0.14GiB\tray::DashboardAgent\n3412\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1412\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4812\t0.09GiB\tray::RuntimeEnvAgent\n4283\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 81.40547605262907
+            "perf_metric_value": 80.5479506142037
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.287
+            "perf_metric_value": 5.549
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 78.689
+            "perf_metric_value": 123.178
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2390.781
+            "perf_metric_value": 1232.673
         }
     ],
-    "pgs_per_second": 81.40547605262907,
-    "time": 12.284185886383057
+    "pgs_per_second": 80.5479506142037,
+    "time": 12.414965152740479
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 106.504192,
+    "_dashboard_memory_usage_mb": 109.01504,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.88,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3752\t1.1GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5081\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3957\t0.5GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3196\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3960\t0.16GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4414\t0.13GiB\tray::DashboardAgent\n1398\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3337\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3880\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5271\t0.09GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 4.19,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4034\t1.5GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n7860\t0.64GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n4242\t0.4GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3440\t0.4GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4245\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4699\t0.13GiB\tray::DashboardAgent\n3116\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1354\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4164\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n8043\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 695.6022071314425
+            "perf_metric_value": 394.485537053648
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.624
+            "perf_metric_value": 5.626
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 549.229
+            "perf_metric_value": 539.129
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 826.157
+            "perf_metric_value": 821.172
         }
     ],
-    "tasks_per_second": 695.6022071314425,
-    "time": 314.3760325908661,
+    "tasks_per_second": 394.485537053648,
+    "time": 325.34947180747986,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.56.0"}
+{"release_version": "2.57.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8342.568803508693,
-        409.43886660421316
+        8186.409763644163,
+        486.5307476289957
     ],
     "1_1_actor_calls_concurrent": [
-        5456.76183608015,
-        149.29467253197765
+        5284.869670924241,
+        124.34422351130499
     ],
     "1_1_actor_calls_sync": [
-        1875.0279275238897,
-        49.40205766058054
+        1762.981738621782,
+        30.020607171834822
     ],
     "1_1_async_actor_calls_async": [
-        4674.834383534435,
-        232.57006597926497
+        4316.252934983355,
+        244.42668329991048
     ],
     "1_1_async_actor_calls_sync": [
-        1394.4268791918364,
-        15.24206462330469
+        1431.6733545471534,
+        29.528161597975707
     ],
     "1_1_async_actor_calls_with_args_async": [
-        3095.214627776353,
-        121.39660247574591
+        2787.1513643694384,
+        94.73319485213824
     ],
     "1_n_actor_calls_async": [
-        7040.378512116067,
-        141.86458492326545
+        7290.9981617147205,
+        109.80643807629221
     ],
     "1_n_async_actor_calls_async": [
-        6788.316704875271,
-        77.05220000176223
+        6593.858018500617,
+        50.10711194322327
     ],
     "client__1_1_actor_calls_async": [
-        1057.5113866970246,
-        13.869553032268188
+        1092.036489331336,
+        21.251398497292133
     ],
     "client__1_1_actor_calls_concurrent": [
-        1081.7307840702588,
-        19.359582107431898
+        1084.8717687413014,
+        10.829594843788104
     ],
     "client__1_1_actor_calls_sync": [
-        546.5462754693076,
-        4.769363506758825
+        565.7541836789418,
+        9.292877526993491
     ],
     "client__get_calls": [
-        1268.2621386289416,
-        18.098812220449094
+        1278.569826688682,
+        14.088477736189011
     ],
     "client__put_calls": [
-        895.6970682564656,
-        21.35291764881878
+        889.5329862378343,
+        11.620405625510138
     ],
     "client__put_gigabytes": [
-        0.09907086001824938,
-        0.0006618851832748623
+        0.09831584527705356,
+        0.00023628170361922253
     ],
     "client__tasks_and_get_batch": [
-        0.9872625245252546,
-        0.027137922752983233
+        0.9961826702031711,
+        0.022938571970378286
     ],
     "client__tasks_and_put_batch": [
-        12226.580116183099,
-        101.66892202557969
+        12454.124196972278,
+        116.27942566772052
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12736.988267796403,
-        82.08132189135176
+        13244.105950746582,
+        112.3717261116124
     ],
     "multi_client_put_gigabytes": [
-        33.19310764876294,
-        0.7078519327392999
+        25.381910497853127,
+        0.6742332658538565
     ],
     "multi_client_tasks_async": [
-        20764.825419627614,
-        2629.3497580957887
+        20040.412649086153,
+        2431.055244583116
     ],
     "n_n_actor_calls_async": [
-        23724.72845970961,
-        267.42069527657407
+        23595.113141483285,
+        685.4980586704168
     ],
     "n_n_actor_calls_with_arg_async": [
-        9560.124425456765,
-        45.98251082693428
+        13039.93450305723,
+        164.59369993875492
     ],
     "n_n_async_actor_calls_async": [
-        21588.896745325528,
-        495.1457556369605
+        21466.85058122358,
+        526.1864549109472
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13307.428346767498
+            "perf_metric_value": 13365.861980877578
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4638.961748423475
+            "perf_metric_value": 3835.5368509218897
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12736.988267796403
+            "perf_metric_value": 13244.105950746582
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.9262999947537205
+            "perf_metric_value": 16.486982160932076
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.689211462260507
+            "perf_metric_value": 7.359631180965369
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 33.19310764876294
+            "perf_metric_value": 25.381910497853127
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.306253537383725
+            "perf_metric_value": 11.636464936390913
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.10474924198598
+            "perf_metric_value": 5.151820832614535
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 847.2523785992521
+            "perf_metric_value": 805.0151398744031
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7044.008888726476
+            "perf_metric_value": 7532.807888515144
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20764.825419627614
+            "perf_metric_value": 20040.412649086153
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1875.0279275238897
+            "perf_metric_value": 1762.981738621782
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8342.568803508693
+            "perf_metric_value": 8186.409763644163
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5456.76183608015
+            "perf_metric_value": 5284.869670924241
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7040.378512116067
+            "perf_metric_value": 7290.9981617147205
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23724.72845970961
+            "perf_metric_value": 23595.113141483285
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9560.124425456765
+            "perf_metric_value": 13039.93450305723
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1394.4268791918364
+            "perf_metric_value": 1431.6733545471534
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4674.834383534435
+            "perf_metric_value": 4316.252934983355
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3095.214627776353
+            "perf_metric_value": 2787.1513643694384
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6788.316704875271
+            "perf_metric_value": 6593.858018500617
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21588.896745325528
+            "perf_metric_value": 21466.85058122358
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 650.9409444317282
+            "perf_metric_value": 685.2610263762494
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1268.2621386289416
+            "perf_metric_value": 1278.569826688682
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 895.6970682564656
+            "perf_metric_value": 889.5329862378343
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.09907086001824938
+            "perf_metric_value": 0.09831584527705356
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12226.580116183099
+            "perf_metric_value": 12454.124196972278
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 546.5462754693076
+            "perf_metric_value": 565.7541836789418
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1057.5113866970246
+            "perf_metric_value": 1092.036489331336
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1081.7307840702588
+            "perf_metric_value": 1084.8717687413014
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9872625245252546
+            "perf_metric_value": 0.9961826702031711
         }
     ],
     "placement_group_create/removal": [
-        650.9409444317282,
-        3.4369842155053876
+        685.2610263762494,
+        13.311054672654826
     ],
     "single_client_get_calls_Plasma_Store": [
-        13307.428346767498,
-        124.19362621147212
+        13365.861980877578,
+        53.56537524402756
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.306253537383725,
-        0.1292574303967555
+        11.636464936390913,
+        0.12467210613607298
     ],
     "single_client_put_calls_Plasma_Store": [
-        4638.961748423475,
-        14.171431696132693
+        3835.5368509218897,
+        36.88280252113266
     ],
     "single_client_put_gigabytes": [
-        6.9262999947537205,
-        4.926803289933447
+        16.486982160932076,
+        7.479877025042128
     ],
     "single_client_tasks_and_get_batch": [
-        7.689211462260507,
-        0.43050221975482145
+        7.359631180965369,
+        0.5093000051388014
     ],
     "single_client_tasks_async": [
-        7044.008888726476,
-        460.0339215170094
+        7532.807888515144,
+        350.78157707571137
     ],
     "single_client_tasks_sync": [
-        847.2523785992521,
-        4.09258394508908
+        805.0151398744031,
+        4.947216886404141
     ],
     "single_client_wait_1k_refs": [
-        5.10474924198598,
-        0.17082054672729655
+        5.151820832614535,
+        0.12973753812448197
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.559787903,
+    "broadcast_time": 12.227769943000013,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.559787903
+            "perf_metric_value": 12.227769943000013
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 11.414861877,
-    "get_time": 15.554129597,
+    "args_time": 11.455117911999992,
+    "get_time": 15.232457393000004,
     "large_object_size": 107374182400,
-    "large_object_time": 25.059670065000006,
+    "large_object_time": 23.115384712000008,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 11.414861877
+            "perf_metric_value": 11.455117911999992
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.651634725000008
+            "perf_metric_value": 3.682571508999999
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.554129597
+            "perf_metric_value": 15.232457393000004
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 113.14399953099999
+            "perf_metric_value": 117.105490623
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.059670065000006
+            "perf_metric_value": 23.115384712000008
         }
     ],
-    "queued_time": 113.14399953099999,
-    "returns_time": 3.651634725000008,
+    "queued_time": 117.105490623,
+    "returns_time": 3.682571508999999,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 1.0267318749427796,
-    "max_iteration_time": 4.054374694824219,
-    "min_iteration_time": 0.06292486190795898,
+    "avg_iteration_time": 1.0499977922439576,
+    "max_iteration_time": 2.2114224433898926,
+    "min_iteration_time": 0.16539263725280762,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0267318749427796
+            "perf_metric_value": 1.0499977922439576
         }
     ],
-    "total_time": 102.67332315444946
+    "total_time": 104.99990391731262
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.522381067276001
+            "perf_metric_value": 7.086855411529541
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.57498586177826
+            "perf_metric_value": 14.038756632804871
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 36.382873344421384
+            "perf_metric_value": 34.95041303634643
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.72922945022583
+            "perf_metric_value": 1.732691764831543
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2306.0974526405334
+            "perf_metric_value": 2363.575121164322
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.2940698300890875
+            "perf_metric_value": 0.2916004517821898
         }
     ],
-    "stage_0_time": 7.522381067276001,
-    "stage_1_avg_iteration_time": 13.57498586177826,
-    "stage_1_max_iteration_time": 14.0574471950531,
-    "stage_1_min_iteration_time": 12.494763135910034,
-    "stage_1_time": 135.7499294281006,
-    "stage_2_avg_iteration_time": 36.382873344421384,
-    "stage_2_max_iteration_time": 37.604820013046265,
-    "stage_2_min_iteration_time": 35.432323932647705,
-    "stage_2_time": 181.91491556167603,
-    "stage_3_creation_time": 1.72922945022583,
-    "stage_3_time": 2306.0974526405334,
-    "stage_4_spread": 0.2940698300890875
+    "stage_0_time": 7.086855411529541,
+    "stage_1_avg_iteration_time": 14.038756632804871,
+    "stage_1_max_iteration_time": 14.964024543762207,
+    "stage_1_min_iteration_time": 12.448106288909912,
+    "stage_1_time": 140.38762545585632,
+    "stage_2_avg_iteration_time": 34.95041303634643,
+    "stage_2_max_iteration_time": 36.673638582229614,
+    "stage_2_min_iteration_time": 34.362250328063965,
+    "stage_2_time": 174.7525782585144,
+    "stage_3_creation_time": 1.732691764831543,
+    "stage_3_time": 2363.575121164322,
+    "stage_4_spread": 0.2916004517821898
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.7084268978985828,
-    "avg_pg_remove_time_ms": 1.4966242087084354,
+    "avg_pg_create_time_ms": 1.7500006561557806,
+    "avg_pg_remove_time_ms": 1.497989546546467,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.7084268978985828
+            "perf_metric_value": 1.7500006561557806
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4966242087084354
+            "perf_metric_value": 1.497989546546467
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 43.29%: tasks_per_second (THROUGHPUT) regresses from 695.6022071314425 to 394.485537053648 in benchmarks/many_tasks.json
REGRESSION 23.53%: multi_client_put_gigabytes (THROUGHPUT) regresses from 33.19310764876294 to 25.381910497853127 in microbenchmark.json
REGRESSION 17.32%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 4638.961748423475 to 3835.5368509218897 in microbenchmark.json
REGRESSION 9.95%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 3095.214627776353 to 2787.1513643694384 in microbenchmark.json
REGRESSION 8.01%: tasks_per_second (THROUGHPUT) regresses from 404.91633590598434 to 372.4894970726082 in benchmarks/many_nodes.json
REGRESSION 7.67%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4674.834383534435 to 4316.252934983355 in microbenchmark.json
REGRESSION 5.98%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1875.0279275238897 to 1762.981738621782 in microbenchmark.json
REGRESSION 5.44%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.306253537383725 to 11.636464936390913 in microbenchmark.json
REGRESSION 4.99%: single_client_tasks_sync (THROUGHPUT) regresses from 847.2523785992521 to 805.0151398744031 in microbenchmark.json
REGRESSION 4.29%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.689211462260507 to 7.359631180965369 in microbenchmark.json
REGRESSION 3.49%: multi_client_tasks_async (THROUGHPUT) regresses from 20764.825419627614 to 20040.412649086153 in microbenchmark.json
REGRESSION 3.15%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5456.76183608015 to 5284.869670924241 in microbenchmark.json
REGRESSION 2.86%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 6788.316704875271 to 6593.858018500617 in microbenchmark.json
REGRESSION 1.87%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8342.568803508693 to 8186.409763644163 in microbenchmark.json
REGRESSION 1.05%: pgs_per_second (THROUGHPUT) regresses from 81.40547605262907 to 80.5479506142037 in benchmarks/many_pgs.json
REGRESSION 0.76%: client__put_gigabytes (THROUGHPUT) regresses from 0.09907086001824938 to 0.09831584527705356 in microbenchmark.json
REGRESSION 0.69%: client__put_calls (THROUGHPUT) regresses from 895.6970682564656 to 889.5329862378343 in microbenchmark.json
REGRESSION 0.57%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 21588.896745325528 to 21466.85058122358 in microbenchmark.json
REGRESSION 0.55%: n_n_actor_calls_async (THROUGHPUT) regresses from 23724.72845970961 to 23595.113141483285 in microbenchmark.json
REGRESSION 81.82%: dashboard_p99_latency_ms (LATENCY) regresses from 40.594 to 73.808 in benchmarks/many_nodes.json
REGRESSION 56.54%: dashboard_p95_latency_ms (LATENCY) regresses from 78.689 to 123.178 in benchmarks/many_pgs.json
REGRESSION 45.62%: dashboard_p99_latency_ms (LATENCY) regresses from 3448.611 to 5021.808 in benchmarks/many_actors.json
REGRESSION 21.67%: dashboard_p50_latency_ms (LATENCY) regresses from 4.624 to 5.626 in benchmarks/many_tasks.json
REGRESSION 10.05%: dashboard_p50_latency_ms (LATENCY) regresses from 8.979 to 9.881 in benchmarks/many_actors.json
REGRESSION 3.50%: 1000000_queued_time (LATENCY) regresses from 113.14399953099999 to 117.105490623 in scalability/single_node.json
REGRESSION 3.42%: stage_1_avg_iteration_time (LATENCY) regresses from 13.57498586177826 to 14.038756632804871 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.49%: stage_3_time (LATENCY) regresses from 2306.0974526405334 to 2363.575121164322 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.43%: avg_pg_create_time_ms (LATENCY) regresses from 1.7084268978985828 to 1.7500006561557806 in stress_tests/stress_test_placement_group.json
REGRESSION 2.27%: avg_iteration_time (LATENCY) regresses from 1.0267318749427796 to 1.0499977922439576 in stress_tests/stress_test_dead_actors.json
REGRESSION 0.85%: 3000_returns_time (LATENCY) regresses from 3.651634725000008 to 3.682571508999999 in scalability/single_node.json
REGRESSION 0.35%: 10000_args_time (LATENCY) regresses from 11.414861877 to 11.455117911999992 in scalability/single_node.json
REGRESSION 0.20%: stage_3_creation_time (LATENCY) regresses from 1.72922945022583 to 1.732691764831543 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.09%: avg_pg_remove_time_ms (LATENCY) regresses from 1.4966242087084354 to 1.497989546546467 in stress_tests/stress_test_placement_group.json
```