### PR TITLE
[Data] Add unnest() expression for multi-column struct expansion

### DIFF
--- a/doc/source/data/api/expressions.rst
+++ b/doc/source/data/api/expressions.rst
@@ -21,6 +21,7 @@ Public API
     :toctree: doc/
 
     star
+    unnest
     col
     lit
     udf
@@ -47,6 +48,7 @@ instantiate them directly, but you may encounter them when working with expressi
     UnaryExpr
     UDFExpr
     StarExpr
+    UnnestExpr
     DownloadExpr
     MonotonicallyIncreasingIdExpr
     RandomExpr

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -27,6 +27,7 @@ from ray.data.expressions import (
     Expr,
     StarExpr,
     expand_star_exprs,
+    expand_unnest_exprs,
     exprlist_to_fields,
 )
 from ray.data.preprocessor import Preprocessor
@@ -409,6 +410,20 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             object.__setattr__(
                 self, "exprs", expand_star_exprs(self.exprs, input_schema)
             )
+        # Eagerly desugar ``UnnestExpr`` into aliased per-field struct
+        # accesses. Unlike star expansion this runs even without an input
+        # schema: an unnest wrapping a UDF resolves its struct type from the
+        # UDF's declared ``return_dtype``. If the type cannot be resolved at
+        # plan time, this raises — ``UnnestExpr`` never survives into
+        # optimizer rules or runtime evaluation.
+        object.__setattr__(
+            self,
+            "exprs",
+            expand_unnest_exprs(
+                self.exprs,
+                input_schema if isinstance(input_schema, pa.Schema) else None,
+            ),
+        )
         if self.compute is None:
             object.__setattr__(
                 self,

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -26,8 +26,8 @@ from ray.data.block import UserDefinedFunction
 from ray.data.expressions import (
     Expr,
     StarExpr,
+    expand_projection_exprs,
     expand_star_exprs,
-    expand_unnest_exprs,
     exprlist_to_fields,
 )
 from ray.data.preprocessor import Preprocessor
@@ -410,16 +410,18 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             object.__setattr__(
                 self, "exprs", expand_star_exprs(self.exprs, input_schema)
             )
-        # Eagerly desugar ``UnnestExpr`` into aliased per-field struct
-        # accesses. Unlike star expansion this runs even without an input
-        # schema: an unnest wrapping a UDF resolves its struct type from the
-        # UDF's declared ``return_dtype``. If the type cannot be resolved at
-        # plan time, this raises — ``UnnestExpr`` never survives into
-        # optimizer rules or runtime evaluation.
+        # Eagerly expand any expression that stands for several output
+        # columns (``UnnestExpr`` today) into ordinary named expressions, via
+        # ``Expr.expand_projection``. Unlike star expansion this runs even
+        # without an input schema: an unnest wrapping a UDF resolves its
+        # struct type from the UDF's declared ``return_dtype``. If an
+        # expression cannot be expanded at plan time it raises here, so no
+        # multi-column marker survives into optimizer rules or runtime
+        # evaluation.
         object.__setattr__(
             self,
             "exprs",
-            expand_unnest_exprs(
+            expand_projection_exprs(
                 self.exprs,
                 input_schema if isinstance(input_schema, pa.Schema) else None,
             ),

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -15,6 +15,7 @@ from ray.data.expressions import (
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    UnnestExpr,
     UUIDExpr,
     _CallableClassUDF,
     _ExprVisitor,
@@ -191,6 +192,11 @@ class _IdempotencyVisitor(_ExprVisitor[bool]):
 
     def visit_star(self, expr: StarExpr) -> bool:
         return True
+
+    def visit_unnest(self, expr: UnnestExpr) -> bool:
+        # Unnesting only reshapes the wrapped value into columns, so the
+        # wrapped expression alone decides idempotency.
+        return expr.expr.is_idempotent()
 
     def visit_download(self, expr: DownloadExpr) -> bool:
         # ``DownloadExpr`` is a leaf with no Expr children. It is idempotent (same URI
@@ -551,6 +557,13 @@ class _TreeReprVisitor(_ExprVisitor[str]):
 
     def visit_star(self, expr: "StarExpr") -> str:
         return self._make_tree_lines("COL(*)", expr=expr)
+
+    def visit_unnest(self, expr: "UnnestExpr") -> str:
+        return self._make_tree_lines(
+            "UNNEST",
+            children=[("", expr.expr)],
+            expr=expr,
+        )
 
     def visit_monotonically_increasing_id(
         self, expr: "MonotonicallyIncreasingIdExpr"

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -174,7 +174,7 @@ if TYPE_CHECKING:
     from ray.data.grouped_data import GroupedData
     from ray.data.stats import DatasetSummary
 
-from ray.data.expressions import Expr, StarExpr, col
+from ray.data.expressions import Expr, StarExpr, UnnestExpr, col
 
 logger = logging.getLogger(__name__)
 
@@ -1018,8 +1018,8 @@ class Dataset:
     @PublicAPI(api_group=EXPRESSION_API_GROUP, stability="alpha")
     def with_columns(
         self,
-        exprs: Mapping[str, "Expr"],
-        *,
+        exprs: Optional[Union[Mapping[str, "Expr"], "UnnestExpr"]] = None,
+        *more_exprs: Union[Mapping[str, "Expr"], "UnnestExpr"],
         compute: Optional[ComputeStrategy] = None,
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
@@ -1041,6 +1041,11 @@ class Dataset:
         columns, which avoids the repeated work of chaining several
         ``with_column`` calls.
 
+        In addition to a mapping from column name to expression, positional
+        arguments may be :func:`~ray.data.expressions.unnest` expressions:
+        each wraps a struct-typed expression and contributes one output
+        column per struct field, named after the fields.
+
         Examples:
             >>> import ray
             >>> from ray.data.expressions import col
@@ -1052,10 +1057,19 @@ class Dataset:
             {'id': 0, 'id_2': 0, 'id_3': 0}
             {'id': 1, 'id_2': 2, 'id_3': 3}
 
+            See :func:`~ray.data.expressions.unnest` for expanding a
+            struct-returning UDF into multiple columns, including mixed
+            usage such as ``ds.with_columns({"a2": col("a") * 2},
+            unnest(make_features(col("a"), col("b"))))``.
+
         Args:
             exprs: A mapping from new column name to the expression that
-                defines its values. Column order follows the mapping's
-                insertion order.
+                defines its values, or an
+                :func:`~ray.data.expressions.unnest` expression. Column
+                order follows the mapping's insertion order.
+            more_exprs: Additional mappings or
+                :func:`~ray.data.expressions.unnest` expressions, appended
+                in argument order.
             compute: The compute strategy to use for the projection operation.
             num_cpus: The number of CPUs to reserve for each worker.
             num_gpus: The number of GPUs to reserve for each worker.
@@ -1081,13 +1095,28 @@ class Dataset:
 
         _warn_on_ray_remote_args(ray_remote_args)
 
-        if not exprs:
+        args = [] if exprs is None else [exprs]
+        args.extend(more_exprs)
+
+        projection_exprs: List[Expr] = [StarExpr()]
+        for arg in args:
+            if isinstance(arg, UnnestExpr):
+                projection_exprs.append(arg)
+            elif isinstance(arg, Mapping):
+                if any(isinstance(expr, DownloadExpr) for expr in arg.values()):
+                    raise ValueError(
+                        "`with_columns` does not support DownloadExpr. "
+                        "Use `with_column` for download expressions instead."
+                    )
+                projection_exprs.extend(expr.alias(name) for name, expr in arg.items())
+            else:
+                raise TypeError(
+                    "`with_columns` arguments must be mappings from column "
+                    "name to expression, or unnest() expressions, got "
+                    f"{type(arg).__name__}."
+                )
+        if len(projection_exprs) == 1:
             return self
-        if any(isinstance(expr, DownloadExpr) for expr in exprs.values()):
-            raise ValueError(
-                "`with_columns` does not support DownloadExpr. "
-                "Use `with_column` for download expressions instead."
-            )
 
         from ray.data._internal.logical.operators import Project
 
@@ -1108,7 +1137,7 @@ class Dataset:
         )
 
         project_op = Project(
-            exprs=[StarExpr(), *(expr.alias(name) for name, expr in exprs.items())],
+            exprs=projection_exprs,
             input_dependencies=[self._logical_plan.dag],
             compute=compute,
             ray_remote_args=ray_remote_args,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1067,7 +1067,7 @@ class Dataset:
                 defines its values, or an
                 :func:`~ray.data.expressions.unnest` expression. Column
                 order follows the mapping's insertion order.
-            more_exprs: Additional mappings or
+            *more_exprs: Additional mappings or
                 :func:`~ray.data.expressions.unnest` expressions, appended
                 in argument order.
             compute: The compute strategy to use for the projection operation.

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1849,6 +1849,54 @@ class StarExpr(Expr):
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
+class UnnestExpr(Expr):
+    """Expression that expands a struct-typed expression into one output
+    column per struct field.
+
+    This is a plan-time marker, analogous to ``StarExpr``: it never survives
+    into the optimizer or the evaluation engine. ``Project.__post_init__``
+    eagerly desugars it (via ``expand_unnest_exprs``) into one
+    ``expr.struct.field_by_index(i).alias(field_name)`` projection entry per
+    struct field, so downstream code only ever sees ordinary named
+    expressions. The struct field names and order come from the expression's
+    resolved PyArrow struct type; ``CommonSubExprElimination`` then
+    deduplicates the shared inner subtree so it is evaluated once per block.
+
+    Because desugaring needs the struct type at plan time, the wrapped
+    expression must either carry a declared struct ``return_dtype`` (UDFs) or
+    reference a struct column resolvable from the input schema. Otherwise
+    ``Project`` construction raises.
+
+    See :func:`unnest` for the public constructor.
+    """
+
+    #: The wrapped expression; must resolve to a PyArrow struct type.
+    expr: Expr
+
+    # Like ``StarExpr``, an unnest has no single output type.
+    data_type: DataType = field(default_factory=lambda: DataType(object), init=False)
+
+    def structurally_equals(self, other: Any) -> bool:
+        return isinstance(other, UnnestExpr) and self.expr.structurally_equals(
+            other.expr
+        )
+
+    def alias(self, name: str) -> "Expr":
+        raise TypeError(
+            "unnest() cannot be aliased: it produces one output column per "
+            "struct field, named after the fields themselves. Pass it "
+            "positionally to with_columns(), e.g. "
+            "ds.with_columns(unnest(expr))."
+        )
+
+    def to_field(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.Field"]:
+        # ``UnnestExpr`` represents many columns, not one. It is desugared by
+        # ``expand_unnest_exprs`` before any schema resolution happens.
+        return None
+
+
+@DeveloperAPI(stability="alpha")
+@dataclass(frozen=True, eq=False, repr=False)
 class MonotonicallyIncreasingIdExpr(Expr):
     """Expression that represents a monotonically increasing ID column."""
 
@@ -1969,6 +2017,84 @@ def expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> List
             continue
         else:
             expanded.append(expr)
+    return expanded
+
+
+@DeveloperAPI(stability="alpha")
+def expand_unnest_exprs(
+    exprs: List[Expr], input_schema: Optional["pyarrow.Schema"]
+) -> List[Expr]:
+    """Desugar any ``UnnestExpr`` in ``exprs`` into one aliased struct-field
+    access per field of the wrapped expression's struct type.
+
+    ``unnest(expr)`` where ``expr`` resolves to
+    ``struct<f0: t0, f1: t1, ...>`` expands, in place, to::
+
+        expr.struct.field_by_index(0).alias("f0"),
+        expr.struct.field_by_index(1).alias("f1"),
+        ...
+
+    Fields are accessed by index (never by name) so the expansion is
+    unambiguous even for structs with duplicate field names — though such
+    structs are rejected below, since both fields would target the same
+    output column and one would silently win. The N expansion entries share
+    the single inner ``Expr`` subtree, so ``CommonSubExprElimination``
+    hoists it into a temp column evaluated once per block.
+
+    The struct type is resolved via ``Expr.get_type``: self-typed
+    expressions (a UDF with a declared ``return_dtype``) resolve without a
+    schema; schema-dependent expressions (``col("s")``) need
+    ``input_schema``. If the type cannot be resolved at plan time — e.g.
+    ``unnest(col("s"))`` downstream of an opaque ``map_batches`` — this
+    raises rather than deferring to runtime.
+
+    Called eagerly from ``Project.__post_init__`` so that, like
+    ``StarExpr`` after ``expand_star_exprs``, no ``UnnestExpr`` ever
+    reaches optimizer rules or ``eval_projection``.
+    """
+    if not any(isinstance(e, UnnestExpr) for e in exprs):
+        return exprs
+
+    expanded: List[Expr] = []
+    for expr in exprs:
+        if not isinstance(expr, UnnestExpr):
+            expanded.append(expr)
+            continue
+
+        try:
+            resolved_type = expr.expr.get_type(input_schema)
+        except AttributeError:
+            # Schema-dependent inner expression, but ``input_schema`` is None.
+            resolved_type = None
+        if resolved_type is None:
+            raise ValueError(
+                "unnest() requires the struct type of the wrapped expression "
+                "to be known when the plan is built, but it could not be "
+                "resolved. Either wrap an expression with a declared struct "
+                "return_dtype (e.g. @udf(return_dtype=DataType.struct(...))), "
+                "or ensure the input dataset's schema is known (upstream "
+                "map/map_batches calls make it unavailable)."
+            )
+        if not pyarrow.types.is_struct(resolved_type):
+            raise TypeError(
+                f"unnest() requires a struct-typed expression, but the "
+                f"wrapped expression resolves to {resolved_type}."
+            )
+
+        field_names = [
+            resolved_type.field(i).name for i in range(resolved_type.num_fields)
+        ]
+        duplicates = {name for name in field_names if field_names.count(name) > 1}
+        if duplicates:
+            raise ValueError(
+                f"unnest() cannot expand a struct with duplicate field names "
+                f"{sorted(duplicates)}: the expanded columns would overwrite "
+                f"each other."
+            )
+
+        for i, field_name in enumerate(field_names):
+            expanded.append(expr.expr.struct.field_by_index(i).alias(field_name))
+
     return expanded
 
 
@@ -2112,6 +2238,67 @@ def star() -> StarExpr:
         A StarExpr that represents all input columns.
     """
     return StarExpr()
+
+
+@PublicAPI(stability="alpha")
+def unnest(expr: Expr) -> UnnestExpr:
+    """
+    Expand a struct-typed expression into one output column per struct field.
+
+    Use this with :meth:`Dataset.with_columns
+    <ray.data.Dataset.with_columns>` to let a single expression — typically
+    a UDF that computes several related values and returns them bundled as
+    a struct — produce multiple output columns. The output column names and
+    order come from the struct's fields. The wrapped expression is
+    evaluated once per block, not once per field.
+
+    The struct type must be known when the plan is built: either the
+    wrapped expression declares it (a UDF's ``return_dtype``), or it is a
+    reference to a struct column of a dataset whose schema is known.
+
+    Expansion is one level deep: a field that is itself a struct comes out
+    as a single struct-typed column, not flattened further. Chaining a
+    second ``with_columns(unnest(col(...)))`` flattens it, provided the
+    intermediate schema is known at plan time: it is when the struct type
+    came from a declared ``return_dtype``; for a plain struct column, call
+    ``materialize()`` between the two steps. ``unnest()`` cannot wrap
+    another ``unnest()`` — the inner one already denotes multiple columns,
+    so there is no single struct value left to expand — and raises
+    ``TypeError`` if you try.
+
+    Args:
+        expr: An expression that resolves to a PyArrow struct type.
+
+    Returns:
+        An UnnestExpr suitable for passing positionally to
+        :meth:`Dataset.with_columns <ray.data.Dataset.with_columns>`.
+
+    Example:
+        >>> import pyarrow as pa
+        >>> import pyarrow.compute as pc
+        >>> import ray
+        >>> from ray.data.datatype import DataType
+        >>> from ray.data.expressions import col, udf, unnest
+        >>>
+        >>> @udf(return_dtype=DataType.struct([
+        ...     ("sum_ab", DataType.int64()),
+        ...     ("product_ab", DataType.int64()),
+        ... ]))
+        ... def make_features(a, b):
+        ...     return pa.StructArray.from_arrays(
+        ...         [pc.add(a, b).combine_chunks(), pc.multiply(a, b).combine_chunks()],
+        ...         names=["sum_ab", "product_ab"],
+        ...     )
+        >>>
+        >>> ds = ray.data.from_items([{"a": 2, "b": 10}, {"a": 3, "b": 20}])
+        >>> ds.with_columns(unnest(make_features(col("a"), col("b")))).show(1)
+        {'a': 2, 'b': 10, 'sum_ab': 12, 'product_ab': 20}
+    """
+    if isinstance(expr, UnnestExpr):
+        raise TypeError("unnest() cannot be nested inside another unnest().")
+    if not isinstance(expr, Expr):
+        raise TypeError(f"unnest() expects an expression, got {type(expr).__name__}.")
+    return UnnestExpr(expr=expr)
 
 
 @PublicAPI(stability="alpha")
@@ -2297,6 +2484,7 @@ __all__ = [
     "DownloadExpr",
     "AliasExpr",
     "StarExpr",
+    "UnnestExpr",
     "MonotonicallyIncreasingIdExpr",
     "pyarrow_udf",
     "udf",
@@ -2306,6 +2494,7 @@ __all__ = [
     "monotonically_increasing_id",
     "random",
     "star",
+    "unnest",
     "uuid",
     "_ArrayNamespace",
     "_ListNamespace",

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -116,6 +116,8 @@ class _ExprVisitor(ABC, Generic[T]):
             return self.visit_download(expr)
         elif isinstance(expr, StarExpr):
             return self.visit_star(expr)
+        elif isinstance(expr, UnnestExpr):
+            return self.visit_unnest(expr)
         elif isinstance(expr, MonotonicallyIncreasingIdExpr):
             return self.visit_monotonically_increasing_id(expr)
         elif isinstance(expr, RandomExpr):
@@ -152,6 +154,22 @@ class _ExprVisitor(ABC, Generic[T]):
     @abstractmethod
     def visit_star(self, expr: "StarExpr") -> T:
         pass
+
+    def visit_unnest(self, expr: "UnnestExpr") -> T:
+        """Handle an ``UnnestExpr``.
+
+        Concrete, unlike the other ``visit_*`` methods: ``UnnestExpr`` is a
+        plan-time marker that ``Project.__post_init__`` desugars away, so no
+        visitor running during planning or evaluation can encounter one. Only
+        the visitors reachable from user code before ``with_columns`` override
+        this; the rest inherit an error that names the real constraint instead
+        of the generic "unsupported expression type" from ``visit``.
+        """
+        raise TypeError(
+            "unnest() expands to multiple columns, so it has no single value "
+            "to evaluate. Pass it directly to `with_columns`; it cannot be "
+            "composed into another expression."
+        )
 
     @abstractmethod
     def visit_download(self, expr: "DownloadExpr") -> T:
@@ -302,6 +320,9 @@ class _PyArrowConvertibilityVisitor(_ExprVisitor[bool]):
         return False
 
     def visit_star(self, expr: "StarExpr") -> bool:
+        return False
+
+    def visit_unnest(self, expr: "UnnestExpr") -> bool:
         return False
 
     def visit_monotonically_increasing_id(

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import uuid as builtin_uuid
 from abc import ABC, abstractmethod
+from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
@@ -2084,7 +2085,7 @@ def expand_unnest_exprs(
         field_names = [
             resolved_type.field(i).name for i in range(resolved_type.num_fields)
         ]
-        duplicates = {name for name in field_names if field_names.count(name) > 1}
+        duplicates = {name for name, n in Counter(field_names).items() if n > 1}
         if duplicates:
             raise ValueError(
                 f"unnest() cannot expand a struct with duplicate field names "

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -990,6 +990,26 @@ class Expr(ABC):
             return None
         return pyarrow.field(name, data_type, nullable=self.nullable(input_schema))
 
+    def expand_projection(
+        self, input_schema: Optional["pyarrow.Schema"]
+    ) -> List["Expr"]:
+        """Return the projection-list entries this expression stands for.
+
+        Almost every expression denotes exactly one output column and so
+        returns ``[self]``. An expression that denotes *several* columns —
+        ``UnnestExpr`` today, a regex column selector tomorrow — overrides
+        this to expand itself into ordinary named expressions.
+
+        ``Project.__post_init__`` applies this once, when the plan is built,
+        so optimizer rules and the evaluation engine only ever see
+        single-column expressions. ``input_schema`` is the schema of the
+        operator's input, or ``None`` when it is not known at plan time
+        (e.g. downstream of an opaque ``map_batches``); an implementation
+        that cannot expand without it should raise rather than defer to
+        runtime.
+        """
+        return [self]
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1868,6 +1888,17 @@ class StarExpr(Expr):
         # expands it inline rather than calling ``to_field`` on it.
         return None
 
+    def expand_projection(
+        self, input_schema: Optional["pyarrow.Schema"]
+    ) -> List["Expr"]:
+        # Deliberately not on this hook. Unlike an unnest, expanding a star
+        # rewrites *sibling* entries: a rename ``AliasExpr`` elsewhere in the
+        # projection list is substituted at its source column's position and
+        # its trailing copy dropped. A per-expression method cannot reach its
+        # siblings, so ``expand_star_exprs`` rewrites the whole list instead,
+        # and runs before this hook.
+        return [self]
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1877,7 +1908,7 @@ class UnnestExpr(Expr):
 
     This is a plan-time marker, analogous to ``StarExpr``: it never survives
     into the optimizer or the evaluation engine. ``Project.__post_init__``
-    eagerly desugars it (via ``expand_unnest_exprs``) into one
+    eagerly desugars it (via ``expand_projection``) into one
     ``expr.struct.field_by_index(i).alias(field_name)`` projection entry per
     struct field, so downstream code only ever sees ordinary named
     expressions. The struct field names and order come from the expression's
@@ -1913,8 +1944,70 @@ class UnnestExpr(Expr):
 
     def to_field(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.Field"]:
         # ``UnnestExpr`` represents many columns, not one. It is desugared by
-        # ``expand_unnest_exprs`` before any schema resolution happens.
+        # ``expand_projection`` before any schema resolution happens.
         return None
+
+    def expand_projection(
+        self, input_schema: Optional["pyarrow.Schema"]
+    ) -> List["Expr"]:
+        """Desugar into one aliased struct-field access per struct field.
+
+        ``unnest(expr)`` where ``expr`` resolves to
+        ``struct<f0: t0, f1: t1, ...>`` expands to::
+
+            expr.struct.field_by_index(0).alias("f0"),
+            expr.struct.field_by_index(1).alias("f1"),
+            ...
+
+        Fields are accessed by index (never by name) so the expansion is
+        unambiguous even for structs with duplicate field names — though such
+        structs are rejected below, since both fields would target the same
+        output column and one would silently win. The N entries share the
+        single inner ``Expr`` subtree, so ``CommonSubExprElimination`` hoists
+        it into a temp column evaluated once per block.
+
+        The struct type is resolved via ``Expr.get_type``: self-typed
+        expressions (a UDF with a declared ``return_dtype``) resolve without a
+        schema; schema-dependent expressions (``col("s")``) need
+        ``input_schema``. If the type cannot be resolved when the plan is
+        built — e.g. ``unnest(col("s"))`` downstream of an opaque
+        ``map_batches`` — this raises rather than deferring to runtime.
+        """
+        try:
+            resolved_type = self.expr.get_type(input_schema)
+        except AttributeError:
+            # Schema-dependent inner expression, but ``input_schema`` is None.
+            resolved_type = None
+        if resolved_type is None:
+            raise ValueError(
+                "unnest() requires the struct type of the wrapped expression "
+                "to be known when the plan is built, but it could not be "
+                "resolved. Either wrap an expression with a declared struct "
+                "return_dtype (e.g. @udf(return_dtype=DataType.struct(...))), "
+                "or ensure the input dataset's schema is known (upstream "
+                "map/map_batches calls make it unavailable)."
+            )
+        if not pyarrow.types.is_struct(resolved_type):
+            raise TypeError(
+                f"unnest() requires a struct-typed expression, but the "
+                f"wrapped expression resolves to {resolved_type}."
+            )
+
+        field_names = [
+            resolved_type.field(i).name for i in range(resolved_type.num_fields)
+        ]
+        duplicates = {name for name, n in Counter(field_names).items() if n > 1}
+        if duplicates:
+            raise ValueError(
+                f"unnest() cannot expand a struct with duplicate field names "
+                f"{sorted(duplicates)}: the expanded columns would overwrite "
+                f"each other."
+            )
+
+        return [
+            self.expr.struct.field_by_index(i).alias(field_name)
+            for i, field_name in enumerate(field_names)
+        ]
 
 
 @DeveloperAPI(stability="alpha")
@@ -2043,80 +2136,29 @@ def expand_star_exprs(exprs: List[Expr], input_schema: "pyarrow.Schema") -> List
 
 
 @DeveloperAPI(stability="alpha")
-def expand_unnest_exprs(
+def expand_projection_exprs(
     exprs: List[Expr], input_schema: Optional["pyarrow.Schema"]
 ) -> List[Expr]:
-    """Desugar any ``UnnestExpr`` in ``exprs`` into one aliased struct-field
-    access per field of the wrapped expression's struct type.
+    """Expand every multi-column expression in ``exprs`` in place, via
+    :meth:`Expr.expand_projection`.
 
-    ``unnest(expr)`` where ``expr`` resolves to
-    ``struct<f0: t0, f1: t1, ...>`` expands, in place, to::
+    Most expressions denote a single output column and pass through
+    unchanged. ``UnnestExpr`` desugars into one aliased struct-field access
+    per field of its struct type. Any future multi-column expression — a
+    regex column selector, say — joins in by overriding
+    ``Expr.expand_projection``; neither this driver nor its caller in
+    ``Project.__post_init__`` needs to change.
 
-        expr.struct.field_by_index(0).alias("f0"),
-        expr.struct.field_by_index(1).alias("f1"),
-        ...
+    ``StarExpr`` is the one exception: star expansion rewrites sibling
+    entries, so it gets its own whole-list pass in ``expand_star_exprs``,
+    which runs first.
 
-    Fields are accessed by index (never by name) so the expansion is
-    unambiguous even for structs with duplicate field names — though such
-    structs are rejected below, since both fields would target the same
-    output column and one would silently win. The N expansion entries share
-    the single inner ``Expr`` subtree, so ``CommonSubExprElimination``
-    hoists it into a temp column evaluated once per block.
-
-    The struct type is resolved via ``Expr.get_type``: self-typed
-    expressions (a UDF with a declared ``return_dtype``) resolve without a
-    schema; schema-dependent expressions (``col("s")``) need
-    ``input_schema``. If the type cannot be resolved at plan time — e.g.
-    ``unnest(col("s"))`` downstream of an opaque ``map_batches`` — this
-    raises rather than deferring to runtime.
-
-    Called eagerly from ``Project.__post_init__`` so that, like
-    ``StarExpr`` after ``expand_star_exprs``, no ``UnnestExpr`` ever
-    reaches optimizer rules or ``eval_projection``.
+    Called eagerly from ``Project.__post_init__``, so no multi-column marker
+    ever reaches optimizer rules or ``eval_projection``.
     """
-    if not any(isinstance(e, UnnestExpr) for e in exprs):
-        return exprs
-
     expanded: List[Expr] = []
     for expr in exprs:
-        if not isinstance(expr, UnnestExpr):
-            expanded.append(expr)
-            continue
-
-        try:
-            resolved_type = expr.expr.get_type(input_schema)
-        except AttributeError:
-            # Schema-dependent inner expression, but ``input_schema`` is None.
-            resolved_type = None
-        if resolved_type is None:
-            raise ValueError(
-                "unnest() requires the struct type of the wrapped expression "
-                "to be known when the plan is built, but it could not be "
-                "resolved. Either wrap an expression with a declared struct "
-                "return_dtype (e.g. @udf(return_dtype=DataType.struct(...))), "
-                "or ensure the input dataset's schema is known (upstream "
-                "map/map_batches calls make it unavailable)."
-            )
-        if not pyarrow.types.is_struct(resolved_type):
-            raise TypeError(
-                f"unnest() requires a struct-typed expression, but the "
-                f"wrapped expression resolves to {resolved_type}."
-            )
-
-        field_names = [
-            resolved_type.field(i).name for i in range(resolved_type.num_fields)
-        ]
-        duplicates = {name for name, n in Counter(field_names).items() if n > 1}
-        if duplicates:
-            raise ValueError(
-                f"unnest() cannot expand a struct with duplicate field names "
-                f"{sorted(duplicates)}: the expanded columns would overwrite "
-                f"each other."
-            )
-
-        for i, field_name in enumerate(field_names):
-            expanded.append(expr.expr.struct.field_by_index(i).alias(field_name))
-
+        expanded.extend(expr.expand_projection(input_schema))
     return expanded
 
 
@@ -2306,7 +2348,7 @@ def unnest(expr: Expr) -> UnnestExpr:
         ...     ("sum_ab", DataType.int64()),
         ...     ("product_ab", DataType.int64()),
         ... ]))
-        ... def make_features(a, b):
+        ... def make_features(a: pa.Array, b: pa.Array) -> pa.StructArray:
         ...     return pa.StructArray.from_arrays(
         ...         [pc.add(a, b).combine_chunks(), pc.multiply(a, b).combine_chunks()],
         ...         names=["sum_ab", "product_ab"],

--- a/python/ray/data/tests/expressions/test_unnest.py
+++ b/python/ray/data/tests/expressions/test_unnest.py
@@ -1,0 +1,228 @@
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+
+import ray
+from ray.data.datatype import DataType
+from ray.data.expressions import AliasExpr, UnnestExpr, col, udf, unnest
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+_FEATURES_DTYPE = DataType.struct(
+    [
+        ("sum_ab", DataType.int64()),
+        ("product_ab", DataType.int64()),
+    ]
+)
+
+
+def _make_features_udf():
+    """Build a struct-returning UDF computing sum_ab/product_ab from a, b.
+
+    Everything the UDF references is defined inside this function so
+    cloudpickle serializes it by value; a reference to a module-level helper
+    would make workers try to import this test module.
+    """
+
+    @udf(return_dtype=_FEATURES_DTYPE)
+    def make_features(a, b):
+        def arr(x):
+            return x.combine_chunks() if isinstance(x, pa.ChunkedArray) else x
+
+        a, b = arr(a), arr(b)
+        return pa.StructArray.from_arrays(
+            [arr(pc.add(a, b)), arr(pc.multiply(a, b))],
+            names=["sum_ab", "product_ab"],
+        )
+
+    return make_features
+
+
+@pytest.fixture
+def ab_dataset(ray_start_regular_shared):
+    return ray.data.from_items([{"a": 2, "b": 10}, {"a": 3, "b": 20}])
+
+
+def test_unnest_udf_struct(ab_dataset):
+    """unnest of a struct-returning UDF adds one column per struct field,
+    in field order."""
+    make_features = _make_features_udf()
+    result = ab_dataset.with_columns(
+        unnest(make_features(col("a"), col("b")))
+    ).take_all()
+    assert result == [
+        {"a": 2, "b": 10, "sum_ab": 12, "product_ab": 20},
+        {"a": 3, "b": 20, "sum_ab": 23, "product_ab": 60},
+    ]
+
+
+def test_unnest_mixed_with_mapping(ab_dataset):
+    """A mapping and an unnest combine in one projection, in argument order."""
+    make_features = _make_features_udf()
+    result = ab_dataset.with_columns(
+        {"a2": col("a") * 2},
+        unnest(make_features(col("a"), col("b"))),
+    ).take_all()
+    assert result == [
+        {"a": 2, "b": 10, "a2": 4, "sum_ab": 12, "product_ab": 20},
+        {"a": 3, "b": 20, "a2": 6, "sum_ab": 23, "product_ab": 60},
+    ]
+
+
+def test_unnest_existing_struct_column(ray_start_regular_shared):
+    """unnest(col(...)) resolves the struct type from the dataset schema.
+    The source struct column is preserved (with_columns adds columns)."""
+    ds = ray.data.from_items(
+        [
+            {"name": "bob", "stats": {"h": 180, "w": 80}},
+            {"name": "amy", "stats": {"h": 165, "w": 55}},
+        ]
+    )
+    result = ds.with_columns(unnest(col("stats"))).take_all()
+    assert result == [
+        {"name": "bob", "stats": {"h": 180, "w": 80}, "h": 180, "w": 80},
+        {"name": "amy", "stats": {"h": 165, "w": 55}, "h": 165, "w": 55},
+    ]
+
+
+def test_unnest_desugars_before_optimizer(ab_dataset):
+    """UnnestExpr never survives Project construction: the logical plan
+    contains only aliased single-column expressions."""
+    make_features = _make_features_udf()
+    ds = ab_dataset.with_columns(unnest(make_features(col("a"), col("b"))))
+    project_op = ds._logical_plan.dag
+    assert not any(isinstance(e, UnnestExpr) for e in project_op.exprs)
+    unnested = [
+        e
+        for e in project_op.exprs
+        if isinstance(e, AliasExpr) and e.name in ("sum_ab", "product_ab")
+    ]
+    assert [e.name for e in unnested] == ["sum_ab", "product_ab"]
+
+
+def test_unnest_single_evaluation(ray_start_regular_shared, tmp_path):
+    """The struct expression is evaluated once per block, not once per field.
+    Counted via a marker file appended on each UDF invocation."""
+    marker = tmp_path / "invocations.log"
+
+    marker_path = str(marker)
+
+    @udf(return_dtype=_FEATURES_DTYPE)
+    def make_features(a, b):
+        def arr(x):
+            return x.combine_chunks() if isinstance(x, pa.ChunkedArray) else x
+
+        with open(marker_path, "a") as f:
+            f.write("x\n")
+        a, b = arr(a), arr(b)
+        return pa.StructArray.from_arrays(
+            [arr(pc.add(a, b)), arr(pc.multiply(a, b))],
+            names=["sum_ab", "product_ab"],
+        )
+
+    ds = ray.data.from_items([{"a": 2, "b": 10}, {"a": 3, "b": 20}]).repartition(1)
+    ds.with_columns(unnest(make_features(col("a"), col("b")))).materialize()
+    assert marker.read_text().count("x") == 1
+
+
+def test_unnest_non_struct_raises(ab_dataset):
+    with pytest.raises(TypeError, match="struct-typed expression"):
+        ab_dataset.with_columns(unnest(col("a")))
+
+
+def test_unnest_unknown_schema_raises(ab_dataset):
+    """unnest(col(...)) downstream of an opaque map_batches cannot resolve
+    the struct type at plan time and raises."""
+    opaque = ab_dataset.map_batches(lambda b: b)
+    with pytest.raises(ValueError, match="known when the plan is built"):
+        opaque.with_columns(unnest(col("stats")))
+
+
+def test_unnest_udf_works_after_opaque_input(ab_dataset):
+    """A UDF-wrapped unnest resolves from return_dtype, so it works even when
+    the input schema is opaque."""
+    make_features = _make_features_udf()
+    opaque = ab_dataset.map_batches(lambda b: b)
+    result = opaque.with_columns(unnest(make_features(col("a"), col("b")))).take_all()
+    assert sorted(result, key=lambda r: r["a"]) == [
+        {"a": 2, "b": 10, "sum_ab": 12, "product_ab": 20},
+        {"a": 3, "b": 20, "sum_ab": 23, "product_ab": 60},
+    ]
+
+
+def test_unnest_cannot_be_aliased():
+    with pytest.raises(TypeError, match="cannot be aliased"):
+        unnest(col("stats")).alias("x")
+
+
+def test_unnest_cannot_nest():
+    with pytest.raises(TypeError, match="cannot be nested"):
+        unnest(unnest(col("stats")))
+
+
+def test_unnest_rejects_non_expr():
+    with pytest.raises(TypeError, match="expects an expression"):
+        unnest("stats")
+
+
+def test_with_columns_rejects_unknown_positional(ab_dataset):
+    with pytest.raises(TypeError, match="mappings from column name"):
+        ab_dataset.with_columns(col("a"))
+
+
+def test_with_columns_empty_returns_self(ab_dataset):
+    assert ab_dataset.with_columns() is ab_dataset
+    assert ab_dataset.with_columns({}) is ab_dataset
+
+
+def test_with_columns_mapping_unchanged(ab_dataset):
+    """Pre-existing with_columns(mapping) behavior is untouched."""
+    result = ab_dataset.with_columns({"a2": col("a") * 2}).take_all()
+    assert result == [
+        {"a": 2, "b": 10, "a2": 4},
+        {"a": 3, "b": 20, "a2": 6},
+    ]
+
+
+def test_unnest_pushdown_prunes_unused_columns(ray_start_regular_shared, tmp_path):
+    """Because unnest desugars to ordinary expressions, projection pushdown
+    still prunes columns the projection doesn't reference."""
+    import pyarrow.parquet as pq
+
+    table = pa.table({"a": [2, 3], "b": [10, 20], "unused": ["x", "y"]})
+    path = str(tmp_path / "t.parquet")
+    pq.write_table(table, path)
+
+    make_features = _make_features_udf()
+    ds = (
+        ray.data.read_parquet(path)
+        .with_columns(unnest(make_features(col("a"), col("b"))))
+        .select_columns(["sum_ab", "product_ab"])
+    )
+    # The optimized read should be narrowed to the columns the desugared
+    # projection references (a, b) — "unused" must be pruned. Check the plan
+    # BEFORE executing: execution optimizes the plan in place, and optimizing
+    # an already-optimized plan a second time double-applies pushdown.
+    from ray.data._internal.logical.optimizers import LogicalOptimizer
+
+    optimized = LogicalOptimizer().optimize(ds._logical_plan)
+    op, read_op = optimized.dag, None
+    while op is not None:
+        if hasattr(op, "scanner"):
+            read_op = op
+            break
+        op = op.input_dependencies[0] if op.input_dependencies else None
+    assert read_op is not None, "no read operator with a scanner found"
+    pruned = read_op.scanner.pruned_column_names()
+    assert pruned is not None and set(pruned) == {"a", "b"}
+
+    assert ds.take_all() == [
+        {"sum_ab": 12, "product_ab": 20},
+        {"sum_ab": 23, "product_ab": 60},
+    ]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/expressions/test_unnest.py
+++ b/python/ray/data/tests/expressions/test_unnest.py
@@ -1,22 +1,24 @@
+from typing import Callable
+
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
 import ray
 from ray.data.datatype import DataType
-from ray.data.expressions import AliasExpr, UnnestExpr, col, udf, unnest
+from ray.data.expressions import AliasExpr, UDFExpr, UnnestExpr, col, udf, unnest
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
 _FEATURES_DTYPE = DataType.struct(
     [
-        ("sum_ab", DataType.int64()),
-        ("product_ab", DataType.int64()),
+        ("sum_ab", DataType.from_arrow(pa.int64())),
+        ("product_ab", DataType.from_arrow(pa.int64())),
     ]
 )
 
 
-def _make_features_udf():
+def _make_features_udf() -> Callable[..., UDFExpr]:
     """Build a struct-returning UDF computing sum_ab/product_ab from a, b.
 
     Everything the UDF references is defined inside this function so
@@ -31,10 +33,13 @@ def _make_features_udf():
 
         a, b = arr(a), arr(b)
         return pa.StructArray.from_arrays(
+            # pyrefly: ignore[missing-attribute]  # pc functions are runtime-generated.
             [arr(pc.add(a, b)), arr(pc.multiply(a, b))],
             names=["sum_ab", "product_ab"],
         )
 
+    # pyrefly: ignore[bad-return]  # @udf mis-annotates the decorated function
+    # as UDFExpr; it is a callable producing UDFExpr (see udf_callable).
     return make_features
 
 
@@ -116,11 +121,13 @@ def test_unnest_single_evaluation(ray_start_regular_shared, tmp_path):
             f.write("x\n")
         a, b = arr(a), arr(b)
         return pa.StructArray.from_arrays(
+            # pyrefly: ignore[missing-attribute]  # pc functions are runtime-generated.
             [arr(pc.add(a, b)), arr(pc.multiply(a, b))],
             names=["sum_ab", "product_ab"],
         )
 
     ds = ray.data.from_items([{"a": 2, "b": 10}, {"a": 3, "b": 20}]).repartition(1)
+    # pyrefly: ignore[not-callable]  # @udf mis-annotates make_features as UDFExpr.
     ds.with_columns(unnest(make_features(col("a"), col("b")))).materialize()
     assert marker.read_text().count("x") == 1
 
@@ -162,6 +169,7 @@ def test_unnest_cannot_nest():
 
 def test_unnest_rejects_non_expr():
     with pytest.raises(TypeError, match="expects an expression"):
+        # pyrefly: ignore[bad-argument-type]  # the bad argument is the test.
         unnest("stats")
 
 
@@ -203,16 +211,21 @@ def test_unnest_pushdown_prunes_unused_columns(ray_start_regular_shared, tmp_pat
     # projection references (a, b) — "unused" must be pruned. Check the plan
     # BEFORE executing: execution optimizes the plan in place, and optimizing
     # an already-optimized plan a second time double-applies pushdown.
+    from typing import Optional
+
+    from ray.data._internal.logical.interfaces import Operator
     from ray.data._internal.logical.optimizers import LogicalOptimizer
 
     optimized = LogicalOptimizer().optimize(ds._logical_plan)
-    op, read_op = optimized.dag, None
+    op: Optional[Operator] = optimized.dag
+    read_op = None
     while op is not None:
         if hasattr(op, "scanner"):
             read_op = op
             break
         op = op.input_dependencies[0] if op.input_dependencies else None
     assert read_op is not None, "no read operator with a scanner found"
+    # pyrefly: ignore[missing-attribute]  # hasattr-guarded; scanner is on ReadFiles.
     pruned = read_op.scanner.pruned_column_names()
     assert pruned is not None and set(pruned) == {"a", "b"}
 

--- a/python/ray/data/tests/expressions/test_unnest.py
+++ b/python/ray/data/tests/expressions/test_unnest.py
@@ -235,6 +235,30 @@ def test_unnest_pushdown_prunes_unused_columns(ray_start_regular_shared, tmp_pat
     ]
 
 
+def test_unnest_is_registered_with_expr_visitor():
+    """``UnnestExpr`` is dispatched by ``_ExprVisitor``, so introspecting an
+    unnest before passing it to ``with_columns`` works instead of raising the
+    generic "unsupported expression type" error."""
+    from ray.data.expressions import random as random_expr
+
+    expr = unnest(col("stats"))
+
+    # ``repr`` renders the tree rather than raising.
+    assert "UNNEST" in repr(expr)
+    assert "COL('stats')" in repr(expr)
+
+    # Idempotency delegates to the wrapped expression: unnesting only
+    # reshapes the value into columns.
+    assert expr.is_idempotent()
+    assert not unnest(random_expr()).is_idempotent()
+
+    # An unnest denotes multiple columns, so it has no PyArrow lowering. It
+    # reports that rather than raising, and the raising path explains why.
+    assert not expr._is_pyarrow_convertible()
+    with pytest.raises(TypeError, match="expands to multiple columns"):
+        expr.to_pyarrow()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/expressions/test_unnest.py
+++ b/python/ray/data/tests/expressions/test_unnest.py
@@ -1,4 +1,5 @@
-from typing import Callable
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -257,6 +258,56 @@ def test_unnest_is_registered_with_expr_visitor():
     assert not expr._is_pyarrow_convertible()
     with pytest.raises(TypeError, match="expands to multiple columns"):
         expr.to_pyarrow()
+
+
+def test_expand_projection_default_and_overrides():
+    """``Expr.expand_projection`` is the plan-time hook for expressions that
+    stand for more than one output column."""
+    from ray.data.expressions import star
+
+    schema = pa.schema([("stats", pa.struct([("h", pa.int64()), ("w", pa.int64())]))])
+
+    # The default: an ordinary expression is exactly one column, so it comes
+    # back untouched. (Identity, not ``==``: ``Expr.__eq__`` builds a
+    # comparison expression rather than answering a question.)
+    ordinary = col("stats")
+    default = ordinary.expand_projection(schema)
+    assert len(default) == 1 and default[0] is ordinary
+
+    # ``UnnestExpr`` overrides it: one aliased field access per struct field.
+    expanded = unnest(col("stats")).expand_projection(schema)
+    assert [e.name for e in expanded] == ["h", "w"]
+
+    # ``StarExpr`` opts out. Expanding a star rewrites sibling entries, which
+    # a per-expression hook cannot do, so it returns itself and the whole-list
+    # ``expand_star_exprs`` pass handles it.
+    star_expr = star()
+    star_result = star_expr.expand_projection(schema)
+    assert len(star_result) == 1 and star_result[0] is star_expr
+
+
+def test_expand_projection_exprs_dispatches_on_the_hook():
+    """The driver knows nothing about ``UnnestExpr`` — it just calls the hook.
+    A future multi-column expression (a regex column selector, say) only has
+    to override ``expand_projection`` to work everywhere unnest does."""
+    from ray.data.expressions import Expr, expand_projection_exprs
+
+    @dataclass(frozen=True, eq=False, repr=False)
+    class _PairOfColumns(Expr):
+        """Stands in for any future expression yielding several columns."""
+
+        data_type: DataType = field(
+            default_factory=lambda: DataType(object), init=False
+        )
+
+        def structurally_equals(self, other: Any) -> bool:
+            return isinstance(other, _PairOfColumns)
+
+        def expand_projection(self, input_schema: Optional["pa.Schema"]) -> List[Expr]:
+            return [col("a").alias("x"), col("b").alias("y")]
+
+    expanded = expand_projection_exprs([col("keep"), _PairOfColumns()], None)
+    assert [e.name for e in expanded] == ["keep", "x", "y"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Implements the `unnest()` half of #63838. A UDF (or any expression) that returns a struct can now produce multiple output columns:

```python
ds.with_columns(unnest(make_features(col("a"), col("b"))))
# adds one column per struct field: sum_ab, product_ab
```

It also flattens existing struct columns, and mixes with the mapping form:

```python
ds.with_columns({"a2": col("a") * 2}, unnest(col("stats")))
```

### Design

`UnnestExpr` is a plan-time marker, analogous to `StarExpr`. `Project.__post_init__` eagerly desugars it into one `expr.struct.field_by_index(i).alias(field_name)` entry per struct field, so no `UnnestExpr` ever reaches optimizer rules or the evaluator. Consequences, each covered by a test:

- Projection pushdown still prunes unused columns through an unnest.
- Common-subexpression elimination evaluates the struct expression once per block, not once per field.
- The output schema is known at plan time, and unresolvable/invalid unnests fail at plan construction with actionable errors.

The struct type must be resolvable when the plan is built: a declared UDF `return_dtype`, or a struct column of a dataset whose schema is known. Structs with duplicate field names are rejected (the expanded columns would collide). Expansion is one level deep.

### Known limitation

`unnest(col("s").struct.field("nested"))` raises even when the schema is known, because `_StructNamespace.field()` resolves its output type from the parent expression's construction-time `data_type` rather than against the input schema — a pre-existing gap that unnest makes user-visible. Flattening nested structs works by chaining a second unnest when the intermediate schema is known (declared `return_dtype`, or `materialize()` between steps); this is documented in the `unnest()` docstring. Fixing the namespace type resolution is left for a follow-up.

Alternative runtime-expansion implementation: #63879. This approach avoids evaluator changes and keeps fusion/pushdown enabled.

## Related issue number

Closes #63838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
