### PR TITLE
[Core] Avoid repeated Colorama initialization during serialization checks

### DIFF
--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -837,6 +837,31 @@ def test_inspect_func_serialization_prints_qualname():
     ), f"Expected inner closure qualname in output, got:\n{output}"
 
 
+def test_inspect_serializability_initializes_colorama_once(mocker):
+    import threading
+
+    from ray.util.check_serialize import inspect_serializability
+
+    lock = threading.Lock()
+
+    def inner():
+        return lock
+
+    def outer():
+        return inner()
+
+    init = mocker.patch("ray.util.check_serialize.colorama.init")
+    just_fix_windows_console = mocker.patch(
+        "ray.util.check_serialize.colorama.just_fix_windows_console"
+    )
+
+    serializable, _ = inspect_serializability(outer, print_file=io.StringIO())
+
+    assert not serializable
+    just_fix_windows_console.assert_called_once_with()
+    init.assert_not_called()
+
+
 def test_streaming_generator_replay_inconsistent_error_deserialization(monkeypatch):
     """The STREAMING_GENERATOR_REPLAY_INCONSISTENT error type must deserialize
     to StreamingGeneratorReplayInconsistentError carrying the C++-side

--- a/python/ray/util/check_serialize.py
+++ b/python/ray/util/check_serialize.py
@@ -197,6 +197,7 @@ def inspect_serializability(
     .. versionadded:: 1.1.0
 
     """
+    colorama.just_fix_windows_console()
     printer = _Printer(print_file)
     return _inspect_serializability(base_obj, name, depth, None, None, printer)
 
@@ -204,7 +205,6 @@ def inspect_serializability(
 def _inspect_serializability(
     base_obj, name, depth, parent, failure_set, printer, path=()
 ) -> Tuple[bool, Set[FailureTuple]]:
-    colorama.init()
     top_level = False
     declaration = ""
     found = False


### PR DESCRIPTION
## Description

inspect_serializability initialized Colorama from its recursive helper, so every nested inspection frame could wrap the process output streams again. This change performs the idempotent Colorama console setup once at the public entry point and keeps recursive traversal free of stream initialization side effects.

A regression test exercises nested closure traversal and verifies that the non-wrapping setup runs once while colorama.init is not called.

## Related issues

Fixes #51337

## Additional information

No public API or diagnostic text changes.

Testing:
- 3 focused serialization inspection tests passed
- applicable pre-commit hooks passed, including Ruff, Black, pydoclint, docstyle, semgrep, and import-order checks
- DCO signed-off commit