### PR TITLE
[StateAPI] Support --headers and --verify in State CLI

### DIFF
--- a/doc/source/ray-observability/reference/cli.rst
+++ b/doc/source/ray-observability/reference/cli.rst
@@ -16,6 +16,27 @@ This section contains commands to access the :ref:`live state of Ray resources (
 
 State CLI allows users to access the state of various resources (e.g., actor, task, object).
 
+Authentication and TLS options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+State CLI commands that connect to the Ray Dashboard support ``--headers`` for
+HTTP headers encoded as a JSON object. If ``--headers`` is omitted, Ray reads
+``RAY_STATE_HEADERS``. A command-line value takes precedence over the environment
+variable.
+
+For TLS, ``--verify true`` enables certificate verification, ``--verify false``
+disables it, and a path value such as ``--verify /path/to/ca-bundle.pem`` uses a
+trusted CA file or directory.
+
+For example:
+
+.. code-block:: bash
+
+    ray list actors \
+        --address https://cluster.example.com:8265 \
+        --headers '{"Authorization": "Bearer <token>"}' \
+        --verify /path/to/ca-bundle.pem
+
 .. click:: ray.util.state.state_cli:task_summary
    :prog: ray summary tasks
 

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -1,4 +1,3 @@
-import json
 import os
 import pprint
 import shlex
@@ -20,7 +19,7 @@ from ray._private.utils import (
 )
 from ray.autoscaler._private.cli_logger import add_click_logging_options, cf, cli_logger
 from ray.dashboard.modules.dashboard_sdk import parse_runtime_env_args
-from ray.dashboard.modules.job.cli_utils import add_common_job_options
+from ray.dashboard.modules.job.cli_utils import add_common_job_options, parse_headers
 from ray.dashboard.modules.job.utils import redact_url_password
 from ray.job_submission import JobStatus, JobSubmissionClient
 from ray.util.annotations import PublicAPI
@@ -46,19 +45,7 @@ def _get_sdk_client(
 
 
 def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
-    if headers is None and "RAY_JOB_HEADERS" in os.environ:
-        headers = os.environ["RAY_JOB_HEADERS"]
-    if headers is not None:
-        try:
-            return json.loads(headers)
-        except Exception as exc:
-            raise ValueError(
-                """Failed to parse headers into JSON.
-                Expected format: {{"KEY": "VALUE"}}, got {}, {}""".format(
-                    headers, exc
-                )
-            )
-    return None
+    return parse_headers(headers, env_var="RAY_JOB_HEADERS")
 
 
 def _log_big_success_msg(success_msg):

--- a/python/ray/dashboard/modules/job/cli_utils.py
+++ b/python/ray/dashboard/modules/job/cli_utils.py
@@ -33,6 +33,12 @@ def parse_headers(headers: Optional[str], *, env_var: str) -> Optional[Dict[str,
     if not isinstance(parsed_headers, dict):
         raise ValueError("Expected headers to be a JSON object/dictionary.")
 
+    if any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in parsed_headers.items()
+    ):
+        raise ValueError("All header keys and values must be strings.")
+
     return dict(parsed_headers)
 
 

--- a/python/ray/dashboard/modules/job/cli_utils.py
+++ b/python/ray/dashboard/modules/job/cli_utils.py
@@ -1,5 +1,7 @@
 import functools
-from typing import Union
+import json
+import os
+from typing import Any, Dict, Optional, Union
 
 import click
 
@@ -12,6 +14,26 @@ def bool_cast(string: str) -> Union[bool, str]:
         return False
     else:
         return string
+
+
+def parse_headers(headers: Optional[str], *, env_var: str) -> Optional[Dict[str, Any]]:
+    """Parse HTTP headers from a JSON string or environment variable."""
+    if headers is None:
+        headers = os.environ.get(env_var)
+    if headers is None:
+        return None
+
+    try:
+        parsed_headers = json.loads(headers)
+    except Exception as exc:
+        raise ValueError(
+            "Failed to parse headers into JSON. " 'Expected format: {"KEY": "VALUE"}.'
+        ) from exc
+
+    if not isinstance(parsed_headers, dict):
+        raise ValueError("Expected headers to be a JSON object/dictionary.")
+
+    return dict(parsed_headers)
 
 
 class BoolOrStringParam(click.ParamType):

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -128,6 +128,8 @@ def test_parse_headers_no_input_returns_none():
     [
         ("{bad json", "Failed to parse headers into JSON"),
         ("[]", "Expected headers to be a JSON object/dictionary"),
+        ('{"X-Retry": 3}', "All header keys and values must be strings"),
+        ('{"X-Enabled": true}', "All header keys and values must be strings"),
     ],
 )
 def test_parse_headers_rejects_invalid_input(headers, error):

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -15,6 +15,7 @@ import yaml
 from click.testing import CliRunner
 
 from ray.dashboard.modules.job.cli import job_cli_group
+from ray.dashboard.modules.job.cli_utils import parse_headers
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,41 @@ def _expected_entrypoint(*args):
     if sys.platform == "win32":
         return list2cmdline(args)
     return shlex.join(args)
+
+
+def test_parse_headers_explicit_json_object():
+    assert parse_headers('{"X-API-Key": "abc"}', env_var="RAY_JOB_HEADERS") == {
+        "X-API-Key": "abc"
+    }
+
+
+def test_parse_headers_env_fallback():
+    with set_env_var("RAY_JOB_HEADERS", '{"X-Env": "env"}'):
+        assert parse_headers(None, env_var="RAY_JOB_HEADERS") == {"X-Env": "env"}
+
+
+def test_parse_headers_explicit_value_overrides_env():
+    with set_env_var("RAY_JOB_HEADERS", '{"X-Env": "env"}'):
+        assert parse_headers('{"X-CLI": "cli"}', env_var="RAY_JOB_HEADERS") == {
+            "X-CLI": "cli"
+        }
+
+
+def test_parse_headers_no_input_returns_none():
+    with set_env_var("RAY_JOB_HEADERS"):
+        assert parse_headers(None, env_var="RAY_JOB_HEADERS") is None
+
+
+@pytest.mark.parametrize(
+    "headers,error",
+    [
+        ("{bad json", "Failed to parse headers into JSON"),
+        ("[]", "Expected headers to be a JSON object/dictionary"),
+    ],
+)
+def test_parse_headers_rejects_invalid_input(headers, error):
+    with pytest.raises(ValueError, match=error):
+        parse_headers(headers, env_var="RAY_JOB_HEADERS")
 
 
 def _job_cli_group_test_address(mock_sdk_client, cmd, *args):

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -7,6 +7,7 @@ import threading
 import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
@@ -18,6 +19,8 @@ from click.testing import CliRunner
 import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.state as global_state
+import ray.util.state.api as state_api
+import ray.util.state.state_cli as state_cli
 from ray._common.network_utils import find_free_port, parse_address
 from ray._common.test_utils import (
     SignalActor,
@@ -92,6 +95,7 @@ from ray.util.state.state_cli import (
     _normalize_filter_keys,
     _parse_filter,
     format_list_api_output,
+    logs_state_cli_group,
     ray_get,
     ray_list,
     summary_state_cli_group,
@@ -101,6 +105,45 @@ from ray.util.state.state_manager import StateDataSourceClient
 """
 Unit tests
 """
+
+
+class FakeStateApiClient:
+    captured = None
+
+    def __init__(
+        self,
+        address=None,
+        cookies=None,
+        headers=None,
+        verify=True,
+        **kwargs,
+    ):
+        FakeStateApiClient.captured = {
+            "address": address,
+            "cookies": cookies,
+            "headers": headers,
+            "verify": verify,
+            "kwargs": kwargs,
+        }
+
+    def get(self, *args, **kwargs):
+        FakeStateApiClient.captured["get"] = {"args": args, "kwargs": kwargs}
+        return None
+
+    def list(self, *args, **kwargs):
+        FakeStateApiClient.captured["list"] = {"args": args, "kwargs": kwargs}
+        return []
+
+    def summary(self, *args, **kwargs):
+        FakeStateApiClient.captured["summary"] = {"args": args, "kwargs": kwargs}
+        return {"cluster": {"summary": {}, "summary_by": "state"}}
+
+
+@pytest.fixture
+def reset_fake_state_api_client():
+    FakeStateApiClient.captured = None
+    yield
+    FakeStateApiClient.captured = None
 
 
 @pytest.fixture
@@ -454,6 +497,445 @@ def test_parse_filter():
         _parse_filter("key>value")
     with pytest.raises(ValueError):
         _parse_filter("key>value!=")
+
+
+def test_state_cli_get_headers_and_verify_false(
+    monkeypatch, reset_fake_state_api_client
+):
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+
+    result = CliRunner().invoke(
+        ray_get,
+        [
+            "actors",
+            "actor-id",
+            "--headers",
+            '{"Authorization": "Bearer cli"}',
+            "--verify",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert FakeStateApiClient.captured["headers"] == {"Authorization": "Bearer cli"}
+    assert FakeStateApiClient.captured["verify"] is False
+
+
+def test_state_cli_list_headers_and_verify_false(
+    monkeypatch, reset_fake_state_api_client
+):
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+
+    result = CliRunner().invoke(
+        ray_list,
+        [
+            "actors",
+            "--headers",
+            '{"X-API-Key": "cli"}',
+            "--verify",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert FakeStateApiClient.captured["headers"] == {"X-API-Key": "cli"}
+    assert FakeStateApiClient.captured["verify"] is False
+
+
+def test_state_cli_headers_from_env(monkeypatch, reset_fake_state_api_client):
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+    monkeypatch.setenv("RAY_STATE_HEADERS", '{"X-Env": "env"}')
+
+    result = CliRunner().invoke(ray_list, ["actors"])
+
+    assert result.exit_code == 0, result.output
+    assert FakeStateApiClient.captured["headers"] == {"X-Env": "env"}
+
+
+def test_state_cli_headers_cli_precedence_over_env(
+    monkeypatch, reset_fake_state_api_client
+):
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+    monkeypatch.setenv("RAY_STATE_HEADERS", '{"X-Env": "env"}')
+
+    result = CliRunner().invoke(ray_list, ["actors", "--headers", '{"X-CLI": "cli"}'])
+
+    assert result.exit_code == 0, result.output
+    assert FakeStateApiClient.captured["headers"] == {"X-CLI": "cli"}
+
+
+@pytest.mark.parametrize(
+    "headers,error",
+    [
+        ("{bad json", "Failed to parse headers into JSON"),
+        ("[]", "Expected headers to be a JSON object/dictionary"),
+    ],
+)
+def test_state_cli_rejects_invalid_headers(headers, error, reset_fake_state_api_client):
+    result = CliRunner().invoke(ray_list, ["actors", "--headers", headers])
+
+    assert result.exit_code != 0
+    assert error in result.output
+    assert FakeStateApiClient.captured is None
+
+
+@pytest.mark.parametrize(
+    "cli_value,expected",
+    [
+        ("true", True),
+        ("false", False),
+        ("/tmp/test-ca.pem", "/tmp/test-ca.pem"),
+    ],
+)
+def test_state_cli_verify_values(
+    monkeypatch, reset_fake_state_api_client, cli_value, expected
+):
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+
+    result = CliRunner().invoke(ray_list, ["actors", "--verify", cli_value])
+
+    assert result.exit_code == 0, result.output
+    assert FakeStateApiClient.captured["verify"] == expected
+
+
+def _empty_summary_response():
+    return {"cluster": {"summary": {}, "summary_by": "state"}}
+
+
+@pytest.mark.parametrize(
+    "args,function_name",
+    [
+        (["tasks"], "summarize_tasks"),
+        (["actors"], "summarize_actors"),
+        (["objects"], "summarize_objects"),
+    ],
+)
+def test_state_cli_summary_headers_and_verify(monkeypatch, args, function_name):
+    captured = {}
+
+    def fake_summarize(**kwargs):
+        captured.update(kwargs)
+        return _empty_summary_response()
+
+    monkeypatch.setattr(state_cli, function_name, fake_summarize)
+
+    result = CliRunner().invoke(
+        summary_state_cli_group,
+        [
+            *args,
+            "--headers",
+            '{"Authorization": "Bearer summary"}',
+            "--verify",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"Authorization": "Bearer summary"}
+    assert captured["verify"] is False
+
+
+def test_state_cli_logs_cluster_list_headers_and_verify(monkeypatch):
+    captured = {}
+
+    def fake_list_logs(**kwargs):
+        captured.update(kwargs)
+        return {"worker": ["a.log", "b.log"]}
+
+    monkeypatch.setattr(state_cli, "_get_head_node_ip", lambda address: "127.0.0.1")
+    monkeypatch.setattr(state_cli, "list_logs", fake_list_logs)
+
+    result = CliRunner().invoke(
+        logs_state_cli_group,
+        [
+            "cluster",
+            "*.log",
+            "--headers",
+            '{"X-API-Key": "logs"}',
+            "--verify",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"X-API-Key": "logs"}
+    assert captured["verify"] is False
+
+
+def test_state_cli_logs_cluster_print_headers_and_verify(monkeypatch):
+    list_captured = {}
+    print_captured = {}
+
+    def fake_list_logs(**kwargs):
+        list_captured.update(kwargs)
+        return {"worker": ["a.log"]}
+
+    def fake_print_log(**kwargs):
+        print_captured.update(kwargs)
+
+    monkeypatch.setattr(state_cli, "_get_head_node_ip", lambda address: "127.0.0.1")
+    monkeypatch.setattr(state_cli, "list_logs", fake_list_logs)
+    monkeypatch.setattr(state_cli, "_print_log", fake_print_log)
+
+    result = CliRunner().invoke(
+        logs_state_cli_group,
+        [
+            "cluster",
+            "a.log",
+            "--headers",
+            '{"X-API-Key": "logs"}',
+            "--verify",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert list_captured["headers"] == {"X-API-Key": "logs"}
+    assert list_captured["verify"] is False
+    assert print_captured["headers"] == {"X-API-Key": "logs"}
+    assert print_captured["verify"] is False
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["actor", "--id", "actor-id", "--node-ip", "127.0.0.1"],
+        ["worker", "--pid", "123", "--node-ip", "127.0.0.1"],
+        ["job", "--id", "raysubmit_123"],
+        ["task", "--id", "task-id"],
+    ],
+)
+def test_state_cli_logs_print_commands_headers_and_verify(monkeypatch, args):
+    captured = {}
+
+    def fake_print_log(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(state_cli, "_print_log", fake_print_log)
+
+    result = CliRunner().invoke(
+        logs_state_cli_group,
+        [
+            *args,
+            "--headers",
+            '{"X-API-Key": "logs"}',
+            "--verify",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"X-API-Key": "logs"}
+    assert captured["verify"] is False
+
+
+class _FakeLogResponse:
+    def __init__(self, json_data=None, chunks=None):
+        self.status_code = 200
+        self.text = ""
+        self._json_data = json_data or {
+            "result": True,
+            "data": {"result": {"worker": ["worker.log"]}},
+        }
+        self._chunks = chunks or [b"log"]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def iter_content(self, chunk_size=None):
+        yield from self._chunks
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._json_data
+
+
+def test_list_logs_forwards_headers_verify_and_does_not_mutate(monkeypatch):
+    captured = {}
+    headers = {"X-API-Key": "logs"}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return _FakeLogResponse()
+
+    monkeypatch.setattr(
+        state_api, "ray_address_to_api_server_url", lambda address: "http://api"
+    )
+    monkeypatch.setattr(state_api.requests, "get", fake_get)
+    monkeypatch.setattr(
+        state_api, "get_auth_headers_if_auth_enabled", lambda headers: {}
+    )
+
+    assert state_api.list_logs(
+        address="http://api",
+        node_ip="127.0.0.1",
+        headers=headers,
+        verify="/tmp/test-ca.pem",
+    ) == {"worker": ["worker.log"]}
+    assert captured["headers"] == {"X-API-Key": "logs"}
+    assert captured["verify"] == "/tmp/test-ca.pem"
+    assert headers == {"X-API-Key": "logs"}
+
+
+def test_get_log_forwards_headers_verify_and_does_not_mutate(monkeypatch):
+    captured = {}
+    headers = {"X-API-Key": "logs"}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return _FakeLogResponse(chunks=[b"hello"])
+
+    monkeypatch.setattr(
+        state_api, "ray_address_to_api_server_url", lambda address: "http://api"
+    )
+    monkeypatch.setattr(state_api.requests, "get", fake_get)
+    monkeypatch.setattr(
+        state_api, "get_auth_headers_if_auth_enabled", lambda headers: {}
+    )
+
+    chunks = list(
+        state_api.get_log(
+            address="http://api",
+            node_ip="127.0.0.1",
+            filename="worker.log",
+            headers=headers,
+            verify=False,
+        )
+    )
+
+    assert chunks == ["hello"]
+    assert captured["headers"] == {"X-API-Key": "logs"}
+    assert captured["verify"] is False
+    assert headers == {"X-API-Key": "logs"}
+
+
+def test_state_api_client_forwards_headers_verify_and_does_not_mutate(monkeypatch):
+    captured = {}
+    headers = {"Authorization": "Bearer user"}
+
+    def fake_submission_init(self, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        state_api, "get_address_for_submission_client", lambda address: "http://api"
+    )
+    monkeypatch.setattr(state_api.SubmissionClient, "__init__", fake_submission_init)
+
+    state_api.StateApiClient(
+        address="http://api",
+        headers=headers,
+        verify=False,
+    )
+
+    assert captured["address"] == "http://api"
+    assert captured["headers"] == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer user",
+    }
+    assert captured["verify"] is False
+    assert headers == {"Authorization": "Bearer user"}
+
+
+@pytest.mark.parametrize(
+    "input_headers,expected_authorization",
+    [
+        ({"authorization": "Bearer user"}, "Bearer user"),
+        ({"X-API-Key": "logs"}, "Bearer internal"),
+    ],
+)
+def test_log_headers_preserve_user_auth_and_add_internal_auth(
+    monkeypatch, input_headers, expected_authorization
+):
+    captured = {}
+    original_headers = dict(input_headers)
+
+    def fake_get(url, **kwargs):
+        captured.update(kwargs)
+        return _FakeLogResponse()
+
+    def fake_auth(headers):
+        if any(key.lower() == "authorization" for key in headers):
+            return {}
+        return {"Authorization": "Bearer internal"}
+
+    monkeypatch.setattr(
+        state_api, "ray_address_to_api_server_url", lambda address: "http://api"
+    )
+    monkeypatch.setattr(state_api.requests, "get", fake_get)
+    monkeypatch.setattr(state_api, "get_auth_headers_if_auth_enabled", fake_auth)
+
+    state_api.list_logs(
+        address="http://api", node_ip="127.0.0.1", headers=input_headers
+    )
+
+    authorization = next(
+        value
+        for key, value in captured["headers"].items()
+        if key.lower() == "authorization"
+    )
+    assert authorization == expected_authorization
+    assert input_headers == original_headers
+
+
+def test_state_cli_list_integration_sends_headers_to_http_server():
+    class RecordingHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.server.received_headers = dict(self.headers)
+            self.server.received_path = self.path
+            body = json.dumps(
+                {
+                    "result": True,
+                    "msg": "",
+                    "data": {
+                        "result": {
+                            "result": [],
+                            "total": 0,
+                            "num_after_truncation": 0,
+                            "num_filtered": 0,
+                        }
+                    },
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        result = CliRunner().invoke(
+            ray_list,
+            [
+                "actors",
+                "--address",
+                f"http://127.0.0.1:{server.server_port}",
+                "--headers",
+                '{"Authorization": "Bearer integration"}',
+                "--verify",
+                "false",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert server.received_headers["Authorization"] == "Bearer integration"
+        assert server.received_path.startswith("/api/v0/actors")
+        assert "No resource in the cluster" in result.output
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
 
 
 # Without this, capsys will have a race condition

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -569,6 +569,7 @@ def test_state_cli_headers_cli_precedence_over_env(
     [
         ("{bad json", "Failed to parse headers into JSON"),
         ("[]", "Expected headers to be a JSON object/dictionary"),
+        ('{"X-Retry": 3}', "All header keys and values must be strings"),
     ],
 )
 def test_state_cli_rejects_invalid_headers(headers, error, reset_fake_state_api_client):
@@ -764,20 +765,22 @@ def test_list_logs_forwards_headers_verify_and_does_not_mutate(monkeypatch):
         captured.update(kwargs)
         return _FakeLogResponse()
 
-    monkeypatch.setattr(
-        state_api, "ray_address_to_api_server_url", lambda address: "http://api"
+    monkeypatch.delenv(
+        ray_constants.RAY_API_SERVER_ADDRESS_ENVIRONMENT_VARIABLE, raising=False
     )
+    monkeypatch.delenv(ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE, raising=False)
     monkeypatch.setattr(state_api.requests, "get", fake_get)
     monkeypatch.setattr(
         state_api, "get_auth_headers_if_auth_enabled", lambda headers: {}
     )
 
     assert state_api.list_logs(
-        address="http://api",
+        address="https://cluster.example.com:8265",
         node_ip="127.0.0.1",
         headers=headers,
         verify="/tmp/test-ca.pem",
     ) == {"worker": ["worker.log"]}
+    assert captured["url"].startswith("https://cluster.example.com:8265/api/v0/logs?")
     assert captured["headers"] == {"X-API-Key": "logs"}
     assert captured["verify"] == "/tmp/test-ca.pem"
     assert headers == {"X-API-Key": "logs"}
@@ -792,9 +795,10 @@ def test_get_log_forwards_headers_verify_and_does_not_mutate(monkeypatch):
         captured.update(kwargs)
         return _FakeLogResponse(chunks=[b"hello"])
 
-    monkeypatch.setattr(
-        state_api, "ray_address_to_api_server_url", lambda address: "http://api"
+    monkeypatch.delenv(
+        ray_constants.RAY_API_SERVER_ADDRESS_ENVIRONMENT_VARIABLE, raising=False
     )
+    monkeypatch.delenv(ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE, raising=False)
     monkeypatch.setattr(state_api.requests, "get", fake_get)
     monkeypatch.setattr(
         state_api, "get_auth_headers_if_auth_enabled", lambda headers: {}
@@ -802,7 +806,7 @@ def test_get_log_forwards_headers_verify_and_does_not_mutate(monkeypatch):
 
     chunks = list(
         state_api.get_log(
-            address="http://api",
+            address="https://cluster.example.com:8265",
             node_ip="127.0.0.1",
             filename="worker.log",
             headers=headers,
@@ -811,6 +815,9 @@ def test_get_log_forwards_headers_verify_and_does_not_mutate(monkeypatch):
     )
 
     assert chunks == ["hello"]
+    assert captured["url"].startswith(
+        "https://cluster.example.com:8265/api/v0/logs/file?"
+    )
     assert captured["headers"] == {"X-API-Key": "logs"}
     assert captured["verify"] is False
     assert headers == {"X-API-Key": "logs"}
@@ -843,6 +850,29 @@ def test_state_api_client_forwards_headers_verify_and_does_not_mutate(monkeypatc
     assert headers == {"Authorization": "Bearer user"}
 
 
+def test_state_api_client_merges_content_type_case_insensitively(monkeypatch):
+    captured = {}
+    headers = {"content-type": "application/custom"}
+
+    def fake_submission_init(self, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        state_api, "get_address_for_submission_client", lambda address: "http://api"
+    )
+    monkeypatch.setattr(state_api.SubmissionClient, "__init__", fake_submission_init)
+
+    state_api.StateApiClient(address="http://api", headers=headers)
+
+    content_type_headers = [
+        (key, value)
+        for key, value in captured["headers"].items()
+        if key.lower() == "content-type"
+    ]
+    assert content_type_headers == [("content-type", "application/custom")]
+    assert headers == {"content-type": "application/custom"}
+
+
 @pytest.mark.parametrize(
     "input_headers,expected_authorization",
     [
@@ -861,12 +891,12 @@ def test_log_headers_preserve_user_auth_and_add_internal_auth(
         return _FakeLogResponse()
 
     def fake_auth(headers):
-        if any(key.lower() == "authorization" for key in headers):
+        if "Authorization" in headers:
             return {}
         return {"Authorization": "Bearer internal"}
 
     monkeypatch.setattr(
-        state_api, "ray_address_to_api_server_url", lambda address: "http://api"
+        state_api, "get_address_for_submission_client", lambda address: "http://api"
     )
     monkeypatch.setattr(state_api.requests, "get", fake_get)
     monkeypatch.setattr(state_api, "get_auth_headers_if_auth_enabled", fake_auth)
@@ -875,13 +905,38 @@ def test_log_headers_preserve_user_auth_and_add_internal_auth(
         address="http://api", node_ip="127.0.0.1", headers=input_headers
     )
 
-    authorization = next(
+    authorization_headers = [
         value
         for key, value in captured["headers"].items()
         if key.lower() == "authorization"
-    )
-    assert authorization == expected_authorization
+    ]
+    assert authorization_headers == [expected_authorization]
     assert input_headers == original_headers
+
+
+def test_log_apis_delegate_bootstrap_address_to_submission_resolver(monkeypatch):
+    resolved_addresses = []
+    requested_urls = []
+
+    def fake_resolve(address):
+        resolved_addresses.append(address)
+        return "http://api"
+
+    def fake_get(url, **kwargs):
+        requested_urls.append(url)
+        return _FakeLogResponse(chunks=[b"hello"])
+
+    monkeypatch.setattr(state_api, "get_address_for_submission_client", fake_resolve)
+    monkeypatch.setattr(state_api.requests, "get", fake_get)
+    monkeypatch.setattr(
+        state_api, "get_auth_headers_if_auth_enabled", lambda headers: {}
+    )
+
+    state_api.list_logs(address="auto", node_ip="127.0.0.1")
+    list(state_api.get_log(address="auto", node_ip="127.0.0.1", filename="worker.log"))
+
+    assert resolved_addresses == ["auto", "auto"]
+    assert all(url.startswith("http://api/api/v0/logs") for url in requested_urls)
 
 
 def test_state_cli_list_integration_sends_headers_to_http_server():

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -119,6 +119,7 @@ class StateApiClient(SubmissionClient):
         address: Optional[str] = None,
         cookies: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
+        verify: Union[str, bool] = True,
     ):
         """Initialize a StateApiClient and check the connection to the cluster.
 
@@ -131,14 +132,16 @@ class StateApiClient(SubmissionClient):
             cookies: Cookies to use when sending requests to the HTTP job server.
             headers: Headers to use when sending requests to the HTTP job server, used
                 for cases like authentication to a remote cluster.
+            verify: TLS verification flag or path to a CA bundle/directory.
         """
         if requests is None:
             raise RuntimeError(
                 "The Ray state CLI & SDK require the ray[default] "
                 "installation: `pip install 'ray[default']``"
             )
-        if not headers:
-            headers = {"Content-Type": "application/json"}
+        request_headers = {"Content-Type": "application/json"}
+        if headers:
+            request_headers.update(headers)
 
         # Resolve API server URL
         api_server_url = get_address_for_submission_client(address)
@@ -146,8 +149,9 @@ class StateApiClient(SubmissionClient):
         super().__init__(
             address=api_server_url,
             create_cluster_if_needed=False,
-            headers=headers,
+            headers=request_headers,
             cookies=cookies,
+            verify=verify,
         )
 
     @classmethod
@@ -1176,6 +1180,12 @@ Log APIs
 """
 
 
+def _prepare_request_headers(headers: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    request_headers = headers.copy() if headers else {}
+    request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
+    return request_headers
+
+
 @DeveloperAPI
 def get_log(
     address: Optional[str] = None,
@@ -1195,6 +1205,8 @@ def get_log(
     attempt_number: int = 0,
     _interval: Optional[float] = None,
     filter_ansi_code: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[str, bool] = True,
 ) -> Generator[str, None, None]:
     """Retrieve log file based on file name or some entities ids (pid, actor id, task id).
 
@@ -1255,6 +1267,8 @@ def get_log(
         _interval: The interval in secs to print new logs when `follow=True`.
         filter_ansi_code: A boolean flag for determining whether to filter ANSI escape codes.
             Setting to `True` removes ANSI escape codes from the output. The default value is `False`.
+        headers: Headers to use when sending requests to the HTTP job server.
+        verify: TLS verification flag or path to a CA bundle/directory.
 
     Yields:
         str: A chunk of log content. When ``encoding`` is ``None`` the raw bytes
@@ -1295,7 +1309,8 @@ def get_log(
         f"{api_server_url}/api/v0/logs/{media_type}?"
         f"{urllib.parse.urlencode(options_dict)}",
         stream=True,
-        headers=get_auth_headers_if_auth_enabled({}),
+        headers=_prepare_request_headers(headers),
+        verify=verify,
     ) as r:
         if r.status_code != 200:
             raise RayStateApiException(r.text)
@@ -1312,6 +1327,8 @@ def list_logs(
     node_ip: Optional[str] = None,
     glob_filter: Optional[str] = None,
     timeout: int = DEFAULT_RPC_TIMEOUT,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[str, bool] = True,
 ) -> Dict[str, List[str]]:
     """Listing log files available.
 
@@ -1323,6 +1340,8 @@ def list_logs(
         glob_filter: Name of the file (relative to the ray log directory) to be
             retrieved. E.g. `glob_filter="*worker*"` for all worker logs.
         timeout: Max timeout for requests made when getting the logs.
+        headers: Headers to use when sending requests to the HTTP job server.
+        verify: TLS verification flag or path to a CA bundle/directory.
 
     Returns:
         A dictionary where the keys are log groups (e.g. gcs, raylet, worker), and
@@ -1352,7 +1371,8 @@ def list_logs(
 
     r = requests.get(
         f"{api_server_url}/api/v0/logs?{urllib.parse.urlencode(options_dict)}",
-        headers=get_auth_headers_if_auth_enabled({}),
+        headers=_prepare_request_headers(headers),
+        verify=verify,
     )
     # TODO(rickyx): we could do better at error handling here.
     r.raise_for_status()
@@ -1377,6 +1397,8 @@ def summarize_tasks(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[str, bool] = True,
 ) -> Dict:
     """Summarize the tasks in cluster.
 
@@ -1388,6 +1410,8 @@ def summarize_tasks(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP job server.
+        verify: TLS verification flag or path to a CA bundle/directory.
 
     Returns:
         Dictionarified
@@ -1396,7 +1420,7 @@ def summarize_tasks(
     Raises:
         RayStateApiException: if the CLI is failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.TASKS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1410,6 +1434,8 @@ def summarize_actors(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[str, bool] = True,
 ) -> Dict:
     """Summarize the actors in cluster.
 
@@ -1421,6 +1447,8 @@ def summarize_actors(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP job server.
+        verify: TLS verification flag or path to a CA bundle/directory.
 
     Returns:
         Dictionarified
@@ -1429,7 +1457,7 @@ def summarize_actors(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.ACTORS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1443,6 +1471,8 @@ def summarize_objects(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[str, bool] = True,
 ) -> Dict:
     """Summarize the objects in cluster.
 
@@ -1454,6 +1484,8 @@ def summarize_objects(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP job server.
+        verify: TLS verification flag or path to a CA bundle/directory.
 
     Returns:
         Dictionarified :class:`~ray.util.state.common.ObjectSummaries`
@@ -1461,7 +1493,7 @@ def summarize_objects(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.OBJECTS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -13,10 +13,7 @@ from ray._private.authentication.http_token_authentication import (
     get_auth_headers_if_auth_enabled,
 )
 from ray.dashboard.modules.dashboard_sdk import SubmissionClient
-from ray.dashboard.utils import (
-    get_address_for_submission_client,
-    ray_address_to_api_server_url,
-)
+from ray.dashboard.utils import get_address_for_submission_client
 from ray.util.annotations import DeveloperAPI
 from ray.util.state.common import (
     DEFAULT_LIMIT,
@@ -139,7 +136,9 @@ class StateApiClient(SubmissionClient):
                 "The Ray state CLI & SDK require the ray[default] "
                 "installation: `pip install 'ray[default']``"
             )
-        request_headers = {"Content-Type": "application/json"}
+        request_headers = requests.structures.CaseInsensitiveDict(
+            {"Content-Type": "application/json"}
+        )
         if headers:
             request_headers.update(headers)
 
@@ -149,7 +148,7 @@ class StateApiClient(SubmissionClient):
         super().__init__(
             address=api_server_url,
             create_cluster_if_needed=False,
-            headers=request_headers,
+            headers=dict(request_headers),
             cookies=cookies,
             verify=verify,
         )
@@ -1181,9 +1180,9 @@ Log APIs
 
 
 def _prepare_request_headers(headers: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-    request_headers = headers.copy() if headers else {}
+    request_headers = requests.structures.CaseInsensitiveDict(headers or {})
     request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
-    return request_headers
+    return dict(request_headers)
 
 
 @DeveloperAPI
@@ -1278,7 +1277,7 @@ def get_log(
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
 
-    api_server_url = ray_address_to_api_server_url(address)
+    api_server_url = get_address_for_submission_client(address)
     media_type = "stream" if follow else "file"
 
     options = GetLogOptions(
@@ -1355,7 +1354,7 @@ def list_logs(
         node_ip is not None or node_id is not None
     ), "At least one of node ip and node id is required"
 
-    api_server_url = ray_address_to_api_server_url(address)
+    api_server_url = get_address_for_submission_client(address)
 
     if not glob_filter:
         glob_filter = "*"

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime
 from enum import Enum, unique
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 import yaml
@@ -10,6 +10,7 @@ import yaml
 import ray._private.services as services
 from ray._common.network_utils import parse_address
 from ray._private.thirdparty.tabulate.tabulate import tabulate
+from ray.dashboard.modules.job.cli_utils import BoolOrStringParam, parse_headers
 from ray.util.annotations import PublicAPI
 from ray.util.state import (
     StateApiClient,
@@ -379,6 +380,31 @@ address_option = click.option(
         "automatically from querying the GCS server."
     ),
 )
+headers_option = click.option(
+    "--headers",
+    type=str,
+    default=None,
+    help=(
+        "HTTP headers as a JSON object. " 'Example: {"Authorization": "Bearer <token>"}'
+    ),
+)
+verify_option = click.option(
+    "--verify",
+    default=True,
+    show_default=True,
+    type=BoolOrStringParam(),
+    help=(
+        "Whether to verify the server TLS certificate, or a path to a "
+        "trusted CA file or directory."
+    ),
+)
+
+
+def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
+    try:
+        return parse_headers(headers, env_var="RAY_STATE_HEADERS")
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
 
 
 @click.command()
@@ -398,12 +424,16 @@ address_option = click.option(
 )
 @address_option
 @timeout_option
+@headers_option
+@verify_option
 @PublicAPI(stability="stable")
 def ray_get(
     resource: str,
     id: str,
     address: Optional[str],
     timeout: float,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Get a state of a given resource by ID.
 
@@ -437,6 +467,8 @@ def ray_get(
         id: The id of the resource.
         address: Ray bootstrap address. If None, it's resolved from the local cluster.
         timeout: Max timeout for the state API request.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -452,7 +484,9 @@ def ray_get(
 
     # Create the State API server and put it into context
     logger.debug(f"Create StateApiClient to ray instance at: {address}...")
-    client = StateApiClient(address=address)
+    client = StateApiClient(
+        address=address, headers=_handle_headers(headers), verify=verify
+    )
     options = GetApiOptions(timeout=timeout)
 
     # If errors occur, exceptions will be thrown.
@@ -516,6 +550,8 @@ def ray_get(
 )
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @PublicAPI(stability="stable")
 def ray_list(
     resource: str,
@@ -525,6 +561,8 @@ def ray_list(
     detail: bool,
     timeout: float,
     address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """List all states of a given resource.
 
@@ -588,6 +626,8 @@ def ray_list(
         detail: When True, include detail-only columns.
         timeout: Max timeout for the state API request.
         address: Ray bootstrap address. If empty, resolved from the local cluster.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -602,7 +642,9 @@ def ray_list(
     format = AvailableFormat(format)
 
     # Create the State API server and put it into context
-    client = StateApiClient(address=address)
+    client = StateApiClient(
+        address=address, headers=_handle_headers(headers), verify=verify
+    )
 
     filter = [_parse_filter(f) for f in filter]
     filter = _normalize_filter_keys(resource, filter)
@@ -651,9 +693,17 @@ def summary_state_cli_group(ctx):
 @summary_state_cli_group.command(name="tasks")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
-def task_summary(ctx: click.Context, timeout: float, address: str):
+def task_summary(
+    ctx: click.Context,
+    timeout: float,
+    address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
+):
     """Summarize the task state of the cluster.
 
     By default, the output contains the information grouped by
@@ -666,6 +716,8 @@ def task_summary(ctx: click.Context, timeout: float, address: str):
         ctx: The Click invocation context.
         timeout: Max timeout for the state API request.
         address: Ray bootstrap address. If empty, resolved from the local cluster.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -678,6 +730,8 @@ def task_summary(ctx: click.Context, timeout: float, address: str):
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
             resource=StateResource.TASKS,
         )
@@ -687,9 +741,17 @@ def task_summary(ctx: click.Context, timeout: float, address: str):
 @summary_state_cli_group.command(name="actors")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
-def actor_summary(ctx: click.Context, timeout: float, address: str):
+def actor_summary(
+    ctx: click.Context,
+    timeout: float,
+    address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
+):
     """Summarize the actor state of the cluster.
 
     By default, the output contains the information grouped by
@@ -703,6 +765,8 @@ def actor_summary(ctx: click.Context, timeout: float, address: str):
         ctx: The Click invocation context.
         timeout: Max timeout for the state API request.
         address: Ray bootstrap address. If empty, resolved from the local cluster.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -715,6 +779,8 @@ def actor_summary(ctx: click.Context, timeout: float, address: str):
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
             resource=StateResource.ACTORS,
         )
@@ -724,9 +790,17 @@ def actor_summary(ctx: click.Context, timeout: float, address: str):
 @summary_state_cli_group.command(name="objects")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
-def object_summary(ctx: click.Context, timeout: float, address: str):
+def object_summary(
+    ctx: click.Context,
+    timeout: float,
+    address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
+):
     """Summarize the object state of the cluster.
 
     The API is recommended when debugging memory leaks.
@@ -759,6 +833,8 @@ def object_summary(ctx: click.Context, timeout: float, address: str):
         ctx: The Click invocation context.
         timeout: Max timeout for the state API request.
         address: Ray bootstrap address. If empty, resolved from the local cluster.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -771,6 +847,8 @@ def object_summary(ctx: click.Context, timeout: float, address: str):
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
         )
     )
@@ -899,6 +977,8 @@ def _print_log(
     task_id: Optional[str] = None,
     attempt_number: int = 0,
     submission_id: Optional[str] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[bool, str] = True,
 ):
     """Wrapper around `get_log()` that prints the preamble and the log lines"""
     if tail > 0:
@@ -928,6 +1008,8 @@ def _print_log(
         task_id=task_id,
         attempt_number=attempt_number,
         submission_id=submission_id,
+        headers=headers,
+        verify=verify,
     ):
         print(chunk, end="", flush=True)
 
@@ -1014,6 +1096,8 @@ logs_state_cli_group = LogCommandGroup(help=LOG_CLI_HELP_MSG)
 @log_timeout_option
 @log_encoding_option
 @log_encoding_errors_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def log_cluster(
@@ -1028,6 +1112,8 @@ def log_cluster(
     timeout: int,
     encoding: str,
     encoding_errors: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Get/List logs that matches the GLOB_FILTER in the cluster.
     By default, it prints a list of log files that match the filter.
@@ -1072,6 +1158,8 @@ def log_cluster(
         timeout: Max timeout for the underlying API request.
         encoding: Encoding used to decode log bytes into strings.
         encoding_errors: Decoder error-handling scheme (e.g. ``strict``).
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Returns:
         ``None``. Output is written to stdout.
@@ -1084,12 +1172,15 @@ def log_cluster(
     if node_id is None and node_ip is None:
         node_ip = _get_head_node_ip(address)
 
+    parsed_headers = _handle_headers(headers)
     logs = list_logs(
         address=address,
         node_id=node_id,
         node_ip=node_ip,
         glob_filter=glob_filter,
         timeout=timeout,
+        headers=parsed_headers,
+        verify=verify,
     )
 
     log_files_found = []
@@ -1120,6 +1211,8 @@ def log_cluster(
         timeout=timeout,
         encoding=encoding,
         encoding_errors=encoding_errors,
+        headers=parsed_headers,
+        verify=verify,
     )
 
 
@@ -1148,6 +1241,8 @@ def log_cluster(
 @log_interval_option
 @log_timeout_option
 @log_suffix_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def log_actor(
@@ -1162,6 +1257,8 @@ def log_actor(
     interval: float,
     timeout: int,
     err: bool,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Get/List logs associated with an actor.
 
@@ -1199,6 +1296,8 @@ def log_actor(
         interval: How frequently to poll for new content when ``follow`` is set.
         timeout: Max timeout for the underlying API request.
         err: When True, query stderr files instead of stdout.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -1223,6 +1322,8 @@ def log_actor(
         interval=interval,
         timeout=timeout,
         suffix="err" if err else "out",
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1243,6 +1344,8 @@ def log_actor(
 @log_interval_option
 @log_timeout_option
 @log_suffix_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def log_worker(
@@ -1256,6 +1359,8 @@ def log_worker(
     interval: float,
     timeout: int,
     err: bool,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Get logs associated with a worker process.
 
@@ -1284,6 +1389,8 @@ def log_worker(
         interval: How frequently to poll for new content when ``follow`` is set.
         timeout: Max timeout for the underlying API request.
         err: When True, query stderr files instead of stdout.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -1301,6 +1408,8 @@ def log_worker(
         interval=interval,
         timeout=timeout,
         suffix="err" if err else "out",
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1320,6 +1429,8 @@ def log_worker(
 @log_tail_option
 @log_interval_option
 @log_timeout_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def log_job(
@@ -1330,6 +1441,8 @@ def log_job(
     tail: int,
     interval: float,
     timeout: int,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Get logs associated with a submission job.
 
@@ -1356,6 +1469,8 @@ def log_job(
         tail: Number of lines to tail from the end of the file. ``-1`` for all.
         interval: How frequently to poll for new content when ``follow`` is set.
         timeout: Max timeout for the underlying API request.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -1370,6 +1485,8 @@ def log_job(
         interval=interval,
         timeout=timeout,
         submission_id=submission_id,
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1395,6 +1512,8 @@ def log_job(
 @log_tail_option
 @log_timeout_option
 @log_suffix_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def log_task(
@@ -1407,6 +1526,8 @@ def log_task(
     tail: int,
     timeout: int,
     err: bool,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Get logs associated with a task.
 
@@ -1438,6 +1559,8 @@ def log_task(
         tail: Number of lines to tail from the end of the file. ``-1`` for all.
         timeout: Max timeout for the underlying API request.
         err: When True, query stderr files instead of stdout.
+        headers: JSON-serialized headers.
+        verify: TLS verification flag or path.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -1454,4 +1577,6 @@ def log_task(
         interval=interval,
         timeout=timeout,
         suffix="err" if err else "out",
+        headers=_handle_headers(headers),
+        verify=verify,
     )


### PR DESCRIPTION
## Description

Add `--headers` and `--verify` support to the State CLI so it can connect to secured Ray Dashboard endpoints that require custom authentication headers or TLS verification settings.

This change:

- adds `--headers` support with `RAY_STATE_HEADERS` as an environment-variable fallback;
- adds `--verify` support for `true`, `false`, or a custom CA bundle path;
- propagates both options through State API get/list, summary, and log commands;
- preserves user-provided `Authorization` headers when internal authentication headers are merged;
- reuses the shared header parsing logic between the Job CLI and State CLI;
- adds unit and HTTP integration tests;
- documents the new CLI authentication and TLS options.

## Related issues

Closes #50256

Related to #61958. This is a fresh implementation of the accepted scope, incorporating review feedback from that PR. Thanks to @Anarion-zuo for the earlier work and context.

## Additional information

Example usage:

```bash
ray list actors \
  --address https://cluster.example.com:8265 \
  --headers '{"Authorization": "Bearer <token>"}' \
  --verify /path/to/ca-bundle.pem
```

Validation performed locally:

- Full State API test suite
- Job CLI test suite
- HTTP integration test for forwarding authentication headers
- Manually verified `ray list actors` against a local HTTPS State API server using:
  - a custom CA bundle via `--verify`;
  - an `Authorization` header via `--headers`;
  - `--verify false`;
  - expected TLS failure when the custom CA bundle is omitted.
- `ruff`
- `black`
- `pydoclint`
- Ray `docstyle`
- `semgrep`
- `python -m compileall`
- `git diff --check`
