### PR TITLE
[runtime_env] Block browser requests on the runtime env agent HTTP server

### DIFF
--- a/python/ray/_private/browser_request_middleware.py
+++ b/python/ray/_private/browser_request_middleware.py
@@ -1,0 +1,96 @@
+"""Browser-request detection and blocking middleware for internal HTTP servers.
+
+Internal Ray HTTP servers (dashboard head, dashboard agent, runtime env agent)
+bind TCP sockets and are meant to be accessed only by other Ray processes.
+Blocking browser-originated requests on them prevents DNS rebinding and CSRF
+attacks against state-changing endpoints.
+
+This module lives in ray._private so core components (e.g. the runtime env
+agent) can use it without importing ray.dashboard, which is not import-safe
+from minimal installations. ray.dashboard.optional_utils keeps its own
+historical copy; converging the two is intentionally left out of scope to keep
+changes minimal.
+"""
+
+from types import ModuleType
+from typing import List, Optional, Set
+
+
+def is_browser_request(req) -> bool:
+    """Best-effort detection if the request was made by a browser.
+
+    Uses three heuristics:
+        1) If the `User-Agent` header starts with 'Mozilla'. This heuristic is weak,
+        but hard for a browser to bypass e.g., fetch/xhr and friends cannot alter the
+        user agent, but requests made with an HTTP library can stumble into this if
+        they choose to user a browser-like user agent. At the time of writing, all
+        common browsers' user agents start with 'Mozilla'.
+        2) If any of the `Sec-Fetch-*` headers are present.
+        3) If any of the various CORS headers are present
+    """
+    return req.headers.get("User-Agent", "").startswith("Mozilla") or any(
+        h in req.headers
+        for h in (
+            # Origin and Referer are sent by browser user agents to give
+            # information about the requesting origin
+            "Referer",
+            "Origin",
+            # Sec-Fetch headers are sent with many but not all `fetch`
+            # requests, and will eventually be sent on all requests.
+            "Sec-Fetch-Mode",
+            "Sec-Fetch-Dest",
+            "Sec-Fetch-Site",
+            "Sec-Fetch-User",
+            # CORS headers specifying which other headers are modified
+            "Access-Control-Request-Method",
+            "Access-Control-Request-Headers",
+        )
+    )
+
+
+def get_browser_request_middleware(
+    aiohttp_module: ModuleType,
+    allowed_methods: Optional[Set[str]] = None,
+    allowed_paths: Optional[List[str]] = None,
+):
+    """Create middleware that restricts browser access to specified HTTP methods.
+
+    This middleware blocks browser requests to prevent DNS rebinding and CSRF
+    attacks. Only explicitly allowed methods are permitted from browsers.
+
+    Args:
+        aiohttp_module: The aiohttp module to use
+        allowed_methods: Set of HTTP methods browsers are allowed to use.
+        allowed_paths: List of paths that bypass the method check entirely,
+            allowing any method from browsers.
+
+    Returns:
+        An aiohttp middleware function
+    """
+    allowed_methods = allowed_methods or set()
+
+    @aiohttp_module.web.middleware
+    async def browser_request_middleware(request, handler):
+        if not is_browser_request(request):
+            return await handler(request)
+
+        # Allow whitelisted paths to bypass the check
+        if allowed_paths and request.path in allowed_paths:
+            return await handler(request)
+
+        # No methods allowed for browsers, return `403` status.
+        if not allowed_methods:
+            return aiohttp_module.web.Response(
+                status=403, text="Browser requests not allowed."
+            )
+
+        # This specific method is not allowed, return `405` status.
+        if request.method not in allowed_methods:
+            return aiohttp_module.web.Response(
+                status=405,
+                text=f"'{request.method}' method not allowed for browser traffic.",
+            )
+
+        return await handler(request)
+
+    return browser_request_middleware

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -13,6 +13,7 @@ from ray._private import logging_utils
 from ray._private.authentication.http_token_authentication import (
     get_token_auth_middleware,
 )
+from ray._private.browser_request_middleware import get_browser_request_middleware
 from ray._private.process_watcher import create_check_raylet_task
 from ray._raylet import RUNTIME_ENV_AGENT_PORT_NAME, GcsClient, persist_port
 from ray.core.generated import (
@@ -215,7 +216,14 @@ if __name__ == "__main__":
             body=reply.SerializeToString(), content_type="application/octet-stream"
         )
 
-    app = web.Application(middlewares=[get_token_auth_middleware(aiohttp)])
+    app = web.Application(
+        middlewares=[
+            get_token_auth_middleware(aiohttp),
+            # Block all browser requests - the runtime env agent is only
+            # accessed internally, same as the dashboard agent.
+            get_browser_request_middleware(aiohttp),
+        ]
+    )
 
     app.router.add_post("/get_or_create_runtime_env", get_or_create_runtime_env)
     app.router.add_post(


### PR DESCRIPTION
## Description

The runtime env agent (`ray._private.runtime_env.agent`) binds a TCP socket on the node IP and serves state-changing endpoints — notably `POST /get_or_create_runtime_env`, which triggers runtime environment creation (pip/conda package installation, setup commands).

Both sibling Ray HTTP servers apply a browser-request middleware whose documented purpose is to "block browser requests to prevent DNS rebinding and CSRF attacks":

- dashboard head (`http_server_head.py`)
- dashboard agent (`http_server_agent.py`, with the comment `# Block all browser requests - agent is only accessed internally`)

The runtime env agent applies only `get_token_auth_middleware` — which is a documented no-op when token authentication is not enabled (the default configuration) — and no browser-request middleware. So in default deployments this agent is the one Ray HTTP server with no browser/DNS-rebinding protection at all, despite being equally internal-only and arguably the most sensitive (package installation).

This PR applies the same browser-request middleware to the runtime env agent for parity with its siblings.

Because `ray._private` components cannot import `ray.dashboard` (not import-safe in minimal installations), the generic detection/middleware is provided by a new `ray._private.browser_request_middleware` module with the same logic as `dashboard.optional_utils`. Converging `optional_utils` onto the private module is intentionally left out of scope to keep this change minimal; happy to do that here if preferred.

## Checks

- [x] I've signed off every commit (by submitting pull requests, you agree to the [Developer Certificate of Origin](https://github.com/dcoapp/app#readme))
- [ ] I've run `scripts/format.sh` to lint the changes in this PR. *(could not run locally — bazel toolchain not available on this machine; logic mirrors the existing dashboard middleware and compiles clean)*
- [ ] I've included any doc changes needed
- [ ] I've made sure the tests are passing.

**Verification performed:** `py_compile` on both changed files; standalone behavioral smoke test of the middleware (browser UA / `Sec-Fetch-*` / `Origin` requests → 403; internal non-browser client → passes through). Relying on CI for the full suite.

Happy to route this via security@anyscale.com instead if you'd rather treat the middleware asymmetry as a security report — filing as a hardening-parity PR since the protection is already documented and deployed on the sibling servers.

Made with [Cursor](https://cursor.com)