### PR TITLE
[core] Warn when configured accelerators are not detected

### DIFF
--- a/python/ray/_private/resource_and_label_spec.py
+++ b/python/ray/_private/resource_and_label_spec.py
@@ -455,6 +455,31 @@ class ResourceAndLabelSpec:
                 num_accelerators = num_gpus
             else:
                 num_accelerators = resources.get(resource_name)
+
+            if num_accelerators is not None and num_accelerators > 0:
+                try:
+                    detected_num_accelerators = (
+                        accelerator_manager.get_current_node_num_accelerators()
+                    )
+                except Exception:
+                    logger.warning(
+                        "Ray was configured to use %s %s accelerator(s), but "
+                        "auto-detection failed. Check that the accelerator driver "
+                        "and discovery library are installed and accessible to Ray.",
+                        num_accelerators,
+                        resource_name,
+                        exc_info=True,
+                    )
+                else:
+                    if detected_num_accelerators == 0:
+                        logger.warning(
+                            "Ray was configured to use %s %s accelerator(s), but "
+                            "auto-detection found none. Check that the accelerator "
+                            "hardware is present and its driver is installed and "
+                            "accessible to Ray.",
+                            num_accelerators,
+                            resource_name,
+                        )
             if num_accelerators is None:
                 num_accelerators = (
                     accelerator_manager.get_current_node_num_accelerators()

--- a/python/ray/tests/unit/test_resource_and_label_spec.py
+++ b/python/ray/tests/unit/test_resource_and_label_spec.py
@@ -230,6 +230,35 @@ def test_resolve_handles_no_accelerators():
     assert spec.resolved()
 
 
+def test_user_configured_accelerator_warns_if_autodetection_finds_none():
+    manager = FakeAcceleratorManager("GPU", accelerator_type=None, num_accelerators=0)
+
+    with patch(
+        "ray._private.accelerators.get_accelerator_manager_for_resource",
+        return_value=manager,
+    ), patch(
+        "ray._private.accelerators.get_all_accelerator_resource_names",
+        return_value=["GPU"],
+    ), patch(
+        "ray._private.resource_and_label_spec.logger.warning"
+    ) as warning:
+        (
+            resolved_manager,
+            num_accelerators,
+        ) = ResourceAndLabelSpec._get_current_node_accelerator(2, {})
+
+    assert resolved_manager is manager
+    assert num_accelerators == 2
+    warning.assert_called_once_with(
+        "Ray was configured to use %s %s accelerator(s), but "
+        "auto-detection found none. Check that the accelerator "
+        "hardware is present and its driver is installed and "
+        "accessible to Ray.",
+        2,
+        "GPU",
+    )
+
+
 def test_label_spec_resolve_merged_env_labels(monkeypatch):
     """Validate that LABELS_ENVIRONMENT_VARIABLE is merged into final labels."""
     override_labels = {"autoscaler-override-label": "example"}


### PR DESCRIPTION
## Description

Ray currently preserves an explicitly configured accelerator resource count even when local accelerator discovery reports no devices, but it does so silently. That can leave a node advertising accelerator resources that cannot run accelerator work, with no actionable diagnostic at startup.

This change adds a warning when a user-configured positive accelerator count cannot be confirmed because discovery either returns zero or raises an exception. The configured count and existing resource-resolution behavior are preserved. The warning points users to the hardware, driver, and discovery-library setup without turning the diagnostic into a startup failure.

The regression test covers the zero-device case and verifies that the configured resource count remains unchanged.

## Related issues

Closes #43328

## Additional information

### Duplicate-work check

No open pull request referencing #43328 or matching the accelerator auto-detection warning was found before publication. A related earlier attempt, #45240, is closed.

### Validation

- Regression baseline: the new warning test failed on the base revision because no warning was emitted.
- `python/ray/tests/unit/test_resource_and_label_spec.py`: 13 passed, 1 deselected with the host GPUs visible.
- Auto-detection test with `CUDA_VISIBLE_DEVICES=""`: 1 passed.
- Executable exception-path check: configured count preserved and one warning emitted with exception information.
- Applicable pre-commit hooks passed after formatting: basic file checks, both Ruff hooks, Black, pydoclint, docstyle, `python-no-log-warn`, and `python-check-mock-methods`.
- Single-GPU Ray workload: a PyTorch CUDA kernel ran through a `num_gpus=1` Ray task on an RTX 3090 with `CUDA_VISIBLE_DEVICES=0`.

### AI-assisted contribution

AI assistance was used in preparing this change. The submitting human reviewed every changed line. This pull request is intentionally a draft; before requesting maintainer review, the submitting human will independently run the relevant checks and confirm that they understand and can explain the implementation and test behavior.
