### PR TITLE
[Core] Fail loudly on an unhandled GetObjectStatus reply instead of hanging

### DIFF
--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -64,14 +64,6 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
     in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_DELETED),
                           object_id,
                           reference_counter_->HasReference(object_id));
-  } else if (reply.status() == rpc::GetObjectStatusReply::FREED) {
-    // The owner freed the value while our reference was in scope. The owner-side reply
-    // is still there behind no flag, and owners on released versions still have
-    // ray.internal.free, so this is not dead. The catch-all below would blame a node
-    // failure that did not happen.
-    in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_FREED),
-                          object_id,
-                          reference_counter_->HasReference(object_id));
   } else if (reply.status() == rpc::GetObjectStatusReply::CREATED) {
     // The object is either an indicator that the object is in Plasma, or
     // the object has been returned directly in the reply. In either
@@ -122,8 +114,8 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
                           reference_counter_->HasReference(object_id));
   } else {
     // Nothing above matched, so nothing would fill the store and a get on this
-    // object would block forever. Reachable from an owner on a newer version that
-    // has a status this build has never heard of.
+    // object would block forever. FREED is the only such status this build knows
+    // about; a peer on a newer version can send one it does not.
     RAY_LOG(WARNING).WithField(object_id)
         << "Owner replied with an object status this worker does not handle: "
         << static_cast<int>(reply.status());

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -64,15 +64,6 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
     in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_DELETED),
                           object_id,
                           reference_counter_->HasReference(object_id));
-  } else if (reply.status() == rpc::GetObjectStatusReply::FREED) {
-    // The owner replied that the object's value was freed while our reference
-    // was still in scope (ray.internal.free). Store an error so that an
-    // exception will be thrown immediately when the worker tries to get the
-    // value; otherwise nothing would ever fill the store and the get would
-    // block forever.
-    in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_FREED),
-                          object_id,
-                          reference_counter_->HasReference(object_id));
   } else if (reply.status() == rpc::GetObjectStatusReply::CREATED) {
     // The object is either an indicator that the object is in Plasma, or
     // the object has been returned directly in the reply. In either
@@ -119,6 +110,16 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
                                             inlined_ref.owner_address());
     }
     in_memory_store_->Put(RayObject(data_buffer, metadata_buffer, inlined_refs),
+                          object_id,
+                          reference_counter_->HasReference(object_id));
+  } else {
+    // No branch above matched, so nothing would fill the store and a get on this
+    // object would block forever. FREED is the only such status this build knows
+    // about; a peer on a newer version can send one it does not.
+    RAY_LOG(WARNING).WithField(object_id)
+        << "Owner replied with an object status this worker does not handle: "
+        << static_cast<int>(reply.status());
+    in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_LOST),
                           object_id,
                           reference_counter_->HasReference(object_id));
   }

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -64,6 +64,14 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
     in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_DELETED),
                           object_id,
                           reference_counter_->HasReference(object_id));
+  } else if (reply.status() == rpc::GetObjectStatusReply::FREED) {
+    // The owner freed the value while our reference was in scope. The owner-side reply
+    // is still there behind no flag, and owners on released versions still have
+    // ray.internal.free, so this is not dead. The catch-all below would blame a node
+    // failure that did not happen.
+    in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_FREED),
+                          object_id,
+                          reference_counter_->HasReference(object_id));
   } else if (reply.status() == rpc::GetObjectStatusReply::CREATED) {
     // The object is either an indicator that the object is in Plasma, or
     // the object has been returned directly in the reply. In either
@@ -113,9 +121,9 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
                           object_id,
                           reference_counter_->HasReference(object_id));
   } else {
-    // No branch above matched, so nothing would fill the store and a get on this
-    // object would block forever. FREED is the only such status this build knows
-    // about; a peer on a newer version can send one it does not.
+    // Nothing above matched, so nothing would fill the store and a get on this
+    // object would block forever. Reachable from an owner on a newer version that
+    // has a status this build has never heard of.
     RAY_LOG(WARNING).WithField(object_id)
         << "Owner replied with an object status this worker does not handle: "
         << static_cast<int>(reply.status());

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -113,9 +113,9 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
                           object_id,
                           reference_counter_->HasReference(object_id));
   } else {
-    // Nothing above matched, so nothing would fill the store and a get on this
-    // object would block forever. FREED is the only such status this build knows
-    // about; a peer on a newer version can send one it does not.
+    // Without this branch nothing fills the store and a get on the object blocks
+    // forever. It has to stay even once every named status has a branch: proto3 enums
+    // are open, so a reply can carry a value this build has no name for.
     RAY_LOG(WARNING).WithField(object_id)
         << "Owner replied with an object status this worker does not handle: "
         << static_cast<int>(reply.status());

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -64,6 +64,15 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
     in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_DELETED),
                           object_id,
                           reference_counter_->HasReference(object_id));
+  } else if (reply.status() == rpc::GetObjectStatusReply::FREED) {
+    // The owner replied that the object's value was freed while our reference
+    // was still in scope (ray.internal.free). Store an error so that an
+    // exception will be thrown immediately when the worker tries to get the
+    // value; otherwise nothing would ever fill the store and the get would
+    // block forever.
+    in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_FREED),
+                          object_id,
+                          reference_counter_->HasReference(object_id));
   } else if (reply.status() == rpc::GetObjectStatusReply::CREATED) {
     // The object is either an indicator that the object is in Plasma, or
     // the object has been returned directly in the reply. In either

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -57,7 +57,7 @@ ray_cc_test(
         "//src/mock/ray/pubsub:mock_publisher",
         "//src/ray/asio:instrumented_io_context",
         "//src/ray/common:ray_object",
-        "//src/ray/common:test_utils",
+        "//src/ray/common:status",
         "//src/ray/core_worker:future_resolver",
         "//src/ray/core_worker:memory_store",
         "//src/ray/core_worker:reference_counter",

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -49,6 +49,25 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "future_resolver_test",
+    size = "small",
+    srcs = ["future_resolver_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/mock/ray/pubsub:mock_publisher",
+        "//src/ray/asio:instrumented_io_context",
+        "//src/ray/common:ray_object",
+        "//src/ray/common:test_utils",
+        "//src/ray/core_worker:future_resolver",
+        "//src/ray/core_worker:memory_store",
+        "//src/ray/core_worker:reference_counter",
+        "//src/ray/observability:fake_metric",
+        "//src/ray/pubsub:fake_subscriber",
+        "//src/ray/util:clock",
+    ],
+)
+
+ray_cc_test(
     name = "reference_counter_test",
     size = "small",
     srcs = ["reference_counter_test.cc"],

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -64,6 +64,7 @@ ray_cc_test(
         "//src/ray/observability:fake_metric",
         "//src/ray/pubsub:fake_subscriber",
         "//src/ray/util:clock",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -1,0 +1,121 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/future_resolver.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "mock/ray/pubsub/publisher.h"
+#include "ray/common/test_utils.h"
+#include "ray/core_worker/reference_counter.h"
+#include "ray/observability/fake_metric.h"
+#include "ray/pubsub/fake_subscriber.h"
+#include "ray/util/clock.h"
+
+namespace ray {
+namespace core {
+
+class FutureResolverTest : public ::testing::Test {
+ public:
+  FutureResolverTest()
+      : io_context_("TestOnly.FutureResolverTest"),
+        publisher_(std::make_shared<pubsub::MockPublisher>()),
+        subscriber_(std::make_shared<pubsub::FakeSubscriber>()),
+        memory_store_(
+            std::make_shared<CoreWorkerMemoryStore>(io_context_.GetIoService(), clock_)),
+        ref_counter_(std::make_shared<ReferenceCounter>(
+            rpc::Address(),
+            publisher_.get(),
+            subscriber_.get(),
+            /*is_node_dead=*/[](const NodeID &) { return false; },
+            /*free_object_on_nodes_async=*/
+            [](const ObjectID &, const absl::flat_hash_set<NodeID> &) {},
+            *std::make_shared<ray::observability::FakeGauge>(),
+            *std::make_shared<ray::observability::FakeGauge>())),
+        resolver_(
+            memory_store_,
+            ref_counter_,
+            /*report_locality_data_callback=*/
+            [](const ObjectID &, const absl::flat_hash_set<NodeID> &, uint64_t) {},
+            /*core_worker_client_pool=*/nullptr,
+            rpc::Address()) {}
+
+  // Registers a local reference so that CoreWorkerMemoryStore::Put actually inserts
+  // the object. Without a reference, Put treats the object as added-and-immediately-
+  // deleted and GetIfExists would return null regardless of the resolved status.
+  ObjectID AddBorrowedObject() {
+    ObjectID object_id = ObjectID::FromRandom();
+    ref_counter_->AddLocalReference(object_id, "");
+    return object_id;
+  }
+
+ protected:
+  Clock clock_;
+  InstrumentedIOContextWithThread io_context_;
+  std::shared_ptr<pubsub::MockPublisher> publisher_;
+  std::shared_ptr<pubsub::FakeSubscriber> subscriber_;
+  std::shared_ptr<CoreWorkerMemoryStore> memory_store_;
+  std::shared_ptr<ReferenceCounter> ref_counter_;
+  FutureResolver resolver_;
+};
+
+// The owner replies FREED when the object was freed (ray.internal.free) while the
+// reference was still in scope. The borrower must store an error, otherwise a
+// ray.get() on the reference blocks forever with nothing ever filling the store.
+TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
+  ObjectID object_id = AddBorrowedObject();
+  rpc::GetObjectStatusReply reply;
+  reply.set_status(rpc::GetObjectStatusReply::FREED);
+
+  resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
+
+  auto object = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(object, nullptr);
+  rpc::ErrorType error_type;
+  ASSERT_TRUE(object->IsException(&error_type));
+  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_FREED);
+}
+
+// Sibling statuses, kept as regression anchors for the branch above.
+TEST_F(FutureResolverTest, ProcessResolvedObjectOutOfScopeStoresError) {
+  ObjectID object_id = AddBorrowedObject();
+  rpc::GetObjectStatusReply reply;
+  reply.set_status(rpc::GetObjectStatusReply::OUT_OF_SCOPE);
+
+  resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
+
+  auto object = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(object, nullptr);
+  rpc::ErrorType error_type;
+  ASSERT_TRUE(object->IsException(&error_type));
+  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_DELETED);
+}
+
+TEST_F(FutureResolverTest, ProcessResolvedObjectOwnerUnreachableStoresError) {
+  ObjectID object_id = AddBorrowedObject();
+  rpc::GetObjectStatusReply reply;
+
+  resolver_.ProcessResolvedObject(
+      object_id, rpc::Address(), Status::IOError("owner unreachable"), reply);
+
+  auto object = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(object, nullptr);
+  rpc::ErrorType error_type;
+  ASSERT_TRUE(object->IsException(&error_type));
+  ASSERT_EQ(error_type, rpc::ErrorType::OWNER_DIED);
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -85,8 +85,8 @@ class FutureResolverTest : public ::testing::Test {
   FutureResolver resolver_;
 };
 
-// The owner freed the value. Must report that, not let the catch-all blame a node
-// failure that never happened.
+// FREED is the one status this build knows that no branch handles, so it lands on the
+// catch-all. No owner on master can send it, but nothing stops one on the wire.
 TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;
@@ -98,11 +98,11 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ASSERT_NE(object, nullptr);
   rpc::ErrorType error_type;
   ASSERT_TRUE(object->IsException(&error_type));
-  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_FREED);
+  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
 }
 
-// A status this build has never heard of, which an owner on a newer version can send
-// during a rolling upgrade, has to leave an error too.
+// Same for a status this build has never heard of, which is what makes removing FREED
+// from the proto safe.
 TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;
@@ -117,7 +117,7 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
   ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
 }
 
-// Sibling statuses, kept as regression anchors for the two branches above.
+// Sibling statuses, kept as regression anchors for the branches above.
 TEST_F(FutureResolverTest, ProcessResolvedObjectOutOfScopeStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -18,8 +18,11 @@
 
 #include "gtest/gtest.h"
 #include "mock/ray/pubsub/publisher.h"
-#include "ray/common/test_utils.h"
+#include "ray/asio/asio_util.h"
+#include "ray/common/ray_object.h"
+#include "ray/common/status.h"
 #include "ray/core_worker/reference_counter.h"
+#include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/observability/fake_metric.h"
 #include "ray/pubsub/fake_subscriber.h"
 #include "ray/util/clock.h"
@@ -42,13 +45,17 @@ class FutureResolverTest : public ::testing::Test {
             /*is_node_dead=*/[](const NodeID &) { return false; },
             /*free_object_on_nodes_async=*/
             [](const ObjectID &, const absl::flat_hash_set<NodeID> &) {},
-            *std::make_shared<ray::observability::FakeGauge>(),
-            *std::make_shared<ray::observability::FakeGauge>())),
+            owned_object_count_by_state_,
+            owned_object_sizes_by_state_)),
         resolver_(
             memory_store_,
             ref_counter_,
             /*report_locality_data_callback=*/
             [](const ObjectID &, const absl::flat_hash_set<NodeID> &, uint64_t) {},
+            // These tests only drive ProcessResolvedObject, which never touches the
+            // client pool. A test for ResolveFutureAsync would need a real pool and a
+            // non-empty owner worker ID, otherwise it either dereferences this null
+            // pool or silently returns early as if we owned the object.
             /*core_worker_client_pool=*/nullptr,
             rpc::Address()) {}
 
@@ -61,9 +68,15 @@ class FutureResolverTest : public ::testing::Test {
     return object_id;
   }
 
+  // Stop the io thread before the members it may run callbacks against are
+  // destroyed.
+  void TearDown() override { io_context_.Stop(); }
+
  protected:
   Clock clock_;
   InstrumentedIOContextWithThread io_context_;
+  ray::observability::FakeGauge owned_object_count_by_state_;
+  ray::observability::FakeGauge owned_object_sizes_by_state_;
   std::shared_ptr<pubsub::MockPublisher> publisher_;
   std::shared_ptr<pubsub::FakeSubscriber> subscriber_;
   std::shared_ptr<CoreWorkerMemoryStore> memory_store_;

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -15,6 +15,8 @@
 #include "ray/core_worker/future_resolver.h"
 
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "absl/container/flat_hash_set.h"
 #include "gtest/gtest.h"
@@ -52,7 +54,14 @@ class FutureResolverTest : public ::testing::Test {
             memory_store_,
             ref_counter_,
             /*report_locality_data_callback=*/
-            [](const ObjectID &, const absl::flat_hash_set<NodeID> &, uint64_t) {},
+            [this](const ObjectID &object_id,
+                   const absl::flat_hash_set<NodeID> &locations,
+                   uint64_t object_size) {
+              locality_reports_++;
+              reported_object_id_ = object_id;
+              reported_locations_ = locations;
+              reported_object_size_ = object_size;
+            },
             // These tests only drive ProcessResolvedObject, which never touches the
             // client pool. A test for ResolveFutureAsync would need a real pool and a
             // non-empty owner worker ID, otherwise it either dereferences this null
@@ -63,7 +72,7 @@ class FutureResolverTest : public ::testing::Test {
   // Registers a local reference so that CoreWorkerMemoryStore::Put actually inserts
   // the object. Without a reference, Put treats the object as added-and-immediately-
   // deleted and GetIfExists would return null regardless of the resolved status.
-  ObjectID AddBorrowedObject() {
+  ObjectID NewObjectWithLocalRef() {
     ObjectID object_id = ObjectID::FromRandom();
     ref_counter_->AddLocalReference(object_id, "");
     return object_id;
@@ -82,13 +91,18 @@ class FutureResolverTest : public ::testing::Test {
   std::shared_ptr<pubsub::FakeSubscriber> subscriber_;
   std::shared_ptr<CoreWorkerMemoryStore> memory_store_;
   std::shared_ptr<ReferenceCounter> ref_counter_;
+  // Filled by report_locality_data_callback_.
+  int locality_reports_ = 0;
+  ObjectID reported_object_id_;
+  absl::flat_hash_set<NodeID> reported_locations_;
+  uint64_t reported_object_size_ = 0;
   FutureResolver resolver_;
 };
 
-// FREED is the one status this build knows that no branch handles, so it lands on the
-// catch-all. No owner on master can send it, but nothing stops one on the wire.
+// FREED is the one status named in this build that no branch handles, so it reaches the
+// catch-all without a cast.
 TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
-  ObjectID object_id = AddBorrowedObject();
+  ObjectID object_id = NewObjectWithLocalRef();
   rpc::GetObjectStatusReply reply;
   reply.set_status(rpc::GetObjectStatusReply::FREED);
 
@@ -101,10 +115,10 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
 }
 
-// Same for a status this build has never heard of, which is what makes removing FREED
-// from the proto safe.
+// A value this build has no name for. One case the catch-all exists for: proto3 enums
+// are open, so a reply can carry one.
 TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
-  ObjectID object_id = AddBorrowedObject();
+  ObjectID object_id = NewObjectWithLocalRef();
   rpc::GetObjectStatusReply reply;
   reply.set_status(static_cast<rpc::GetObjectStatusReply::ObjectStatus>(99));
 
@@ -117,9 +131,56 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
   ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
 }
 
-// Sibling statuses, kept as regression anchors for the branches above.
+// The branches that predate the catch-all. All of them pass without it, and are here so
+// that a later edit cannot reroute them into it unnoticed.
+
+// CREATED is the branch that carries the owner's reply through to the caller. An object
+// already in plasma comes back with data empty and only the marker in metadata, so this
+// is the case that catches a CREATED check narrowed to replies carrying data.
+TEST_F(FutureResolverTest, ProcessResolvedObjectCreatedInPlasmaStoresPlasmaMarker) {
+  ObjectID object_id = NewObjectWithLocalRef();
+  NodeID node_id = NodeID::FromRandom();
+  rpc::GetObjectStatusReply reply;
+  reply.set_status(rpc::GetObjectStatusReply::CREATED);
+  reply.mutable_object()->set_metadata(
+      std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA)));
+  reply.add_node_ids(node_id.Binary());
+  reply.set_object_size(1234);
+
+  resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
+
+  auto object = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(object, nullptr);
+  ASSERT_FALSE(object->HasData());
+  ASSERT_TRUE(object->IsInPlasmaError());
+  ASSERT_EQ(locality_reports_, 1);
+  ASSERT_EQ(reported_object_id_, object_id);
+  ASSERT_EQ(reported_locations_, absl::flat_hash_set<NodeID>{node_id});
+  ASSERT_EQ(reported_object_size_, 1234U);
+}
+
+// Python inlines a value with metadata alongside it, so set both. The assertion is on
+// the data because metadata of "PYTHON" makes IsException() false whether or not the
+// payload arrived.
+TEST_F(FutureResolverTest, ProcessResolvedObjectCreatedInlineStoresValue) {
+  ObjectID object_id = NewObjectWithLocalRef();
+  rpc::GetObjectStatusReply reply;
+  reply.set_status(rpc::GetObjectStatusReply::CREATED);
+  reply.mutable_object()->set_data("hello");
+  reply.mutable_object()->set_metadata("PYTHON");
+
+  resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
+
+  auto object = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(object, nullptr);
+  ASSERT_TRUE(object->HasData());
+  ASSERT_EQ(std::string_view(reinterpret_cast<const char *>(object->GetData()->Data()),
+                             object->GetData()->Size()),
+            "hello");
+}
+
 TEST_F(FutureResolverTest, ProcessResolvedObjectOutOfScopeStoresError) {
-  ObjectID object_id = AddBorrowedObject();
+  ObjectID object_id = NewObjectWithLocalRef();
   rpc::GetObjectStatusReply reply;
   reply.set_status(rpc::GetObjectStatusReply::OUT_OF_SCOPE);
 
@@ -132,8 +193,9 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectOutOfScopeStoresError) {
   ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_DELETED);
 }
 
+// An RPC failure rather than a reply status, so this one enters through !status.ok().
 TEST_F(FutureResolverTest, ProcessResolvedObjectOwnerUnreachableStoresError) {
-  ObjectID object_id = AddBorrowedObject();
+  ObjectID object_id = NewObjectWithLocalRef();
   rpc::GetObjectStatusReply reply;
 
   resolver_.ProcessResolvedObject(

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Ray Authors.
+// Copyright 2026 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "absl/container/flat_hash_set.h"
 #include "gtest/gtest.h"
 #include "mock/ray/pubsub/publisher.h"
 #include "ray/asio/asio_util.h"
@@ -73,7 +74,7 @@ class FutureResolverTest : public ::testing::Test {
   void TearDown() override { io_context_.Stop(); }
 
  protected:
-  Clock clock_;
+  FakeClock clock_;
   InstrumentedIOContextWithThread io_context_;
   ray::observability::FakeGauge owned_object_count_by_state_;
   ray::observability::FakeGauge owned_object_sizes_by_state_;
@@ -84,9 +85,8 @@ class FutureResolverTest : public ::testing::Test {
   FutureResolver resolver_;
 };
 
-// A status no branch handles must still leave an error in the store, otherwise a
-// ray.get() on the reference blocks forever with nothing ever filling it. FREED is
-// the only such status this build knows; no in-tree owner sends it today.
+// The owner freed the value. Must report that, not let the catch-all blame a node
+// failure that never happened.
 TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;
@@ -98,11 +98,11 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ASSERT_NE(object, nullptr);
   rpc::ErrorType error_type;
   ASSERT_TRUE(object->IsException(&error_type));
-  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
+  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_FREED);
 }
 
-// The same branch has to cover a status this build has never heard of, which is what
-// an owner on a newer version can send during a rolling upgrade.
+// A status this build has never heard of, which an owner on a newer version can send
+// during a rolling upgrade, has to leave an error too.
 TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;
@@ -117,7 +117,7 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
   ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
 }
 
-// Sibling statuses, kept as regression anchors for the branch above.
+// Sibling statuses, kept as regression anchors for the two branches above.
 TEST_F(FutureResolverTest, ProcessResolvedObjectOutOfScopeStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -84,9 +84,9 @@ class FutureResolverTest : public ::testing::Test {
   FutureResolver resolver_;
 };
 
-// The owner replies FREED when the object was freed (ray.internal.free) while the
-// reference was still in scope. The borrower must store an error, otherwise a
-// ray.get() on the reference blocks forever with nothing ever filling the store.
+// A status no branch handles must still leave an error in the store, otherwise a
+// ray.get() on the reference blocks forever with nothing ever filling it. FREED is
+// the only such status this build knows; no in-tree owner sends it today.
 TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ObjectID object_id = AddBorrowedObject();
   rpc::GetObjectStatusReply reply;
@@ -98,7 +98,23 @@ TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
   ASSERT_NE(object, nullptr);
   rpc::ErrorType error_type;
   ASSERT_TRUE(object->IsException(&error_type));
-  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_FREED);
+  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
+}
+
+// The same branch has to cover a status this build has never heard of, which is what
+// an owner on a newer version can send during a rolling upgrade.
+TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
+  ObjectID object_id = AddBorrowedObject();
+  rpc::GetObjectStatusReply reply;
+  reply.set_status(static_cast<rpc::GetObjectStatusReply::ObjectStatus>(99));
+
+  resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
+
+  auto object = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(object, nullptr);
+  rpc::ErrorType error_type;
+  ASSERT_TRUE(object->IsException(&error_type));
+  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
 }
 
 // Sibling statuses, kept as regression anchors for the branch above.


### PR DESCRIPTION
## Description

`FutureResolver::ProcessResolvedObject` branches on the outcomes it knows: an unreachable owner stores `OWNER_DIED`, `OUT_OF_SCOPE` stores `OBJECT_DELETED`, `CREATED` stores the value. Anything else falls off the end of the function, nothing is put into the memory store, and a borrower's `ray.get` on that reference blocks forever with no log line and no timeout. Nothing else fills the store either: `ResolveFutureAsync` sends one RPC and does not retry, `GetObjects` only falls through to plasma for entries that already carry `IsInPlasmaError`, and the `OWNER_DIED` put in this function is the only one in the tree.

This adds a catch-all that stores `OBJECT_LOST` and logs the numeric status. `OBJECT_LOST` is the enum's documented fallback for unexpected conditions. The branch has to stay even once every named status has its own arm: proto3 enums are open, so a reply can carry a value this build has no name for.

@Yicheng-Lu-llll — thanks, and agreed on `ray.internal.free`. The FREED-specific branch is gone; a reply carrying that status now reaches the catch-all like any other unhandled value. I stopped short of asserting the status is unreachable, because `freed_objects_` still gets written outside the deleted API: `SealExisting` calls `FreePlasmaObjects` on its `pin_object == false` path, which is what `HandleGetObjectStatus` tests before replying `FREED`. What I could not close is whether a borrower ever observes it — that needs the reference serialized before the seal and the RPC arriving after. The catch-all behaves the same either way, so the fix does not rest on the answer, and neither do the comments.

Removing `FREED` from the proto is a good follow-up and I am happy to take it. It is not a pure deletion: the setter in `core_worker.cc` and the seal path above go with it, so it is worth its own PR rather than riding along here.

## Related issues

Fixes #65269

No open PR touches `future_resolver.cc`; #65269 has no other linked PR.

## Additional information

`future_resolver.cc` had no test file. This adds one with six cases, each branch pinned by its own case. Checked in the failing direction, one edit at a time:

| edit | cases that fail |
|-|-|
| delete the catch-all | FREED, unknown-status |
| narrow the catch-all to `else if (FREED)` | unknown-status |
| narrow `CREATED` to replies carrying data | CREATED in-plasma |
| delete the locality report | CREATED in-plasma |

The two `CREATED` cases cover the forms the owner actually sends: an in-plasma marker with data empty, and an inlined value. Only the in-plasma one catches a narrowed `CREATED` check, since data empty is exactly what such a check would test. The unknown-status case sets the field to `99` with a cast, which is well defined — proto3 enums are open and protoc emits an `int`-backed type.

Commands, on macOS 15.5 / arm64 with Apple clang 21. The two extra flags work around that toolchain, not this change (a deprecated builtin in the pinned absl, and a `.dylib` link failure in `com_google_googleapis`):

```
bazel build --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/core_worker/tests:future_resolver_test
./bazel-bin/src/ray/core_worker/tests/future_resolver_test
```

```
[==========] 6 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 6 tests.
```

`pre-commit run` passes `clang-format`, `cpplint` and `buildifier` on the changed files.

Not verified: I have not run a mixed-version cluster.

## AI assistance

AI assistance was used for this change and for the reviews of it. I have read every changed line and run the tests above locally.
