### PR TITLE
[Core] Enforce the task_id/put_index contract in GetGeneratorReturnId

### DIFF
--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -435,9 +435,11 @@ bool WorkerContext::CurrentActorDetached() const {
 ObjectID WorkerContext::GetGeneratorReturnId(const TaskID &task_id,
                                              std::optional<ObjectIDIndexType> put_index) {
   TaskID current_task_id;
-  // We only allow to specify both task id and put index or not specifying both.
+  // Deducing only one of the two would key the ObjectID to one task while drawing the
+  // index from another, so the caller must supply both or neither.
   RAY_CHECK((task_id.IsNil() && !put_index.has_value()) ||
-            (!task_id.IsNil() || put_index.has_value()));
+            (!task_id.IsNil() && put_index.has_value()))
+      << "task_id and put_index must both be specified or both omitted";
   if (task_id.IsNil()) {
     const auto &task_spec = GetCurrentTask();
     current_task_id = task_spec->TaskId();
@@ -454,7 +456,7 @@ ObjectID WorkerContext::GetGeneratorReturnId(const TaskID &task_id,
     // We don't allow to return more than GetMaxNumGeneratorReturnIndex()
     // return values.
     auto max_generator_returns = GetThreadContext().GetMaxNumGeneratorReturnIndex();
-    if (put_index > max_generator_returns) {
+    if (current_put_index > max_generator_returns) {
       RAY_LOG(FATAL).WithField(current_task_id)
           << "The generator returns " << current_put_index
           << " items, which exceed the maximum number of return values allowed, "

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -434,25 +434,17 @@ bool WorkerContext::CurrentActorDetached() const {
 
 ObjectID WorkerContext::GetGeneratorReturnId(const TaskID &task_id,
                                              std::optional<ObjectIDIndexType> put_index) {
-  TaskID current_task_id;
   // Deducing only one of the two would key the ObjectID to one task while drawing the
   // index from another, so the caller must supply both or neither.
-  RAY_CHECK((task_id.IsNil() && !put_index.has_value()) ||
-            (!task_id.IsNil() && put_index.has_value()))
+  RAY_CHECK_EQ(task_id.IsNil(), !put_index.has_value())
       << "task_id and put_index must both be specified or both omitted";
-  if (task_id.IsNil()) {
-    const auto &task_spec = GetCurrentTask();
-    current_task_id = task_spec->TaskId();
-  } else {
-    current_task_id = task_id;
-  }
 
-  ObjectIDIndexType current_put_index = 0;
-  if (!put_index.has_value()) {
-    current_put_index = GetNextPutIndex();
-  } else {
+  TaskID current_task_id;
+  ObjectIDIndexType current_put_index;
+  if (put_index.has_value()) {
     // Streaming generator case.
-    current_put_index = put_index.value();
+    current_task_id = task_id;
+    current_put_index = *put_index;
     // We don't allow to return more than GetMaxNumGeneratorReturnIndex()
     // return values.
     auto max_generator_returns = GetThreadContext().GetMaxNumGeneratorReturnIndex();
@@ -462,6 +454,9 @@ ObjectID WorkerContext::GetGeneratorReturnId(const TaskID &task_id,
           << " items, which exceed the maximum number of return values allowed, "
           << max_generator_returns;
     }
+  } else {
+    current_task_id = GetCurrentTask()->TaskId();
+    current_put_index = GetNextPutIndex();
   }
 
   return ObjectID::FromIndex(current_task_id, current_put_index);

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -43,12 +43,13 @@ class WorkerContext {
   /// or specify both at the same time. Otherwise it will panic.
   ///
   /// \param[in] task_id The task id of the dynamically generated return ID.
-  /// If Nil() is specified, it will deduce the Task ID from the current
+  /// Nil() together with a std::nullopt put_index deduces both from the current
   /// worker context.
   /// \param[in] put_index The equivalent of the return value of
   /// WorkerContext::GetNextPutIndex.
-  /// If std::nullopt is specified, it will deduce the put index from the
-  /// current worker context.
+  /// Both task_id and put_index have to be supplied, or neither: deducing one
+  /// while the caller supplies the other would key the ObjectID to one task
+  /// while drawing the index from another. Mixing them panics.
   ObjectID GetGeneratorReturnId(const TaskID &task_id,
                                 std::optional<ObjectIDIndexType> put_index);
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1282,12 +1282,13 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// \param[in] owner_address The address of the owner who will own this
   /// dynamically generated object.
   /// \param[in] task_id The task id of the dynamically generated return ID.
-  /// If Nil() is specified, it will deduce the Task ID from the current
+  /// Nil() together with a std::nullopt put_index deduces both from the current
   /// worker context.
   /// \param[in] put_index The equivalent of the return value of
   /// WorkerContext::GetNextPutIndex.
-  /// If std::nullopt is specified, it will deduce the put index from the
-  /// current worker context.
+  /// Both task_id and put_index have to be supplied, or neither: deducing one
+  /// while the caller supplies the other would key the ObjectID to one task
+  /// while drawing the index from another. Mixing them panics.
   ObjectID AllocateDynamicReturnId(
       const rpc::Address &owner_address,
       const TaskID &task_id = TaskID::Nil(),

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1288,9 +1288,10 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// WorkerContext::GetNextPutIndex.
   /// If std::nullopt is specified, it will deduce the put index from the
   /// current worker context.
-  ObjectID AllocateDynamicReturnId(const rpc::Address &owner_address,
-                                   const TaskID &task_id = TaskID::Nil(),
-                                   std::optional<ObjectIDIndexType> put_index = -1);
+  ObjectID AllocateDynamicReturnId(
+      const rpc::Address &owner_address,
+      const TaskID &task_id = TaskID::Nil(),
+      std::optional<ObjectIDIndexType> put_index = std::nullopt);
 
   /// Get a handle to an actor.
   ///

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -28,7 +28,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_config",
         "//src/ray/common:task_common",
         "//src/ray/core_worker:core_worker_context",
     ],

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -22,6 +22,19 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "context_test",
+    size = "small",
+    srcs = ["context_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:id",
+        "//src/ray/common:ray_config",
+        "//src/ray/common:task_common",
+        "//src/ray/core_worker:core_worker_context",
+    ],
+)
+
+ray_cc_test(
     name = "memory_store_test",
     size = "small",
     srcs = ["memory_store_test.cc"],

--- a/src/ray/core_worker/tests/context_test.cc
+++ b/src/ray/core_worker/tests/context_test.cc
@@ -21,7 +21,6 @@
 
 #include "gtest/gtest.h"
 #include "ray/common/id.h"
-#include "ray/common/ray_config.h"
 #include "ray/common/task/task_util.h"
 
 namespace ray {
@@ -64,10 +63,11 @@ TaskSpecification MakeTaskSpec(const TaskID &task_id, uint64_t num_returns) {
 
 }  // namespace
 
-// WorkerContext keeps its per-thread state in a static thread_local, so that state
-// outlives any one WorkerContext and is shared by every test on this thread. Reset it
-// after each test: SetCurrentTask requires the put counter to be zero, so a test that
-// leaves it dirty would crash the next one.
+// ResetCurrentTask zeroes the per-thread task index and put counter, which is what
+// SetCurrentTask requires to be zero. The counters live in a static thread_local that
+// outlives any one WorkerContext, so without this a test that advances the put counter
+// would crash the next test that sets a task. It leaves the current task spec in place;
+// no test here reads a task it did not set itself.
 class WorkerContextTest : public ::testing::Test {
  protected:
   void TearDown() override { context_.ResetCurrentTask(); }
@@ -91,9 +91,9 @@ TEST_F(WorkerContextTest, GeneratorReturnIdUsesBothSuppliedArguments) {
   EXPECT_EQ(object_id, ObjectID::FromIndex(task_id, 1));
 }
 
-// Omitting both is the form the production callers use: the task ID and the put index
-// both come from the worker context. Asserting the deduced values, not a literal
-// index, keeps this independent of the max_num_generator_returns config.
+// Omitting both is the form the production callers use: the task ID comes from the
+// current task and the index from the thread's put counter. Assert those two properties
+// rather than the index GetNextPutIndex computes, which would just restate its formula.
 TEST_F(WorkerContextTest, GeneratorReturnIdDeducesBothWhenOmitted) {
   const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
   const uint64_t num_returns = 1;
@@ -101,13 +101,16 @@ TEST_F(WorkerContextTest, GeneratorReturnIdDeducesBothWhenOmitted) {
 
   const ObjectID object_id =
       context_.GetGeneratorReturnId(TaskID::Nil(), /*put_index=*/std::nullopt);
+  const ObjectID next_object_id =
+      context_.GetGeneratorReturnId(TaskID::Nil(), /*put_index=*/std::nullopt);
 
+  // The task came from the context, not from the Nil() we passed.
   EXPECT_EQ(object_id.TaskId(), task_id);
-  // GetNextPutIndex reserves the generator window, so the deduced index lands past
-  // both the return indices and that window.
-  EXPECT_EQ(object_id.ObjectIndex(),
-            static_cast<ObjectIDIndexType>(
-                num_returns + RayConfig::instance().max_num_generator_returns() + 1));
+  EXPECT_EQ(next_object_id.TaskId(), task_id);
+  // The index came from the put counter: it advances per call and stays clear of the
+  // indices reserved for the task's own returns.
+  EXPECT_GT(object_id.ObjectIndex(), num_returns);
+  EXPECT_EQ(next_object_id.ObjectIndex(), object_id.ObjectIndex() + 1);
 }
 
 // Supplying a task ID without a put index would take the index from this thread's put

--- a/src/ray/core_worker/tests/context_test.cc
+++ b/src/ray/core_worker/tests/context_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/context.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "ray/common/id.h"
+#include "ray/common/ray_config.h"
+#include "ray/common/task/task_util.h"
+
+namespace ray {
+namespace core {
+
+namespace {
+
+constexpr int kTestJobId = 1;
+
+WorkerContext MakeWorkerContext() {
+  return WorkerContext(
+      WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(kTestJobId));
+}
+
+// The job ID has to match the context's, otherwise WorkerContext::SetCurrentTask
+// rejects the spec.
+TaskSpecification MakeTaskSpec(const TaskID &task_id, uint64_t num_returns) {
+  TaskSpecBuilder builder;
+  rpc::Address empty_address;
+  rpc::JobConfig config;
+  std::unordered_map<std::string, double> resources = {{"CPU", 1}};
+  builder.SetCommonTaskSpec(
+      task_id,
+      "dummy_task",
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("dummy_module", "", "dummy_function", ""),
+      JobID::FromInt(kTestJobId),
+      config,
+      TaskID::Nil(),
+      0,
+      TaskID::Nil(),
+      empty_address,
+      num_returns,
+      /*returns_dynamic=*/false,
+      /*is_streaming_generator=*/false,
+      /*generator_backpressure_num_objects=*/-1,
+      resources,
+      resources,
+      "",
+      0,
+      TaskID::Nil(),
+      "");
+  return std::move(builder).ConsumeAndBuild();
+}
+
+}  // namespace
+
+// Supplying both arguments keys the ObjectID to the caller's task and index rather
+// than to whatever this thread's context happens to hold.
+TEST(WorkerContextTest, GeneratorReturnIdUsesBothSuppliedArguments) {
+  WorkerContext context = MakeWorkerContext();
+  const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
+
+  const ObjectID object_id =
+      context.GetGeneratorReturnId(task_id, /*put_index=*/ObjectIDIndexType{1});
+
+  EXPECT_EQ(object_id, ObjectID::FromIndex(task_id, 1));
+}
+
+// Omitting both is the form the production callers use: the task ID and the put index
+// both come from the worker context. Asserting the deduced values, not a literal
+// index, keeps this independent of the max_num_generator_returns config.
+TEST(WorkerContextTest, GeneratorReturnIdDeducesBothWhenOmitted) {
+  WorkerContext context = MakeWorkerContext();
+  const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
+  const uint64_t num_returns = 1;
+  // thread_context_ is a static thread_local shared by every WorkerContext on this
+  // thread, so reset the put counter: SetCurrentTask requires it to be zero.
+  context.ResetCurrentTask();
+  context.SetCurrentTask(MakeTaskSpec(task_id, num_returns));
+
+  const ObjectID object_id =
+      context.GetGeneratorReturnId(TaskID::Nil(), /*put_index=*/std::nullopt);
+
+  EXPECT_EQ(object_id.TaskId(), task_id);
+  // GetNextPutIndex reserves the generator window, so the deduced index lands past
+  // both the return indices and that window.
+  EXPECT_EQ(object_id.ObjectIndex(),
+            static_cast<ObjectIDIndexType>(
+                num_returns + RayConfig::instance().max_num_generator_returns() + 1));
+}
+
+// Supplying a task ID without a put index would take the index from this thread's put
+// counter, which belongs to whatever task this thread is running, not to task_id. The
+// resulting ObjectID can collide with one the other task mints.
+TEST(WorkerContextDeathTest, GeneratorReturnIdRejectsTaskIdWithoutPutIndex) {
+  WorkerContext context = MakeWorkerContext();
+  const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
+
+  EXPECT_DEATH((void)context.GetGeneratorReturnId(task_id, /*put_index=*/std::nullopt),
+               "task_id and put_index must both be specified or both omitted");
+}
+
+// The mirror case: a put index with no task ID would attach a caller-chosen index to
+// whichever task this thread happens to be running.
+TEST(WorkerContextDeathTest, GeneratorReturnIdRejectsPutIndexWithoutTaskId) {
+  WorkerContext context = MakeWorkerContext();
+
+  EXPECT_DEATH((void)context.GetGeneratorReturnId(TaskID::Nil(),
+                                                  /*put_index=*/ObjectIDIndexType{1}),
+               "task_id and put_index must both be specified or both omitted");
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/tests/context_test.cc
+++ b/src/ray/core_worker/tests/context_test.cc
@@ -31,11 +31,6 @@ namespace {
 
 constexpr int kTestJobId = 1;
 
-WorkerContext MakeWorkerContext() {
-  return WorkerContext(
-      WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(kTestJobId));
-}
-
 // The job ID has to match the context's, otherwise WorkerContext::SetCurrentTask
 // rejects the spec.
 TaskSpecification MakeTaskSpec(const TaskID &task_id, uint64_t num_returns) {
@@ -69,14 +64,29 @@ TaskSpecification MakeTaskSpec(const TaskID &task_id, uint64_t num_returns) {
 
 }  // namespace
 
+// WorkerContext keeps its per-thread state in a static thread_local, so that state
+// outlives any one WorkerContext and is shared by every test on this thread. Reset it
+// after each test: SetCurrentTask requires the put counter to be zero, so a test that
+// leaves it dirty would crash the next one.
+class WorkerContextTest : public ::testing::Test {
+ protected:
+  void TearDown() override { context_.ResetCurrentTask(); }
+
+  WorkerContext context_{
+      WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(kTestJobId)};
+};
+
+// gtest runs suites whose name ends in DeathTest before the others; both share the
+// fixture so the reset above applies to every case in this file.
+class WorkerContextDeathTest : public WorkerContextTest {};
+
 // Supplying both arguments keys the ObjectID to the caller's task and index rather
 // than to whatever this thread's context happens to hold.
-TEST(WorkerContextTest, GeneratorReturnIdUsesBothSuppliedArguments) {
-  WorkerContext context = MakeWorkerContext();
+TEST_F(WorkerContextTest, GeneratorReturnIdUsesBothSuppliedArguments) {
   const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
 
   const ObjectID object_id =
-      context.GetGeneratorReturnId(task_id, /*put_index=*/ObjectIDIndexType{1});
+      context_.GetGeneratorReturnId(task_id, /*put_index=*/ObjectIDIndexType{1});
 
   EXPECT_EQ(object_id, ObjectID::FromIndex(task_id, 1));
 }
@@ -84,17 +94,13 @@ TEST(WorkerContextTest, GeneratorReturnIdUsesBothSuppliedArguments) {
 // Omitting both is the form the production callers use: the task ID and the put index
 // both come from the worker context. Asserting the deduced values, not a literal
 // index, keeps this independent of the max_num_generator_returns config.
-TEST(WorkerContextTest, GeneratorReturnIdDeducesBothWhenOmitted) {
-  WorkerContext context = MakeWorkerContext();
+TEST_F(WorkerContextTest, GeneratorReturnIdDeducesBothWhenOmitted) {
   const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
   const uint64_t num_returns = 1;
-  // thread_context_ is a static thread_local shared by every WorkerContext on this
-  // thread, so reset the put counter: SetCurrentTask requires it to be zero.
-  context.ResetCurrentTask();
-  context.SetCurrentTask(MakeTaskSpec(task_id, num_returns));
+  context_.SetCurrentTask(MakeTaskSpec(task_id, num_returns));
 
   const ObjectID object_id =
-      context.GetGeneratorReturnId(TaskID::Nil(), /*put_index=*/std::nullopt);
+      context_.GetGeneratorReturnId(TaskID::Nil(), /*put_index=*/std::nullopt);
 
   EXPECT_EQ(object_id.TaskId(), task_id);
   // GetNextPutIndex reserves the generator window, so the deduced index lands past
@@ -107,21 +113,18 @@ TEST(WorkerContextTest, GeneratorReturnIdDeducesBothWhenOmitted) {
 // Supplying a task ID without a put index would take the index from this thread's put
 // counter, which belongs to whatever task this thread is running, not to task_id. The
 // resulting ObjectID can collide with one the other task mints.
-TEST(WorkerContextDeathTest, GeneratorReturnIdRejectsTaskIdWithoutPutIndex) {
-  WorkerContext context = MakeWorkerContext();
+TEST_F(WorkerContextDeathTest, GeneratorReturnIdRejectsTaskIdWithoutPutIndex) {
   const TaskID task_id = TaskID::FromRandom(JobID::FromInt(kTestJobId));
 
-  EXPECT_DEATH((void)context.GetGeneratorReturnId(task_id, /*put_index=*/std::nullopt),
+  EXPECT_DEATH((void)context_.GetGeneratorReturnId(task_id, /*put_index=*/std::nullopt),
                "task_id and put_index must both be specified or both omitted");
 }
 
 // The mirror case: a put index with no task ID would attach a caller-chosen index to
 // whichever task this thread happens to be running.
-TEST(WorkerContextDeathTest, GeneratorReturnIdRejectsPutIndexWithoutTaskId) {
-  WorkerContext context = MakeWorkerContext();
-
-  EXPECT_DEATH((void)context.GetGeneratorReturnId(TaskID::Nil(),
-                                                  /*put_index=*/ObjectIDIndexType{1}),
+TEST_F(WorkerContextDeathTest, GeneratorReturnIdRejectsPutIndexWithoutTaskId) {
+  EXPECT_DEATH((void)context_.GetGeneratorReturnId(TaskID::Nil(),
+                                                   /*put_index=*/ObjectIDIndexType{1}),
                "task_id and put_index must both be specified or both omitted");
 }
 


### PR DESCRIPTION
## Description

`WorkerContext::GetGeneratorReturnId` documents that the caller supplies both `task_id` and `put_index` or neither, because deducing only one of them keys the ObjectID to one task while drawing the index from another. The `RAY_CHECK` meant to enforce that is a tautology:

```cpp
RAY_CHECK((task_id.IsNil() && !put_index.has_value()) ||
          (!task_id.IsNil() || put_index.has_value()));
```

With A = `task_id.IsNil()` and B = `put_index.has_value()`, the second term `!A || B` is false only when `A && !B`, and in exactly that case the first term `A && !B` is true. The disjunction holds for all four inputs, so the check has never fired since it was added in #35584. The unguarded combination that matters is a real `task_id` with no `put_index`: it takes the index from this thread's put counter, which belongs to whatever task this thread is running, so the resulting ObjectID can collide with one that task mints. Using `&&` for the second term makes the check the both-or-neither predicate the doc describes.

`AllocateDynamicReturnId`'s `put_index` default was `-1`. `ObjectIDIndexType` is `uint32_t`, so that default is an optional holding `UINT32_MAX`, not the `std::nullopt` its docstring describes. A caller using the default would abort: the two defaults together are the illegal Nil-plus-index combination, and even past the check, 4294967295 exceeds the 1e8 generator-return limit. Defaulting it to `std::nullopt` makes the two defaults together mean "deduce both", which is what the docstring promises.

This also compares the unwrapped `current_put_index` against the generator-return limit instead of the optional. `std::optional`'s mixed comparison yields false when empty, so an empty optional would skip that check rather than trip it. The optional is engaged at that point today, so this is only to keep the guard from silently going dead if the surrounding branches are ever merged.

Neither defect is reachable today: `libcoreworker.pxd` declares all three parameters without defaults so Cython cannot omit one, there is no C++ caller, and all four call sites in `_raylet.pyx` pass a legal combination. So this makes the contract hold for the next caller rather than fixing something users hit.

## Related issues

Fixes #65300

## Additional information

Adds `context_test.cc`; `WorkerContext` had no test file. Two death tests cover the illegal combinations and two cases cover the legal ones, including the Nil-plus-nullopt form that both production Python call sites use.

The death tests match the check message rather than `""` or `".*"` deliberately. Before the fix, Nil with an index slipped past the tautology and segfaulted dereferencing a null current task, and since a segfault also counts as death, a permissive matcher would have accepted it as the expected failure. I verified both directions by reverting only the predicate and re-running: the two death tests then fail in two different ways (one never dies, the other dies with the segfault instead of the check), and both pass with the fix. `bazel test //src/ray/core_worker/tests:context_test` passes, and `//src/ray/core_worker:core_worker_lib` builds.

I used AI assistance to investigate and draft this change. I reviewed every changed line and ran the build and tests myself.
