### PR TITLE
[doc] Record why the docs setuptools pin can't move past 82

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,6 +1,13 @@
 # Production requirements. This is what readthedocs.com picks up
 
-# Required to build the docs on 3.12 due to pkg_resources deprecation
+# Declared explicitly because Python 3.12 and later no longer ship setuptools,
+# and sphinxcontrib-redoc imports pkg_resources at module load.
+# Don't bump to 82 or later: setuptools 82.0.0 removed pkg_resources, and the
+# docs build then fails at extension load with
+# "Could not import extension sphinxcontrib.redoc".
+# No released sphinxcontrib-redoc fixes this. 1.6.0 is the latest release and
+# dates from 2020; the 2.0.0a1 alpha still imports pkg_resources. Lifting this
+# ceiling means replacing or vendoring that extension.
 setuptools==80.9.0
 
 # Syntax highlighting


### PR DESCRIPTION
## Why are these changes needed?

The `setuptools` pin in `doc/requirements-doc.txt` is load-bearing, but the comment above it didn't say so:

```
# Required to build the docs on 3.12 due to pkg_resources deprecation
setuptools==80.9.0
```

That explains why setuptools is *declared*, not why it can't *move*. A dependency bot has proposed bumping it more than once (most recently to 83.0.0), and each attempt has to rediscover the failure from scratch. This adds the ceiling and the reason.

## The actual constraint

`setuptools` **82.0.0 removed `pkg_resources`**, and `sphinxcontrib-redoc` imports `pkg_resources` at module load. With setuptools ≥ 82 the docs build dies during extension loading:

```
sphinx.errors.ExtensionError: Could not import extension sphinxcontrib.redoc
  (exception: No module named 'pkg_resources')
```

Verified in a clean Python 3.11 docs environment built from `doc/requirements-doc.lock.txt`:

| setuptools | `pkg_resources` |
|---|---|
| 80.9.0 | present |
| 81.0.0 | present |
| 82.0.1 | **removed** |
| 83.0.0 | **removed** |

Same-environment differential, changing only the setuptools version: `import sphinxcontrib.redoc` raises `ModuleNotFoundError: No module named 'pkg_resources'` on 83.0.0 and succeeds on 80.9.0. So the failure is attributable to setuptools alone, not to anything else in the environment.

Worth noting the failure mode: `raydepsets --check` passes cleanly with setuptools 83.0.0 and the regenerated lock diff is a tidy three-line change. Only an actual Sphinx build catches this.

## There's nothing to upgrade into

`sphinxcontrib-redoc` 1.6.0 is the latest release on PyPI and was uploaded in **April 2020**. The only newer artifact is a `2.0.0a1` alpha, which still imports `pkg_resources` — and additionally uses `__import__('pkg_resources').declare_namespace(__name__)`, so it's further from working, not closer.

So the ceiling can only lift by replacing or vendoring that extension. Flagging it because an unmaintained-since-2020 extension gating a setuptools upgrade path is worth someone's attention independent of this comment change; happy to file a separate issue if that's useful.

## Checks

- Comment-only change. `raydepsets build ci/raydepsets/configs/docs.depsets.yaml --check` exits 0 and the lock is untouched.
- The bisection and differential above were run against a real docs environment installed from the committed lock.

## Related issue number

None.

## Checks

- [x] I've signed off every commit (`-s`).
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
