### PR TITLE
[Data] Vectorize aggregation v2 (#64956) (cherry-pick 2.58.0)

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -1,3 +1,4 @@
+python/ray/data/_internal/arrow_aggregation.py
 python/ray/data/_internal/arrow_block.py
 python/ray/data/_internal/arrow_ops/transform_polars.py
 python/ray/data/_internal/arrow_ops/transform_pyarrow.py

--- a/python/ray/data/_internal/arrow_aggregation.py
+++ b/python/ray/data/_internal/arrow_aggregation.py
@@ -1,0 +1,197 @@
+from typing import Callable, List, NamedTuple, Optional, Tuple
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+
+class ArrowAggOptions(NamedTuple):
+    """PyArrow aggregate options derived from a single agg's ``ignore_nulls``."""
+
+    # Aggregating actual values (sum/min/max/mean): skip nulls per ignore_nulls,
+    # min_count=1 so an empty / all-null group yields null (not 0).
+    value_opts: "pc.ScalarAggregateOptions"
+    # Counting values: only-valid vs all rows, per ignore_nulls.
+    count_opts: "pc.CountOptions"
+    # Summing count / 0-1-indicator columns: min_count=0 so an empty group
+    # yields 0, never null (counts and percentages have no "missing" state).
+    zero_sum_opts: "pc.ScalarAggregateOptions"
+    ignore_nulls: bool
+
+
+def arrow_agg_options(ignore_nulls: bool) -> ArrowAggOptions:
+    return ArrowAggOptions(
+        value_opts=pc.ScalarAggregateOptions(skip_nulls=ignore_nulls, min_count=1),
+        count_opts=pc.CountOptions(mode="only_valid" if ignore_nulls else "all"),
+        zero_sum_opts=pc.ScalarAggregateOptions(min_count=0),
+        ignore_nulls=ignore_nulls,
+    )
+
+
+# raw_agg_specs / merge_specs return lists of PyArrow ``TableGroupBy.aggregate``
+# specs e.g. ``(col, "sum", options)`` or ``([], "count_all")``.
+_Specs = List[tuple]
+
+
+class ArrowAggSpec(NamedTuple):
+    # Per-agg column suffixes present AFTER the reduce group_by (what
+    # ``finalize`` reads).  The driver prefixes ``__agg{i}_`` so two aggs on the
+    # same column never collide.
+    components: Tuple[str, ...]
+    # (agg_index, source_col, options) -> specs that aggregate RAW values into
+    # ``components``.  Used both by the two-phase map (to pre-aggregate) and by
+    # the single-phase reduce (to aggregate the raw rows a collection query
+    # shipped, correct because the shuffle co-locates a group's rows).
+    raw_agg_specs: Callable[[int, Optional[str], ArrowAggOptions], _Specs]
+    # (merged_table, component_cols) -> the output column array.
+    finalize: Callable
+    # True for collection-valued aggs (distinct set): no bounded mergeable
+    # partial, so the query runs single-phase (see the module docstring for
+    # the two shapes and the mixing/keyless fallback rules).
+    collection: bool = False
+    # Reduction only: (component_cols, options) -> specs merging the map's
+    # partial ``components`` across shards.  Unused (None) for collection aggs.
+    merge_specs: Optional[Callable[[Tuple[str, ...], ArrowAggOptions], _Specs]] = None
+    # (agg_index, source_col, block) -> block with a derived indicator column
+    # appended (e.g. percentages).
+    prep: Optional[Callable] = None
+
+
+# --- reusable finalizers (multi-line; referenced from AggregateFn specs) ------
+_NULL_FLOAT = pa.scalar(None, pa.float64())
+
+
+def _finalize_mean(merged: "pa.Table", component_cols: Tuple[str, ...]):
+    sum_col, count_col = component_cols
+    denominator = pc.cast(merged[count_col], pa.float64())
+    # count 0 -> null (empty / all-null group has no mean).
+    denominator = pc.if_else(pc.equal(denominator, 0.0), _NULL_FLOAT, denominator)
+    return pc.divide(pc.cast(merged[sum_col], pa.float64()), denominator)
+
+
+def _finalize_pct(merged: "pa.Table", component_cols: Tuple[str, ...]):
+    numerator_col, denominator_col = component_cols
+    numerator = pc.cast(merged[numerator_col], pa.float64())
+    denominator = pc.cast(merged[denominator_col], pa.float64())
+    # Avoid dividing by zero, then null it out below.
+    safe_denominator = pc.if_else(
+        pc.greater(denominator, 0.0), denominator, pa.scalar(1.0)
+    )
+    pct = pc.multiply(pc.divide(numerator, safe_denominator), 100.0)
+    return pc.if_else(pc.equal(denominator, 0.0), _NULL_FLOAT, pct)  # den 0 -> null
+
+
+# --- spec builders (an AggregateFn picks one in its _arrow_agg_spec) ----------
+def sum_spec() -> ArrowAggSpec:
+    return ArrowAggSpec(
+        components=("sum",),
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            (source_col, "sum", options.value_opts)
+        ],
+        merge_specs=lambda input_cols, options: [
+            (input_cols[0], "sum", options.value_opts)
+        ],
+        finalize=lambda merged, component_cols: merged[component_cols[0]],
+    )
+
+
+def count_spec() -> ArrowAggSpec:
+    return ArrowAggSpec(
+        components=("count",),
+        # global Count() has no target column -> count_all (count rows).
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            ([], "count_all")
+            if source_col is None
+            else (source_col, "count", options.count_opts)
+        ],
+        merge_specs=lambda input_cols, options: [
+            (input_cols[0], "sum", options.zero_sum_opts)
+        ],
+        finalize=lambda merged, component_cols: pc.cast(
+            merged[component_cols[0]], pa.int64()
+        ),
+    )
+
+
+def minmax_spec(kind: str) -> ArrowAggSpec:
+    return ArrowAggSpec(
+        components=("minmax",),
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            (source_col, kind, options.value_opts)
+        ],
+        merge_specs=lambda input_cols, options: [
+            (input_cols[0], kind, options.value_opts)
+        ],
+        finalize=lambda merged, component_cols: merged[component_cols[0]],
+    )
+
+
+def mean_spec() -> ArrowAggSpec:
+    return ArrowAggSpec(
+        components=("sum", "count"),
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            (source_col, "sum", options.value_opts),
+            (source_col, "count", options.count_opts),
+        ],
+        merge_specs=lambda input_cols, options: [
+            (input_cols[0], "sum", options.value_opts),
+            (input_cols[1], "sum", options.zero_sum_opts),
+        ],
+        finalize=_finalize_mean,
+    )
+
+
+def missing_pct_spec() -> ArrowAggSpec:
+    # numerator = #(null or nan) via a 0/1 indicator; denominator = #rows.
+    return ArrowAggSpec(
+        components=("numerator", "denominator"),
+        prep=lambda agg_index, source_col, block: block.append_column(
+            f"__d{agg_index}_miss",
+            pc.cast(pc.is_null(block[source_col], nan_is_null=True), pa.int64()),
+        ),
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            (f"__d{agg_index}_miss", "sum", options.zero_sum_opts),
+            ([], "count_all"),
+        ],
+        merge_specs=lambda input_cols, options: [
+            (input_cols[0], "sum", options.zero_sum_opts),
+            (input_cols[1], "sum", options.zero_sum_opts),
+        ],
+        finalize=_finalize_pct,
+    )
+
+
+def zero_pct_spec() -> ArrowAggSpec:
+    # numerator = #zeros; denominator = #non-null (ignore_nulls) or #rows.
+    return ArrowAggSpec(
+        components=("numerator", "denominator"),
+        prep=lambda agg_index, source_col, block: block.append_column(
+            f"__d{agg_index}_zero", pc.cast(pc.equal(block[source_col], 0), pa.int64())
+        ),
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            (f"__d{agg_index}_zero", "sum", options.zero_sum_opts),
+            (source_col, "count", options.count_opts)
+            if options.ignore_nulls
+            else ([], "count_all"),
+        ],
+        merge_specs=lambda input_cols, options: [
+            (input_cols[0], "sum", options.zero_sum_opts),
+            (input_cols[1], "sum", options.zero_sum_opts),
+        ],
+        finalize=_finalize_pct,
+    )
+
+
+def distinct_spec(kernel: str, finalize: Callable) -> ArrowAggSpec:
+    """Collection agg: ``raw_agg_specs`` aggregates the raw source column with
+    ``kernel`` (``distinct``/``count_distinct``) in one grouped pass.  Because it
+    has no mergeable partial it is marked ``collection=True``, so the whole query
+    runs single-phase and this runs in the reduce over co-located raw rows.  The
+    mode (only_valid vs all, via count_opts) carries ``ignore_nulls`` in."""
+    return ArrowAggSpec(
+        collection=True,
+        components=("distinct",),
+        raw_agg_specs=lambda agg_index, source_col, options: [
+            (source_col, kernel, options.count_opts)
+        ],
+        finalize=finalize,
+    )

--- a/python/ray/data/_internal/execution/operators/hash_aggregate_v2.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate_v2.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 import pyarrow as pa
+import pyarrow.types as pa_types
 
+from ray.data._internal.arrow_aggregation import ArrowAggSpec, arrow_agg_options
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks import (
     BlockTransformer,
     ReduceFn,
@@ -9,22 +11,211 @@ from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks impo
 from ray.data.block import Block, BlockAccessor
 
 if TYPE_CHECKING:
-    from ray.data.aggregate import AggregateFn
+    from ray.data.aggregate import AggregateFn, AggregateFnV2
+
+
+def _agg_specs(
+    aggregation_fns: Tuple["AggregateFn", ...],
+) -> Optional[Tuple[Tuple["AggregateFnV2", ...], List[ArrowAggSpec]]]:
+    """Per-agg Arrow vectorization specs, each aggregation declares its own via
+    ``AggregateFn._arrow_agg_spec``.  Returns None (caller falls back to the
+    Python engine) if there are no aggregations or any one isn't vectorizable."""
+    from ray.data.aggregate import AggregateFnV2
+
+    if not aggregation_fns:
+        return None
+    aggs: List[AggregateFnV2] = []
+    specs: List[ArrowAggSpec] = []
+    for agg in aggregation_fns:
+        spec = agg._arrow_agg_spec()
+        if spec is None or not isinstance(agg, AggregateFnV2):
+            return None
+        aggs.append(agg)
+        specs.append(spec)
+    return tuple(aggs), specs
+
+
+def _is_vectorizable(keys: List[str], specs: List[ArrowAggSpec]) -> bool:
+    """Query-shape gate shared by the map and reduce builders, the two must
+    decide identically (the reduce's expected input format depends on what the
+    map shipped)."""
+    has_collection = any(spec.collection for spec in specs)
+    if has_collection and not all(spec.collection for spec in specs):
+        # Mixed reduction + collection shapes need different map outputs
+        # (bounded partials vs raw rows); Python handles both in one pass.
+        return False
+    if not keys:
+        # Keyless (global) = one group: per-group vectorization buys nothing
+        # (the Python path's intra-group aggregation is already vectorized).
+        return False
+    return True
 
 
 def _make_aggregating_transformer(
     key_columns: Tuple[str, ...],
     aggregation_fns: Tuple["AggregateFn", ...],
 ) -> BlockTransformer:
-    """Creates input block transformer performing partial aggregation of
-    the block applied prior to block being shuffled (to reduce amount of bytes shuffled)
-    Copy of `_create_aggregating_transformer` in `hash_aggregate.py`.
-    """
+    return _make_vectorized_aggregating_transformer(
+        key_columns, aggregation_fns
+    ) or _fallback_aggregating_transformer(key_columns, aggregation_fns)
+
+
+def _make_aggregating_reduce_fn(
+    key_columns: Tuple[str, ...],
+    aggregation_fns: Tuple["AggregateFn", ...],
+) -> ReduceFn:
+    return _make_vectorized_aggregating_reduce_fn(
+        key_columns, aggregation_fns
+    ) or _fallback_aggregating_reduce_fn(key_columns, aggregation_fns)
+
+
+def _make_vectorized_aggregating_transformer(
+    key_columns: Tuple[str, ...],
+    aggregation_fns: Tuple["AggregateFn", ...],
+) -> Optional[BlockTransformer]:
+    """Arrow-vectorized map-side combiner, driven by each agg's own spec, or None
+    if the query isn't vectorizable (caller falls back to the Python engine)."""
+    unpacked = _agg_specs(aggregation_fns)
+    if unpacked is None:
+        return None
+    aggs, specs = unpacked
+
+    keys = list(key_columns)
+    if not _is_vectorizable(keys, specs):
+        return None
+    has_collection = any(spec.collection for spec in specs)
+
+    if has_collection:
+        # All-collection query: the map prunes to keys + source columns;
+        # the reduce aggregates the raw rows directly.
+        keep = list(
+            dict.fromkeys(
+                keys
+                + [
+                    a.get_target_column()
+                    for a in aggs
+                    if a.get_target_column() is not None
+                ]
+            )
+        )
+
+        def _prune_transform(block: pa.Table) -> pa.Table:
+            block_schema = BlockAccessor.for_block(block).schema()
+            for agg in aggs:
+                agg._validate(block_schema)
+            if block.num_rows == 0:
+                return block
+            return block.select(keep)
+
+        return _prune_transform
+
+    def _arrow_transform(block: pa.Table) -> pa.Table:
+        block_schema = BlockAccessor.for_block(block).schema()
+        for agg in aggs:
+            agg._validate(block_schema)
+
+        if block.num_rows == 0:
+            return block
+
+        agg_specs: List[tuple] = []
+        names: List[str] = []
+        for i, (agg, spec) in enumerate(zip(aggs, specs)):
+            col = agg.get_target_column()
+            opts = arrow_agg_options(agg._ignore_nulls)
+            if spec.prep is not None:
+                block = spec.prep(i, col, block)
+            names.extend(f"__agg{i}_{c}" for c in spec.components)
+            agg_specs += spec.raw_agg_specs(i, col, opts)
+
+        out = block.group_by(keys, use_threads=False).aggregate(agg_specs)
+        return out.rename_columns(keys + names)
+
+    return _arrow_transform
+
+
+def _make_vectorized_aggregating_reduce_fn(
+    key_columns: Tuple[str, ...],
+    aggregation_fns: Tuple["AggregateFn", ...],
+) -> Optional[ReduceFn]:
+    unpacked = _agg_specs(aggregation_fns)
+    if unpacked is None:
+        return None
+    aggs, specs = unpacked
+
+    keys = list(key_columns)
+    if not _is_vectorizable(keys, specs):
+        return None
+    has_collection = any(spec.collection for spec in specs)
+    _fallback_map = _fallback_aggregating_transformer(key_columns, aggregation_fns)
+    _fallback_reduce = _fallback_aggregating_reduce_fn(key_columns, aggregation_fns)
+    src_cols = [a.get_target_column() for a in aggs] if has_collection else []
+
+    def _arrow_reduce(
+        partition_id: int, tables_by_input: List[List[pa.Table]]
+    ) -> Iterable[Block]:
+        shards = tables_by_input[0]
+        tables = [t for t in shards if t.num_rows > 0]
+        if not tables:
+            return
+        combined = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
+
+        # The distinct/count_distinct kernels have no impl for a nested source
+        # column (the map shipped raw rows); delegate the partition to Python.
+        if has_collection and any(
+            c is not None and pa_types.is_nested(combined.schema.field(c).type)
+            for c in src_cols
+        ):
+            yield from _fallback_reduce(partition_id, [[_fallback_map(combined)]])
+            return
+
+        # Collection query: aggregate the raw rows via raw_agg_specs (a
+        # group's rows are all co-located here, so this yields the final
+        # value).  Reduction: merge the map's partials via merge_specs.
+        agg_specs: List[tuple] = []
+        names: List[str] = []
+        comps: List[Tuple[str, ...]] = []
+        for i, (agg, spec) in enumerate(zip(aggs, specs)):
+            opts = arrow_agg_options(agg._ignore_nulls)
+            out_cols = tuple(f"__agg{i}_{c}" for c in spec.components)
+            comps.append(out_cols)
+            names += out_cols
+            if has_collection:
+                col = agg.get_target_column()
+                if spec.prep is not None:
+                    combined = spec.prep(i, col, combined)
+                agg_specs += spec.raw_agg_specs(i, col, opts)
+            else:
+                assert spec.merge_specs is not None  # reduction specs define it
+                agg_specs += spec.merge_specs(out_cols, opts)
+
+        merged = combined.group_by(keys, use_threads=False).aggregate(agg_specs)
+        merged = merged.rename_columns(keys + names)
+
+        # Finalize into output columns.  Duplicate output names are munged to
+        # name, name_2, name_3, ... (counting against the original name).
+        cols = {k: merged[k] for k in keys}
+        seen: dict = {}
+        for i, (agg, spec) in enumerate(zip(aggs, specs)):
+            name = agg.name
+            n = seen.get(name, 0)
+            seen[name] = n + 1
+            if n > 0:
+                name = f"{name}_{n + 1}"
+            cols[name] = spec.finalize(merged, comps[i])
+        yield pa.table(cols)
+
+    return _arrow_reduce
+
+
+def _fallback_aggregating_transformer(
+    key_columns: Tuple[str, ...],
+    aggregation_fns: Tuple["AggregateFn", ...],
+) -> BlockTransformer:
     from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
     sort_key = SortKey(key=list(key_columns), descending=False)
 
-    def _transform(block: Block) -> Block:
+    def _transform(block: pa.Table) -> pa.Table:
         from ray.data._internal.planner.exchange.aggregate_task_spec import (
             SortAggregateTaskSpec,
         )
@@ -32,11 +223,10 @@ def _make_aggregating_transformer(
         # TODO unify block schemas to avoid validating every block.
         block_schema = BlockAccessor.for_block(block).schema()
         for agg_fn in aggregation_fns:
-            agg_fn._validate(block_schema)  # pyrefly: ignore[bad-argument-type]
+            agg_fn._validate(block_schema)
 
-        # Project down to only the key + aggregation-input columns.
         pruned_block = SortAggregateTaskSpec._prune_unused_columns(
-            block, sort_key, aggregation_fns  # pyrefly: ignore[bad-argument-type]
+            block, sort_key, aggregation_fns
         )
 
         # `_aggregate` assumes the block is sorted by key; skip when global.
@@ -46,13 +236,13 @@ def _make_aggregating_transformer(
             target_block = pruned_block
 
         return BlockAccessor.for_block(target_block)._aggregate(
-            sort_key, aggregation_fns  # pyrefly: ignore[bad-argument-type]
+            sort_key, aggregation_fns
         )
 
     return _transform
 
 
-def _make_aggregating_reduce_fn(
+def _fallback_aggregating_reduce_fn(
     key_columns: Tuple[str, ...],
     aggregation_fns: Tuple["AggregateFn", ...],
 ) -> ReduceFn:
@@ -73,7 +263,7 @@ def _make_aggregating_reduce_fn(
         )._combine_aggregated_blocks(
             list(tables),
             sort_key=sort_key,
-            aggs=aggregation_fns,  # pyrefly: ignore[bad-argument-type]
+            aggs=aggregation_fns,
             finalize=True,
         )
         yield combined_block

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 PartitionFn = Callable[[pa.Table], Dict[int, pa.Table]]
 ReduceFn = Callable[[int, List[List[pa.Table]]], Iterable[Block]]
-BlockTransformer = Callable[[Block], Block]
+BlockTransformer = Callable[["pa.Table"], "pa.Table"]
 
 # Peak working-set of a shuffle map/reduce task is ~2x the input bytes
 SHUFFLE_PEAK_MEMORY_MULTIPLIER = 2

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -91,7 +91,7 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
     def _prune_unused_columns(
         block: Block,
         sort_key: SortKey,
-        aggs: Tuple[AggregateFn],
+        aggs: Tuple[AggregateFn, ...],
     ) -> Block:
         """Prune unused columns from block before aggregate."""
         prune_columns = True

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -4,7 +4,6 @@ import math
 import pickle
 import re
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Collection,
@@ -22,6 +21,16 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 
+from ray.data._internal.arrow_aggregation import (
+    ArrowAggSpec,
+    count_spec,
+    distinct_spec,
+    mean_spec,
+    minmax_spec,
+    missing_pct_spec,
+    sum_spec,
+    zero_pct_spec,
+)
 from ray.data._internal.util import is_null
 from ray.data.block import (
     Block,
@@ -31,9 +40,6 @@ from ray.data.block import (
     KeyType,
 )
 from ray.util.annotations import Deprecated, PublicAPI
-
-if TYPE_CHECKING:
-    from ray.data.dataset import Schema
 
 
 class _SupportsRichComparison(Protocol):
@@ -147,9 +153,17 @@ class AggregateFn:
         self.accumulate_block = accumulate_block
         self.finalize = finalize
 
-    def _validate(self, schema: Optional["Schema"]) -> None:
+    def _validate(self, schema: Optional[Union[type, "pa.Schema"]]) -> None:
         """Raise an error if this cannot be applied to the given schema."""
         pass
+
+    def _arrow_agg_spec(self) -> Optional["ArrowAggSpec"]:
+        """Return this aggregation's Arrow-vectorized plan for the shuffle-v2
+        aggregate path, or ``None`` to use the Python engine (the default).
+
+        See ``ray.data._internal.arrow_aggregation``.
+        """
+        return None
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         """Return the PyArrow ``Field`` this aggregator produces.
@@ -337,7 +351,7 @@ class AggregateFnV2(AggregateFn, abc.ABC, Generic[AccumulatorType, AggOutputType
         """
         return accumulator
 
-    def _validate(self, schema: Optional["Schema"]) -> None:
+    def _validate(self, schema: Optional[Union[type, "pa.Schema"]]) -> None:
         if self._target_col_name:
             from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
@@ -456,6 +470,9 @@ class Count(AggregateFnV2[int, int]):
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return pa.field(self.name, pa.int64(), nullable=False)
+
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return count_spec()  # Count() (no column) counts all rows -> count_all
 
 
 @PublicAPI
@@ -579,6 +596,9 @@ class Sum(AggregateFnV2[Union[int, float], Union[int, float]]):
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return _agg_output_field(self.name, input_schema, self._target_col_name, pc.sum)
 
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return sum_spec() if isinstance(self._target_col_name, str) else None
+
 
 @PublicAPI
 class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType]):
@@ -645,6 +665,9 @@ class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return _agg_output_field(self.name, input_schema, self._target_col_name, pc.min)
 
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return minmax_spec("min") if isinstance(self._target_col_name, str) else None
+
 
 @PublicAPI
 class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType]):
@@ -710,6 +733,9 @@ class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return _agg_output_field(self.name, input_schema, self._target_col_name, pc.max)
+
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return minmax_spec("max") if isinstance(self._target_col_name, str) else None
 
 
 @PublicAPI
@@ -794,6 +820,9 @@ class Mean(AggregateFnV2[List[Union[int, float]], float]):
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
         return pa.field(self.name, pa.float64(), nullable=True)
+
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return mean_spec() if isinstance(self._target_col_name, str) else None
 
 
 @PublicAPI
@@ -1170,6 +1199,17 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
     def combine(self, current_accumulator: Set[Any], new: Set[Any]) -> Set[Any]:
         return self._to_set(current_accumulator) | self._to_set(new)
 
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        # Only the plain (scalar-column, no list-encoding) form vectorizes; the
+        # single-phase `distinct` kernel returns the per-group set of values.
+        if self._list_encoding_mode is not None or not isinstance(
+            self._target_col_name, str
+        ):
+            return None
+        return distinct_spec(
+            "distinct", lambda merged, component_cols: merged[component_cols[0]]
+        )
+
     def _compute_unique(self, block: Block) -> BlockColumn:
         column = block[self._target_col_name]
         column_accessor = BlockColumnAccessor.for_column(column)
@@ -1278,6 +1318,19 @@ class CountDistinct(Unique):
     def finalize(self, accumulator: Set[Any]) -> int:
         """Return the count of distinct values."""
         return len(accumulator)
+
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        # Same gate as Unique, but the `count_distinct` kernel returns the count.
+        if self._list_encoding_mode is not None or not isinstance(
+            self._target_col_name, str
+        ):
+            return None
+        return distinct_spec(
+            "count_distinct",
+            lambda merged, component_cols: pc.cast(
+                merged[component_cols[0]], pa.int64()
+            ),
+        )
 
 
 @PublicAPI
@@ -1568,6 +1621,9 @@ class MissingValuePercentage(AggregateFnV2[List[int], float]):
             return None
         return (accumulator[0] / accumulator[1]) * 100.0
 
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return missing_pct_spec() if isinstance(self._target_col_name, str) else None
+
 
 @PublicAPI(stability="alpha")
 class ZeroPercentage(AggregateFnV2[List[int], float]):
@@ -1665,6 +1721,9 @@ class ZeroPercentage(AggregateFnV2[List[int], float]):
         if accumulator[1] == 0:
             return None
         return (accumulator[0] / accumulator[1]) * 100.0
+
+    def _arrow_agg_spec(self) -> Optional[ArrowAggSpec]:
+        return zero_pct_spec() if isinstance(self._target_col_name, str) else None
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -719,7 +719,7 @@ class BlockAccessor:
         """Return a list of sorted partitions of this block."""
         raise NotImplementedError
 
-    def _aggregate(self, key: "SortKey", aggs: Tuple["AggregateFn"]) -> Block:
+    def _aggregate(self, key: "SortKey", aggs: Tuple["AggregateFn", ...]) -> Block:
         """Combine rows with the same key into an accumulator."""
         raise NotImplementedError
 
@@ -734,7 +734,7 @@ class BlockAccessor:
     def _combine_aggregated_blocks(
         blocks: List[Block],
         sort_key: "SortKey",
-        aggs: Tuple["AggregateFn"],
+        aggs: Tuple["AggregateFn", ...],
         finalize: bool = True,
     ) -> Tuple[Block, BlockMetadataWithSchema]:
         """Aggregate partially combined and sorted blocks."""


### PR DESCRIPTION
## Description
 Adds Arrow-vectorized aggregation to the shuffle-v2 (`HASH_SHUFFLE_V2`) aggregate path: the map-side combiner and reduce finalizer now run PyArrow `TableGroupBy` kernels instead of the per-group Python engine. Motivating measurements: grouped `Sum/Mean/Count` map-side combine 3.12s → 0.03s (1M rows / 1k groups); 

**Design**

- New `arrow_aggregation.py`: an `ArrowAggSpec` protocol, each `AggregateFn` self-declares its vectorization via `_arrow_agg_spec()` (returning `None` keeps it on the Python engine). Adding a vectorizable agg = one method on its class, no driver changes.
- Two execution shapes:
  - **Reduction** (`Count`, `Sum`, `Min`, `Max`, `Mean`, `MissingValuePercentage`, `ZeroPercentage`): two-phase map pre-aggregates into bounded partials, reduce merges partials and finalizes.
  - **Collection** (`Unique`, `CountDistinct`): single-phase, map prunes to keys + source columns and ships raw rows, reduce runs the `hash_distinct`/`hash_count_distinct` kernels over the co-located rows.
- Engine selection is fully plan-time and centralized (`_agg_specs` + `_is_vectorizable`); both map and reduce derive it identically. Falls back to the existing Python engine (unchanged behavior) for:
  - queries containing any unvectorizable agg (`Std`, `Quantile`, `AsList`, custom `AggregateFn`s, …), **Will add some of them in followups!!!**
  - mixed reduction + collection queries (the two shapes need different map output formats),
  - keyless/global aggregations (Python engine's per-block accumulate is already kernel-vectorized and since it's global so there will be only 1 group so no iterating),
  - `Unique`/`CountDistinct` with `encode_lists` or non-string targets.
- Preserves Python-engine semantics: `ignore_nulls` threaded via kernel options, duplicate output names munged (`name`, `name_2`, …), empty-dataset global aggregation emits the same identity row.

**Result** 
We got really nice result from this.
| Test | v1 | v2 | v2 \+ vec agg | vs v2  | vs v1 |
| :---- | :---- | :---- | :---- | :---- | :---- |
| aggregate\_groups\_fixed\_size col02/14 | 768.5 | 717.7 | 22.3 | 32.2× | 34.5× |
| tpch\_q1\_fixed\_size (sf1000) | 36.3 | 43.6 | 20.9 | 2.1× | 1.7× |
| tpch\_q13\_fixed\_size | 28.6 | 46.1 | 16.3 | 2.8× | 1.8× |
| tpch\_q15\_fixed\_size | 45.4 | 56.7 | 17.3 | 3.3× | 2.6× |
| tpch\_q21\_fixed\_size | 505.4 | 501.0 | 32.0 | 15.7× | 15.8× |


 

<br class="Apple-interchange-newline">

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
