### PR TITLE
[autoscaler v2] Fix handling of multiple node types with same request_id

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -368,8 +368,10 @@ class Reconciler:
             and instance.status
             not in [IMInstance.TERMINATED, IMInstance.ALLOCATION_FAILED]
         }
-        launch_errors: Dict[str, LaunchNodeError] = {
-            error.request_id: error
+        # Use (request_id, node_type) as key to avoid overwriting when multiple
+        # LaunchNodeErrors share the same request_id but have different node_types.
+        launch_errors: Dict[Tuple[str, NodeType], LaunchNodeError] = {
+            (error.request_id, error.node_type): error
             for error in cloud_provider_errors
             if isinstance(error, LaunchNodeError)
         }
@@ -408,7 +410,7 @@ class Reconciler:
     def _try_resolve_pending_allocation(
         im_instance: IMInstance,
         unassigned_cloud_instances_by_type: Dict[str, List[CloudInstance]],
-        launch_errors: Dict[str, LaunchNodeError],
+        launch_errors: Dict[Tuple[str, NodeType], LaunchNodeError],
     ) -> Optional[IMInstanceUpdateEvent]:
         """
         Allocate, or fail the cloud instance allocation for the instance.
@@ -416,7 +418,8 @@ class Reconciler:
         Args:
             im_instance: The instance to allocate or fail.
             unassigned_cloud_instances_by_type: The unassigned cloud instances by type.
-            launch_errors: The launch errors from the cloud provider.
+            launch_errors: The launch errors from the cloud provider, keyed by
+                (request_id, node_type).
 
         Returns:
             Instance update to ALLOCATED: if there's a matching unassigned cloud
@@ -451,8 +454,10 @@ class Reconciler:
             )
 
         # If there's a launch error, transition to ALLOCATION_FAILED.
-        launch_error = launch_errors.get(im_instance.launch_request_id)
-        if launch_error and launch_error.node_type == im_instance.instance_type:
+        launch_error = launch_errors.get(
+            (im_instance.launch_request_id, im_instance.instance_type)
+        )
+        if launch_error:
             return IMInstanceUpdateEvent(
                 instance_id=im_instance.instance_id,
                 new_instance_status=IMInstance.ALLOCATION_FAILED,

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -273,6 +273,72 @@ class TestReconciler:
         assert instances["i-2"].status == Instance.ALLOCATION_FAILED
 
     @staticmethod
+    def test_requested_multiple_node_types_same_request_id_to_allocation_failed(setup):
+        """
+        Test that when multiple instances with different node_types share the same
+        request_id and all fail to launch, each instance should be transitioned to
+        ALLOCATION_FAILED with its corresponding launch error.
+
+        This tests the scenario where a single scaling request contains multiple
+        node_types, and each node_type fails independently.
+        """
+        instance_manager, instance_storage, _, cloud_resource_monitor = setup
+
+        instances = [
+            create_instance(
+                "i-1",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+            ),
+            create_instance(
+                "i-2",
+                status=Instance.REQUESTED,
+                instance_type="type-2",
+                launch_request_id="l1",
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, instances)
+
+        # Both node_types failed to launch
+        launch_errors = [
+            LaunchNodeError(
+                request_id="l1",
+                count=1,
+                node_type="type-1",
+                timestamp_ns=1,
+                details="Type-1 node failed: workers_to_be_deleted conflict",
+            ),
+            LaunchNodeError(
+                request_id="l1",
+                count=1,
+                node_type="type-2",
+                timestamp_ns=1,
+                details="Type-2 node failed: workers_to_be_deleted conflict",
+            ),
+        ]
+
+        cloud_instances = {}
+
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            cloud_resource_monitor=cloud_resource_monitor,
+            ray_cluster_resource_state=ClusterResourceState(),
+            non_terminated_cloud_instances=cloud_instances,
+            cloud_provider_errors=launch_errors,
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+
+        result_instances, _ = instance_storage.get_instances()
+
+        # Both instances should be ALLOCATION_FAILED
+        assert result_instances["i-1"].status == Instance.ALLOCATION_FAILED
+        assert result_instances["i-2"].status == Instance.ALLOCATION_FAILED
+
+    @staticmethod
     def test_reconcile_terminated_cloud_instances(setup):
 
         instance_manager, instance_storage, subscriber, cloud_resource_monitor = setup


### PR DESCRIPTION
## Description

When multiple instances with different `node_types` share the same `request_id` and all fail to launch, only one instance is transitioned to `ALLOCATION_FAILED`. This happens because `launch_errors` is keyed by `request_id` alone (`Dict[str, LaunchNodeError]`), so later failures overwrite earlier ones — leaving some stuck instances that never reach a terminal state.

This PR changes the key to a `(request_id, node_type)` tuple so each `(request_id, node_type)` combination is tracked independently. The scope is limited to `reconciler.py` and its tests; no API surface changes.

## Related issues

Closes #65223.
Fixes https://github.com/ray-project/ray/issues/65223

## Additional information

**Changes:**
- `reconciler.py`: `launch_errors` key type changed from `str` to `Tuple[str, NodeType]` (`(request_id, node_type)`)
- `_try_resolve_pending_allocation`: updated to use the new key format
- `test_reconciler.py`: added `test_requested_multiple_node_types_same_request_id_to_allocation_failed` (66 lines, covers 2 node types sharing one request_id)

**AI assistance:** This PR was developed with AI assistance. Every changed line has been reviewed and the relevant tests have been run locally by the human submitter.
