### PR TITLE
[data] Move non-data related stuff oustide release test timing

### DIFF
--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -66,16 +66,12 @@ def main(args):
     # Get the preprocessing transforms from the pre-trained weights.
     transform = weights.transforms()
 
-    start_time = time.time()
-
-    if data_format == "raw":
-        if smoke_test:
-            data_url += "/dog_1.jpg"
-        ds = ray.data.read_images(data_url, size=(256, 256))
-    elif data_format == "parquet":
-        if smoke_test:
-            data_url += "/8cc8856e16c343829ef320fef4b353b1_000000.parquet"
-        ds = ray.data.read_parquet(data_url)
+    if smoke_test:
+        compute = ActorPoolStrategy(size=4)
+        num_gpus = 0
+    else:
+        compute = ActorPoolStrategy(min_size=1, max_size=10)
+        num_gpus = 1
 
     # Preprocess the images using standard preprocessing
     def preprocess(image_batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
@@ -97,37 +93,55 @@ def main(args):
                 output = self.model(torch.as_tensor(batch["image"], device=device))
                 return {"predictions": output.cpu().numpy()}
 
-    start_time_without_metadata_fetching = time.time()
+    holder = {}
 
-    if smoke_test:
-        compute = ActorPoolStrategy(size=4)
-        num_gpus = 0
-    else:
-        compute = ActorPoolStrategy(min_size=1, max_size=10)
-        num_gpus = 1
-    ds = ds.map_batches(preprocess, batch_size="auto")
-    ds = ds.map_batches(
-        Predictor,
-        batch_size=INFERENCE_BATCH_SIZE,
-        compute=compute,
-        num_gpus=num_gpus,
-        fn_constructor_kwargs={"model": model_ref},
-    )
+    def benchmark_fn():
+        url = data_url
+        if data_format == "raw":
+            if smoke_test:
+                url += "/dog_1.jpg"
+            ds = ray.data.read_images(url, size=(256, 256))
+        elif data_format == "parquet":
+            if smoke_test:
+                url += "/8cc8856e16c343829ef320fef4b353b1_000000.parquet"
+            ds = ray.data.read_parquet(url)
 
-    total_images = 0
+        # Secondary timer that excludes the read_* metadata fetch.
+        start_time_without_metadata_fetching = time.time()
 
-    # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
-    #       driver, therefore making it a factor impacting benchmark performance
-    for bundle in ds.iter_internal_ref_bundles():
-        total_images += bundle.num_rows()
+        ds = ds.map_batches(preprocess, batch_size="auto")
+        ds = ds.map_batches(
+            Predictor,
+            batch_size=INFERENCE_BATCH_SIZE,
+            compute=compute,
+            num_gpus=num_gpus,
+            fn_constructor_kwargs={"model": model_ref},
+        )
 
-    end_time = time.time()
+        total_images = 0
 
-    total_time = end_time - start_time
-    throughput = total_images / (total_time)
-    total_time_without_metadata_fetch = end_time - start_time_without_metadata_fetching
-    throughput_without_metadata_fetch = total_images / (
-        total_time_without_metadata_fetch
+        # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
+        #       driver, therefore making it a factor impacting benchmark performance
+        for bundle in ds.iter_internal_ref_bundles():
+            total_images += bundle.num_rows()
+
+        holder["ds"] = ds
+        holder["total_images"] = total_images
+        holder["total_time_s_wo_metadata_fetch"] = (
+            time.time() - start_time_without_metadata_fetching
+        )
+
+    benchmark = Benchmark()
+    benchmark.run_fn("batch-inference", benchmark_fn)
+
+    total_time = benchmark.result["batch-inference"][BenchmarkMetric.RUNTIME.value]
+    total_images = holder["total_images"]
+    total_time_without_metadata_fetch = holder["total_time_s_wo_metadata_fetch"]
+    throughput = total_images / total_time if total_time else 0
+    throughput_without_metadata_fetch = (
+        total_images / total_time_without_metadata_fetch
+        if total_time_without_metadata_fetch
+        else 0
     )
 
     print("Total time (sec): ", total_time)
@@ -143,23 +157,22 @@ def main(args):
         print(f"Total chaos killed: {dead_nodes}")
 
     # For structured output integration with internal tooling
-    results = collect_dataset_stats(ds)
-    results = {
-        BenchmarkMetric.RUNTIME: total_time,
-        BenchmarkMetric.THROUGHPUT: throughput,
-        "data_directory": data_directory,
-        "data_format": data_format,
-        "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
-        "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
-    }
-    results["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-
-    return results
+    results = collect_dataset_stats(holder["ds"])
+    results.update(
+        {
+            BenchmarkMetric.THROUGHPUT.value: throughput,
+            "data_directory": data_directory,
+            "data_format": data_format,
+            "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
+            "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
+            "runtime_env_setup": RuntimeEnvSetupTracker.collect(),
+        }
+    )
+    benchmark.result["batch-inference"].update(results)
+    benchmark.write_result()
 
 
 if __name__ == "__main__":
     args = parse_args()
     ray.init(runtime_env={"py_modules": benchmark_py_modules()})
-    benchmark = Benchmark()
-    benchmark.run_fn("batch-inference", main, args)
-    benchmark.write_result()
+    main(args)

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -155,22 +155,6 @@ def build_and_run_pipeline(
 # ---------------------------------------------------------------------------
 
 
-def main(args):
-    build_and_run_pipeline(
-        num_rows=args.num_rows,
-        gen_batch_size=args.gen_batch_size,
-        cpu_batch_size=args.cpu_batch_size,
-        gpu_batch_size=args.gpu_batch_size,
-        gpu_concurrency=args.gpu_concurrency,
-        set_memory=args.set_memory,
-    )
-
-    return {
-        "num_rows_input": int(args.num_rows),
-        "gpu_concurrency": int(args.gpu_concurrency),
-    }
-
-
 def parse_args():
     p = argparse.ArgumentParser(
         description="Heterogeneous memory batch inference benchmark"
@@ -194,5 +178,20 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
     benchmark = Benchmark()
-    benchmark.run_fn("heterogeneous-memory-batch-inference", main, args)
+    benchmark.run_fn(
+        "heterogeneous-memory-batch-inference",
+        build_and_run_pipeline,
+        num_rows=args.num_rows,
+        gen_batch_size=args.gen_batch_size,
+        cpu_batch_size=args.cpu_batch_size,
+        gpu_batch_size=args.gpu_batch_size,
+        gpu_concurrency=args.gpu_concurrency,
+        set_memory=args.set_memory,
+    )
+    benchmark.result["heterogeneous-memory-batch-inference"].update(
+        {
+            "num_rows_input": int(args.num_rows),
+            "gpu_concurrency": int(args.gpu_concurrency),
+        }
+    )
     benchmark.write_result()

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference_multitenancy.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference_multitenancy.py
@@ -192,13 +192,62 @@ def verify_placement() -> dict:
     }
 
 
-def main(args: argparse.Namespace) -> dict:
-    """Returns the benchmark dict. Errors are recorded under "_errors" so
-    metrics can be written first; the caller raises after write_result."""
-    errors: List[str] = []
-
+def run_workload(args: argparse.Namespace) -> dict:
+    """Run the solo and concurrent dataset pipelines. Returns raw timings."""
     solo_time = run_solo(args)
     per_tenant = run_concurrent(args)
+    return {
+        "solo_runtime_s": solo_time,
+        "per_tenant": per_tenant,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Heterogeneous memory batch inference multitenancy benchmark"
+    )
+    p.add_argument("--num-rows", type=int, default=400_000)
+    p.add_argument("--gen-batch-size", type=int, default=1024)
+    p.add_argument("--cpu-batch-size", type=int, default=1024)
+    p.add_argument("--gpu-batch-size", type=int, default=256)
+    p.add_argument("--gpu-concurrency", type=int, default=8)
+    p.add_argument(
+        "--set-memory",
+        action="store_true",
+        help=(
+            "Set per-operator memory requirements and enable logical memory "
+            "accounting. Otherwise, leave memory unset (None)."
+        ),
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    name = "heterogeneous-memory-batch-inference-multitenancy"
+    # Ship both benchmark.py and heterogeneous_memory_batch_inference.py to
+    # workers: when this script is run as ``__main__``, the UDF classes
+    # (FakeGPUInference, etc.) live in the imported
+    # ``heterogeneous_memory_batch_inference`` module, so cloudpickle
+    # serializes them by reference and each worker needs to import the
+    # module to deserialize.
+    ray.init(
+        runtime_env={
+            "py_modules": benchmark_py_modules() + [os.path.abspath(hmbi.__file__)],
+        }
+    )
+    benchmark = Benchmark()
+    holder = {}
+
+    def benchmark_fn():
+        holder["timings"] = run_workload(args)
+
+    benchmark.run_fn(name, benchmark_fn)
+
+    # Post-run analysis stays outside the timed section.
+    errors: List[str] = []
+    solo_time = holder["timings"]["solo_runtime_s"]
+    per_tenant = holder["timings"]["per_tenant"]
     multi_time = max(per_tenant.values()) if per_tenant else float("nan")
     overhead_ratio = multi_time / solo_time if solo_time > 0 else float("inf")
     per_tenant_str = ", ".join(
@@ -240,50 +289,12 @@ def main(args: argparse.Namespace) -> dict:
     result.update(placement_metrics)
     if errors:
         result["_errors"] = errors
-    return result
+    benchmark.result[name].update(result)
 
-
-def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(
-        description="Heterogeneous memory batch inference multitenancy benchmark"
-    )
-    p.add_argument("--num-rows", type=int, default=400_000)
-    p.add_argument("--gen-batch-size", type=int, default=1024)
-    p.add_argument("--cpu-batch-size", type=int, default=1024)
-    p.add_argument("--gpu-batch-size", type=int, default=256)
-    p.add_argument("--gpu-concurrency", type=int, default=8)
-    p.add_argument(
-        "--set-memory",
-        action="store_true",
-        help=(
-            "Set per-operator memory requirements and enable logical memory "
-            "accounting. Otherwise, leave memory unset (None)."
-        ),
-    )
-    return p.parse_args()
-
-
-if __name__ == "__main__":
-    args = parse_args()
-    name = "heterogeneous-memory-batch-inference-multitenancy"
-    # Ship both benchmark.py and heterogeneous_memory_batch_inference.py to
-    # workers: when this script is run as ``__main__``, the UDF classes
-    # (FakeGPUInference, etc.) live in the imported
-    # ``heterogeneous_memory_batch_inference`` module, so cloudpickle
-    # serializes them by reference and each worker needs to import the
-    # module to deserialize.
-    ray.init(
-        runtime_env={
-            "py_modules": benchmark_py_modules() + [os.path.abspath(hmbi.__file__)],
-        }
-    )
-    benchmark = Benchmark()
-    benchmark.run_fn(name, main, args)
     benchmark.write_result()
 
     # Raise after metrics have been written so the dashboard still records
     # the failed run (matches the sort_benchmark.py "print then raise"
     # convention).
-    errors = benchmark.result.get(name, {}).get("_errors", [])
     if errors:
         raise AssertionError("; ".join(errors))

--- a/release/nightly_tests/dataset/image_classification_from_parquet/main.py
+++ b/release/nightly_tests/dataset/image_classification_from_parquet/main.py
@@ -69,16 +69,12 @@ def main(args):
     # Get the preprocessing transforms from the pre-trained weights.
     transform = weights.transforms()
 
-    start_time = time.time()
-
-    if data_format == "raw":
-        if smoke_test:
-            data_url += "/dog_1.jpg"
-        ds = ray.data.read_images(data_url, size=(256, 256))
-    elif data_format == "parquet":
-        if smoke_test:
-            data_url += "/8cc8856e16c343829ef320fef4b353b1_000000.parquet"
-        ds = ray.data.read_parquet(data_url)
+    if smoke_test:
+        compute = ActorPoolStrategy(size=4)
+        num_gpus = 0
+    else:
+        compute = None
+        num_gpus = 1
 
     # Preprocess the images using standard preprocessing
     def preprocess(image_batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
@@ -100,28 +96,42 @@ def main(args):
                 output = self.model(torch.as_tensor(batch["image"], device=device))
                 return {"predictions": output.cpu().numpy()}
 
-    start_time_without_metadata_fetching = time.time()
+    holder = {}
 
-    if smoke_test:
-        compute = ActorPoolStrategy(size=4)
-        num_gpus = 0
-    else:
-        compute = None
-        num_gpus = 1
-    ds = ds.map_batches(preprocess, batch_size="auto")
-    ds = ds.map_batches(
-        Predictor,
-        batch_size=INFERENCE_BATCH_SIZE,
-        compute=compute,
-        num_gpus=num_gpus,
-        fn_constructor_kwargs={"model": model_ref},
-    )
-    ds.write_parquet(WRITE_PATH)
+    def benchmark_fn():
+        url = data_url
+        if data_format == "raw":
+            if smoke_test:
+                url += "/dog_1.jpg"
+            ds = ray.data.read_images(url, size=(256, 256))
+        elif data_format == "parquet":
+            if smoke_test:
+                url += "/8cc8856e16c343829ef320fef4b353b1_000000.parquet"
+            ds = ray.data.read_parquet(url)
 
-    end_time = time.time()
+        # Secondary timer that excludes the read_* metadata fetch.
+        start_time_without_metadata_fetching = time.time()
 
-    total_time = end_time - start_time
-    total_time_without_metadata_fetch = end_time - start_time_without_metadata_fetching
+        ds = ds.map_batches(preprocess, batch_size="auto")
+        ds = ds.map_batches(
+            Predictor,
+            batch_size=INFERENCE_BATCH_SIZE,
+            compute=compute,
+            num_gpus=num_gpus,
+            fn_constructor_kwargs={"model": model_ref},
+        )
+        ds.write_parquet(WRITE_PATH)
+
+        holder["ds"] = ds
+        holder["total_time_s_wo_metadata_fetch"] = (
+            time.time() - start_time_without_metadata_fetching
+        )
+
+    benchmark = Benchmark()
+    benchmark.run_fn("batch-inference", benchmark_fn)
+
+    total_time = benchmark.result["batch-inference"][BenchmarkMetric.RUNTIME.value]
+    total_time_without_metadata_fetch = holder["total_time_s_wo_metadata_fetch"]
 
     print("Total time (sec): ", total_time)
     print("Total time w/o metadata fetching (sec): ", total_time_without_metadata_fetch)
@@ -131,21 +141,20 @@ def main(args):
         assert dead_nodes
         print(f"Total chaos killed: {dead_nodes}")
 
-    results = collect_dataset_stats(ds)
-    results = {
-        BenchmarkMetric.RUNTIME: total_time,
-        "data_directory": data_directory,
-        "data_format": data_format,
-        "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
-    }
-    results["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-
-    return results
+    results = collect_dataset_stats(holder["ds"])
+    results.update(
+        {
+            "data_directory": data_directory,
+            "data_format": data_format,
+            "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
+            "runtime_env_setup": RuntimeEnvSetupTracker.collect(),
+        }
+    )
+    benchmark.result["batch-inference"].update(results)
+    benchmark.write_result()
 
 
 if __name__ == "__main__":
     args = parse_args()
     ray.init(runtime_env={"py_modules": benchmark_py_modules()})
-    benchmark = Benchmark()
-    benchmark.run_fn("batch-inference", main, args)
-    benchmark.write_result()
+    main(args)

--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
@@ -229,6 +229,8 @@ def main(args: argparse.Namespace, profiling: Profiling):
     if args.chaos:
         start_chaos()
 
+    ray.data.DataContext.get_current().default_map_logical_memory_enabled = True
+
     infer_cls = FakeInfer if args.fake_gpu else Infer
     infer_kwargs = {
         "batch_size": BATCH_SIZE,
@@ -245,13 +247,9 @@ def main(args: argparse.Namespace, profiling: Profiling):
         infer_kwargs["runtime_env"] = nsys_env
 
     num_gpus = max(args.inference_concurrency)
+    ds_holder = {}
 
     def benchmark_fn():
-        # `default_map_logical_memory_enabled` is a best practice that's required for
-        # Ray Data to prevent OOMs. It's not enabled by default in Ray 2.56, but we
-        # intend to enable it by default in a future release.
-        ray.data.DataContext.get_current().default_map_logical_memory_enabled = True
-
         ds = (
             ray.data.read_json(INPUT_PREFIX, lines=True, memory=READ_MEMORY)
             .flat_map(decode)
@@ -262,22 +260,27 @@ def main(args: argparse.Namespace, profiling: Profiling):
             )
         )
         ds.write_parquet(OUTPUT_PREFIX)
-        metrics = collect_dataset_stats(ds)
-        metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-        # Hold ds in scope so Ray Data keeps the actor pool alive while nsys
-        # finalizes its .nsys-rep files via stop-on-exit / atexit. Without
-        # this, ds drops out of scope on return and Ray tears the actors
-        # down before nsys gets to flush.
-        if profiling.profiler_mode == "nsys":
-            print("Holding ds in scope for 30s to let nsys finalize...", flush=True)
-            time.sleep(30)
-        if profiling.is_enabled():
-            metrics.update(
-                extract_pipeline_metrics(ds, num_gpus=num_gpus, outdir=SHARED_OUTDIR)
-            )
-        return metrics
+        ds_holder["ds"] = ds
 
     benchmark.run_fn("main", benchmark_fn)
+
+    ds = ds_holder["ds"]
+    # Hold ds in scope so Ray Data keeps the actor pool alive while nsys
+    # finalizes its .nsys-rep files via stop-on-exit / atexit. Without
+    # this, ds drops out of scope on return and Ray tears the actors
+    # down before nsys gets to flush.
+    if profiling.profiler_mode == "nsys":
+        print("Holding ds in scope for 30s to let nsys finalize...", flush=True)
+        time.sleep(30)
+
+    metrics = collect_dataset_stats(ds)
+    metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
+    if profiling.is_enabled():
+        metrics.update(
+            extract_pipeline_metrics(ds, num_gpus=num_gpus, outdir=SHARED_OUTDIR)
+        )
+    benchmark.result["main"].update(metrics)
+
     benchmark.write_result()
 
     # Copy result.json to shared storage for telemetry upload.

--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
@@ -229,6 +229,9 @@ def main(args: argparse.Namespace, profiling: Profiling):
     if args.chaos:
         start_chaos()
 
+    # `default_map_logical_memory_enabled` is a best practice that's required for
+    # Ray Data to prevent OOMs. It's not enabled by default in Ray 2.56, but we
+    # intend to enable it by default in a future release.
     ray.data.DataContext.get_current().default_map_logical_memory_enabled = True
 
     infer_cls = FakeInfer if args.fake_gpu else Infer

--- a/release/nightly_tests/dataset/image_embedding_from_uris/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_uris/main.py
@@ -203,12 +203,14 @@ def main(args: argparse.Namespace):
     print("Creating metadata")
     metadata = create_metadata(scale_factor=args.scale_factor)
 
-    def benchmark_fn():
-        weights = ViT_B_16_Weights.DEFAULT
-        model = vit_b_16(weights=weights)
-        transform = weights.transforms()
-        model_ref = ray.put(model)
+    weights = ViT_B_16_Weights.DEFAULT
+    model = vit_b_16(weights=weights)
+    transform = weights.transforms()
+    model_ref = ray.put(model)
 
+    ds_holder = {}
+
+    def benchmark_fn():
         ds = (
             ray.data.from_pandas(metadata)
             .with_column("channel0", download("channel0_uris"))
@@ -228,11 +230,14 @@ def main(args: argparse.Namespace):
             )
         )
         ds.write_parquet(WRITE_PATH)
-        metrics = collect_dataset_stats(ds)
-        metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-        return metrics
+        ds_holder["ds"] = ds
 
     benchmark.run_fn("main", benchmark_fn)
+
+    metrics = collect_dataset_stats(ds_holder["ds"])
+    metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
+    benchmark.result["main"].update(metrics)
+
     benchmark.write_result()
 
 

--- a/release/nightly_tests/dataset/model_inference_pipeline_benchmark.py
+++ b/release/nightly_tests/dataset/model_inference_pipeline_benchmark.py
@@ -368,7 +368,7 @@ def main(args):
     print(f"  Tokenizer max length: {args.tokenizer_max_length}")
     print(f"  Model: {args.model_name}")
 
-    # Build pipeline configuration
+    # Build pipeline configuration outside the timed section.
     # Use TPC-H lineitem columns:
     # - column00, column01: metadata (l_orderkey, l_partkey)
     # - column04-07: numeric features (l_quantity, l_extendedprice, l_discount, l_tax)
@@ -398,51 +398,53 @@ def main(args):
         model_name=args.model_name,
     )
 
-    start_time = time.time()
-
-    # Load input data
     columns_to_load = list(
         set(config.metadata_columns + config.feature_columns + config.text_columns)
     )
 
-    ds = ray.data.read_parquet(
-        config.input_path,
-        columns=columns_to_load,
-    ).limit(15_000_000)
-    ds._set_name("input_data")
+    holder = {}
 
-    # Execute end-to-end pipeline
-    output_ds = execute_pipeline(ds, config)
+    def benchmark_fn():
+        ds = ray.data.read_parquet(
+            config.input_path,
+            columns=columns_to_load,
+        ).limit(15_000_000)
+        ds._set_name("input_data")
 
-    # Consume output
-    total_rows = 0
-    for batch in output_ds.iter_batches(batch_size=None, batch_format="pandas"):
-        total_rows += len(batch)
+        output_ds = execute_pipeline(ds, config)
 
-    end_time = time.time()
+        total_rows = 0
+        for batch in output_ds.iter_batches(batch_size=None, batch_format="pandas"):
+            total_rows += len(batch)
+        holder["total_rows"] = total_rows
 
-    total_time = end_time - start_time
+    benchmark = Benchmark()
+    benchmark.run_fn("model-inference-pipeline", benchmark_fn)
+
+    total_time = benchmark.result["model-inference-pipeline"][
+        BenchmarkMetric.RUNTIME.value
+    ]
+    total_rows = holder["total_rows"]
     throughput = total_rows / total_time if total_time > 0 else 0
 
     print(f"Total rows processed: {total_rows}")
     print(f"Total time (sec): {total_time:.2f}")
     print(f"Throughput (rows/sec): {throughput:.2f}")
 
-    return {
-        BenchmarkMetric.RUNTIME: total_time,
-        BenchmarkMetric.THROUGHPUT: throughput,
-        BenchmarkMetric.NUM_ROWS: total_rows,
-        "preprocessing_batch_size": args.preprocessing_batch_size,
-        "inference_batch_size": args.inference_batch_size,
-        "inference_min_actors": args.inference_min_actors,
-        "inference_max_actors": args.inference_max_actors,
-        "tokenizer_max_length": args.tokenizer_max_length,
-    }
+    benchmark.result["model-inference-pipeline"].update(
+        {
+            BenchmarkMetric.THROUGHPUT.value: throughput,
+            BenchmarkMetric.NUM_ROWS.value: total_rows,
+            "preprocessing_batch_size": args.preprocessing_batch_size,
+            "inference_batch_size": args.inference_batch_size,
+            "inference_min_actors": args.inference_min_actors,
+            "inference_max_actors": args.inference_max_actors,
+            "tokenizer_max_length": args.tokenizer_max_length,
+        }
+    )
+    benchmark.write_result()
 
 
 if __name__ == "__main__":
     args = parse_args()
-
-    benchmark = Benchmark()
-    benchmark.run_fn("model-inference-pipeline", main, args)
-    benchmark.write_result()
+    main(args)

--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -124,13 +124,15 @@ if __name__ == "__main__":
         f"{num_partitions * partition_size / GiB}GB total"
     )
 
-    def run_benchmark(args):
-        # Override target max-block size to avoid creating too many blocks
-        DataContext.get_current().target_max_block_size = 1 * GiB
+    # Override target max-block size to avoid creating too many blocks
+    DataContext.get_current().target_max_block_size = 1 * GiB
+    source = RandomIntRowDatasource()
+    # Each row has an int64 key.
+    num_rows_per_partition = partition_size // (8 + args.row_size_bytes)
 
-        source = RandomIntRowDatasource()
-        # Each row has an int64 key.
-        num_rows_per_partition = partition_size // (8 + args.row_size_bytes)
+    holder = {}
+
+    def run_benchmark(args):
         ds = ray.data.read_datasource(
             source,
             override_num_blocks=num_partitions,
@@ -142,49 +144,50 @@ if __name__ == "__main__":
             ds = ds.random_shuffle()
         else:
             ds = ds.sort(key="c_0")
-        exc = None
         try:
-            ds = ds.materialize()
+            holder["ds"] = ds.materialize()
         except Exception as e:
-            exc = e
-
-        ds_stats = ds.stats()
-
-        # TODO(swang): Add stats for OOM worker kills. This is not very
-        # convenient to do programmatically right now because it requires
-        # querying Prometheus.
-        print("==== Driver memory summary ====")
-        maxrss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1e3)
-        print(f"max: {maxrss / 1e9}/GB")
-        process = psutil.Process(os.getpid())
-        rss = int(process.memory_info().rss)
-        print(f"rss: {rss / 1e9}/GB")
-
-        try:
-            print(memory_summary(stats_only=True))
-        except Exception:
-            print("Failed to retrieve memory summary")
-            print(traceback.format_exc())
-        print("")
-
-        if ds_stats is not None:
-            print(ds_stats)
-
-        results = {
-            "num_partitions": num_partitions,
-            "partition_size": partition_size,
-            "peak_driver_memory": maxrss,
-        }
-
-        # Wait until after the stats have been printed to raise any exceptions.
-        if exc is not None:
-            print(results)
-            raise exc
-
-        return results
+            holder["exc"] = e
+            holder["ds"] = ds
 
     benchmark = Benchmark()
     benchmark.run_fn("main", run_benchmark, args)
+
+    ds = holder["ds"]
+    ds_stats = ds.stats()
+
+    # TODO(swang): Add stats for OOM worker kills. This is not very
+    # convenient to do programmatically right now because it requires
+    # querying Prometheus.
+    print("==== Driver memory summary ====")
+    maxrss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1e3)
+    print(f"max: {maxrss / 1e9}/GB")
+    process = psutil.Process(os.getpid())
+    rss = int(process.memory_info().rss)
+    print(f"rss: {rss / 1e9}/GB")
+
+    try:
+        print(memory_summary(stats_only=True))
+    except Exception:
+        print("Failed to retrieve memory summary")
+        print(traceback.format_exc())
+    print("")
+
+    if ds_stats is not None:
+        print(ds_stats)
+
+    results = {
+        "num_partitions": num_partitions,
+        "partition_size": partition_size,
+        "peak_driver_memory": maxrss,
+    }
+    benchmark.result["main"].update(results)
+
+    # Wait until after the stats have been printed to raise any exceptions.
+    if "exc" in holder:
+        print(results)
+        raise holder["exc"]
+
     benchmark.write_result()
 
     ray.timeline("dump.json")

--- a/release/nightly_tests/dataset/text_embedding/main.py
+++ b/release/nightly_tests/dataset/text_embedding/main.py
@@ -88,6 +88,9 @@ def main(args: argparse.Namespace):
     if args.chaos:
         start_chaos()
 
+    hf_token = get_hf_token()
+    ds_holder = {}
+
     def benchmark_fn():
         ds = (
             ray.data.read_parquet(INPUT_PREFIX, schema=SCHEMA)
@@ -97,15 +100,18 @@ def main(args: argparse.Namespace):
                 concurrency=tuple(args.inference_concurrency),
                 num_gpus=1,
                 batch_size=BATCH_SIZE,
-                fn_constructor_kwargs={"model": "BAAI/bge-m3", "token": get_hf_token()},
+                fn_constructor_kwargs={"model": "BAAI/bge-m3", "token": hf_token},
             )
         )
         ds.write_parquet(OUTPUT_PREFIX, mode="overwrite")
-        metrics = collect_dataset_stats(ds)
-        metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-        return metrics
+        ds_holder["ds"] = ds
 
     benchmark.run_fn("main", benchmark_fn)
+
+    metrics = collect_dataset_stats(ds_holder["ds"])
+    metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
+    benchmark.result["main"].update(metrics)
+
     benchmark.write_result()
 
 

--- a/release/nightly_tests/dataset/worker_scaling_benchmark.py
+++ b/release/nightly_tests/dataset/worker_scaling_benchmark.py
@@ -207,73 +207,75 @@ def main(args: argparse.Namespace):
 
     benchmark = Benchmark()
 
-    def benchmark_fn():
-        num_blocks = args.blocks_per_worker * args.num_workers
-        rows_per_block = _rows_per_block(
+    num_blocks = args.blocks_per_worker * args.num_workers
+    rows_per_block = _rows_per_block(
+        args.num_scalar_cols,
+        args.num_array_cols,
+    )
+    num_rows = num_blocks * rows_per_block
+
+    # Split the total worker pool evenly across the chained operators so the
+    # cluster footprint stays the same regardless of --num-operators. With
+    # 5000 workers and 15 operators each operator gets ~333 workers, which
+    # mirrors production pipelines that pay the per-iteration cost of many
+    # ops with a moderately sized pool per op.
+    workers_per_operator = args.num_workers // args.num_operators
+
+    map_kwargs = {"num_cpus": 0.5}
+    if args.worker_type == "actors":
+        map_kwargs["compute"] = ray.data.ActorPoolStrategy(size=workers_per_operator)
+        udf = RealisticSchemaUDF
+        map_kwargs["fn_constructor_kwargs"] = {
+            "seed": args.seed,
+            "num_scalar_cols": args.num_scalar_cols,
+            "num_array_cols": args.num_array_cols,
+        }
+    else:
+        # ``concurrency`` caps in-flight tasks per operator. Without this
+        # cap, all tasks of a single operator can fan out across the entire
+        # cluster and the next operator in the chain starves — but the goal
+        # here is N_operators sharing the pool, so each gets
+        # ``workers_per_operator`` task slots.
+        #
+        # Only apply the cap when actually chaining operators. With a single
+        # operator there's nothing to share with, and capping would diverge
+        # from the original 1-op baseline, which left ``concurrency`` unset
+        # and used Ray Data's default unbounded ``TaskPoolStrategy``.
+        if args.num_operators > 1:
+            map_kwargs["concurrency"] = workers_per_operator
+        udf = make_realistic_schema_udf(
+            args.seed,
             args.num_scalar_cols,
             args.num_array_cols,
         )
-        num_rows = num_blocks * rows_per_block
+
+    ds_holder = {}
+
+    def benchmark_fn():
         ds = ray.data.range(num_rows, override_num_blocks=num_blocks)
-
-        # Split the total worker pool evenly across the chained operators so the
-        # cluster footprint stays the same regardless of --num-operators. With
-        # 5000 workers and 15 operators each operator gets ~333 workers, which
-        # mirrors production pipelines that pay the per-iteration cost of many
-        # ops with a moderately sized pool per op.
-        workers_per_operator = args.num_workers // args.num_operators
-
-        map_kwargs = {"num_cpus": 0.5}
-        if args.worker_type == "actors":
-            map_kwargs["compute"] = ray.data.ActorPoolStrategy(
-                size=workers_per_operator
-            )
-            udf = RealisticSchemaUDF
-            map_kwargs["fn_constructor_kwargs"] = {
-                "seed": args.seed,
-                "num_scalar_cols": args.num_scalar_cols,
-                "num_array_cols": args.num_array_cols,
-            }
-        else:
-            # ``concurrency`` caps in-flight tasks per operator. Without this
-            # cap, all tasks of a single operator can fan out across the entire
-            # cluster and the next operator in the chain starves — but the goal
-            # here is N_operators sharing the pool, so each gets
-            # ``workers_per_operator`` task slots.
-            #
-            # Only apply the cap when actually chaining operators. With a single
-            # operator there's nothing to share with, and capping would diverge
-            # from the original 1-op baseline, which left ``concurrency`` unset
-            # and used Ray Data's default unbounded ``TaskPoolStrategy``.
-            if args.num_operators > 1:
-                map_kwargs["concurrency"] = workers_per_operator
-            udf = make_realistic_schema_udf(
-                args.seed,
-                args.num_scalar_cols,
-                args.num_array_cols,
-            )
-
         for _ in range(args.num_operators):
             ds = ds.map_batches(udf, **map_kwargs)
-
-        ds = ds.materialize()
-        metrics = collect_dataset_stats(ds)
-        metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-        metrics["num_blocks"] = num_blocks
-        metrics["num_rows"] = num_rows
-        metrics["num_scalar_cols"] = args.num_scalar_cols
-        metrics["num_array_cols"] = args.num_array_cols
-        metrics["rows_per_block"] = rows_per_block
-        metrics["bytes_per_row"] = _bytes_per_row(
-            args.num_scalar_cols,
-            args.num_array_cols,
-        )
-        metrics["schema_pickled_bytes"] = len(pickle.dumps(ds.schema()))
-        metrics["num_operators"] = args.num_operators
-        metrics["workers_per_operator"] = workers_per_operator
-        return metrics
+        ds_holder["ds"] = ds.materialize()
 
     benchmark.run_fn("worker_scaling", benchmark_fn)
+
+    ds = ds_holder["ds"]
+    metrics = collect_dataset_stats(ds)
+    metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
+    metrics["num_blocks"] = num_blocks
+    metrics["num_rows"] = num_rows
+    metrics["num_scalar_cols"] = args.num_scalar_cols
+    metrics["num_array_cols"] = args.num_array_cols
+    metrics["rows_per_block"] = rows_per_block
+    metrics["bytes_per_row"] = _bytes_per_row(
+        args.num_scalar_cols,
+        args.num_array_cols,
+    )
+    metrics["schema_pickled_bytes"] = len(pickle.dumps(ds.schema()))
+    metrics["num_operators"] = args.num_operators
+    metrics["workers_per_operator"] = workers_per_operator
+    benchmark.result["worker_scaling"].update(metrics)
+
     benchmark.write_result()
 
 


### PR DESCRIPTION
## Description
As titled, i noticed that sometimes we have extra non-data related stuff in the `benchmark_fn` which can lead to variance in runtime outside of the ray data. I want to eliminate that
## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
