### PR TITLE
[ci/doc] Treat __all__ membership as public in the API-doc resolve check

### DIFF
--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -41,6 +41,7 @@ py_test(
     size = "small",
     srcs = [
         "mock/__init__.py",
+        "mock/_internal/__init__.py",
         "mock/mock_module.py",
         "test_module.py",
     ],
@@ -60,6 +61,7 @@ py_test(
     size = "small",
     srcs = [
         "mock/__init__.py",
+        "mock/_internal/__init__.py",
         "mock/mock_module.py",
         "test_api.py",
     ],
@@ -79,6 +81,7 @@ py_test(
     size = "small",
     srcs = [
         "mock/__init__.py",
+        "mock/_internal/__init__.py",
         "mock/mock_module.py",
         "test_autodoc.py",
     ],
@@ -99,6 +102,7 @@ py_test(
     srcs = [
         "cmd_check_api_discrepancy.py",
         "mock/__init__.py",
+        "mock/_internal/__init__.py",
         "mock/mock_module.py",
         "test_cmd_check_api_discrepancy.py",
     ],

--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -252,6 +252,48 @@ class API:
         return name_has_underscore or is_internal
 
     @staticmethod
+    def _is_public_reexport(documented_name: str, canonical_name: str) -> bool:
+        """
+        Whether a documented name is a public re-export of an implementation
+        that lives in a private module.
+
+        A library routinely declares its public surface in a package's
+        ``__all__`` while keeping the implementation private:
+        ``ray.data.ActorPoolStrategy`` is exported from ``ray.data.__all__``
+        though the class is defined in ``ray.data._internal.compute``. The
+        export is the public contract and the implementation's location is not
+        part of it, so a ``._internal.`` segment in the canonical name must not
+        read as private for such a name.
+
+        Only an explicit ``__all__`` entry on a public module counts, which is
+        what keeps this from laundering genuinely private symbols:
+
+        - A private module can't confer public-ness. Its own ``__all__`` is not
+          a public contract, so a name documented through a private path
+          (``ray.data._internal.foo.Bar``) stays flagged.
+        - An underscore leaf stays private on either side of the re-export. A
+          name that begins with an underscore is non-public by convention no
+          matter what re-exports it.
+        - A symbol merely reachable as a module attribute isn't enough. Absent
+          an ``__all__`` entry, the check's verdict is unchanged.
+        """
+        module_name, _, leaf = documented_name.rpartition(".")
+        if not module_name or not leaf:
+            return False
+        if leaf.startswith("_") or canonical_name.split(".")[-1].startswith("_"):
+            return False
+        if any(token.startswith("_") for token in module_name.split(".")):
+            return False
+        try:
+            module = importlib.import_module(module_name)
+        except (ImportError, ValueError):
+            # The documented name's parent is a class rather than a module
+            # (``Dataset.map_batches``), or it doesn't import. Either way there
+            # is no module ``__all__`` to read.
+            return False
+        return leaf in getattr(module, "__all__", ())
+
+    @staticmethod
     def _is_override_hook(obj: object) -> bool:
         """
         A leading underscore carries two meanings in Python. PEP 8 uses it for
@@ -328,7 +370,9 @@ class API:
           This is the breakage that today only the Sphinx render catches.
         - ``non_public``: documented names that resolve, but whose *live*
           annotation is non-public (``@Deprecated``) or whose canonical name is
-          private (``_foo`` / ``._internal.``).
+          private (``_foo`` / ``._internal.``). A private canonical name that a
+          public module re-exports through its ``__all__`` is public; see
+          _is_public_reexport().
 
         Objects that resolve but carry no annotation are accepted -- the Sphinx
         autosummary import check only warns on import failure, and documented
@@ -370,6 +414,11 @@ class API:
             is_private = resolved_api._is_private_name() and not API._is_override_hook(
                 obj
             )
+            # A name exported from a public module's __all__ is public
+            # regardless of where its implementation lives, so the private
+            # canonical path of a re-exported symbol is not a doc bug.
+            if is_private and API._is_public_reexport(api.name, canonical_name):
+                is_private = False
             if resolved_api.is_deprecated() or is_private:
                 non_public.append(canonical_name)
 

--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -289,9 +289,18 @@ class API:
         except (ImportError, ValueError):
             # The documented name's parent is a class rather than a module
             # (``Dataset.map_batches``), or it doesn't import. Either way there
-            # is no module ``__all__`` to read.
+            # is no module ``__all__`` to read. Only the import-machinery errors
+            # are caught, matching resolve(): this runs on a name that already
+            # resolved, so every prefix of it has imported once already.
             return False
-        return leaf in getattr(module, "__all__", ())
+        exports = getattr(module, "__all__", None)
+        if not isinstance(exports, (list, tuple, set, frozenset)):
+            # __all__ is conventionally a list or a tuple of names, and Ray uses
+            # both. Anything else is not a declaration to read: absent or None
+            # confers nothing, and a bare string would make the membership test
+            # below match a substring rather than a name.
+            return False
+        return leaf in exports
 
     @staticmethod
     def _is_override_hook(obj: object) -> bool:

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -64,25 +64,12 @@ TEAM_API_CONFIGS = {
             "ray.data.llm.HttpRequestStageConfig",
             "ray.data.llm.ServeDeploymentProcessorConfig",
         },
-        # Documented public APIs whose canonical name resolves under a private
-        # (._internal.) module: the class is re-exported from ray.data.__all__
-        # while its implementation lives in _internal. They resolve fine and are
-        # correctly documented; only the resolve check's private-name heuristic
-        # flags them. doc_only_whitelist exempts them from that check
-        # (split_resolvable_and_broken_doc_apis) without touching the
-        # must-be-documented check. Permanent (implementation location, not debt).
-        "doc_only_whitelist": {
-            "ray.data._internal.compute.ActorPoolStrategy",
-            "ray.data._internal.compute.TaskPoolStrategy",
-            "ray.data._internal.execution.interfaces.execution_options.ExecutionOptions",
-            "ray.data._internal.execution.interfaces.execution_options.ExecutionResources",
-            "ray.data._internal.logical.operators.n_ary_operator.MixStoppingCondition",
-            "ray.data._internal.random_config.RandomSeedConfig",
-            # Same pattern under ray.data.llm: the @PublicAPI Processor is
-            # re-exported through ray.data.llm (documented in data/api/llm.rst)
-            # while its implementation lives under ray.llm._internal.
-            "ray.llm._internal.batch.processor.base.Processor",
-        },
+        # No doc_only_whitelist. The documented public APIs whose canonical name
+        # resolves under a private module (ActorPoolStrategy, ExecutionOptions,
+        # the ray.data.llm Processor, ...) were listed here until the resolve
+        # check learned to read __all__: each is exported from ray.data.__all__
+        # or ray.data.llm.__all__, so API._is_public_reexport now exempts them
+        # generically and a newly re-exported API needs no entry.
         # Canonical names intentionally documented in more than one place. Each
         # is listed both in the generated ray.data.Dataset.rst method table
         # (included by dataset.rst) and in saving_data.rst's save-topic grouping.

--- a/ci/ray_ci/doc/mock/_internal/__init__.py
+++ b/ci/ray_ci/doc/mock/_internal/__init__.py
@@ -1,0 +1,27 @@
+"""Stand-in for a library's private implementation package.
+
+Mirrors ``ray.data._internal``: the implementation lives under a private module
+while the public name is re-exported from a public module's ``__all__``. The
+package is named ``_internal`` on purpose, because the check's private-name
+heuristic keys on that exact segment.
+"""
+
+
+class MockReexportedClass:
+    """Implemented privately, re-exported from ``mock_module.__all__``.
+
+    Documenting this through its public name is correct, so the check must not
+    flag its private canonical name.
+    """
+
+    pass
+
+
+class MockInternalOnlyClass:
+    """Implemented privately and absent from any public ``__all__``.
+
+    The negative control: reachable as a module attribute but never exported,
+    so the check must keep flagging it.
+    """
+
+    pass

--- a/ci/ray_ci/doc/mock/mock_module.py
+++ b/ci/ray_ci/doc/mock/mock_module.py
@@ -1,4 +1,20 @@
 from ci.ray_ci.doc.api import _OVERRIDE_HOOK_MARKER, AnnotationType
+from ci.ray_ci.doc.mock._internal import (  # noqa: F401
+    MockInternalOnlyClass,
+    MockReexportedClass,
+)
+
+# Mirrors a library head module such as ray.data: the declared public surface
+# names a class whose implementation lives in a private module. Both classes
+# above are importable from here; only MockReexportedClass is exported, so the
+# pair covers the exempt and the still-flagged case.
+__all__ = [
+    "MockClass",
+    "MockDeprecatedClass",
+    "MockReexportedClass",
+    "mock_function",
+    "mock_w00t",
+]
 
 
 def PublicAPI(*args, **kwargs):

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -419,6 +419,24 @@ def test_is_public_reexport():
     assert not API._is_public_reexport("MockReexportedClass", "pkg.Thing")
 
 
+def test_is_public_reexport_requires_a_real_export_list(monkeypatch):
+    from ci.ray_ci.doc.mock import mock_module
+
+    documented = f"{_MOCK}.MockReexportedClass"
+    canonical = f"{_INTERNAL_MOCK}.MockReexportedClass"
+
+    # A tuple is as valid a declaration as a list; Ray modules use both.
+    monkeypatch.setattr(mock_module, "__all__", ("MockReexportedClass",))
+    assert API._is_public_reexport(documented, canonical)
+
+    # Anything that isn't a collection of names confers nothing. A bare string
+    # is the case worth naming: a membership test against it would match a
+    # substring and silently exempt a symbol nobody exported.
+    for not_an_export_list in ("MockReexportedClass", None, 42):
+        monkeypatch.setattr(mock_module, "__all__", not_an_export_list)
+        assert not API._is_public_reexport(documented, canonical)
+
+
 def test_find_duplicate_doc_apis():
     # mock_w00t appears twice, MockClass once. Names canonicalize first, so the
     # duplicate is reported under the canonical name.

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -19,6 +19,7 @@ from ci.ray_ci.doc.mock.mock_module import (
 )
 
 _MOCK = "ci.ray_ci.doc.mock.mock_module"
+_INTERNAL_MOCK = "ci.ray_ci.doc.mock._internal"
 
 
 def _doc_api(name: str, code_type: CodeType = CodeType.FUNCTION) -> API:
@@ -357,6 +358,65 @@ def test_split_resolvable_exempts_override_hook():
 
     assert unresolved == []
     assert non_public == [f"{_MOCK}.MockClass._mock_private"]
+
+
+def test_split_resolvable_exempts_public_reexport_of_private_module():
+    # A class implemented in a private module but re-exported through a public
+    # module's __all__ is public: the export is the contract, the implementation
+    # path is not. Its sibling in the same private module, absent from __all__,
+    # is still flagged -- the exemption must not weaken detection of genuinely
+    # private symbols.
+    unresolved, non_public = API.split_resolvable_and_broken_doc_apis(
+        [
+            _doc_api(f"{_MOCK}.MockReexportedClass", CodeType.CLASS),
+            _doc_api(f"{_MOCK}.MockInternalOnlyClass", CodeType.CLASS),
+        ],
+        set(),
+    )
+
+    assert unresolved == []
+    assert non_public == [f"{_INTERNAL_MOCK}.MockInternalOnlyClass"]
+
+
+def test_split_resolvable_flags_reexport_documented_by_private_path():
+    # The same object documented through its private canonical path instead of
+    # its public re-export stays flagged. A private module's __all__ is not a
+    # public contract, so it can't launder the name.
+    unresolved, non_public = API.split_resolvable_and_broken_doc_apis(
+        [_doc_api(f"{_INTERNAL_MOCK}.MockReexportedClass", CodeType.CLASS)],
+        set(),
+    )
+
+    assert unresolved == []
+    assert non_public == [f"{_INTERNAL_MOCK}.MockReexportedClass"]
+
+
+def test_is_public_reexport():
+    # Exported from a public module's __all__.
+    assert API._is_public_reexport(
+        f"{_MOCK}.MockReexportedClass",
+        f"{_INTERNAL_MOCK}.MockReexportedClass",
+    )
+    # Importable from the same module but not exported.
+    assert not API._is_public_reexport(
+        f"{_MOCK}.MockInternalOnlyClass",
+        f"{_INTERNAL_MOCK}.MockInternalOnlyClass",
+    )
+    # Documented through a private module path.
+    assert not API._is_public_reexport(
+        f"{_INTERNAL_MOCK}.MockReexportedClass",
+        f"{_INTERNAL_MOCK}.MockReexportedClass",
+    )
+    # An underscore leaf stays private on either side of the re-export, so
+    # __all__ membership can never promote one.
+    assert not API._is_public_reexport(f"{_MOCK}._MockReexportedClass", "pkg.Thing")
+    assert not API._is_public_reexport(
+        f"{_MOCK}.MockReexportedClass", "pkg._internal._Thing"
+    )
+    # A parent that is a class, not a module, has no __all__ to read.
+    assert not API._is_public_reexport(f"{_MOCK}.MockClass.mock_method", "pkg.Thing")
+    # A name with no module part.
+    assert not API._is_public_reexport("MockReexportedClass", "pkg.Thing")
 
 
 def test_find_duplicate_doc_apis():


### PR DESCRIPTION
## Why this change is needed

The API-doc consistency check (`ci/ray_ci/doc/`) classifies a documented API as non-public when its canonical name resolves under a private module, keying on the `._internal.` segment in `API._is_private_name()`.

Several public Ray Data APIs are re-exported into `ray.data.__all__` while their implementation lives in `_internal`, so the heuristic flags names that are legitimately public and correctly documented. Those false positives were suppressed with a per-team `doc_only_whitelist` — a hand-maintained list that had to grow by one entry every time a team re-exported another API from a private module.

## What this change does

Reads the export instead of guessing from the path. A name that the documented module declares in its `__all__` is public regardless of where its implementation lives, so the new `API._is_public_reexport()` exempts it from the private-name rule and the list goes away.

The exemption is deliberately narrow, so genuinely private symbols stay flagged:

- **Only a public module's `__all__` counts.** A name documented through a private path (`ray.data._internal.foo.Bar`) keeps its verdict — a private module's `__all__` is not a public contract.
- **An underscore leaf stays private** on either side of the re-export. `__all__` membership can never promote a `_foo` name.
- **Module-attribute reachability alone changes nothing.** Absent an explicit `__all__` entry, the verdict is unchanged.

Scope is limited to the resolve check's non-public classification (`split_resolvable_and_broken_doc_apis`). The "every `@PublicAPI` must be documented" check and the duplicate-documentation check are untouched, as is `API.is_public()` on the code side.

## Whitelist entries retired

All seven `doc_only_whitelist` entries on the data team config:

| Retired entry | Public name it's documented under |
|---|---|
| `ray.data._internal.compute.ActorPoolStrategy` | `ray.data.ActorPoolStrategy` |
| `ray.data._internal.compute.TaskPoolStrategy` | `ray.data.TaskPoolStrategy` |
| `ray.data._internal.execution.interfaces.execution_options.ExecutionOptions` | `ray.data.ExecutionOptions` |
| `ray.data._internal.execution.interfaces.execution_options.ExecutionResources` | `ray.data.ExecutionResources` |
| `ray.data._internal.logical.operators.n_ary_operator.MixStoppingCondition` | `ray.data.MixStoppingCondition` |
| `ray.data._internal.random_config.RandomSeedConfig` | `ray.data.RandomSeedConfig` |
| `ray.llm._internal.batch.processor.base.Processor` | `ray.data.llm.Processor` |

Each is present in `ray.data.__all__` or `ray.data.llm.__all__`, and each is documented through its public `currentmodule` in `doc/source/data/api/`. None carries a `@Deprecated` annotation, so none relied on the whitelist for anything beyond the private-path suppression this change replaces.

RLlib's `doc_only_whitelist` is a different case — instance attributes assigned in `setup()` that the import walk can't resolve — and is untouched.

## Related PRs

- #64423 added the `doc_only_whitelist` workaround.
- #64786 split the whitelists into permanent exemptions and tracked debt.

## Checks

- [x] I've signed off every commit (`git commit --signoff`).
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests

`ci/ray_ci/doc/test_api.py` gains coverage for the re-export case, for the same object documented through its private canonical path, and for the negative control — a class importable from the same public module but absent from its `__all__`, which must still be flagged. A private mock subpackage (`ci/ray_ci/doc/mock/_internal/`) provides the fixture so the test exercises the real `._internal.` code path rather than a spoofed `__module__`.

Verified locally: the four `ci/ray_ci/doc` unit-test files pass (44 tests), and `pre-commit` is clean on the changed files. The end-to-end `api_policy_check` step needs a bazel-built Ray in the docbuild image, so the whitelist retirement is verified statically here (`__all__` membership and annotations read from source, per the table above) and premerge's `doc_api_policy_check` is the decisive check.
