### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][8/n] Reroute state head to task events head for state APIs. (#65160)

### DIFF
--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -291,3 +291,79 @@ class GcsAioNodeInfoSubscriber(_AioSubscriber):
             msgs.append((msg.key_id, msg.node_info_message))
             popped += 1
         return msgs
+
+
+class GcsAioWorkerDeltaSubscriber(_AioSubscriber):
+    def __init__(
+        self,
+        worker_id: bytes = None,
+        address: str = None,
+        channel: grpc.Channel = None,
+    ):
+        super().__init__(
+            pubsub_pb2.GCS_WORKER_DELTA_CHANNEL, worker_id, address, channel
+        )
+
+    async def poll(
+        self, batch_size: int, timeout: Optional[float] = None
+    ) -> List[Tuple[bytes, gcs_pb2.WorkerDeltaData]]:
+        """Polls for new worker failure messages.
+
+        Args:
+            batch_size: Maximum number of messages to return.
+            timeout: Optional timeout in seconds for the poll request.
+
+        Returns:
+            A list of tuples of (worker_id, WorkerDeltaData).
+        """
+        await self._poll(timeout=timeout)
+        return self._pop_worker_deltas(self._queue, batch_size=batch_size)
+
+    @staticmethod
+    def _pop_worker_deltas(queue, batch_size):
+        if len(queue) == 0:
+            return []
+        popped = 0
+        msgs = []
+        while len(queue) > 0 and popped < batch_size:
+            msg = queue.popleft()
+            msgs.append((msg.key_id, msg.worker_delta_message))
+            popped += 1
+        return msgs
+
+
+class GcsAioJobSubscriber(_AioSubscriber):
+    def __init__(
+        self,
+        worker_id: bytes = None,
+        address: str = None,
+        channel: grpc.Channel = None,
+    ):
+        super().__init__(pubsub_pb2.GCS_JOB_CHANNEL, worker_id, address, channel)
+
+    async def poll(
+        self, batch_size: int, timeout: Optional[float] = None
+    ) -> List[Tuple[bytes, gcs_pb2.JobTableData]]:
+        """Polls for new job messages.
+
+        Args:
+            batch_size: Maximum number of messages to return.
+            timeout: Optional timeout in seconds for the poll request.
+
+        Returns:
+            A list of tuples of (job_id, JobTableData).
+        """
+        await self._poll(timeout=timeout)
+        return self._pop_job_messages(self._queue, batch_size=batch_size)
+
+    @staticmethod
+    def _pop_job_messages(queue, batch_size):
+        if len(queue) == 0:
+            return []
+        popped = 0
+        msgs = []
+        while len(queue) > 0 and popped < batch_size:
+            msg = queue.popleft()
+            msgs.append((msg.key_id, msg.job_message))
+            popped += 1
+        return msgs

--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import logging
+import os
 import pprint
 import time
 import traceback
@@ -349,8 +350,14 @@ def get_state_api_manager(gcs_address: str) -> StateAPIManager:
     gcs_client = GcsClient(address=gcs_address)
     gcs_channel = GcsChannel(gcs_address=gcs_address, aio=True)
     gcs_channel.connect()
+    # Task events are read from the dashboard head, which the client reaches over the
+    # subprocess module's socket rather than through the GCS channel.
+    node = ray._private.worker.global_worker.node
     state_api_data_source_client = StateDataSourceClient(
-        gcs_channel.channel(), gcs_client
+        gcs_channel.channel(),
+        gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
     )
     return StateAPIManager(
         state_api_data_source_client,

--- a/python/ray/dashboard/consts.py
+++ b/python/ray/dashboard/consts.py
@@ -15,6 +15,7 @@ DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_S = env_integer(
 # The maximum time that parent can be considered
 # as dead before agent kills itself.
 _PARENT_DEATH_THREASHOLD = 5
+
 RAY_STATE_SERVER_MAX_HTTP_REQUEST_ENV_NAME = "RAY_STATE_SERVER_MAX_HTTP_REQUEST"
 # Default number of in-progress requests to the state api server.
 RAY_STATE_SERVER_MAX_HTTP_REQUEST = env_integer(

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -192,9 +192,10 @@ class DashboardHead:
             dashboard_head_modules,
             skipped_head_modules,
         ) = self._load_dashboard_head_modules(modules_to_load)
-        subprocess_module_handles = self._load_subprocess_module_handles(
-            modules_to_load
-        )
+        (
+            subprocess_module_handles,
+            skipped_subprocess_modules,
+        ) = self._load_subprocess_module_handles(modules_to_load)
 
         all_names = {type(m).__name__ for m in dashboard_head_modules} | {
             h.module_cls.__name__ for h in subprocess_module_handles
@@ -203,9 +204,12 @@ class DashboardHead:
             subprocess_module_handles
         ), "Duplicate module names. A module name can't be a DashboardHeadModule and a SubprocessModule at the same time."
 
-        # Verify modules are loaded as expected.
+        # Verify modules are loaded as expected. Subtract both kinds of disabled modules;
+        # a requested-but-disabled module (head or subprocess) is legitimately skipped.
         if modules_to_load is not None:
-            expected_names = modules_to_load - skipped_head_modules
+            expected_names = (
+                modules_to_load - skipped_head_modules - skipped_subprocess_modules
+            )
             if all_names != expected_names:
                 assert False, (
                     f"Actual loaded modules {all_names}, doesn't match the requested modules "
@@ -265,10 +269,10 @@ class DashboardHead:
 
     def _load_subprocess_module_handles(
         self, modules_to_load: Optional[Set[str]] = None
-    ) -> List["SubprocessModuleHandle"]:
+    ) -> Tuple[List["SubprocessModuleHandle"], Set[str]]:
         """Load ``SubprocessModule`` handles.
 
-        If minimal, return an empty list.
+        If minimal, load no subprocess modules.
         If non-minimal, load `SubprocessModule`s by creating Handles to them.
 
         Args:
@@ -276,12 +280,13 @@ class DashboardHead:
                 it loads all modules.
 
         Returns:
-            A list of ``SubprocessModuleHandle`` instances, or an empty list in
-            minimal mode.
+            A tuple of ``(handles, skipped_module_names)``: the loaded
+            ``SubprocessModuleHandle`` instances, and the names of modules skipped
+            because they are disabled. Both are empty in minimal mode.
         """
         if self.minimal:
             logger.info("Subprocess modules not loaded in minimal mode.")
-            return []
+            return [], set()
 
         from ray.dashboard.subprocesses.handle import SubprocessModuleHandle
         from ray.dashboard.subprocesses.module import (
@@ -290,6 +295,7 @@ class DashboardHead:
         )
 
         handles = []
+        skipped_modules = set()
         subprocess_cls_list = dashboard_utils.get_all_modules(SubprocessModule)
 
         loop = ray._common.utils.get_or_create_event_loop()
@@ -315,12 +321,16 @@ class DashboardHead:
             ]
 
         for cls in subprocess_cls_list:
+            if not cls.is_enabled():
+                logger.info(f"Skipping {SubprocessModule.__name__}: {cls} (disabled).")
+                skipped_modules.add(cls.__name__)
+                continue
             logger.info(f"Loading {SubprocessModule.__name__}: {cls}.")
             handle = SubprocessModuleHandle(loop, cls, config)
             handles.append(handle)
 
         logger.info(f"Loaded {len(handles)} subprocess modules: {handles}.")
-        return handles
+        return handles, skipped_modules
 
     async def _setup_metrics(self, gcs_client):
         metrics = DashboardPrometheusMetrics()

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -18,9 +18,11 @@ from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
     MultiConsumerEventBuffer,
 )
 from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
+    AsyncDashboardHeadPublisherClient,
     AsyncGCSTaskEventsPublisherClient,
     AsyncHttpPublisherClient,
 )
+from ray.dashboard.modules.aggregator.publisher.configs import TASK_EVENT_TYPES
 from ray.dashboard.modules.aggregator.publisher.ray_event_publisher import (
     NoopPublisher,
     RayEventPublisher,
@@ -65,6 +67,13 @@ PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE = ray_constants.env_bool(
 PUBLISH_EVENTS_TO_GCS = ray_constants.env_bool(
     "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_GCS", False
 )
+# flag to enable publishing task events to the dashboard head.
+# This happens only when this flag is true since it control spinning up
+# of TaskEventsHead, if task events are published there and if read
+# happens from there.
+PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD = (
+    ray._config.enable_task_events_to_dashboard_head()
+)
 # flag to control whether preserve the proto field name when converting the events to
 # JSON. If True, the proto field name will be preserved. If False, the proto field name
 # will be converted to camel case.
@@ -107,8 +116,14 @@ class AggregatorAgent(
             thread_name_prefix="aggregator_agent_executor",
         )
 
-        # Task metadata buffer accumulates dropped task attempts for GCS publishing
+        # Task metadata buffers accumulate dropped task attempts to publish. Each
+        # publisher needs its own buffer because reads are destructive
+        # (TaskEventsMetadataBuffer.get() pops), so a shared buffer would split the
+        # dropped attempts across publishers instead of delivering them to both.
         self._task_metadata_buffer = TaskEventsMetadataBuffer(
+            common_metric_tags=self._common_tags
+        )
+        self._dashboard_head_task_metadata_buffer = TaskEventsMetadataBuffer(
             common_metric_tags=self._common_tags
         )
 
@@ -155,6 +170,25 @@ class AggregatorAgent(
             logger.info("Publishing events to GCS is disabled")
             self._gcs_publisher = NoopPublisher()
 
+        if PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD:
+            logger.info("Publishing events to the dashboard head is enabled")
+            self._event_processing_enabled = True
+            self._dashboard_head_publisher = RayEventPublisher(
+                name="dashboard_head",
+                publish_client=AsyncDashboardHeadPublisherClient(
+                    gcs_client=self._dashboard_agent.gcs_client,
+                    executor=self._executor,
+                    endpoint_path="/api/task_events",
+                    exposable_event_types=TASK_EVENT_TYPES,
+                ),
+                event_buffer=self._event_buffer,
+                common_metric_tags=self._common_tags,
+                task_metadata_buffer=self._dashboard_head_task_metadata_buffer,
+            )
+        else:
+            logger.info("Publishing events to the dashboard head is disabled")
+            self._dashboard_head_publisher = NoopPublisher()
+
         # Metrics
         self._open_telemetry_metric_recorder = OpenTelemetryMetricRecorder()
 
@@ -189,6 +223,10 @@ class AggregatorAgent(
 
         if PUBLISH_EVENTS_TO_GCS:
             self._task_metadata_buffer.merge(events_data.task_events_metadata)
+        if PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD:
+            self._dashboard_head_task_metadata_buffer.merge(
+                events_data.task_events_metadata
+            )
 
         for event in events_data.events:
             try:
@@ -221,6 +259,7 @@ class AggregatorAgent(
             await asyncio.gather(
                 self._http_endpoint_publisher.run_forever(),
                 self._gcs_publisher.run_forever(),
+                self._dashboard_head_publisher.run_forever(),
             )
         finally:
             self._executor.shutdown()

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -121,10 +121,12 @@ class AggregatorAgent(
         # (TaskEventsMetadataBuffer.get() pops), so a shared buffer would split the
         # dropped attempts across publishers instead of delivering them to both.
         self._task_metadata_buffer = TaskEventsMetadataBuffer(
-            common_metric_tags=self._common_tags
+            common_metric_tags=self._common_tags,
+            publisher_name="ray_gcs",
         )
         self._dashboard_head_task_metadata_buffer = TaskEventsMetadataBuffer(
-            common_metric_tags=self._common_tags
+            common_metric_tags=self._common_tags,
+            publisher_name="dashboard_head",
         )
 
         self._events_export_addr = (

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -9,16 +10,21 @@ import aiohttp
 
 import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
+from ray._private import ray_constants
+from ray._private.authentication.http_token_authentication import (
+    get_auth_headers_if_auth_enabled,
+)
 from ray._private.protobuf_compat import message_to_json
 from ray._raylet import GcsClient
 from ray.core.generated import (
     events_base_event_pb2,
     events_event_aggregator_service_pb2,
 )
+from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
 from ray.dashboard.modules.aggregator.publisher.configs import (
-    GCS_EXPOSABLE_EVENT_TYPES,
     HTTP_EXPOSABLE_EVENT_TYPES,
     PUBLISHER_TIMEOUT_SECONDS,
+    TASK_EVENT_TYPES,
 )
 
 logger = logging.getLogger(__name__)
@@ -203,7 +209,7 @@ class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
         self._executor = executor
         self._timeout_s = timeout_s
 
-        self._exposable_event_types_list = GCS_EXPOSABLE_EVENT_TYPES
+        self._exposable_event_types_list = TASK_EVENT_TYPES
 
     async def publish(
         self,
@@ -289,3 +295,154 @@ class AsyncGCSTaskEventsPublisherClient(PublisherClientInterface):
 
     async def close(self) -> None:
         pass
+
+
+class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
+    """Client for publishing ray event batches to the dashboard head over HTTP.
+
+    The destination endpoint path and the set of event types this client may publish are
+    supplied by the caller, so the same client can serve any dashboard-head ingestion
+    endpoint."""
+
+    def __init__(
+        self,
+        gcs_client: GcsClient,
+        executor: ThreadPoolExecutor,
+        endpoint_path: str,
+        exposable_event_types: List[str],
+        timeout_s: float = PUBLISHER_TIMEOUT_SECONDS,
+    ) -> None:
+        super().__init__()
+        self._gcs_client = gcs_client
+        self._executor = executor
+        self._endpoint_path = endpoint_path
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._session = None
+        # Resolved lazily from InternalKV on first publish and cached.
+        self._endpoint = None
+
+        self._exposable_event_types_list = exposable_event_types
+
+    async def _get_endpoint(self) -> Optional[str]:
+        """Lazily resolve and cache the dashboard head's endpoint from InternalKV.
+        Returns None if the head has not registered its address yet, so the caller can
+        retry later."""
+        if self._endpoint:
+            return self._endpoint
+        address = await self._gcs_client.async_internal_kv_get(
+            ray_constants.DASHBOARD_ADDRESS.encode(),
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+            timeout=GCS_RPC_TIMEOUT_SECONDS,
+        )
+        if not address:
+            return None
+        address = address.decode()
+        if not address.startswith(("http://", "https://")):
+            address = f"http://{address}"
+        self._endpoint = f"{address}{self._endpoint_path}"
+        return self._endpoint
+
+    async def publish(
+        self,
+        batch: PublishBatch,
+    ) -> PublishStats:
+        events = batch.events
+        task_events_metadata = batch.task_events_metadata
+        has_dropped_task_attempts = (
+            task_events_metadata and task_events_metadata.dropped_task_attempts
+        )
+        if not events and not has_dropped_task_attempts:
+            # Nothing to publish -> success but nothing published
+            return PublishStats(
+                is_publish_successful=True,
+                num_events_published=0,
+                num_events_filtered_out=0,
+            )
+
+        # Filter events based on exposable event types
+        filtered_events = [e for e in events if self._can_expose_event(e)]
+        num_filtered_out = len(events) - len(filtered_events)
+
+        if not filtered_events and not has_dropped_task_attempts:
+            # all events filtered out and no task events metadata -> success but nothing published
+            return PublishStats(
+                is_publish_successful=True,
+                num_events_published=0,
+                num_events_filtered_out=num_filtered_out,
+            )
+
+        try:
+            endpoint = await self._get_endpoint()
+            if endpoint is None:
+                logger.warning(
+                    "Dashboard head address not yet in InternalKV; will retry."
+                )
+                return PublishStats(
+                    is_publish_successful=False,
+                    num_events_published=0,
+                    num_events_filtered_out=0,
+                )
+            events_data = self._create_ray_events_data(
+                filtered_events, task_events_metadata
+            )
+            request = events_event_aggregator_service_pb2.AddEventsRequest(
+                events_data=events_data
+            )
+            serialized_request = await get_or_create_event_loop().run_in_executor(
+                self._executor,
+                lambda: request.SerializeToString(),
+            )
+
+            # Create session on first use (lazy initialization)
+            if not self._session:
+                self._session = aiohttp.ClientSession(timeout=self._timeout)
+            # Propagate the auth token so the POST passes the dashboard's auth middleware.
+            headers = get_auth_headers_if_auth_enabled({})
+            try:
+                async with self._session.post(
+                    endpoint,
+                    data=serialized_request,
+                    headers=headers,
+                ) as resp:
+                    resp.raise_for_status()
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
+                # Couldn't reach the endpoint; the dashboard head may have restarted at a
+                # new address. Drop the cached endpoint so the next publish re-resolves it
+                # from InternalKV.
+                self._endpoint = None
+                raise
+            return PublishStats(
+                is_publish_successful=True,
+                num_events_published=len(filtered_events),
+                num_events_filtered_out=num_filtered_out,
+            )
+        except Exception as e:
+            logger.error(f"Failed to send events to the dashboard head: {e}")
+            return PublishStats(
+                is_publish_successful=False,
+                num_events_published=0,
+                num_events_filtered_out=0,
+            )
+
+    def _create_ray_events_data(
+        self,
+        event_batch: List[events_base_event_pb2.RayEvent],
+        task_events_metadata: Optional[
+            events_event_aggregator_service_pb2.TaskEventsMetadata
+        ] = None,
+    ) -> events_event_aggregator_service_pb2.RayEventsData:
+        """
+        Helper method to create RayEventsData from event batch and metadata.
+        """
+        events_data = events_event_aggregator_service_pb2.RayEventsData()
+        events_data.events.extend(event_batch)
+
+        if task_events_metadata:
+            events_data.task_events_metadata.CopyFrom(task_events_metadata)
+
+        return events_data
+
+    async def close(self) -> None:
+        if self._session:
+            await self._session.close()
+            self._session = None

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -11,9 +11,6 @@ import aiohttp
 import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private import ray_constants
-from ray._private.authentication.http_token_authentication import (
-    get_auth_headers_if_auth_enabled,
-)
 from ray._private.protobuf_compat import message_to_json
 from ray._raylet import GcsClient
 from ray.core.generated import (
@@ -21,6 +18,9 @@ from ray.core.generated import (
     events_event_aggregator_service_pb2,
 )
 from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
+from ray.dashboard.modules.aggregator.publisher.authenticated_http_client import (
+    AuthenticatedHttpClient,
+)
 from ray.dashboard.modules.aggregator.publisher.configs import (
     HTTP_EXPOSABLE_EVENT_TYPES,
     PUBLISHER_TIMEOUT_SECONDS,
@@ -316,8 +316,7 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
         self._gcs_client = gcs_client
         self._executor = executor
         self._endpoint_path = endpoint_path
-        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
-        self._session = None
+        self._http_client = AuthenticatedHttpClient(timeout_s=timeout_s)
         # Resolved lazily from InternalKV on first publish and cached.
         self._endpoint = None
 
@@ -393,17 +392,8 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
                 lambda: request.SerializeToString(),
             )
 
-            # Create session on first use (lazy initialization)
-            if not self._session:
-                self._session = aiohttp.ClientSession(timeout=self._timeout)
-            # Propagate the auth token so the POST passes the dashboard's auth middleware.
-            headers = get_auth_headers_if_auth_enabled({})
             try:
-                async with self._session.post(
-                    endpoint,
-                    data=serialized_request,
-                    headers=headers,
-                ) as resp:
+                async with self._http_client.post(endpoint, serialized_request) as resp:
                     resp.raise_for_status()
             except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
                 # Couldn't reach the endpoint; the dashboard head may have restarted at a
@@ -443,6 +433,4 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
         return events_data
 
     async def close(self) -> None:
-        if self._session:
-            await self._session.close()
-            self._session = None
+        await self._http_client.close()

--- a/python/ray/dashboard/modules/aggregator/publisher/authenticated_http_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/authenticated_http_client.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Optional
+
+import aiohttp
+
+from ray._private.authentication.http_token_authentication import (
+    get_auth_headers_if_auth_enabled,
+)
+from ray.dashboard.modules.aggregator.publisher.configs import (
+    PUBLISHER_TIMEOUT_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AuthenticatedHttpClient:
+    """Reusable aiohttp client that attaches Ray's cluster auth token on every request.
+
+    Wraps a single lazily-created ``aiohttp.ClientSession`` and injects the auth headers
+    in one place, so callers POSTing to authenticated dashboard endpoints can't
+    accidentally send an unauthenticated request.
+    """
+
+    def __init__(self, timeout_s: float = PUBLISHER_TIMEOUT_SECONDS) -> None:
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    def post(self, url: str, data: bytes):
+        """POST ``data`` to ``url`` with auth headers attached.
+
+        Mirrors ``aiohttp.ClientSession.post`` and returns its request context manager,
+        so callers use ``async with client.post(...) as resp``.
+        """
+        if self._session is None:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+        headers = get_auth_headers_if_auth_enabled({})
+        return self._session.post(url, data=data, headers=headers)
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -44,10 +44,10 @@ HTTP_EXPOSABLE_EVENT_TYPES = os.environ.get(
     DEFAULT_HTTP_EXPOSABLE_EVENT_TYPES,
 )
 
-# GCS Publisher specific configurations
-# List of event types that are allowed to be exposed to GCS, not overridden by environment variable
-# as GCS only supports Task event types
-GCS_EXPOSABLE_EVENT_TYPES = [
+# The task event types. Both the GCS publisher and the dashboard-head publisher expose
+# only these, since GCS and the dashboard-head task-events store only handle task events.
+# Not overridden by an environment variable.
+TASK_EVENT_TYPES = [
     "TASK_DEFINITION_EVENT",
     "TASK_LIFECYCLE_EVENT",
     "TASK_PROFILE_EVENT",

--- a/python/ray/dashboard/modules/aggregator/task_events_metadata_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/task_events_metadata_buffer.py
@@ -19,6 +19,7 @@ class TaskEventsMetadataBuffer:
         max_buffer_size: int = 1000,
         max_dropped_attempts_per_metadata_entry: int = 100,
         common_metric_tags: Optional[Dict[str, str]] = None,
+        publisher_name: str = "",
     ):
         self._buffer_maxlen = max(
             max_buffer_size - 1, 1
@@ -31,7 +32,13 @@ class TaskEventsMetadataBuffer:
 
         self._common_metric_tags = common_metric_tags or {}
         self._metric_recorder = OpenTelemetryMetricRecorder()
-        self._dropped_metadata_count_metric_name = f"{AGGREGATOR_AGENT_METRIC_PREFIX}_task_metadata_buffer_dropped_attempts_total"
+        # Namespace the counter per publisher so buffers feeding different publishers
+        # register distinct instruments on the process-global meter instead of colliding
+        # on a single name.
+        self._dropped_metadata_count_metric_name = (
+            f"{AGGREGATOR_AGENT_METRIC_PREFIX}_{publisher_name}"
+            "_task_metadata_buffer_dropped_attempts_total"
+        )
         self._metric_recorder.register_counter_metric(
             self._dropped_metadata_count_metric_name,
             "Total number of dropped task attempt metadata entries which were dropped due to buffer being full",

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -1213,6 +1213,19 @@ def test_aggregator_agent_http_svc_publish_disabled(
     assert len(httpserver.log) == 0
 
 
+def _create_task_definition_event_with_ids(timestamp, unique_task_name: str):
+    """Create a task definition event with valid task/job ids and a unique task name."""
+    job_id = JobID.from_int(1)
+    task_id = TaskID.for_fake_task(job_id)
+
+    event = _create_task_definition_event_proto(timestamp)
+    event.task_definition_event.task_name = unique_task_name
+    event.task_definition_event.task_id = task_id.binary()
+    event.task_definition_event.job_id = job_id.binary()
+    event.task_definition_event.parent_task_id = task_id.binary()
+    return event
+
+
 def _get_task_from_gcs(
     unique_task_name: str,
 ):
@@ -1224,19 +1237,6 @@ def _get_task_from_gcs(
         return None
     except Exception:
         return None
-
-
-def _create_task_definition_event_for_gcs(timestamp, unique_task_name: str):
-    """Create and return a task definition event for GCS with valid task id and job id and a unique task name"""
-    job_id = JobID.from_int(1)
-    task_id = TaskID.for_fake_task(job_id)
-
-    event = _create_task_definition_event_proto(timestamp)
-    event.task_definition_event.task_name = unique_task_name
-    event.task_definition_event.task_id = task_id.binary()
-    event.task_definition_event.job_id = job_id.binary()
-    event.task_definition_event.parent_task_id = task_id.binary()
-    return event
 
 
 def _wait_for_and_verify_task_definition_event_in_gcs(
@@ -1253,6 +1253,185 @@ def _wait_for_and_verify_task_definition_event_in_gcs(
     assert matched_task.task_id == expected.task_id.hex()
     assert matched_task.job_id == expected.job_id.hex()
     assert matched_task.parent_task_id == expected.parent_task_id.hex()
+
+
+def override_dashboard_address_to_httpserver(gcs_address):
+    """Point the dashboard-head publisher at the test httpserver by overwriting
+    DASHBOARD_ADDRESS in InternalKV. The publisher resolves this address lazily on its
+    first publish and caches it, so this must run before any exposable event is sent."""
+    gcs_client = GcsClient(address=gcs_address)
+    gcs_client.internal_kv_put(
+        ray_constants.DASHBOARD_ADDRESS.encode(),
+        _EVENT_AGGREGATOR_AGENT_TARGET_ADDR.encode(),
+        True,
+        namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+    )
+
+
+def _get_json_events_from_httpserver(httpserver):
+    """Return every event POSTed as JSON by the external HTTP publisher to "/"."""
+    events = []
+    for req, _ in httpserver.log:
+        if req.path == "/":
+            events.extend(json.loads(req.get_data()))
+    return events
+
+
+def _get_dashboard_head_events_from_httpserver(httpserver):
+    """Return every RayEvent POSTed as a serialized AddEventsRequest proto by the
+    dashboard-head publisher to "/api/task_events"."""
+    events = []
+    for req, _ in httpserver.log:
+        if req.path == "/api/task_events":
+            add_events_request = AddEventsRequest.FromString(req.get_data())
+            events.extend(add_events_request.events_data.events)
+    return events
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                # Enable both publishers
+                "RAY_enable_task_events_to_dashboard_head": "1",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_publish_to_both_dashboard_head_and_http(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    cluster = ray_start_cluster_head_with_env_vars
+    agg_stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    # The external HTTP publisher POSTs JSON to "/"; the dashboard-head publisher POSTs a
+    # serialized AddEventsRequest proto to "/api/task_events". Redirect the dashboard-head
+    # publisher to the same test httpserver by overriding its InternalKV address.
+    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
+
+    unique_task_name = f"task_{uuid.uuid4()}"
+    event = _create_task_definition_event_with_ids(fake_timestamp[0], unique_task_name)
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[event],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    agg_stub.AddEvents(request)
+
+    # The external HTTP publisher received the event as JSON at "/".
+    wait_for_condition(lambda: len(_get_json_events_from_httpserver(httpserver)) == 1)
+    json_events = _get_json_events_from_httpserver(httpserver)
+    assert json_events[0]["eventType"] == "TASK_DEFINITION_EVENT"
+    assert json_events[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+
+    # The dashboard-head publisher received the same event as a serialized proto at
+    # "/api/task_events".
+    wait_for_condition(
+        lambda: len(_get_dashboard_head_events_from_httpserver(httpserver)) == 1
+    )
+    dashboard_events = _get_dashboard_head_events_from_httpserver(httpserver)
+    assert dashboard_events[0].event_type == RayEvent.EventType.TASK_DEFINITION_EVENT
+    assert dashboard_events[0].task_definition_event.task_name == unique_task_name
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                # Disable the external HTTP publisher to test filtering in isolation
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
+                # Enable the dashboard-head publisher
+                "RAY_enable_task_events_to_dashboard_head": "1",
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_dashboard_head_filtering_driver_job_events(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    """Driver job events are filtered out and never sent to the dashboard head."""
+    cluster = ray_start_cluster_head_with_env_vars
+    agg_stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    httpserver.expect_request("/api/task_events", method="POST").respond_with_data(
+        "", status=200
+    )
+    override_dashboard_address_to_httpserver(cluster.gcs_address)
+
+    unique_task_name = f"task_{uuid.uuid4()}"
+    task_event = _create_task_definition_event_with_ids(
+        fake_timestamp[0], unique_task_name
+    )
+
+    # DRIVER_JOB_LIFECYCLE_EVENT is not in TASK_EVENT_TYPES, so the dashboard-head
+    # publisher must filter it out.
+    driver_job_event = RayEvent(
+        event_id=b"driver_job_1",
+        source_type=RayEvent.SourceType.CORE_WORKER,
+        event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        timestamp=fake_timestamp[0],
+        severity=RayEvent.Severity.INFO,
+        message="driver job execution event - should be filtered",
+        driver_job_lifecycle_event=DriverJobLifecycleEvent(
+            job_id=b"test_job_1",
+            state_transitions=[
+                DriverJobLifecycleEvent.StateTransition(
+                    state=DriverJobLifecycleEvent.State.CREATED,
+                    timestamp=Timestamp(seconds=1234567890),
+                ),
+                DriverJobLifecycleEvent.StateTransition(
+                    state=DriverJobLifecycleEvent.State.FINISHED,
+                    timestamp=Timestamp(seconds=1234567890),
+                ),
+            ],
+        ),
+    )
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[task_event, driver_job_event],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    agg_stub.AddEvents(request)
+
+    # The task definition event reaches the dashboard head.
+    def _task_event_received():
+        return any(
+            event.event_type == RayEvent.EventType.TASK_DEFINITION_EVENT
+            and event.task_definition_event.task_name == unique_task_name
+            for event in _get_dashboard_head_events_from_httpserver(httpserver)
+        )
+
+    wait_for_condition(_task_event_received)
+
+    # The driver job lifecycle event was filtered out and never sent.
+    assert all(
+        event.event_type != RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
+        for event in _get_dashboard_head_events_from_httpserver(httpserver)
+    )
 
 
 @pytest.mark.parametrize(
@@ -1281,7 +1460,7 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
 
     # Create an event with a unique task name to filter on
     unique_task_name = f"gcs_only_task_{uuid.uuid4()}"
-    event = _create_task_definition_event_for_gcs(fake_timestamp[0], unique_task_name)
+    event = _create_task_definition_event_with_ids(fake_timestamp[0], unique_task_name)
 
     request = AddEventsRequest(
         events_data=RayEventsData(
@@ -1331,11 +1510,11 @@ def test_aggregator_agent_gcs_filtering_driver_job_events(
 
     unique_task_name = f"gcs_filter_task_{uuid.uuid4()}"
 
-    task_event = _create_task_definition_event_for_gcs(
+    task_event = _create_task_definition_event_with_ids(
         fake_timestamp[0], unique_task_name
     )
 
-    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in GCS_EXPOSABLE_EVENT_TYPES)
+    # This event should be filtered out (DRIVER_JOB_LIFECYCLE_EVENT is NOT in TASK_EVENT_TYPES)
     driver_job_event = RayEvent(
         event_id=b"driver_job_1",
         source_type=RayEvent.SourceType.CORE_WORKER,

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -1087,7 +1087,10 @@ class ReportHead(SubprocessModule):
     async def run(self):
         await super().run()
         self._state_api_data_source_client = StateDataSourceClient(
-            self.aiogrpc_gcs_channel, self.gcs_client
+            self.aiogrpc_gcs_channel,
+            self.gcs_client,
+            dashboard_socket_dir=self._config.socket_dir,
+            dashboard_session_name=self._config.session_name,
         )
         # Set up the state API in order to fetch task information.
         # This is only used to get task info. If we have Task APIs in GcsClient we can

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -351,7 +351,10 @@ class StateHead(SubprocessModule, RateLimitedModule):
         await SubprocessModule.run(self)
         gcs_channel = self.aiogrpc_gcs_channel
         self._state_api_data_source_client = StateDataSourceClient(
-            gcs_channel, self.gcs_client
+            gcs_channel,
+            self.gcs_client,
+            dashboard_socket_dir=self._config.socket_dir,
+            dashboard_session_name=self._config.session_name,
         )
         self._state_api = StateAPIManager(
             self._state_api_data_source_client,

--- a/python/ray/dashboard/modules/task_events/gc_policy.py
+++ b/python/ray/dashboard/modules/task_events/gc_policy.py
@@ -1,0 +1,44 @@
+"""Garbage-collection priority policy for the task-event store.
+
+Each task event is assigned a priority tier. When the store is over capacity, events in
+lower-priority tiers are evicted first: finished tasks first, then actor tasks, then
+everything else.
+"""
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+
+
+class FinishedTaskActorTaskGcPolicy:
+    """Buckets task events into priority tiers; a higher tier is evicted later."""
+
+    # Number of priority tiers, i.e. valid tiers are 0 .. max_priority - 1.
+    _MAX_PRIORITY = 3
+
+    @property
+    def max_priority(self) -> int:
+        """Number of priority tiers; valid tiers are 0 .. max_priority - 1."""
+        return self._MAX_PRIORITY
+
+    def get_task_list_priority(self, task_event: gcs_pb2.TaskEvents) -> int:
+        if self._is_task_finished(task_event):
+            return 0
+        if self._is_actor_task(task_event):
+            return 1
+        return 2
+
+    @staticmethod
+    def _is_task_finished(task_event: gcs_pb2.TaskEvents) -> bool:
+        """Whether the task attempt has reported a FINISHED state."""
+        if not task_event.HasField("state_updates"):
+            return False
+        return TaskStatus.FINISHED in task_event.state_updates.state_ts_ns
+
+    @staticmethod
+    def _is_actor_task(task_event: gcs_pb2.TaskEvents) -> bool:
+        """Whether the task attempt is an actor task or an actor creation task."""
+        if not task_event.HasField("task_info"):
+            return False
+        return task_event.task_info.type in (
+            TaskType.ACTOR_TASK,
+            TaskType.ACTOR_CREATION_TASK,
+        )

--- a/python/ray/dashboard/modules/task_events/ray_event_converter.py
+++ b/python/ray/dashboard/modules/task_events/ray_event_converter.py
@@ -1,0 +1,213 @@
+"""Convert aggregator ``RayEvent``s into the ``TaskEvents`` storage model.
+"""
+from typing import List, Tuple
+
+from ray._raylet import TaskID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import FunctionDescriptor, TaskInfoEntry, TaskType
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_event_aggregator_service_pb2 import AddEventsRequest
+
+
+def _short_name(name: str) -> str:
+    """Return the component after the last '.' (e.g. ``module.foo`` -> ``foo``)."""
+    return name[name.rfind(".") + 1 :]
+
+
+def _call_string(function_descriptor: FunctionDescriptor) -> str:
+    """Return the short function/class name (for ``TaskInfoEntry.func_or_class_name``)
+    encoded in a ``FunctionDescriptor`` proto."""
+    which = function_descriptor.WhichOneof("function_descriptor")
+    if which == "python_function_descriptor":
+        p = function_descriptor.python_function_descriptor
+        if not p.class_name:
+            return _short_name(p.function_name)
+        return f"{_short_name(p.class_name)}.{_short_name(p.function_name)}"
+    if which == "java_function_descriptor":
+        j = function_descriptor.java_function_descriptor
+        if not j.class_name:
+            return j.function_name
+        return f"{j.class_name}.{j.function_name}"
+    if which == "cpp_function_descriptor":
+        return function_descriptor.cpp_function_descriptor.function_name
+    return ""
+
+
+def _populate_task_runtime_and_function_info(
+    task_info: TaskInfoEntry,
+    serialized_runtime_env: str,
+    function_descriptor: FunctionDescriptor,
+    required_resources,
+    language,
+) -> None:
+    task_info.language = language
+    task_info.runtime_env_info.serialized_runtime_env = serialized_runtime_env
+    task_info.func_or_class_name = _call_string(function_descriptor)
+    task_info.required_resources.update(required_resources)
+
+
+def _convert_task_definition_event(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.task_attempt
+    task_event.job_id = event.job_id
+
+    task_info = task_event.task_info
+    task_info.type = event.task_type
+    task_info.name = event.task_name
+    task_info.task_id = event.task_id
+    task_info.job_id = event.job_id
+    task_info.parent_task_id = event.parent_task_id
+    if event.task_type == TaskType.ACTOR_CREATION_TASK:
+        task_info.actor_id = TaskID(event.task_id).actor_id().binary()
+        if event.is_detached_actor:
+            task_info.is_detached_actor = True
+    if event.placement_group_id:
+        task_info.placement_group_id = event.placement_group_id
+    if event.HasField("call_site"):
+        task_info.call_site = event.call_site
+    if event.label_selector:
+        task_info.label_selector.update(event.label_selector)
+    if event.HasField("fallback_strategy"):
+        task_info.fallback_strategy.CopyFrom(event.fallback_strategy)
+
+    _populate_task_runtime_and_function_info(
+        task_info,
+        event.serialized_runtime_env,
+        event.task_func,
+        event.required_resources,
+        event.language,
+    )
+    return task_event
+
+
+_TASK_LOG_INFO_FIELDS = (
+    "stdout_file",
+    "stderr_file",
+    "stdout_start",
+    "stdout_end",
+    "stderr_start",
+    "stderr_end",
+)
+
+
+def _convert_task_log_info(src, dst) -> None:
+    """Copy only the fields the event actually set.
+
+    The log paths and start offsets arrive when the task starts and the end offsets in a
+    later event, so copying an unset field would overwrite what the earlier event
+    reported once the two are merged.
+    """
+    for field in _TASK_LOG_INFO_FIELDS:
+        if src.HasField(field):
+            setattr(dst, field, getattr(src, field))
+
+
+def _convert_task_lifecycle_event(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.task_attempt
+    task_event.job_id = event.job_id
+
+    state_update = task_event.state_updates
+    if event.node_id:
+        state_update.node_id = event.node_id
+    if event.worker_id:
+        state_update.worker_id = event.worker_id
+    # worker pid can never be 0.
+    if event.worker_pid != 0:
+        state_update.worker_pid = event.worker_pid
+    if event.HasField("ray_error_info"):
+        state_update.error_info.CopyFrom(event.ray_error_info)
+    if event.HasField("is_debugger_paused"):
+        state_update.is_debugger_paused = event.is_debugger_paused
+    if event.HasField("actor_repr_name"):
+        state_update.actor_repr_name = event.actor_repr_name
+    if event.HasField("task_log_info"):
+        _convert_task_log_info(event.task_log_info, state_update.task_log_info)
+
+    for transition in event.state_transitions:
+        ts = transition.timestamp
+        state_update.state_ts_ns[transition.state] = ts.seconds * 10**9 + ts.nanos
+    return task_event
+
+
+def _convert_actor_task_definition_event(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.task_attempt
+    task_event.job_id = event.job_id
+
+    task_info = task_event.task_info
+    task_info.type = TaskType.ACTOR_TASK
+    task_info.name = event.actor_task_name
+    task_info.task_id = event.task_id
+    task_info.job_id = event.job_id
+    task_info.parent_task_id = event.parent_task_id
+    if event.placement_group_id:
+        task_info.placement_group_id = event.placement_group_id
+    if event.actor_id:
+        task_info.actor_id = event.actor_id
+    if event.is_detached_actor:
+        task_info.is_detached_actor = True
+    if event.HasField("call_site"):
+        task_info.call_site = event.call_site
+    if event.label_selector:
+        task_info.label_selector.update(event.label_selector)
+    if event.HasField("fallback_strategy"):
+        task_info.fallback_strategy.CopyFrom(event.fallback_strategy)
+
+    _populate_task_runtime_and_function_info(
+        task_info,
+        event.serialized_runtime_env,
+        event.actor_func,
+        event.required_resources,
+        event.language,
+    )
+    return task_event
+
+
+def _convert_task_profile_events(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.attempt_number
+    task_event.job_id = event.job_id
+
+    if event.HasField("profile_events"):
+        task_event.profile_events.CopyFrom(event.profile_events)
+    return task_event
+
+
+def convert_to_task_events(
+    request: AddEventsRequest,
+) -> Tuple[List[gcs_pb2.TaskEvents], list]:
+    """Convert an ``AddEventsRequest`` into ``TaskEvents`` for the store, plus the
+    upstream dropped-task-attempt metadata.
+    Returns ``(task_events, dropped_task_attempts)``.
+    """
+    events_data = request.events_data
+    task_events: List[gcs_pb2.TaskEvents] = []
+    for event in events_data.events:
+        event_type = event.event_type
+        if event_type == RayEvent.EventType.TASK_DEFINITION_EVENT:
+            task_events.append(
+                _convert_task_definition_event(event.task_definition_event)
+            )
+        elif event_type == RayEvent.EventType.TASK_LIFECYCLE_EVENT:
+            task_events.append(
+                _convert_task_lifecycle_event(event.task_lifecycle_event)
+            )
+        elif event_type == RayEvent.EventType.TASK_PROFILE_EVENT:
+            task_events.append(_convert_task_profile_events(event.task_profile_events))
+        elif event_type == RayEvent.EventType.ACTOR_TASK_DEFINITION_EVENT:
+            task_events.append(
+                _convert_actor_task_definition_event(event.actor_task_definition_event)
+            )
+        else:
+            # the aggregator only forwards the four exposable task event types,
+            # so any other type is a bug.
+            raise AssertionError(
+                f"Unsupported event type for task events: {event_type}"
+            )
+    dropped_task_attempts = list(events_data.task_events_metadata.dropped_task_attempts)
+    return task_events, dropped_task_attempts

--- a/python/ray/dashboard/modules/task_events/task_event_manager.py
+++ b/python/ray/dashboard/modules/task_events/task_event_manager.py
@@ -1,0 +1,227 @@
+import asyncio
+import logging
+from typing import List, Optional, Set
+
+import ray
+from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
+from ray.core.generated import gcs_pb2, gcs_service_pb2, gcs_service_pb2_grpc
+from ray.dashboard.modules.task_events.task_event_storage import (
+    GC_JOB_SUMMARY_INTERVAL_S,
+    TaskEventStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+# Max notifications drained from a GCS pubsub subscriber per poll.
+_SUBSCRIBER_POLL_BATCH_SIZE = 100
+# Delay before failing a dead worker's tasks, so in-flight FINISHED events can still land.
+_MARK_FAILED_ON_WORKER_DEAD_DELAY_S = (
+    ray._config.gcs_mark_task_failed_on_worker_dead_delay_ms() / 1000
+)
+# Delay before failing a finished job's tasks, for the same reason.
+_MARK_FAILED_ON_JOB_DONE_DELAY_S = (
+    ray._config.gcs_mark_task_failed_on_job_done_delay_ms() / 1000
+)
+# Timeout for the GCS table fetches used to reconcile dead workers and finished jobs.
+_GCS_INFO_FETCH_TIMEOUT_S = 30
+
+
+class TaskEventManager:
+    """Reconciles the in-memory task-event store against GCS pubsub: marks a dead
+    worker's or finished job's running tasks failed, and periodically GCs per-job
+    summaries.
+    """
+
+    def __init__(
+        self,
+        store: TaskEventStorage,
+        gcs_address: str,
+        gcs_aio_channel,
+    ):
+        self._store = store
+        self._gcs_address = gcs_address
+        self._gcs_aio_channel = gcs_aio_channel
+        self._background_tasks: Set[asyncio.Task] = set()
+        self._worker_info_stub = None
+        self._job_info_stub = None
+
+    def start(self) -> None:
+        """Spawn the subscription and GC loops on the running event loop."""
+        self._spawn(self._subscribe_for_worker_deaths())
+        self._spawn(self._subscribe_for_finished_jobs())
+        self._spawn(self._gc_job_summary_loop())
+
+    def _handle_worker_delta(self, worker_delta: gcs_pb2.WorkerDeltaData) -> None:
+        # GCS_WORKER_DELTA_CHANNEL only carries failures, since it is published
+        # only when GCS receives a worker failure event. So every message is a death.
+        self._spawn(self._on_worker_dead(worker_delta.worker_id))
+
+    def _handle_job_update(self, job_data: gcs_pb2.JobTableData) -> None:
+        # GCS_JOB_CHANNEL fires on both job start and finish; only act on finished jobs.
+        if job_data.is_dead:
+            self._spawn(self._on_job_finished(job_data.job_id, job_data.end_time))
+
+    async def _on_worker_dead(self, worker_id: bytes) -> None:
+        # Fetch the dead worker's exit info concurrently with the delay: we start the
+        # fetch immediately so the record is less likely to be trimmed from the worker
+        # table first, and the delay lets in-flight FINISHED events land, so the two
+        # overlap instead of adding up. If the fetch comes back empty (record evicted, or
+        # a transient failure), we still fail the tasks — just without exit details.
+        # TODO(karticam): avoid this round-trip by having the worker-death subscription
+        #   carry the fields we need. PR #64887 moves worker events to the one-event
+        #   framework; migrating those to the dashboard head would give full worker data
+        #   inline (like node_head, which acts on the subscription payload) and drop this RPC.
+        worker_table_data, _ = await asyncio.gather(
+            self._get_worker_info(worker_id),
+            asyncio.sleep(_MARK_FAILED_ON_WORKER_DEAD_DELAY_S),
+        )
+        if worker_table_data is None:
+            logger.warning(
+                f"Could not fetch exit info for dead worker {worker_id.hex()}; marking "
+                "its tasks failed without exit details."
+            )
+        else:
+            logger.debug(
+                f"Marking all running tasks of worker {worker_id.hex()} as failed."
+            )
+        self._store.mark_tasks_failed_on_worker_dead(worker_id, worker_table_data)
+
+    async def _on_job_finished(self, job_id: bytes, end_time_ms: int) -> None:
+        # Delay so in-flight FINISHED events can still land before we fail the tasks.
+        await asyncio.sleep(_MARK_FAILED_ON_JOB_DONE_DELAY_S)
+        logger.info(f"Marking all running tasks of job {job_id.hex()} as failed.")
+        self._store.mark_tasks_failed_on_job_ends(job_id, end_time_ms * 10**6)
+        self._store.update_job_summary_on_job_done(job_id)
+
+    async def _get_worker_info(
+        self, worker_id: bytes
+    ) -> Optional[gcs_pb2.WorkerTableData]:
+        if self._worker_info_stub is None:
+            self._worker_info_stub = gcs_service_pb2_grpc.WorkerInfoGcsServiceStub(
+                self._gcs_aio_channel
+            )
+        try:
+            reply = await self._worker_info_stub.GetWorkerInfo(
+                gcs_service_pb2.GetWorkerInfoRequest(worker_id=worker_id),
+                timeout=_GCS_INFO_FETCH_TIMEOUT_S,
+            )
+        except Exception as e:
+            # A transient GCS/RPC failure must not sink the reconciliation task; treat it
+            # like a missing record so the caller still fails the worker's tasks.
+            logger.warning(f"Failed to fetch worker info for {worker_id.hex()}: {e}")
+            return None
+        if not reply.HasField("worker_table_data"):
+            return None
+        return reply.worker_table_data
+
+    async def _get_all_worker_info(self) -> List[gcs_pb2.WorkerTableData]:
+        if self._worker_info_stub is None:
+            self._worker_info_stub = gcs_service_pb2_grpc.WorkerInfoGcsServiceStub(
+                self._gcs_aio_channel
+            )
+        # Empty request → GCS returns every worker (no limit); the is_alive filter can't
+        # select dead-only server-side (only `true` is respected), so the caller filters.
+        reply = await self._worker_info_stub.GetAllWorkerInfo(
+            gcs_service_pb2.GetAllWorkerInfoRequest(),
+            timeout=_GCS_INFO_FETCH_TIMEOUT_S,
+        )
+        return reply.worker_table_data
+
+    async def _get_all_job_info(self) -> List[gcs_pb2.JobTableData]:
+        if self._job_info_stub is None:
+            self._job_info_stub = gcs_service_pb2_grpc.JobInfoGcsServiceStub(
+                self._gcs_aio_channel
+            )
+        # Empty request → GCS returns every job (no limit).
+        reply = await self._job_info_stub.GetAllJobInfo(
+            gcs_service_pb2.GetAllJobInfoRequest(),
+            timeout=_GCS_INFO_FETCH_TIMEOUT_S,
+        )
+        return reply.job_info_list
+
+    async def _reconcile_dead_workers_on_startup(self) -> None:
+        # GCS pubsub does not replay worker deaths from before we subscribed, so snapshot
+        # the worker table once and fail tasks for any already-dead worker. This must run
+        # AFTER subscribe() so a death between the snapshot and the subscription is still
+        # delivered over pubsub — no gap (see node_head._subscribe_for_node_updates).
+        try:
+            # Overlap the snapshot fetch with the same delay _on_worker_dead uses, so
+            # in-flight FINISHED events can land before we fail the tasks.
+            worker_infos, _ = await asyncio.gather(
+                self._get_all_worker_info(),
+                asyncio.sleep(_MARK_FAILED_ON_WORKER_DEAD_DELAY_S),
+            )
+        except Exception:
+            logger.exception("Failed to reconcile dead workers on startup.")
+            return
+        for worker_table_data in worker_infos:
+            if not worker_table_data.is_alive:
+                self._store.mark_tasks_failed_on_worker_dead(
+                    worker_table_data.worker_address.worker_id, worker_table_data
+                )
+
+    async def _reconcile_finished_jobs_on_startup(self) -> None:
+        # GCS pubsub does not replay job finishes from before we subscribed, so snapshot
+        # the job table once and fail tasks for any already-finished job. This must run
+        # AFTER subscribe() so a finish between the snapshot and the subscription is still
+        # delivered over pubsub.
+        try:
+            # Overlap the snapshot fetch with the same delay _on_job_finished uses, so
+            # in-flight FINISHED events can land before we fail the tasks.
+            job_infos, _ = await asyncio.gather(
+                self._get_all_job_info(),
+                asyncio.sleep(_MARK_FAILED_ON_JOB_DONE_DELAY_S),
+            )
+        except Exception:
+            logger.exception("Failed to reconcile finished jobs on startup.")
+            return
+        for job_data in job_infos:
+            if job_data.is_dead:
+                self._store.mark_tasks_failed_on_job_ends(
+                    job_data.job_id, job_data.end_time * 10**6
+                )
+                self._store.update_job_summary_on_job_done(job_data.job_id)
+
+    async def _subscribe_for_worker_deaths(self) -> None:
+        subscriber = GcsAioWorkerDeltaSubscriber(address=self._gcs_address)
+        await subscriber.subscribe()
+        # Backfill deaths from before the subscription (pubsub won't replay them). Order
+        # matters: subscribe first, then snapshot, so nothing falls between the two.
+        await self._reconcile_dead_workers_on_startup()
+        while True:
+            try:
+                for _, worker_delta in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_worker_delta(worker_delta)
+            except Exception:
+                logger.exception("Failed handling worker-death notifications.")
+
+    async def _subscribe_for_finished_jobs(self) -> None:
+        subscriber = GcsAioJobSubscriber(address=self._gcs_address)
+        await subscriber.subscribe()
+        # Backfill finishes from before the subscription (pubsub won't replay them).
+        # Spawn it (unlike the worker path) so the 15s job-done delay doesn't stall the
+        # poll loop; a finish also seen via pubsub is fine since marking is idempotent.
+        self._spawn(self._reconcile_finished_jobs_on_startup())
+        while True:
+            try:
+                for _, job_data in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_job_update(job_data)
+            except Exception:
+                logger.exception("Failed handling job-finished notifications.")
+
+    async def _gc_job_summary_loop(self) -> None:
+        while True:
+            await asyncio.sleep(GC_JOB_SUMMARY_INTERVAL_S)
+            try:
+                self._store.gc_job_summary()
+            except Exception:
+                logger.exception("Failed trimming task-event job summaries.")
+
+    def _spawn(self, coro) -> None:
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)

--- a/python/ray/dashboard/modules/task_events/task_event_query.py
+++ b/python/ray/dashboard/modules/task_events/task_event_query.py
@@ -1,0 +1,161 @@
+"""Read-path query over the task-event store — answers ``GetTaskEvents`` requests.
+
+Candidate events are selected via the store's indices where an equality filter allows it,
+then the full filter set is applied and the result truncated to the requested limit.
+"""
+from ray.core.generated import gcs_pb2, gcs_service_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
+
+_EQUAL = gcs_service_pb2.FilterPredicate.EQUAL
+_NOT_EQUAL = gcs_service_pb2.FilterPredicate.NOT_EQUAL
+
+# GcsStatus.code for an invalid argument.
+_INVALID_ARGUMENT_STATUS_CODE = 34
+
+# TaskStatus values highest first: a task's latest state is the highest-valued status
+# present in its state timestamps.
+_TASK_STATUS_DESC = sorted(TaskStatus.values(), reverse=True)
+
+
+def _apply_predicate(predicate: int, actual, expected) -> bool:
+    if predicate == _EQUAL:
+        return actual == expected
+    if predicate == _NOT_EQUAL:
+        return actual != expected
+    raise ValueError(f"Unknown filter predicate: {predicate}")
+
+
+def _apply_predicate_ignore_case(predicate: int, actual: str, expected: str) -> bool:
+    return _apply_predicate(predicate, actual.lower(), expected.lower())
+
+
+def _latest_state_name(task_event: gcs_pb2.TaskEvents) -> str:
+    state_ts_ns = task_event.state_updates.state_ts_ns
+    latest = TaskStatus.NIL
+    for status in _TASK_STATUS_DESC:
+        if status in state_ts_ns:
+            latest = status
+            break
+    return TaskStatus.Name(latest)
+
+
+def _passes_filters(
+    task_event: gcs_pb2.TaskEvents,
+    filters: gcs_service_pb2.GetTaskEventsRequest.Filters,
+) -> bool:
+    if not task_event.HasField("task_info"):
+        return False
+    task_info = task_event.task_info
+    if filters.exclude_driver and task_info.type == TaskType.DRIVER_TASK:
+        return False
+    for task_filter in filters.task_filters:
+        if not _apply_predicate(
+            task_filter.predicate, task_event.task_id, task_filter.task_id
+        ):
+            return False
+    for job_filter in filters.job_filters:
+        if not _apply_predicate(
+            job_filter.predicate, task_info.job_id, job_filter.job_id
+        ):
+            return False
+    for actor_filter in filters.actor_filters:
+        if not _apply_predicate(
+            actor_filter.predicate, task_info.actor_id, actor_filter.actor_id
+        ):
+            return False
+    for name_filter in filters.task_name_filters:
+        if not _apply_predicate_ignore_case(
+            name_filter.predicate, task_info.name, name_filter.task_name
+        ):
+            return False
+    if len(filters.state_filters) > 0:
+        state_name = _latest_state_name(task_event)
+        for state_filter in filters.state_filters:
+            if not _apply_predicate_ignore_case(
+                state_filter.predicate, state_name, state_filter.state
+            ):
+                return False
+    return True
+
+
+def _select_candidates(
+    store: TaskEventStorage,
+    request: gcs_service_pb2.GetTaskEventsRequest,
+    reply: gcs_service_pb2.GetTaskEventsReply,
+):
+    """Pick candidate events via index where an equality filter allows it, else scan all.
+
+    A single equality filter on task id or job id uses that index; multiple equality ids
+    short-circuit to an empty result; anything else scans all stored events. Populates the
+    reply's dropped counts at the same scope as the candidates (per-job or global).
+    """
+    filters = request.filters
+    if len(filters.task_filters) > 0:
+        task_ids = {f.task_id for f in filters.task_filters if f.predicate == _EQUAL}
+        if len(task_ids) == 1:
+            return store.get_task_events_by_tasks(task_ids)
+        if len(task_ids) > 1:
+            return []
+    elif len(filters.job_filters) > 0:
+        job_ids = {f.job_id for f in filters.job_filters if f.predicate == _EQUAL}
+        if len(job_ids) == 1:
+            job_id = next(iter(job_ids))
+            candidates = store.get_task_events_by_job(job_id)
+            summary = store.job_summary(job_id)
+            if summary is not None:
+                reply.num_profile_task_events_dropped = (
+                    summary.num_profile_events_dropped
+                )
+                reply.num_status_task_events_dropped = summary.num_task_attempts_dropped
+            return candidates
+        if len(job_ids) > 1:
+            return []
+
+    candidates = store.get_all_task_events()
+    reply.num_profile_task_events_dropped = store.num_profile_events_dropped()
+    reply.num_status_task_events_dropped = store.num_task_attempts_dropped()
+    return candidates
+
+
+def get_task_events(
+    store: TaskEventStorage, request: gcs_service_pb2.GetTaskEventsRequest
+) -> gcs_service_pb2.GetTaskEventsReply:
+    """Answer a ``GetTaskEventsRequest``: select candidates, filter, truncate to limit."""
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    # Every reply carries a status field (OK unless a bad predicate below).
+    reply.status.SetInParent()
+    candidates = _select_candidates(store, request, reply)
+
+    limit = request.limit if request.HasField("limit") else -1
+    count = 0
+    num_status_truncated = 0
+    num_profile_truncated = 0
+    num_truncated = 0
+    num_filtered = 0
+    try:
+        # Iterate newest-first so a limit keeps the most recent events.
+        for task_event in reversed(candidates):
+            if not _passes_filters(task_event, request.filters):
+                num_filtered += 1
+                continue
+            if limit < 0 or count < limit:
+                count += 1
+                reply.events_by_task.add().CopyFrom(task_event)
+            else:
+                num_profile_truncated += len(task_event.profile_events.events)
+                num_status_truncated += 1 if task_event.HasField("state_updates") else 0
+                num_truncated += 1
+    except ValueError as e:
+        reply.Clear()
+        reply.status.code = _INVALID_ARGUMENT_STATUS_CODE
+        reply.status.message = str(e)
+        return reply
+
+    # Truncated events count as dropped for the caller's data-loss accounting.
+    reply.num_profile_task_events_dropped += num_profile_truncated
+    reply.num_status_task_events_dropped += num_status_truncated
+    reply.num_total_stored = len(candidates)
+    reply.num_truncated = num_truncated
+    reply.num_filtered_on_gcs = num_filtered
+    return reply

--- a/python/ray/dashboard/modules/task_events/task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/task_event_storage.py
@@ -1,0 +1,343 @@
+"""In-memory store for task events on the dashboard head.
+
+Events from the same task attempt (same task id + attempt number) are merged into a single
+``TaskEvents`` entry. The store is bounded by ``MAX_NUM_TASK_EVENTS``; when full, entries
+in lower-priority tiers are evicted first (see ``gc_policy``). Per-job bookkeeping tracks
+which task attempts have been dropped so that late events for a dropped attempt are not
+partially re-stored.
+"""
+import collections
+import logging
+import time
+from typing import Dict, List, Optional, Set, Tuple
+
+import ray
+from ray._raylet import JobID, TaskID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskType
+from ray.dashboard.modules.task_events.gc_policy import FinishedTaskActorTaskGcPolicy
+
+logger = logging.getLogger(__name__)
+
+# Max number of task events kept before eviction kicks in.
+MAX_NUM_TASK_EVENTS = ray._config.task_events_max_num_task_in_gcs()
+# Max profile events kept per task attempt; older ones are dropped past this.
+MAX_NUM_PROFILE_EVENTS_PER_TASK = (
+    ray._config.task_events_max_num_profile_events_per_task()
+)
+# Max dropped task attempts tracked per job before the tracking set is trimmed.
+MAX_DROPPED_TASK_ATTEMPTS_PER_JOB = (
+    ray._config.task_events_max_dropped_task_attempts_tracked_per_job_in_gcs()
+)
+# How often the per-job dropped-attempt tracking is trimmed. The RayConfig value is in ms.
+GC_JOB_SUMMARY_INTERVAL_S = ray._config.task_events_gc_job_summary_interval_ms() / 1000
+# Minimum seconds between "at capacity" warnings, to avoid log spam on every eviction.
+_CAPACITY_WARNING_INTERVAL_S = 10.0
+
+# Stat counter keys.
+STAT_NUM_STORED = "num_task_events_stored"
+STAT_TOTAL_REPORTED = "total_num_task_events_reported"
+STAT_TOTAL_ATTEMPTS_DROPPED = "total_num_task_attempts_dropped"
+STAT_TOTAL_PROFILE_DROPPED = "total_num_profile_task_events_dropped"
+_TASK_TYPE_STAT = {
+    TaskType.NORMAL_TASK: "total_num_normal_task",
+    TaskType.ACTOR_CREATION_TASK: "total_num_actor_creation_task",
+    TaskType.ACTOR_TASK: "total_num_actor_task",
+    TaskType.DRIVER_TASK: "total_num_driver_task",
+}
+
+# A task attempt is identified by (task_id bytes, attempt number).
+TaskAttempt = Tuple[bytes, int]
+
+_NIL_TASK_ID = TaskID.nil().binary()
+_NIL_JOB_ID = JobID.nil().binary()
+
+
+def _is_nil_id(id_bytes: bytes, nil_bytes: bytes) -> bool:
+    return not id_bytes or id_bytes == nil_bytes
+
+
+def _task_attempt(task_event: gcs_pb2.TaskEvents) -> TaskAttempt:
+    return (task_event.task_id, task_event.attempt_number)
+
+
+def _worker_id(task_event: gcs_pb2.TaskEvents) -> bytes:
+    return task_event.state_updates.worker_id
+
+
+def _num_profile_events(task_event: gcs_pb2.TaskEvents) -> int:
+    return len(task_event.profile_events.events)
+
+
+class JobTaskSummary:
+    """Per-job tracking of dropped task attempts and dropped profile events."""
+
+    def __init__(self):
+        self._num_profile_events_dropped = 0
+        self._num_task_attempts_dropped_tracked = 0
+        self._num_dropped_task_attempts_evicted = 0
+        self._dropped_task_attempts: Set[TaskAttempt] = set()
+
+    def record_task_attempt_dropped(self, task_attempt: TaskAttempt) -> None:
+        self._dropped_task_attempts.add(task_attempt)
+        self._num_task_attempts_dropped_tracked = len(self._dropped_task_attempts)
+
+    def record_profile_events_dropped(self, count: int) -> None:
+        self._num_profile_events_dropped += count
+
+    def should_drop_task_attempt(self, task_attempt: TaskAttempt) -> bool:
+        """A task attempt is dropped once any of its events have been dropped."""
+        return task_attempt in self._dropped_task_attempts
+
+    @property
+    def num_profile_events_dropped(self) -> int:
+        return self._num_profile_events_dropped
+
+    @property
+    def num_task_attempts_dropped(self) -> int:
+        return (
+            self._num_task_attempts_dropped_tracked
+            + self._num_dropped_task_attempts_evicted
+        )
+
+    def on_job_ends(self) -> None:
+        """No more events arrive for a finished job, so stop tracking its drops."""
+        self._dropped_task_attempts.clear()
+
+    def gc_old_dropped_task_attempts(self, job_id: bytes) -> None:
+        """Trim the dropped-attempt set when it grows past the per-job cap."""
+        max_tracked = MAX_DROPPED_TASK_ATTEMPTS_PER_JOB
+        if len(self._dropped_task_attempts) <= max_tracked:
+            return
+        logger.info(
+            "Evicting extra tracked dropped task attempts (%d > %d) for job %s. Set "
+            "RAY_task_events_max_dropped_task_attempts_tracked_per_job_in_gcs to a higher "
+            "value to track more.",
+            len(self._dropped_task_attempts),
+            max_tracked,
+            job_id.hex(),
+        )
+        num_to_evict = len(self._dropped_task_attempts) - max_tracked
+        # Evict an extra 10% to avoid trimming on every pass.
+        num_to_evict = min(
+            len(self._dropped_task_attempts), num_to_evict + int(0.1 * num_to_evict)
+        )
+        self._num_task_attempts_dropped_tracked = len(self._dropped_task_attempts)
+        if num_to_evict == 0:
+            return
+        self._num_dropped_task_attempts_evicted += num_to_evict
+        to_evict = list(self._dropped_task_attempts)[:num_to_evict]
+        self._dropped_task_attempts.difference_update(to_evict)
+        self._num_task_attempts_dropped_tracked = len(self._dropped_task_attempts)
+
+
+class TaskEventStorage:
+    """Bounded, deduplicated in-memory store of ``TaskEvents`` keyed by task attempt.
+
+    - ``_tiers``: one insertion-ordered dict per GC priority tier (task attempt ->
+      ``TaskEvents``); the first key is the oldest, so eviction drops the oldest entry in
+      the lowest-priority non-empty tier.
+    - ``_primary_index``: task attempt -> the tier holding it, so an entry is found (and
+      moved between tiers when its priority changes) via
+      ``_tiers[_primary_index[attempt]][attempt]``.
+    - ``_task_index`` / ``_job_index`` / ``_worker_index``: id -> set of task attempts,
+      for lookups by task / job / worker.
+    """
+
+    def __init__(
+        self,
+        max_num_task_events: int = MAX_NUM_TASK_EVENTS,
+        gc_policy: Optional[FinishedTaskActorTaskGcPolicy] = None,
+    ):
+        self._max_num_task_events = max_num_task_events
+        self._gc_policy = gc_policy or FinishedTaskActorTaskGcPolicy()
+        # One insertion-ordered map per priority tier; oldest key first.
+        self._tiers: List[Dict[TaskAttempt, gcs_pb2.TaskEvents]] = [
+            {} for _ in range(self._gc_policy.max_priority)
+        ]
+        # Primary index: task attempt -> which tier holds it.
+        self._primary_index: Dict[TaskAttempt, int] = {}
+        # Secondary indices: id -> set of task attempts.
+        self._task_index: Dict[bytes, Set[TaskAttempt]] = {}
+        self._job_index: Dict[bytes, Set[TaskAttempt]] = {}
+        self._worker_index: Dict[bytes, Set[TaskAttempt]] = {}
+        self._job_task_summary: Dict[bytes, JobTaskSummary] = {}
+        self._stats: collections.Counter = collections.Counter()
+        self._last_capacity_warning_time = float("-inf")
+
+    def add_or_replace_task_event(self, task_event: gcs_pb2.TaskEvents) -> None:
+        """Add a new task attempt or merge into an existing one, evicting if over capacity."""
+        self._stats[STAT_TOTAL_REPORTED] += 1
+        job_id = task_event.job_id
+        task_id = task_event.task_id
+        if _is_nil_id(job_id, _NIL_JOB_ID) or _is_nil_id(task_id, _NIL_TASK_ID):
+            # Missing task/job id, e.g. profile events created without a task id.
+            logger.debug(
+                "Skipping invalid task event with missing job or task id: %s",
+                task_event,
+            )
+            return
+
+        attempt = _task_attempt(task_event)
+        if self._summary(job_id).should_drop_task_attempt(attempt):
+            logger.debug(
+                "Already dropping task %s attempt %d of job %s",
+                task_id.hex(),
+                task_event.attempt_number,
+                job_id.hex(),
+            )
+            return
+
+        if attempt in self._primary_index:
+            self._update_existing(attempt, task_event)
+        else:
+            self._add_new(attempt, task_event)
+
+        if (
+            self._max_num_task_events > 0
+            and self._stats[STAT_NUM_STORED] > self._max_num_task_events
+        ):
+            self._warn_capacity_reached()
+            self._evict_task_event()
+
+    def _warn_capacity_reached(self) -> None:
+        now = time.monotonic()
+        if now - self._last_capacity_warning_time < _CAPACITY_WARNING_INTERVAL_S:
+            return
+        self._last_capacity_warning_time = now
+        logger.warning(
+            "Max number of task events (%d) reached; old task events will be "
+            "overwritten. Set RAY_task_events_max_num_task_in_gcs to a higher "
+            "value to store more.",
+            self._max_num_task_events,
+        )
+
+    def record_data_loss_from_worker(self, dropped_task_attempts) -> None:
+        """Honor drops reported upstream: mark the attempts dropped and evict any partial
+        copy already stored, so data loss is at task-attempt granularity."""
+        for dropped in dropped_task_attempts:
+            task_id = dropped.task_id
+            attempt = (task_id, dropped.attempt_number)
+            job_id = TaskID(task_id).job_id().binary()
+            self._summary(job_id).record_task_attempt_dropped(attempt)
+            self._stats[STAT_TOTAL_ATTEMPTS_DROPPED] += 1
+            if attempt in self._primary_index:
+                self._remove_task_attempt(attempt)
+
+    def gc_job_summary(self) -> None:
+        for job_id, summary in self._job_task_summary.items():
+            summary.gc_old_dropped_task_attempts(job_id)
+
+    @property
+    def stats(self) -> collections.Counter:
+        return self._stats
+
+    @property
+    def num_task_events_stored(self) -> int:
+        return self._stats[STAT_NUM_STORED]
+
+    def get_task_event(self, task_attempt: TaskAttempt) -> Optional[gcs_pb2.TaskEvents]:
+        tier = self._primary_index.get(task_attempt)
+        return None if tier is None else self._tiers[tier][task_attempt]
+
+    def job_summary(self, job_id: bytes) -> Optional[JobTaskSummary]:
+        return self._job_task_summary.get(job_id)
+
+    def _summary(self, job_id: bytes) -> JobTaskSummary:
+        summary = self._job_task_summary.get(job_id)
+        if summary is None:
+            summary = JobTaskSummary()
+            self._job_task_summary[job_id] = summary
+        return summary
+
+    def _add_new(self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents) -> None:
+        tier = self._gc_policy.get_task_list_priority(task_event)
+        self._tiers[tier][attempt] = task_event
+        self._primary_index[attempt] = tier
+        self._stats[STAT_NUM_STORED] += 1
+        if task_event.HasField("task_info") and task_event.attempt_number == 0:
+            self._increment_task_type(task_event.task_info.type)
+        self._update_index(attempt, task_event)
+
+    def _update_existing(
+        self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents
+    ) -> None:
+        tier = self._primary_index[attempt]
+        existing = self._tiers[tier][attempt]
+        if task_event.HasField("task_info") and not existing.HasField("task_info"):
+            self._increment_task_type(task_event.task_info.type)
+
+        existing.MergeFrom(task_event)
+
+        num_profile = len(existing.profile_events.events)
+        if num_profile > MAX_NUM_PROFILE_EVENTS_PER_TASK:
+            to_drop = num_profile - MAX_NUM_PROFILE_EVENTS_PER_TASK
+            del existing.profile_events.events[:to_drop]
+            self._summary(existing.job_id).record_profile_events_dropped(to_drop)
+            self._stats[STAT_TOTAL_PROFILE_DROPPED] += to_drop
+
+        new_tier = self._gc_policy.get_task_list_priority(existing)
+        if new_tier != tier:
+            del self._tiers[tier][attempt]
+            self._tiers[new_tier][attempt] = existing
+            self._primary_index[attempt] = new_tier
+
+        self._update_index(attempt, existing)
+
+    def _increment_task_type(self, task_type) -> None:
+        stat = _TASK_TYPE_STAT.get(task_type)
+        if stat is not None:
+            self._stats[stat] += 1
+
+    def _update_index(
+        self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents
+    ) -> None:
+        self._task_index.setdefault(task_event.task_id, set()).add(attempt)
+        self._job_index.setdefault(task_event.job_id, set()).add(attempt)
+        worker_id = _worker_id(task_event)
+        if worker_id:
+            self._worker_index.setdefault(worker_id, set()).add(attempt)
+
+    def _remove_from_index(
+        self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents
+    ) -> None:
+        self._discard(self._job_index, task_event.job_id, attempt)
+        self._discard(self._task_index, task_event.task_id, attempt)
+        worker_id = _worker_id(task_event)
+        if worker_id:
+            self._discard(self._worker_index, worker_id, attempt)
+        del self._primary_index[attempt]
+
+    @staticmethod
+    def _discard(
+        index: Dict[bytes, Set[TaskAttempt]], key: bytes, attempt: TaskAttempt
+    ) -> None:
+        attempts = index.get(key)
+        if attempts is None:
+            return
+        attempts.discard(attempt)
+        if not attempts:
+            del index[key]
+
+    def _remove_task_attempt(self, attempt: TaskAttempt) -> None:
+        tier = self._primary_index[attempt]
+        task_event = self._tiers[tier][attempt]
+        num_profile = _num_profile_events(task_event)
+
+        summary = self._summary(task_event.job_id)
+        summary.record_profile_events_dropped(num_profile)
+        summary.record_task_attempt_dropped(attempt)
+        self._stats[STAT_NUM_STORED] -= 1
+        self._stats[STAT_TOTAL_ATTEMPTS_DROPPED] += 1
+        self._stats[STAT_TOTAL_PROFILE_DROPPED] += num_profile
+
+        self._remove_from_index(attempt, task_event)
+        del self._tiers[tier][attempt]
+
+    def _evict_task_event(self) -> None:
+        for tier in range(self._gc_policy.max_priority):
+            if self._tiers[tier]:
+                # The first key is the oldest (least recently inserted) in this tier.
+                oldest = next(iter(self._tiers[tier]))
+                self._remove_task_attempt(oldest)
+                return

--- a/python/ray/dashboard/modules/task_events/task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/task_event_storage.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import ray
 from ray._raylet import JobID, TaskID
 from ray.core.generated import gcs_pb2
-from ray.core.generated.common_pb2 import TaskType
+from ray.core.generated.common_pb2 import ErrorType, RayErrorInfo, TaskStatus, TaskType
 from ray.dashboard.modules.task_events.gc_policy import FinishedTaskActorTaskGcPolicy
 
 logger = logging.getLogger(__name__)
@@ -224,6 +224,67 @@ class TaskEventStorage:
             if attempt in self._primary_index:
                 self._remove_task_attempt(attempt)
 
+    def mark_tasks_failed_on_worker_dead(
+        self,
+        worker_id: bytes,
+        worker_table_data: Optional[gcs_pb2.WorkerTableData],
+    ) -> None:
+        """Mark all non-terminal task attempts run by a dead worker as failed.
+
+        ``worker_table_data`` is None when the worker's record could not be fetched from
+        GCS. The tasks are still failed so they don't linger as running, but without exit
+        details and stamped with the current time instead of the worker's end time.
+        """
+        # TODO(karticam): there are edge cases where _worker_index might not have all tasks
+        #  for the worker when we receive worker death notification since some task events
+        #  might not have reached us to populate the index. So we might not mark all tasks
+        #  as failed. Check the comment thread below for more details:
+        #  https://github.com/ray-project/ray/pull/65141#discussion_r3734119692
+        attempts = self._worker_index.get(worker_id)
+        if attempts is None:
+            return
+        error_info = RayErrorInfo(error_type=ErrorType.WORKER_DIED)
+        if worker_table_data is not None:
+            error_info.error_message = (
+                f"Worker running the task ({worker_id.hex()}) died with exit_type: "
+                f"{worker_table_data.exit_type} with error_message: "
+                f"{worker_table_data.exit_detail}"
+            )
+            failed_ts_ns = worker_table_data.end_time_ms * 10**6
+        else:
+            error_info.error_message = (
+                f"Worker running the task ({worker_id.hex()}) died, but its exit details "
+                "could not be fetched from GCS: either GCS evicted the worker's "
+                "record or the GetWorkerInfo request failed (e.g. timed out or GCS was"
+                " unavailable)."
+            )
+            failed_ts_ns = time.time_ns()
+        for attempt in list(attempts):
+            self._mark_task_attempt_failed_if_needed(attempt, failed_ts_ns, error_info)
+
+    def mark_tasks_failed_on_job_ends(
+        self, job_id: bytes, job_finish_time_ns: int
+    ) -> None:
+        """Mark all non-terminal task attempts of a finished job as failed."""
+        attempts = self._job_index.get(job_id)
+        if attempts is None:
+            return
+        error_info = RayErrorInfo(error_type=ErrorType.WORKER_DIED)
+        error_info.error_message = (
+            f"Job finishes ({job_id.hex()}) as driver exits. "
+            "Marking all non-terminal tasks as failed."
+        )
+        for attempt in list(attempts):
+            self._mark_task_attempt_failed_if_needed(
+                attempt, job_finish_time_ns, error_info
+            )
+
+    def update_job_summary_on_job_done(self, job_id: bytes) -> None:
+        """Clear a finished job's dropped-attempt tracking (no more events will arrive)."""
+        summary = self._job_task_summary.get(job_id)
+        if summary is not None:
+            summary.on_job_ends()
+
     def gc_job_summary(self) -> None:
         for job_id, summary in self._job_task_summary.items():
             summary.gc_old_dropped_task_attempts(job_id)
@@ -242,6 +303,49 @@ class TaskEventStorage:
 
     def job_summary(self, job_id: bytes) -> Optional[JobTaskSummary]:
         return self._job_task_summary.get(job_id)
+
+    def get_all_task_events(self) -> List[gcs_pb2.TaskEvents]:
+        """All stored task events, higher-priority tiers first, oldest-first within a tier."""
+        result: List[gcs_pb2.TaskEvents] = []
+        for tier in range(self._gc_policy.max_priority - 1, -1, -1):
+            result.extend(self._tiers[tier].values())
+        return result
+
+    def get_task_events_by_job(self, job_id: bytes) -> List[gcs_pb2.TaskEvents]:
+        """All stored task events for the given job."""
+        return self._events_for_attempts(self._job_index.get(job_id))
+
+    def get_task_events_by_tasks(
+        self, task_ids: Set[bytes]
+    ) -> List[gcs_pb2.TaskEvents]:
+        """All stored task events for the given task ids."""
+        attempts: Set[TaskAttempt] = set()
+        for task_id in task_ids:
+            attempts |= self._task_index.get(task_id, set())
+        return self._events_for_attempts(attempts)
+
+    def _events_for_attempts(
+        self, attempts: Optional[Set[TaskAttempt]]
+    ) -> List[gcs_pb2.TaskEvents]:
+        if not attempts:
+            return []
+        return [
+            self._tiers[self._primary_index[attempt]][attempt] for attempt in attempts
+        ]
+
+    def num_profile_events_dropped(self) -> int:
+        """Profile events dropped across all jobs (for read-path data-loss reporting)."""
+        return sum(
+            summary.num_profile_events_dropped
+            for summary in self._job_task_summary.values()
+        )
+
+    def num_task_attempts_dropped(self) -> int:
+        """Task attempts dropped across all jobs (for read-path data-loss reporting)."""
+        return sum(
+            summary.num_task_attempts_dropped
+            for summary in self._job_task_summary.values()
+        )
 
     def _summary(self, job_id: bytes) -> JobTaskSummary:
         summary = self._job_task_summary.get(job_id)
@@ -341,3 +445,21 @@ class TaskEventStorage:
                 oldest = next(iter(self._tiers[tier]))
                 self._remove_task_attempt(oldest)
                 return
+
+    @staticmethod
+    def _is_task_terminated(task_event: gcs_pb2.TaskEvents) -> bool:
+        """Whether the task attempt has reported a FINISHED or FAILED state."""
+        if not task_event.HasField("state_updates"):
+            return False
+        state_ts_ns = task_event.state_updates.state_ts_ns
+        return TaskStatus.FINISHED in state_ts_ns or TaskStatus.FAILED in state_ts_ns
+
+    def _mark_task_attempt_failed_if_needed(
+        self, attempt: TaskAttempt, failed_ts_ns: int, error_info: RayErrorInfo
+    ) -> None:
+        task_event = self._tiers[self._primary_index[attempt]][attempt]
+        # Don't fail a task attempt that already reached a terminal state.
+        if self._is_task_terminated(task_event):
+            return
+        task_event.state_updates.state_ts_ns[TaskStatus.FAILED] = failed_ts_ns
+        task_event.state_updates.error_info.CopyFrom(error_info)

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -1,35 +1,65 @@
+import asyncio
 import collections
 import logging
+from typing import Set
 
 import aiohttp.web
 
+import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
-from ray.core.generated import events_event_aggregator_service_pb2
+from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
+from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 
 logger = logging.getLogger(__name__)
 
+# Max notifications drained from a GCS pubsub subscriber per poll.
+_SUBSCRIBER_POLL_BATCH_SIZE = 100
+
 
 class TaskEventsHead(SubprocessModule):
-    """Dashboard-head endpoint that receives task events from per-node aggregators.
+    """Dashboard-head sink for task events and their GCS reconciliation signals.
 
-    The per-node aggregator agent POSTs an ``AddEventsRequest`` payload
-     to this module, which holds the received``RayEvent``s in memory.
+    Receives task events over HTTP from the per-node aggregator agents (which POST an
+    ``AddEventsRequest`` payload), and subscribes to GCS pubsub for the worker-death and
+    job-finished notifications needed to reconcile task state (the signals
+    ``GcsTaskManager`` consumes in-process today). Everything is held in memory for now.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO(karticam): Replace this with an in-memory store of task events.
-        #   This will mimic current GcsTaskManager and will power state API.
-        #   Will be done in future PRs.
+        # TODO(karticam): Replace these in-memory buffers with a task-event store +
+        #   reconciliation logic (mirroring GcsTaskManager) that powers the state API.
+        #   Consuming the worker-death / job-finished notifications below to actually
+        #   fail tasks (MarkTasksFailedOnWorkerDead / MarkTasksFailedOnJobEnds) is a
+        #   follow-up PR.
         self._events = collections.deque()
+        self._dead_workers = collections.deque()
+        self._finished_jobs = collections.deque()
+        self._background_tasks: Set[asyncio.Task] = set()
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        """Only load while the "task events out of GCS" migration is enabled; otherwise
+        the module (and its GCS pubsub subscriptions) shouldn't run at all."""
+        return ray._config.enable_task_events_to_dashboard_head()
 
     @property
     def num_events_received(self) -> int:
         """Number of task events currently held in the in-memory buffer (for tests)."""
         return len(self._events)
+
+    @property
+    def num_dead_workers_received(self) -> int:
+        """Number of worker-death notifications received (for tests)."""
+        return len(self._dead_workers)
+
+    @property
+    def num_finished_jobs_received(self) -> int:
+        """Number of job-finished notifications received (for tests)."""
+        return len(self._finished_jobs)
 
     def _deserialize_request(
         self, body: bytes
@@ -47,7 +77,7 @@ class TaskEventsHead(SubprocessModule):
         except Exception as e:
             logger.warning(f"Failed to deserialize task events request: {e}")
             return dashboard_optional_utils.rest_response(
-                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                status_code=dashboard_utils.HTTPStatusCode.BAD_REQUEST,
                 message=f"Failed to deserialize task events request: {e}",
             )
 
@@ -63,5 +93,47 @@ class TaskEventsHead(SubprocessModule):
             message="",
         )
 
+    def _handle_worker_delta(self, worker_delta: gcs_pb2.WorkerDeltaData) -> None:
+        """Record a worker-death notification. GCS_WORKER_DELTA_CHANNEL only carries
+        failures, so every message is a death."""
+        self._dead_workers.append(worker_delta)
+
+    def _handle_job_update(self, job_data: gcs_pb2.JobTableData) -> None:
+        """Record a job-finished notification. GCS_JOB_CHANNEL fires on both job start and
+        finish; keep only finished jobs (``is_dead``) to mirror ``OnJobFinished``."""
+        if job_data.is_dead:
+            self._finished_jobs.append(job_data)
+
+    async def _subscribe_for_worker_deaths(self) -> None:
+        subscriber = GcsAioWorkerDeltaSubscriber(address=self.gcs_address)
+        await subscriber.subscribe()
+        while True:
+            try:
+                for _, worker_delta in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_worker_delta(worker_delta)
+            except Exception:
+                logger.exception("Failed handling worker-death notifications.")
+
+    async def _subscribe_for_finished_jobs(self) -> None:
+        subscriber = GcsAioJobSubscriber(address=self.gcs_address)
+        await subscriber.subscribe()
+        while True:
+            try:
+                for _, job_data in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_job_update(job_data)
+            except Exception:
+                logger.exception("Failed handling job-finished notifications.")
+
     async def run(self):
         await super().run()
+        for coro in (
+            self._subscribe_for_worker_deaths(),
+            self._subscribe_for_finished_jobs(),
+        ):
+            task = asyncio.create_task(coro)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -10,6 +10,11 @@ import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
 from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
+from ray.dashboard.modules.task_events.ray_event_converter import convert_to_task_events
+from ray.dashboard.modules.task_events.task_event_storage import (
+    GC_JOB_SUMMARY_INTERVAL_S,
+    TaskEventStorage,
+)
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 
@@ -20,22 +25,19 @@ _SUBSCRIBER_POLL_BATCH_SIZE = 100
 
 
 class TaskEventsHead(SubprocessModule):
-    """Dashboard-head sink for task events and their GCS reconciliation signals.
+    """Dashboard-head sink for task events and their reconciliation signals.
 
     Receives task events over HTTP from the per-node aggregator agents (which POST an
-    ``AddEventsRequest`` payload), and subscribes to GCS pubsub for the worker-death and
-    job-finished notifications needed to reconcile task state (the signals
-    ``GcsTaskManager`` consumes in-process today). Everything is held in memory for now.
+    ``AddEventsRequest`` payload) and stores them, and subscribes to GCS pubsub for the
+    worker-death and job-finished notifications needed to reconcile task state. Everything
+    is held in memory.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO(karticam): Replace these in-memory buffers with a task-event store +
-        #   reconciliation logic (mirroring GcsTaskManager) that powers the state API.
-        #   Consuming the worker-death / job-finished notifications below to actually
-        #   fail tasks (MarkTasksFailedOnWorkerDead / MarkTasksFailedOnJobEnds) is a
-        #   follow-up PR.
-        self._events = collections.deque()
+        self._store = TaskEventStorage()
+        # TODO(karticam): consume these worker-death / job-finished notifications to fail
+        #   the affected tasks in the store. Will be done in the next PR.
         self._dead_workers = collections.deque()
         self._finished_jobs = collections.deque()
         self._background_tasks: Set[asyncio.Task] = set()
@@ -47,9 +49,9 @@ class TaskEventsHead(SubprocessModule):
         return ray._config.enable_task_events_to_dashboard_head()
 
     @property
-    def num_events_received(self) -> int:
-        """Number of task events currently held in the in-memory buffer (for tests)."""
-        return len(self._events)
+    def num_task_events_stored(self) -> int:
+        """Number of task attempts currently held in the store (for tests)."""
+        return self._store.num_task_events_stored
 
     @property
     def num_dead_workers_received(self) -> int:
@@ -81,12 +83,14 @@ class TaskEventsHead(SubprocessModule):
                 message=f"Failed to deserialize task events request: {e}",
             )
 
-        events_data = add_events_request.events_data
-        self._events.extend(events_data.events)
+        task_events, dropped_task_attempts = convert_to_task_events(add_events_request)
+        self._store.record_data_loss_from_worker(dropped_task_attempts)
+        for task_event in task_events:
+            self._store.add_or_replace_task_event(task_event)
         logger.debug(
-            "Received %d task events (%d total buffered)",
-            len(events_data.events),
-            len(self._events),
+            "Received %d task events (%d attempts stored)",
+            len(task_events),
+            self._store.num_task_events_stored,
         )
         return dashboard_optional_utils.rest_response(
             status_code=dashboard_utils.HTTPStatusCode.OK,
@@ -128,11 +132,20 @@ class TaskEventsHead(SubprocessModule):
             except Exception:
                 logger.exception("Failed handling job-finished notifications.")
 
+    async def _gc_job_summary_loop(self) -> None:
+        while True:
+            await asyncio.sleep(GC_JOB_SUMMARY_INTERVAL_S)
+            try:
+                self._store.gc_job_summary()
+            except Exception:
+                logger.exception("Failed trimming task-event job summaries.")
+
     async def run(self):
         await super().run()
         for coro in (
             self._subscribe_for_worker_deaths(),
             self._subscribe_for_finished_jobs(),
+            self._gc_job_summary_loop(),
         ):
             task = asyncio.create_task(coro)
             self._background_tasks.add(task)

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -1,0 +1,67 @@
+import collections
+import logging
+
+import aiohttp.web
+
+import ray.dashboard.optional_utils as dashboard_optional_utils
+import ray.dashboard.utils as dashboard_utils
+from ray.core.generated import events_event_aggregator_service_pb2
+from ray.dashboard.subprocesses.module import SubprocessModule
+from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
+
+logger = logging.getLogger(__name__)
+
+
+class TaskEventsHead(SubprocessModule):
+    """Dashboard-head endpoint that receives task events from per-node aggregators.
+
+    The per-node aggregator agent POSTs an ``AddEventsRequest`` payload
+     to this module, which holds the received``RayEvent``s in memory.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # TODO(karticam): Replace this with an in-memory store of task events.
+        #   This will mimic current GcsTaskManager and will power state API.
+        #   Will be done in future PRs.
+        self._events = collections.deque()
+
+    @property
+    def num_events_received(self) -> int:
+        """Number of task events currently held in the in-memory buffer (for tests)."""
+        return len(self._events)
+
+    def _deserialize_request(
+        self, body: bytes
+    ) -> events_event_aggregator_service_pb2.AddEventsRequest:
+        """Deserialize the binary-proto POST body into an ``AddEventsRequest``."""
+        return events_event_aggregator_service_pb2.AddEventsRequest.FromString(body)
+
+    @routes.post("/api/task_events")
+    async def add_task_events(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        body = await request.read()
+        try:
+            add_events_request = self._deserialize_request(body)
+        except Exception as e:
+            logger.warning(f"Failed to deserialize task events request: {e}")
+            return dashboard_optional_utils.rest_response(
+                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                message=f"Failed to deserialize task events request: {e}",
+            )
+
+        events_data = add_events_request.events_data
+        self._events.extend(events_data.events)
+        logger.debug(
+            "Received %d task events (%d total buffered)",
+            len(events_data.events),
+            len(self._events),
+        )
+        return dashboard_optional_utils.rest_response(
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="",
+        )
+
+    async def run(self):
+        await super().run()

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -1,46 +1,37 @@
-import asyncio
-import collections
 import logging
-from typing import Set
 
 import aiohttp.web
 
 import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
-from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
-from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
-from ray.dashboard.modules.task_events.ray_event_converter import convert_to_task_events
-from ray.dashboard.modules.task_events.task_event_storage import (
-    GC_JOB_SUMMARY_INTERVAL_S,
-    TaskEventStorage,
+from ray.core.generated import (
+    events_event_aggregator_service_pb2,
+    gcs_service_pb2,
 )
+from ray.dashboard.modules.task_events import task_event_query
+from ray.dashboard.modules.task_events.ray_event_converter import convert_to_task_events
+from ray.dashboard.modules.task_events.task_event_manager import TaskEventManager
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 
 logger = logging.getLogger(__name__)
 
-# Max notifications drained from a GCS pubsub subscriber per poll.
-_SUBSCRIBER_POLL_BATCH_SIZE = 100
-
 
 class TaskEventsHead(SubprocessModule):
-    """Dashboard-head sink for task events and their reconciliation signals.
+    """Dashboard-head sink for task events.
 
-    Receives task events over HTTP from the per-node aggregator agents (which POST an
-    ``AddEventsRequest`` payload) and stores them, and subscribes to GCS pubsub for the
-    worker-death and job-finished notifications needed to reconcile task state. Everything
-    is held in memory.
+    Defines the HTTP API external clients interact with. Events
+    are held in memory in a ``TaskEventStorage``; the background upkeep of that store
+    (reconciling it against GCS worker-death and job-finished signals, plus periodic GC) is
+    delegated to a ``TaskEventManager``.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._store = TaskEventStorage()
-        # TODO(karticam): consume these worker-death / job-finished notifications to fail
-        #   the affected tasks in the store. Will be done in the next PR.
-        self._dead_workers = collections.deque()
-        self._finished_jobs = collections.deque()
-        self._background_tasks: Set[asyncio.Task] = set()
+        self._manager = None
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -52,16 +43,6 @@ class TaskEventsHead(SubprocessModule):
     def num_task_events_stored(self) -> int:
         """Number of task attempts currently held in the store (for tests)."""
         return self._store.num_task_events_stored
-
-    @property
-    def num_dead_workers_received(self) -> int:
-        """Number of worker-death notifications received (for tests)."""
-        return len(self._dead_workers)
-
-    @property
-    def num_finished_jobs_received(self) -> int:
-        """Number of job-finished notifications received (for tests)."""
-        return len(self._finished_jobs)
 
     def _deserialize_request(
         self, body: bytes
@@ -97,56 +78,30 @@ class TaskEventsHead(SubprocessModule):
             message="",
         )
 
-    def _handle_worker_delta(self, worker_delta: gcs_pb2.WorkerDeltaData) -> None:
-        """Record a worker-death notification. GCS_WORKER_DELTA_CHANNEL only carries
-        failures, so every message is a death."""
-        self._dead_workers.append(worker_delta)
+    @routes.post("/api/task_events/query")
+    async def get_task_events(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        """Answer a serialized ``GetTaskEventsRequest`` with a serialized reply.
 
-    def _handle_job_update(self, job_data: gcs_pb2.JobTableData) -> None:
-        """Record a job-finished notification. GCS_JOB_CHANNEL fires on both job start and
-        finish; keep only finished jobs (``is_dead``) to mirror ``OnJobFinished``."""
-        if job_data.is_dead:
-            self._finished_jobs.append(job_data)
-
-    async def _subscribe_for_worker_deaths(self) -> None:
-        subscriber = GcsAioWorkerDeltaSubscriber(address=self.gcs_address)
-        await subscriber.subscribe()
-        while True:
-            try:
-                for _, worker_delta in await subscriber.poll(
-                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
-                ):
-                    self._handle_worker_delta(worker_delta)
-            except Exception:
-                logger.exception("Failed handling worker-death notifications.")
-
-    async def _subscribe_for_finished_jobs(self) -> None:
-        subscriber = GcsAioJobSubscriber(address=self.gcs_address)
-        await subscriber.subscribe()
-        while True:
-            try:
-                for _, job_data in await subscriber.poll(
-                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
-                ):
-                    self._handle_job_update(job_data)
-            except Exception:
-                logger.exception("Failed handling job-finished notifications.")
-
-    async def _gc_job_summary_loop(self) -> None:
-        while True:
-            await asyncio.sleep(GC_JOB_SUMMARY_INTERVAL_S)
-            try:
-                self._store.gc_job_summary()
-            except Exception:
-                logger.exception("Failed trimming task-event job summaries.")
+        Internal read endpoint for the State API (``StateHead``); the request/reply protos
+        match GCS's ``GetTaskEvents`` so the caller is transport-only.
+        """
+        body = await request.read()
+        try:
+            query_request = gcs_service_pb2.GetTaskEventsRequest.FromString(body)
+            reply = task_event_query.get_task_events(self._store, query_request)
+        except Exception as e:
+            logger.warning(f"Failed to query task events: {e}")
+            return aiohttp.web.Response(status=400, text=str(e))
+        return aiohttp.web.Response(
+            body=reply.SerializeToString(),
+            content_type="application/octet-stream",
+        )
 
     async def run(self):
         await super().run()
-        for coro in (
-            self._subscribe_for_worker_deaths(),
-            self._subscribe_for_finished_jobs(),
-            self._gc_job_summary_loop(),
-        ):
-            task = asyncio.create_task(coro)
-            self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
+        self._manager = TaskEventManager(
+            self._store, self.gcs_address, self.aiogrpc_gcs_channel
+        )
+        self._manager.start()

--- a/python/ray/dashboard/modules/task_events/tests/test_gc_policy.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_gc_policy.py
@@ -1,0 +1,46 @@
+import sys
+
+import pytest
+
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+from ray.dashboard.modules.task_events.gc_policy import FinishedTaskActorTaskGcPolicy
+
+
+def _finished_event() -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents()
+    event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    return event
+
+
+def _typed_event(task_type) -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents()
+    event.task_info.type = task_type
+    return event
+
+
+def test_max_priority():
+    assert FinishedTaskActorTaskGcPolicy().max_priority == 3
+
+
+def test_priority_tiers():
+    policy = FinishedTaskActorTaskGcPolicy()
+    assert policy.get_task_list_priority(_finished_event()) == 0
+    assert policy.get_task_list_priority(_typed_event(TaskType.ACTOR_TASK)) == 1
+    assert (
+        policy.get_task_list_priority(_typed_event(TaskType.ACTOR_CREATION_TASK)) == 1
+    )
+    assert policy.get_task_list_priority(_typed_event(TaskType.NORMAL_TASK)) == 2
+    # Empty event: neither finished nor an actor task -> lowest priority.
+    assert policy.get_task_list_priority(gcs_pb2.TaskEvents()) == 2
+
+
+def test_finished_wins_over_actor():
+    policy = FinishedTaskActorTaskGcPolicy()
+    event = _typed_event(TaskType.ACTOR_TASK)
+    event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    assert policy.get_task_list_priority(event) == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_ray_event_converter.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_ray_event_converter.py
@@ -1,0 +1,224 @@
+import sys
+
+import pytest
+
+from ray._raylet import JobID, TaskID
+from ray.core.generated.common_pb2 import (
+    FunctionDescriptor,
+    Language,
+    TaskAttempt,
+    TaskStatus,
+    TaskType,
+)
+from ray.core.generated.events_actor_task_definition_event_pb2 import (
+    ActorTaskDefinitionEvent,
+)
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_event_aggregator_service_pb2 import (
+    AddEventsRequest,
+    RayEventsData,
+    TaskEventsMetadata,
+)
+from ray.core.generated.events_task_definition_event_pb2 import TaskDefinitionEvent
+from ray.core.generated.events_task_lifecycle_event_pb2 import TaskLifecycleEvent
+from ray.core.generated.events_task_profile_events_pb2 import TaskProfileEvents
+from ray.core.generated.profile_events_pb2 import ProfileEventEntry, ProfileEvents
+from ray.dashboard.modules.task_events import ray_event_converter as rec
+
+
+def _ids():
+    job = JobID.from_int(1)
+    return job, TaskID.for_fake_task(job)
+
+
+def _python_fd(module_name="", class_name="", function_name=""):
+    fd = FunctionDescriptor()
+    fd.python_function_descriptor.module_name = module_name
+    fd.python_function_descriptor.class_name = class_name
+    fd.python_function_descriptor.function_name = function_name
+    return fd
+
+
+def test_call_string_python_no_class():
+    assert rec._call_string(_python_fd(function_name="mymod.myfunc")) == "myfunc"
+
+
+def test_call_string_python_with_class():
+    fd = _python_fd(class_name="pkg.MyCls", function_name="pkg.MyCls.m")
+    assert rec._call_string(fd) == "MyCls.m"
+
+
+def test_call_string_java_and_cpp_and_empty():
+    java = FunctionDescriptor()
+    java.java_function_descriptor.class_name = "C"
+    java.java_function_descriptor.function_name = "f"
+    assert rec._call_string(java) == "C.f"
+
+    cpp = FunctionDescriptor()
+    cpp.cpp_function_descriptor.function_name = "g"
+    assert rec._call_string(cpp) == "g"
+
+    assert rec._call_string(FunctionDescriptor()) == ""
+
+
+def test_convert_task_definition_event():
+    job, tid = _ids()
+    event = TaskDefinitionEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        task_type=TaskType.NORMAL_TASK,
+        task_name="foo",
+        parent_task_id=tid.binary(),
+        task_func=_python_fd(function_name="mymod.foo"),
+        language=Language.PYTHON,
+        serialized_runtime_env="{}",
+    )
+    event.required_resources["CPU"] = 1.0
+
+    task_event = rec._convert_task_definition_event(event)
+
+    assert task_event.task_id == tid.binary()
+    assert task_event.attempt_number == 0
+    assert task_event.job_id == job.binary()
+    info = task_event.task_info
+    assert info.type == TaskType.NORMAL_TASK
+    assert info.name == "foo"
+    assert info.func_or_class_name == "foo"
+    assert info.language == Language.PYTHON
+    assert info.required_resources["CPU"] == 1.0
+    assert info.runtime_env_info.serialized_runtime_env == "{}"
+
+
+def test_convert_task_lifecycle_event():
+    job, tid = _ids()
+    event = TaskLifecycleEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        worker_pid=42,
+        node_id=b"n" * 28,
+    )
+    transition = event.state_transitions.add()
+    transition.state = TaskStatus.RUNNING
+    transition.timestamp.seconds = 5
+    transition.timestamp.nanos = 123
+
+    task_event = rec._convert_task_lifecycle_event(event)
+
+    state = task_event.state_updates
+    assert state.worker_pid == 42
+    assert state.node_id == b"n" * 28
+    assert state.state_ts_ns[TaskStatus.RUNNING] == 5 * 10**9 + 123
+
+
+def test_convert_task_lifecycle_event_copies_set_task_log_info_fields():
+    # A start event reports the paths and start offsets; the end offsets arrive in a
+    # later event. Only the fields the event set should cross over, so the unset ones
+    # stay absent and a later merge can fill them without clobbering.
+    job, tid = _ids()
+    event = TaskLifecycleEvent(
+        task_id=tid.binary(), task_attempt=0, job_id=job.binary()
+    )
+    event.task_log_info.stdout_file = "/logs/out"
+    event.task_log_info.stderr_file = "/logs/err"
+    event.task_log_info.stdout_start = 10
+    event.task_log_info.stderr_start = 20
+
+    log_info = rec._convert_task_lifecycle_event(event).state_updates.task_log_info
+
+    assert log_info.stdout_file == "/logs/out"
+    assert log_info.stderr_file == "/logs/err"
+    assert log_info.stdout_start == 10
+    assert log_info.stderr_start == 20
+    assert not log_info.HasField("stdout_end")
+    assert not log_info.HasField("stderr_end")
+
+
+def test_convert_actor_task_definition_event():
+    job, tid = _ids()
+    event = ActorTaskDefinitionEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        actor_task_name="act",
+        parent_task_id=tid.binary(),
+        actor_id=b"a" * 16,
+        actor_func=_python_fd(function_name="m.run"),
+        language=Language.PYTHON,
+    )
+
+    task_event = rec._convert_actor_task_definition_event(event)
+
+    info = task_event.task_info
+    assert info.type == TaskType.ACTOR_TASK
+    assert info.name == "act"
+    assert info.actor_id == b"a" * 16
+    assert info.func_or_class_name == "run"
+
+
+def test_convert_task_profile_events():
+    job, tid = _ids()
+    profile = ProfileEvents()
+    entry = ProfileEventEntry(event_name="e")
+    profile.events.append(entry)
+    event = TaskProfileEvents(
+        task_id=tid.binary(),
+        attempt_number=0,
+        job_id=job.binary(),
+        profile_events=profile,
+    )
+
+    task_event = rec._convert_task_profile_events(event)
+
+    assert task_event.task_id == tid.binary()
+    assert len(task_event.profile_events.events) == 1
+
+
+def test_convert_dispatches_and_returns_dropped_attempts():
+    job, tid = _ids()
+    definition = TaskDefinitionEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        task_type=TaskType.NORMAL_TASK,
+        task_name="foo",
+        task_func=_python_fd(function_name="foo"),
+    )
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[
+                RayEvent(
+                    event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                    task_definition_event=definition,
+                )
+            ],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[
+                    TaskAttempt(task_id=tid.binary(), attempt_number=3)
+                ]
+            ),
+        )
+    )
+
+    task_events, dropped = rec.convert_to_task_events(request)
+
+    assert len(task_events) == 1
+    assert task_events[0].task_info.name == "foo"
+    assert len(dropped) == 1
+    assert dropped[0].attempt_number == 3
+
+
+def test_convert_raises_on_unsupported_event_type():
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[RayEvent(event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT)]
+        )
+    )
+
+    with pytest.raises(AssertionError):
+        rec.convert_to_task_events(request)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_manager.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_manager.py
@@ -1,0 +1,276 @@
+import asyncio
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ray._common.test_utils import async_wait_for_condition
+from ray._raylet import JobID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+from ray.dashboard.modules.task_events.task_event_manager import TaskEventManager
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
+
+_MANAGER = "ray.dashboard.modules.task_events.task_event_manager"
+_JOB = JobID.from_int(1).binary()
+_WORKER = b"worker_1"
+_WORKER_2 = b"worker_2"
+
+
+def _worker_table_data(worker_id: bytes, is_alive: bool) -> gcs_pb2.WorkerTableData:
+    data = gcs_pb2.WorkerTableData(is_alive=is_alive, exit_detail="boom", end_time_ms=5)
+    data.worker_address.worker_id = worker_id
+    return data
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
+
+
+def _make_manager() -> TaskEventManager:
+    return TaskEventManager(TaskEventStorage(), "127.0.0.1:6379", None)
+
+
+def _add_stored_task(manager, task_id, worker=None, job=_JOB):
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=0, job_id=job)
+    event.task_info.type = TaskType.NORMAL_TASK
+    if worker is not None:
+        event.state_updates.worker_id = worker
+    manager._store.add_or_replace_task_event(event)
+
+
+def _is_failed(manager, task_id) -> bool:
+    task_event = manager._store.get_task_event((task_id, 0))
+    return (
+        task_event is not None
+        and TaskStatus.FAILED in task_event.state_updates.state_ts_ns
+    )
+
+
+class _FakeSubscriber:
+    """Delivers a canned batch on the first poll, then parks so the loop settles."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self._delivered = False
+
+    async def subscribe(self):
+        pass
+
+    async def poll(self, batch_size, timeout=None):
+        if self._delivered:
+            await asyncio.sleep(3600)
+            return []
+        self._delivered = True
+        return self._messages
+
+
+async def _cancel(task: asyncio.Task) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_handle_worker_delta_fails_tasks(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+
+    async def fake_get(worker_id):
+        assert worker_id == _WORKER
+        return gcs_pb2.WorkerTableData(exit_detail="boom", end_time_ms=5)
+
+    monkeypatch.setattr(manager, "_get_worker_info", fake_get)
+
+    manager._handle_worker_delta(gcs_pb2.WorkerDeltaData(worker_id=_WORKER))
+
+    await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+
+
+@pytest.mark.asyncio
+async def test_handle_worker_delta_missing_worker_info_still_fails(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+
+    async def fake_get(worker_id):
+        return None
+
+    monkeypatch.setattr(manager, "_get_worker_info", fake_get)
+
+    manager._handle_worker_delta(gcs_pb2.WorkerDeltaData(worker_id=_WORKER))
+
+    # Even without worker table data, the task is failed — with a fallback message.
+    await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+    error = manager._store.get_task_event((_task_id(1), 0)).state_updates.error_info
+    assert "could not be fetched" in error.error_message
+
+
+@pytest.mark.asyncio
+async def test_get_worker_info_returns_none_on_rpc_failure():
+    manager = _make_manager()
+
+    stub = AsyncMock()
+    stub.GetWorkerInfo.side_effect = RuntimeError("gcs unavailable")
+    manager._worker_info_stub = stub
+
+    # A failing fetch must be swallowed (returns None) so the spawned reconciliation task
+    # doesn't die silently; the caller then fails the tasks without exit details.
+    assert await manager._get_worker_info(_WORKER) is None
+
+
+@pytest.mark.asyncio
+async def test_handle_job_update_finished_fails_tasks(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1))
+
+    manager._handle_job_update(
+        gcs_pb2.JobTableData(job_id=_JOB, is_dead=True, end_time=5)
+    )
+
+    await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+
+
+@pytest.mark.asyncio
+async def test_handle_job_update_ignores_running_job():
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1))
+
+    manager._handle_job_update(gcs_pb2.JobTableData(job_id=_JOB, is_dead=False))
+    await asyncio.sleep(0.05)
+
+    assert not _is_failed(manager, _task_id(1))
+
+
+@pytest.mark.asyncio
+async def test_gc_job_summary_loop_trims_over_cap(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}.GC_JOB_SUMMARY_INTERVAL_S", 0.01)
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_event_storage."
+        "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB",
+        2,
+    )
+    manager = _make_manager()
+    summary = manager._store._summary(_JOB)
+    for i in range(10):
+        summary.record_task_attempt_dropped((_task_id(i), 0))
+    assert len(summary._dropped_task_attempts) == 10
+
+    task = asyncio.create_task(manager._gc_job_summary_loop())
+    try:
+        await async_wait_for_condition(lambda: len(summary._dropped_task_attempts) < 10)
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_worker_death_subscription_loop_reconciles(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+
+    async def fake_get(worker_id):
+        return gcs_pb2.WorkerTableData(exit_detail="boom", end_time_ms=5)
+
+    monkeypatch.setattr(manager, "_get_worker_info", fake_get)
+
+    # Isolate the subscription path from the startup backfill (no real GCS here).
+    async def no_backfill():
+        return []
+
+    monkeypatch.setattr(manager, "_get_all_worker_info", no_backfill)
+
+    fake = _FakeSubscriber([(b"key", gcs_pb2.WorkerDeltaData(worker_id=_WORKER))])
+    monkeypatch.setattr(
+        f"{_MANAGER}.GcsAioWorkerDeltaSubscriber", lambda address=None: fake
+    )
+
+    task = asyncio.create_task(manager._subscribe_for_worker_deaths())
+    try:
+        await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_dead_workers_on_startup(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+    _add_stored_task(manager, _task_id(2), worker=_WORKER_2)
+
+    async def fake_get_all():
+        return [
+            _worker_table_data(_WORKER, is_alive=False),
+            _worker_table_data(_WORKER_2, is_alive=True),
+        ]
+
+    monkeypatch.setattr(manager, "_get_all_worker_info", fake_get_all)
+
+    await manager._reconcile_dead_workers_on_startup()
+
+    # The dead worker's task is failed; the live worker's task is left alone.
+    assert _is_failed(manager, _task_id(1))
+    assert not _is_failed(manager, _task_id(2))
+
+
+@pytest.mark.asyncio
+async def test_reconcile_finished_jobs_on_startup(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
+    manager = _make_manager()
+    finished_job = JobID.from_int(1).binary()
+    running_job = JobID.from_int(2).binary()
+    _add_stored_task(manager, _task_id(1), job=finished_job)
+    _add_stored_task(manager, _task_id(2), job=running_job)
+
+    async def fake_get_all():
+        return [
+            gcs_pb2.JobTableData(job_id=finished_job, is_dead=True),
+            gcs_pb2.JobTableData(job_id=running_job, is_dead=False),
+        ]
+
+    monkeypatch.setattr(manager, "_get_all_job_info", fake_get_all)
+
+    await manager._reconcile_finished_jobs_on_startup()
+
+    # The finished job's task is failed; the running job's task is left alone.
+    assert _is_failed(manager, _task_id(1))
+    assert not _is_failed(manager, _task_id(2))
+
+
+@pytest.mark.asyncio
+async def test_job_subscription_loop_reconciles_only_finished(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
+    manager = _make_manager()
+    running_job = JobID.from_int(1).binary()
+    finished_job = JobID.from_int(2).binary()
+    _add_stored_task(manager, _task_id(1), job=running_job)
+    _add_stored_task(manager, _task_id(2), job=finished_job)
+
+    fake = _FakeSubscriber(
+        [
+            (b"k1", gcs_pb2.JobTableData(job_id=running_job, is_dead=False)),
+            (
+                b"k2",
+                gcs_pb2.JobTableData(job_id=finished_job, is_dead=True, end_time=5),
+            ),
+        ]
+    )
+    monkeypatch.setattr(f"{_MANAGER}.GcsAioJobSubscriber", lambda address=None: fake)
+
+    task = asyncio.create_task(manager._subscribe_for_finished_jobs())
+    try:
+        await async_wait_for_condition(lambda: _is_failed(manager, _task_id(2)))
+    finally:
+        await _cancel(task)
+
+    # The running job was ignored; its task is not failed.
+    assert not _is_failed(manager, _task_id(1))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_query.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_query.py
@@ -1,0 +1,561 @@
+import sys
+
+import pytest
+
+from ray._raylet import JobID, TaskID
+from ray.core.generated import gcs_pb2, gcs_service_pb2
+from ray.core.generated.common_pb2 import TaskAttempt, TaskStatus, TaskType
+from ray.dashboard.modules.task_events import task_event_query as q
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
+
+_EQUAL = gcs_service_pb2.FilterPredicate.EQUAL
+_NOT_EQUAL = gcs_service_pb2.FilterPredicate.NOT_EQUAL
+
+_JOB = JobID.from_int(1).binary()
+_JOB_B = JobID.from_int(2).binary()
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
+
+
+def _event(
+    task_id,
+    *,
+    job_id=_JOB,
+    task_type=TaskType.NORMAL_TASK,
+    name="",
+    actor_id=b"",
+    states=None,
+) -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=0, job_id=job_id)
+    event.task_info.type = task_type
+    event.task_info.name = name
+    event.task_info.job_id = job_id
+    if actor_id:
+        event.task_info.actor_id = actor_id
+    for status, ts in (states or {}).items():
+        event.state_updates.state_ts_ns[status] = ts
+    return event
+
+
+def _request(limit=None, exclude_driver=False) -> gcs_service_pb2.GetTaskEventsRequest:
+    request = gcs_service_pb2.GetTaskEventsRequest()
+    request.filters.exclude_driver = exclude_driver
+    if limit is not None:
+        request.limit = limit
+    return request
+
+
+def _add_filter(request, kind, value, predicate=_EQUAL):
+    filters = request.filters
+    if kind == "job":
+        f = filters.job_filters.add()
+        f.job_id = value
+    elif kind == "task":
+        f = filters.task_filters.add()
+        f.task_id = value
+    elif kind == "actor":
+        f = filters.actor_filters.add()
+        f.actor_id = value
+    elif kind == "name":
+        f = filters.task_name_filters.add()
+        f.task_name = value
+    elif kind == "state":
+        f = filters.state_filters.add()
+        f.state = value
+    f.predicate = predicate
+
+
+def _store(*events) -> TaskEventStorage:
+    store = TaskEventStorage()
+    for event in events:
+        store.add_or_replace_task_event(event)
+    return store
+
+
+def _task_ids(reply):
+    return {e.task_id for e in reply.events_by_task}
+
+
+def test_no_filters_returns_all():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    reply = q.get_task_events(store, _request())
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(2), _task_id(3)}
+    assert reply.num_total_stored == 3
+    assert reply.num_truncated == 0
+    assert reply.num_filtered_on_gcs == 0
+    assert reply.num_profile_task_events_dropped == 0
+    assert reply.num_status_task_events_dropped == 0
+
+
+def test_job_filter_returns_only_that_job():
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB),
+        _event(_task_id(3), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(2)}
+    # Candidate set is the job's events, so total-stored is scoped to the job.
+    assert reply.num_total_stored == 2
+
+
+def test_task_filter_returns_only_that_task():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    # Single equality task filter uses the index, so total-stored is scoped to it.
+    assert reply.num_total_stored == 1
+
+
+def test_task_filter_not_equal_scans_and_filters():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(2), _task_id(3)}
+    # A NOT_EQUAL filter can't use the index, so it scans all events.
+    assert reply.num_total_stored == 3
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_task_ids_returns_empty():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    _add_filter(request, "task", _task_id(2))
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_total_stored == 0
+
+
+def test_multiple_not_equal_task_ids_scans():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    _add_filter(request, "task", _task_id(2), predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(3)}
+    assert reply.num_total_stored == 3
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_task_equal_and_not_equal_mixed():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    _add_filter(request, "task", _task_id(2), predicate=_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    # The single EQUAL id drives index selection; the NOT_EQUAL is applied on top.
+    assert _task_ids(reply) == {_task_id(2)}
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 0
+
+
+def test_job_filter_not_equal_scans_and_filters():
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(2)}
+    assert reply.num_total_stored == 2
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_job_ids_returns_empty():
+    store = _store(_event(_task_id(1), job_id=_JOB), _event(_task_id(2), job_id=_JOB_B))
+
+    request = _request()
+    _add_filter(request, "job", _JOB)
+    _add_filter(request, "job", _JOB_B)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+
+
+def test_multiple_not_equal_job_ids_scans():
+    _JOB_C = JobID.from_int(3).binary()
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+        _event(_task_id(3), job_id=_JOB_C),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB, predicate=_NOT_EQUAL)
+    _add_filter(request, "job", _JOB_B, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(3)}
+    assert reply.num_total_stored == 3
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_job_equal_and_not_equal_mixed():
+    _JOB_C = JobID.from_int(3).binary()
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+        _event(_task_id(3), job_id=_JOB_C),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB, predicate=_EQUAL)
+    _add_filter(request, "job", _JOB_B, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    # The single EQUAL job drives index selection; the NOT_EQUAL is applied on top.
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 0
+
+
+def test_task_and_job_combined_filter():
+    # Task 1 is in job A; requiring it also be in job B filters it out.
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    _add_filter(request, "job", _JOB_B)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+    # Candidates come from the single-task index; the job filter drops the one candidate.
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_task_equal_and_job_not_equal_combined():
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    _add_filter(request, "job", _JOB, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_exclude_driver():
+    store = _store(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK),
+        _event(_task_id(2), task_type=TaskType.DRIVER_TASK),
+    )
+
+    reply = q.get_task_events(store, _request(exclude_driver=True))
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_include_driver():
+    store = _store(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK),
+        _event(_task_id(2), task_type=TaskType.DRIVER_TASK),
+    )
+
+    reply = q.get_task_events(store, _request(exclude_driver=False))
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(2)}
+    assert reply.num_filtered_on_gcs == 0
+
+
+_ACTOR_A = b"a" * 16
+_ACTOR_B = b"b" * 16
+
+
+def _actor_store() -> TaskEventStorage:
+    return _store(
+        _event(_task_id(1), task_type=TaskType.ACTOR_TASK, actor_id=_ACTOR_A),
+        _event(_task_id(2), task_type=TaskType.ACTOR_TASK, actor_id=_ACTOR_B),
+        _event(_task_id(3)),
+    )
+
+
+def test_actor_filter():
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A)
+    reply = q.get_task_events(_actor_store(), request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_actor_filter_not_equal():
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(_actor_store(), request)
+
+    # Non-actor tasks have an empty actor id, so they also satisfy != actor_a.
+    assert _task_ids(reply) == {_task_id(2), _task_id(3)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_actor_ids_returns_empty():
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A)
+    _add_filter(request, "actor", _ACTOR_B)
+    reply = q.get_task_events(_actor_store(), request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_filtered_on_gcs == 3
+
+
+def _name_store() -> TaskEventStorage:
+    return _store(
+        _event(_task_id(1), name="Foo"),
+        _event(_task_id(2), name="Bar"),
+        _event(_task_id(3), name="Baz"),
+    )
+
+
+def test_name_filter_is_case_insensitive():
+    request = _request()
+    _add_filter(request, "name", "foo")
+    reply = q.get_task_events(_name_store(), request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_name_filter_not_equal():
+    request = _request()
+    _add_filter(request, "name", "FOO", predicate=_NOT_EQUAL)
+    reply = q.get_task_events(_name_store(), request)
+
+    assert _task_ids(reply) == {_task_id(2), _task_id(3)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_names_returns_empty():
+    request = _request()
+    _add_filter(request, "name", "Foo")
+    _add_filter(request, "name", "Bar")
+    reply = q.get_task_events(_name_store(), request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_filtered_on_gcs == 3
+
+
+def _state_store() -> TaskEventStorage:
+    # Latest state is the highest-valued status present: RUNNING + FINISHED -> FINISHED.
+    return _store(
+        _event(_task_id(1), states={TaskStatus.RUNNING: 1, TaskStatus.FINISHED: 2}),
+        _event(_task_id(2), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(3)),  # no state updates -> latest state NIL
+    )
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        ("finished", {1}),
+        ("RUNNING", {2}),
+        ("nil", {3}),
+    ],
+)
+def test_state_filter_uses_latest_state(state, expected):
+    request = _request()
+    _add_filter(request, "state", state)
+    reply = q.get_task_events(_state_store(), request)
+
+    assert _task_ids(reply) == {_task_id(n) for n in expected}
+
+
+def test_state_filter_not_equal():
+    request = _request()
+    _add_filter(request, "state", "RUNNING", predicate=_NOT_EQUAL)
+    reply = q.get_task_events(_state_store(), request)
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(3)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_states_returns_empty():
+    request = _request()
+    _add_filter(request, "state", "RUNNING")
+    _add_filter(request, "state", "NIL")
+    reply = q.get_task_events(_state_store(), request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_filtered_on_gcs == 3
+
+
+def test_not_equal_predicate():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(2)}
+
+
+def test_name_and_actor_combined_no_match():
+    # task_id(1) has the name but no actor; nothing satisfies both.
+    store = _store(
+        _event(_task_id(1), name="foo"),
+        _event(_task_id(2), task_type=TaskType.ACTOR_TASK, actor_id=_ACTOR_A),
+    )
+
+    request = _request()
+    _add_filter(request, "name", "foo")
+    _add_filter(request, "actor", _ACTOR_A)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+
+
+def test_actor_and_state_combined():
+    store = _store(
+        _event(
+            _task_id(1),
+            task_type=TaskType.ACTOR_TASK,
+            actor_id=_ACTOR_A,
+            states={TaskStatus.RUNNING: 1},
+        ),
+        _event(
+            _task_id(2),
+            task_type=TaskType.ACTOR_TASK,
+            actor_id=_ACTOR_A,
+            states={TaskStatus.FINISHED: 1},
+        ),
+    )
+
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A)
+    _add_filter(request, "state", "running")
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_invalid_predicate_returns_invalid_argument_status():
+    store = _store(_event(_task_id(1)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=100)
+    reply = q.get_task_events(store, request)
+
+    assert reply.status.code == q._INVALID_ARGUMENT_STATUS_CODE
+    assert len(reply.events_by_task) == 0
+
+
+def test_success_reply_has_ok_status():
+    store = _store(_event(_task_id(1)))
+
+    reply = q.get_task_events(store, _request())
+
+    assert reply.HasField("status")
+    assert reply.status.code == 0
+
+
+def test_limit_truncates_and_counts_dropped():
+    store = _store(
+        _event(_task_id(1), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(2), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(3), states={TaskStatus.RUNNING: 1}),
+    )
+
+    reply = q.get_task_events(store, _request(limit=1))
+
+    assert len(reply.events_by_task) == 1
+    assert reply.num_total_stored == 3
+    assert reply.num_truncated == 2
+    # Truncated status events are reported as dropped.
+    assert reply.num_status_task_events_dropped == 2
+
+
+@pytest.mark.parametrize(
+    "limit,expected_kept",
+    [
+        (2, 2),  # partial
+        (0, 0),  # keep nothing, everything truncated
+        (-1, 3),  # unlimited
+    ],
+)
+def test_limit_boundaries(limit, expected_kept):
+    store = _store(
+        _event(_task_id(1), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(2), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(3), states={TaskStatus.RUNNING: 1}),
+    )
+
+    reply = q.get_task_events(store, _request(limit=limit))
+
+    num_truncated = 3 - expected_kept
+    assert len(reply.events_by_task) == expected_kept
+    assert reply.num_total_stored == 3
+    assert reply.num_truncated == num_truncated
+    assert reply.num_status_task_events_dropped == num_truncated
+
+
+def test_limit_keeps_most_recent():
+    # Insert oldest-to-newest; a limit must keep the most recently added events.
+    events = [_event(_task_id(n), states={TaskStatus.RUNNING: 1}) for n in range(1, 21)]
+    store = _store(*events)
+
+    reply = q.get_task_events(store, _request(limit=5))
+
+    newest_five = {_task_id(n) for n in range(16, 21)}
+    assert _task_ids(reply) == newest_five
+    assert reply.num_truncated == 15
+
+
+def test_global_dropped_counts_reported():
+    store = _store(_event(_task_id(1)))
+    dropped = TaskID.for_fake_task(JobID.from_int(1)).binary()
+    store.record_data_loss_from_worker([TaskAttempt(task_id=dropped, attempt_number=0)])
+
+    reply = q.get_task_events(store, _request())
+
+    assert reply.num_status_task_events_dropped == 1
+
+
+def test_per_job_dropped_counts_reported():
+    store = _store(_event(_task_id(1), job_id=JobID.from_int(1).binary()))
+    dropped = TaskID.for_fake_task(JobID.from_int(1)).binary()
+    store.record_data_loss_from_worker([TaskAttempt(task_id=dropped, attempt_number=0)])
+
+    request = _request()
+    _add_filter(request, "job", JobID.from_int(1).binary())
+    reply = q.get_task_events(store, request)
+
+    assert reply.num_status_task_events_dropped == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
@@ -1,0 +1,133 @@
+import sys
+
+import pytest
+
+from ray._raylet import JobID, TaskID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskAttempt, TaskStatus, TaskType
+from ray.dashboard.modules.task_events import task_event_storage as tes
+
+_JOB = JobID.from_int(1).binary()
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
+
+
+def _event(
+    task_id, attempt=0, task_type=None, finished=False, name=""
+) -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=attempt, job_id=_JOB)
+    if task_type is not None:
+        event.task_info.type = task_type
+        event.task_info.name = name
+    if finished:
+        event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    return event
+
+
+def test_add_and_merge_dedups_by_attempt():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK, name="foo")
+    )
+    store.add_or_replace_task_event(_event(_task_id(1), finished=True))
+
+    assert store.num_task_events_stored == 1
+    stored = store.get_task_event((_task_id(1), 0))
+    assert stored.task_info.name == "foo"
+    assert TaskStatus.FINISHED in stored.state_updates.state_ts_ns
+    assert store.stats[tes.STAT_TOTAL_REPORTED] == 2
+
+
+def test_task_type_counters_increment_once():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+    store.add_or_replace_task_event(_event(_task_id(2), task_type=TaskType.ACTOR_TASK))
+
+    assert store.stats[tes._TASK_TYPE_STAT[TaskType.NORMAL_TASK]] == 1
+    assert store.stats[tes._TASK_TYPE_STAT[TaskType.ACTOR_TASK]] == 1
+
+
+def test_eviction_prefers_lower_priority_tier():
+    store = tes.TaskEventStorage(max_num_task_events=2)
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+    store.add_or_replace_task_event(_event(_task_id(2), task_type=TaskType.ACTOR_TASK))
+    store.add_or_replace_task_event(_event(_task_id(3), finished=True))
+
+    assert store.num_task_events_stored == 2
+    assert store.get_task_event((_task_id(3), 0)) is None
+    assert store.get_task_event((_task_id(1), 0)) is not None
+    assert store.get_task_event((_task_id(2), 0)) is not None
+    assert store.stats[tes.STAT_TOTAL_ATTEMPTS_DROPPED] == 1
+
+
+def test_evicted_attempt_is_rejected():
+    store = tes.TaskEventStorage(max_num_task_events=1)
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+    store.add_or_replace_task_event(_event(_task_id(2), finished=True))
+
+    # The finished attempt was the lowest tier, so it was evicted; re-adding is rejected.
+    assert store.get_task_event((_task_id(2), 0)) is None
+    store.add_or_replace_task_event(_event(_task_id(2), finished=True))
+    assert store.get_task_event((_task_id(2), 0)) is None
+
+
+def test_profile_events_truncated_fifo(monkeypatch):
+    monkeypatch.setattr(tes, "MAX_NUM_PROFILE_EVENTS_PER_TASK", 2)
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+
+    update = gcs_pb2.TaskEvents(task_id=_task_id(1), attempt_number=0, job_id=_JOB)
+    for i in range(4):
+        update.profile_events.events.add().event_name = f"e{i}"
+    store.add_or_replace_task_event(update)
+
+    kept = store.get_task_event((_task_id(1), 0)).profile_events.events
+    assert [e.event_name for e in kept] == ["e2", "e3"]
+    assert store.stats[tes.STAT_TOTAL_PROFILE_DROPPED] == 2
+
+
+def test_record_data_loss_evicts_and_rejects():
+    store = tes.TaskEventStorage()
+    task_id = TaskID.for_fake_task(JobID.from_int(1)).binary()
+    store.add_or_replace_task_event(_event(task_id, task_type=TaskType.NORMAL_TASK))
+
+    store.record_data_loss_from_worker([TaskAttempt(task_id=task_id, attempt_number=0)])
+    assert store.get_task_event((task_id, 0)) is None
+
+    store.add_or_replace_task_event(_event(task_id, task_type=TaskType.NORMAL_TASK))
+    assert store.get_task_event((task_id, 0)) is None
+
+
+def test_nil_ids_skipped_but_counted_as_reported():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(gcs_pb2.TaskEvents())
+
+    assert store.num_task_events_stored == 0
+    assert store.stats[tes.STAT_TOTAL_REPORTED] == 1
+
+
+def test_job_summary_on_job_ends_clears_drops():
+    summary = tes.JobTaskSummary()
+    summary.record_task_attempt_dropped((_task_id(1), 0))
+    assert summary.should_drop_task_attempt((_task_id(1), 0))
+
+    summary.on_job_ends()
+    assert not summary.should_drop_task_attempt((_task_id(1), 0))
+
+
+def test_job_summary_gc_trims_over_cap(monkeypatch):
+    monkeypatch.setattr(tes, "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB", 4)
+    summary = tes.JobTaskSummary()
+    for i in range(10):
+        summary.record_task_attempt_dropped((_task_id(i), 0))
+
+    summary.gc_old_dropped_task_attempts(_JOB)
+
+    # 10 tracked, cap 4 -> 6 evicted; total-ever count is preserved.
+    assert summary.num_task_attempts_dropped == 10
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
@@ -2,9 +2,9 @@ import sys
 
 import pytest
 
-from ray._raylet import JobID, TaskID
+from ray._raylet import JobID, TaskID, WorkerID
 from ray.core.generated import gcs_pb2
-from ray.core.generated.common_pb2 import TaskAttempt, TaskStatus, TaskType
+from ray.core.generated.common_pb2 import ErrorType, TaskAttempt, TaskStatus, TaskType
 from ray.dashboard.modules.task_events import task_event_storage as tes
 
 _JOB = JobID.from_int(1).binary()
@@ -15,7 +15,7 @@ def _task_id(n: int) -> bytes:
 
 
 def _event(
-    task_id, attempt=0, task_type=None, finished=False, name=""
+    task_id, attempt=0, task_type=None, finished=False, name="", worker=None
 ) -> gcs_pb2.TaskEvents:
     event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=attempt, job_id=_JOB)
     if task_type is not None:
@@ -23,6 +23,8 @@ def _event(
         event.task_info.name = name
     if finished:
         event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    if worker is not None:
+        event.state_updates.worker_id = worker
     return event
 
 
@@ -127,6 +129,85 @@ def test_job_summary_gc_trims_over_cap(monkeypatch):
 
     # 10 tracked, cap 4 -> 6 evicted; total-ever count is preserved.
     assert summary.num_task_attempts_dropped == 10
+
+
+_WORKER = WorkerID.from_random().binary()
+
+
+def test_mark_tasks_failed_on_worker_dead():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK, worker=_WORKER)
+    )
+
+    store.mark_tasks_failed_on_worker_dead(
+        _WORKER, gcs_pb2.WorkerTableData(exit_detail="boom", end_time_ms=5)
+    )
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert state.state_ts_ns[TaskStatus.FAILED] == 5 * 10**6
+    assert state.error_info.error_type == ErrorType.WORKER_DIED
+    assert "boom" in state.error_info.error_message
+
+
+def test_mark_tasks_failed_on_worker_dead_without_worker_data():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK, worker=_WORKER)
+    )
+
+    # No worker table data (record evicted, or the fetch failed): the task is still failed,
+    # stamped with a best-effort time and a message noting the details are unavailable.
+    store.mark_tasks_failed_on_worker_dead(_WORKER, None)
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert state.state_ts_ns[TaskStatus.FAILED] > 0
+    assert state.error_info.error_type == ErrorType.WORKER_DIED
+    assert "could not be fetched" in state.error_info.error_message
+
+
+def test_mark_tasks_failed_on_worker_dead_skips_terminated():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(
+            _task_id(1), task_type=TaskType.NORMAL_TASK, worker=_WORKER, finished=True
+        )
+    )
+
+    store.mark_tasks_failed_on_worker_dead(
+        _WORKER, gcs_pb2.WorkerTableData(end_time_ms=5)
+    )
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert TaskStatus.FAILED not in state.state_ts_ns
+
+
+def test_mark_tasks_failed_on_worker_dead_unknown_worker_is_noop():
+    store = tes.TaskEventStorage()
+    # No tasks indexed for this worker; must not raise.
+    store.mark_tasks_failed_on_worker_dead(_WORKER, gcs_pb2.WorkerTableData())
+
+
+def test_mark_tasks_failed_on_job_ends():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+
+    store.mark_tasks_failed_on_job_ends(_JOB, 9)
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert state.state_ts_ns[TaskStatus.FAILED] == 9
+    assert state.error_info.error_type == ErrorType.WORKER_DIED
+
+
+def test_update_job_summary_on_job_done_clears_drops():
+    store = tes.TaskEventStorage()
+    summary = store._summary(_JOB)
+    summary.record_task_attempt_dropped((_task_id(1), 0))
+    assert summary.should_drop_task_attempt((_task_id(1), 0))
+
+    store.update_job_summary_on_job_done(_JOB)
+
+    assert not summary.should_drop_task_attempt((_task_id(1), 0))
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from unittest.mock import AsyncMock
 
@@ -9,10 +10,20 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
+from ray._common.test_utils import async_wait_for_condition
+from ray._raylet import JobID
 from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
+from ray.core.generated.common_pb2 import TaskType
 from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_task_definition_event_pb2 import TaskDefinitionEvent
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
+
+_JOB = JobID.from_int(1).binary()
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
 
 
 def _make_config() -> SubprocessModuleConfig:
@@ -36,10 +47,21 @@ def _make_head() -> TaskEventsHead:
     return TaskEventsHead(_make_config())
 
 
-def _make_add_events_request(num_events: int) -> bytes:
+def _make_add_events_request(num_events: int, start: int = 0) -> bytes:
     events_data = events_event_aggregator_service_pb2.RayEventsData()
-    for i in range(num_events):
-        events_data.events.append(RayEvent(event_id=f"event_{i}".encode()))
+    for i in range(start, start + num_events):
+        events_data.events.append(
+            RayEvent(
+                event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                task_definition_event=TaskDefinitionEvent(
+                    task_id=_task_id(i),
+                    task_attempt=0,
+                    job_id=_JOB,
+                    task_type=TaskType.NORMAL_TASK,
+                    task_name=f"task_{i}",
+                ),
+            )
+        )
     request = events_event_aggregator_service_pb2.AddEventsRequest(
         events_data=events_data
     )
@@ -55,23 +77,23 @@ def _fake_request(body: bytes):
 @pytest.mark.asyncio
 async def test_add_task_events_buffers_events():
     head = _make_head()
-    assert head.num_events_received == 0
+    assert head.num_task_events_stored == 0
 
     body = _make_add_events_request(num_events=2)
     response = await head.add_task_events(_fake_request(body))
 
     assert response.status == 200
-    assert head.num_events_received == 2
+    assert head.num_task_events_stored == 2
 
 
 @pytest.mark.asyncio
 async def test_add_task_events_accumulates_across_requests():
     head = _make_head()
 
-    await head.add_task_events(_fake_request(_make_add_events_request(num_events=2)))
-    await head.add_task_events(_fake_request(_make_add_events_request(num_events=3)))
+    await head.add_task_events(_fake_request(_make_add_events_request(2, start=0)))
+    await head.add_task_events(_fake_request(_make_add_events_request(3, start=2)))
 
-    assert head.num_events_received == 5
+    assert head.num_task_events_stored == 5
 
 
 @pytest.mark.asyncio
@@ -81,7 +103,7 @@ async def test_add_task_events_empty_payload():
     response = await head.add_task_events(_fake_request(_make_add_events_request(0)))
 
     assert response.status == 200
-    assert head.num_events_received == 0
+    assert head.num_task_events_stored == 0
 
 
 @pytest.mark.asyncio
@@ -96,7 +118,7 @@ async def test_add_task_events_bad_payload_returns_error():
     # Malformed body must not raise; the handler returns an error response and
     # nothing is buffered.
     assert response.status != 200
-    assert head.num_events_received == 0
+    assert head.num_task_events_stored == 0
 
 
 def test_deserialize_request_roundtrip():
@@ -135,6 +157,95 @@ def test_handle_job_update_ignores_running_job():
     head._handle_job_update(gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False))
 
     assert head.num_finished_jobs_received == 0
+
+
+class _FakeSubscriber:
+    """Delivers a canned batch on the first poll, then parks so the loop settles."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self._delivered = False
+
+    async def subscribe(self):
+        pass
+
+    async def poll(self, batch_size, timeout=None):
+        if self._delivered:
+            await asyncio.sleep(3600)
+            return []
+        self._delivered = True
+        return self._messages
+
+
+async def _cancel(task: asyncio.Task) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_gc_job_summary_loop_trims_over_cap(monkeypatch):
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_events_head.GC_JOB_SUMMARY_INTERVAL_S",
+        0.01,
+    )
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_event_storage."
+        "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB",
+        2,
+    )
+    head = _make_head()
+    summary = head._store._summary(_JOB)
+    for i in range(10):
+        summary.record_task_attempt_dropped((_task_id(i), 0))
+    assert len(summary._dropped_task_attempts) == 10
+
+    task = asyncio.create_task(head._gc_job_summary_loop())
+    try:
+        await async_wait_for_condition(lambda: len(summary._dropped_task_attempts) < 10)
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_worker_death_subscription_loop_buffers(monkeypatch):
+    head = _make_head()
+    worker_delta = gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
+    fake = _FakeSubscriber([(b"key", worker_delta)])
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_events_head."
+        "GcsAioWorkerDeltaSubscriber",
+        lambda address=None: fake,
+    )
+
+    task = asyncio.create_task(head._subscribe_for_worker_deaths())
+    try:
+        await async_wait_for_condition(lambda: head.num_dead_workers_received == 1)
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_job_subscription_loop_buffers_only_finished(monkeypatch):
+    head = _make_head()
+    running = gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False)
+    finished = gcs_pb2.JobTableData(job_id=b"job_2", is_dead=True)
+    fake = _FakeSubscriber([(b"k1", running), (b"k2", finished)])
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_events_head.GcsAioJobSubscriber",
+        lambda address=None: fake,
+    )
+
+    task = asyncio.create_task(head._subscribe_for_finished_jobs())
+    try:
+        await async_wait_for_condition(lambda: head.num_finished_jobs_received == 1)
+    finally:
+        await _cancel(task)
+
+    # The running job was filtered out; only the finished one was buffered.
+    assert head.num_finished_jobs_received == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -9,7 +9,7 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
-from ray.core.generated import events_event_aggregator_service_pb2
+from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
@@ -106,6 +106,35 @@ def test_deserialize_request_roundtrip():
     request = head._deserialize_request(body)
 
     assert len(request.events_data.events) == 1
+
+
+def test_handle_worker_delta_buffers():
+    head = _make_head()
+    assert head.num_dead_workers_received == 0
+
+    head._handle_worker_delta(
+        gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
+    )
+
+    assert head.num_dead_workers_received == 1
+
+
+def test_handle_job_update_buffers_finished_job():
+    head = _make_head()
+
+    head._handle_job_update(
+        gcs_pb2.JobTableData(job_id=b"job_1", is_dead=True, end_time=123)
+    )
+
+    assert head.num_finished_jobs_received == 1
+
+
+def test_handle_job_update_ignores_running_job():
+    head = _make_head()
+
+    head._handle_job_update(gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False))
+
+    assert head.num_finished_jobs_received == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 from unittest.mock import AsyncMock
 
@@ -10,12 +9,16 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
-from ray._common.test_utils import async_wait_for_condition
 from ray._raylet import JobID
-from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
+from ray.core.generated import (
+    events_event_aggregator_service_pb2,
+    gcs_pb2,
+    gcs_service_pb2,
+)
 from ray.core.generated.common_pb2 import TaskType
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.core.generated.events_task_definition_event_pb2 import TaskDefinitionEvent
+from ray.dashboard.modules.task_events import task_event_query
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
 
@@ -74,6 +77,14 @@ def _fake_request(body: bytes):
     return request
 
 
+def _add_stored_task(head, task_id, worker=None, job=_JOB):
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=0, job_id=job)
+    event.task_info.type = TaskType.NORMAL_TASK
+    if worker is not None:
+        event.state_updates.worker_id = worker
+    head._store.add_or_replace_task_event(event)
+
+
 @pytest.mark.asyncio
 async def test_add_task_events_buffers_events():
     head = _make_head()
@@ -130,122 +141,36 @@ def test_deserialize_request_roundtrip():
     assert len(request.events_data.events) == 1
 
 
-def test_handle_worker_delta_buffers():
+@pytest.mark.asyncio
+async def test_get_task_events_endpoint_roundtrip():
     head = _make_head()
-    assert head.num_dead_workers_received == 0
+    _add_stored_task(head, _task_id(1))
 
-    head._handle_worker_delta(
-        gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
-    )
+    query = gcs_service_pb2.GetTaskEventsRequest()
+    response = await head.get_task_events(_fake_request(query.SerializeToString()))
 
-    assert head.num_dead_workers_received == 1
-
-
-def test_handle_job_update_buffers_finished_job():
-    head = _make_head()
-
-    head._handle_job_update(
-        gcs_pb2.JobTableData(job_id=b"job_1", is_dead=True, end_time=123)
-    )
-
-    assert head.num_finished_jobs_received == 1
-
-
-def test_handle_job_update_ignores_running_job():
-    head = _make_head()
-
-    head._handle_job_update(gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False))
-
-    assert head.num_finished_jobs_received == 0
-
-
-class _FakeSubscriber:
-    """Delivers a canned batch on the first poll, then parks so the loop settles."""
-
-    def __init__(self, messages):
-        self._messages = messages
-        self._delivered = False
-
-    async def subscribe(self):
-        pass
-
-    async def poll(self, batch_size, timeout=None):
-        if self._delivered:
-            await asyncio.sleep(3600)
-            return []
-        self._delivered = True
-        return self._messages
-
-
-async def _cancel(task: asyncio.Task) -> None:
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
+    assert response.status == 200
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    reply.ParseFromString(response.body)
+    assert [event.task_id for event in reply.events_by_task] == [_task_id(1)]
 
 
 @pytest.mark.asyncio
-async def test_gc_job_summary_loop_trims_over_cap(monkeypatch):
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_events_head.GC_JOB_SUMMARY_INTERVAL_S",
-        0.01,
-    )
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_event_storage."
-        "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB",
-        2,
-    )
+async def test_get_task_events_invalid_predicate_returns_status_in_reply():
     head = _make_head()
-    summary = head._store._summary(_JOB)
-    for i in range(10):
-        summary.record_task_attempt_dropped((_task_id(i), 0))
-    assert len(summary._dropped_task_attempts) == 10
+    _add_stored_task(head, _task_id(1))
 
-    task = asyncio.create_task(head._gc_job_summary_loop())
-    try:
-        await async_wait_for_condition(lambda: len(summary._dropped_task_attempts) < 10)
-    finally:
-        await _cancel(task)
+    query = gcs_service_pb2.GetTaskEventsRequest()
+    task_filter = query.filters.task_filters.add()
+    task_filter.task_id = _task_id(1)
+    task_filter.predicate = 100
+    response = await head.get_task_events(_fake_request(query.SerializeToString()))
 
-
-@pytest.mark.asyncio
-async def test_worker_death_subscription_loop_buffers(monkeypatch):
-    head = _make_head()
-    worker_delta = gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
-    fake = _FakeSubscriber([(b"key", worker_delta)])
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_events_head."
-        "GcsAioWorkerDeltaSubscriber",
-        lambda address=None: fake,
-    )
-
-    task = asyncio.create_task(head._subscribe_for_worker_deaths())
-    try:
-        await async_wait_for_condition(lambda: head.num_dead_workers_received == 1)
-    finally:
-        await _cancel(task)
-
-
-@pytest.mark.asyncio
-async def test_job_subscription_loop_buffers_only_finished(monkeypatch):
-    head = _make_head()
-    running = gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False)
-    finished = gcs_pb2.JobTableData(job_id=b"job_2", is_dead=True)
-    fake = _FakeSubscriber([(b"k1", running), (b"k2", finished)])
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_events_head.GcsAioJobSubscriber",
-        lambda address=None: fake,
-    )
-
-    task = asyncio.create_task(head._subscribe_for_finished_jobs())
-    try:
-        await async_wait_for_condition(lambda: head.num_finished_jobs_received == 1)
-    finally:
-        await _cancel(task)
-
-    # The running job was filtered out; only the finished one was buffered.
-    assert head.num_finished_jobs_received == 1
+    assert response.status == 200
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    reply.ParseFromString(response.body)
+    assert reply.status.code == task_event_query._INVALID_ARGUMENT_STATUS_CODE
+    assert len(reply.events_by_task) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -1,0 +1,112 @@
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+import ray._private.ray_constants as ray_constants
+import ray.dashboard.consts as dashboard_consts
+from ray._common.ray_constants import (
+    LOGGING_ROTATE_BACKUP_COUNT,
+    LOGGING_ROTATE_BYTES,
+)
+from ray.core.generated import events_event_aggregator_service_pb2
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
+from ray.dashboard.subprocesses.module import SubprocessModuleConfig
+
+
+def _make_config() -> SubprocessModuleConfig:
+    return SubprocessModuleConfig(
+        cluster_id_hex="deadbeef",
+        gcs_address="127.0.0.1:6379",
+        session_name="test_session",
+        temp_dir="/tmp",
+        session_dir="/tmp",
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        log_dir="/tmp",
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
+        socket_dir="/tmp",
+    )
+
+
+def _make_head() -> TaskEventsHead:
+    return TaskEventsHead(_make_config())
+
+
+def _make_add_events_request(num_events: int) -> bytes:
+    events_data = events_event_aggregator_service_pb2.RayEventsData()
+    for i in range(num_events):
+        events_data.events.append(RayEvent(event_id=f"event_{i}".encode()))
+    request = events_event_aggregator_service_pb2.AddEventsRequest(
+        events_data=events_data
+    )
+    return request.SerializeToString()
+
+
+def _fake_request(body: bytes):
+    request = AsyncMock()
+    request.read.return_value = body
+    return request
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_buffers_events():
+    head = _make_head()
+    assert head.num_events_received == 0
+
+    body = _make_add_events_request(num_events=2)
+    response = await head.add_task_events(_fake_request(body))
+
+    assert response.status == 200
+    assert head.num_events_received == 2
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_accumulates_across_requests():
+    head = _make_head()
+
+    await head.add_task_events(_fake_request(_make_add_events_request(num_events=2)))
+    await head.add_task_events(_fake_request(_make_add_events_request(num_events=3)))
+
+    assert head.num_events_received == 5
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_empty_payload():
+    head = _make_head()
+
+    response = await head.add_task_events(_fake_request(_make_add_events_request(0)))
+
+    assert response.status == 200
+    assert head.num_events_received == 0
+
+
+@pytest.mark.asyncio
+async def test_add_task_events_bad_payload_returns_error():
+    head = _make_head()
+
+    # A lone continuation byte is a truncated protobuf tag varint and reliably
+    # fails to parse, unlike arbitrary ASCII which protobuf may accept as
+    # unknown fields.
+    response = await head.add_task_events(_fake_request(b"\xff"))
+
+    # Malformed body must not raise; the handler returns an error response and
+    # nothing is buffered.
+    assert response.status != 200
+    assert head.num_events_received == 0
+
+
+def test_deserialize_request_roundtrip():
+    head = _make_head()
+
+    body = _make_add_events_request(num_events=1)
+    request = head._deserialize_request(body)
+
+    assert len(request.events_data.events) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
@@ -11,15 +11,19 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BYTES,
 )
 from ray._common.test_utils import async_wait_for_condition, run_string_as_driver
+from ray.dashboard.modules.task_events.task_event_manager import TaskEventManager
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
 from ray.tests.conftest import *  # noqa
 
+_MANAGER = "ray.dashboard.modules.task_events.task_event_manager"
 
-def _make_head(gcs_address: str) -> TaskEventsHead:
-    """Build a TaskEventsHead directly in the test's driver process (not as its usual
-    separate SubprocessModule) so the test can drive its subscription loops and read its
-    in-memory buffers in-process. Test-only."""
+
+def _make_manager(gcs_address: str) -> TaskEventManager:
+    """Build a TaskEventManager directly in the test's driver process (not inside its usual
+    separate SubprocessModule) so the test can drive its subscription loops and inspect its
+    in-memory store in-process. Reuses TaskEventsHead only to obtain a GCS aio channel wired
+    to the test cluster. Test-only."""
     config = SubprocessModuleConfig(
         cluster_id_hex="deadbeef",
         gcs_address=gcs_address,
@@ -34,7 +38,8 @@ def _make_head(gcs_address: str) -> TaskEventsHead:
         logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
         socket_dir="/tmp",
     )
-    return TaskEventsHead(config)
+    head = TaskEventsHead(config)
+    return TaskEventManager(head._store, head.gcs_address, head.aiogrpc_gcs_channel)
 
 
 async def _stop(subscription: asyncio.Task) -> None:
@@ -46,12 +51,23 @@ async def _stop(subscription: asyncio.Task) -> None:
 
 
 @pytest.mark.asyncio
-async def test_worker_death_lands_in_buffer(ray_start_regular):
-    """A killed worker's failure is delivered over GCS pubsub and buffered by the head."""
+async def test_worker_death_triggers_reconciliation(ray_start_regular, monkeypatch):
+    """A killed worker's failure is delivered over GCS pubsub, its exit info is fetched,
+    and the manager fails that worker's tasks."""
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
     gcs_address = ray_start_regular["gcs_address"]
-    head = _make_head(gcs_address)
+    manager = _make_manager(gcs_address)
 
-    subscription = asyncio.create_task(head._subscribe_for_worker_deaths())
+    marked_workers = []
+    original = manager._store.mark_tasks_failed_on_worker_dead
+
+    def record(worker_id, worker_table_data):
+        marked_workers.append(worker_id)
+        return original(worker_id, worker_table_data)
+
+    monkeypatch.setattr(manager._store, "mark_tasks_failed_on_worker_dead", record)
+
+    subscription = asyncio.create_task(manager._subscribe_for_worker_deaths())
     try:
         # Let the subscription register before triggering the death: GCS only queues
         # messages for a subscriber once its subscription is established.
@@ -66,35 +82,50 @@ async def test_worker_death_lands_in_buffer(ray_start_regular):
         worker_id = bytes.fromhex(await actor.get_worker_id.remote())
         ray.kill(actor, no_restart=True)
 
-        await async_wait_for_condition(
-            lambda: worker_id in {wd.worker_id for wd in head._dead_workers},
-            timeout=30,
-        )
+        # Reaching the store call means the worker delta arrived and GetWorkerInfo
+        # returned the dead worker's exit info (otherwise reconciliation returns early).
+        await async_wait_for_condition(lambda: worker_id in marked_workers, timeout=30)
     finally:
         await _stop(subscription)
 
 
 @pytest.mark.asyncio
-async def test_job_finished_lands_in_buffer(ray_start_regular):
-    """A finished job is delivered over GCS pubsub and buffered by the head."""
+async def test_job_finished_triggers_reconciliation(ray_start_regular, monkeypatch):
+    """A finished job is delivered over GCS pubsub and the manager fails that job's
+    tasks. Running-job updates are ignored, so only the finished job is acted on."""
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
     gcs_address = ray_start_regular["gcs_address"]
-    head = _make_head(gcs_address)
+    manager = _make_manager(gcs_address)
 
-    subscription = asyncio.create_task(head._subscribe_for_finished_jobs())
+    marked_jobs = []
+    original = manager._store.mark_tasks_failed_on_job_ends
+
+    def record(job_id, job_finish_time_ns):
+        marked_jobs.append(job_id)
+        return original(job_id, job_finish_time_ns)
+
+    monkeypatch.setattr(manager._store, "mark_tasks_failed_on_job_ends", record)
+
+    subscription = asyncio.create_task(manager._subscribe_for_finished_jobs())
     try:
         await asyncio.sleep(2)
 
-        # A driver that connects and immediately exits, finishing its job. Run it off the
-        # event loop so the subscription keeps polling while the subprocess runs.
-        driver = f'import ray\nray.init(address="{gcs_address}")\n'
-        await asyncio.get_running_loop().run_in_executor(
+        # A driver that connects, reports its job id, and exits (finishing its job). Run
+        # it off the event loop so the subscription keeps polling while it runs.
+        driver = (
+            "import ray\n"
+            f'ray.init(address="{gcs_address}")\n'
+            'print("JOBID:" + ray.get_runtime_context().get_job_id())\n'
+        )
+        output = await asyncio.get_running_loop().run_in_executor(
             None, run_string_as_driver, driver
         )
-
-        await async_wait_for_condition(
-            lambda: any(job.is_dead for job in head._finished_jobs),
-            timeout=30,
+        job_line = next(
+            line for line in output.splitlines() if line.startswith("JOBID:")
         )
+        job_id = bytes.fromhex(job_line[len("JOBID:") :].strip())
+
+        await async_wait_for_condition(lambda: job_id in marked_jobs, timeout=30)
     finally:
         await _stop(subscription)
 

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
@@ -1,0 +1,103 @@
+import asyncio
+import sys
+
+import pytest
+
+import ray
+import ray._private.ray_constants as ray_constants
+import ray.dashboard.consts as dashboard_consts
+from ray._common.ray_constants import (
+    LOGGING_ROTATE_BACKUP_COUNT,
+    LOGGING_ROTATE_BYTES,
+)
+from ray._common.test_utils import async_wait_for_condition, run_string_as_driver
+from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
+from ray.dashboard.subprocesses.module import SubprocessModuleConfig
+from ray.tests.conftest import *  # noqa
+
+
+def _make_head(gcs_address: str) -> TaskEventsHead:
+    """Build a TaskEventsHead directly in the test's driver process (not as its usual
+    separate SubprocessModule) so the test can drive its subscription loops and read its
+    in-memory buffers in-process. Test-only."""
+    config = SubprocessModuleConfig(
+        cluster_id_hex="deadbeef",
+        gcs_address=gcs_address,
+        session_name="test_session",
+        temp_dir="/tmp",
+        session_dir="/tmp",
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        log_dir="/tmp",
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
+        socket_dir="/tmp",
+    )
+    return TaskEventsHead(config)
+
+
+async def _stop(subscription: asyncio.Task) -> None:
+    subscription.cancel()
+    try:
+        await subscription
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_worker_death_lands_in_buffer(ray_start_regular):
+    """A killed worker's failure is delivered over GCS pubsub and buffered by the head."""
+    gcs_address = ray_start_regular["gcs_address"]
+    head = _make_head(gcs_address)
+
+    subscription = asyncio.create_task(head._subscribe_for_worker_deaths())
+    try:
+        # Let the subscription register before triggering the death: GCS only queues
+        # messages for a subscriber once its subscription is established.
+        await asyncio.sleep(2)
+
+        @ray.remote
+        class Actor:
+            def get_worker_id(self):
+                return ray.get_runtime_context().get_worker_id()
+
+        actor = Actor.remote()
+        worker_id = bytes.fromhex(await actor.get_worker_id.remote())
+        ray.kill(actor, no_restart=True)
+
+        await async_wait_for_condition(
+            lambda: worker_id in {wd.worker_id for wd in head._dead_workers},
+            timeout=30,
+        )
+    finally:
+        await _stop(subscription)
+
+
+@pytest.mark.asyncio
+async def test_job_finished_lands_in_buffer(ray_start_regular):
+    """A finished job is delivered over GCS pubsub and buffered by the head."""
+    gcs_address = ray_start_regular["gcs_address"]
+    head = _make_head(gcs_address)
+
+    subscription = asyncio.create_task(head._subscribe_for_finished_jobs())
+    try:
+        await asyncio.sleep(2)
+
+        # A driver that connects and immediately exits, finishing its job. Run it off the
+        # event loop so the subscription keeps polling while the subprocess runs.
+        driver = f'import ray\nray.init(address="{gcs_address}")\n'
+        await asyncio.get_running_loop().run_in_executor(
+            None, run_string_as_driver, driver
+        )
+
+        await async_wait_for_condition(
+            lambda: any(job.is_dead for job in head._finished_jobs),
+            timeout=30,
+        )
+    finally:
+        await _stop(subscription)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -99,6 +99,12 @@ class SubprocessModule(abc.ABC):
         """
         return False
 
+    @classmethod
+    def is_enabled(cls) -> bool:
+        """Return True if the module should be loaded. Subclasses can override to gate
+        loading behind a feature flag."""
+        return True
+
     async def run(self):
         """
         Start running the module.

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1476,15 +1476,34 @@ async def test_dashboard_module_load(tmpdir):
     with pytest.raises(AssertionError):
         head._load_modules(modules_to_load=loaded_modules_expected)
 
+    # A requested-but-disabled subprocess module (is_enabled() is False, e.g. the
+    # flag-gated TaskEventsHead) is skipped, not treated as a load failure.
+    disabled_subprocess_modules = {
+        m.__name__
+        for m in dashboard_utils.get_all_modules(SubprocessModule)
+        if not m.is_enabled()
+    }
+    if disabled_subprocess_modules:
+        _, subprocess_module_handles = head._load_modules(
+            modules_to_load=disabled_subprocess_modules
+        )
+        assert len(subprocess_module_handles) == 0
+
     # Test the base case.
     # It is needed to pass assertion check from one of modules.
     gcs_client = MagicMock()
     _initialize_internal_kv(gcs_client)
+    # Mirror the loader, which skips modules whose is_enabled() is False (e.g. modules
+    # gated behind a feature flag such as TaskEventsHead / PlatformEventsHead).
     loaded_dashboard_head_modules_expected = {
-        m.__name__ for m in dashboard_utils.get_all_modules(DashboardHeadModule)
+        m.__name__
+        for m in dashboard_utils.get_all_modules(DashboardHeadModule)
+        if m.is_enabled()
     }
     loaded_subprocess_module_handles_expected = {
-        m.__name__ for m in dashboard_utils.get_all_modules(SubprocessModule)
+        m.__name__
+        for m in dashboard_utils.get_all_modules(SubprocessModule)
+        if m.is_enabled()
     }
     dashboard_head_modules, subprocess_module_handles = head._load_modules()
     assert {

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -86,3 +86,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool record_task_actor_creation_sites() const
 
         c_bool start_python_gc_manager_thread() const
+
+        c_bool enable_task_events_to_dashboard_head() const

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -88,3 +88,12 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool start_python_gc_manager_thread() const
 
         c_bool enable_task_events_to_dashboard_head() const
+
+        # TODO: Deprecate this once task events are fully moved out of GCS.
+        int64_t task_events_max_num_task_in_gcs() const
+
+        int64_t task_events_max_num_profile_events_per_task() const
+
+        int64_t task_events_max_dropped_task_attempts_tracked_per_job_in_gcs() const
+
+        int64_t task_events_gc_job_summary_interval_ms() const

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -97,3 +97,7 @@ cdef extern from "ray/common/ray_config.h" nogil:
         int64_t task_events_max_dropped_task_attempts_tracked_per_job_in_gcs() const
 
         int64_t task_events_gc_job_summary_interval_ms() const
+
+        uint64_t gcs_mark_task_failed_on_worker_dead_delay_ms() const
+
+        uint64_t gcs_mark_task_failed_on_job_done_delay_ms() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -139,3 +139,7 @@ cdef class Config:
     @staticmethod
     def start_python_gc_manager_thread():
         return RayConfig.instance().start_python_gc_manager_thread()
+
+    @staticmethod
+    def enable_task_events_to_dashboard_head():
+        return RayConfig.instance().enable_task_events_to_dashboard_head()

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -160,3 +160,11 @@ cdef class Config:
     @staticmethod
     def task_events_gc_job_summary_interval_ms():
         return RayConfig.instance().task_events_gc_job_summary_interval_ms()
+
+    @staticmethod
+    def gcs_mark_task_failed_on_worker_dead_delay_ms():
+        return RayConfig.instance().gcs_mark_task_failed_on_worker_dead_delay_ms()
+
+    @staticmethod
+    def gcs_mark_task_failed_on_job_done_delay_ms():
+        return RayConfig.instance().gcs_mark_task_failed_on_job_done_delay_ms()

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -143,3 +143,20 @@ cdef class Config:
     @staticmethod
     def enable_task_events_to_dashboard_head():
         return RayConfig.instance().enable_task_events_to_dashboard_head()
+
+    @staticmethod
+    def task_events_max_num_task_in_gcs():
+        return RayConfig.instance().task_events_max_num_task_in_gcs()
+
+    @staticmethod
+    def task_events_max_num_profile_events_per_task():
+        return RayConfig.instance().task_events_max_num_profile_events_per_task()
+
+    @staticmethod
+    def task_events_max_dropped_task_attempts_tracked_per_job_in_gcs():
+        return (RayConfig.instance()
+                .task_events_max_dropped_task_attempts_tracked_per_job_in_gcs())
+
+    @staticmethod
+    def task_events_gc_job_summary_interval_ms():
+        return RayConfig.instance().task_events_gc_job_summary_interval_ms()

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -84,9 +84,10 @@ _EXPECTED_DASHBOARD_MODULES = [
     "ray.dashboard.modules.reporter.reporter_head.ReportHead",
     "ray.dashboard.modules.serve.serve_head.ServeHead",
     "ray.dashboard.modules.state.state_head.StateHead",
-    "ray.dashboard.modules.task_events.task_events_head.TaskEventsHead",
     "ray.dashboard.modules.train.train_head.TrainHead",
 ]
+# TaskEventsHead is intentionally omitted: it is gated off by default
+# (RAY_enable_task_events_to_dashboard_head) and so does not run as a subprocess here.
 
 # The list of processes expected to be started in the system cgroup
 # with default params for 'ray start' and 'ray.init(...)'

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -84,6 +84,7 @@ _EXPECTED_DASHBOARD_MODULES = [
     "ray.dashboard.modules.reporter.reporter_head.ReportHead",
     "ray.dashboard.modules.serve.serve_head.ServeHead",
     "ray.dashboard.modules.state.state_head.StateHead",
+    "ray.dashboard.modules.task_events.task_events_head.TaskEventsHead",
     "ray.dashboard.modules.train.train_head.TrainHead",
 ]
 

--- a/python/ray/tests/test_state_api_data_source_client_get.py
+++ b/python/ray/tests/test_state_api_data_source_client_get.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import signal
 import sys
@@ -5,6 +6,7 @@ import uuid
 from collections import Counter
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from click.testing import CliRunner
 
@@ -601,6 +603,53 @@ def test_list_get_tasks(shutdown_only):
 
     wait_for_condition(verify)
     print(list_tasks())
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Exercises the POSIX unix-socket hop between the StateHead and "
+    "TaskEventsHead subprocesses.",
+)
+def test_list_tasks_reads_from_dashboard_head(monkeypatch, shutdown_only):
+    """End-to-end: with ``RAY_enable_task_events_to_dashboard_head`` on, ``ray list
+    tasks`` reads from the ``TaskEventsHead`` subprocess over its unix socket, not GCS.
+    """
+    # Feed task events into the dashboard-head store via the aggregator, and read them
+    # back from there instead of GCS. The single umbrella flag enables both the publish
+    # path and the read reroute.
+    monkeypatch.setenv("RAY_enable_core_worker_ray_event_to_aggregator", "1")
+    monkeypatch.setenv("RAY_enable_core_worker_task_event_to_gcs", "0")
+    monkeypatch.setenv("RAY_enable_task_events_to_dashboard_head", "1")
+
+    ray_context = ray.init(num_cpus=2)
+    wait_for_aggregator_agent_if_enabled(
+        ray_context.address_info["address"],
+        ray_context.address_info["node_id"],
+    )
+    job_id = ray.get_runtime_context().get_job_id()
+
+    @ray.remote
+    def f():
+        return 1
+
+    names = [f"dh_task_{i}" for i in range(3)]
+    ray.get([f.options(name=name).remote() for name in names])
+
+    def verify():
+        tasks = list_tasks()
+        names_seen = {task["name"] for task in tasks}
+        assert set(names).issubset(names_seen), (names, names_seen)
+        for task in tasks:
+            assert task["job_id"] == job_id
+
+        # The filter is serialized into the request and applied on the dashboard-head
+        # side, so a correct filtered result also proves the request survived the wire.
+        filtered = list_tasks(filters=[("name", "=", names[0])])
+        assert len(filtered) == 1
+        assert filtered[0]["name"] == names[0]
+        return True
+
+    wait_for_condition(verify, timeout=30)
 
 
 @pytest.mark.parametrize(
@@ -1473,6 +1522,107 @@ def test_get_actor_timeout_multiplier(shutdown_only):
     # This should work without timeout issues
     result = get_actor(actor_id, timeout=1)
     assert result["actor_id"] == actor_id
+
+
+class _FakeAsyncResponse:
+    """Minimal aiohttp-style response usable as an async context manager."""
+
+    def __init__(self, status, body=b""):
+        self.status = status
+        self.reason = "test-reason"
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _task_info_client(**kwargs):
+    return StateDataSourceClient(
+        gcs_channel=MagicMock(), gcs_client=MagicMock(), **kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_all_task_info_reads_from_gcs_by_default(monkeypatch):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", False
+    )
+    client = _task_info_client()
+    expected = GetTaskEventsReply()
+    client._gcs_task_info_stub.GetTaskEvents = AsyncMock(return_value=expected)
+
+    reply = await client.get_all_task_info()
+
+    client._gcs_task_info_stub.GetTaskEvents.assert_awaited_once()
+    assert reply is expected
+
+
+@pytest.mark.asyncio
+async def test_get_all_task_info_reads_from_dashboard_head_when_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    client = _task_info_client(
+        dashboard_socket_dir="/tmp/sock", dashboard_session_name="session-1"
+    )
+    expected = GetTaskEventsReply(num_status_task_events_dropped=3)
+    session = MagicMock()
+    session.post = MagicMock(
+        return_value=_FakeAsyncResponse(200, expected.SerializeToString())
+    )
+    client._task_events_head_session = session
+
+    reply = await client.get_all_task_info()
+
+    session.post.assert_called_once()
+    assert session.post.call_args.args[0] == "http://localhost/api/task_events/query"
+    # The co-located socket call is trusted, so no auth header is attached.
+    assert "headers" not in session.post.call_args.kwargs
+    assert reply.num_status_task_events_dropped == 3
+
+
+@pytest.mark.asyncio
+async def test_get_all_task_info_from_dashboard_head_non_2xx_raises(monkeypatch):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    client = _task_info_client(
+        dashboard_socket_dir="/tmp/sock", dashboard_session_name="session-1"
+    )
+    session = MagicMock()
+    session.post = MagicMock(return_value=_FakeAsyncResponse(500))
+    client._task_events_head_session = session
+
+    with pytest.raises(DataSourceUnavailable):
+        await client.get_all_task_info()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error", [aiohttp.ClientError("boom"), asyncio.TimeoutError()]
+)
+async def test_get_all_task_info_from_dashboard_head_unreachable_raises(
+    monkeypatch, transport_error
+):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    client = _task_info_client(
+        dashboard_socket_dir="/tmp/sock", dashboard_session_name="session-1"
+    )
+    session = MagicMock()
+    # An unreachable dashboard head raises a transport error, not an HTTP status.
+    session.post = MagicMock(side_effect=transport_error)
+    client._task_events_head_session = session
+
+    with pytest.raises(DataSourceUnavailable):
+        await client.get_all_task_info()
 
 
 if __name__ == "__main__":

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -9,6 +10,7 @@ import aiohttp
 import grpc
 from grpc.aio._call import UnaryStreamCall
 
+import ray
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.modules.log.log_consts as log_consts
 from ray._common.network_utils import build_address
@@ -64,6 +66,11 @@ _STATE_MANAGER_GRPC_OPTIONS = [
     ("grpc.max_send_message_length", ray_constants.GRPC_CPP_MAX_MESSAGE_SIZE),
     ("grpc.max_receive_message_length", ray_constants.GRPC_CPP_MAX_MESSAGE_SIZE),
 ]
+
+# Serve the State API's task queries from the dashboard-head store instead of GCS.
+_READ_TASK_EVENTS_FROM_DASHBOARD_HEAD = (
+    ray._config.enable_task_events_to_dashboard_head()
+)
 
 
 def handle_grpc_network_errors(func):
@@ -126,11 +133,28 @@ class StateDataSourceClient:
     - throw a ValueError if it cannot find the source.
     """
 
-    def __init__(self, gcs_channel: grpc.aio.Channel, gcs_client: GcsClient):
+    def __init__(
+        self,
+        gcs_channel: grpc.aio.Channel,
+        gcs_client: GcsClient,
+        dashboard_socket_dir: Optional[str] = None,
+        dashboard_session_name: Optional[str] = None,
+    ):
         self.register_gcs_client(gcs_channel)
         self._job_client = JobInfoStorageClient(gcs_client)
         self._gcs_client = gcs_client
         self._client_session = aiohttp.ClientSession()
+        self._dashboard_socket_dir = dashboard_socket_dir
+        self._dashboard_session_name = dashboard_session_name
+        if _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD and (
+            dashboard_socket_dir is None or dashboard_session_name is None
+        ):
+            raise ValueError(
+                "Cannot read task events from the dashboard head: the dashboard "
+                "subprocess socket directory and session name were not provided to "
+                "StateDataSourceClient."
+            )
+        self._task_events_head_session: Optional[aiohttp.ClientSession] = None
 
     def register_gcs_client(self, gcs_channel: grpc.aio.Channel):
         self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
@@ -228,7 +252,6 @@ class StateDataSourceClient:
         )
         return reply
 
-    @handle_grpc_network_errors
     async def get_all_task_info(
         self,
         timeout: int = None,
@@ -236,7 +259,17 @@ class StateDataSourceClient:
         filters: Optional[List[Tuple[str, PredicateType, SupportedFilterType]]] = None,
         exclude_driver: bool = False,
     ) -> Optional[GetTaskEventsReply]:
+        request = self._build_task_events_request(limit, filters, exclude_driver)
+        if _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD:
+            return await self._get_task_events_from_dashboard_head(request, timeout)
+        return await self._get_task_events_from_gcs(request, timeout)
 
+    def _build_task_events_request(
+        self,
+        limit: int,
+        filters: Optional[List[Tuple[str, PredicateType, SupportedFilterType]]],
+        exclude_driver: bool,
+    ) -> GetTaskEventsRequest:
         if filters is None:
             filters = []
 
@@ -289,9 +322,48 @@ class StateDataSourceClient:
 
         req_filters.exclude_driver = exclude_driver
 
-        request = GetTaskEventsRequest(limit=limit, filters=req_filters)
-        reply = await self._gcs_task_info_stub.GetTaskEvents(request, timeout=timeout)
-        return reply
+        return GetTaskEventsRequest(limit=limit, filters=req_filters)
+
+    @handle_grpc_network_errors
+    async def _get_task_events_from_gcs(
+        self, request: GetTaskEventsRequest, timeout: int = None
+    ) -> Optional[GetTaskEventsReply]:
+        return await self._gcs_task_info_stub.GetTaskEvents(request, timeout=timeout)
+
+    async def _get_task_events_from_dashboard_head(
+        self, request: GetTaskEventsRequest, timeout: int = None
+    ) -> Optional[GetTaskEventsReply]:
+        if self._task_events_head_session is None:
+            from ray.dashboard.subprocesses.utils import get_http_session_to_module
+
+            self._task_events_head_session = get_http_session_to_module(
+                "TaskEventsHead",
+                self._dashboard_socket_dir,
+                self._dashboard_session_name,
+            )
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        try:
+            async with self._task_events_head_session.post(
+                "http://localhost/api/task_events/query",
+                data=request.SerializeToString(),
+                timeout=client_timeout,
+            ) as resp:
+                if 200 <= resp.status < 300:
+                    reply = GetTaskEventsReply()
+                    reply.ParseFromString(await resp.read())
+                    return reply
+                raise DataSourceUnavailable(
+                    "Failed to query task events from the dashboard head. "
+                    f"Response is {resp.status}, reason {resp.reason}"
+                )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            # An unreachable dashboard head (connection refused, socket gone, timeout)
+            # must surface as DataSourceUnavailable so list_tasks shows the normal
+            # failure warning instead of a raw error, matching the GCS gRPC path.
+            raise DataSourceUnavailable(
+                "Failed to query task events from the dashboard head; it may be down "
+                "or unreachable."
+            ) from e
 
     @handle_grpc_network_errors
     async def get_all_placement_group_info(

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1120,6 +1120,12 @@ RAY_CONFIG(bool, enable_core_worker_task_event_to_gcs, true)
 // event aggregator.
 RAY_CONFIG(bool, enable_core_worker_ray_event_to_aggregator, false)
 
+// Flag for the migration of task events from GCS to dashboard head. When true: the
+// aggregator publishes task events to the dashboard head, the TaskEventsHead module is
+// loaded, and the state API (list tasks / ray.timeline) reads task events from the
+// dashboard head instead of GCS.
+RAY_CONFIG(bool, enable_task_events_to_dashboard_head, false)
+
 // Configuration for pipe logger buffer size.
 RAY_CONFIG(uint64_t, pipe_logger_read_buf_size, 1024)
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -601,6 +601,10 @@ RAY_CONFIG(int64_t, task_events_dropped_task_attempt_batch_size, 10 * 1000)
 /// this duration for in-flight gRPC calls to complete before stopping the io_service.
 RAY_CONFIG(int64_t, task_events_shutdown_flush_timeout_ms, 5000)
 
+/// Interval in milliseconds at which the dashboard-head task-event store trims each job's
+/// tracked dropped-attempt set (GcJobSummary).
+RAY_CONFIG(int64_t, task_events_gc_job_summary_interval_ms, 5 * 1000)
+
 /// The delay in ms that GCS should mark any running tasks from a job as failed.
 /// Setting this value too smaller might result in some finished tasks marked as failed by
 /// GCS.


### PR DESCRIPTION
Cherry-pick of #65160 (merge commit 12436ea75080433a9134cfa362b3dbb98fe9e73f) into `releases/2.58.0`.

This PR builds on #65141, so this branch is stacked on the #65141 cherry-pick (#65303) and must merge after it — until then the diff shown here includes both commits. The pick applied cleanly on top of that branch, and the patch-id matches the original merge commit exactly.

The intermediate 7/n (#65158) that this PR builds on needs no separate cherry-pick — it was merged into the #65141 PR branch rather than into master, so its content already arrives via #65303.

Not a duplicate: no existing open PR against `releases/2.58.0` contains this change. Cherry-picked with AI assistance (Claude Code); pre-commit hooks ran on the changed files and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)