### PR TITLE
[Core] Make public ObjectRef typing compatible with runtime refs

### DIFF
--- a/python/ray/tests/typing_files/check_typing_bad.py
+++ b/python/ray/tests/typing_files/check_typing_bad.py
@@ -1,4 +1,5 @@
 import ray
+from ray.types import ObjectRef as PublicObjectRef
 
 ray.init()
 
@@ -26,6 +27,7 @@ d = f.remote(1) + 1
 
 # Check return type
 ref_to_str = f.remote(1)
+wrong_public_object_ref: PublicObjectRef[int] = ref_to_str  # Fail
 unwrapped_str = ray.get(ref_to_str)
 unwrapped_str + 100  # Fail
 

--- a/python/ray/tests/typing_files/check_typing_good.py
+++ b/python/ray/tests/typing_files/check_typing_good.py
@@ -2,6 +2,7 @@ from typing import Generator
 
 import ray
 from ray import ObjectRef
+from ray.types import ObjectRef as PublicObjectRef
 
 ray.init()
 
@@ -37,6 +38,16 @@ def func(a: "ObjectRef[str]"):
 print(f.remote(1))
 object_ref_str = f.remote(1)
 object_ref_int = int_task.remote()
+
+# Make sure remote results are compatible with the public ObjectRef type.
+public_object_ref_int: PublicObjectRef[int] = int_task.remote()
+
+
+def consume_public_object_ref(ref: PublicObjectRef[int]) -> None:
+    pass
+
+
+consume_public_object_ref(int_task.remote())
 
 # Make sure the ObjectRef[T] variant of function arg is checked
 print(g.remote(object_ref_str))

--- a/python/ray/types.py
+++ b/python/ray/types.py
@@ -1,14 +1,1 @@
-from typing import Generic, TypeVar
-
-from ray.util.annotations import PublicAPI
-
-T = TypeVar("T")
-
-
-# TODO(ekl) this is a dummy generic ref type for documentation purposes only.
-# We should try to make the Cython ray.ObjectRef properly generic.
-# NOTE(sang): Looks like using Generic in Cython is not currently possible.
-# We should update Cython > 3.0 for this.
-@PublicAPI
-class ObjectRef(Generic[T]):
-    pass
+from ray._raylet import ObjectRef as ObjectRef


### PR DESCRIPTION
## Description

`ray.types.ObjectRef[T]` is currently a separate dummy generic class, while Ray remote functions return the real `ray._raylet.ObjectRef[T]`. Static type checkers therefore reject valid annotations that use the public import path.

This change re-exports the canonical runtime/stub `ObjectRef` from `ray.types` and adds positive and negative typing regressions. Generic type information remains intact, and no distributed runtime, object-store, scheduling, serialization, or reference-counting behavior is changed.

This is not duplicate work: #53591 remains open, searches for open PRs mentioning `53591` or `ray.types.ObjectRef` returned no results, and the broad `ObjectRef typing`/`ObjectRef generic` matches were inspected and are unrelated. Historical PR #55566 added generic runtime stub support but did not unify the public `ray.types.ObjectRef` symbol.

AI assistance was used. I reviewed every changed line, understand the public-type/runtime-type boundary, and accept responsibility for the change.

## Related issues

Closes #53591

## Additional information

Testing:

- `MYPYPATH=python .venv/bin/mypy --follow-imports=silent python/ray/tests/typing_files/check_typing_good.py` -> PASS
- negative mypy fixture -> expected 7 errors, including rejection of `ObjectRef[str]` assigned to `ObjectRef[int]`
- `PYTHONPATH=$PWD/python .venv/bin/pyright python/ray/tests/typing_files/check_typing_good.py` -> PASS
- `PYTHONPATH=$PWD/python .venv/bin/pyright python/ray/tests/typing_files/check_typing_actor_async.py` -> PASS
- all pre-commit hooks applicable to the changed Python files -> PASS
- runtime alias plus `ray.put`/`ray.get` smoke test with the locally installed Ray 2.54 runtime -> PASS
- `git diff --check` -> PASS

Bazel verification was attempted with the repository-required Bazel 7.5.0 binary. `//python/ray/tests:test_typing` built successfully, but the local test harness did not reach the assertions because the hermetic Python toolchain did not include `mypy`. After injecting the repository-pinned typing dependencies, the harness loaded the locally installed Ray 2.54 package rather than a current-master Ray wheel and failed in `conftest.py` on the newer `rocksdb_gcs_test_enabled` symbol. These were environment setup failures rather than typing-test failures.