### PR TITLE
[Data] Disable throttling for `Union` and `Mix` operators

### DIFF
--- a/python/ray/data/_internal/execution/operators/mix_operator.py
+++ b/python/ray/data/_internal/execution/operators/mix_operator.py
@@ -147,8 +147,7 @@ class MixOperator(InternalQueueOperatorMixin, NAryOperator):
 
     @override
     def throttling_disabled(self) -> bool:
-        # TODO: Disable throttling along with Union once NAry operator resource accounting is fixed.
-        return False
+        return True
 
     # ------------------------------------------------------------------
     # Output selection

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -119,6 +119,12 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
         # Check if the output buffer still contains at least one block.
         return len(self._output_buffer) > 0
 
+    def throttling_disabled(self) -> bool:
+        """Union doesn't produce new blocks, so it should not be considered
+        for backpressure or resource budgeting.
+        Instead, upstream inputs are backpressured independently."""
+        return True
+
     def _get_next_inner(self) -> RefBundle:
         refs = self._output_buffer.get_next()
         self._metrics.on_output_dequeued(refs)

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -1,13 +1,17 @@
 import gc
 from typing import List
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 import ray
+from ray.data._internal.execution import create_resource_allocator
+from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
     ExecutionOptions,
+    ExecutionResources,
     RefBundle,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
@@ -15,6 +19,11 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.union_operator import UnionOperator
+from ray.data._internal.execution.resource_manager import ResourceManager
+from ray.data._internal.execution.streaming_executor_state import (
+    build_streaming_topology,
+)
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.progress.base_progress import NoopSubProgressBar
 from ray.data.block import BlockAccessor
@@ -221,6 +230,42 @@ def test_input_data_buffer_does_not_free_inputs():
     # `InputDataBuffer` should still hold a reference to the input block even after
     # `get_next` is called.
     assert len(gc.get_referrers(block_ref)) > 0
+
+
+def test_union_operator_throttling_disabled(ray_start_regular_shared):
+    """Test that UnionOperator has throttling disabled.
+
+    UnionOperator only manipulates bundle metadata and doesn't launch any tasks,
+    so it should not be allocated resources.
+    """
+    ctx = DataContext.get_current()
+    union_op = UnionOperator(ctx)
+
+    assert union_op.throttling_disabled() is True
+
+
+def test_union_operator_not_allocated_resources(
+    ray_start_regular_shared, restore_data_context
+):
+    ctx = DataContext.get_current()
+    ctx.op_resource_reservation_enabled = True
+    input_op1 = InputDataBuffer(ctx, make_ref_bundles([[1, 2, 3]]))
+    input_op2 = InputDataBuffer(ctx, make_ref_bundles([[4, 5, 6]]))
+    union_op = UnionOperator(ctx, input_op1, input_op2)
+
+    counter = BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True)
+    topo = build_streaming_topology(union_op, ExecutionOptions(), counter)
+    resource_manager = ResourceManager(
+        topo, ExecutionOptions(), MagicMock(), ctx, counter
+    )
+    allocator = create_resource_allocator(resource_manager, ctx)
+    assert allocator is not None
+
+    allocator.update_budgets(
+        limits=ExecutionResources(cpu=1, gpu=0, object_store_memory=1000)
+    )
+    allocation = allocator.get_allocation(union_op)
+    assert allocation is None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -1,17 +1,13 @@
 import gc
 from typing import List
-from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 import ray
-from ray.data._internal.execution import create_resource_allocator
-from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
     ExecutionOptions,
-    ExecutionResources,
     RefBundle,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
@@ -19,11 +15,6 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
-from ray.data._internal.execution.operators.union_operator import UnionOperator
-from ray.data._internal.execution.resource_manager import ResourceManager
-from ray.data._internal.execution.streaming_executor_state import (
-    build_streaming_topology,
-)
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.progress.base_progress import NoopSubProgressBar
 from ray.data.block import BlockAccessor
@@ -230,42 +221,6 @@ def test_input_data_buffer_does_not_free_inputs():
     # `InputDataBuffer` should still hold a reference to the input block even after
     # `get_next` is called.
     assert len(gc.get_referrers(block_ref)) > 0
-
-
-def test_union_operator_throttling_disabled(ray_start_regular_shared):
-    """Test that UnionOperator has throttling disabled.
-
-    UnionOperator only manipulates bundle metadata and doesn't launch any tasks,
-    so it should not be allocated resources.
-    """
-    ctx = DataContext.get_current()
-    union_op = UnionOperator(ctx)
-
-    assert union_op.throttling_disabled() is True
-
-
-def test_union_operator_not_allocated_resources(
-    ray_start_regular_shared, restore_data_context
-):
-    ctx = DataContext.get_current()
-    ctx.op_resource_reservation_enabled = True
-    input_op1 = InputDataBuffer(ctx, make_ref_bundles([[1, 2, 3]]))
-    input_op2 = InputDataBuffer(ctx, make_ref_bundles([[4, 5, 6]]))
-    union_op = UnionOperator(ctx, input_op1, input_op2)
-
-    counter = BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True)
-    topo = build_streaming_topology(union_op, ExecutionOptions(), counter)
-    resource_manager = ResourceManager(
-        topo, ExecutionOptions(), MagicMock(), ctx, counter
-    )
-    allocator = create_resource_allocator(resource_manager, ctx)
-    assert allocator is not None
-
-    allocator.update_budgets(
-        limits=ExecutionResources(cpu=1, gpu=0, object_store_memory=1000)
-    )
-    allocation = allocator.get_allocation(union_op)
-    assert allocation is None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -1113,69 +1113,64 @@ class TestReservationOpResourceAllocator:
         resource_manager._update_allocated_budgets()
 
         """
+        UnionOperator (o6) has throttling disabled, so only o8 gets budget allocation.
         global_limits (20 CPU, 2000 mem) - o2 usage (2 CPU, 150 mem) - o3 usage (2 CPU, 50 mem) - o5 usage (3 CPU, 100 mem) - o7 usage (1 CPU, 100 mem) = remaining (12 CPU, 1600 mem)
         +-----+------------------+------------------+--------------+
         |     | _op_reserved     | _reserved_for    | used shared  |
         |     | (used/remaining) | _op_outputs      | resources    |
         |     |                  | (used/remaining) |              |
         +-----+------------------+------------------+--------------+
-        | op6 | 0/200            | 0/200            | 0            |
-        +-----+------------------+------------------+--------------+
-        | op8 | 0/200            | 0/200            | 0            |
+        | op8 | 0/400            | 0/400            | 0            |
         +-----+------------------+------------------+--------------+
         """
         allocator = resource_manager._op_resource_allocator
 
-        assert set(allocator._op_budgets.keys()) == {o6, o8}
-        assert set(allocator._op_reserved.keys()) == {o6, o8}
-        assert allocator._op_reserved[o6] == ExecutionResources(
-            cpu=3, object_store_memory=200
-        )
+        assert set(allocator._op_budgets.keys()) == {o8}
+        assert set(allocator._op_reserved.keys()) == {o8}
         assert allocator._op_reserved[o8] == ExecutionResources(
-            cpu=3, object_store_memory=200
+            cpu=6, object_store_memory=400
         )
-        assert allocator._reserved_for_op_outputs[o6] == 200
-        assert allocator._reserved_for_op_outputs[o8] == 200
+        assert allocator._reserved_for_op_outputs[o8] == 400
         assert allocator._total_shared == ExecutionResources(
             cpu=6, object_store_memory=800
         )
-        assert allocator._op_budgets[o6] == ExecutionResources(
-            cpu=6, object_store_memory=600
-        )
         # object_store_memory budget is unlimited, since join is a materializing
-        # operator
+        # operator. CPU budget gets all remaining 12 CPU.
         assert allocator._op_budgets[o8] == ExecutionResources(
-            cpu=6, object_store_memory=float("inf")
+            cpu=12, object_store_memory=float("inf")
         )
 
         # Test when resources are used.
-        op_usages[o6] = ExecutionResources(2, 0, 500)
-        op_internal_usage[o6] = 300
-        op_outputs_usages[o6] = 200
+        op_usages[o6] = ExecutionResources.zero()
+        op_internal_usage[o6] = 0
+        op_outputs_usages[o6] = 0
         op_usages[o8] = ExecutionResources(2, 0, 100)
         op_internal_usage[o8] = 50
         op_outputs_usages[o8] = 50
+
         """
+        global_limits (20 CPU, 2000 mem) - o2 usage (2 CPU, 150 mem) - o3 usage (2 CPU, 50 mem) - o5 usage (3 CPU, 100 mem) - o7 usage (1 CPU, 100 mem) = remaining (12 CPU, 1600 mem)
         +-----+------------------+------------------+--------------+
         |     | _op_reserved     | _reserved_for    | used shared  |
         |     | (used/remaining) | _op_outputs      | resources    |
         |     |                  | (used/remaining) |              |
         +-----+------------------+------------------+--------------+
-        | op6 | 200/0            | 200/0            | 100          |
-        +-----+------------------+------------------+--------------+
-        | op8 | 50/150           | 50/150           | 0            |
+        | op8 | 50/350           | 50/350           | 0            |
         +-----+------------------+------------------+--------------+
         """
-
         resource_manager._update_allocated_budgets()
 
-        assert allocator._op_budgets[o6] == ExecutionResources(
-            cpu=4, object_store_memory=350
+        assert allocator._op_reserved[o8] == ExecutionResources(
+            cpu=6, object_store_memory=400
+        )
+        assert allocator._reserved_for_op_outputs[o8] == 400
+        assert allocator._total_shared == ExecutionResources(
+            cpu=6, object_store_memory=800
         )
         # object_store_memory budget is unlimited, since join is a materializing
-        # operator
+        # operator. CPU budget = 12 - 2 (o8 internal) = 10
         assert allocator._op_budgets[o8] == ExecutionResources(
-            cpu=4, object_store_memory=float("inf")
+            cpu=10, object_store_memory=float("inf")
         )
 
         # Test when completed ops update the usage.
@@ -1190,32 +1185,22 @@ class TestReservationOpResourceAllocator:
         |     | (used/remaining) | _op_outputs      | resources    |
         |     |                  | (used/remaining) |              |
         +-----+------------------+------------------+--------------+
-        | op6 | 213/0            | 200/13           | 300-213=87   |
-        +-----+------------------+------------------+--------------+
-        | op8 | 50/163           | 50/163           | 0            |
+        | op8 | 50/375           | 50/375           | 0            |
         +-----+------------------+------------------+--------------+
         """
-        assert set(allocator._op_budgets.keys()) == {o6, o8}
-        assert set(allocator._op_reserved.keys()) == {o6, o8}
-        assert allocator._op_reserved[o6] == ExecutionResources(
-            cpu=3.75, object_store_memory=213
-        )
+        assert set(allocator._op_budgets.keys()) == {o8}
+        assert set(allocator._op_reserved.keys()) == {o8}
         assert allocator._op_reserved[o8] == ExecutionResources(
-            cpu=3.75, object_store_memory=213
+            cpu=7.5, object_store_memory=425
         )
-        assert allocator._reserved_for_op_outputs[o6] == 212
-        assert allocator._reserved_for_op_outputs[o8] == 212
+        assert allocator._reserved_for_op_outputs[o8] == 425
         assert allocator._total_shared == ExecutionResources(
             cpu=7.5, object_store_memory=850
         )
-        # object_store_memory budget = 0 + (850 - 87) / 2 = 381 (rounded down)
-        assert allocator._op_budgets[o6] == ExecutionResources(
-            cpu=5.5, object_store_memory=381
-        )
         # object_store_memory budget is unlimited, since join is a materializing
-        # operator
+        # operator. CPU budget = 15 - 2 (o8 internal) = 13
         assert allocator._op_budgets[o8] == ExecutionResources(
-            cpu=5.5, object_store_memory=float("inf")
+            cpu=13, object_store_memory=float("inf")
         )
 
 

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -13,6 +13,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
     ExecutionResources,
 )
+from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.resource_manager import (
     ResourceManager,
@@ -229,7 +230,7 @@ def test_does_not_double_count_usage_from_union():
     assert total_object_store_memory == 2, total_object_store_memory
 
 
-def test_per_input_inqueue_attribution_for_union():
+def test_union_memory_attribution_internal_inqueue():
     """Test that per-input attribution correctly charges each upstream operator
     only for the blocks it produced in the union's internal input queue.
 
@@ -296,6 +297,165 @@ def test_per_input_inqueue_attribution_for_union():
 
     assert input1_usage == 0
     assert input2_usage == 20
+
+
+def test_union_memory_attribution_outqueue():
+    """Test that Union's external output queue memory is attributed per-producer
+    to upstream operators, avoiding double-counting.
+
+    When Union is ineligible (throttling_disabled=True), its memory is rolled
+    into upstream operators via _get_downstream_ineligible_ops_usage. With
+    per-producer tracking on BlockRefCounter, each upstream only gets
+    charged for the bytes it contributed to Union's ext output queue.
+
+    Regression test for https://github.com/ray-project/ray/pull/61040.
+    """
+    # Topology:
+    #   input1 ───┐
+    #             ├─▶ union_op
+    #   input2 ───┘
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    union_op = UnionOperator(DataContext.get_current(), input1, input2)
+    counter = StubBlockRefCounter()
+    topology = build_streaming_topology(union_op, ExecutionOptions(), counter)
+
+    total_resources = ExecutionResources(cpu=0, object_store_memory=200)
+    resource_manager = ResourceManager(
+        topology,
+        ExecutionOptions(),
+        lambda: total_resources,
+        DataContext.get_current(),
+        counter,
+    )
+
+    # Create RefBundles tagged with producer via BlockRefCounter.
+    block_ref1 = ray.ObjectRef(b"1" * 28)
+    block_ref2 = ray.ObjectRef(b"2" * 28)
+    meta1 = BlockMetadata(num_rows=1, size_bytes=10, input_files=None, exec_stats=None)
+    meta2 = BlockMetadata(num_rows=1, size_bytes=30, input_files=None, exec_stats=None)
+    bundle1 = RefBundle(
+        [BlockEntry(block_ref1, meta1)],
+        owns_blocks=True,
+        schema=None,
+    )
+    bundle2 = RefBundle(
+        [BlockEntry(block_ref2, meta2)],
+        owns_blocks=True,
+        schema=None,
+    )
+
+    # Add to Union's ext output queue (simulating process_completed_tasks drain).
+    topology[union_op].add_output(bundle1)
+    topology[union_op].add_output(bundle2)
+    counter.on_block_produced(block_ref1, 10, input1.id)
+    counter.on_block_produced(block_ref2, 30, input2.id)
+    resource_manager.update_usages()
+
+    # Union is ineligible, so its memory is attributed to upstream ops.
+    # input1 should only be charged for bundle1 (10 bytes).
+    # input2 should only be charged for bundle2 (30 bytes).
+    input1_usage = resource_manager.get_op_usage(
+        input1, include_ineligible_downstream=True
+    ).object_store_memory
+    input2_usage = resource_manager.get_op_usage(
+        input2, include_ineligible_downstream=True
+    ).object_store_memory
+
+    assert input1_usage == 10, f"Expected 10, got {input1_usage}"
+    assert input2_usage == 30, f"Expected 30, got {input2_usage}"
+
+    # Total should be 40, not 80 (which would happen with double-counting).
+    total = input1_usage + input2_usage
+    assert total == 40, f"Expected 40, got {total}"
+
+
+def test_union_memory_attribution_through_limit():
+    """Test that producer attribution survives through other ineligible operators
+    (e.g., Limit) so that per-producer memory attribution works for longer
+    ineligible chains.
+
+    Topology:
+        input1 -> limit1 ---+
+                             +---> union_op ---> limit_out
+        input2 -> limit2 ---+
+
+    Simulates a steady-state snapshot where bundles accumulate at multiple
+    queues of operators simultaneously, matching real execution behavior.
+    """
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    limit1 = LimitOperator(100, input1, DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    limit2 = LimitOperator(100, input2, DataContext.get_current())
+    union_op = UnionOperator(DataContext.get_current(), limit1, limit2)
+    limit_out = LimitOperator(100, union_op, DataContext.get_current())
+    counter = StubBlockRefCounter()
+    topology = build_streaming_topology(limit_out, ExecutionOptions(), counter)
+
+    total_resources = ExecutionResources(cpu=0, object_store_memory=1000)
+    resource_manager = ResourceManager(
+        topology,
+        ExecutionOptions(),
+        lambda: total_resources,
+        DataContext.get_current(),
+        counter,
+    )
+
+    def make_bundle(ref_byte, size_bytes):
+        block_ref = ray.ObjectRef(ref_byte * 28)
+        meta = BlockMetadata(
+            num_rows=1, size_bytes=size_bytes, input_files=None, exec_stats=None
+        )
+        return block_ref, RefBundle(
+            [BlockEntry(block_ref, meta)],
+            owns_blocks=True,
+            schema=None,
+        )
+
+    def get_attributed_usage(op):
+        return resource_manager.get_op_usage(
+            op, include_ineligible_downstream=True
+        ).object_store_memory
+
+    # Place bundles at different points in the ineligible chain,
+    # simulating a steady-state snapshot:
+    #
+    # limit1 outqueue:    [B_a(10MB, input1.id)]  <- from input1
+    # union_op outqueue:  [B_b(10MB, input1.id)]  <- from input1
+    # limit_out outqueue: [B_c(30MB, input2.id)]  <- from input2
+
+    # Bundle waiting in limit1's outqueue (tagged with input1's id).
+    ref_a, bundle_a = make_bundle(b"a", 10)
+    topology[limit1].add_output(bundle_a)
+    counter.on_block_produced(ref_a, 10, input1.id)
+
+    # Bundle in Union's outqueue, tagged with input1's id.
+    ref_b, bundle_b = make_bundle(b"b", 10)
+    topology[union_op].add_output(bundle_b)
+    counter.on_block_produced(ref_b, 10, input1.id)
+
+    # Feed a tagged bundle through limit_out.
+    ref_c, bundle_c = make_bundle(b"c", 30)
+    limit_out._add_input_inner(bundle_c, input_index=0)
+    counter.on_block_produced(ref_c, 30, input2.id)
+    while limit_out.has_next():
+        topology[limit_out].add_output(limit_out.get_next())
+
+    resource_manager.update_usages()
+
+    # input1 should be charged for:
+    #   - B_a in limit1 outqueue (10MB)
+    #   - B_b in union_op outqueue (10MB)
+    # Total for input1: 20MB
+    assert get_attributed_usage(input1) == 20, get_attributed_usage(input1)
+
+    # input2 should be charged for:
+    #   - B_c in limit_out outqueue (30MB)
+    # Total for input2: 30MB
+    assert get_attributed_usage(input2) == 30, get_attributed_usage(input2)
+
+    total = get_attributed_usage(input1) + get_attributed_usage(input2)
+    assert total == 50, f"Expected 50, got {total}"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -1,8 +1,10 @@
 import warnings
+from unittest.mock import MagicMock
 
 import pytest
 
 import ray
+from ray.data._internal.execution import create_resource_allocator
 from ray.data._internal.execution.block_ref_counter import BlockRefCounter
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
@@ -172,133 +174,6 @@ def test_physical_apply_transform_rejects_in_place_input_mutation():
         root._apply_transform(transform)
 
 
-def test_does_not_double_count_usage_from_union():
-    """Regression test for https://github.com/ray-project/ray/pull/61040."""
-    # Create a mock topology:
-    #
-    #   input1 ───┐
-    #             ├─▶ union_op
-    #   input2 ───┘
-    input1 = PhysicalOperator("op1", [], DataContext.get_current())
-    input2 = PhysicalOperator("op2", [], DataContext.get_current())
-    union_op = UnionOperator(DataContext.get_current(), input1, input2)
-    counter = StubBlockRefCounter()
-    topology = build_streaming_topology(union_op, ExecutionOptions(), counter)
-
-    # Create a resource manager.
-    total_resources = ExecutionResources(cpu=0, object_store_memory=2)
-    resource_manager = ResourceManager(
-        topology,
-        ExecutionOptions(),
-        lambda: total_resources,
-        DataContext.get_current(),
-        counter,
-    )
-
-    # Create two 1-byte `RefBundle`s.
-    block_ref1 = ray.ObjectRef(b"1" * 28)
-    block_ref2 = ray.ObjectRef(b"2" * 28)
-    block_metadata = BlockMetadata(
-        num_rows=1, size_bytes=1, input_files=None, exec_stats=None
-    )
-    bundle1 = RefBundle(
-        [BlockEntry(block_ref1, block_metadata)], owns_blocks=True, schema=None
-    )
-    bundle2 = RefBundle(
-        [BlockEntry(block_ref2, block_metadata)], owns_blocks=True, schema=None
-    )
-
-    # Add two 1-byte `RefBundle` to the union operator.
-    topology[union_op].add_output(bundle1)
-    topology[union_op].add_output(bundle2)
-    # Blocks are attributed to their original producer, not union_op.
-    counter.on_block_produced(block_ref1, 1, input1.id)
-    counter.on_block_produced(block_ref2, 1, input2.id)
-    resource_manager.update_usages()
-
-    # The total object store memory usage should be 2. If the resource manager double-
-    # counts the usage from the union operator, the total object store memory usage can
-    # be greater than 2.
-    total_object_store_memory = sum(
-        [
-            resource_manager.get_op_usage(
-                op, include_ineligible_downstream=True
-            ).object_store_memory
-            for op in topology.keys()
-        ]
-    )
-    assert total_object_store_memory == 2, total_object_store_memory
-
-
-def test_union_memory_attribution_internal_inqueue():
-    """Test that per-input attribution correctly charges each upstream operator
-    only for the blocks it produced in the union's internal input queue.
-
-    When preserve_order=True, the union operator buffers blocks per-input.
-    The resource manager should attribute each input buffer's memory only to
-    the corresponding upstream operator, not to all upstream operators.
-    """
-    # Create a mock topology:
-    #
-    #   input1 ───┐
-    #             ├─▶ union_op
-    #   input2 ───┘
-    input1 = PhysicalOperator("op1", [], DataContext.get_current())
-    input2 = PhysicalOperator("op2", [], DataContext.get_current())
-    union_op = UnionOperator(DataContext.get_current(), input1, input2)
-
-    options = ExecutionOptions()
-    options.preserve_order = True
-    counter = StubBlockRefCounter()
-    topology = build_streaming_topology(union_op, options, counter)
-
-    # Create a resource manager.
-    total_resources = ExecutionResources(cpu=0, object_store_memory=200)
-    resource_manager = ResourceManager(
-        topology,
-        options,
-        lambda: total_resources,
-        DataContext.get_current(),
-        counter,
-    )
-
-    # Create two 10-byte RefBundles with distinct block refs (simulates real execution
-    # where each block from a source has its own ObjectRef).
-    block_ref1 = ray.ObjectRef(b"1" * 28)
-    block_ref2 = ray.ObjectRef(b"2" * 28)
-    block_metadata = BlockMetadata(
-        num_rows=1, size_bytes=10, input_files=None, exec_stats=None
-    )
-    bundle1 = RefBundle(
-        [BlockEntry(block_ref1, block_metadata)], owns_blocks=True, schema=None
-    )
-    bundle2 = RefBundle(
-        [BlockEntry(block_ref2, block_metadata)], owns_blocks=True, schema=None
-    )
-
-    # Add blocks only to input2's buffer inside the union operator.
-    # With preserve_order=True, _add_input_inner routes to _input_buffers[input_index].
-    union_op.add_input(bundle1, input_index=1)
-    union_op.add_input(bundle2, input_index=1)
-    # Blocks in union's input buffer are attributed to their producer (input2).
-    counter.on_block_produced(block_ref1, 10, input2.id)
-    counter.on_block_produced(block_ref2, 10, input2.id)
-
-    resource_manager.update_usages()
-
-    # input2 should be charged for its blocks in the union's input buffer (20 bytes).
-    input2_usage = resource_manager.get_op_usage(
-        input2, include_ineligible_downstream=True
-    ).object_store_memory
-    # input1 should NOT be charged for input2's blocks (0 bytes from union inqueue).
-    input1_usage = resource_manager.get_op_usage(
-        input1, include_ineligible_downstream=True
-    ).object_store_memory
-
-    assert input1_usage == 0
-    assert input2_usage == 20
-
-
 def test_union_memory_attribution_outqueue():
     """Test that Union's external output queue memory is attributed per-producer
     to upstream operators, avoiding double-counting.
@@ -370,6 +245,75 @@ def test_union_memory_attribution_outqueue():
     assert total == 40, f"Expected 40, got {total}"
 
 
+def test_union_memory_attribution_internal_inqueue():
+    """Test that per-input attribution correctly charges each upstream operator
+    only for the blocks it produced in the union's internal input queue.
+
+    When preserve_order=True, the union operator buffers blocks per-input.
+    The resource manager should attribute each input buffer's memory only to
+    the corresponding upstream operator, not to all upstream operators.
+    """
+    # Create a mock topology:
+    #
+    #   input1 ───┐
+    #             ├─▶ union_op
+    #   input2 ───┘
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    union_op = UnionOperator(DataContext.get_current(), input1, input2)
+
+    options = ExecutionOptions()
+    options.preserve_order = True
+    counter = StubBlockRefCounter()
+    topology = build_streaming_topology(union_op, options, counter)
+
+    # Create a resource manager.
+    total_resources = ExecutionResources(cpu=0, object_store_memory=200)
+    resource_manager = ResourceManager(
+        topology,
+        options,
+        lambda: total_resources,
+        DataContext.get_current(),
+        counter,
+    )
+
+    # Create two 10-byte RefBundles with distinct block refs (simulates real execution
+    # where each block from a source has its own ObjectRef).
+    block_ref1 = ray.ObjectRef(b"1" * 28)
+    block_ref2 = ray.ObjectRef(b"2" * 28)
+    block_metadata = BlockMetadata(
+        num_rows=1, size_bytes=10, input_files=None, exec_stats=None
+    )
+    bundle1 = RefBundle(
+        [BlockEntry(block_ref1, block_metadata)], owns_blocks=True, schema=None
+    )
+    bundle2 = RefBundle(
+        [BlockEntry(block_ref2, block_metadata)], owns_blocks=True, schema=None
+    )
+
+    # Add blocks only to input2's buffer inside the union operator.
+    # With preserve_order=True, _add_input_inner routes to _input_buffers[input_index].
+    union_op.add_input(bundle1, input_index=1)
+    union_op.add_input(bundle2, input_index=1)
+    # Blocks in union's input buffer are attributed to their producer (input2).
+    counter.on_block_produced(block_ref1, 10, input2.id)
+    counter.on_block_produced(block_ref2, 10, input2.id)
+
+    resource_manager.update_usages()
+
+    # input2 should be charged for its blocks in the union's input buffer (20 bytes).
+    input2_usage = resource_manager.get_op_usage(
+        input2, include_ineligible_downstream=True
+    ).object_store_memory
+    # input1 should NOT be charged for input2's blocks (0 bytes from union inqueue).
+    input1_usage = resource_manager.get_op_usage(
+        input1, include_ineligible_downstream=True
+    ).object_store_memory
+
+    assert input1_usage == 0
+    assert input2_usage == 20
+
+
 def test_union_memory_attribution_through_limit():
     """Test that producer attribution survives through other ineligible operators
     (e.g., Limit) so that per-producer memory attribution works for longer
@@ -434,12 +378,10 @@ def test_union_memory_attribution_through_limit():
     topology[union_op].add_output(bundle_b)
     counter.on_block_produced(ref_b, 10, input1.id)
 
-    # Feed a tagged bundle through limit_out.
+    # Bundle in limit_out's outqueue, tagged with input2's id.
     ref_c, bundle_c = make_bundle(b"c", 30)
-    limit_out._add_input_inner(bundle_c, input_index=0)
+    topology[limit_out].add_output(bundle_c)
     counter.on_block_produced(ref_c, 30, input2.id)
-    while limit_out.has_next():
-        topology[limit_out].add_output(limit_out.get_next())
 
     resource_manager.update_usages()
 
@@ -456,6 +398,28 @@ def test_union_memory_attribution_through_limit():
 
     total = get_attributed_usage(input1) + get_attributed_usage(input2)
     assert total == 50, f"Expected 50, got {total}"
+
+
+def test_union_operator_not_allocated_resources(restore_data_context):
+    ctx = DataContext.get_current()
+    ctx.op_resource_reservation_enabled = True
+    input_op1 = PhysicalOperator("input1", [], ctx)
+    input_op2 = PhysicalOperator("input2", [], ctx)
+    union_op = UnionOperator(ctx, input_op1, input_op2)
+
+    counter = StubBlockRefCounter()
+    topo = build_streaming_topology(union_op, ExecutionOptions(), counter)
+    resource_manager = ResourceManager(
+        topo, ExecutionOptions(), MagicMock(), ctx, counter
+    )
+    allocator = create_resource_allocator(resource_manager, ctx)
+    assert allocator is not None
+
+    allocator.update_budgets(
+        limits=ExecutionResources(cpu=1, gpu=0, object_store_memory=1000)
+    )
+    allocation = allocator.get_allocation(union_op)
+    assert allocation is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

* Turn Union into an ineligible operator that doesn't get allocated resources.
  * Currently, Union is an eligible operator that owns its outputs.
  * Union's output queue can build up to be really large.
  * Then, because Union doesn't actually spawn tasks, backpressure is not able to limit the memory usage to the allotted budget, so Union outputs can greatly exceed the budget.
* Fix double-counting of Union's output queue memory when attributing to upstream operators
  * Previously, [we tried making Union ineligible](https://github.com/ray-project/ray/pull/61040) but ran into this double-counting issue. This led to a deadlock when preserve_order=True since Union does strict round robining, but then backpressure applies to all input branches equally due to the double counting.

<img width="804" height="625" alt="Screenshot 2026-08-05 at 4 23 44 PM" src="https://github.com/user-attachments/assets/c8a32f74-80c2-4f06-a286-425ad56c36a6" />

## Related PRs

Note: this fix is made possible by https://github.com/ray-project/ray/pull/64456, which simplifies resource accounting to be per-producer rather than adding across multiple eligible and ineligible operator queues.

This was the original attempt that we abandoned to pursue the above refactor: https://github.com/ray-project/ray/pull/61609 