### PR TITLE
[Data] Raise a clear error when _backfill_missing_fields gets a non-struct column

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -512,6 +512,12 @@ def _backfill_missing_fields(
 
     Returns:
         pa.StructArray: The aligned struct array.
+
+    Raises:
+        ValueError: If ``column`` is not a struct array. This happens when the
+            unified schema claims a field is a struct but some block holds a
+            non-struct there, which ``unify_schemas`` allows because struct
+            reconciliation ignores the non-struct arms.
     """
     import pyarrow as pa
 
@@ -526,6 +532,17 @@ def _backfill_missing_fields(
     # Flatten chunked arrays into a single array if necessary
     if isinstance(column, pa.ChunkedArray):
         column = pa.concat_arrays(column.chunks)
+
+    # The caller in ``_align_struct_fields`` checks this for top-level columns,
+    # but the recursive call below only inspects the *target* field type, so a
+    # nested non-struct field reaches here and would fail while iterating
+    # ``column.type``.
+    if not pa.types.is_struct(column.type):
+        raise ValueError(
+            f"Column of type {column.type} cannot be aligned with struct type "
+            f"{unified_struct_type}. A block holds a non-struct value where the "
+            "unified schema expects a struct."
+        )
 
     # Extract the current struct field names and their corresponding data
     current_fields = {

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -514,10 +514,10 @@ def _backfill_missing_fields(
         pa.StructArray: The aligned struct array.
 
     Raises:
-        ValueError: If ``column`` is not a struct array. This happens when the
-            unified schema claims a field is a struct but some block holds a
-            non-struct there, which ``unify_schemas`` allows because struct
-            reconciliation ignores the non-struct arms.
+        ValueError: If ``column`` is neither a struct nor an all-null array.
+            This happens when the unified schema claims a field is a struct but
+            some block holds a non-struct there, which ``unify_schemas`` allows
+            because struct reconciliation ignores the non-struct arms.
     """
     import pyarrow as pa
 
@@ -532,6 +532,12 @@ def _backfill_missing_fields(
     # Flatten chunked arrays into a single array if necessary
     if isinstance(column, pa.ChunkedArray):
         column = pa.concat_arrays(column.chunks)
+
+    # A field that is entirely null in this block infers as ``pa.null()``, which
+    # ``unify_schemas`` promotes to the struct type from the other blocks. Fill
+    # it with nulls of the target type rather than treating it as a conflict.
+    if pa.types.is_null(column.type):
+        return pa.nulls(len(column), type=unified_struct_type)
 
     # The caller in ``_align_struct_fields`` checks this for top-level columns,
     # but the recursive call below only inspects the *target* field type, so a

--- a/python/ray/data/tests/unit/test_transform_pyarrow.py
+++ b/python/ray/data/tests/unit/test_transform_pyarrow.py
@@ -1767,6 +1767,23 @@ def test_concat_nested_non_struct_field():
         concat([t1, t2])
 
 
+def test_concat_nested_all_null_field():
+    """An all-null nested field is filled, not treated as a conflict."""
+    t1 = pa.table({"outer": pa.array([{"inner": {"y": 1}}])})
+    t2 = pa.table({"outer": pa.array([{"inner": None}, {"inner": None}])})
+
+    # ``inner`` infers as null in ``t2`` and is promoted to the struct type.
+    assert pa.types.is_null(t2.schema.field("outer").type.field("inner").type)
+
+    result = concat([t1, t2])
+
+    assert result["outer"].to_pylist() == [
+        {"inner": {"y": 1}},
+        {"inner": None},
+        {"inner": None},
+    ]
+
+
 # Test fixtures for tensor-related tests
 @pytest.fixture
 def uniform_tensor_blocks(tensor_format_context):

--- a/python/ray/data/tests/unit/test_transform_pyarrow.py
+++ b/python/ray/data/tests/unit/test_transform_pyarrow.py
@@ -1743,6 +1743,30 @@ def test_align_struct_fields_deep_nesting(deep_nesting_blocks, deep_nesting_sche
     ]
 
 
+def test_align_struct_fields_nested_non_struct_field():
+    """A nested field that is a struct in one block and a primitive in another."""
+    t1 = pa.table({"outer": pa.array([{"inner": {"y": 1}}])})
+    t2 = pa.table({"outer": pa.array([{"inner": 5}])})
+
+    # ``unify_schemas`` drops the non-struct arm when reconciling, so the
+    # unified type claims ``inner`` is a struct even though ``t2`` holds an
+    # int64 there.
+    schema = unify_schemas([t1.schema, t2.schema])
+    assert pa.types.is_struct(schema.field("outer").type.field("inner").type)
+
+    with pytest.raises(ValueError, match="cannot be aligned with struct type"):
+        _align_struct_fields([t1, t2], schema)
+
+
+def test_concat_nested_non_struct_field():
+    """The same mismatch reaching ``_align_struct_fields`` through ``concat``."""
+    t1 = pa.table({"outer": pa.array([{"inner": {"y": 1}}])})
+    t2 = pa.table({"outer": pa.array([{"inner": 5}])})
+
+    with pytest.raises(ValueError, match="cannot be aligned with struct type"):
+        concat([t1, t2])
+
+
 # Test fixtures for tensor-related tests
 @pytest.fixture
 def uniform_tensor_blocks(tensor_format_context):


### PR DESCRIPTION
## Description

`_align_struct_fields` guards top-level columns with `isinstance(column.type, pa.StructType)`, but its recursive call only checks the *target* field type. So a nested field that is a struct in one block and a primitive in another passed the outer guard and failed inside `_backfill_missing_fields` while iterating `column.type`. `unify_schemas` permits the mismatch: `_reconcile_field` keeps only the struct arms, so the unified type claims `inner` is a struct even though one block holds an `int64`.

```
a = ray.data.from_items([{"c": {"inner": {"y": 1}}}])
b = ray.data.from_items([{"c": {"inner": 5}}])
a.union(b).repartition(1).take_all()
# was: TypeError: 'pyarrow.lib.DataType' object is not iterable
# now: ValueError: Column of type int64 cannot be aligned with struct type
#      struct<y: int64>. A block holds a non-struct value where the unified
#      schema expects a struct.
```

This adds that same check at the top of the function. An all-null nested field infers as `pa.null()` and is filled with nulls of the target type rather than rejected.

Raising seemed safer than the issue's other option (backfilling a null struct), since coercing a schema conflict silently alters data — happy to switch.

The issue's repro no longer reaches this path: for a *top-level* mismatch the outer guard skips alignment and `pa.concat_tables` raises a readable `ArrowTypeError`. Only the nested case leaked the `TypeError`.

## Related issues

Fixes #61656

## Additional information

Tests: the nested mismatch via `_align_struct_fields` and via `concat`, plus the all-null case. `unit/test_transform_pyarrow.py` 81 passed (was 78); `unit/test_arrow_block.py` 66, `test_map.py` 240, `test_union.py` 5, `datasource/test_json.py` 58 passed; `pre-commit` clean; reverting either branch fails its test. Bazel/C++ not run locally.

#61656 is unassigned and no open PR touches this file; two earlier attempts (#62170, #63960) were closed by the stale bot without maintainer objection. AI assistance (Claude) was used; I reviewed every changed line and ran the tests above.
