### PR TITLE
[cherry-pick][2.58.0][ci] Install data CI depset after conda ffmpeg to fix removed packages (#65334)

### DIFF
--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -17,17 +17,6 @@ RUN <<EOF
 
 set -ex
 
-uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
-
-if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
-  uv pip install \
-    --system \
-    --prerelease allow \
-    --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
-    --upgrade-package pyarrow \
-    pyarrow
-fi
-
 curl -fsSL https://pgp.mongodb.com/server-8.0.asc | \
   sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] \
@@ -44,6 +33,28 @@ sudo apt-get install -y mongodb-org
 conda install -y -c conda-forge "ffmpeg=7.*"
 echo "$(conda info --base)/lib" | sudo tee /etc/ld.so.conf.d/conda-ffmpeg.conf > /dev/null
 sudo ldconfig
+
+# The conda solve above can remove or downgrade python packages in the
+# miniforge env (e.g. exceptiongroup, jinja2) while satisfying ffmpeg's
+# constraints, so the depset must be installed after it to keep the env
+# matching the lock. --reinstall is required because conda can delete files
+# of packages whose dist-info still matches the lock (stale conda-meta
+# entries for packages pip previously replaced, e.g. msgpack), which would
+# otherwise make uv skip them.
+# TODO(elliot-barn): install ffmpeg into a dedicated conda env
+# (conda create -n ffmpeg) and point ld.so.conf at that env's lib dir, so the
+# solve cannot touch base site-packages at all; then this --reinstall and the
+# ordering constraint can go away.
+uv pip install -r /home/ray/python_depset.lock --no-deps --system --reinstall --index-strategy unsafe-best-match
+
+if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
+  uv pip install \
+    --system \
+    --prerelease allow \
+    --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
+    --upgrade-package pyarrow \
+    pyarrow
+fi
 
 if [[ $RAY_CI_JAVA_BUILD == 1 ]]; then
   # These packages increase the image size quite a bit, so we only install them


### PR DESCRIPTION
Cherry-pick of #65334 (master commit 4283d39b4af3b4dec24be8a0c7dd3c1d287e52a6) onto `releases/2.58.0`.

## Why are these changes needed?

Same as #65334: `data17build-py3.10`-based CI jobs (data arrow v17 shards, docs example, integration, dashboard) fail with `ModuleNotFoundError: No module named 'exceptiongroup'` because the conda ffmpeg install step removes packages from the data CI depset. The release branch carries the same Dockerfile ordering, so its data CI is subject to the same breakage — this keeps 2.58.0 release CI green.

## Notes

- Clean cherry-pick, no conflicts (`git cherry-pick -x -s`); diff is identical to the master commit (1 file, +22/−11).
- No existing open PR cherry-picks #65334 to this branch (checked via `gh pr list --search`).
- Original change and this cherry-pick were AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)