### PR TITLE
[autoscaler][kuberay] Propagate worker group priority from RayCluster CR to the autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 AUTOSCALER_OPTIONS_KEY = "autoscalerOptions"
 IDLE_SECONDS_KEY = "idleTimeoutSeconds"
+PRIORITY_KEY = "priority"
 UPSCALING_KEY = "upscalingMode"
 UPSCALING_VALUE_AGGRESSIVE = "Aggressive"
 UPSCALING_VALUE_DEFAULT = "Default"
@@ -222,6 +223,10 @@ def _node_type_from_group_spec(
     idle_timeout_s = group_spec.get(IDLE_SECONDS_KEY)
     if idle_timeout_s is not None:
         node_type["idle_timeout_s"] = float(idle_timeout_s)
+
+    priority = group_spec.get(PRIORITY_KEY)
+    if priority is not None:
+        node_type[PRIORITY_KEY] = int(priority)
 
     return node_type
 

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -354,6 +354,19 @@ def _get_autoscaling_config_with_options() -> dict:
     return config
 
 
+def _get_ray_cr_with_worker_group_priority() -> dict:
+    """CR with a `priority` field set on a worker group."""
+    cr = get_basic_ray_cr()
+    cr["spec"]["workerGroupSpecs"][1]["priority"] = 10
+    return cr
+
+
+def _get_autoscaling_config_with_worker_group_priority() -> dict:
+    config = _get_basic_autoscaling_config()
+    config["available_node_types"]["gpu-group"]["priority"] = 10
+    return config
+
+
 def _get_tpu_group_with_no_node_selectors() -> dict[str, Any]:
     cr = get_basic_ray_cr()
     tpu_group = cr["spec"]["workerGroupSpecs"][2]
@@ -487,6 +500,14 @@ TEST_DATA = (
             None,
             None,
             id="autoscaler-options",
+        ),
+        pytest.param(
+            _get_ray_cr_with_worker_group_priority(),
+            _get_autoscaling_config_with_worker_group_priority(),
+            None,
+            None,
+            None,
+            id="worker-group-priority",
         ),
         pytest.param(
             _get_ray_cr_with_tpu_custom_resource(),


### PR DESCRIPTION
## Description

The RayCluster CRD gained a per-worker-group `priority` field ([ray-project/kuberay#4942](https://github.com/ray-project/kuberay/pull/4942)), and the v2 autoscaler scheduler consumes a node type's priority for priority-aware worker group selection ([#62997](https://github.com/ray-project/ray/pull/62997)). However, the value never actually reached the scheduler.

The KubeRay autoscaling-config producer (`_node_type_from_group_spec` in `python/ray/autoscaler/_private/kuberay/autoscaling_config.py`) translates each RayCluster worker group spec into the autoscaler's `available_node_types`, but it never copied the group's `priority` field. As a result, `NodeTypeConfig.priority` (read via `node_config.get("priority", 0)` in `config.py`) always defaulted to `0`, so a `priority` set on the CRD had no effect on scale-up decisions.

This PR copies the worker group `priority` from the CR group spec into the generated node type, closing the gap between the CRD field and the scheduler that consumes it. The head group has no `priority` in the CRD, so it is unaffected; when `priority` is absent it is omitted and continues to default to `0`.

**Changes:**
- `python/ray/autoscaler/_private/kuberay/autoscaling_config.py`: add `PRIORITY_KEY` and copy `priority` into the node type in `_node_type_from_group_spec`.
- `python/ray/tests/kuberay/test_autoscaling_config.py`: add a `worker-group-priority` case asserting the CR `priority` propagates into `available_node_types`.

## Related issues

Related to [#62997](https://github.com/ray-project/ray/pull/62997) and [ray-project/kuberay#4942](https://github.com/ray-project/kuberay/pull/4942).

## Additional information

**Testing:**
```
pytest python/ray/tests/kuberay/test_autoscaling_config.py -k worker_group_priority
```

**Before:** a RayCluster worker group with `priority: 10` produced a node type with no `priority`, so `NodeTypeConfig.priority == 0`.
**After:** the same group produces `available_node_types["<group>"]["priority"] == 10`, which flows through to `NodeTypeConfig.priority` and the scheduler's priority tie-breaking.