### PR TITLE
change version to 2.58.0

### DIFF
--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -19,7 +19,7 @@ from ray_release.test import Test, TestState
 GLOBAL_CONFIG_FILE = (
     os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
 )
-RAY_VERSION = "3.0.0.dev0"
+RAY_VERSION = "2.58.0"
 
 
 def ci_init() -> None:

--- a/java/api/pom_template.xml
+++ b/java/api/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.58.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/performance_test/pom_template.xml
+++ b/java/performance_test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.58.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.58.0</version>
   <packaging>pom</packaging>
   <name>Ray Project Parent POM</name>
   <description>An open source framework that provides a simple, universal API for building distributed applications.
@@ -63,7 +63,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.version>2.0.0-SNAPSHOT</project.version>
+    <project.version>2.58.0</project.version>
   </properties>
 
   <dependencyManagement>

--- a/java/runtime/pom_template.xml
+++ b/java/runtime/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.58.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/serve/pom_template.xml
+++ b/java/serve/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.58.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test/pom_template.xml
+++ b/java/test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.58.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "3.0.0.dev0"
+version = "2.58.0"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/rayci.env
+++ b/rayci.env
@@ -1,3 +1,3 @@
 # Common variable defaults used in rayci.
 MANYLINUX_VERSION=260128.221a193
-RAY_VERSION=3.0.0.dev0
+RAY_VERSION=2.58.0

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -74,7 +74,7 @@ constexpr char kDashboardAgentListenPortName[] = "dashboard_agent_listen_port";
 constexpr char kGcsServerPortName[] = "gcs_server_port";
 
 /// The version of Ray
-constexpr char kRayVersion[] = "3.0.0.dev0";
+constexpr char kRayVersion[] = "2.58.0";
 
 /*****************************/
 /* ENV labels for autoscaler */


### PR DESCRIPTION
Standard release-branch version bump for the 2.58.0 release, generated by running:

```
bazelisk run //ci/ray_ci/automation:update_version -- --new_version 2.58.0
```

on `releases/2.58.0` (cut today at b45b0b4592). Updates the version string from `3.0.0.dev0` to `2.58.0` in `python/ray/_version.py`, `src/ray/common/constants.h`, `rayci.env`, `ci/ray_ci/utils.py`, and the Java poms — same shape as previous release version bumps (e.g. #59049 for 2.52.1).

Not a duplicate: no other open PR targets `releases/2.58.0` (branch was cut minutes ago). No tests beyond pre-commit hooks (all passed) — this is the standard mechanical output of the update_version tool. AI assistance (Claude Code) was used to run the tool and prepare this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)