### PR TITLE
[doc] Document the documentation CI checks and the local API-check recipe

### DIFF
--- a/doc/.claude/CLAUDE.md
+++ b/doc/.claude/CLAUDE.md
@@ -11,14 +11,21 @@ Author new files under `doc/source/` as MyST Markdown (`.md`). A lint check reje
 
 ## How CI is configured
 
-`.buildkite/test.rules.txt` maps file-change patterns to tag sets, and tags drive which CI suites run. The `doc` tag covers content under `doc/`, `doc/requirements-doc.txt`, `.vale.ini`/`.vale/`, and `.buildkite/doc.rayci.yml`. Docs-only deplock changes (`python/deplocks/docs/*.lock`, `ci/raydepsets/configs/docs.depsets.yaml`) tag to `doc python_dependencies` to skip the full python-deps test set.
+`.buildkite/test.rules.txt` maps file-change patterns to tag sets, and tags drive which CI suites run. Documentation routing splits three ways:
+
+- **`doc`** is build and validation infrastructure, not content: `.readthedocs.yaml`, `doc/requirements-doc.txt`, `.buildkite/doc.rayci.yml`, `.vale.ini`/`.vale/`, and the build scripts under `doc/`. Docs-only deplock changes (`python/deplocks/docs/*.lock`, `ci/raydepsets/configs/docs.depsets.yaml`) tag `doc doc_api python_dependencies` to skip the full python-deps test set.
+- **`<lib>_doc`** (`core_doc`, `data_doc`, `ml_doc`, `rllib_doc`, `serve_doc`) routes executable doc assets to that library's `<library>: docs example tests` step, so a one-library doc change runs only that library's examples. Ray Core owns the fallback; `doc/source/llm/` routes to the general `llm` tag instead.
+- **`doc_api`** covers the API reference pages and autodoc machinery. It's the entire trigger for the two API-consistency checks, which carry no `if:` guard, so a surface that stops emitting `doc_api` stops being checked silently.
+
+Prose and images trigger nothing: a change to only `.md`, `.rst`, or image files under `doc/` runs no library test steps. Config assets examples consume (`.yaml`, `.sh`) still route to the owning library, because they can change what a test does. Contributor-facing detail: `doc/source/ray-contribute/ci.md`.
 
 ## Scope discipline for PRs
 
 For docs-only fixes, take the lightest path:
 
-- Touch only files mapped to the `doc` tag.
+- Touch only files under `doc/`. A prose-only change runs no library tests at all, the cheapest path there is.
 - Don't bundle in a non-doc change "while you're at it" — that change pulls its own (often expensive) test set into the PR.
+- The `docs-go` label skips the per-library docs example steps on a content-only PR. A guard step, `lint: validate docs-go scope`, fails unless the PR is content-only, so the label never skips tests on a code, CI, or build change.
 - If a docs change requires a non-doc change to land cleanly (e.g., autodoc references a renamed symbol), land them in the larger non-doc PR, not a docs-led PR.
 
 For generated API docs that depend on Python source under `python/ray/...`, expect broader test runs. That's correct, not a misconfiguration.
@@ -29,7 +36,7 @@ Every commit on a `ray-project/ray` PR needs a `Signed-off-by:` trailer (Develop
 
 ## When to revise the test rules
 
-If a docs-only PR hits unnecessarily broad tests, file a `.buildkite/test.rules.txt` PR (precedent: #63132) instead of working around it. Quick check: does the file change affect any non-`doc` build artifact, runtime behavior, or API surface? If no, tag it `doc`.
+If a docs-only PR hits unnecessarily broad tests, file a `.buildkite/test.rules.txt` PR (precedent: #63132) instead of working around it. Quick check: can the file change any build artifact, runtime behavior, or API surface? If no, it belongs on the prose skip rule or the owning library's `<lib>_doc` tag, not on a library's full test set.
 
 ## Cross-references between .md and .rst sources
 

--- a/doc/.claude/CLAUDE.md
+++ b/doc/.claude/CLAUDE.md
@@ -25,7 +25,7 @@ For docs-only fixes, take the lightest path:
 
 - Touch only files under `doc/`. A prose-only change runs no library tests at all, the cheapest path there is.
 - Don't bundle in a non-doc change "while you're at it" — that change pulls its own (often expensive) test set into the PR.
-- The `docs-go` label skips the per-library docs example steps on a content-only PR. A guard step, `lint: validate docs-go scope`, fails unless the PR is content-only, so the label never skips tests on a code, CI, or build change.
+- The `docs-go` label skips the per-library docs example steps on a content-only PR. It's optional, and applying it takes write access, so suggest it to the reviewer rather than assuming the PR author can add it. A guard step, `lint: validate docs-go scope`, fails unless the PR is content-only, so the label never skips tests on a code, CI, or build change.
 - If a docs change requires a non-doc change to land cleanly (e.g., autodoc references a renamed symbol), land them in the larger non-doc PR, not a docs-led PR.
 
 For generated API docs that depend on Python source under `python/ray/...`, expect broader test runs. That's correct, not a misconfiguration.

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -131,7 +131,7 @@ PYTHONPATH="$(pwd)" python doc/source/api_autogen.py
 PYTHONPATH="$(pwd)" python ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
 ```
 
-Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.
+Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. These team names don't line up with the docs example test steps above, so two cases need translating: the `ml` step covers `train` and `tune`, which the check treats as separate teams, and there's no `llm` team at all, because `ray.data.llm` is walked under `data` and `ray.serve.llm` under `serve`. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.
 
 A bare Ray wheel doesn't pull in `pandas`, so locally the check mocks it where CI walks it for real. Install `pandas` in the virtual environment when you're checking the `data` team.
 

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -22,7 +22,7 @@ These tests are designed to be 90% accurate at catching bugs on your PR while ru
   git commit -a -s
 
   // content of the commit message
-  run other serve doc tests
+  run other serve docs example tests
 
   @microcheck //doc:source/serve/doc_code/distilbert //doc:source/serve/doc_code/object_detection //doc:source/serve/doc_code/stable_diffusion
 
@@ -38,3 +38,103 @@ If microcheck passes, you'll see a green checkmark on your PR. If it fails, you'
 If you're a committer, add the `go` label to your PR once it's ready, then merge after the full suite passes. Clicking **Enable auto-merge** does both in one step: it adds the `go` label and merges the PR automatically once the suite passes. Pushing a new commit disables auto-merge, so re-enable it afterward. When you review an external contributor's PR, add the `go` label for them, since they can't add it themselves.
 
 If you're an external contributor, adding the `go` label and enabling auto-merge both require write access, so a committer runs the full suite and merges when your PR is ready.
+
+## Documentation CI checks
+
+A change under `doc/` runs a different set of checks than a code change, and which ones run depends on the kind of file you touched. Ray routes documentation changes by path, so a change to one library's docs doesn't run every other library's tests.
+
+### The Read the Docs render gate
+
+Read the Docs builds the site on your PR and reports the `docs/readthedocs.com:anyscale-ray` check. The build runs `make -C doc html` with `fail_on_warning: true`, so any Sphinx warning fails it. A malformed directive, a broken cross-reference, or a page missing from a toctree surfaces here rather than in Buildkite.
+
+The preview build skips when your PR changes nothing under `doc/` and nothing in `.readthedocs.yaml`. Files under `doc/.claude/` don't count, because they never participate in the Sphinx build. This check isn't a required merge gate, but a red render gate almost always means the published page is broken.
+
+### The API surface checks
+
+Two Buildkite steps cross-check the documented API surface against the code:
+
+* `doc: check API annotations` verifies the `@PublicAPI`, `@DeveloperAPI`, and `@Deprecated` annotations in the source.
+* `doc: check API doc consistency` verifies that the annotated surface and the surface documented in the API reference pages agree.
+
+Both run when you change library code, and also when you change an API reference page such as `doc/source/data/api/` or the autodoc machinery under `doc/source/_ext/`. Those paths carry a dedicated `doc_api` tag so an API page edit still reaches the checks, even though it's a documentation change. To reproduce the second check on your own machine, see [Running the API consistency check locally](#running-the-api-consistency-check-locally).
+
+### Per-library docs example tests
+
+Each library runs the executable examples in its own documentation in a step named `<library>: docs example tests`. These execute the `doctest`, `testcode`, and `literalinclude` snippets described in [How to write code snippets](writing-code-snippets.md).
+
+The steps are path-scoped, so editing one library's docs runs only that library's examples:
+
+| Path you change | Step that runs | Tag |
+| --- | --- | --- |
+| `doc/source/ray-core/`, `doc/source/ray-observability/` | `core: docs example tests` | `core_doc` |
+| `doc/source/data/`, `doc/source/ray-more-libs/` | `data: docs example tests`, `data: dask docs example tests` | `data_doc` |
+| `doc/source/train/`, `doc/source/tune/`, `doc/source/ray-air/` | `ml: docs example tests` | `ml_doc` |
+| `doc/source/rllib/` | `rllib: docs example tests` | `rllib_doc` |
+| `doc/source/serve/` | `serve: docs example tests` | `serve_doc` |
+
+Ray Core owns the fallback: an executable doc asset that doesn't sit under one of these directories routes to `core: docs example tests`. Ray LLM is the exception to the pattern, because `doc/source/llm/` routes to the general `llm` tag rather than a dedicated docs example step.
+
+The `doc` tag itself no longer selects these steps. It now covers the documentation build and validation infrastructure, such as `.readthedocs.yaml` and the docs dependency locks.
+
+### What a prose-only change runs
+
+Narrative documentation and images don't block premerge. A PR that changes only `.md`, `.rst`, or image files under `doc/` runs no library test steps at all. Neither can change tested code, and the post-merge documentation build is the coverage for them. Executable assets such as `.py` and `.ipynb` still route to the owning library, and so do config assets that examples consume, such as `.yaml` and `.sh`, because those can change what a test does.
+
+Three lints run on every PR whatever you changed: a README check, a ban on newly added `.rst` files, since new pages must be MyST Markdown, and a documentation style linter.
+
+### Skipping example tests with the docs-go label
+
+Adding the `docs-go` label skips the per-library docs example steps. It's for a content-only PR where executing the examples adds nothing.
+
+A guard step, `lint: validate docs-go scope`, bounds what the label can skip. It runs whenever the label is present and fails unless the PR changes only content under `doc/`. So the label skips example tests on a prose change but never on a code, CI, or build change. The API surface checks ignore the label by design, since an API reference page edit is exactly the content-only change they need to cover.
+
+### What doesn't run on your PR
+
+Two heavier steps are post-merge only, and both carry `skip-on-premerge`:
+
+* `doc: build` renders the site with `make html` and uploads the build artifacts to S3, which it does only on `master`.
+* `doc: linkcheck` validates links and is soft-fail, so it reports without blocking.
+
+For building and previewing the docs on your own machine, see [Contributing to the Ray documentation](docs.md).
+
+## Running the API consistency check locally
+
+The `doc: check API doc consistency` premerge step runs the `api_policy_check` function in `ci/lint/lint.sh`, which does three things: installs Ray from your checkout with `--no-deps`, generates the autosummary stub `.rst` files with `doc/source/api_autogen.py`, then runs `ci/ray_ci/doc/cmd_check_api_discrepancy.py`. The checker compares each team's documented API surface against the annotated (`@PublicAPI`/`@DeveloperAPI`/`@Deprecated`) surface in the code, importing Ray's own symbols for real. So it needs an environment where Ray installs and imports, which is the opposite of the docs *build* environment, which deliberately doesn't install Ray (see [Building the Ray documentation](docs.md#building-the-ray-documentation)).
+
+The optional third-party backends that some surfaces pull in at import time don't have to be installed. Examples include the vLLM and SGLang stack behind `ray.data.llm` and `ray.serve.llm`, and the deep-learning backends behind `ray.train`, `ray.tune`, and `ray.rllib`. The check mocks whichever of them are absent, reading the list from `doc/source/api_mock_imports.py`, the same source of truth the docs build uses for `autodoc_mock_imports`. It mocks only the absent ones, because shadowing an installed library breaks the plain `import` the walk relies on.
+
+### The faithful environment: the docbuild image
+
+CI runs this check inside the `docbuild` image (`ci/docker/doc.build.Dockerfile`). The image doesn't pip-install Ray. It stages the prebuilt `ray-core` and `ray-dashboard` artifacts into `/opt/ray-build` on top of the `oss-ci-base_build` base image, then installs the docs dependency lock (`python/deplocks/docs/docbuild_depset_py3.11.lock`), which is where Sphinx and Jinja2 come from. At step time `lint.sh` unpacks those artifacts and runs `pip install -e "python[all]" --no-deps`, so the walked surface is your checkout's source over prebuilt compiled extensions.
+
+The base image supplies `python/requirements.txt`, so a few of the libraries the walk imports are real rather than mocked, `pandas` most notably. The heavy deep-learning backends aren't installed even in CI: `torch`, `transformers`, and `tensorflow` are all mocked there too. Because the lock pins Linux wheels, the only fully faithful local reproduction is the Linux docbuild image through Docker, or a CI run on your branch.
+
+### A lightweight local approximation
+
+For quick iteration on the checker itself, a Python 3.11 virtual environment with a nightly Ray wheel and Sphinx is usually enough. Sphinx isn't a Ray dependency, and both halves of the step need it: the checker imports `sphinx.ext.autodoc.mock` and the stub generator imports `sphinx.ext.autosummary`. You generally don't need to install the mocked backends by hand. Install one for real only when you want the check to walk that library's true surface instead of a mock.
+
+```bash
+uv venv --python 3.11 ~/.virtualenvs/ray-apiref
+source ~/.virtualenvs/ray-apiref/bin/activate
+
+# The wheel URL below is macOS arm64 / Python 3.11. Adjust it for your OS, architecture, and Python version.
+uv pip install sphinx \
+  "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl"
+
+# Link your checkout's Python files over the wheel so the check walks your local @PublicAPI changes, not the wheel's:
+python python/ray/setup-dev.py --yes
+
+# Generate the autosummary stubs the check reads, as CI does in the same step:
+PYTHONPATH="$(pwd)" python doc/source/api_autogen.py
+
+# Run the check against your checkout (PYTHONPATH so the checker imports from your tree):
+PYTHONPATH="$(pwd)" python ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
+```
+
+Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.
+
+A bare Ray wheel doesn't pull in `pandas`, so locally the check mocks it where CI walks it for real. Install `pandas` in the virtual environment when you're checking the `data` team.
+
+```{warning}
+`setup-dev.py` links your checkout's Python packages over the wheel, so the walked `@PublicAPI` surface reflects your local changes. The rest of the wheel (compiled extensions and generated code) is still the nightly build, cut at a different commit than your checkout, so treat a clean local run as a fast iteration signal rather than a definitive result. For sign-off, rely on the CI run in the docbuild image.
+```

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -82,9 +82,9 @@ Narrative documentation and images don't block premerge. A PR that changes only 
 
 Three lints run on every PR whatever you changed: a README check, a ban on newly added `.rst` files, since new pages must be MyST Markdown, and a documentation style linter.
 
-### Skipping example tests with the docs-go label
+### Skipping example tests with the `docs-go` label
 
-Adding the `docs-go` label skips the per-library docs example steps. It's for a content-only PR where executing the examples adds nothing.
+Adding the `docs-go` label skips the per-library docs example steps. It's optional. Reach for it on a content-only PR where executing the examples adds nothing and you don't want to wait on them. Like the `go` label, it requires write access, so an external contributor asks a reviewer to add it.
 
 A guard step, `lint: validate docs-go scope`, bounds what the label can skip. It runs whenever the label is present and fails unless the PR changes only content under `doc/`. So the label skips example tests on a prose change but never on a code, CI, or build change. The API surface checks ignore the label by design, since an API reference page edit is exactly the content-only change they need to cover.
 
@@ -131,7 +131,7 @@ PYTHONPATH="$(pwd)" python doc/source/api_autogen.py
 PYTHONPATH="$(pwd)" python ci/ray_ci/doc/cmd_check_api_discrepancy.py "$(pwd)" serve
 ```
 
-Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. These team names don't line up with the docs example test steps above, so two cases need translating: the `ml` step covers `train` and `tune`, which the check treats as separate teams, and there's no `llm` team at all, because `ray.data.llm` is walked under `data` and `ray.serve.llm` under `serve`. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.
+Pass a single team (`core`, `data`, `serve`, `train`, `tune`, `rllib`) to check one surface, or pass `ALL` or omit the argument to check every team. These team names don't line up with the steps in [Per-library docs example tests](#per-library-docs-example-tests), so two cases need translating: the `ml` step covers `train` and `tune`, which the check treats as separate teams, and there's no `llm` team at all, since the check walks `ray.data.llm` under `data` and `ray.serve.llm` under `serve`. Two things only happen on the full pass. Every team after `core` depends on `core` running first, and the cross-team guard that catches annotated public subpackages no team's walk reaches runs at the end. Run without a team argument before you trust a green result.
 
 A bare Ray wheel doesn't pull in `pandas`, so locally the check mocks it where CI walks it for real. Install `pandas` in the virtual environment when you're checking the `data` team.
 


### PR DESCRIPTION
## Why this change

`doc/source/ray-contribute/ci.md` explains what CI runs on a PR, but stops at `microcheck` and the `go` label. It says nothing about what runs when the PR changes documentation, which is the case the page's likely reader is in.

This adds that, and folds in a recipe for reproducing the API consistency check locally.

### What's new

**"Documentation CI checks"** covers, in the order a contributor meets them:

- The Read the Docs render gate, including that `fail_on_warning: true` makes any Sphinx warning a build failure, and when the preview build skips.
- The two API surface checks, and the `doc_api` tag that lets an API reference page edit reach them even though it's a documentation change.
- The per-library `<library>: docs example tests` steps, with a table mapping path to step to tag, plus the Ray Core fallback and the Ray LLM exception.
- That a prose-only or image-only change runs no library test steps at all.
- The `docs-go` label and the `lint: validate docs-go scope` guard that bounds it.
- The two post-merge-only steps, `doc: build` and `doc: linkcheck`.

**"Running the API consistency check locally"** documents the three phases of `api_policy_check`, what the `docbuild` image does and doesn't install (the deep-learning backends are mocked even in CI), and a `uv` recipe that gets close enough for iteration.

It also updates one example commit message under the `microcheck` section that named the old `serve doc tests` step label.

**`doc/.claude/CLAUDE.md`** carried the same staleness, so it's fixed in the same PR. It still said the `doc` tag "covers content under `doc/`", which stopped being true when #64775 landed. It now describes the three-way split (`doc` for build and validation infra, `<lib>_doc` for executable doc assets, `doc_api` for the API reference surface), records that prose and images trigger nothing, and documents the `docs-go` label and its scope guard. Two smaller drifts are corrected alongside: the docs deplock rule emits `doc_api` now too, and the "tag it `doc`" advice pointed at a tag that no longer selects content steps.

This file is an agent instruction file rather than published documentation, so it's worth saying why it rides along here instead of going out separately. `AGENTS.md` requires a dedicated PR for changes to itself, which this isn't. `doc/.claude/` is on the skip rule in `test.rules.txt` and excluded from the Read the Docs build guard, so including it changes this PR's trigger set by nothing. And it's the same factual correction as the page, from the same source reading — splitting them would mean verifying the same CI configuration twice and risking the two descriptions drifting apart again.

## Not a duplicate

This supersedes two of my own open PRs and replaces both:

- #64842 added a documentation CI overview. It was written before #64775 landed and describes the pre-rework model, where a single `doc` tag selected the per-team doc test steps. That's no longer how routing works, so landing it as-is would have documented the wrong thing.
- #64450 added the local API-check section. Its content is carried over here essentially unchanged.

Both branched from the same pre-#64775 commit and added an identically titled section, so they also conflicted with each other. Combining them is cheaper to review than rebasing two PRs that overlap.

I'm not aware of another open PR touching this page. Checked with `gh pr list --repo ray-project/ray --state open --search "ray-contribute ci.md"`.

## Verification

Every factual claim was checked against `master` at `695a8814ea` rather than carried over from the superseded PRs:

- Step labels, tags, and `if:` guards read from `.buildkite/doc.rayci.yml`, `core.rayci.yml`, `data.rayci.yml`, `ml.rayci.yml`, `rllib.rayci.yml`, `serve.rayci.yml`, and `lint.rayci.yml`.
- Path-to-tag routing read from `.buildkite/test.rules.txt`.
- The render gate behavior read from `.readthedocs.yaml` (`fail_on_warning: true`, the `post_checkout` skip guard) and `doc/Makefile`.
- The mocked-backend claim checked against `ci/docker/doc.build.Dockerfile`, which stages the `ray-core` and `ray-dashboard` artifacts and installs only the docs lock, and `doc/source/api_mock_imports.py`, which lists `torch`, `transformers`, and `tensorflow`. This corrects #64842, which claimed the base images supply those libraries for real.
- `doc: build`'s upload behavior read from `ci/ray_ci/doc/cmd_build.py` (postmerge, `master` only).
- The `docs/readthedocs.com:anyscale-ray` check name confirmed from the status checks on an open PR.

Commands run:

```
vale --config=.vale.ini doc/source/ray-contribute/ci.md
python doc/test_no_new_rst.py
pre-commit run --files doc/source/ray-contribute/ci.md
```

`test_no_new_rst.py` passes. `pre-commit` reports no applicable hooks for a Markdown file under `doc/source/`. Vale surfaces no new findings in the added text beyond spelling hits on project vocabulary (`Buildkite`, `premerge`, `docbuild`, `autodoc`, `autosummary`, `toctree`); note that CI's `documentation_style` lint scopes Vale to `doc/source/data` and `doc/source/ray-overview/examples`, so this page isn't in its path set.

The same source reading backs the `doc/.claude/CLAUDE.md` edit; it asserts nothing the page doesn't.

Rendering verified by parsing the page with `myst-parser` using the repo's `myst_heading_anchors = 4`: the table, the `{warning}` directive, and the heading hierarchy all parse, with no skipped heading levels. Both cross-references (`writing-code-snippets.md`, `docs.md#building-the-ray-documentation`) point at existing `.md` sources and an existing heading. The Read the Docs preview on this PR is the real render check.

## AI assistance

AI assistance (Claude Code) was used to draft this change and to cross-check the claims against the CI configuration. I've reviewed every line.
