### PR TITLE
[ci] Install data CI depset after conda ffmpeg to fix removed packages

### DIFF
--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -37,8 +37,15 @@ sudo ldconfig
 # The conda solve above can remove or downgrade python packages in the
 # miniforge env (e.g. exceptiongroup, jinja2) while satisfying ffmpeg's
 # constraints, so the depset must be installed after it to keep the env
-# matching the lock.
-uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
+# matching the lock. --reinstall is required because conda can delete files
+# of packages whose dist-info still matches the lock (stale conda-meta
+# entries for packages pip previously replaced, e.g. msgpack), which would
+# otherwise make uv skip them.
+# TODO(elliot-barn): install ffmpeg into a dedicated conda env
+# (conda create -n ffmpeg) and point ld.so.conf at that env's lib dir, so the
+# solve cannot touch base site-packages at all; then this --reinstall and the
+# ordering constraint can go away.
+uv pip install -r /home/ray/python_depset.lock --no-deps --system --reinstall --index-strategy unsafe-best-match
 
 if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
   uv pip install \

--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -17,17 +17,6 @@ RUN <<EOF
 
 set -ex
 
-uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
-
-if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
-  uv pip install \
-    --system \
-    --prerelease allow \
-    --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
-    --upgrade-package pyarrow \
-    pyarrow
-fi
-
 curl -fsSL https://pgp.mongodb.com/server-8.0.asc | \
   sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] \
@@ -44,6 +33,21 @@ sudo apt-get install -y mongodb-org
 conda install -y -c conda-forge "ffmpeg=7.*"
 echo "$(conda info --base)/lib" | sudo tee /etc/ld.so.conf.d/conda-ffmpeg.conf > /dev/null
 sudo ldconfig
+
+# The conda solve above can remove or downgrade python packages in the
+# miniforge env (e.g. exceptiongroup, jinja2) while satisfying ffmpeg's
+# constraints, so the depset must be installed after it to keep the env
+# matching the lock.
+uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
+
+if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
+  uv pip install \
+    --system \
+    --prerelease allow \
+    --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
+    --upgrade-package pyarrow \
+    pyarrow
+fi
 
 if [[ $RAY_CI_JAVA_BUILD == 1 ]]; then
   # These packages increase the image size quite a bit, so we only install them


### PR DESCRIPTION
## Why are these changes needed?

All `data17build-py3.10`-based CI jobs (data arrow v17 shards, docs example, integration, dashboard) are currently red on master and premerge with:

```
import pytest → from exceptiongroup import BaseExceptionGroup
ModuleNotFoundError: No module named 'exceptiongroup'
```

e.g. master postmerge [build 19099](https://buildkite.com/ray-project/postmerge/builds/19099) and premerge [build 71680](https://buildkite.com/ray-project/premerge/builds/71680).

Root cause: in `ci/docker/data.build.Dockerfile`, the depset lock is installed **before** `conda install -y -c conda-forge "ffmpeg=7.*"`. With the current `oss-ci-base_ml` base image (which ships conda 26.7.0), the ffmpeg solve upgrades core native libs (libmamba 2.0.8 → 2.9.0, libarchive, libcurl, fmt), and since no conda 26.x py3.10 build is compatible with that upgraded stack, the solver **downgrades conda 26.7.0 → 23.9.0 and removes conda 26's entire python dependency tree** — including `exceptiongroup`, `jinja2`, `markupsafe`, `httpx` and `typing-inspection` (visible under "The following packages will be REMOVED" in the wanda `data17build-py3.10` job log). `exceptiongroup` is a hard runtime dep of pytest on Python < 3.11, so every pytest target import-fails.

Fix: move the `uv pip install -r python_depset.lock` step (and the pyarrow-nightly override) **after** the conda ffmpeg step, so uv restores everything the lock declares. All five data depset locks contain the removed packages (`exceptiongroup` with a `python_full_version < '3.11'` marker, so py3.12 images are unaffected by design).

Not a duplicate: searched open PRs for `exceptiongroup`, `ffmpeg conda`, and data image/depset changes — no existing PR addresses this.

## Related issue number

N/A — master CI breakage, no issue filed.

## Checks

- Verification: this is a CI image build-order change; validated by triaging the wanda `data17build-py3.10` build logs (conda removal transaction) and confirming the removed packages are present in all `python/deplocks/ci/data-*` locks. The premerge data jobs on this PR rebuild the image and are the end-to-end test.
- `pre-commit` hooks ran and passed on commit.
- AI assistance (Claude Code) was used for triage and this change; reviewed line-by-line by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)