### PR TITLE
[Core] Fix double-free in redis_async_context_test

### DIFF
--- a/src/ray/common/test_utils.cc
+++ b/src/ray/common/test_utils.cc
@@ -14,9 +14,12 @@
 
 #include "ray/common/test_utils.h"
 
+#include <boost/asio.hpp>
+#include <chrono>
 #include <cstdlib>
 #include <fstream>
 #include <functional>
+#include <thread>
 #ifndef _WIN32
 #include <sys/socket.h>
 #else
@@ -37,6 +40,40 @@
 #include "ray/util/time.h"
 
 namespace ray {
+
+namespace {
+
+/// How long to wait for a spawned Redis to start serving before giving up.
+constexpr int kRedisStartupTimeoutMs = 30000;
+
+/// Poll until something accepts a TCP connection on `port`.
+///
+/// `Process::Spawn` only reports that the binary launched; the server may not
+/// have bound and listened yet. Callers that connect immediately afterwards
+/// would then hit a closed port, so wait for the socket to actually answer.
+bool WaitForPortAcceptingConnections(int port, int timeout_ms) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  boost::asio::io_context io_context;
+  const boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address_v4::loopback(),
+                                                static_cast<unsigned short>(port));
+
+  while (true) {
+    boost::asio::ip::tcp::socket socket(io_context);
+    boost::system::error_code ec;
+    socket.connect(endpoint, ec);
+    socket.close();
+    if (!ec) {
+      return true;
+    }
+    if (std::chrono::steady_clock::now() >= deadline) {
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
+}  // namespace
 
 static void InitRedisPathsFromEnv() {
   auto init_from_env = [](std::string &path, const char *env_name) {
@@ -93,7 +130,9 @@ int TestSetupUtil::StartUpRedisServer(int port, bool save) {
   auto [proc, ec] = Process::Spawn(cmdargs, true);
   RAY_CHECK(!ec) << "Failed to start redis because process failed to spawn: "
                  << ec.message();
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  RAY_CHECK(WaitForPortAcceptingConnections(actual_port, kRedisStartupTimeoutMs))
+      << "Redis on port " << actual_port << " did not accept connections within "
+      << kRedisStartupTimeoutMs << "ms.";
   return actual_port;
 }
 

--- a/src/ray/common/test_utils.cc
+++ b/src/ray/common/test_utils.cc
@@ -66,7 +66,11 @@ bool WaitForPortAcceptingConnections(int port, int timeout_ms) {
     boost::asio::ip::tcp::socket socket(io_context);
     boost::system::error_code ec;
     socket.connect(endpoint, ec);
-    socket.close();
+    // Non-throwing overload: the connect above routinely fails while the
+    // server is still coming up, and close() must not turn that into an
+    // exception that escapes the helper.
+    boost::system::error_code ignored;
+    socket.close(ignored);
     if (!ec) {
       return true;
     }

--- a/src/ray/common/test_utils.cc
+++ b/src/ray/common/test_utils.cc
@@ -51,6 +51,10 @@ constexpr int kRedisStartupTimeoutMs = 30000;
 /// `Process::Spawn` only reports that the binary launched; the server may not
 /// have bound and listened yet. Callers that connect immediately afterwards
 /// would then hit a closed port, so wait for the socket to actually answer.
+///
+/// \param port The localhost TCP port to probe.
+/// \param timeout_ms How long to keep polling before giving up.
+/// \return True if the port accepted a connection before the timeout expired.
 bool WaitForPortAcceptingConnections(int port, int timeout_ms) {
   const auto deadline =
       std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);

--- a/src/ray/gcs/store_client/tests/redis_async_context_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_async_context_test.cc
@@ -37,10 +37,25 @@ namespace gcs {
 instrumented_io_context io_service;
 
 void ConnectCallback(const redisAsyncContext *c, int status) {
+  if (status != REDIS_OK) {
+    // A failed connect frees the context without ever running the disconnect
+    // callback: hiredis only runs that one once REDIS_CONNECTED has been set
+    // (__redisAsyncFree). Release here, or the destructor frees the context a
+    // second time. Must come before the assertion, which returns early.
+    RAY_CHECK(c->data != nullptr) << "ac->data must point at the owning context";
+    static_cast<RedisAsyncContext *>(c->data)->ResetRawRedisAsyncContext();
+  }
   ASSERT_EQ(status, REDIS_OK);
 }
 
 void DisconnectCallback(const redisAsyncContext *c, int status) {
+  // hiredis frees the raw context around this callback
+  // (__redisAsyncDisconnect -> __redisAsyncFree), so hand ownership back
+  // first. Otherwise the RedisAsyncContext destructor frees it a second time
+  // and the test crashes instead of reporting the failure. Do this before any
+  // assertion, which would return early.
+  RAY_CHECK(c->data != nullptr) << "ac->data must point at the owning context";
+  static_cast<RedisAsyncContext *>(c->data)->ResetRawRedisAsyncContext();
   ASSERT_EQ(status, REDIS_OK);
 }
 
@@ -65,6 +80,9 @@ TEST_F(RedisAsyncContextTest, TestRedisCommands) {
       io_service,
       std::unique_ptr<redisAsyncContext, RedisContextDeleter>(ac, RedisContextDeleter()));
 
+  // Mirrors SetDisconnectCallback() in redis_context.cc: the callbacks need a
+  // way back to the owning RedisAsyncContext to release the raw pointer.
+  ac->data = &redis_async_context;
   redisAsyncSetConnectCallback(ac, ConnectCallback);
   redisAsyncSetDisconnectCallback(ac, DisconnectCallback);
 


### PR DESCRIPTION
## Description

### Problem

1. Double free. `TestRedisCommands` gives a raw redisAsyncContext to a `RedisAsyncContext`, which owns it, but neither of its callbacks releases it. hiredis frees that context itself once the connection ends, so the destructor frees it a second time. The test process dies instead of reporting what went wrong.

- Two paths reach it, and hiredis handles them differently:
   - The connection is established and later drops. hiredis runs __redisAsyncDisconnect -> __redisAsyncFree, which invokes the disconnect callback and then frees.
   - The connection never completes. __redisAsyncHandleConnectFailure runs the connect callback with REDIS_ERR and then frees, but the disconnect callback is skipped: __redisAsyncFree only runs it when REDIS_CONNECTED was set.

Both reproduce. Killing the server after a successful connect dies on every run (9/10 SIGSEGV in redisFree, 1/10 caught by the allocator); connecting to a port with no listener dies in redisFree as well.

2. Startup race, which is how the second path is reached in CI. `StartUpRedisServer` sleeps a flat 200ms after Process::Spawn, and Process::Spawn only reports that the binary launched. If the server has not bound yet, the caller connects to a closed port. Eight test files share this helper; two of them have been flagged flaky before (#55773, #55772) and closed without a root cause.

### Fix

1. Release the raw context from both callbacks, the same way the production callback in redis_context.cc does it, and only on the connect path when the status is an error, since a successful connect frees nothing. Both releases come before the assertion so an early return cannot skip them. redisAsyncContext::data is a user field ("Not used by hiredis"), distinct from the ev.data that RedisAsyncContext uses. Both probes now end in an ordinary gtest failure.

2. Poll until the port accepts a TCP connection instead of sleeping, bounded by 30s. That is also faster when Redis starts quickly: redis_async_context_test goes from ~1.2s to ~0.4s.

## Related issues
Related to #55773, #55772

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
