### PR TITLE
[serve] Env-gated observe layer4 mark-down on HAProxy servers

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -901,16 +901,14 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
 # redispatch + the `backup` fallback take over. Health checks revive a false
 # positive in ~0.5s. Backup/fallback servers are never observed.
 RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = get_env_bool(
-    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
-    os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"),
+    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"
 )
 
 # Consecutive observed layer4 errors before a server is marked DOWN. Only
 # used when RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED is set; a successful
 # connection resets the counter.
 RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
-    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
-    get_env_int_positive("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3),
+    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3
 )
 
 # The balancing algorithm to use in HAProxy backends. Default is leastconn.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -904,22 +904,17 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
 # frozen config would otherwise black-hole requests to torn-down replicas
 # (e.g. node drains). Health checks keep probing DOWN servers, so a false
 # positive self-heals in ~0.5s. Backup/fallback servers are never observed.
-RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = (
-    os.environ.get(
-        "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
-        os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"),
-    )
-    == "1"
+RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = get_env_bool(
+    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
+    os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"),
 )
 
 # Consecutive observed layer4 errors before a server is marked DOWN. Only
 # used when RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED is set; a successful
 # connection resets the counter.
-RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = int(
-    os.environ.get(
-        "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
-        os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", "3"),
-    )
+RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
+    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
+    get_env_int_positive("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3),
 )
 
 # The balancing algorithm to use in HAProxy backends. Default is leastconn.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -896,23 +896,21 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
     "RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER", "250ms"
 )
 
-# When enabled, backend replica servers get
-# `observe layer4 error-limit <N> on-error mark-down`: live traffic marks a
-# server DOWN after <N> consecutive connect failures without waiting for the
-# health checker, so `option redispatch` + the `backup` fallback take over.
-# This matters in soft-stopped (reloaded-away) HAProxy processes, whose
-# frozen config would otherwise black-hole requests to torn-down replicas
-# (e.g. node drains). Health checks keep probing DOWN servers, so a false
-# positive self-heals in ~0.5s. Backup/fallback servers are never observed.
+# Adds `observe layer4 error-limit <N> on-error mark-down` to replica servers:
+# live traffic marks a dead server DOWN (no health checker needed) and
+# redispatch + the `backup` fallback take over. Health checks revive a false
+# positive in ~0.5s. Backup/fallback servers are never observed.
 RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = get_env_bool(
-    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"
+    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
+    os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"),
 )
 
 # Consecutive observed layer4 errors before a server is marked DOWN. Only
 # used when RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED is set; a successful
 # connection resets the counter.
 RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
-    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3
+    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
+    get_env_int_positive("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3),
 )
 
 # The balancing algorithm to use in HAProxy backends. Default is leastconn.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -905,16 +905,14 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
 # (e.g. node drains). Health checks keep probing DOWN servers, so a false
 # positive self-heals in ~0.5s. Backup/fallback servers are never observed.
 RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = get_env_bool(
-    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
-    os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"),
+    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"
 )
 
 # Consecutive observed layer4 errors before a server is marked DOWN. Only
 # used when RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED is set; a successful
 # connection resets the counter.
 RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
-    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
-    get_env_int_positive("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3),
+    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3
 )
 
 # The balancing algorithm to use in HAProxy backends. Default is leastconn.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -896,23 +896,14 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
     "RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER", "250ms"
 )
 
-# When enabled, backend replica servers are configured with
-# `observe layer4 error-limit <N> on-error mark-down`: HAProxy marks a server
-# DOWN as soon as live traffic observes <N> consecutive connection-level
-# failures to it, without waiting for the health checker. This matters most
-# in a soft-stopped (reloaded-away) process, which keeps serving its
-# established connections with a frozen config and receives no backend
-# updates: when replicas are torn down under it (node drain / scale-down /
-# spot reclaim), traffic observation is its only way to learn a server is
-# gone, letting `option redispatch` + the `backup` fallback server take over.
-# Without it, requests entering such a process can be black-holed until
-# hard-stop-after because dead servers stay nominally UP. Recovery is
-# automatic: health checks keep probing DOWN servers every
-# HEALTH_CHECK_DOWNINTER (default 250ms) and HEALTH_CHECK_RISE (default 2)
-# passes restore the server, so a false positive self-heals in ~0.5s. The
-# backup/fallback servers are never configured with observation (the last
-# resort must not mark itself down); router-path servers inherit server
-# state via `track`.
+# When enabled, backend replica servers get
+# `observe layer4 error-limit <N> on-error mark-down`: live traffic marks a
+# server DOWN after <N> consecutive connect failures without waiting for the
+# health checker, so `option redispatch` + the `backup` fallback take over.
+# This matters in soft-stopped (reloaded-away) HAProxy processes, whose
+# frozen config would otherwise black-hole requests to torn-down replicas
+# (e.g. node drains). Health checks keep probing DOWN servers, so a false
+# positive self-heals in ~0.5s. Backup/fallback servers are never observed.
 RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = (
     os.environ.get(
         "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -896,6 +896,41 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
     "RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER", "250ms"
 )
 
+# When enabled, backend replica servers are configured with
+# `observe layer4 error-limit <N> on-error mark-down`: HAProxy marks a server
+# DOWN as soon as live traffic observes <N> consecutive connection-level
+# failures to it, without waiting for the health checker. This matters most
+# in a soft-stopped (reloaded-away) process, which keeps serving its
+# established connections with a frozen config and receives no backend
+# updates: when replicas are torn down under it (node drain / scale-down /
+# spot reclaim), traffic observation is its only way to learn a server is
+# gone, letting `option redispatch` + the `backup` fallback server take over.
+# Without it, requests entering such a process can be black-holed until
+# hard-stop-after because dead servers stay nominally UP. Recovery is
+# automatic: health checks keep probing DOWN servers every
+# HEALTH_CHECK_DOWNINTER (default 250ms) and HEALTH_CHECK_RISE (default 2)
+# passes restore the server, so a false positive self-heals in ~0.5s. The
+# backup/fallback servers are never configured with observation (the last
+# resort must not mark itself down); router-path servers inherit server
+# state via `track`.
+RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = (
+    os.environ.get(
+        "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
+        os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"),
+    )
+    == "1"
+)
+
+# Consecutive observed layer4 errors before a server is marked DOWN. Only
+# used when RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED is set; a successful
+# connection resets the counter.
+RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = int(
+    os.environ.get(
+        "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
+        os.environ.get("ANYSCALE_RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", "3"),
+    )
+)
+
 # The balancing algorithm to use in HAProxy backends. Default is leastconn.
 RAY_SERVE_HAPROXY_BALANCE_ALGORITHM = get_env_str(
     "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "leastconn"

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -62,6 +62,8 @@ from ray.serve._private.constants import (
     RAY_SERVE_HAPROXY_METRICS_REPORT_INTERVAL_S,
     RAY_SERVE_HAPROXY_METRICS_SOCKET_PATH,
     RAY_SERVE_HAPROXY_NBTHREAD,
+    RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT,
+    RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED,
     RAY_SERVE_HAPROXY_RETRIES,
     RAY_SERVE_HAPROXY_RETRY_ON,
     RAY_SERVE_HAPROXY_SERVER_STATE_BASE,
@@ -651,6 +653,9 @@ class HAProxyConfig:
     hard_stop_after_s: Optional[int] = RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S
     # See RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S.
     close_spread_time_s: Optional[int] = RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S
+    # See RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED.
+    observe_mark_down_enabled: bool = RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED
+    observe_error_limit: int = RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT
     custom_global: Dict[str, str] = field(default_factory=dict)
     custom_defaults: Dict[str, str] = field(default_factory=dict)
     inject_process_id_header: bool = False

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -287,12 +287,7 @@ backend {{ backend.name or 'unknown' }}
     http-check expect status 200
     {%- endif %}
     {{ hc.default_server_directive }}
-    # Servers in this backend. With observe enabled, live traffic marks a
-    # server DOWN after error-limit consecutive connect failures (without
-    # waiting for the checker), so redispatch reaches the backup even in a
-    # soft-stopped process whose checker/config state is frozen. The backup
-    # fallback below is deliberately NOT observed; router-path servers
-    # inherit this state via `track`.
+    # Servers in this backend
     {%- for server in backend.servers %}
     server {{ server.name }} {{ server.host }}:{{ server.port }} check{% if config.observe_mark_down_enabled %} observe layer4 error-limit {{ config.observe_error_limit }} on-error mark-down{% endif %}
     {%- endfor %}

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -287,9 +287,14 @@ backend {{ backend.name or 'unknown' }}
     http-check expect status 200
     {%- endif %}
     {{ hc.default_server_directive }}
-    # Servers in this backend
+    # Servers in this backend. With observe enabled, live traffic marks a
+    # server DOWN after error-limit consecutive connect failures (without
+    # waiting for the checker), so redispatch reaches the backup even in a
+    # soft-stopped process whose checker/config state is frozen. The backup
+    # fallback below is deliberately NOT observed; router-path servers
+    # inherit this state via `track`.
     {%- for server in backend.servers %}
-    server {{ server.name }} {{ server.host }}:{{ server.port }} check
+    server {{ server.name }} {{ server.host }}:{{ server.port }} check{% if config.observe_mark_down_enabled %} observe layer4 error-limit {{ config.observe_error_limit }} on-error mark-down{% endif %}
     {%- endfor %}
     {%- if backend.fallback_server %}
     # Fallback to head node's Serve proxy when no ingress replicas are available
@@ -435,7 +440,7 @@ backend {{ backend.name or 'unknown' }}
     {{ hc.default_server_directive }}
     # `proto h2` makes HAProxy speak HTTP/2 cleartext to backend gRPC servers.
     {%- for server in backend.servers %}
-    server {{ server.name }} {{ server.host }}:{{ server.port }} proto h2 check
+    server {{ server.name }} {{ server.host }}:{{ server.port }} proto h2 check{% if config.observe_mark_down_enabled %} observe layer4 error-limit {{ config.observe_error_limit }} on-error mark-down{% endif %}
     {%- endfor %}
     {%- if backend.fallback_server %}
     server {{ backend.fallback_server.name }} {{ backend.fallback_server.host }}:{{ backend.fallback_server.port }} proto h2 check backup


### PR DESCRIPTION
## Summary

When a node is drained (spot reclaim, compaction, scale-down), its displaced (soft-stopped) HAProxy processes keep serving established connections with a frozen config in which torn-down replicas remain nominally UP. Requests those processes accept are black-holed until `hard-stop-after` instead of failing over. This PR adds an env-gated `observe layer4 error-limit <N> on-error mark-down` to backend replica servers so live traffic itself marks dead servers DOWN and the existing `backup` fallback takes over. Default off; the rendered config is byte-identical when unset.

## Chain of events

1. A node starts draining (2026-08-04 incident: spot reclaim; 2026-07-23: replica compaction).
2. The controller migrates the node's replicas; replacements are healthy elsewhere in ~2s.
3. Updated backend configs are pushed to every proxy.
4. Each HAProxy applies the new config by reloading: a new process starts, and the old one is soft-stopped (`-sf`) but keeps serving its established connections.
5. The old process's view is frozen: the stopped replicas stay UP in its map, and the replacements don't exist in it.
6. A request arrives on a connection held by the old process; the frontend accepts it.
7. Dispatch picks a stale server; the connect fails — the replica is gone.
8. Retries and redispatch only consider servers believed UP: the same dead ones. `nbsrv > 0`, so the `backup` fallback stays ineligible.
9. No error is ever returned; the client burns its full timeout (150s in our fleet).
10. Steps 6-9 repeat for every request landing on that process until `hard-stop-after` (400s) kills it: queued requests die as 502s (last client failures at drain+401s, to the second), and traffic then flows only to healthy processes.

Impact: 8 failed client requests over ~6.5 minutes, exactly on the apps whose replicas all sat on the drained node (echo 1/1 replica, highscale 2/2).

## Fix

`RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED` (default off) renders `observe layer4 error-limit <N> on-error mark-down` (`RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT`, default 3) on HTTP and gRPC replica server lines. Connection-level failures observed by live traffic mark the server DOWN synchronously in the request path — verified in HAProxy source: `__health_adjust()` runs inline with no `stopping` guard, and soft-stop does not destroy check tasks, so this works inside displaced processes, the one place nothing else can. With all primaries DOWN, `option redispatch` + the existing `backup` fallback serve the request. Recovery is automatic: DOWN servers keep being health-probed and `rise` passes restore them in ~0.5s, so a false positive self-heals. Backup/fallback servers are never observed; router-path servers inherit state via `track`.