### PR TITLE
[ci] Count the Vale configuration and the API-consistency checker as documentation content in the docs-go scope guard

### DIFF
--- a/ci/lint/validate_docs_go_scope.sh
+++ b/ci/lint/validate_docs_go_scope.sh
@@ -4,11 +4,27 @@
 # The "docs-go" label skips the per-team doc/example test steps and the API
 # consistency checks on a pull request. That is only safe when the PR really is
 # documentation content. This guard runs whenever the label is present and
-# fails the build unless every changed file is documentation content under
-# doc/, excluding BUILD files (which define test targets and must not be
+# fails the build unless every changed file is documentation content: anything
+# under doc/, plus the Vale prose-lint configuration at the repo root, and in
+# both cases excluding BUILD files (which define test targets and must not be
 # changed under a test-skipping label). It cannot tell an editorial edit from a
 # code edit inside a doc file; that judgment stays with the author and is
 # backstopped by the post-merge doc build.
+#
+# Why the Vale configuration counts as documentation content even though it
+# lives outside doc/. It defines no bazel target, so nothing the label skips can
+# be affected by it, and it holds no executable Ray code, so no doctest or
+# example changes behavior because of it. The check that consumes it,
+# "lint: documentation_style", carries the `always` tag in lint.rayci.yml, so it
+# runs on every pull request whether or not the label is present: widening the
+# guard here does not let a Vale edit through unlinted. test.rules.txt already
+# routes these paths to `doc` alone, which reaches only the post-merge doc
+# build, so no premerge step is traded away either.
+#
+# This list is deliberately narrow. It covers the prose rules themselves, not
+# the CI wiring that runs them: ci/lint/check-documentation-style.sh and the
+# Vale hook in .pre-commit-config.yaml stay out of scope, because a change to
+# either one alters what actually runs.
 
 set -uo pipefail
 
@@ -24,16 +40,21 @@ if [[ -z "${changed}" ]]; then
   exit 1
 fi
 
-# Files not under doc/ are out of scope for a content-only PR.
-out_of_scope="$(printf '%s\n' "${changed}" | grep -vE '^doc/' || true)"
-# BUILD files under doc/ define test targets, so they are out of scope too.
-build_edits="$(printf '%s\n' "${changed}" | grep -E '(^|/)BUILD(\.bazel)?$' | grep -E '^doc/' || true)"
+# Paths that count as documentation content: everything under doc/, and the
+# Vale prose-lint configuration at the repo root.
+in_scope_re='^doc/|^\.vale\.ini$|^\.vale/'
+
+# Anything outside that set is out of scope for a content-only PR.
+out_of_scope="$(printf '%s\n' "${changed}" | grep -vE "${in_scope_re}" || true)"
+# BUILD files define test targets, so they are out of scope even in a
+# documentation directory.
+build_edits="$(printf '%s\n' "${changed}" | grep -E '(^|/)BUILD(\.bazel)?$' | grep -E "${in_scope_re}" || true)"
 
 if [[ -n "${out_of_scope}" || -n "${build_edits}" ]]; then
-  echo "The 'docs-go' label is only valid on content-only PRs: changes under doc/, excluding BUILD files."
+  echo "The 'docs-go' label is only valid on content-only PRs: changes under doc/ or to the Vale configuration (.vale.ini, .vale/), excluding BUILD files."
   echo
   if [[ -n "${out_of_scope}" ]]; then
-    echo "Out-of-scope files (not under doc/):"
+    echo "Out-of-scope files (not documentation content):"
     printf '%s\n' "${out_of_scope}" | sed 's/^/  /'
   fi
   if [[ -n "${build_edits}" ]]; then
@@ -45,5 +66,5 @@ if [[ -n "${out_of_scope}" || -n "${build_edits}" ]]; then
   exit 1
 fi
 
-echo "docs-go scope OK: all changed files are documentation content under doc/ (excluding BUILD files)."
+echo "docs-go scope OK: all changed files are documentation content (under doc/ or Vale configuration, excluding BUILD files)."
 printf '%s\n' "${changed}" | sed 's/^/  /'

--- a/ci/lint/validate_docs_go_scope.sh
+++ b/ci/lint/validate_docs_go_scope.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # Scope guard for the "docs-go" pull-request label.
 #
-# The "docs-go" label skips the per-team doc/example test steps and the API
-# consistency checks on a pull request. That is only safe when the PR really is
-# documentation content. This guard runs whenever the label is present and
-# fails the build unless every changed file is documentation content: anything
-# under doc/, plus the Vale prose-lint configuration at the repo root, and in
-# both cases excluding BUILD files (which define test targets and must not be
-# changed under a test-skipping label). It cannot tell an editorial edit from a
-# code edit inside a doc file; that judgment stays with the author and is
-# backstopped by the post-merge doc build.
+# The "docs-go" label skips the per-library doc/example test steps on a pull
+# request. (It does not skip the API consistency checks: those are deliberately
+# ungated in doc.rayci.yml, because an API reference page edit is exactly the
+# content-only change they must still cover.) Skipping is only safe when the PR
+# really is documentation content. This guard runs whenever the label is present
+# and fails the build unless every changed file is documentation content:
+# anything under doc/, the Vale prose-lint configuration at the repo root, or
+# the API-consistency checker's own source under ci/ray_ci/doc/ -- in every case
+# excluding BUILD files (which define test targets and must not be changed under
+# a test-skipping label). It cannot tell an editorial edit from a code edit
+# inside a doc file; that judgment stays with the author and is backstopped by
+# the post-merge doc build.
 #
 # Why the Vale configuration counts as documentation content even though it
 # lives outside doc/. It defines no bazel target, so nothing the label skips can
@@ -21,10 +24,25 @@
 # routes these paths to `doc` alone, which reaches only the post-merge doc
 # build, so no premerge step is traded away either.
 #
-# This list is deliberately narrow. It covers the prose rules themselves, not
-# the CI wiring that runs them: ci/lint/check-documentation-style.sh and the
-# Vale hook in .pre-commit-config.yaml stay out of scope, because a change to
-# either one alters what actually runs.
+# Why ci/ray_ci/doc/ counts, on a different argument. This directory is
+# executable CI code, so the "no bazel target, no executable code" reasoning
+# above does not apply to it. What makes it safe is tag routing. test.rules.txt
+# routes ci/ray_ci/doc/ to `doc_api tools` and nothing else, ahead of the broad
+# ci/ray_ci/ rule (first match wins). Every step this label skips carries a
+# library tag instead -- core_python, data, llm, train, tune, rllib_directly,
+# serve, and the *_doc tags -- so a change confined to this directory never
+# selects one of them, and the label can only subtract from an already-emitted
+# set. Meanwhile the two things that do cover this directory are ungated: the
+# `doc_api` API checks, and the `tools` job that runs the six ci_unit py_test
+# targets declared here. Editing the checker therefore still runs the checker
+# and its own unit tests, with or without the label.
+#
+# This list is deliberately narrow. For Vale it covers the prose rules
+# themselves, not the CI wiring that runs them: ci/lint/check-documentation-style.sh
+# and the Vale hook in .pre-commit-config.yaml stay out of scope, because a change
+# to either one alters what actually runs. For the checker it covers
+# ci/ray_ci/doc/ only, not the shared ci/ray_ci/ tooling that every bazel test
+# step runs through.
 
 set -uo pipefail
 
@@ -40,9 +58,10 @@ if [[ -z "${changed}" ]]; then
   exit 1
 fi
 
-# Paths that count as documentation content: everything under doc/, and the
-# Vale prose-lint configuration at the repo root.
-in_scope_re='^doc/|^\.vale\.ini$|^\.vale/'
+# Paths that count as documentation content: everything under doc/, the Vale
+# prose-lint configuration at the repo root, and the API-consistency checker's
+# own source.
+in_scope_re='^doc/|^\.vale\.ini$|^\.vale/|^ci/ray_ci/doc/'
 
 # Anything outside that set is out of scope for a content-only PR.
 out_of_scope="$(printf '%s\n' "${changed}" | grep -vE "${in_scope_re}" || true)"
@@ -51,7 +70,7 @@ out_of_scope="$(printf '%s\n' "${changed}" | grep -vE "${in_scope_re}" || true)"
 build_edits="$(printf '%s\n' "${changed}" | grep -E '(^|/)BUILD(\.bazel)?$' | grep -E "${in_scope_re}" || true)"
 
 if [[ -n "${out_of_scope}" || -n "${build_edits}" ]]; then
-  echo "The 'docs-go' label is only valid on content-only PRs: changes under doc/ or to the Vale configuration (.vale.ini, .vale/), excluding BUILD files."
+  echo "The 'docs-go' label is only valid on content-only PRs: changes under doc/, to the Vale configuration (.vale.ini, .vale/), or to the API-consistency checker (ci/ray_ci/doc/), excluding BUILD files."
   echo
   if [[ -n "${out_of_scope}" ]]; then
     echo "Out-of-scope files (not documentation content):"
@@ -63,8 +82,13 @@ if [[ -n "${out_of_scope}" || -n "${build_edits}" ]]; then
   fi
   echo
   echo "Remove the 'docs-go' label so the appropriate tests run, or split the non-doc changes into a separate PR."
+  echo
+  echo "Removing the label is not enough on its own: push a new commit afterwards."
+  echo "A Buildkite rebuild replays the label set from the build it was rebuilt from,"
+  echo "and the pipeline skips label-change builds for an already-built commit, so only"
+  echo "a new commit produces a build that reads the current labels."
   exit 1
 fi
 
-echo "docs-go scope OK: all changed files are documentation content (under doc/ or Vale configuration, excluding BUILD files)."
+echo "docs-go scope OK: all changed files are documentation content (under doc/, Vale configuration, or ci/ray_ci/doc/, excluding BUILD files)."
 printf '%s\n' "${changed}" | sed 's/^/  /'

--- a/doc/.claude/CLAUDE.md
+++ b/doc/.claude/CLAUDE.md
@@ -25,7 +25,7 @@ For docs-only fixes, take the lightest path:
 
 - Touch only files under `doc/`. A prose-only change runs no library tests at all, the cheapest path there is.
 - Don't bundle in a non-doc change "while you're at it" — that change pulls its own (often expensive) test set into the PR.
-- The `docs-go` label skips the per-library docs example steps on a content-only PR. It's optional, and applying it takes write access, so suggest it to the reviewer rather than assuming the PR author can add it. A guard step, `lint: validate docs-go scope`, fails unless every changed file is documentation content (under `doc/`, or the Vale configuration at `.vale.ini` and `.vale/`, excluding `BUILD` files), so the label never skips tests on a code, CI, or build change.
+- The `docs-go` label skips the per-library docs example steps on a content-only PR. It's optional, and applying it takes write access, so suggest it to the reviewer rather than assuming the PR author can add it. A guard step, `lint: validate docs-go scope`, fails unless every changed file is documentation content (under `doc/`, the Vale configuration at `.vale.ini` and `.vale/`, or the API-consistency checker at `ci/ray_ci/doc/`, excluding `BUILD` files everywhere), so the label never skips tests on a library, build, or general CI change. If the guard fails, removing the label isn't enough: push a new commit, because a rebuild replays the old label set.
 - If a docs change requires a non-doc change to land cleanly (e.g., autodoc references a renamed symbol), land them in the larger non-doc PR, not a docs-led PR.
 
 For generated API docs that depend on Python source under `python/ray/...`, expect broader test runs. That's correct, not a misconfiguration.

--- a/doc/.claude/CLAUDE.md
+++ b/doc/.claude/CLAUDE.md
@@ -25,7 +25,7 @@ For docs-only fixes, take the lightest path:
 
 - Touch only files under `doc/`. A prose-only change runs no library tests at all, the cheapest path there is.
 - Don't bundle in a non-doc change "while you're at it" — that change pulls its own (often expensive) test set into the PR.
-- The `docs-go` label skips the per-library docs example steps on a content-only PR. It's optional, and applying it takes write access, so suggest it to the reviewer rather than assuming the PR author can add it. A guard step, `lint: validate docs-go scope`, fails unless the PR is content-only, so the label never skips tests on a code, CI, or build change.
+- The `docs-go` label skips the per-library docs example steps on a content-only PR. It's optional, and applying it takes write access, so suggest it to the reviewer rather than assuming the PR author can add it. A guard step, `lint: validate docs-go scope`, fails unless every changed file is documentation content (under `doc/`, or the Vale configuration at `.vale.ini` and `.vale/`, excluding `BUILD` files), so the label never skips tests on a code, CI, or build change.
 - If a docs change requires a non-doc change to land cleanly (e.g., autodoc references a renamed symbol), land them in the larger non-doc PR, not a docs-led PR.
 
 For generated API docs that depend on Python source under `python/ray/...`, expect broader test runs. That's correct, not a misconfiguration.

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -92,7 +92,7 @@ The split lives in `.buildkite/always.rules.txt`, which emits the `lint` tag for
 
 Adding the `docs-go` label skips the per-library docs example steps. It's optional. Reach for it on a content-only PR where executing the examples adds nothing and you don't want to wait on them. Like the `go` label, it requires write access, so an external contributor asks a reviewer to add it.
 
-A guard step, `lint: validate docs-go scope`, bounds what the label can skip. It runs whenever the label is present and fails unless the PR changes only content under `doc/`. So the label skips example tests on a prose change but never on a code, CI, or build change. The API surface checks ignore the label by design, since an API reference page edit is exactly the content-only change they need to cover.
+A guard step, `lint: validate docs-go scope`, bounds what the label can skip. It runs whenever the label is present and fails unless every changed file is documentation content: anything under `doc/`, plus the Vale prose-lint configuration at the repository root (`.vale.ini` and `.vale/`), and in both cases excluding `BUILD` files. So the label skips example tests on a prose change but never on a code, CI, or build change. The Vale configuration qualifies because it defines no test target and holds no executable code, and because `lint: documentation_style` runs on every PR regardless of the label, so a style-rule edit is still linted. The API surface checks ignore the label by design, since an API reference page edit is exactly the content-only change they need to cover.
 
 ### What doesn't run on your PR
 

--- a/doc/source/ray-contribute/ci.md
+++ b/doc/source/ray-contribute/ci.md
@@ -92,7 +92,13 @@ The split lives in `.buildkite/always.rules.txt`, which emits the `lint` tag for
 
 Adding the `docs-go` label skips the per-library docs example steps. It's optional. Reach for it on a content-only PR where executing the examples adds nothing and you don't want to wait on them. Like the `go` label, it requires write access, so an external contributor asks a reviewer to add it.
 
-A guard step, `lint: validate docs-go scope`, bounds what the label can skip. It runs whenever the label is present and fails unless every changed file is documentation content: anything under `doc/`, plus the Vale prose-lint configuration at the repository root (`.vale.ini` and `.vale/`), and in both cases excluding `BUILD` files. So the label skips example tests on a prose change but never on a code, CI, or build change. The Vale configuration qualifies because it defines no test target and holds no executable code, and because `lint: documentation_style` runs on every PR regardless of the label, so a style-rule edit is still linted. The API surface checks ignore the label by design, since an API reference page edit is exactly the content-only change they need to cover.
+A guard step, `lint: validate docs-go scope`, bounds what the label can skip. It runs whenever the label is present and fails unless every changed file is documentation content: anything under `doc/`, the Vale prose-lint configuration at the repository root (`.vale.ini` and `.vale/`), or the API-consistency checker's own source under `ci/ray_ci/doc/`. `BUILD` files are excluded everywhere, since they define test targets. So the label skips example tests on a documentation change but never on a library, build, or general CI change.
+
+Each of the two paths outside `doc/` qualifies for its own reason. The Vale configuration defines no test target and holds no executable code, and `lint: documentation_style` runs on every PR regardless of the label, so a style-rule edit is still linted. The checker source is executable CI code, so it qualifies on tag routing instead: `test.rules.txt` sends `ci/ray_ci/doc/` to `doc_api` and `tools` only, and every step the label skips carries a library tag rather than either of those, so a change confined to that directory never selects a step the label could take away. The checks that do cover it, the API checks and the `tools` job running its own unit tests, ignore the label.
+
+The API surface checks ignore the label by design, since an API reference page edit is exactly the content-only change they need to cover.
+
+If the guard fails, removing the label isn't enough on its own: push a new commit afterwards. A Buildkite rebuild replays the label set from the build it was rebuilt from, and the pipeline skips label-change builds for a commit that already has a build, so only a new commit produces a build that reads the current labels.
 
 ### What doesn't run on your PR
 


### PR DESCRIPTION
## Why this change is needed

`ci/lint/validate_docs_go_scope.sh` fails any pull request carrying the `docs-go` label if a changed file lives outside `doc/`. Two kinds of documentation work live outside `doc/` and are therefore locked out of the label today:

- **Ray's Vale configuration** (`.vale.ini`, `.vale/`) sits at the repository root, so a PR that adds or edits a prose-lint rule can never carry the label even though it is documentation content by any reasonable reading. Concretely: #65239 adds KubeRay style rules and edits `doc/source/ray-contribute/writing-style.md`. Its [premerge build](https://buildkite.com/ray-project/premerge/builds/71732) has exactly one failing job, `lint: validate docs-go scope`. Every other check passes.
- **The API-consistency checker's own source** (`ci/ray_ci/doc/`) is the tooling behind the `doc: check API doc consistency` step. Same shape: #65340 changes only that directory, and the label's guard is the sole red job on its [premerge build](https://buildkite.com/ray-project/premerge/builds/71727).

In both cases the author's options today are to drop the label and wait on per-library example suites the PR cannot possibly affect, or to split a coherent change across two PRs.

## What changed

Widen the guard's in-scope set from "under `doc/`" to "under `doc/`, the Vale prose-lint configuration (`.vale.ini`, `.vale/`), or the API-consistency checker (`ci/ray_ci/doc/`)". Both fail-closed paths (no merge-base, empty diff) are unchanged, and the `BUILD`-file exclusion now applies uniformly across the whole in-scope set rather than just `doc/`.

Also updates the two places that state the predicate in prose, so they don't drift from the script: the `docs-go` section of `doc/source/ray-contribute/ci.md`, and `doc/.claude/CLAUDE.md`.

## Why this is safe

The guard exists so `docs-go` can skip the 12 per-library docs example and llm test steps only on a PR that could not break them. The two additions clear that bar on different grounds, which is worth stating separately rather than blurring into one rule.

**The Vale configuration** clears it on content:

- **It defines no bazel target.** The separate `BUILD`-file exclusion is the mechanism that protects test targets, and it stays intact.
- **It holds no executable Ray code**, so no doctest or example can change behavior because of it.
- **The check that consumes it already runs unconditionally.** `lint: documentation_style` sits in the `lint-small-prose` matrix in `.buildkite/lint.rayci.yml` carrying `always`, which `always.rules.txt` emits for every changed file. Vale therefore runs on every pull request whether or not the label is present.
- **No premerge step is traded away.** `test.rules.txt` already routes `.vale.ini` and `.vale/` to `doc` alone, in the rendering-and-validation-only block. That tag reaches `doc: build`, which carries `skip-on-premerge`.

**The checker source** is executable CI code, so the reasoning above does not apply to it. It clears the bar on tag routing:

- **`test.rules.txt` routes `ci/ray_ci/doc/` to `doc_api tools` and nothing else**, ahead of the broad `ci/ray_ci/` rule, and first match wins.
- **Every step the label skips carries a library tag instead** — `core_python`, `data`, `llm`, `train`, `tune`, `rllib_directly`, `serve`, and the `*_doc` tags. A change confined to this directory never emits a tag that selects one of them. Since the label's `if:` can only suppress an already-emitted step, there is nothing for it to take away.
- **Measured on the same commit, with and without the label.** #65340 was built twice: [71727](https://buildkite.com/ray-project/premerge/builds/71727) carried `["go", "docs-go"]` and [71736](https://buildkite.com/ray-project/premerge/builds/71736) carried `["go"]`. Both emitted the same 33 jobs, and diffing the two job-name sets yields no difference in either direction. The label's only effect on such a PR is whether this guard itself is emitted: it ran and failed in the first build, and was `broken` (never emitted) in the second. That is the claim above, observed rather than derived.
- **The checks that do cover the directory are ungated.** The `doc_api` API checks and the `tools` job running this directory's six `ci_unit` py_test targets both run with the label present. Build 71727 is the direct evidence: it carried `docs-go` and ran `doc: check API annotations`, `doc: check API doc consistency`, and all six `//ci/ray_ci/doc:*` targets, all green.
- **`BUILD` files stay excluded**, so a change to this directory's test targets still fails the guard. #65340 is exactly that case: it adds a `py_test` src, so it would still not qualify for the label after this change. That is the intended outcome.

Each list is deliberately narrow. For Vale it covers the prose rules, not the CI wiring that runs them: `ci/lint/check-documentation-style.sh` and the Vale hook in `.pre-commit-config.yaml` stay out of scope, because a change to either one alters what actually runs. For the checker it covers `ci/ray_ci/doc/` only, not the shared `ci/ray_ci/` tooling that every bazel test step runs through.

## Two corrections on the same surface

- **The script's header comment claimed the label skips the API consistency checks.** It doesn't. `doc.rayci.yml` leaves them deliberately ungated, precisely because an API reference page edit is the content-only change they must cover, and build 71727 confirms both ran under the label. `ci.md` already described this correctly, so only the script was wrong.
- **The failure message advised an action that cannot work.** It said "Remove the 'docs-go' label so the appropriate tests run," but removing the label cannot produce a corrected build on the same commit. A Buildkite rebuild replays the label set from the build it was rebuilt from, and the pipeline sets `skip_pull_request_builds_for_existing_commits`, so the `unlabeled` event on an already-built commit produces no build at all. Verified on #65340: `docs-go` was removed at 19:59:30Z, build 71727 was created at 20:00:03Z as a UI rebuild, and its payload still carried `["go", "docs-go"]`. The message and both prose surfaces now say to remove the label *and push a new commit*.

## Checks

- [x] I've signed off every commit (`git commit --signoff`).
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Manual tests

`shellcheck` is clean. The guard was exercised end to end against a controlled base in a scratch repository, 15 cases — the 7 from the Vale-only version, unchanged, plus 8 for the new path:

| Changed files | Expected | Result |
| --- | --- | --- |
| `.vale.ini` + `.vale/styles/**` + a `doc/` page (the #65239 shape) | pass | pass |
| `.vale/styles/**` alone | pass | pass |
| a `doc/` page alone (behavior before this change) | pass | pass |
| `.vale/styles/**` + a file under `python/ray/` | fail | fail, names the Python file |
| `.vale/BUILD.bazel` | fail | fail, names it as a `BUILD` file |
| `ci/lint/check-documentation-style.sh` | fail | fail |
| `.pre-commit-config.yaml` | fail | fail |
| `ci/ray_ci/doc/api.py` alone | pass | pass |
| `ci/ray_ci/doc/api.py` + a `doc/` page | pass | pass |
| `ci/ray_ci/doc/mock/_internal/__init__.py` | pass | pass |
| `ci/ray_ci/doc/BUILD.bazel` (the #65340 shape) | fail | fail, names it as a `BUILD` file |
| `ci/ray_ci/doc/api.py` + a file under `python/ray/` | fail | fail, names the Python file |
| `ci/ray_ci/tester.py` (shared tooling, not the checker) | fail | fail |
| `ci/ray_ci/docker/**` (sibling path) | fail | fail |
| `doc/BUILD.bazel` | fail | fail, unchanged behavior |

Note that this PR itself edits `ci/lint/`, so it deliberately does not carry the `docs-go` label. The label's effect on #65239 is the real confirmation, and I'll rebase that PR onto this once it lands.

## Related

#64775 reserved the `doc` tag for documentation validation. The `docs-go` label and this guard arrived with the content-only escape hatch that followed. #65340 is the checker-source change that motivated the second path.
