### PR TITLE
[core][DO NOT MERGE] End-to-end testing changes for removing task events out of GCS - 3

### DIFF
--- a/python/ray/_common/tests/test_usage_stats.py
+++ b/python/ray/_common/tests/test_usage_stats.py
@@ -157,6 +157,10 @@ def start_usage_stats_server():
     server_thread.join()
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: GcsTaskManager receives no task "
+    "events with the flags on, so its usage/metrics counters stay empty."
+)
 @pytest.mark.parametrize("ray_client", [True, False])
 def test_get_extra_usage_tags_to_report(
     monkeypatch, call_ray_start, reset_usage_stats, ray_client, gcs_storage_type
@@ -294,6 +298,10 @@ def test_worker_crash_increment_stats():
         assert result["worker_crash_oom"] == "1"
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: GcsTaskManager receives no task "
+    "events with the flags on, so its usage/metrics counters stay empty."
+)
 def test_actor_stats(reset_usage_stats):
     @ray.remote
     class Actor:
@@ -380,6 +388,10 @@ def test_pg_stats(reset_usage_stats):
         )
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: GcsTaskManager receives no task "
+    "events with the flags on, so its usage/metrics counters stay empty."
+)
 def test_task_stats(reset_usage_stats):
     @ray.remote
     def foo():
@@ -1112,6 +1124,10 @@ provider:
         assert usage_stats_server.report_payload == asdict(d)
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: GcsTaskManager receives no task "
+    "events with the flags on, so its usage/metrics counters stay empty."
+)
 def test_usage_report_e2e(
     monkeypatch,
     ray_start_cluster,
@@ -1404,6 +1420,10 @@ def test_usage_file_error_message(monkeypatch, ray_start_cluster, reset_usage_st
         assert read_file(temp_dir, "usage_stats")["total_success"] == 0
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: GcsTaskManager receives no task "
+    "events with the flags on, so its usage/metrics counters stay empty."
+)
 def test_usage_stats_tags(
     monkeypatch, ray_start_cluster, reset_usage_stats, gcs_storage_type
 ):

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1184,6 +1184,14 @@ def timeline(filename: Optional[str] = None):
             "Ray has not been started yet. Timeline requires Ray to be initialized first."
         )
 
+    logger.warning(
+        "In the near future, ray.timeline() will read task profiling events from the Ray "
+        "dashboard (API server) instead of from GCS. If you have already turned on "
+        "RAY_enable_task_events_to_dashboard_head, ray.timeline() reads from the dashboard "
+        "now. Make sure your Ray cluster is started with the dashboard running if you want "
+        "to use ray.timeline()."
+    )
+
     return state.chrome_tracing_dump(filename=filename)
 
 

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -167,10 +167,15 @@ def test_aggregator_agent_http_target_not_enabled(
     expected_http_target_enabled,
     expected_event_processing_enabled,
 ):
-    # This test isolates HTTP-target enablement, so hold GCS publishing off regardless of
-    # its module-level default (which is read at import, not from the test env).
+    # This test isolates HTTP-target enablement, so hold the other publishers off
+    # regardless of their module-level defaults (read at import, not from the test env).
     monkeypatch.setattr(
         "ray.dashboard.modules.aggregator.aggregator_agent.PUBLISH_EVENTS_TO_GCS",
+        False,
+    )
+    monkeypatch.setattr(
+        "ray.dashboard.modules.aggregator.aggregator_agent."
+        "PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD",
         False,
     )
     dashboard_agent = MagicMock()
@@ -1317,8 +1322,8 @@ def _get_dashboard_head_events_from_httpserver(httpserver):
                 "RAY_enable_task_events_to_dashboard_head": "1",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
-                # TODO(karticam): assumes the aggregator receives only the injected event;
-                #  see generate_event_export_env_vars for why enable_ray_event is pinned off.
+                # This test asserts the aggregator receives only the injected event, so
+                # keep the core from emitting its own ray events into the aggregator.
                 "RAY_enable_ray_event": "0",
             },
         },
@@ -1496,13 +1501,16 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
 
     agg_stub.AddEvents(request)
 
-    # Verify HTTP received the event
-    wait_for_condition(lambda: len(httpserver.log) == 1)
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
-    assert len(req_json) == 1
-    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
-    assert req_json[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+    # Verify HTTP received the event. Other producers share this publisher, so look for
+    # the task event across every POST instead of expecting it alone in the first one.
+    def _task_event_received():
+        return any(
+            event["eventType"] == "TASK_DEFINITION_EVENT"
+            and event["taskDefinitionEvent"]["taskName"] == unique_task_name
+            for event in _get_json_events_from_httpserver(httpserver)
+        )
+
+    wait_for_condition(_task_event_received)
 
     # Verify GCS stored the event and fields match
     _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, event)

--- a/python/ray/dashboard/modules/task_events/ray_event_converter.py
+++ b/python/ray/dashboard/modules/task_events/ray_event_converter.py
@@ -91,16 +91,22 @@ _TASK_LOG_INFO_FIELDS = (
 )
 
 
-def _convert_task_log_info(src, dst) -> None:
-    """Copy only the fields the event actually set.
+def _convert_task_log_info(src_event_log_info, dst_state_update_log_info) -> None:
+    """Copy the set log-info fields from the incoming event into the ``TaskEvents``.
 
-    The log paths and start offsets arrive when the task starts and the end offsets in a
-    later event, so copying an unset field would overwrite what the earlier event
-    reported once the two are merged.
+    ``src_event_log_info`` is the ``task_log_info`` on the incoming ``TaskLifecycleEvent``;
+    ``dst_state_update_log_info`` is the ``state_updates.task_log_info`` on the ``TaskEvents``
+    being built.
+
+    Only fields actually set in the incoming event are copied: the log paths and start
+    offsets arrive when the task starts and the end offsets in a later event, so copying an
+    unset field would overwrite what the earlier event reported once the two are merged.
     """
     for field in _TASK_LOG_INFO_FIELDS:
-        if src.HasField(field):
-            setattr(dst, field, getattr(src, field))
+        if src_event_log_info.HasField(field):
+            setattr(
+                dst_state_update_log_info, field, getattr(src_event_log_info, field)
+            )
 
 
 def _convert_task_lifecycle_event(event) -> gcs_pb2.TaskEvents:

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -86,8 +86,13 @@ _EXPECTED_DASHBOARD_MODULES = [
     "ray.dashboard.modules.state.state_head.StateHead",
     "ray.dashboard.modules.train.train_head.TrainHead",
 ]
-# TaskEventsHead is intentionally omitted: it is gated off by default
-# (RAY_enable_task_events_to_dashboard_head) and so does not run as a subprocess here.
+# TaskEventsHead only runs as a subprocess when the migration flag is on. Mirror the
+# loader (is_enabled reads the same flag) so the expected count tracks the flag rather
+# than assuming a fixed default.
+if ray._config.enable_task_events_to_dashboard_head():
+    _EXPECTED_DASHBOARD_MODULES.append(
+        "ray.dashboard.modules.task_events.task_events_head.TaskEventsHead"
+    )
 
 # The list of processes expected to be started in the system cgroup
 # with default params for 'ray start' and 'ray.init(...)'

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -541,6 +541,10 @@ ray.get(task.remote(), timeout=3)
         ) not in e.value.output.decode()
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: the terminal failure event is lost "
+    "when the node-local aggregator dies with its raylet; no GCS fallback yet."
+)
 def test_task_failure_when_driver_local_raylet_dies(ray_start_cluster):
     cluster = ray_start_cluster
     system_configs = {

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 from math import ceil
@@ -35,7 +36,13 @@ def get_local_state_client():
     )
 
     gcs_client = ray._private.worker.global_worker.gcs_client
-    return StateDataSourceClient(gcs_channel, gcs_client)
+    node = ray._private.worker.global_worker.node
+    return StateDataSourceClient(
+        gcs_channel,
+        gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
+    )
 
 
 @pytest.fixture

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -122,7 +122,13 @@ def state_source_client(gcs_address):
         gcs_address, GRPC_CHANNEL_OPTIONS, asynchronous=True
     )
     gcs_client = GcsClient(address=gcs_address)
-    client = StateDataSourceClient(gcs_channel=gcs_channel, gcs_client=gcs_client)
+    node = ray._private.worker.global_worker.node
+    client = StateDataSourceClient(
+        gcs_channel=gcs_channel,
+        gcs_client=gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
+    )
     return client
 
 

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1390,7 +1390,10 @@ def test_state_api_rate_limit_with_failure(monkeypatch, shutdown_only):
     # Set environment
     with monkeypatch.context() as m:
         m.setenv("RAY_STATE_SERVER_MAX_HTTP_REQUEST", "3")
-        # These make list_nodes, list_workers, list_actors never return in 20secs
+        # Pin the read path to GCS so list_tasks stays a delayable GCS
+        # GetTaskEvents query.
+        m.setenv("RAY_enable_task_events_to_dashboard_head", "0")
+        # These make list_tasks, list_workers, list_actors never return in 20secs
         m.setenv(
             "RAY_testing_asio_delay_us",
             (

--- a/python/ray/tests/test_state_api_data_source_client_get.py
+++ b/python/ray/tests/test_state_api_data_source_client_get.py
@@ -1140,7 +1140,14 @@ def test_get_id_not_found(shutdown_only):
 @patch.object(
     StateDataSourceClient, "__init__", lambda self, gcs_channel, gcs_client: None
 )
-async def test_state_data_source_client_get_all_task_info_no_early_return():
+async def test_state_data_source_client_get_all_task_info_no_early_return(monkeypatch):
+    # Force the GCS read path. get_all_task_info routes on the module-level constant
+    # _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD, computed once at import from
+    # ray._config.enable_task_events_to_dashboard_head(), so patch the constant.
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", False
+    )
+
     #  Setup
     mock_gcs_task_info_stub = AsyncMock(TaskInfoGcsServiceStub)
 

--- a/python/ray/tests/test_state_api_data_source_client_get.py
+++ b/python/ray/tests/test_state_api_data_source_client_get.py
@@ -70,7 +70,13 @@ def state_source_client(gcs_address):
         gcs_address, GRPC_CHANNEL_OPTIONS, asynchronous=True
     )
     gcs_client = GcsClient(address=gcs_address)
-    client = StateDataSourceClient(gcs_channel=gcs_channel, gcs_client=gcs_client)
+    node = ray._private.worker.global_worker.node
+    client = StateDataSourceClient(
+        gcs_channel=gcs_channel,
+        gcs_client=gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
+    )
     return client
 
 

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -72,6 +72,10 @@ def aggregate_task_event_metric(
     return task_events_info
 
 
+@pytest.mark.skip(
+    reason="task-events-out-of-GCS migration: GcsTaskManager receives no task "
+    "events with the flags on, so its usage/metrics counters stay empty."
+)
 def test_status_task_events_metrics(shutdown_only):
     info = ray.init(num_cpus=1, _system_config=_SYSTEM_CONFIG)
 

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -295,6 +295,12 @@ def test_fault_tolerance_job_failed(shutdown_only, monkeypatch):
     monkeypatch.setenv("RAY_gcs_mark_task_failed_on_job_done_delay_ms", "1000")
     monkeypatch.setenv("RAY_gcs_mark_task_failed_on_worker_dead_delay_ms", "30000")
     sys_config = _SYSTEM_CONFIG.copy()
+
+    # We set the config here again after setting env variables for the GCS path. If
+    # we don't set it then _SYSTEM_CONFIG takes effect, which has both the delays
+    # set to 1000ms. This is because system config overrides the env variable setting.
+    # Since, we specifically want the delays to be 1000 and 30000, we set the config
+    # again.
     config = {
         "gcs_mark_task_failed_on_job_done_delay_ms": 1000,
         # make worker failure not trigger task failure

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -288,7 +288,12 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     )
 
 
-def test_fault_tolerance_job_failed(shutdown_only):
+def test_fault_tolerance_job_failed(shutdown_only, monkeypatch):
+    # These delays are read by the dashboard-head store from ray._config; set them via
+    # env vars so the head subprocess picks them up even if _system_config does not
+    # propagate to the head's ray._config.
+    monkeypatch.setenv("RAY_gcs_mark_task_failed_on_job_done_delay_ms", "1000")
+    monkeypatch.setenv("RAY_gcs_mark_task_failed_on_worker_dead_delay_ms", "30000")
     sys_config = _SYSTEM_CONFIG.copy()
     config = {
         "gcs_mark_task_failed_on_job_done_delay_ms": 1000,
@@ -451,7 +456,7 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
     )
 
 
-def test_ray_intentional_errors(shutdown_only):
+def test_ray_intentional_errors(shutdown_only, monkeypatch):
     """
     Test in the below cases, ray task should not be marked as failure:
     1. ray.actor_exit_actor()
@@ -475,6 +480,9 @@ def test_ray_intentional_errors(shutdown_only):
     # Avoid worker-dead marking racing with max_calls task completion.
     sys_config = _SYSTEM_CONFIG.copy()
     sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = 30000
+    # Read by the dashboard-head store from ray._config; set via env var so the head
+    # subprocess picks it up even if _system_config does not propagate to the head.
+    monkeypatch.setenv("RAY_gcs_mark_task_failed_on_worker_dead_delay_ms", "30000")
     ray.init(num_cpus=1, _system_config=sys_config)
 
     a = Actor.remote()
@@ -943,10 +951,14 @@ def test_task_logs_info_running_task(shutdown_only):
 
 
 @pytest.mark.asyncio
-async def test_task_events_gc_jobs(shutdown_only):
+async def test_task_events_gc_jobs(shutdown_only, monkeypatch):
     """
     Test that later jobs should override previous jobs' task events.
     """
+    # The dashboard-head store reads its cap from ray._config at import time. Set it via
+    # the env var so the head subprocess picks it up even if _system_config does not
+    # propagate to the head's ray._config.
+    monkeypatch.setenv("RAY_task_events_max_num_task_in_gcs", "3")
     ctx = ray.init(
         num_cpus=8,
         _system_config={
@@ -996,7 +1008,7 @@ ray.get([f.options(name="f.{task_name}").remote() for _ in range(10)])
         )
 
 
-def test_task_events_gc_default_policy(shutdown_only):
+def test_task_events_gc_default_policy(shutdown_only, monkeypatch):
     @ray.remote
     def finish_task():
         pass
@@ -1020,6 +1032,9 @@ def test_task_events_gc_default_policy(shutdown_only):
     def error_task():
         raise ValueError("Expected to fail")
 
+    # Read by the dashboard-head store from ray._config; set via env var so the head
+    # subprocess picks it up even if _system_config does not propagate to the head.
+    monkeypatch.setenv("RAY_task_events_max_num_task_in_gcs", "5")
     ray_context = ray.init(
         num_cpus=8,
         _system_config={

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -634,7 +634,7 @@ RAY_CONFIG(bool, disable_open_telemetry_sdk_log, true)
 
 /// Whether to enable Ray Event as the event collection backend. The default is
 /// using the Export API.
-RAY_CONFIG(bool, enable_ray_event, false)
+RAY_CONFIG(bool, enable_ray_event, true)
 
 RAY_CONFIG(uint64_t, ray_event_recorder_max_queued_events, 10000)
 
@@ -1116,7 +1116,7 @@ RAY_CONFIG(std::vector<std::string>, enable_export_api_write_config, {})
 // Whether the task events from the core worker are sent to GCS directly.
 // TODO(myan): #54515 Remove this flag after the task events to GCS path is fully
 // migrated to the event aggregator.
-RAY_CONFIG(bool, enable_core_worker_task_event_to_gcs, true)
+RAY_CONFIG(bool, enable_core_worker_task_event_to_gcs, false)
 
 // Whether to enable the ray event to send to the event aggregator.
 // Currently, only task events are supported.
@@ -1127,13 +1127,13 @@ RAY_CONFIG(bool, enable_core_worker_ray_event_to_aggregator, false)
 // Whether core-worker task events are sent to the event aggregator via the
 // RayTaskEventRecorder. When true (and enable_ray_event is also true),
 // the recorder is used.
-RAY_CONFIG(bool, enable_ray_task_event_recorder, false)
+RAY_CONFIG(bool, enable_ray_task_event_recorder, true)
 
 // Flag for the migration of task events from GCS to dashboard head. When true: the
 // aggregator publishes task events to the dashboard head, the TaskEventsHead module is
 // loaded, and the state API (list tasks / ray.timeline) reads task events from the
 // dashboard head instead of GCS.
-RAY_CONFIG(bool, enable_task_events_to_dashboard_head, false)
+RAY_CONFIG(bool, enable_task_events_to_dashboard_head, true)
 
 // Configuration for pipe logger buffer size.
 RAY_CONFIG(uint64_t, pipe_logger_read_buf_size, 1024)


### PR DESCRIPTION
test PR

contains all changes for migrating task events out of GCS to dashboard head. All such PRs are prefixed by [taskEvents out of GCS].

List of PRs:
https://github.com/ray-project/ray/pull/64168
https://github.com/ray-project/ray/pull/64835
https://github.com/ray-project/ray/pull/65288
https://github.com/ray-project/ray/pull/65028
https://github.com/ray-project/ray/pull/65057
https://github.com/ray-project/ray/pull/65123
https://github.com/ray-project/ray/pull/65141
https://github.com/ray-project/ray/pull/65158
https://github.com/ray-project/ray/pull/65160
https://github.com/ray-project/ray/pull/65218
https://github.com/ray-project/ray/pull/65247

Besides that, the other commits are:
https://github.com/ray-project/ray/pull/65253/changes/da6b98247fdd2c2a260d6f69713b75d7a2372e78 => toggles the flag used to trigger the entire feature
essentially these flags were configured:
enable_ray_event: true
enable_ray_task_event_recorder: true
enable_task_events_to_dashboard_head: true
enable_core_worker_task_event_to_gcs: false

https://github.com/ray-project/ray/pull/65253/changes/ace5e71e19b52b063178bcc274ef228d399b6b57 => disables some tests which are known followups for the feature.
- Unlike GcsTaskManager, we have not yet added support for metrics on task events head for events stored, events recorder etc.
- There is one edge case in test_task_failure_4.py which is yet to be covered.