### PR TITLE
[docs] Add a Kubernetes and Ray scheduling orientation guide

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides.md
+++ b/doc/source/cluster/kubernetes/user-guides.md
@@ -15,6 +15,7 @@ user-guides/upgrade-guide
 user-guides/k8s-cluster-setup
 user-guides/storage
 user-guides/config
+user-guides/scheduling
 user-guides/configuring-autoscaling
 user-guides/configuring-ippr
 user-guides/label-based-scheduling
@@ -56,6 +57,7 @@ To learn the basics of Ray on Kubernetes, we recommend taking a look at the {ref
 * {ref}`kuberay-k8s-setup`
 * {ref}`kuberay-storage`
 * {ref}`kuberay-config`
+* {ref}`kuberay-scheduling`
 * {ref}`kuberay-autoscaling`
 * {ref}`kuberay-gpu`
 * {ref}`kuberay-tpu`

--- a/doc/source/cluster/kubernetes/user-guides/k8s-autoscaler.md
+++ b/doc/source/cluster/kubernetes/user-guides/k8s-autoscaler.md
@@ -2,6 +2,8 @@
 # (Advanced) Understanding the Ray Autoscaler in the Context of Kubernetes
 We describe the relationship between the Ray autoscaler and other autoscalers in the Kubernetes ecosystem.
 
+For how Ray and Kubernetes divide scheduling responsibility more generally, see {ref}`kuberay-scheduling`.
+
 ## Ray Autoscaler vs. Horizontal Pod Autoscaler
 The Ray autoscaler adjusts the number of Ray nodes in a Ray cluster. On Kubernetes, each Ray node is run as a Kubernetes Pod. Thus in the context of Kubernetes, the Ray autoscaler scales Ray **Pod quantities**. In this sense, the Ray autoscaler plays a role similar to that of the Kubernetes [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-Pod-autoscale/) (HPA). However, the following features distinguish the Ray Autoscaler from the HPA.
 

--- a/doc/source/cluster/kubernetes/user-guides/scheduling.md
+++ b/doc/source/cluster/kubernetes/user-guides/scheduling.md
@@ -54,7 +54,7 @@ Start from what the pods are doing. The pod state separates the cases cleanly.
 
 ## Choosing where to express a constraint
 
-Express a constraint in Kubernetes when it's about machines: which hardware a pod may land on, which team's quota it draws from, or whether to admit a workload at all. Node selectors, taints, tolerations, and resource quotas are the tools. Ray integrates with four batch schedulers for queueing, priority, and gang scheduling at the pod level. See {ref}`kuberay-kueue`, {ref}`kuberay-kai-scheduler`, {ref}`kuberay-volcano`, and {ref}`kuberay-yunikorn`.
+Express a constraint in Kubernetes when it's about machines: which hardware a pod may land on, which team's quota it draws from, or whether to admit a workload at all. Node selectors, taints, tolerations, and resource quotas are the tools. Ray integrates with five batch schedulers for queueing, priority, and gang scheduling at the pod level. See {ref}`kuberay-kueue`, {ref}`kuberay-kai-scheduler`, {ref}`kuberay-volcano`, {ref}`kuberay-yunikorn`, and {ref}`kuberay-scheduler-plugins`.
 
 Express a constraint in Ray when it's about your application: which tasks need accelerators, which actors must sit together for low-latency communication, and how work spreads across the nodes you already have. Use resource requirements, {ref}`scheduling strategies <ray-scheduling-strategies>`, {ref}`placement groups <ray-placement-group-doc-ref>` for gang scheduling within a Ray cluster, and {ref}`label-based scheduling <kuberay-label-scheduling>` to target nodes by label rather than by ID.
 

--- a/doc/source/cluster/kubernetes/user-guides/scheduling.md
+++ b/doc/source/cluster/kubernetes/user-guides/scheduling.md
@@ -1,0 +1,68 @@
+---
+myst:
+  html_meta:
+    description: "How Kubernetes and Ray divide scheduling responsibility when you run Ray on Kubernetes, how KubeRay maps container resources to Ray's logical capacity, and which layer to investigate when a workload doesn't start."
+---
+
+(kuberay-scheduling)=
+
+# Scheduling on Kubernetes
+
+When you run Ray on Kubernetes, two schedulers are at work. Kubernetes decides which machine each Ray pod runs on. Ray decides which pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
+
+This page explains how the two layers divide the work, how KubeRay connects them, and how to tell which layer to look at when something doesn't start.
+
+## The two layers
+
+The Kubernetes scheduler assigns pods to nodes. It reads the resource requests in each container spec, compares them against allocatable capacity, and applies node selectors, taints, tolerations, affinity rules, and any admission or queueing controller you've installed. When it can't place a pod, the pod stays `Pending`.
+
+The Ray scheduler assigns tasks and actors to Ray nodes. Every Ray node is a Kubernetes pod. Ray reads the logical resource requirements you declare in `@ray.remote`, finds nodes that can satisfy them, and picks one according to the active scheduling strategy. When it can't place a task or actor, that task or actor stays pending while your remaining program logic keeps running.
+
+The two layers stack rather than run side by side. Ray only distributes resources that Kubernetes already granted to the pods in the cluster. A Ray-level request can never conjure capacity the Kubernetes layer hasn't handed over.
+
+The following table summarizes the split:
+
+|  | Kubernetes | Ray |
+|---|---|---|
+| Unit it places | Pod | Task or actor |
+| Target it places onto | Kubernetes node | Ray node, which is a pod |
+| What it reads | Container resource requests | Logical resources in `@ray.remote` |
+| How you configure it | YAML in the pod template | Python arguments and scheduling strategies |
+| Symptom when it's stuck | Pod is `Pending` | Task or actor is pending, pods are running |
+
+## How KubeRay connects the layers
+
+The two layers need to agree on how much capacity each pod has. KubeRay establishes that agreement when it starts each Ray container, deriving Ray's logical resource capacity from the Kubernetes container spec. Three details matter, because this is where the layers most often disagree:
+
+- KubeRay reads the CPU, memory, and GPU **limits** from the Ray container config and uses them as the pod's logical capacity. Starting with KubeRay 1.3.0, it falls back to the CPU request when no CPU limit is set.
+- KubeRay rounds CPU quantities up to the nearest integer. A container limit of `500m` becomes one logical CPU to Ray.
+- KubeRay ignores memory and GPU **requests**. Set those requests equal to their limits so both layers see the same numbers.
+
+Override any of these with `rayStartParams`. See {ref}`rayStartParams` for the full list. The common override is `num-cpus: "0"` on the head group, which tells Ray the head pod has no CPU capacity and so keeps CPU-requiring workloads off it. The head pod still has real CPU from Kubernetes' point of view. You're only changing what Ray believes it can schedule there.
+
+Check this seam first when the layers seem to disagree. A pod that Kubernetes considers healthy and well-provisioned can still look full, or empty, to Ray.
+
+## Deciding which layer to investigate
+
+Start from what the pods are doing. The pod state separates the cases cleanly.
+
+**Pods running, tasks or actors pending**: The Ray layer is holding the work. Ray classifies each node as *feasible* if it has the required resources at all, and *infeasible* if it doesn't. A GPU task is infeasible on a CPU-only pod no matter how long you wait. Ray further splits feasible nodes into *available* and *unavailable*, depending on whether the resources are free. If every node is infeasible, nothing runs until you add a node type that fits. Check the resource arguments in your `@ray.remote` decorators, any placement group constraints, and the logical capacity KubeRay assigned to your pods. See {ref}`ray-scheduling` for the full model.
+
+**Pods stuck in `Pending`**: The Kubernetes layer is holding the work. Run `kubectl describe pod` and read the scheduler events at the bottom. Typical causes are insufficient allocatable capacity, unsatisfied node selectors or taints, exhausted resource quotas, or a queueing controller holding the workload back. Nothing in your Ray code changes the outcome.
+
+**Pods stuck in `Pending` on an autoscaling cluster**: Both layers are in play, in sequence. The Ray autoscaler decides it needs more Ray nodes and asks KubeRay to create pods. The Kubernetes Cluster Autoscaler then provisions machines so those pods can be placed. A stall can come from either step. See {ref}`ray-k8s-autoscaler-comparison` for how the two autoscalers relate, including why the Ray autoscaler scales on logical resources from your task and actor annotations rather than on observed CPU and memory the way the Horizontal Pod Autoscaler does.
+
+## Choosing where to express a constraint
+
+Express a constraint in Kubernetes when it's about machines: which hardware a pod may land on, which team's quota it draws from, or whether to admit a workload at all. Node selectors, taints, tolerations, and resource quotas are the tools. Ray integrates with four batch schedulers for queueing, priority, and gang scheduling at the pod level. See {ref}`kuberay-kueue`, {ref}`kuberay-kai-scheduler`, {ref}`kuberay-volcano`, and {ref}`kuberay-yunikorn`.
+
+Express a constraint in Ray when it's about your application: which tasks need accelerators, which actors must sit together for low-latency communication, and how work spreads across the nodes you already have. Use resource requirements, {ref}`scheduling strategies <ray-scheduling-strategies>`, {ref}`placement groups <ray-placement-group-doc-ref>` for gang scheduling within a Ray cluster, and {ref}`label-based scheduling <kuberay-label-scheduling>` to target nodes by label rather than by ID.
+
+A useful rule of thumb: if the constraint would still make sense with your application code deleted, it belongs in Kubernetes.
+
+## See also
+
+- {ref}`ray-scheduling` for how Ray places tasks and actors, including scheduling strategies and the resource model.
+- {ref}`kuberay-config` for the RayCluster configuration fields this page references.
+- {ref}`ray-k8s-autoscaler-comparison` for the relationship between the Ray autoscaler and Kubernetes autoscalers.
+- {ref}`kuberay-gpu` and {ref}`kuberay-tpu` for accelerator-specific configuration.

--- a/doc/source/cluster/kubernetes/user-guides/scheduling.md
+++ b/doc/source/cluster/kubernetes/user-guides/scheduling.md
@@ -8,7 +8,7 @@ myst:
 
 # Scheduling on Kubernetes
 
-KubeRay runs each Ray node as a Kubernetes Pod. A Ray cluster's head node is its head Pod, and its worker nodes are its worker Pods. Elsewhere in Ray's documentation a node is just a node, because a Ray node can equally be a VM or a physical machine. On Kubernetes it's a Pod, so this page says "Pod" where the Kubernetes object is the point and "Ray node" where Ray's view of it is.
+KubeRay runs each Ray node (head or worker) as a Kubernetes Pod. While Ray nodes can generally be VMs or physical machines, this guide uses "Pod" when referring to the Kubernetes object and "Ray node" when referring to Ray's perspective.
 
 Two schedulers act on that arrangement, one on each half of it. Kubernetes decides which machine each Pod runs on. Ray decides which Pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
 
@@ -24,7 +24,7 @@ The two layers stack rather than run side by side. Ray only distributes resource
 
 The following table summarizes the split:
 
-|  | Kubernetes | Ray |
+| Scheduling aspect | Kubernetes | Ray |
 |---|---|---|
 | Unit it places | Pod | Task or actor |
 | Target it places onto | Kubernetes node | Ray node, which runs as a Pod |
@@ -42,7 +42,9 @@ The two layers need to agree on how much capacity each Pod has. KubeRay establis
 
 Override any of these with `rayStartParams`. See {ref}`rayStartParams` for the full list. The common override is `num-cpus: "0"` on the head group, which tells Ray the head Pod has no CPU capacity and so keeps CPU-requiring workloads off it. The head Pod still has real CPU from Kubernetes' point of view. You're only changing what Ray believes it can schedule there.
 
-Check this seam first when the layers seem to disagree. A Pod that Kubernetes considers healthy and well-provisioned can still look full, or empty, to Ray.
+:::{note}
+Check the capacity KubeRay derived before you suspect either scheduler. A Pod that Kubernetes considers healthy and well-provisioned can still look full, or empty, to Ray, because the two layers are reading different numbers for the same Pod.
+:::
 
 ## Deciding which layer to investigate
 

--- a/doc/source/cluster/kubernetes/user-guides/scheduling.md
+++ b/doc/source/cluster/kubernetes/user-guides/scheduling.md
@@ -8,53 +8,53 @@ myst:
 
 # Scheduling on Kubernetes
 
-When you run Ray on Kubernetes, two schedulers are at work. Kubernetes decides which machine each Ray pod runs on. Ray decides which pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
+When you run Ray on Kubernetes, two schedulers are at work. KubeRay runs each Ray node as a Kubernetes Pod, and each scheduler acts on a different half of that arrangement. Kubernetes decides which machine each Pod runs on. Ray decides which Pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
 
 This page explains how the two layers divide the work, how KubeRay connects them, and how to tell which layer to look at when something doesn't start.
 
 ## The two layers
 
-The Kubernetes scheduler assigns pods to nodes. It reads the resource requests in each container spec, compares them against allocatable capacity, and applies node selectors, taints, tolerations, affinity rules, and any admission or queueing controller you've installed. When it can't place a pod, the pod stays `Pending`.
+The Kubernetes scheduler assigns Pods to nodes. It reads the resource requests in each container spec, compares them against allocatable capacity, and applies node selectors, taints, tolerations, affinity rules, and any admission or queueing controller you've installed. When it can't place a Pod, the Pod stays `Pending`.
 
-The Ray scheduler assigns tasks and actors to Ray nodes. Every Ray node is a Kubernetes pod. Ray reads the logical resource requirements you declare in `@ray.remote`, finds nodes that can satisfy them, and picks one according to the active scheduling strategy. When it can't place a task or actor, that task or actor stays pending while your remaining program logic keeps running.
+The Ray scheduler assigns tasks and actors to Ray nodes. Ray reads the logical resource requirements you declare in `@ray.remote`, finds nodes that can satisfy them, and picks one according to the active scheduling strategy. When it can't place a task or actor, that task or actor stays pending while your remaining program logic keeps running.
 
-The two layers stack rather than run side by side. Ray only distributes resources that Kubernetes already granted to the pods in the cluster. A Ray-level request can never conjure capacity the Kubernetes layer hasn't handed over.
+The two layers stack rather than run side by side. Ray only distributes resources that Kubernetes already granted to the Pods in the cluster. A Ray-level request can never conjure capacity the Kubernetes layer hasn't handed over.
 
 The following table summarizes the split:
 
 |  | Kubernetes | Ray |
 |---|---|---|
 | Unit it places | Pod | Task or actor |
-| Target it places onto | Kubernetes node | Ray node, which is a pod |
+| Target it places onto | Kubernetes node | Ray node, which is a Pod |
 | What it reads | Container resource requests | Logical resources in `@ray.remote` |
-| How you configure it | YAML in the pod template | Python arguments and scheduling strategies |
-| Symptom when it's stuck | Pod is `Pending` | Task or actor is pending, pods are running |
+| How you configure it | YAML in the Pod template | Python arguments and scheduling strategies |
+| Symptom when it's stuck | Pod is `Pending` | Task or actor is pending, Pods are running |
 
 ## How KubeRay connects the layers
 
-The two layers need to agree on how much capacity each pod has. KubeRay establishes that agreement when it starts each Ray container, deriving Ray's logical resource capacity from the Kubernetes container spec. Three details matter, because this is where the layers most often disagree:
+The two layers need to agree on how much capacity each Pod has. KubeRay establishes that agreement when it starts each Ray container, deriving Ray's logical resource capacity from the Kubernetes container spec. Three details matter, because this is where the layers most often disagree:
 
-- KubeRay reads the CPU, memory, and GPU **limits** from the Ray container config and uses them as the pod's logical capacity. Starting with KubeRay 1.3.0, it falls back to the CPU request when no CPU limit is set.
+- KubeRay reads the CPU, memory, and GPU **limits** from the Ray container config and uses them as the Pod's logical capacity. Starting with KubeRay 1.3.0, it falls back to the CPU request when no CPU limit is set.
 - KubeRay rounds CPU quantities up to the nearest integer. A container limit of `500m` becomes one logical CPU to Ray.
 - KubeRay ignores memory and GPU **requests**. Set those requests equal to their limits so both layers see the same numbers.
 
-Override any of these with `rayStartParams`. See {ref}`rayStartParams` for the full list. The common override is `num-cpus: "0"` on the head group, which tells Ray the head pod has no CPU capacity and so keeps CPU-requiring workloads off it. The head pod still has real CPU from Kubernetes' point of view. You're only changing what Ray believes it can schedule there.
+Override any of these with `rayStartParams`. See {ref}`rayStartParams` for the full list. The common override is `num-cpus: "0"` on the head group, which tells Ray the head Pod has no CPU capacity and so keeps CPU-requiring workloads off it. The head Pod still has real CPU from Kubernetes' point of view. You're only changing what Ray believes it can schedule there.
 
-Check this seam first when the layers seem to disagree. A pod that Kubernetes considers healthy and well-provisioned can still look full, or empty, to Ray.
+Check this seam first when the layers seem to disagree. A Pod that Kubernetes considers healthy and well-provisioned can still look full, or empty, to Ray.
 
 ## Deciding which layer to investigate
 
-Start from what the pods are doing. The pod state separates the cases cleanly.
+Start from what the Pods are doing. The Pod state separates the cases cleanly.
 
-**Pods running, tasks or actors pending**: The Ray layer is holding the work. Ray classifies each node as *feasible* if it has the required resources at all, and *infeasible* if it doesn't. A GPU task is infeasible on a CPU-only pod no matter how long you wait. Ray further splits feasible nodes into *available* and *unavailable*, depending on whether the resources are free. If every node is infeasible, nothing runs until you add a node type that fits. Check the resource arguments in your `@ray.remote` decorators, any placement group constraints, and the logical capacity KubeRay assigned to your pods. See {ref}`ray-scheduling` for the full model.
+**Pods running, tasks or actors pending**: The Ray layer is holding the work. Ray classifies each node as *feasible* if it has the required resources at all, and *infeasible* if it doesn't. A GPU task is infeasible on a CPU-only Pod no matter how long you wait. Ray further splits feasible nodes into *available* and *unavailable*, depending on whether the resources are free. If every node is infeasible, nothing runs until you add a node type that fits. Check the resource arguments in your `@ray.remote` decorators, any placement group constraints, and the logical capacity KubeRay assigned to your Pods. See {ref}`ray-scheduling` for the full model.
 
 **Pods stuck in `Pending`**: The Kubernetes layer is holding the work. Run `kubectl describe pod` and read the scheduler events at the bottom. Typical causes are insufficient allocatable capacity, unsatisfied node selectors or taints, exhausted resource quotas, or a queueing controller holding the workload back. Nothing in your Ray code changes the outcome.
 
-**Pods stuck in `Pending` on an autoscaling cluster**: Both layers are in play, in sequence. The Ray autoscaler decides it needs more Ray nodes and asks KubeRay to create pods. The Kubernetes Cluster Autoscaler then provisions machines so those pods can be placed. A stall can come from either step. See {ref}`ray-k8s-autoscaler-comparison` for how the two autoscalers relate, including why the Ray autoscaler scales on logical resources from your task and actor annotations rather than on observed CPU and memory the way the Horizontal Pod Autoscaler does.
+**Pods stuck in `Pending` on an autoscaling cluster**: Both layers are in play, in sequence. The Ray autoscaler decides it needs more Ray nodes and asks KubeRay to create Pods. The Kubernetes Cluster Autoscaler then provisions machines so those Pods can be placed. A stall can come from either step. See {ref}`ray-k8s-autoscaler-comparison` for how the two autoscalers relate, including why the Ray autoscaler scales on logical resources from your task and actor annotations rather than on observed CPU and memory the way the Horizontal Pod Autoscaler does.
 
 ## Choosing where to express a constraint
 
-Express a constraint in Kubernetes when it's about machines: which hardware a pod may land on, which team's quota it draws from, or whether to admit a workload at all. Node selectors, taints, tolerations, and resource quotas are the tools. Ray integrates with five batch schedulers for queueing, priority, and gang scheduling at the pod level. See {ref}`kuberay-kueue`, {ref}`kuberay-kai-scheduler`, {ref}`kuberay-volcano`, {ref}`kuberay-yunikorn`, and {ref}`kuberay-scheduler-plugins`.
+Express a constraint in Kubernetes when it's about machines: which hardware a Pod may land on, which team's quota it draws from, or whether to admit a workload at all. Node selectors, taints, tolerations, and resource quotas are the tools. Ray integrates with five batch schedulers for queueing, priority, and gang scheduling at the Pod level. See {ref}`kuberay-kueue`, {ref}`kuberay-kai-scheduler`, {ref}`kuberay-volcano`, {ref}`kuberay-yunikorn`, and {ref}`kuberay-scheduler-plugins`.
 
 Express a constraint in Ray when it's about your application: which tasks need accelerators, which actors must sit together for low-latency communication, and how work spreads across the nodes you already have. Use resource requirements, {ref}`scheduling strategies <ray-scheduling-strategies>`, {ref}`placement groups <ray-placement-group-doc-ref>` for gang scheduling within a Ray cluster, and {ref}`label-based scheduling <kuberay-label-scheduling>` to target nodes by label rather than by ID.
 

--- a/doc/source/cluster/kubernetes/user-guides/scheduling.md
+++ b/doc/source/cluster/kubernetes/user-guides/scheduling.md
@@ -8,7 +8,7 @@ myst:
 
 # Scheduling on Kubernetes
 
-KubeRay runs each Ray node (head or worker) as a Kubernetes Pod. While Ray nodes can generally be VMs or physical machines, this guide uses "Pod" when referring to the Kubernetes object and "Ray node" when referring to Ray's perspective.
+KubeRay runs each Ray node, head or worker, as a Kubernetes Pod. While Ray nodes can generally be VMs or physical machines, this guide uses "Pod" when referring to the Kubernetes object and "Ray node" when referring to Ray's perspective.
 
 Two schedulers act on that arrangement, one on each half of it. Kubernetes decides which machine each Pod runs on. Ray decides which Pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
 
@@ -36,9 +36,9 @@ The following table summarizes the split:
 
 The two layers need to agree on how much capacity each Pod has. KubeRay establishes that agreement when it starts each Ray container, deriving Ray's logical resource capacity from the Kubernetes container spec. Three details matter, because this is where the layers most often disagree:
 
-- KubeRay reads the CPU, memory, and GPU **limits** from the main Ray container, which must be the first container in the Pod's `containers` list, and uses them as the Pod's logical capacity. Limits you set on a sidecar don't count toward it. Starting with KubeRay 1.3.0, it falls back to the CPU request when no CPU limit is set.
+- KubeRay reads the CPU, memory, and GPU `limits` from the main Ray container, which must be the first container in the Pod's `containers` list, and uses them as the Pod's logical capacity. Limits you set on a sidecar don't count toward it. Starting with KubeRay 1.3.0, it falls back to the CPU request when you don't set a CPU limit.
 - KubeRay rounds CPU quantities up to the nearest integer. A container limit of `500m` becomes one logical CPU to Ray.
-- KubeRay ignores memory and GPU **requests**. Set those requests equal to their limits so both layers see the same numbers.
+- KubeRay ignores memory and GPU `requests`. Set those requests equal to their limits so both layers see the same numbers.
 
 Override any of these with `rayStartParams`. See {ref}`rayStartParams` for the full list. The common override is `num-cpus: "0"` on the head group, which tells Ray the head Pod has no CPU capacity and so keeps CPU-requiring workloads off it. The head Pod still has real CPU from Kubernetes' point of view. You're only changing what Ray believes it can schedule there.
 
@@ -46,7 +46,7 @@ Override any of these with `rayStartParams`. See {ref}`rayStartParams` for the f
 Check the capacity KubeRay derived before you suspect either scheduler. A Pod that Kubernetes considers healthy and well-provisioned can still look full, or empty, to Ray, because the two layers are reading different numbers for the same Pod.
 :::
 
-## Deciding which layer to investigate
+## Decide which layer to investigate
 
 Start from what the Pods are doing. The Pod state separates the cases cleanly.
 
@@ -54,15 +54,15 @@ Start from what the Pods are doing. The Pod state separates the cases cleanly.
 
 **Pods stuck in `Pending`**: The Kubernetes layer is holding the work. Run `kubectl describe pod <pod-name>` and read the scheduler events at the bottom. Typical causes are insufficient allocatable capacity, unsatisfied node selectors or taints, exhausted resource quotas, or a queueing controller holding the workload back. Nothing in your Ray code changes the outcome.
 
-**Pods stuck in `Pending` on an autoscaling cluster**: Both layers are in play, in sequence. The Ray autoscaler decides it needs more Ray nodes and asks KubeRay to create Pods. The Kubernetes Cluster Autoscaler then provisions machines so those Pods can be placed. A stall can come from either step. See {ref}`ray-k8s-autoscaler-comparison` for how the two autoscalers relate, including why the Ray autoscaler scales on logical resources from your task and actor annotations rather than on observed CPU and memory the way the Horizontal Pod Autoscaler does.
+**Pods stuck in `Pending` on an autoscaling cluster**: Both layers are in play, in sequence. The Ray autoscaler decides it needs more Ray nodes and asks KubeRay to create Pods. The Kubernetes Cluster Autoscaler then provisions machines so Kubernetes can place those Pods. A stall can come from either step. See {ref}`ray-k8s-autoscaler-comparison` for how the two autoscalers relate, including why the Ray autoscaler scales on logical resources from your task and actor annotations rather than on observed CPU and memory the way the Horizontal Pod Autoscaler does.
 
-## Choosing where to express a constraint
+## Choose where to express a constraint
 
 Express a constraint in Kubernetes when it's about machines: which hardware a Pod may land on, which team's quota it draws from, or whether to admit a workload at all. Node selectors, taints, tolerations, and resource quotas are the tools. Ray integrates with five batch schedulers for queueing, priority, and gang scheduling at the Pod level. See {ref}`kuberay-kueue`, {ref}`kuberay-kai-scheduler`, {ref}`kuberay-volcano`, {ref}`kuberay-yunikorn`, and {ref}`kuberay-scheduler-plugins`.
 
 Express a constraint in Ray when it's about your application: which tasks need accelerators, which actors must sit together for low-latency communication, and how work spreads across the nodes you already have. Use resource requirements, {ref}`scheduling strategies <ray-scheduling-strategies>`, {ref}`placement groups <ray-placement-group-doc-ref>` for gang scheduling within a Ray cluster, and {ref}`label-based scheduling <kuberay-label-scheduling>` to target nodes by label rather than by ID.
 
-A useful rule of thumb: if the constraint would still make sense with your application code deleted, it belongs in Kubernetes.
+As a rule of thumb, if the constraint would still make sense with your application code deleted, it belongs in Kubernetes.
 
 ## See also
 

--- a/doc/source/cluster/kubernetes/user-guides/scheduling.md
+++ b/doc/source/cluster/kubernetes/user-guides/scheduling.md
@@ -8,7 +8,9 @@ myst:
 
 # Scheduling on Kubernetes
 
-When you run Ray on Kubernetes, two schedulers are at work. KubeRay runs each Ray node as a Kubernetes Pod, and each scheduler acts on a different half of that arrangement. Kubernetes decides which machine each Pod runs on. Ray decides which Pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
+KubeRay runs each Ray node as a Kubernetes Pod. A Ray cluster's head node is its head Pod, and its worker nodes are its worker Pods. Elsewhere in Ray's documentation a node is just a node, because a Ray node can equally be a VM or a physical machine. On Kubernetes it's a Pod, so this page says "Pod" where the Kubernetes object is the point and "Ray node" where Ray's view of it is.
+
+Two schedulers act on that arrangement, one on each half of it. Kubernetes decides which machine each Pod runs on. Ray decides which Pod each task and actor runs on. Knowing which of the two is holding up your workload is the difference between a quick fix and an afternoon of guessing.
 
 This page explains how the two layers divide the work, how KubeRay connects them, and how to tell which layer to look at when something doesn't start.
 
@@ -25,7 +27,7 @@ The following table summarizes the split:
 |  | Kubernetes | Ray |
 |---|---|---|
 | Unit it places | Pod | Task or actor |
-| Target it places onto | Kubernetes node | Ray node, which is a Pod |
+| Target it places onto | Kubernetes node | Ray node, which runs as a Pod |
 | What it reads | Container resource requests | Logical resources in `@ray.remote` |
 | How you configure it | YAML in the Pod template | Python arguments and scheduling strategies |
 | Symptom when it's stuck | Pod is `Pending` | Task or actor is pending, Pods are running |
@@ -34,7 +36,7 @@ The following table summarizes the split:
 
 The two layers need to agree on how much capacity each Pod has. KubeRay establishes that agreement when it starts each Ray container, deriving Ray's logical resource capacity from the Kubernetes container spec. Three details matter, because this is where the layers most often disagree:
 
-- KubeRay reads the CPU, memory, and GPU **limits** from the Ray container config and uses them as the Pod's logical capacity. Starting with KubeRay 1.3.0, it falls back to the CPU request when no CPU limit is set.
+- KubeRay reads the CPU, memory, and GPU **limits** from the main Ray container, which must be the first container in the Pod's `containers` list, and uses them as the Pod's logical capacity. Limits you set on a sidecar don't count toward it. Starting with KubeRay 1.3.0, it falls back to the CPU request when no CPU limit is set.
 - KubeRay rounds CPU quantities up to the nearest integer. A container limit of `500m` becomes one logical CPU to Ray.
 - KubeRay ignores memory and GPU **requests**. Set those requests equal to their limits so both layers see the same numbers.
 
@@ -48,7 +50,7 @@ Start from what the Pods are doing. The Pod state separates the cases cleanly.
 
 **Pods running, tasks or actors pending**: The Ray layer is holding the work. Ray classifies each node as *feasible* if it has the required resources at all, and *infeasible* if it doesn't. A GPU task is infeasible on a CPU-only Pod no matter how long you wait. Ray further splits feasible nodes into *available* and *unavailable*, depending on whether the resources are free. If every node is infeasible, nothing runs until you add a node type that fits. Check the resource arguments in your `@ray.remote` decorators, any placement group constraints, and the logical capacity KubeRay assigned to your Pods. See {ref}`ray-scheduling` for the full model.
 
-**Pods stuck in `Pending`**: The Kubernetes layer is holding the work. Run `kubectl describe pod` and read the scheduler events at the bottom. Typical causes are insufficient allocatable capacity, unsatisfied node selectors or taints, exhausted resource quotas, or a queueing controller holding the workload back. Nothing in your Ray code changes the outcome.
+**Pods stuck in `Pending`**: The Kubernetes layer is holding the work. Run `kubectl describe pod <pod-name>` and read the scheduler events at the bottom. Typical causes are insufficient allocatable capacity, unsatisfied node selectors or taints, exhausted resource quotas, or a queueing controller holding the workload back. Nothing in your Ray code changes the outcome.
 
 **Pods stuck in `Pending` on an autoscaling cluster**: Both layers are in play, in sequence. The Ray autoscaler decides it needs more Ray nodes and asks KubeRay to create Pods. The Kubernetes Cluster Autoscaler then provisions machines so those Pods can be placed. A stall can come from either step. See {ref}`ray-k8s-autoscaler-comparison` for how the two autoscalers relate, including why the Ray autoscaler scales on logical resources from your task and actor annotations rather than on observed CPU and memory the way the Horizontal Pod Autoscaler does.
 


### PR DESCRIPTION
## Description

Running Ray on Kubernetes involves two schedulers. Kubernetes places pods on machines, and Ray places tasks and actors on pods. The docs cover each layer well on its own, but nothing explains how they relate or which one to investigate when a workload doesn't start.

The closest existing page is `k8s-autoscaler.md`, but it's scoped to autoscaling and marked advanced, so a user debugging a pending actor is unlikely to find it.

This PR adds a user guide that:

- Names the two layers and what each one places.
- Documents how KubeRay derives Ray's logical resource capacity from the container spec, which is where the two layers most often disagree.
- Maps pod state to the layer worth investigating.
- Defers all mechanism to the existing Ray Core scheduling, RayCluster config, and autoscaler pages rather than restating them.

It also adds a pointer to the new page from the autoscaler guide.

The KubeRay resource-derivation details are drawn from `user-guides/config.md` (container limits, the CPU-request fallback as of KubeRay 1.3.0, integer rounding, and ignored memory and GPU requests).

## Related issues

None. This came out of a documentation gap audit, not a filed issue.

## Additional information

### Not a duplicate

Searched open PRs against `ray-project/ray` for "kubernetes scheduling", "scheduling overview", and related area keywords. No open PR covers this. No existing page in `doc/source` joins the two scheduling layers.

### Testing

**Source verification against the KubeRay implementation.** Every claim about how KubeRay derives Ray's logical capacity was checked against `ray-operator/controllers/ray/common/pod.go` in `ray-project/kuberay`, not just against the existing docs:

- `generateRayStartCommand` reads `resource.Limits[ResourceCPU]` for `num-cpus`, and falls back to `resource.Requests[ResourceCPU]` when the limit is zero.
- The CPU-request fallback landed in kuberay commit `ba50bfa8` (#2365). It's absent from `v1.2.1` and present in `v1.3.0`, which confirms the "starting with KubeRay 1.3.0" attribution.
- Integer rounding follows from `Quantity.Value()`, which rounds up away from zero, so a `500m` limit becomes one logical CPU.
- Memory reads `Limits[ResourceMemory]` only, with no request fallback, and accelerators go through `addWellKnownAcceleratorResources(rayStartParams, resource.Limits)`. Both confirm that requests are ignored for memory and GPU.

**Other checks:**

- `vale doc/source/cluster/kubernetes/user-guides/scheduling.md` — remaining errors are `Vale.Spelling` on "tolerations" and "autoscalers" (standard terms used throughout the existing KubeRay docs, absent from the Vale vocabulary) and one `Google.OxfordComma` false positive on a two-item disjunction. The existing `k8s-autoscaler.md` reports a comparable baseline.
- `pre-commit run` on the staged files — every hook reports "no files to check". No pre-commit hook currently covers Markdown under `doc/source/`.
- Every `{ref}` target used on the page was verified to exist by grepping for its label definition.
- **A full Sphinx docs build was not run locally.** Link resolution and toctree wiring rely on CI. Flagging this explicitly rather than implying broader verification than was performed.

### Self-review findings already fixed

A critical pass before requesting review caught that the page claimed Ray integrates with four batch schedulers. There are five: the `kubernetes-sigs/scheduler-plugins` integration provides gang scheduling for RayCluster through the PodGroup API as of KubeRay v1.4.0. Corrected, with the fifth link added.
### AI assistance

AI assistance was used to draft this page. The content is grounded in the repository sources cited above rather than generated from prior knowledge. It still needs a final human review pass before it should be considered ready, which is why this is opened as a draft.


---

### Update: review feedback addressed (983186c)

No longer a draft, so the "final human review pass" caveat above is satisfied.

@andrewsykim asked for the Ray node to Kubernetes Pod mapping stated in the intro, since it isn't obvious to readers new to Ray or KubeRay. It was present but buried as a subordinate clause. It now opens the page in its own paragraph, with the head and worker corollary and a note on why the page switches between "Pod" and "Ray node". The resource table also said a Ray node "is" a Pod; it runs as one, and the Pod is a superset that can hold the autoscaler sidecar, a log shipper, or a RayJob submitter.

Both bot comments applied. One added a technical claim, verified the same way as the rest:

- **The limits come from the main Ray container, which must be first in the `containers` list.** `utils.RayContainerIndex` is `0` in `ray-operator/controllers/ray/utils/constant.go`, and `BuildPod` passes `pod.Spec.Containers[utils.RayContainerIndex].Resources` into `generateRayStartCommand`. So limits set on a sidecar don't contribute to the Pod's logical capacity, which is the reason the detail is worth stating.
- Added a `<pod-name>` placeholder to the `kubectl describe pod` command.

`pre-commit run` again reports "no files to check" for every hook, consistent with the note above that nothing covers Markdown under `doc/source/`. Still no local Sphinx build.
