### PR TITLE
[Serve] Fix serve.ingress(FastAPI()) pickling under FastAPI >= 0.137 (#64814) (cherry-pick 2.56.1)

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -243,11 +243,31 @@ def copy_class_metadata(wrapper_cls, target_cls) -> None:
     wrapper_cls.__wrapped__ = target_cls
 
 
+def _register_thread_lock_serializer(serialization_context):
+    """Make threading locks cloudpickle-serializable.
+
+    FastAPI >= 0.137 embeds a threading.Lock in the ASGI app object, which cloudpickle
+    cannot serialize ("cannot pickle '_thread.lock' object"). serve.ingress(app) pickles
+    the app to freeze it (and again to ship it to replicas), so both fail. A lock carries
+    no transferable state and the app is frozen/shipped before it serves any request, so
+    reconstruct a fresh, unlocked lock on deserialization.
+    """
+    import threading
+
+    for lock_factory in (threading.Lock, threading.RLock):
+        serialization_context._register_cloudpickle_serializer(
+            type(lock_factory()),
+            custom_serializer=lambda lock: None,
+            custom_deserializer=lambda _serialized, factory=lock_factory: factory(),
+        )
+
+
 def ensure_serialization_context():
     """Ensure the serialization addons on registered, even when Ray has not
     been started."""
     ctx = StandaloneSerializationContext()
     ray.util.serialization_addons.apply(ctx)
+    _register_thread_lock_serializer(ctx)
 
 
 def msgpack_serialize(obj):

--- a/python/ray/serve/tests/unit/test_serialization.py
+++ b/python/ray/serve/tests/unit/test_serialization.py
@@ -1,0 +1,37 @@
+import sys
+import threading
+
+import pytest
+
+from ray import cloudpickle
+from ray.serve._private.utils import ensure_serialization_context
+
+
+def test_thread_lock_serializer_round_trips():
+    """FastAPI >= 0.137 embeds a threading.Lock in the ASGI app object, breaking
+    serve.ingress(app) with 'cannot pickle _thread.lock'. The addon serializer must let
+    an object holding a lock round-trip through cloudpickle, reconstructing a fresh,
+    usable lock (locks carry no transferable state).
+    """
+    ensure_serialization_context()
+
+    class Holder:
+        def __init__(self):
+            self.lock = threading.Lock()
+            self.rlock = threading.RLock()
+            self.value = 7
+
+    restored = cloudpickle.loads(cloudpickle.dumps(Holder()))
+
+    assert restored.value == 7
+    assert isinstance(restored.lock, type(threading.Lock()))
+    assert isinstance(restored.rlock, type(threading.RLock()))
+    # The reconstructed locks are fresh and usable.
+    assert restored.lock.acquire(blocking=False)
+    restored.lock.release()
+    assert restored.rlock.acquire(blocking=False)
+    restored.rlock.release()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description

Cherry-pick of #64814 onto the `releases/2.56.1` branch.

FastAPI >= 0.139.2 embeds a `threading.Lock` in the ASGI app object, which cloudpickle cannot serialize (`cannot pickle '_thread.lock' object`). `@serve.ingress` freezes the app by pickling it at decoration time and again to ship it to replicas, so decorating any FastAPI app fails. The fix registers a cloudpickle serializer for `threading.Lock`/`threading.RLock` in Serve's serialization context so the lock round-trips as a fresh, unlocked lock (a lock carries no transferable state).

This was fixed on `master` in #64814 but is missing from the released 2.56.x wheels. Issue #64939 asks for a 2.56.x backport and has had no maintainer response; if the release team prefers to cherry-pick internally, this PR can be closed in favor of that.

## Related issues

Fixes #64939

## Additional information

Original PR: https://github.com/ray-project/ray/pull/64814

Verified against the 2.56.1 wheel: without the change, decorating a minimal FastAPI app fails with the reported TypeError; with the change, decoration and `serve.run` succeed. The regression test `test_thread_lock_serializer_round_trips` fails on the unpatched wheel and passes with the patch applied.