### PR TITLE
[Data] Recognize TensorFlow-style sharded file extensions

### DIFF
--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import re
 import sys
 import warnings
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
@@ -144,6 +145,7 @@ def _has_file_extension(path: str, extensions: Optional[List[str]]) -> bool:
     # versioned object-store paths like `...parquet?versionId=...`).
     # Keep `#` untouched because it can be part of object keys.
     parsed_path = path.split("?", 1)[0]
+    parsed_path = re.sub(r"-\d+-of-\d+$", "", parsed_path)
     return any(parsed_path.lower().endswith(ext) for ext in extensions)
 
 

--- a/python/ray/data/tests/unit/test_path_util.py
+++ b/python/ray/data/tests/unit/test_path_util.py
@@ -33,6 +33,17 @@ from ray.util.annotations import RayDeprecationWarning
         ("s3://bucket/data#v2/file.parquet", ["parquet"], True),
         ("C:\\data\\test.parquet", ["parquet"], True),
         ("C:\\data\\parquet", ["parquet"], False),
+        ("mnist-train.tfrecord-00000-of-00001", ["tfrecord"], True),
+        ("mnist-train.TFRECORD-00000-of-00001", ["tfrecord"], True),
+        (
+            "s3://bucket/mnist.tfrecord-00000-of-00001?versionId=abc123",
+            ["tfrecord"],
+            True,
+        ),
+        ("mnist.tfrecord-backup", ["tfrecord"], False),
+        ("mnist.tfrecord-abc-of-def", ["tfrecord"], False),
+        ("mnist.tfrecord-00000-of-00001.tmp", ["tfrecord"], False),
+        ("mnist-tfrecord-00000-of-00001", ["tfrecord"], False),
         ("foo.csv", None, True),
     ],
 )


### PR DESCRIPTION
## Description

Ray Data's file extension filter required paths to end exactly in the configured extension, which rejected canonical TensorFlow Dataset shard names such as mnist-train.tfrecord-00000-of-00001.

This change strips only a terminal numeric -INDEX-of-COUNT shard marker before applying the existing case-insensitive exact extension check. It deliberately does not use substring matching. Regression coverage includes canonical local and versioned object-store paths plus negative cases for backup suffixes, nonnumeric shard markers, trailing extensions, and embedded extension text.

## Related issues

Fixes #41159

## Additional information

No public API changes.

Testing:
- python/ray/data/tests/unit/test_path_util.py: 49 passed, 7 skipped
- applicable pre-commit hooks passed, including Ruff, Black, pydoclint, docstyle, semgrep, and import-order checks
- DCO signed-off commit