### PR TITLE
[ci] Give the prose doctest step a real tag and an honest label

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -10,8 +10,23 @@ steps:
       PYTHON: "3.10"
     tags: cibase
 
-  - label: doc tests
-    tags: python
+  # Runs //doc:doctest, the catch-all doctest target for documentation prose that
+  # no library owns (tagged team:none). The five per-library docs example steps
+  # each filter on their own team:<lib>, so this is the only step that reaches it.
+  #
+  # Postmerge only. It was already postmerge-only before this comment existed, but
+  # by accident rather than intent: the step carried the tag `python`, which no
+  # .rules.txt file declares and no rule emits, so premerge tag selection dropped
+  # it every time. `skip-on-premerge` states that intent explicitly, matching
+  # `doc: build` and `doc: linkcheck` in doc.rayci.yml and the postmerge-only core
+  # minimal-tests step in core.rayci.yml. `doc` is the build-and-validation tag,
+  # which is what this step is; it does not re-enable the step on premerge, since
+  # skip tags are rejected before tag selection runs.
+  - label: "doc: doctest"
+    tags:
+      - oss
+      - doc
+      - skip-on-premerge
     instance_type: large
     commands:
       # Disable test DB to avoid any hidden failures going forward.


### PR DESCRIPTION
## Why this change

`.buildkite/others.rayci.yml` has a step labeled `doc tests`, tagged `python`.

**`python` is declared in no `.rules.txt` file and emitted by no rule.** It isn't in the tag-declaration block of `test.rules.txt` or `always.rules.txt`, and no rule emits it. In `raycicmd/step_filter.go`, `acceptTagHit` returns early only when `runAll` is set; the `noTagMeansAlways` escape doesn't apply because the step *does* carry a tag, so it falls through to `step.hasTagInMap(f.tags)` and misses. On non-pull-request builds `needRunAllTags` returns `["*"]`, `runAll` is set, and the step runs.

So the step is postmerge-only, but by accident rather than by intent. Nothing in the file says so, and the behavior rests on a tag that reads like it means something.

Confirmed against real builds:

- Premerge [71703](https://buildkite.com/ray-project/premerge/builds/71703) — 231 jobs, the broadest recent build, with all five per-library docs example steps present. A job named `doc tests` is **absent**.
- Postmerge [19099](https://buildkite.com/ray-project/postmerge/builds/19099) — 923 jobs. `doc tests [g14_s1]` is **present** and passed.

It's also the last step in the repo still called `doc tests`, after #64775 renamed the per-library steps to `<library>: docs example tests`. `git grep 'label:.*doc test'` returned exactly this one line. That's a naming collision with five steps that do something else: those execute a library's documentation examples, while this one runs `//doc:doctest`, the catch-all doctest target for documentation prose that no library owns (tagged `team:none`). The per-library steps each filter on their own `team:<lib>`, so this is the only step that reaches it.

## What this changes

Tags and label only. **No behavior change** — the step runs exactly where it ran before.

- **`skip-on-premerge`** states the existing postmerge-only behavior explicitly, instead of leaving it to an unmatched tag. Matches `doc: build` and `doc: linkcheck` in `doc.rayci.yml`, and the postmerge-only minimal-tests step in `core.rayci.yml`, which uses the same pattern with a comment.
- **`doc`** is the build-and-validation tag, which is what this step is. It does **not** re-enable the step on premerge: skip tags are rejected in the filter's first pass (`hit = !reject(step) && accept(step)`) before tag selection runs. That's why `doc: build` carries `doc`, a rule-emitted tag, and is still postmerge-only.
- **`oss`** matches the sibling doc steps.
- **`python`** is dropped. It stays on `core_minimal_tests_postmerge` in `core.rayci.yml`, where it's harmless because that step also carries real tags and an explicit `skip-on-premerge`.
- The label becomes **`doc: doctest`**, after the target it runs, matching the `doc:` prefix the other doc steps use.

Renaming is safe for microcheck step-id selection because ids are positional (`g<group>_s<step>`) and the step keeps its position in its group. Reordering would be the risky operation; this isn't one.

## Testing

**Emitted-pipeline differential using the pinned rayci binary** (`v0.46.0`, from the repo's own `.rayciversion`), rather than inferring from tags. Probe path `.readthedocs.yaml`, chosen because it emits `doc` — the tag being added — so this is the case most likely to expose an accidental premerge trigger.

Both runs report `selected tags: always doc lint` and emit the same 6 steps:

```
wanda: forge
:test_tube: test-rules [g5_s0]
:lint-roller: lint: {{matrix}} [g11_s0]
:lint-roller: lint: {{matrix}} [g11_s1]
:lint-roller: pre-commit pydoclint [g11_s2]
:lint-roller: lint: validate docs-go scope [g11_s3]
```

Diffing the two full pipeline YAMLs, the only differences are the probe commit SHAs in `BUILDKITE_ARTIFACT_UPLOAD_DESTINATION`, which are an artifact of how the probe commit is generated. Everything else is byte-identical, and `doc: doctest` appears in neither pipeline. So with `doc` emitted, the step stays off premerge before and after.

**Postmerge preservation.** `doc: build [g9_s2]` and `doc: linkcheck [g9_s5]` both carry `skip-on-premerge` and both appear on postmerge build 19099, so the added skip tag doesn't remove a step from postmerge.

**Filter simulation** across four scenarios (prose-only premerge, broad code premerge, docs-infra premerge, and postmerge run-all): identical selection before and after in all four.

**Lint.** `pre-commit run --files .buildkite/others.rayci.yml` passes. YAML parses, and the step's `depends_on`, `instance_type`, and commands are untouched.

## Not a duplicate

`gh pr list --repo ray-project/ray --state open` searched for `others.rayci.yml`, `"doc tests"`, and `doctest` in title and body — no open PR touches this step or this file.

## Follow-ups deliberately not in this PR

While measuring this step I found two things that are about the *target*, not its routing, so they need different reviewers and their own change:

- **`//doc:doctest` currently collects zero doctests.** Of the 204 files in its glob, the 131 `.md` files contain no `>>>` prompt, which is the only form pytest collects. The one file in the glob that has a doctest is `ray-references/glossary.rst`, and the pytest arg is `--doctest-glob=*.md`, so `.rst` isn't collected. The three other prose files in the tree carrying `>>>` are all in the target's own exclude list. Its measured cost is ~8m wall clock for 57.9s of bazel work.
- **`bazel/pytest_wrapper.py` maps `NO_TESTS_COLLECTED` to `OK`**, so a target that collects nothing passes green. That applies to every `doctest()` target in the repo, so any of them could silently stop collecting and stay green.

Happy to open those separately, or to fold the size correction bazel already suggests (`Test execution time (57.9s ...) outside of range for LONG tests`) into whichever change resolves the collection question, since the right size depends on what the target ends up collecting.

## AI assistance

AI assistance (Claude Code) was used to research and draft this change. I reviewed every changed line and ran the verification commands above locally.
