### PR TITLE
[authentication] Fail closed when RAY_AUTH_MODE=token but ray._raylet is unavailable

### DIFF
--- a/python/ray/_private/authentication/authentication_utils.py
+++ b/python/ray/_private/authentication/authentication_utils.py
@@ -1,3 +1,5 @@
+import os
+
 try:
     from ray._raylet import (
         AuthenticationMode,
@@ -18,7 +20,12 @@ def is_token_auth_enabled() -> bool:
         bool: True if AUTH_MODE is set to "token".
     """
     if not _RAYLET_AVAILABLE:
-        return False
+        # Fail closed: if the operator explicitly requested token auth via
+        # RAY_AUTH_MODE=token, report it enabled even though the raylet
+        # extension is unavailable, so the HTTP/gRPC middlewares keep
+        # enforcing (and validate_request_token fails closed) instead of
+        # silently downgrading the deployment to unauthenticated.
+        return os.environ.get("RAY_AUTH_MODE", "").lower() == "token"
 
     return get_authentication_mode() == AuthenticationMode.TOKEN
 

--- a/python/ray/tests/authentication/test_authentication_utils.py
+++ b/python/ray/tests/authentication/test_authentication_utils.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+
+from ray._private.authentication import authentication_utils
+
+
+def test_token_auth_enabled_fail_closed_without_raylet(monkeypatch):
+    """If RAY_AUTH_MODE=token is set but ray._raylet is unavailable (broken or
+    partial install), auth must fail closed (report enabled so middlewares
+    enforce) rather than silently disabling itself."""
+    monkeypatch.setattr(authentication_utils, "_RAYLET_AVAILABLE", False)
+    monkeypatch.setenv("RAY_AUTH_MODE", "token")
+    assert authentication_utils.is_token_auth_enabled() is True
+
+
+def test_token_auth_disabled_without_raylet_when_unset(monkeypatch):
+    """Doc builds / minimal installs without ray._raylet keep the no-op
+    behaviour when the operator has not requested token auth."""
+    monkeypatch.setattr(authentication_utils, "_RAYLET_AVAILABLE", False)
+    monkeypatch.delenv("RAY_AUTH_MODE", raising=False)
+    assert authentication_utils.is_token_auth_enabled() is False
+
+
+def test_token_auth_disabled_without_raylet_when_explicitly_disabled(monkeypatch):
+    monkeypatch.setattr(authentication_utils, "_RAYLET_AVAILABLE", False)
+    monkeypatch.setenv("RAY_AUTH_MODE", "disabled")
+    assert authentication_utils.is_token_auth_enabled() is False
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

`is_token_auth_enabled()` returns `False` whenever the `ray._raylet` extension cannot be imported (the `except ImportError` path, originally intended for doc builds).

In a real deployment where the operator has explicitly set `RAY_AUTH_MODE=token`, a missing or broken `ray._raylet` extension therefore **silently disables token authentication entirely**: every HTTP middleware and gRPC interceptor that gates on `is_token_auth_enabled()` becomes a no-op, and the cluster serves all traffic unauthenticated with no error logged. The sibling validator `validate_request_token` already fails closed in exactly this situation (returns `False` when `_RAYLET_AVAILABLE` is `False`) — but it is never reached, because the mode check dominates.

This PR makes the mode check consistent with the validator: when `RAY_AUTH_MODE=token` is explicitly set, `is_token_auth_enabled()` reports enabled even without `ray._raylet`, so middlewares keep enforcing and all requests fail closed. When `RAY_AUTH_MODE` is unset (doc builds, minimal installs), behaviour is unchanged.

## Checks

- [x] I've signed off every commit (DCO)
- [ ] I've run `scripts/format.sh` *(bazel toolchain unavailable locally; change is 9 lines + a unit test, both compile clean)*
- [x] I've included any doc changes needed (none — no behaviour change for default/minimal installs)
- [x] Tests: added `python/ray/tests/authentication/test_authentication_utils.py` covering (a) explicit token + no raylet → fail closed, (b) unset + no raylet → no-op preserved, (c) explicitly disabled + no raylet → disabled. Relying on CI for execution (local run requires a built raylet).

Made with [Cursor](https://cursor.com)