### PR TITLE
[cherry-pick][2.58.0][Train] Fix `test_state.py`, uuid regenerated on deserialization (#65290)

### DIFF
--- a/python/ray/train/tests/test_state.py
+++ b/python/ray/train/tests/test_state.py
@@ -290,11 +290,12 @@ def test_track_e2e_training(ray_start_gpu_cluster, gpus_per_worker):
         assert flat_gpu_ids == set(range(8))
 
     # Check Datasets
+    assert {dataset_info.name for dataset_info in run.datasets} == set(datasets)
     for dataset_info in run.datasets:
-        dataset = datasets[dataset_info.name]
         # DataConfig will automatically set the dataset_name to the key of the dataset dict.
         assert dataset_info.dataset_name == dataset_info.name
-        assert dataset_info.dataset_uuid == dataset._uuid
+        # The uuid is regenerated on deserialized so will not be equal the driver-side uuid
+        assert dataset_info.dataset_uuid
 
 
 @pytest.mark.parametrize("raise_error", [True, False])


### PR DESCRIPTION
Cherry-pick of #65290 (merge commit f22677d67a94e175de430d74c79f32fdcef49d4b) into `releases/2.58.0`.

`releases/2.58.0` contains #65075 (dataset UUIDs regenerate on deserialization) but not this test fix, which merged to master after the branch cut. As a result `//python/ray/train:test_state::test_track_e2e_training` fails on every PR against the release branch (e.g. https://buildkite.com/ray-project/microcheck/builds/51689, `ml: train v1 tests`, `assert dataset_info.dataset_uuid == dataset._uuid` AssertionError). This picks the one-file test fix so premerge on the release branch goes green.

Applied cleanly with no conflicts. Not a duplicate: no existing open PR against `releases/2.58.0` contains this change. Cherry-picked with AI assistance (Claude Code); pre-commit hooks ran on the commit and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)