### PR TITLE
[docs] Add a scheduling overview with defaults to the Ray Core scheduling page

### DIFF
--- a/doc/source/ray-core/scheduling/index.rst
+++ b/doc/source/ray-core/scheduling/index.rst
@@ -8,9 +8,9 @@ This page provides an overview of how Ray decides to schedule tasks and actors t
 Scheduling at a glance
 ----------------------
 
-Ray schedules every task and actor without any configuration from you. Each control below has a default that applies until you override it, so read this section as a map of the available controls rather than a list of required settings.
+Ray schedules every task and actor without any configuration from you. Each control that follows has a default that applies until you override it, so read this section as a map of the available controls rather than a list of required settings.
 
-Ray places a task or actor in two steps. First it narrows the cluster to the nodes that can run the work at all, using the resource requirements and label selectors you declared. Then it picks one of those nodes using the scheduling strategy. For tasks under the ``"DEFAULT"`` strategy, data locality takes precedence over utilization, so Ray prefers a node that already holds the task's large arguments.
+Ray places a task or actor in two steps. First it narrows the cluster to the nodes that can run the work, using the resource requirements and label selectors you declare. Then it picks one of those nodes using the scheduling strategy. For tasks under the ``"DEFAULT"`` strategy, data locality takes precedence over utilization, so Ray prefers a node that already holds the task's large arguments.
 
 .. list-table::
    :header-rows: 1
@@ -41,7 +41,7 @@ Ray places a task or actor in two steps. First it narrows the cluster to the nod
      - None. Ray schedules each task and actor independently unless you create a placement group
      - :doc:`./placement-group`
 
-Because the actor scheduling default is non-zero while its running default is zero, an actor with no arguments still needs a node with at least one free CPU to start, and any number of them can then run there. A node with ``num_cpus=0`` runs neither tasks nor actors by default.
+Because the actor scheduling default is non-zero while its running default is zero, an actor that declares no resource requirements still needs a node with at least one free CPU to start, and any number of them can then run there. A node with ``num_cpus=0`` runs neither tasks nor actors by default.
 
 The ``"DEFAULT"`` strategy's node selection is tunable through environment variables, though most clusters never need to change them:
 
@@ -57,7 +57,7 @@ The ``"DEFAULT"`` strategy's node selection is tunable through environment varia
      - Utilization below this scores a node as 0, making it equally preferred with other lightly loaded nodes.
    * - ``RAY_scheduler_top_k_fraction``
      - ``0.2``
-     - Fraction of cluster nodes forming the candidate set Ray randomly picks from.
+     - Sizes the candidate set Ray randomly picks from, as a fraction of total cluster nodes.
    * - ``RAY_scheduler_top_k_absolute``
      - ``1``
      - Floor on that candidate set, so ``k`` never drops below this in a small cluster.

--- a/doc/source/ray-core/scheduling/index.rst
+++ b/doc/source/ray-core/scheduling/index.rst
@@ -10,7 +10,7 @@ Scheduling at a glance
 
 Ray schedules every task and actor without any configuration from you. Each control below has a default that applies until you override it, so read this section as a map of the available controls rather than a list of required settings.
 
-Ray places a task or actor in two steps. First it narrows the cluster to the nodes that can run the work at all, using the resource requirements and label selectors you declared. Then it picks one of those nodes using the scheduling strategy, with data locality breaking ties for tasks.
+Ray places a task or actor in two steps. First it narrows the cluster to the nodes that can run the work at all, using the resource requirements and label selectors you declared. Then it picks one of those nodes using the scheduling strategy. For tasks under the ``"DEFAULT"`` strategy, data locality takes precedence over utilization, so Ray prefers a node that already holds the task's large arguments.
 
 .. list-table::
    :header-rows: 1
@@ -38,10 +38,10 @@ Ray places a task or actor in two steps. First it narrows the cluster to the nod
      - Enabled for tasks, ignored for actors and when you set a strategy
      - :ref:`Locality-aware scheduling <ray-scheduling-locality>`
    * - Gang placement
-     - None; bundles are scheduled independently unless you create a placement group
+     - None. Ray schedules each task and actor independently unless you create a placement group
      - :doc:`./placement-group`
 
-Because both defaults above are non-zero, an actor with no arguments still needs a node with at least one free CPU to start, and any number of them can then run there. A node with ``num_cpus=0`` runs neither by default.
+Because the actor scheduling default is non-zero while its running default is zero, an actor with no arguments still needs a node with at least one free CPU to start, and any number of them can then run there. A node with ``num_cpus=0`` runs neither tasks nor actors by default.
 
 The ``"DEFAULT"`` strategy's node selection is tunable through environment variables, though most clusters never need to change them:
 

--- a/doc/source/ray-core/scheduling/index.rst
+++ b/doc/source/ray-core/scheduling/index.rst
@@ -5,8 +5,64 @@ Scheduling
 
 This page provides an overview of how Ray decides to schedule tasks and actors to nodes.
 
-.. DJS 19 Sept 2025: There should be an overview of all features and configs that impact scheduling here.
-  This should include descriptions for default values and behaviors, and links to things like default labels or resource definitions that can be used for scheduling without customization.
+Scheduling at a glance
+----------------------
+
+Ray schedules every task and actor without any configuration from you. Each control below has a default that applies until you override it, so read this section as a map of the available controls rather than a list of required settings.
+
+Ray places a task or actor in two steps. First it narrows the cluster to the nodes that can run the work at all, using the resource requirements and label selectors you declared. Then it picks one of those nodes using the scheduling strategy, with data locality breaking ties for tasks.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 30 48
+
+   * - Control
+     - Default
+     - Where it's documented
+   * - Node logical resources
+     - Auto-detected from the machine's physical CPU, GPU, and memory
+     - :ref:`Resources <ray-scheduling-resources>`
+   * - Task resource requirements
+     - 1 logical CPU
+     - :ref:`Specifying resource requirements <resource-requirements>`
+   * - Actor resource requirements
+     - 1 logical CPU to schedule, 0 to run
+     - :ref:`Specifying resource requirements <resource-requirements>`
+   * - Node labels
+     - ``ray.io/node-id`` on every node; ``ray.io/accelerator-type`` on accelerator nodes
+     - :doc:`./labels`
+   * - Scheduling strategy
+     - ``"DEFAULT"``
+     - :ref:`Scheduling strategies <ray-scheduling-strategies>`
+   * - Data locality
+     - Enabled for tasks, ignored for actors and when you set a strategy
+     - :ref:`Locality-aware scheduling <ray-scheduling-locality>`
+   * - Gang placement
+     - None; bundles are scheduled independently unless you create a placement group
+     - :doc:`./placement-group`
+
+Because both defaults above are non-zero, an actor with no arguments still needs a node with at least one free CPU to start, and any number of them can then run there. A node with ``num_cpus=0`` runs neither by default.
+
+The ``"DEFAULT"`` strategy's node selection is tunable through environment variables, though most clusters never need to change them:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 12 48
+
+   * - Environment variable
+     - Default
+     - Effect
+   * - ``RAY_scheduler_spread_threshold``
+     - ``0.5``
+     - Utilization below this scores a node as 0, making it equally preferred with other lightly loaded nodes.
+   * - ``RAY_scheduler_top_k_fraction``
+     - ``0.2``
+     - Fraction of cluster nodes forming the candidate set Ray randomly picks from.
+   * - ``RAY_scheduler_top_k_absolute``
+     - ``1``
+     - Floor on that candidate set, so ``k`` never drops below this in a small cluster.
+
+See :ref:`"DEFAULT" <ray-scheduling-strategies>` for how Ray combines these into a score.
 
 Labels
 ------


### PR DESCRIPTION
## Description

`doc/source/ray-core/scheduling/index.rst` carried a standing note that the page lacked an overview of the features and configs that affect scheduling, along with their default values.

Most of those defaults are already documented, but they're spread across the resources, labels, and placement group pages, so a reader has no single place to see what Ray does before any configuration.

This PR adds a "Scheduling at a glance" section that:

- Describes the two-step placement model: narrow to feasible nodes, then pick one.
- Tabulates each control with its default, linking to the page that documents it rather than restating the mechanism.
- Tabulates the three environment variables that tune the `"DEFAULT"` strategy.
- Calls out that the non-zero actor scheduling default means an actor needs a node with a free CPU to start, which is a recurring source of confusion.

It removes the standing note, since this addresses it. Happy to restore it if maintainers consider the gap only partly closed.

One genuine addition: `RAY_scheduler_top_k_absolute` was named on the page without its value. It defaults to `1` per `src/ray/common/ray_config_def.h`.

## Related issues

None. The work is driven by the in-file note.

## Additional information

### Not a duplicate

Searched open PRs against `ray-project/ray` for "scheduling overview" and related area keywords. Nothing open touches this page.

### Testing

**Every default in the new tables was verified against source, not against other docs pages:**

- The three scheduler environment variables come from `src/ray/common/ray_config_def.h`: `scheduler_spread_threshold` 0.5, `scheduler_top_k_fraction` 0.2, `scheduler_top_k_absolute` 1.
- The actor defaults were checked in `python/ray/actor.py`. A bare actor takes the simple branch, giving it 0 lifetime CPU and an `actor_method_cpu` of 1. Because method CPU is 1, `actor_placement_resources` becomes the lifetime resources with CPU incremented by 1. That's what makes "1 CPU for scheduling, 0 for running" true, and it's why the constants alone read as if they say the opposite.
- Node auto-detection and the task default come from `scheduling/resources.rst`; the default labels come from `scheduling/labels.md`.
- Every `:ref:` and `:doc:` target in the new section was verified to exist by grepping for its label definition.

**Other checks:**

- `vale doc/source/ray-core/scheduling/index.rst` — the added content introduces no new class of Vale error. The message-set diff against the pre-change file is empty.
- `pre-commit run` on the staged file — every hook reports "no files to check".
- **A full Sphinx docs build was not run locally.** Cross-reference resolution relies on CI.

### Self-review findings already fixed

A critical pass before requesting review caught three problems in the first draft:

- Data locality was described as breaking ties for tasks. The page's own `"DEFAULT"` section says locality takes precedence over utilization scoring, so Ray prefers the locality node regardless of how utilized it is. "Tie-breaking" understated it.
- The gang placement row referred to bundles being scheduled independently outside a placement group, but bundles only exist inside one, so it described something that can't happen.
- A sentence said "both defaults above are non-zero" when the two actor defaults are 1 and 0, contradicting the row directly above it.

### AI assistance

AI assistance was used to draft this section. Every default stated was read out of the source tree rather than recalled. It still needs a final human review pass, which is why this is opened as a draft.
