### PR TITLE
[docs] generate heading anchors for h4 headings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -193,7 +193,7 @@ myst_enable_extensions = [
     "replacements",
 ]
 
-myst_heading_anchors = 3
+myst_heading_anchors = 4
 
 # Add these for attachment handling
 nb_render_key_pairs = {


### PR DESCRIPTION
## Why are these changes needed?

`myst_heading_anchors` is currently `3`, so MyST generates implicit anchors for h1–h3 headings only. Markdown pages that link to their own level-4 headings emit `myst.xref_missing`, and `doc/Makefile` builds with `-W`, so those links fail the build rather than degrading to a dead link.

This raises the setting to `4`.

The motivating case is vendoring KubeRay's generated CRD API reference into the Ray docs. `crd-ref-docs` renders every CRD type as an h4 heading and cross-links types by anchor (`[AuthMode](#authmode)`), so that page cannot build under the current setting. The change is independently useful for any page that links to its own h4 headings.

## Related issue number

N/A — no existing issue or open PR covers this. Checked with:

```
gh pr list --repo ray-project/ray --state open --search "myst_heading_anchors"
gh pr list --repo ray-project/ray --state open --search "heading anchors in:title"
```

Both returned no results.

## Checks

**Scope.** One line in `doc/source/conf.py`. `doc` tag only.

**Blast radius.** 138 h4 headings across 34 markdown files under `doc/source`, producing 132 distinct new anchor slugs. Enumerated three collision classes and checked each:

| Class | Count | Sites |
| --- | --- | --- |
| h4 slug matches an explicit `(target)=` label in the same file | 3 | `ray-observability/user-guides/profiling.md` (×2), `cluster/kubernetes/k8s-ecosystem/kueue.md` |
| Duplicate h4 slug within one file | 2 | `serve/tutorials/video-analysis/README.md`, `ray-security/token-auth.md` |
| h4 slug shadows an existing h1–h3 anchor in the same file | 1 | `cluster/kubernetes/user-guides/config.md` |

**Test.** Built a minimal Sphinx project reproducing all three classes with well-formed heading nesting (so `myst.header` level-jump warnings can't confound the result), against the pinned docs versions — sphinx 8.2.3, myst-parser 5.1.0 — with `nitpicky = True` and `-W --keep-going`. Ran it twice, changing only `myst_heading_anchors`:

```
myst_heading_anchors = 3
  WARNING: local id not found in doc 'explicit': 'profiling-result' [myst.xref_missing]
  WARNING: local id not found in doc 'dupe': 'step-1-generate-a-token' [myst.xref_missing]
  build finished with problems, 2 warnings (with warnings treated as errors).
  exit 1

myst_heading_anchors = 4
  build succeeded.
  exit 0
```

None of the three collision classes produces a warning. MyST resolves colliding slugs by assigning fallback ids (`id1`, `id2`) to the later heading — silently, with no duplicate-label or ambiguity warning. So the change removes build errors and introduces none.

One consequence worth recording for reviewers: because collisions resolve silently, a page with two identically-named h4 headings gets one real anchor and one opaque `idN`. Any in-page link to the second heading resolves to the first. That is pre-existing behavior for h1–h3 and is not introduced here, but it becomes reachable at h4.

A full `make rtd` build was not run locally; the docs CI build on this PR is the check for that.

## AI assistance

AI assistance (Claude Code) was used for the collision analysis, the control experiment, and drafting this description. I reviewed the one-line change and the test methodology and can defend both.
