### PR TITLE
[ci] Stop routing unexecutable doc assets to the core docs example step

### DIFF
--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -126,12 +126,31 @@ doc/source/data/images/dataset-arch.png:
 doc/source/train/images/overview.jpg:
 doc/source/tune/images/tune-flow.gif:
 # Config and script assets a doc example consumes can change what the test
-# does, so under a library doc dir they keep routing to that library. Under an
-# unowned dir they still fall through to the trailing `doc/` skip, because the
-# catch-all matches only .py, .ipynb, and BUILD.bazel. That is unchanged from
-# before this rework, and none of those assets is a bazel test dep today.
+# does, so under a library doc dir they keep routing to that library.
 doc/source/serve/doc_code/config.yaml: serve_doc
-doc/source/cluster/doc_code/slurm-basic.sh:
+# Under an unowned dir the asset is not a test input at all -- no bazel target
+# covers doc/source/cluster/doc_code/ -- but a rendered page literalincludes it,
+# so it routes to the build. This asserts the whole directory lands on `doc`
+# regardless of extension: the .sh here and the .py sibling below must agree,
+# since it is the include that matters, not whether the catch-all's .py/.ipynb
+# patterns happen to reach the file.
+doc/source/cluster/doc_code/slurm-basic.sh: doc
+doc/source/cluster/doc_code/slurm-launch.py: doc
+doc/source/ray-contribute/doc_code/example_module.py: doc
+# Starter templates and the authoring boilerplate are excluded from the Sphinx
+# build and back no bazel target, so they emit nothing at all. 05 is the lone
+# exception: a rendered Train page literalincludes its sources, so those route
+# to the build like any other include input.
+doc/source/templates/01_batch_inference/start.ipynb:
+doc/source/templates/03_serving_stable_diffusion/app.py:
+doc/source/templates/04_finetuning_llms_with_deepspeed/utils.py:
+doc/source/_templates/template.ipynb:
+doc/source/templates/05_dreambooth_finetuning/dreambooth/train.py: doc
+# The leading prose-and-image skip still wins inside a `doc`-routed directory,
+# so an image or README under 05 emits nothing. Locks in that the new rule did
+# not accidentally reorder past that skip.
+doc/source/templates/05_dreambooth_finetuning/dreambooth/images/lego-car/1.jpg:
+doc/source/templates/05_dreambooth_finetuning/README.md:
 # Documentation validation infra stays on the `doc` tag. The Sphinx config, the
 # modules it imports, the in-repo build extensions, and the doc-build helper
 # scripts build the docs, so they route to the `doc` build and validation only,

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -343,6 +343,27 @@ doc/source/train/examples.yml
 # build renders it (`nb_execution_mode` is `off`, so render-and-lint only, no
 # execution), which is the only validation premerge actually offers here.
 doc/source/ray-core/examples/highly_parallel.ipynb
+# Snippet sources that a rendered page pulls in with `literalinclude`. No bazel
+# target executes any of them, so the docs example steps have nothing to run;
+# but Sphinx reads them at build time, so renaming or deleting one breaks the
+# page that includes it. Route them to the build, which is the only check that
+# can catch that. Same reasoning as highly_parallel.ipynb above: render-and-lint
+# is the validation premerge actually offers for these files.
+#
+# Images and prose under these directories are unaffected -- the leading skip
+# rule matches them first, as it does everywhere else in the tree. So the
+# dreambooth page's `.. image::` targets stay skipped, consistent with every
+# other doc image, even though a rename would break the build the same way.
+# Widening the image policy is a separate decision and belongs in that rule.
+#
+# These are directory rules, matching how doc/external/ is handled below, so a
+# few non-included assets under 05 (its Dockerfile, compute configs, and
+# requirements.txt) start the build too. That is a deliberate trade: the build
+# is the cheap step, and enumerating individual include targets would rot the
+# moment someone adds a literalinclude.
+doc/source/templates/05_dreambooth_finetuning/
+doc/source/cluster/doc_code/
+doc/source/ray-contribute/doc_code/
 @ doc
 ;
 
@@ -411,9 +432,25 @@ doc/external/
 @ ml_doc
 ;
 
-# Any remaining executable doc asset (cluster/, ray-contribute/, other
-# unowned doc dirs, and any example BUILD.bazel outside the library dirs
-# above) falls to the core docs example step as the catch-all owner.
+# Starter-template sources and the notebook authoring boilerplate. Sphinx never
+# reads any of these: `exclude_patterns` in doc/source/conf.py drops
+# `templates/*` from the build outright, and `_templates/template.ipynb` is a
+# file contributors copy, not a page. Nothing includes them either -- 01 through
+# 03 have no reference anywhere in the repo, and 04 is cited only as a GitHub
+# URL, from train/deepspeed.rst, train/huggingface-accelerate.rst, and the train
+# examples gallery, none of which any build step resolves. They also back no bazel target: doc/BUILD.bazel names
+# source/templates/ exactly once, as a doctest exclusion. So the catch-all was
+# starting the core docs example step for files that step cannot run and the
+# build does not read. 05_dreambooth_finetuning is the exception and is routed
+# to `doc` above, because a rendered Train page literalincludes it.
+doc/source/templates/
+doc/source/_templates/
+# pass
+;
+
+# Any remaining executable doc asset (other unowned doc dirs, and any example
+# BUILD.bazel outside the library dirs above) falls to the core docs example
+# step as the catch-all owner.
 #
 # `doc/test_myst_doc.py` lands here too. It is the shared notebook runner behind
 # every library's example targets, so a change to it could in principle break


### PR DESCRIPTION
## Why this change

The trailing catch-all in `.buildkite/test.rules.txt` routes any remaining `.py` or `.ipynb` under `doc/` to `core_doc`. For a few directories that starts Ray Core's docs example step for files the step cannot run, because no bazel target covers them:

- `doc/BUILD.bazel` names `source/templates/` exactly once, and it's a doctest *exclusion*.
- Nothing covers `doc/source/cluster/doc_code/`, `doc/source/ray-contribute/doc_code/`, or `doc/source/_templates/`.

So the step spins up, runs Core's own targets, and never touches the file that changed. Cost without signal.

This is a follow-on to #64775, which introduced the per-library `<lib>_doc` tags and left this population on the catch-all deliberately, pending a check of what was actually there.

## What it does

Splits the population by what the documentation build actually reads.

**Routed to `doc` (build and validation only).** Sources a rendered page pulls in with `literalinclude`. Nothing executes them, but Sphinx reads them, so a rename or delete breaks the including page and the build is the only premerge check that can catch it. Same reasoning #64775 applied to `highly_parallel.ipynb`.

- `doc/source/cluster/doc_code/` — included by four `cluster/vms/user-guides/community/` pages
- `doc/source/ray-contribute/doc_code/` — included 3x by `writing-code-snippets.md`
- `doc/source/templates/05_dreambooth_finetuning/` — included ~12x by `train/examples/pytorch/dreambooth_finetuning.rst`

**Skipped.** `exclude_patterns` in `doc/source/conf.py` drops `templates/*` from the build outright, so Sphinx never reads any of it. `01`–`03` have no reference anywhere in the repo; `04` is cited only as a GitHub URL from `train/deepspeed.rst`, `train/huggingface-accelerate.rst`, and the Train examples gallery, none of which a build step resolves. `_templates/template.ipynb` is boilerplate contributors copy, linked as a GitHub URL from `ray-contribute/docs.md`.

- `doc/source/templates/` (01 through 04)
- `doc/source/_templates/`

Images and prose under the `doc`-routed directories are unaffected: the leading prose-and-image skip still matches them first, as everywhere else in the tree. The dreambooth page's `.. image::` targets therefore stay skipped, consistent with every other doc image. Widening that is a separate decision and belongs in that rule.

## Blast radius

Dry-ran `ci/pipeline/determine_tests_to_run.py` over **all 10,255 tracked files**, before and after:

- **33 paths change routing. All are under `doc/`. Zero outside.**
- 14 move `core_doc` → `doc` (the `literalinclude` sources)
- 11 move `core_doc` → nothing (templates 01–04, `_templates`)
- 8 move nothing → `doc` (non-`.py` include inputs such as `slurm-basic.sh`, `ray-skein.yaml`, `dreambooth_run.sh`, which the catch-all's `.py`/`.ipynb` patterns never reached)

Net: 25 files stop starting a docs example step that couldn't run them; 8 gain the documentation build, which is the cheap step and the one that can catch a broken include.

These are directory rules, matching how `doc/external/` is handled. That means four non-included assets under `05` (its Dockerfile, two compute configs, `requirements.txt`) start the build too. Deliberate trade — enumerating individual include targets would rot the moment someone adds a `literalinclude`.

## Tests

Added 8 cases to `.buildkite/test.rules.test.txt`, including two regression guards: that the leading prose-and-image skip still wins *inside* a `doc`-routed directory, and that `doc/test_myst_doc.py` stays on `core_doc` so the catch-all keeps working for its real purpose.

```
$ python ci/pipeline/determine_tests_to_run.py   # replayed over every fixture case
fixture cases: 124   evaluated: 124   mismatches: 0
```

All 124 cases pass, the 116 pre-existing ones included. `pre-commit run --files .buildkite/test.rules.txt .buildkite/test.rules.test.txt` passes.

The authoritative tag computation is the external `rayci` `test-rules` step, not this in-repo parser, so premerge on this PR is the real confirmation.

## Not a duplicate

No open PR touches `.buildkite/test.rules.txt` (`gh pr list --search "test.rules.txt in:title,body"` returns four unrelated PRs). This continues #64775, which is merged.

## Follow-up, deliberately not in this PR

`doc/source/templates/README.md` documents a contribution workflow that can't be followed: it points at `templates.yaml`, `testing/validate.py`, `testing/release/`, and `//doc:workspace_templates`, none of which exist. Templates `01`–`03` look like orphaned 2.6-era artifacts and are probably deletable, but `04` and `05` are not, since published pages link to or inline them. That's content cleanup with its own reviewers, and external links to those GitHub paths may exist, so it wants a maintainer's call separately.

---

AI assistance was used to research and draft this change. Opening as a draft for my own review pass before requesting maintainer review.
